### PR TITLE
[Feature] Add split-service AURA serving path

### DIFF
--- a/docs/user_guide/examples/online_serving/aura_split_services.md
+++ b/docs/user_guide/examples/online_serving/aura_split_services.md
@@ -118,4 +118,3 @@ python examples/online_serving/aura_omni/split_services_client.py \
   --tts-ref-audio /data/yrr/vllm-omni/tests/assets/qwen3_tts/clone_2.wav \
   --tts-ref-text "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you."
 ```
-

--- a/docs/user_guide/examples/online_serving/aura_split_services.md
+++ b/docs/user_guide/examples/online_serving/aura_split_services.md
@@ -1,0 +1,121 @@
+# AURA Split Services
+
+This deployment splits the semantic AURA pipeline into three independently
+served HTTP services:
+
+```text
+Client/orchestrator -> ASR service -> AURA service -> TTS service
+```
+
+The TTS service still uses the native Qwen3-TTS two-stage topology:
+
+```text
+Qwen3-TTS Talker -> Code2Wav
+```
+
+Because TTS runs as its own `qwen3_tts` service, its deploy profile can keep
+`async_chunk: true` by default. The ASR and AURA services remain simple
+single-stage text-producing services. The split-service examples default to
+Qwen3-TTS CustomVoice mode with speaker `Vivian`; Base voice-clone mode is an
+explicit override.
+
+## Workflow
+
+1. Start ASR with `vllm_omni/deploy/aura_asr_service.yaml`.
+2. Start AURA with `vllm_omni/deploy/aura_vl_service.yaml`.
+3. Start TTS with `vllm_omni/deploy/aura_tts_service.yaml`.
+4. The client sends audio to ASR and receives a transcript.
+5. The client sends transcript plus video to AURA and receives response text.
+6. If AURA returns `<|silent|>`, the client stops.
+7. Otherwise the client sends response text to TTS `/v1/audio/speech`.
+8. TTS streams PCM chunks and the client writes a WAV file.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User/Benchmark
+    participant C as Split Client
+    participant ASR as ASR Service
+    participant AURA as AURA Service
+    participant TTS as TTS Service
+    participant Talker as TTS Talker
+    participant Code2Wav as Code2Wav
+
+    U->>C: audio + video
+    C->>ASR: /v1/chat/completions(audio)
+    ASR-->>C: transcript text
+    C->>AURA: /v1/chat/completions(video + transcript)
+    AURA-->>C: response text or <|silent|>
+    alt response text
+        C->>TTS: /v1/audio/speech(stream=true)
+        TTS->>Talker: text -> codec tokens
+        Talker-->>Code2Wav: async chunks via shared memory
+        Code2Wav-->>TTS: PCM chunks
+        TTS-->>C: streamed audio bytes
+        C-->>U: text + wav
+    else <|silent|>
+        C-->>U: text only; no TTS call
+    end
+```
+
+## Start Services
+
+```bash
+CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-ASR-1.7B \
+  --omni \
+  --port 8661 \
+  --deploy-config vllm_omni/deploy/aura_asr_service.yaml \
+  --served-model-name Qwen/Qwen3-ASR-1.7B \
+  --allowed-local-media-path /data/ \
+  --trust-remote-code
+
+CUDA_VISIBLE_DEVICES=1 vllm serve aurateam/AURA \
+  --omni \
+  --port 8662 \
+  --deploy-config vllm_omni/deploy/aura_vl_service.yaml \
+  --served-model-name aurateam/AURA \
+  --allowed-local-media-path /data/ \
+  --trust-remote-code
+
+CUDA_VISIBLE_DEVICES=2 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --omni \
+  --port 8663 \
+  --deploy-config vllm_omni/deploy/aura_tts_service.yaml \
+  --served-model-name Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --allowed-local-media-path /data/ \
+  --trust-remote-code
+```
+
+For local checkpoints, set `ASR_MODEL`, `AURA_MODEL`, and `TTS_MODEL` before
+running `/data/yrr/rein_test/start_aura_split_services.sh`. The service YAMLs do
+not hardcode model paths, so the command-line model remains the source of truth.
+
+## Run Client
+
+```bash
+python examples/online_serving/aura_omni/split_services_client.py \
+  --audio-path /data/models/datasets/OmniInteract/data/1q1a/audios/0038_2.wav \
+  --video-path /data/models/datasets/OmniInteract/data/1q1a/videos/0038.mp4 \
+  --output-dir output_aura_split_services
+```
+
+The default TTS request is:
+
+```text
+task_type=CustomVoice, language=Chinese, voice=Vivian, stream=true
+```
+
+To run Base voice-clone mode instead, start the TTS service with a Base
+checkpoint and pass reference audio/text:
+
+```bash
+python examples/online_serving/aura_omni/split_services_client.py \
+  --audio-path /data/models/datasets/OmniInteract/data/1q1a/audios/0038_2.wav \
+  --video-path /data/models/datasets/OmniInteract/data/1q1a/videos/0038.mp4 \
+  --tts-model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --tts-task-type Base \
+  --tts-ref-audio /data/yrr/vllm-omni/tests/assets/qwen3_tts/clone_2.wav \
+  --tts-ref-text "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you."
+```
+

--- a/examples/online_serving/aura_omni/README.md
+++ b/examples/online_serving/aura_omni/README.md
@@ -109,6 +109,44 @@ By default, AURA responses are passed to Qwen3-TTS as text. Set
 to Qwen3-TTS instead. The processor still uses AURA token ids, when available,
 to estimate the Talker prompt length in the default text path.
 
+## Split Services
+
+`aura_omni` can also be served as three independent HTTP services:
+
+```text
+ASR service -> AURA service -> TTS service
+```
+
+The TTS service remains the native Qwen3-TTS `Talker -> Code2Wav` pipeline and
+uses `async_chunk: true` in `vllm_omni/deploy/aura_tts_service.yaml`. This keeps
+the text-to-speech streaming path enabled without prewarming TTS inside the
+ASR/AURA pipeline.
+
+Start all three services with the helper script:
+
+```bash
+bash /data/yrr/rein_test/start_aura_split_services.sh
+```
+
+The split-services client defaults to CustomVoice mode:
+
+```text
+task_type=CustomVoice, language=Chinese, speaker=Vivian
+```
+
+Run it with local OmniInteract media:
+
+```bash
+python examples/online_serving/aura_omni/split_services_client.py \
+  --audio-path /data/models/datasets/OmniInteract/data/1q1a/audios/0038_2.wav \
+  --video-path /data/models/datasets/OmniInteract/data/1q1a/videos/0038.mp4 \
+  --output-dir output_aura_split_services
+```
+
+For the full workflow, sequence diagram, Base-mode override, and replica
+coordination notes, see
+`docs/user_guide/examples/online_serving/aura_split_services.md`.
+
 ## Curl
 
 ```bash

--- a/examples/online_serving/aura_omni/split_services_client.py
+++ b/examples/online_serving/aura_omni/split_services_client.py
@@ -1,0 +1,239 @@
+"""Client-side orchestrator for split AURA services.
+
+The three semantic services are:
+  1. Qwen3-ASR service: audio -> transcript
+  2. AURA service: transcript + video -> response text
+  3. Qwen3-TTS service: response text -> audio
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+
+import httpx
+import numpy as np
+import soundfile as sf
+from openai import OpenAI
+from vllm.assets.audio import AudioAsset
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from vllm_omni.model_executor.stage_input_processors.aura_omni import (
+    DEFAULT_AURA_SYSTEM_PROMPT,
+    DEFAULT_QWEN3_TTS_REF_TEXT,
+    SILENT_TEXT,
+    default_qwen3_tts_ref_audio_path,
+)
+
+DEFAULT_VIDEO_URL = "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4"
+PCM_SAMPLE_RATE = 24000
+
+
+def _encode_file(path: str) -> str:
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def _data_url(path: str, default_mime: str) -> str:
+    suffix = os.path.splitext(path)[1].lower()
+    mime_by_suffix = {
+        ".wav": "audio/wav",
+        ".mp3": "audio/mpeg",
+        ".ogg": "audio/ogg",
+        ".flac": "audio/flac",
+        ".m4a": "audio/mp4",
+        ".mp4": "video/mp4",
+        ".webm": "video/webm",
+        ".mov": "video/quicktime",
+        ".avi": "video/x-msvideo",
+        ".mkv": "video/x-matroska",
+    }
+    return f"data:{mime_by_suffix.get(suffix, default_mime)};base64,{_encode_file(path)}"
+
+
+def media_url(path_or_url: str | None, *, kind: str) -> str:
+    if path_or_url:
+        if path_or_url.startswith(("http://", "https://", "data:")):
+            return path_or_url
+        if not os.path.exists(path_or_url):
+            raise FileNotFoundError(f"{kind} file not found: {path_or_url}")
+        return _data_url(path_or_url, "audio/wav" if kind == "audio" else "video/mp4")
+    if kind == "audio":
+        return AudioAsset("mary_had_lamb").url
+    return DEFAULT_VIDEO_URL
+
+
+def text_from_chat_response(response) -> str:
+    if not response.choices:
+        return ""
+    content = response.choices[0].message.content
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = [item.get("text", "") for item in content if isinstance(item, dict)]
+        return "".join(parts).strip()
+    return str(content or "").strip()
+
+
+def run_asr(args, audio_url: str) -> str:
+    client = OpenAI(base_url=f"{args.asr_base_url}/v1", api_key=args.api_key)
+    response = client.chat.completions.create(
+        model=args.asr_model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio_url", "audio_url": {"url": audio_url}},
+                    {"type": "text", "text": args.asr_prompt},
+                ],
+            }
+        ],
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=args.asr_max_tokens,
+        timeout=args.timeout,
+    )
+    transcript = text_from_chat_response(response)
+    if not transcript:
+        raise RuntimeError("ASR service returned empty transcript.")
+    return transcript
+
+
+def run_aura(args, video_url: str, transcript: str) -> str:
+    client = OpenAI(base_url=f"{args.aura_base_url}/v1", api_key=args.api_key)
+    content: list[dict] = [{"type": "text", "text": transcript}]
+    if video_url:
+        content.insert(0, {"type": "video_url", "video_url": {"url": video_url}})
+
+    response = client.chat.completions.create(
+        model=args.aura_model,
+        messages=[
+            {"role": "system", "content": args.aura_system_prompt},
+            {"role": "user", "content": content},
+        ],
+        temperature=args.aura_temperature,
+        top_p=1.0,
+        max_tokens=args.aura_max_tokens,
+        extra_body={"top_k": -1, "repetition_penalty": 1.0},
+        timeout=args.timeout,
+    )
+    aura_text = text_from_chat_response(response)
+    if not aura_text:
+        raise RuntimeError("AURA service returned empty text.")
+    return aura_text
+
+
+def _tts_payload(args, text: str) -> dict:
+    payload: dict = {
+        "model": args.tts_model,
+        "input": text,
+        "task_type": args.tts_task_type,
+        "language": args.tts_language,
+        "response_format": "pcm" if args.tts_stream else args.tts_response_format,
+        "stream": args.tts_stream,
+    }
+    if args.tts_task_type == "CustomVoice":
+        payload["voice"] = args.tts_speaker
+        if args.tts_instruct:
+            payload["instructions"] = args.tts_instruct
+    elif args.tts_task_type == "Base":
+        payload["ref_audio"] = media_url(args.tts_ref_audio, kind="audio")
+        payload["ref_text"] = args.tts_ref_text
+        if args.tts_x_vector_only_mode:
+            payload["x_vector_only_mode"] = True
+    return payload
+
+
+def run_tts(args, text: str, output_path: Path) -> None:
+    payload = _tts_payload(args, text)
+    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {args.api_key}"}
+    api_url = f"{args.tts_base_url}/v1/audio/speech"
+
+    with httpx.Client(timeout=args.timeout) as client:
+        if not args.tts_stream:
+            response = client.post(api_url, json=payload, headers=headers)
+            if response.status_code != 200:
+                raise RuntimeError(f"TTS service error {response.status_code}: {response.text}")
+            output_path.write_bytes(response.content)
+            return
+
+        chunks: list[bytes] = []
+        with client.stream("POST", api_url, json=payload, headers=headers) as response:
+            if response.status_code != 200:
+                response.read()
+                raise RuntimeError(f"TTS service error {response.status_code}: {response.text}")
+            for chunk in response.iter_bytes():
+                if chunk:
+                    chunks.append(chunk)
+
+    pcm = b"".join(chunks)
+    if len(pcm) % 2:
+        pcm = pcm[:-1]
+    audio = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32767.0
+    sf.write(output_path, audio, PCM_SAMPLE_RATE, format="WAV")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+def main(args) -> None:
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    audio_url = media_url(args.audio_path, kind="audio")
+    video_url = media_url(args.video_path, kind="video") if args.video_path or not args.no_video else ""
+
+    transcript = run_asr(args, audio_url)
+    write_text(output_dir / "asr_transcript.txt", transcript)
+    print(f"ASR transcript: {transcript}")
+
+    aura_text = run_aura(args, video_url, transcript)
+    write_text(output_dir / "aura_response.txt", aura_text)
+    print(f"AURA response: {aura_text}")
+
+    if aura_text.strip() == SILENT_TEXT:
+        print("AURA returned <|silent|>; skipping TTS.")
+        return
+
+    suffix = "wav" if args.tts_stream else args.tts_response_format
+    audio_path = output_dir / f"tts_output.{suffix}"
+    run_tts(args, aura_text, audio_path)
+    print(f"TTS audio saved to {audio_path}")
+
+
+def parse_args():
+    parser = FlexibleArgumentParser(description="AURA split-services online client")
+    parser.add_argument("--api-key", default="EMPTY")
+    parser.add_argument("--asr-base-url", default="http://localhost:8661")
+    parser.add_argument("--aura-base-url", default="http://localhost:8662")
+    parser.add_argument("--tts-base-url", default="http://localhost:8663")
+    parser.add_argument("--asr-model", default="Qwen/Qwen3-ASR-1.7B")
+    parser.add_argument("--aura-model", default="aurateam/AURA")
+    parser.add_argument("--tts-model", default="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice")
+    parser.add_argument("--audio-path", default=None, help="Audio file, URL, or data URL.")
+    parser.add_argument("--video-path", default=None, help="Video file, URL, or data URL.")
+    parser.add_argument("--no-video", action="store_true", help="Do not send video to AURA.")
+    parser.add_argument("--output-dir", default="output_aura_split_services")
+    parser.add_argument("--asr-prompt", default="Transcribe the audio accurately.")
+    parser.add_argument("--asr-max-tokens", type=int, default=256)
+    parser.add_argument("--aura-system-prompt", default=DEFAULT_AURA_SYSTEM_PROMPT)
+    parser.add_argument("--aura-temperature", type=float, default=0.5)
+    parser.add_argument("--aura-max-tokens", type=int, default=256)
+    parser.add_argument("--tts-task-type", default="CustomVoice", choices=["Base", "CustomVoice"])
+    parser.add_argument("--tts-language", default="Chinese")
+    parser.add_argument("--tts-speaker", default="Vivian")
+    parser.add_argument("--tts-instruct", default="")
+    parser.add_argument("--tts-ref-audio", default=default_qwen3_tts_ref_audio_path())
+    parser.add_argument("--tts-ref-text", default=DEFAULT_QWEN3_TTS_REF_TEXT)
+    parser.add_argument("--tts-x-vector-only-mode", action="store_true")
+    parser.add_argument("--tts-response-format", default="wav", choices=["wav", "mp3", "flac", "opus", "aac", "pcm"])
+    parser.add_argument("--no-tts-stream", dest="tts_stream", action="store_false")
+    parser.set_defaults(tts_stream=True)
+    parser.add_argument("--timeout", type=float, default=600.0)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1546,6 +1546,38 @@ class TestAuraOmniDeploy:
 
         assert deploy.pipeline == "aura_omni"
 
+    @pytest.mark.parametrize(
+        ("model_type", "deploy_name", "expected_model_stage"),
+        [
+            ("qwen3_asr", "aura_asr_service.yaml", "asr"),
+            ("qwen3_vl", "aura_vl_service.yaml", "aura"),
+        ],
+    )
+    def test_aura_split_deploy_pipeline_overrides_unregistered_model_type(
+        self,
+        model_type,
+        deploy_name,
+        expected_model_stage,
+    ):
+        deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / deploy_name
+
+        class FakeConfig(PretrainedConfig):
+            pass
+
+        hf_config = FakeConfig()
+        hf_config.model_type = model_type
+
+        with patch("vllm_omni.config.config_factory.get_config", return_value=hf_config):
+            stages = StageConfigFactory.create_from_model(
+                "fake/model",
+                deploy_config_path=str(deploy_path),
+            )
+
+        assert stages is not None
+        assert len(stages) == 1
+        assert stages[0].model_stage == expected_model_stage
+        assert stages[0].stage_type == StageType.LLM
+
     def test_aura_omni_deploy_resolves_four_native_stages(self):
         pipeline_cfg = StageConfigFactory.resolve_pipeline_config("aura_omni")
 
@@ -1578,8 +1610,10 @@ class TestAuraOmniDeploy:
     )
     def test_aura_split_single_stage_deploys(self, deploy_name, expected_model_stage, expected_model_arch):
         deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / deploy_name
+        pipeline_cfg = StageConfigFactory.resolve_pipeline_config("qwen3_tts")
         stages = StageConfigFactory._create_from_registry(
             "qwen3_tts",
+            pipeline_cfg,
             cli_overrides={},
             deploy_config_path=str(deploy_path),
         )
@@ -1592,8 +1626,10 @@ class TestAuraOmniDeploy:
 
     def test_aura_split_tts_deploy_keeps_async_chunk(self):
         deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / "aura_tts_service.yaml"
+        pipeline_cfg = StageConfigFactory.resolve_pipeline_config("qwen3_tts")
         stages = StageConfigFactory._create_from_registry(
             "qwen3_tts",
+            pipeline_cfg,
             cli_overrides={},
             deploy_config_path=str(deploy_path),
         )
@@ -1601,9 +1637,7 @@ class TestAuraOmniDeploy:
         assert [stage.model_stage for stage in stages] == ["qwen3_tts", "code2wav"]
         assert stages[0].yaml_engine_args["async_chunk"] is True
         assert (
-            stages[0]
-            .yaml_engine_args["custom_process_next_stage_input_func"]
-            .endswith("talker2code2wav_async_chunk")
+            stages[0].yaml_engine_args["custom_process_next_stage_input_func"].endswith("talker2code2wav_async_chunk")
         )
 
 

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1569,6 +1569,43 @@ class TestAuraOmniDeploy:
         assert stages[2].yaml_engine_args["model_arch"] == "Qwen3TTSTalkerForConditionalGeneration"
         assert stages[3].yaml_engine_args["model_arch"] == "Qwen3TTSCode2Wav"
 
+    @pytest.mark.parametrize(
+        ("deploy_name", "expected_model_stage", "expected_model_arch"),
+        [
+            ("aura_asr_service.yaml", "asr", "Qwen3ASRForConditionalGeneration"),
+            ("aura_vl_service.yaml", "aura", "AuraQwen3VLForConditionalGeneration"),
+        ],
+    )
+    def test_aura_split_single_stage_deploys(self, deploy_name, expected_model_stage, expected_model_arch):
+        deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / deploy_name
+        stages = StageConfigFactory._create_from_registry(
+            "qwen3_tts",
+            cli_overrides={},
+            deploy_config_path=str(deploy_path),
+        )
+
+        assert len(stages) == 1
+        assert stages[0].model_stage == expected_model_stage
+        assert stages[0].final_output is True
+        assert stages[0].final_output_type == "text"
+        assert stages[0].yaml_engine_args["model_arch"] == expected_model_arch
+
+    def test_aura_split_tts_deploy_keeps_async_chunk(self):
+        deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / "aura_tts_service.yaml"
+        stages = StageConfigFactory._create_from_registry(
+            "qwen3_tts",
+            cli_overrides={},
+            deploy_config_path=str(deploy_path),
+        )
+
+        assert [stage.model_stage for stage in stages] == ["qwen3_tts", "code2wav"]
+        assert stages[0].yaml_engine_args["async_chunk"] is True
+        assert (
+            stages[0]
+            .yaml_engine_args["custom_process_next_stage_input_func"]
+            .endswith("talker2code2wav_async_chunk")
+        )
+
 
 class TestSentinelDefaultPrecedence:
     """Caller-typed (non-None) values win over YAML; None values fall through

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -73,6 +73,25 @@ class StageConfigFactory:
             if _looks_like_dreamzero(model):
                 model_type = "dreamzero"
 
+        if deploy_config_path is not None:
+            deploy_path = Path(deploy_config_path)
+            if deploy_path.exists():
+                deploy_cfg = load_deploy_config(deploy_path)
+                if deploy_cfg.pipeline:
+                    pipeline_cfg = cls.resolve_pipeline_config(deploy_cfg.pipeline, hf_config)
+                    if pipeline_cfg is None:
+                        raise KeyError(
+                            f"Pipeline {deploy_cfg.pipeline!r} from {deploy_path.name!r} "
+                            f"not found in OMNI_PIPELINES. Available: "
+                            f"{sorted(OMNI_PIPELINES.keys())}"
+                        )
+                    return cls._create_from_registry(
+                        deploy_cfg.pipeline,
+                        pipeline_cfg,
+                        cli_overrides,
+                        deploy_config_path,
+                    )
+
         if model_type and model_type in OMNI_PIPELINES:
             pipeline_cfg = cls.resolve_pipeline_config(model_type, hf_config)
             if pipeline_cfg is not None:

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -33,7 +33,7 @@ from vllm.logger import init_logger
 from vllm_omni.config.stage_config import (
     PipelineConfig,
 )
-from vllm_omni.model_executor.models.aura_omni.pipeline import AURA_OMNI_PIPELINE
+from vllm_omni.model_executor.models.aura_omni.pipeline import AURA_ASR_PIPELINE, AURA_OMNI_PIPELINE, AURA_VL_PIPELINE
 from vllm_omni.model_executor.models.bagel.pipeline import (
     BAGEL_PIPELINE,
     BAGEL_SINGLE_STAGE_PIPELINE,

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -83,6 +83,8 @@ PipelineResolverFunc: TypeAlias = Callable[[PreTrainedConfig | None], PipelineCo
 # --- Multi-stage omni pipelines (LLM-centric; audio / video I/O) ---
 OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "aura_omni": AURA_OMNI_PIPELINE,
+    "aura_asr": AURA_ASR_PIPELINE,
+    "aura_vl": AURA_VL_PIPELINE,
     "qwen2_5_omni": QWEN2_5_OMNI_PIPELINE,
     "qwen2_5_omni_thinker_only": QWEN2_5_OMNI_THINKER_ONLY_PIPELINE,
     "qwen3_omni_moe": resolve_qwen3_omni_pipeline,

--- a/vllm_omni/deploy/aura_asr_service.yaml
+++ b/vllm_omni/deploy/aura_asr_service.yaml
@@ -1,0 +1,18 @@
+pipeline: aura_asr
+async_chunk: false
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 8
+    gpu_memory_utilization: 0.3
+    trust_remote_code: true
+    enable_prefix_caching: true
+    async_scheduling: true
+    max_model_len: 8192
+    max_num_batched_tokens: 4096
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 256

--- a/vllm_omni/deploy/aura_tts_service.yaml
+++ b/vllm_omni/deploy/aura_tts_service.yaml
@@ -1,0 +1,68 @@
+# AURA split-service TTS profile. This is intentionally the native Qwen3-TTS
+# Talker -> Code2Wav pipeline with async chunk streaming enabled.
+pipeline: qwen3_tts
+async_chunk: true
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      shm_threshold_bytes: 65536
+      codec_streaming: true
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      codec_chunk_frames: 25
+      codec_left_context_frames: 72
+      initial_codec_chunk_frames: 1
+      decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 10
+    gpu_memory_utilization: 0.3
+    trust_remote_code: true
+    enable_prefix_caching: true
+    async_scheduling: true
+    max_num_batched_tokens: 512
+    max_model_len: 4096
+    devices: "0"
+    output_connectors:
+      to_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.9
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      repetition_penalty: 1.05
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 1
+    max_num_seqs: 10
+    gpu_memory_utilization: 0.3
+    enforce_eager: false
+    trust_remote_code: true
+    enable_prefix_caching: false
+    async_scheduling: true
+    max_num_batched_tokens: 65536
+    max_model_len: 65536
+    devices: "0"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      repetition_penalty: 1.0
+
+platforms:
+  npu:
+    stages:
+      - stage_id: 0
+        enforce_eager: false

--- a/vllm_omni/deploy/aura_vl_service.yaml
+++ b/vllm_omni/deploy/aura_vl_service.yaml
@@ -1,0 +1,19 @@
+pipeline: aura_vl
+async_chunk: false
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.6
+    trust_remote_code: true
+    enable_prefix_caching: true
+    async_scheduling: true
+    max_model_len: 262144
+    max_num_batched_tokens: 15360
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.5
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 256
+      repetition_penalty: 1.0

--- a/vllm_omni/model_executor/models/aura_omni/pipeline.py
+++ b/vllm_omni/model_executor/models/aura_omni/pipeline.py
@@ -82,3 +82,46 @@ AURA_OMNI_PIPELINE = PipelineConfig(
         ),
     ),
 )
+
+
+AURA_ASR_PIPELINE = PipelineConfig(
+    model_type="aura_asr",
+    model_arch="Qwen3ASRForConditionalGeneration",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="asr",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            engine_output_type="text",
+            model_arch="Qwen3ASRForConditionalGeneration",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)
+
+
+AURA_VL_PIPELINE = PipelineConfig(
+    model_type="aura_vl",
+    model_arch="AuraQwen3VLForConditionalGeneration",
+    hf_architectures=("AuraQwen3VLForConditionalGeneration",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="aura",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            engine_output_type="text",
+            model_arch="AuraQwen3VLForConditionalGeneration",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)


### PR DESCRIPTION
Introduce single-stage ASR and AURA pipeline profiles plus a split-services client that routes audio, video, and response text across independent ASR, AURA, and Qwen3-TTS services.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Add split-service AURA serving path

## Test Plan
1. test accuracy 
2. test performance

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result
1. accuracy
start server with command 
```sh
CUDA_VISIBLE_DEVICES="${ASR_CUDA_VISIBLE_DEVICES:-3}" vllm serve "${ASR_MODEL}" \
  --omni \
  --port "${ASR_PORT}" \
  --deploy-config "${VLLM_OMNI_ROOT}/vllm_omni/deploy/aura_asr_service.yaml" \
  --served-model-name "${ASR_MODEL}" \
  --allowed-local-media-path "${ALLOWED_MEDIA_PATH}" \
  --trust-remote-code \
  > aura_asr_service.log 2>&1 &

CUDA_VISIBLE_DEVICES="${AURA_CUDA_VISIBLE_DEVICES:-1}" vllm serve "${AURA_MODEL}" \
  --omni \
  --port "${AURA_PORT}" \
  --deploy-config "${VLLM_OMNI_ROOT}/vllm_omni/deploy/aura_vl_service.yaml" \
  --served-model-name "${AURA_MODEL}" \
  --allowed-local-media-path "${ALLOWED_MEDIA_PATH}" \
  --trust-remote-code \
  > aura_vl_service.log 2>&1 &

CUDA_VISIBLE_DEVICES="${TTS_CUDA_VISIBLE_DEVICES:-2}" vllm serve "${TTS_MODEL}" \
  --omni \
  --port "${TTS_PORT}" \
  --deploy-config "${VLLM_OMNI_ROOT}/vllm_omni/deploy/aura_tts_service.yaml" \
  --served-model-name "${TTS_MODEL}" \
  --allowed-local-media-path "${ALLOWED_MEDIA_PATH}" \
  --trust-remote-code \
  > aura_tts_service.log 2>&1 &

echo "Started AURA split services:"
echo "  ASR:  http://localhost:${ASR_PORT}"
echo "  AURA: http://localhost:${AURA_PORT}"
echo "  TTS:  http://localhost:${TTS_PORT}"

```
<img width="180" height="50" alt="image" src="https://github.com/user-attachments/assets/77835dde-aa99-4454-b10b-76417606710c" />

send request with command:
```sh
python /data/yrr/vllm-omni/examples/online_serving/aura_omni/split_services_client.py \
  --audio-path /data/models/datasets/OmniInteract/data/1q1a/audios/0038_2.wav \
  --video-path /data/models/datasets/OmniInteract/data/1q1a/videos/0038.mp4 \
  --tts-task-type CustomVoice \
  --tts-language English \
  --tts-speaker Vivian \
  --asr-model /data/models/Qwen3-ASR-1.7B \
  --aura-model /data/models/AURA \
  --tts-model /data/model/hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-CustomVoice/snapshots/0c0e3051f131929182e2c023b9537f8b1c68adfe 
```
<img width="1789" height="110" alt="image" src="https://github.com/user-attachments/assets/7466c104-2fae-4aaf-939e-34f0e465fd47" />

2. performance test
Test with OmniInteract datasets. Random 32 requests(each ~8s video + ~2s audio question).
<img width="300" height="550" alt="image" src="https://github.com/user-attachments/assets/8ad2a7b1-7055-45be-abe1-cf5fa2c49b65" />



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
