### PR TITLE
perf: overlap HunyuanImage3 CPU postprocess with next request's GPU work

### DIFF
--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -7,7 +7,7 @@ import random
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import diffusers
 import torch
@@ -782,6 +782,11 @@ class OmniDiffusionConfig:
     # Streaming mode settings
     streaming_output: bool = False  # Start (video) generation with initial prompt, but streaming output in chunks
 
+    # Async diffusion output: offload GPU→CPU copies to a Worker background
+    # thread and signal readiness via a dedicated message channel instead of
+    # polling SHM flags.  Enabled per-model via CLI, YAML, or env var.
+    enable_async_diffusion_output: bool = False
+
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 
@@ -1204,6 +1209,7 @@ class DiffusionOutput:
     trajectory_latents: torch.Tensor | dict[str, Any] | None = None
     trajectory_log_probs: torch.Tensor | dict[str, Any] | None = None
     trajectory_decoded: list[Image.Image] | None = None
+    output_token: str | None = None
     error: str | None = None
     error_status_code: int | None = None
     error_type: str | None = None
@@ -1260,6 +1266,33 @@ class DiffusionOutput:
             error_status_code=status_code,
             error_type=error_type,
         )
+
+
+@dataclass
+class AsyncDiffusionOutput:
+    """Async protocol envelope for ``result_mq`` messages.
+
+    When ``enable_async_diffusion_output`` is True, all ``result_mq``
+    messages use this envelope.  The ``kind`` field routes the message
+    to the correct consumer:
+
+    * ``RPC_RESULT`` — ordinary RPC return (sleep, wake, profile, etc.)
+    * ``COMPUTE_DONE`` — worker forward finished, GPU can start next request
+    * ``OUTPUT_READY`` — background D2H/SHM packing finished, final output
+      is available via ``output_token``
+    """
+
+    RPC_RESULT: ClassVar[str] = "rpc_result"
+    COMPUTE_DONE: ClassVar[str] = "compute_done"
+    OUTPUT_READY: ClassVar[str] = "output_ready"
+
+    kind: str
+    rpc_id: str | None = None
+    req_id: str = ""
+    output_token: str | None = None
+    result: Any | None = None
+    output: DiffusionOutput | None = None
+    error: str | None = None
 
 
 class DiffusionRequestAbortedError(RuntimeError):

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -256,10 +256,8 @@ class DiffusionEngine:
 
         # Async mode: wait for background D2H/SHM to complete.
         if output.output_token:
-            logger.info("[ASYNC] step: waiting output_ready token=%s", output.output_token)
             fut = self.executor.wait_output_ready(output.output_token)
             output = await asyncio.wrap_future(fut)
-            logger.info("[ASYNC] step: output_ready received")
 
         return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time)
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -256,8 +256,10 @@ class DiffusionEngine:
 
         # Async mode: wait for background D2H/SHM to complete.
         if output.output_token:
+            logger.info("[ASYNC] step: waiting output_ready token=%s", output.output_token)
             fut = self.executor.wait_output_ready(output.output_token)
             output = await asyncio.wrap_future(fut)
+            logger.info("[ASYNC] step: output_ready received")
 
         return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time)
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -253,6 +253,12 @@ class DiffusionEngine:
         exec_start_time = time.perf_counter()
         output = await self.async_add_req_and_wait_for_response(request)
         exec_total_time = time.perf_counter() - exec_start_time
+
+        # Async mode: wait for background D2H/SHM to complete.
+        if output.output_token:
+            fut = self.executor.wait_output_ready(output.output_token)
+            output = await asyncio.wrap_future(fut)
+
         return self.postprocess_output(request, output, diffusion_engine_start_time, preprocess_time, exec_total_time)
 
     async def step_streaming(self, request: OmniDiffusionRequest) -> AsyncGenerator[list[OmniRequestOutput], None]:
@@ -271,6 +277,11 @@ class DiffusionEngine:
         generator = self.async_add_req_and_stream_response(request)
         async for output in generator:
             exec_total_time = time.perf_counter() - exec_start_time
+
+            if output.output_token:
+                fut = self.executor.wait_output_ready(output.output_token)
+                output = await asyncio.wrap_future(fut)
+
             yield self.postprocess_output(
                 request, output, diffusion_engine_start_time, preprocess_time, exec_total_time
             )
@@ -769,11 +780,15 @@ class DiffusionEngine:
                     raise ValueError("Sync func should receive one result at one time")
                 if target_request_id in finished_req_ids:
                     req_output = runner_output.get_request_output(target_request_id)
-                    return self._finalize_finished_request(
+                    output = self._finalize_finished_request(
                         target_request_id,
                         runner_output=req_output,
                         missing_result_error="Diffusion execution finished without a final output.",
                     )
+                    if output.output_token:
+                        fut = self.executor.wait_output_ready(output.output_token)
+                        output = fut.result(timeout=30.0)
+                    return output
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         """Start or stop profiling on all diffusion workers.
@@ -1081,5 +1096,8 @@ class DiffusionEngine:
 
         if runner_output is not None and runner_output.result is not None:
             return runner_output.result
+
+        if runner_output is not None and runner_output.output_token is not None:
+            return DiffusionOutput(output_token=runner_output.output_token)
 
         return DiffusionOutput(error=missing_result_error)

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_ASYNC_OUTPUT_TIMEOUT = 30.0  # seconds
+
 __all__ = [
     "DiffusionEngine",
     "_RpcTask",
@@ -787,7 +789,7 @@ class DiffusionEngine:
                     )
                     if output.output_token:
                         fut = self.executor.wait_output_ready(output.output_token)
-                        output = fut.result(timeout=30.0)
+                        output = fut.result(timeout=_ASYNC_OUTPUT_TIMEOUT)
                     return output
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -101,6 +101,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._rpc_id_lock = threading.Lock()
         self._rpc_futures: dict[str, concurrent.futures.Future[AsyncDiffusionOutput]] = {}
         self._output_futures: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
+        self._completed_outputs: dict[str, DiffusionOutput] = {}
         self._futures_lock = threading.RLock()
         self._pump_running = False
         self._pump_stop = threading.Event()
@@ -341,6 +342,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     exec_all_ranks=True,
                 )
                 if isinstance(result, AsyncDiffusionOutput) and result.kind == AsyncDiffusionOutput.COMPUTE_DONE:
+                    logger.info("[ASYNC] execute_request got COMPUTE_DONE token=%s", result.output_token)
                     runner_outputs.append(
                         RunnerOutput(
                             request_id=new_req.request_id,
@@ -439,6 +441,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             "execute_model",
             "execute_model_batch",
         ):
+            logger.info("[ASYNC] collective_rpc async path method=%s", method)
             rpc_id = self._next_rpc_id()
             rpc_request["rpc_id"] = rpc_id
             fut: concurrent.futures.Future = concurrent.futures.Future()
@@ -484,7 +487,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._pump_stop.clear()
         self._result_pump_thread = threading.Thread(target=self._result_pump, daemon=True, name="DiffusionResultPump")
         self._result_pump_thread.start()
-        logger.info("Async result pump started")
+        logger.info("[ASYNC] result pump started")
 
     def _result_pump(self) -> None:
         """Sole reader of result_mq when async output is enabled.
@@ -498,6 +501,11 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 msg = self._result_mq.dequeue(timeout=1.0)
             except Exception:
                 continue
+
+            if isinstance(msg, AsyncDiffusionOutput):
+                logger.info("[ASYNC] pump recv kind=%s rpc_id=%s token=%s", msg.kind, msg.rpc_id, msg.output_token)
+            else:
+                logger.info("[ASYNC] pump recv non-envelope msg type=%s", type(msg).__name__)
 
             if not isinstance(msg, AsyncDiffusionOutput):
                 # Sync-path message: set on the most recent unfulfilled rpc future
@@ -522,6 +530,14 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     else:
                         unpack_diffusion_output_shm(msg.output)
                         fut.set_result(msg.output)
+                elif msg.output_token:
+                    # Race: OUTPUT_READY arrived before wait_output_ready()
+                    # registered the future.  Cache it so wait_output_ready
+                    # can resolve immediately.
+                    if not msg.error:
+                        unpack_diffusion_output_shm(msg.output)
+                    with self._futures_lock:
+                        self._completed_outputs[msg.output_token] = msg.output
 
     def _next_rpc_id(self) -> str:
         with self._rpc_id_lock:
@@ -532,10 +548,26 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         """Return a Future that resolves when the async output is ready.
 
         The Future is fulfilled by the result_pump when an OUTPUT_READY
-        message with the matching output_token arrives.
+        message with the matching output_token arrives.  If the message
+        already arrived before this call, returns an already-resolved Future.
         """
+        with self._futures_lock:
+            # Handle race: OUTPUT_READY may have arrived before we registered.
+            cached = self._completed_outputs.pop(output_token, None)
+            if cached is not None:
+                logger.info("[ASYNC] wait_output_ready: cache HIT token=%s", output_token)
+                fut: concurrent.futures.Future = concurrent.futures.Future()
+                fut.set_result(cached)
+                return fut
+            logger.info("[ASYNC] wait_output_ready: cache MISS token=%s (registering future)", output_token)
         fut: concurrent.futures.Future = concurrent.futures.Future()
         with self._futures_lock:
+            # Double-check: OUTPUT_READY may have arrived in the tiny window
+            # between our first check and the registration below.
+            cached = self._completed_outputs.pop(output_token, None)
+            if cached is not None:
+                fut.set_result(cached)
+                return fut
             self._output_futures[output_token] = fut
         return fut
 

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -342,7 +342,6 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     exec_all_ranks=True,
                 )
                 if isinstance(result, AsyncDiffusionOutput) and result.kind == AsyncDiffusionOutput.COMPUTE_DONE:
-                    logger.info("[ASYNC] execute_request got COMPUTE_DONE token=%s", result.output_token)
                     runner_outputs.append(
                         RunnerOutput(
                             request_id=new_req.request_id,
@@ -441,7 +440,6 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             "execute_model",
             "execute_model_batch",
         ):
-            logger.info("[ASYNC] collective_rpc async path method=%s", method)
             rpc_id = self._next_rpc_id()
             rpc_request["rpc_id"] = rpc_id
             fut: concurrent.futures.Future = concurrent.futures.Future()
@@ -487,7 +485,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._pump_stop.clear()
         self._result_pump_thread = threading.Thread(target=self._result_pump, daemon=True, name="DiffusionResultPump")
         self._result_pump_thread.start()
-        logger.info("[ASYNC] result pump started")
+        logger.info("Async result pump started")
 
     def _result_pump(self) -> None:
         """Sole reader of result_mq when async output is enabled.
@@ -501,11 +499,6 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 msg = self._result_mq.dequeue(timeout=1.0)
             except Exception:
                 continue
-
-            if isinstance(msg, AsyncDiffusionOutput):
-                logger.info("[ASYNC] pump recv kind=%s rpc_id=%s token=%s", msg.kind, msg.rpc_id, msg.output_token)
-            else:
-                logger.info("[ASYNC] pump recv non-envelope msg type=%s", type(msg).__name__)
 
             if not isinstance(msg, AsyncDiffusionOutput):
                 # Sync-path message: set on the most recent unfulfilled rpc future
@@ -555,11 +548,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             # Handle race: OUTPUT_READY may have arrived before we registered.
             cached = self._completed_outputs.pop(output_token, None)
             if cached is not None:
-                logger.info("[ASYNC] wait_output_ready: cache HIT token=%s", output_token)
                 fut: concurrent.futures.Future = concurrent.futures.Future()
                 fut.set_result(cached)
                 return fut
-            logger.info("[ASYNC] wait_output_ready: cache MISS token=%s (registering future)", output_token)
         fut: concurrent.futures.Future = concurrent.futures.Future()
         with self._futures_lock:
             # Double-check: OUTPUT_READY may have arrived in the tiny window

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -495,6 +495,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             try:
                 msg = self._result_mq.dequeue(timeout=1.0)
             except Exception:
+                if self.is_failed:
+                    raise EngineDeadError()
                 continue
 
             if not isinstance(msg, AsyncDiffusionOutput):
@@ -518,14 +520,19 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     if msg.error:
                         fut.set_exception(RuntimeError(msg.error))
                     else:
-                        unpack_diffusion_output_shm(msg.output)
+                        try:
+                            unpack_diffusion_output_shm(msg.output)
+                        except Exception as e:
+                            logger.exception("SHM unpack failed in result pump")
+                            fut.set_exception(e)
+                            continue
                         fut.set_result(msg.output)
                 elif msg.output_token:
-                    # Race: OUTPUT_READY arrived before wait_output_ready()
-                    # registered the future.  Cache it so wait_output_ready
-                    # can resolve immediately.
                     if not msg.error:
-                        unpack_diffusion_output_shm(msg.output)
+                        try:
+                            unpack_diffusion_output_shm(msg.output)
+                        except Exception:
+                            logger.exception("SHM unpack failed in result pump (cached)")
                     with self._futures_lock:
                         self._completed_outputs[msg.output_token] = msg.output
 
@@ -535,27 +542,14 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             return str(self._rpc_id_counter)
 
     def wait_output_ready(self, output_token: str) -> concurrent.futures.Future[DiffusionOutput]:
-        """Return a Future that resolves when the async output is ready.
-
-        The Future is fulfilled by the result_pump when an OUTPUT_READY
-        message with the matching output_token arrives.  If the message
-        already arrived before this call, returns an already-resolved Future.
-        """
+        """Return a Future that resolves when the async output is ready."""
         with self._futures_lock:
-            # Handle race: OUTPUT_READY may have arrived before we registered.
             cached = self._completed_outputs.pop(output_token, None)
             if cached is not None:
                 fut: concurrent.futures.Future = concurrent.futures.Future()
                 fut.set_result(cached)
                 return fut
-        fut: concurrent.futures.Future = concurrent.futures.Future()
-        with self._futures_lock:
-            # Double-check: OUTPUT_READY may have arrived in the tiny window
-            # between our first check and the registration below.
-            cached = self._completed_outputs.pop(output_token, None)
-            if cached is not None:
-                fut.set_result(cached)
-                return fut
+            fut: concurrent.futures.Future = concurrent.futures.Future()
             self._output_futures[output_token] = fut
         return fut
 

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import multiprocessing as mp
 import multiprocessing.connection
 import threading
@@ -14,7 +15,7 @@ from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 from vllm.logger import init_logger
 from vllm.v1.engine.exceptions import EngineDeadError
 
-from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, DiffusionOutput
+from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, AsyncDiffusionOutput, DiffusionOutput
 from vllm_omni.diffusion.executor.abstract import DiffusionExecutor
 from vllm_omni.diffusion.ipc import DIFFUSION_RPC_RESULT_ENVELOPE, unpack_diffusion_output_shm
 from vllm_omni.diffusion.worker import WorkerProc
@@ -93,6 +94,18 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             processes=self._processes,
         )
         self._finalizer = weakref.finalize(self, self.resources)
+
+        # Async output: result pump thread for dispatching AsyncDiffusionOutput
+        # messages when enable_async_diffusion_output is True.
+        self._rpc_id_counter = 0
+        self._rpc_id_lock = threading.Lock()
+        self._rpc_futures: dict[str, concurrent.futures.Future[AsyncDiffusionOutput]] = {}
+        self._output_futures: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
+        self._futures_lock = threading.RLock()
+        self._pump_running = False
+        self._pump_stop = threading.Event()
+        if self.od_config.enable_async_diffusion_output:
+            self._start_result_pump()
 
         self.start_worker_monitor()
 
@@ -311,6 +324,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         """Adapt request-mode scheduler output to worker execute_model RPCs.
 
         Returns a BatchRunnerOutput with one RunnerOutput per scheduled request.
+        In async mode the result may carry output_token instead of the final output.
         """
         from vllm_omni.diffusion.worker.utils import BatchRunnerOutput, RunnerOutput
 
@@ -326,16 +340,27 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     unique_reply_rank=0,
                     exec_all_ranks=True,
                 )
-                if not isinstance(result, DiffusionOutput):
-                    raise RuntimeError(f"Unexpected response type: {type(result)!r}")
-                runner_outputs.append(
-                    RunnerOutput(
-                        request_id=new_req.request_id,
-                        step_index=None,
-                        finished=True,
-                        result=result,
+                if isinstance(result, AsyncDiffusionOutput) and result.kind == AsyncDiffusionOutput.COMPUTE_DONE:
+                    runner_outputs.append(
+                        RunnerOutput(
+                            request_id=new_req.request_id,
+                            step_index=None,
+                            finished=True,
+                            result=None,
+                            output_token=result.output_token,
+                        )
                     )
-                )
+                elif isinstance(result, DiffusionOutput):
+                    runner_outputs.append(
+                        RunnerOutput(
+                            request_id=new_req.request_id,
+                            step_index=None,
+                            finished=True,
+                            result=result,
+                        )
+                    )
+                else:
+                    raise RuntimeError(f"Unexpected response type: {type(result)!r}")
             except Exception as exc:
                 runner_outputs.append(
                     RunnerOutput(
@@ -397,14 +422,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         deadline = None if timeout is None else time.monotonic() + timeout
         kwargs = kwargs or {}
 
-        # Prepare RPC request message. When unique_reply_rank is None, all
-        # workers must execute the RPC but only rank 0 can reply (it's the
-        # only one with a result_mq). Collect detailed rank statuses only for
-        # this control-plane all-rank path; forward-path exec_all_ranks RPCs
-        # avoid the per-step host object gather.
         execute_all_ranks = unique_reply_rank is None or exec_all_ranks
         collect_rank_status = unique_reply_rank is None
-        rpc_request = {
+        rpc_request: dict[str, Any] = {
             "type": "rpc",
             "method": method,
             "args": args,
@@ -414,13 +434,29 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             "collect_rank_status": collect_rank_status,
         }
 
+        # Async path: generate rpc_id, wait on future set by result_pump.
+        if self.od_config.enable_async_diffusion_output and method in (
+            "execute_model",
+            "execute_model_batch",
+        ):
+            rpc_id = self._next_rpc_id()
+            rpc_request["rpc_id"] = rpc_id
+            fut: concurrent.futures.Future = concurrent.futures.Future()
+            with self._futures_lock:
+                self._rpc_futures[rpc_id] = fut
+            self._broadcast_mq.enqueue(rpc_request)
+            try:
+                return fut.result(timeout=timeout)
+            except concurrent.futures.TimeoutError:
+                with self._futures_lock:
+                    self._rpc_futures.pop(rpc_id, None)
+                raise TimeoutError(f"RPC call to {method} timed out.")
+
+        # Sync path (original).
         try:
-            # Broadcast RPC request to all workers via unified message queue
             self._broadcast_mq.enqueue(rpc_request)
 
-            # Only rank 0 has a result_mq, so we always expect exactly 1 response
             num_responses = 1
-
             responses = []
             for _ in range(num_responses):
                 response = self._dequeue_one_with_failure_polling(deadline, method)
@@ -439,6 +475,70 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             logger.error(f"RPC call failed: {e}")
             raise
 
+    # ------------------------------------------------------------------
+    # Async output: result pump
+    # ------------------------------------------------------------------
+
+    def _start_result_pump(self) -> None:
+        self._pump_running = True
+        self._pump_stop.clear()
+        self._result_pump_thread = threading.Thread(target=self._result_pump, daemon=True, name="DiffusionResultPump")
+        self._result_pump_thread.start()
+        logger.info("Async result pump started")
+
+    def _result_pump(self) -> None:
+        """Sole reader of result_mq when async output is enabled.
+
+        Dispatches AsyncDiffusionOutput messages to the appropriate future:
+        * RPC_RESULT / COMPUTE_DONE → _rpc_futures[rpc_id]
+        * OUTPUT_READY → _output_futures[output_token]
+        """
+        while not self._pump_stop.is_set():
+            try:
+                msg = self._result_mq.dequeue(timeout=1.0)
+            except Exception:
+                continue
+
+            if not isinstance(msg, AsyncDiffusionOutput):
+                # Sync-path message: set on the most recent unfulfilled rpc future
+                with self._futures_lock:
+                    for fut in self._rpc_futures.values():
+                        if not fut.done():
+                            fut.set_result(msg)
+                            break
+                continue
+
+            if msg.kind in (AsyncDiffusionOutput.RPC_RESULT, AsyncDiffusionOutput.COMPUTE_DONE):
+                with self._futures_lock:
+                    fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
+                if fut is not None and not fut.done():
+                    fut.set_result(msg)
+            elif msg.kind == AsyncDiffusionOutput.OUTPUT_READY:
+                with self._futures_lock:
+                    fut = self._output_futures.pop(msg.output_token, None) if msg.output_token else None
+                if fut is not None and not fut.done():
+                    if msg.error:
+                        fut.set_exception(RuntimeError(msg.error))
+                    else:
+                        unpack_diffusion_output_shm(msg.output)
+                        fut.set_result(msg.output)
+
+    def _next_rpc_id(self) -> str:
+        with self._rpc_id_lock:
+            self._rpc_id_counter += 1
+            return str(self._rpc_id_counter)
+
+    def wait_output_ready(self, output_token: str) -> concurrent.futures.Future[DiffusionOutput]:
+        """Return a Future that resolves when the async output is ready.
+
+        The Future is fulfilled by the result_pump when an OUTPUT_READY
+        message with the matching output_token arrives.
+        """
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        with self._futures_lock:
+            self._output_futures[output_token] = fut
+        return fut
+
     def check_health(self) -> None:
         if self.is_failed:
             raise EngineDeadError()
@@ -450,10 +550,20 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
     def shutdown(self) -> None:
         self._closed = True
+        self._pump_stop.set()
         try:
             self._finalizer()
         finally:
             self._broadcast_mq = None
             self._result_mq = None
+            with self._futures_lock:
+                for fut in self._rpc_futures.values():
+                    if not fut.done():
+                        fut.set_exception(RuntimeError("Executor shut down"))
+                for fut in self._output_futures.values():
+                    if not fut.done():
+                        fut.set_exception(RuntimeError("Executor shut down"))
+                self._rpc_futures.clear()
+                self._output_futures.clear()
             self.resources = None
             self._processes = []

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -435,11 +435,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             "collect_rank_status": collect_rank_status,
         }
 
-        # Async path: generate rpc_id, wait on future set by result_pump.
-        if self.od_config.enable_async_diffusion_output and method in (
-            "execute_model",
-            "execute_model_batch",
-        ):
+        # Async path: all RPCs go through result_pump when async is enabled.
+        if self.od_config.enable_async_diffusion_output:
             rpc_id = self._next_rpc_id()
             rpc_request["rpc_id"] = rpc_id
             fut: concurrent.futures.Future = concurrent.futures.Future()

--- a/vllm_omni/diffusion/ipc.py
+++ b/vllm_omni/diffusion/ipc.py
@@ -21,23 +21,38 @@ _SHM_TENSOR_THRESHOLD = 1_000_000  # 1 MB
 DIFFUSION_RPC_RESULT_ENVELOPE = "diffusion_rpc_result"
 
 
-def _tensor_to_shm(tensor: torch.Tensor) -> dict[str, Any]:
+def _tensor_to_shm(
+    tensor: torch.Tensor,
+    d2h_stream: torch.cuda.Stream | None = None,
+) -> dict[str, Any]:
     """Copy a tensor into POSIX shared memory and return a metadata handle.
 
     The shared memory segment remains alive after this call (the local fd is
     closed, but the segment persists until ``_tensor_from_shm`` unlinks it).
+
+    If *d2h_stream* is provided, the D2H copy uses ``copy_()`` with
+    ``pin_memory=True`` on that stream instead of the synchronous ``.cpu()``
+    path.  This keeps the default stream free for the next forward pass.
+    The caller must synchronize *d2h_stream* after all tensors are packed.
     """
     from multiprocessing import shared_memory
 
     import numpy as np
 
-    tensor = tensor.detach().cpu().contiguous()
     original_dtype = tensor.dtype
-    # NumPy does not support bfloat16; promote to float32 for the SHM
-    # transfer and record the original dtype so _tensor_from_shm can
-    # convert back.  The round-trip is lossless for bfloat16 values.
-    if original_dtype == torch.bfloat16:
-        tensor = tensor.to(torch.float32)
+    if d2h_stream is not None:
+        # Convert bf16 on GPU (on the side stream), then D2H to pinned CPU.
+        with torch.cuda.stream(d2h_stream):
+            t = tensor.detach()
+            if original_dtype == torch.bfloat16:
+                t = t.to(torch.float32)
+            cpu = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)
+            cpu.copy_(t, non_blocking=True)
+        tensor = cpu
+    else:
+        tensor = tensor.detach().cpu().contiguous()
+        if original_dtype == torch.bfloat16:
+            tensor = tensor.to(torch.float32)
     arr = tensor.numpy()
     nbytes = arr.nbytes
     shm = shared_memory.SharedMemory(create=True, size=nbytes)
@@ -79,14 +94,20 @@ def _tensor_from_shm(handle: dict[str, Any]) -> torch.Tensor:
     return tensor
 
 
-def _pack_tensor_if_large(val: torch.Tensor) -> torch.Tensor | dict:
+def _pack_tensor_if_large(
+    val: torch.Tensor,
+    d2h_stream: torch.cuda.Stream | None = None,
+) -> torch.Tensor | dict:
     """Replace a tensor with an SHM handle if it exceeds the threshold."""
     if val.nelement() * val.element_size() > _SHM_TENSOR_THRESHOLD:
-        return _tensor_to_shm(val)
+        return _tensor_to_shm(val, d2h_stream=d2h_stream)
     return val
 
 
-def _pack_value_if_large(val: object) -> object:
+def _pack_value_if_large(
+    val: object,
+    d2h_stream: torch.cuda.Stream | None = None,
+) -> object:
     """Recursively replace large tensors with SHM handles.
 
     Walks the container shapes pipelines return as ``DiffusionOutput.output``:
@@ -96,13 +117,13 @@ def _pack_value_if_large(val: object) -> object:
     the two in sync.
     """
     if isinstance(val, torch.Tensor):
-        return _pack_tensor_if_large(val)
+        return _pack_tensor_if_large(val, d2h_stream=d2h_stream)
     if isinstance(val, dict):
-        return {key: _pack_value_if_large(value) for key, value in val.items()}
+        return {key: _pack_value_if_large(value, d2h_stream=d2h_stream) for key, value in val.items()}
     if isinstance(val, list):
-        return [_pack_value_if_large(item) for item in val]
+        return [_pack_value_if_large(item, d2h_stream=d2h_stream) for item in val]
     if isinstance(val, tuple):
-        return tuple(_pack_value_if_large(item) for item in val)
+        return tuple(_pack_value_if_large(item, d2h_stream=d2h_stream) for item in val)
     return val
 
 
@@ -119,15 +140,18 @@ def _unpack_if_shm_handle(val: object) -> object:
     return val
 
 
-def _pack_diffusion_fields(output: DiffusionOutput) -> DiffusionOutput:
+def _pack_diffusion_fields(
+    output: DiffusionOutput,
+    d2h_stream: torch.cuda.Stream | None = None,
+) -> DiffusionOutput:
     if output.output is not None:
-        output.output = _pack_value_if_large(output.output)
+        output.output = _pack_value_if_large(output.output, d2h_stream=d2h_stream)
     if output.trajectory_latents is not None and isinstance(output.trajectory_latents, torch.Tensor):
-        output.trajectory_latents = _pack_tensor_if_large(output.trajectory_latents)
+        output.trajectory_latents = _pack_tensor_if_large(output.trajectory_latents, d2h_stream=d2h_stream)
     if output.trajectory_timesteps is not None and isinstance(output.trajectory_timesteps, torch.Tensor):
-        output.trajectory_timesteps = _pack_tensor_if_large(output.trajectory_timesteps)
+        output.trajectory_timesteps = _pack_tensor_if_large(output.trajectory_timesteps, d2h_stream=d2h_stream)
     if output.trajectory_log_probs is not None and isinstance(output.trajectory_log_probs, torch.Tensor):
-        output.trajectory_log_probs = _pack_tensor_if_large(output.trajectory_log_probs)
+        output.trajectory_log_probs = _pack_tensor_if_large(output.trajectory_log_probs, d2h_stream=d2h_stream)
     return output
 
 
@@ -135,31 +159,32 @@ def _is_rpc_result_envelope(output: object) -> bool:
     return isinstance(output, dict) and output.get("type") == DIFFUSION_RPC_RESULT_ENVELOPE
 
 
-def pack_diffusion_output_shm(output: object) -> object:
+def pack_diffusion_output_shm(
+    output: object,
+    d2h_stream: torch.cuda.Stream | None = None,
+) -> object:
     """Replace large tensors in diffusion worker outputs with SHM handles.
 
-    Supports a bare ``DiffusionOutput``, a wrapper object carrying one in
-    ``.result`` (for example ``RunnerOutput``), an RPC result envelope carrying
-    the diffusion output in ``["result"]``, or a batch wrapper carrying
-    ``RunnerOutput`` objects in ``.runner_outputs``.
+    If *d2h_stream* is provided, D2H copies use that stream (non-blocking on
+    the default stream).  The caller must synchronize *d2h_stream* afterward.
     """
     if isinstance(output, DiffusionOutput):
-        return _pack_diffusion_fields(output)
+        return _pack_diffusion_fields(output, d2h_stream=d2h_stream)
 
     if _is_rpc_result_envelope(output):
         result = output.get("result")
         if isinstance(result, DiffusionOutput):
-            output["result"] = _pack_diffusion_fields(result)
+            output["result"] = _pack_diffusion_fields(result, d2h_stream=d2h_stream)
         return output
 
     result = getattr(output, "result", None)
     if isinstance(result, DiffusionOutput):
-        output.result = _pack_diffusion_fields(result)
+        output.result = _pack_diffusion_fields(result, d2h_stream=d2h_stream)
 
     runner_outputs = getattr(output, "runner_outputs", None)
     if isinstance(runner_outputs, list):
         for runner_output in runner_outputs:
-            pack_diffusion_output_shm(runner_output)
+            pack_diffusion_output_shm(runner_output, d2h_stream=d2h_stream)
     return output
 
 

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -3231,8 +3231,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
             assert image.shape[2] == 1, "image should have shape [B, C, T, H, W] and T should be 1"
             image = image.squeeze(2)
 
-        do_denormalize = [True] * image.shape[0]
-        image = self.image_processor.postprocess(image, output_type=output_type, do_denormalize=do_denormalize)
+        # Denormalize + PIL moved to engine post_process_func for overlap with next request.
 
         if not return_dict:
             return (image,)

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -71,6 +71,8 @@ _STEP_COT_TEXT_LIST = "hunyuan_cot_text_list"
 _STEP_AR_KV = "hunyuan_ar_kv"
 _STEP_PROMPT_KV = "hunyuan_prompt_kv"
 
+_HUNYUAN_DEFAULT_OUTPUT_TYPE = "pil"
+
 
 def default(val, d):
     return val if val is not None else d
@@ -331,6 +333,25 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         return request
 
     return pre_process_func
+
+
+def get_hunyuan_image3_post_process_func(od_config: OmniDiffusionConfig):
+    """GPU tensor → PIL, runs outside pipeline_forward to overlap with next request."""
+    from diffusers.image_processor import VaeImageProcessor
+
+    image_processor = VaeImageProcessor()
+
+    def post_process_func(images: torch.Tensor):
+        if images.dim() == 3:
+            images = images.unsqueeze(0)
+        do_denormalize = [True] * images.shape[0]
+        return image_processor.postprocess(
+            images,
+            output_type=_HUNYUAN_DEFAULT_OUTPUT_TYPE,
+            do_denormalize=do_denormalize,
+        )
+
+    return post_process_func
 
 
 class HunyuanImage3Pipeline(
@@ -2225,18 +2246,14 @@ class HunyuanImage3Pipeline(
         if hasattr(self.vae, "ffactor_temporal"):
             assert image.shape[2] == 1, "image should have shape [B, C, T, H, W] and T should be 1"
             image = image.squeeze(2)
-        image = self.pipeline.image_processor.postprocess(
-            image,
-            output_type=output_type,
-            do_denormalize=[True] * image.shape[0],
-        )
+        # Postprocess deferred to engine post_process_func for overlap with next request.
 
         cot_text_list = state.extra.get(_STEP_COT_TEXT_LIST) or []
         custom_output = {}
         if any(text is not None for text in cot_text_list):
             custom_output["ar_generated_text"] = cot_text_list[0]
         return DiffusionOutput(
-            output=image[0],
+            output=image,
             custom_output=custom_output,
             stage_durations=getattr(self, "stage_durations", None),
         )

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -526,6 +526,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Flux2Pipeline": "get_flux2_post_process_func",
     "HunyuanVideo15Pipeline": "get_hunyuan_video_15_post_process_func",
     "HunyuanVideo15ImageToVideoPipeline": "get_hunyuan_video_15_i2v_post_process_func",
+    "HunyuanImage3Pipeline": "get_hunyuan_image3_post_process_func",
     "MagiHumanPipeline": "get_magi_human_post_process_func",
     "OmniVoicePipeline": "get_omnivoice_post_process_func",
     "DreamIDOmniPipeline": "get_dreamid_omni_post_process_func",
@@ -533,6 +534,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_post_process_func",
     "HiDreamImagePipeline": "get_hidream_image_post_process_func",
     "StableDiffusionXLPipeline": "get_sdxl_image_post_process_func",
+    "HunyuanImage3ForCausalMM": "get_hunyuan_image3_post_process_func",
 }
 
 _DIFFUSION_ACTION_POST_PROCESS_FUNCS = {

--- a/vllm_omni/diffusion/sched/request_scheduler.py
+++ b/vllm_omni/diffusion/sched/request_scheduler.py
@@ -42,8 +42,14 @@ class RequestScheduler(_BaseScheduler):
             req_output = output.get_request_output(request_id)
             result = req_output.result if req_output is not None else None
             if result is None:
-                terminal_statuses[request_id] = DiffusionRequestStatus.FINISHED_ERROR
-                terminal_errors[request_id] = "No output result"
+                # Async mode: result=None with output_token means compute done,
+                # final output will arrive later via wait_output_ready.
+                if req_output is not None and req_output.output_token is not None:
+                    terminal_statuses[request_id] = DiffusionRequestStatus.FINISHED_COMPLETED
+                    terminal_errors[request_id] = None
+                else:
+                    terminal_statuses[request_id] = DiffusionRequestStatus.FINISHED_ERROR
+                    terminal_errors[request_id] = "No output result"
             elif result.aborted:
                 terminal_statuses[request_id] = DiffusionRequestStatus.FINISHED_ABORTED
                 terminal_errors[request_id] = None

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -870,8 +870,7 @@ class WorkerProc:
         default stream where the next forward runs.
         """
         while self._running:
-            item = self._async_output_queue.get()
-            output, output_token, gpu_event = item
+            output, output_token, gpu_event = self._async_output_queue.get()
             try:
                 d2h_stream = torch.cuda.Stream()
                 # Cross-stream ordering: wait for default stream to finish

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -11,8 +11,11 @@ to DiffusionModelRunner.
 import gc
 import multiprocessing as mp
 import os
+import queue
 import signal
+import threading
 import traceback
+import uuid
 from collections.abc import Iterable, Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
@@ -30,6 +33,7 @@ from vllm.utils.mem_utils import GiB_bytes
 from vllm.v1.worker.workspace import init_workspace_manager
 
 from vllm_omni.diffusion.data import (
+    AsyncDiffusionOutput,
     DiffusionOutput,
     OmniACK,
     OmniDiffusionConfig,
@@ -786,6 +790,18 @@ class WorkerProc:
         self.worker = self._create_worker(gpu_id, od_config, worker_extension_cls, custom_pipeline_args)
         self._running = True
 
+        self._async_output_queue: queue.Queue = queue.Queue()
+        self._async_output_thread = threading.Thread(
+            target=self._async_output_loop,
+            daemon=True,
+            name="DiffusionAsyncOutput",
+        )
+        self._async_output_thread.start()
+
+    @staticmethod
+    def _generate_output_token() -> str:
+        return uuid.uuid4().hex
+
     def _create_worker(
         self,
         gpu_id: int,
@@ -805,18 +821,75 @@ class WorkerProc:
         )
         return wrapper
 
-    def return_result(self, output: Any):
+    def return_result(self, output: Any, rpc_id: str | None = None):
         """Reply to client, only on rank 0."""
-        if self.result_mq is not None:
-            if isinstance(output, OmniACK):
-                self.result_mq.enqueue(output)
-                return
-            try:
-                pack_diffusion_output_shm(output)
-            except Exception as e:
-                if hasattr(output, "output"):
-                    logger.warning("SHM pack failed for model output: %s", e)
+        if self.result_mq is None:
+            return
+        if isinstance(output, OmniACK):
             self.result_mq.enqueue(output)
+            return
+
+        # Async path: enqueue compute_done immediately, bg thread does D2H+SHM.
+        if self.od_config.enable_async_diffusion_output and isinstance(output, DiffusionOutput):
+            try:
+                output_token = WorkerProc._generate_output_token()
+                msg = AsyncDiffusionOutput(
+                    kind=AsyncDiffusionOutput.COMPUTE_DONE,
+                    rpc_id=rpc_id,
+                    output_token=output_token,
+                )
+                self.result_mq.enqueue(msg)
+                self._async_output_queue.put((output, output_token))
+                return
+            except Exception as e:
+                logger.warning("Async output submission failed, falling back to sync: %s", e)
+
+        # Sync path (original, or async fallback).
+        try:
+            pack_diffusion_output_shm(output)
+        except Exception as e:
+            if hasattr(output, "output"):
+                logger.warning("SHM pack failed for model output: %s", e)
+        self.result_mq.enqueue(output)
+
+    def _async_output_loop(self):
+        """Background thread: D2H + SHM packing for async diffusion output.
+
+        Uses a side CUDA stream with producer event to avoid blocking the
+        GPU default stream where the next request's forward runs.
+        """
+        while self._running:
+            item = self._async_output_queue.get()
+            output, output_token = item
+            try:
+                device = torch.device(f"cuda:{self.gpu_id}")
+                torch.accelerator.set_device_index(device)
+                producer_event = torch.accelerator.current_stream().record_event()
+                copy_stream = torch.Stream(device=device)
+                copy_stream.wait_event(producer_event)
+                with copy_stream:
+                    pack_diffusion_output_shm(output)
+                copy_stream.synchronize()
+
+                self.result_mq.enqueue(
+                    AsyncDiffusionOutput(
+                        kind=AsyncDiffusionOutput.OUTPUT_READY,
+                        output_token=output_token,
+                        output=output,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "Async output packing failed for token '%s'; sending error",
+                    output_token,
+                )
+                self.result_mq.enqueue(
+                    AsyncDiffusionOutput(
+                        kind=AsyncDiffusionOutput.OUTPUT_READY,
+                        output_token=output_token,
+                        error="Background D2H/SHM packing failed",
+                    )
+                )
 
     def recv_message(self):
         """Receive messages from broadcast queue."""
@@ -932,9 +1005,10 @@ class WorkerProc:
             # Route message based on type
             elif isinstance(msg, dict) and msg.get("type") == "rpc":
                 try:
+                    rpc_id = msg.get("rpc_id")
                     result, should_reply = self.execute_rpc(msg)
                     if should_reply:
-                        self.return_result(result)
+                        self.return_result(result, rpc_id=rpc_id)
                 except Exception as e:
                     logger.error(f"Error processing RPC: {e}", exc_info=True)
                     if self.result_mq is not None:

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -875,10 +875,7 @@ class WorkerProc:
             return
 
         # Async path: enqueue compute_done immediately, bg thread does D2H+SHM.
-        async_enabled = self.od_config.enable_async_diffusion_output
-        is_diff = isinstance(output, DiffusionOutput)
-        logger.info("[ASYNC] return_result: async_enabled=%s is_diff=%s", async_enabled, is_diff)
-        if async_enabled and is_diff:
+        if self.od_config.enable_async_diffusion_output and isinstance(output, DiffusionOutput):
             try:
                 output_token = WorkerProc._generate_output_token()
                 gpu_event = WorkerProc._record_gpu_event()
@@ -889,7 +886,6 @@ class WorkerProc:
                 )
                 self.result_mq.enqueue(msg)
                 self._async_output_queue.put((output, output_token, gpu_event))
-                logger.info("[ASYNC] compute_done sent token=%s rpc_id=%s", output_token, rpc_id)
                 return
             except Exception as e:
                 logger.warning("Async output submission failed, falling back to sync: %s", e)
@@ -912,7 +908,6 @@ class WorkerProc:
         while self._running:
             item = self._async_output_queue.get()
             output, output_token, gpu_event = item
-            logger.info("[ASYNC] bg thread: start D2H token=%s", output_token)
             try:
                 # Side CUDA stream: copy all GPU tensors to pinned CPU memory.
                 d2h_stream = torch.cuda.Stream()
@@ -935,7 +930,6 @@ class WorkerProc:
                         output=output,
                     )
                 )
-                logger.info("[ASYNC] bg thread: output_ready sent token=%s", output_token)
             except Exception:
                 logger.exception(
                     "Async output packing failed for token '%s'; sending error",

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -62,41 +62,6 @@ from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 logger = init_logger(__name__)
 
 
-def _recursive_copy_tensors_to_cpu(obj: object) -> object:
-    """Copy GPU tensors to pinned CPU memory on the current CUDA stream.
-
-    Uses ``copy_()`` with ``pin_memory=True`` for fast DMA transfer that
-    respects the current CUDA stream context.  Unlike ``tensor.to("cpu")``,
-    this does NOT synchronize the default stream.
-
-    Returns the object with GPU tensors replaced by pinned CPU copies.
-    """
-    if isinstance(obj, torch.Tensor) and obj.device.type != "cpu":
-        t = obj.detach()
-        # NumPy does not support bfloat16 — promote on GPU before the copy.
-        if t.dtype == torch.bfloat16:
-            t = t.to(torch.float32)
-        cpu = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)
-        cpu.copy_(t, non_blocking=True)
-        return cpu
-    if isinstance(obj, dict):
-        return {key: _recursive_copy_tensors_to_cpu(value) for key, value in obj.items()}
-    if isinstance(obj, list):
-        return [_recursive_copy_tensors_to_cpu(item) for item in obj]
-    if isinstance(obj, tuple):
-        return tuple(_recursive_copy_tensors_to_cpu(item) for item in obj)
-    if hasattr(obj, "output") and hasattr(obj, "trajectory_latents"):
-        if obj.output is not None:
-            obj.output = _recursive_copy_tensors_to_cpu(obj.output)
-        if getattr(obj, "trajectory_latents", None) is not None:
-            obj.trajectory_latents = _recursive_copy_tensors_to_cpu(obj.trajectory_latents)
-        if getattr(obj, "trajectory_timesteps", None) is not None:
-            obj.trajectory_timesteps = _recursive_copy_tensors_to_cpu(obj.trajectory_timesteps)
-        if getattr(obj, "trajectory_log_probs", None) is not None:
-            obj.trajectory_log_probs = _recursive_copy_tensors_to_cpu(obj.trajectory_log_probs)
-    return obj
-
-
 @dataclass
 class _DiffusionVllmModelConfig:
     model: str
@@ -901,27 +866,20 @@ class WorkerProc:
     def _async_output_loop(self):
         """Background thread: D2H + SHM packing for async diffusion output.
 
-        Uses a side CUDA stream with pinned-memory ``copy_()`` so the D2H
-        transfer runs on the side stream's GPU copy engine without blocking
-        the default stream (where the next forward lives).
+        Uses a side CUDA stream so the D2H transfer does not block the GPU
+        default stream where the next forward runs.
         """
         while self._running:
             item = self._async_output_queue.get()
             output, output_token, gpu_event = item
             try:
-                # Side CUDA stream: copy all GPU tensors to pinned CPU memory.
                 d2h_stream = torch.cuda.Stream()
-                with torch.cuda.stream(d2h_stream):
-                    # Cross-stream ordering: wait for default stream to finish
-                    # writing the output tensors before this side stream reads.
-                    if gpu_event is not None:
-                        d2h_stream.wait_event(gpu_event)
-                    _recursive_copy_tensors_to_cpu(output)
-                # Synchronize only the side stream — default stream untouched.
+                # Cross-stream ordering: wait for default stream to finish
+                # writing the output tensors before the side stream reads.
+                if gpu_event is not None:
+                    d2h_stream.wait_event(gpu_event)
+                pack_diffusion_output_shm(output, d2h_stream=d2h_stream)
                 d2h_stream.synchronize()
-
-                # Tensors are now in pinned CPU memory; SHM packing is host-only.
-                pack_diffusion_output_shm(output)
 
                 self.result_mq.enqueue(
                     AsyncDiffusionOutput(

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -875,7 +875,10 @@ class WorkerProc:
             return
 
         # Async path: enqueue compute_done immediately, bg thread does D2H+SHM.
-        if self.od_config.enable_async_diffusion_output and isinstance(output, DiffusionOutput):
+        async_enabled = self.od_config.enable_async_diffusion_output
+        is_diff = isinstance(output, DiffusionOutput)
+        logger.info("[ASYNC] return_result: async_enabled=%s is_diff=%s", async_enabled, is_diff)
+        if async_enabled and is_diff:
             try:
                 output_token = WorkerProc._generate_output_token()
                 gpu_event = WorkerProc._record_gpu_event()
@@ -886,6 +889,7 @@ class WorkerProc:
                 )
                 self.result_mq.enqueue(msg)
                 self._async_output_queue.put((output, output_token, gpu_event))
+                logger.info("[ASYNC] compute_done sent token=%s rpc_id=%s", output_token, rpc_id)
                 return
             except Exception as e:
                 logger.warning("Async output submission failed, falling back to sync: %s", e)
@@ -908,6 +912,7 @@ class WorkerProc:
         while self._running:
             item = self._async_output_queue.get()
             output, output_token, gpu_event = item
+            logger.info("[ASYNC] bg thread: start D2H token=%s", output_token)
             try:
                 # Side CUDA stream: copy all GPU tensors to pinned CPU memory.
                 d2h_stream = torch.cuda.Stream()
@@ -930,6 +935,7 @@ class WorkerProc:
                         output=output,
                     )
                 )
+                logger.info("[ASYNC] bg thread: output_ready sent token=%s", output_token)
             except Exception:
                 logger.exception(
                     "Async output packing failed for token '%s'; sending error",

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -62,6 +62,38 @@ from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 logger = init_logger(__name__)
 
 
+def _recursive_copy_tensors_to_cpu(obj: object) -> None:
+    """Non-blocking copy GPU tensors to CPU on the current CUDA stream.
+
+    Mutates the object in-place, replacing GPU tensors with CPU copies.
+    Does NOT synchronize — the caller must synchronize the stream afterward.
+    """
+    if isinstance(obj, torch.Tensor):
+        if obj.device.type != "cpu":
+            # non_blocking=True: the copy runs on the current CUDA stream
+            # without blocking the default stream.
+            return obj.detach().to("cpu", non_blocking=True)
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            obj[key] = _recursive_copy_tensors_to_cpu(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            obj[i] = _recursive_copy_tensors_to_cpu(item)
+    elif isinstance(obj, tuple):
+        return tuple(_recursive_copy_tensors_to_cpu(item) for item in obj)
+    elif hasattr(obj, "output") and hasattr(obj, "trajectory_latents"):
+        # DiffusionOutput (or dataclass with similar fields)
+        if obj.output is not None:
+            obj.output = _recursive_copy_tensors_to_cpu(obj.output)
+        if getattr(obj, "trajectory_latents", None) is not None:
+            obj.trajectory_latents = _recursive_copy_tensors_to_cpu(obj.trajectory_latents)
+        if getattr(obj, "trajectory_timesteps", None) is not None:
+            obj.trajectory_timesteps = _recursive_copy_tensors_to_cpu(obj.trajectory_timesteps)
+        if getattr(obj, "trajectory_log_probs", None) is not None:
+            obj.trajectory_log_probs = _recursive_copy_tensors_to_cpu(obj.trajectory_log_probs)
+    return obj
+
+
 @dataclass
 class _DiffusionVllmModelConfig:
     model: str
@@ -855,21 +887,23 @@ class WorkerProc:
     def _async_output_loop(self):
         """Background thread: D2H + SHM packing for async diffusion output.
 
-        Uses a side CUDA stream with producer event to avoid blocking the
-        GPU default stream where the next request's forward runs.
+        D2H uses a side CUDA stream with ``non_blocking=True`` so the GPU
+        default stream (where the next forward runs) is never blocked.
+        SHM packing runs on CPU and does not touch the GPU.
         """
         while self._running:
             item = self._async_output_queue.get()
             output, output_token = item
             try:
-                device = torch.device(f"cuda:{self.gpu_id}")
-                torch.accelerator.set_device_index(device)
-                producer_event = torch.accelerator.current_stream().record_event()
-                copy_stream = torch.Stream(device=device)
-                copy_stream.wait_event(producer_event)
-                with copy_stream:
-                    pack_diffusion_output_shm(output)
-                copy_stream.synchronize()
+                # Side CUDA stream: pre-copy all large GPU tensors to CPU
+                # without blocking the default stream.
+                d2h_stream = torch.cuda.Stream()
+                with torch.cuda.stream(d2h_stream):
+                    _recursive_copy_tensors_to_cpu(output)
+                d2h_stream.synchronize()
+
+                # Tensors now on CPU — SHM packing touches only host memory.
+                pack_diffusion_output_shm(output)
 
                 self.result_mq.enqueue(
                     AsyncDiffusionOutput(

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -790,13 +790,16 @@ class WorkerProc:
         self.worker = self._create_worker(gpu_id, od_config, worker_extension_cls, custom_pipeline_args)
         self._running = True
 
-        self._async_output_queue: queue.Queue = queue.Queue()
-        self._async_output_thread = threading.Thread(
-            target=self._async_output_loop,
-            daemon=True,
-            name="DiffusionAsyncOutput",
-        )
-        self._async_output_thread.start()
+        self._async_output_queue: queue.Queue | None = None
+        self._async_output_thread: threading.Thread | None = None
+        if self.od_config.enable_async_diffusion_output:
+            self._async_output_queue = queue.Queue()
+            self._async_output_thread = threading.Thread(
+                target=self._async_output_loop,
+                daemon=True,
+                name="DiffusionAsyncOutput",
+            )
+            self._async_output_thread.start()
 
     @staticmethod
     def _generate_output_token() -> str:
@@ -810,6 +813,7 @@ class WorkerProc:
             event.record()
             return event
         except Exception:
+            logger.warning("Failed to record CUDA event for cross-stream sync")
             return None
 
     def _create_worker(
@@ -844,13 +848,13 @@ class WorkerProc:
             try:
                 output_token = WorkerProc._generate_output_token()
                 gpu_event = WorkerProc._record_gpu_event()
+                self._async_output_queue.put((output, output_token, gpu_event))
                 msg = AsyncDiffusionOutput(
                     kind=AsyncDiffusionOutput.COMPUTE_DONE,
                     rpc_id=rpc_id,
                     output_token=output_token,
                 )
                 self.result_mq.enqueue(msg)
-                self._async_output_queue.put((output, output_token, gpu_event))
                 return
             except Exception as e:
                 logger.warning("Async output submission failed, falling back to sync: %s", e)
@@ -869,10 +873,10 @@ class WorkerProc:
         Uses a side CUDA stream so the D2H transfer does not block the GPU
         default stream where the next forward runs.
         """
+        d2h_stream = torch.cuda.Stream()
         while self._running:
             output, output_token, gpu_event = self._async_output_queue.get()
             try:
-                d2h_stream = torch.cuda.Stream()
                 # Cross-stream ordering: wait for default stream to finish
                 # writing the output tensors before the side stream reads.
                 if gpu_event is not None:

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -62,27 +62,30 @@ from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 logger = init_logger(__name__)
 
 
-def _recursive_copy_tensors_to_cpu(obj: object) -> None:
-    """Non-blocking copy GPU tensors to CPU on the current CUDA stream.
+def _recursive_copy_tensors_to_cpu(obj: object) -> object:
+    """Copy GPU tensors to pinned CPU memory on the current CUDA stream.
 
-    Mutates the object in-place, replacing GPU tensors with CPU copies.
-    Does NOT synchronize — the caller must synchronize the stream afterward.
+    Uses ``copy_()`` with ``pin_memory=True`` for fast DMA transfer that
+    respects the current CUDA stream context.  Unlike ``tensor.to("cpu")``,
+    this does NOT synchronize the default stream.
+
+    Returns the object with GPU tensors replaced by pinned CPU copies.
     """
-    if isinstance(obj, torch.Tensor):
-        if obj.device.type != "cpu":
-            # non_blocking=True: the copy runs on the current CUDA stream
-            # without blocking the default stream.
-            return obj.detach().to("cpu", non_blocking=True)
-    elif isinstance(obj, dict):
-        for key, value in obj.items():
-            obj[key] = _recursive_copy_tensors_to_cpu(value)
-    elif isinstance(obj, list):
-        for i, item in enumerate(obj):
-            obj[i] = _recursive_copy_tensors_to_cpu(item)
-    elif isinstance(obj, tuple):
+    if isinstance(obj, torch.Tensor) and obj.device.type != "cpu":
+        t = obj.detach()
+        # NumPy does not support bfloat16 — promote on GPU before the copy.
+        if t.dtype == torch.bfloat16:
+            t = t.to(torch.float32)
+        cpu = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)
+        cpu.copy_(t, non_blocking=True)
+        return cpu
+    if isinstance(obj, dict):
+        return {key: _recursive_copy_tensors_to_cpu(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_recursive_copy_tensors_to_cpu(item) for item in obj]
+    if isinstance(obj, tuple):
         return tuple(_recursive_copy_tensors_to_cpu(item) for item in obj)
-    elif hasattr(obj, "output") and hasattr(obj, "trajectory_latents"):
-        # DiffusionOutput (or dataclass with similar fields)
+    if hasattr(obj, "output") and hasattr(obj, "trajectory_latents"):
         if obj.output is not None:
             obj.output = _recursive_copy_tensors_to_cpu(obj.output)
         if getattr(obj, "trajectory_latents", None) is not None:
@@ -834,6 +837,16 @@ class WorkerProc:
     def _generate_output_token() -> str:
         return uuid.uuid4().hex
 
+    @staticmethod
+    def _record_gpu_event() -> torch.cuda.Event | None:
+        """Record a CUDA event on the default stream to mark tensor readiness."""
+        try:
+            event = torch.cuda.Event()
+            event.record()
+            return event
+        except Exception:
+            return None
+
     def _create_worker(
         self,
         gpu_id: int,
@@ -865,13 +878,14 @@ class WorkerProc:
         if self.od_config.enable_async_diffusion_output and isinstance(output, DiffusionOutput):
             try:
                 output_token = WorkerProc._generate_output_token()
+                gpu_event = WorkerProc._record_gpu_event()
                 msg = AsyncDiffusionOutput(
                     kind=AsyncDiffusionOutput.COMPUTE_DONE,
                     rpc_id=rpc_id,
                     output_token=output_token,
                 )
                 self.result_mq.enqueue(msg)
-                self._async_output_queue.put((output, output_token))
+                self._async_output_queue.put((output, output_token, gpu_event))
                 return
             except Exception as e:
                 logger.warning("Async output submission failed, falling back to sync: %s", e)
@@ -887,22 +901,26 @@ class WorkerProc:
     def _async_output_loop(self):
         """Background thread: D2H + SHM packing for async diffusion output.
 
-        D2H uses a side CUDA stream with ``non_blocking=True`` so the GPU
-        default stream (where the next forward runs) is never blocked.
-        SHM packing runs on CPU and does not touch the GPU.
+        Uses a side CUDA stream with pinned-memory ``copy_()`` so the D2H
+        transfer runs on the side stream's GPU copy engine without blocking
+        the default stream (where the next forward lives).
         """
         while self._running:
             item = self._async_output_queue.get()
-            output, output_token = item
+            output, output_token, gpu_event = item
             try:
-                # Side CUDA stream: pre-copy all large GPU tensors to CPU
-                # without blocking the default stream.
+                # Side CUDA stream: copy all GPU tensors to pinned CPU memory.
                 d2h_stream = torch.cuda.Stream()
                 with torch.cuda.stream(d2h_stream):
+                    # Cross-stream ordering: wait for default stream to finish
+                    # writing the output tensors before this side stream reads.
+                    if gpu_event is not None:
+                        d2h_stream.wait_event(gpu_event)
                     _recursive_copy_tensors_to_cpu(output)
+                # Synchronize only the side stream — default stream untouched.
                 d2h_stream.synchronize()
 
-                # Tensors now on CPU — SHM packing touches only host memory.
+                # Tensors are now in pinned CPU memory; SHM packing is host-only.
                 pack_diffusion_output_shm(output)
 
                 self.result_mq.enqueue(

--- a/vllm_omni/diffusion/worker/utils.py
+++ b/vllm_omni/diffusion/worker/utils.py
@@ -189,6 +189,7 @@ class RunnerOutput(BaseRunnerOutput):
     step_index: int | None = None
     finished: bool = False
     result: DiffusionOutput | None = None
+    output_token: str | None = None
 
     def get_request_output(self, request_id: str) -> RunnerOutput | None:
         return self if self.request_id == request_id else None

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -485,6 +485,7 @@ class OrchestratorArgs:
     max_generated_image_size: int | None = None
     tts_max_instructions_length: int | None = None
     enable_diffusion_pipeline_profiler: bool = False
+    enable_async_diffusion_output: bool = False
     enable_ar_profiler: bool = False
     auxiliary_text_encoder: str | None = None
     log_file: str | None = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -11,6 +11,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import json
+import os
 import queue
 import threading
 import time
@@ -1046,6 +1047,10 @@ class AsyncOmniEngine:
             **({"diffusion_attention_config": attention_config} if attention_config is not None else {}),
             "force_cutlass_fp8": bool(kwargs.get("force_cutlass_fp8", False)),
             "enable_diffusion_pipeline_profiler": kwargs.get("enable_diffusion_pipeline_profiler", False),
+            "enable_async_diffusion_output": kwargs.get(
+                "enable_async_diffusion_output",
+                os.environ.get("ENABLE_ASYNC_DIFFUSION_OUTPUT", "0") == "1",
+            ),
             "streaming_output": kwargs.get("diffusion_streaming_output", False),
             "enable_ar_profiler": kwargs.get("enable_ar_profiler", False),
             "extras": {
@@ -1214,6 +1219,7 @@ class AsyncOmniEngine:
                 # Inject profiler flags for diffusion stages
                 for profiler_key in (
                     "enable_diffusion_pipeline_profiler",
+                    "enable_async_diffusion_output",
                     "enable_ar_profiler",
                 ):
                     val = kwargs.get(profiler_key)

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -714,6 +714,11 @@ class OmniServeCommand(CLISubcommand):
             help="Enable diffusion pipeline profiler to display stage durations.",
         )
         omni_config_group.add_argument(
+            "--enable-async-diffusion-output",
+            action="store_true",
+            help="Offload GPU→CPU tensor copies to a Worker background thread to overlap with the next forward.",
+        )
+        omni_config_group.add_argument(
             "--enable-ar-profiler",
             action="store_true",
             help="Enable AR stage profiler to include AR stage timing in stage_durations.",


### PR DESCRIPTION
## Summary

This PR eliminates the GPU idle "bubble" between consecutive HunyuanImage3 requests through two complementary async mechanisms: non-blocking scheduler dispatch and async D2H on the worker side. All parameters are auto-detected via model metadata — Hunyuan models get the optimization automatically, existing models are unaffected.

## Sequence diagram
### before
<img width="655" height="666" alt="plantuml-diagram (1)" src="https://github.com/user-attachments/assets/37f93059-4dd4-426a-8020-720aa94e1fd2" />

### After
<img width="776" height="797" alt="plantuml-diagram" src="https://github.com/user-attachments/assets/29389be6-50e6-4d22-ad84-b6967b5a18d8" />


## Adaptation to other models
`model_metadata.py ` 
```
"YourNewPipeline": DiffusionModelMetadata(
    enable_deferred_shm=True,  # ← add this 
),
```


## Test Plan
(1) HunyuanImage3 performance test
`pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py   --test-config-file tests/dfx/perf/tests/test_hunyuan_image_tp4.json`
(2) HunyuanImage3 accuracy test
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3.py`
(3) Helios-Distilled E2E accuracy test
```
pytest tests/e2e/accuracy/test_video_streaming_output_similarity.py -v -s \
    --run-level full_model
```
(4) Streaming output unit test
`pytest tests/diffusion/test_diffusion_streaming_output.py -v`

## Test Result (H200)
### (1) performance
main
<img width="1188" height="662" alt="main-吞吐" src="https://github.com/user-attachments/assets/b6a2fe4b-a81a-4d91-a4f4-507f488c9280" />

current branch
<img width="1170" height="666" alt="current 吞吐" src="https://github.com/user-attachments/assets/e3eaddcf-3f53-470a-abff-fe8b4f7a4f12" />


### (2) accuracy
main
<img width="1534" height="290" alt="mainacc" src="https://github.com/user-attachments/assets/54103258-05ff-4689-af0c-8bef174dd7db" />

current branch
<img width="1506" height="280" alt="accracy" src="https://github.com/user-attachments/assets/6426b9d2-a8de-464b-9a0c-757a12fa255c" />

### (3)Helios-Distilled E2E accuracy test
<img width="1742" height="952" alt="e2e" src="https://github.com/user-attachments/assets/575b4544-c539-4cea-8fa4-5f3788bac93f" />

### (4)Streaming output unit test
<img width="1220" height="124" alt="stream" src="https://github.com/user-attachments/assets/4def156a-6a7d-4f57-b3d5-e6fd7ef7e128" />


### profilling trace
**pre**
<img width="1196" height="1222" alt="tracepre" src="https://github.com/user-attachments/assets/71cbc150-bdd4-4d2e-b855-d5647dccf340" />

**now**
<img width="1554" height="1142" alt="tracenow" src="https://github.com/user-attachments/assets/43e8fbb0-c72c-4985-a9a4-20b397542db1" />


