### PR TITLE
[WIP][NO MERGE][Model] MOSS-TTS-Local-v1.5: native vLLM backbone + CUDA Graph

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -12,6 +12,7 @@ This section contains design documents and architecture specifications for vLLM-
 - [Ray-based Execution](feature/ray_based_execution.md)
 - [Adding Step Execution Support for Diffusion Pipelines](feature/diffusion_step_execution.md)
 - [Continuous Batching for Step-Wise Diffusion](feature/diffusion_continuous_batching.md)
+- [MOSS-TTS Local Serving Defaults](moss_tts_local_best_practices.md)
 
 ## Infrastructure Design Documents
 

--- a/docs/design/moss_tts_local_best_practices.md
+++ b/docs/design/moss_tts_local_best_practices.md
@@ -93,6 +93,70 @@ validated default path:
 These should be tested with end-to-end serving benchmarks and audio-quality
 checks before being promoted to defaults.
 
+## Benchmark Commands
+
+Start the server with the recommended deploy config:
+
+```bash
+export MODEL=/path/to/OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
+export PORT=18038
+
+CUDA_VISIBLE_DEVICES=0 vllm serve "$MODEL" \
+  --omni \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --trust-remote-code \
+  --deploy-config vllm_omni/deploy/moss_tts_local.yaml
+```
+
+Run a warmup pass before measuring:
+
+```bash
+vllm bench serve \
+  --omni \
+  --backend openai-audio-speech \
+  --endpoint /v1/audio/speech \
+  --model "$MODEL" \
+  --port "$PORT" \
+  --dataset-name seed-tts-text \
+  --dataset-path benchmarks/build_dataset/seed_tts_smoke \
+  --num-prompts 128 \
+  --max-concurrency 64 \
+  --request-rate inf \
+  --extra-body '{"voice":"default","max_new_tokens":2048}' \
+  --percentile-metrics e2el,audio_ttfp,audio_rtf,audio_duration \
+  --metric-percentiles 50,90,95,99
+```
+
+Run the formal p500 pass:
+
+```bash
+vllm bench serve \
+  --omni \
+  --backend openai-audio-speech \
+  --endpoint /v1/audio/speech \
+  --model "$MODEL" \
+  --port "$PORT" \
+  --dataset-name seed-tts-text \
+  --dataset-path benchmarks/build_dataset/seed_tts_smoke \
+  --num-prompts 500 \
+  --max-concurrency 64 \
+  --request-rate inf \
+  --extra-body '{"voice":"default","max_new_tokens":2048}' \
+  --percentile-metrics e2el,audio_ttfp,audio_rtf,audio_duration \
+  --metric-percentiles 50,90,95,99 \
+  --save-result \
+  --save-detailed \
+  --result-dir /tmp \
+  --result-filename moss_tts_local_p500_vllm_bench.json
+```
+
+The `vllm bench serve` command uses the standard streaming PCM speech backend.
+It is the recommended command for repeatable PR validation. The historical p500
+numbers below were collected with the same warmup-then-formal discipline on a
+local mixed-prompt JSONL driver, so treat them as a reference point rather than
+as byte-for-byte output from the command above.
+
 ## Benchmark Reference
 
 The latest H20 p500 validation used warmup before the formal run and the

--- a/docs/design/moss_tts_local_best_practices.md
+++ b/docs/design/moss_tts_local_best_practices.md
@@ -1,0 +1,109 @@
+# MOSS-TTS Local Serving Defaults
+
+This note documents the default high-throughput path for
+MOSS-TTS-Local-Transformer-v1.5 in vLLM-Omni.
+
+## Recommended Path
+
+Use the HF-compatible Stage0 backbone path by default. It is the hand-written
+Qwen3-compatible implementation under
+`vllm_omni/model_executor/models/moss_tts_local/hf_compatible_qwen3.py`.
+
+The native vLLM Qwen3 path remains available for experiments by setting:
+
+```bash
+MOSS_TTS_LOCAL_NATIVE=1
+```
+
+The default is intentionally not native. For this TTS workload, the
+HF-compatible path keeps the Stage0 decode/output routing behavior closer to
+the reference implementation and avoids the native outer CUDA graph padding
+interactions observed during throughput testing.
+
+## Recommended Deploy Config
+
+Use:
+
+```bash
+--deploy-config vllm_omni/deploy/moss_tts_local.yaml
+```
+
+The deploy config uses:
+
+- Stage0 `max_num_seqs: 64`
+- Stage1 `max_num_seqs: 8`
+- `async_chunk: true`
+- connector `codec_streaming: false`
+
+`codec_streaming: false` is important for throughput. Stage0 still uses the
+async chunk adapter for transfer, but it sends one terminal full-sequence codec
+payload per finished request. Stage1 can then batch completed utterances and run
+full-sequence vocoder decode.
+
+## Default Performance Features
+
+The following MOSS Local performance features are enabled by default:
+
+- Stage0 batched decode preprocess
+- Stage0 fast pure-decode preprocess
+- Stage0 local frame CUDA graph
+- Stage0 delayed stop synchronization
+- HF-compatible backbone fused QKV projection
+- HF-compatible backbone fused RMSNorm
+- HF-compatible backbone fused RoPE when Triton and CUDA are available
+- Stage1 full-sequence admission coalescing for `codec_streaming: false`
+- Stage1 opportunistic ready-payload drain
+- Stage1 vocoder CUDA graph
+- Stage1 vocoder graph-bucket grouping
+
+These were selected because they are lossless or default-safe for the
+full-sequence high-throughput path.
+
+## Explicit Opt-Outs
+
+The defaults can be disabled independently for debugging:
+
+```bash
+MOSS_TTS_LOCAL_DISABLE_BATCH_PREPROCESS=1
+MOSS_TTS_LOCAL_DISABLE_FAST_BATCH_PREPROCESS=1
+MOSS_TTS_LOCAL_DISABLE_FRAME_GRAPH=1
+MOSS_TTS_LOCAL_DISABLE_DELAY_STOP_SYNC=1
+MOSS_TTS_LOCAL_DISABLE_FUSED_QKV=1
+MOSS_TTS_LOCAL_DISABLE_FUSED_RMSNORM=1
+MOSS_TTS_LOCAL_DISABLE_FUSED_ROPE=1
+MOSS_TTS_LOCAL_VOCODER_DISABLE_CUDA_GRAPH=1
+MOSS_TTS_LOCAL_STAGE1_SYNC_DRAIN=0
+```
+
+The legacy positive enable flags are not required for the recommended path.
+
+## Experimental Features
+
+The following features remain opt-in because they did not become part of the
+validated default path:
+
+- native vLLM Qwen3 backbone (`MOSS_TTS_LOCAL_NATIVE=1`)
+- local transformer `torch.compile`
+- MLP `torch.compile`
+- vocoder `torch.compile`
+- vocoder TensorRT export/runtime
+- vocoder multi-stream overlap
+- FlashInfer single/batched decode experiments in the HF-compatible backbone
+
+These should be tested with end-to-end serving benchmarks and audio-quality
+checks before being promoted to defaults.
+
+## Benchmark Reference
+
+The latest H20 p500 validation used warmup before the formal run and the
+recommended HF-compatible full-sequence configuration. Across three p500 runs,
+the observed throughput was approximately:
+
+- 41.77 audio seconds/s
+- 37.40 audio seconds/s
+- 45.47 audio seconds/s
+
+The SGLang-Omni comparison baseline provided for the same input shape was
+34.39 audio seconds/s. The median validated run is above that baseline by about
+20 percent, while one run was lower due to run-to-run variance. Use repeated
+warmup plus formal p500 runs when comparing future changes.

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -1,142 +1,170 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Pipeline registry and factory for vllm-omni.
+"""Central declarative registry of all vllm-omni pipelines.
 
-``OMNI_PIPELINES`` maps each ``model_type`` to either a ``PipelineConfig``
-instance or a resolver callable that accepts an optional HF config and returns
-a ``PipelineConfig``.
+Mirrors the pattern in ``vllm/model_executor/models/registry.py``: each entry
+is ``model_type -> (module_path, variable_name)``, and the module is imported
+lazily on first lookup (see ``_LazyPipelineRegistry`` in
+``vllm_omni/config/stage_config.py``). Keeping every pipeline declared in one
+file makes it easy to spot a missing registration, which was the original
+motivation in https://github.com/vllm-project/vllm-omni/issues/2887 (item 4).
 
-To add a new pipeline:
+Per-model ``pipeline.py`` modules still define the ``PipelineConfig`` instance;
+they just no longer need to self-register via ``register_pipeline(...)``.
+
+Adding a new pipeline:
     1. Define the ``PipelineConfig`` instance as a module-level variable in
        ``vllm_omni/.../pipeline.py``.
-    2. If the model needs to support several configurations, e.g., because some
-       stages are optional, implement a resolver that consumes the HF config
-       and returns a ``PipelineConfig``.
-    3. Update the registry to map the key to the new config object (in the case
-       of new keys) or to the resolver func.
+    2. Add one line to ``_OMNI_PIPELINES`` below.
 
-Out of tree pipeline configs or resolvers can also be registered with register_pipeline.
+Plain single-stage diffusion models continue to use the
+``_create_default_diffusion_stage_cfg`` fallback in ``async_omni_engine.py``.
+The empty ``_DIFFUSION_PIPELINES`` placeholder previously here (#2915) was
+removed once #2987 (which would have populated it) was deferred.
 
-NOTE: Single-stage diffusion models continue to use the
-``_create_default_diffusion_stage_cfg`` fallback in
-``async_omni_engine.py``; for now we do not add them to registry.
+``register_pipeline(config)`` in ``stage_config`` is still supported for
+out-of-tree plugins and tests that create pipelines at runtime; those override
+the entries declared here.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TypeAlias
-
-from transformers import PreTrainedConfig
-from vllm.logger import init_logger
-
-from vllm_omni.config.stage_config import (
-    PipelineConfig,
-)
-from vllm_omni.model_executor.models.aura_omni.pipeline import AURA_OMNI_PIPELINE
-from vllm_omni.model_executor.models.bagel.pipeline import (
-    BAGEL_PIPELINE,
-    BAGEL_SINGLE_STAGE_PIPELINE,
-    BAGEL_THINK_PIPELINE,
-)
-from vllm_omni.model_executor.models.cosyvoice3.pipeline import COSYVOICE3_PIPELINE
-from vllm_omni.model_executor.models.covo_audio.pipeline import COVO_AUDIO_PIPELINE
-from vllm_omni.model_executor.models.dreamzero.pipeline import DREAMZERO_PIPELINE
-from vllm_omni.model_executor.models.dynin_omni.pipeline import DYNIN_OMNI_PIPELINE
-from vllm_omni.model_executor.models.fish_speech.pipeline import FISH_SPEECH_PIPELINE
-from vllm_omni.model_executor.models.glm_image.pipeline import GLM_IMAGE_PIPELINE
-from vllm_omni.model_executor.models.glm_tts.pipeline import GLM_TTS_PIPELINE
-from vllm_omni.model_executor.models.gr00t.pipeline import GR00T_N1D7_PIPELINE
-from vllm_omni.model_executor.models.higgs_audio_v2.pipeline import HIGGS_AUDIO_V2_PIPELINE
-from vllm_omni.model_executor.models.higgs_audio_v3.pipeline import HIGGS_AUDIO_V3_PIPELINE
-from vllm_omni.model_executor.models.hunyuan_image3.pipeline import (
-    HUNYUAN_IMAGE3_AR_PIPELINE,
-    HUNYUAN_IMAGE3_DIT_PIPELINE,
-    HUNYUAN_IMAGE3_PIPELINE,
-)
-from vllm_omni.model_executor.models.indextts2.pipeline import INDEXTTS2_PIPELINE
-from vllm_omni.model_executor.models.lance.pipeline import LANCE_PIPELINE
-from vllm_omni.model_executor.models.mimo_audio.pipeline import MIMO_AUDIO_PIPELINE
-from vllm_omni.model_executor.models.ming_flash_omni.pipeline import (
-    MING_FLASH_OMNI_IMAGE_PIPELINE,
-    MING_FLASH_OMNI_PIPELINE,
-    MING_FLASH_OMNI_THINKER_ONLY_PIPELINE,
-    MING_FLASH_OMNI_TTS_PIPELINE,
-)
-from vllm_omni.model_executor.models.ming_tts.pipeline import MING_TTS_PIPELINE
-from vllm_omni.model_executor.models.minicpmo_4_5.pipeline import MINICPMO_4_5_PIPELINE
-from vllm_omni.model_executor.models.moss_tts.pipeline import MOSS_TTS_PIPELINE, MOSS_TTS_REALTIME_PIPELINE
-from vllm_omni.model_executor.models.moss_tts_nano.pipeline import MOSS_TTS_NANO_PIPELINE
-from vllm_omni.model_executor.models.qwen2_5_omni.pipeline import (
-    QWEN2_5_OMNI_PIPELINE,
-    QWEN2_5_OMNI_THINKER_ONLY_PIPELINE,
-)
-from vllm_omni.model_executor.models.qwen3_omni.pipeline import resolve_qwen3_omni_pipeline
-from vllm_omni.model_executor.models.qwen3_tts.pipeline import QWEN3_TTS_PIPELINE
-from vllm_omni.model_executor.models.voxcpm2.pipeline import VOXCPM2_PIPELINE
-from vllm_omni.model_executor.models.voxtral_tts.pipeline import VOXTRAL_TTS_PIPELINE
-
-logger = init_logger(__name__)
-
-PipelineResolverFunc: TypeAlias = Callable[[PreTrainedConfig | None], PipelineConfig | None]
+import os
 
 # --- Multi-stage omni pipelines (LLM-centric; audio / video I/O) ---
-OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
-    "aura_omni": AURA_OMNI_PIPELINE,
-    "qwen2_5_omni": QWEN2_5_OMNI_PIPELINE,
-    "qwen2_5_omni_thinker_only": QWEN2_5_OMNI_THINKER_ONLY_PIPELINE,
-    "qwen3_omni_moe": resolve_qwen3_omni_pipeline,
-    "qwen3_tts": QWEN3_TTS_PIPELINE,
-    "covo_audio": COVO_AUDIO_PIPELINE,
-    "bagel": BAGEL_PIPELINE,
-    "bagel_think": BAGEL_THINK_PIPELINE,
-    "bagel_single_stage": BAGEL_SINGLE_STAGE_PIPELINE,
-    "lance": LANCE_PIPELINE,
-    "dreamzero": DREAMZERO_PIPELINE,
-    "Gr00tN1d7": GR00T_N1D7_PIPELINE,
-    "glm_image": GLM_IMAGE_PIPELINE,
-    "hunyuan_image_3_moe": HUNYUAN_IMAGE3_PIPELINE,
-    "hunyuan_image3_ar": HUNYUAN_IMAGE3_AR_PIPELINE,
-    "hunyuan_image3_dit": HUNYUAN_IMAGE3_DIT_PIPELINE,
-    "voxcpm2": VOXCPM2_PIPELINE,
-    "cosyvoice3": COSYVOICE3_PIPELINE,
-    "mimo_audio": MIMO_AUDIO_PIPELINE,
-    "ming_tts": MING_TTS_PIPELINE,
-    "voxtral_tts": VOXTRAL_TTS_PIPELINE,
-    "glm_tts": GLM_TTS_PIPELINE,
-    "fish_qwen3_omni": FISH_SPEECH_PIPELINE,
-    "ming_flash_omni": MING_FLASH_OMNI_PIPELINE,
-    "ming_flash_omni_tts": MING_FLASH_OMNI_TTS_PIPELINE,
-    "ming_flash_omni_thinker_only": MING_FLASH_OMNI_THINKER_ONLY_PIPELINE,
-    "ming_flash_omni_image": MING_FLASH_OMNI_IMAGE_PIPELINE,
-    "moss_tts_nano": MOSS_TTS_NANO_PIPELINE,
-    "moss_tts_delay": MOSS_TTS_PIPELINE,
-    "moss_tts_realtime": MOSS_TTS_REALTIME_PIPELINE,
-    "minicpmo_4_5": MINICPMO_4_5_PIPELINE,
-    "higgs_audio_v2": HIGGS_AUDIO_V2_PIPELINE,
-    "higgs_multimodal_qwen3": HIGGS_AUDIO_V3_PIPELINE,
-    "dynin_omni": DYNIN_OMNI_PIPELINE,
-    "indextts2": INDEXTTS2_PIPELINE,
+_OMNI_PIPELINES: dict[str, tuple[str, str]] = {
+    # model_type -> (module_path, variable_name)
+    "qwen2_5_omni": (
+        "vllm_omni.model_executor.models.qwen2_5_omni.pipeline",
+        "QWEN2_5_OMNI_PIPELINE",
+    ),
+    "qwen2_5_omni_thinker_only": (
+        "vllm_omni.model_executor.models.qwen2_5_omni.pipeline",
+        "QWEN2_5_OMNI_THINKER_ONLY_PIPELINE",
+    ),
+    "qwen3_omni_moe": (
+        "vllm_omni.model_executor.models.qwen3_omni.pipeline",
+        "QWEN3_OMNI_PIPELINE",
+    ),
+    "qwen3_tts": (
+        "vllm_omni.model_executor.models.qwen3_tts.pipeline",
+        "QWEN3_TTS_PIPELINE",
+    ),
+    "covo_audio": (
+        "vllm_omni.model_executor.models.covo_audio.pipeline",
+        "COVO_AUDIO_PIPELINE",
+    ),
+    "bagel": (
+        "vllm_omni.model_executor.models.bagel.pipeline",
+        "BAGEL_PIPELINE",
+    ),
+    "bagel_think": (
+        "vllm_omni.model_executor.models.bagel.pipeline",
+        "BAGEL_THINK_PIPELINE",
+    ),
+    "bagel_single_stage": (
+        "vllm_omni.model_executor.models.bagel.pipeline",
+        "BAGEL_SINGLE_STAGE_PIPELINE",
+    ),
+    # Lance (ByteDance) — BAGEL-lineage unified AR+diffusion, single-stage DiT.
+    "lance": (
+        "vllm_omni.model_executor.models.lance.pipeline",
+        "LANCE_PIPELINE",
+    ),
+    "dreamzero": (
+        "vllm_omni.model_executor.models.dreamzero.pipeline",
+        "DREAMZERO_PIPELINE",
+    ),
+    "glm_image": (
+        "vllm_omni.model_executor.models.glm_image.pipeline",
+        "GLM_IMAGE_PIPELINE",
+    ),
+    "hunyuan_image_3_moe": (
+        "vllm_omni.model_executor.models.hunyuan_image3.pipeline",
+        "HUNYUAN_IMAGE3_PIPELINE",
+    ),
+    "hunyuan_image3_ar": (
+        "vllm_omni.model_executor.models.hunyuan_image3.pipeline",
+        "HUNYUAN_IMAGE3_AR_PIPELINE",
+    ),
+    "hunyuan_image3_dit": (
+        "vllm_omni.model_executor.models.hunyuan_image3.pipeline",
+        "HUNYUAN_IMAGE3_DIT_PIPELINE",
+    ),
+    "voxcpm2": (
+        "vllm_omni.model_executor.models.voxcpm2.pipeline",
+        "VOXCPM2_PIPELINE",
+    ),
+    "cosyvoice3": (
+        "vllm_omni.model_executor.models.cosyvoice3.pipeline",
+        "COSYVOICE3_PIPELINE",
+    ),
+    "mimo_audio": (
+        "vllm_omni.model_executor.models.mimo_audio.pipeline",
+        "MIMO_AUDIO_PIPELINE",
+    ),
+    "ming_tts": (
+        "vllm_omni.model_executor.models.ming_tts.pipeline",
+        "MING_TTS_PIPELINE",
+    ),
+    "voxtral_tts": (
+        "vllm_omni.model_executor.models.voxtral_tts.pipeline",
+        "VOXTRAL_TTS_PIPELINE",
+    ),
+    "glm_tts": (
+        "vllm_omni.model_executor.models.glm_tts.pipeline",
+        "GLM_TTS_PIPELINE",
+    ),
+    "fish_qwen3_omni": (
+        "vllm_omni.model_executor.models.fish_speech.pipeline",
+        "FISH_SPEECH_PIPELINE",
+    ),
+    "ming_flash_omni": (
+        "vllm_omni.model_executor.models.ming_flash_omni.pipeline",
+        "MING_FLASH_OMNI_PIPELINE",
+    ),
+    "ming_flash_omni_tts": (
+        "vllm_omni.model_executor.models.ming_flash_omni.pipeline",
+        "MING_FLASH_OMNI_TTS_PIPELINE",
+    ),
+    "ming_flash_omni_thinker_only": (
+        "vllm_omni.model_executor.models.ming_flash_omni.pipeline",
+        "MING_FLASH_OMNI_THINKER_ONLY_PIPELINE",
+    ),
+    "ming_flash_omni_image": (
+        "vllm_omni.model_executor.models.ming_flash_omni.pipeline",
+        "MING_FLASH_OMNI_IMAGE_PIPELINE",
+    ),
+    "moss_tts_nano": (
+        "vllm_omni.model_executor.models.moss_tts_nano.pipeline",
+        "MOSS_TTS_NANO_PIPELINE",
+    ),
+    "moss_tts_delay": (
+        "vllm_omni.model_executor.models.moss_tts.pipeline",
+        "MOSS_TTS_PIPELINE",
+    ),
+    "moss_tts_realtime": (
+        "vllm_omni.model_executor.models.moss_tts.pipeline",
+        "MOSS_TTS_REALTIME_PIPELINE",
+    ),
+    "moss_tts_local": (
+        "vllm_omni.model_executor.models.moss_tts_local.pipeline",
+        "MOSS_TTS_LOCAL_NATIVE_PIPELINE" if os.environ.get("MOSS_TTS_LOCAL_NATIVE") == "1" else "MOSS_TTS_LOCAL_PIPELINE",
+    ),
+    "minicpmo_4_5": (
+        "vllm_omni.model_executor.models.minicpmo_4_5.pipeline",
+        "MINICPMO_4_5_PIPELINE",
+    ),
+    "higgs_audio_v2": (
+        "vllm_omni.model_executor.models.higgs_audio_v2.pipeline",
+        "HIGGS_AUDIO_V2_PIPELINE",
+    ),
+    "higgs_multimodal_qwen3": (
+        "vllm_omni.model_executor.models.higgs_audio_v3.pipeline",
+        "HIGGS_AUDIO_V3_PIPELINE",
+    ),
+    "dynin_omni": (
+        "vllm_omni.model_executor.models.dynin_omni.pipeline",
+        "DYNIN_OMNI_PIPELINE",
+    ),
 }
-
-
-def register_pipeline(pipeline: PipelineConfig | PipelineResolverFunc, model_type: str | None = None):
-    """Register an out of tree pipeline or PipelineResolverFunc to a model_type key.
-    If a PipelineConfig is provided, model_type is optional, and pipeline.model_type
-    will be used by default. If a callable is provided, model_type must be provided,
-    since resolvers can return multiple different PipelineConfigs depending on the
-    consumed config.
-    """
-    errors: list[str] = []
-    if isinstance(pipeline, PipelineConfig):
-        errors = pipeline.validate()
-        model_type = model_type if model_type is not None else pipeline.model_type
-    else:
-        if model_type is None:
-            raise ValueError("Model type must be explicitly provided when registering a pipeline resolver")
-
-    if model_type in OMNI_PIPELINES:
-        errors.append(f"Model type {model_type} is already registered; the old mapping will be clobbered")
-    if errors:
-        logger.warning("Registration for pipeline of type %s produced the following issues: %s", model_type, errors)
-    OMNI_PIPELINES[model_type] = pipeline

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -30,9 +30,20 @@ the entries declared here.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
+
+PipelineRegistryEntry = tuple[str, str | Callable[[], str]]
+
+
+def _moss_tts_local_pipeline_name() -> str:
+    native_flag = os.environ.get("MOSS_TTS_LOCAL_NATIVE", "0").strip().lower()
+    if native_flag in ("1", "true", "yes", "on"):
+        return "MOSS_TTS_LOCAL_NATIVE_PIPELINE"
+    return "MOSS_TTS_LOCAL_PIPELINE"
+
 
 # --- Multi-stage omni pipelines (LLM-centric; audio / video I/O) ---
-_OMNI_PIPELINES: dict[str, tuple[str, str]] = {
+_OMNI_PIPELINES: dict[str, PipelineRegistryEntry] = {
     # model_type -> (module_path, variable_name)
     "qwen2_5_omni": (
         "vllm_omni.model_executor.models.qwen2_5_omni.pipeline",
@@ -149,7 +160,7 @@ _OMNI_PIPELINES: dict[str, tuple[str, str]] = {
     ),
     "moss_tts_local": (
         "vllm_omni.model_executor.models.moss_tts_local.pipeline",
-        "MOSS_TTS_LOCAL_NATIVE_PIPELINE" if os.environ.get("MOSS_TTS_LOCAL_NATIVE") == "1" else "MOSS_TTS_LOCAL_PIPELINE",
+        _moss_tts_local_pipeline_name,
     ),
     "minicpmo_4_5": (
         "vllm_omni.model_executor.models.minicpmo_4_5.pipeline",

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -12,6 +12,7 @@ transport half lives in OmniConnectorModelRunnerMixin.
 
 from __future__ import annotations
 
+import os
 import time
 from collections import deque
 from typing import Any
@@ -51,9 +52,6 @@ _FULL_PAYLOAD_INPUT_STAGES: frozenset[tuple[str, str]] = frozenset(
         ("Qwen3TTSCode2Wav", "code2wav"),
         # cosyvoice3: cosyvoice3_talker (Stage 0) -> cosyvoice3_code2wav (Stage 1).
         ("CosyVoice3Model", "cosyvoice3_code2wav"),
-        # indextts2: indextts2_talker (Stage 0) -> indextts2_s2mel_decoder
-        # (Stage 1). Stage 1 consumes the complete mel/latent payload.
-        ("IndexTTS2S2MelDecoder", "indextts2_s2mel_decoder"),
         # dynin: token2text (Stage 0) -> token2image (Stage 1) ->
         # token2audio (Stage 2).  Producer wires via
         # custom_process_next_stage_input_func: *_full_payload in deploy yaml.
@@ -120,6 +118,26 @@ class OmniSchedulingCoordinator:
         # WAITING_FOR_CHUNK or WAITING_FOR_INPUT.  Used by
         # collect_timed_out_request_ids() to detect orphaned waits.
         self._waiting_since: dict[str, float] = {}
+        # Optional full-payload admission coalescing for bursty two-stage
+        # pipelines.  Keep this env-gated because the coordinator is shared by
+        # multiple model families and extra admission latency is not universally
+        # desirable.
+        try:
+            self._full_payload_coalesce_target = max(
+                int(os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_TARGET", "0") or 0),
+                0,
+            )
+        except ValueError:
+            self._full_payload_coalesce_target = 0
+        try:
+            self._full_payload_coalesce_window_s = max(
+                float(os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_WINDOW_MS", "0") or 0.0) / 1000.0,
+                0.0,
+            )
+        except ValueError:
+            self._full_payload_coalesce_window_s = 0.0
+        self._full_payload_ready_since: dict[str, float] = {}
+        self.last_full_payload_profile: dict[str, int] = {}
 
     # ------------------------------------------------------------------ #
     #  Core scheduling methods
@@ -186,7 +204,14 @@ class OmniSchedulingCoordinator:
         if self._stage_id == 0:
             return
 
+        profile_enabled = os.environ.get("MOSS_TTS_LOCAL_STAGE1_ADMISSION_PROFILE") == "1"
+        waiting_before = len(waiting_queue) if profile_enabled else 0
+        waiting_for_input_before = len(self._waiting_for_input) if profile_enabled else 0
+        running_before = len(running_queue) if profile_enabled else 0
+        now = time.monotonic()
         self._full_payload_input_received.update(stage_recv_req_ids)
+        for req_id in stage_recv_req_ids:
+            self._full_payload_ready_since.setdefault(req_id, now)
         if not self._async_chunk and stage_recv_req_ids:
             self.finished_requests.update(stage_recv_req_ids)
             logger.debug(
@@ -196,12 +221,34 @@ class OmniSchedulingCoordinator:
             )
         self.pending_input_registrations = []
 
+        coalesce_enabled = (
+            not self._async_chunk
+            and self._full_payload_coalesce_target > 1
+            and self._full_payload_coalesce_window_s > 0
+        )
+        ready_waiting = [
+            request for request in self._waiting_for_input if request.request_id in self._full_payload_input_received
+        ]
+        release_ready_ids: set[str] = set()
+        if ready_waiting:
+            if not coalesce_enabled or len(ready_waiting) >= self._full_payload_coalesce_target:
+                release_ready_ids = {request.request_id for request in ready_waiting}
+            else:
+                oldest_ready = min(
+                    self._full_payload_ready_since.get(request.request_id, now) for request in ready_waiting
+                )
+                if now - oldest_ready >= self._full_payload_coalesce_window_s:
+                    release_ready_ids = {request.request_id for request in ready_waiting}
+
         remaining: deque[Any] = deque()
+        released = 0
         for request in self._waiting_for_input:
-            if request.request_id in stage_recv_req_ids:
+            if request.request_id in release_ready_ids:
                 request.status = RequestStatus.WAITING
                 self._waiting_since.pop(request.request_id, None)
+                self._full_payload_ready_since.pop(request.request_id, None)
                 waiting_queue.add_request(request)
+                released += 1
             else:
                 remaining.append(request)
         self._waiting_for_input = remaining
@@ -245,6 +292,34 @@ class OmniSchedulingCoordinator:
                 # repeated O(N) removes from a list-backed queue.
                 waiting_queue.remove_requests(to_remove)
 
+        if profile_enabled:
+            self.last_full_payload_profile = {
+                "stage": self._stage_id,
+                "recv": len(stage_recv_req_ids),
+                "released": released,
+                "registered": len(self.pending_input_registrations),
+                "waiting_before": waiting_before,
+                "waiting_after": len(waiting_queue),
+                "waiting_for_input_before": waiting_for_input_before,
+                "waiting_for_input_after": len(self._waiting_for_input),
+                "running_before": running_before,
+                "running_after": len(running_queue),
+            }
+        if profile_enabled and (stage_recv_req_ids or released or self.pending_input_registrations):
+            logger.info(
+                "[moss-stage1-admission] coordinator recv=%d released=%d registered=%d "
+                "waiting=%d->%d waiting_input=%d->%d running=%d->%d",
+                self.last_full_payload_profile["recv"],
+                self.last_full_payload_profile["released"],
+                self.last_full_payload_profile["registered"],
+                self.last_full_payload_profile["waiting_before"],
+                self.last_full_payload_profile["waiting_after"],
+                self.last_full_payload_profile["waiting_for_input_before"],
+                self.last_full_payload_profile["waiting_for_input_after"],
+                self.last_full_payload_profile["running_before"],
+                self.last_full_payload_profile["running_after"],
+            )
+
     def process_pending_full_payload_inputs_legacy(
         self,
         waiting_queue: Any,
@@ -260,6 +335,7 @@ class OmniSchedulingCoordinator:
         self.finished_requests.discard(request_id)
         self.requests_with_ready_chunks.discard(request_id)
         self._waiting_since.pop(request_id, None)
+        self._full_payload_ready_since.pop(request_id, None)
 
     def collect_timed_out_request_ids(
         self,

--- a/vllm_omni/deploy/moss_tts_local.yaml
+++ b/vllm_omni/deploy/moss_tts_local.yaml
@@ -1,0 +1,65 @@
+# MOSS-TTS Local Transformer v1.5 high-throughput serving config.
+#
+# This config intentionally uses full-sequence Stage1 vocoder decode. Stage0
+# still transfers payloads through the async chunk adapter, but Stage1 receives
+# one terminal codec payload per request so completed utterances can be batched
+# safely without sharing streaming codec state across requests.
+async_chunk: true
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      shm_threshold_bytes: 65536
+      codec_streaming: false
+      connector_get_sleep_s: 0.001
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      codec_chunk_frames: 15
+      initial_codec_chunk_frames: 5
+      codec_left_context_frames: 0
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 64
+    gpu_memory_utilization: 0.70
+    enforce_eager: false
+    trust_remote_code: true
+    skip_tokenizer_init: true
+    enable_prefix_caching: false
+    async_scheduling: true
+    max_num_batched_tokens: 4096
+    max_model_len: 4096
+    devices: "0"
+    output_connectors:
+      to_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      repetition_penalty: 1.0
+      stop_token_ids: [151670]
+
+  - stage_id: 1
+    max_num_seqs: 8
+    active_stream_window: 8
+    gpu_memory_utilization: 0.20
+    enforce_eager: true
+    trust_remote_code: true
+    skip_tokenizer_init: true
+    enable_prefix_caching: false
+    async_scheduling: true
+    max_num_batched_tokens: 65536
+    max_model_len: 65536
+    devices: "0"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      repetition_penalty: 1.0

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import importlib
+import os
+import time
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping
 from typing import Any
@@ -88,6 +90,88 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self._held_non_active: deque[Any] = deque()
         self.requests_num_chunks_sent: dict[str, int] = defaultdict(int)
         self._pending_streaming_prefills: dict[str, dict] = {}
+        self.last_full_sequence_admission_profile: dict[str, Any] = {}
+
+    @staticmethod
+    def _parse_optional_bool(value: Any) -> bool | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                return None
+            return bool(value.item())
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in ("1", "true", "yes", "on"):
+                return True
+            if normalized in ("0", "false", "no", "off"):
+                return False
+            return None
+        return bool(value)
+
+    def _codec_streaming_default(self) -> bool | None:
+        raw = os.environ.get("MOSS_TTS_LOCAL_CODEC_STREAMING")
+        if raw is None:
+            raw = os.environ.get("MOSS_TTS_LOCAL_DEFAULT_CODEC_STREAMING")
+        parsed = self._parse_optional_bool(raw)
+        if parsed is not None:
+            return parsed
+
+        connector_cfg = getattr(self.connector, "config", None)
+        if isinstance(connector_cfg, Mapping):
+            extra = connector_cfg.get("extra", connector_cfg)
+            if isinstance(extra, Mapping) and "codec_streaming" in extra:
+                return self._parse_optional_bool(extra.get("codec_streaming"))
+        return None
+
+    def _use_full_sequence_chunk_admission(self) -> bool:
+        """Whether async-chunk transport is carrying terminal full payloads.
+
+        ``active_stream_window`` protects stateful streaming codec sessions.
+        When MOSS Local is explicitly configured to send one terminal
+        full-sequence payload per request through the async-chunk transport,
+        the active-window gate only throttles which finished payloads can be
+        polled.  Bulk registration is safe for that mode and is required to
+        form larger Stage1 vocoder batches.
+        """
+        return self.model_mode != "ar" and self._codec_streaming_default() is False
+
+    def _full_sequence_admission_coalesce_delay_s(self) -> float:
+        raw = (
+            os.environ.get("MOSS_TTS_LOCAL_STAGE1_FULLSEQ_ADMISSION_COALESCE_MS")
+            or os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_WINDOW_MS")
+            or os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_MS")
+            or os.environ.get("OMNI_CONNECTOR_COALESCE_MS")
+        )
+        if raw is None:
+            return 0.04 if self._use_full_sequence_chunk_admission() else 0.0
+        try:
+            return max(float(raw), 0.0) / 1000.0
+        except ValueError:
+            return 0.0
+
+    def _full_sequence_admission_target(self) -> int:
+        raw = (
+            os.environ.get("MOSS_TTS_LOCAL_STAGE1_FULLSEQ_ADMISSION_TARGET")
+            or os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_TARGET")
+            or os.environ.get("OMNI_CONNECTOR_COALESCE_TARGET")
+        )
+        if not raw:
+            if self._use_full_sequence_chunk_admission():
+                target = 6
+                if self.scheduler_max_num_seqs > 0:
+                    target = min(target, int(self.scheduler_max_num_seqs))
+                return target
+            return max(int(self.scheduler_max_num_seqs or 0), 0)
+        try:
+            target = max(int(raw), 0)
+        except ValueError:
+            return max(int(self.scheduler_max_num_seqs or 0), 0)
+        if self.scheduler_max_num_seqs > 0:
+            return min(target, int(self.scheduler_max_num_seqs))
+        return target
 
     @staticmethod
     def _is_truthy_scalar(value: Any) -> bool:
@@ -242,7 +326,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
                 new_ids = payload_data.get("codes", {}).get("audio")
                 has_tensor_codes = isinstance(new_ids, torch.Tensor)
-                use_tensor_codes = has_tensor_codes and new_ids.ndim >= 2
+                use_tensor_codes = has_tensor_codes and (self.model_mode == "generation" or new_ids.ndim >= 2)
                 if use_tensor_codes:
                     request.prompt_token_ids = [0] if new_ids.numel() > 0 else []
                 elif has_tensor_codes:
@@ -256,7 +340,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 info = dict(prev_info) if isinstance(prev_info, dict) else {}
                 for key, value in payload_data.items():
                     if key == "codes":
-                        if use_tensor_codes and isinstance(value, dict):
+                        if isinstance(value, dict):
                             existing_sub = info.get(key)
                             merged_sub = dict(existing_sub) if isinstance(existing_sub, dict) else {}
                             merged_sub.update(value)
@@ -300,8 +384,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         stage_id = self.connector.stage_id
         next_stage_id = stage_id + 1
         external_req_id = request.external_req_id
-        chunk_id = self.put_req_chunk[external_req_id]
-        connector_put_key = f"{external_req_id}_{stage_id}_{chunk_id}"
         # Process payload in save_loop thread
         payload_data: OmniPayloadStruct | None = None
         if self.custom_process_next_stage_input_func:
@@ -323,37 +405,43 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             # Segment/request finish markers must still reach downstream even when
             # the processor has no tensor payload.
             payload_data = OmniPayloadStruct()
-        if payload_data.meta is None:
-            payload_data.meta = MetaStruct()
-        payload_data.meta.finished = torch.tensor(is_finished, dtype=torch.bool)
-        payload_data.meta.is_segment_finished = torch.tensor(is_segment_finished, dtype=torch.bool)
 
-        success, size, metadata = self.connector.put(
-            from_stage=str(stage_id),
-            to_stage=str(next_stage_id),
-            put_key=connector_put_key,
-            data=payload_data,
-        )
+        payloads = payload_data if isinstance(payload_data, list) else [payload_data]
+        for payload_index, payload in enumerate(payloads):
+            if payload.meta is None:
+                payload.meta = MetaStruct()
+            is_last_payload = payload_index == len(payloads) - 1
+            payload.meta.finished = torch.tensor(is_finished and is_last_payload, dtype=torch.bool)
+            payload.meta.is_segment_finished = torch.tensor(is_segment_finished and is_last_payload, dtype=torch.bool)
 
-        if success:
-            self.put_req_chunk[external_req_id] += 1
-            logger.debug(f"[Stage-{stage_id}] Sent {connector_put_key}")
-            # Sender uses struct attr access here; the receive path in
-            # `_load_one_request` / `_update_request_payload` reads dict keys.
-            # That asymmetry is intentional: `OmniMsgpackDecoder` is type-erased
-            # (no target type), so the wire round-trips struct -> dict. If you
-            # change the schema, update both ends — see test_wire_round_trip.
-            finished_flag = payload_data.meta.finished if payload_data.meta is not None else None
-            is_payload_finished = False
-            if isinstance(finished_flag, torch.Tensor):
-                is_payload_finished = finished_flag.numel() == 1 and bool(finished_flag.item())
-            elif finished_flag is not None:
-                is_payload_finished = bool(finished_flag)
+            chunk_id = self.put_req_chunk[external_req_id]
+            connector_put_key = f"{external_req_id}_{stage_id}_{chunk_id}"
+            success, size, metadata = self.connector.put(
+                from_stage=str(stage_id),
+                to_stage=str(next_stage_id),
+                put_key=connector_put_key,
+                data=payload,
+            )
 
-            # Reclaim per-request async state only after the terminal payload
-            # has been sent successfully. This avoids cleanup->save races.
-            if is_payload_finished:
-                self.cleanup(request.request_id, external_req_id)
+            if success:
+                self.put_req_chunk[external_req_id] += 1
+                logger.debug(f"[Stage-{stage_id}] Sent {connector_put_key}")
+                # Sender uses struct attr access here; the receive path in
+                # `_load_one_request` / `_update_request_payload` reads dict keys.
+                # That asymmetry is intentional: `OmniMsgpackDecoder` is type-erased
+                # (no target type), so the wire round-trips struct -> dict. If you
+                # change the schema, update both ends — see test_wire_round_trip.
+                finished_flag = payload.meta.finished if payload.meta is not None else None
+                is_payload_finished = False
+                if isinstance(finished_flag, torch.Tensor):
+                    is_payload_finished = finished_flag.numel() == 1 and bool(finished_flag.item())
+                elif finished_flag is not None:
+                    is_payload_finished = bool(finished_flag)
+
+                # Reclaim per-request async state only after the terminal payload
+                # has been sent successfully. This avoids cleanup->save races.
+                if is_payload_finished:
+                    self.cleanup(request.request_id, external_req_id)
 
         if is_segment_finished:
             self.code_prompt_token_ids.pop(external_req_id, None)
@@ -475,7 +563,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_waiting_requests, scheduler_requests)
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_running_requests, scheduler_requests)
 
-        if self._active_window <= 0:
+        if self._active_window <= 0 or self._use_full_sequence_chunk_admission():
             self._process_chunk_queue_legacy(
                 waiting_queue, self.waiting_for_chunk_waiting_requests, RequestStatus.WAITING, self._finished_load_reqs
             )
@@ -485,6 +573,12 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 RequestStatus.RUNNING,
                 self._finished_load_reqs,
             )
+            if self._use_full_sequence_chunk_admission():
+                self._coalesce_and_release_full_sequence_requests(
+                    waiting_queue,
+                    running_queue,
+                    scheduler_requests=scheduler_requests,
+                )
             while len(running_queue) > self.scheduler_max_num_seqs:
                 request = running_queue.pop()
                 request.status = RequestStatus.PREEMPTED
@@ -582,6 +676,114 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             queue.remove(request)
             self.requests_origin_status[request.request_id] = target_status
             waiting_for_chunk_list.append(request)
+
+    def _count_ready_full_sequence_requests(self) -> int:
+        return sum(
+            1
+            for request in (
+                list(self.waiting_for_chunk_waiting_requests) + list(self.waiting_for_chunk_running_requests)
+            )
+            if request.request_id in self._finished_load_reqs
+        )
+
+    def _coalesce_and_release_full_sequence_requests(
+        self,
+        waiting_queue: Any,
+        running_queue: list[Request],
+        *,
+        scheduler_requests: dict[str, Request] | None = None,
+    ) -> None:
+        parked_before = len(self.waiting_for_chunk_waiting_requests) + len(self.waiting_for_chunk_running_requests)
+        ready_before = self._count_ready_full_sequence_requests()
+        target = self._full_sequence_admission_target()
+        delay_s = self._full_sequence_admission_coalesce_delay_s()
+        pending_before = len(self._pending_load_reqs)
+
+        if delay_s > 0 and parked_before > 0 and (target <= 0 or ready_before < min(target, parked_before)):
+            deadline = time.perf_counter() + delay_s
+            sleep_step = min(0.0005, delay_s)
+            while True:
+                ready_now = self._count_ready_full_sequence_requests()
+                if ready_now >= parked_before or (target > 0 and ready_now >= target):
+                    break
+                if not self._pending_load_reqs:
+                    break
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    break
+                time.sleep(min(sleep_step, remaining))
+
+        if scheduler_requests is not None:
+            self._purge_untracked_chunk_requests(self.waiting_for_chunk_waiting_requests, scheduler_requests)
+            self._purge_untracked_chunk_requests(self.waiting_for_chunk_running_requests, scheduler_requests)
+
+        released_waiting = self._release_ready_full_sequence_requests(
+            waiting_queue,
+            self.waiting_for_chunk_waiting_requests,
+            RequestStatus.WAITING,
+            scheduler_requests=scheduler_requests,
+        )
+        released_running = self._release_ready_full_sequence_requests(
+            running_queue,
+            self.waiting_for_chunk_running_requests,
+            RequestStatus.RUNNING,
+            scheduler_requests=scheduler_requests,
+        )
+        released = released_waiting + released_running
+        self.last_full_sequence_admission_profile = {
+            "parked": parked_before,
+            "ready_before": ready_before,
+            "ready_after_wait": self._count_ready_full_sequence_requests(),
+            "released": released,
+            "released_waiting": released_waiting,
+            "released_running": released_running,
+            "pending_before": pending_before,
+            "pending_after": len(self._pending_load_reqs),
+            "target": target,
+            "delay_ms": delay_s * 1000.0,
+        }
+        if released and os.environ.get("MOSS_TTS_LOCAL_STAGE1_ADMISSION_PROFILE") == "1":
+            logger.info(
+                "[moss-stage1-fullseq-admission] parked=%d ready_before=%d released=%d "
+                "waiting=%d running=%d pending=%d->%d target=%d delay_ms=%.3f",
+                parked_before,
+                ready_before,
+                released,
+                released_waiting,
+                released_running,
+                pending_before,
+                len(self._pending_load_reqs),
+                target,
+                delay_s * 1000.0,
+            )
+
+    def _release_ready_full_sequence_requests(
+        self,
+        queue: Any,
+        waiting_for_chunk_list: deque[Any],
+        target_status: RequestStatus,
+        *,
+        scheduler_requests: dict[str, Request] | None = None,
+    ) -> int:
+        released = 0
+        for _ in range(len(waiting_for_chunk_list)):
+            request = waiting_for_chunk_list.popleft()
+            request_id = request.request_id
+            if scheduler_requests is not None and request_id not in scheduler_requests:
+                self.cleanup_receiver(request_id)
+                continue
+            if request_id not in self._finished_load_reqs:
+                waiting_for_chunk_list.append(request)
+                continue
+            request.status = target_status
+            self._finished_load_reqs.remove(request_id)
+            self.requests_with_ready_chunks.add(request_id)
+            if target_status == RequestStatus.WAITING:
+                queue.add_request(request)
+            else:
+                queue.append(request)
+            released += 1
+        return released
 
     def _purge_untracked_chunk_requests(
         self,

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -81,6 +81,7 @@ _VOXCPM2_TTS_MODEL_STAGES = {"latent_generator"}
 _MING_TTS_MODEL_STAGES = {"ming_tts"}
 _MOSS_TTS_MODEL_STAGES = {"moss_tts_nano"}
 _MOSS_TTS_FULL_MODEL_STAGES = {"moss_tts", "moss_tts_codec"}
+_MOSS_TTS_LOCAL_MODEL_STAGES = {"moss_tts_local"}
 _HIGGS_AUDIO_V2_TTS_MODEL_STAGES = {"higgs_audio_v2"}
 _HIGGS_V3_TTS_MODEL_STAGES = {"higgs_audio_v3"}
 _GLM_TTS_MODEL_STAGES = {"glm_tts"}
@@ -99,6 +100,7 @@ _TTS_MODEL_STAGES: set[str] = (
     | _MING_TTS_MODEL_STAGES
     | _MOSS_TTS_MODEL_STAGES
     | _MOSS_TTS_FULL_MODEL_STAGES
+    | _MOSS_TTS_LOCAL_MODEL_STAGES
     | _GLM_TTS_MODEL_STAGES
     | _STEP_AUDIO2_TTS_MODEL_STAGES
     | _INDEXTTS2_TTS_MODEL_STAGES
@@ -688,6 +690,8 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             return "moss_tts_nano"
         if model_stage in _MOSS_TTS_FULL_MODEL_STAGES:
             return "moss_tts"
+        if model_stage in _MOSS_TTS_LOCAL_MODEL_STAGES:
+            return "moss_tts_local"
         if model_stage in _HIGGS_AUDIO_V2_TTS_MODEL_STAGES:
             return "higgs_audio_v2"
         if model_stage in _HIGGS_V3_TTS_MODEL_STAGES:
@@ -3430,6 +3434,8 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             model_type = "moss_tts_nano"
         elif self._tts_model_type == "moss_tts":
             model_type = "moss_tts"
+        elif self._tts_model_type == "moss_tts_local":
+            model_type = "moss_tts_local"
         elif self._tts_model_type == "higgs_audio_v2":
             model_type = "higgs_audio_v2"
         elif self._tts_model_type == "glm_tts":

--- a/vllm_omni/entrypoints/openai/tts_adapters/moss_tts.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/moss_tts.py
@@ -56,3 +56,51 @@ class MossTTSNanoAdapter(_MossTTSAdapterBase):
 class MossTTSAdapter(_MossTTSAdapterBase):
     stage_keys = frozenset({"moss_tts", "moss_tts_codec"})
     name = "moss_tts"
+
+
+@register_tts_adapter
+class MossTTSLocalAdapter(ARTTSAdapter):
+    """Adapter for MOSS-TTS Local Transformer v1.5 default-voice serving."""
+
+    stage_keys = frozenset({"moss_tts_local"})
+    name = "moss_tts_local"
+
+    def validate(self, request: "OpenAICreateSpeechRequest") -> str | None:
+        if not request.input or not request.input.strip():
+            return "Input text cannot be empty"
+        if request.voice is not None and request.voice.lower() != "default":
+            return "MOSS-TTS Local currently supports only voice='default'"
+        unsupported_fields = {
+            "task_type": request.task_type,
+            "instructions": request.instructions,
+            "ref_audio": request.ref_audio,
+            "ref_text": request.ref_text,
+            "ref_audio_2": request.ref_audio_2,
+            "ambient_sound": request.ambient_sound,
+            "duration_seconds": request.duration_seconds,
+            "x_vector_only_mode": request.x_vector_only_mode,
+            "speaker_embedding": request.speaker_embedding,
+        }
+        for name, value in unsupported_fields.items():
+            if value is not None:
+                return f"'{name}' is not supported for MOSS-TTS Local; use seed-tts-text/default voice"
+        if request.max_new_tokens is not None and request.max_new_tokens <= 0:
+            return "'max_new_tokens' must be a positive integer"
+        return None
+
+    async def build(
+        self, request: "OpenAICreateSpeechRequest", sampling_params_list: list, has_inline_ref_audio: bool
+    ) -> PreparedRequest:
+        del has_inline_ref_audio
+        tts_params = dict(request.extra_params or {})
+        if request.seed is not None:
+            tts_params["seed"] = [request.seed]
+        elif sampling_params_list and getattr(sampling_params_list[0], "seed", None) is not None:
+            tts_params["seed"] = [sampling_params_list[0].seed]
+
+        prompt = {
+            "prompt": request.input,
+            "additional_information": tts_params,
+            "cache_salt": conditioning_cache_salt(request, tts_params),
+        }
+        return PreparedRequest(prompt=prompt, tts_params=tts_params, model_type=self.name)

--- a/vllm_omni/model_executor/models/moss_tts_local/__init__.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""MOSS-TTS Local Transformer v1.5 model stubs and config."""
+
+from vllm_omni.model_executor.models.moss_tts_local.configuration_moss_tts_local import (
+    MossTTSLocalConfig,
+)
+from vllm_omni.model_executor.models.moss_tts_local.modeling_moss_tts_local import (
+    MossTTSLocalForGeneration,
+)
+from vllm_omni.model_executor.models.moss_tts_local.modeling_moss_tts_local_v2 import (
+    MossTTSLocalNativeModel,
+)
+from vllm_omni.model_executor.models.moss_tts_local.modeling_moss_tts_local_vocoder import (
+    MossTTSLocalVocoder,
+)
+
+__all__ = [
+    "MossTTSLocalConfig",
+    "MossTTSLocalForGeneration",
+    "MossTTSLocalNativeModel",
+    "MossTTSLocalVocoder",
+]

--- a/vllm_omni/model_executor/models/moss_tts_local/codec_path.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/codec_path.py
@@ -1,0 +1,57 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Path helpers for MOSS-TTS Local Transformer v1.5."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolve_moss_tts_local_codec_path(
+    model_path: str,
+    explicit_codec_path: str | None = None,
+) -> str | None:
+    """Resolve a local MOSS-Audio-Tokenizer-v2 path when one is colocated.
+
+    ``AutoProcessor`` can load the codec from the repo id stored in config, but
+    remote profiling hosts often run with restricted Hugging Face access.  When
+    the main checkpoint is local, prefer a sibling codec directory so both
+    prompt building and vocoder decode stay offline.
+    """
+    if explicit_codec_path:
+        return explicit_codec_path
+
+    env_path = os.environ.get("MOSS_TTS_LOCAL_CODEC_PATH")
+    if env_path:
+        return env_path
+
+    path = Path(model_path).expanduser()
+    if not path.exists():
+        return None
+
+    for candidate in (
+        path.parent / "MOSS-Audio-Tokenizer-v2",
+        path.parent / "OpenMOSS-Team" / "MOSS-Audio-Tokenizer-v2",
+    ):
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def moss_tts_local_processor_kwargs(
+    model_path: str,
+    explicit_codec_path: str | None = None,
+) -> dict[str, object]:
+    """Common kwargs for loading the upstream MOSS-TTS Local processor."""
+    kwargs: dict[str, object] = {
+        "trust_remote_code": True,
+    }
+    codec_path = resolve_moss_tts_local_codec_path(model_path, explicit_codec_path)
+    if codec_path is not None:
+        kwargs["codec_path"] = codec_path
+    return kwargs
+
+
+__all__ = ["moss_tts_local_processor_kwargs", "resolve_moss_tts_local_codec_path"]

--- a/vllm_omni/model_executor/models/moss_tts_local/configuration_moss_tts_local.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/configuration_moss_tts_local.py
@@ -1,0 +1,128 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Configuration for MOSS-TTS Local Transformer v1.5."""
+
+from __future__ import annotations
+
+from transformers import AutoConfig, GPT2Config
+from transformers.configuration_utils import PretrainedConfig
+from transformers.models.qwen3 import Qwen3Config
+
+
+class MossTTSLocalConfig(PretrainedConfig):
+    """Config for ``OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5``.
+
+    This is a distinct architecture from the existing MOSS-TTS Delay and
+    Realtime checkpoints.  It uses a Qwen3 backbone plus a one-layer GPT2 local
+    frame transformer, emits 12 audio codebooks and decodes with
+    ``MOSS-Audio-Tokenizer-v2`` at 48 kHz.
+    """
+
+    model_type = "moss_tts_local"
+
+    def __init__(
+        self,
+        qwen3_config: dict | Qwen3Config | None = None,
+        language_config: dict | Qwen3Config | None = None,
+        gpt2_config: dict | GPT2Config | None = None,
+        n_vq: int = 12,
+        audio_vocab_size: int = 1024,
+        audio_codebook_sizes: list[int] | None = None,
+        audio_pad_token_id: int = 1024,
+        audio_pad_code: int = 1024,
+        pad_token_id: int = 151643,
+        im_start_token_id: int = 151644,
+        im_end_token_id: int = 151645,
+        audio_start_token_id: int = 151669,
+        audio_end_token_id: int = 151670,
+        audio_user_slot_token_id: int = 151654,
+        audio_assistant_slot_token_id: int = 151656,
+        audio_assistant_gen_slot_token_id: int | None = None,
+        sampling_rate: int = 48000,
+        audio_tokenizer_name_or_path: str = "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2",
+        attn_implementation: str | None = None,
+        local_transformer_attn_implementation: str | None = None,
+        local_transformer_layers: int = 1,
+        local_text_head_mode: str = "binary",
+        use_static_local_kv_cache: bool = True,
+        initializer_range: float = 0.02,
+        architectures: list[str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        qwen3_source = qwen3_config if qwen3_config is not None else language_config
+        self.qwen3_config = self._coerce_qwen3_config(qwen3_source)
+        # Upstream keeps both names in config.json.  Mirror that layout so
+        # remote configs round-trip and older call sites can read either name.
+        self.language_config = self.qwen3_config
+        self.gpt2_config = self._coerce_gpt2_config(gpt2_config)
+
+        if audio_codebook_sizes is None:
+            audio_codebook_sizes = [audio_vocab_size] * n_vq
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            architectures=architectures or ["MossTTSLocalModel"],
+            **kwargs,
+        )
+
+        self.n_vq = n_vq
+        self.audio_vocab_size = audio_vocab_size
+        self.audio_codebook_sizes = audio_codebook_sizes
+        self.audio_pad_token_id = audio_pad_token_id
+        self.audio_pad_code = audio_pad_code
+        self.im_start_token_id = im_start_token_id
+        self.im_end_token_id = im_end_token_id
+        self.audio_start_token_id = audio_start_token_id
+        self.audio_end_token_id = audio_end_token_id
+        self.audio_user_slot_token_id = audio_user_slot_token_id
+        self.audio_assistant_slot_token_id = (
+            audio_assistant_slot_token_id
+            if audio_assistant_gen_slot_token_id is None
+            else audio_assistant_gen_slot_token_id
+        )
+        self.audio_assistant_gen_slot_token_id = self.audio_assistant_slot_token_id
+        self.sampling_rate = sampling_rate
+        self.audio_tokenizer_name_or_path = audio_tokenizer_name_or_path
+        self.attn_implementation = attn_implementation
+        self.local_transformer_attn_implementation = local_transformer_attn_implementation or attn_implementation
+        self.local_transformer_layers = local_transformer_layers
+        self.local_text_head_mode = local_text_head_mode
+        self.use_static_local_kv_cache = use_static_local_kv_cache
+        self.initializer_range = initializer_range
+        self.speculative_config = None
+
+        self.hidden_size = int(self.qwen3_config.hidden_size)
+        self.vocab_size = int(self.qwen3_config.vocab_size)
+        self.channels = int(self.n_vq) + 1
+        self.vocab_size_list = [self.vocab_size] + [self.audio_vocab_size + 1] * self.n_vq
+        self.pad_token = [self.pad_token_id] + [self.audio_pad_code] * self.n_vq
+
+    @staticmethod
+    def _coerce_qwen3_config(config: dict | Qwen3Config | None) -> Qwen3Config:
+        if config is None:
+            config = {}
+        if isinstance(config, Qwen3Config):
+            return config
+        config = dict(config)
+        config.pop("model_type", None)
+        return Qwen3Config(**config)
+
+    @staticmethod
+    def _coerce_gpt2_config(config: dict | GPT2Config | None) -> GPT2Config:
+        if config is None:
+            config = {}
+        if isinstance(config, GPT2Config):
+            return config
+        config = dict(config)
+        config.pop("model_type", None)
+        return GPT2Config(**config)
+
+    def get_text_config(self, **_: object) -> Qwen3Config:
+        """Return the Qwen3 backbone config for vLLM KV-cache sizing."""
+        return self.qwen3_config
+
+
+AutoConfig.register(MossTTSLocalConfig.model_type, MossTTSLocalConfig)
+
+__all__ = ["MossTTSLocalConfig"]

--- a/vllm_omni/model_executor/models/moss_tts_local/hf_compatible_qwen3.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/hf_compatible_qwen3.py
@@ -1,0 +1,731 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""HF-compatible Qwen3 backbone for MOSS-TTS Local stage-0.
+
+MOSS-TTS Local audio quality is sensitive to small global-backbone numerical
+differences because the downstream local transformer autoregressively amplifies
+argmax changes across codebooks.  This module mirrors the reference PyTorch
+Qwen3 decoder while keeping the vLLM-Omni stage interface unchanged.  It is
+owns its KV cache internally.  Static KV cache supports multiple request slots
+for batched TTS decode while preserving the legacy slot-0 path.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterable
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
+
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+
+class MossQwen3RMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class MossQwen3RotaryEmbedding(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        head_dim = int(getattr(config, "head_dim", config.hidden_size // config.num_attention_heads))
+        rope_theta = getattr(config, "rope_theta", None)
+        if rope_theta is None:
+            rope_scaling = getattr(config, "rope_scaling", None)
+            if isinstance(rope_scaling, dict):
+                rope_theta = rope_scaling.get("rope_theta")
+        self.head_dim = head_dim
+        self.rope_theta = float(rope_theta if rope_theta is not None else 1_000_000.0)
+        self.register_buffer("inv_freq", self._compute_inv_freq(), persistent=False)
+
+    def _compute_inv_freq(self, device: torch.device | None = None) -> torch.Tensor:
+        return 1.0 / (
+            self.rope_theta ** (torch.arange(0, self.head_dim, 2, device=device, dtype=torch.float32) / self.head_dim)
+        )
+
+    def forward(self, hidden_states: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq = self._compute_inv_freq(device=hidden_states.device)
+        freqs = torch.einsum(
+            "bs,d->bsd",
+            position_ids.to(device=hidden_states.device, dtype=inv_freq.dtype),
+            inv_freq,
+        )
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return emb.cos().to(dtype=hidden_states.dtype), emb.sin().to(dtype=hidden_states.dtype)
+
+
+def _rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
+    first_half = hidden_states[..., : hidden_states.shape[-1] // 2]
+    second_half = hidden_states[..., hidden_states.shape[-1] // 2 :]
+    return torch.cat((-second_half, first_half), dim=-1)
+
+
+def _apply_rotary_pos_emb(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(-2)
+    sin = sin.unsqueeze(-2)
+    return (query * cos) + (_rotate_half(query) * sin), (key * cos) + (_rotate_half(key) * sin)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch, seq_len, num_key_value_heads, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, :, None, :].expand(batch, seq_len, num_key_value_heads, n_rep, head_dim)
+    return hidden_states.reshape(batch, seq_len, num_key_value_heads * n_rep, head_dim)
+
+
+class MossQwen3MLP(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.act_fn = ACT2FN[getattr(config, "hidden_act", "silu")]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
+
+
+class MossQwen3Attention(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.hidden_size = int(config.hidden_size)
+        self.num_heads = int(config.num_attention_heads)
+        self.num_key_value_heads = int(config.num_key_value_heads)
+        self.head_dim = int(getattr(config, "head_dim", self.hidden_size // self.num_heads))
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = float(getattr(config, "attention_dropout", 0.0))
+        self.static_key_cache: torch.Tensor | None = None
+        self.static_value_cache: torch.Tensor | None = None
+        self.static_cache_positions: torch.Tensor | None = None
+        self._slot_cache_lens: list[int] = [0]
+        self.active_slot = 0
+        self.use_static_full_cache = False
+
+        bias = bool(getattr(config, "attention_bias", False))
+        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=bias)
+        self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=bias)
+        self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=bias)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=bias)
+        self.q_norm = MossQwen3RMSNorm(self.head_dim, eps=float(config.rms_norm_eps))
+        self.k_norm = MossQwen3RMSNorm(self.head_dim, eps=float(config.rms_norm_eps))
+
+    def forward_batched_decode(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        slot_ids: list[int],
+        slot_idx_t: torch.Tensor | None = None,
+        step_cache: dict[str, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        batch_size = hidden_states.shape[0]
+        cache_capacity = int(self.static_key_cache.shape[1])
+        bp = self._backbone_profile if getattr(self, "_backbone_profile_enabled", False) else None
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t0 = time.perf_counter()
+
+        query_states = self.q_norm(
+            self.q_proj(hidden_states).view(batch_size, 1, self.num_heads, self.head_dim)
+        )
+        key_states = self.k_norm(
+            self.k_proj(hidden_states).view(batch_size, 1, self.num_key_value_heads, self.head_dim)
+        )
+        value_states = self.v_proj(hidden_states).view(batch_size, 1, self.num_key_value_heads, self.head_dim)
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t1 = time.perf_counter()
+            bp["qkv"] += (_t1 - _t0) * 1000
+
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t2 = time.perf_counter()
+            bp["rope"] += (_t2 - _t1) * 1000
+
+        starts = [self._slot_cache_lens[sid] for sid in slot_ids]
+        for i, (sid, start) in enumerate(zip(slot_ids, starts)):
+            self.static_key_cache[sid, start] = key_states[i, 0]
+            self.static_value_cache[sid, start] = value_states[i, 0]
+            self._slot_cache_lens[sid] = start + 1
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t3 = time.perf_counter()
+            bp["kv_write"] += (_t3 - _t2) * 1000
+
+        if step_cache is not None and "mask" in step_cache:
+            mask = step_cache["mask"]
+            max_len = int(step_cache["max_len"])
+        else:
+            cache_lens = [self._slot_cache_lens[sid] for sid in slot_ids]
+            max_len = max(cache_lens)
+            lens_t = torch.tensor(cache_lens, device=hidden_states.device, dtype=torch.long)
+            positions = torch.arange(max_len, device=hidden_states.device, dtype=torch.long)
+            mask = (positions.unsqueeze(0) < lens_t.unsqueeze(1))[:, None, None, :]
+            if step_cache is not None:
+                step_cache["mask"] = mask
+                step_cache["max_len"] = torch.tensor(max_len)
+
+        if slot_idx_t is None:
+            slot_idx_t = torch.tensor(slot_ids, device=hidden_states.device, dtype=torch.long)
+        k_batch = self.static_key_cache[slot_idx_t, :max_len]
+        v_batch = self.static_value_cache[slot_idx_t, :max_len]
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t4 = time.perf_counter()
+            bp["kv_gather"] += (_t4 - _t3) * 1000
+
+        k_batch = _repeat_kv(k_batch, self.num_key_value_groups).transpose(1, 2)
+        v_batch = _repeat_kv(v_batch, self.num_key_value_groups).transpose(1, 2)
+        query = query_states.transpose(1, 2)
+
+        output = F.scaled_dot_product_attention(
+            query, k_batch, v_batch, attn_mask=mask, dropout_p=0.0, is_causal=False, scale=self.scaling
+        )
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t5 = time.perf_counter()
+            bp["sdpa"] += (_t5 - _t4) * 1000
+
+        output = output.transpose(1, 2).reshape(batch_size, 1, -1).contiguous()
+        result = self.o_proj(output)
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _t6 = time.perf_counter()
+            bp["o_proj"] += (_t6 - _t5) * 1000
+
+        return result
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        layer_past: tuple[torch.Tensor, torch.Tensor] | None = None,
+        use_cache: bool = True,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
+        input_shape = hidden_states.shape[:-1]
+        query_states = self.q_norm(
+            self.q_proj(hidden_states).view(*input_shape, self.num_heads, self.head_dim)
+        )
+        key_states = self.k_norm(
+            self.k_proj(hidden_states).view(*input_shape, self.num_key_value_heads, self.head_dim)
+        )
+        value_states = self.v_proj(hidden_states).view(*input_shape, self.num_key_value_heads, self.head_dim)
+
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if self.static_key_cache is not None and self.static_value_cache is not None:
+            slot_id = int(self.active_slot)
+            if self.use_static_full_cache:
+                assert self.static_cache_positions is not None
+                self.static_key_cache[: key_states.shape[0]].index_copy_(1, self.static_cache_positions, key_states)
+                self.static_value_cache[: value_states.shape[0]].index_copy_(1, self.static_cache_positions, value_states)
+                key_states = self.static_key_cache[: key_states.shape[0]]
+                value_states = self.static_value_cache[: value_states.shape[0]]
+            else:
+                if slot_id < 0 or slot_id >= len(self._slot_cache_lens):
+                    raise IndexError(f"active_slot {slot_id} is outside static KV cache slots")
+                start = int(self._slot_cache_lens[slot_id])
+                end = start + int(key_states.shape[1])
+                cache_capacity = int(self.static_key_cache.shape[1])
+                if end > cache_capacity:
+                    end = cache_capacity
+                    key_states = key_states[:, : end - start]
+                    value_states = value_states[:, : end - start]
+                    if end <= start:
+                        key_states = self.static_key_cache[slot_id : slot_id + 1, :start]
+                        value_states = self.static_value_cache[slot_id : slot_id + 1, :start]
+                        present = (key_states, value_states) if use_cache else None
+                        key = _repeat_kv(key_states, self.num_key_value_groups).transpose(1, 2)
+                        value = _repeat_kv(value_states, self.num_key_value_groups).transpose(1, 2)
+                        query = query_states.transpose(1, 2)
+                        output = F.scaled_dot_product_attention(query, key, value, is_causal=False, scale=self.scaling)
+                        output = output.transpose(1, 2).reshape(*input_shape, -1).contiguous()
+                        return self.o_proj(output), present
+                else:
+                    self.static_key_cache[slot_id : slot_id + 1, start:end].copy_(key_states)
+                    self.static_value_cache[slot_id : slot_id + 1, start:end].copy_(value_states)
+                    key_states = self.static_key_cache[slot_id : slot_id + 1, :end]
+                    value_states = self.static_value_cache[slot_id : slot_id + 1, :end]
+                    self._slot_cache_lens[slot_id] = end
+        elif layer_past is not None:
+            past_key, past_value = layer_past
+            key_states = torch.cat([past_key.to(device=key_states.device, dtype=key_states.dtype), key_states], dim=1)
+            value_states = torch.cat(
+                [past_value.to(device=value_states.device, dtype=value_states.dtype), value_states],
+                dim=1,
+            )
+
+        present = (key_states, value_states) if use_cache else None
+        key = _repeat_kv(key_states, self.num_key_value_groups).transpose(1, 2)
+        value = _repeat_kv(value_states, self.num_key_value_groups).transpose(1, 2)
+        query = query_states.transpose(1, 2)
+
+        if self.use_static_full_cache:
+            assert self.static_cache_positions is not None
+            query_positions = self.static_cache_positions[-query.shape[-2] :]
+            key_positions = torch.arange(key.shape[-2], device=query.device, dtype=torch.long)
+        else:
+            query_positions = torch.arange(query.shape[-2], device=query.device, dtype=torch.long)
+            query_positions = query_positions + max(key.shape[-2] - query.shape[-2], 0)
+            key_positions = torch.arange(key.shape[-2], device=query.device, dtype=torch.long)
+        mask = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+        mask = mask.unsqueeze(0).unsqueeze(0)
+
+        output = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=mask,
+            dropout_p=self.attention_dropout if self.training else 0.0,
+            is_causal=False,
+            scale=self.scaling,
+        )
+        output = output.transpose(1, 2).reshape(*input_shape, -1).contiguous()
+        return self.o_proj(output), present
+
+
+class MossQwen3DecoderLayer(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.self_attn = MossQwen3Attention(config)
+        self.mlp = MossQwen3MLP(config)
+        self.input_layernorm = MossQwen3RMSNorm(config.hidden_size, eps=float(config.rms_norm_eps))
+        self.post_attention_layernorm = MossQwen3RMSNorm(config.hidden_size, eps=float(config.rms_norm_eps))
+
+    def forward_batched_decode(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        slot_ids: list[int],
+        slot_idx_t: torch.Tensor | None = None,
+        step_cache: dict[str, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        bp = getattr(self.self_attn, "_backbone_profile", None) if getattr(self.self_attn, "_backbone_profile_enabled", False) else None
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        attn_output = self.self_attn.forward_batched_decode(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            slot_ids=slot_ids,
+            slot_idx_t=slot_idx_t,
+            step_cache=step_cache,
+        )
+        hidden_states = residual + attn_output
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            _tm0 = time.perf_counter()
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+
+        if bp is not None:
+            torch.cuda.synchronize()
+            bp["norm_mlp"] += (time.perf_counter() - _tm0) * 1000
+
+        return hidden_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        layer_past: tuple[torch.Tensor, torch.Tensor] | None = None,
+        use_cache: bool = True,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        attn_output, present = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            layer_past=layer_past,
+            use_cache=use_cache,
+        )
+        hidden_states = residual + attn_output
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+        return hidden_states, present
+
+
+class MossTTSLocalQwen3Backbone(nn.Module):
+    """Reference-numerics Qwen3 backbone with an internal multi-slot KV cache."""
+
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.config = config
+        self.padding_idx = getattr(config, "pad_token_id", None)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([MossQwen3DecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.norm = MossQwen3RMSNorm(config.hidden_size, eps=float(config.rms_norm_eps))
+        self.rotary_emb = MossQwen3RotaryEmbedding(config)
+        self._past_key_values: tuple[tuple[torch.Tensor, torch.Tensor], ...] | None = None
+        self._static_cache_bucket_len: int = 0
+        self._decode_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self._decode_static_input: torch.Tensor | None = None
+        self._decode_static_output: torch.Tensor | None = None
+        self._decode_static_position: torch.Tensor | None = None
+        self._decode_graph_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_DECODE_GRAPH") == "1"
+        self.active_slot: int = 0
+        self._backbone_profile_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_BACKBONE_PROFILE") == "1"
+        self._backbone_profile: dict[str, float] = {"qkv": 0, "rope": 0, "kv_write": 0, "kv_gather": 0, "sdpa": 0, "o_proj": 0, "norm_mlp": 0, "n": 0}
+        self._compile_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_COMPILE") == "1"
+        self._compiled_step: Any = None
+
+    def reset_slot(self, slot_id: int) -> None:
+        self._past_key_values = None
+        self.active_slot = int(slot_id)
+        for layer in self.layers:
+            attn = layer.self_attn
+            if attn.static_key_cache is not None:
+                if slot_id < 0 or slot_id >= len(attn._slot_cache_lens):
+                    raise IndexError(f"slot_id {slot_id} is outside static KV cache slots")
+                attn._slot_cache_lens[slot_id] = 0
+            attn.active_slot = int(slot_id)
+            attn.use_static_full_cache = False
+
+    def reset_cache(self) -> None:
+        self._past_key_values = None
+        self.active_slot = 0
+        for layer in self.layers:
+            attn = layer.self_attn
+            attn._slot_cache_lens = [0 for _ in attn._slot_cache_lens]
+            attn.active_slot = 0
+            attn.use_static_full_cache = False
+
+    def init_static_kv_cache(
+        self,
+        *,
+        max_len: int,
+        max_batch: int | None = None,
+        device: torch.device,
+        dtype: torch.dtype,
+        batch_size: int | None = None,
+    ) -> None:
+        if max_batch is None:
+            if batch_size is None:
+                raise TypeError("init_static_kv_cache() missing required argument: 'max_batch'")
+            max_batch = batch_size
+        current_max_batch = 0
+        if self.layers and self.layers[0].self_attn.static_key_cache is not None:
+            current_max_batch = int(self.layers[0].self_attn.static_key_cache.shape[0])
+        if self._static_cache_bucket_len >= max_len and current_max_batch >= int(max_batch):
+            return
+        self._decode_graphs.clear()
+        self._decode_static_input = None
+        self._decode_static_output = None
+        self._decode_static_position = None
+        positions = torch.empty(1, device=device, dtype=torch.long)
+        for layer in self.layers:
+            attn = layer.self_attn
+            shape = (int(max_batch), int(max_len), attn.num_key_value_heads, attn.head_dim)
+            attn.static_key_cache = torch.zeros(shape, device=device, dtype=dtype)
+            attn.static_value_cache = torch.zeros(shape, device=device, dtype=dtype)
+            attn.static_cache_positions = positions
+            attn._slot_cache_lens = [0 for _ in range(int(max_batch))]
+            attn.active_slot = 0
+            attn.use_static_full_cache = False
+            attn._backbone_profile_enabled = self._backbone_profile_enabled
+            attn._backbone_profile = self._backbone_profile
+        self._static_cache_bucket_len = max_len
+        self._past_key_values = None
+
+    def warmup_decode_graphs(self, bucket_sizes: list[int], device: torch.device, dtype: torch.dtype, max_batch: int = 1) -> None:
+        if not self._decode_graph_enabled:
+            return
+        for bucket in bucket_sizes:
+            self.init_static_kv_cache(max_len=bucket, max_batch=max_batch, device=device, dtype=dtype)
+            dummy_ids = torch.zeros(2, dtype=torch.long, device=device)
+            dummy_pos = torch.arange(2, dtype=torch.long, device=device)
+            self.forward(input_ids=dummy_ids, positions=dummy_pos)
+            dummy_token = torch.zeros(1, dtype=torch.long, device=device)
+            dummy_step_pos = torch.tensor([2], dtype=torch.long, device=device)
+            self.forward(input_ids=dummy_token, positions=dummy_step_pos)
+            if bucket in self._decode_graphs:
+                continue
+        self.reset_cache()
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def _forward_eager_batched(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        slot_ids: list[int],
+    ) -> torch.Tensor:
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        device = hidden_states.device
+        slot_idx_t = torch.tensor(slot_ids, device=device, dtype=torch.long)
+        step_cache: dict[str, torch.Tensor] = {}
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer.forward_batched_decode(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                slot_ids=slot_ids,
+                slot_idx_t=slot_idx_t,
+                step_cache=step_cache,
+            )
+        result = self.norm(hidden_states)
+        bp = self._backbone_profile
+        if self._backbone_profile_enabled:
+            bp["n"] += 1
+            if int(bp["n"]) % 50 == 0:
+                n = int(bp["n"])
+                nl = len(self.layers)
+                total = sum(bp[k] for k in ["qkv", "rope", "kv_write", "kv_gather", "sdpa", "o_proj", "norm_mlp"]) / n
+                import sys
+                print(
+                    f"BackboneProfile[{n} steps, {nl} layers]: qkv={bp['qkv']/n:.2f}ms rope={bp['rope']/n:.2f}ms "
+                    f"kv_write={bp['kv_write']/n:.2f}ms kv_gather={bp['kv_gather']/n:.2f}ms "
+                    f"sdpa={bp['sdpa']/n:.2f}ms o_proj={bp['o_proj']/n:.2f}ms norm_mlp={bp['norm_mlp']/n:.2f}ms | "
+                    f"total={total:.2f}ms/step",
+                    file=sys.stderr, flush=True,
+                )
+        return result
+
+
+    def _forward_eager(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        for layer in self.layers:
+            layer.self_attn.active_slot = self.active_slot
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        presents: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for layer_index, decoder_layer in enumerate(self.layers):
+            layer_past = None if self._past_key_values is None else self._past_key_values[layer_index]
+            hidden_states, present = decoder_layer(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                layer_past=layer_past,
+                use_cache=True,
+            )
+            assert present is not None
+            presents.append(present)
+
+        hidden_states = self.norm(hidden_states)
+        if self.layers[0].self_attn.static_key_cache is None:
+            self._past_key_values = tuple(presents)
+        else:
+            self._past_key_values = None
+        return hidden_states
+
+    def _ensure_decode_graph_buffers(self, device: torch.device, dtype: torch.dtype) -> None:
+        if self._decode_static_input is not None:
+            return
+        hidden_size = int(self.config.hidden_size)
+        self._decode_static_input = torch.zeros(1, 1, hidden_size, device=device, dtype=dtype)
+        self._decode_static_position = torch.zeros(1, 1, device=device, dtype=torch.long)
+        self._decode_static_output = torch.zeros(1, 1, hidden_size, device=device, dtype=dtype)
+
+    def _switch_to_full_cache_mode(self) -> None:
+        pos_tensor = self._decode_static_position.reshape(-1)
+        for layer in self.layers:
+            attn = layer.self_attn
+            attn.use_static_full_cache = True
+            attn.static_cache_positions = pos_tensor
+
+    def _clear_full_cache_mode(self) -> None:
+        for layer in self.layers:
+            layer.self_attn.use_static_full_cache = False
+
+    def _capture_decode_graph(self, bucket: int) -> torch.cuda.CUDAGraph:
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            out = self._forward_eager(self._decode_static_input, self._decode_static_position)
+            self._decode_static_output.copy_(out)
+        self._decode_graphs[bucket] = g
+        return g
+
+    def _ensure_batch_decode_buffers(self, max_batch: int, device: torch.device, dtype: torch.dtype) -> None:
+        if getattr(self, "_batch_static_input", None) is not None and self._batch_static_input.shape[0] >= max_batch:
+            return
+        hidden_size = int(self.config.hidden_size)
+        self._batch_static_input = torch.zeros(max_batch, 1, hidden_size, device=device, dtype=dtype)
+        self._batch_static_pos = torch.zeros(max_batch, 1, device=device, dtype=torch.long)
+        self._batch_static_output = torch.zeros(max_batch, 1, hidden_size, device=device, dtype=dtype)
+        self._batch_static_slots = torch.zeros(max_batch, device=device, dtype=torch.long)
+        self._batch_decode_graphs: dict[tuple[int, int], torch.cuda.CUDAGraph] = {}
+
+    def _decode_batched_with_graph(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        slot_ids: list[int],
+    ) -> torch.Tensor:
+        n = len(slot_ids)
+        bucket = self._static_cache_bucket_len
+        key = (n, bucket)
+        self._ensure_batch_decode_buffers(n, hidden_states.device, hidden_states.dtype)
+        self._batch_static_input[:n].copy_(hidden_states)
+        self._batch_static_pos[:n].copy_(position_ids)
+        self._batch_static_slots[:n].copy_(torch.tensor(slot_ids, device=hidden_states.device, dtype=torch.long))
+
+        if not hasattr(self, "_batch_decode_graphs"):
+            self._batch_decode_graphs = {}
+
+        if key not in self._batch_decode_graphs:
+            out = self._forward_eager_batched(
+                self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids
+            )
+            self._batch_static_output[:n].copy_(out)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                out = self._forward_eager_batched(
+                    self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids
+                )
+                self._batch_static_output[:n].copy_(out)
+            self._batch_decode_graphs[key] = g
+            return self._batch_static_output[:n].clone()
+
+        self._batch_decode_graphs[key].replay()
+        return self._batch_static_output[:n].clone()
+
+    def _decode_with_graph(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        bucket = self._static_cache_bucket_len
+        self._ensure_decode_graph_buffers(hidden_states.device, hidden_states.dtype)
+        self._switch_to_full_cache_mode()
+        try:
+            if bucket not in self._decode_graphs:
+                self._decode_static_input.copy_(hidden_states)
+                self._decode_static_position.copy_(position_ids)
+                out = self._forward_eager(self._decode_static_input, self._decode_static_position)
+                self._decode_static_output.copy_(out)
+                self._capture_decode_graph(bucket)
+                return self._decode_static_output.clone()
+
+            self._decode_static_input.copy_(hidden_states)
+            self._decode_static_position.copy_(position_ids)
+            self._decode_graphs[bucket].replay()
+            return self._decode_static_output.clone()
+        finally:
+            self._clear_full_cache_mode()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors=None,
+        inputs_embeds: torch.Tensor | None = None,
+        slot_id: int | None = None,
+        slot_ids: list[int] | None = None,
+    ) -> torch.Tensor:
+        del intermediate_tensors
+
+        # Batched decode path: N requests each with 1 token
+        if slot_ids is not None and len(slot_ids) > 1:
+            n = len(slot_ids)
+            if inputs_embeds is None:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds must be provided")
+                inputs_embeds = self.embed_input_ids(input_ids)
+            hidden_states = inputs_embeds.view(n, 1, -1)
+            position_ids = positions.view(n, 1).to(device=hidden_states.device, dtype=torch.long)
+
+            # Batch CUDA graph is disabled: per-slot dynamic KV indexing and mask
+            # computation cannot be captured in a static graph. Eager batched matmul
+            # already provides ~2x throughput over sequential.
+            hidden_states = self._forward_eager_batched(hidden_states, position_ids, slot_ids)
+            return hidden_states.squeeze(1)
+
+        # Single-slot path (prefill or batch=1 decode)
+        self.active_slot = 0 if slot_id is None else int(slot_id)
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids or inputs_embeds must be provided")
+            inputs_embeds = self.embed_input_ids(input_ids)
+
+        squeeze_batch = inputs_embeds.dim() == 2
+        if squeeze_batch:
+            hidden_states = inputs_embeds.unsqueeze(0)
+        else:
+            hidden_states = inputs_embeds
+        position_ids = positions.reshape(1, -1).to(device=hidden_states.device, dtype=torch.long)
+        if position_ids.numel() != hidden_states.shape[1]:
+            position_ids = torch.arange(hidden_states.shape[1], device=hidden_states.device, dtype=torch.long).view(1, -1)
+
+        is_decode = position_ids.numel() == 1
+        if not is_decode:
+            self.reset_slot(self.active_slot)
+
+        use_graph = (
+            self.active_slot == 0
+            and hidden_states.shape[0] == 1
+            and is_decode
+            and self._decode_graph_enabled
+            and self._static_cache_bucket_len > 0
+            and self.layers[0].self_attn.static_key_cache is not None
+        )
+
+        if use_graph:
+            try:
+                hidden_states = self._decode_with_graph(hidden_states, position_ids)
+            except Exception:
+                self._decode_graph_enabled = False
+                self._decode_graphs.clear()
+                self._clear_full_cache_mode()
+                hidden_states = self._forward_eager(hidden_states, position_ids)
+        else:
+            hidden_states = self._forward_eager(hidden_states, position_ids)
+
+        return hidden_states.squeeze(0) if squeeze_batch else hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            target = name
+            if target.startswith("model."):
+                target = target[len("model.") :]
+            if target.startswith("transformer."):
+                target = target[len("transformer.") :]
+            if target.startswith("model."):
+                target = target[len("model.") :]
+            if "rotary_emb.inv_freq" in target:
+                continue
+            param = params_dict.get(target)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(target)
+        return loaded
+
+
+__all__ = ["MossTTSLocalQwen3Backbone"]

--- a/vllm_omni/model_executor/models/moss_tts_local/hf_compatible_qwen3.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/hf_compatible_qwen3.py
@@ -16,12 +16,56 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Iterable
+from typing import Any
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
-
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+try:
+    import triton
+    import triton.language as tl
+except Exception:
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _rope_neox_inplace_kernel(
+        x,
+        cos,
+        sin,
+        x_stride_t: tl.constexpr,
+        x_stride_h: tl.constexpr,
+        x_stride_d: tl.constexpr,
+        cos_stride_t: tl.constexpr,
+        cos_stride_d: tl.constexpr,
+        half_dim: tl.constexpr,
+        block: tl.constexpr,
+    ) -> None:
+        token = tl.program_id(0)
+        head = tl.program_id(1)
+        offs = tl.arange(0, block)
+        mask = offs < half_dim
+        x_base = x + token * x_stride_t + head * x_stride_h
+        cos_base = cos + token * cos_stride_t
+        first = tl.load(x_base + offs * x_stride_d, mask=mask, other=0.0).to(tl.float32)
+        second = tl.load(x_base + (offs + half_dim) * x_stride_d, mask=mask, other=0.0).to(tl.float32)
+        c = tl.load(cos_base + offs * cos_stride_d, mask=mask, other=0.0).to(tl.float32)
+        s = tl.load(sin + token * cos_stride_t + offs * cos_stride_d, mask=mask, other=0.0).to(tl.float32)
+        tl.store(x_base + offs * x_stride_d, first * c - second * s, mask=mask)
+        tl.store(x_base + (offs + half_dim) * x_stride_d, second * c + first * s, mask=mask)
+
+
+_fused_rope_runtime_disabled = False
+
+
+def _disabled_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 class MossQwen3RMSNorm(nn.Module):
@@ -29,8 +73,18 @@ class MossQwen3RMSNorm(nn.Module):
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
+        self._fused_rmsnorm_enabled = not _disabled_env("MOSS_TTS_LOCAL_DISABLE_FUSED_RMSNORM")
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self._fused_rmsnorm_enabled and hidden_states.is_cuda:
+            try:
+                from vllm import _custom_ops as ops
+
+                out = torch.empty_like(hidden_states)
+                ops.rms_norm(out, hidden_states, self.weight, self.variance_epsilon)
+                return out
+            except Exception:
+                self._fused_rmsnorm_enabled = False
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -79,9 +133,76 @@ def _apply_rotary_pos_emb(
     cos: torch.Tensor,
     sin: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if _fused_rotary_enabled() and _apply_rotary_pos_emb_triton(query, key, cos, sin):
+        return query, key
     cos = cos.unsqueeze(-2)
     sin = sin.unsqueeze(-2)
     return (query * cos) + (_rotate_half(query) * sin), (key * cos) + (_rotate_half(key) * sin)
+
+
+def _fused_rotary_enabled() -> bool:
+    return not _disabled_env("MOSS_TTS_LOCAL_DISABLE_FUSED_ROPE")
+
+
+def _apply_rotary_pos_emb_triton(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> bool:
+    global _fused_rope_runtime_disabled
+    if _fused_rope_runtime_disabled:
+        return False
+    if triton is None or not query.is_cuda or not key.is_cuda:
+        return False
+    if query.dim() != 4 or key.dim() != 4 or query.shape[1] != 1 or key.shape[1] != 1:
+        return False
+    if query.shape[-1] != key.shape[-1] or query.shape[0] != key.shape[0]:
+        return False
+    head_dim = int(query.shape[-1])
+    if head_dim <= 0 or head_dim % 2 != 0:
+        return False
+    try:
+        q = query.reshape(-1, int(query.shape[-2]), head_dim)
+        k = key.reshape(-1, int(key.shape[-2]), head_dim)
+        cos_flat = cos.reshape(-1, int(cos.shape[-1]))
+        sin_flat = sin.reshape(-1, int(sin.shape[-1]))
+        if cos_flat.shape[0] != q.shape[0] or sin_flat.shape[0] != q.shape[0]:
+            return False
+        if cos_flat.shape[-1] < head_dim or sin_flat.shape[-1] < head_dim:
+            return False
+        half_dim = head_dim // 2
+        block = 1 << max(0, (half_dim - 1).bit_length())
+        grid_q = (int(q.shape[0]), int(q.shape[1]))
+        _rope_neox_inplace_kernel[grid_q](
+            q,
+            cos_flat,
+            sin_flat,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            cos_flat.stride(0),
+            cos_flat.stride(1),
+            half_dim,
+            block=block,
+        )
+        grid_k = (int(k.shape[0]), int(k.shape[1]))
+        _rope_neox_inplace_kernel[grid_k](
+            k,
+            cos_flat,
+            sin_flat,
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            cos_flat.stride(0),
+            cos_flat.stride(1),
+            half_dim,
+            block=block,
+        )
+        return True
+    except Exception:
+        _fused_rope_runtime_disabled = True
+        return False
 
 
 def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -99,9 +220,61 @@ class MossQwen3MLP(nn.Module):
         self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
         self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
         self.act_fn = ACT2FN[getattr(config, "hidden_act", "silu")]
+        self._fused_gate_up_enabled = os.environ.get("MOSS_TTS_LOCAL_FUSED_MLP", "0").strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+        self._gate_up_weight_cache: torch.Tensor | None = None
+        self._compiled_forward = None
+        self._compile_enabled = os.environ.get("MOSS_TTS_LOCAL_COMPILE_MLP", "0").strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+
+    def _forward_impl(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self._fused_gate_up_enabled:
+            weight = self._gate_up_weight_cache
+            if weight is None or weight.device != hidden_states.device or weight.dtype != hidden_states.dtype:
+                weight = (
+                    torch.cat(
+                        [
+                            self.gate_proj.weight.detach(),
+                            self.up_proj.weight.detach(),
+                        ],
+                        dim=0,
+                    )
+                    .to(device=hidden_states.device, dtype=hidden_states.dtype)
+                    .contiguous()
+                )
+                self._gate_up_weight_cache = weight
+            gate, up = F.linear(hidden_states, weight).chunk(2, dim=-1)
+            return self.down_proj(self.act_fn(gate) * up)
+        return self.down_proj(self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return self.down_proj(self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
+        if self._compile_enabled:
+            compiled = self._compiled_forward
+            if compiled is None:
+                compile_fn = getattr(torch, "compile", None)
+                if compile_fn is None:
+                    self._compile_enabled = False
+                else:
+                    mode = os.environ.get("MOSS_TTS_LOCAL_COMPILE_MLP_MODE", "reduce-overhead")
+                    try:
+                        compiled = compile_fn(self._forward_impl, mode=mode, dynamic=True)
+                        self._compiled_forward = compiled
+                    except Exception:
+                        self._compile_enabled = False
+            if compiled is not None:
+                try:
+                    return compiled(hidden_states)
+                except Exception:
+                    self._compile_enabled = False
+        return self._forward_impl(hidden_states)
 
 
 class MossQwen3Attention(nn.Module):
@@ -128,6 +301,188 @@ class MossQwen3Attention(nn.Module):
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=bias)
         self.q_norm = MossQwen3RMSNorm(self.head_dim, eps=float(config.rms_norm_eps))
         self.k_norm = MossQwen3RMSNorm(self.head_dim, eps=float(config.rms_norm_eps))
+        self._fused_qkv_enabled = not _disabled_env("MOSS_TTS_LOCAL_DISABLE_FUSED_QKV")
+        self._sdpa_gqa_enabled = os.environ.get("MOSS_TTS_LOCAL_SDPA_GQA", "0").strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+        self._flashinfer_single_decode_enabled = os.environ.get(
+            "MOSS_TTS_LOCAL_FLASHINFER_SINGLE_DECODE",
+            "0",
+        ).strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+        self._flashinfer_batch_decode_enabled = os.environ.get(
+            "MOSS_TTS_LOCAL_FLASHINFER_BATCH_DECODE",
+            "0",
+        ).strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+        self._flashinfer_single_decode_warned = False
+        self._flashinfer_batch_decode_warned = False
+        self._flashinfer_batch_wrapper = None
+        self._flashinfer_batch_workspace: torch.Tensor | None = None
+        self._qkv_weight_cache: torch.Tensor | None = None
+        self._qkv_bias_cache: torch.Tensor | None = None
+
+    def _invalidate_qkv_cache(self) -> None:
+        self._qkv_weight_cache = None
+        self._qkv_bias_cache = None
+
+    def _qkv_linear(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if not self._fused_qkv_enabled:
+            return (
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+            )
+        weight = self._qkv_weight_cache
+        if weight is None or weight.device != hidden_states.device or weight.dtype != hidden_states.dtype:
+            weight = (
+                torch.cat(
+                    [
+                        self.q_proj.weight.detach(),
+                        self.k_proj.weight.detach(),
+                        self.v_proj.weight.detach(),
+                    ],
+                    dim=0,
+                )
+                .to(device=hidden_states.device, dtype=hidden_states.dtype)
+                .contiguous()
+            )
+            self._qkv_weight_cache = weight
+            if self.q_proj.bias is None:
+                self._qkv_bias_cache = None
+            else:
+                self._qkv_bias_cache = (
+                    torch.cat(
+                        [
+                            self.q_proj.bias.detach(),
+                            self.k_proj.bias.detach(),
+                            self.v_proj.bias.detach(),
+                        ],
+                        dim=0,
+                    )
+                    .to(device=hidden_states.device, dtype=hidden_states.dtype)
+                    .contiguous()
+                )
+        qkv = F.linear(hidden_states, weight, self._qkv_bias_cache)
+        q_end = self.num_heads * self.head_dim
+        kv_width = self.num_key_value_heads * self.head_dim
+        return qkv.split((q_end, kv_width, kv_width), dim=-1)
+
+    def _flashinfer_single_decode(
+        self,
+        *,
+        query: torch.Tensor,
+        k_batch: torch.Tensor,
+        v_batch: torch.Tensor,
+        cache_lens: list[int],
+    ) -> torch.Tensor | None:
+        if not self._flashinfer_single_decode_enabled:
+            return None
+        try:
+            import flashinfer  # type: ignore[import-not-found]
+
+            outs: list[torch.Tensor] = []
+            for row, cache_len in enumerate(cache_lens):
+                q_row = query[row, :, 0, :].contiguous()
+                k_row = k_batch[row, : int(cache_len)].contiguous()
+                v_row = v_batch[row, : int(cache_len)].contiguous()
+                outs.append(
+                    flashinfer.single_decode_with_kv_cache(
+                        q_row,
+                        k_row,
+                        v_row,
+                        kv_layout="NHD",
+                        sm_scale=self.scaling,
+                    )
+                )
+            return torch.stack(outs, dim=0).unsqueeze(2)
+        except Exception:
+            self._flashinfer_single_decode_enabled = False
+            if not self._flashinfer_single_decode_warned:
+                self._flashinfer_single_decode_warned = True
+                import traceback
+
+                traceback.print_exc()
+            return None
+
+    def _flashinfer_batch_decode(
+        self,
+        *,
+        query: torch.Tensor,
+        k_batch: torch.Tensor,
+        v_batch: torch.Tensor,
+        cache_lens: list[int],
+        step_cache: dict[str, torch.Tensor] | None,
+    ) -> torch.Tensor | None:
+        if not self._flashinfer_batch_decode_enabled:
+            return None
+        if not query.is_cuda or query.shape[2] != 1:
+            return None
+        try:
+            from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper  # type: ignore[import-not-found]
+
+            batch_size = int(query.shape[0])
+            max_len = int(k_batch.shape[1])
+            if batch_size <= 0 or max_len <= 0:
+                return None
+
+            workspace = self._flashinfer_batch_workspace
+            if workspace is None or workspace.device != query.device:
+                workspace = torch.empty(128 * 1024 * 1024, device=query.device, dtype=torch.uint8)
+                self._flashinfer_batch_workspace = workspace
+                self._flashinfer_batch_wrapper = BatchDecodeWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+            wrapper = self._flashinfer_batch_wrapper
+
+            if step_cache is not None and "flashinfer_indptr" in step_cache:
+                indptr = step_cache["flashinfer_indptr"]
+                indices = step_cache["flashinfer_indices"]
+                last_page_len = step_cache["flashinfer_last_page_len"]
+            else:
+                indptr = torch.arange(batch_size + 1, device=query.device, dtype=torch.int32)
+                indices = torch.arange(batch_size, device=query.device, dtype=torch.int32)
+                last_page_len = torch.tensor(cache_lens, device=query.device, dtype=torch.int32)
+                if step_cache is not None:
+                    step_cache["flashinfer_indptr"] = indptr
+                    step_cache["flashinfer_indices"] = indices
+                    step_cache["flashinfer_last_page_len"] = last_page_len
+
+            q = query[:, :, 0, :].contiguous()
+            # FlashInfer's NHD paged cache expects [pages, page_size, kv_heads, head_dim].
+            # A request row is one page here, with page_size equal to the current max KV length.
+            k = k_batch.contiguous()
+            v = v_batch.contiguous()
+            wrapper.plan(
+                indptr,
+                indices,
+                last_page_len,
+                self.num_heads,
+                self.num_key_value_heads,
+                self.head_dim,
+                max_len,
+                q_data_type=q.dtype,
+                kv_data_type=k.dtype,
+                sm_scale=self.scaling,
+            )
+            return wrapper.run(q, (k, v)).unsqueeze(2)
+        except Exception:
+            self._flashinfer_batch_decode_enabled = False
+            if not self._flashinfer_batch_decode_warned:
+                self._flashinfer_batch_decode_warned = True
+                import traceback
+
+                traceback.print_exc()
+            return None
 
     def forward_batched_decode(
         self,
@@ -138,23 +493,19 @@ class MossQwen3Attention(nn.Module):
         step_cache: dict[str, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
-        cache_capacity = int(self.static_key_cache.shape[1])
         bp = self._backbone_profile if getattr(self, "_backbone_profile_enabled", False) else None
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t0 = time.perf_counter()
 
-        query_states = self.q_norm(
-            self.q_proj(hidden_states).view(batch_size, 1, self.num_heads, self.head_dim)
-        )
-        key_states = self.k_norm(
-            self.k_proj(hidden_states).view(batch_size, 1, self.num_key_value_heads, self.head_dim)
-        )
-        value_states = self.v_proj(hidden_states).view(batch_size, 1, self.num_key_value_heads, self.head_dim)
+        query_raw, key_raw, value_raw = self._qkv_linear(hidden_states)
+        query_states = self.q_norm(query_raw.view(batch_size, 1, self.num_heads, self.head_dim))
+        key_states = self.k_norm(key_raw.view(batch_size, 1, self.num_key_value_heads, self.head_dim))
+        value_states = value_raw.view(batch_size, 1, self.num_key_value_heads, self.head_dim)
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t1 = time.perf_counter()
             bp["qkv"] += (_t1 - _t0) * 1000
 
@@ -162,18 +513,41 @@ class MossQwen3Attention(nn.Module):
         query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t2 = time.perf_counter()
             bp["rope"] += (_t2 - _t1) * 1000
 
-        starts = [self._slot_cache_lens[sid] for sid in slot_ids]
-        for i, (sid, start) in enumerate(zip(slot_ids, starts)):
-            self.static_key_cache[sid, start] = key_states[i, 0]
-            self.static_value_cache[sid, start] = value_states[i, 0]
-            self._slot_cache_lens[sid] = start + 1
+        if step_cache is not None and "starts" in step_cache:
+            starts = step_cache["starts"]
+            starts_t = step_cache["starts_t"]
+            uniform_start = step_cache["uniform_start"]
+            slot_slice = step_cache["slot_slice"]
+        else:
+            starts = [self._slot_cache_lens[sid] for sid in slot_ids]
+            starts_t = torch.tensor(starts, device=hidden_states.device, dtype=torch.long)
+            uniform_start = starts[0] if starts and all(start == starts[0] for start in starts) else None
+            slot_slice = None
+            if slot_ids and all(slot_ids[i] + 1 == slot_ids[i + 1] for i in range(len(slot_ids) - 1)):
+                slot_slice = (int(slot_ids[0]), int(slot_ids[0]) + len(slot_ids))
+            if step_cache is not None:
+                step_cache["starts"] = starts
+                step_cache["starts_t"] = starts_t
+                step_cache["uniform_start"] = uniform_start
+                step_cache["slot_slice"] = slot_slice
+        if slot_idx_t is None:
+            slot_idx_t = torch.tensor(slot_ids, device=hidden_states.device, dtype=torch.long)
+        if slot_slice is not None and uniform_start is not None:
+            s0, s1 = slot_slice
+            self.static_key_cache[s0:s1, int(uniform_start)] = key_states[:, 0]
+            self.static_value_cache[s0:s1, int(uniform_start)] = value_states[:, 0]
+        else:
+            self.static_key_cache[slot_idx_t, starts_t] = key_states[:, 0]
+            self.static_value_cache[slot_idx_t, starts_t] = value_states[:, 0]
+        for sid, start in zip(slot_ids, starts):
+            self._slot_cache_lens[sid] = int(start) + 1
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t3 = time.perf_counter()
             bp["kv_write"] += (_t3 - _t2) * 1000
 
@@ -183,33 +557,80 @@ class MossQwen3Attention(nn.Module):
         else:
             cache_lens = [self._slot_cache_lens[sid] for sid in slot_ids]
             max_len = max(cache_lens)
-            lens_t = torch.tensor(cache_lens, device=hidden_states.device, dtype=torch.long)
-            positions = torch.arange(max_len, device=hidden_states.device, dtype=torch.long)
-            mask = (positions.unsqueeze(0) < lens_t.unsqueeze(1))[:, None, None, :]
+            if cache_lens and all(length == max_len for length in cache_lens):
+                mask = None
+            else:
+                lens_t = torch.tensor(cache_lens, device=hidden_states.device, dtype=torch.long)
+                positions = torch.arange(max_len, device=hidden_states.device, dtype=torch.long)
+                mask = (positions.unsqueeze(0) < lens_t.unsqueeze(1))[:, None, None, :]
             if step_cache is not None:
                 step_cache["mask"] = mask
                 step_cache["max_len"] = torch.tensor(max_len)
+                step_cache["cache_lens"] = cache_lens
+        cache_lens = step_cache.get("cache_lens", None) if step_cache is not None else None
+        if cache_lens is None:
+            cache_lens = [self._slot_cache_lens[sid] for sid in slot_ids]
 
-        if slot_idx_t is None:
-            slot_idx_t = torch.tensor(slot_ids, device=hidden_states.device, dtype=torch.long)
-        k_batch = self.static_key_cache[slot_idx_t, :max_len]
-        v_batch = self.static_value_cache[slot_idx_t, :max_len]
+        if slot_slice is not None:
+            s0, s1 = slot_slice
+            k_batch = self.static_key_cache[s0:s1, :max_len]
+            v_batch = self.static_value_cache[s0:s1, :max_len]
+        else:
+            k_batch = self.static_key_cache[slot_idx_t, :max_len]
+            v_batch = self.static_value_cache[slot_idx_t, :max_len]
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t4 = time.perf_counter()
             bp["kv_gather"] += (_t4 - _t3) * 1000
 
-        k_batch = _repeat_kv(k_batch, self.num_key_value_groups).transpose(1, 2)
-        v_batch = _repeat_kv(v_batch, self.num_key_value_groups).transpose(1, 2)
         query = query_states.transpose(1, 2)
-
-        output = F.scaled_dot_product_attention(
-            query, k_batch, v_batch, attn_mask=mask, dropout_p=0.0, is_causal=False, scale=self.scaling
+        output = self._flashinfer_batch_decode(
+            query=query,
+            k_batch=k_batch,
+            v_batch=v_batch,
+            cache_lens=cache_lens,
+            step_cache=step_cache,
         )
+        if output is not None:
+            pass
+        else:
+            output = self._flashinfer_single_decode(
+                query=query,
+                k_batch=k_batch,
+                v_batch=v_batch,
+                cache_lens=cache_lens,
+            )
+        if output is not None:
+            pass
+        elif self._sdpa_gqa_enabled and self.num_key_value_groups > 1:
+            try:
+                output = F.scaled_dot_product_attention(
+                    query,
+                    k_batch.transpose(1, 2),
+                    v_batch.transpose(1, 2),
+                    attn_mask=mask,
+                    dropout_p=0.0,
+                    is_causal=False,
+                    scale=self.scaling,
+                    enable_gqa=True,
+                )
+            except TypeError:
+                self._sdpa_gqa_enabled = False
+                k_batch = _repeat_kv(k_batch, self.num_key_value_groups).transpose(1, 2)
+                v_batch = _repeat_kv(v_batch, self.num_key_value_groups).transpose(1, 2)
+                output = F.scaled_dot_product_attention(
+                    query, k_batch, v_batch, attn_mask=mask, dropout_p=0.0, is_causal=False, scale=self.scaling
+                )
+        else:
+            k_batch = _repeat_kv(k_batch, self.num_key_value_groups).transpose(1, 2)
+            v_batch = _repeat_kv(v_batch, self.num_key_value_groups).transpose(1, 2)
+            output = F.scaled_dot_product_attention(
+                query, k_batch, v_batch, attn_mask=mask, dropout_p=0.0, is_causal=False, scale=self.scaling
+            )
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t5 = time.perf_counter()
             bp["sdpa"] += (_t5 - _t4) * 1000
 
@@ -217,7 +638,7 @@ class MossQwen3Attention(nn.Module):
         result = self.o_proj(output)
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _t6 = time.perf_counter()
             bp["o_proj"] += (_t6 - _t5) * 1000
 
@@ -231,13 +652,10 @@ class MossQwen3Attention(nn.Module):
         use_cache: bool = True,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
         input_shape = hidden_states.shape[:-1]
-        query_states = self.q_norm(
-            self.q_proj(hidden_states).view(*input_shape, self.num_heads, self.head_dim)
-        )
-        key_states = self.k_norm(
-            self.k_proj(hidden_states).view(*input_shape, self.num_key_value_heads, self.head_dim)
-        )
-        value_states = self.v_proj(hidden_states).view(*input_shape, self.num_key_value_heads, self.head_dim)
+        query_raw, key_raw, value_raw = self._qkv_linear(hidden_states)
+        query_states = self.q_norm(query_raw.view(*input_shape, self.num_heads, self.head_dim))
+        key_states = self.k_norm(key_raw.view(*input_shape, self.num_key_value_heads, self.head_dim))
+        value_states = value_raw.view(*input_shape, self.num_key_value_heads, self.head_dim)
 
         cos, sin = position_embeddings
         query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
@@ -247,7 +665,11 @@ class MossQwen3Attention(nn.Module):
             if self.use_static_full_cache:
                 assert self.static_cache_positions is not None
                 self.static_key_cache[: key_states.shape[0]].index_copy_(1, self.static_cache_positions, key_states)
-                self.static_value_cache[: value_states.shape[0]].index_copy_(1, self.static_cache_positions, value_states)
+                self.static_value_cache[: value_states.shape[0]].index_copy_(
+                    1,
+                    self.static_cache_positions,
+                    value_states,
+                )
                 key_states = self.static_key_cache[: key_states.shape[0]]
                 value_states = self.static_value_cache[: value_states.shape[0]]
             else:
@@ -329,7 +751,11 @@ class MossQwen3DecoderLayer(nn.Module):
         slot_idx_t: torch.Tensor | None = None,
         step_cache: dict[str, torch.Tensor] | None = None,
     ) -> torch.Tensor:
-        bp = getattr(self.self_attn, "_backbone_profile", None) if getattr(self.self_attn, "_backbone_profile_enabled", False) else None
+        bp = (
+            getattr(self.self_attn, "_backbone_profile", None)
+            if getattr(self.self_attn, "_backbone_profile_enabled", False)
+            else None
+        )
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
         attn_output = self.self_attn.forward_batched_decode(
@@ -342,7 +768,7 @@ class MossQwen3DecoderLayer(nn.Module):
         hidden_states = residual + attn_output
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             _tm0 = time.perf_counter()
 
         residual = hidden_states
@@ -350,7 +776,7 @@ class MossQwen3DecoderLayer(nn.Module):
         hidden_states = residual + self.mlp(hidden_states)
 
         if bp is not None:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize(hidden_states.device)
             bp["norm_mlp"] += (time.perf_counter() - _tm0) * 1000
 
         return hidden_states
@@ -398,7 +824,16 @@ class MossTTSLocalQwen3Backbone(nn.Module):
         self._decode_graph_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_DECODE_GRAPH") == "1"
         self.active_slot: int = 0
         self._backbone_profile_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_BACKBONE_PROFILE") == "1"
-        self._backbone_profile: dict[str, float] = {"qkv": 0, "rope": 0, "kv_write": 0, "kv_gather": 0, "sdpa": 0, "o_proj": 0, "norm_mlp": 0, "n": 0}
+        self._backbone_profile: dict[str, float] = {
+            "qkv": 0,
+            "rope": 0,
+            "kv_write": 0,
+            "kv_gather": 0,
+            "sdpa": 0,
+            "o_proj": 0,
+            "norm_mlp": 0,
+            "n": 0,
+        }
         self._compile_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_COMPILE") == "1"
         self._compiled_step: Any = None
 
@@ -460,7 +895,13 @@ class MossTTSLocalQwen3Backbone(nn.Module):
         self._static_cache_bucket_len = max_len
         self._past_key_values = None
 
-    def warmup_decode_graphs(self, bucket_sizes: list[int], device: torch.device, dtype: torch.dtype, max_batch: int = 1) -> None:
+    def warmup_decode_graphs(
+        self,
+        bucket_sizes: list[int],
+        device: torch.device,
+        dtype: torch.dtype,
+        max_batch: int = 1,
+    ) -> None:
         if not self._decode_graph_enabled:
             return
         for bucket in bucket_sizes:
@@ -505,15 +946,17 @@ class MossTTSLocalQwen3Backbone(nn.Module):
                 nl = len(self.layers)
                 total = sum(bp[k] for k in ["qkv", "rope", "kv_write", "kv_gather", "sdpa", "o_proj", "norm_mlp"]) / n
                 import sys
+
                 print(
-                    f"BackboneProfile[{n} steps, {nl} layers]: qkv={bp['qkv']/n:.2f}ms rope={bp['rope']/n:.2f}ms "
-                    f"kv_write={bp['kv_write']/n:.2f}ms kv_gather={bp['kv_gather']/n:.2f}ms "
-                    f"sdpa={bp['sdpa']/n:.2f}ms o_proj={bp['o_proj']/n:.2f}ms norm_mlp={bp['norm_mlp']/n:.2f}ms | "
+                    f"BackboneProfile[{n} steps, {nl} layers]: qkv={bp['qkv'] / n:.2f}ms rope={bp['rope'] / n:.2f}ms "
+                    f"kv_write={bp['kv_write'] / n:.2f}ms kv_gather={bp['kv_gather'] / n:.2f}ms "
+                    f"sdpa={bp['sdpa'] / n:.2f}ms o_proj={bp['o_proj'] / n:.2f}ms "
+                    f"norm_mlp={bp['norm_mlp'] / n:.2f}ms | "
                     f"total={total:.2f}ms/step",
-                    file=sys.stderr, flush=True,
+                    file=sys.stderr,
+                    flush=True,
                 )
         return result
-
 
     def _forward_eager(
         self,
@@ -597,15 +1040,11 @@ class MossTTSLocalQwen3Backbone(nn.Module):
             self._batch_decode_graphs = {}
 
         if key not in self._batch_decode_graphs:
-            out = self._forward_eager_batched(
-                self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids
-            )
+            out = self._forward_eager_batched(self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids)
             self._batch_static_output[:n].copy_(out)
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):
-                out = self._forward_eager_batched(
-                    self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids
-                )
+                out = self._forward_eager_batched(self._batch_static_input[:n], self._batch_static_pos[:n], slot_ids)
                 self._batch_static_output[:n].copy_(out)
             self._batch_decode_graphs[key] = g
             return self._batch_static_output[:n].clone()
@@ -647,6 +1086,12 @@ class MossTTSLocalQwen3Backbone(nn.Module):
         slot_ids: list[int] | None = None,
     ) -> torch.Tensor:
         del intermediate_tensors
+        if inputs_embeds is None and (input_ids is None or int(input_ids.numel()) == 0):
+            hidden_size = int(self.config.hidden_size)
+            return positions.new_empty((0, hidden_size), dtype=self.embed_tokens.weight.dtype)
+        if inputs_embeds is not None and int(inputs_embeds.numel()) == 0:
+            hidden_size = int(self.config.hidden_size)
+            return inputs_embeds.new_empty((0, hidden_size))
 
         # Batched decode path: N requests each with 1 token
         if slot_ids is not None and len(slot_ids) > 1:
@@ -678,7 +1123,11 @@ class MossTTSLocalQwen3Backbone(nn.Module):
             hidden_states = inputs_embeds
         position_ids = positions.reshape(1, -1).to(device=hidden_states.device, dtype=torch.long)
         if position_ids.numel() != hidden_states.shape[1]:
-            position_ids = torch.arange(hidden_states.shape[1], device=hidden_states.device, dtype=torch.long).view(1, -1)
+            position_ids = torch.arange(
+                hidden_states.shape[1],
+                device=hidden_states.device,
+                dtype=torch.long,
+            ).view(1, -1)
 
         is_decode = position_ids.numel() == 1
         if not is_decode:
@@ -725,6 +1174,8 @@ class MossTTSLocalQwen3Backbone(nn.Module):
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
             loaded.add(target)
+        for layer in self.layers:
+            layer.self_attn._invalidate_qkv_cache()
         return loaded
 
 

--- a/vllm_omni/model_executor/models/moss_tts_local/local_transformer.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/local_transformer.py
@@ -30,16 +30,39 @@ def sample_top_k_top_p(
 
     scores = logits / max(float(temperature), 1e-6)
     vocab = int(scores.shape[-1])
+    top_k = int(top_k)
+    top_p = float(top_p)
 
-    if 0 < int(top_k) < vocab:
-        values, _ = torch.topk(scores, int(top_k), dim=-1)
-        scores = scores.masked_fill(scores < values[..., -1:], float("-inf"))
+    if 0 < top_k < vocab:
+        topk_scores, topk_indices = torch.topk(scores, top_k, dim=-1)
+        if 0.0 < top_p < 1.0:
+            sorted_scores, sorted_order = torch.sort(topk_scores, descending=True, dim=-1)
+            sorted_indices = topk_indices.gather(-1, sorted_order)
+            sorted_probs = torch.softmax(sorted_scores, dim=-1)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            remove = cumulative > top_p
+            remove[..., 1:] = remove[..., :-1].clone()
+            remove[..., 0] = False
+            sorted_scores = sorted_scores.masked_fill(remove, float("-inf"))
+            probs = torch.softmax(sorted_scores, dim=-1)
+            probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+            fallback = probs.sum(dim=-1) <= 0
+            sampled_rel = torch.multinomial(probs, num_samples=1, generator=generator)
+            sampled = sorted_indices.gather(-1, sampled_rel).reshape(-1)
+            return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
 
-    if 0.0 < float(top_p) < 1.0:
+        probs = torch.softmax(topk_scores, dim=-1)
+        probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+        fallback = probs.sum(dim=-1) <= 0
+        sampled_rel = torch.multinomial(probs, num_samples=1, generator=generator)
+        sampled = topk_indices.gather(-1, sampled_rel).reshape(-1)
+        return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
+
+    if 0.0 < top_p < 1.0:
         sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
         sorted_probs = torch.softmax(sorted_scores, dim=-1)
         cumulative = torch.cumsum(sorted_probs, dim=-1)
-        remove = cumulative > float(top_p)
+        remove = cumulative > top_p
         remove[..., 1:] = remove[..., :-1].clone()
         remove[..., 0] = False
         mask = torch.zeros_like(scores, dtype=torch.bool).scatter_(-1, sorted_indices, remove)
@@ -104,16 +127,11 @@ class MossTTSLocalTransformer(nn.Module):
         self.max_positions = int(max_positions)
         self.attn_implementation = str(attn_implementation or "eager").lower()
         self.h = nn.ModuleList(
-            [
-                MossTTSLocalBlock(hidden_size, num_heads, inner_size, layer_norm_eps)
-                for _ in range(int(num_layers))
-            ]
+            [MossTTSLocalBlock(hidden_size, num_heads, inner_size, layer_norm_eps) for _ in range(int(num_layers))]
         )
         self.ln_f = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
-        inv_freq = 1.0 / (
-            float(rope_base) ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim)
-        )
+        inv_freq = 1.0 / (float(rope_base) ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim))
         positions = torch.arange(self.max_positions, dtype=torch.float32)
         freqs = torch.outer(positions, inv_freq)
         self.register_buffer("rope_cos", freqs.cos().repeat_interleave(2, dim=-1), persistent=False)
@@ -125,6 +143,18 @@ class MossTTSLocalTransformer(nn.Module):
         self._graph_input: torch.Tensor | None = None
         self._graph_output: torch.Tensor | None = None
         self._graph_batch_size: int = 0
+        self._rope_cache: dict[tuple[str, int | None, torch.dtype], tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _rope_tables(self, device: torch.device, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+        key = (device.type, device.index, dtype)
+        cached = self._rope_cache.get(key)
+        if cached is None:
+            cached = (
+                self.rope_cos.to(device=device, dtype=dtype),
+                self.rope_sin.to(device=device, dtype=dtype),
+            )
+            self._rope_cache[key] = cached
+        return cached
 
     def _ensure_kv_cache(self, batch_size: int, device: torch.device, dtype: torch.dtype) -> None:
         if (
@@ -161,8 +191,9 @@ class MossTTSLocalTransformer(nn.Module):
     def _step_eager(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
         """The actual computation (no graph)."""
         batch_size = int(hidden_states.shape[0])
-        cos = self.rope_cos[position].to(dtype=hidden_states.dtype)
-        sin = self.rope_sin[position].to(dtype=hidden_states.dtype)
+        rope_cos, rope_sin = self._rope_tables(hidden_states.device, hidden_states.dtype)
+        cos = rope_cos[position]
+        sin = rope_sin[position]
         x = hidden_states
         for layer_idx, block in enumerate(self.h):
             normed = block.ln_1(x)
@@ -178,7 +209,7 @@ class MossTTSLocalTransformer(nn.Module):
             key_len = position + 1
             keys = key_cache[:batch_size, :key_len]
             values = value_cache[:batch_size, :key_len]
-            scores = torch.einsum("bhd,bthd->bht", query, keys) * (self.head_dim ** -0.5)
+            scores = torch.einsum("bhd,bthd->bht", query, keys) * (self.head_dim**-0.5)
             probs = torch.softmax(scores, dim=-1)
             attn_out = torch.einsum("bht,bthd->bhd", probs, values).reshape(batch_size, self.hidden_size)
             x = x + block.attn.c_proj(attn_out)
@@ -192,11 +223,7 @@ class MossTTSLocalTransformer(nn.Module):
         self._ensure_kv_cache(batch_size, hidden_states.device, hidden_states.dtype)
 
         # Graph-accelerated path
-        if (
-            self._graph_enabled
-            and batch_size <= self._graph_batch_size
-            and hidden_states.device.type == "cuda"
-        ):
+        if self._graph_enabled and batch_size <= self._graph_batch_size and hidden_states.device.type == "cuda":
             key = (batch_size, position)
             if key not in self._graphs:
                 # Warmup + capture

--- a/vllm_omni/model_executor/models/moss_tts_local/local_transformer.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/local_transformer.py
@@ -1,0 +1,220 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Frame-local transformer for MOSS-TTS Local Transformer v1.5."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _rotate_half_interleaved(x: torch.Tensor) -> torch.Tensor:
+    even = x[..., ::2]
+    odd = x[..., 1::2]
+    return torch.stack((-odd, even), dim=-1).reshape_as(x)
+
+
+def sample_top_k_top_p(
+    logits: torch.Tensor,
+    *,
+    temperature: float = 1.0,
+    top_p: float = 1.0,
+    top_k: int = -1,
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    """Sample one token per row with the model-card defaults."""
+    if temperature <= 0:
+        return torch.argmax(logits, dim=-1)
+
+    scores = logits / max(float(temperature), 1e-6)
+    vocab = int(scores.shape[-1])
+
+    if 0 < int(top_k) < vocab:
+        values, _ = torch.topk(scores, int(top_k), dim=-1)
+        scores = scores.masked_fill(scores < values[..., -1:], float("-inf"))
+
+    if 0.0 < float(top_p) < 1.0:
+        sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+        sorted_probs = torch.softmax(sorted_scores, dim=-1)
+        cumulative = torch.cumsum(sorted_probs, dim=-1)
+        remove = cumulative > float(top_p)
+        remove[..., 1:] = remove[..., :-1].clone()
+        remove[..., 0] = False
+        mask = torch.zeros_like(scores, dtype=torch.bool).scatter_(-1, sorted_indices, remove)
+        scores = scores.masked_fill(mask, float("-inf"))
+
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+    fallback = probs.sum(dim=-1) <= 0
+    sampled = torch.multinomial(probs, num_samples=1, generator=generator).reshape(-1)
+    return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
+
+
+class MossTTSLocalMLP(nn.Module):
+    def __init__(self, hidden_size: int, inner_size: int) -> None:
+        super().__init__()
+        self.fc_in = nn.Linear(hidden_size, inner_size)
+        self.fc_out = nn.Linear(inner_size, hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.fc_out(F.silu(self.fc_in(hidden_states)))
+
+
+class MossTTSLocalAttention(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int) -> None:
+        super().__init__()
+        if hidden_size % num_heads != 0:
+            raise ValueError(f"hidden_size={hidden_size} not divisible by num_heads={num_heads}")
+        self.num_heads = int(num_heads)
+        self.head_dim = hidden_size // num_heads
+        self.c_attn = nn.Linear(hidden_size, 3 * hidden_size)
+        self.c_proj = nn.Linear(hidden_size, hidden_size)
+
+
+class MossTTSLocalBlock(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int, inner_size: int, layer_norm_eps: float) -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.attn = MossTTSLocalAttention(hidden_size, num_heads)
+        self.ln_2 = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.mlp = MossTTSLocalMLP(hidden_size, inner_size)
+
+
+class MossTTSLocalTransformer(nn.Module):
+    """Incremental local decoder over one frame's text+RVQ positions."""
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_heads: int,
+        inner_size: int,
+        num_layers: int,
+        max_positions: int,
+        rope_base: float,
+        layer_norm_eps: float = 1e-6,
+        attn_implementation: str | None = "eager",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.num_heads = int(num_heads)
+        self.head_dim = self.hidden_size // self.num_heads
+        self.max_positions = int(max_positions)
+        self.attn_implementation = str(attn_implementation or "eager").lower()
+        self.h = nn.ModuleList(
+            [
+                MossTTSLocalBlock(hidden_size, num_heads, inner_size, layer_norm_eps)
+                for _ in range(int(num_layers))
+            ]
+        )
+        self.ln_f = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+
+        inv_freq = 1.0 / (
+            float(rope_base) ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim)
+        )
+        positions = torch.arange(self.max_positions, dtype=torch.float32)
+        freqs = torch.outer(positions, inv_freq)
+        self.register_buffer("rope_cos", freqs.cos().repeat_interleave(2, dim=-1), persistent=False)
+        self.register_buffer("rope_sin", freqs.sin().repeat_interleave(2, dim=-1), persistent=False)
+        self._kv_cache: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self._kv_capacity = 0
+        self._graph_enabled = False
+        self._graphs: dict[tuple[int, int], torch.cuda.CUDAGraph] = {}
+        self._graph_input: torch.Tensor | None = None
+        self._graph_output: torch.Tensor | None = None
+        self._graph_batch_size: int = 0
+
+    def _ensure_kv_cache(self, batch_size: int, device: torch.device, dtype: torch.dtype) -> None:
+        if (
+            self._kv_capacity >= batch_size
+            and self._kv_cache
+            and self._kv_cache[0][0].device == device
+            and self._kv_cache[0][0].dtype == dtype
+        ):
+            return
+        capacity = max(batch_size, self._kv_capacity, 1)
+        # Match the upstream static-cache layout [batch, seq, heads, dim].
+        # The local GPT2 head is sensitive enough that the SDPA backend can
+        # pick a different numerical path for [B, H, T, D] cache strides.
+        shape = (capacity, self.max_positions, self.num_heads, self.head_dim)
+        self._kv_cache = [
+            (
+                torch.empty(shape, device=device, dtype=dtype),
+                torch.empty(shape, device=device, dtype=dtype),
+            )
+            for _ in self.h
+        ]
+        self._kv_capacity = capacity
+
+    def enable_graphs(self, batch_size: int) -> None:
+        """Pre-allocate static buffers for graph capture."""
+        self._graph_enabled = True
+        self._graph_batch_size = batch_size
+        device = self._kv_cache[0][0].device if self._kv_cache else torch.device("cuda")
+        dtype = self._kv_cache[0][0].dtype if self._kv_cache else torch.bfloat16
+        self._graph_input = torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype)
+        self._graph_output = torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype)
+        self._graphs.clear()
+
+    def _step_eager(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
+        """The actual computation (no graph)."""
+        batch_size = int(hidden_states.shape[0])
+        cos = self.rope_cos[position].to(dtype=hidden_states.dtype)
+        sin = self.rope_sin[position].to(dtype=hidden_states.dtype)
+        x = hidden_states
+        for layer_idx, block in enumerate(self.h):
+            normed = block.ln_1(x)
+            query, key, value = block.attn.c_attn(normed).split(self.hidden_size, dim=-1)
+            query = query.view(batch_size, self.num_heads, self.head_dim)
+            key = key.view(batch_size, self.num_heads, self.head_dim)
+            value = value.view(batch_size, self.num_heads, self.head_dim)
+            query = query * cos + _rotate_half_interleaved(query) * sin
+            key = key * cos + _rotate_half_interleaved(key) * sin
+            key_cache, value_cache = self._kv_cache[layer_idx]
+            key_cache[:batch_size, position] = key
+            value_cache[:batch_size, position] = value
+            key_len = position + 1
+            keys = key_cache[:batch_size, :key_len]
+            values = value_cache[:batch_size, :key_len]
+            scores = torch.einsum("bhd,bthd->bht", query, keys) * (self.head_dim ** -0.5)
+            probs = torch.softmax(scores, dim=-1)
+            attn_out = torch.einsum("bht,bthd->bhd", probs, values).reshape(batch_size, self.hidden_size)
+            x = x + block.attn.c_proj(attn_out)
+            x = x + block.mlp(block.ln_2(x))
+        return self.ln_f(x)
+
+    def step(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
+        if not 0 <= position < self.max_positions:
+            raise ValueError(f"local position {position} out of range [0, {self.max_positions})")
+        batch_size = int(hidden_states.shape[0])
+        self._ensure_kv_cache(batch_size, hidden_states.device, hidden_states.dtype)
+
+        # Graph-accelerated path
+        if (
+            self._graph_enabled
+            and batch_size <= self._graph_batch_size
+            and hidden_states.device.type == "cuda"
+        ):
+            key = (batch_size, position)
+            if key not in self._graphs:
+                # Warmup + capture
+                self._graph_input[:batch_size].copy_(hidden_states)
+                out = self._step_eager(self._graph_input[:batch_size], position)
+                self._graph_output[:batch_size].copy_(out)
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(g):
+                    out = self._step_eager(self._graph_input[:batch_size], position)
+                    self._graph_output[:batch_size].copy_(out)
+                self._graphs[key] = g
+                return self._graph_output[:batch_size].clone()
+            self._graph_input[:batch_size].copy_(hidden_states)
+            self._graphs[key].replay()
+            return self._graph_output[:batch_size].clone()
+
+        # Eager path
+        return self._step_eager(hidden_states, position)
+
+
+__all__ = ["MossTTSLocalTransformer", "sample_top_k_top_p"]

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local.py
@@ -1,0 +1,994 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""MOSS-TTS Local Transformer v1.5 AR stage."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.sequence import IntermediateTensors
+
+from vllm_omni.model_executor.models.moss_tts_local.configuration_moss_tts_local import (
+    MossTTSLocalConfig,
+)
+from vllm_omni.model_executor.models.moss_tts_local.hf_compatible_qwen3 import (
+    MossTTSLocalQwen3Backbone,
+)
+from vllm_omni.model_executor.models.moss_tts_local.local_transformer import (
+    MossTTSLocalTransformer,
+    sample_top_k_top_p,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+
+def _first_scalar(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else None
+    return value
+
+
+def _make_sampling_generator(seed: Any, device: torch.device) -> torch.Generator | None:
+    seed = _first_scalar(seed)
+    if seed is None:
+        return None
+    try:
+        seed_int = int(seed)
+    except (TypeError, ValueError):
+        return None
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed_int)
+    return generator
+
+
+_SAMPLING_OVERRIDE_KEYS = (
+    "text_temperature",
+    "text_top_p",
+    "text_top_k",
+    "audio_temperature",
+    "audio_top_p",
+    "audio_top_k",
+)
+
+
+def _copy_sampling_overrides(state: dict[str, Any], info: dict[str, Any]) -> None:
+    for key in _SAMPLING_OVERRIDE_KEYS:
+        value = _first_scalar(info.get(key))
+        if value is not None:
+            state[key] = value
+
+
+_BUCKET_SIZES = (64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096)
+
+
+def _next_bucket(value: int) -> int:
+    for b in _BUCKET_SIZES:
+        if b >= value:
+            return b
+    return value
+
+
+def _debug_value(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.detach().to("cpu")
+    if isinstance(value, torch.Generator):
+        return f"torch.Generator(initial_seed={value.initial_seed()})"
+    if isinstance(value, dict):
+        return {str(k): _debug_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_debug_value(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return repr(value)
+
+
+class MossTTSLocalForGeneration(nn.Module):
+    """Stage-0 AR model: Qwen3 backbone plus per-frame local transformer."""
+
+    input_modalities = "audio"
+    have_multimodal_outputs: bool = True
+    has_preprocess: bool = True
+    has_postprocess: bool = True
+    requires_raw_input_tokens: bool = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config: MossTTSLocalConfig = vllm_config.model_config.hf_config
+        lang_cfg = self.config.qwen3_config
+        gpt2_cfg = self.config.gpt2_config
+
+        self.hidden_size = int(lang_cfg.hidden_size)
+        self.vocab_size = int(lang_cfg.vocab_size)
+        self.n_vq = int(self.config.n_vq)
+        self.audio_vocab_size = int(self.config.audio_vocab_size)
+        self.audio_pad_code = int(self.config.audio_pad_code)
+        self.audio_assistant_slot_token_id = int(self.config.audio_assistant_slot_token_id)
+        self.audio_end_token_id = int(self.config.audio_end_token_id)
+
+        del prefix
+        self.model = MossTTSLocalQwen3Backbone(lang_cfg)
+
+        self.audio_embeddings = nn.ModuleList(
+            [nn.Embedding(self.audio_vocab_size + 1, self.hidden_size) for _ in range(self.n_vq)]
+        )
+        self.local_transformer = MossTTSLocalTransformer(
+            hidden_size=self.hidden_size,
+            num_heads=int(getattr(gpt2_cfg, "n_head", 32)),
+            inner_size=int(getattr(gpt2_cfg, "n_inner", 4 * self.hidden_size) or 4 * self.hidden_size),
+            num_layers=int(getattr(self.config, "local_transformer_layers", 1)),
+            max_positions=self.n_vq + 1,
+            rope_base=float(getattr(gpt2_cfg, "rope_base", 1_000_000.0)),
+            layer_norm_eps=float(getattr(gpt2_cfg, "layer_norm_epsilon", 1e-6)),
+            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL") or getattr(self.config, "local_transformer_attn_implementation", None) or "eager",
+        )
+        self.local_text_lm_head = nn.Linear(self.hidden_size, 2, bias=False)
+        self._batch_state: list[dict[str, Any]] | None = None
+        self._graph_warmup_done: bool = False
+        self._max_num_seqs = int(getattr(vllm_config.scheduler_config, "max_num_seqs", 1))
+        self._slot_to_request: list[str | None] = [None] * self._max_num_seqs
+        self._request_to_slot: dict[str, int] = {}
+        self._free_slots: list[int] = list(range(self._max_num_seqs))
+        self._pending_slot_ids: list[int] = []
+        self._pending_token_counts: list[int] = []
+        self._batch_stats: dict[str, Any] = {
+            "batched": 0, "fallback_no_cache": 0, "fallback_overflow": 0,
+            "fallback_prefill": 0, "single": 0, "log_interval": 100,
+            "batch_sizes": [],
+            "t_backbone_ms": 0.0, "t_local_tx_ms": 0.0, "t_output_asm_ms": 0.0,
+            "n_steps": 0,
+            "completed_frames": [],
+        }
+        self._local_graph: torch.cuda.CUDAGraph | None = None
+        self._local_graph_sampling: torch.cuda.CUDAGraph | None = None
+        self._local_graph_input: torch.Tensor | None = None
+        self._local_graph_stop: torch.Tensor | None = None
+        self._local_graph_codes: torch.Tensor | None = None
+        self._local_graph_rand: torch.Tensor | None = None
+        self._local_graph_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_DECODE_GRAPH") == "1"
+        if os.environ.get("MOSS_TTS_LOCAL_COMPILE_LOCAL_TX") == "1":
+            self.local_transformer.step = torch.compile(self.local_transformer.step, dynamic=True)
+
+        self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
+            ("audio_codes", "current"),
+            ("hidden_states", "last"),
+        }
+
+    def _allocate_slot(self, request_id: str) -> int:
+        if request_id in self._request_to_slot:
+            return self._request_to_slot[request_id]
+        if not self._free_slots:
+            raise RuntimeError(f"No free KV slots (max_num_seqs={self._max_num_seqs})")
+        slot_id = self._free_slots.pop(0)
+        self._slot_to_request[slot_id] = request_id
+        self._request_to_slot[request_id] = slot_id
+        return slot_id
+
+    def _release_slot(self, request_id: str) -> None:
+        slot_id = self._request_to_slot.pop(request_id, None)
+        if slot_id is not None:
+            self._slot_to_request[slot_id] = None
+            self._free_slots.append(slot_id)
+
+    def on_requests_finished(self, finished_req_ids: list[str]) -> None:
+        for req_id in finished_req_ids:
+            self._release_slot(req_id)
+
+    def _log_batch_stats(self) -> None:
+        s = self._batch_stats
+        total = s["batched"] + s.get("fallback_no_cache", 0) + s.get("fallback_overflow", 0) + s["fallback_prefill"] + s["single"]
+        if total > 0 and total % s["log_interval"] == 0:
+            hit = s["batched"]
+            multi = hit + s.get("fallback_no_cache", 0) + s.get("fallback_overflow", 0) + s["fallback_prefill"]
+            rate = hit / max(1, multi) * 100
+            n = s["n_steps"] or 1
+            avg_backbone = s["t_backbone_ms"] / n
+            avg_local = s["t_local_tx_ms"] / n
+            avg_output_asm = s["t_output_asm_ms"] / n
+            bsizes = s["batch_sizes"][-20:]
+            avg_bs = sum(bsizes) / max(1, len(bsizes))
+            frames = s["completed_frames"]
+            frames_info = ""
+            if frames:
+                frames_sorted = sorted(frames)
+                p50 = frames_sorted[len(frames_sorted) // 2]
+                p95 = frames_sorted[min(len(frames_sorted) - 1, int(len(frames_sorted) * 0.95))]
+                frames_info = f" | frames: n={len(frames)} p50={p50} p95={p95} avg={sum(frames)/len(frames):.0f}"
+            logger.info(
+                "Profile[%d steps]: hit=%.0f%% avg_bs=%.1f | backbone=%.2fms local_tx=%.2fms output_asm=%.2fms | "
+                "batched=%d prefill=%d single=%d%s",
+                n, rate, avg_bs, avg_backbone, avg_local, avg_output_asm,
+                hit, s["fallback_prefill"], s["single"], frames_info,
+            )
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **_: Any,
+    ) -> torch.Tensor | IntermediateTensors:
+        pending_slots = getattr(self, "_pending_slot_ids", None)
+        pending_counts = getattr(self, "_pending_token_counts", None)
+        if pending_slots and len(pending_slots) > 1:
+            slot_ids = list(pending_slots)
+            token_counts = list(pending_counts)
+            pending_slots.clear()
+            pending_counts.clear()
+            if all(c == 1 for c in token_counts):
+                if (
+                    hasattr(self.model, 'layers')
+                    and self.model.layers[0].self_attn.static_key_cache is None
+                    and hasattr(self.model, 'init_static_kv_cache')
+                ):
+                    max_pos = int(getattr(self.config.qwen3_config, "max_position_embeddings", 4096))
+                    device = input_ids.device if input_ids is not None else positions.device
+                    dtype = self.model.embed_tokens.weight.dtype
+                    self.model.init_static_kv_cache(
+                        max_len=min(max_pos, 512), max_batch=self._max_num_seqs, device=device, dtype=dtype,
+                    )
+                can_batch = (
+                    hasattr(self.model, 'layers')
+                    and self.model.layers[0].self_attn.static_key_cache is not None
+                )
+                fallback_reason = ""
+                if not can_batch:
+                    fallback_reason = "no_cache"
+                if can_batch:
+                    cap = int(self.model.layers[0].self_attn.static_key_cache.shape[1])
+                    for sid in slot_ids:
+                        if self.model.layers[0].self_attn._slot_cache_lens[sid] + 1 > cap:
+                            can_batch = False
+                            fallback_reason = "overflow"
+                            break
+                if can_batch:
+                    self._batch_stats["batched"] += 1
+                    self._batch_stats["batch_sizes"].append(len(slot_ids))
+                    t0 = time.perf_counter()
+                    result = self.model(
+                        input_ids=input_ids,
+                        positions=positions,
+                        inputs_embeds=inputs_embeds,
+                        slot_ids=slot_ids,
+                    )
+                    self._batch_stats["t_backbone_ms"] += (time.perf_counter() - t0) * 1000
+                    self._batch_stats["n_steps"] += 1
+                    self._log_batch_stats()
+                    return result
+                else:
+                    self._batch_stats[f"fallback_{fallback_reason}"] = self._batch_stats.get(f"fallback_{fallback_reason}", 0) + 1
+                    self._log_batch_stats()
+            else:
+                self._batch_stats["fallback_prefill"] += 1
+                self._log_batch_stats()
+            outputs = []
+            offset = 0
+            for slot_id, count in zip(slot_ids, token_counts):
+                seg_embeds = inputs_embeds[offset:offset + count] if inputs_embeds is not None else None
+                seg_ids = input_ids[offset:offset + count] if input_ids is not None else None
+                seg_pos = positions[offset:offset + count]
+                out = self.model(
+                    input_ids=seg_ids,
+                    positions=seg_pos,
+                    intermediate_tensors=intermediate_tensors,
+                    inputs_embeds=seg_embeds,
+                    slot_id=slot_id,
+                )
+                outputs.append(out)
+                offset += count
+            return torch.cat(outputs, dim=0)
+        self._batch_stats["single"] += 1
+        self._log_batch_stats()
+        slot_id = 0
+        if pending_slots:
+            slot_id = pending_slots.pop(0)
+            if pending_counts:
+                pending_counts.pop(0)
+        return self.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            slot_id=slot_id,
+        )
+
+
+    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> torch.Tensor | None:
+        """Return one-hot text logits: continue slot or audio_end."""
+        if isinstance(hidden_states, OmniOutput):
+            hidden_states = hidden_states.text_hidden_states
+        if hidden_states is None or hidden_states.numel() == 0:
+            return None
+        logits = hidden_states.new_full((hidden_states.shape[0], self.vocab_size), float("-inf"))
+        states = self._batch_state or []
+        if not states:
+            logits[:, self.audio_assistant_slot_token_id] = 0.0
+            return logits
+        rows_per_state = max(1, hidden_states.shape[0] // max(1, len(states)))
+        for i, state in enumerate(states):
+            r0 = i * rows_per_state
+            r1 = min(r0 + rows_per_state, hidden_states.shape[0])
+            if r0 >= r1:
+                continue
+            token_id = int(state.get("next_text", self.audio_assistant_slot_token_id))
+            if not 0 <= token_id < self.vocab_size:
+                token_id = self.audio_end_token_id
+            logits[r0:r1, token_id] = 0.0
+        if os.environ.get("MOSS_TTS_LOCAL_DEBUG_BATCH") and len(states) > 1:
+            tokens = [int(s.get("next_text", self.audio_assistant_slot_token_id)) for s in states]
+            steps = [int(s.get("step", 0)) for s in states]
+            stopping = [bool(s.get("is_stopping")) for s in states]
+            logger.info(
+                "compute_logits batch=%d tokens=%s steps=%s stopping=%s",
+                len(states), tokens, steps, stopping,
+            )
+        return logits
+
+    def _build_input_embeds(self, text_ids: torch.Tensor, audio_codes: torch.Tensor | None) -> torch.Tensor:
+        embeds = self.model.embed_tokens(text_ids)
+        if audio_codes is None:
+            return embeds
+        codes = audio_codes.to(device=text_ids.device, dtype=torch.long)
+        if codes.dim() == 1:
+            codes = codes.unsqueeze(0)
+        for idx, emb in enumerate(self.audio_embeddings):
+            col = codes[:, idx].clamp(0, self.audio_vocab_size)
+            valid = col.ne(self.audio_pad_code)
+            safe_col = col.masked_fill(~valid, 0)
+            embeds = embeds + emb(safe_col) * valid.unsqueeze(-1)
+        return embeds
+
+    def preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        **info_dict: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        del input_embeds
+        device = input_ids.device
+        span_len = int(input_ids.shape[0])
+        audio_state = info_dict.get("audio_state")
+        is_first_call = not isinstance(audio_state, dict)
+
+        request_id = str(
+            info_dict.get("request_id")
+            or info_dict.get("global_request_id")
+            or ""
+        )
+        try:
+            request_to_slot = self._request_to_slot
+            slot_id = request_to_slot.get(request_id) if request_id else None
+            if is_first_call and slot_id is None and request_id:
+                slot_id = self._allocate_slot(request_id)
+        except AttributeError:
+            slot_id = None
+        if slot_id is None:
+            slot_id = 0
+
+        if span_len > 1 or is_first_call:
+            reset_fn = getattr(self.model, "reset_slot", None) or getattr(self.model, "reset_cache", None)
+            if callable(reset_fn):
+                try:
+                    reset_fn(slot_id)
+                except TypeError:
+                    reset_fn()
+            prompt_rows = info_dict.get("prompt_rows")
+            if isinstance(prompt_rows, torch.Tensor) and prompt_rows.numel() > 0:
+                rows = prompt_rows.to(device=device, dtype=torch.long)
+                text_ids = rows[:, 0]
+                audio_codes = rows[:, 1 : self.n_vq + 1]
+                embeds = self._build_input_embeds(text_ids, audio_codes)
+                current_codes = audio_codes[-1].detach()
+            else:
+                ref_codes = (info_dict.get("codes", {}) or {}).get("ref")
+                ref_offset = int(info_dict.get("ref_offset", 0))
+                chunk_audio = None
+                if isinstance(ref_codes, torch.Tensor) and ref_codes.numel() > 0:
+                    if ref_codes.dim() == 1 and ref_codes.numel() % self.n_vq == 0:
+                        ref_codes = ref_codes.view(-1, self.n_vq)
+                    if isinstance(ref_codes, torch.Tensor) and ref_codes.dim() == 2:
+                        sliced = ref_codes[ref_offset : ref_offset + span_len]
+                        if sliced.shape[0] == span_len:
+                            chunk_audio = sliced.to(device=device, dtype=torch.long)
+                embeds = self._build_input_embeds(input_ids, chunk_audio)
+                current_codes = (
+                    chunk_audio[-1].detach()
+                    if chunk_audio is not None
+                    else torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+                )
+                ref_offset = ref_offset + span_len
+
+            max_new_frames = _first_scalar(info_dict.get("max_new_frames"))
+            try:
+                max_new_frames = int(max_new_frames) if max_new_frames is not None else -1
+            except (TypeError, ValueError):
+                max_new_frames = -1
+            max_positions = int(getattr(self.config.qwen3_config, "max_position_embeddings", 4096))
+            needed_len = span_len + (max_new_frames if max_new_frames > 0 else 512) + 1
+            bucket_len = min(max_positions, _next_bucket(needed_len))
+            self.model.init_static_kv_cache(
+                max_len=bucket_len,
+                max_batch=self._max_num_seqs,
+                device=device,
+                dtype=self.model.embed_tokens.weight.dtype,
+            )
+            if not self._graph_warmup_done and os.environ.get("MOSS_TTS_LOCAL_WARMUP_GRAPHS") == "1":
+                self._graph_warmup_done = True
+                warmup_buckets = [b for b in _BUCKET_SIZES if b <= max_positions and b != bucket_len]
+                if warmup_buckets:
+                    self.model.warmup_decode_graphs(
+                        warmup_buckets, device=device, dtype=self.model.embed_tokens.weight.dtype,
+                        max_batch=self._max_num_seqs,
+                    )
+                    self.model.init_static_kv_cache(
+                        max_len=bucket_len, max_batch=self._max_num_seqs, device=device, dtype=self.model.embed_tokens.weight.dtype,
+                    )
+            sampling_generator = _make_sampling_generator(info_dict.get("seed"), device)
+            state = {
+                "step": 0,
+                "is_stopping": False,
+                "next_text": self.audio_assistant_slot_token_id,
+                "max_new_frames": max_new_frames,
+            }
+            _copy_sampling_overrides(state, info_dict)
+            if sampling_generator is not None:
+                state["sampling_generator"] = sampling_generator
+            self._maybe_dump_request_debug(
+                input_ids=input_ids,
+                info_dict=info_dict,
+                state=state,
+            )
+            try:
+                self._pending_slot_ids.append(slot_id)
+                self._pending_token_counts.append(span_len)
+            except AttributeError:
+                pass
+            return input_ids, embeds, {
+                "audio_state": state,
+                "audio_codes": {"current": current_codes},
+                "ref_offset": int(info_dict.get("ref_offset", 0)) + span_len,
+                "_kv_slot_id": slot_id,
+            }
+
+        prev_codes = (info_dict.get("audio_codes", {}) or {}).get("current")
+        if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
+            prev_codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(input_ids.reshape(-1), prev_codes.to(device=device).unsqueeze(0))
+        try:
+            self._pending_slot_ids.append(slot_id)
+            self._pending_token_counts.append(1)
+        except AttributeError:
+            pass
+        return input_ids, embeds, {"_kv_slot_id": slot_id}
+
+    def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
+        if hidden_states.numel() == 0:
+            return {}
+        return {"hidden_states": {"last": hidden_states[-1].detach()}}
+
+    def _maybe_dump_request_debug(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        info_dict: dict[str, Any],
+        state: dict[str, Any],
+    ) -> None:
+        dump_dir = os.environ.get("MOSS_TTS_LOCAL_DUMP_CODES_DIR")
+        if not dump_dir:
+            return
+        try:
+            os.makedirs(dump_dir, exist_ok=True)
+            path = os.path.join(dump_dir, f"stage0_request_{os.getpid()}_{id(state)}.pt")
+            torch.save(
+                {
+                    "input_ids": input_ids.detach().to("cpu"),
+                    "prompt_rows": _debug_value(info_dict.get("prompt_rows")),
+                    "max_new_frames": state.get("max_new_frames"),
+                    "seed": _debug_value(info_dict.get("seed")),
+                    "sampling_overrides": {
+                        key: state[key] for key in _SAMPLING_OVERRIDE_KEYS if key in state
+                    },
+                    "info": {
+                        key: _debug_value(value)
+                        for key, value in info_dict.items()
+                        if key != "audio_state"
+                    },
+                },
+                path,
+            )
+        except Exception:
+            logger.exception("Failed to dump MOSS-TTS Local debug request")
+
+    @staticmethod
+    def _sample_graph_safe(logits: torch.Tensor, top_k: int, top_p: float, temperature: float, rand_val: torch.Tensor) -> torch.Tensor:
+        scores = logits / max(temperature, 1e-6)
+        vocab = int(scores.shape[-1])
+        if 0 < top_k < vocab:
+            values, _ = torch.topk(scores, top_k, dim=-1)
+            scores = scores.masked_fill(scores < values[..., -1:], float("-inf"))
+        if 0.0 < top_p < 1.0:
+            sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+            sorted_probs = torch.softmax(sorted_scores, dim=-1)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            remove = cumulative > top_p
+            remove[..., 1:] = remove[..., :-1].clone()
+            remove[..., 0] = False
+            mask = torch.zeros_like(scores, dtype=torch.bool).scatter_(-1, sorted_indices, remove)
+            scores = scores.masked_fill(mask, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+        cdf = torch.cumsum(probs, dim=-1)
+        sampled = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+        return sampled.clamp(0, vocab - 1)
+
+    def _sampling_decode_frame_kernel(self) -> None:
+        hidden = self._local_graph_input
+        local_hidden = self.local_transformer.step(hidden.to(dtype=self.audio_embeddings[0].weight.dtype), 0)
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop = self._sample_graph_safe(text_logits, 50, 1.0, 1.0, self._local_graph_rand[0:1])
+        self._local_graph_stop.copy_(stop)
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            code = self._sample_graph_safe(logits, 50, 0.95, 1.0, self._local_graph_rand[1 + channel:2 + channel])
+            self._local_graph_codes[channel] = code.reshape(())
+            if channel + 1 < self.n_vq:
+                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+
+    def _greedy_decode_frame_kernel(self) -> None:
+        hidden = self._local_graph_input
+        local_hidden = self.local_transformer.step(hidden.to(dtype=self.audio_embeddings[0].weight.dtype), 0)
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        self._local_graph_stop.copy_(torch.argmax(text_logits, dim=-1))
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            code = torch.argmax(logits, dim=-1)
+            self._local_graph_codes[channel] = code.reshape(())
+            if channel + 1 < self.n_vq:
+                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+
+    def _ensure_local_graph(self, device: torch.device) -> None:
+        if self._local_graph is not None:
+            return
+        dtype = self.audio_embeddings[0].weight.dtype
+        self._local_graph_input = torch.zeros(1, self.hidden_size, device=device, dtype=dtype)
+        self._local_graph_stop = torch.zeros(1, dtype=torch.long, device=device)
+        self._local_graph_codes = torch.zeros(self.n_vq, dtype=torch.long, device=device)
+        self._local_graph_rand = torch.zeros(1 + self.n_vq, device=device, dtype=torch.float32)
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                self._greedy_decode_frame_kernel()
+        torch.cuda.current_stream().wait_stream(s)
+        self._local_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._local_graph):
+            self._greedy_decode_frame_kernel()
+
+    def _ensure_local_sampling_graph(self, device: torch.device) -> None:
+        if self._local_graph_sampling is not None:
+            return
+        self._ensure_local_graph(device)
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                self._sampling_decode_frame_kernel()
+        torch.cuda.current_stream().wait_stream(s)
+        self._local_graph_sampling = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._local_graph_sampling):
+            self._sampling_decode_frame_kernel()
+
+    def _decode_frame_greedy_graph(self, hidden: torch.Tensor) -> tuple[int, torch.Tensor]:
+        self._ensure_local_graph(hidden.device)
+        self._local_graph_input.copy_(hidden.to(dtype=self._local_graph_input.dtype))
+        self._local_graph.replay()
+        return int(self._local_graph_stop.item()), self._local_graph_codes.clone()
+
+    def _decode_frame_sampling_graph(self, hidden: torch.Tensor, generator: torch.Generator | None) -> tuple[int, torch.Tensor]:
+        self._ensure_local_sampling_graph(hidden.device)
+        self._local_graph_input.copy_(hidden.to(dtype=self._local_graph_input.dtype))
+        rand_vals = torch.rand(1 + self.n_vq, device=hidden.device, generator=generator)
+        self._local_graph_rand.copy_(rand_vals)
+        self._local_graph_sampling.replay()
+        return int(self._local_graph_stop.item()), self._local_graph_codes.clone()
+
+    def _decode_frame(self, hidden: torch.Tensor, info: dict[str, Any]) -> tuple[int, torch.Tensor]:
+        state = info.get("audio_state", {}) or {}
+        if int(state.get("max_new_frames", -1)) > 0:
+            emitted = int(state.get("step", 0))
+            if emitted >= int(state["max_new_frames"]):
+                return 1, torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=hidden.device)
+
+        text_temp = float(state.get("text_temperature", _first_scalar(info.get("text_temperature", 1.0))))
+        audio_temp = float(state.get("audio_temperature", _first_scalar(info.get("audio_temperature", 1.0))))
+
+        if getattr(self, "_local_graph_enabled", False) and hidden.device.type == "cuda":
+            if text_temp <= 0 and audio_temp <= 0:
+                return self._decode_frame_greedy_graph(hidden)
+            text_top_k_v = int(state.get("text_top_k", _first_scalar(info.get("text_top_k", 50))))
+            audio_top_k_v = int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", 50))))
+            audio_top_p_v = float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", 0.95))))
+            default_sampling = (
+                text_top_k_v == 50 and audio_top_k_v == 50
+                and abs(audio_top_p_v - 0.95) < 0.01
+                and abs(text_temp - 1.0) < 0.01 and abs(audio_temp - 1.0) < 0.01
+            )
+            if default_sampling:
+                generator = state.get("sampling_generator")
+                if not isinstance(generator, torch.Generator):
+                    generator = None
+                return self._decode_frame_sampling_graph(hidden, generator)
+
+        text_top_p = float(state.get("text_top_p", _first_scalar(info.get("text_top_p", 1.0))))
+        text_top_k = int(state.get("text_top_k", _first_scalar(info.get("text_top_k", 50))))
+        audio_top_p = float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", 0.95))))
+        audio_top_k = int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", 50))))
+        generator = state.get("sampling_generator")
+        if not isinstance(generator, torch.Generator):
+            generator = None
+
+        local_hidden = self.local_transformer.step(hidden.to(dtype=self.audio_embeddings[0].weight.dtype), 0)
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop_choice = int(
+            sample_top_k_top_p(
+                text_logits,
+                temperature=text_temp,
+                top_p=text_top_p,
+                top_k=text_top_k,
+                generator=generator,
+            )[0]
+        )
+
+        codes: list[torch.Tensor] = []
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            code = sample_top_k_top_p(
+                logits,
+                temperature=audio_temp,
+                top_p=audio_top_p,
+                top_k=audio_top_k,
+                generator=generator,
+            )
+            codes.append(code.reshape(()))
+            if channel + 1 < self.n_vq:
+                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+        return stop_choice, torch.stack(codes).to(dtype=torch.long)
+
+    def _decode_frame_batched(
+        self,
+        hidden_batch: torch.Tensor,
+        infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Batched local transformer decode: [B, H] -> (stop_choices[B], codes[B, n_vq])."""
+        B = hidden_batch.shape[0]
+        dtype = self.audio_embeddings[0].weight.dtype
+        self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
+        local_hidden = self.local_transformer.step(hidden_batch.to(dtype=dtype), 0)
+
+        # Extract per-request params once
+        text_temp = 1.0
+        text_top_k = 50
+        text_top_p = 1.0
+        audio_temp = 1.0
+        audio_top_k = 50
+        audio_top_p = 0.95
+        homogeneous = True
+        for info in infos:
+            if not isinstance(info, dict):
+                continue
+            state = info.get("audio_state", {}) or {}
+            tt = float(state.get("text_temperature", _first_scalar(info.get("text_temperature", 1.0))))
+            tk = int(state.get("text_top_k", _first_scalar(info.get("text_top_k", 50))))
+            tp = float(state.get("text_top_p", _first_scalar(info.get("text_top_p", 1.0))))
+            at = float(state.get("audio_temperature", _first_scalar(info.get("audio_temperature", 1.0))))
+            ak = int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", 50))))
+            ap = float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", 0.95))))
+            if abs(tt - text_temp) > 0.01 or tk != text_top_k or abs(tp - text_top_p) > 0.01:
+                homogeneous = False
+                break
+            if abs(at - audio_temp) > 0.01 or ak != audio_top_k or abs(ap - audio_top_p) > 0.01:
+                homogeneous = False
+                break
+
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+
+        if homogeneous:
+            # Fast path: single batched call for all B rows (no per-request generator)
+            stop_choices = sample_top_k_top_p(
+                text_logits, temperature=text_temp, top_p=text_top_p, top_k=text_top_k,
+            )
+            all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
+            current = local_hidden
+            for channel in range(self.n_vq):
+                head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+                logits = F.linear(current, head_weight).float()
+                codes = sample_top_k_top_p(
+                    logits, temperature=audio_temp, top_p=audio_top_p, top_k=audio_top_k,
+                )
+                all_codes[:, channel] = codes
+                if channel + 1 < self.n_vq:
+                    embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
+                    current = self.local_transformer.step(embedded, channel + 1)
+            return stop_choices, all_codes
+
+        # Slow path: per-request sampling (heterogeneous params or per-request generator)
+        stop_choices = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
+        for b in range(B):
+            info = infos[b] if b < len(infos) else {}
+            state = (info.get("audio_state", {}) or {}) if isinstance(info, dict) else {}
+            gen = state.get("sampling_generator") if isinstance(state, dict) else None
+            if not isinstance(gen, torch.Generator):
+                gen = None
+            stop_choices[b] = sample_top_k_top_p(
+                text_logits[b:b+1],
+                temperature=float(state.get("text_temperature", 1.0)),
+                top_p=float(state.get("text_top_p", 1.0)),
+                top_k=int(state.get("text_top_k", 50)),
+                generator=gen,
+            )[0]
+
+        all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            codes = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
+            for b in range(B):
+                info = infos[b] if b < len(infos) else {}
+                state = (info.get("audio_state", {}) or {}) if isinstance(info, dict) else {}
+                gen = state.get("sampling_generator") if isinstance(state, dict) else None
+                if not isinstance(gen, torch.Generator):
+                    gen = None
+                codes[b] = sample_top_k_top_p(
+                    logits[b:b+1],
+                    temperature=float(state.get("audio_temperature", 1.0)),
+                    top_p=float(state.get("audio_top_p", 0.95)),
+                    top_k=int(state.get("audio_top_k", 50)),
+                    generator=gen,
+                )[0]
+            all_codes[:, channel] = codes
+            if channel + 1 < self.n_vq:
+                embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
+                current = self.local_transformer.step(embedded, channel + 1)
+        return stop_choices, all_codes
+
+    def _maybe_dump_codes_debug(
+        self,
+        *,
+        hidden: torch.Tensor,
+        new_codes: torch.Tensor,
+        accumulated_codes: torch.Tensor,
+        state: dict[str, Any],
+    ) -> None:
+        dump_dir = os.environ.get("MOSS_TTS_LOCAL_DUMP_CODES_DIR")
+        if not dump_dir:
+            return
+        try:
+            os.makedirs(dump_dir, exist_ok=True)
+            step = int(state.get("step", 0))
+            path = os.path.join(dump_dir, f"stage0_codes_{os.getpid()}_step{step}.pt")
+            torch.save(
+                {
+                    "decode_hidden": hidden.detach().to("cpu"),
+                    "new_codes": new_codes.detach().to("cpu"),
+                    "codes": accumulated_codes.detach().to("cpu"),
+                },
+                path,
+            )
+        except Exception:
+            logger.exception("Failed to dump MOSS-TTS Local debug codes")
+
+    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        if isinstance(model_outputs, OmniOutput):
+            self._batch_state = None
+            return model_outputs
+        hidden = model_outputs
+        info_dicts: list[dict[str, Any]] = (
+            kwargs.get("model_intermediate_buffer") or kwargs.get("runtime_additional_information") or []
+        )
+        for info in info_dicts:
+            if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
+                state = {"step": 0, "is_stopping": False}
+                _copy_sampling_overrides(state, info)
+                sampling_generator = _make_sampling_generator(info.get("seed"), hidden.device)
+                if sampling_generator is not None:
+                    state["sampling_generator"] = sampling_generator
+                info["audio_state"] = state
+
+        audio_codes_list: list[torch.Tensor | None] = []
+        if hidden.numel() > 0 and info_dicts:
+            num_rows = int(hidden.shape[0])
+            rows_per_req = max(1, num_rows // max(1, len(info_dicts)))
+
+            # Try batched decode: all active (non-stopping) requests processed in one pass
+            active_indices: list[int] = []
+            for i, info in enumerate(info_dicts):
+                if not isinstance(info, dict):
+                    continue
+                state = info.get("audio_state", {}) or {}
+                if not state.get("is_stopping"):
+                    active_indices.append(i)
+
+            use_batched = (
+                len(active_indices) > 1
+                and num_rows == len(info_dicts)
+                and all(isinstance(info_dicts[j], dict) for j in active_indices)
+            )
+
+            if use_batched:
+                hidden_batch = torch.stack([hidden[j] for j in active_indices])
+                _t_local = time.perf_counter()
+                stop_choices, all_codes = self._decode_frame_batched(hidden_batch, [info_dicts[j] for j in active_indices])
+                self._batch_stats["t_local_tx_ms"] += (time.perf_counter() - _t_local) * 1000
+
+                _t_asm = time.perf_counter()
+                stop_list = stop_choices.detach().cpu().tolist()
+                active_set = set(active_indices)
+                bi = 0
+                for i, info in enumerate(info_dicts):
+                    if not isinstance(info, dict):
+                        audio_codes_list.append(None)
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    if state.get("is_stopping"):
+                        state["next_text"] = self.audio_end_token_id
+                        audio_codes_list.append(None)
+                        continue
+                    if i not in active_set:
+                        audio_codes_list.append(None)
+                        continue
+                    new_codes = all_codes[bi]
+                    step_num = int(state.get("step", 0))
+                    min_frames = int(state.get("min_new_frames", 3))
+                    if stop_list[bi] == 1 and step_num >= min_frames:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(None)
+                        self._batch_stats["completed_frames"].append(step_num)
+                    else:
+                        state["next_text"] = self.audio_assistant_slot_token_id
+                        state["step"] = int(state.get("step", 0)) + 1
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(new_codes.unsqueeze(0))
+                    bi += 1
+                self._batch_stats["t_output_asm_ms"] += (time.perf_counter() - _t_asm) * 1000
+            else:
+                # Sequential fallback (prefill, single request, or mixed)
+                for i, info in enumerate(info_dicts):
+                    if not isinstance(info, dict):
+                        audio_codes_list.append(None)
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    row_end = min((i + 1) * rows_per_req, num_rows)
+                    if row_end <= i * rows_per_req:
+                        audio_codes_list.append(None)
+                        continue
+                    if state.get("is_stopping"):
+                        state["next_text"] = self.audio_end_token_id
+                        audio_codes_list.append(None)
+                        continue
+                    stop_choice, new_codes = self._decode_frame(hidden[row_end - 1].unsqueeze(0), info)
+                    step_num = int(state.get("step", 0))
+                    min_frames = int(state.get("min_new_frames", 3))
+                    if stop_choice == 1 and step_num >= min_frames:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(None)
+                        continue
+                    state["next_text"] = self.audio_assistant_slot_token_id
+                    state["step"] = int(state.get("step", 0)) + 1
+                    info["audio_codes"] = {"current": new_codes}
+                    self._maybe_dump_codes_debug(
+                        hidden=hidden[row_end - 1].unsqueeze(0),
+                        new_codes=new_codes,
+                        accumulated_codes=new_codes.unsqueeze(0),
+                        state=state,
+                    )
+                    audio_codes_list.append(new_codes.unsqueeze(0))
+
+        self._batch_state = [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
+        active_codes = [c for c in audio_codes_list if c is not None]
+        if not active_codes:
+            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        step_counter = max(
+            (int((info.get("audio_state", {}) or {}).get("step", 0)) for info in info_dicts if isinstance(info, dict)),
+            default=0,
+        )
+        # Single request: emit codes directly (original behavior, proven correct).
+        if len(info_dicts) == 1 and len(active_codes) == 1:
+            return OmniOutput(
+                text_hidden_states=hidden,
+                multimodal_outputs={"codes": {"audio": active_codes[0]}, "meta": {"raw_rows": True, "step": step_counter}},
+            )
+        # Batch>1: sparse routing with delta rows (only this step's new_codes).
+        # Each active request emits [1, n_vq]; stopped requests are skipped.
+        req_ids: list[str] = []
+        delta_codes: list[torch.Tensor] = []
+        for i, info in enumerate(info_dicts):
+            code = audio_codes_list[i] if i < len(audio_codes_list) else None
+            if code is None or not isinstance(info, dict):
+                continue
+            rid = str(info.get("request_id") or info.get("global_request_id") or "")
+            if rid:
+                req_ids.append(rid)
+                delta_codes.append(code)
+        if not delta_codes:
+            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        return OmniOutput(
+            text_hidden_states=hidden,
+            multimodal_outputs={
+                "codes": {"audio": delta_codes},
+                "meta": {"sparse_audio": True, "req_id": req_ids, "raw_rows": True, "step": step_counter},
+            },
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loaded: set[str] = set()
+        params_dict = dict(self.named_parameters())
+        backbone_weights: list[tuple[str, torch.Tensor]] = []
+        skipped = 0
+
+        for original_name, tensor in weights:
+            name = original_name
+            if name.startswith("transformer."):
+                backbone_weights.append((name[len("transformer.") :], tensor))
+                name = "model." + name[len("transformer.") :]
+            elif name.startswith("model."):
+                backbone_weights.append((name, tensor))
+
+            if name.startswith("text_lm_head.") or name.startswith("audio_lm_heads."):
+                continue
+            if name.startswith("audio_embeddings.") and name.endswith(".weight"):
+                param = params_dict.get(name)
+                if param is not None:
+                    rows = min(int(tensor.shape[0]), int(param.shape[0]))
+                    with torch.no_grad():
+                        param[:rows].copy_(tensor[:rows].to(device=param.device, dtype=param.dtype))
+                    loaded.add(name)
+                continue
+            if name.startswith("local_transformer.") or name.startswith("local_text_lm_head."):
+                param = params_dict.get(name)
+                if param is not None:
+                    default_weight_loader(param, tensor)
+                    loaded.add(name)
+                else:
+                    skipped += 1
+                continue
+
+        backbone_loaded = self.model.load_weights(iter(backbone_weights))
+        for name in backbone_loaded:
+            loaded.add(f"model.{name}")
+
+        with torch.no_grad():
+            for emb in self.audio_embeddings:
+                if emb.weight.shape[0] > self.audio_vocab_size:
+                    emb.weight[self.audio_vocab_size :].zero_()
+        if skipped:
+            logger.warning("MOSS-TTS Local skipped %d unmatched local parameters", skipped)
+        return loaded
+
+
+__all__ = ["MossTTSLocalForGeneration"]

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local.py
@@ -39,6 +39,26 @@ def _first_scalar(value: Any) -> Any:
     return value
 
 
+def _stream_flag_from_info(info: dict[str, Any], default: bool = True) -> bool:
+    for key in ("stream", "codec_streaming"):
+        value = _first_scalar(info.get(key))
+        if value is not None:
+            return bool(value)
+    return default
+
+
+def _env_enabled(*names: str) -> bool:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None and value.strip().lower() in ("1", "true", "yes", "on"):
+            return True
+    return False
+
+
+def _env_disabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def _make_sampling_generator(seed: Any, device: torch.device) -> torch.Generator | None:
     seed = _first_scalar(seed)
     if seed is None:
@@ -93,6 +113,190 @@ def _debug_value(value: Any) -> Any:
     return repr(value)
 
 
+class MossTTSLocalRequestStatePool:
+    """Small request/slot state pool for the next model forward."""
+
+    def __init__(self, max_slots: int) -> None:
+        self.max_slots = max(1, int(max_slots))
+        self._slot_to_request: list[str | None] = [None] * self.max_slots
+        self._request_to_slot: dict[str, int] = {}
+        self._free_slots: list[int] = list(range(self.max_slots))
+        self._scheduled_slot_ids: list[int] = []
+        self._scheduled_token_counts: list[int] = []
+        self.steps_cpu = torch.zeros(self.max_slots, dtype=torch.long)
+        self.min_frames_cpu = torch.full((self.max_slots,), 3, dtype=torch.long)
+        self.max_frames_cpu = torch.full((self.max_slots,), 150, dtype=torch.long)
+        self.is_stopping_cpu = torch.zeros(self.max_slots, dtype=torch.bool)
+        # Keep Python mirrors for the per-frame hot path. Reading many
+        # 0-d torch CPU tensors from Python costs milliseconds per decode step.
+        self.steps_py = [0 for _ in range(self.max_slots)]
+        self.min_frames_py = [3 for _ in range(self.max_slots)]
+        self.max_frames_py = [150 for _ in range(self.max_slots)]
+        self.is_stopping_py = [False for _ in range(self.max_slots)]
+        self._frame_state_device: torch.device | None = None
+        self.steps_gpu: torch.Tensor | None = None
+        self.min_frames_gpu: torch.Tensor | None = None
+        self.max_frames_gpu: torch.Tensor | None = None
+        self.is_stopping_gpu: torch.Tensor | None = None
+
+    def allocate_slot(self, request_id: str) -> int:
+        if request_id in self._request_to_slot:
+            return self._request_to_slot[request_id]
+        if not self._free_slots:
+            raise RuntimeError(f"No free KV slots (max_num_seqs={self.max_slots})")
+        slot_id = self._free_slots.pop(0)
+        self._slot_to_request[slot_id] = request_id
+        self._request_to_slot[request_id] = slot_id
+        return slot_id
+
+    def slot_for_request(self, request_id: str) -> int | None:
+        return self._request_to_slot.get(request_id)
+
+    def release_slot(self, request_id: str) -> None:
+        slot_id = self._request_to_slot.pop(request_id, None)
+        if slot_id is not None:
+            self._slot_to_request[slot_id] = None
+            self.steps_cpu[slot_id] = 0
+            self.min_frames_cpu[slot_id] = 3
+            self.max_frames_cpu[slot_id] = 150
+            self.is_stopping_cpu[slot_id] = False
+            self.steps_py[slot_id] = 0
+            self.min_frames_py[slot_id] = 3
+            self.max_frames_py[slot_id] = 150
+            self.is_stopping_py[slot_id] = False
+            if (
+                self.steps_gpu is not None
+                and self.min_frames_gpu is not None
+                and self.max_frames_gpu is not None
+                and self.is_stopping_gpu is not None
+            ):
+                self.steps_gpu[slot_id] = 0
+                self.min_frames_gpu[slot_id] = 3
+                self.max_frames_gpu[slot_id] = 150
+                self.is_stopping_gpu[slot_id] = False
+            self._free_slots.append(slot_id)
+
+    def schedule_forward_slot(self, slot_id: int, token_count: int) -> None:
+        self._scheduled_slot_ids.append(int(slot_id))
+        self._scheduled_token_counts.append(int(token_count))
+
+    def consume_scheduled_forward_slots(self) -> tuple[list[int], list[int]]:
+        slot_ids = self._scheduled_slot_ids
+        token_counts = self._scheduled_token_counts
+        self._scheduled_slot_ids = []
+        self._scheduled_token_counts = []
+        return list(slot_ids), list(token_counts)
+
+    def init_frame_state(self, *, slot_id: int, min_new_frames: int = 3, max_new_frames: int = 150) -> None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return
+        self.steps_cpu[slot_id] = 0
+        self.min_frames_cpu[slot_id] = int(min_new_frames)
+        self.max_frames_cpu[slot_id] = int(max_new_frames)
+        self.is_stopping_cpu[slot_id] = False
+        self.steps_py[slot_id] = 0
+        self.min_frames_py[slot_id] = int(min_new_frames)
+        self.max_frames_py[slot_id] = int(max_new_frames)
+        self.is_stopping_py[slot_id] = False
+        if (
+            self.steps_gpu is not None
+            and self.min_frames_gpu is not None
+            and self.max_frames_gpu is not None
+            and self.is_stopping_gpu is not None
+        ):
+            self.steps_gpu[slot_id] = 0
+            self.min_frames_gpu[slot_id] = int(min_new_frames)
+            self.max_frames_gpu[slot_id] = int(max_new_frames)
+            self.is_stopping_gpu[slot_id] = False
+
+    def ensure_frame_state_device(self, device: torch.device) -> None:
+        if device.type != "cuda" or not _env_enabled("MOSS_TTS_LOCAL_GPU_FRAME_STATE"):
+            return
+        if (
+            self._frame_state_device == device
+            and self.steps_gpu is not None
+            and self.min_frames_gpu is not None
+            and self.max_frames_gpu is not None
+            and self.is_stopping_gpu is not None
+        ):
+            return
+        self._frame_state_device = device
+        self.steps_gpu = self.steps_cpu.to(device=device, non_blocking=True)
+        self.min_frames_gpu = self.min_frames_cpu.to(device=device, non_blocking=True)
+        self.max_frames_gpu = self.max_frames_cpu.to(device=device, non_blocking=True)
+        self.is_stopping_gpu = self.is_stopping_cpu.to(device=device, non_blocking=True)
+
+    def advance_frame_state(self, slot_ids: list[int], should_stop: list[bool]) -> None:
+        for slot_id, stop in zip(slot_ids, should_stop):
+            slot_id = int(slot_id)
+            if slot_id < 0 or slot_id >= self.max_slots:
+                continue
+            if stop:
+                self.is_stopping_py[slot_id] = True
+                self.is_stopping_cpu[slot_id] = True
+                if self.is_stopping_gpu is not None:
+                    self.is_stopping_gpu[slot_id] = True
+            else:
+                self.steps_py[slot_id] += 1
+                self.steps_cpu[slot_id] += 1
+                if self.steps_gpu is not None:
+                    self.steps_gpu[slot_id] += 1
+
+    def advance_frame_state_gpu(
+        self,
+        slot_ids: torch.Tensor,
+        should_stop: torch.Tensor,
+        should_stop_cpu: list[bool],
+        slot_ids_cpu: list[int] | None = None,
+    ) -> None:
+        if (
+            self.steps_gpu is None
+            or self.is_stopping_gpu is None
+            or slot_ids.numel() == 0
+            or slot_ids.device.type != "cuda"
+        ):
+            if slot_ids_cpu is None:
+                slot_ids_cpu = [int(x) for x in slot_ids.detach().to("cpu").tolist()]
+            self.advance_frame_state(slot_ids_cpu, should_stop_cpu)
+            return
+        slot_ids = slot_ids.reshape(-1).to(dtype=torch.long)
+        should_stop = should_stop.reshape(-1).to(dtype=torch.bool)
+        old_steps = self.steps_gpu.index_select(0, slot_ids)
+        new_steps = old_steps + (~should_stop).to(dtype=torch.long)
+        old_stopping = self.is_stopping_gpu.index_select(0, slot_ids)
+        new_stopping = old_stopping.logical_or(should_stop)
+        self.steps_gpu.index_copy_(0, slot_ids, new_steps)
+        self.is_stopping_gpu.index_copy_(0, slot_ids, new_stopping)
+        if slot_ids_cpu is None:
+            slot_ids_cpu = [int(x) for x in slot_ids.detach().to("cpu").tolist()]
+        for slot_id, stop in zip(slot_ids_cpu, should_stop_cpu):
+            slot_id = int(slot_id)
+            if slot_id < 0 or slot_id >= self.max_slots:
+                continue
+            if stop:
+                self.is_stopping_py[slot_id] = True
+                self.is_stopping_cpu[slot_id] = True
+            else:
+                self.steps_py[slot_id] += 1
+                self.steps_cpu[slot_id] += 1
+
+    def mark_stopping(self, slot_id: int) -> None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return
+        self.is_stopping_py[slot_id] = True
+        self.is_stopping_cpu[slot_id] = True
+        if self.is_stopping_gpu is not None:
+            self.is_stopping_gpu[slot_id] = True
+
+    def slot_request_id(self, slot_id: int) -> str | None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return None
+        return self._slot_to_request[slot_id]
+
+
 class MossTTSLocalForGeneration(nn.Module):
     """Stage-0 AR model: Qwen3 backbone plus per-frame local transformer."""
 
@@ -101,6 +305,8 @@ class MossTTSLocalForGeneration(nn.Module):
     has_preprocess: bool = True
     has_postprocess: bool = True
     requires_raw_input_tokens: bool = True
+    supports_omni_query_start_loc: bool = True
+    disable_outer_cudagraph: bool = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
@@ -131,32 +337,80 @@ class MossTTSLocalForGeneration(nn.Module):
             max_positions=self.n_vq + 1,
             rope_base=float(getattr(gpt2_cfg, "rope_base", 1_000_000.0)),
             layer_norm_eps=float(getattr(gpt2_cfg, "layer_norm_epsilon", 1e-6)),
-            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL") or getattr(self.config, "local_transformer_attn_implementation", None) or "eager",
+            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL")
+            or getattr(self.config, "local_transformer_attn_implementation", None)
+            or "eager",
         )
         self.local_text_lm_head = nn.Linear(self.hidden_size, 2, bias=False)
         self._batch_state: list[dict[str, Any]] | None = None
+        self._batch_next_text: torch.Tensor | None = None
+        self._audio_embedding_indices = torch.arange(self.n_vq, dtype=torch.long)
+        self._audio_embedding_weight_cache: torch.Tensor | None = None
         self._graph_warmup_done: bool = False
         self._max_num_seqs = int(getattr(vllm_config.scheduler_config, "max_num_seqs", 1))
-        self._slot_to_request: list[str | None] = [None] * self._max_num_seqs
-        self._request_to_slot: dict[str, int] = {}
-        self._free_slots: list[int] = list(range(self._max_num_seqs))
-        self._pending_slot_ids: list[int] = []
-        self._pending_token_counts: list[int] = []
+        self._request_state_pool = MossTTSLocalRequestStatePool(self._max_num_seqs)
         self._batch_stats: dict[str, Any] = {
-            "batched": 0, "fallback_no_cache": 0, "fallback_overflow": 0,
-            "fallback_prefill": 0, "single": 0, "log_interval": 100,
+            "batched": 0,
+            "fallback_no_cache": 0,
+            "fallback_overflow": 0,
+            "fallback_prefill": 0,
+            "single": 0,
+            "log_interval": 100,
             "batch_sizes": [],
-            "t_backbone_ms": 0.0, "t_local_tx_ms": 0.0, "t_output_asm_ms": 0.0,
+            "t_backbone_ms": 0.0,
+            "t_local_tx_ms": 0.0,
+            "t_output_asm_ms": 0.0,
+            "t_stop_sync_ms": 0.0,
             "n_steps": 0,
             "completed_frames": [],
         }
+        self._profile_detail_enabled = _env_enabled("MOSS_TTS_LOCAL_PROFILE_DETAIL")
+        self._frame_graph_profile_enabled = _env_enabled("MOSS_TTS_LOCAL_FRAME_GRAPH_PROFILE")
+        self._batch_stats.update(
+            {
+                "t_asm_active_state_ms": 0.0,
+                "t_asm_state_gather_ms": 0.0,
+                "t_asm_stop_compute_ms": 0.0,
+                "t_asm_stop_wait_ms": 0.0,
+                "t_asm_next_text_ms": 0.0,
+                "t_asm_pool_advance_ms": 0.0,
+                "t_asm_state_loop_ms": 0.0,
+                "t_asm_tail_ms": 0.0,
+                "frame_graph_replay": 0,
+                "frame_graph_capture": 0,
+                "frame_graph_buffer_reset": 0,
+                "frame_graph_rand_ms": 0.0,
+                "frame_graph_input_ms": 0.0,
+                "frame_graph_replay_ms": 0.0,
+                "frame_graph_capture_ms": 0.0,
+                "frame_graph_clone_ms": 0.0,
+                "frame_graph_keys": {},
+            }
+        )
         self._local_graph: torch.cuda.CUDAGraph | None = None
         self._local_graph_sampling: torch.cuda.CUDAGraph | None = None
         self._local_graph_input: torch.Tensor | None = None
         self._local_graph_stop: torch.Tensor | None = None
         self._local_graph_codes: torch.Tensor | None = None
         self._local_graph_rand: torch.Tensor | None = None
-        self._local_graph_enabled: bool = os.environ.get("MOSS_TTS_LOCAL_DECODE_GRAPH") == "1"
+        self._batch_frame_graphs: dict[
+            tuple[int, tuple[float, float, int, float, float, int]], torch.cuda.CUDAGraph
+        ] = {}
+        self._batch_frame_graph_input: torch.Tensor | None = None
+        self._batch_frame_graph_rand: torch.Tensor | None = None
+        self._batch_frame_graph_stop: torch.Tensor | None = None
+        self._batch_frame_graph_codes: torch.Tensor | None = None
+        self._batch_frame_graph_max_batch: int = 0
+        self._batch_frame_graph_bucket_sizes = self._parse_frame_graph_bucket_sizes()
+        self._output_asm_buffers: dict[str, Any] = {}
+        self._local_graph_enabled = not _env_disabled("MOSS_TTS_LOCAL_DISABLE_FRAME_GRAPH")
+        try:
+            self._stop_check_interval = max(int(os.environ.get("MOSS_TTS_LOCAL_STOP_CHECK_INTERVAL", "1") or 1), 1)
+        except ValueError:
+            self._stop_check_interval = 1
+        self._delay_stop_sync_enabled = not _env_disabled("MOSS_TTS_LOCAL_DISABLE_DELAY_STOP_SYNC")
+        self._delay_delta_routing_enabled = _env_enabled("MOSS_TTS_LOCAL_DELAY_DELTA_ROUTING")
+        self._pending_stop_result: dict[str, Any] | None = None
         if os.environ.get("MOSS_TTS_LOCAL_COMPILE_LOCAL_TX") == "1":
             self.local_transformer.step = torch.compile(self.local_transformer.step, dynamic=True)
 
@@ -165,29 +419,215 @@ class MossTTSLocalForGeneration(nn.Module):
             ("hidden_states", "last"),
         }
 
+    def _get_request_state_pool(self) -> MossTTSLocalRequestStatePool:
+        pool = getattr(self, "_request_state_pool", None)
+        if not isinstance(pool, MossTTSLocalRequestStatePool):
+            pool = MossTTSLocalRequestStatePool(int(getattr(self, "_max_num_seqs", 1)))
+            self._request_state_pool = pool
+        return pool
+
+    @staticmethod
+    def _parse_frame_graph_bucket_sizes() -> tuple[int, ...]:
+        raw = os.environ.get("MOSS_TTS_LOCAL_FRAME_GRAPH_BATCH_BUCKETS", "").strip()
+        if not raw:
+            return (8, 16, 32, 64)
+        if raw.lower() in ("auto", "default"):
+            return (8, 16, 32, 64)
+        buckets: list[int] = []
+        for part in raw.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                value = int(part)
+            except ValueError:
+                logger.warning("Ignoring invalid MOSS_TTS_LOCAL_FRAME_GRAPH_BATCH_BUCKETS entry: %s", part)
+                continue
+            if value > 0:
+                buckets.append(value)
+        return tuple(sorted(set(buckets)))
+
+    def _frame_graph_capture_batch_size(self, batch_size: int) -> int:
+        for bucket in self._batch_frame_graph_bucket_sizes:
+            if int(batch_size) <= bucket:
+                return int(bucket)
+        return int(batch_size)
+
+    def _schedule_forward_slot(self, slot_id: int, token_count: int) -> None:
+        self._get_request_state_pool().schedule_forward_slot(slot_id, token_count)
+
+    def _consume_scheduled_forward_slots(self) -> tuple[list[int], list[int]]:
+        return self._get_request_state_pool().consume_scheduled_forward_slots()
+
+    def should_disable_outer_cudagraph(self) -> bool:
+        return not _env_enabled("MOSS_TTS_LOCAL_ENABLE_OUTER_CUDAGRAPH")
+
     def _allocate_slot(self, request_id: str) -> int:
-        if request_id in self._request_to_slot:
-            return self._request_to_slot[request_id]
-        if not self._free_slots:
-            raise RuntimeError(f"No free KV slots (max_num_seqs={self._max_num_seqs})")
-        slot_id = self._free_slots.pop(0)
-        self._slot_to_request[slot_id] = request_id
-        self._request_to_slot[request_id] = slot_id
-        return slot_id
+        return self._get_request_state_pool().allocate_slot(request_id)
 
     def _release_slot(self, request_id: str) -> None:
-        slot_id = self._request_to_slot.pop(request_id, None)
-        if slot_id is not None:
-            self._slot_to_request[slot_id] = None
-            self._free_slots.append(slot_id)
+        self._get_request_state_pool().release_slot(request_id)
 
     def on_requests_finished(self, finished_req_ids: list[str]) -> None:
         for req_id in finished_req_ids:
             self._release_slot(req_id)
 
+    def _ensure_output_asm_buffers(self, *, batch_size: int, device: torch.device) -> dict[str, torch.Tensor]:
+        buffers = getattr(self, "_output_asm_buffers", None)
+        if not isinstance(buffers, dict):
+            buffers = {}
+            self._output_asm_buffers = buffers
+        bucket = _next_bucket(max(1, int(batch_size)))
+        if buffers.get("bucket") != bucket or buffers.get("device") != device:
+            buffers.clear()
+            buffers["bucket"] = bucket
+            buffers["device"] = device
+            pin_cpu = device.type == "cuda" and torch.cuda.is_available()
+
+            def cpu_empty(*shape: int, dtype: torch.dtype) -> torch.Tensor:
+                try:
+                    return torch.empty(*shape, dtype=dtype, pin_memory=pin_cpu)
+                except RuntimeError:
+                    return torch.empty(*shape, dtype=dtype)
+
+            buffers["rows_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["slot_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["steps_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["min_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["max_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["stop_cpu"] = cpu_empty(bucket, dtype=torch.bool)
+            buffers["rows_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["slot_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["steps_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["min_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["max_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["stop_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["tmp_stop_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["poll_cpu"] = cpu_empty(bucket, dtype=torch.bool)
+            buffers["poll_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["next_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            if device.type == "cuda":
+                buffers["stop_copy_event"] = torch.cuda.Event()
+        return buffers
+
+    def _consume_pending_stop_result(
+        self, info_dicts: list[dict[str, Any]]
+    ) -> tuple[list[str], list[torch.Tensor], list[bool]]:
+        pending = getattr(self, "_pending_stop_result", None)
+        if not pending:
+            return [], [], []
+        self._pending_stop_result = None
+
+        event = pending.get("event")
+        if isinstance(event, torch.cuda.Event):
+            event.synchronize()
+        stop_cpu = pending.get("stop_cpu")
+        slot_ids = pending.get("slot_ids") or []
+        req_ids = pending.get("req_ids") or []
+        if not isinstance(stop_cpu, torch.Tensor) or not slot_ids:
+            return [], [], []
+        stop_values = [bool(x) for x in stop_cpu[: len(slot_ids)].tolist()]
+        force_stop = pending.get("force_stop") or []
+        stop_values = [
+            bool(model_stop or (idx < len(force_stop) and force_stop[idx]))
+            for idx, model_stop in enumerate(stop_values)
+        ]
+        pending_steps = pending.get("steps") or []
+        pending_codes = pending.get("codes")
+        pending_streaming = pending.get("codec_streaming") or []
+        emit_req_ids: list[str] = []
+        emit_codes: list[torch.Tensor] = []
+        emit_streaming: list[bool] = []
+
+        pool = self._get_request_state_pool()
+        state_by_slot: dict[int, tuple[dict[str, Any], dict[str, Any]]] = {}
+        for info in info_dicts:
+            if not isinstance(info, dict):
+                continue
+            try:
+                slot_id = int(info.get("_kv_slot_id"))
+            except (TypeError, ValueError):
+                continue
+            state = info.get("audio_state", {}) or {}
+            state_by_slot[slot_id] = (info, state)
+
+        for idx, should_stop in enumerate(stop_values):
+            if idx >= len(slot_ids):
+                continue
+            slot_id = int(slot_ids[idx])
+            if slot_id < 0 or slot_id >= pool.max_slots:
+                continue
+            expected_req_id = str(req_ids[idx]) if idx < len(req_ids) else ""
+            current_req_id = pool.slot_request_id(slot_id)
+            if expected_req_id and current_req_id != expected_req_id:
+                continue
+            if not should_stop:
+                if isinstance(pending_codes, torch.Tensor) and idx < int(pending_codes.shape[0]):
+                    rid = expected_req_id or str(current_req_id or "")
+                    if rid or len(info_dicts) == 1:
+                        emit_req_ids.append(rid)
+                        emit_codes.append(pending_codes[idx : idx + 1])
+                        emit_streaming.append(bool(pending_streaming[idx]) if idx < len(pending_streaming) else True)
+                continue
+            info_state = state_by_slot.get(slot_id)
+            stop_step = int(pending_steps[idx]) if idx < len(pending_steps) else pool.steps_py[slot_id]
+            pool.steps_py[slot_id] = stop_step
+            pool.steps_cpu[slot_id] = stop_step
+            if pool.steps_gpu is not None:
+                pool.steps_gpu[slot_id] = stop_step
+            if info_state is None:
+                pool.mark_stopping(slot_id)
+                continue
+            _info, state = info_state
+            pool.mark_stopping(slot_id)
+            state["is_stopping"] = True
+            state["next_text"] = self.audio_end_token_id
+            state["stop_reason"] = "model_stop"
+            state["step"] = stop_step
+            self._batch_stats["completed_frames"].append(stop_step)
+        return emit_req_ids, emit_codes, emit_streaming
+
+    @staticmethod
+    def _compute_stop_and_next_tokens(
+        *,
+        stop_choices: torch.Tensor,
+        steps: torch.Tensor,
+        min_frames: torch.Tensor,
+        max_frames: torch.Tensor,
+        audio_assistant_slot_token_id: int,
+        audio_end_token_id: int,
+        should_stop_out: torch.Tensor | None = None,
+        tmp_out: torch.Tensor | None = None,
+        next_tokens_out: torch.Tensor | None = None,
+        model_stop_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        should_stop = (
+            should_stop_out if should_stop_out is not None else torch.empty_like(stop_choices, dtype=torch.bool)
+        )
+        tmp = tmp_out if tmp_out is not None else torch.empty_like(should_stop)
+        next_tokens = next_tokens_out if next_tokens_out is not None else torch.empty_like(steps, dtype=torch.long)
+
+        torch.eq(stop_choices.reshape(-1)[: steps.numel()], 1, out=should_stop)
+        if model_stop_mask is not None:
+            should_stop.logical_and_(model_stop_mask.reshape(-1)[: steps.numel()])
+        torch.ge(steps, min_frames, out=tmp)
+        should_stop.logical_and_(tmp)
+        torch.ge(steps, max_frames, out=tmp)
+        should_stop.logical_or_(tmp)
+
+        next_tokens.fill_(int(audio_assistant_slot_token_id))
+        next_tokens.masked_fill_(should_stop, int(audio_end_token_id))
+        return should_stop, next_tokens
+
     def _log_batch_stats(self) -> None:
         s = self._batch_stats
-        total = s["batched"] + s.get("fallback_no_cache", 0) + s.get("fallback_overflow", 0) + s["fallback_prefill"] + s["single"]
+        total = (
+            s["batched"]
+            + s.get("fallback_no_cache", 0)
+            + s.get("fallback_overflow", 0)
+            + s["fallback_prefill"]
+            + s["single"]
+        )
         if total > 0 and total % s["log_interval"] == 0:
             hit = s["batched"]
             multi = hit + s.get("fallback_no_cache", 0) + s.get("fallback_overflow", 0) + s["fallback_prefill"]
@@ -196,6 +636,7 @@ class MossTTSLocalForGeneration(nn.Module):
             avg_backbone = s["t_backbone_ms"] / n
             avg_local = s["t_local_tx_ms"] / n
             avg_output_asm = s["t_output_asm_ms"] / n
+            avg_stop_sync = s.get("t_stop_sync_ms", 0.0) / n
             bsizes = s["batch_sizes"][-20:]
             avg_bs = sum(bsizes) / max(1, len(bsizes))
             frames = s["completed_frames"]
@@ -204,13 +645,60 @@ class MossTTSLocalForGeneration(nn.Module):
                 frames_sorted = sorted(frames)
                 p50 = frames_sorted[len(frames_sorted) // 2]
                 p95 = frames_sorted[min(len(frames_sorted) - 1, int(len(frames_sorted) * 0.95))]
-                frames_info = f" | frames: n={len(frames)} p50={p50} p95={p95} avg={sum(frames)/len(frames):.0f}"
+                frames_info = f" | frames: n={len(frames)} p50={p50} p95={p95} avg={sum(frames) / len(frames):.0f}"
             logger.info(
-                "Profile[%d steps]: hit=%.0f%% avg_bs=%.1f | backbone=%.2fms local_tx=%.2fms output_asm=%.2fms | "
+                "Profile[%d steps]: hit=%.0f%% avg_bs=%.1f | backbone=%.2fms local_tx=%.2fms "
+                "output_asm=%.2fms stop_sync=%.2fms | "
                 "batched=%d prefill=%d single=%d%s",
-                n, rate, avg_bs, avg_backbone, avg_local, avg_output_asm,
-                hit, s["fallback_prefill"], s["single"], frames_info,
+                n,
+                rate,
+                avg_bs,
+                avg_backbone,
+                avg_local,
+                avg_output_asm,
+                avg_stop_sync,
+                hit,
+                s["fallback_prefill"],
+                s["single"],
+                frames_info,
             )
+            if bool(getattr(self, "_profile_detail_enabled", False)):
+                logger.info(
+                    "ProfileDetail[%d steps]: active_state=%.2fms state_gather=%.2fms "
+                    "stop_compute=%.2fms stop_wait=%.2fms next_text=%.2fms "
+                    "pool_advance=%.2fms state_loop=%.2fms tail=%.2fms",
+                    n,
+                    s.get("t_asm_active_state_ms", 0.0) / n,
+                    s.get("t_asm_state_gather_ms", 0.0) / n,
+                    s.get("t_asm_stop_compute_ms", 0.0) / n,
+                    s.get("t_asm_stop_wait_ms", 0.0) / n,
+                    s.get("t_asm_next_text_ms", 0.0) / n,
+                    s.get("t_asm_pool_advance_ms", 0.0) / n,
+                    s.get("t_asm_state_loop_ms", 0.0) / n,
+                    s.get("t_asm_tail_ms", 0.0) / n,
+                )
+            if bool(getattr(self, "_frame_graph_profile_enabled", False)):
+                replay = int(s.get("frame_graph_replay", 0))
+                capture = int(s.get("frame_graph_capture", 0))
+                graph_calls = max(1, replay + capture)
+                key_counts = s.get("frame_graph_keys", {})
+                top_keys = sorted(key_counts.items(), key=lambda item: item[1], reverse=True)[:5]
+                top_key_text = ",".join(f"{key}:{count}" for key, count in top_keys)
+                logger.info(
+                    "FrameGraphProfile[%d steps]: replay=%d capture=%d resets=%d "
+                    "input=%.3fms rand=%.3fms replay_wall=%.3fms capture_wall=%.3fms "
+                    "clone=%.3fms keys=%s",
+                    n,
+                    replay,
+                    capture,
+                    int(s.get("frame_graph_buffer_reset", 0)),
+                    s.get("frame_graph_input_ms", 0.0) / graph_calls,
+                    s.get("frame_graph_rand_ms", 0.0) / graph_calls,
+                    s.get("frame_graph_replay_ms", 0.0) / max(1, replay),
+                    s.get("frame_graph_capture_ms", 0.0) / max(1, capture),
+                    s.get("frame_graph_clone_ms", 0.0) / graph_calls,
+                    top_key_text or "-",
+                )
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -223,28 +711,25 @@ class MossTTSLocalForGeneration(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         **_: Any,
     ) -> torch.Tensor | IntermediateTensors:
-        pending_slots = getattr(self, "_pending_slot_ids", None)
-        pending_counts = getattr(self, "_pending_token_counts", None)
-        if pending_slots and len(pending_slots) > 1:
-            slot_ids = list(pending_slots)
-            token_counts = list(pending_counts)
-            pending_slots.clear()
-            pending_counts.clear()
+        slot_ids, token_counts = self._consume_scheduled_forward_slots()
+        if len(slot_ids) > 1:
             if all(c == 1 for c in token_counts):
                 if (
-                    hasattr(self.model, 'layers')
+                    hasattr(self.model, "layers")
                     and self.model.layers[0].self_attn.static_key_cache is None
-                    and hasattr(self.model, 'init_static_kv_cache')
+                    and hasattr(self.model, "init_static_kv_cache")
                 ):
                     max_pos = int(getattr(self.config.qwen3_config, "max_position_embeddings", 4096))
                     device = input_ids.device if input_ids is not None else positions.device
                     dtype = self.model.embed_tokens.weight.dtype
                     self.model.init_static_kv_cache(
-                        max_len=min(max_pos, 512), max_batch=self._max_num_seqs, device=device, dtype=dtype,
+                        max_len=min(max_pos, 512),
+                        max_batch=self._max_num_seqs,
+                        device=device,
+                        dtype=dtype,
                     )
                 can_batch = (
-                    hasattr(self.model, 'layers')
-                    and self.model.layers[0].self_attn.static_key_cache is not None
+                    hasattr(self.model, "layers") and self.model.layers[0].self_attn.static_key_cache is not None
                 )
                 fallback_reason = ""
                 if not can_batch:
@@ -271,7 +756,9 @@ class MossTTSLocalForGeneration(nn.Module):
                     self._log_batch_stats()
                     return result
                 else:
-                    self._batch_stats[f"fallback_{fallback_reason}"] = self._batch_stats.get(f"fallback_{fallback_reason}", 0) + 1
+                    self._batch_stats[f"fallback_{fallback_reason}"] = (
+                        self._batch_stats.get(f"fallback_{fallback_reason}", 0) + 1
+                    )
                     self._log_batch_stats()
             else:
                 self._batch_stats["fallback_prefill"] += 1
@@ -279,9 +766,9 @@ class MossTTSLocalForGeneration(nn.Module):
             outputs = []
             offset = 0
             for slot_id, count in zip(slot_ids, token_counts):
-                seg_embeds = inputs_embeds[offset:offset + count] if inputs_embeds is not None else None
-                seg_ids = input_ids[offset:offset + count] if input_ids is not None else None
-                seg_pos = positions[offset:offset + count]
+                seg_embeds = inputs_embeds[offset : offset + count] if inputs_embeds is not None else None
+                seg_ids = input_ids[offset : offset + count] if input_ids is not None else None
+                seg_pos = positions[offset : offset + count]
                 out = self.model(
                     input_ids=seg_ids,
                     positions=seg_pos,
@@ -294,11 +781,7 @@ class MossTTSLocalForGeneration(nn.Module):
             return torch.cat(outputs, dim=0)
         self._batch_stats["single"] += 1
         self._log_batch_stats()
-        slot_id = 0
-        if pending_slots:
-            slot_id = pending_slots.pop(0)
-            if pending_counts:
-                pending_counts.pop(0)
+        slot_id = slot_ids[0] if slot_ids else 0
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -307,35 +790,56 @@ class MossTTSLocalForGeneration(nn.Module):
             slot_id=slot_id,
         )
 
-
-    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> torch.Tensor | None:
+    def compute_logits(
+        self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None
+    ) -> torch.Tensor | None:
         """Return one-hot text logits: continue slot or audio_end."""
         if isinstance(hidden_states, OmniOutput):
             hidden_states = hidden_states.text_hidden_states
         if hidden_states is None or hidden_states.numel() == 0:
             return None
-        logits = hidden_states.new_full((hidden_states.shape[0], self.vocab_size), float("-inf"))
+        num_rows = hidden_states.shape[0]
+        next_text = self._batch_next_text
+        if isinstance(next_text, torch.Tensor) and next_text.numel() > 0:
+            row_tokens = next_text.to(device=hidden_states.device, dtype=torch.long).reshape(-1)
+            num_rows = int(row_tokens.numel())
+            row_tokens = row_tokens.clamp_(0, self.vocab_size - 1)
+            logits = hidden_states.new_full((num_rows, self.vocab_size), float("-inf"))
+            logits.scatter_(1, row_tokens.unsqueeze(1), 0.0)
+            return logits
         states = self._batch_state or []
         if not states:
+            logits = hidden_states.new_full((num_rows, self.vocab_size), float("-inf"))
             logits[:, self.audio_assistant_slot_token_id] = 0.0
             return logits
-        rows_per_state = max(1, hidden_states.shape[0] // max(1, len(states)))
+        rows_per_state = max(1, num_rows // max(1, len(states)))
+        row_tokens = torch.full(
+            (num_rows,),
+            self.audio_end_token_id,
+            dtype=torch.long,
+            device=hidden_states.device,
+        )
         for i, state in enumerate(states):
             r0 = i * rows_per_state
-            r1 = min(r0 + rows_per_state, hidden_states.shape[0])
+            r1 = min(r0 + rows_per_state, num_rows)
             if r0 >= r1:
                 continue
             token_id = int(state.get("next_text", self.audio_assistant_slot_token_id))
             if not 0 <= token_id < self.vocab_size:
                 token_id = self.audio_end_token_id
-            logits[r0:r1, token_id] = 0.0
+            row_tokens[r0:r1] = token_id
+        logits = hidden_states.new_full((num_rows, self.vocab_size), float("-inf"))
+        logits.scatter_(1, row_tokens.unsqueeze(1), 0.0)
         if os.environ.get("MOSS_TTS_LOCAL_DEBUG_BATCH") and len(states) > 1:
             tokens = [int(s.get("next_text", self.audio_assistant_slot_token_id)) for s in states]
             steps = [int(s.get("step", 0)) for s in states]
             stopping = [bool(s.get("is_stopping")) for s in states]
             logger.info(
                 "compute_logits batch=%d tokens=%s steps=%s stopping=%s",
-                len(states), tokens, steps, stopping,
+                len(states),
+                tokens,
+                steps,
+                stopping,
             )
         return logits
 
@@ -346,12 +850,20 @@ class MossTTSLocalForGeneration(nn.Module):
         codes = audio_codes.to(device=text_ids.device, dtype=torch.long)
         if codes.dim() == 1:
             codes = codes.unsqueeze(0)
-        for idx, emb in enumerate(self.audio_embeddings):
-            col = codes[:, idx].clamp(0, self.audio_vocab_size)
-            valid = col.ne(self.audio_pad_code)
-            safe_col = col.masked_fill(~valid, 0)
-            embeds = embeds + emb(safe_col) * valid.unsqueeze(-1)
-        return embeds
+        valid = codes.ne(self.audio_pad_code)
+        safe_codes = codes.clamp(0, self.audio_vocab_size).masked_fill(~valid, 0)
+        weights = self._stacked_audio_embedding_weights(device=text_ids.device)
+        codebook_idx = self._audio_embedding_indices.to(device=text_ids.device)
+        audio_embeds = weights[codebook_idx.unsqueeze(0), safe_codes]
+        return embeds + (audio_embeds * valid.unsqueeze(-1)).sum(dim=1)
+
+    def _stacked_audio_embedding_weights(self, *, device: torch.device) -> torch.Tensor:
+        cache = self._audio_embedding_weight_cache
+        dtype = self.audio_embeddings[0].weight.dtype
+        if cache is None or cache.device != device or cache.dtype != dtype:
+            cache = torch.stack([emb.weight for emb in self.audio_embeddings], dim=0).to(device=device)
+            self._audio_embedding_weight_cache = cache
+        return cache
 
     def preprocess(
         self,
@@ -365,18 +877,11 @@ class MossTTSLocalForGeneration(nn.Module):
         audio_state = info_dict.get("audio_state")
         is_first_call = not isinstance(audio_state, dict)
 
-        request_id = str(
-            info_dict.get("request_id")
-            or info_dict.get("global_request_id")
-            or ""
-        )
-        try:
-            request_to_slot = self._request_to_slot
-            slot_id = request_to_slot.get(request_id) if request_id else None
-            if is_first_call and slot_id is None and request_id:
-                slot_id = self._allocate_slot(request_id)
-        except AttributeError:
-            slot_id = None
+        request_id = str(info_dict.get("request_id") or info_dict.get("global_request_id") or "")
+        pool = self._get_request_state_pool()
+        slot_id = pool.slot_for_request(request_id) if request_id else None
+        if is_first_call and slot_id is None and request_id:
+            slot_id = self._allocate_slot(request_id)
         if slot_id is None:
             slot_id = 0
 
@@ -418,6 +923,11 @@ class MossTTSLocalForGeneration(nn.Module):
                 max_new_frames = int(max_new_frames) if max_new_frames is not None else -1
             except (TypeError, ValueError):
                 max_new_frames = -1
+            min_new_frames = _first_scalar(info_dict.get("min_new_frames"))
+            try:
+                min_new_frames = int(min_new_frames) if min_new_frames is not None else 3
+            except (TypeError, ValueError):
+                min_new_frames = 3
             max_positions = int(getattr(self.config.qwen3_config, "max_position_embeddings", 4096))
             needed_len = span_len + (max_new_frames if max_new_frames > 0 else 512) + 1
             bucket_len = min(max_positions, _next_bucket(needed_len))
@@ -432,11 +942,16 @@ class MossTTSLocalForGeneration(nn.Module):
                 warmup_buckets = [b for b in _BUCKET_SIZES if b <= max_positions and b != bucket_len]
                 if warmup_buckets:
                     self.model.warmup_decode_graphs(
-                        warmup_buckets, device=device, dtype=self.model.embed_tokens.weight.dtype,
+                        warmup_buckets,
+                        device=device,
+                        dtype=self.model.embed_tokens.weight.dtype,
                         max_batch=self._max_num_seqs,
                     )
                     self.model.init_static_kv_cache(
-                        max_len=bucket_len, max_batch=self._max_num_seqs, device=device, dtype=self.model.embed_tokens.weight.dtype,
+                        max_len=bucket_len,
+                        max_batch=self._max_num_seqs,
+                        device=device,
+                        dtype=self.model.embed_tokens.weight.dtype,
                     )
             sampling_generator = _make_sampling_generator(info_dict.get("seed"), device)
             state = {
@@ -444,7 +959,14 @@ class MossTTSLocalForGeneration(nn.Module):
                 "is_stopping": False,
                 "next_text": self.audio_assistant_slot_token_id,
                 "max_new_frames": max_new_frames,
+                "min_new_frames": min_new_frames,
             }
+            pool.init_frame_state(
+                slot_id=slot_id,
+                min_new_frames=min_new_frames,
+                max_new_frames=max_new_frames if max_new_frames > 0 else 150,
+            )
+            pool.ensure_frame_state_device(device)
             _copy_sampling_overrides(state, info_dict)
             if sampling_generator is not None:
                 state["sampling_generator"] = sampling_generator
@@ -453,28 +975,110 @@ class MossTTSLocalForGeneration(nn.Module):
                 info_dict=info_dict,
                 state=state,
             )
-            try:
-                self._pending_slot_ids.append(slot_id)
-                self._pending_token_counts.append(span_len)
-            except AttributeError:
-                pass
-            return input_ids, embeds, {
-                "audio_state": state,
-                "audio_codes": {"current": current_codes},
-                "ref_offset": int(info_dict.get("ref_offset", 0)) + span_len,
-                "_kv_slot_id": slot_id,
-            }
+            self._schedule_forward_slot(slot_id, span_len)
+            return (
+                input_ids,
+                embeds,
+                {
+                    "audio_state": state,
+                    "audio_codes": {"current": current_codes},
+                    "ref_offset": int(info_dict.get("ref_offset", 0)) + span_len,
+                    "_kv_slot_id": slot_id,
+                },
+            )
 
         prev_codes = (info_dict.get("audio_codes", {}) or {}).get("current")
         if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
             prev_codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
         embeds = self._build_input_embeds(input_ids.reshape(-1), prev_codes.to(device=device).unsqueeze(0))
-        try:
-            self._pending_slot_ids.append(slot_id)
-            self._pending_token_counts.append(1)
-        except AttributeError:
-            pass
+        self._schedule_forward_slot(slot_id, 1)
         return input_ids, embeds, {"_kv_slot_id": slot_id}
+
+    def preprocess_decode_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Batch decode preprocess for single-frame MOSS Local decode rows.
+
+        This is equivalent to calling ``preprocess(..., span_len=1)`` for each
+        request, but it batches the text/audio embedding work into one GPU path.
+        """
+        device = input_ids.device
+        text_ids = input_ids.reshape(-1)
+        pool = self._get_request_state_pool()
+        slot_ids: list[int] = []
+        prev_codes_list: list[torch.Tensor] = []
+        for info in req_infos:
+            request_id = str(info.get("request_id") or info.get("global_request_id") or "")
+            slot_id = pool.slot_for_request(request_id) if request_id else None
+            if slot_id is None:
+                slot_id = 0
+            slot_ids.append(int(slot_id))
+
+            prev_codes = (info.get("audio_codes", {}) or {}).get("current")
+            if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
+                prev_codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+            prev_codes_list.append(prev_codes.to(device=device, dtype=torch.long).reshape(-1)[: self.n_vq])
+
+        if prev_codes_list:
+            prev_codes_batch = torch.stack(prev_codes_list, dim=0)
+        else:
+            prev_codes_batch = torch.empty((0, self.n_vq), dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(text_ids, prev_codes_batch)
+        for slot_id in slot_ids:
+            self._schedule_forward_slot(slot_id, 1)
+        updates = [{"_kv_slot_id": slot_id} for slot_id in slot_ids]
+        return text_ids, embeds, updates
+
+    def preprocess_decode_batch_fast(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_ids: list[str],
+        prev_codes: list[torch.Tensor | None],
+        slot_ids: list[int | None] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Fast single-frame decode preprocess for the MOSS Local HF path.
+
+        The generic path attaches a full req_info dictionary for every decode
+        row before batching.  MOSS decode only needs the sampled text token, the
+        previous RVQ codes and the state-pool slot, so this keeps the hot path
+        out of the per-request metadata loop.
+        """
+        device = input_ids.device
+        text_ids = input_ids.reshape(-1)
+        pool = self._get_request_state_pool()
+        resolved_slot_ids: list[int] = []
+        prev_codes_list: list[torch.Tensor] = []
+        for idx, req_id in enumerate(req_ids):
+            slot_id = None
+            if slot_ids is not None and idx < len(slot_ids):
+                try:
+                    slot_id = int(slot_ids[idx]) if slot_ids[idx] is not None else None
+                except (TypeError, ValueError):
+                    slot_id = None
+            if slot_id is None or slot_id < 0:
+                slot_id = pool.slot_for_request(str(req_id)) if req_id else None
+            if slot_id is None:
+                slot_id = 0
+            resolved_slot_ids.append(int(slot_id))
+
+            codes = prev_codes[idx] if idx < len(prev_codes) else None
+            if not isinstance(codes, torch.Tensor) or codes.numel() != self.n_vq:
+                codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+            prev_codes_list.append(codes.to(device=device, dtype=torch.long).reshape(-1)[: self.n_vq])
+
+        if prev_codes_list:
+            prev_codes_batch = torch.stack(prev_codes_list, dim=0)
+        else:
+            prev_codes_batch = torch.empty((0, self.n_vq), dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(text_ids, prev_codes_batch)
+        for slot_id in resolved_slot_ids:
+            self._schedule_forward_slot(slot_id, 1)
+        updates = [{"_kv_slot_id": slot_id} for slot_id in resolved_slot_ids]
+        return text_ids, embeds, updates
 
     def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
         if hidden_states.numel() == 0:
@@ -500,14 +1104,8 @@ class MossTTSLocalForGeneration(nn.Module):
                     "prompt_rows": _debug_value(info_dict.get("prompt_rows")),
                     "max_new_frames": state.get("max_new_frames"),
                     "seed": _debug_value(info_dict.get("seed")),
-                    "sampling_overrides": {
-                        key: state[key] for key in _SAMPLING_OVERRIDE_KEYS if key in state
-                    },
-                    "info": {
-                        key: _debug_value(value)
-                        for key, value in info_dict.items()
-                        if key != "audio_state"
-                    },
+                    "sampling_overrides": {key: state[key] for key in _SAMPLING_OVERRIDE_KEYS if key in state},
+                    "info": {key: _debug_value(value) for key, value in info_dict.items() if key != "audio_state"},
                 },
                 path,
             )
@@ -515,12 +1113,38 @@ class MossTTSLocalForGeneration(nn.Module):
             logger.exception("Failed to dump MOSS-TTS Local debug request")
 
     @staticmethod
-    def _sample_graph_safe(logits: torch.Tensor, top_k: int, top_p: float, temperature: float, rand_val: torch.Tensor) -> torch.Tensor:
+    def _sample_graph_safe(
+        logits: torch.Tensor, top_k: int, top_p: float, temperature: float, rand_val: torch.Tensor
+    ) -> torch.Tensor:
         scores = logits / max(temperature, 1e-6)
         vocab = int(scores.shape[-1])
+        top_k = int(top_k)
+        top_p = float(top_p)
         if 0 < top_k < vocab:
-            values, _ = torch.topk(scores, top_k, dim=-1)
-            scores = scores.masked_fill(scores < values[..., -1:], float("-inf"))
+            topk_scores, topk_indices = torch.topk(scores, top_k, dim=-1)
+            if 0.0 < top_p < 1.0:
+                sorted_scores, sorted_order = torch.sort(topk_scores, descending=True, dim=-1)
+                sorted_indices = topk_indices.gather(-1, sorted_order)
+                sorted_probs = torch.softmax(sorted_scores, dim=-1)
+                cumulative = torch.cumsum(sorted_probs, dim=-1)
+                remove = cumulative > top_p
+                remove[..., 1:] = remove[..., :-1].clone()
+                remove[..., 0] = False
+                sorted_scores = sorted_scores.masked_fill(remove, float("-inf"))
+                probs = torch.softmax(sorted_scores, dim=-1)
+                probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+                cdf = torch.cumsum(probs, dim=-1)
+                sampled_rel = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+                sampled_rel = sampled_rel.clamp(0, top_k - 1).unsqueeze(-1)
+                return sorted_indices.gather(-1, sampled_rel).reshape(-1).clamp(0, vocab - 1)
+
+            probs = torch.softmax(topk_scores, dim=-1)
+            probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+            cdf = torch.cumsum(probs, dim=-1)
+            sampled_rel = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+            sampled_rel = sampled_rel.clamp(0, top_k - 1).unsqueeze(-1)
+            return topk_indices.gather(-1, sampled_rel).reshape(-1).clamp(0, vocab - 1)
+
         if 0.0 < top_p < 1.0:
             sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
             sorted_probs = torch.softmax(sorted_scores, dim=-1)
@@ -536,6 +1160,25 @@ class MossTTSLocalForGeneration(nn.Module):
         sampled = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
         return sampled.clamp(0, vocab - 1)
 
+    @staticmethod
+    def _sample_graph_safe_param(
+        logits: torch.Tensor,
+        *,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        rand_val: torch.Tensor,
+    ) -> torch.Tensor:
+        if float(temperature) <= 0:
+            return torch.argmax(logits, dim=-1)
+        return MossTTSLocalForGeneration._sample_graph_safe(
+            logits,
+            int(top_k),
+            float(top_p),
+            float(temperature),
+            rand_val,
+        )
+
     def _sampling_decode_frame_kernel(self) -> None:
         hidden = self._local_graph_input
         local_hidden = self.local_transformer.step(hidden.to(dtype=self.audio_embeddings[0].weight.dtype), 0)
@@ -546,10 +1189,12 @@ class MossTTSLocalForGeneration(nn.Module):
         for channel in range(self.n_vq):
             head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
             logits = F.linear(current, head_weight).float()
-            code = self._sample_graph_safe(logits, 50, 0.95, 1.0, self._local_graph_rand[1 + channel:2 + channel])
+            code = self._sample_graph_safe(logits, 50, 0.95, 1.0, self._local_graph_rand[1 + channel : 2 + channel])
             self._local_graph_codes[channel] = code.reshape(())
             if channel + 1 < self.n_vq:
-                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+                current = self.local_transformer.step(
+                    F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1
+                )
 
     def _greedy_decode_frame_kernel(self) -> None:
         hidden = self._local_graph_input
@@ -563,7 +1208,9 @@ class MossTTSLocalForGeneration(nn.Module):
             code = torch.argmax(logits, dim=-1)
             self._local_graph_codes[channel] = code.reshape(())
             if channel + 1 < self.n_vq:
-                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+                current = self.local_transformer.step(
+                    F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1
+                )
 
     def _ensure_local_graph(self, device: torch.device) -> None:
         if self._local_graph is not None:
@@ -603,13 +1250,144 @@ class MossTTSLocalForGeneration(nn.Module):
         self._local_graph.replay()
         return int(self._local_graph_stop.item()), self._local_graph_codes.clone()
 
-    def _decode_frame_sampling_graph(self, hidden: torch.Tensor, generator: torch.Generator | None) -> tuple[int, torch.Tensor]:
+    def _decode_frame_sampling_graph(
+        self, hidden: torch.Tensor, generator: torch.Generator | None
+    ) -> tuple[int, torch.Tensor]:
         self._ensure_local_sampling_graph(hidden.device)
         self._local_graph_input.copy_(hidden.to(dtype=self._local_graph_input.dtype))
         rand_vals = torch.rand(1 + self.n_vq, device=hidden.device, generator=generator)
         self._local_graph_rand.copy_(rand_vals)
         self._local_graph_sampling.replay()
         return int(self._local_graph_stop.item()), self._local_graph_codes.clone()
+
+    def _ensure_batch_frame_graph_buffers(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if (
+            self._batch_frame_graph_input is not None
+            and self._batch_frame_graph_input.device == device
+            and self._batch_frame_graph_input.dtype == dtype
+            and self._batch_frame_graph_max_batch >= batch_size
+        ):
+            return
+        cap = max(batch_size, self._batch_frame_graph_max_batch, 8)
+        self._batch_frame_graph_input = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
+        self._batch_frame_graph_rand = torch.zeros(1 + self.n_vq, cap, device=device, dtype=torch.float32)
+        self._batch_frame_graph_stop = torch.zeros(cap, device=device, dtype=torch.long)
+        self._batch_frame_graph_codes = torch.zeros(cap, self.n_vq, device=device, dtype=torch.long)
+        self._batch_frame_graph_max_batch = cap
+        self._batch_frame_graphs.clear()
+        self._batch_stats["frame_graph_buffer_reset"] = self._batch_stats.get("frame_graph_buffer_reset", 0) + 1
+
+    def _batch_frame_graph_kernel(
+        self,
+        batch_size: int,
+        params: tuple[float, float, int, float, float, int],
+    ) -> None:
+        assert self._batch_frame_graph_input is not None
+        assert self._batch_frame_graph_rand is not None
+        assert self._batch_frame_graph_stop is not None
+        assert self._batch_frame_graph_codes is not None
+        text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k = params
+        hidden = self._batch_frame_graph_input[:batch_size]
+        rand = self._batch_frame_graph_rand[:, :batch_size]
+        local_hidden = self.local_transformer._step_eager(
+            hidden.to(dtype=self.audio_embeddings[0].weight.dtype),
+            0,
+        )
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop = self._sample_graph_safe_param(
+            text_logits,
+            temperature=text_temp,
+            top_p=text_top_p,
+            top_k=text_top_k,
+            rand_val=rand[0],
+        )
+        self._batch_frame_graph_stop[:batch_size].copy_(stop)
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            codes = self._sample_graph_safe_param(
+                logits,
+                temperature=audio_temp,
+                top_p=audio_top_p,
+                top_k=audio_top_k,
+                rand_val=rand[1 + channel],
+            )
+            self._batch_frame_graph_codes[:batch_size, channel].copy_(codes)
+            if channel + 1 < self.n_vq:
+                current = self.local_transformer._step_eager(
+                    F.embedding(codes, head_weight).to(dtype=current.dtype),
+                    channel + 1,
+                )
+
+    def _decode_frame_batched_graph(
+        self,
+        hidden_batch: torch.Tensor,
+        params: tuple[float, float, int, float, float, int],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = int(hidden_batch.shape[0])
+        capture_batch_size = self._frame_graph_capture_batch_size(batch_size)
+        dtype = self.audio_embeddings[0].weight.dtype
+        self.local_transformer._ensure_kv_cache(capture_batch_size, hidden_batch.device, dtype)
+        self._ensure_batch_frame_graph_buffers(
+            batch_size=capture_batch_size,
+            device=hidden_batch.device,
+            dtype=dtype,
+        )
+        assert self._batch_frame_graph_input is not None
+        assert self._batch_frame_graph_rand is not None
+        assert self._batch_frame_graph_stop is not None
+        assert self._batch_frame_graph_codes is not None
+        profile = bool(getattr(self, "_frame_graph_profile_enabled", False))
+        _t = time.perf_counter()
+        self._batch_frame_graph_input[:batch_size].copy_(hidden_batch.to(dtype=dtype))
+        if capture_batch_size > batch_size:
+            self._batch_frame_graph_input[batch_size:capture_batch_size].zero_()
+        if profile:
+            self._batch_stats["frame_graph_input_ms"] += (time.perf_counter() - _t) * 1000
+            _t = time.perf_counter()
+        self._batch_frame_graph_rand[:, :capture_batch_size].copy_(
+            torch.rand(1 + self.n_vq, capture_batch_size, device=hidden_batch.device)
+        )
+        if profile:
+            self._batch_stats["frame_graph_rand_ms"] += (time.perf_counter() - _t) * 1000
+        graph_key = (capture_batch_size, params)
+        if profile:
+            key_counts = self._batch_stats.setdefault("frame_graph_keys", {})
+            key_counts[str(graph_key)] = int(key_counts.get(str(graph_key), 0)) + 1
+        if graph_key not in self._batch_frame_graphs:
+            _t = time.perf_counter()
+            self._batch_frame_graph_kernel(capture_batch_size, params)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                self._batch_frame_graph_kernel(capture_batch_size, params)
+            self._batch_frame_graphs[graph_key] = graph
+            if profile:
+                self._batch_stats["frame_graph_capture"] += 1
+                self._batch_stats["frame_graph_capture_ms"] += (time.perf_counter() - _t) * 1000
+                _t = time.perf_counter()
+            stop = self._batch_frame_graph_stop[:batch_size].clone()
+            codes = self._batch_frame_graph_codes[:batch_size].clone()
+            if profile:
+                self._batch_stats["frame_graph_clone_ms"] += (time.perf_counter() - _t) * 1000
+            return stop, codes
+        _t = time.perf_counter()
+        self._batch_frame_graphs[graph_key].replay()
+        if profile:
+            self._batch_stats["frame_graph_replay"] += 1
+            self._batch_stats["frame_graph_replay_ms"] += (time.perf_counter() - _t) * 1000
+            _t = time.perf_counter()
+        stop = self._batch_frame_graph_stop[:batch_size].clone()
+        codes = self._batch_frame_graph_codes[:batch_size].clone()
+        if profile:
+            self._batch_stats["frame_graph_clone_ms"] += (time.perf_counter() - _t) * 1000
+        return stop, codes
 
     def _decode_frame(self, hidden: torch.Tensor, info: dict[str, Any]) -> tuple[int, torch.Tensor]:
         state = info.get("audio_state", {}) or {}
@@ -628,9 +1406,11 @@ class MossTTSLocalForGeneration(nn.Module):
             audio_top_k_v = int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", 50))))
             audio_top_p_v = float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", 0.95))))
             default_sampling = (
-                text_top_k_v == 50 and audio_top_k_v == 50
+                text_top_k_v == 50
+                and audio_top_k_v == 50
                 and abs(audio_top_p_v - 0.95) < 0.01
-                and abs(text_temp - 1.0) < 0.01 and abs(audio_temp - 1.0) < 0.01
+                and abs(text_temp - 1.0) < 0.01
+                and abs(audio_temp - 1.0) < 0.01
             )
             if default_sampling:
                 generator = state.get("sampling_generator")
@@ -672,7 +1452,9 @@ class MossTTSLocalForGeneration(nn.Module):
             )
             codes.append(code.reshape(()))
             if channel + 1 < self.n_vq:
-                current = self.local_transformer.step(F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1)
+                current = self.local_transformer.step(
+                    F.embedding(code, head_weight).to(dtype=current.dtype), channel + 1
+                )
         return stop_choice, torch.stack(codes).to(dtype=torch.long)
 
     def _decode_frame_batched(
@@ -684,19 +1466,14 @@ class MossTTSLocalForGeneration(nn.Module):
         B = hidden_batch.shape[0]
         dtype = self.audio_embeddings[0].weight.dtype
         self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
-        local_hidden = self.local_transformer.step(hidden_batch.to(dtype=dtype), 0)
 
-        # Extract per-request params once
-        text_temp = 1.0
-        text_top_k = 50
-        text_top_p = 1.0
-        audio_temp = 1.0
-        audio_top_k = 50
-        audio_top_p = 0.95
-        homogeneous = True
-        for info in infos:
+        # Extract per-request params once.  Seed the comparison from the first
+        # request instead of hard-coded defaults so model-card sampling
+        # (audio_temperature=1.7, top_k=25, top_p=0.8) can still use the
+        # homogeneous batched path.
+        def frame_params(info: dict[str, Any]) -> tuple[float, int, float, float, int, float]:
             if not isinstance(info, dict):
-                continue
+                info = {}
             state = info.get("audio_state", {}) or {}
             tt = float(state.get("text_temperature", _first_scalar(info.get("text_temperature", 1.0))))
             tk = int(state.get("text_top_k", _first_scalar(info.get("text_top_k", 50))))
@@ -704,6 +1481,14 @@ class MossTTSLocalForGeneration(nn.Module):
             at = float(state.get("audio_temperature", _first_scalar(info.get("audio_temperature", 1.0))))
             ak = int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", 50))))
             ap = float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", 0.95))))
+            return tt, tk, tp, at, ak, ap
+
+        text_temp, text_top_k, text_top_p, audio_temp, audio_top_k, audio_top_p = (
+            frame_params(infos[0]) if infos else (1.0, 50, 1.0, 1.0, 50, 0.95)
+        )
+        homogeneous = True
+        for info in infos[1:]:
+            tt, tk, tp, at, ak, ap = frame_params(info)
             if abs(tt - text_temp) > 0.01 or tk != text_top_k or abs(tp - text_top_p) > 0.01:
                 homogeneous = False
                 break
@@ -711,21 +1496,60 @@ class MossTTSLocalForGeneration(nn.Module):
                 homogeneous = False
                 break
 
+        graph_params = (
+            float(text_temp),
+            float(text_top_p),
+            int(text_top_k),
+            float(audio_temp),
+            float(audio_top_p),
+            int(audio_top_k),
+        )
+        if (
+            homogeneous
+            and self._local_graph_enabled
+            and hidden_batch.device.type == "cuda"
+            and torch.cuda.is_available()
+        ):
+            try:
+                return self._decode_frame_batched_graph(hidden_batch, graph_params)
+            except Exception:
+                logger.exception("MOSS-TTS Local batched frame graph failed; falling back to eager local decode")
+                self._batch_frame_graphs.clear()
+
+        if self._local_graph_enabled and hidden_batch.device.type == "cuda":
+            bucket = _next_bucket(B)
+            if not self.local_transformer._graph_enabled or self.local_transformer._graph_batch_size < bucket:
+                self.local_transformer._ensure_kv_cache(bucket, hidden_batch.device, dtype)
+                self.local_transformer.enable_graphs(bucket)
+        local_hidden = self.local_transformer.step(hidden_batch.to(dtype=dtype), 0)
+
         text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
 
         if homogeneous:
             # Fast path: single batched call for all B rows (no per-request generator)
-            stop_choices = sample_top_k_top_p(
-                text_logits, temperature=text_temp, top_p=text_top_p, top_k=text_top_k,
-            )
+            if text_temp <= 0:
+                stop_choices = torch.argmax(text_logits, dim=-1)
+            else:
+                stop_choices = sample_top_k_top_p(
+                    text_logits,
+                    temperature=text_temp,
+                    top_p=text_top_p,
+                    top_k=text_top_k,
+                )
             all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
             current = local_hidden
             for channel in range(self.n_vq):
                 head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
                 logits = F.linear(current, head_weight).float()
-                codes = sample_top_k_top_p(
-                    logits, temperature=audio_temp, top_p=audio_top_p, top_k=audio_top_k,
-                )
+                if audio_temp <= 0:
+                    codes = torch.argmax(logits, dim=-1)
+                else:
+                    codes = sample_top_k_top_p(
+                        logits,
+                        temperature=audio_temp,
+                        top_p=audio_top_p,
+                        top_k=audio_top_k,
+                    )
                 all_codes[:, channel] = codes
                 if channel + 1 < self.n_vq:
                     embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
@@ -741,7 +1565,7 @@ class MossTTSLocalForGeneration(nn.Module):
             if not isinstance(gen, torch.Generator):
                 gen = None
             stop_choices[b] = sample_top_k_top_p(
-                text_logits[b:b+1],
+                text_logits[b : b + 1],
                 temperature=float(state.get("text_temperature", 1.0)),
                 top_p=float(state.get("text_top_p", 1.0)),
                 top_k=int(state.get("text_top_k", 50)),
@@ -761,7 +1585,7 @@ class MossTTSLocalForGeneration(nn.Module):
                 if not isinstance(gen, torch.Generator):
                     gen = None
                 codes[b] = sample_top_k_top_p(
-                    logits[b:b+1],
+                    logits[b : b + 1],
                     temperature=float(state.get("audio_temperature", 1.0)),
                     top_p=float(state.get("audio_top_p", 0.95)),
                     top_k=int(state.get("audio_top_k", 50)),
@@ -800,13 +1624,65 @@ class MossTTSLocalForGeneration(nn.Module):
             logger.exception("Failed to dump MOSS-TTS Local debug codes")
 
     def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        return self.decode_omni_frame_output(model_outputs, **kwargs)
+
+    def decode_omni_frame_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
         if isinstance(model_outputs, OmniOutput):
             self._batch_state = None
+            self._batch_next_text = None
             return model_outputs
         hidden = model_outputs
         info_dicts: list[dict[str, Any]] = (
             kwargs.get("model_intermediate_buffer") or kwargs.get("runtime_additional_information") or []
         )
+        query_start_loc = kwargs.get("omni_query_start_loc")
+        request_token_spans = kwargs.get("request_token_spans")
+        sample_row_by_req = kwargs.get("omni_sample_row_by_req")
+        span_lens: list[int] | None = kwargs.get("omni_span_lens")
+        if span_lens is not None:
+            span_lens = [int(x) for x in span_lens[: len(info_dicts)]]
+        elif isinstance(request_token_spans, (list, tuple)) and len(request_token_spans) >= len(info_dicts):
+            span_lens = [int(end) - int(start) for start, end in request_token_spans[: len(info_dicts)]]
+        elif isinstance(query_start_loc, torch.Tensor) and query_start_loc.numel() >= len(info_dicts) + 1:
+            qsl_cpu = query_start_loc[: len(info_dicts) + 1].detach().to("cpu").tolist()
+            span_lens = [int(qsl_cpu[i + 1]) - int(qsl_cpu[i]) for i in range(len(info_dicts))]
+            request_token_spans = [(int(qsl_cpu[i]), int(qsl_cpu[i + 1])) for i in range(len(info_dicts))]
+
+        logits_index = kwargs.get("logits_index")
+        sample_hidden = hidden
+        logits_rows: list[int] | None = None
+        if isinstance(logits_index, torch.Tensor) and logits_index.numel() > 0:
+            logits_index_gpu = logits_index.to(device=hidden.device, dtype=torch.long).reshape(-1)
+            num_sample_rows = int(logits_index_gpu.numel())
+            if int(hidden.shape[0]) == num_sample_rows:
+                sample_hidden = hidden
+            elif int(logits_index_gpu.max().item()) < int(hidden.shape[0]):
+                sample_hidden = hidden.index_select(0, logits_index_gpu)
+            else:
+                sample_hidden = hidden[:num_sample_rows]
+            if not isinstance(sample_row_by_req, (list, tuple)):
+                logits_rows = logits_index.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
+        elif isinstance(logits_index, int):
+            logits_rows = [int(logits_index)]
+            sample_hidden = hidden[int(logits_index) : int(logits_index) + 1]
+        elif isinstance(request_token_spans, (list, tuple)) and len(request_token_spans) >= len(info_dicts):
+            sample_rows: list[int] = []
+            for start, end in request_token_spans[: len(info_dicts)]:
+                del start
+                sample_rows.append(int(end) - 1)
+            if sample_rows and all(0 <= row < int(hidden.shape[0]) for row in sample_rows):
+                sample_rows_t = torch.tensor(sample_rows, device=hidden.device, dtype=torch.long)
+                sample_hidden = hidden.index_select(0, sample_rows_t)
+                logits_rows = sample_rows
+        elif (
+            span_lens is not None
+            and len(span_lens) >= len(info_dicts)
+            and all(span == 1 for span in span_lens[: len(info_dicts)])
+            and len(info_dicts) > 0
+            and int(hidden.shape[0]) > len(info_dicts)
+        ):
+            sample_hidden = hidden[: len(info_dicts)]
+
         for info in info_dicts:
             if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
                 state = {"step": 0, "is_stopping": False}
@@ -816,136 +1692,443 @@ class MossTTSLocalForGeneration(nn.Module):
                     state["sampling_generator"] = sampling_generator
                 info["audio_state"] = state
 
-        audio_codes_list: list[torch.Tensor | None] = []
-        if hidden.numel() > 0 and info_dicts:
-            num_rows = int(hidden.shape[0])
-            rows_per_req = max(1, num_rows // max(1, len(info_dicts)))
+        pending_req_ids, pending_codes, pending_codec_streaming = self._consume_pending_stop_result(info_dicts)
 
-            # Try batched decode: all active (non-stopping) requests processed in one pass
-            active_indices: list[int] = []
+        delta_req_ids: list[str] = list(pending_req_ids)
+        delta_codes: list[torch.Tensor] = list(pending_codes)
+        delta_codec_streaming: list[bool] = list(pending_codec_streaming)
+        next_text_tensor: torch.Tensor | None = None
+        batch_state_by_sample_row: list[dict[str, Any] | None] = []
+        if sample_hidden.numel() > 0 and info_dicts:
+            num_rows = int(sample_hidden.shape[0])
+            next_text_tensor = torch.full(
+                (num_rows,),
+                self.audio_end_token_id,
+                dtype=torch.long,
+                device=hidden.device,
+            )
+            batch_state_by_sample_row = [None for _ in range(num_rows)]
+            logits_row_to_sample_row = (
+                {int(row): pos for pos, row in enumerate(logits_rows)} if logits_rows is not None else None
+            )
+            pure_decode_rows = (
+                num_rows == len(info_dicts) and span_lens is not None and all(span == 1 for span in span_lens)
+            )
+
+            def sample_row_for_request(req_index: int) -> int | None:
+                if isinstance(sample_row_by_req, (list, tuple)) and req_index < len(sample_row_by_req):
+                    row = int(sample_row_by_req[req_index])
+                    return row if row >= 0 else None
+                if pure_decode_rows:
+                    return req_index
+                if isinstance(request_token_spans, (list, tuple)) and req_index < len(request_token_spans):
+                    start, end = request_token_spans[req_index]
+                    start_i = int(start)
+                    end_i = int(end)
+                    if end_i <= start_i:
+                        return None
+                    hidden_row = end_i - 1
+                    if logits_row_to_sample_row is not None:
+                        return logits_row_to_sample_row.get(hidden_row)
+                    if 0 <= hidden_row < num_rows:
+                        return hidden_row
+                    return None
+                if num_rows == len(info_dicts) == 1:
+                    return req_index
+                return None
+
+            decode_items: list[tuple[int, int]] = []
             for i, info in enumerate(info_dicts):
                 if not isinstance(info, dict):
                     continue
                 state = info.get("audio_state", {}) or {}
-                if not state.get("is_stopping"):
-                    active_indices.append(i)
+                row_idx = sample_row_for_request(i)
+                if row_idx is None or row_idx < 0 or row_idx >= num_rows:
+                    continue
+                batch_state_by_sample_row[row_idx] = state
+                if state.get("is_stopping"):
+                    state["next_text"] = self.audio_end_token_id
+                    next_text_tensor[row_idx] = self.audio_end_token_id
+                    continue
+                if span_lens is not None and i < len(span_lens) and span_lens[i] != 1:
+                    state["next_text"] = self.audio_assistant_slot_token_id
+                    next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
+                    continue
+                decode_items.append((i, row_idx))
 
-            use_batched = (
-                len(active_indices) > 1
-                and num_rows == len(info_dicts)
-                and all(isinstance(info_dicts[j], dict) for j in active_indices)
-            )
+            use_batched = len(decode_items) > 1 and all(isinstance(info_dicts[j], dict) for j, _ in decode_items)
 
             if use_batched:
-                hidden_batch = torch.stack([hidden[j] for j in active_indices])
+                profile_detail = bool(getattr(self, "_profile_detail_enabled", False))
+                decode_rows = [row_idx for _, row_idx in decode_items]
+                n_active = len(decode_items)
+                asm_buffers = self._ensure_output_asm_buffers(batch_size=n_active, device=hidden.device)
+                rows_cpu = asm_buffers["rows_cpu"][:n_active]
+                for bi, row_idx in enumerate(decode_rows):
+                    rows_cpu[bi] = int(row_idx)
+                decode_rows_t = asm_buffers["rows_gpu"][:n_active]
+                decode_rows_t.copy_(rows_cpu, non_blocking=hidden.device.type == "cuda")
+                hidden_batch = (
+                    sample_hidden
+                    if decode_rows == list(range(len(decode_rows))) and len(decode_rows) == int(sample_hidden.shape[0])
+                    else sample_hidden.index_select(0, decode_rows_t)
+                )
                 _t_local = time.perf_counter()
-                stop_choices, all_codes = self._decode_frame_batched(hidden_batch, [info_dicts[j] for j in active_indices])
+                stop_choices, all_codes = self._decode_frame_batched(
+                    hidden_batch, [info_dicts[j] for j, _ in decode_items]
+                )
                 self._batch_stats["t_local_tx_ms"] += (time.perf_counter() - _t_local) * 1000
 
                 _t_asm = time.perf_counter()
-                stop_list = stop_choices.detach().cpu().tolist()
-                active_set = set(active_indices)
-                bi = 0
-                for i, info in enumerate(info_dicts):
-                    if not isinstance(info, dict):
-                        audio_codes_list.append(None)
-                        continue
-                    state = info.get("audio_state", {}) or {}
-                    if state.get("is_stopping"):
-                        state["next_text"] = self.audio_end_token_id
-                        audio_codes_list.append(None)
-                        continue
-                    if i not in active_set:
-                        audio_codes_list.append(None)
-                        continue
+                _t_detail = _t_asm
+                active_states: list[dict[str, Any]] = []
+                active_slot_ids: list[int] = []
+                pool = self._get_request_state_pool()
+                pool.ensure_frame_state_device(hidden.device)
+                slot_cpu = asm_buffers["slot_cpu"][:n_active]
+                all_slots_valid = (
+                    pool.steps_gpu is not None
+                    and pool.min_frames_gpu is not None
+                    and pool.max_frames_gpu is not None
+                    and pool.is_stopping_gpu is not None
+                    and hidden.device.type == "cuda"
+                )
+                for bi, (i, _) in enumerate(decode_items):
+                    state = info_dicts[i].get("audio_state", {}) or {}
+                    active_states.append(state)
+                    slot_id_raw = info_dicts[i].get("_kv_slot_id")
+                    try:
+                        slot_id = int(slot_id_raw)
+                    except (TypeError, ValueError):
+                        slot_id = -1
+                    active_slot_ids.append(slot_id)
+                    slot_cpu[bi] = slot_id
+                    if 0 <= slot_id < pool.max_slots:
+                        if pool.is_stopping_py[slot_id]:
+                            state["is_stopping"] = True
+                    else:
+                        all_slots_valid = False
+                if profile_detail:
+                    _now = time.perf_counter()
+                    self._batch_stats["t_asm_active_state_ms"] += (_now - _t_detail) * 1000
+                    _t_detail = _now
+
+                next_for_active = asm_buffers["next_gpu"][:n_active]
+                next_for_active.fill_(self.audio_assistant_slot_token_id)
+                should_stop_list: list[bool] = [False for _ in range(n_active)]
+                stop_sync_start: float | None = None
+                delay_stop_pending = False
+                slot_ids_t = asm_buffers["slot_gpu"][:n_active]
+                slot_ids_t.copy_(slot_cpu, non_blocking=hidden.device.type == "cuda")
+                steps_t = asm_buffers["steps_gpu"][:n_active]
+                min_frames_t = asm_buffers["min_gpu"][:n_active]
+                max_frames_t = asm_buffers["max_gpu"][:n_active]
+                should_stop_t = asm_buffers["stop_gpu"][:n_active]
+                tmp_stop_t = asm_buffers["tmp_stop_gpu"][:n_active]
+                stop_interval = int(getattr(self, "_stop_check_interval", 1))
+                step_values: list[int] = []
+                min_values: list[int] = []
+                max_values: list[int] = []
+                model_stop_poll: list[bool] = []
+                max_stop_list: list[bool] = []
+                active_req_ids: list[str] = []
+                for state, slot_id in zip(active_states, active_slot_ids):
+                    if 0 <= slot_id < pool.max_slots:
+                        step_num = pool.steps_py[slot_id]
+                        min_frames = pool.min_frames_py[slot_id]
+                        max_frames = pool.max_frames_py[slot_id]
+                    else:
+                        step_num = int(state.get("step", 0))
+                        min_frames = int(state.get("min_new_frames", 3))
+                        max_frames = int(state.get("max_new_frames", 150))
+                    step_values.append(step_num)
+                    min_values.append(min_frames)
+                    max_values.append(max_frames)
+                    max_due = step_num >= max_frames
+                    max_stop_list.append(max_due)
+                    model_stop_poll.append(
+                        (not max_due)
+                        and step_num >= min_frames
+                        and (stop_interval <= 1 or ((step_num - min_frames) % stop_interval) == 0)
+                    )
+                for i, _ in decode_items:
+                    info = info_dicts[i]
+                    active_req_ids.append(str(info.get("request_id") or info.get("global_request_id") or ""))
+                stop_possible = any(model_stop_poll) or any(max_stop_list)
+                if all_slots_valid:
+                    torch.index_select(pool.steps_gpu, 0, slot_ids_t, out=steps_t)
+                    torch.index_select(pool.min_frames_gpu, 0, slot_ids_t, out=min_frames_t)
+                    torch.index_select(pool.max_frames_gpu, 0, slot_ids_t, out=max_frames_t)
+                else:
+                    steps_cpu = asm_buffers["steps_cpu"][:n_active]
+                    min_cpu = asm_buffers["min_cpu"][:n_active]
+                    max_cpu = asm_buffers["max_cpu"][:n_active]
+                    for bi, (step_num, min_frames, max_frames) in enumerate(zip(step_values, min_values, max_values)):
+                        steps_cpu[bi] = step_num
+                        min_cpu[bi] = min_frames
+                        max_cpu[bi] = max_frames
+                    steps_t.copy_(steps_cpu, non_blocking=hidden.device.type == "cuda")
+                    min_frames_t.copy_(min_cpu, non_blocking=hidden.device.type == "cuda")
+                    max_frames_t.copy_(max_cpu, non_blocking=hidden.device.type == "cuda")
+                if profile_detail:
+                    _now = time.perf_counter()
+                    self._batch_stats["t_asm_state_gather_ms"] += (_now - _t_detail) * 1000
+                    _t_detail = _now
+                delay_model_stop = (
+                    bool(getattr(self, "_delay_stop_sync_enabled", False))
+                    and hidden.device.type == "cuda"
+                    and stop_interval == 1
+                    and not all_slots_valid
+                    and any(model_stop_poll)
+                )
+                delay_delta_routing = bool(getattr(self, "_delay_delta_routing_enabled", False))
+                if stop_possible:
+                    stop_cpu = asm_buffers["stop_cpu"][:n_active]
+                    if delay_model_stop:
+                        torch.eq(stop_choices.reshape(-1)[:n_active], 1, out=should_stop_t)
+                        torch.ge(steps_t, min_frames_t, out=tmp_stop_t)
+                        should_stop_t.logical_and_(tmp_stop_t)
+                        stop_cpu.copy_(should_stop_t, non_blocking=True)
+                        stop_copy_event = asm_buffers.get("stop_copy_event")
+                        if isinstance(stop_copy_event, torch.cuda.Event):
+                            stop_copy_event.record(torch.cuda.current_stream(hidden.device))
+                            pending_stop_result = {
+                                "event": stop_copy_event,
+                                "stop_cpu": stop_cpu,
+                                "slot_ids": list(active_slot_ids),
+                                "req_ids": list(active_req_ids),
+                                "force_stop": list(max_stop_list),
+                                "steps": list(step_values),
+                            }
+                            if delay_delta_routing:
+                                pending_stop_result["codes"] = all_codes.detach().clone()
+                                pending_stop_result["codec_streaming"] = [
+                                    _stream_flag_from_info(info_dicts[i]) for i, _ in decode_items
+                                ]
+                            self._pending_stop_result = pending_stop_result
+                            delay_stop_pending = True
+                        should_stop_list = [bool(x) for x in max_stop_list]
+                        next_for_active.fill_(self.audio_assistant_slot_token_id)
+                        if any(max_stop_list):
+                            poll_cpu = asm_buffers["poll_cpu"][:n_active]
+                            for bi, should_stop in enumerate(max_stop_list):
+                                poll_cpu[bi] = bool(should_stop)
+                            max_stop_t = asm_buffers["poll_gpu"][:n_active]
+                            max_stop_t.copy_(poll_cpu, non_blocking=True)
+                            next_for_active.masked_fill_(max_stop_t, self.audio_end_token_id)
+                    elif any(model_stop_poll):
+                        stop_sync_start = time.perf_counter()
+                        model_stop_mask = None
+                        if stop_interval > 1:
+                            poll_cpu = asm_buffers["poll_cpu"][:n_active]
+                            for bi, allowed in enumerate(model_stop_poll):
+                                poll_cpu[bi] = bool(allowed)
+                            model_stop_mask = asm_buffers["poll_gpu"][:n_active]
+                            model_stop_mask.copy_(poll_cpu, non_blocking=hidden.device.type == "cuda")
+                        should_stop_t, next_for_active = self._compute_stop_and_next_tokens(
+                            stop_choices=stop_choices.reshape(-1)[:n_active],
+                            steps=steps_t,
+                            min_frames=min_frames_t,
+                            max_frames=max_frames_t,
+                            audio_assistant_slot_token_id=self.audio_assistant_slot_token_id,
+                            audio_end_token_id=self.audio_end_token_id,
+                            should_stop_out=should_stop_t,
+                            tmp_out=tmp_stop_t,
+                            next_tokens_out=next_for_active,
+                            model_stop_mask=model_stop_mask,
+                        )
+                        stop_cpu.copy_(should_stop_t, non_blocking=hidden.device.type == "cuda")
+                        stop_copy_event = asm_buffers.get("stop_copy_event")
+                        if isinstance(stop_copy_event, torch.cuda.Event):
+                            stop_copy_event.record(torch.cuda.current_stream(hidden.device))
+                    else:
+                        for bi, should_stop in enumerate(max_stop_list):
+                            stop_cpu[bi] = bool(should_stop)
+                        should_stop_t.copy_(stop_cpu, non_blocking=hidden.device.type == "cuda")
+                        next_for_active.fill_(self.audio_assistant_slot_token_id)
+                        if any(max_stop_list):
+                            next_for_active.masked_fill_(should_stop_t, self.audio_end_token_id)
+                    if profile_detail:
+                        _now = time.perf_counter()
+                        self._batch_stats["t_asm_stop_compute_ms"] += (_now - _t_detail) * 1000
+                        _t_detail = _now
+                    if delay_model_stop and delay_stop_pending:
+                        stop_copy_event = asm_buffers.get("stop_copy_event")
+                        if isinstance(stop_copy_event, torch.cuda.Event) and stop_copy_event.query():
+                            model_stop_list = [bool(x) for x in stop_cpu.tolist()]
+                            should_stop_list = [
+                                bool(max_due or model_due) for max_due, model_due in zip(max_stop_list, model_stop_list)
+                            ]
+                            for bi, should_stop in enumerate(should_stop_list):
+                                stop_cpu[bi] = bool(should_stop)
+                            should_stop_t.copy_(stop_cpu, non_blocking=True)
+                            next_for_active.fill_(self.audio_assistant_slot_token_id)
+                            next_for_active.masked_fill_(should_stop_t, self.audio_end_token_id)
+                            self._pending_stop_result = None
+                            delay_stop_pending = False
+                next_text_tensor.index_copy_(0, decode_rows_t, next_for_active)
+                if profile_detail:
+                    _now = time.perf_counter()
+                    self._batch_stats["t_asm_next_text_ms"] += (_now - _t_detail) * 1000
+                    _t_detail = _now
+                if stop_possible:
+                    stop_copy_event = asm_buffers.get("stop_copy_event")
+                    if (
+                        (not delay_model_stop)
+                        and any(model_stop_poll)
+                        and isinstance(stop_copy_event, torch.cuda.Event)
+                    ):
+                        stop_copy_event.synchronize()
+                    if stop_sync_start is not None:
+                        self._batch_stats["t_stop_sync_ms"] += (time.perf_counter() - stop_sync_start) * 1000
+                    if not delay_model_stop:
+                        should_stop_list = [bool(x) for x in stop_cpu.tolist()]
+                    if profile_detail:
+                        _now = time.perf_counter()
+                        self._batch_stats["t_asm_stop_wait_ms"] += (_now - _t_detail) * 1000
+                        _t_detail = _now
+                else:
+                    should_stop_t.zero_()
+                if all_slots_valid:
+                    pool.advance_frame_state_gpu(
+                        slot_ids_t,
+                        should_stop_t,
+                        should_stop_list,
+                        slot_ids_cpu=active_slot_ids,
+                    )
+                else:
+                    pool.advance_frame_state(active_slot_ids, should_stop_list)
+                if profile_detail:
+                    _now = time.perf_counter()
+                    self._batch_stats["t_asm_pool_advance_ms"] += (_now - _t_detail) * 1000
+                    _t_detail = _now
+
+                for bi, (i, _row_idx) in enumerate(decode_items):
+                    info = info_dicts[i]
+                    state = active_states[bi]
                     new_codes = all_codes[bi]
-                    step_num = int(state.get("step", 0))
-                    min_frames = int(state.get("min_new_frames", 3))
-                    if stop_list[bi] == 1 and step_num >= min_frames:
+                    should_stop = should_stop_list[bi]
+                    slot_id = active_slot_ids[bi]
+                    if 0 <= slot_id < pool.max_slots:
+                        step_num = pool.steps_py[slot_id]
+                        max_frames = pool.max_frames_py[slot_id]
+                    else:
+                        step_num = int(state.get("step", 0))
+                        max_frames = int(state.get("max_new_frames", 150))
+                    if should_stop:
                         state["is_stopping"] = True
                         state["next_text"] = self.audio_end_token_id
+                        state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(None)
                         self._batch_stats["completed_frames"].append(step_num)
                     else:
                         state["next_text"] = self.audio_assistant_slot_token_id
-                        state["step"] = int(state.get("step", 0)) + 1
+                        state["step"] = pool.steps_py[slot_id] if 0 <= slot_id < pool.max_slots else step_num + 1
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(new_codes.unsqueeze(0))
-                    bi += 1
+                        rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                        if rid or len(info_dicts) == 1:
+                            if not (delay_model_stop and delay_stop_pending and delay_delta_routing):
+                                delta_req_ids.append(rid)
+                                delta_codes.append(all_codes[bi : bi + 1])
+                                delta_codec_streaming.append(_stream_flag_from_info(info))
+                if profile_detail:
+                    _now = time.perf_counter()
+                    self._batch_stats["t_asm_state_loop_ms"] += (_now - _t_detail) * 1000
                 self._batch_stats["t_output_asm_ms"] += (time.perf_counter() - _t_asm) * 1000
             else:
                 # Sequential fallback (prefill, single request, or mixed)
-                for i, info in enumerate(info_dicts):
+                for i, row_idx in decode_items:
+                    info = info_dicts[i]
                     if not isinstance(info, dict):
-                        audio_codes_list.append(None)
                         continue
                     state = info.get("audio_state", {}) or {}
-                    row_end = min((i + 1) * rows_per_req, num_rows)
-                    if row_end <= i * rows_per_req:
-                        audio_codes_list.append(None)
-                        continue
                     if state.get("is_stopping"):
                         state["next_text"] = self.audio_end_token_id
-                        audio_codes_list.append(None)
+                        if next_text_tensor is not None:
+                            next_text_tensor[row_idx] = self.audio_end_token_id
                         continue
-                    stop_choice, new_codes = self._decode_frame(hidden[row_end - 1].unsqueeze(0), info)
+                    stop_choice, new_codes = self._decode_frame(sample_hidden[row_idx].unsqueeze(0), info)
                     step_num = int(state.get("step", 0))
                     min_frames = int(state.get("min_new_frames", 3))
                     if stop_choice == 1 and step_num >= min_frames:
                         state["is_stopping"] = True
                         state["next_text"] = self.audio_end_token_id
+                        if next_text_tensor is not None:
+                            next_text_tensor[row_idx] = self.audio_end_token_id
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(None)
                         continue
                     state["next_text"] = self.audio_assistant_slot_token_id
+                    if next_text_tensor is not None:
+                        next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
                     state["step"] = int(state.get("step", 0)) + 1
                     info["audio_codes"] = {"current": new_codes}
+                    rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                    if rid or len(info_dicts) == 1:
+                        delta_req_ids.append(rid)
+                        delta_codes.append(new_codes.unsqueeze(0))
+                        delta_codec_streaming.append(_stream_flag_from_info(info))
                     self._maybe_dump_codes_debug(
-                        hidden=hidden[row_end - 1].unsqueeze(0),
+                        hidden=sample_hidden[row_idx].unsqueeze(0),
                         new_codes=new_codes,
                         accumulated_codes=new_codes.unsqueeze(0),
                         state=state,
                     )
-                    audio_codes_list.append(new_codes.unsqueeze(0))
 
-        self._batch_state = [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
-        active_codes = [c for c in audio_codes_list if c is not None]
-        if not active_codes:
-            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        _t_tail = time.perf_counter() if bool(getattr(self, "_profile_detail_enabled", False)) else 0.0
+        self._batch_state = [
+            (state if isinstance(state, dict) else {"next_text": self.audio_end_token_id})
+            for state in batch_state_by_sample_row
+        ] or [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
+        self._batch_next_text = next_text_tensor
+        if not delta_codes:
+            if _t_tail:
+                self._batch_stats["t_asm_tail_ms"] += (time.perf_counter() - _t_tail) * 1000
+            return OmniOutput(
+                text_hidden_states=sample_hidden,
+                multimodal_outputs={"meta": {"next_text": next_text_tensor}} if next_text_tensor is not None else {},
+            )
         step_counter = max(
             (int((info.get("audio_state", {}) or {}).get("step", 0)) for info in info_dicts if isinstance(info, dict)),
             default=0,
         )
         # Single request: emit codes directly (original behavior, proven correct).
-        if len(info_dicts) == 1 and len(active_codes) == 1:
+        if len(info_dicts) == 1 and len(delta_codes) == 1:
+            codec_streaming = _stream_flag_from_info(info_dicts[0]) if isinstance(info_dicts[0], dict) else True
+            if _t_tail:
+                self._batch_stats["t_asm_tail_ms"] += (time.perf_counter() - _t_tail) * 1000
             return OmniOutput(
-                text_hidden_states=hidden,
-                multimodal_outputs={"codes": {"audio": active_codes[0]}, "meta": {"raw_rows": True, "step": step_counter}},
+                text_hidden_states=sample_hidden,
+                multimodal_outputs={
+                    "codes": {"audio": delta_codes[0]},
+                    "meta": {
+                        "raw_rows": True,
+                        "step": step_counter,
+                        "codec_streaming": codec_streaming,
+                        "next_text": next_text_tensor,
+                    },
+                },
             )
         # Batch>1: sparse routing with delta rows (only this step's new_codes).
         # Each active request emits [1, n_vq]; stopped requests are skipped.
-        req_ids: list[str] = []
-        delta_codes: list[torch.Tensor] = []
-        for i, info in enumerate(info_dicts):
-            code = audio_codes_list[i] if i < len(audio_codes_list) else None
-            if code is None or not isinstance(info, dict):
-                continue
-            rid = str(info.get("request_id") or info.get("global_request_id") or "")
-            if rid:
-                req_ids.append(rid)
-                delta_codes.append(code)
-        if not delta_codes:
-            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        if _t_tail:
+            self._batch_stats["t_asm_tail_ms"] += (time.perf_counter() - _t_tail) * 1000
         return OmniOutput(
-            text_hidden_states=hidden,
+            text_hidden_states=sample_hidden,
             multimodal_outputs={
                 "codes": {"audio": delta_codes},
-                "meta": {"sparse_audio": True, "req_id": req_ids, "raw_rows": True, "step": step_counter},
+                "meta": {
+                    "sparse_audio": True,
+                    "req_id": delta_req_ids,
+                    "raw_rows": True,
+                    "step": step_counter,
+                    "codec_streaming": delta_codec_streaming,
+                    "next_text": next_text_tensor,
+                },
             },
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        self._audio_embedding_weight_cache = None
         loaded: set[str] = set()
         params_dict = dict(self.named_parameters())
         backbone_weights: list[tuple[str, torch.Tensor]] = []

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
@@ -15,9 +15,11 @@ Activated via MOSS_TTS_LOCAL_NATIVE=1 environment variable.
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Iterable
 from typing import Any
 
+import hashlib
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -54,6 +56,45 @@ def _copy_sampling_overrides(state: dict[str, Any], info: dict[str, Any]) -> Non
             state[key] = _first_scalar(val)
 
 
+def _make_sampling_generator(seed: Any, device: torch.device) -> torch.Generator | None:
+    seed = _first_scalar(seed)
+    if seed is None:
+        return None
+    try:
+        seed_int = int(seed)
+    except (TypeError, ValueError):
+        return None
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed_int)
+    return generator
+
+
+def _debug_state_enabled() -> bool:
+    return os.environ.get("MOSS_TTS_LOCAL_DEBUG_STATE") == "1"
+
+
+def _request_label(info: dict[str, Any]) -> str:
+    return str(info.get("request_id") or info.get("global_request_id") or "")[-12:]
+
+
+def _update_debug_code_hash(state: dict[str, Any], codes: torch.Tensor) -> int:
+    values = codes.detach().to(device="cpu", dtype=torch.long).reshape(-1).tolist()
+    h = int(state.get("_debug_code_hash", 1469598103934665603))
+    for value in values:
+        h ^= int(value) & 0xFFFFFFFF
+        h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    state["_debug_code_hash"] = h
+    return h
+
+
+def _debug_tensor_digest(tensor: torch.Tensor) -> tuple[str, float, list[float]]:
+    sample = tensor.detach().to(device="cpu", dtype=torch.float32).contiguous()
+    digest = hashlib.sha256(sample.numpy().tobytes()).hexdigest()[:16]
+    norm = float(sample.norm().item())
+    head = [float(x) for x in sample.reshape(-1)[:4].tolist()]
+    return digest, norm, head
+
+
 class MossTTSLocalNativeModel(nn.Module):
     """Stage-0 AR model with vLLM native Qwen3 backbone.
 
@@ -67,6 +108,7 @@ class MossTTSLocalNativeModel(nn.Module):
     has_preprocess: bool = True
     has_postprocess: bool = False
     requires_raw_input_tokens: bool = True
+    supports_omni_query_start_loc: bool = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
@@ -107,11 +149,61 @@ class MossTTSLocalNativeModel(nn.Module):
         self._frame_graph_stop: torch.Tensor = torch.empty(0)
         self._frame_graph_codes: torch.Tensor = torch.empty(0)
         self._frame_graph_max_batch: int = 0
+        self._profile_enabled = os.environ.get("MOSS_TTS_LOCAL_PROFILE") == "1"
+        self._profile_sync = os.environ.get("MOSS_TTS_LOCAL_PROFILE_SYNC") == "1"
+        self._profile_log_every = int(os.environ.get("MOSS_TTS_LOCAL_PROFILE_LOG_EVERY", "100") or 100)
+        self._profile_stats: dict[str, Any] = {
+            "n_forward": 0,
+            "n_decode": 0,
+            "qwen_ms": 0.0,
+            "local_ms": 0.0,
+            "make_output_ms": 0.0,
+            "batch_sizes": [],
+        }
 
         self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
             ("audio_codes", "current"),
             ("hidden_states", "last"),
         }
+
+    def _can_profile_sync(self) -> bool:
+        if not self._profile_sync or not torch.cuda.is_available():
+            return False
+        try:
+            return not torch.cuda.is_current_stream_capturing()
+        except Exception:
+            return True
+
+    def _profile_mark(self) -> float:
+        if self._can_profile_sync():
+            torch.cuda.synchronize()
+        return time.perf_counter()
+
+    def _profile_elapsed_ms(self, start: float) -> float:
+        if self._can_profile_sync():
+            torch.cuda.synchronize()
+        return (time.perf_counter() - start) * 1000
+
+    def _maybe_log_profile(self) -> None:
+        if not self._profile_enabled:
+            return
+        n_decode = int(self._profile_stats["n_decode"])
+        n_forward = int(self._profile_stats["n_forward"])
+        if n_decode == 0 or n_decode % self._profile_log_every != 0:
+            return
+        batch_sizes = self._profile_stats["batch_sizes"][-self._profile_log_every :]
+        avg_bs = sum(batch_sizes) / max(1, len(batch_sizes))
+        logger.info(
+            "[moss-local-profile] forward=%d decode=%d avg_bs=%.2f "
+            "qwen=%.3fms local=%.3fms make_output=%.3fms sync=%s",
+            n_forward,
+            n_decode,
+            avg_bs,
+            self._profile_stats["qwen_ms"] / max(1, n_forward),
+            self._profile_stats["local_ms"] / max(1, n_decode),
+            self._profile_stats["make_output_ms"] / max(1, n_decode),
+            self._profile_sync,
+        )
 
     def _build_input_embeds(self, text_ids: torch.Tensor, audio_codes: torch.Tensor | None) -> torch.Tensor:
         embeds = self.model.embed_tokens(text_ids)
@@ -195,45 +287,164 @@ class MossTTSLocalNativeModel(nn.Module):
         **_: Any,
     ) -> torch.Tensor | IntermediateTensors:
         # Native path: vLLM handles batching, KV cache, attention via forward context
-        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        if not self._profile_enabled:
+            return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        start = self._profile_mark()
+        result = self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        self._profile_stats["qwen_ms"] += self._profile_elapsed_ms(start)
+        self._profile_stats["n_forward"] += 1
+        return result
 
     def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> torch.Tensor | None:
+        next_text_from_output: torch.Tensor | None = None
         if isinstance(hidden_states, OmniOutput):
+            meta = hidden_states.multimodal_outputs.get("meta", {}) if hidden_states.multimodal_outputs else {}
+            next_text = meta.get("next_text") if isinstance(meta, dict) else None
+            if isinstance(next_text, torch.Tensor):
+                next_text_from_output = next_text.to(device=hidden_states.text_hidden_states.device, dtype=torch.long)
             hidden_states = hidden_states.text_hidden_states
         if hidden_states.numel() == 0:
             return torch.zeros(1, self.vocab_size, device=hidden_states.device)
+        if next_text_from_output is not None:
+            rows = []
+            for token in next_text_from_output.reshape(-1).tolist():
+                one_hot = torch.full((self.vocab_size,), -1e9, device=hidden_states.device)
+                one_hot[int(token)] = 0.0
+                rows.append(one_hot)
+            self._batch_state = None
+            if _debug_state_enabled():
+                logger.info(
+                    "[moss-local-state] compute_logits source=meta rows=%d next=%s",
+                    len(rows),
+                    next_text_from_output.reshape(-1).detach().cpu().tolist(),
+                )
+            return torch.stack(rows)
         batch_state = self._batch_state
         if not batch_state:
             num_rows = hidden_states.shape[0] if hidden_states.dim() >= 1 else 1
+            if _debug_state_enabled():
+                logger.info("[moss-local-state] compute_logits source=zeros rows=%d", num_rows)
             return torch.zeros(num_rows, self.vocab_size, device=hidden_states.device)
         logit_rows: list[torch.Tensor] = []
+        debug_next: list[int | None] = []
         for i, state in enumerate(batch_state):
             if not isinstance(state, dict):
                 logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
+                debug_next.append(None)
                 continue
             next_text = state.get("next_text")
             if next_text is not None:
                 one_hot = torch.full((self.vocab_size,), -1e9, device=hidden_states.device)
                 one_hot[int(next_text)] = 0.0
                 logit_rows.append(one_hot)
+                debug_next.append(int(next_text))
             else:
                 logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
+                debug_next.append(None)
         self._batch_state = None
+        if _debug_state_enabled():
+            logger.info(
+                "[moss-local-state] compute_logits source=batch_state rows=%d next=%s",
+                len(logit_rows),
+                debug_next,
+            )
         return torch.stack(logit_rows)
 
-    def _decode_frame_eager(self, hidden_batch: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    @staticmethod
+    def _frame_params(info: dict[str, Any]) -> tuple[float, float, int, float, float, int, torch.Generator | None]:
+        state = info.get("audio_state", {}) or {}
+        generator = state.get("sampling_generator")
+        if not isinstance(generator, torch.Generator):
+            generator = None
+        temperature = _first_scalar(info.get("temperature", 1.0))
+        top_p = _first_scalar(info.get("top_p", 1.0))
+        top_k = _first_scalar(info.get("top_k", 50))
+        return (
+            float(state.get("text_temperature", _first_scalar(info.get("text_temperature", temperature)))),
+            float(state.get("text_top_p", _first_scalar(info.get("text_top_p", top_p)))),
+            int(state.get("text_top_k", _first_scalar(info.get("text_top_k", top_k)))),
+            float(state.get("audio_temperature", _first_scalar(info.get("audio_temperature", temperature)))),
+            float(state.get("audio_top_p", _first_scalar(info.get("audio_top_p", top_p)))),
+            int(state.get("audio_top_k", _first_scalar(info.get("audio_top_k", top_k)))),
+            generator,
+        )
+
+    @staticmethod
+    def _sample_with_params(
+        logits: torch.Tensor,
+        *,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        if float(temperature) <= 0:
+            return torch.argmax(logits, dim=-1)
+        return sample_top_k_top_p(
+            logits,
+            temperature=float(temperature),
+            top_p=float(top_p),
+            top_k=int(top_k),
+            generator=generator,
+        )
+
+    def _decode_frame_eager(
+        self,
+        hidden_batch: torch.Tensor,
+        infos: list[dict[str, Any]] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Pure computation path (no graph logic) for capture or eager fallback."""
         B = hidden_batch.shape[0]
+        infos = infos or [{} for _ in range(B)]
         dtype = self.audio_embeddings[0].weight.dtype
         local_hidden = self.local_transformer._step_eager(hidden_batch.to(dtype=dtype), 0)
         text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
-        stop_choices = sample_top_k_top_p(text_logits, temperature=1.0, top_p=1.0, top_k=50)
+
+        params = [self._frame_params(infos[i] if i < len(infos) and isinstance(infos[i], dict) else {}) for i in range(B)]
+        first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
+        homogeneous = all(item[:6] == first_params and item[6] is None for item in params)
+
+        if homogeneous:
+            text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k = first_params
+            stop_choices = self._sample_with_params(
+                text_logits,
+                temperature=text_temp,
+                top_p=text_top_p,
+                top_k=text_top_k,
+            )
+        else:
+            stop_choices = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
+            for b, (text_temp, text_top_p, text_top_k, _, _, _, generator) in enumerate(params):
+                stop_choices[b] = self._sample_with_params(
+                    text_logits[b:b + 1],
+                    temperature=text_temp,
+                    top_p=text_top_p,
+                    top_k=text_top_k,
+                    generator=generator,
+                )[0]
+
         all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
         current = local_hidden
         for channel in range(self.n_vq):
             head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
             logits = F.linear(current, head_weight).float()
-            codes = sample_top_k_top_p(logits, temperature=1.0, top_p=0.95, top_k=50)
+            if homogeneous:
+                codes = self._sample_with_params(
+                    logits,
+                    temperature=audio_temp,
+                    top_p=audio_top_p,
+                    top_k=audio_top_k,
+                )
+            else:
+                codes = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
+                for b, (_, _, _, audio_temp, audio_top_p, audio_top_k, generator) in enumerate(params):
+                    codes[b] = self._sample_with_params(
+                        logits[b:b + 1],
+                        temperature=audio_temp,
+                        top_p=audio_top_p,
+                        top_k=audio_top_k,
+                        generator=generator,
+                    )[0]
             all_codes[:, channel] = codes
             if channel + 1 < self.n_vq:
                 embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
@@ -261,16 +472,29 @@ class MossTTSLocalNativeModel(nn.Module):
         self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
 
         if hidden_batch.device.type != "cuda":
-            return self._decode_frame_eager(hidden_batch)
+            return self._decode_frame_eager(hidden_batch, infos)
+        if os.environ.get("MOSS_TTS_LOCAL_ENABLE_FRAME_GRAPH") != "1":
+            return self._decode_frame_eager(hidden_batch, infos)
+
+        params = [
+            self._frame_params(info if isinstance(info, dict) else {})
+            for info in infos[:B]
+        ]
+        if len(params) != B:
+            params.extend([self._frame_params({}) for _ in range(B - len(params))])
+        first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
+        graphable = all(item[:6] == first_params and item[6] is None for item in params)
+        if not graphable:
+            return self._decode_frame_eager(hidden_batch, infos)
 
         self._ensure_frame_graph_buffers(B, hidden_batch.device, dtype)
-        graph_key = B
+        graph_key = (B, first_params)
         if graph_key not in self._frame_graphs:
             self._frame_graph_input[:B].copy_(hidden_batch)
-            self._decode_frame_eager(self._frame_graph_input[:B])
+            self._decode_frame_eager(self._frame_graph_input[:B], infos)
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):
-                stop, codes = self._decode_frame_eager(self._frame_graph_input[:B])
+                stop, codes = self._decode_frame_eager(self._frame_graph_input[:B], infos)
                 self._frame_graph_stop[:B].copy_(stop)
                 self._frame_graph_codes[:B].copy_(codes)
             self._frame_graphs[graph_key] = g
@@ -281,6 +505,8 @@ class MossTTSLocalNativeModel(nn.Module):
         return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
 
     def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        profile_start = self._profile_mark() if self._profile_enabled else 0.0
+        profile_local_ms = 0.0
         if isinstance(model_outputs, OmniOutput):
             self._batch_state = None
             return model_outputs
@@ -288,46 +514,191 @@ class MossTTSLocalNativeModel(nn.Module):
         info_dicts: list[dict[str, Any]] = (
             kwargs.get("model_intermediate_buffer") or kwargs.get("runtime_additional_information") or []
         )
+        logits_index = kwargs.get("logits_index")
+        sample_hidden = hidden
+        logits_rows: list[int] | None = None
+        if isinstance(logits_index, torch.Tensor) and logits_index.numel() > 0:
+            logits_rows = logits_index.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
+            sample_hidden = hidden[logits_index.to(device=hidden.device, dtype=torch.long)]
+        elif isinstance(logits_index, int):
+            logits_rows = [int(logits_index)]
+            sample_hidden = hidden[logits_index:logits_index + 1]
+
+        query_start_loc = kwargs.get("omni_query_start_loc")
+        request_token_spans = kwargs.get("request_token_spans")
+        span_lens: list[int] | None = None
+        qsl_cpu: list[int] | None = None
+        if isinstance(query_start_loc, torch.Tensor) and query_start_loc.numel() >= len(info_dicts) + 1:
+            qsl_cpu = query_start_loc[:len(info_dicts) + 1].detach().to("cpu").tolist()
+            span_lens = [int(qsl_cpu[i + 1]) - int(qsl_cpu[i]) for i in range(len(info_dicts))]
+            if not isinstance(request_token_spans, (list, tuple)):
+                request_token_spans = [(int(qsl_cpu[i]), int(qsl_cpu[i + 1])) for i in range(len(info_dicts))]
+        elif (
+            isinstance(request_token_spans, (list, tuple))
+            and len(request_token_spans) >= len(info_dicts)
+        ):
+            span_lens = [
+                int(end) - int(start)
+                for start, end in request_token_spans[:len(info_dicts)]
+            ]
+        if _debug_state_enabled():
+            if isinstance(logits_index, torch.Tensor):
+                logits_index_dbg = logits_index.detach().to("cpu").reshape(-1).tolist()
+            else:
+                logits_index_dbg = logits_index
+            logger.info(
+                "[moss-local-state] make_output enter hidden=%s sample=%s infos=%d qsl=%s logits_index=%s spans=%s reqs=%s",
+                tuple(hidden.shape),
+                tuple(sample_hidden.shape),
+                len(info_dicts),
+                qsl_cpu,
+                logits_index_dbg,
+                span_lens,
+                [_request_label(info) for info in info_dicts if isinstance(info, dict)],
+            )
         for info in info_dicts:
             if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
                 state = {"step": 0, "is_stopping": False}
                 _copy_sampling_overrides(state, info)
+                sampling_generator = _make_sampling_generator(info.get("seed"), hidden.device)
+                if sampling_generator is not None:
+                    state["sampling_generator"] = sampling_generator
                 info["audio_state"] = state
 
-        audio_codes_list: list[torch.Tensor | None] = []
+        audio_codes_list: list[torch.Tensor | None] = [None for _ in info_dicts]
+        batch_state_by_sample_row: list[dict[str, Any] | None] = []
         if hidden.numel() > 0 and info_dicts:
-            num_rows = int(hidden.shape[0])
-            active_indices: list[int] = []
+            num_rows = int(sample_hidden.shape[0])
+            batch_state_by_sample_row = [None for _ in range(num_rows)]
+            logits_row_to_sample_row = (
+                {int(row): pos for pos, row in enumerate(logits_rows)}
+                if logits_rows is not None
+                else None
+            )
+            decode_items: list[tuple[int, int]] = []
+
+            def sample_row_for_request(req_index: int) -> int | None:
+                if (
+                    isinstance(request_token_spans, (list, tuple))
+                    and req_index < len(request_token_spans)
+                ):
+                    start, end = request_token_spans[req_index]
+                    start_i = int(start)
+                    end_i = int(end)
+                    if end_i <= start_i:
+                        return None
+                    hidden_row = end_i - 1
+                    if logits_row_to_sample_row is not None:
+                        return logits_row_to_sample_row.get(hidden_row)
+                    if 0 <= hidden_row < num_rows:
+                        return hidden_row
+                    return None
+                if num_rows == len(info_dicts) == 1:
+                    return req_index
+                return None
+
             for i, info in enumerate(info_dicts):
                 if not isinstance(info, dict):
                     continue
                 state = info.get("audio_state", {}) or {}
-                if not state.get("is_stopping"):
-                    active_indices.append(i)
+                if state.get("is_stopping"):
+                    row_idx = sample_row_for_request(i)
+                    if row_idx is not None and 0 <= row_idx < num_rows:
+                        state["next_text"] = self.audio_end_token_id
+                        batch_state_by_sample_row[row_idx] = state
+                    continue
 
-            use_batched = len(active_indices) > 0 and num_rows == len(info_dicts)
+                row_idx = sample_row_for_request(i)
+                if row_idx is None or row_idx < 0 or row_idx >= num_rows:
+                    continue
+                if span_lens is not None and span_lens[i] != 1:
+                    # This request is still consuming a prefill span. The runner
+                    # will sample one text token for it, but MOSS local should not
+                    # generate an audio frame until the next decode-only step.
+                    state["next_text"] = self.audio_assistant_slot_token_id
+                    batch_state_by_sample_row[row_idx] = state
+                    continue
+                batch_state_by_sample_row[row_idx] = state
+                decode_items.append((i, row_idx))
 
-            if use_batched and len(active_indices) > 1:
-                hidden_batch = torch.stack([hidden[j] for j in active_indices])
-                stop_choices, all_codes = self._decode_frame_batched(hidden_batch, [info_dicts[j] for j in active_indices])
-                stop_list = stop_choices.detach().cpu().tolist()
-                active_set = set(active_indices)
-                bi = 0
+            use_batched = len(decode_items) > 0
+            if _debug_state_enabled():
+                row_debug = []
                 for i, info in enumerate(info_dicts):
                     if not isinstance(info, dict):
-                        audio_codes_list.append(None)
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    row_idx = sample_row_for_request(i)
+                    row_debug.append(
+                        {
+                            "req": _request_label(info),
+                            "info_idx": i,
+                            "row": row_idx,
+                            "span": span_lens[i] if span_lens is not None and i < len(span_lens) else None,
+                            "step": int(state.get("step", 0)),
+                            "next": state.get("next_text"),
+                        }
+                    )
+                logger.info(
+                    "[moss-local-state] make_output active=%s use_batched=%s rows=%d infos=%d rowmap=%s",
+                    [i for i, _ in decode_items],
+                    use_batched,
+                    num_rows,
+                    len(info_dicts),
+                    row_debug,
+                )
+
+            if (
+                use_batched
+                and len(decode_items) > 1
+                and os.environ.get("MOSS_TTS_LOCAL_DISABLE_LOCAL_BATCH") != "1"
+            ):
+                if _debug_state_enabled():
+                    for i, row_idx in decode_items:
+                        info = info_dicts[i]
+                        state = info.get("audio_state", {}) if isinstance(info, dict) else {}
+                        digest, norm, head = _debug_tensor_digest(sample_hidden[row_idx])
+                        logger.info(
+                            "[moss-local-state] hidden req=%s step=%d row=%d digest=%s norm=%.6f head=%s",
+                            _request_label(info) if isinstance(info, dict) else "",
+                            int(state.get("step", 0)) if isinstance(state, dict) else 0,
+                            row_idx,
+                            digest,
+                            norm,
+                            head,
+                        )
+                hidden_batch = torch.stack([sample_hidden[row_idx] for _, row_idx in decode_items])
+                local_start = self._profile_mark() if self._profile_enabled else 0.0
+                stop_choices, all_codes = self._decode_frame_batched(
+                    hidden_batch,
+                    [info_dicts[i] for i, _ in decode_items],
+                )
+                if self._profile_enabled:
+                    elapsed = self._profile_elapsed_ms(local_start)
+                    self._profile_stats["local_ms"] += elapsed
+                    profile_local_ms += elapsed
+                    self._profile_stats["n_decode"] += 1
+                    self._profile_stats["batch_sizes"].append(len(decode_items))
+                stop_list = stop_choices.detach().cpu().tolist()
+                batch_min_frames = int(os.environ.get("MOSS_TTS_LOCAL_BATCH_MIN_FRAMES", "80") or 80)
+                if _debug_state_enabled():
+                    logger.info(
+                        "[moss-local-state] decode batched reqs=%s stops=%s",
+                        [_request_label(info_dicts[i]) for i, _ in decode_items],
+                        stop_list,
+                    )
+                for bi, (i, _) in enumerate(decode_items):
+                    info = info_dicts[i]
+                    if not isinstance(info, dict):
                         continue
                     state = info.get("audio_state", {}) or {}
                     if state.get("is_stopping"):
                         state["next_text"] = self.audio_end_token_id
-                        audio_codes_list.append(None)
-                        continue
-                    if i not in active_set:
-                        audio_codes_list.append(None)
                         continue
                     new_codes = all_codes[bi]
+                    debug_hash = _update_debug_code_hash(state, new_codes) if _debug_state_enabled() else 0
                     step_num = int(state.get("step", 0))
-                    min_frames = int(state.get("min_new_frames", 3))
+                    min_frames = max(int(state.get("min_new_frames", 3)), batch_min_frames)
                     max_frames = int(state.get("max_new_frames", 150))
                     should_stop = (stop_list[bi] == 1 and step_num >= min_frames) or step_num >= max_frames
                     if should_stop:
@@ -335,26 +706,58 @@ class MossTTSLocalNativeModel(nn.Module):
                         state["next_text"] = self.audio_end_token_id
                         state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(None)
                     else:
                         state["next_text"] = self.audio_assistant_slot_token_id
                         state["step"] = step_num + 1
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(new_codes.unsqueeze(0))
-                    bi += 1
+                        audio_codes_list[i] = new_codes.unsqueeze(0)
+                    if _debug_state_enabled():
+                        logger.info(
+                            "[moss-local-state] update req=%s step=%d stop=%s next=%s code0=%d",
+                            _request_label(info),
+                            int(state.get("step", 0)),
+                            bool(should_stop),
+                            int(state.get("next_text", -1)),
+                            int(new_codes[0].item()),
+                        )
+                        if should_stop:
+                            logger.info(
+                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x",
+                                _request_label(info),
+                                step_num + 1,
+                                state.get("stop_reason"),
+                                debug_hash,
+                            )
             elif use_batched:
-                # Single active request
-                for i, info in enumerate(info_dicts):
+                for i, row_idx in decode_items:
+                    info = info_dicts[i]
                     if not isinstance(info, dict):
-                        audio_codes_list.append(None)
                         continue
                     state = info.get("audio_state", {}) or {}
                     if state.get("is_stopping"):
                         state["next_text"] = self.audio_end_token_id
-                        audio_codes_list.append(None)
                         continue
-                    stop_choices, all_codes = self._decode_frame_batched(hidden[i:i+1], [info])
+                    if _debug_state_enabled():
+                        digest, norm, head = _debug_tensor_digest(sample_hidden[row_idx])
+                        logger.info(
+                            "[moss-local-state] hidden req=%s step=%d row=%d digest=%s norm=%.6f head=%s",
+                            _request_label(info),
+                            int(state.get("step", 0)),
+                            row_idx,
+                            digest,
+                            norm,
+                            head,
+                        )
+                    local_start = self._profile_mark() if self._profile_enabled else 0.0
+                    stop_choices, all_codes = self._decode_frame_batched(sample_hidden[row_idx:row_idx + 1], [info])
+                    if self._profile_enabled:
+                        elapsed = self._profile_elapsed_ms(local_start)
+                        self._profile_stats["local_ms"] += elapsed
+                        profile_local_ms += elapsed
+                        self._profile_stats["n_decode"] += 1
+                        self._profile_stats["batch_sizes"].append(1)
                     new_codes = all_codes[0]
+                    debug_hash = _update_debug_code_hash(state, new_codes) if _debug_state_enabled() else 0
                     step_num = int(state.get("step", 0))
                     min_frames = int(state.get("min_new_frames", 3))
                     max_frames = int(state.get("max_new_frames", 150))
@@ -364,45 +767,107 @@ class MossTTSLocalNativeModel(nn.Module):
                         state["next_text"] = self.audio_end_token_id
                         state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(None)
                     else:
                         state["next_text"] = self.audio_assistant_slot_token_id
                         state["step"] = step_num + 1
                         info["audio_codes"] = {"current": new_codes}
-                        audio_codes_list.append(new_codes.unsqueeze(0))
+                        audio_codes_list[i] = new_codes.unsqueeze(0)
+                    if _debug_state_enabled():
+                        logger.info(
+                            "[moss-local-state] update req=%s step=%d stop=%s next=%s code0=%d",
+                            _request_label(info),
+                            int(state.get("step", 0)),
+                            bool(should_stop),
+                            int(state.get("next_text", -1)),
+                            int(new_codes[0].item()),
+                        )
+                        if should_stop:
+                            logger.info(
+                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x",
+                                _request_label(info),
+                                step_num + 1,
+                                state.get("stop_reason"),
+                                debug_hash,
+                            )
 
-        self._batch_state = [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
+        self._batch_state = [
+            (state if isinstance(state, dict) else {"next_text": self.audio_end_token_id})
+            for state in batch_state_by_sample_row
+        ]
+        next_text_values = [
+            int(state.get("next_text", self.audio_end_token_id))
+            if isinstance(state, dict)
+            else self.audio_end_token_id
+            for state in batch_state_by_sample_row
+        ]
+        next_text_tensor = torch.tensor(next_text_values, dtype=torch.long, device=hidden.device)
         active_codes = [c for c in audio_codes_list if c is not None]
         if not active_codes:
-            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+            output = OmniOutput(text_hidden_states=hidden, multimodal_outputs={"meta": {"next_text": next_text_tensor}})
+            if self._profile_enabled:
+                self._profile_stats["make_output_ms"] += max(
+                    0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+                )
+                self._maybe_log_profile()
+            return output
         step_counter = max(
             (int((info.get("audio_state", {}) or {}).get("step", 0)) for info in info_dicts if isinstance(info, dict)),
             default=0,
         )
         if len(info_dicts) == 1 and len(active_codes) == 1:
-            return OmniOutput(
+            output = OmniOutput(
                 text_hidden_states=hidden,
-                multimodal_outputs={"codes": {"audio": active_codes[0]}, "meta": {"raw_rows": True, "step": step_counter}},
+                multimodal_outputs={
+                    "codes": {"audio": active_codes[0]},
+                    "meta": {"raw_rows": True, "step": step_counter, "next_text": next_text_tensor},
+                },
             )
+            if self._profile_enabled:
+                self._profile_stats["make_output_ms"] += max(
+                    0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+                )
+                self._maybe_log_profile()
+            return output
         req_ids: list[str] = []
         delta_codes: list[torch.Tensor] = []
+        delta_steps: list[int] = []
         for i, info in enumerate(info_dicts):
             code = audio_codes_list[i] if i < len(audio_codes_list) else None
             if code is None or not isinstance(info, dict):
                 continue
             rid = str(info.get("request_id") or info.get("global_request_id") or "")
             if rid:
+                state = info.get("audio_state", {}) or {}
                 req_ids.append(rid)
                 delta_codes.append(code)
+                delta_steps.append(max(0, int(state.get("step", 0)) - 1))
         if not delta_codes:
-            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
-        return OmniOutput(
+            output = OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+            if self._profile_enabled:
+                self._profile_stats["make_output_ms"] += max(
+                    0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+                )
+                self._maybe_log_profile()
+            return output
+        output = OmniOutput(
             text_hidden_states=hidden,
             multimodal_outputs={
                 "codes": {"audio": delta_codes},
-                "meta": {"sparse_audio": True, "req_id": req_ids, "raw_rows": True, "step": step_counter},
+                "meta": {
+                    "sparse_audio": True,
+                    "req_id": req_ids,
+                    "raw_rows": True,
+                    "step": delta_steps,
+                    "next_text": next_text_tensor,
+                },
             },
         )
+        if self._profile_enabled:
+            self._profile_stats["make_output_ms"] += max(
+                0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+            )
+            self._maybe_log_profile()
+        return output
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loaded: set[str] = set()

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
@@ -1,0 +1,470 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""MOSS-TTS Local Transformer v1.5 AR stage — native vLLM backbone.
+
+Uses vLLM's compiled Qwen3Model with paged attention and CUDA graph
+instead of the custom HF-compatible backbone, plus a full-frame CUDA
+graph for the local transformer decode (13 sequential RVQ steps captured
+as a single graph replay). Achieves ~3ms/token vs ~30ms/token with the
+HF-compatible eager path (~9x speedup).
+
+Activated via MOSS_TTS_LOCAL_NATIVE=1 environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.qwen3 import Qwen3Model
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.sequence import IntermediateTensors
+
+from vllm_omni.model_executor.models.moss_tts_local.configuration_moss_tts_local import (
+    MossTTSLocalConfig,
+)
+from vllm_omni.model_executor.models.moss_tts_local.local_transformer import (
+    MossTTSLocalTransformer,
+    sample_top_k_top_p,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+
+def _first_scalar(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else None
+    return value
+
+
+def _copy_sampling_overrides(state: dict[str, Any], info: dict[str, Any]) -> None:
+    for key in ("text_temperature", "audio_temperature", "text_top_k", "audio_top_k",
+                "text_top_p", "audio_top_p", "max_new_frames", "min_new_frames"):
+        val = info.get(key)
+        if val is not None:
+            state[key] = _first_scalar(val)
+
+
+class MossTTSLocalNativeModel(nn.Module):
+    """Stage-0 AR model with vLLM native Qwen3 backbone.
+
+    The backbone uses vLLM's compiled Qwen3Model which handles KV cache
+    management, paged attention, and CUDA graph automatically via the
+    model runner's forward context.
+    """
+
+    input_modalities = "audio"
+    have_multimodal_outputs: bool = True
+    has_preprocess: bool = True
+    has_postprocess: bool = False
+    requires_raw_input_tokens: bool = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config: MossTTSLocalConfig = vllm_config.model_config.hf_config
+        gpt2_cfg = self.config.gpt2_config
+
+        self.hidden_size = int(self.config.qwen3_config.hidden_size)
+        self.vocab_size = int(self.config.qwen3_config.vocab_size)
+        self.n_vq = int(self.config.n_vq)
+        self.audio_vocab_size = int(self.config.audio_vocab_size)
+        self.audio_pad_code = int(self.config.audio_pad_code)
+        self.audio_assistant_slot_token_id = int(self.config.audio_assistant_slot_token_id)
+        self.audio_end_token_id = int(self.config.audio_end_token_id)
+
+        # Native vLLM Qwen3 backbone — gets paged attn + compile + CUDA graph
+        self.model = Qwen3Model(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+
+        self.audio_embeddings = nn.ModuleList(
+            [nn.Embedding(self.audio_vocab_size + 1, self.hidden_size) for _ in range(self.n_vq)]
+        )
+        self.local_transformer = MossTTSLocalTransformer(
+            hidden_size=self.hidden_size,
+            num_heads=int(getattr(gpt2_cfg, "n_head", 32)),
+            inner_size=int(getattr(gpt2_cfg, "n_inner", 4 * self.hidden_size) or 4 * self.hidden_size),
+            num_layers=int(getattr(self.config, "local_transformer_layers", 1)),
+            max_positions=self.n_vq + 1,
+            rope_base=float(getattr(gpt2_cfg, "rope_base", 1_000_000.0)),
+            layer_norm_eps=float(getattr(gpt2_cfg, "layer_norm_epsilon", 1e-6)),
+            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL") or getattr(self.config, "local_transformer_attn_implementation", None) or "eager",
+        )
+        self.local_text_lm_head = nn.Linear(self.hidden_size, 2, bias=False)
+        self._batch_state: list[dict[str, Any]] | None = None
+
+        # Full-frame CUDA graph: captures the entire _decode_frame_eager as one graph
+        self._frame_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self._frame_graph_input: torch.Tensor = torch.empty(0)
+        self._frame_graph_stop: torch.Tensor = torch.empty(0)
+        self._frame_graph_codes: torch.Tensor = torch.empty(0)
+        self._frame_graph_max_batch: int = 0
+
+        self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
+            ("audio_codes", "current"),
+            ("hidden_states", "last"),
+        }
+
+    def _build_input_embeds(self, text_ids: torch.Tensor, audio_codes: torch.Tensor | None) -> torch.Tensor:
+        embeds = self.model.embed_tokens(text_ids)
+        if audio_codes is None:
+            return embeds
+        codes = audio_codes.to(device=text_ids.device, dtype=torch.long)
+        if codes.dim() == 1:
+            codes = codes.unsqueeze(0)
+        for idx, emb in enumerate(self.audio_embeddings):
+            col = codes[:, idx].clamp(0, self.audio_vocab_size)
+            valid = col.ne(self.audio_pad_code)
+            safe_col = col.masked_fill(~valid, 0)
+            embeds = embeds + emb(safe_col) * valid.unsqueeze(-1)
+        return embeds
+
+    def preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        **info_dict: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        del input_embeds
+        device = input_ids.device
+        span_len = int(input_ids.shape[0])
+        audio_state = info_dict.get("audio_state")
+        is_first_call = not isinstance(audio_state, dict)
+
+        if span_len > 1 or is_first_call:
+            prompt_rows = info_dict.get("prompt_rows")
+            if isinstance(prompt_rows, torch.Tensor) and prompt_rows.numel() > 0:
+                rows = prompt_rows.to(device=device, dtype=torch.long)
+                text_ids = rows[:, 0]
+                audio_codes = rows[:, 1 : self.n_vq + 1]
+                embeds = self._build_input_embeds(text_ids, audio_codes)
+                current_codes = audio_codes[-1].detach()
+            else:
+                ref_codes = (info_dict.get("codes", {}) or {}).get("ref")
+                ref_offset = int(info_dict.get("ref_offset", 0))
+                chunk_audio = None
+                if isinstance(ref_codes, torch.Tensor) and ref_codes.numel() > 0:
+                    if ref_codes.dim() == 1 and ref_codes.numel() % self.n_vq == 0:
+                        ref_codes = ref_codes.view(-1, self.n_vq)
+                    if isinstance(ref_codes, torch.Tensor) and ref_codes.dim() == 2:
+                        sliced = ref_codes[ref_offset : ref_offset + span_len]
+                        if sliced.shape[0] == span_len:
+                            chunk_audio = sliced.to(device=device, dtype=torch.long)
+                embeds = self._build_input_embeds(input_ids, chunk_audio)
+                current_codes = (
+                    chunk_audio[-1].detach()
+                    if chunk_audio is not None
+                    else torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+                )
+                ref_offset = ref_offset + span_len
+
+            state = {
+                "step": 0,
+                "is_stopping": False,
+                "next_text": self.audio_assistant_slot_token_id,
+            }
+            _copy_sampling_overrides(state, info_dict)
+            return input_ids, embeds, {
+                "audio_state": state,
+                "audio_codes": {"current": current_codes},
+            }
+
+        prev_codes = (info_dict.get("audio_codes", {}) or {}).get("current")
+        if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
+            prev_codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(input_ids.reshape(-1), prev_codes.to(device=device).unsqueeze(0))
+        return input_ids, embeds, {}
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **_: Any,
+    ) -> torch.Tensor | IntermediateTensors:
+        # Native path: vLLM handles batching, KV cache, attention via forward context
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> torch.Tensor | None:
+        if isinstance(hidden_states, OmniOutput):
+            hidden_states = hidden_states.text_hidden_states
+        if hidden_states.numel() == 0:
+            return torch.zeros(1, self.vocab_size, device=hidden_states.device)
+        batch_state = self._batch_state
+        if not batch_state:
+            num_rows = hidden_states.shape[0] if hidden_states.dim() >= 1 else 1
+            return torch.zeros(num_rows, self.vocab_size, device=hidden_states.device)
+        logit_rows: list[torch.Tensor] = []
+        for i, state in enumerate(batch_state):
+            if not isinstance(state, dict):
+                logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
+                continue
+            next_text = state.get("next_text")
+            if next_text is not None:
+                one_hot = torch.full((self.vocab_size,), -1e9, device=hidden_states.device)
+                one_hot[int(next_text)] = 0.0
+                logit_rows.append(one_hot)
+            else:
+                logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
+        self._batch_state = None
+        return torch.stack(logit_rows)
+
+    def _decode_frame_eager(self, hidden_batch: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Pure computation path (no graph logic) for capture or eager fallback."""
+        B = hidden_batch.shape[0]
+        dtype = self.audio_embeddings[0].weight.dtype
+        local_hidden = self.local_transformer._step_eager(hidden_batch.to(dtype=dtype), 0)
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop_choices = sample_top_k_top_p(text_logits, temperature=1.0, top_p=1.0, top_k=50)
+        all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            codes = sample_top_k_top_p(logits, temperature=1.0, top_p=0.95, top_k=50)
+            all_codes[:, channel] = codes
+            if channel + 1 < self.n_vq:
+                embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
+                current = self.local_transformer._step_eager(embedded, channel + 1)
+        return stop_choices, all_codes
+
+    def _ensure_frame_graph_buffers(self, batch_size: int, device: torch.device, dtype: torch.dtype) -> None:
+        if batch_size <= self._frame_graph_max_batch:
+            return
+        cap = max(batch_size, 8)
+        self._frame_graph_input = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
+        self._frame_graph_stop = torch.zeros(cap, device=device, dtype=torch.long)
+        self._frame_graph_codes = torch.zeros(cap, self.n_vq, device=device, dtype=torch.long)
+        self._frame_graph_max_batch = cap
+        self._frame_graphs.clear()
+
+    def _decode_frame_batched(
+        self,
+        hidden_batch: torch.Tensor,
+        infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Batched local transformer decode: [B, H] -> (stop_choices[B], codes[B, n_vq])."""
+        B = hidden_batch.shape[0]
+        dtype = self.audio_embeddings[0].weight.dtype
+        self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
+
+        if hidden_batch.device.type != "cuda":
+            return self._decode_frame_eager(hidden_batch)
+
+        self._ensure_frame_graph_buffers(B, hidden_batch.device, dtype)
+        graph_key = B
+        if graph_key not in self._frame_graphs:
+            self._frame_graph_input[:B].copy_(hidden_batch)
+            self._decode_frame_eager(self._frame_graph_input[:B])
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                stop, codes = self._decode_frame_eager(self._frame_graph_input[:B])
+                self._frame_graph_stop[:B].copy_(stop)
+                self._frame_graph_codes[:B].copy_(codes)
+            self._frame_graphs[graph_key] = g
+            return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
+
+        self._frame_graph_input[:B].copy_(hidden_batch)
+        self._frame_graphs[graph_key].replay()
+        return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
+
+    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        if isinstance(model_outputs, OmniOutput):
+            self._batch_state = None
+            return model_outputs
+        hidden = model_outputs
+        info_dicts: list[dict[str, Any]] = (
+            kwargs.get("model_intermediate_buffer") or kwargs.get("runtime_additional_information") or []
+        )
+        for info in info_dicts:
+            if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
+                state = {"step": 0, "is_stopping": False}
+                _copy_sampling_overrides(state, info)
+                info["audio_state"] = state
+
+        audio_codes_list: list[torch.Tensor | None] = []
+        if hidden.numel() > 0 and info_dicts:
+            num_rows = int(hidden.shape[0])
+            active_indices: list[int] = []
+            for i, info in enumerate(info_dicts):
+                if not isinstance(info, dict):
+                    continue
+                state = info.get("audio_state", {}) or {}
+                if not state.get("is_stopping"):
+                    active_indices.append(i)
+
+            use_batched = len(active_indices) > 0 and num_rows == len(info_dicts)
+
+            if use_batched and len(active_indices) > 1:
+                hidden_batch = torch.stack([hidden[j] for j in active_indices])
+                stop_choices, all_codes = self._decode_frame_batched(hidden_batch, [info_dicts[j] for j in active_indices])
+                stop_list = stop_choices.detach().cpu().tolist()
+                active_set = set(active_indices)
+                bi = 0
+                for i, info in enumerate(info_dicts):
+                    if not isinstance(info, dict):
+                        audio_codes_list.append(None)
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    if state.get("is_stopping"):
+                        state["next_text"] = self.audio_end_token_id
+                        audio_codes_list.append(None)
+                        continue
+                    if i not in active_set:
+                        audio_codes_list.append(None)
+                        continue
+                    new_codes = all_codes[bi]
+                    step_num = int(state.get("step", 0))
+                    min_frames = int(state.get("min_new_frames", 3))
+                    max_frames = int(state.get("max_new_frames", 150))
+                    should_stop = (stop_list[bi] == 1 and step_num >= min_frames) or step_num >= max_frames
+                    if should_stop:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(None)
+                    else:
+                        state["next_text"] = self.audio_assistant_slot_token_id
+                        state["step"] = step_num + 1
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(new_codes.unsqueeze(0))
+                    bi += 1
+            elif use_batched:
+                # Single active request
+                for i, info in enumerate(info_dicts):
+                    if not isinstance(info, dict):
+                        audio_codes_list.append(None)
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    if state.get("is_stopping"):
+                        state["next_text"] = self.audio_end_token_id
+                        audio_codes_list.append(None)
+                        continue
+                    stop_choices, all_codes = self._decode_frame_batched(hidden[i:i+1], [info])
+                    new_codes = all_codes[0]
+                    step_num = int(state.get("step", 0))
+                    min_frames = int(state.get("min_new_frames", 3))
+                    max_frames = int(state.get("max_new_frames", 150))
+                    should_stop = (int(stop_choices[0].item()) == 1 and step_num >= min_frames) or step_num >= max_frames
+                    if should_stop:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(None)
+                    else:
+                        state["next_text"] = self.audio_assistant_slot_token_id
+                        state["step"] = step_num + 1
+                        info["audio_codes"] = {"current": new_codes}
+                        audio_codes_list.append(new_codes.unsqueeze(0))
+
+        self._batch_state = [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
+        active_codes = [c for c in audio_codes_list if c is not None]
+        if not active_codes:
+            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        step_counter = max(
+            (int((info.get("audio_state", {}) or {}).get("step", 0)) for info in info_dicts if isinstance(info, dict)),
+            default=0,
+        )
+        if len(info_dicts) == 1 and len(active_codes) == 1:
+            return OmniOutput(
+                text_hidden_states=hidden,
+                multimodal_outputs={"codes": {"audio": active_codes[0]}, "meta": {"raw_rows": True, "step": step_counter}},
+            )
+        req_ids: list[str] = []
+        delta_codes: list[torch.Tensor] = []
+        for i, info in enumerate(info_dicts):
+            code = audio_codes_list[i] if i < len(audio_codes_list) else None
+            if code is None or not isinstance(info, dict):
+                continue
+            rid = str(info.get("request_id") or info.get("global_request_id") or "")
+            if rid:
+                req_ids.append(rid)
+                delta_codes.append(code)
+        if not delta_codes:
+            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        return OmniOutput(
+            text_hidden_states=hidden,
+            multimodal_outputs={
+                "codes": {"audio": delta_codes},
+                "meta": {"sparse_audio": True, "req_id": req_ids, "raw_rows": True, "step": step_counter},
+            },
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loaded: set[str] = set()
+        params_dict = dict(self.named_parameters())
+
+        # vLLM Qwen3Model expects stacked qkv_proj and gate_up_proj
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        for original_name, tensor in weights:
+            name = original_name
+            if name.startswith("transformer."):
+                name = "model." + name[len("transformer."):]
+
+            # Skip text/audio lm heads from checkpoint (we have our own)
+            if name.startswith("text_lm_head.") or name.startswith("audio_lm_heads."):
+                continue
+
+            # Handle audio_embeddings separately
+            if name.startswith("audio_embeddings.") and name.endswith(".weight"):
+                param = params_dict.get(name)
+                if param is not None:
+                    rows = min(int(tensor.shape[0]), int(param.shape[0]))
+                    with torch.no_grad():
+                        param[:rows].copy_(tensor[:rows].to(device=param.device, dtype=param.dtype))
+                    loaded.add(name)
+                continue
+
+            # local_transformer and local_text_lm_head
+            if name.startswith("local_transformer.") or name.startswith("local_text_lm_head."):
+                param = params_dict.get(name)
+                if param is not None:
+                    default_weight_loader(param, tensor)
+                    loaded.add(name)
+                continue
+
+            # Backbone weights: try stacked mapping first
+            is_stacked = False
+            for packed_name, source_name, shard_id in stacked_params_mapping:
+                if source_name in name:
+                    packed_key = name.replace(source_name, packed_name)
+                    param = params_dict.get(packed_key)
+                    if param is not None:
+                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                        weight_loader(param, tensor, shard_id)
+                        loaded.add(packed_key)
+                        is_stacked = True
+                    break
+
+            if not is_stacked:
+                param = params_dict.get(name)
+                if param is not None:
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, tensor)
+                    loaded.add(name)
+
+        return loaded
+
+
+__all__ = ["MossTTSLocalNativeModel"]

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
@@ -9,17 +9,18 @@ graph for the local transformer decode (13 sequential RVQ steps captured
 as a single graph replay). Achieves ~3ms/token vs ~30ms/token with the
 HF-compatible eager path (~9x speedup).
 
-Activated via MOSS_TTS_LOCAL_NATIVE=1 environment variable.
+This native path is the default MOSS-TTS Local pipeline. Set
+MOSS_TTS_LOCAL_NATIVE=0 to use the HF-compatible fallback backbone.
 """
 
 from __future__ import annotations
 
+import hashlib
 import os
 import time
 from collections.abc import Iterable
 from typing import Any
 
-import hashlib
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -49,11 +50,35 @@ def _first_scalar(value: Any) -> Any:
 
 
 def _copy_sampling_overrides(state: dict[str, Any], info: dict[str, Any]) -> None:
-    for key in ("text_temperature", "audio_temperature", "text_top_k", "audio_top_k",
-                "text_top_p", "audio_top_p", "max_new_frames", "min_new_frames"):
+    for key in (
+        "text_temperature",
+        "audio_temperature",
+        "text_top_k",
+        "audio_top_k",
+        "text_top_p",
+        "audio_top_p",
+        "max_new_frames",
+        "min_new_frames",
+    ):
         val = info.get(key)
         if val is not None:
             state[key] = _first_scalar(val)
+
+
+def _stream_flag_from_info(info: dict[str, Any], default: bool = True) -> bool:
+    for key in ("stream", "codec_streaming"):
+        value = _first_scalar(info.get(key))
+        if value is not None:
+            return bool(value)
+    return default
+
+
+def _env_enabled(*names: str) -> bool:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None and value.strip().lower() in ("1", "true", "yes", "on"):
+            return True
+    return False
 
 
 def _make_sampling_generator(seed: Any, device: torch.device) -> torch.Generator | None:
@@ -87,12 +112,253 @@ def _update_debug_code_hash(state: dict[str, Any], codes: torch.Tensor) -> int:
     return h
 
 
+_BUCKET_SIZES = (64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096)
+
+
+def _next_bucket(value: int) -> int:
+    for bucket in _BUCKET_SIZES:
+        if int(value) <= bucket:
+            return int(bucket)
+    return int(value)
+
+
 def _debug_tensor_digest(tensor: torch.Tensor) -> tuple[str, float, list[float]]:
     sample = tensor.detach().to(device="cpu", dtype=torch.float32).contiguous()
     digest = hashlib.sha256(sample.numpy().tobytes()).hexdigest()[:16]
     norm = float(sample.norm().item())
     head = [float(x) for x in sample.reshape(-1)[:4].tolist()]
     return digest, norm, head
+
+
+class MossTTSLocalRequestStatePool:
+    """Request-slot frame state used by output assembly.
+
+    Native v2 leaves backbone KV management to vLLM.  This pool only mirrors
+    per-request frame counters and stop state so output assembly can use
+    batched tensor ops instead of per-row CPU/GPU synchronization.
+    """
+
+    def __init__(self, max_slots: int) -> None:
+        self.max_slots = max(1, int(max_slots))
+        self._slot_to_request: list[str | None] = [None] * self.max_slots
+        self._request_to_slot: dict[str, int] = {}
+        self._free_slots: list[int] = list(range(self.max_slots))
+        self.steps_cpu = torch.zeros(self.max_slots, dtype=torch.long)
+        self.min_frames_cpu = torch.full((self.max_slots,), 3, dtype=torch.long)
+        self.max_frames_cpu = torch.full((self.max_slots,), 150, dtype=torch.long)
+        self.is_stopping_cpu = torch.zeros(self.max_slots, dtype=torch.bool)
+        self.current_codes_cpu: torch.Tensor | None = None
+        self.steps_py = [0 for _ in range(self.max_slots)]
+        self.min_frames_py = [3 for _ in range(self.max_slots)]
+        self.max_frames_py = [150 for _ in range(self.max_slots)]
+        self.is_stopping_py = [False for _ in range(self.max_slots)]
+        self._frame_state_device: torch.device | None = None
+        self.steps_gpu: torch.Tensor | None = None
+        self.min_frames_gpu: torch.Tensor | None = None
+        self.max_frames_gpu: torch.Tensor | None = None
+        self.is_stopping_gpu: torch.Tensor | None = None
+        self.current_codes_gpu: torch.Tensor | None = None
+
+    def allocate_slot(self, request_id: str) -> int:
+        if request_id in self._request_to_slot:
+            return self._request_to_slot[request_id]
+        if not self._free_slots:
+            raise RuntimeError(f"No free MOSS-TTS Local state slots (max_slots={self.max_slots})")
+        slot_id = self._free_slots.pop(0)
+        self._slot_to_request[slot_id] = request_id
+        self._request_to_slot[request_id] = slot_id
+        return slot_id
+
+    def slot_for_request(self, request_id: str) -> int | None:
+        return self._request_to_slot.get(request_id)
+
+    def slot_request_id(self, slot_id: int) -> str | None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return None
+        return self._slot_to_request[slot_id]
+
+    def release_slot(self, request_id: str) -> None:
+        slot_id = self._request_to_slot.pop(request_id, None)
+        if slot_id is None:
+            return
+        self._slot_to_request[slot_id] = None
+        self.steps_cpu[slot_id] = 0
+        self.min_frames_cpu[slot_id] = 3
+        self.max_frames_cpu[slot_id] = 150
+        self.is_stopping_cpu[slot_id] = False
+        self.steps_py[slot_id] = 0
+        self.min_frames_py[slot_id] = 3
+        self.max_frames_py[slot_id] = 150
+        self.is_stopping_py[slot_id] = False
+        if self.steps_gpu is not None:
+            self.steps_gpu[slot_id] = 0
+        if self.min_frames_gpu is not None:
+            self.min_frames_gpu[slot_id] = 3
+        if self.max_frames_gpu is not None:
+            self.max_frames_gpu[slot_id] = 150
+        if self.is_stopping_gpu is not None:
+            self.is_stopping_gpu[slot_id] = False
+        if self.current_codes_cpu is not None:
+            self.current_codes_cpu[slot_id].fill_(0)
+        if self.current_codes_gpu is not None:
+            self.current_codes_gpu[slot_id].fill_(0)
+        self._free_slots.append(slot_id)
+
+    def init_frame_state(self, *, slot_id: int, min_new_frames: int = 3, max_new_frames: int = 150) -> None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return
+        self.steps_cpu[slot_id] = 0
+        self.min_frames_cpu[slot_id] = int(min_new_frames)
+        self.max_frames_cpu[slot_id] = int(max_new_frames)
+        self.is_stopping_cpu[slot_id] = False
+        self.steps_py[slot_id] = 0
+        self.min_frames_py[slot_id] = int(min_new_frames)
+        self.max_frames_py[slot_id] = int(max_new_frames)
+        self.is_stopping_py[slot_id] = False
+        if self.steps_gpu is not None:
+            self.steps_gpu[slot_id] = 0
+        if self.min_frames_gpu is not None:
+            self.min_frames_gpu[slot_id] = int(min_new_frames)
+        if self.max_frames_gpu is not None:
+            self.max_frames_gpu[slot_id] = int(max_new_frames)
+        if self.is_stopping_gpu is not None:
+            self.is_stopping_gpu[slot_id] = False
+        if self.current_codes_cpu is not None:
+            self.current_codes_cpu[slot_id].fill_(0)
+        if self.current_codes_gpu is not None:
+            self.current_codes_gpu[slot_id].fill_(0)
+
+    def ensure_frame_state_device(self, device: torch.device) -> None:
+        if device.type != "cuda" or not _env_enabled("MOSS_TTS_LOCAL_GPU_FRAME_STATE"):
+            return
+        if (
+            self._frame_state_device == device
+            and self.steps_gpu is not None
+            and self.min_frames_gpu is not None
+            and self.max_frames_gpu is not None
+            and self.is_stopping_gpu is not None
+        ):
+            return
+        self._frame_state_device = device
+        self.steps_gpu = self.steps_cpu.to(device=device, non_blocking=True)
+        self.min_frames_gpu = self.min_frames_cpu.to(device=device, non_blocking=True)
+        self.max_frames_gpu = self.max_frames_cpu.to(device=device, non_blocking=True)
+        self.is_stopping_gpu = self.is_stopping_cpu.to(device=device, non_blocking=True)
+
+    def ensure_current_codes(self, *, n_vq: int, audio_pad_code: int, device: torch.device) -> None:
+        if self.current_codes_cpu is None or tuple(self.current_codes_cpu.shape) != (self.max_slots, int(n_vq)):
+            self.current_codes_cpu = torch.full(
+                (self.max_slots, int(n_vq)),
+                int(audio_pad_code),
+                dtype=torch.long,
+            )
+            self.current_codes_gpu = None
+        if device.type != "cuda":
+            return
+        if (
+            self._frame_state_device == device
+            and self.current_codes_gpu is not None
+            and tuple(self.current_codes_gpu.shape) == (self.max_slots, int(n_vq))
+        ):
+            return
+        self._frame_state_device = device
+        self.current_codes_gpu = self.current_codes_cpu.to(device=device, non_blocking=True)
+
+    def set_current_codes(self, slot_id: int, codes: torch.Tensor, *, n_vq: int, audio_pad_code: int) -> None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return
+        device = codes.device
+        self.ensure_current_codes(n_vq=n_vq, audio_pad_code=audio_pad_code, device=device)
+        codes_1d = codes.reshape(-1)[: int(n_vq)].to(dtype=torch.long)
+        if self.current_codes_gpu is not None and device.type == "cuda":
+            self.current_codes_gpu[slot_id].copy_(codes_1d, non_blocking=True)
+        elif self.current_codes_cpu is not None:
+            self.current_codes_cpu[slot_id].copy_(codes_1d.detach().to(device="cpu"), non_blocking=False)
+
+    def gather_current_codes(
+        self,
+        slot_ids: list[int],
+        *,
+        n_vq: int,
+        audio_pad_code: int,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        if not slot_ids:
+            return torch.empty((0, int(n_vq)), dtype=torch.long, device=device)
+        if any(int(slot_id) < 0 or int(slot_id) >= self.max_slots for slot_id in slot_ids):
+            return None
+        self.ensure_current_codes(n_vq=n_vq, audio_pad_code=audio_pad_code, device=device)
+        source = self.current_codes_gpu if device.type == "cuda" else self.current_codes_cpu
+        if source is None:
+            return None
+        slot_t = torch.tensor([int(slot_id) for slot_id in slot_ids], device=source.device, dtype=torch.long)
+        return source.index_select(0, slot_t).to(device=device, dtype=torch.long)
+
+    def advance_frame_state(self, slot_ids: list[int], should_stop: list[bool]) -> None:
+        for slot_id, stop in zip(slot_ids, should_stop, strict=False):
+            slot_id = int(slot_id)
+            if slot_id < 0 or slot_id >= self.max_slots:
+                continue
+            if stop:
+                self.is_stopping_py[slot_id] = True
+                self.is_stopping_cpu[slot_id] = True
+                if self.is_stopping_gpu is not None:
+                    self.is_stopping_gpu[slot_id] = True
+            else:
+                self.steps_py[slot_id] += 1
+                self.steps_cpu[slot_id] += 1
+                if self.steps_gpu is not None:
+                    self.steps_gpu[slot_id] += 1
+
+    def advance_frame_state_gpu(
+        self,
+        slot_ids: torch.Tensor,
+        should_stop: torch.Tensor,
+        should_stop_cpu: list[bool],
+        slot_ids_cpu: list[int] | None = None,
+    ) -> None:
+        if (
+            self.steps_gpu is None
+            or self.is_stopping_gpu is None
+            or slot_ids.numel() == 0
+            or slot_ids.device.type != "cuda"
+        ):
+            if slot_ids_cpu is None:
+                slot_ids_cpu = [int(x) for x in slot_ids.detach().to("cpu").tolist()]
+            self.advance_frame_state(slot_ids_cpu, should_stop_cpu)
+            return
+        slot_ids = slot_ids.reshape(-1).to(dtype=torch.long)
+        should_stop = should_stop.reshape(-1).to(dtype=torch.bool)
+        old_steps = self.steps_gpu.index_select(0, slot_ids)
+        new_steps = old_steps + (~should_stop).to(dtype=torch.long)
+        old_stopping = self.is_stopping_gpu.index_select(0, slot_ids)
+        new_stopping = old_stopping.logical_or(should_stop)
+        self.steps_gpu.index_copy_(0, slot_ids, new_steps)
+        self.is_stopping_gpu.index_copy_(0, slot_ids, new_stopping)
+        if slot_ids_cpu is None:
+            slot_ids_cpu = [int(x) for x in slot_ids.detach().to("cpu").tolist()]
+        for slot_id, stop in zip(slot_ids_cpu, should_stop_cpu, strict=False):
+            slot_id = int(slot_id)
+            if slot_id < 0 or slot_id >= self.max_slots:
+                continue
+            if stop:
+                self.is_stopping_py[slot_id] = True
+                self.is_stopping_cpu[slot_id] = True
+            else:
+                self.steps_py[slot_id] += 1
+                self.steps_cpu[slot_id] += 1
+
+    def mark_stopping(self, slot_id: int) -> None:
+        slot_id = int(slot_id)
+        if slot_id < 0 or slot_id >= self.max_slots:
+            return
+        self.is_stopping_py[slot_id] = True
+        self.is_stopping_cpu[slot_id] = True
+        if self.is_stopping_gpu is not None:
+            self.is_stopping_gpu[slot_id] = True
 
 
 class MossTTSLocalNativeModel(nn.Module):
@@ -138,18 +404,38 @@ class MossTTSLocalNativeModel(nn.Module):
             max_positions=self.n_vq + 1,
             rope_base=float(getattr(gpt2_cfg, "rope_base", 1_000_000.0)),
             layer_norm_eps=float(getattr(gpt2_cfg, "layer_norm_epsilon", 1e-6)),
-            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL") or getattr(self.config, "local_transformer_attn_implementation", None) or "eager",
+            attn_implementation=os.environ.get("MOSS_TTS_LOCAL_ATTN_IMPL")
+            or getattr(self.config, "local_transformer_attn_implementation", None)
+            or "eager",
         )
         self.local_text_lm_head = nn.Linear(self.hidden_size, 2, bias=False)
         self._batch_state: list[dict[str, Any]] | None = None
         self._audio_embedding_indices = torch.arange(self.n_vq, dtype=torch.long)
+        self._audio_embedding_weight_cache: torch.Tensor | None = None
+        self._max_num_seqs = int(getattr(vllm_config.scheduler_config, "max_num_seqs", 1))
+        self._request_state_pool = MossTTSLocalRequestStatePool(self._max_num_seqs)
 
         # Full-frame CUDA graph: captures the entire _decode_frame_eager as one graph
-        self._frame_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self._frame_graphs: dict[tuple[int, tuple[float, float, int, float, float, int]], torch.cuda.CUDAGraph] = {}
         self._frame_graph_input: torch.Tensor = torch.empty(0)
+        self._frame_graph_rand: torch.Tensor = torch.empty(0)
         self._frame_graph_stop: torch.Tensor = torch.empty(0)
         self._frame_graph_codes: torch.Tensor = torch.empty(0)
         self._frame_graph_max_batch: int = 0
+        self._frame_graph_batch_buckets = self._parse_frame_graph_batch_buckets()
+        self._delay_stop_sync_enabled = os.environ.get("MOSS_TTS_LOCAL_DELAY_STOP_SYNC", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self._pending_stop_result: dict[str, Any] | None = None
+        self._output_asm_buffers: dict[str, Any] = {}
+        self._delay_delta_routing_enabled = _env_enabled("MOSS_TTS_LOCAL_DELAY_DELTA_ROUTING")
+        try:
+            self._stop_check_interval = max(int(os.environ.get("MOSS_TTS_LOCAL_STOP_CHECK_INTERVAL", "1") or 1), 1)
+        except ValueError:
+            self._stop_check_interval = 1
         self._profile_enabled = os.environ.get("MOSS_TTS_LOCAL_PROFILE") == "1"
         self._profile_sync = os.environ.get("MOSS_TTS_LOCAL_PROFILE_SYNC") == "1"
         self._profile_log_every = int(os.environ.get("MOSS_TTS_LOCAL_PROFILE_LOG_EVERY", "100") or 100)
@@ -159,13 +445,106 @@ class MossTTSLocalNativeModel(nn.Module):
             "qwen_ms": 0.0,
             "local_ms": 0.0,
             "make_output_ms": 0.0,
+            "rowmap_ms": 0.0,
+            "update_ms": 0.0,
+            "output_ms": 0.0,
             "batch_sizes": [],
+            "frame_graph_capture": 0,
+            "frame_graph_replay": 0,
+            "frame_graph_fallback": 0,
+            "output_asm_ms": 0.0,
+            "stop_sync_ms": 0.0,
+            "hidden_rows": 0,
+            "sample_rows": 0,
+            "logits_rows": 0,
+            "info_rows": 0,
+            "hidden_pad_rows": 0,
+            "shape_samples": 0,
         }
+        self._default_min_frames = int(os.environ.get("MOSS_TTS_LOCAL_MIN_FRAMES", "0") or 0)
 
         self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
             ("audio_codes", "current"),
             ("hidden_states", "last"),
         }
+
+    def _get_request_state_pool(self) -> MossTTSLocalRequestStatePool:
+        pool = getattr(self, "_request_state_pool", None)
+        if not isinstance(pool, MossTTSLocalRequestStatePool):
+            pool = MossTTSLocalRequestStatePool(int(getattr(self, "_max_num_seqs", 1)))
+            self._request_state_pool = pool
+        return pool
+
+    def _allocate_slot(self, request_id: str) -> int:
+        return self._get_request_state_pool().allocate_slot(request_id)
+
+    def _release_slot(self, request_id: str) -> None:
+        self._get_request_state_pool().release_slot(request_id)
+
+    def on_requests_finished(self, finished_req_ids: list[str]) -> None:
+        for req_id in finished_req_ids:
+            self._release_slot(req_id)
+
+    def should_disable_outer_cudagraph(self) -> bool:
+        return _env_enabled("MOSS_TTS_LOCAL_DISABLE_OUTER_CUDAGRAPH")
+
+    def _set_slot_current_codes(self, slot_id: int, codes: torch.Tensor) -> None:
+        if not _env_enabled("MOSS_TTS_LOCAL_USE_CODE_POOL"):
+            return
+        self._get_request_state_pool().set_current_codes(
+            slot_id,
+            codes,
+            n_vq=self.n_vq,
+            audio_pad_code=self.audio_pad_code,
+        )
+
+    def _gather_slot_current_codes(self, slot_ids: list[int], device: torch.device) -> torch.Tensor | None:
+        if not _env_enabled("MOSS_TTS_LOCAL_USE_CODE_POOL"):
+            return None
+        return self._get_request_state_pool().gather_current_codes(
+            slot_ids,
+            n_vq=self.n_vq,
+            audio_pad_code=self.audio_pad_code,
+            device=device,
+        )
+
+    def _ensure_output_asm_buffers(self, *, batch_size: int, device: torch.device) -> dict[str, Any]:
+        buffers = getattr(self, "_output_asm_buffers", None)
+        if not isinstance(buffers, dict):
+            buffers = {}
+            self._output_asm_buffers = buffers
+        bucket = _next_bucket(max(1, int(batch_size)))
+        if buffers.get("bucket") != bucket or buffers.get("device") != device:
+            buffers.clear()
+            buffers["bucket"] = bucket
+            buffers["device"] = device
+            pin_cpu = device.type == "cuda" and torch.cuda.is_available()
+
+            def cpu_empty(*shape: int, dtype: torch.dtype) -> torch.Tensor:
+                try:
+                    return torch.empty(*shape, dtype=dtype, pin_memory=pin_cpu)
+                except RuntimeError:
+                    return torch.empty(*shape, dtype=dtype)
+
+            buffers["rows_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["slot_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["steps_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["min_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["max_cpu"] = cpu_empty(bucket, dtype=torch.long)
+            buffers["stop_cpu"] = cpu_empty(bucket, dtype=torch.bool)
+            buffers["poll_cpu"] = cpu_empty(bucket, dtype=torch.bool)
+            buffers["rows_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["slot_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["steps_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["min_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["max_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            buffers["stop_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["tmp_stop_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["poll_gpu"] = torch.empty(bucket, device=device, dtype=torch.bool)
+            buffers["next_gpu"] = torch.empty(bucket, device=device, dtype=torch.long)
+            if device.type == "cuda":
+                buffers["stop_copy_event"] = torch.cuda.Event()
+        return buffers
 
     def _can_profile_sync(self) -> bool:
         if not self._profile_sync or not torch.cuda.is_available():
@@ -177,13 +556,30 @@ class MossTTSLocalNativeModel(nn.Module):
 
     def _profile_mark(self) -> float:
         if self._can_profile_sync():
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
         return time.perf_counter()
 
     def _profile_elapsed_ms(self, start: float) -> float:
         if self._can_profile_sync():
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
         return (time.perf_counter() - start) * 1000
+
+    def _record_shape_profile(
+        self,
+        *,
+        hidden_rows: int,
+        sample_rows: int,
+        logits_rows: int,
+        info_rows: int,
+    ) -> None:
+        if not self._profile_enabled:
+            return
+        self._profile_stats["hidden_rows"] += int(hidden_rows)
+        self._profile_stats["sample_rows"] += int(sample_rows)
+        self._profile_stats["logits_rows"] += int(logits_rows)
+        self._profile_stats["info_rows"] += int(info_rows)
+        self._profile_stats["hidden_pad_rows"] += max(0, int(hidden_rows) - int(sample_rows))
+        self._profile_stats["shape_samples"] += 1
 
     def _maybe_log_profile(self) -> None:
         if not self._profile_enabled:
@@ -194,17 +590,160 @@ class MossTTSLocalNativeModel(nn.Module):
             return
         batch_sizes = self._profile_stats["batch_sizes"][-self._profile_log_every :]
         avg_bs = sum(batch_sizes) / max(1, len(batch_sizes))
+        shape_samples = int(self._profile_stats.get("shape_samples", 0))
         logger.info(
             "[moss-local-profile] forward=%d decode=%d avg_bs=%.2f "
-            "qwen=%.3fms local=%.3fms make_output=%.3fms sync=%s",
+            "qwen=%.3fms local=%.3fms make_output=%.3fms rowmap=%.3fms update=%.3fms output=%.3fms "
+            "shape(hidden=%.1f sample=%.1f logits=%.1f infos=%.1f pad=%.1f) "
+            "frame_graph(capture=%d replay=%d fallback=%d) sync=%s outer_graph_off=%s",
             n_forward,
             n_decode,
             avg_bs,
             self._profile_stats["qwen_ms"] / max(1, n_forward),
             self._profile_stats["local_ms"] / max(1, n_decode),
             self._profile_stats["make_output_ms"] / max(1, n_decode),
+            self._profile_stats["rowmap_ms"] / max(1, n_decode),
+            self._profile_stats["update_ms"] / max(1, n_decode),
+            self._profile_stats["output_ms"] / max(1, n_decode),
+            self._profile_stats.get("hidden_rows", 0) / max(1, shape_samples),
+            self._profile_stats.get("sample_rows", 0) / max(1, shape_samples),
+            self._profile_stats.get("logits_rows", 0) / max(1, shape_samples),
+            self._profile_stats.get("info_rows", 0) / max(1, shape_samples),
+            self._profile_stats.get("hidden_pad_rows", 0) / max(1, shape_samples),
+            int(self._profile_stats.get("frame_graph_capture", 0)),
+            int(self._profile_stats.get("frame_graph_replay", 0)),
+            int(self._profile_stats.get("frame_graph_fallback", 0)),
             self._profile_sync,
+            self.should_disable_outer_cudagraph(),
         )
+
+    def _consume_pending_stop_result(
+        self, info_dicts: list[dict[str, Any]]
+    ) -> tuple[list[str], list[torch.Tensor], list[bool]]:
+        pending = getattr(self, "_pending_stop_result", None)
+        if not pending:
+            return [], [], []
+        self._pending_stop_result = None
+        event = pending.get("event")
+        if isinstance(event, torch.cuda.Event):
+            event.synchronize()
+        stop_cpu = pending.get("stop_cpu")
+        slot_ids = pending.get("slot_ids") or []
+        req_ids = pending.get("req_ids") or []
+        if isinstance(stop_cpu, torch.Tensor) and not slot_ids and req_ids:
+            stop_values = [bool(x) for x in stop_cpu[: len(req_ids)].tolist()]
+            info_by_req = {
+                str(info.get("request_id") or info.get("global_request_id") or ""): info
+                for info in info_dicts
+                if isinstance(info, dict)
+            }
+            for req_id, should_stop in zip(req_ids, stop_values, strict=False):
+                if not should_stop:
+                    continue
+                info = info_by_req.get(str(req_id))
+                if info is None:
+                    continue
+                state = info.get("audio_state")
+                if not isinstance(state, dict):
+                    state = {}
+                    info["audio_state"] = state
+                state["is_stopping"] = True
+                state["next_text"] = self.audio_end_token_id
+                state.setdefault("stop_reason", "model_stop")
+            return [], [], []
+        if not isinstance(stop_cpu, torch.Tensor) or not slot_ids:
+            return [], [], []
+        stop_values = [bool(x) for x in stop_cpu[: len(slot_ids)].tolist()]
+        force_stop = pending.get("force_stop") or []
+        stop_values = [
+            bool(model_stop or (idx < len(force_stop) and force_stop[idx]))
+            for idx, model_stop in enumerate(stop_values)
+        ]
+        pending_steps = pending.get("steps") or []
+        pending_codes = pending.get("codes")
+        pending_streaming = pending.get("codec_streaming") or []
+        emit_req_ids: list[str] = []
+        emit_codes: list[torch.Tensor] = []
+        emit_streaming: list[bool] = []
+
+        pool = self._get_request_state_pool()
+        state_by_slot: dict[int, tuple[dict[str, Any], dict[str, Any]]] = {}
+        for info in info_dicts:
+            if not isinstance(info, dict):
+                continue
+            try:
+                slot_id = int(info.get("_kv_slot_id"))
+            except (TypeError, ValueError):
+                continue
+            state = info.get("audio_state")
+            if isinstance(state, dict):
+                state_by_slot[slot_id] = (info, state)
+
+        for idx, should_stop in enumerate(stop_values):
+            if idx >= len(slot_ids):
+                continue
+            slot_id = int(slot_ids[idx])
+            if slot_id < 0 or slot_id >= pool.max_slots:
+                continue
+            expected_req_id = str(req_ids[idx]) if idx < len(req_ids) else ""
+            current_req_id = pool.slot_request_id(slot_id)
+            if expected_req_id and current_req_id != expected_req_id:
+                continue
+            if not should_stop:
+                if isinstance(pending_codes, torch.Tensor) and idx < int(pending_codes.shape[0]):
+                    rid = expected_req_id or str(current_req_id or "")
+                    if rid or len(info_dicts) == 1:
+                        emit_req_ids.append(rid)
+                        emit_codes.append(pending_codes[idx : idx + 1])
+                        emit_streaming.append(bool(pending_streaming[idx]) if idx < len(pending_streaming) else True)
+                continue
+            info_state = state_by_slot.get(slot_id)
+            stop_step = int(pending_steps[idx]) if idx < len(pending_steps) else pool.steps_py[slot_id]
+            pool.steps_py[slot_id] = stop_step
+            pool.steps_cpu[slot_id] = stop_step
+            if pool.steps_gpu is not None:
+                pool.steps_gpu[slot_id] = stop_step
+            pool.mark_stopping(slot_id)
+            if info_state is None:
+                continue
+            _info, state = info_state
+            state["is_stopping"] = True
+            state["next_text"] = self.audio_end_token_id
+            state["stop_reason"] = "model_stop"
+            state["step"] = stop_step
+        return emit_req_ids, emit_codes, emit_streaming
+
+    @staticmethod
+    def _compute_stop_and_next_tokens(
+        *,
+        stop_choices: torch.Tensor,
+        steps: torch.Tensor,
+        min_frames: torch.Tensor,
+        max_frames: torch.Tensor,
+        audio_assistant_slot_token_id: int,
+        audio_end_token_id: int,
+        should_stop_out: torch.Tensor | None = None,
+        tmp_out: torch.Tensor | None = None,
+        next_tokens_out: torch.Tensor | None = None,
+        model_stop_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        should_stop = (
+            should_stop_out if should_stop_out is not None else torch.empty_like(stop_choices, dtype=torch.bool)
+        )
+        tmp = tmp_out if tmp_out is not None else torch.empty_like(should_stop)
+        next_tokens = next_tokens_out if next_tokens_out is not None else torch.empty_like(steps, dtype=torch.long)
+
+        torch.eq(stop_choices.reshape(-1)[: steps.numel()], 1, out=should_stop)
+        if model_stop_mask is not None:
+            should_stop.logical_and_(model_stop_mask.reshape(-1)[: steps.numel()])
+        torch.ge(steps, min_frames, out=tmp)
+        should_stop.logical_and_(tmp)
+        torch.ge(steps, max_frames, out=tmp)
+        should_stop.logical_or_(tmp)
+
+        next_tokens.fill_(int(audio_assistant_slot_token_id))
+        next_tokens.masked_fill_(should_stop, int(audio_end_token_id))
+        return should_stop, next_tokens
 
     def _build_input_embeds(self, text_ids: torch.Tensor, audio_codes: torch.Tensor | None) -> torch.Tensor:
         embeds = self.model.embed_tokens(text_ids)
@@ -215,10 +754,44 @@ class MossTTSLocalNativeModel(nn.Module):
             codes = codes.unsqueeze(0)
         valid = codes.ne(self.audio_pad_code)
         safe_codes = codes.clamp(0, self.audio_vocab_size).masked_fill(~valid, 0)
-        weights = torch.stack([emb.weight for emb in self.audio_embeddings], dim=0)
+        weights = self._stacked_audio_embedding_weights(device=text_ids.device)
         codebook_idx = self._audio_embedding_indices.to(device=text_ids.device)
         audio_embeds = weights[codebook_idx.unsqueeze(0), safe_codes]
         return embeds + (audio_embeds * valid.unsqueeze(-1)).sum(dim=1)
+
+    @staticmethod
+    def _parse_frame_graph_batch_buckets() -> tuple[int, ...]:
+        raw = os.environ.get("MOSS_TTS_LOCAL_FRAME_GRAPH_BATCH_BUCKETS", "").strip()
+        values: list[int] = []
+        if raw:
+            for part in raw.split(","):
+                part = part.strip()
+                if not part:
+                    continue
+                try:
+                    value = int(part)
+                except ValueError:
+                    logger.warning("Ignoring invalid MOSS_TTS_LOCAL_FRAME_GRAPH_BATCH_BUCKETS entry: %s", part)
+                    continue
+                if value > 0:
+                    values.append(value)
+        if not values:
+            values = [1, 2, 4, 8, 16, 32, 64]
+        return tuple(sorted(set(values)))
+
+    def _frame_graph_bucket_for_batch(self, batch_size: int) -> int:
+        for bucket in self._frame_graph_batch_buckets:
+            if batch_size <= bucket:
+                return int(bucket)
+        return int(batch_size)
+
+    def _stacked_audio_embedding_weights(self, *, device: torch.device) -> torch.Tensor:
+        cache = self._audio_embedding_weight_cache
+        dtype = self.audio_embeddings[0].weight.dtype
+        if cache is None or cache.device != device or cache.dtype != dtype:
+            cache = torch.stack([emb.weight for emb in self.audio_embeddings], dim=0).to(device=device)
+            self._audio_embedding_weight_cache = cache
+        return cache
 
     def preprocess(
         self,
@@ -231,6 +804,14 @@ class MossTTSLocalNativeModel(nn.Module):
         span_len = int(input_ids.shape[0])
         audio_state = info_dict.get("audio_state")
         is_first_call = not isinstance(audio_state, dict)
+
+        request_id = str(info_dict.get("request_id") or info_dict.get("global_request_id") or "")
+        pool = self._get_request_state_pool()
+        slot_id = pool.slot_for_request(request_id) if request_id else None
+        if is_first_call and slot_id is None and request_id:
+            slot_id = self._allocate_slot(request_id)
+        if slot_id is None:
+            slot_id = 0
 
         if span_len > 1 or is_first_call:
             prompt_rows = info_dict.get("prompt_rows")
@@ -259,22 +840,151 @@ class MossTTSLocalNativeModel(nn.Module):
                 )
                 ref_offset = ref_offset + span_len
 
+            max_new_frames = _first_scalar(info_dict.get("max_new_frames"))
+            try:
+                max_new_frames = int(max_new_frames) if max_new_frames is not None else -1
+            except (TypeError, ValueError):
+                max_new_frames = -1
+            min_new_frames = _first_scalar(info_dict.get("min_new_frames"))
+            try:
+                min_new_frames = int(min_new_frames) if min_new_frames is not None else 3
+            except (TypeError, ValueError):
+                min_new_frames = 3
             state = {
                 "step": 0,
                 "is_stopping": False,
                 "next_text": self.audio_assistant_slot_token_id,
+                "max_new_frames": max_new_frames,
+                "min_new_frames": min_new_frames,
             }
+            pool.init_frame_state(
+                slot_id=slot_id,
+                min_new_frames=min_new_frames,
+                max_new_frames=max_new_frames if max_new_frames > 0 else 150,
+            )
+            pool.ensure_frame_state_device(device)
+            self._set_slot_current_codes(slot_id, current_codes)
             _copy_sampling_overrides(state, info_dict)
-            return input_ids, embeds, {
-                "audio_state": state,
-                "audio_codes": {"current": current_codes},
-            }
+            return (
+                input_ids,
+                embeds,
+                {
+                    "audio_state": state,
+                    "audio_codes": {"current": current_codes},
+                    "ref_offset": int(info_dict.get("ref_offset", 0)) + span_len,
+                    "_kv_slot_id": slot_id,
+                },
+            )
 
-        prev_codes = (info_dict.get("audio_codes", {}) or {}).get("current")
+        prev_codes = None
+        if _env_enabled("MOSS_TTS_LOCAL_USE_CODE_POOL"):
+            gathered = self._gather_slot_current_codes([int(slot_id)], device)
+            if isinstance(gathered, torch.Tensor) and gathered.numel() == self.n_vq:
+                prev_codes = gathered.reshape(-1)
+        if prev_codes is None:
+            prev_codes = (info_dict.get("audio_codes", {}) or {}).get("current")
         if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
             prev_codes = torch.full((self.n_vq,), self.audio_pad_code, dtype=torch.long, device=device)
         embeds = self._build_input_embeds(input_ids.reshape(-1), prev_codes.to(device=device).unsqueeze(0))
-        return input_ids, embeds, {}
+        return input_ids, embeds, {"_kv_slot_id": slot_id}
+
+    def preprocess_decode_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Batch single-token decode embedding construction.
+
+        Native Stage0 relies on vLLM for KV/cache routing, so decode
+        preprocess only needs to combine the sampled text token with the
+        previous frame's RVQ codes.  Doing this once for the whole scheduled
+        decode batch avoids one embedding/gather/sum launch sequence per
+        request at high concurrency.
+        """
+        device = input_ids.device
+        text_ids = input_ids.reshape(-1)
+        pool = self._get_request_state_pool()
+        slot_ids: list[int] = []
+        prev_codes_list: list[torch.Tensor] = []
+        for info in req_infos:
+            request_id = str(info.get("request_id") or info.get("global_request_id") or "")
+            slot_id = pool.slot_for_request(request_id) if request_id else None
+            if slot_id is None:
+                slot_id = 0
+            slot_ids.append(int(slot_id))
+            prev_codes = (info.get("audio_codes", {}) or {}).get("current")
+            if not isinstance(prev_codes, torch.Tensor) or prev_codes.numel() != self.n_vq:
+                prev_codes = torch.full(
+                    (self.n_vq,),
+                    self.audio_pad_code,
+                    dtype=torch.long,
+                    device=device,
+                )
+            prev_codes_list.append(prev_codes.to(device=device, dtype=torch.long).reshape(-1)[: self.n_vq])
+
+        prev_codes_batch = self._gather_slot_current_codes(slot_ids, device)
+        if prev_codes_batch is not None:
+            prev_codes_batch = prev_codes_batch.reshape(len(slot_ids), self.n_vq)
+        elif prev_codes_list:
+            prev_codes_batch = torch.stack(prev_codes_list, dim=0)
+        else:
+            prev_codes_batch = torch.empty((0, self.n_vq), dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(text_ids, prev_codes_batch)
+        return text_ids, embeds, [{"_kv_slot_id": slot_id} for slot_id in slot_ids]
+
+    def preprocess_decode_batch_fast(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_ids: list[str],
+        prev_codes: list[torch.Tensor | None],
+        slot_ids: list[int | None] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Fast decode preprocess with only the fields needed by MOSS native.
+
+        The generic runner path attaches per-request metadata dictionaries
+        before calling preprocess.  Single-token MOSS decode only needs the
+        sampled token, previous RVQ codes and the request slot, so this entry
+        point keeps the hot path out of the larger req_info dictionaries.
+        """
+        device = input_ids.device
+        text_ids = input_ids.reshape(-1)
+        pool = self._get_request_state_pool()
+        resolved_slot_ids: list[int] = []
+        prev_codes_list: list[torch.Tensor] = []
+        for idx, req_id in enumerate(req_ids):
+            slot_id = None
+            if slot_ids is not None and idx < len(slot_ids):
+                try:
+                    slot_id = int(slot_ids[idx]) if slot_ids[idx] is not None else None
+                except (TypeError, ValueError):
+                    slot_id = None
+            if slot_id is None or slot_id < 0:
+                slot_id = pool.slot_for_request(str(req_id)) if req_id else None
+            if slot_id is None:
+                slot_id = 0
+            resolved_slot_ids.append(int(slot_id))
+
+            codes = prev_codes[idx] if idx < len(prev_codes) else None
+            if not isinstance(codes, torch.Tensor) or codes.numel() != self.n_vq:
+                codes = torch.full(
+                    (self.n_vq,),
+                    self.audio_pad_code,
+                    dtype=torch.long,
+                    device=device,
+                )
+            prev_codes_list.append(codes.to(device=device, dtype=torch.long).reshape(-1)[: self.n_vq])
+
+        prev_codes_batch = self._gather_slot_current_codes(resolved_slot_ids, device)
+        if prev_codes_batch is not None:
+            prev_codes_batch = prev_codes_batch.reshape(len(resolved_slot_ids), self.n_vq)
+        elif prev_codes_list:
+            prev_codes_batch = torch.stack(prev_codes_list, dim=0)
+        else:
+            prev_codes_batch = torch.empty((0, self.n_vq), dtype=torch.long, device=device)
+        embeds = self._build_input_embeds(text_ids, prev_codes_batch)
+        return text_ids, embeds, [{"_kv_slot_id": slot_id} for slot_id in resolved_slot_ids]
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -296,7 +1006,11 @@ class MossTTSLocalNativeModel(nn.Module):
         self._profile_stats["n_forward"] += 1
         return result
 
-    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> torch.Tensor | None:
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor | OmniOutput,
+        sampling_metadata: Any = None,
+    ) -> torch.Tensor | None:
         next_text_from_output: torch.Tensor | None = None
         if isinstance(hidden_states, OmniOutput):
             meta = hidden_states.multimodal_outputs.get("meta", {}) if hidden_states.multimodal_outputs else {}
@@ -307,49 +1021,57 @@ class MossTTSLocalNativeModel(nn.Module):
         if hidden_states.numel() == 0:
             return torch.zeros(1, self.vocab_size, device=hidden_states.device)
         if next_text_from_output is not None:
-            rows = []
-            for token in next_text_from_output.reshape(-1).tolist():
-                one_hot = torch.full((self.vocab_size,), -1e9, device=hidden_states.device)
-                one_hot[int(token)] = 0.0
-                rows.append(one_hot)
+            tokens = next_text_from_output.reshape(-1).clamp(0, self.vocab_size - 1)
+            logits = hidden_states.new_full((int(tokens.numel()), self.vocab_size), -1e9)
+            logits.scatter_(1, tokens.unsqueeze(1), 0.0)
             self._batch_state = None
             if _debug_state_enabled():
                 logger.info(
                     "[moss-local-state] compute_logits source=meta rows=%d next=%s",
-                    len(rows),
+                    int(tokens.numel()),
                     next_text_from_output.reshape(-1).detach().cpu().tolist(),
                 )
-            return torch.stack(rows)
+            return logits
         batch_state = self._batch_state
         if not batch_state:
             num_rows = hidden_states.shape[0] if hidden_states.dim() >= 1 else 1
             if _debug_state_enabled():
                 logger.info("[moss-local-state] compute_logits source=zeros rows=%d", num_rows)
             return torch.zeros(num_rows, self.vocab_size, device=hidden_states.device)
-        logit_rows: list[torch.Tensor] = []
+        tokens = torch.full(
+            (len(batch_state),),
+            -1,
+            dtype=torch.long,
+            device=hidden_states.device,
+        )
         debug_next: list[int | None] = []
         for i, state in enumerate(batch_state):
             if not isinstance(state, dict):
-                logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
                 debug_next.append(None)
                 continue
             next_text = state.get("next_text")
             if next_text is not None:
-                one_hot = torch.full((self.vocab_size,), -1e9, device=hidden_states.device)
-                one_hot[int(next_text)] = 0.0
-                logit_rows.append(one_hot)
-                debug_next.append(int(next_text))
+                token = max(0, min(int(next_text), self.vocab_size - 1))
+                tokens[i] = token
+                debug_next.append(token)
             else:
-                logit_rows.append(torch.zeros(self.vocab_size, device=hidden_states.device))
                 debug_next.append(None)
         self._batch_state = None
+        logits = hidden_states.new_full((len(batch_state), self.vocab_size), -1e9)
+        forced = tokens.ge(0)
+        if forced.any():
+            forced_tokens = tokens[forced]
+            logits[forced] = -1e9
+            logits[forced, forced_tokens] = 0.0
+        if (~forced).any():
+            logits[~forced] = 0.0
         if _debug_state_enabled():
             logger.info(
                 "[moss-local-state] compute_logits source=batch_state rows=%d next=%s",
-                len(logit_rows),
+                len(batch_state),
                 debug_next,
             )
-        return torch.stack(logit_rows)
+        return logits
 
     @staticmethod
     def _frame_params(info: dict[str, Any]) -> tuple[float, float, int, float, float, int, torch.Generator | None]:
@@ -370,6 +1092,18 @@ class MossTTSLocalNativeModel(nn.Module):
             generator,
         )
 
+    def _frame_graph_params(
+        self,
+        infos: list[dict[str, Any]],
+        batch_size: int,
+    ) -> tuple[tuple[float, float, int, float, float, int], bool]:
+        params = [self._frame_params(info if isinstance(info, dict) else {}) for info in infos[:batch_size]]
+        if len(params) != batch_size:
+            params.extend([self._frame_params({}) for _ in range(batch_size - len(params))])
+        first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
+        graphable = all(item[:6] == first_params and item[6] is None for item in params)
+        return first_params, graphable
+
     @staticmethod
     def _sample_with_params(
         logits: torch.Tensor,
@@ -389,6 +1123,111 @@ class MossTTSLocalNativeModel(nn.Module):
             generator=generator,
         )
 
+    @staticmethod
+    def _sample_graph_safe(
+        logits: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        rand_val: torch.Tensor,
+    ) -> torch.Tensor:
+        scores = logits / max(float(temperature), 1e-6)
+        vocab = int(scores.shape[-1])
+        top_k = int(top_k)
+        top_p = float(top_p)
+        if 0 < top_k < vocab:
+            topk_scores, topk_indices = torch.topk(scores, top_k, dim=-1)
+            if 0.0 < top_p < 1.0:
+                sorted_scores, sorted_order = torch.sort(topk_scores, descending=True, dim=-1)
+                sorted_indices = topk_indices.gather(-1, sorted_order)
+                sorted_probs = torch.softmax(sorted_scores, dim=-1)
+                cumulative = torch.cumsum(sorted_probs, dim=-1)
+                remove = cumulative > top_p
+                remove[..., 1:] = remove[..., :-1].clone()
+                remove[..., 0] = False
+                sorted_scores = sorted_scores.masked_fill(remove, float("-inf"))
+                probs = torch.softmax(sorted_scores, dim=-1)
+                probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+                cdf = torch.cumsum(probs, dim=-1)
+                sampled_rel = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+                sampled_rel = sampled_rel.clamp(0, top_k - 1).unsqueeze(-1)
+                return sorted_indices.gather(-1, sampled_rel).reshape(-1).clamp(0, vocab - 1)
+
+            probs = torch.softmax(topk_scores, dim=-1)
+            probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+            cdf = torch.cumsum(probs, dim=-1)
+            sampled_rel = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+            sampled_rel = sampled_rel.clamp(0, top_k - 1).unsqueeze(-1)
+            return topk_indices.gather(-1, sampled_rel).reshape(-1).clamp(0, vocab - 1)
+
+        if 0.0 < top_p < 1.0:
+            sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+            sorted_probs = torch.softmax(sorted_scores, dim=-1)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            remove = cumulative > top_p
+            remove[..., 1:] = remove[..., :-1].clone()
+            remove[..., 0] = False
+            mask = torch.zeros_like(scores, dtype=torch.bool).scatter_(-1, sorted_indices, remove)
+            scores = scores.masked_fill(mask, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+        cdf = torch.cumsum(probs, dim=-1)
+        sampled = torch.searchsorted(cdf, rand_val.unsqueeze(-1)).reshape(-1)
+        return sampled.clamp(0, vocab - 1)
+
+    @staticmethod
+    def _sample_graph_safe_param(
+        logits: torch.Tensor,
+        *,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        rand_val: torch.Tensor,
+    ) -> torch.Tensor:
+        if float(temperature) <= 0:
+            return torch.argmax(logits, dim=-1)
+        return MossTTSLocalNativeModel._sample_graph_safe(
+            logits,
+            int(top_k),
+            float(top_p),
+            float(temperature),
+            rand_val,
+        )
+
+    def _frame_graph_kernel(
+        self,
+        batch_size: int,
+        params: tuple[float, float, int, float, float, int],
+    ) -> None:
+        text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k = params
+        hidden = self._frame_graph_input[:batch_size]
+        rand = self._frame_graph_rand[:, :batch_size]
+        local_hidden = self.local_transformer._step_eager(hidden.to(dtype=self.audio_embeddings[0].weight.dtype), 0)
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop = self._sample_graph_safe_param(
+            text_logits,
+            temperature=text_temp,
+            top_p=text_top_p,
+            top_k=text_top_k,
+            rand_val=rand[0],
+        )
+        self._frame_graph_stop[:batch_size].copy_(stop)
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
+            logits = F.linear(current, head_weight).float()
+            codes = self._sample_graph_safe_param(
+                logits,
+                temperature=audio_temp,
+                top_p=audio_top_p,
+                top_k=audio_top_k,
+                rand_val=rand[1 + channel],
+            )
+            self._frame_graph_codes[:batch_size, channel].copy_(codes)
+            if channel + 1 < self.n_vq:
+                embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
+                current = self.local_transformer._step_eager(embedded, channel + 1)
+
     def _decode_frame_eager(
         self,
         hidden_batch: torch.Tensor,
@@ -401,7 +1240,9 @@ class MossTTSLocalNativeModel(nn.Module):
         local_hidden = self.local_transformer._step_eager(hidden_batch.to(dtype=dtype), 0)
         text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
 
-        params = [self._frame_params(infos[i] if i < len(infos) and isinstance(infos[i], dict) else {}) for i in range(B)]
+        params = [
+            self._frame_params(infos[i] if i < len(infos) and isinstance(infos[i], dict) else {}) for i in range(B)
+        ]
         first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
         homogeneous = all(item[:6] == first_params and item[6] is None for item in params)
 
@@ -421,12 +1262,40 @@ class MossTTSLocalNativeModel(nn.Module):
             stop_choices = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
             for b, (text_temp, text_top_p, text_top_k, _, _, _, generator) in enumerate(params):
                 stop_choices[b] = self._sample_with_params(
-                    text_logits[b:b + 1],
+                    text_logits[b : b + 1],
                     temperature=text_temp,
                     top_p=text_top_p,
                     top_k=text_top_k,
                     generator=generator,
                 )[0]
+
+        if os.environ.get("MOSS_TTS_LOCAL_DEBUG_STOP_LOGITS") == "1":
+            logits_cpu = text_logits.detach().to("cpu", dtype=torch.float32)
+            stops_cpu = stop_choices.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
+            for b in range(B):
+                info = infos[b] if b < len(infos) and isinstance(infos[b], dict) else {}
+                state = info.get("audio_state", {}) or {}
+                step = int(state.get("step", 0))
+                margin = float((logits_cpu[b, 1] - logits_cpu[b, 0]).item())
+                if stops_cpu[b] == 1 or step < 5 or os.environ.get("MOSS_TTS_LOCAL_TRACE_STEPS") == "1":
+                    probs = torch.softmax(logits_cpu[b], dim=-1).tolist()
+                    text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k, generator = params[b]
+                    logger.info(
+                        "[moss-local-stop] req=%s step=%d stop=%d logits=%s probs=%s "
+                        "margin=%.4f text_temp=%.3f audio_temp=%.3f text_top_k=%d "
+                        "audio_top_k=%d gen=%s",
+                        _request_label(info),
+                        step,
+                        int(stops_cpu[b]),
+                        [float(x) for x in logits_cpu[b].tolist()],
+                        [float(x) for x in probs],
+                        margin,
+                        text_temp,
+                        audio_temp,
+                        text_top_k,
+                        audio_top_k,
+                        generator is not None,
+                    )
 
         all_codes = torch.zeros(B, self.n_vq, dtype=torch.long, device=hidden_batch.device)
         current = local_hidden
@@ -446,7 +1315,7 @@ class MossTTSLocalNativeModel(nn.Module):
                 codes = torch.zeros(B, dtype=torch.long, device=hidden_batch.device)
                 for b, (_, _, _, audio_temp, audio_top_p, audio_top_k, generator) in enumerate(params):
                     codes[b] = self._sample_with_params(
-                        logits[b:b + 1],
+                        logits[b : b + 1],
                         temperature=audio_temp,
                         top_p=audio_top_p,
                         top_k=audio_top_k,
@@ -456,6 +1325,24 @@ class MossTTSLocalNativeModel(nn.Module):
             if channel + 1 < self.n_vq:
                 embedded = F.embedding(codes, head_weight).to(dtype=current.dtype)
                 current = self.local_transformer._step_eager(embedded, channel + 1)
+        if os.environ.get("MOSS_TTS_LOCAL_TRACE_STEPS") == "1":
+            codes_cpu = all_codes.detach().to("cpu", dtype=torch.long)
+            for b in range(B):
+                info = infos[b] if b < len(infos) and isinstance(infos[b], dict) else {}
+                state = info.get("audio_state", {}) or {}
+                values = codes_cpu[b].reshape(-1).tolist()
+                h = 1469598103934665603
+                for value in values:
+                    h ^= int(value) & 0xFFFFFFFF
+                    h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+                logger.info(
+                    "[moss-local-trace] req=%s step=%d stop=%d code_hash=%016x codes0=%s",
+                    _request_label(info),
+                    int(state.get("step", 0)),
+                    int(stop_choices[b].item()),
+                    h,
+                    [int(x) for x in values[:4]],
+                )
         return stop_choices, all_codes
 
     def _ensure_frame_graph_buffers(self, batch_size: int, device: torch.device, dtype: torch.dtype) -> None:
@@ -463,6 +1350,7 @@ class MossTTSLocalNativeModel(nn.Module):
             return
         cap = max(batch_size, 8)
         self._frame_graph_input = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
+        self._frame_graph_rand = torch.zeros(1 + self.n_vq, cap, device=device, dtype=torch.float32)
         self._frame_graph_stop = torch.zeros(cap, device=device, dtype=torch.long)
         self._frame_graph_codes = torch.zeros(cap, self.n_vq, device=device, dtype=torch.long)
         self._frame_graph_max_batch = cap
@@ -476,46 +1364,567 @@ class MossTTSLocalNativeModel(nn.Module):
         """Batched local transformer decode: [B, H] -> (stop_choices[B], codes[B, n_vq])."""
         B = hidden_batch.shape[0]
         dtype = self.audio_embeddings[0].weight.dtype
-        self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
 
         if hidden_batch.device.type != "cuda":
+            self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
             return self._decode_frame_eager(hidden_batch, infos)
         if os.environ.get("MOSS_TTS_LOCAL_ENABLE_FRAME_GRAPH") != "1":
+            self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
             return self._decode_frame_eager(hidden_batch, infos)
 
-        params = [
-            self._frame_params(info if isinstance(info, dict) else {})
-            for info in infos[:B]
-        ]
-        if len(params) != B:
-            params.extend([self._frame_params({}) for _ in range(B - len(params))])
-        first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
-        graphable = (
-            float(first_params[0]) <= 0
-            and float(first_params[3]) <= 0
-            and all(item[:6] == first_params and item[6] is None for item in params)
-        )
+        first_params, graphable = self._frame_graph_params(infos, B)
         if not graphable:
+            self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
             return self._decode_frame_eager(hidden_batch, infos)
 
-        self._ensure_frame_graph_buffers(B, hidden_batch.device, dtype)
-        graph_key = (B, first_params)
-        if graph_key not in self._frame_graphs:
-            self._frame_graph_input[:B].copy_(hidden_batch)
-            self._decode_frame_eager(self._frame_graph_input[:B], infos)
-            g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g):
-                stop, codes = self._decode_frame_eager(self._frame_graph_input[:B], infos)
-                self._frame_graph_stop[:B].copy_(stop)
-                self._frame_graph_codes[:B].copy_(codes)
-            self._frame_graphs[graph_key] = g
-            return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
+        try:
+            bucket = self._frame_graph_bucket_for_batch(B)
+            self.local_transformer._ensure_kv_cache(bucket, hidden_batch.device, dtype)
+            self._ensure_frame_graph_buffers(bucket, hidden_batch.device, dtype)
+            graph_key = (bucket, first_params)
+            self._frame_graph_rand[:, :bucket].copy_(torch.rand(1 + self.n_vq, bucket, device=hidden_batch.device))
+            if graph_key not in self._frame_graphs:
+                self._frame_graph_input[:bucket].zero_()
+                self._frame_graph_input[:B].copy_(hidden_batch)
+                self._frame_graph_kernel(bucket, first_params)
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(g):
+                    self._frame_graph_kernel(bucket, first_params)
+                self._frame_graphs[graph_key] = g
+                if self._profile_enabled:
+                    self._profile_stats["frame_graph_capture"] += 1
+                return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
 
-        self._frame_graph_input[:B].copy_(hidden_batch)
-        self._frame_graphs[graph_key].replay()
-        return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
+            if bucket > B:
+                self._frame_graph_input[:bucket].zero_()
+            self._frame_graph_input[:B].copy_(hidden_batch)
+            self._frame_graphs[graph_key].replay()
+            if self._profile_enabled:
+                self._profile_stats["frame_graph_replay"] += 1
+            return self._frame_graph_stop[:B].clone(), self._frame_graph_codes[:B].clone()
+        except Exception:
+            logger.exception("MOSS-TTS Local native frame graph failed; falling back to eager local decode")
+            self._frame_graphs.clear()
+            if self._profile_enabled:
+                self._profile_stats["frame_graph_fallback"] += 1
+            self.local_transformer._ensure_kv_cache(B, hidden_batch.device, dtype)
+            return self._decode_frame_eager(hidden_batch, infos)
+
+    def decode_omni_frame_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        if isinstance(model_outputs, OmniOutput):
+            self._batch_state = None
+            return model_outputs
+        hidden = model_outputs
+        info_dicts: list[dict[str, Any]] = (
+            kwargs.get("model_intermediate_buffer") or kwargs.get("runtime_additional_information") or []
+        )
+        query_start_loc = kwargs.get("omni_query_start_loc")
+        request_token_spans = kwargs.get("request_token_spans")
+        sample_row_by_req = kwargs.get("omni_sample_row_by_req")
+        span_lens: list[int] | None = kwargs.get("omni_span_lens")
+        if span_lens is not None:
+            span_lens = [int(x) for x in span_lens[: len(info_dicts)]]
+        elif isinstance(request_token_spans, (list, tuple)) and len(request_token_spans) >= len(info_dicts):
+            span_lens = [int(end) - int(start) for start, end in request_token_spans[: len(info_dicts)]]
+        elif isinstance(query_start_loc, torch.Tensor) and query_start_loc.numel() >= len(info_dicts) + 1:
+            qsl_cpu = query_start_loc[: len(info_dicts) + 1].detach().to("cpu").tolist()
+            span_lens = [int(qsl_cpu[i + 1]) - int(qsl_cpu[i]) for i in range(len(info_dicts))]
+            request_token_spans = [(int(qsl_cpu[i]), int(qsl_cpu[i + 1])) for i in range(len(info_dicts))]
+
+        logits_index = kwargs.get("logits_index")
+        sample_hidden = hidden
+        logits_rows: list[int] | None = None
+        logits_row_count = 0
+        if isinstance(logits_index, torch.Tensor) and logits_index.numel() > 0:
+            logits_index_gpu = logits_index.to(device=hidden.device, dtype=torch.long).reshape(-1)
+            num_sample_rows = int(logits_index_gpu.numel())
+            logits_row_count = num_sample_rows
+            if int(hidden.shape[0]) == num_sample_rows:
+                sample_hidden = hidden
+            elif num_sample_rows <= int(hidden.shape[0]):
+                sample_hidden = hidden.index_select(0, logits_index_gpu)
+            else:
+                sample_hidden = hidden[:num_sample_rows]
+            if not isinstance(sample_row_by_req, (list, tuple)):
+                logits_rows = logits_index.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
+        elif isinstance(logits_index, int):
+            logits_rows = [int(logits_index)]
+            logits_row_count = 1
+            sample_hidden = hidden[int(logits_index) : int(logits_index) + 1]
+        elif isinstance(request_token_spans, (list, tuple)) and len(request_token_spans) >= len(info_dicts):
+            sample_rows = [int(end) - 1 for _start, end in request_token_spans[: len(info_dicts)]]
+            if sample_rows and all(0 <= row < int(hidden.shape[0]) for row in sample_rows):
+                sample_rows_t = torch.tensor(sample_rows, device=hidden.device, dtype=torch.long)
+                sample_hidden = hidden.index_select(0, sample_rows_t)
+                logits_rows = sample_rows
+        elif (
+            span_lens is not None
+            and len(span_lens) >= len(info_dicts)
+            and all(span == 1 for span in span_lens[: len(info_dicts)])
+            and len(info_dicts) > 0
+            and int(hidden.shape[0]) > len(info_dicts)
+        ):
+            sample_hidden = hidden[: len(info_dicts)]
+        self._record_shape_profile(
+            hidden_rows=int(hidden.shape[0]) if hidden.dim() >= 1 else 1,
+            sample_rows=int(sample_hidden.shape[0]) if sample_hidden.dim() >= 1 else 1,
+            logits_rows=logits_row_count,
+            info_rows=len(info_dicts),
+        )
+
+        for info in info_dicts:
+            if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
+                state = {"step": 0, "is_stopping": False}
+                _copy_sampling_overrides(state, info)
+                default_seed = os.environ.get("MOSS_TTS_LOCAL_DEFAULT_SEED")
+                sampling_generator = _make_sampling_generator(info.get("seed", default_seed), hidden.device)
+                if sampling_generator is not None:
+                    state["sampling_generator"] = sampling_generator
+                info["audio_state"] = state
+
+        pending_req_ids, pending_codes, pending_codec_streaming = self._consume_pending_stop_result(info_dicts)
+        delta_req_ids: list[str] = list(pending_req_ids)
+        delta_codes: list[torch.Tensor] = list(pending_codes)
+        delta_codec_streaming: list[bool] = list(pending_codec_streaming)
+        next_text_tensor: torch.Tensor | None = None
+        batch_state_by_sample_row: list[dict[str, Any] | None] = []
+        profile_local_ms = 0.0
+        profile_start = self._profile_mark() if getattr(self, "_profile_enabled", False) else 0.0
+
+        if sample_hidden.numel() > 0 and info_dicts:
+            num_rows = int(sample_hidden.shape[0])
+            rowmap_start = time.perf_counter() if getattr(self, "_profile_enabled", False) else 0.0
+            next_text_tensor = torch.full(
+                (num_rows,),
+                self.audio_end_token_id,
+                dtype=torch.long,
+                device=hidden.device,
+            )
+            batch_state_by_sample_row = [None for _ in range(num_rows)]
+            logits_row_to_sample_row = (
+                {int(row): pos for pos, row in enumerate(logits_rows)} if logits_rows is not None else None
+            )
+            pure_decode_rows = (
+                num_rows == len(info_dicts) and span_lens is not None and all(span == 1 for span in span_lens)
+            )
+
+            def sample_row_for_request(req_index: int) -> int | None:
+                if isinstance(sample_row_by_req, (list, tuple)) and req_index < len(sample_row_by_req):
+                    row = int(sample_row_by_req[req_index])
+                    return row if row >= 0 else None
+                if pure_decode_rows:
+                    return req_index
+                if isinstance(request_token_spans, (list, tuple)) and req_index < len(request_token_spans):
+                    start, end = request_token_spans[req_index]
+                    start_i = int(start)
+                    end_i = int(end)
+                    if end_i <= start_i:
+                        return None
+                    hidden_row = end_i - 1
+                    if logits_row_to_sample_row is not None:
+                        return logits_row_to_sample_row.get(hidden_row)
+                    if 0 <= hidden_row < num_rows:
+                        return hidden_row
+                if num_rows == len(info_dicts) == 1:
+                    return req_index
+                return None
+
+            decode_items: list[tuple[int, int]] = []
+            for i, info in enumerate(info_dicts):
+                if not isinstance(info, dict):
+                    continue
+                state = info.get("audio_state", {}) or {}
+                row_idx = sample_row_for_request(i)
+                if row_idx is None or row_idx < 0 or row_idx >= num_rows:
+                    continue
+                batch_state_by_sample_row[row_idx] = state
+                if state.get("is_stopping"):
+                    state["next_text"] = self.audio_end_token_id
+                    next_text_tensor[row_idx] = self.audio_end_token_id
+                    continue
+                if span_lens is not None and i < len(span_lens) and span_lens[i] != 1:
+                    state["next_text"] = self.audio_assistant_slot_token_id
+                    next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
+                    continue
+                decode_items.append((i, row_idx))
+            if getattr(self, "_profile_enabled", False):
+                self._profile_stats["rowmap_ms"] += (time.perf_counter() - rowmap_start) * 1000
+
+            use_batched = (
+                len(decode_items) > 1
+                and os.environ.get("MOSS_TTS_LOCAL_DISABLE_LOCAL_BATCH") != "1"
+                and all(isinstance(info_dicts[j], dict) for j, _ in decode_items)
+            )
+
+            if use_batched:
+                decode_rows = [row_idx for _, row_idx in decode_items]
+                n_active = len(decode_items)
+                asm_buffers = self._ensure_output_asm_buffers(batch_size=n_active, device=hidden.device)
+                rows_cpu = asm_buffers["rows_cpu"][:n_active]
+                for bi, row_idx in enumerate(decode_rows):
+                    rows_cpu[bi] = int(row_idx)
+                decode_rows_t = asm_buffers["rows_gpu"][:n_active]
+                decode_rows_t.copy_(rows_cpu, non_blocking=hidden.device.type == "cuda")
+                hidden_batch = (
+                    sample_hidden
+                    if decode_rows == list(range(len(decode_rows))) and len(decode_rows) == int(sample_hidden.shape[0])
+                    else sample_hidden.index_select(0, decode_rows_t)
+                )
+
+                local_start = self._profile_mark() if getattr(self, "_profile_enabled", False) else 0.0
+                stop_choices, all_codes = self._decode_frame_batched(
+                    hidden_batch, [info_dicts[j] for j, _ in decode_items]
+                )
+                if getattr(self, "_profile_enabled", False):
+                    elapsed = self._profile_elapsed_ms(local_start)
+                    self._profile_stats["local_ms"] += elapsed
+                    profile_local_ms += elapsed
+                    self._profile_stats["n_decode"] += 1
+                    self._profile_stats["batch_sizes"].append(n_active)
+
+                asm_start = time.perf_counter() if getattr(self, "_profile_enabled", False) else 0.0
+                pool = self._get_request_state_pool()
+                pool.ensure_frame_state_device(hidden.device)
+                slot_cpu = asm_buffers["slot_cpu"][:n_active]
+                active_states: list[dict[str, Any]] = []
+                active_slot_ids: list[int] = []
+                all_slots_valid = (
+                    pool.steps_gpu is not None
+                    and pool.min_frames_gpu is not None
+                    and pool.max_frames_gpu is not None
+                    and pool.is_stopping_gpu is not None
+                    and hidden.device.type == "cuda"
+                )
+                for bi, (i, _) in enumerate(decode_items):
+                    state = info_dicts[i].get("audio_state", {}) or {}
+                    active_states.append(state)
+                    try:
+                        slot_id = int(info_dicts[i].get("_kv_slot_id"))
+                    except (TypeError, ValueError):
+                        slot_id = -1
+                    active_slot_ids.append(slot_id)
+                    slot_cpu[bi] = slot_id
+                    if 0 <= slot_id < pool.max_slots:
+                        if pool.is_stopping_py[slot_id]:
+                            state["is_stopping"] = True
+                    else:
+                        all_slots_valid = False
+
+                next_for_active = asm_buffers["next_gpu"][:n_active]
+                next_for_active.fill_(self.audio_assistant_slot_token_id)
+                slot_ids_t = asm_buffers["slot_gpu"][:n_active]
+                slot_ids_t.copy_(slot_cpu, non_blocking=hidden.device.type == "cuda")
+                steps_t = asm_buffers["steps_gpu"][:n_active]
+                min_frames_t = asm_buffers["min_gpu"][:n_active]
+                max_frames_t = asm_buffers["max_gpu"][:n_active]
+                should_stop_t = asm_buffers["stop_gpu"][:n_active]
+                tmp_stop_t = asm_buffers["tmp_stop_gpu"][:n_active]
+                step_values: list[int] = []
+                min_values: list[int] = []
+                max_values: list[int] = []
+                model_stop_poll: list[bool] = []
+                max_stop_list: list[bool] = []
+                active_req_ids: list[str] = []
+                stop_interval = int(getattr(self, "_stop_check_interval", 1))
+                for state, slot_id in zip(active_states, active_slot_ids, strict=False):
+                    if 0 <= slot_id < pool.max_slots:
+                        step_num = pool.steps_py[slot_id]
+                        min_frames = pool.min_frames_py[slot_id]
+                        max_frames = pool.max_frames_py[slot_id]
+                    else:
+                        step_num = int(state.get("step", 0))
+                        min_frames = max(int(state.get("min_new_frames", 3)), self._default_min_frames)
+                        max_frames = int(state.get("max_new_frames", 150))
+                    step_values.append(step_num)
+                    min_values.append(min_frames)
+                    max_values.append(max_frames)
+                    max_due = step_num >= max_frames
+                    max_stop_list.append(max_due)
+                    model_stop_poll.append(
+                        (not max_due)
+                        and step_num >= min_frames
+                        and (stop_interval <= 1 or ((step_num - min_frames) % stop_interval) == 0)
+                    )
+                for i, _ in decode_items:
+                    info = info_dicts[i]
+                    active_req_ids.append(str(info.get("request_id") or info.get("global_request_id") or ""))
+                stop_possible = any(model_stop_poll) or any(max_stop_list)
+
+                if all_slots_valid:
+                    torch.index_select(pool.steps_gpu, 0, slot_ids_t, out=steps_t)
+                    torch.index_select(pool.min_frames_gpu, 0, slot_ids_t, out=min_frames_t)
+                    torch.index_select(pool.max_frames_gpu, 0, slot_ids_t, out=max_frames_t)
+                else:
+                    steps_cpu = asm_buffers["steps_cpu"][:n_active]
+                    min_cpu = asm_buffers["min_cpu"][:n_active]
+                    max_cpu = asm_buffers["max_cpu"][:n_active]
+                    for bi, (step_num, min_frames, max_frames) in enumerate(
+                        zip(step_values, min_values, max_values, strict=False)
+                    ):
+                        steps_cpu[bi] = int(step_num)
+                        min_cpu[bi] = int(min_frames)
+                        max_cpu[bi] = int(max_frames)
+                    steps_t.copy_(steps_cpu, non_blocking=hidden.device.type == "cuda")
+                    min_frames_t.copy_(min_cpu, non_blocking=hidden.device.type == "cuda")
+                    max_frames_t.copy_(max_cpu, non_blocking=hidden.device.type == "cuda")
+
+                should_stop_list: list[bool] = [False for _ in range(n_active)]
+                delay_model_stop = (
+                    bool(getattr(self, "_delay_stop_sync_enabled", False))
+                    and hidden.device.type == "cuda"
+                    and stop_interval == 1
+                    and any(model_stop_poll)
+                )
+                delay_delta_routing = bool(getattr(self, "_delay_delta_routing_enabled", False))
+                stop_sync_start: float | None = None
+                if stop_possible:
+                    stop_cpu = asm_buffers["stop_cpu"][:n_active]
+                    if delay_model_stop:
+                        torch.eq(stop_choices.reshape(-1)[:n_active], 1, out=should_stop_t)
+                        torch.ge(steps_t, min_frames_t, out=tmp_stop_t)
+                        should_stop_t.logical_and_(tmp_stop_t)
+                        stop_cpu.copy_(should_stop_t, non_blocking=True)
+                        stop_copy_event = asm_buffers.get("stop_copy_event")
+                        if isinstance(stop_copy_event, torch.cuda.Event):
+                            stop_copy_event.record(torch.cuda.current_stream(hidden.device))
+                            pending_stop_result: dict[str, Any] = {
+                                "event": stop_copy_event,
+                                "stop_cpu": stop_cpu,
+                                "slot_ids": list(active_slot_ids),
+                                "req_ids": list(active_req_ids),
+                                "force_stop": list(max_stop_list),
+                                "steps": list(step_values),
+                            }
+                            if delay_delta_routing:
+                                pending_stop_result["codes"] = all_codes.detach().clone()
+                                pending_stop_result["codec_streaming"] = [
+                                    _stream_flag_from_info(info_dicts[i]) for i, _ in decode_items
+                                ]
+                            self._pending_stop_result = pending_stop_result
+                        should_stop_list = [bool(x) for x in max_stop_list]
+                        next_for_active.fill_(self.audio_assistant_slot_token_id)
+                        should_stop_t.zero_()
+                        if any(max_stop_list):
+                            poll_cpu = asm_buffers["poll_cpu"][:n_active]
+                            for bi, should_stop in enumerate(max_stop_list):
+                                poll_cpu[bi] = bool(should_stop)
+                            max_stop_t = asm_buffers["poll_gpu"][:n_active]
+                            max_stop_t.copy_(poll_cpu, non_blocking=True)
+                            should_stop_t.copy_(max_stop_t, non_blocking=True)
+                            next_for_active.masked_fill_(max_stop_t, self.audio_end_token_id)
+                    elif any(model_stop_poll):
+                        stop_sync_start = time.perf_counter()
+                        model_stop_mask = None
+                        if stop_interval > 1:
+                            poll_cpu = asm_buffers["poll_cpu"][:n_active]
+                            for bi, allowed in enumerate(model_stop_poll):
+                                poll_cpu[bi] = bool(allowed)
+                            model_stop_mask = asm_buffers["poll_gpu"][:n_active]
+                            model_stop_mask.copy_(poll_cpu, non_blocking=hidden.device.type == "cuda")
+                        should_stop_t, next_for_active = self._compute_stop_and_next_tokens(
+                            stop_choices=stop_choices.reshape(-1)[:n_active],
+                            steps=steps_t,
+                            min_frames=min_frames_t,
+                            max_frames=max_frames_t,
+                            audio_assistant_slot_token_id=self.audio_assistant_slot_token_id,
+                            audio_end_token_id=self.audio_end_token_id,
+                            should_stop_out=should_stop_t,
+                            tmp_out=tmp_stop_t,
+                            next_tokens_out=next_for_active,
+                            model_stop_mask=model_stop_mask,
+                        )
+                        stop_cpu.copy_(should_stop_t, non_blocking=hidden.device.type == "cuda")
+                        stop_copy_event = asm_buffers.get("stop_copy_event")
+                        if isinstance(stop_copy_event, torch.cuda.Event):
+                            stop_copy_event.record(torch.cuda.current_stream(hidden.device))
+                    else:
+                        for bi, should_stop in enumerate(max_stop_list):
+                            stop_cpu[bi] = bool(should_stop)
+                        should_stop_t.copy_(stop_cpu, non_blocking=hidden.device.type == "cuda")
+                        if any(max_stop_list):
+                            next_for_active.masked_fill_(should_stop_t, self.audio_end_token_id)
+                    if (
+                        (not delay_model_stop)
+                        and any(model_stop_poll)
+                        and isinstance(asm_buffers.get("stop_copy_event"), torch.cuda.Event)
+                    ):
+                        asm_buffers["stop_copy_event"].synchronize()
+                    if stop_sync_start is not None and getattr(self, "_profile_enabled", False):
+                        self._profile_stats["stop_sync_ms"] += (time.perf_counter() - stop_sync_start) * 1000
+                    if not delay_model_stop:
+                        should_stop_list = [bool(x) for x in stop_cpu.tolist()]
+                else:
+                    should_stop_t.zero_()
+                next_text_tensor.index_copy_(0, decode_rows_t, next_for_active)
+
+                if all_slots_valid:
+                    pool.advance_frame_state_gpu(
+                        slot_ids_t,
+                        should_stop_t,
+                        should_stop_list,
+                        slot_ids_cpu=active_slot_ids,
+                    )
+                else:
+                    pool.advance_frame_state(active_slot_ids, should_stop_list)
+
+                update_start = time.perf_counter() if getattr(self, "_profile_enabled", False) else 0.0
+                for bi, (i, _row_idx) in enumerate(decode_items):
+                    info = info_dicts[i]
+                    state = active_states[bi]
+                    new_codes = all_codes[bi]
+                    should_stop = should_stop_list[bi]
+                    slot_id = active_slot_ids[bi]
+                    if 0 <= slot_id < pool.max_slots:
+                        step_num = pool.steps_py[slot_id]
+                        max_frames = pool.max_frames_py[slot_id]
+                    else:
+                        step_num = int(state.get("step", 0))
+                        max_frames = int(state.get("max_new_frames", 150))
+                    if should_stop:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
+                        info["audio_codes"] = {"current": new_codes}
+                        self._set_slot_current_codes(slot_id, new_codes)
+                    else:
+                        state["next_text"] = self.audio_assistant_slot_token_id
+                        state["step"] = pool.steps_py[slot_id] if 0 <= slot_id < pool.max_slots else step_num + 1
+                        info["audio_codes"] = {"current": new_codes}
+                        self._set_slot_current_codes(slot_id, new_codes)
+                        rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                        if rid or len(info_dicts) == 1:
+                            if not (delay_model_stop and delay_delta_routing):
+                                delta_req_ids.append(rid)
+                                delta_codes.append(all_codes[bi : bi + 1])
+                                delta_codec_streaming.append(_stream_flag_from_info(info))
+                if getattr(self, "_profile_enabled", False):
+                    self._profile_stats["update_ms"] += (time.perf_counter() - update_start) * 1000
+                    self._profile_stats["output_asm_ms"] += (time.perf_counter() - asm_start) * 1000
+            else:
+                for i, row_idx in decode_items:
+                    info = info_dicts[i]
+                    if not isinstance(info, dict):
+                        continue
+                    state = info.get("audio_state", {}) or {}
+                    if state.get("is_stopping"):
+                        state["next_text"] = self.audio_end_token_id
+                        next_text_tensor[row_idx] = self.audio_end_token_id
+                        continue
+                    local_start = self._profile_mark() if getattr(self, "_profile_enabled", False) else 0.0
+                    stop_choices, all_codes = self._decode_frame_batched(sample_hidden[row_idx : row_idx + 1], [info])
+                    if getattr(self, "_profile_enabled", False):
+                        elapsed = self._profile_elapsed_ms(local_start)
+                        self._profile_stats["local_ms"] += elapsed
+                        profile_local_ms += elapsed
+                        self._profile_stats["n_decode"] += 1
+                        self._profile_stats["batch_sizes"].append(1)
+                    new_codes = all_codes[0]
+                    step_num = int(state.get("step", 0))
+                    min_frames = max(int(state.get("min_new_frames", 3)), self._default_min_frames)
+                    max_frames = int(state.get("max_new_frames", 150))
+                    should_stop = (
+                        int(stop_choices[0].item()) == 1 and step_num >= min_frames
+                    ) or step_num >= max_frames
+                    if should_stop:
+                        state["is_stopping"] = True
+                        state["next_text"] = self.audio_end_token_id
+                        state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
+                        info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
+                        next_text_tensor[row_idx] = self.audio_end_token_id
+                    else:
+                        state["next_text"] = self.audio_assistant_slot_token_id
+                        state["step"] = step_num + 1
+                        info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
+                        next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
+                        rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                        if rid or len(info_dicts) == 1:
+                            delta_req_ids.append(rid)
+                            delta_codes.append(new_codes.unsqueeze(0))
+                            delta_codec_streaming.append(_stream_flag_from_info(info))
+
+        output_start = time.perf_counter() if getattr(self, "_profile_enabled", False) else 0.0
+        self._batch_state = [
+            (state if isinstance(state, dict) else {"next_text": self.audio_end_token_id})
+            for state in batch_state_by_sample_row
+        ] or [(info.get("audio_state", {}) if isinstance(info, dict) else {}) for info in info_dicts]
+        if not delta_codes:
+            output = OmniOutput(
+                text_hidden_states=sample_hidden,
+                multimodal_outputs={"meta": {"next_text": next_text_tensor}} if next_text_tensor is not None else {},
+            )
+            if getattr(self, "_profile_enabled", False):
+                self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
+                self._profile_stats["make_output_ms"] += max(
+                    0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+                )
+                self._maybe_log_profile()
+            return output
+
+        step_counter = max(
+            (int((info.get("audio_state", {}) or {}).get("step", 0)) for info in info_dicts if isinstance(info, dict)),
+            default=0,
+        )
+        if len(info_dicts) == 1 and len(delta_codes) == 1:
+            codec_streaming = _stream_flag_from_info(info_dicts[0]) if isinstance(info_dicts[0], dict) else True
+            output = OmniOutput(
+                text_hidden_states=sample_hidden,
+                multimodal_outputs={
+                    "codes": {"audio": delta_codes[0]},
+                    "meta": {
+                        "raw_rows": True,
+                        "step": step_counter,
+                        "next_text": next_text_tensor,
+                        "codec_streaming": codec_streaming,
+                    },
+                },
+            )
+            if getattr(self, "_profile_enabled", False):
+                self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
+                self._profile_stats["make_output_ms"] += max(
+                    0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+                )
+                self._maybe_log_profile()
+            return output
+        output = OmniOutput(
+            text_hidden_states=sample_hidden,
+            multimodal_outputs={
+                "codes": {"audio": delta_codes},
+                "meta": {
+                    "sparse_audio": True,
+                    "req_id": delta_req_ids,
+                    "raw_rows": True,
+                    "step": [
+                        int((info.get("audio_state", {}) or {}).get("step", 0))
+                        for info in info_dicts
+                        if isinstance(info, dict)
+                    ][: len(delta_codes)],
+                    "next_text": next_text_tensor,
+                    "codec_streaming": delta_codec_streaming,
+                },
+            },
+        )
+        if getattr(self, "_profile_enabled", False):
+            self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
+            self._profile_stats["make_output_ms"] += max(
+                0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
+            )
+            self._maybe_log_profile()
+        return output
 
     def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        if _env_enabled("MOSS_TTS_LOCAL_NATIVE_STATEPOOL_OUTPUT"):
+            return self.decode_omni_frame_output(model_outputs, **kwargs)
+        return self._make_omni_output_legacy(model_outputs, **kwargs)
+
+    def _make_omni_output_legacy(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
         profile_start = self._profile_mark() if self._profile_enabled else 0.0
         profile_local_ms = 0.0
         if isinstance(model_outputs, OmniOutput):
@@ -528,37 +1937,47 @@ class MossTTSLocalNativeModel(nn.Module):
         logits_index = kwargs.get("logits_index")
         sample_hidden = hidden
         logits_rows: list[int] | None = None
+        logits_row_count = 0
         if isinstance(logits_index, torch.Tensor) and logits_index.numel() > 0:
-            logits_rows = logits_index.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
-            sample_hidden = hidden[logits_index.to(device=hidden.device, dtype=torch.long)]
+            logits_index_gpu = logits_index.to(device=hidden.device, dtype=torch.long).reshape(-1)
+            logits_row_count = int(logits_index_gpu.numel())
+            sample_hidden = (
+                hidden
+                if int(hidden.shape[0]) == int(logits_index_gpu.numel())
+                else hidden.index_select(0, logits_index_gpu)
+            )
         elif isinstance(logits_index, int):
             logits_rows = [int(logits_index)]
-            sample_hidden = hidden[logits_index:logits_index + 1]
+            logits_row_count = 1
+            sample_hidden = hidden[logits_index : logits_index + 1]
 
         query_start_loc = kwargs.get("omni_query_start_loc")
         request_token_spans = kwargs.get("request_token_spans")
-        span_lens: list[int] | None = None
+        sample_row_by_req = kwargs.get("omni_sample_row_by_req")
+        span_lens: list[int] | None = kwargs.get("omni_span_lens")
         qsl_cpu: list[int] | None = None
-        if isinstance(query_start_loc, torch.Tensor) and query_start_loc.numel() >= len(info_dicts) + 1:
-            qsl_cpu = query_start_loc[:len(info_dicts) + 1].detach().to("cpu").tolist()
+        if span_lens is not None:
+            span_lens = [int(x) for x in span_lens[: len(info_dicts)]]
+        elif isinstance(request_token_spans, (list, tuple)) and len(request_token_spans) >= len(info_dicts):
+            span_lens = [int(end) - int(start) for start, end in request_token_spans[: len(info_dicts)]]
+        elif isinstance(query_start_loc, torch.Tensor) and query_start_loc.numel() >= len(info_dicts) + 1:
+            qsl_cpu = query_start_loc[: len(info_dicts) + 1].detach().to("cpu").tolist()
             span_lens = [int(qsl_cpu[i + 1]) - int(qsl_cpu[i]) for i in range(len(info_dicts))]
-            if not isinstance(request_token_spans, (list, tuple)):
-                request_token_spans = [(int(qsl_cpu[i]), int(qsl_cpu[i + 1])) for i in range(len(info_dicts))]
-        elif (
-            isinstance(request_token_spans, (list, tuple))
-            and len(request_token_spans) >= len(info_dicts)
-        ):
-            span_lens = [
-                int(end) - int(start)
-                for start, end in request_token_spans[:len(info_dicts)]
-            ]
+            request_token_spans = [(int(qsl_cpu[i]), int(qsl_cpu[i + 1])) for i in range(len(info_dicts))]
+        self._record_shape_profile(
+            hidden_rows=int(hidden.shape[0]) if hidden.dim() >= 1 else 1,
+            sample_rows=int(sample_hidden.shape[0]) if sample_hidden.dim() >= 1 else 1,
+            logits_rows=logits_row_count,
+            info_rows=len(info_dicts),
+        )
         if _debug_state_enabled():
             if isinstance(logits_index, torch.Tensor):
                 logits_index_dbg = logits_index.detach().to("cpu").reshape(-1).tolist()
             else:
                 logits_index_dbg = logits_index
             logger.info(
-                "[moss-local-state] make_output enter hidden=%s sample=%s infos=%d qsl=%s logits_index=%s spans=%s reqs=%s",
+                "[moss-local-state] make_output enter hidden=%s sample=%s infos=%d "
+                "qsl=%s logits_index=%s spans=%s reqs=%s",
                 tuple(hidden.shape),
                 tuple(sample_hidden.shape),
                 len(info_dicts),
@@ -571,28 +1990,44 @@ class MossTTSLocalNativeModel(nn.Module):
             if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
                 state = {"step": 0, "is_stopping": False}
                 _copy_sampling_overrides(state, info)
-                sampling_generator = _make_sampling_generator(info.get("seed"), hidden.device)
+                default_seed = os.environ.get("MOSS_TTS_LOCAL_DEFAULT_SEED")
+                sampling_generator = _make_sampling_generator(info.get("seed", default_seed), hidden.device)
                 if sampling_generator is not None:
                     state["sampling_generator"] = sampling_generator
                 info["audio_state"] = state
+        self._consume_pending_stop_result(info_dicts)
 
         audio_codes_list: list[torch.Tensor | None] = [None for _ in info_dicts]
         batch_state_by_sample_row: list[dict[str, Any] | None] = []
+        next_text_tensor: torch.Tensor | None = None
+        delta_req_ids: list[str] = []
+        delta_codes: list[torch.Tensor] = []
+        delta_steps: list[int] = []
         if hidden.numel() > 0 and info_dicts:
             num_rows = int(sample_hidden.shape[0])
+            rowmap_start = time.perf_counter() if self._profile_enabled else 0.0
             batch_state_by_sample_row = [None for _ in range(num_rows)]
+            next_text_tensor = torch.full(
+                (num_rows,),
+                self.audio_end_token_id,
+                dtype=torch.long,
+                device=hidden.device,
+            )
             logits_row_to_sample_row = (
-                {int(row): pos for pos, row in enumerate(logits_rows)}
-                if logits_rows is not None
-                else None
+                {int(row): pos for pos, row in enumerate(logits_rows)} if logits_rows is not None else None
             )
             decode_items: list[tuple[int, int]] = []
+            pure_decode_rows = (
+                num_rows == len(info_dicts) and span_lens is not None and all(span == 1 for span in span_lens)
+            )
 
             def sample_row_for_request(req_index: int) -> int | None:
-                if (
-                    isinstance(request_token_spans, (list, tuple))
-                    and req_index < len(request_token_spans)
-                ):
+                if isinstance(sample_row_by_req, (list, tuple)) and req_index < len(sample_row_by_req):
+                    row = int(sample_row_by_req[req_index])
+                    return row if row >= 0 else None
+                if pure_decode_rows:
+                    return req_index
+                if isinstance(request_token_spans, (list, tuple)) and req_index < len(request_token_spans):
                     start, end = request_token_spans[req_index]
                     start_i = int(start)
                     end_i = int(end)
@@ -617,21 +2052,33 @@ class MossTTSLocalNativeModel(nn.Module):
                     if row_idx is not None and 0 <= row_idx < num_rows:
                         state["next_text"] = self.audio_end_token_id
                         batch_state_by_sample_row[row_idx] = state
+                        next_text_tensor[row_idx] = self.audio_end_token_id
                     continue
 
                 row_idx = sample_row_for_request(i)
                 if row_idx is None or row_idx < 0 or row_idx >= num_rows:
                     continue
                 if span_lens is not None and span_lens[i] != 1:
-                    # This request is still consuming a prefill span. The runner
-                    # will sample one text token for it, but MOSS local should not
-                    # generate an audio frame until the next decode-only step.
+                    if _debug_state_enabled():
+                        digest, norm, head = _debug_tensor_digest(sample_hidden[row_idx])
+                        logger.info(
+                            "[moss-local-state] prefill-hidden req=%s span=%s row=%d digest=%s norm=%.6f head=%s",
+                            _request_label(info),
+                            span_lens[i],
+                            row_idx,
+                            digest,
+                            norm,
+                            head,
+                        )
                     state["next_text"] = self.audio_assistant_slot_token_id
                     batch_state_by_sample_row[row_idx] = state
+                    next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
                     continue
                 batch_state_by_sample_row[row_idx] = state
                 decode_items.append((i, row_idx))
 
+            if self._profile_enabled:
+                self._profile_stats["rowmap_ms"] += (time.perf_counter() - rowmap_start) * 1000
             use_batched = len(decode_items) > 0
             if _debug_state_enabled():
                 row_debug = []
@@ -659,11 +2106,7 @@ class MossTTSLocalNativeModel(nn.Module):
                     row_debug,
                 )
 
-            if (
-                use_batched
-                and len(decode_items) > 1
-                and os.environ.get("MOSS_TTS_LOCAL_DISABLE_LOCAL_BATCH") != "1"
-            ):
+            if use_batched and len(decode_items) > 1 and os.environ.get("MOSS_TTS_LOCAL_DISABLE_LOCAL_BATCH") != "1":
                 if _debug_state_enabled():
                     for i, row_idx in decode_items:
                         info = info_dicts[i]
@@ -678,7 +2121,13 @@ class MossTTSLocalNativeModel(nn.Module):
                             norm,
                             head,
                         )
-                hidden_batch = torch.stack([sample_hidden[row_idx] for _, row_idx in decode_items])
+                decode_rows = [row_idx for _, row_idx in decode_items]
+                if len(decode_rows) == int(sample_hidden.shape[0]) and decode_rows == list(range(len(decode_rows))):
+                    hidden_batch = sample_hidden
+                    decode_rows_t = None
+                else:
+                    decode_rows_t = torch.tensor(decode_rows, device=sample_hidden.device, dtype=torch.long)
+                    hidden_batch = sample_hidden.index_select(0, decode_rows_t)
                 local_start = self._profile_mark() if self._profile_enabled else 0.0
                 stop_choices, all_codes = self._decode_frame_batched(
                     hidden_batch,
@@ -690,24 +2139,66 @@ class MossTTSLocalNativeModel(nn.Module):
                     profile_local_ms += elapsed
                     self._profile_stats["n_decode"] += 1
                     self._profile_stats["batch_sizes"].append(len(decode_items))
-                batch_min_frames = int(os.environ.get("MOSS_TTS_LOCAL_BATCH_MIN_FRAMES", "80") or 80)
-                step_nums = torch.tensor(
-                    [int((info_dicts[i].get("audio_state", {}) or {}).get("step", 0)) for i, _ in decode_items],
-                    dtype=torch.long,
-                    device=stop_choices.device,
+                batch_min_frames = self._default_min_frames
+                step_values = [
+                    int((info_dicts[i].get("audio_state", {}) or {}).get("step", 0)) for i, _ in decode_items
+                ]
+                min_values = [
+                    max(int((info_dicts[i].get("audio_state", {}) or {}).get("min_new_frames", 3)), batch_min_frames)
+                    for i, _ in decode_items
+                ]
+                max_values = [
+                    int((info_dicts[i].get("audio_state", {}) or {}).get("max_new_frames", 150))
+                    for i, _ in decode_items
+                ]
+                step_nums = torch.tensor(step_values, dtype=torch.long, device=stop_choices.device)
+                min_frames_t = torch.tensor(min_values, dtype=torch.long, device=stop_choices.device)
+                max_frames_t = torch.tensor(max_values, dtype=torch.long, device=stop_choices.device)
+                model_stop_tensor = (stop_choices == 1) & (step_nums >= min_frames_t)
+                max_stop_tensor = step_nums >= max_frames_t
+                delay_model_stop = (
+                    bool(getattr(self, "_delay_stop_sync_enabled", False))
+                    and stop_choices.device.type == "cuda"
+                    and torch.cuda.is_available()
+                    and any(step >= min_frame for step, min_frame in zip(step_values, min_values))
                 )
-                min_frames_t = torch.tensor(
-                    [max(int((info_dicts[i].get("audio_state", {}) or {}).get("min_new_frames", 3)), batch_min_frames) for i, _ in decode_items],
-                    dtype=torch.long,
-                    device=stop_choices.device,
-                )
-                max_frames_t = torch.tensor(
-                    [int((info_dicts[i].get("audio_state", {}) or {}).get("max_new_frames", 150)) for i, _ in decode_items],
-                    dtype=torch.long,
-                    device=stop_choices.device,
-                )
-                should_stop_tensor = ((stop_choices == 1) & (step_nums >= min_frames_t)) | (step_nums >= max_frames_t)
-                should_stop_list = should_stop_tensor.detach().cpu().tolist()
+                if delay_model_stop:
+                    should_stop_tensor = max_stop_tensor
+                    next_for_decode = torch.where(
+                        max_stop_tensor,
+                        torch.full_like(step_nums, self.audio_end_token_id),
+                        torch.full_like(step_nums, self.audio_assistant_slot_token_id),
+                    )
+                    try:
+                        stop_cpu = torch.empty(len(decode_items), dtype=torch.bool, pin_memory=True)
+                    except RuntimeError:
+                        stop_cpu = torch.empty(len(decode_items), dtype=torch.bool)
+                    stop_cpu.copy_(model_stop_tensor.detach(), non_blocking=True)
+                    stop_event = torch.cuda.Event()
+                    stop_event.record(torch.cuda.current_stream(stop_choices.device))
+                    self._pending_stop_result = {
+                        "event": stop_event,
+                        "stop_cpu": stop_cpu,
+                        "req_ids": [
+                            str(info_dicts[i].get("request_id") or info_dicts[i].get("global_request_id") or "")
+                            for i, _ in decode_items
+                        ],
+                    }
+                    should_stop_list = [bool(step >= max_frame) for step, max_frame in zip(step_values, max_values)]
+                else:
+                    should_stop_tensor = model_stop_tensor | max_stop_tensor
+                    next_for_decode = torch.where(
+                        should_stop_tensor,
+                        torch.full_like(step_nums, self.audio_end_token_id),
+                        torch.full_like(step_nums, self.audio_assistant_slot_token_id),
+                    )
+                    should_stop_list = should_stop_tensor.detach().cpu().tolist()
+                if next_text_tensor is not None:
+                    if decode_rows_t is None:
+                        next_text_tensor[: len(decode_items)].copy_(next_for_decode)
+                    else:
+                        next_text_tensor.index_copy_(0, decode_rows_t, next_for_decode)
+                update_start = time.perf_counter() if self._profile_enabled else 0.0
                 if _debug_state_enabled():
                     logger.info(
                         "[moss-local-state] decode batched reqs=%s stops=%s should_stop=%s",
@@ -725,19 +2216,32 @@ class MossTTSLocalNativeModel(nn.Module):
                         continue
                     new_codes = all_codes[bi]
                     debug_hash = _update_debug_code_hash(state, new_codes) if _debug_state_enabled() else 0
-                    step_num = int(step_nums[bi].item())
-                    max_frames = int(max_frames_t[bi].item())
+                    step_num = int(step_values[bi])
+                    max_frames = int(max_values[bi])
                     should_stop = bool(should_stop_list[bi])
                     if should_stop:
                         state["is_stopping"] = True
                         state["next_text"] = self.audio_end_token_id
                         state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
                         info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
                     else:
                         state["next_text"] = self.audio_assistant_slot_token_id
                         state["step"] = step_num + 1
                         info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
                         audio_codes_list[i] = new_codes.unsqueeze(0)
+                        rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                        if rid:
+                            delta_req_ids.append(rid)
+                            delta_codes.append(new_codes.unsqueeze(0))
+                            delta_steps.append(step_num)
                     if _debug_state_enabled():
                         logger.info(
                             "[moss-local-state] update req=%s step=%d stop=%s next=%s code0=%d",
@@ -749,12 +2253,19 @@ class MossTTSLocalNativeModel(nn.Module):
                         )
                         if should_stop:
                             logger.info(
-                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x",
+                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x "
+                                "row=%d span=%s next=%s stop_choice=%d",
                                 _request_label(info),
                                 step_num + 1,
                                 state.get("stop_reason"),
                                 debug_hash,
+                                int(decode_items[bi][1]),
+                                span_lens[i] if span_lens is not None and i < len(span_lens) else None,
+                                state.get("next_text"),
+                                int(stop_choices[bi].item()),
                             )
+                if self._profile_enabled:
+                    self._profile_stats["update_ms"] += (time.perf_counter() - update_start) * 1000
             elif use_batched:
                 for i, row_idx in decode_items:
                     info = info_dicts[i]
@@ -776,7 +2287,7 @@ class MossTTSLocalNativeModel(nn.Module):
                             head,
                         )
                     local_start = self._profile_mark() if self._profile_enabled else 0.0
-                    stop_choices, all_codes = self._decode_frame_batched(sample_hidden[row_idx:row_idx + 1], [info])
+                    stop_choices, all_codes = self._decode_frame_batched(sample_hidden[row_idx : row_idx + 1], [info])
                     if self._profile_enabled:
                         elapsed = self._profile_elapsed_ms(local_start)
                         self._profile_stats["local_ms"] += elapsed
@@ -786,19 +2297,38 @@ class MossTTSLocalNativeModel(nn.Module):
                     new_codes = all_codes[0]
                     debug_hash = _update_debug_code_hash(state, new_codes) if _debug_state_enabled() else 0
                     step_num = int(state.get("step", 0))
-                    min_frames = int(state.get("min_new_frames", 3))
+                    min_frames = max(int(state.get("min_new_frames", 3)), self._default_min_frames)
                     max_frames = int(state.get("max_new_frames", 150))
-                    should_stop = (int(stop_choices[0].item()) == 1 and step_num >= min_frames) or step_num >= max_frames
+                    should_stop = (
+                        int(stop_choices[0].item()) == 1 and step_num >= min_frames
+                    ) or step_num >= max_frames
                     if should_stop:
                         state["is_stopping"] = True
                         state["next_text"] = self.audio_end_token_id
                         state["stop_reason"] = "max_new_frames" if step_num >= max_frames else "model_stop"
                         info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
+                        if next_text_tensor is not None:
+                            next_text_tensor[row_idx] = self.audio_end_token_id
                     else:
                         state["next_text"] = self.audio_assistant_slot_token_id
                         state["step"] = step_num + 1
                         info["audio_codes"] = {"current": new_codes}
+                        try:
+                            self._set_slot_current_codes(int(info.get("_kv_slot_id")), new_codes)
+                        except (TypeError, ValueError):
+                            pass
                         audio_codes_list[i] = new_codes.unsqueeze(0)
+                        if next_text_tensor is not None:
+                            next_text_tensor[row_idx] = self.audio_assistant_slot_token_id
+                        rid = str(info.get("request_id") or info.get("global_request_id") or "")
+                        if rid:
+                            delta_req_ids.append(rid)
+                            delta_codes.append(new_codes.unsqueeze(0))
+                            delta_steps.append(step_num)
                     if _debug_state_enabled():
                         logger.info(
                             "[moss-local-state] update req=%s step=%d stop=%s next=%s code0=%d",
@@ -810,28 +2340,36 @@ class MossTTSLocalNativeModel(nn.Module):
                         )
                         if should_stop:
                             logger.info(
-                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x",
+                                "[moss-local-state] final req=%s frames=%d reason=%s hash=%016x "
+                                "row=%d span=%s next=%s stop_choice=%d",
                                 _request_label(info),
                                 step_num + 1,
                                 state.get("stop_reason"),
                                 debug_hash,
+                                int(row_idx),
+                                span_lens[i] if span_lens is not None and i < len(span_lens) else None,
+                                state.get("next_text"),
+                                int(stop_choices[0].item()),
                             )
 
+        output_start = time.perf_counter() if self._profile_enabled else 0.0
         self._batch_state = [
             (state if isinstance(state, dict) else {"next_text": self.audio_end_token_id})
             for state in batch_state_by_sample_row
         ]
-        next_text_values = [
-            int(state.get("next_text", self.audio_end_token_id))
-            if isinstance(state, dict)
-            else self.audio_end_token_id
-            for state in batch_state_by_sample_row
-        ]
-        next_text_tensor = torch.tensor(next_text_values, dtype=torch.long, device=hidden.device)
+        if next_text_tensor is None:
+            next_text_values = [
+                int(state.get("next_text", self.audio_end_token_id))
+                if isinstance(state, dict)
+                else self.audio_end_token_id
+                for state in batch_state_by_sample_row
+            ]
+            next_text_tensor = torch.tensor(next_text_values, dtype=torch.long, device=hidden.device)
         active_codes = [c for c in audio_codes_list if c is not None]
         if not active_codes:
             output = OmniOutput(text_hidden_states=hidden, multimodal_outputs={"meta": {"next_text": next_text_tensor}})
             if self._profile_enabled:
+                self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
                 self._profile_stats["make_output_ms"] += max(
                     0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
                 )
@@ -850,27 +2388,16 @@ class MossTTSLocalNativeModel(nn.Module):
                 },
             )
             if self._profile_enabled:
+                self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
                 self._profile_stats["make_output_ms"] += max(
                     0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
                 )
                 self._maybe_log_profile()
             return output
-        req_ids: list[str] = []
-        delta_codes: list[torch.Tensor] = []
-        delta_steps: list[int] = []
-        for i, info in enumerate(info_dicts):
-            code = audio_codes_list[i] if i < len(audio_codes_list) else None
-            if code is None or not isinstance(info, dict):
-                continue
-            rid = str(info.get("request_id") or info.get("global_request_id") or "")
-            if rid:
-                state = info.get("audio_state", {}) or {}
-                req_ids.append(rid)
-                delta_codes.append(code)
-                delta_steps.append(max(0, int(state.get("step", 0)) - 1))
         if not delta_codes:
             output = OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
             if self._profile_enabled:
+                self._profile_stats["output_ms"] += (time.perf_counter() - output_start) * 1000
                 self._profile_stats["make_output_ms"] += max(
                     0.0, self._profile_elapsed_ms(profile_start) - profile_local_ms
                 )
@@ -882,7 +2409,7 @@ class MossTTSLocalNativeModel(nn.Module):
                 "codes": {"audio": delta_codes},
                 "meta": {
                     "sparse_audio": True,
-                    "req_id": req_ids,
+                    "req_id": delta_req_ids,
                     "raw_rows": True,
                     "step": delta_steps,
                     "next_text": next_text_tensor,
@@ -897,6 +2424,7 @@ class MossTTSLocalNativeModel(nn.Module):
         return output
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        self._audio_embedding_weight_cache = None
         loaded: set[str] = set()
         params_dict = dict(self.named_parameters())
 
@@ -912,7 +2440,7 @@ class MossTTSLocalNativeModel(nn.Module):
         for original_name, tensor in weights:
             name = original_name
             if name.startswith("transformer."):
-                name = "model." + name[len("transformer."):]
+                name = "model." + name[len("transformer.") :]
 
             # Skip text/audio lm heads from checkpoint (we have our own)
             if name.startswith("text_lm_head.") or name.startswith("audio_lm_heads."):

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_v2.py
@@ -142,6 +142,7 @@ class MossTTSLocalNativeModel(nn.Module):
         )
         self.local_text_lm_head = nn.Linear(self.hidden_size, 2, bias=False)
         self._batch_state: list[dict[str, Any]] | None = None
+        self._audio_embedding_indices = torch.arange(self.n_vq, dtype=torch.long)
 
         # Full-frame CUDA graph: captures the entire _decode_frame_eager as one graph
         self._frame_graphs: dict[int, torch.cuda.CUDAGraph] = {}
@@ -212,12 +213,12 @@ class MossTTSLocalNativeModel(nn.Module):
         codes = audio_codes.to(device=text_ids.device, dtype=torch.long)
         if codes.dim() == 1:
             codes = codes.unsqueeze(0)
-        for idx, emb in enumerate(self.audio_embeddings):
-            col = codes[:, idx].clamp(0, self.audio_vocab_size)
-            valid = col.ne(self.audio_pad_code)
-            safe_col = col.masked_fill(~valid, 0)
-            embeds = embeds + emb(safe_col) * valid.unsqueeze(-1)
-        return embeds
+        valid = codes.ne(self.audio_pad_code)
+        safe_codes = codes.clamp(0, self.audio_vocab_size).masked_fill(~valid, 0)
+        weights = torch.stack([emb.weight for emb in self.audio_embeddings], dim=0)
+        codebook_idx = self._audio_embedding_indices.to(device=text_ids.device)
+        audio_embeds = weights[codebook_idx.unsqueeze(0), safe_codes]
+        return embeds + (audio_embeds * valid.unsqueeze(-1)).sum(dim=1)
 
     def preprocess(
         self,
@@ -404,7 +405,11 @@ class MossTTSLocalNativeModel(nn.Module):
         first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
         homogeneous = all(item[:6] == first_params and item[6] is None for item in params)
 
-        if homogeneous:
+        greedy = homogeneous and float(first_params[0]) <= 0 and float(first_params[3]) <= 0
+        if greedy:
+            text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k = first_params
+            stop_choices = torch.argmax(text_logits, dim=-1)
+        elif homogeneous:
             text_temp, text_top_p, text_top_k, audio_temp, audio_top_p, audio_top_k = first_params
             stop_choices = self._sample_with_params(
                 text_logits,
@@ -428,7 +433,9 @@ class MossTTSLocalNativeModel(nn.Module):
         for channel in range(self.n_vq):
             head_weight = self.audio_embeddings[channel].weight[: self.audio_vocab_size]
             logits = F.linear(current, head_weight).float()
-            if homogeneous:
+            if greedy:
+                codes = torch.argmax(logits, dim=-1)
+            elif homogeneous:
                 codes = self._sample_with_params(
                     logits,
                     temperature=audio_temp,
@@ -483,7 +490,11 @@ class MossTTSLocalNativeModel(nn.Module):
         if len(params) != B:
             params.extend([self._frame_params({}) for _ in range(B - len(params))])
         first_params = params[0][:6] if params else (1.0, 1.0, 50, 1.0, 0.95, 50)
-        graphable = all(item[:6] == first_params and item[6] is None for item in params)
+        graphable = (
+            float(first_params[0]) <= 0
+            and float(first_params[3]) <= 0
+            and all(item[:6] == first_params and item[6] is None for item in params)
+        )
         if not graphable:
             return self._decode_frame_eager(hidden_batch, infos)
 
@@ -679,13 +690,30 @@ class MossTTSLocalNativeModel(nn.Module):
                     profile_local_ms += elapsed
                     self._profile_stats["n_decode"] += 1
                     self._profile_stats["batch_sizes"].append(len(decode_items))
-                stop_list = stop_choices.detach().cpu().tolist()
                 batch_min_frames = int(os.environ.get("MOSS_TTS_LOCAL_BATCH_MIN_FRAMES", "80") or 80)
+                step_nums = torch.tensor(
+                    [int((info_dicts[i].get("audio_state", {}) or {}).get("step", 0)) for i, _ in decode_items],
+                    dtype=torch.long,
+                    device=stop_choices.device,
+                )
+                min_frames_t = torch.tensor(
+                    [max(int((info_dicts[i].get("audio_state", {}) or {}).get("min_new_frames", 3)), batch_min_frames) for i, _ in decode_items],
+                    dtype=torch.long,
+                    device=stop_choices.device,
+                )
+                max_frames_t = torch.tensor(
+                    [int((info_dicts[i].get("audio_state", {}) or {}).get("max_new_frames", 150)) for i, _ in decode_items],
+                    dtype=torch.long,
+                    device=stop_choices.device,
+                )
+                should_stop_tensor = ((stop_choices == 1) & (step_nums >= min_frames_t)) | (step_nums >= max_frames_t)
+                should_stop_list = should_stop_tensor.detach().cpu().tolist()
                 if _debug_state_enabled():
                     logger.info(
-                        "[moss-local-state] decode batched reqs=%s stops=%s",
+                        "[moss-local-state] decode batched reqs=%s stops=%s should_stop=%s",
                         [_request_label(info_dicts[i]) for i, _ in decode_items],
-                        stop_list,
+                        stop_choices.detach().cpu().tolist(),
+                        should_stop_list,
                     )
                 for bi, (i, _) in enumerate(decode_items):
                     info = info_dicts[i]
@@ -697,10 +725,9 @@ class MossTTSLocalNativeModel(nn.Module):
                         continue
                     new_codes = all_codes[bi]
                     debug_hash = _update_debug_code_hash(state, new_codes) if _debug_state_enabled() else 0
-                    step_num = int(state.get("step", 0))
-                    min_frames = max(int(state.get("min_new_frames", 3)), batch_min_frames)
-                    max_frames = int(state.get("max_new_frames", 150))
-                    should_stop = (stop_list[bi] == 1 and step_num >= min_frames) or step_num >= max_frames
+                    step_num = int(step_nums[bi].item())
+                    max_frames = int(max_frames_t[bi].item())
+                    should_stop = bool(should_stop_list[bi])
                     if should_stop:
                         state["is_stopping"] = True
                         state["next_text"] = self.audio_end_token_id

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_vocoder.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_vocoder.py
@@ -1,0 +1,291 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""MOSS-TTS Local Transformer v1.5 vocoder stage."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+from transformers import AutoProcessor
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.model_executor.models.moss_tts_local.codec_path import (
+    moss_tts_local_processor_kwargs,
+)
+
+logger = init_logger(__name__)
+
+
+def _codec_ids_from_payload_or_input(input_ids: torch.Tensor | None, runtime_info: dict[str, Any] | None) -> torch.Tensor:
+    if isinstance(runtime_info, dict):
+        codes = runtime_info.get("codes")
+        if isinstance(codes, dict):
+            audio = codes.get("audio")
+            if isinstance(audio, torch.Tensor) and audio.numel() > 0:
+                return audio.reshape(-1).to(dtype=torch.long)
+            if isinstance(audio, (list, tuple)) and audio:
+                return torch.as_tensor(audio, dtype=torch.long).reshape(-1)
+    if input_ids is None:
+        return torch.empty(0, dtype=torch.long)
+    return input_ids.reshape(-1).to(dtype=torch.long)
+
+
+def _meta_bool(value: Any) -> bool:
+    if isinstance(value, list):
+        value = value[0] if value else False
+    if isinstance(value, torch.Tensor):
+        return bool(value.reshape(-1)[0].item()) if value.numel() > 0 else False
+    return bool(value)
+
+
+def _meta_str(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if value is None:
+        return None
+    return str(value)
+
+
+@dataclass
+class _StreamingDecodeState:
+    exit_stack: contextlib.ExitStack
+
+    @classmethod
+    def create(cls, codec: Any) -> "_StreamingDecodeState":
+        stack = contextlib.ExitStack()
+        stack.enter_context(codec.streaming(batch_size=1))
+        return cls(exit_stack=stack)
+
+    def close(self) -> None:
+        self.exit_stack.close()
+
+
+class MossTTSLocalVocoder(nn.Module):
+    """Decode raw ``[T, 12]`` Local v1.5 audio codes with MOSS-Audio-Tokenizer-v2."""
+
+    input_modalities = "audio"
+    have_multimodal_outputs: bool = True
+    has_preprocess: bool = False
+    has_postprocess: bool = False
+    enable_update_additional_information: bool = True
+    requires_raw_input_tokens: bool = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.prefix = prefix
+        self.model_path = vllm_config.model_config.model
+        self.config = vllm_config.model_config.hf_config
+        self._n_vq = int(getattr(self.config, "n_vq", 12))
+        self._sample_rate = int(getattr(self.config, "sampling_rate", 48000))
+        self._processor: Any | None = None
+        self._sr_tensor = torch.tensor(self._sample_rate, dtype=torch.int32)
+        self._streaming_states: dict[str, _StreamingDecodeState] = {}
+
+    def _ensure_processor(self) -> Any:
+        if self._processor is None:
+            logger.info("Loading MOSS-TTS Local processor from %s", self.model_path)
+            self._processor = AutoProcessor.from_pretrained(
+                self.model_path,
+                **moss_tts_local_processor_kwargs(self.model_path),
+            )
+            audio_tokenizer = getattr(self._processor, "audio_tokenizer", None)
+            if audio_tokenizer is not None:
+                if hasattr(audio_tokenizer, "eval"):
+                    audio_tokenizer.eval()
+                if torch.cuda.is_available() and hasattr(audio_tokenizer, "to"):
+                    audio_tokenizer.to("cuda")
+        return self._processor
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        if input_ids.numel() == 0:
+            return torch.empty((0, 1), device=input_ids.device, dtype=torch.float32)
+        return torch.zeros((input_ids.shape[0], 1), device=input_ids.device, dtype=torch.float32)
+
+    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> None:
+        return None
+
+    def _request_id_from_runtime_info(self, runtime_info: dict[str, Any] | None, index: int) -> str:
+        if isinstance(runtime_info, dict):
+            request_id = runtime_info.get("request_id")
+            if request_id is not None:
+                return str(request_id)
+            meta = runtime_info.get("meta")
+            if isinstance(meta, dict):
+                req_id = _meta_str(meta.get("req_id"))
+                if req_id is not None:
+                    return req_id
+        return str(index)
+
+    def _runtime_info_uses_streaming(self, runtime_info: dict[str, Any] | None) -> bool:
+        if not isinstance(runtime_info, dict):
+            return False
+        meta = runtime_info.get("meta")
+        if not isinstance(meta, dict):
+            return False
+        return _meta_bool(meta.get("codec_streaming"))
+
+    def _runtime_info_finished(self, runtime_info: dict[str, Any] | None) -> bool:
+        if not isinstance(runtime_info, dict):
+            return False
+        meta = runtime_info.get("meta")
+        if not isinstance(meta, dict):
+            return False
+        return _meta_bool(meta.get("finished")) or _meta_bool(meta.get("is_segment_finished"))
+
+    def _streaming_codec_device(self, codec: Any) -> torch.device:
+        try:
+            return next(codec.parameters()).device
+        except StopIteration:
+            return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def _decode_streaming_chunk(
+        self,
+        seg: torch.Tensor,
+        *,
+        runtime_info: dict[str, Any] | None,
+        index: int,
+    ) -> torch.Tensor:
+        processor = self._ensure_processor()
+        codec = getattr(processor, "audio_tokenizer", None)
+        if codec is None:
+            raise RuntimeError("MOSS-TTS Local streaming decode requires processor.audio_tokenizer")
+        missing = [name for name in ("streaming", "_set_streaming_exec_mask", "_decode_frame") if not hasattr(codec, name)]
+        if missing:
+            raise RuntimeError(
+                "MOSS-TTS Local streaming decode requires codec methods "
+                f"{missing}; installed MOSS-Audio-Tokenizer-v2 is incompatible"
+            )
+
+        req_id = self._request_id_from_runtime_info(runtime_info, index)
+        finished = self._runtime_info_finished(runtime_info)
+        empty = torch.zeros((0,), dtype=torch.float32)
+        if seg.numel() == 0:
+            if finished:
+                state = self._streaming_states.pop(req_id, None)
+                if state is not None:
+                    state.close()
+            return empty
+
+        if seg.numel() % self._n_vq != 0:
+            logger.warning("MOSS-TTS Local streaming vocoder got %d ids not divisible by n_vq=%d", seg.numel(), self._n_vq)
+            return empty
+
+        if req_id not in self._streaming_states:
+            if self._streaming_states:
+                logger.warning(
+                    "MOSS-TTS Local streaming vocoder has %d live request(s); "
+                    "current deploy config should keep stage-1 max_num_seqs=1 until batched slots are implemented.",
+                    len(self._streaming_states),
+                )
+            self._streaming_states[req_id] = _StreamingDecodeState.create(codec)
+
+        device = self._streaming_codec_device(codec)
+        frames = int(seg.numel() // self._n_vq)
+        codes_step = seg.reshape(self._n_vq, frames).to(device=device, dtype=torch.long).unsqueeze(1)
+        codes_lengths = torch.tensor([frames], dtype=torch.long, device=device)
+        exec_mask = torch.tensor([True], dtype=torch.bool, device=device)
+
+        try:
+            codec._set_streaming_exec_mask(exec_mask)
+            result = codec._decode_frame(codes_step, codes_lengths)
+            audio = getattr(result, "audio", None)
+            audio_lengths = getattr(result, "audio_lengths", None)
+            if audio is None:
+                if isinstance(result, tuple) and result:
+                    audio = result[0]
+                    audio_lengths = result[1] if len(result) > 1 else None
+                else:
+                    audio = result
+            if not isinstance(audio, torch.Tensor):
+                raise TypeError(f"MOSS-TTS Local streaming codec returned {type(audio).__name__}, expected Tensor")
+            if isinstance(audio_lengths, torch.Tensor) and audio_lengths.numel() > 0:
+                n_samples = int(audio_lengths.reshape(-1)[0].item())
+            else:
+                n_samples = int(audio.shape[-1])
+            if audio.dim() == 3:
+                wav = audio[0, :, :n_samples]
+            elif audio.dim() == 2:
+                wav = audio[:, :n_samples]
+            else:
+                wav = audio.reshape(-1)[:n_samples]
+            return wav.detach().to("cpu", torch.float32).contiguous()
+        finally:
+            if finished:
+                state = self._streaming_states.pop(req_id, None)
+                if state is not None:
+                    state.close()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        runtime_additional_information: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> OmniOutput:
+        del positions, intermediate_tensors, inputs_embeds
+        info_list = runtime_additional_information or []
+        num_req = max(len(info_list), 1)
+        empty = torch.zeros((0,), dtype=torch.float32)
+        audios: list[torch.Tensor] = [empty] * num_req
+        srs: list[torch.Tensor] = [self._sr_tensor] * num_req
+
+        ids = input_ids.reshape(-1).to(dtype=torch.long) if isinstance(input_ids, torch.Tensor) else torch.empty(0, dtype=torch.long)
+        counts = kwargs.get("num_scheduled_tokens")
+        if isinstance(counts, list) and len(counts) == num_req:
+            offsets = [0]
+            for count in counts:
+                offsets.append(offsets[-1] + int(count))
+        else:
+            offsets = [0, int(ids.numel())]
+
+        processor = None
+        decode_items: list[tuple[int, torch.Tensor]] = []
+        streaming_items: list[tuple[int, torch.Tensor, dict[str, Any] | None]] = []
+        for i in range(num_req):
+            runtime_info = info_list[i] if i < len(info_list) and isinstance(info_list[i], dict) else None
+            seg = _codec_ids_from_payload_or_input(
+                ids[offsets[i] : offsets[i + 1]] if i + 1 < len(offsets) else ids,
+                runtime_info,
+            )
+            if self._runtime_info_uses_streaming(runtime_info):
+                streaming_items.append((i, seg, runtime_info))
+                continue
+            if seg.numel() == 0:
+                continue
+            if seg.numel() % self._n_vq != 0:
+                logger.warning("MOSS-TTS Local vocoder got %d ids not divisible by n_vq=%d", seg.numel(), self._n_vq)
+                continue
+            codes_t_nq = seg.view(self._n_vq, -1).transpose(0, 1).contiguous().cpu()
+            decode_items.append((i, codes_t_nq))
+
+        if decode_items:
+            processor = self._ensure_processor()
+            wavs = processor.decode_audio_codes([codes for _, codes in decode_items])
+            for (i, _), wav in zip(decode_items, wavs):
+                wav_t = torch.as_tensor(wav).detach().to("cpu", torch.float32)
+                audios[i] = wav_t.contiguous()
+
+        for i, seg, runtime_info in streaming_items:
+            audios[i] = self._decode_streaming_chunk(seg, runtime_info=runtime_info, index=i)
+
+        return OmniOutput(text_hidden_states=None, multimodal_outputs={"model_outputs": audios, "sr": srs})
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # The vocoder owns a separate MOSS-Audio-Tokenizer-v2 loaded by the HF
+        # processor. The Local checkpoint weights belong to stage 0.
+        return set()
+
+
+__all__ = ["MossTTSLocalVocoder"]

--- a/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_vocoder.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/modeling_moss_tts_local_vocoder.py
@@ -5,9 +5,13 @@
 
 from __future__ import annotations
 
+import bisect
 import contextlib
+import os
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 import torch
@@ -16,15 +20,33 @@ from transformers import AutoProcessor
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
-from vllm_omni.model_executor.models.output_templates import OmniOutput
 from vllm_omni.model_executor.models.moss_tts_local.codec_path import (
     moss_tts_local_processor_kwargs,
 )
+from vllm_omni.model_executor.models.moss_tts_local.vocoder_cuda_graph import (
+    MossTTSLocalVocoderCUDAGraphWrapper,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
 
 logger = init_logger(__name__)
 
 
-def _codec_ids_from_payload_or_input(input_ids: torch.Tensor | None, runtime_info: dict[str, Any] | None) -> torch.Tensor:
+def _vocoder_debug_enabled() -> bool:
+    return os.environ.get("MOSS_TTS_LOCAL_VOCODER_DEBUG", "0").lower() in ("1", "true", "yes", "on")
+
+
+def _shape_numel(value: Any) -> str:
+    if isinstance(value, torch.Tensor):
+        return f"Tensor(shape={tuple(value.shape)}, numel={value.numel()}, dtype={value.dtype})"
+    if isinstance(value, (list, tuple)):
+        return f"{type(value).__name__}(len={len(value)})"
+    return type(value).__name__
+
+
+def _codec_ids_from_payload_or_input(
+    input_ids: torch.Tensor | None,
+    runtime_info: dict[str, Any] | None,
+) -> torch.Tensor:
     if isinstance(runtime_info, dict):
         codes = runtime_info.get("codes")
         if isinstance(codes, dict):
@@ -33,6 +55,11 @@ def _codec_ids_from_payload_or_input(input_ids: torch.Tensor | None, runtime_inf
                 return audio.reshape(-1).to(dtype=torch.long)
             if isinstance(audio, (list, tuple)) and audio:
                 return torch.as_tensor(audio, dtype=torch.long).reshape(-1)
+        task_type = runtime_info.get("task_type")
+        if task_type == "moss_tts_local" or (isinstance(task_type, list) and "moss_tts_local" in task_type):
+            return torch.empty(0, dtype=torch.long)
+        if "prompt_rows" in runtime_info:
+            return torch.empty(0, dtype=torch.long)
     if input_ids is None:
         return torch.empty(0, dtype=torch.long)
     return input_ids.reshape(-1).to(dtype=torch.long)
@@ -59,13 +86,97 @@ class _StreamingDecodeState:
     exit_stack: contextlib.ExitStack
 
     @classmethod
-    def create(cls, codec: Any) -> "_StreamingDecodeState":
+    def create(cls, codec: Any) -> _StreamingDecodeState:
         stack = contextlib.ExitStack()
         stack.enter_context(codec.streaming(batch_size=1))
         return cls(exit_stack=stack)
 
     def close(self) -> None:
         self.exit_stack.close()
+
+
+@dataclass
+class _FullDecodeGroupResult:
+    audio: torch.Tensor
+    audio_lengths: torch.Tensor | None
+    code_lengths: list[int]
+    audio_shape: tuple[int, ...]
+    pack_ms: float
+    decode_ms: float
+
+
+class _TensorRTCodecDecodeWrapper(nn.Module):
+    """TensorRT-friendly wrapper around MOSS full-frame codec decode.
+
+    ``codec.decode`` builds a Python list by calling ``codes_lengths[i].item()``
+    and slicing per request, which blocks torch.export/TensorRT.  The
+    non-streaming ``batch_decode`` path ultimately calls ``_decode_frame`` with
+    already-padded codes and a length tensor, so use that lower-level tensor
+    entrypoint directly.
+    """
+
+    def __init__(self, codec: Any, *, num_quantizers: int) -> None:
+        super().__init__()
+        self.codec = codec
+        self.num_quantizers = int(num_quantizers)
+
+    def forward(self, audio_codes: torch.Tensor, code_lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if not hasattr(self.codec, "_decode_frame"):
+            raise RuntimeError("MOSS-TTS Local TensorRT decode requires codec._decode_frame")
+        decoded = self.codec._decode_frame(
+            audio_codes[: self.num_quantizers],
+            code_lengths.to(dtype=torch.long),
+        )
+        audio = getattr(decoded, "audio", None)
+        audio_lengths = getattr(decoded, "audio_lengths", None)
+        if audio is None:
+            if isinstance(decoded, tuple) and decoded:
+                audio = decoded[0]
+                audio_lengths = decoded[1] if len(decoded) > 1 else None
+            else:
+                audio = decoded
+        if not isinstance(audio, torch.Tensor):
+            raise TypeError(f"MOSS-TTS Local codec returned {type(audio).__name__}, expected Tensor")
+        if not isinstance(audio_lengths, torch.Tensor):
+            audio_lengths = torch.full(
+                (int(audio.shape[0]),),
+                int(audio.shape[-1]),
+                dtype=torch.long,
+                device=audio.device,
+            )
+        return audio, audio_lengths
+
+
+class _TensorRTCodecDecoderWrapper(nn.Module):
+    """TensorRT wrapper for the float decoder half of MOSS codec decode.
+
+    TensorRT cannot reliably convert the LFQ codebook path when the graph starts
+    from integer code ids: the converter may propagate the int tensor into later
+    linear nodes.  Keep ``quantizer.decode_codes`` in PyTorch and compile the
+    heavier decoder transformer from float hidden states.
+    """
+
+    def __init__(self, codec: Any) -> None:
+        super().__init__()
+        self.decoder = codec.decoder
+        object.__setattr__(self, "_codec_ref", codec)
+
+    def forward(
+        self,
+        decoder_hidden_states: torch.Tensor,
+        code_lengths: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        codec = getattr(self, "_codec_ref")
+        try:
+            target_dtype = next(self.decoder.parameters()).dtype
+        except StopIteration:
+            target_dtype = decoder_hidden_states.dtype
+        audio = decoder_hidden_states.to(dtype=target_dtype)
+        audio_lengths = code_lengths.to(dtype=torch.long)
+        for decoder_module in self.decoder:
+            audio, audio_lengths = decoder_module(audio, audio_lengths)
+        audio, audio_lengths = codec._restore_channels_from_codec(audio, audio_lengths)
+        return audio, audio_lengths
 
 
 class MossTTSLocalVocoder(nn.Module):
@@ -89,6 +200,82 @@ class MossTTSLocalVocoder(nn.Module):
         self._processor: Any | None = None
         self._sr_tensor = torch.tensor(self._sample_rate, dtype=torch.int32)
         self._streaming_states: dict[str, _StreamingDecodeState] = {}
+        self._decode_audio_codes_buffer: torch.Tensor | None = None
+        self._decode_padding_mask_buffer: torch.Tensor | None = None
+        self._cuda_graph_wrapper: MossTTSLocalVocoderCUDAGraphWrapper | None = None
+        self._cuda_graph_codec: Any | None = None
+        self._cuda_graph_disabled = False
+        self._cuda_graph_warned = False
+        self._compile_codec: Any | None = None
+        self._compile_applied = False
+        self._trt_codec: dict[tuple[int, int], Any] | Any | None = None
+        self._trt_codec_source: Any | None = None
+        self._trt_disabled = False
+        self._trt_warned = False
+        self._multi_stream_warned = False
+        self._profile_enabled = os.environ.get("MOSS_TTS_LOCAL_VOCODER_PROFILE") == "1"
+        self._profile_sync = os.environ.get("MOSS_TTS_LOCAL_VOCODER_PROFILE_SYNC") == "1"
+        self._profile_log_every = max(int(os.environ.get("MOSS_TTS_LOCAL_VOCODER_PROFILE_LOG_EVERY", "20") or 20), 1)
+        self._profile_stats: dict[str, float | int | list[int]] = {
+            "groups": 0,
+            "requests": 0,
+            "frames": 0,
+            "pack_ms": 0.0,
+            "decode_ms": 0.0,
+            "d2h_ms": 0.0,
+            "batches": [],
+        }
+
+    def _profile_mark(self, device: torch.device | None = None) -> float:
+        if self._profile_sync and device is not None and device.type == "cuda":
+            torch.accelerator.synchronize(device)
+        return time.perf_counter()
+
+    def _profile_elapsed_ms(self, start: float, device: torch.device | None = None) -> float:
+        if self._profile_sync and device is not None and device.type == "cuda":
+            torch.accelerator.synchronize(device)
+        return (time.perf_counter() - start) * 1000
+
+    def _record_profile_group(
+        self,
+        *,
+        batch_size: int,
+        frame_count: int,
+        pack_ms: float,
+        decode_ms: float,
+        d2h_ms: float,
+    ) -> None:
+        if not bool(getattr(self, "_profile_enabled", False)):
+            return
+        stats = getattr(self, "_profile_stats", None)
+        if not isinstance(stats, dict):
+            return
+        stats["groups"] = int(stats["groups"]) + 1
+        stats["requests"] = int(stats["requests"]) + int(batch_size)
+        stats["frames"] = int(stats["frames"]) + int(frame_count)
+        stats["pack_ms"] = float(stats["pack_ms"]) + float(pack_ms)
+        stats["decode_ms"] = float(stats["decode_ms"]) + float(decode_ms)
+        stats["d2h_ms"] = float(stats["d2h_ms"]) + float(d2h_ms)
+        batches = stats["batches"]
+        if isinstance(batches, list):
+            batches.append(int(batch_size))
+            del batches[:-100]
+        groups = int(stats["groups"])
+        if groups % self._profile_log_every != 0:
+            return
+        avg_batch = sum(batches) / max(1, len(batches)) if isinstance(batches, list) else 0.0
+        logger.info(
+            "[moss-vocoder-profile] groups=%d requests=%d avg_batch=%.2f frames=%d "
+            "pack=%.2fms decode=%.2fms d2h=%.2fms sync=%s",
+            groups,
+            int(stats["requests"]),
+            avg_batch,
+            int(stats["frames"]),
+            float(stats["pack_ms"]) / max(1, groups),
+            float(stats["decode_ms"]) / max(1, groups),
+            float(stats["d2h_ms"]) / max(1, groups),
+            self._profile_sync,
+        )
 
     def _ensure_processor(self) -> Any:
         if self._processor is None:
@@ -144,8 +331,732 @@ class MossTTSLocalVocoder(nn.Module):
     def _streaming_codec_device(self, codec: Any) -> torch.device:
         try:
             return next(codec.parameters()).device
-        except StopIteration:
+        except (AttributeError, StopIteration):
             return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def _resolve_audio_codec(self, processor: Any) -> Any:
+        audio_tokenizer = getattr(processor, "audio_tokenizer", None)
+        codec = getattr(audio_tokenizer, "model", None) if audio_tokenizer is not None else None
+        if codec is None:
+            codec = audio_tokenizer
+        if codec is None or not hasattr(codec, "decode"):
+            raise RuntimeError(
+                "MOSS-TTS Local full-sequence decode requires processor.audio_tokenizer.decode "
+                "or processor.audio_tokenizer.model.decode"
+            )
+        return codec
+
+    @staticmethod
+    def _env_enabled(name: str, default: str = "0") -> bool:
+        return os.environ.get(name, default).lower() in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _parse_shape_triplet(name: str, default: tuple[int, int, int]) -> tuple[int, int, int]:
+        raw = os.environ.get(name)
+        if not raw:
+            return default
+        values: list[int] = []
+        for item in raw.replace("x", ",").replace(";", ",").split(","):
+            item = item.strip()
+            if not item:
+                continue
+            try:
+                values.append(int(item))
+            except ValueError:
+                return default
+        return tuple(values[:3]) if len(values) >= 3 and all(v > 0 for v in values[:3]) else default
+
+    def _maybe_compile_codec_decode(self, codec: Any) -> Any:
+        if not self._env_enabled("MOSS_TTS_LOCAL_VOCODER_COMPILE"):
+            return codec
+        if getattr(self, "_compile_codec", None) is codec and bool(getattr(self, "_compile_applied", False)):
+            return codec
+        compile_fn = getattr(torch, "compile", None)
+        if compile_fn is None:
+            logger.warning("MOSS-TTS Local vocoder torch.compile requested but torch.compile is unavailable")
+            return codec
+        try:
+            mode = os.environ.get("MOSS_TTS_LOCAL_VOCODER_COMPILE_MODE", "max-autotune-no-cudagraphs")
+            compiled_decode = compile_fn(codec.decode, mode=mode)
+            setattr(codec, "decode", compiled_decode)
+            self.__dict__["_compile_codec"] = codec
+            self.__dict__["_compile_applied"] = True
+            logger.info("MOSS-TTS Local vocoder torch.compile enabled for codec.decode mode=%s", mode)
+        except Exception:
+            self.__dict__["_compile_applied"] = False
+            logger.warning(
+                "MOSS-TTS Local vocoder torch.compile failed; falling back to original decode",
+                exc_info=True,
+            )
+        return codec
+
+    def _warn_trt_fallback(self, message: str, *args: Any) -> None:
+        if bool(getattr(self, "_trt_warned", False)):
+            return
+        self.__dict__["_trt_warned"] = True
+        logger.warning(message, *args, exc_info=True)
+
+    @staticmethod
+    def _parse_int_list_env(name: str, default: list[int]) -> list[int]:
+        raw = os.environ.get(name)
+        if not raw:
+            return list(default)
+        values: set[int] = set()
+        for item in raw.replace(";", ",").split(","):
+            item = item.strip()
+            if not item:
+                continue
+            try:
+                value = int(item)
+            except ValueError:
+                continue
+            if value > 0:
+                values.add(value)
+        return sorted(values) or list(default)
+
+    @classmethod
+    def _trt_bucket(cls, *, batch_size: int, frame_count: int) -> tuple[int, int] | None:
+        batch_buckets = cls._parse_int_list_env("MOSS_TTS_LOCAL_VOCODER_TRT_BATCH_BUCKETS", [1, 2, 4, 8])
+        frame_buckets = cls._parse_int_list_env("MOSS_TTS_LOCAL_VOCODER_TRT_FRAME_BUCKETS", [32, 48, 64, 80, 96, 128])
+        batch_idx = bisect.bisect_left(batch_buckets, int(batch_size))
+        frame_idx = bisect.bisect_left(frame_buckets, int(frame_count))
+        if batch_idx >= len(batch_buckets) or frame_idx >= len(frame_buckets):
+            return None
+        return batch_buckets[batch_idx], frame_buckets[frame_idx]
+
+    @staticmethod
+    def _vocoder_trt_mode() -> str:
+        return os.environ.get("MOSS_TTS_LOCAL_VOCODER_TRT_MODE", "decoder_hidden").strip().lower()
+
+    def _get_or_init_trt_codec(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+        batch_size: int,
+        frame_count: int,
+    ) -> tuple[Any, tuple[int, int], str, torch.dtype] | None:
+        if not self._env_enabled("MOSS_TTS_LOCAL_VOCODER_TRT") or bool(getattr(self, "_trt_disabled", False)):
+            return None
+        if device.type != "cuda":
+            return None
+        if not hasattr(codec, "_decode_frame"):
+            self.__dict__["_trt_disabled"] = True
+            logger.warning("MOSS-TTS Local vocoder TensorRT requires codec._decode_frame; falling back to PyTorch")
+            return None
+        bucket = self._trt_bucket(batch_size=batch_size, frame_count=frame_count)
+        if bucket is None:
+            return None
+        if getattr(self, "_trt_codec_source", None) is not codec:
+            self.__dict__["_trt_codec"] = {}
+            self.__dict__["_trt_codec_source"] = codec
+        trt_codecs = getattr(self, "_trt_codec", None)
+        if not isinstance(trt_codecs, dict):
+            trt_codecs = {}
+            self.__dict__["_trt_codec"] = trt_codecs
+        trt_mode = self._vocoder_trt_mode()
+        trt_input_dtype = torch.float32
+        trt_key = (bucket, trt_mode, trt_input_dtype)
+        trt_codec = trt_codecs.get(trt_key)
+        if trt_codec is not None:
+            return trt_codec, bucket, trt_mode, trt_input_dtype
+
+        try:
+            import torch_tensorrt  # type: ignore[import-not-found]
+
+            bucket_b, bucket_t = bucket
+            if trt_mode == "full_codes":
+                wrapper = _TensorRTCodecDecodeWrapper(codec, num_quantizers=self._n_vq).eval().to(device)
+                inputs = [
+                    torch_tensorrt.Input(
+                        shape=(self._n_vq, bucket_b, bucket_t),
+                        dtype=torch.long,
+                        name="audio_codes",
+                    ),
+                    torch_tensorrt.Input(
+                        shape=(bucket_b,),
+                        dtype=torch.long,
+                        name="code_lengths",
+                    ),
+                ]
+            else:
+                wrapper = _TensorRTCodecDecoderWrapper(codec).eval().to(device)
+                try:
+                    decoder_dtype = next(wrapper.decoder.parameters()).dtype
+                except StopIteration:
+                    decoder_dtype = torch.float32
+                trt_input_dtype = (
+                    decoder_dtype if decoder_dtype in (torch.float32, torch.float16, torch.bfloat16) else torch.float32
+                )
+                trt_key = (bucket, trt_mode, trt_input_dtype)
+                trt_codec = trt_codecs.get(trt_key)
+                if trt_codec is not None:
+                    return trt_codec, bucket, trt_mode, trt_input_dtype
+                inputs = [
+                    torch_tensorrt.Input(
+                        shape=(bucket_b, 768, bucket_t),
+                        dtype=trt_input_dtype,
+                        name="decoder_hidden_states",
+                    ),
+                    torch_tensorrt.Input(
+                        shape=(bucket_b,),
+                        dtype=torch.long,
+                        name="code_lengths",
+                    ),
+                ]
+            compile_kwargs: dict[str, Any] = {"inputs": inputs}
+            if self._env_enabled("MOSS_TTS_LOCAL_VOCODER_TRT_ENABLE_PRECISIONS"):
+                compile_kwargs["enabled_precisions"] = {torch.float16, torch.float32}
+            ir = os.environ.get("MOSS_TTS_LOCAL_VOCODER_TRT_IR")
+            if ir:
+                compile_kwargs["ir"] = ir
+            trt_codec = torch_tensorrt.compile(wrapper, **compile_kwargs)
+            trt_codecs[trt_key] = trt_codec
+            logger.info(
+                "MOSS-TTS Local vocoder TensorRT enabled for bucket batch=%d frames=%d mode=%s input_dtype=%s",
+                bucket_b,
+                bucket_t,
+                trt_mode,
+                trt_input_dtype,
+            )
+            return trt_codec, bucket, trt_mode, trt_input_dtype
+        except Exception:
+            self.__dict__["_trt_disabled"] = True
+            self._warn_trt_fallback("MOSS-TTS Local vocoder TensorRT init failed; falling back to PyTorch")
+            return None
+
+    @staticmethod
+    def _vocoder_cuda_graph_enabled() -> bool:
+        return os.environ.get("MOSS_TTS_LOCAL_VOCODER_DISABLE_CUDA_GRAPH", "0").lower() not in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+    @staticmethod
+    def _vocoder_cuda_graph_min_batch() -> int:
+        try:
+            return max(int(os.environ.get("MOSS_TTS_LOCAL_VOCODER_GRAPH_MIN_BATCH", "2") or 2), 1)
+        except ValueError:
+            return 2
+
+    def _warn_cuda_graph_fallback(self, message: str, *args: Any) -> None:
+        if bool(getattr(self, "_cuda_graph_warned", False)):
+            return
+        self._cuda_graph_warned = True
+        logger.warning(message, *args, exc_info=True)
+
+    def _get_or_init_cuda_graph_wrapper(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+    ) -> MossTTSLocalVocoderCUDAGraphWrapper | None:
+        if not self._vocoder_cuda_graph_enabled() or bool(getattr(self, "_cuda_graph_disabled", False)):
+            return None
+
+        wrapper = getattr(self, "_cuda_graph_wrapper", None)
+        if wrapper is not None and getattr(self, "_cuda_graph_codec", None) is codec:
+            return wrapper
+
+        try:
+            wrapper = MossTTSLocalVocoderCUDAGraphWrapper.from_env(
+                codec=codec,
+                num_quantizers=self._n_vq,
+            )
+            wrapper.warmup(device)
+        except Exception:
+            self._cuda_graph_disabled = True
+            self._warn_cuda_graph_fallback("MOSS-TTS Local vocoder CUDA Graph init failed; falling back to eager")
+            return None
+
+        self.__dict__["_cuda_graph_wrapper"] = wrapper
+        self.__dict__["_cuda_graph_codec"] = codec
+        return wrapper
+
+    def _decode_codec_full_sequence(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+        audio_codes: torch.Tensor,
+        padding_mask: torch.Tensor,
+    ) -> Any:
+        batch_size = int(audio_codes.shape[1]) if audio_codes.dim() >= 2 else 1
+        frame_count = int(audio_codes.shape[2]) if audio_codes.dim() >= 3 else 0
+        trt_entry = self._get_or_init_trt_codec(
+            codec=codec,
+            device=device,
+            batch_size=batch_size,
+            frame_count=frame_count,
+        )
+        if trt_entry is not None:
+            try:
+                trt_codec, (bucket_b, bucket_t), trt_mode, trt_input_dtype = trt_entry
+                code_lengths = padding_mask.sum(dim=-1).to(dtype=torch.long)
+                if bucket_b != batch_size or bucket_t != frame_count:
+                    padded_codes = torch.zeros(
+                        self._n_vq,
+                        bucket_b,
+                        bucket_t,
+                        dtype=audio_codes.dtype,
+                        device=audio_codes.device,
+                    )
+                    padded_lengths = torch.zeros(bucket_b, dtype=torch.long, device=audio_codes.device)
+                    padded_codes[:, :batch_size, :frame_count].copy_(audio_codes)
+                    padded_lengths[:batch_size].copy_(code_lengths)
+                else:
+                    padded_codes = audio_codes
+                    padded_lengths = code_lengths
+                if trt_mode == "full_codes":
+                    audio, audio_lengths = trt_codec(padded_codes, padded_lengths)
+                else:
+                    quantizer = getattr(codec, "quantizer", None)
+                    if quantizer is None or not hasattr(quantizer, "decode_codes"):
+                        raise RuntimeError("MOSS-TTS Local decoder-hidden TensorRT requires quantizer.decode_codes")
+                    decoder_hidden_states = quantizer.decode_codes(padded_codes[: self._n_vq]).to(dtype=trt_input_dtype)
+                    audio, audio_lengths = trt_codec(decoder_hidden_states, padded_lengths)
+                if isinstance(audio, torch.Tensor):
+                    audio = audio[:batch_size].clone()
+                if isinstance(audio_lengths, torch.Tensor):
+                    audio_lengths = audio_lengths[:batch_size].clone()
+                return SimpleNamespace(audio=audio, audio_lengths=audio_lengths)
+            except Exception:
+                self.__dict__["_trt_disabled"] = True
+                self._warn_trt_fallback("MOSS-TTS Local vocoder TensorRT decode failed; falling back to PyTorch")
+
+        batch_size = int(audio_codes.shape[1]) if audio_codes.dim() >= 2 else 1
+        graph_wrapper = (
+            self._get_or_init_cuda_graph_wrapper(codec=codec, device=device)
+            if batch_size >= self._vocoder_cuda_graph_min_batch()
+            else None
+        )
+        if graph_wrapper is not None:
+            try:
+                return graph_wrapper.decode(audio_codes, padding_mask)
+            except Exception:
+                self._cuda_graph_disabled = True
+                self._warn_cuda_graph_fallback("MOSS-TTS Local vocoder CUDA Graph decode failed; falling back to eager")
+
+        return codec.decode(
+            audio_codes,
+            padding_mask=padding_mask,
+            num_quantizers=self._n_vq,
+            return_dict=True,
+            chunk_duration=None,
+        )
+
+    @staticmethod
+    def _vocoder_max_pad_ratio() -> float:
+        try:
+            return max(float(os.environ.get("MOSS_TTS_LOCAL_VOCODER_MAX_PAD_RATIO", "2.0") or 2.0), 1.0)
+        except ValueError:
+            return 2.0
+
+    @staticmethod
+    def _vocoder_max_batch_size() -> int:
+        try:
+            return max(int(os.environ.get("MOSS_TTS_LOCAL_VOCODER_MAX_BATCH", "0") or 0), 0)
+        except ValueError:
+            return 0
+
+    @staticmethod
+    def _vocoder_grouping_strategy() -> str:
+        strategy = os.environ.get("MOSS_TTS_LOCAL_VOCODER_GROUPING", "graph_bucket")
+        return strategy.strip().lower().replace("-", "_")
+
+    @staticmethod
+    def _vocoder_multi_stream_enabled() -> bool:
+        return os.environ.get("MOSS_TTS_LOCAL_VOCODER_MULTI_STREAM", "0").lower() in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _vocoder_multi_stream_max_groups() -> int:
+        try:
+            return max(int(os.environ.get("MOSS_TTS_LOCAL_VOCODER_MULTI_STREAM_MAX_GROUPS", "4") or 4), 1)
+        except ValueError:
+            return 4
+
+    @staticmethod
+    def _vocoder_multi_stream_allow_cuda_graph() -> bool:
+        return os.environ.get("MOSS_TTS_LOCAL_VOCODER_MULTI_STREAM_ALLOW_CUDA_GRAPH", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+    @staticmethod
+    def _group_by_pad_ratio(
+        *,
+        lengths: list[int],
+        order: list[int],
+        max_pad_ratio: float,
+        max_batch_size: int,
+    ) -> list[list[int]]:
+        groups: list[list[int]] = []
+        current: list[int] = []
+        current_min = 0
+        for index in order:
+            length = lengths[index]
+            next_min = length if not current else current_min
+            next_max = length
+            would_exceed_ratio = bool(current) and next_max > max(1, int(next_min * max_pad_ratio))
+            would_exceed_batch = bool(max_batch_size and len(current) >= max_batch_size)
+            if current and (would_exceed_ratio or would_exceed_batch):
+                groups.append(current)
+                current = []
+            if not current:
+                current_min = length
+            current.append(index)
+        if current:
+            groups.append(current)
+        return groups
+
+    @staticmethod
+    def _graph_bucket_batch_limit(
+        *,
+        graph_wrapper: MossTTSLocalVocoderCUDAGraphWrapper,
+        max_batch_size: int,
+    ) -> int:
+        graph_batch_sizes = getattr(graph_wrapper, "capture_batch_sizes", None)
+        graph_max_batch = max(graph_batch_sizes) if graph_batch_sizes else 0
+        if max_batch_size > 0 and graph_max_batch > 0:
+            return min(max_batch_size, int(graph_max_batch))
+        if max_batch_size > 0:
+            return max_batch_size
+        if graph_max_batch > 0:
+            return int(graph_max_batch)
+        return 0
+
+    @staticmethod
+    def _group_by_graph_bucket(
+        *,
+        lengths: list[int],
+        order: list[int],
+        graph_wrapper: MossTTSLocalVocoderCUDAGraphWrapper,
+        max_batch_size: int,
+    ) -> list[list[int]] | None:
+        """Pack groups to the largest usable CUDA graph batch/frame bucket.
+
+        The graph wrapper already pads every replay to bucketed static buffers.
+        Once the longest request in a group selects a frame bucket, shorter
+        requests are essentially free from a launch-count perspective, so this
+        strategy fills that bucket before starting another group.
+        """
+        batch_limit = MossTTSLocalVocoder._graph_bucket_batch_limit(
+            graph_wrapper=graph_wrapper,
+            max_batch_size=max_batch_size,
+        )
+        if batch_limit <= 0:
+            return None
+
+        pending = sorted(order, key=lambda i: lengths[i], reverse=True)
+        groups: list[list[int]] = []
+        while pending:
+            anchor = pending.pop(0)
+            anchor_len = lengths[anchor]
+            anchor_bucket = graph_wrapper.get_bucket(batch_size=1, frame_count=anchor_len)
+            if anchor_bucket is None:
+                groups.append([anchor])
+                continue
+            _, frame_bucket = anchor_bucket
+            group = [anchor]
+            keep: list[int] = []
+            for index in pending:
+                if len(group) >= batch_limit:
+                    keep.append(index)
+                    continue
+                if lengths[index] <= frame_bucket:
+                    group.append(index)
+                else:
+                    keep.append(index)
+            pending = keep
+            groups.append(group)
+        return groups
+
+    def _decode_batch_full_sequence(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
+        """Decode complete ``[T, n_vq]`` code rows in one codec call."""
+        if not codes_list:
+            return []
+
+        processor = self._ensure_processor()
+        codec = self._resolve_audio_codec(processor)
+        codec = self._maybe_compile_codec_decode(codec)
+        device = self._streaming_codec_device(codec)
+        n_vq = self._n_vq
+
+        codes_channels_first: list[torch.Tensor] = []
+        for codes in codes_list:
+            if codes.dim() != 2 or int(codes.shape[1]) < n_vq:
+                raise ValueError(f"Expected MOSS-TTS Local codes shaped [T, >={n_vq}], got {tuple(codes.shape)}")
+            codes_channels_first.append(codes[:, :n_vq].transpose(0, 1).contiguous())
+
+        lengths = [int(codes.shape[1]) for codes in codes_channels_first]
+        order = sorted(range(len(codes_channels_first)), key=lambda i: lengths[i])
+        max_batch_size = self._vocoder_max_batch_size()
+        groups: list[list[int]] | None = None
+        if self._vocoder_grouping_strategy() == "graph_bucket" and self._vocoder_cuda_graph_enabled():
+            graph_wrapper = self._get_or_init_cuda_graph_wrapper(codec=codec, device=device)
+            if graph_wrapper is not None:
+                groups = self._group_by_graph_bucket(
+                    lengths=lengths,
+                    order=order,
+                    graph_wrapper=graph_wrapper,
+                    max_batch_size=max_batch_size,
+                )
+        if groups is None:
+            groups = self._group_by_pad_ratio(
+                lengths=lengths,
+                order=order,
+                max_pad_ratio=self._vocoder_max_pad_ratio(),
+                max_batch_size=max_batch_size,
+            )
+
+        wavs: list[torch.Tensor | None] = [None for _ in codes_channels_first]
+        use_multi_stream = (
+            self._vocoder_multi_stream_enabled()
+            and device.type == "cuda"
+            and len(groups) > 1
+            and (not self._vocoder_cuda_graph_enabled() or self._vocoder_multi_stream_allow_cuda_graph())
+        )
+        if (
+            self._vocoder_multi_stream_enabled()
+            and device.type == "cuda"
+            and len(groups) > 1
+            and self._vocoder_cuda_graph_enabled()
+            and not self._vocoder_multi_stream_allow_cuda_graph()
+        ):
+            if not bool(getattr(self, "_multi_stream_warned", False)):
+                self.__dict__["_multi_stream_warned"] = True
+                logger.warning(
+                    "MOSS-TTS Local vocoder multi-stream is disabled for CUDA Graph decode because "
+                    "the graph wrapper uses shared static buffers. Set "
+                    "MOSS_TTS_LOCAL_VOCODER_MULTI_STREAM_ALLOW_CUDA_GRAPH=1 only for explicit experiments."
+                )
+        if use_multi_stream:
+            group_results = self._decode_full_sequence_groups_multi_stream(
+                codec=codec,
+                device=device,
+                groups=groups,
+                codes_channels_first=codes_channels_first,
+            )
+            for group, group_wavs in group_results:
+                for original_index, wav in zip(group, group_wavs):
+                    wavs[original_index] = wav
+        else:
+            for group in groups:
+                group_wavs = self._decode_full_sequence_group(
+                    codec=codec,
+                    device=device,
+                    codes_channels_first=[codes_channels_first[i] for i in group],
+                )
+                for original_index, wav in zip(group, group_wavs):
+                    wavs[original_index] = wav
+        return [wav if wav is not None else torch.zeros((0,), dtype=torch.float32) for wav in wavs]
+
+    def _decode_full_sequence_groups_multi_stream(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+        groups: list[list[int]],
+        codes_channels_first: list[torch.Tensor],
+    ) -> list[tuple[list[int], list[torch.Tensor]]]:
+        max_groups = self._vocoder_multi_stream_max_groups()
+        outputs: list[tuple[list[int], list[torch.Tensor]]] = []
+        for chunk_start in range(0, len(groups), max_groups):
+            chunk = groups[chunk_start : chunk_start + max_groups]
+            main_stream = torch.cuda.current_stream(device)
+            launched: list[tuple[list[int], _FullDecodeGroupResult, torch.cuda.Stream]] = []
+            for group in chunk:
+                stream = torch.cuda.Stream(device=device)
+                stream.wait_stream(main_stream)
+                with torch.cuda.stream(stream):
+                    result = self._decode_full_sequence_group_result(
+                        codec=codec,
+                        device=device,
+                        codes_channels_first=[codes_channels_first[i] for i in group],
+                        use_shared_buffers=False,
+                    )
+                launched.append((group, result, stream))
+            for _, _, stream in launched:
+                main_stream.wait_stream(stream)
+            for group, result, _ in launched:
+                outputs.append((group, self._finalize_full_sequence_group_result(result)))
+        return outputs
+
+    def _decode_full_sequence_group(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+        codes_channels_first: list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        result = self._decode_full_sequence_group_result(
+            codec=codec,
+            device=device,
+            codes_channels_first=codes_channels_first,
+            use_shared_buffers=True,
+        )
+        return self._finalize_full_sequence_group_result(result)
+
+    def _decode_full_sequence_group_result(
+        self,
+        *,
+        codec: Any,
+        device: torch.device,
+        codes_channels_first: list[torch.Tensor],
+        use_shared_buffers: bool,
+    ) -> _FullDecodeGroupResult:
+        max_len = max(int(codes.shape[1]) for codes in codes_channels_first)
+        if max_len <= 0:
+            empty_audio = torch.zeros(
+                (len(codes_channels_first), 1, 0),
+                dtype=torch.float32,
+                device=device,
+            )
+            empty_lengths = torch.zeros((len(codes_channels_first),), dtype=torch.long, device=device)
+            return _FullDecodeGroupResult(
+                audio=empty_audio,
+                audio_lengths=empty_lengths,
+                code_lengths=[0 for _ in codes_channels_first],
+                audio_shape=tuple(empty_audio.shape),
+                pack_ms=0.0,
+                decode_ms=0.0,
+            )
+
+        profile_enabled = bool(getattr(self, "_profile_enabled", False))
+        if use_shared_buffers:
+            audio_codes, padding_mask = self._decode_pack_buffers(
+                batch_size=len(codes_channels_first),
+                max_len=max_len,
+                device=device,
+            )
+        else:
+            audio_codes = torch.empty(self._n_vq, len(codes_channels_first), max_len, device=device, dtype=torch.long)
+            padding_mask = torch.empty(len(codes_channels_first), max_len, device=device, dtype=torch.bool)
+        pack_start = self._profile_mark(device) if profile_enabled else 0.0
+        audio_codes.zero_()
+        padding_mask.zero_()
+        code_lengths: list[int] = []
+        for index, codes in enumerate(codes_channels_first):
+            length = int(codes.shape[1])
+            code_lengths.append(length)
+            audio_codes[:, index, :length] = codes.to(device=device, dtype=torch.long)
+            padding_mask[index, :length] = True
+        pack_ms = self._profile_elapsed_ms(pack_start, device) if profile_enabled else 0.0
+
+        decode_start = self._profile_mark(device) if profile_enabled else 0.0
+        decoded = self._decode_codec_full_sequence(
+            codec=codec,
+            device=device,
+            audio_codes=audio_codes,
+            padding_mask=padding_mask,
+        )
+        decode_ms = self._profile_elapsed_ms(decode_start, device) if profile_enabled else 0.0
+        audio = getattr(decoded, "audio", None)
+        audio_lengths = getattr(decoded, "audio_lengths", None)
+        if audio is None:
+            if isinstance(decoded, tuple) and decoded:
+                audio = decoded[0]
+                audio_lengths = decoded[1] if len(decoded) > 1 else None
+            else:
+                audio = decoded
+        if not isinstance(audio, torch.Tensor):
+            raise TypeError(f"MOSS-TTS Local codec returned {type(audio).__name__}, expected Tensor")
+        if audio.dim() == 2:
+            if len(codes_channels_first) == 1:
+                audio = audio.unsqueeze(0)
+            else:
+                audio = audio.unsqueeze(1)
+        if audio.dim() != 3:
+            raise ValueError(f"MOSS-TTS Local codec returned audio shaped {tuple(audio.shape)}, expected [B, C, T]")
+        if int(audio.shape[0]) != len(codes_channels_first):
+            raise ValueError(
+                f"MOSS-TTS Local codec returned batch size {int(audio.shape[0])}, expected {len(codes_channels_first)}"
+            )
+        return _FullDecodeGroupResult(
+            audio=audio,
+            audio_lengths=audio_lengths if isinstance(audio_lengths, torch.Tensor) else None,
+            code_lengths=code_lengths,
+            audio_shape=tuple(audio.shape),
+            pack_ms=pack_ms,
+            decode_ms=decode_ms,
+        )
+
+    def _finalize_full_sequence_group_result(self, result: _FullDecodeGroupResult) -> list[torch.Tensor]:
+        audio = result.audio
+        audio_lengths = result.audio_lengths
+        device = audio.device
+        profile_enabled = bool(getattr(self, "_profile_enabled", False))
+        if isinstance(audio_lengths, torch.Tensor):
+            lengths_cpu = audio_lengths.detach().to("cpu")
+        else:
+            lengths_cpu = torch.full((audio.shape[0],), int(audio.shape[-1]), dtype=torch.long)
+        if _vocoder_debug_enabled():
+            logger.warning(
+                "[moss-vocoder-debug] full_group batch=%d code_lens=%s audio_shape=%s audio_lengths=%s",
+                len(result.code_lengths),
+                result.code_lengths,
+                result.audio_shape,
+                lengths_cpu.reshape(-1).tolist(),
+            )
+        d2h_start = self._profile_mark(device) if profile_enabled else 0.0
+        audio_cpu = audio.detach().to("cpu", torch.float32)
+        if device.type == "cuda":
+            audio_cpu = audio_cpu.contiguous()
+        d2h_ms = self._profile_elapsed_ms(d2h_start, device) if profile_enabled else 0.0
+        self._record_profile_group(
+            batch_size=len(result.code_lengths),
+            frame_count=sum(result.code_lengths),
+            pack_ms=result.pack_ms,
+            decode_ms=result.decode_ms,
+            d2h_ms=d2h_ms,
+        )
+        wavs: list[torch.Tensor] = []
+        for index in range(int(audio_cpu.shape[0])):
+            n_samples = int(lengths_cpu.reshape(-1)[index].item())
+            if n_samples <= 0 and result.code_lengths[index] > 0:
+                logger.warning(
+                    "MOSS-TTS Local full vocoder decoded empty audio for non-empty codes: "
+                    "index=%d code_frames=%d audio_shape=%s audio_lengths=%s",
+                    index,
+                    result.code_lengths[index],
+                    result.audio_shape,
+                    lengths_cpu.reshape(-1).tolist(),
+                )
+            wavs.append(audio_cpu[index, :, :n_samples].contiguous())
+        return wavs
+
+    def _decode_pack_buffers(
+        self,
+        *,
+        batch_size: int,
+        max_len: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        audio_buffer = getattr(self, "_decode_audio_codes_buffer", None)
+        mask_buffer = getattr(self, "_decode_padding_mask_buffer", None)
+        needs_new = (
+            audio_buffer is None
+            or mask_buffer is None
+            or audio_buffer.device != device
+            or mask_buffer.device != device
+            or int(audio_buffer.shape[0]) < self._n_vq
+            or int(audio_buffer.shape[1]) < batch_size
+            or int(audio_buffer.shape[2]) < max_len
+            or int(mask_buffer.shape[0]) < batch_size
+            or int(mask_buffer.shape[1]) < max_len
+        )
+        if needs_new:
+            new_batch = max(batch_size, int(audio_buffer.shape[1]) if isinstance(audio_buffer, torch.Tensor) else 0)
+            new_len = max(max_len, int(audio_buffer.shape[2]) if isinstance(audio_buffer, torch.Tensor) else 0)
+            audio_buffer = torch.empty(self._n_vq, new_batch, new_len, device=device, dtype=torch.long)
+            mask_buffer = torch.empty(new_batch, new_len, device=device, dtype=torch.bool)
+            self._decode_audio_codes_buffer = audio_buffer
+            self._decode_padding_mask_buffer = mask_buffer
+        return audio_buffer[: self._n_vq, :batch_size, :max_len], mask_buffer[:batch_size, :max_len]
 
     def _decode_streaming_chunk(
         self,
@@ -158,7 +1069,9 @@ class MossTTSLocalVocoder(nn.Module):
         codec = getattr(processor, "audio_tokenizer", None)
         if codec is None:
             raise RuntimeError("MOSS-TTS Local streaming decode requires processor.audio_tokenizer")
-        missing = [name for name in ("streaming", "_set_streaming_exec_mask", "_decode_frame") if not hasattr(codec, name)]
+        missing = [
+            name for name in ("streaming", "_set_streaming_exec_mask", "_decode_frame") if not hasattr(codec, name)
+        ]
         if missing:
             raise RuntimeError(
                 "MOSS-TTS Local streaming decode requires codec methods "
@@ -176,7 +1089,11 @@ class MossTTSLocalVocoder(nn.Module):
             return empty
 
         if seg.numel() % self._n_vq != 0:
-            logger.warning("MOSS-TTS Local streaming vocoder got %d ids not divisible by n_vq=%d", seg.numel(), self._n_vq)
+            logger.warning(
+                "MOSS-TTS Local streaming vocoder got %d ids not divisible by n_vq=%d",
+                seg.numel(),
+                self._n_vq,
+            )
             return empty
 
         if req_id not in self._streaming_states:
@@ -241,24 +1158,66 @@ class MossTTSLocalVocoder(nn.Module):
         audios: list[torch.Tensor] = [empty] * num_req
         srs: list[torch.Tensor] = [self._sr_tensor] * num_req
 
-        ids = input_ids.reshape(-1).to(dtype=torch.long) if isinstance(input_ids, torch.Tensor) else torch.empty(0, dtype=torch.long)
+        ids = (
+            input_ids.reshape(-1).to(dtype=torch.long)
+            if isinstance(input_ids, torch.Tensor)
+            else torch.empty(0, dtype=torch.long)
+        )
         counts = kwargs.get("num_scheduled_tokens")
+        if counts is None:
+            counts = kwargs.get("seq_token_counts")
         if isinstance(counts, list) and len(counts) == num_req:
             offsets = [0]
             for count in counts:
                 offsets.append(offsets[-1] + int(count))
         else:
-            offsets = [0, int(ids.numel())]
+            offsets = [0, int(ids.numel())] if num_req == 1 else None
 
-        processor = None
+        debug = _vocoder_debug_enabled()
+        if debug:
+            logger.warning(
+                "[moss-vocoder-debug] forward num_req=%d ids=%d counts=%s offsets=%s",
+                num_req,
+                int(ids.numel()),
+                counts,
+                offsets,
+            )
+
         decode_items: list[tuple[int, torch.Tensor]] = []
         streaming_items: list[tuple[int, torch.Tensor, dict[str, Any] | None]] = []
         for i in range(num_req):
             runtime_info = info_list[i] if i < len(info_list) and isinstance(info_list[i], dict) else None
+            if offsets is None:
+                input_slice = torch.empty(0, dtype=torch.long, device=ids.device)
+            elif i + 1 < len(offsets):
+                input_slice = ids[offsets[i] : offsets[i + 1]]
+            else:
+                input_slice = torch.empty(0, dtype=torch.long, device=ids.device)
             seg = _codec_ids_from_payload_or_input(
-                ids[offsets[i] : offsets[i + 1]] if i + 1 < len(offsets) else ids,
+                input_slice,
                 runtime_info,
             )
+            if debug:
+                codes_audio = None
+                meta = None
+                if isinstance(runtime_info, dict):
+                    codes_dict = runtime_info.get("codes")
+                    if isinstance(codes_dict, dict):
+                        codes_audio = codes_dict.get("audio")
+                    meta = runtime_info.get("meta")
+                logger.warning(
+                    "[moss-vocoder-debug] item=%d req=%s input_slice=%d codes_audio=%s "
+                    "seg=%d seg_mod=%d streaming=%s finished=%s meta=%s",
+                    i,
+                    self._request_id_from_runtime_info(runtime_info, i),
+                    int(input_slice.numel()),
+                    _shape_numel(codes_audio),
+                    int(seg.numel()),
+                    int(seg.numel() % self._n_vq) if self._n_vq else -1,
+                    self._runtime_info_uses_streaming(runtime_info),
+                    self._runtime_info_finished(runtime_info),
+                    meta,
+                )
             if self._runtime_info_uses_streaming(runtime_info):
                 streaming_items.append((i, seg, runtime_info))
                 continue
@@ -267,14 +1226,25 @@ class MossTTSLocalVocoder(nn.Module):
             if seg.numel() % self._n_vq != 0:
                 logger.warning("MOSS-TTS Local vocoder got %d ids not divisible by n_vq=%d", seg.numel(), self._n_vq)
                 continue
-            codes_t_nq = seg.view(self._n_vq, -1).transpose(0, 1).contiguous().cpu()
+            codes_t_nq = seg.view(self._n_vq, -1).transpose(0, 1).contiguous()
             decode_items.append((i, codes_t_nq))
 
         if decode_items:
-            processor = self._ensure_processor()
-            wavs = processor.decode_audio_codes([codes for _, codes in decode_items])
+            if debug:
+                logger.warning(
+                    "[moss-vocoder-debug] decode_items=%s",
+                    [(i, tuple(codes.shape)) for i, codes in decode_items],
+                )
+            wavs = self._decode_batch_full_sequence([codes for _, codes in decode_items])
             for (i, _), wav in zip(decode_items, wavs):
                 wav_t = torch.as_tensor(wav).detach().to("cpu", torch.float32)
+                if debug:
+                    logger.warning(
+                        "[moss-vocoder-debug] decoded item=%d wav_shape=%s wav_numel=%d",
+                        i,
+                        tuple(wav_t.shape),
+                        int(wav_t.numel()),
+                    )
                 audios[i] = wav_t.contiguous()
 
         for i, seg, runtime_info in streaming_items:

--- a/vllm_omni/model_executor/models/moss_tts_local/pipeline.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/pipeline.py
@@ -24,7 +24,7 @@ MOSS_TTS_LOCAL_PIPELINE = PipelineConfig(
             owns_tokenizer=True,
             engine_output_type="audio",
             async_chunk_process_next_stage_input_func=f"{_PROC}.talker2vocoder_async_chunk",
-            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder_full_payload",
             sampling_constraints={"detokenize": False},
         ),
         StagePipelineConfig(
@@ -55,7 +55,7 @@ MOSS_TTS_LOCAL_NATIVE_PIPELINE = PipelineConfig(
             owns_tokenizer=True,
             engine_output_type="audio",
             async_chunk_process_next_stage_input_func=f"{_PROC}.talker2vocoder_async_chunk",
-            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder_full_payload",
             sampling_constraints={"detokenize": False},
         ),
         StagePipelineConfig(

--- a/vllm_omni/model_executor/models/moss_tts_local/pipeline.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/pipeline.py
@@ -1,0 +1,76 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Pipeline topology for MOSS-TTS Local Transformer v1.5."""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+_PROC = "vllm_omni.model_executor.stage_input_processors.moss_tts_local"
+
+MOSS_TTS_LOCAL_PIPELINE = PipelineConfig(
+    model_type="moss_tts_local",
+    model_arch="MossTTSLocalModel",
+    hf_architectures=("MossTTSLocalModel",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="moss_tts_local",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            owns_tokenizer=True,
+            engine_output_type="audio",
+            async_chunk_process_next_stage_input_func=f"{_PROC}.talker2vocoder_async_chunk",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder",
+            sampling_constraints={"detokenize": False},
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="moss_tts_local_vocoder",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            model_arch="MossTTSLocalVocoder",
+            sync_process_input_func=f"{_PROC}.vocoder_token_only",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)
+
+MOSS_TTS_LOCAL_NATIVE_PIPELINE = PipelineConfig(
+    model_type="moss_tts_local",
+    model_arch="MossTTSLocalNativeModel",
+    hf_architectures=("MossTTSLocalNativeModel",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="moss_tts_local",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            owns_tokenizer=True,
+            engine_output_type="audio",
+            async_chunk_process_next_stage_input_func=f"{_PROC}.talker2vocoder_async_chunk",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2vocoder",
+            sampling_constraints={"detokenize": False},
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="moss_tts_local_vocoder",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            model_arch="MossTTSLocalVocoder",
+            sync_process_input_func=f"{_PROC}.vocoder_token_only",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)
+
+__all__ = ["MOSS_TTS_LOCAL_PIPELINE", "MOSS_TTS_LOCAL_NATIVE_PIPELINE"]

--- a/vllm_omni/model_executor/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/vllm_omni/model_executor/models/moss_tts_local/vocoder_cuda_graph.py
@@ -1,0 +1,267 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""CUDA Graph acceleration for MOSS-TTS Local full-sequence vocoder decode."""
+
+from __future__ import annotations
+
+import bisect
+import os
+import time
+from collections import Counter
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+from torch.cuda import CUDAGraph
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+
+def _parse_int_list(raw: str | None, default: list[int]) -> list[int]:
+    if not raw:
+        return list(default)
+    values: set[int] = set()
+    for item in raw.replace(";", ",").split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            value = int(item)
+        except ValueError:
+            continue
+        if value > 0:
+            values.add(value)
+    return sorted(values) or list(default)
+
+
+class MossTTSLocalVocoderCUDAGraphWrapper:
+    """CUDA Graph wrapper for ``MOSS-Audio-Tokenizer-v2`` full decode.
+
+    The wrapped codec API is:
+
+    ``codec.decode(audio_codes, padding_mask=..., num_quantizers=..., return_dict=True, chunk_duration=None)``
+
+    where ``audio_codes`` is shaped ``[n_vq, batch, frames]`` and
+    ``padding_mask`` is shaped ``[batch, frames]``. Graphs are keyed by
+    ``(bucket_batch, bucket_frames)``. Smaller actual inputs are left-aligned
+    into static buffers and right-padded with zeros / False mask values.
+    """
+
+    DEFAULT_FRAME_BUCKETS = [32, 48, 64, 80, 96, 128]
+    DEFAULT_BATCH_BUCKETS = [1, 2, 4, 8]
+
+    def __init__(
+        self,
+        *,
+        codec: Any,
+        capture_frame_sizes: list[int] | None = None,
+        capture_batch_sizes: list[int] | None = None,
+        num_quantizers: int = 12,
+        enabled: bool = True,
+    ) -> None:
+        self.codec = codec
+        self.capture_frame_sizes = sorted(set(capture_frame_sizes or self.DEFAULT_FRAME_BUCKETS))
+        self.capture_batch_sizes = sorted(set(capture_batch_sizes or self.DEFAULT_BATCH_BUCKETS))
+        self.num_quantizers = int(num_quantizers)
+        self.enabled = bool(enabled)
+
+        self.graphs: dict[tuple[int, int], CUDAGraph] = {}
+        self.static_audio_codes: dict[tuple[int, int], torch.Tensor] = {}
+        self.static_padding_masks: dict[tuple[int, int], torch.Tensor] = {}
+        self.static_outputs: dict[tuple[int, int], Any] = {}
+        self._warmed_up = False
+        self._device: torch.device | None = None
+
+        self._stats_enabled = os.environ.get("MOSS_TTS_LOCAL_VOCODER_GRAPH_STATS", "").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self._stats_log_every = int(os.environ.get("MOSS_TTS_LOCAL_VOCODER_GRAPH_STATS_LOG_EVERY", "50") or 50)
+        self._stats_total = 0
+        self._stats_hits = 0
+        self._stats_fallbacks = 0
+        self._stats_shapes: Counter[tuple[int, int, int, int]] = Counter()
+
+    @classmethod
+    def from_env(cls, *, codec: Any, num_quantizers: int) -> MossTTSLocalVocoderCUDAGraphWrapper:
+        return cls(
+            codec=codec,
+            capture_frame_sizes=_parse_int_list(
+                os.environ.get("MOSS_TTS_LOCAL_VOCODER_GRAPH_FRAME_BUCKETS"),
+                cls.DEFAULT_FRAME_BUCKETS,
+            ),
+            capture_batch_sizes=_parse_int_list(
+                os.environ.get("MOSS_TTS_LOCAL_VOCODER_GRAPH_BATCH_BUCKETS"),
+                cls.DEFAULT_BATCH_BUCKETS,
+            ),
+            num_quantizers=num_quantizers,
+            enabled=os.environ.get("MOSS_TTS_LOCAL_VOCODER_DISABLE_CUDA_GRAPH", "0").lower()
+            not in ("1", "true", "yes", "on"),
+        )
+
+    def get_bucket(self, *, batch_size: int, frame_count: int) -> tuple[int, int] | None:
+        batch_idx = bisect.bisect_left(self.capture_batch_sizes, int(batch_size))
+        frame_idx = bisect.bisect_left(self.capture_frame_sizes, int(frame_count))
+        if batch_idx >= len(self.capture_batch_sizes) or frame_idx >= len(self.capture_frame_sizes):
+            return None
+        return self.capture_batch_sizes[batch_idx], self.capture_frame_sizes[frame_idx]
+
+    def warmup(self, device: torch.device) -> None:
+        if device.type != "cuda" or not self.enabled or self._warmed_up:
+            return
+
+        self._device = device
+        if hasattr(self.codec, "eval"):
+            self.codec.eval()
+        shapes = [(batch, frames) for batch in self.capture_batch_sizes for frames in self.capture_frame_sizes]
+        logger.info(
+            "MOSS-TTS Local vocoder CUDA Graph warmup: shapes=%s n_vq=%d",
+            shapes,
+            self.num_quantizers,
+        )
+        start_s = time.perf_counter()
+        for batch_size, frame_count in shapes:
+            audio_codes = torch.zeros(
+                self.num_quantizers,
+                batch_size,
+                frame_count,
+                dtype=torch.long,
+                device=device,
+            )
+            padding_mask = torch.ones(batch_size, frame_count, dtype=torch.bool, device=device)
+            with torch.no_grad():
+                _ = self._decode_eager(audio_codes, padding_mask)
+        torch.accelerator.synchronize(device)
+
+        for batch_size, frame_count in shapes:
+            try:
+                self._capture(batch_size, frame_count, device)
+                logger.info("  Captured MOSS vocoder CUDA Graph batch=%d frames=%d", batch_size, frame_count)
+            except Exception:
+                logger.warning(
+                    "  Failed to capture MOSS vocoder CUDA Graph batch=%d frames=%d",
+                    batch_size,
+                    frame_count,
+                    exc_info=True,
+                )
+        self._warmed_up = True
+        logger.info(
+            "MOSS-TTS Local vocoder CUDA Graph warmup complete: %d/%d captured in %.1f ms",
+            len(self.graphs),
+            len(shapes),
+            (time.perf_counter() - start_s) * 1000.0,
+        )
+
+    def _decode_eager(self, audio_codes: torch.Tensor, padding_mask: torch.Tensor) -> Any:
+        if hasattr(self.codec, "_decode_frame"):
+            code_lengths = (
+                padding_mask.sum(dim=-1).to(dtype=torch.long)
+                if padding_mask is not None
+                else torch.full(
+                    (audio_codes.shape[1],),
+                    int(audio_codes.shape[-1]),
+                    dtype=torch.long,
+                    device=audio_codes.device,
+                )
+            )
+            return self.codec._decode_frame(audio_codes[: self.num_quantizers], code_lengths)
+        return self.codec.decode(
+            audio_codes,
+            padding_mask=padding_mask,
+            num_quantizers=self.num_quantizers,
+            return_dict=True,
+            chunk_duration=None,
+        )
+
+    def _capture(self, batch_size: int, frame_count: int, device: torch.device) -> None:
+        key = (batch_size, frame_count)
+        audio_codes = torch.zeros(
+            self.num_quantizers,
+            batch_size,
+            frame_count,
+            dtype=torch.long,
+            device=device,
+        )
+        padding_mask = torch.ones(batch_size, frame_count, dtype=torch.bool, device=device)
+        with torch.no_grad():
+            _ = self._decode_eager(audio_codes, padding_mask)
+        torch.accelerator.synchronize(device)
+
+        graph = CUDAGraph()
+        with torch.no_grad():
+            with torch.cuda.graph(graph, pool=current_platform.get_global_graph_pool()):
+                static_output = self._decode_eager(audio_codes, padding_mask)
+
+        self.graphs[key] = graph
+        self.static_audio_codes[key] = audio_codes
+        self.static_padding_masks[key] = padding_mask
+        self.static_outputs[key] = static_output
+
+    def _record(self, *, hit: bool, batch_size: int, frame_count: int, bucket: tuple[int, int] | None) -> None:
+        if not self._stats_enabled:
+            return
+        self._stats_total += 1
+        if hit:
+            self._stats_hits += 1
+        else:
+            self._stats_fallbacks += 1
+        bucket_batch, bucket_frames = bucket if bucket is not None else (-1, -1)
+        self._stats_shapes[(batch_size, frame_count, bucket_batch, bucket_frames)] += 1
+        if self._stats_log_every > 0 and self._stats_total % self._stats_log_every == 0:
+            hit_rate = 100.0 * self._stats_hits / max(1, self._stats_total)
+            logger.info(
+                "[moss-vocoder-graph] total=%d hits=%d fallbacks=%d hit_rate=%.1f%% top_shapes=%s",
+                self._stats_total,
+                self._stats_hits,
+                self._stats_fallbacks,
+                hit_rate,
+                self._stats_shapes.most_common(12),
+            )
+
+    @torch.no_grad()
+    def decode(self, audio_codes: torch.Tensor, padding_mask: torch.Tensor) -> Any:
+        if not self.enabled or not self._warmed_up or audio_codes.device.type != "cuda":
+            return self._decode_eager(audio_codes, padding_mask)
+        if torch.cuda.is_current_stream_capturing():
+            return self._decode_eager(audio_codes, padding_mask)
+
+        batch_size = int(audio_codes.shape[1])
+        frame_count = int(audio_codes.shape[2])
+        bucket = self.get_bucket(batch_size=batch_size, frame_count=frame_count)
+        if bucket is None or bucket not in self.graphs:
+            self._record(hit=False, batch_size=batch_size, frame_count=frame_count, bucket=bucket)
+            return self._decode_eager(audio_codes, padding_mask)
+
+        bucket_batch, bucket_frames = bucket
+        static_codes = self.static_audio_codes[bucket]
+        static_mask = self.static_padding_masks[bucket]
+        static_codes.zero_()
+        static_mask.zero_()
+        static_codes[:, :batch_size, :frame_count].copy_(audio_codes)
+        static_mask[:batch_size, :frame_count].copy_(padding_mask)
+
+        self.graphs[bucket].replay()
+        self._record(hit=True, batch_size=batch_size, frame_count=frame_count, bucket=bucket)
+
+        output = self.static_outputs[bucket]
+        audio = getattr(output, "audio", None)
+        audio_lengths = getattr(output, "audio_lengths", None)
+        if isinstance(audio, torch.Tensor):
+            audio = audio[:batch_size].clone()
+        if isinstance(audio_lengths, torch.Tensor):
+            audio_lengths = audio_lengths[:batch_size].clone()
+        if hasattr(output, "__dict__"):
+            values = {**output.__dict__, "audio": audio, "audio_lengths": audio_lengths}
+            try:
+                return type(output)(**values)
+            except Exception:
+                return SimpleNamespace(**values)
+        return output
+
+
+__all__ = ["MossTTSLocalVocoderCUDAGraphWrapper"]

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -300,21 +300,26 @@ _OMNI_MODELS = {
         "modeling_moss_tts_codec",
         "MossTTSCodecDecoder",
     ),
+    ## MOSS-TTS Local Transformer v1.5
+    "MossTTSLocalModel": (
+        "moss_tts_local",
+        "modeling_moss_tts_local",
+        "MossTTSLocalForGeneration",
+    ),
+    "MossTTSLocalNativeModel": (
+        "moss_tts_local",
+        "modeling_moss_tts_local_v2",
+        "MossTTSLocalNativeModel",
+    ),
+    "MossTTSLocalVocoder": (
+        "moss_tts_local",
+        "modeling_moss_tts_local_vocoder",
+        "MossTTSLocalVocoder",
+    ),
     "DyninOmniForConditionalGeneration": (
         "dynin_omni",
         "dynin_omni",
         "DyninOmniForConditionalGeneration",
-    ),
-    ## IndexTTS2
-    "IndexTTS2TalkerForConditionalGeneration": (
-        "indextts2",
-        "indextts2_talker",
-        "IndexTTS2TalkerForConditionalGeneration",
-    ),
-    "IndexTTS2S2MelDecoder": (
-        "indextts2",
-        "indextts2_s2mel_decoder",
-        "IndexTTS2S2MelDecoder",
     ),
     ## Ming-flash-omni-2.0
     "MingFlashOmniForConditionalGeneration": (
@@ -353,11 +358,6 @@ _OMNI_MODELS = {
         "minicpmo_4_5",
         "minicpmo_4_5_omni_tts",
         "MiniCPMO45OmniTTSForConditionalGeneration",
-    ),
-    "AuraQwen3VLForConditionalGeneration": (
-        "aura_omni",
-        "qwen3_vl",
-        "AuraQwen3VLForConditionalGeneration",
     ),
 }
 

--- a/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
+++ b/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from typing import Any
 
@@ -15,6 +16,40 @@ from vllm.logger import init_logger
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
 
 logger = init_logger(__name__)
+
+
+def _parse_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return None
+        return bool(value.item())
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("1", "true", "yes", "on"):
+            return True
+        if normalized in ("0", "false", "no", "off"):
+            return False
+        return None
+    return bool(value)
+
+
+def _codec_streaming_from_transfer_manager(transfer_manager: Any) -> bool:
+    raw = os.environ.get("MOSS_TTS_LOCAL_CODEC_STREAMING")
+    if raw is None:
+        raw = os.environ.get("MOSS_TTS_LOCAL_DEFAULT_CODEC_STREAMING")
+    parsed = _parse_optional_bool(raw)
+    if parsed is not None:
+        return parsed
+
+    connector = getattr(transfer_manager, "connector", None)
+    raw_cfg = getattr(connector, "config", {}) or {}
+    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, Mapping) else {}
+    parsed = _parse_optional_bool(cfg.get("codec_streaming"))
+    return True if parsed is None else parsed
 
 
 def _get_audio_from_payload(payload: Any) -> torch.Tensor | None:
@@ -166,6 +201,15 @@ def vocoder_token_only(
     return talker2vocoder(source_outputs, prompt, requires_multimodal_data, streaming_context)
 
 
+def talker2vocoder_full_payload(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+    streaming_context: Any | None = None,
+) -> list[Any]:
+    return talker2vocoder(source_outputs, prompt, requires_multimodal_data, streaming_context)
+
+
 def talker2vocoder_async_chunk(
     transfer_manager: Any,
     multimodal_output: dict[str, Any] | None,
@@ -210,7 +254,7 @@ def talker2vocoder_async_chunk(
                 meta=MetaStruct(
                     left_context_size=0,
                     finished=torch.tensor(True, dtype=torch.bool),
-                    codec_streaming=True,
+                    codec_streaming=_codec_streaming_from_transfer_manager(transfer_manager),
                     req_id=[req_id],
                 ),
                 request_id=req_id,
@@ -220,10 +264,14 @@ def talker2vocoder_async_chunk(
     connector = getattr(transfer_manager, "connector", None)
     raw_cfg = getattr(connector, "config", {}) or {}
     cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
+    codec_streaming = _codec_streaming_from_transfer_manager(transfer_manager)
     chunk_frames = int(cfg.get("codec_chunk_frames", 25) or 25)
     initial_chunk_frames = int(cfg.get("initial_codec_chunk_frames", 0) or 0)
     if initial_chunk_frames > chunk_frames:
         initial_chunk_frames = chunk_frames
+
+    if not codec_streaming and not is_finished:
+        return None
 
     threshold = initial_chunk_frames if emitted_frames == 0 and initial_chunk_frames > 0 else chunk_frames
     if not is_finished and pending_frames < threshold:
@@ -240,24 +288,24 @@ def talker2vocoder_async_chunk(
             meta=MetaStruct(
                 left_context_size=0,
                 finished=torch.tensor(bool(finished), dtype=torch.bool),
-                codec_streaming=True,
+                codec_streaming=codec_streaming,
                 req_id=[req_id],
             ),
             request_id=req_id,
         )
+
+    if not codec_streaming:
+        state.pop(req_id, None)
+        return make_payload(acc, finished=True)
 
     if is_finished:
         payloads: list[OmniPayloadStruct] = []
         cursor = 0
         local_emitted = emitted_frames
         while cursor < pending_frames:
-            local_threshold = (
-                initial_chunk_frames
-                if local_emitted == 0 and initial_chunk_frames > 0
-                else chunk_frames
-            )
+            local_threshold = initial_chunk_frames if local_emitted == 0 and initial_chunk_frames > 0 else chunk_frames
             emit_frames = min(local_threshold, pending_frames - cursor)
-            chunk = acc[cursor:cursor + emit_frames]
+            chunk = acc[cursor : cursor + emit_frames]
             cursor += emit_frames
             local_emitted += emit_frames
             payloads.append(make_payload(chunk, finished=cursor >= pending_frames))
@@ -273,4 +321,9 @@ def talker2vocoder_async_chunk(
     return make_payload(chunk, finished=False)
 
 
-__all__ = ["talker2vocoder", "vocoder_token_only", "talker2vocoder_async_chunk"]
+__all__ = [
+    "talker2vocoder",
+    "talker2vocoder_full_payload",
+    "talker2vocoder_async_chunk",
+    "vocoder_token_only",
+]

--- a/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
+++ b/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
@@ -1,0 +1,237 @@
+# Copyright 2026 OpenMOSS and the vLLM-Omni team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Stage input processors for MOSS-TTS Local Transformer v1.5."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from vllm.inputs import TokensPrompt as OmniTokensPrompt
+from vllm.logger import init_logger
+
+from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
+
+logger = init_logger(__name__)
+
+
+def _get_audio_from_payload(payload: Any) -> torch.Tensor | None:
+    if not isinstance(payload, Mapping):
+        return None
+    codes = payload.get("codes")
+    if isinstance(codes, Mapping):
+        audio = codes.get("audio")
+        if isinstance(audio, torch.Tensor):
+            return audio
+    audio = payload.get("codes.audio")
+    if isinstance(audio, torch.Tensor):
+        return audio
+    return None
+
+
+def _extract_audio_codes(stage_output: Any) -> torch.Tensor | None:
+    outputs = getattr(stage_output, "outputs", None)
+    if outputs:
+        output = outputs[0]
+        audio = _get_audio_from_payload(getattr(output, "multimodal_output", None))
+        if audio is not None:
+            return audio
+
+    audio = _get_audio_from_payload(getattr(stage_output, "multimodal_output", None))
+    if audio is not None:
+        return audio
+
+    audio = _get_audio_from_payload(getattr(stage_output, "multimodal_outputs", None))
+    if audio is not None:
+        return audio
+    return None
+
+
+def _flatten_codes(codes_t_nq: torch.Tensor) -> list[int]:
+    if codes_t_nq.numel() == 0:
+        return []
+    if codes_t_nq.dim() != 2:
+        raise ValueError(f"MOSS-TTS Local codes must be [T, NQ], got {tuple(codes_t_nq.shape)}")
+    return codes_t_nq.to(torch.long).transpose(0, 1).contiguous().reshape(-1).tolist()
+
+
+def _flatten_codes_tensor(codes_t_nq: torch.Tensor) -> torch.Tensor:
+    if codes_t_nq.numel() == 0:
+        return torch.empty(0, dtype=torch.long)
+    if codes_t_nq.dim() != 2:
+        raise ValueError(f"MOSS-TTS Local codes must be [T, NQ], got {tuple(codes_t_nq.shape)}")
+    return codes_t_nq.to(torch.long).transpose(0, 1).contiguous().reshape(-1).cpu()
+
+
+def _get_stage_output(stage_outputs: Any, source: Any) -> Any:
+    if isinstance(stage_outputs, dict):
+        if source in stage_outputs:
+            return stage_outputs[source]
+        source_str = str(source)
+        if source_str in stage_outputs:
+            return stage_outputs[source_str]
+        try:
+            source_int = int(source)
+        except (TypeError, ValueError):
+            return None
+        return stage_outputs.get(source_int)
+
+    try:
+        source_int = int(source)
+    except (TypeError, ValueError):
+        return None
+    if 0 <= source_int < len(stage_outputs):
+        return stage_outputs[source_int]
+    return None
+
+
+def talker2vocoder(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+    streaming_context: Any | None = None,
+) -> list[Any]:
+    del prompt, requires_multimodal_data, streaming_context
+    results: list[Any] = []
+    for i, stage_out in enumerate(source_outputs):
+        if hasattr(stage_out, "finished") and not stage_out.finished:
+            continue
+        audio_codes = _extract_audio_codes(stage_out)
+        if audio_codes is None or audio_codes.numel() == 0:
+            logger.warning("talker2vocoder: no MOSS-TTS Local audio codes in source output %s.", i)
+            results.append(OmniTokensPrompt(prompt_token_ids=[]))
+            continue
+        flat = _flatten_codes(audio_codes)
+        results.append(
+            OmniTokensPrompt(
+                prompt_token_ids=flat,
+                multi_modal_data={"codes": {"audio": flat}},
+            )
+        )
+    return results
+
+
+def talker2vocoder_legacy(
+    stage_list: Any,
+    engine_input_source: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+) -> list[Any]:
+    del prompt, requires_multimodal_data
+    results: list[Any] = []
+    for source in engine_input_source:
+        stage_out = _get_stage_output(stage_list, source)
+        audio_codes = _extract_audio_codes(stage_out)
+        if audio_codes is None or audio_codes.numel() == 0:
+            logger.warning("talker2vocoder: no MOSS-TTS Local audio codes in stage output %s.", source)
+            results.append(OmniTokensPrompt(prompt_token_ids=[]))
+            continue
+        flat = _flatten_codes(audio_codes)
+        results.append(
+            OmniTokensPrompt(
+                prompt_token_ids=flat,
+                multi_modal_data={"codes": {"audio": flat}},
+            )
+        )
+    return results
+
+
+def vocoder_token_only(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+    streaming_context: Any | None = None,
+) -> list[Any]:
+    return talker2vocoder(source_outputs, prompt, requires_multimodal_data, streaming_context)
+
+
+def talker2vocoder_async_chunk(
+    transfer_manager: Any,
+    multimodal_output: dict[str, Any] | None,
+    request: Any,
+    is_finished: bool = False,
+) -> OmniPayloadStruct | None:
+    req_id = str(getattr(request, "external_req_id", None) or getattr(request, "request_id", id(request)))
+    if not hasattr(transfer_manager, "_moss_tts_local_state"):
+        transfer_manager._moss_tts_local_state = {}
+    state = transfer_manager._moss_tts_local_state
+    req_state = state.setdefault(req_id, {"pending": [], "pending_frames": 0, "emitted_frames": 0, "last_step": -1})
+
+    if multimodal_output is not None:
+        codes_dict = multimodal_output.get("codes", {}) or {}
+        snapshot = codes_dict.get("audio")
+        if isinstance(snapshot, torch.Tensor) and snapshot.numel() > 0:
+            meta = multimodal_output.get("meta", {}) or {}
+            step = int(meta.get("step", -1)) if isinstance(meta, dict) else -1
+            if step >= 0 and step <= req_state.get("last_step", -1):
+                pass
+            else:
+                if step >= 0:
+                    req_state["last_step"] = step
+                snapshot_cpu = snapshot.detach().cpu().to(torch.long)
+                if bool(meta.get("raw_rows", False)):
+                    new_rows = snapshot_cpu
+                else:
+                    total_frames = req_state["emitted_frames"] + req_state["pending_frames"]
+                    new_rows = snapshot_cpu[total_frames:]
+                if new_rows.numel() > 0:
+                    req_state["pending"].append(new_rows)
+                    req_state["pending_frames"] += int(new_rows.shape[0])
+
+    pending_frames = req_state["pending_frames"]
+    emitted_frames = int(req_state.get("emitted_frames", 0))
+
+    if pending_frames == 0:
+        if is_finished:
+            state.pop(req_id, None)
+            return OmniPayloadStruct(
+                codes=CodesStruct(audio=torch.empty(0, dtype=torch.long)),
+                meta=MetaStruct(
+                    left_context_size=0,
+                    finished=torch.tensor(True, dtype=torch.bool),
+                    codec_streaming=True,
+                    req_id=[req_id],
+                ),
+                request_id=req_id,
+            )
+        return None
+
+    connector = getattr(transfer_manager, "connector", None)
+    raw_cfg = getattr(connector, "config", {}) or {}
+    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
+    chunk_frames = int(cfg.get("codec_chunk_frames", 25) or 25)
+    initial_chunk_frames = int(cfg.get("initial_codec_chunk_frames", 0) or 0)
+    if initial_chunk_frames > chunk_frames:
+        initial_chunk_frames = chunk_frames
+
+    threshold = initial_chunk_frames if emitted_frames == 0 and initial_chunk_frames > 0 else chunk_frames
+    if not is_finished and pending_frames < threshold:
+        return None
+
+    # Only materialize (concat) when we're actually emitting
+    pending_list = req_state["pending"]
+    acc = torch.cat(pending_list, dim=0) if len(pending_list) > 1 else pending_list[0]
+    emit_frames = pending_frames if is_finished else threshold
+    chunk = acc[:emit_frames]
+    remaining = acc[emit_frames:] if emit_frames < pending_frames else None
+    req_state["emitted_frames"] = emitted_frames + emit_frames
+    req_state["pending"] = [remaining] if remaining is not None and remaining.numel() > 0 else []
+    req_state["pending_frames"] = int(remaining.shape[0]) if remaining is not None and remaining.numel() > 0 else 0
+    if is_finished:
+        state.pop(req_id, None)
+    flat = _flatten_codes_tensor(chunk)
+    return OmniPayloadStruct(
+        codes=CodesStruct(audio=flat),
+        meta=MetaStruct(
+            left_context_size=0,
+            finished=torch.tensor(bool(is_finished), dtype=torch.bool),
+            codec_streaming=True,
+            req_id=[req_id],
+        ),
+        request_id=req_id,
+    )
+
+
+__all__ = ["talker2vocoder", "vocoder_token_only", "talker2vocoder_async_chunk"]

--- a/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
+++ b/vllm_omni/model_executor/stage_input_processors/moss_tts_local.py
@@ -65,6 +65,25 @@ def _flatten_codes_tensor(codes_t_nq: torch.Tensor) -> torch.Tensor:
     return codes_t_nq.to(torch.long).transpose(0, 1).contiguous().reshape(-1).cpu()
 
 
+def _meta_step_for_req(meta: Mapping[str, Any], req_id: str) -> int:
+    step = meta.get("step", -1)
+    req_ids = meta.get("req_id")
+    if isinstance(step, torch.Tensor):
+        step = step.detach().cpu().reshape(-1).tolist()
+    if isinstance(req_ids, torch.Tensor):
+        req_ids = req_ids.detach().cpu().reshape(-1).tolist()
+    if isinstance(step, (list, tuple)):
+        if isinstance(req_ids, (list, tuple)):
+            for idx, rid in enumerate(req_ids):
+                if str(rid) == req_id and idx < len(step):
+                    return int(step[idx])
+        return -1
+    try:
+        return int(step)
+    except (TypeError, ValueError):
+        return -1
+
+
 def _get_stage_output(stage_outputs: Any, source: Any) -> Any:
     if isinstance(stage_outputs, dict):
         if source in stage_outputs:
@@ -152,7 +171,7 @@ def talker2vocoder_async_chunk(
     multimodal_output: dict[str, Any] | None,
     request: Any,
     is_finished: bool = False,
-) -> OmniPayloadStruct | None:
+) -> OmniPayloadStruct | list[OmniPayloadStruct] | None:
     req_id = str(getattr(request, "external_req_id", None) or getattr(request, "request_id", id(request)))
     if not hasattr(transfer_manager, "_moss_tts_local_state"):
         transfer_manager._moss_tts_local_state = {}
@@ -164,7 +183,7 @@ def talker2vocoder_async_chunk(
         snapshot = codes_dict.get("audio")
         if isinstance(snapshot, torch.Tensor) and snapshot.numel() > 0:
             meta = multimodal_output.get("meta", {}) or {}
-            step = int(meta.get("step", -1)) if isinstance(meta, dict) else -1
+            step = _meta_step_for_req(meta, req_id) if isinstance(meta, Mapping) else -1
             if step >= 0 and step <= req_state.get("last_step", -1):
                 pass
             else:
@@ -210,28 +229,48 @@ def talker2vocoder_async_chunk(
     if not is_finished and pending_frames < threshold:
         return None
 
-    # Only materialize (concat) when we're actually emitting
+    # Only materialize (concat) when we're actually emitting.
     pending_list = req_state["pending"]
     acc = torch.cat(pending_list, dim=0) if len(pending_list) > 1 else pending_list[0]
-    emit_frames = pending_frames if is_finished else threshold
+
+    def make_payload(chunk_t_nq: torch.Tensor, *, finished: bool) -> OmniPayloadStruct:
+        flat = _flatten_codes_tensor(chunk_t_nq)
+        return OmniPayloadStruct(
+            codes=CodesStruct(audio=flat),
+            meta=MetaStruct(
+                left_context_size=0,
+                finished=torch.tensor(bool(finished), dtype=torch.bool),
+                codec_streaming=True,
+                req_id=[req_id],
+            ),
+            request_id=req_id,
+        )
+
+    if is_finished:
+        payloads: list[OmniPayloadStruct] = []
+        cursor = 0
+        local_emitted = emitted_frames
+        while cursor < pending_frames:
+            local_threshold = (
+                initial_chunk_frames
+                if local_emitted == 0 and initial_chunk_frames > 0
+                else chunk_frames
+            )
+            emit_frames = min(local_threshold, pending_frames - cursor)
+            chunk = acc[cursor:cursor + emit_frames]
+            cursor += emit_frames
+            local_emitted += emit_frames
+            payloads.append(make_payload(chunk, finished=cursor >= pending_frames))
+        state.pop(req_id, None)
+        return payloads
+
+    emit_frames = threshold
     chunk = acc[:emit_frames]
     remaining = acc[emit_frames:] if emit_frames < pending_frames else None
     req_state["emitted_frames"] = emitted_frames + emit_frames
     req_state["pending"] = [remaining] if remaining is not None and remaining.numel() > 0 else []
     req_state["pending_frames"] = int(remaining.shape[0]) if remaining is not None and remaining.numel() > 0 else 0
-    if is_finished:
-        state.pop(req_id, None)
-    flat = _flatten_codes_tensor(chunk)
-    return OmniPayloadStruct(
-        codes=CodesStruct(audio=flat),
-        meta=MetaStruct(
-            left_context_size=0,
-            finished=torch.tensor(bool(is_finished), dtype=torch.bool),
-            codec_streaming=True,
-            req_id=[req_id],
-        ),
-        request_id=req_id,
-    )
+    return make_payload(chunk, finished=False)
 
 
 __all__ = ["talker2vocoder", "vocoder_token_only", "talker2vocoder_async_chunk"]

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1,5 +1,5 @@
 import contextlib
-import inspect
+import os
 from collections.abc import Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
@@ -49,28 +49,26 @@ else:
 logger = init_logger(__name__)
 
 
-def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Return only M-RoPE kwargs accepted by the model implementation."""
-    method = getattr(model, "get_mrope_input_positions")
-    try:
-        signature = inspect.signature(method)
-    except (TypeError, ValueError):
-        return kwargs
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        return kwargs
 
-    accepted = {
-        name
-        for name, param in signature.parameters.items()
-        if name not in {"self", "input_tokens"}
-        and param.kind
-        in {
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        }
-    }
-    return {key: value for key, value in kwargs.items() if key in accepted}
+def _omni_batch_preprocess_enabled() -> bool:
+    if _truthy_env("MOSS_TTS_LOCAL_DISABLE_BATCH_PREPROCESS"):
+        return False
+    value = os.environ.get("MOSS_TTS_LOCAL_ENABLE_BATCH_PREPROCESS")
+    if value is None:
+        return True
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _omni_fast_batch_preprocess_enabled() -> bool:
+    if _truthy_env("MOSS_TTS_LOCAL_DISABLE_FAST_BATCH_PREPROCESS"):
+        return False
+    value = os.environ.get("MOSS_TTS_LOCAL_ENABLE_FAST_BATCH_PREPROCESS")
+    if value is None:
+        return True
+    return value.strip().lower() in ("1", "true", "yes", "on")
 
 
 class OmniGPUModelRunner(GPUModelRunner):
@@ -92,6 +90,20 @@ class OmniGPUModelRunner(GPUModelRunner):
             if sampled is not None:
                 return sampled
         return super()._to_list(sampled_token_ids)
+
+    def _maybe_disable_outer_cudagraph_for_model(self) -> None:
+        should_disable = getattr(self.model, "should_disable_outer_cudagraph", None)
+        if callable(should_disable):
+            disable_outer_cudagraph = bool(should_disable())
+        else:
+            disable_outer_cudagraph = bool(getattr(self.model, "disable_outer_cudagraph", False))
+        if not disable_outer_cudagraph:
+            return
+        cfg = self.compilation_config
+        cfg.cudagraph_mode = CUDAGraphMode.NONE
+        cfg.cudagraph_capture_sizes = []
+        cfg.max_cudagraph_capture_size = 0
+        cfg.cudagraph_num_of_warmups = 0
 
     def _omni_routed_experts_d2h(self, scheduler_output) -> None:
         """Issue routed-experts D2H copy matching upstream GPUModelRunner pattern.
@@ -185,6 +197,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 override_fn = candidate
         self._sampled_token_ids_cpu_override = override_fn
         self._omni_query_start_loc_model_kwarg = bool(getattr(model, "supports_omni_query_start_loc", False))
+        self._maybe_disable_outer_cudagraph_for_model()
         self._maybe_enable_output_token_ids_for_model_sampler()
         self._init_talker_mtp()
         self._prewarm_attention_capture_workspaces()
@@ -363,7 +376,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 kwargs["target_w"] = target_w
             req_state.mrope_positions, req_state.mrope_position_delta = self.model.get_mrope_input_positions(
                 req_state.prompt_token_ids,
-                **_filter_mrope_kwargs_for_model(self.model, kwargs),
+                **kwargs,
             )
         else:
             req_state.mrope_positions, req_state.mrope_position_delta = MRotaryEmbedding.get_input_positions_tensor(
@@ -1338,24 +1351,21 @@ class OmniGPUModelRunner(GPUModelRunner):
 
             traceback.print_exc()
 
-        # Per-request (start, end) hidden-row spans so make_omni_output can map
-        # flat hidden rows to the right request in mixed prefill+decode steps,
-        # instead of assuming an equal rows-per-request split (which samples the
-        # wrong rows whenever per-request token counts differ).
-        nstp = self._omni_num_scheduled_tokens_np
-        if nstp is not None and len(nstp) == len(self.input_batch.req_ids):
-            try:
-                model_kwargs_extra["request_token_spans"] = self._compute_request_token_spans(nstp)
-            except Exception as e:
-                # Visible on purpose: the fallback is the equal rows-per-request
-                # split, which can re-introduce the cross-request corruption this
-                # plumbing fixes — a silent failure here must not pass unnoticed.
-                logger.warning("[OMNI] Failed to compute request_token_spans: %s", e)
-
         if self._omni_query_start_loc_model_kwarg:
             try:
                 num_reqs = len(self.input_batch.req_ids)
                 model_kwargs_extra["omni_query_start_loc"] = self.query_start_loc.gpu[: num_reqs + 1]
+                num_scheduled_tokens_np = getattr(self, "_omni_num_scheduled_tokens_np", None)
+                logits_indices_cpu = getattr(self, "_omni_logits_indices_cpu", None)
+                if num_scheduled_tokens_np is not None:
+                    spans = self._compute_request_token_spans(num_scheduled_tokens_np)
+                    model_kwargs_extra["request_token_spans"] = spans
+                    model_kwargs_extra["omni_span_lens"] = [end - start for start, end in spans]
+                    if logits_indices_cpu is not None:
+                        row_to_sample = {int(row): pos for pos, row in enumerate(logits_indices_cpu)}
+                        model_kwargs_extra["omni_sample_row_by_req"] = [
+                            row_to_sample.get(end - 1, -1) if end > start else -1 for start, end in spans
+                        ]
             except Exception as e:
                 logger.debug("[OMNI] Failed to attach query_start_loc: %s", e)
 
@@ -1378,15 +1388,8 @@ class OmniGPUModelRunner(GPUModelRunner):
         combined_hidden_states: dict[str, torch.Tensor] | None = None,
         combined_multimodal_outputs: dict[str, object] | None = None,
         req_ids_filter: set[str] | None = None,
-        req_ids: list[str] | None = None,
-        query_start_loc_cpu: object | None = None,
     ) -> None:
         """Process model-provided per-request updates and merge into model_intermediate_buffer."""
-        req_ids = req_ids if req_ids is not None else self.input_batch.req_ids
-        if query_start_loc_cpu is None:
-            query_start_loc_cpu = self.query_start_loc.cpu
-            if callable(query_start_loc_cpu):
-                query_start_loc_cpu = query_start_loc_cpu()
         try:
             # execute the custom postprocess function
             # TODO(Peiqi): do we have a more elegant way to do this?
@@ -1394,7 +1397,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 postprocess_uses_hidden_states = getattr(self.model, "postprocess_uses_hidden_states", True)
                 postprocess_uses_multimodal_outputs = getattr(self.model, "postprocess_uses_multimodal_outputs", True)
                 postprocess_uses_req_infos = getattr(self.model, "postprocess_uses_req_infos", True)
-                for req_index, req_id in enumerate(req_ids):
+                for req_index, req_id in enumerate(self.input_batch.req_ids):
                     if req_ids_filter is not None and req_id not in req_ids_filter:
                         continue
                     req_infos = self.model_intermediate_buffer.get(req_id, {}) if postprocess_uses_req_infos else {}
@@ -1403,7 +1406,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                             # Combined hidden states contains all hidden states for every request
                             hidden_states_slice = combined_hidden_states[req_id]
                         else:
-                            start_offset = int(query_start_loc_cpu[req_index])
+                            start_offset = int(self.query_start_loc.cpu[req_index])
                             sched_tokens = int(num_scheduled_tokens_np[req_index])
                             s, e = start_offset, start_offset + sched_tokens
                             # only consider to store data into update dict.
@@ -1433,7 +1436,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                     )
                     self._update_intermediate_buffer(req_id, update_dict)
         except Exception as e:
-            logger.error(f"Error merging for requests:{req_ids} additional information update: {e}")
+            logger.error(f"Error merging for requests:{self.input_batch.req_ids} additional information update: {e}")
             import traceback
 
             traceback.print_exc()
@@ -1659,7 +1662,15 @@ class OmniGPUModelRunner(GPUModelRunner):
             decode_req_ids = []
             decode_start_offsets = []
             decode_batch_items = []
-            batch_decode_preprocess = getattr(self.model, "preprocess_decode_batch", None)
+            batch_decode_preprocess = (
+                getattr(self.model, "preprocess_decode_batch", None) if _omni_batch_preprocess_enabled() else None
+            )
+            decode_batch_fast_items = []
+            batch_decode_preprocess_fast = (
+                getattr(self.model, "preprocess_decode_batch_fast", None)
+                if _omni_batch_preprocess_enabled() and _omni_fast_batch_preprocess_enabled()
+                else None
+            )
 
             def flush_decode_batch() -> None:
                 nonlocal inputs_embeds
@@ -1669,11 +1680,23 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_ids_b = [item[0] for item in decode_batch_items]
                 start_offsets_b = [item[1] for item in decode_batch_items]
                 req_infos_b = [item[2] for item in decode_batch_items]
-                ids_b = torch.stack([input_ids[offset : offset + 1].reshape(-1)[0] for offset in start_offsets_b])
-                req_input_ids, req_embeds, last_talker_hidden, text_step, updates = batch_decode_preprocess(
+                offsets_t = torch.tensor(start_offsets_b, device=input_ids.device, dtype=torch.long)
+                ids_b = input_ids.index_select(0, offsets_t).reshape(-1)
+                batch_result = batch_decode_preprocess(
                     input_ids=ids_b,
                     req_infos=req_infos_b,
                 )
+                if not isinstance(batch_result, tuple) or len(batch_result) not in (3, 5):
+                    raise TypeError(
+                        "preprocess_decode_batch must return either "
+                        "(input_ids, embeds, updates) or "
+                        "(input_ids, embeds, last_talker_hidden, text_step, updates)"
+                    )
+                has_mtp_batch = len(batch_result) == 5
+                if has_mtp_batch:
+                    req_input_ids, req_embeds, last_talker_hidden, text_step, updates = batch_result
+                else:
+                    req_input_ids, req_embeds, updates = batch_result
                 if inputs_embeds is None:
                     inputs_embeds = torch.empty(
                         (input_ids.shape[0], req_embeds.shape[-1]),
@@ -1681,54 +1704,55 @@ class OmniGPUModelRunner(GPUModelRunner):
                         dtype=req_embeds.dtype,
                     )
 
-                offsets_t = torch.tensor(start_offsets_b, device=req_embeds.device, dtype=torch.long)
+                if offsets_t.device != req_embeds.device:
+                    offsets_t = offsets_t.to(device=req_embeds.device)
                 inputs_embeds.index_copy_(0, offsets_t, req_embeds)
                 input_ids.index_copy_(0, offsets_t, req_input_ids.reshape(-1).to(dtype=input_ids.dtype))
 
-                dst = slice(len(decode_req_ids), len(decode_req_ids) + len(req_ids_b))
-                self.talker_mtp_input_ids.gpu[dst].copy_(req_input_ids.reshape(-1))
-                self.talker_mtp_inputs_embeds.gpu[dst].copy_(req_embeds)
-                self.last_talker_hidden.gpu[dst].copy_(last_talker_hidden)
-                self.text_step.gpu[dst].copy_(text_step)
-
                 for req_id_b, update_dict_b in zip(req_ids_b, updates, strict=True):
-                    self._merge_additional_information_update(req_id_b, update_dict_b)
+                    if not update_dict_b:
+                        continue
+                    if isinstance(update_dict_b, dict) and len(update_dict_b) == 1 and "_kv_slot_id" in update_dict_b:
+                        existing = self.model_intermediate_buffer.setdefault(req_id_b, {})
+                        slot_id = update_dict_b["_kv_slot_id"]
+                        if existing.get("_kv_slot_id") != slot_id:
+                            existing["_kv_slot_id"] = slot_id
+                            req_state = self.requests.get(req_id_b)
+                            if req_state is not None:
+                                setattr(req_state, "additional_information_cpu", existing)
+                    else:
+                        self._merge_additional_information_update(req_id_b, update_dict_b)
 
-                decode_req_ids.extend(req_ids_b)
-                decode_start_offsets.extend(start_offsets_b)
+                if has_mtp_batch:
+                    dst = slice(len(decode_req_ids), len(decode_req_ids) + len(req_ids_b))
+                    self.talker_mtp_input_ids.gpu[dst].copy_(req_input_ids.reshape(-1))
+                    self.talker_mtp_inputs_embeds.gpu[dst].copy_(req_embeds)
+                    self.last_talker_hidden.gpu[dst].copy_(last_talker_hidden)
+                    self.text_step.gpu[dst].copy_(text_step)
+                    decode_req_ids.extend(req_ids_b)
+                    decode_start_offsets.extend(start_offsets_b)
                 decode_batch_items.clear()
 
-            for req_index, req_id in enumerate(self.input_batch.req_ids):
-                req_infos = self.model_intermediate_buffer.get(req_id, {})
+            def flush_decode_batch_fast() -> None:
+                nonlocal inputs_embeds
+                if not decode_batch_fast_items:
+                    return
 
-                # mimo-audio check
-                req_state = self.requests.get(req_id)
-                req_infos = self._maybe_attach_mimo_audio_req_infos(req_state, req_infos, req_id)
-
-                start_offset = int(self.query_start_loc.cpu[req_index])
-                sched_tokens = int(num_scheduled_tokens_np[req_index])
-                s, e = start_offset, start_offset + sched_tokens
-                span_len = int(e) - int(s)
-
-                # call the custom process function
-                req_infos["request_id"] = req_id
-                prompt_token_ids = getattr(req_state, "prompt_token_ids", ()) if req_state is not None else ()
-                prompt_len = len(prompt_token_ids or ())
-                num_computed_tokens = int(self.input_batch.num_computed_tokens_cpu[req_index])
-                is_prefill = num_computed_tokens < prompt_len
-                req_infos["_omni_prompt_len"] = prompt_len
-                req_infos["_omni_num_computed_tokens"] = num_computed_tokens
-                req_infos["_omni_is_prefill"] = is_prefill
-                if callable(batch_decode_preprocess) and self.has_talker_mtp and span_len == 1 and not is_prefill:
-                    decode_batch_items.append((req_id, s, req_infos))
-                    continue
-
-                flush_decode_batch()
-
-                embed_slice = inputs_embeds[s:e] if inputs_embeds is not None else None
-                req_input_ids, req_embeds, update_dict = self.model.preprocess(
-                    input_ids=input_ids[s:e], input_embeds=embed_slice, **req_infos
+                req_ids_b = [item[0] for item in decode_batch_fast_items]
+                start_offsets_b = [item[1] for item in decode_batch_fast_items]
+                prev_codes_b = [item[2] for item in decode_batch_fast_items]
+                slot_ids_b = [item[3] for item in decode_batch_fast_items]
+                offsets_t = torch.tensor(start_offsets_b, device=input_ids.device, dtype=torch.long)
+                ids_b = input_ids.index_select(0, offsets_t).reshape(-1)
+                batch_result = batch_decode_preprocess_fast(
+                    input_ids=ids_b,
+                    req_ids=req_ids_b,
+                    prev_codes=prev_codes_b,
+                    slot_ids=slot_ids_b,
                 )
+                if not isinstance(batch_result, tuple) or len(batch_result) != 3:
+                    raise TypeError("preprocess_decode_batch_fast must return (input_ids, embeds, updates)")
+                req_input_ids, req_embeds, updates = batch_result
                 if inputs_embeds is None:
                     inputs_embeds = torch.empty(
                         (input_ids.shape[0], req_embeds.shape[-1]),
@@ -1736,26 +1760,134 @@ class OmniGPUModelRunner(GPUModelRunner):
                         dtype=req_embeds.dtype,
                     )
 
-                if self.has_talker_mtp and span_len == 1 and not is_prefill:
-                    last_talker_hidden, text_step = update_dict.pop("mtp_inputs")
-                    decode_slice = slice(len(decode_req_ids), len(decode_req_ids) + 1)
-                    self.talker_mtp_input_ids.gpu[decode_slice].copy_(req_input_ids)
-                    self.talker_mtp_inputs_embeds.gpu[decode_slice].copy_(req_embeds)
-                    self.last_talker_hidden.gpu[decode_slice].copy_(last_talker_hidden)
-                    self.text_step.gpu[decode_slice].copy_(text_step)
-                    decode_req_ids.append(req_id)
-                    decode_start_offsets.append(s)
+                if offsets_t.device != req_embeds.device:
+                    offsets_t = offsets_t.to(device=req_embeds.device)
+                inputs_embeds.index_copy_(0, offsets_t, req_embeds)
+                input_ids.index_copy_(0, offsets_t, req_input_ids.reshape(-1).to(dtype=input_ids.dtype))
 
-                # TODO(Peiqi): the merge stage could move out from the critical path
-                self._merge_additional_information_update(req_id, update_dict)
+                for req_id_b, update_dict_b in zip(req_ids_b, updates, strict=True):
+                    if not update_dict_b:
+                        continue
+                    if isinstance(update_dict_b, dict) and len(update_dict_b) == 1 and "_kv_slot_id" in update_dict_b:
+                        existing = self.model_intermediate_buffer.setdefault(req_id_b, {})
+                        slot_id = update_dict_b["_kv_slot_id"]
+                        if existing.get("_kv_slot_id") != slot_id:
+                            existing["_kv_slot_id"] = slot_id
+                            req_state = self.requests.get(req_id_b)
+                            if req_state is not None:
+                                setattr(req_state, "additional_information_cpu", existing)
+                    else:
+                        self._merge_additional_information_update(req_id_b, update_dict_b)
+                decode_batch_fast_items.clear()
 
-                # update the inputs_embeds and input_ids
-                seg_len = min(span_len, req_embeds.shape[0])
-                inputs_embeds[s : s + seg_len] = req_embeds[:seg_len]
-                if isinstance(req_input_ids, torch.Tensor) and req_input_ids.numel() == seg_len:
-                    input_ids[s : s + seg_len] = req_input_ids
+            handled_bulk_fast_decode = False
+            if (
+                callable(batch_decode_preprocess_fast)
+                and input_ids is not None
+                and len(self.input_batch.req_ids) > 1
+                and bool(np.all(num_scheduled_tokens_np[: len(self.input_batch.req_ids)] == 1))
+            ):
+                try:
+                    start_offsets = self.query_start_loc.cpu[: len(self.input_batch.req_ids)].tolist()
+                    num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu[: len(self.input_batch.req_ids)]
+                    fast_items: list[tuple[str, int, Any, Any]] = []
+                    for req_index, req_id in enumerate(self.input_batch.req_ids):
+                        req_infos = self.model_intermediate_buffer.get(req_id, {})
+                        if not isinstance(req_infos, dict):
+                            raise TypeError("model_intermediate_buffer entry is not a dict")
+                        req_state = self.requests.get(req_id)
+                        if req_state is None:
+                            raise ValueError("bulk fast decode saw a missing request state")
+                        prompt_token_ids = getattr(req_state, "prompt_token_ids", ()) if req_state is not None else ()
+                        prompt_len = len(prompt_token_ids or ())
+                        num_computed_tokens = int(num_computed_tokens_cpu[req_index])
+                        if num_computed_tokens < prompt_len:
+                            raise ValueError("bulk fast decode saw a prefill row")
+                        audio_codes = req_infos.get("audio_codes", {})
+                        prev_codes = audio_codes.get("current") if isinstance(audio_codes, dict) else None
+                        fast_items.append(
+                            (
+                                req_id,
+                                int(start_offsets[req_index]),
+                                prev_codes,
+                                req_infos.get("_kv_slot_id"),
+                            )
+                        )
+                    decode_batch_fast_items.extend(fast_items)
+                    flush_decode_batch_fast()
+                    handled_bulk_fast_decode = True
+                except Exception:
+                    decode_batch_fast_items.clear()
+                    handled_bulk_fast_decode = False
+
+            if not handled_bulk_fast_decode:
+                for req_index, req_id in enumerate(self.input_batch.req_ids):
+                    req_infos = self.model_intermediate_buffer.get(req_id, {})
+
+                    # mimo-audio check
+                    req_state = self.requests.get(req_id)
+                    req_infos = self._maybe_attach_mimo_audio_req_infos(req_state, req_infos, req_id)
+
+                    start_offset = int(self.query_start_loc.cpu[req_index])
+                    sched_tokens = int(num_scheduled_tokens_np[req_index])
+                    s, e = start_offset, start_offset + sched_tokens
+                    span_len = int(e) - int(s)
+
+                    prompt_token_ids = getattr(req_state, "prompt_token_ids", ()) if req_state is not None else ()
+                    prompt_len = len(prompt_token_ids or ())
+                    num_computed_tokens = int(self.input_batch.num_computed_tokens_cpu[req_index])
+                    is_prefill = num_computed_tokens < prompt_len
+                    if callable(batch_decode_preprocess_fast) and span_len == 1 and not is_prefill:
+                        audio_codes = req_infos.get("audio_codes", {}) if isinstance(req_infos, dict) else {}
+                        prev_codes = audio_codes.get("current") if isinstance(audio_codes, dict) else None
+                        slot_id = req_infos.get("_kv_slot_id") if isinstance(req_infos, dict) else None
+                        decode_batch_fast_items.append((req_id, s, prev_codes, slot_id))
+                        continue
+
+                    # call the custom process function
+                    req_infos["request_id"] = req_id
+                    req_infos["_omni_prompt_len"] = prompt_len
+                    req_infos["_omni_num_computed_tokens"] = num_computed_tokens
+                    req_infos["_omni_is_prefill"] = is_prefill
+                    if callable(batch_decode_preprocess) and span_len == 1 and not is_prefill:
+                        decode_batch_items.append((req_id, s, req_infos))
+                        continue
+
+                    flush_decode_batch_fast()
+                    flush_decode_batch()
+
+                    embed_slice = inputs_embeds[s:e] if inputs_embeds is not None else None
+                    req_input_ids, req_embeds, update_dict = self.model.preprocess(
+                        input_ids=input_ids[s:e], input_embeds=embed_slice, **req_infos
+                    )
+                    if inputs_embeds is None:
+                        inputs_embeds = torch.empty(
+                            (input_ids.shape[0], req_embeds.shape[-1]),
+                            device=req_embeds.device,
+                            dtype=req_embeds.dtype,
+                        )
+
+                    if self.has_talker_mtp and span_len == 1 and not is_prefill:
+                        last_talker_hidden, text_step = update_dict.pop("mtp_inputs")
+                        decode_slice = slice(len(decode_req_ids), len(decode_req_ids) + 1)
+                        self.talker_mtp_input_ids.gpu[decode_slice].copy_(req_input_ids)
+                        self.talker_mtp_inputs_embeds.gpu[decode_slice].copy_(req_embeds)
+                        self.last_talker_hidden.gpu[decode_slice].copy_(last_talker_hidden)
+                        self.text_step.gpu[decode_slice].copy_(text_step)
+                        decode_req_ids.append(req_id)
+                        decode_start_offsets.append(s)
+
+                    # TODO(Peiqi): the merge stage could move out from the critical path
+                    self._merge_additional_information_update(req_id, update_dict)
+
+                    # update the inputs_embeds and input_ids
+                    seg_len = min(span_len, req_embeds.shape[0])
+                    inputs_embeds[s : s + seg_len] = req_embeds[:seg_len]
+                    if isinstance(req_input_ids, torch.Tensor) and req_input_ids.numel() == seg_len:
+                        input_ids[s : s + seg_len] = req_input_ids
 
             flush_decode_batch()
+            flush_decode_batch_fast()
 
             # run talker mtp decode
             if self.has_talker_mtp:
@@ -1876,6 +2008,23 @@ class OmniGPUModelRunner(GPUModelRunner):
             update_dict = {out_key[0]: {out_key[1]: code_predictor_codes[idx : idx + 1]}}
             self._merge_additional_information_update(req_id, update_dict)
 
+    def _maybe_make_omni_output_from_runner(
+        self,
+        model_output: torch.Tensor | OmniOutput,
+        model_kwargs: dict[str, Any],
+        model_kwargs_extra: dict[str, Any],
+    ) -> torch.Tensor | OmniOutput:
+        if isinstance(model_output, OmniOutput):
+            return model_output
+        kwargs = dict(model_kwargs)
+        kwargs.update(model_kwargs_extra)
+        if hasattr(self.model, "make_omni_output"):
+            return self.model.make_omni_output(model_output, **kwargs)
+        decode_omni_frame_output = getattr(self.model, "decode_omni_frame_output", None)
+        if callable(decode_omni_frame_output):
+            return decode_omni_frame_output(model_output, **kwargs)
+        return model_output
+
     def _model_forward(
         self,
         input_ids: torch.Tensor | None = None,
@@ -1903,8 +2052,11 @@ class OmniGPUModelRunner(GPUModelRunner):
             **model_kwargs,
             **model_kwargs_extra,
         )
-        if not isinstance(model_output, OmniOutput) and hasattr(self.model, "make_omni_output"):
-            model_output = self.model.make_omni_output(model_output, **model_kwargs, **model_kwargs_extra)
+        model_output = self._maybe_make_omni_output_from_runner(
+            model_output,
+            model_kwargs,
+            model_kwargs_extra,
+        )
         # Cache model output so later sample_tokens can consume multimodal results.
         self._omni_last_model_output = model_output
         return model_output

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -16,6 +16,7 @@ import importlib
 import inspect
 import os
 import threading
+import time
 from collections import defaultdict, deque
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -110,7 +111,7 @@ class OmniConnectorModelRunnerMixin:
 
         self._custom_process_func_path, self._custom_process_func = self._load_custom_func(model_config)
         self._custom_process_supports_is_finished = self._custom_process_supports_is_finished_kwarg()
-        logger.debug(
+        logger.info(
             "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, connector=%s, func_path=%s",
             self._stage_id,
             self._async_chunk,
@@ -190,6 +191,7 @@ class OmniConnectorModelRunnerMixin:
         self._kv_triggered_requests: set[str] = set()
 
         self._lock = threading.Lock()
+        self._poll_lock = threading.Lock()
         self._stop_event = threading.Event()
         self._work_available = threading.Event()
 
@@ -216,6 +218,104 @@ class OmniConnectorModelRunnerMixin:
         # only after every field above has been bound, so a partially
         # constructed mixin is never observable as initialised.
         self._omni_connector_initialized = True
+
+    @staticmethod
+    def _stage1_coalesce_delay_s() -> float:
+        raw = (
+            os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_MS")
+            or os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_WINDOW_MS")
+            or os.environ.get("OMNI_CONNECTOR_COALESCE_MS")
+            or "0"
+        )
+        try:
+            return max(float(raw), 0.0) / 1000.0
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def _stage1_coalesce_target() -> int:
+        raw = os.environ.get("MOSS_TTS_LOCAL_STAGE1_COALESCE_TARGET") or os.environ.get(
+            "OMNI_CONNECTOR_COALESCE_TARGET"
+        )
+        if not raw:
+            return 0
+        try:
+            return max(int(raw), 0)
+        except ValueError:
+            return 0
+
+    def _maybe_coalesce_ready_payloads(self) -> None:
+        """Briefly wait for nearby connector arrivals to improve Stage1 batches.
+
+        This is intentionally gated and only runs after at least one payload is
+        already ready. It trades a tiny admission delay for fewer single-request
+        generation-stage forwards when many upstream requests finish within the
+        same few milliseconds.
+        """
+        delay_s = self._stage1_coalesce_delay_s()
+        if delay_s <= 0 or self._stage_id <= 0 or self._model_mode == "ar":
+            return
+        max_batch = int(getattr(getattr(self, "scheduler_config", None), "max_num_seqs", 0) or 0)
+        target_batch = self._stage1_coalesce_target()
+        if target_batch <= 0:
+            target_batch = max_batch
+        elif max_batch > 0:
+            target_batch = min(target_batch, max_batch)
+        deadline = time.perf_counter() + delay_s
+        sleep_step = min(0.0005, delay_s)
+        while True:
+            with self._lock:
+                ready = (
+                    len(self._finished_load_reqs)
+                    + len(self._full_payload_pending_broadcast_req_ids)
+                    + len(self._stage_recv_req_ids)
+                )
+                pending = len(self._pending_load_reqs)
+            if ready <= 0 or pending <= 0 or (target_batch > 0 and ready >= target_batch):
+                return
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                return
+            time.sleep(min(sleep_step, remaining))
+
+    @staticmethod
+    def _stage1_sync_drain_enabled() -> bool:
+        raw = os.environ.get("MOSS_TTS_LOCAL_STAGE1_SYNC_DRAIN", "1")
+        return raw.strip().lower() not in ("0", "false", "no", "off")
+
+    def _drain_ready_full_payloads_once(self) -> None:
+        """Synchronously poll already-ready Stage1 payloads without sleeping.
+
+        The background recv thread is still the normal path. This opportunistic
+        drain closes the admission window where Stage 0 has already written
+        several payloads to SHM but Stage 1 reaches execute_model before
+        the recv thread publishes them to scheduler-visible ready sets.
+        Connector ``get`` is non-blocking for SharedMemoryConnector, so this
+        trades bounded metadata polling for larger same-cycle Stage 1 batches.
+        """
+        if (
+            not self._stage1_sync_drain_enabled()
+            or self._stage_id <= 0
+            or self._model_mode == "ar"
+            or self._omni_connector is None
+        ):
+            return
+        with self._lock:
+            pending_ids = list(self._pending_load_reqs.keys())
+        if not pending_ids:
+            return
+        max_batch = int(getattr(getattr(self, "scheduler_config", None), "max_num_seqs", 0) or 0)
+        if max_batch > 0:
+            pending_ids = pending_ids[:max_batch]
+        with self._poll_lock:
+            for req_id in pending_ids:
+                with self._lock:
+                    if req_id not in self._pending_load_reqs:
+                        continue
+                try:
+                    self._poll_single_request(req_id)
+                except Exception:
+                    logger.warning("Error synchronously draining data for %s", req_id, exc_info=True)
 
     def shutdown_omni_connectors(self) -> None:
         """Stop background threads and release connector resources."""
@@ -698,10 +798,12 @@ class OmniConnectorModelRunnerMixin:
         # returns its input unchanged under the same world_size<=1 condition,
         # so the original code path was a no-op here on every empty step.
         tp_group = self._get_local_tp_group()
+        self._drain_ready_full_payloads_once()
         if (
             tp_group is None or getattr(tp_group, "world_size", 1) <= 1
         ) and not self._full_payload_pending_broadcast_req_ids:
             return None
+        self._maybe_coalesce_ready_payloads()
         with self._lock:
             results = self._collect_full_payload_results_locked() if self.is_data_transfer_rank() else None
         results = self._broadcast_tp_payload_packet(results)
@@ -721,6 +823,18 @@ class OmniConnectorModelRunnerMixin:
             list(results.keys()),
             self._stage_recv_req_ids,
         )
+        if os.environ.get("MOSS_TTS_LOCAL_STAGE1_ADMISSION_PROFILE") == "1":
+            with self._lock:
+                pending_load = len(self._pending_load_reqs)
+                pending_broadcast = len(self._full_payload_pending_broadcast_req_ids)
+                stage_recv = len(self._stage_recv_req_ids)
+            logger.info(
+                "[moss-stage1-admission] connector consumed=%d pending_load=%d pending_broadcast=%d stage_recv=%d",
+                len(results),
+                pending_load,
+                pending_broadcast,
+                stage_recv,
+            )
         return results
 
     def _get_model_config(self) -> Any:
@@ -1154,7 +1268,7 @@ class OmniConnectorModelRunnerMixin:
         connector_put_key = f"{request_id}_{self._stage_id}_{chunk_id}"
 
         if chunk_id == 0:
-            logger.debug(
+            logger.info(
                 "[Stage-%s] send_chunk: first chunk enqueued, req=%s key=%s",
                 self._stage_id,
                 request_id,
@@ -1252,7 +1366,7 @@ class OmniConnectorModelRunnerMixin:
 
         active_requests = getattr(self, "requests", None)
         if active_requests is not None and request_id not in active_requests:
-            logger.debug("Skip receiving KV cache for inactive request %s", request_id)
+            logger.info("Skip receiving KV cache for inactive request %s", request_id)
             return False
 
         primary_ok = False
@@ -1272,7 +1386,7 @@ class OmniConnectorModelRunnerMixin:
                 if cfg_kvs and hasattr(req, "sampling_params") and req.sampling_params is not None:
                     for key, value in cfg_kvs.items():
                         setattr(req.sampling_params, key, value)
-                    logger.debug("Applied CFG KV caches: %s", list(cfg_kvs.keys()))
+                    logger.info("Applied CFG KV caches: %s", list(cfg_kvs.keys()))
             except Exception:
                 logger.exception("Failed to collect CFG KV caches for %s", request_id)
 
@@ -1530,6 +1644,10 @@ class OmniConnectorModelRunnerMixin:
             return OmniConnectorOutput()
 
         tp_group = self._get_local_tp_group()
+        if self._async_chunk and not (tp_group is not None and getattr(tp_group, "world_size", 1) > 1):
+            self._drain_ready_full_payloads_once()
+        if not (self._async_chunk and tp_group is not None and getattr(tp_group, "world_size", 1) > 1):
+            self._maybe_coalesce_ready_payloads()
         if self._async_chunk and tp_group is not None and getattr(tp_group, "world_size", 1) > 1:
             if self.is_data_transfer_rank():
                 with self._lock:
@@ -1657,7 +1775,7 @@ class OmniConnectorModelRunnerMixin:
 
             _recv_poll_count += 1
             if _recv_poll_count % 5000 == 1:
-                logger.debug(
+                logger.info(
                     "[Stage-%s] _recv_loop: polling %s pending reqs: %s (poll#%s)",
                     self._stage_id,
                     len(pending_ids),
@@ -1670,7 +1788,8 @@ class OmniConnectorModelRunnerMixin:
                 if self._stop_event.is_set():
                     break
                 try:
-                    made_progress = self._poll_single_request(req_id) or made_progress
+                    with self._poll_lock:
+                        made_progress = self._poll_single_request(req_id) or made_progress
                 except Exception:
                     logger.warning("Error receiving data for %s", req_id, exc_info=True)
 
@@ -2117,6 +2236,7 @@ class OmniConnectorModelRunnerMixin:
             "output_token_ids",
             "all_token_ids",
             "additional_information",
+            "additional_information_cpu",
             "sampling_params",
             "multi_modal_data",
             "mm_hashes",


### PR DESCRIPTION
## Purpose

Add a high-performance native vLLM backbone variant for MOSS-TTS-Local-Transformer-v1.5 that achieves ~9x decode speedup over the HF-compatible eager path.

## Changes

### `MossTTSLocalNativeModel` (new)
- Replaces custom `MossTTSLocalQwen3Backbone` with vLLM's compiled `Qwen3Model` (gets paged attention + torch.compile + CUDA graph automatically)
- Adds full-frame CUDA graph for the local transformer: all 13 RVQ steps (LN→QKV→RoPE→attention→MLP per step) captured as a single graph replay
- Adds `max_new_frames` hard guard (default 150 frames = 12.5s) to prevent runaway generation when stop token is not sampled
- Records `stop_reason` (model_stop / max_new_frames) in audio_state for observability

### `local_transformer.py` enhancements
- Extracts `_step_eager()` as pure computation (no graph logic)
- Adds `enable_graphs(batch_size)` for static buffer pre-allocation
- Per-`(batch_size, position)` CUDA graph capture/replay in `step()`

### Pipeline / Registry
- `MOSS_TTS_LOCAL_NATIVE_PIPELINE` in `pipeline.py`
- `MossTTSLocalNativeModel` in model registry
- `pipeline_registry.py` selects native vs original based on `MOSS_TTS_LOCAL_NATIVE=1` env var

## Performance

Tested on H20 (single GPU), `enforce_eager=false`:

| Metric | HF-compatible (v1) | Native (this PR) |
|--------|--------------------|--------------------|
| Per-token latency | ~30 ms | **~3.3 ms** |
| Single-request p50 | ~1.0 s | **0.32 s** |
| Throughput (c=8) | ~0.2 req/s | **0.82 req/s** |

## Deployment

```bash
MOSS_TTS_LOCAL_NATIVE=1 python -m vllm_omni.entrypoints.cli.main serve \
  OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
  --omni --deploy-config vllm_omni/deploy/moss_tts_local.yaml
```

Stage 0 config should use `enforce_eager: false` to enable torch.compile + CUDA graph for the backbone.

## Test Plan

- [x] Single request produces valid non-silent PCM audio (RMS > 100, peak > 1000)
- [x] 5 sequential requests all succeed with audio 5-15s for short prompts
- [x] `max_new_frames` guard prevents generation > 12.5s (was 6% too_long without guard)
- [x] Concurrent c=2 requests: 6/6 succeed with no state corruption
- [x] Zero errors in service logs after warmup
- [x] First request includes graph capture warmup (~5s), subsequent requests steady-state (~0.3-0.7s)
