### PR TITLE
[Metrics] Opentelemetry Tracing Support

### DIFF
--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_omni.diffusion.output_formatter import DiffusionStepTimings
+from vllm_omni.metrics.stats import PipelineTimings
+from vllm_omni.tracing import OmniSpanAttributes
+
+pytestmark = [pytest.mark.cpu]
+
+
+# ------------------------------------------------------------------ #
+#  PipelineTimings
+# ------------------------------------------------------------------ #
+
+
+def test_pipeline_timings_asdict():
+    pt = PipelineTimings(
+        queue_wait_ms=12.5,
+        preprocess_ms=3.2,
+        ar2diffusion_ms=0.8,
+    )
+    d = dataclasses.asdict(pt)
+    assert d == {
+        "queue_wait_ms": 12.5,
+        "preprocess_ms": 3.2,
+        "ar2diffusion_ms": 0.8,
+    }
+
+
+# ------------------------------------------------------------------ #
+#  DiffusionStepTimings
+# ------------------------------------------------------------------ #
+
+
+def test_step_start_ts_default():
+    timings = DiffusionStepTimings(
+        preprocess_time_s=0.01,
+        exec_time_s=0.02,
+        postprocess_time_s=0.03,
+        total_time_ms=60.0,
+    )
+    assert timings.step_start_ts == 0.0
+
+
+# ------------------------------------------------------------------ #
+#  OmniSchedulerMixin.add_request
+# ------------------------------------------------------------------ #
+
+
+def test_add_request_sets_first_chunk_ts_for_new_request():
+    from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
+
+    class _BaseScheduler:
+        def __init__(self):
+            self.requests = {}
+
+        def add_request(self, request):
+            self.requests[request.request_id] = request
+
+    class _FakeScheduler(OmniSchedulerMixin, _BaseScheduler):
+        def __init__(self):
+            self.requests = {}
+
+    scheduler = _FakeScheduler()
+    request = SimpleNamespace(request_id="req-1")
+
+    before = time.time()
+    scheduler.add_request(request)
+    after = time.time()
+
+    assert hasattr(request, "first_chunk_received_ts")
+    assert before <= request.first_chunk_received_ts <= after
+
+
+# ------------------------------------------------------------------ #
+#  _emit_llm_processing_span
+# ------------------------------------------------------------------ #
+
+
+def _make_output_processor(**kwargs):
+    """Build a MultimodalOutputProcessor with tracing wired up."""
+    from vllm_omni.engine.output_processor import MultimodalOutputProcessor
+
+    defaults = dict(
+        tokenizer=None,
+        log_stats=False,
+        tracing_enabled=True,
+        stage_id=1,
+        stage_name="talker",
+        replica_id=0,
+    )
+    defaults.update(kwargs)
+    return MultimodalOutputProcessor(**defaults)
+
+
+def _make_engine_core_output(first_chunk_ts=None, trace_headers=None):
+    return SimpleNamespace(
+        first_chunk_received_ts=first_chunk_ts,
+        trace_headers=trace_headers or {},
+    )
+
+
+def _make_req_state(
+    scheduled_ts=0.0,
+    first_token_ts=0.0,
+    last_token_ts=0.0,
+):
+    stats = SimpleNamespace(
+        scheduled_ts=scheduled_ts,
+        first_token_ts=first_token_ts,
+        last_token_ts=last_token_ts,
+        arrival_time=0.0,
+    )
+    return SimpleNamespace(
+        native_text_stats=stats,
+        stats=stats,
+        external_req_id="req-1",
+    )
+
+
+@patch("vllm_omni.engine.output_processor.instrument_manual")
+@patch(
+    "vllm_omni.engine.output_processor.extract_trace_context",
+    return_value=None,
+)
+def test_llm_span_skipped_when_no_first_chunk_ts(_mock_extract, mock_instrument):
+    proc = _make_output_processor()
+    output = _make_engine_core_output(first_chunk_ts=None)
+    req_state = _make_req_state(scheduled_ts=1.0, last_token_ts=2.0)
+
+    proc._emit_llm_processing_span(output, req_state)
+
+    mock_instrument.assert_not_called()
+
+
+@patch("vllm_omni.engine.output_processor.instrument_manual")
+@patch(
+    "vllm_omni.engine.output_processor.extract_trace_context",
+    return_value=None,
+)
+def test_llm_span_uses_scheduled_to_last_token_duration(_mock_extract, mock_instrument):
+    proc = _make_output_processor(stage_id=0, stage_name="thinker", replica_id=2)
+    first_chunk_ts = 1700000000.5
+    scheduled_ts = 100.0
+    last_token_ts = 100.25
+
+    output = _make_engine_core_output(first_chunk_ts=first_chunk_ts)
+    req_state = _make_req_state(
+        scheduled_ts=scheduled_ts,
+        last_token_ts=last_token_ts,
+    )
+
+    proc._emit_llm_processing_span(output, req_state)
+
+    mock_instrument.assert_called_once()
+    call_kwargs = mock_instrument.call_args
+    assert call_kwargs.kwargs["span_name"] == "llm_processing"
+
+    duration = last_token_ts - scheduled_ts  # 0.25s
+    expected_start_ns = int(first_chunk_ts * 1e9)
+    expected_end_ns = int((first_chunk_ts + duration) * 1e9)
+    assert call_kwargs.kwargs["start_time"] == expected_start_ns
+    assert call_kwargs.kwargs["end_time"] == expected_end_ns
+
+    attrs = call_kwargs.kwargs["attributes"]
+    assert attrs[OmniSpanAttributes.STAGE_ID] == 0
+    assert attrs[OmniSpanAttributes.STAGE_NAME] == "thinker"
+    assert attrs[OmniSpanAttributes.STAGE_REPLICA_ID] == 2
+
+
+# ------------------------------------------------------------------ #
+#  _emit_diffusion_span
+# ------------------------------------------------------------------ #
+
+
+@patch("vllm_omni.entrypoints.omni_base.instrument_manual")
+@patch(
+    "vllm_omni.entrypoints.omni_base.extract_trace_context",
+    return_value=None,
+)
+def test_diffusion_span_uses_step_start_ts(_mock_extract, mock_instrument):
+    from vllm_omni.entrypoints.omni_base import OmniBase
+
+    step_start = 1700000000.123
+    total_ms = 500.0
+
+    result = SimpleNamespace(
+        trace_headers={},
+    )
+    stage_metrics = SimpleNamespace(
+        diffusion_metrics={
+            "diffusion_engine_total_time_ms": total_ms,
+            "step_start_ts": step_start,
+            "preprocess_time_ms": 10.0,
+            "diffusion_engine_exec_time_ms": 480.0,
+            "postprocess_time_ms": 10.0,
+        },
+        stage_id=2,
+        replica_id=0,
+    )
+
+    # Call the unbound method with a fake self — we only need the method
+    # logic, not the full OmniBase instance.
+    fake_self = SimpleNamespace()
+    OmniBase._emit_diffusion_span(fake_self, result, stage_metrics)
+
+    mock_instrument.assert_called_once()
+    call_kwargs = mock_instrument.call_args
+
+    expected_start_ns = int(step_start * 1e9)
+    expected_end_ns = int((step_start + total_ms / 1000) * 1e9)
+    assert call_kwargs.kwargs["start_time"] == expected_start_ns
+    assert call_kwargs.kwargs["end_time"] == expected_end_ns
+    assert call_kwargs.kwargs["span_name"] == "diffusion_request"
+
+    attrs = call_kwargs.kwargs["attributes"]
+    assert attrs[OmniSpanAttributes.STAGE_ID] == 2
+    assert attrs[OmniSpanAttributes.STAGE_NAME] == "diffusion"
+    assert attrs[OmniSpanAttributes.STAGE_REPLICA_ID] == 0
+    assert attrs[OmniSpanAttributes.DIFFUSION_PREPROCESS_MS] == 10.0
+    assert attrs[OmniSpanAttributes.DIFFUSION_EXEC_MS] == 480.0
+    assert attrs[OmniSpanAttributes.DIFFUSION_TOTAL_MS] == total_ms

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -332,6 +332,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                                 request_id=req_id,
                                 new_token_ids=[],
                                 kv_transfer_params={"kv_ready": True},
+                                first_chunk_received_ts=getattr(req, "first_chunk_received_ts", None),
                             )
                         )
                 except Exception:
@@ -485,6 +486,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         num_nans_in_logits=request.num_nans_in_logits,
                         is_segment_finished=is_segment_finished,
                         new_prompt_len_snapshot=self._new_prompt_len_snapshot.get(req_id, None),
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
                 if self.chunk_transfer_adapter is not None:
@@ -513,6 +515,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
                 if self.chunk_transfer_adapter is not None:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -578,6 +578,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
             else:
@@ -609,6 +610,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     events=request.take_events(),
                     kv_transfer_params=kv_transfer_params,
                     trace_headers=request.trace_headers,
+                    first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                 )
             )
             stopped_running_reqs.add(request)
@@ -634,6 +636,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
                 if self.chunk_transfer_adapter is not None:

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -40,6 +40,11 @@ except ValueError:
 class OmniSchedulerMixin:
     """Shared scheduler helpers for omni-specific request handling."""
 
+    def add_request(self, request) -> None:
+        if request.request_id not in self.requests:
+            request.first_chunk_received_ts = time.time()
+        super().add_request(request)
+
     def _free_input_coordinator_request(self, request_id: str) -> None:
         """Prune full-payload coordinator state for a completed request."""
         input_coordinator = getattr(self, "input_coordinator", None)

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -42,6 +42,8 @@ class OmniSchedulerMixin:
 
     def add_request(self, request) -> None:
         if request.request_id not in self.requests:
+            # Fallback for stage 0 which has no upstream chunks;
+            # downstream stages overwrite this in chunk_transfer_adapter.
             request.first_chunk_received_ts = time.time()
         super().add_request(request)
 

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -12,7 +12,7 @@
 #     MIOpen conv_transpose1d is not capture-safe in the Code2Wav graph path.
 #   * Platform sections flip enforce_eager per-stage where platform
 #     cudagraph support differs.
-async_chunk: false
+async_chunk: true
 
 connectors:
   connector_of_shared_memory:

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -12,7 +12,7 @@
 #     MIOpen conv_transpose1d is not capture-safe in the Code2Wav graph path.
 #   * Platform sections flip enforce_eager per-stage where platform
 #     cudagraph support differs.
-async_chunk: true
+async_chunk: false
 
 connectors:
   connector_of_shared_memory:

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -193,6 +193,7 @@ class DiffusionEngine:
     async def step(self, request: OmniDiffusionRequest) -> list[OmniRequestOutput]:
         await self._check_and_start_background_loop()
 
+        step_start_ts = time.time()
         diffusion_engine_start_time = time.perf_counter()
 
         # Apply pre-processing if available
@@ -206,11 +207,12 @@ class DiffusionEngine:
         exec_start_time = time.perf_counter()
         output = await self.async_add_req_and_wait_for_response(request)
         exec_total_time = time.perf_counter() - exec_start_time
-        return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time)
+        return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time, step_start_ts=step_start_ts)
 
     async def step_streaming(self, request: OmniDiffusionRequest) -> AsyncGenerator[list[OmniRequestOutput], None]:
         await self._check_and_start_background_loop()
 
+        step_start_ts = time.time()
         diffusion_engine_start_time = time.perf_counter()
 
         preprocess_time = 0.0
@@ -225,7 +227,7 @@ class DiffusionEngine:
         async for output in generator:
             exec_total_time = time.perf_counter() - exec_start_time
             yield self.postprocess_output(
-                request, output, diffusion_engine_start_time, preprocess_time, exec_total_time
+                request, output, diffusion_engine_start_time, preprocess_time, exec_total_time, step_start_ts=step_start_ts
             )
 
     def postprocess_output(
@@ -235,6 +237,8 @@ class DiffusionEngine:
         diffusion_engine_start_time: float,
         preprocess_time: float,
         exec_total_time: float,
+        *,
+        step_start_ts: float = 0.0,
     ) -> list[OmniRequestOutput]:
         """Convert a DiffusionOutput to a list of OmniRequestOutput, attaching profiling metrics."""
         if output.aborted:
@@ -324,6 +328,7 @@ class DiffusionEngine:
                 exec_time_s=exec_total_time,
                 postprocess_time_s=postprocess_time,
                 total_time_ms=step_total_ms,
+                step_start_ts=step_start_ts,
             ),
         )
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -207,7 +207,9 @@ class DiffusionEngine:
         exec_start_time = time.perf_counter()
         output = await self.async_add_req_and_wait_for_response(request)
         exec_total_time = time.perf_counter() - exec_start_time
-        return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time, step_start_ts=step_start_ts)
+        return self.postprocess_output(
+            request, output, diffusion_engine_start_time, preprocess_time, exec_total_time, step_start_ts=step_start_ts
+        )
 
     async def step_streaming(self, request: OmniDiffusionRequest) -> AsyncGenerator[list[OmniRequestOutput], None]:
         await self._check_and_start_background_loop()
@@ -227,7 +229,12 @@ class DiffusionEngine:
         async for output in generator:
             exec_total_time = time.perf_counter() - exec_start_time
             yield self.postprocess_output(
-                request, output, diffusion_engine_start_time, preprocess_time, exec_total_time, step_start_ts=step_start_ts
+                request,
+                output,
+                diffusion_engine_start_time,
+                preprocess_time,
+                exec_total_time,
+                step_start_ts=step_start_ts,
             )
 
     def postprocess_output(

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -19,6 +19,7 @@ class DiffusionStepTimings:
     exec_time_s: float
     postprocess_time_s: float
     total_time_ms: float
+    step_start_ts: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -107,6 +108,7 @@ def format_diffusion_outputs(
         "image_num": int(request.sampling_params.num_outputs_per_prompt),
         "resolution": int(request.sampling_params.resolution),
         "postprocess_time_ms": timings.postprocess_time_s * 1000,
+        "step_start_ts": timings.step_start_ts,
     }
 
     # Detect text output: when the pipeline returns a string (e.g.,

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import importlib
+import time as _time
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping
 from typing import Any
@@ -216,6 +217,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         payload_data, size = result
 
         if payload_data:
+            if chunk_id == 0:
+                request.first_chunk_received_ts = _time.time()
             # Update connector state
             self.get_req_chunk[req_id] += 1
 

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -125,6 +125,8 @@ class OmniEngineCoreOutput(EngineCoreOutput):
     is_segment_finished: bool | None = False
     # Streaming update prompt length
     new_prompt_len_snapshot: int | None = None
+    # Wall-clock time when the first KV chunk arrived from upstream
+    first_chunk_received_ts: float | None = None
 
 
 class OmniEngineCoreOutputs(EngineCoreOutputs):

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -238,7 +238,8 @@ class AsyncOmniEngine:
 
         otlp_traces_endpoint = kwargs.get("otlp_traces_endpoint")
         if otlp_traces_endpoint:
-            init_tracer("vllm_omni", otlp_traces_endpoint)
+            init_tracer("vllm_omni", otlp_traces_endpoint,
+                       extra_attributes={"service.name": "vllm-omni"})
             self._tracing_enabled = True
             self._log_stats = True
             logger.info(

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -27,6 +27,7 @@ from vllm import envs as vllm_envs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
+from vllm.tracing import init_tracer
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
@@ -202,6 +203,7 @@ class AsyncOmniEngine:
     # Class-level defaults so tests that bypass __init__ via object.__new__
     # don't AttributeError when stage-init / forward paths touch these attrs.
     _log_stats: bool = False
+    _tracing_enabled: bool = False
     _coordinator_runtime: Any = None
     _transfer_emitter: Any = None
 
@@ -233,6 +235,17 @@ class AsyncOmniEngine:
         # replica) vllm:* wrap stays registered but reads zero. Respects the
         # --log-stats CLI flag set by the user via OmniBase.
         self._log_stats = log_stats
+
+        otlp_traces_endpoint = kwargs.get("otlp_traces_endpoint")
+        if otlp_traces_endpoint:
+            init_tracer("vllm_omni", otlp_traces_endpoint)
+            self._tracing_enabled = True
+            self._log_stats = True
+            logger.info(
+                "[AsyncOmniEngine] OTel tracing enabled, "
+                "endpoint=%s",
+                otlp_traces_endpoint,
+            )
 
         logger.info(f"[AsyncOmniEngine] Initializing with model {model}")
 
@@ -350,6 +363,8 @@ class AsyncOmniEngine:
             diffusion_batch_size=self.diffusion_batch_size,
             async_chunk=self.async_chunk,
             tokenizer=self.tokenizer,
+            log_stats=self._log_stats,
+            tracing_enabled=self._tracing_enabled,
             single_stage_id_filter=self._single_stage_id_filter,
             omni_master_address=self._omni_master_address,
             omni_master_port=self._omni_master_port,
@@ -425,6 +440,7 @@ class AsyncOmniEngine:
                 running_counter=self._running_counter,
                 transfer_emitter=self._transfer_emitter,
                 log_stats=self._log_stats,
+                tracing_enabled=self._tracing_enabled,
             )
             if not startup_future.done():
                 startup_future.set_result(asyncio.get_running_loop())

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -238,13 +238,11 @@ class AsyncOmniEngine:
 
         otlp_traces_endpoint = kwargs.get("otlp_traces_endpoint")
         if otlp_traces_endpoint:
-            init_tracer("vllm_omni", otlp_traces_endpoint,
-                       extra_attributes={"service.name": "vllm-omni"})
+            init_tracer("vllm_omni", otlp_traces_endpoint, extra_attributes={"service.name": "vllm-omni"})
             self._tracing_enabled = True
             self._log_stats = True
             logger.info(
-                "[AsyncOmniEngine] OTel tracing enabled, "
-                "endpoint=%s",
+                "[AsyncOmniEngine] OTel tracing enabled, endpoint=%s",
                 otlp_traces_endpoint,
             )
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -27,7 +27,7 @@ from vllm import envs as vllm_envs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
-from vllm.tracing import init_tracer
+from vllm.tracing import init_tracer, instrument
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
@@ -352,6 +352,7 @@ class AsyncOmniEngine:
             self._diffusion_od_config_view = SimpleNamespace(model_class_name=resolve_model_class_name(self.model))
         return self._diffusion_od_config_view
 
+    @instrument(span_name="Initialize stages")
     def _initialize_stages(self, stage_init_timeout: int) -> None:
         """Initialize stage clients/processors via StageRuntime and assign to self."""
         self._runtime = create_stage_runtime(

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -89,6 +89,7 @@ class OutputMessage(EngineQueueMessage, kw_only=True):
     metrics: StageRequestMetrics | None = None
     finished: bool
     stage_submit_ts: float | None = None
+    trace_headers: dict[str, str] | None = None
 
 
 class StageMetricsMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -12,6 +12,7 @@ handled by :class:`MembershipController`, which is injected optionally.
 from __future__ import annotations
 
 import asyncio
+import json
 import time as _time
 from dataclasses import dataclass, field
 from typing import Any
@@ -23,11 +24,19 @@ from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
+from vllm.tracing import (
+    SpanKind,
+    extract_trace_context,
+    instrument_manual,
+    is_tracing_available,
+)
+from vllm.tracing.utils import SpanAttributes
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.engine import OmniEngineCoreRequest
+from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
 from vllm_omni.engine.membership_controller import MembershipController
 from vllm_omni.engine.messages import (
@@ -123,6 +132,7 @@ def build_engine_core_request_from_tokens(
     model_config: ModelConfig | None = None,
     resumable: bool = False,
     mm_features: list | None = None,
+    trace_headers: dict[str, str] | None = None,
 ) -> OmniEngineCoreRequest:
     """Build an OmniEngineCoreRequest directly from an OmniTokensPrompt."""
     if arrival_time is None:
@@ -158,6 +168,7 @@ def build_engine_core_request_from_tokens(
         prompt_embeds=prompt_embeds,
         resumable=resumable,
         additional_information=additional_info_payload,
+        trace_headers=trace_headers,
     )
 
 
@@ -186,6 +197,11 @@ class OrchestratorRequestState:
     # Per-request pipeline timing accumulator (milliseconds)
     pipeline_timings: dict[str, float] = field(default_factory=dict)
 
+    # Tracing: W3C trace context for downstream propagation
+    trace_headers: dict[str, str] | None = None
+    trace_start_ns: int = 0
+    _omni_span: Any = None
+
 
 @dataclass
 class StreamingInputState:
@@ -207,6 +223,7 @@ class Orchestrator:
     _running_counter: OmniRequestCounter | None = None
     _transfer_emitter: Any = None
     _stat_logger: OmniPrometheusStatLogger | None = None
+    _tracing_enabled: bool = False
 
     def __init__(
         self,
@@ -221,6 +238,7 @@ class Orchestrator:
         running_counter: OmniRequestCounter | None = None,
         transfer_emitter: Any = None,
         log_stats: bool = False,
+        tracing_enabled: bool = False,
     ) -> None:
         self.request_async_queue = request_async_queue
         self.output_async_queue = output_async_queue
@@ -240,6 +258,7 @@ class Orchestrator:
             self._pd_bootstrap_addr = pd_config.get("bootstrap_addr")
             self._pd_prefill_engine_id = pd_config.get("prefill_engine_id")
         self.request_states: dict[str, OrchestratorRequestState] = {}
+        self._tracing_enabled = tracing_enabled
         self._init_metrics_state(stage_pools, running_counter, transfer_emitter, log_stats=log_stats)
 
         self._cfg_tracker = CfgCompanionTracker()
@@ -465,6 +484,8 @@ class Orchestrator:
         preprocess_ms = msg.preprocess_ms
         if preprocess_ms > 0:
             req_state.pipeline_timings["preprocess_ms"] = preprocess_ms
+        if self._tracing_enabled:
+            self._start_omni_request_span(req_state, prompt)
         await self.stage_pools[stage_id].submit_initial(
             request_id,
             req_state,
@@ -808,6 +829,66 @@ class Orchestrator:
             if self.request_states.pop(request_id, None) is not None and self._running_counter is not None:
                 self._running_counter.decrement()
 
+    def _start_omni_request_span(
+        self,
+        req_state: OrchestratorRequestState,
+        prompt: Any,
+    ) -> None:
+        if not is_tracing_available():
+            return
+        try:
+            from opentelemetry import trace
+            from opentelemetry.propagate import inject
+
+            parent_headers = getattr(prompt, "trace_headers", None)
+            parent_ctx = extract_trace_context(parent_headers)
+            req_state.trace_start_ns = int(req_state.request_timestamp * 1e9)
+            tracer = trace.get_tracer("vllm_omni")
+            span = tracer.start_span(
+                "omni_request",
+                context=parent_ctx,
+                kind=SpanKind.SERVER,
+                start_time=req_state.trace_start_ns,
+            )
+            req_state._omni_span = span
+            carrier: dict[str, str] = {}
+            ctx = trace.set_span_in_context(span)
+            inject(carrier, context=ctx)
+            req_state.trace_headers = carrier
+            if hasattr(prompt, "trace_headers"):
+                prompt.trace_headers = carrier
+        except Exception:
+            logger.debug(
+                "[Orchestrator] Failed to start omni_request span",
+                exc_info=True,
+            )
+
+    def _end_omni_request_span(
+        self,
+        req_state: OrchestratorRequestState,
+    ) -> None:
+        span = req_state._omni_span
+        if span is None:
+            return
+        try:
+            span.set_attribute(
+                SpanAttributes.GEN_AI_REQUEST_ID,
+                req_state.request_id,
+            )
+            if req_state.pipeline_timings:
+                span.set_attribute(
+                    OmniSpanAttributes.PIPELINE_TIMINGS,
+                    json.dumps(req_state.pipeline_timings),
+                )
+            span.end()
+        except Exception:
+            logger.debug(
+                "[Orchestrator] Failed to end omni_request span",
+                exc_info=True,
+            )
+        finally:
+            req_state._omni_span = None
+
     async def _apply_raw_terminal_stage_finish(
         self,
         stage_id: int,
@@ -889,6 +970,7 @@ class Orchestrator:
                     metrics=stage_metrics,
                     finished=request_finished,
                     stage_submit_ts=submit_ts,
+                    trace_headers=req_state.trace_headers,
                 )
             )
         elif stage_metrics is not None:
@@ -943,6 +1025,8 @@ class Orchestrator:
                     )
 
         if request_finished:
+            if self._tracing_enabled:
+                self._end_omni_request_span(req_state)
             await self._cleanup_request_ids([req_id, *self._cfg_tracker.cleanup_parent(req_id)])
 
     def _next_stage_already_submitted(self, stage_id: int, req_state: OrchestratorRequestState) -> bool:
@@ -992,6 +1076,7 @@ class Orchestrator:
         *,
         mm_features: list | None = None,
         resumable: bool = False,
+        trace_headers: dict[str, str] | None = None,
     ) -> Any:
         next_pool = self.stage_pools[next_stage_id]
         if self._next_stage_input_is_tokens(next_input):
@@ -1002,6 +1087,7 @@ class Orchestrator:
                 model_config=next_pool.stage_vllm_config.model_config,
                 mm_features=mm_features,
                 resumable=resumable,
+                trace_headers=trace_headers,
             )
             request.external_req_id = request.request_id
             return request
@@ -1017,6 +1103,8 @@ class Orchestrator:
         )
         request = self._upgrade_processed_stage_request(request, next_input)
         request.external_req_id = req_id
+        if trace_headers is not None and hasattr(request, "trace_headers"):
+            request.trace_headers = trace_headers
         return request
 
     async def _handle_cfg_companion_ready(self, req_id: str) -> None:
@@ -1398,8 +1486,8 @@ class Orchestrator:
                 params=params,
                 mm_features=mm_features,
                 resumable=next_stage_resumable,
+                trace_headers=req_state.trace_headers,
             )
-
             if already_submitted:
                 await next_pool.submit_update(req_id, req_state, request)
             else:
@@ -1479,6 +1567,7 @@ class Orchestrator:
                     params=params,
                     model_config=next_pool.stage_vllm_config.model_config,
                     resumable=downstream_resumable,
+                    trace_headers=req_state.trace_headers,
                 )
                 request.external_req_id = request.request_id
                 await next_pool.submit_initial(

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -12,6 +12,7 @@ handled by :class:`MembershipController`, which is injected optionally.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 import time as _time
 from dataclasses import dataclass, field
@@ -27,7 +28,6 @@ from vllm.sampling_params import SamplingParams
 from vllm.tracing import (
     SpanKind,
     extract_trace_context,
-    instrument_manual,
     is_tracing_available,
 )
 from vllm.tracing.utils import SpanAttributes
@@ -36,7 +36,6 @@ from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.engine import OmniEngineCoreRequest
-from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
 from vllm_omni.engine.membership_controller import MembershipController
 from vllm_omni.engine.messages import (
@@ -57,7 +56,9 @@ from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 from vllm_omni.metrics.stat_logger import OmniPrometheusStatLogger
+from vllm_omni.metrics.stats import PipelineTimings
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 
 logger = init_logger(__name__)
 
@@ -195,7 +196,7 @@ class OrchestratorRequestState:
     streaming: StreamingInputState = field(default_factory=lambda: StreamingInputState())
 
     # Per-request pipeline timing accumulator (milliseconds)
-    pipeline_timings: dict[str, float] = field(default_factory=dict)
+    pipeline_timings: PipelineTimings = field(default_factory=PipelineTimings)
 
     # Tracing: W3C trace context for downstream propagation
     trace_headers: dict[str, str] | None = None
@@ -480,10 +481,10 @@ class Orchestrator:
         req_state.stage_submit_ts[stage_id] = _time.time()
         enqueue_ts = msg.enqueue_ts
         if enqueue_ts > 0:
-            req_state.pipeline_timings["queue_wait_ms"] = (_time.perf_counter() - enqueue_ts) * 1000.0
+            req_state.pipeline_timings.queue_wait_ms = (_time.perf_counter() - enqueue_ts) * 1000.0
         preprocess_ms = msg.preprocess_ms
         if preprocess_ms > 0:
-            req_state.pipeline_timings["preprocess_ms"] = preprocess_ms
+            req_state.pipeline_timings.preprocess_ms = preprocess_ms
         if self._tracing_enabled:
             self._start_omni_request_span(req_state, prompt)
         await self.stage_pools[stage_id].submit_initial(
@@ -790,7 +791,7 @@ class Orchestrator:
                     replica_id=replica_id,
                     sampling_params=req_state.sampling_params_list[stage_id],
                 )
-                stage_metrics.pipeline_timings = dict(req_state.pipeline_timings)
+                stage_metrics.pipeline_timings = dataclasses.replace(req_state.pipeline_timings)
 
             await self._route_output(stage_id, replica_id, output, req_state, stage_metrics)
 
@@ -875,10 +876,11 @@ class Orchestrator:
                 SpanAttributes.GEN_AI_REQUEST_ID,
                 req_state.request_id,
             )
-            if req_state.pipeline_timings:
+            pt_dict = dataclasses.asdict(req_state.pipeline_timings)
+            if pt_dict:
                 span.set_attribute(
                     OmniSpanAttributes.PIPELINE_TIMINGS,
-                    json.dumps(req_state.pipeline_timings),
+                    json.dumps(pt_dict),
                 )
             span.end()
         except Exception:
@@ -1296,7 +1298,7 @@ class Orchestrator:
                     **_extra_kwargs,
                 )
                 _dt_ar2d = (_time.perf_counter() - _t_ar2d) * 1000
-                req_state.pipeline_timings["ar2diffusion_ms"] = _dt_ar2d
+                req_state.pipeline_timings.ar2diffusion_ms = _dt_ar2d
                 logger.info(
                     "[Orchestrator] ar2diffusion req=%s wall_time=%.3fms stage=%d->%d",
                     req_id,

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -480,12 +480,31 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         stage_name: str | None = None,
         replica_id: int = 0,
     ):
+        """Initialize the multimodal output processor.
+
+        Args:
+            tokenizer: Tokenizer for detokenizing text outputs
+            log_stats: Whether to log statistics
+            stream_interval: Stream interval for output generation
+            tracing_enabled: Whether OpenTelemetry tracing is active
+            engine_core_output_type: Optional output type string (e.g.,
+                "image", "audio", "latent"). Converted to OutputModality
+                internally. Kept for backward compatibility with
+                stage_init_utils.
+            output_modality: Type-safe output modality flag. Used to tag
+                multimodal outputs with the correct modality key when
+                per-output type info is unavailable.
+            stage_id: Pipeline stage index for span attributes.
+            stage_name: Human-readable stage name for span attributes.
+            replica_id: Replica index for span attributes.
+        """
         super().__init__(
             tokenizer=tokenizer,
             log_stats=log_stats,
             stream_interval=stream_interval,
             tracing_enabled=tracing_enabled,
         )
+        # Convert string-based engine_core_output_type to OutputModality
         if engine_core_output_type is not None:
             self.output_modality = OutputModality.from_string(engine_core_output_type)
         else:

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -1,3 +1,4 @@
+import time as _time
 from dataclasses import fields as dataclass_fields
 from typing import Any
 
@@ -6,6 +7,11 @@ from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.tokenizers import TokenizerLike
+from vllm.tracing import (
+    SpanKind,
+    extract_trace_context,
+    instrument_manual,
+)
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor as VLLMOutputProcessor
 from vllm.v1.engine.output_processor import (
@@ -17,6 +23,7 @@ from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import IterationStats, RequestStateStats
 
 from vllm_omni.data_entry_keys import unflatten_payload
+from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.engine.mm_outputs import MultimodalCompletionOutput, MultimodalPayload
 from vllm_omni.engine.output_modality import (
     DRAINABLE_MODALITIES,
@@ -469,34 +476,25 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         tracing_enabled: bool = False,
         engine_core_output_type: str | None = None,
         output_modality: OutputModality = OutputModality.TEXT,
+        stage_id: int = -1,
+        stage_name: str | None = None,
+        replica_id: int = 0,
     ):
-        """Initialize the multimodal output processor.
-
-        Args:
-            tokenizer: Tokenizer for detokenizing text outputs
-            log_stats: Whether to log statistics
-            stream_interval: Stream interval for output generation
-            engine_core_output_type: Optional output type string (e.g.,
-                "image", "audio", "latent"). Converted to OutputModality
-                internally. Kept for backward compatibility with
-                stage_init_utils.
-            output_modality: Type-safe output modality flag. Used to tag
-                multimodal outputs with the correct modality key when
-                per-output type info is unavailable.
-        """
         super().__init__(
             tokenizer=tokenizer,
             log_stats=log_stats,
             stream_interval=stream_interval,
             tracing_enabled=tracing_enabled,
         )
-        # Convert string-based engine_core_output_type to OutputModality
         if engine_core_output_type is not None:
             self.output_modality = OutputModality.from_string(engine_core_output_type)
         else:
             self.output_modality = output_modality
         self.engine_core_output_type = engine_core_output_type
         self._native_text_metrics_by_request: dict[str, dict[str, Any]] = {}
+        self._stage_id = stage_id
+        self._stage_name = stage_name
+        self._replica_id = replica_id
 
     def _native_text_metric_record(self, request_id: str) -> dict[str, Any]:
         return self._native_text_metrics_by_request.setdefault(
@@ -620,7 +618,9 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
                 upstream_outputs.append(eco)
 
         # Handle multimodal-only outputs (generation stages) locally.
-        self._process_mm_only_outputs(mm_only_outputs)
+        self._process_mm_only_outputs(
+            mm_only_outputs, engine_core_timestamp, iteration_stats,
+        )
 
         # Delegate text/pooling outputs to upstream.
         return super().process_outputs(
@@ -632,6 +632,8 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
     def _process_mm_only_outputs(
         self,
         engine_core_outputs: list[EngineCoreOutput],
+        engine_core_timestamp: float | None = None,
+        iteration_stats: IterationStats | None = None,
     ) -> None:
         """Handle outputs from generation stages that have no detokenizer.
 
@@ -642,6 +644,11 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             req_state = self.request_states.get(eco.request_id)
             if req_state is None or not isinstance(req_state, OmniRequestState):
                 continue
+
+            if req_state.stats is not None:
+                self._update_stats_from_output(
+                    req_state, eco, engine_core_timestamp, iteration_stats,
+                )
 
             new_token_ids = eco.new_token_ids
             finish_reason = eco.finish_reason
@@ -663,6 +670,8 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
                     req_state.queue.put(request_output)
 
             if finish_reason is not None:
+                if self.tracing_enabled:
+                    self._emit_mm_only_tracing(eco, req_state)
                 self._finish_request(req_state)
 
     def _update_stats_from_output(
@@ -741,4 +750,81 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             return
         self._native_text_metric_record(req_state.external_req_id)["vllm_tpot_ms"] = (
             float(finished_request.mean_time_per_output_token) * 1000.0
+        )
+
+    def do_tracing(
+        self,
+        engine_core_output: EngineCoreOutput,
+        req_state: RequestState,
+        iteration_stats: IterationStats | None,
+    ) -> None:
+        super().do_tracing(engine_core_output, req_state, iteration_stats)
+        self._emit_llm_processing_span(engine_core_output, req_state)
+
+    def _emit_mm_only_tracing(
+        self,
+        engine_core_output: EngineCoreOutput,
+        req_state: RequestState,
+    ) -> None:
+        """Create llm_request + llm_processing spans for mm-only stages.
+
+        Cannot use upstream do_tracing because it asserts iteration_stats
+        is not None, which is unavailable for mm-only outputs.
+        """
+        stats = getattr(req_state, "native_text_stats", None) or req_state.stats
+        if stats is None:
+            return
+        trace_context = extract_trace_context(
+            engine_core_output.trace_headers,
+        )
+        arrival_time_ns = int(stats.arrival_time * 1e9)
+        instrument_manual(
+            span_name="llm_request",
+            start_time=arrival_time_ns,
+            attributes={
+                "gen_ai.request.id": req_state.external_req_id,
+            },
+            context=trace_context,
+            kind=SpanKind.INTERNAL,
+        )
+        self._emit_llm_processing_span(engine_core_output, req_state)
+
+    def _emit_llm_processing_span(
+        self,
+        engine_core_output: EngineCoreOutput,
+        req_state: RequestState,
+    ) -> None:
+        stats = getattr(req_state, "native_text_stats", None) or req_state.stats
+        if stats is None:
+            return
+        if stats.last_token_ts <= 0:
+            return
+        start_mono = stats.scheduled_ts if stats.scheduled_ts > 0 else stats.first_token_ts
+        if start_mono <= 0:
+            start_ns = int(stats.arrival_time * 1e9)
+        else:
+            wall_now = _time.time()
+            mono_now = _time.monotonic()
+            start_ns = int((wall_now - (mono_now - start_mono)) * 1e9)
+        trace_context = extract_trace_context(
+            engine_core_output.trace_headers,
+        )
+        wall_now = _time.time()
+        mono_now = _time.monotonic()
+        end_ns = int(
+            (wall_now - (mono_now - stats.last_token_ts)) * 1e9
+        )
+        attributes: dict[str, Any] = {
+            OmniSpanAttributes.STAGE_ID: self._stage_id,
+            OmniSpanAttributes.STAGE_REPLICA_ID: self._replica_id,
+        }
+        if self._stage_name:
+            attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
+        instrument_manual(
+            span_name="llm_processing",
+            start_time=start_ns,
+            end_time=end_ns,
+            attributes=attributes,
+            context=trace_context,
+            kind=SpanKind.INTERNAL,
         )

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -1,4 +1,3 @@
-import time as _time
 from dataclasses import fields as dataclass_fields
 from typing import Any
 
@@ -23,7 +22,6 @@ from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import IterationStats, RequestStateStats
 
 from vllm_omni.data_entry_keys import unflatten_payload
-from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.engine.mm_outputs import MultimodalCompletionOutput, MultimodalPayload
 from vllm_omni.engine.output_modality import (
     DRAINABLE_MODALITIES,
@@ -32,6 +30,7 @@ from vllm_omni.engine.output_modality import (
     get_accumulation_strategy,
 )
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 
 logger = init_logger(__name__)
 
@@ -638,7 +637,9 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
 
         # Handle multimodal-only outputs (generation stages) locally.
         self._process_mm_only_outputs(
-            mm_only_outputs, engine_core_timestamp, iteration_stats,
+            mm_only_outputs,
+            engine_core_timestamp,
+            iteration_stats,
         )
 
         # Delegate text/pooling outputs to upstream.
@@ -666,7 +667,10 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
 
             if req_state.stats is not None:
                 self._update_stats_from_output(
-                    req_state, eco, engine_core_timestamp, iteration_stats,
+                    req_state,
+                    eco,
+                    engine_core_timestamp,
+                    iteration_stats,
                 )
 
             new_token_ids = eco.new_token_ids

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -794,25 +794,24 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         engine_core_output: EngineCoreOutput,
         req_state: RequestState,
     ) -> None:
+        first_chunk_ts = getattr(engine_core_output, "first_chunk_received_ts", None)
+        if first_chunk_ts is None:
+            return
         stats = getattr(req_state, "native_text_stats", None) or req_state.stats
         if stats is None:
             return
-        if stats.last_token_ts <= 0:
-            return
-        start_mono = stats.scheduled_ts if stats.scheduled_ts > 0 else stats.first_token_ts
-        if start_mono <= 0:
-            start_ns = int(stats.arrival_time * 1e9)
+        scheduled_ts = stats.scheduled_ts if stats.scheduled_ts > 0 else 0.0
+        last_token_ts = stats.last_token_ts if stats.last_token_ts > 0 else 0.0
+        if scheduled_ts > 0 and last_token_ts > 0:
+            duration = last_token_ts - scheduled_ts
+        elif stats.first_token_ts > 0 and last_token_ts > 0:
+            duration = last_token_ts - stats.first_token_ts
         else:
-            wall_now = _time.time()
-            mono_now = _time.monotonic()
-            start_ns = int((wall_now - (mono_now - start_mono)) * 1e9)
+            return
+        start_ns = int(first_chunk_ts * 1e9)
+        end_ns = int((first_chunk_ts + duration) * 1e9)
         trace_context = extract_trace_context(
             engine_core_output.trace_headers,
-        )
-        wall_now = _time.time()
-        mono_now = _time.monotonic()
-        end_ns = int(
-            (wall_now - (mono_now - stats.last_token_ts)) * 1e9
         )
         attributes: dict[str, Any] = {
             OmniSpanAttributes.STAGE_ID: self._stage_id,

--- a/vllm_omni/engine/stage_engine_core_proc.py
+++ b/vllm_omni/engine/stage_engine_core_proc.py
@@ -17,6 +17,7 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value,
 )
+from vllm.tracing import maybe_init_worker_tracer
 from vllm.utils.system_utils import (
     decorate_logs,
     set_process_title,
@@ -104,6 +105,9 @@ class StageEngineCoreProc(EngineCoreProc):
             stage_label = f"stage{omni_stage_id}" if omni_stage_id is not None else "noid"
             set_death_signal(signal.SIGTERM)
             set_process_title(f"StageEngineCoreProc_{stage_label}_replica{omni_replica_id}_DP{dp_rank}")
+            maybe_init_worker_tracer(
+                "vllm_omni", "stage_engine_core", stage_label,
+            )
             decorate_logs()
             # Workaround for flashinfer/jit-cache version mismatch in CI.
             # The parent process handles this gracefully via ring_globals.py,

--- a/vllm_omni/engine/stage_engine_core_proc.py
+++ b/vllm_omni/engine/stage_engine_core_proc.py
@@ -14,10 +14,10 @@ from typing import Any
 
 import vllm.v1.engine.core as _vllm_engine_core_module
 from vllm.logger import init_logger
+from vllm.tracing import maybe_init_worker_tracer
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value,
 )
-from vllm.tracing import maybe_init_worker_tracer
 from vllm.utils.system_utils import (
     decorate_logs,
     set_process_title,
@@ -106,7 +106,9 @@ class StageEngineCoreProc(EngineCoreProc):
             set_death_signal(signal.SIGTERM)
             set_process_title(f"StageEngineCoreProc_{stage_label}_replica{omni_replica_id}_DP{dp_rank}")
             maybe_init_worker_tracer(
-                "vllm_omni", "stage_engine_core", stage_label,
+                "vllm_omni",
+                "stage_engine_core",
+                stage_label,
             )
             decorate_logs()
             # Workaround for flashinfer/jit-cache version mismatch in CI.

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -814,6 +814,7 @@ def build_llm_stage_output_processor(
     plan: LogicalStageInitPlan,
     stage_vllm_config: Any,
     log_stats: bool = False,
+    tracing_enabled: bool = False,
 ) -> Any | None:
     """Build one output processor per logical LLM stage.
 
@@ -822,6 +823,8 @@ def build_llm_stage_output_processor(
     the upstream MultimodalOutputProcessor default and respects the
     --log-stats CLI flag plumbed through AsyncOmniEngine.
     """
+    if tracing_enabled:
+        log_stats = True
 
     metadata = plan.replicas[0].metadata
     if stage_vllm_config.model_config.skip_tokenizer_init:
@@ -830,10 +833,18 @@ def build_llm_stage_output_processor(
         tokenizer = cached_tokenizer_from_config(
             model_config=stage_vllm_config.model_config,
         )
+    stage_name = getattr(
+        stage_vllm_config.model_config, "model_stage", None,
+    ) if hasattr(stage_vllm_config, "model_config") else None
+    if stage_name is None:
+        stage_name = metadata.stage_type
     return MultimodalOutputProcessor(
         tokenizer=tokenizer,
         log_stats=log_stats,
+        tracing_enabled=tracing_enabled,
         engine_core_output_type=metadata.engine_output_type,
+        stage_id=plan.stage_idx,
+        stage_name=stage_name,
     )
 
 

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -833,9 +833,15 @@ def build_llm_stage_output_processor(
         tokenizer = cached_tokenizer_from_config(
             model_config=stage_vllm_config.model_config,
         )
-    stage_name = getattr(
-        stage_vllm_config.model_config, "model_stage", None,
-    ) if hasattr(stage_vllm_config, "model_config") else None
+    stage_name = (
+        getattr(
+            stage_vllm_config.model_config,
+            "model_stage",
+            None,
+        )
+        if hasattr(stage_vllm_config, "model_config")
+        else None
+    )
     if stage_name is None:
         stage_name = metadata.stage_type
     return MultimodalOutputProcessor(

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -126,6 +126,8 @@ class StageRuntime:
         diffusion_batch_size: int,
         async_chunk: bool,
         tokenizer: str | None = None,
+        log_stats: bool = False,
+        tracing_enabled: bool = False,
     ) -> None:
         self._stage_configs = stage_configs
         self._model = model
@@ -135,6 +137,8 @@ class StageRuntime:
         self._async_chunk = async_chunk
         self._tokenizer = tokenizer
         self._num_stages = len(stage_configs)
+        self._log_stats = log_stats
+        self._tracing_enabled = tracing_enabled
 
         # Populated by initialize()
         self.stage_pools: list[StagePool] = []
@@ -691,7 +695,12 @@ class StageRuntime:
                 stage_vllm_config = plan.replicas[0].stage_vllm_config
                 if stage_vllm_config is None:
                     raise RuntimeError(f"Stage {plan.stage_id} is missing vllm_config")
-                output_processor = build_llm_stage_output_processor(plan, stage_vllm_config)
+                output_processor = build_llm_stage_output_processor(
+                    plan,
+                    stage_vllm_config,
+                    log_stats=self._log_stats,
+                    tracing_enabled=self._tracing_enabled,
+                )
 
             stage_pools.append(
                 StagePool(
@@ -730,6 +739,8 @@ class DistStageRuntime(StageRuntime):
         diffusion_batch_size: int,
         async_chunk: bool,
         tokenizer: str | None = None,
+        log_stats: bool = False,
+        tracing_enabled: bool = False,
         single_stage_id_filter: int | None,
         omni_master_address: str,
         omni_master_port: int,
@@ -746,6 +757,8 @@ class DistStageRuntime(StageRuntime):
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
             tokenizer=tokenizer,
+            log_stats=log_stats,
+            tracing_enabled=tracing_enabled,
         )
         self._single_stage_id_filter = single_stage_id_filter
         self._omni_master_address = omni_master_address
@@ -1066,6 +1079,8 @@ def create_stage_runtime(
     diffusion_batch_size: int,
     async_chunk: bool,
     tokenizer: str | None = None,
+    log_stats: bool = False,
+    tracing_enabled: bool = False,
     # Distributed-only params:
     single_stage_id_filter: int | None = None,
     omni_master_address: str | None = None,
@@ -1087,6 +1102,8 @@ def create_stage_runtime(
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
             tokenizer=tokenizer,
+            log_stats=log_stats,
+            tracing_enabled=tracing_enabled,
             single_stage_id_filter=single_stage_id_filter,
             omni_master_address=omni_master_address,
             omni_master_port=omni_master_port,
@@ -1103,4 +1120,6 @@ def create_stage_runtime(
         diffusion_batch_size=diffusion_batch_size,
         async_chunk=async_chunk,
         tokenizer=tokenizer,
+        log_stats=log_stats,
+        tracing_enabled=tracing_enabled,
     )

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -29,11 +29,11 @@ from vllm_omni.entrypoints.utils import coerce_param_message_types, get_final_st
 from vllm_omni.errors import raise_client_error_or
 from vllm_omni.metrics.modality import OmniModalityMetrics, observe_modality_at_finalize
 from vllm_omni.metrics.prometheus import OmniPrometheusMetrics
-from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.metrics.stats import OrchestratorAggregator
 from vllm_omni.metrics.transfer import OmniTransferMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.utils.tracking_parser import TrackingNamespace
 
 logger = init_logger(__name__)
@@ -487,7 +487,9 @@ class OmniBase(PDDisaggregationMixin):
         # Merge pipeline timings from Orchestrator into stage_durations
         _m = result.metrics
         if _m is not None and hasattr(_m, "pipeline_timings") and _m.pipeline_timings:
-            for key, value in _m.pipeline_timings.items():
+            import dataclasses as _dc
+
+            for key, value in _dc.asdict(_m.pipeline_timings).items():
                 if key not in stage_durations:
                     stage_durations[key] = value
 
@@ -512,13 +514,9 @@ class OmniBase(PDDisaggregationMixin):
         stage_meta = self.engine.get_stage_metadata(stage_id)
         output_type = getattr(engine_outputs, "final_output_type", stage_meta.final_output_type)
         if finished and _m is not None:
-            metrics.accumulate_diffusion_metrics(
-                stage_meta.stage_type, req_id, engine_outputs)
+            metrics.accumulate_diffusion_metrics(stage_meta.stage_type, req_id, engine_outputs)
             metrics.on_stage_metrics(stage_id, req_id, _m, output_type)
-            if (
-                is_tracing_available()
-                and getattr(_m, "diffusion_metrics", None)
-            ):
+            if is_tracing_available() and getattr(_m, "diffusion_metrics", None):
                 self._emit_diffusion_span(result, _m)
 
         if not stage_meta.final_output:
@@ -658,8 +656,8 @@ class OmniBase(PDDisaggregationMixin):
         """
         return self.engine.collective_rpc(method="profile", args=(False, None), stage_ids=stages)
 
-    @staticmethod
     def _emit_diffusion_span(
+        self,
         result: OutputMessage,
         stage_metrics: Any,
     ) -> None:
@@ -667,11 +665,7 @@ class OmniBase(PDDisaggregationMixin):
         if not dm:
             return
         trace_context = extract_trace_context(result.trace_headers)
-        total_ms = (
-            dm.get("diffusion_engine_total_time_ms")
-            or dm.get("total_ms")
-            or 0
-        )
+        total_ms = dm.get("diffusion_engine_total_time_ms") or dm.get("total_ms") or 0
         if total_ms <= 0:
             return
         step_start = dm.get("step_start_ts", 0.0)
@@ -691,7 +685,11 @@ class OmniBase(PDDisaggregationMixin):
             "diffusion_engine_total_time_ms": OmniSpanAttributes.DIFFUSION_TOTAL_MS,
             "total_ms": OmniSpanAttributes.DIFFUSION_TOTAL_MS,
         }
-        attributes: dict[str, Any] = {}
+        attributes: dict[str, Any] = {
+            OmniSpanAttributes.STAGE_ID: stage_metrics.stage_id,
+            OmniSpanAttributes.STAGE_NAME: "diffusion",
+            OmniSpanAttributes.STAGE_REPLICA_ID: stage_metrics.replica_id,
+        }
         for key, attr in _KEY_MAP.items():
             if key in dm and attr not in attributes:
                 attributes[attr] = float(dm[key])

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -8,6 +8,12 @@ from typing import Any, Literal
 
 import huggingface_hub
 from vllm.logger import init_logger
+from vllm.tracing import (
+    SpanKind,
+    extract_trace_context,
+    instrument_manual,
+    is_tracing_available,
+)
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
@@ -23,6 +29,7 @@ from vllm_omni.entrypoints.utils import coerce_param_message_types, get_final_st
 from vllm_omni.errors import raise_client_error_or
 from vllm_omni.metrics.modality import OmniModalityMetrics, observe_modality_at_finalize
 from vllm_omni.metrics.prometheus import OmniPrometheusMetrics
+from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.metrics.stats import OrchestratorAggregator
 from vllm_omni.metrics.transfer import OmniTransferMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
@@ -506,6 +513,11 @@ class OmniBase(PDDisaggregationMixin):
         output_type = getattr(engine_outputs, "final_output_type", stage_meta.final_output_type)
         if finished and _m is not None:
             metrics.on_stage_metrics(stage_id, req_id, _m, output_type)
+            if (
+                is_tracing_available()
+                and getattr(_m, "diffusion_metrics", None)
+            ):
+                self._emit_diffusion_span(result, _m)
 
         if not stage_meta.final_output:
             return None
@@ -643,6 +655,38 @@ class OmniBase(PDDisaggregationMixin):
             List of results from each stage.
         """
         return self.engine.collective_rpc(method="profile", args=(False, None), stage_ids=stages)
+
+    @staticmethod
+    def _emit_diffusion_span(
+        result: OutputMessage,
+        stage_metrics: Any,
+    ) -> None:
+        dm = stage_metrics.diffusion_metrics
+        if not dm:
+            return
+        trace_context = extract_trace_context(result.trace_headers)
+        total_ms = dm.get("total_ms", 0)
+        if total_ms <= 0:
+            return
+        start_ns = int(time.time_ns() - total_ms * 1_000_000)
+        end_ns = time.time_ns()
+        attributes: dict[str, Any] = {}
+        for key, attr in (
+            ("preprocess_ms", OmniSpanAttributes.DIFFUSION_PREPROCESS_MS),
+            ("exec_ms", OmniSpanAttributes.DIFFUSION_EXEC_MS),
+            ("postprocess_ms", OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS),
+            ("total_ms", OmniSpanAttributes.DIFFUSION_TOTAL_MS),
+        ):
+            if key in dm:
+                attributes[attr] = float(dm[key])
+        instrument_manual(
+            span_name="diffusion_request",
+            start_time=start_ns,
+            end_time=end_ns,
+            attributes=attributes,
+            context=trace_context,
+            kind=SpanKind.INTERNAL,
+        )
 
     def _shutdown_base(self) -> None:
         if getattr(self, "_shutdown_called", False):

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -674,8 +674,13 @@ class OmniBase(PDDisaggregationMixin):
         )
         if total_ms <= 0:
             return
-        start_ns = int(time.time_ns() - total_ms * 1_000_000)
-        end_ns = time.time_ns()
+        step_start = dm.get("step_start_ts", 0.0)
+        if step_start > 0:
+            start_ns = int(step_start * 1e9)
+            end_ns = int((step_start + total_ms / 1000) * 1e9)
+        else:
+            start_ns = int(time.time_ns() - total_ms * 1_000_000)
+            end_ns = time.time_ns()
         _KEY_MAP = {
             "preprocess_time_ms": OmniSpanAttributes.DIFFUSION_PREPROCESS_MS,
             "preprocess_ms": OmniSpanAttributes.DIFFUSION_PREPROCESS_MS,

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -512,6 +512,8 @@ class OmniBase(PDDisaggregationMixin):
         stage_meta = self.engine.get_stage_metadata(stage_id)
         output_type = getattr(engine_outputs, "final_output_type", stage_meta.final_output_type)
         if finished and _m is not None:
+            metrics.accumulate_diffusion_metrics(
+                stage_meta.stage_type, req_id, engine_outputs)
             metrics.on_stage_metrics(stage_id, req_id, _m, output_type)
             if (
                 is_tracing_available()
@@ -665,19 +667,28 @@ class OmniBase(PDDisaggregationMixin):
         if not dm:
             return
         trace_context = extract_trace_context(result.trace_headers)
-        total_ms = dm.get("total_ms", 0)
+        total_ms = (
+            dm.get("diffusion_engine_total_time_ms")
+            or dm.get("total_ms")
+            or 0
+        )
         if total_ms <= 0:
             return
         start_ns = int(time.time_ns() - total_ms * 1_000_000)
         end_ns = time.time_ns()
+        _KEY_MAP = {
+            "preprocess_time_ms": OmniSpanAttributes.DIFFUSION_PREPROCESS_MS,
+            "preprocess_ms": OmniSpanAttributes.DIFFUSION_PREPROCESS_MS,
+            "diffusion_engine_exec_time_ms": OmniSpanAttributes.DIFFUSION_EXEC_MS,
+            "exec_ms": OmniSpanAttributes.DIFFUSION_EXEC_MS,
+            "postprocess_time_ms": OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS,
+            "postprocess_ms": OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS,
+            "diffusion_engine_total_time_ms": OmniSpanAttributes.DIFFUSION_TOTAL_MS,
+            "total_ms": OmniSpanAttributes.DIFFUSION_TOTAL_MS,
+        }
         attributes: dict[str, Any] = {}
-        for key, attr in (
-            ("preprocess_ms", OmniSpanAttributes.DIFFUSION_PREPROCESS_MS),
-            ("exec_ms", OmniSpanAttributes.DIFFUSION_EXEC_MS),
-            ("postprocess_ms", OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS),
-            ("total_ms", OmniSpanAttributes.DIFFUSION_TOTAL_MS),
-        ):
-            if key in dm:
+        for key, attr in _KEY_MAP.items():
+            if key in dm and attr not in attributes:
                 attributes[attr] = float(dm[key])
         instrument_manual(
             span_name="diffusion_request",

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -44,7 +44,7 @@ class StageRequestStats:
     final_output_type: str | None = None
     request_id: str | None = None
     postprocess_time_ms: float = 0.0
-    diffusion_metrics: dict[str, int] = None
+    diffusion_metrics: dict[str, float] = None
     audio_generated_frames: int = 0
     audio_sample_rate: int = 0
     audio_duration_s: float = 0.0
@@ -572,7 +572,7 @@ class OrchestratorAggregator:
         if final_output_type is not None:
             stats.final_output_type = final_output_type
         stats.diffusion_metrics = (
-            {k: int(v) for k, v in self.diffusion_metrics.pop(req_id, {}).items()}
+            {k: float(v) for k, v in self.diffusion_metrics.pop(req_id, {}).items()}
             if req_id in self.diffusion_metrics
             else None
         )

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -29,6 +29,15 @@ class StageStats:
 
 
 @dataclass
+class PipelineTimings:
+    """Orchestrator-level pipeline timing metrics (all in milliseconds)."""
+
+    queue_wait_ms: float = 0.0
+    preprocess_ms: float = 0.0
+    ar2diffusion_ms: float = 0.0
+
+
+@dataclass
 class StageRequestStats:
     batch_id: int
     batch_size: int
@@ -51,7 +60,7 @@ class StageRequestStats:
     audio_rtf: float = 0.0
     image_pixels: int = 0
     denoise_step_latency_ms: float = 0.0
-    pipeline_timings: dict[str, float] | None = None
+    pipeline_timings: PipelineTimings | None = None
     output_unit_type: str | None = None
     output_unit_count: int = 0
     serving_time_to_first_output_ms: float = 0.0
@@ -738,8 +747,8 @@ class OrchestratorAggregator:
         preprocess_times = []
         for _rid, evts in self.stage_events.items():
             for evt in evts:
-                if evt.pipeline_timings and "preprocess_ms" in evt.pipeline_timings:
-                    preprocess_times.append(evt.pipeline_timings["preprocess_ms"])
+                if evt.pipeline_timings and evt.pipeline_timings.preprocess_ms > 0:
+                    preprocess_times.append(evt.pipeline_timings.preprocess_ms)
                     break  # only once per request
         if preprocess_times:
             overall_summary["input_preprocess_time_ms"] = sum(preprocess_times) / len(preprocess_times)
@@ -795,17 +804,17 @@ class OrchestratorAggregator:
                 self.stage_events.get(rid, []),
                 key=lambda e: e.stage_id if e.stage_id is not None else -1,
             )
-            pt = {}
+            pt = PipelineTimings()
             if stage_evts:
-                pt = stage_evts[-1].pipeline_timings or {}
-            if pt or e2e_evt:
+                pt = stage_evts[-1].pipeline_timings or PipelineTimings()
+            if e2e_evt or (stage_evts and stage_evts[-1].pipeline_timings):
                 parts = [f"req={rid}"]
                 if e2e_evt:
                     parts.append(f"total={e2e_evt.e2e_total_ms / 1000.0:.2f}s")
-                if "preprocess_ms" in pt:
-                    parts.append(f"preprocess={pt['preprocess_ms'] / 1000.0:.2f}s")
+                if pt.preprocess_ms > 0:
+                    parts.append(f"preprocess={pt.preprocess_ms / 1000.0:.2f}s")
                 if e2e_evt:
-                    engine_ms = e2e_evt.e2e_total_ms - pt.get("preprocess_ms", 0.0)
+                    engine_ms = e2e_evt.e2e_total_ms - pt.preprocess_ms
                     parts.append(f"engine={engine_ms / 1000.0:.2f}s")
                 stage_parts = []
                 for evt in stage_evts:
@@ -820,8 +829,8 @@ class OrchestratorAggregator:
                         transfer_parts.append(f"{te.from_stage}->{te.to_stage}={te.tx_time_ms:.2f}ms")
                 if transfer_parts:
                     parts.append(f"transfers=[{','.join(transfer_parts)}]")
-                if "ar2diffusion_ms" in pt:
-                    parts.append(f"ar2diffusion={pt['ar2diffusion_ms']:.2f}ms")
+                if pt.ar2diffusion_ms > 0:
+                    parts.append(f"ar2diffusion={pt.ar2diffusion_ms:.2f}ms")
                 logger.info("[OmniTiming] %s", " ".join(parts))
 
             # === Stage table (columns = stage_id) ===

--- a/vllm_omni/tracing.py
+++ b/vllm_omni/tracing.py
@@ -1,5 +1,4 @@
 class OmniSpanAttributes:
-    ENGINE_IDX = "vllm_omni.engine.idx"
     STAGE_ID = "vllm_omni.stage.id"
     STAGE_NAME = "vllm_omni.stage.name"
     STAGE_REPLICA_ID = "vllm_omni.stage.replica_id"

--- a/vllm_omni/tracing.py
+++ b/vllm_omni/tracing.py
@@ -1,0 +1,10 @@
+class OmniSpanAttributes:
+    ENGINE_IDX = "vllm_omni.engine.idx"
+    STAGE_ID = "vllm_omni.stage.id"
+    STAGE_NAME = "vllm_omni.stage.name"
+    STAGE_REPLICA_ID = "vllm_omni.stage.replica_id"
+    PIPELINE_TIMINGS = "vllm_omni.pipeline.timings"
+    DIFFUSION_PREPROCESS_MS = "vllm_omni.diffusion.preprocess_ms"
+    DIFFUSION_EXEC_MS = "vllm_omni.diffusion.exec_ms"
+    DIFFUSION_POSTPROCESS_MS = "vllm_omni.diffusion.postprocess_ms"
+    DIFFUSION_TOTAL_MS = "vllm_omni.diffusion.total_ms"


### PR DESCRIPTION
  Addresses https://github.com/vllm-project/vllm-omni/issues/3995             
                                                                              
  ## Purpose                                                                  
                                                                              
  Add OpenTelemetry tracing to vLLM-Omni's multi-stage pipeline. Each request 
  produces a trace with:                                                      
                                                                              
  • An  omni_request  span (SERVER) covering the full request lifecycle in the
  orchestrator                                                                
  • Per-stage  llm_processing  spans (INTERNAL) for each LLM engine stage, as 
  children of  omni_request                                                   
  • A  diffusion_request  span (INTERNAL) for diffusion stages, as a child of 
  omni_request                                                                
                                                                              
  All spans share a single trace ID via W3C TraceContext propagation across   
  stages.                                                                     
                                                                              
  Upstream vLLM already emits  llm_request  spans with  gen_ai.*  attributes  
  (e.g.  gen_ai.request.id ). The  llm_processing  span added here is an omni-
  specific companion that is async_chunk-aware: its start time is anchored to 
  first_chunk_received_ts  (the wall-clock time the first KV chunk arrived    
  from                                                                        
  upstream), so overlapping stages appear correctly in the trace. It carries  
  vllm_omni.*  attributes ( stage.id ,  stage.name ,  stage.replica_id ) that 
  identify where in the multi-stage pipeline the work happened.               
                                                                              
  Spans include the following attributes:                                     
                                                                              
  •  "vllm_omni.stage.id"                                                     
  •  "vllm_omni.stage.name"  (e.g. thinker, talker, code2wav, diffusion)      
  •  "vllm_omni.stage.replica_id"                                             
  •  "vllm_omni.pipeline.timings"  (JSON-serialized  PipelineTimings :        
  queue_wait_ms ,  preprocess_ms ,  ar2diffusion_ms )                         
  •  "vllm_omni.diffusion.preprocess_ms"                                      
  •  "vllm_omni.diffusion.exec_ms"                                            
  •  "vllm_omni.diffusion.postprocess_ms"                                     
  •  "vllm_omni.diffusion.total_ms"                                           
                                                                              
  Additionally, create a span to capture init events (largely inherited from  
  vLLM: torch compilation, model loading, etc.)                               
                                                                              
  ## Test Plan                                                                
                                                                              
  Tested manually with two model types on 2x RTX PRO 6000 Blackwell, traces   
  collected by a Jaeger sidecar ( --otlp-traces-endpoint localhost:4317 ).    
                                                                              
  Qwen3-Omni (3-stage LLM pipeline,  async_chunk: true )                      
                                                                              
    vllm-omni serve --omni Qwen/Qwen3-Omni-30B-A3B-Instruct \                 
      --otlp-traces-endpoint localhost:4317                                   
                                                                              
    curl -s http://localhost:8000/v1/chat/completions \                       
      -H "Content-Type: application/json" \                                   
      -d '{"model":"Qwen/Qwen3-Omni-30B-A3B-Instruct",                        
  "messages":[{"role":"user","content":"Tell me a short joke"}],              
  "max_tokens":64}'                                                           
                                                                              
  Qwen-Image-2512 (single-stage diffusion)                                    
                                                                              
    vllm-omni serve --omni Qwen/Qwen-Image-2512 \                             
      --otlp-traces-endpoint localhost:4317                                   
                                                                              
    curl -s http://localhost:8000/v1/chat/completions \                       
      -H "Content-Type: application/json" \                                   
      -d '{"model":"Qwen/Qwen-Image-2512","messages":[{"role":"user",         
  "content":"Generate an image of a red fox sitting in snow"}],               
  "max_tokens":1}'                                                            
                                                                              
  Unit tests (no GPU required)                                                
                                                                              
    python -m pytest tests/tracing/test_tracing.py -v                         
<!-- markdownlint-disable -->
Addresses https://github.com/vllm-project/vllm-omni/issues/3995

## Purpose

Add OpenTelemetry tracing to vLLM-Omni's multi-stage pipeline. Each request produces a trace with:

- An **`omni_request`** span (SERVER) covering the full request lifecycle in the orchestrator
- Per-stage **`llm_processing`** spans (INTERNAL) for each LLM engine stage, as children of `omni_request`
- A **`diffusion_request`** span (INTERNAL) for diffusion stages, as a child of `omni_request`

All spans share a single trace ID via W3C TraceContext propagation across stages.

Upstream vLLM already emits `llm_request` spans with `gen_ai.*` attributes (e.g. `gen_ai.request.id`). The `llm_processing` span added here is an omni-specific companion that is async_chunk-aware: its start time is anchored to `first_chunk_received_ts` (the wall-clock time the first KV chunk arrived from upstream), so overlapping stages appear correctly in the trace. It carries `vllm_omni.*` attributes (`stage.id`, `stage.name`, `stage.replica_id`) that identify where in the multi-stage pipeline the work happened.

Spans include the following attributes:

- `"vllm_omni.stage.id"`
- `"vllm_omni.stage.name"` (e.g. thinker, talker, code2wav, diffusion)
- `"vllm_omni.stage.replica_id"`
- `"vllm_omni.pipeline.timings"` (JSON-serialized `PipelineTimings`: `queue_wait_ms`, `preprocess_ms`, `ar2diffusion_ms`)
- `"vllm_omni.diffusion.preprocess_ms"`
- `"vllm_omni.diffusion.exec_ms"`
- `"vllm_omni.diffusion.postprocess_ms"`
- `"vllm_omni.diffusion.total_ms"`

Additionally, create a span to capture init time.

## Test Plan

Tested manually with two model types on 2x RTX PRO 6000 Blackwell, traces collected by a Jaeger sidecar (`--otlp-traces-endpoint localhost:4317`).

### Qwen3-Omni
(3-stage LLM pipeline, `async_chunk: true`)

```bash
vllm-omni serve --omni Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-Omni-30B-A3B-Instruct","messages":[{"role":"user","content":"Tell me a short joke"}],"max_tokens":64}'
```

### Qwen-Image-2512 
(single-stage diffusion)

```bash
vllm-omni serve --omni Qwen/Qwen-Image-2512 \
  --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen-Image-2512","messages":[{"role":"user","content":"Generate an image of a red fox sitting in snow"}],"max_tokens":1}'
```

### Performance and Accuracy
Observe E2E request latency of above deployments (Qwen3-Omni, Qwen-Image-2512). Check for any performance regression when OTel is enabled, and check that `omni_request` span duration matches E2E latency

**Unit tests** (no GPU required)

```bash
python -m pytest tests/tracing/test_tracing.py -v
```

6 tests covering `PipelineTimings` serialization, `DiffusionStepTimings` defaults, scheduler timestamp capture, `llm_processing` span guard and timestamp computation, and `diffusion_request` span timestamp computation. Uses `unittest.mock` to verify span emission without a trace collector.

## Test Results

### Qwen3-Omni
<img width="512" alt="Screenshot From 2026-06-23 19-16-49" src="https://github.com/user-attachments/assets/a292831a-648c-4f85-9670-31955144bbf6" />


### Qwen-Image-2512
<img width="512" alt="Screenshot From 2026-06-23 18-45-39" src="https://github.com/user-attachments/assets/3d8dcf6f-9d32-4bd2-90be-eff321bbae4b" />

### Performance and Accuracy
| Model | Baseline | Tracing | Span duration |
|---|---|---|---|
| Qwen-Image-2512 | 11.86s | 11.87s | 11.85s |
| Qwen3-Omni | 0.566s | 0.542s | 0.532s |

No regression observed and span duration is within http overhead of E2E latency


### Unit tests

```
tests/tracing/test_tracing.py::test_pipeline_timings_asdict PASSED
tests/tracing/test_tracing.py::test_step_start_ts_default PASSED
tests/tracing/test_tracing.py::test_add_request_sets_first_chunk_ts_for_new_request PASSED
tests/tracing/test_tracing.py::test_llm_span_skipped_when_no_first_chunk_ts PASSED
tests/tracing/test_tracing.py::test_llm_span_uses_scheduled_to_last_token_duration PASSED
tests/tracing/test_tracing.py::test_diffusion_span_uses_step_start_ts PASSED

6 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
