### PR TITLE
[feat] Add Krea 2 text-to-image diffusion model support

### DIFF
--- a/examples/offline_inference/text_to_image/krea2_generate.py
+++ b/examples/offline_inference/text_to_image/krea2_generate.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Generate images with Krea 2 (base or distilled/TDM checkpoint).
+
+Usage:
+    # Base model (28 steps, guidance 4.5)
+    python krea2_generate.py --model krea-ai/krea-2-medium
+
+    # Distilled / TDM model (8 steps, no CFG)
+    python krea2_generate.py --model krea-ai/krea-2-medium-tdm \
+        --steps 8 --guidance 0.0
+
+    # Custom prompt and resolution
+    python krea2_generate.py --model krea-ai/krea-2-large \
+        --prompt "a serene Vermont mountain lake at dawn" \
+        --height 768 --width 1360
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import torch
+
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.platforms import current_omni_platform
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Krea 2 text-to-image generation")
+    p.add_argument("--model", default="krea-ai/krea-2-medium",
+                   help="HF repo or local path to a Krea 2 checkpoint.")
+    p.add_argument("--prompt", default="a cup of coffee on the table",
+                   help="Text prompt for image generation.")
+    p.add_argument("--negative-prompt", default=None,
+                   help="Negative prompt for CFG (ignored when guidance=0).")
+    p.add_argument("--steps", type=int, default=28,
+                   help="Number of denoising steps (28 base, 8 distilled).")
+    p.add_argument("--guidance", type=float, default=4.5,
+                   help="Guidance scale (4.5 base, 0 distilled).")
+    p.add_argument("--height", type=int, default=1024)
+    p.add_argument("--width", type=int, default=1024)
+    p.add_argument("--seed", type=int, default=142)
+    p.add_argument("--output", default="krea2_output.png",
+                   help="Output image path.")
+    p.add_argument("--num-images", type=int, default=1,
+                   help="Number of images to generate per prompt.")
+    p.add_argument("--quantization", type=str, default=None,
+                   choices=["fp8", "int8"],
+                   help="Quantization method for the transformer.")
+    p.add_argument("--cfg-parallel-size", type=int, default=1,
+                   choices=[1, 2],
+                   help="GPUs used for CFG parallelism.")
+    p.add_argument("--tensor-parallel-size", type=int, default=1,
+                   help="GPUs used for tensor parallelism.")
+    p.add_argument("--enforce-eager", action="store_true",
+                   help="Disable torch.compile.")
+    p.add_argument("--enable-cpu-offload", action="store_true")
+    current_omni_platform.pre_register_and_update(p)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    generator = torch.Generator(
+        device=current_omni_platform.device_type
+    ).manual_seed(args.seed)
+
+    is_distilled = "tdm" in args.model.lower() or "distill" in args.model.lower()
+    if is_distilled and args.steps == 28:
+        args.steps = 8
+    if is_distilled and args.guidance == 4.5:
+        args.guidance = 0.0
+
+    omni_kwargs = {
+        "model": args.model,
+        "mode": "text-to-image",
+        "cfg_parallel_size": args.cfg_parallel_size,
+        "tensor_parallel_size": args.tensor_parallel_size,
+        "enforce_eager": args.enforce_eager,
+        "enable_cpu_offload": args.enable_cpu_offload,
+    }
+    if is_distilled:
+        omni_kwargs["model_config"] = {"is_distilled": True}
+    if args.quantization:
+        omni_kwargs["quantization"] = args.quantization
+
+    omni = Omni(**omni_kwargs)
+
+    prompt_dict = {"prompt": args.prompt}
+    if args.negative_prompt:
+        prompt_dict["negative_prompt"] = args.negative_prompt
+
+    sampling_params = OmniDiffusionSamplingParams(
+        height=args.height,
+        width=args.width,
+        seed=args.seed,
+        generator=generator,
+        guidance_scale=args.guidance,
+        num_inference_steps=args.steps,
+        num_outputs_per_prompt=args.num_images,
+    )
+
+    print(f"Generating with Krea 2 ({'distilled' if is_distilled else 'base'})")
+    print(f"  Steps: {args.steps}  Guidance: {args.guidance}")
+    print(f"  Size: {args.width}x{args.height}  Seed: {args.seed}")
+
+    t0 = time.perf_counter()
+    outputs = omni.generate(prompt_dict, sampling_params_list=[sampling_params])
+    elapsed = time.perf_counter() - t0
+    print(f"Generated in {elapsed:.2f}s")
+
+    images = None
+    for output in outputs:
+        images = getattr(output, "images", None)
+        if images:
+            break
+        req_out = getattr(output, "request_output", None)
+        images = getattr(req_out, "images", None) if req_out else None
+        if images:
+            break
+
+    if not images:
+        raise ValueError("No images found in output")
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if len(images) == 1:
+        images[0].save(out)
+        print(f"Saved to {out}")
+    else:
+        for i, img in enumerate(images):
+            p = out.parent / f"{out.stem}_{i}{out.suffix or '.png'}"
+            img.save(p)
+            print(f"Saved to {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/text_to_image/krea2_generate.py
+++ b/examples/offline_inference/text_to_image/krea2_generate.py
@@ -29,33 +29,26 @@ from vllm_omni.platforms import current_omni_platform
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Krea 2 text-to-image generation")
-    p.add_argument("--model", default="krea-ai/krea-2-medium",
-                   help="HF repo or local path to a Krea 2 checkpoint.")
-    p.add_argument("--prompt", default="a cup of coffee on the table",
-                   help="Text prompt for image generation.")
-    p.add_argument("--negative-prompt", default=None,
-                   help="Negative prompt for CFG (ignored when guidance=0).")
-    p.add_argument("--steps", type=int, default=28,
-                   help="Number of denoising steps (28 base, 8 distilled).")
-    p.add_argument("--guidance", type=float, default=4.5,
-                   help="Guidance scale (4.5 base, 0 distilled).")
+    p.add_argument("--model", default="krea-ai/krea-2-medium", help="HF repo or local path to a Krea 2 checkpoint.")
+    p.add_argument("--prompt", default="a cup of coffee on the table", help="Text prompt for image generation.")
+    p.add_argument("--negative-prompt", default=None, help="Negative prompt for CFG (ignored when guidance=0).")
+    p.add_argument("--steps", type=int, default=28, help="Number of denoising steps (28 base, 8 distilled).")
+    p.add_argument("--guidance", type=float, default=4.5, help="Guidance scale (4.5 base, 0 distilled).")
     p.add_argument("--height", type=int, default=1024)
     p.add_argument("--width", type=int, default=1024)
     p.add_argument("--seed", type=int, default=142)
-    p.add_argument("--output", default="krea2_output.png",
-                   help="Output image path.")
-    p.add_argument("--num-images", type=int, default=1,
-                   help="Number of images to generate per prompt.")
-    p.add_argument("--quantization", type=str, default=None,
-                   choices=["fp8", "int8"],
-                   help="Quantization method for the transformer.")
-    p.add_argument("--cfg-parallel-size", type=int, default=1,
-                   choices=[1, 2],
-                   help="GPUs used for CFG parallelism.")
-    p.add_argument("--tensor-parallel-size", type=int, default=1,
-                   help="GPUs used for tensor parallelism.")
-    p.add_argument("--enforce-eager", action="store_true",
-                   help="Disable torch.compile.")
+    p.add_argument("--output", default="krea2_output.png", help="Output image path.")
+    p.add_argument("--num-images", type=int, default=1, help="Number of images to generate per prompt.")
+    p.add_argument(
+        "--quantization",
+        type=str,
+        default=None,
+        choices=["fp8", "int8"],
+        help="Quantization method for the transformer.",
+    )
+    p.add_argument("--cfg-parallel-size", type=int, default=1, choices=[1, 2], help="GPUs used for CFG parallelism.")
+    p.add_argument("--tensor-parallel-size", type=int, default=1, help="GPUs used for tensor parallelism.")
+    p.add_argument("--enforce-eager", action="store_true", help="Disable torch.compile.")
     p.add_argument("--enable-cpu-offload", action="store_true")
     current_omni_platform.pre_register_and_update(p)
     return p.parse_args()
@@ -63,9 +56,7 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
-    generator = torch.Generator(
-        device=current_omni_platform.device_type
-    ).manual_seed(args.seed)
+    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
 
     is_distilled = "tdm" in args.model.lower() or "distill" in args.model.lower()
     if is_distilled and args.steps == 28:

--- a/examples/offline_inference/text_to_image/krea2_generate.py
+++ b/examples/offline_inference/text_to_image/krea2_generate.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Generate images with Krea 2 (base or distilled/TDM checkpoint).
+"""Generate images with Krea 2 (base or distilled/Turbo checkpoint).
+
+Note: Krea 2 weights are released under the Krea 2 Community License.
+See the model card at https://huggingface.co/krea/Krea-2-Raw for details.
 
 Usage:
     # Base model (28 steps, guidance 4.5)
-    python krea2_generate.py --model krea-ai/krea-2-medium
+    python krea2_generate.py --model krea/Krea-2-Raw
 
-    # Distilled / TDM model (8 steps, no CFG)
-    python krea2_generate.py --model krea-ai/krea-2-medium-tdm \
-        --steps 8 --guidance 0.0
+    # Distilled / Turbo model (8 steps, no CFG — auto-detected from name)
+    python krea2_generate.py --model krea/Krea-2-Turbo
 
     # Custom prompt and resolution
-    python krea2_generate.py --model krea-ai/krea-2-large \
+    python krea2_generate.py --model krea/Krea-2-Raw \
         --prompt "a serene Vermont mountain lake at dawn" \
         --height 768 --width 1360
 """
@@ -29,7 +31,7 @@ from vllm_omni.platforms import current_omni_platform
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Krea 2 text-to-image generation")
-    p.add_argument("--model", default="krea-ai/krea-2-medium", help="HF repo or local path to a Krea 2 checkpoint.")
+    p.add_argument("--model", default="krea/Krea-2-Raw", help="HF repo or local path to a Krea 2 checkpoint.")
     p.add_argument("--prompt", default="a cup of coffee on the table", help="Text prompt for image generation.")
     p.add_argument("--negative-prompt", default=None, help="Negative prompt for CFG (ignored when guidance=0).")
     p.add_argument("--steps", type=int, default=28, help="Number of denoising steps (28 base, 8 distilled).")
@@ -39,13 +41,6 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=142)
     p.add_argument("--output", default="krea2_output.png", help="Output image path.")
     p.add_argument("--num-images", type=int, default=1, help="Number of images to generate per prompt.")
-    p.add_argument(
-        "--quantization",
-        type=str,
-        default=None,
-        choices=["fp8", "int8"],
-        help="Quantization method for the transformer.",
-    )
     p.add_argument("--cfg-parallel-size", type=int, default=1, choices=[1, 2], help="GPUs used for CFG parallelism.")
     p.add_argument("--tensor-parallel-size", type=int, default=1, help="GPUs used for tensor parallelism.")
     p.add_argument("--enforce-eager", action="store_true", help="Disable torch.compile.")
@@ -58,7 +53,7 @@ def main():
     args = parse_args()
     generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
 
-    is_distilled = "tdm" in args.model.lower() or "distill" in args.model.lower()
+    is_distilled = "turbo" in args.model.lower() or "tdm" in args.model.lower() or "distill" in args.model.lower()
     if is_distilled and args.steps == 28:
         args.steps = 8
     if is_distilled and args.guidance == 4.5:
@@ -74,9 +69,6 @@ def main():
     }
     if is_distilled:
         omni_kwargs["model_config"] = {"is_distilled": True}
-    if args.quantization:
-        omni_kwargs["quantization"] = args.quantization
-
     omni = Omni(**omni_kwargs)
 
     prompt_dict = {"prompt": args.prompt}

--- a/tests/diffusion/models/krea2/__init__.py
+++ b/tests/diffusion/models/krea2/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/diffusion/models/krea2/test_krea2_structure.py
+++ b/tests/diffusion/models/krea2/test_krea2_structure.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Structural tests for the Krea 2 transformer and utilities.
+
+Verifies parameter naming, weight-name compatibility with diffusers
+checkpoints, and correct shapes for the attention / text-fusion modules.
+"""
+
+import os
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+_HIDDEN = 128
+_HEADS = 4
+_KV_HEADS = 2
+_HEAD_DIM = _HIDDEN // _HEADS
+_INTERMEDIATE = 256
+_TEXT_DIM = 64
+_TEXT_LAYERS = 3
+_TEXT_HEADS = 2
+_TEXT_KV_HEADS = 2
+_TEXT_INTERMEDIATE = 128
+_IN_CHANNELS = 16
+_NUM_BLOCKS = 2
+
+
+@pytest.fixture(autouse=True)
+def _init_distributed():
+    from vllm.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29503")
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method="env://",
+    )
+    initialize_model_parallel()
+    yield
+    cleanup_dist_env_and_memory()
+
+
+def _param_names(module) -> set[str]:
+    return {name for name, _ in module.named_parameters()}
+
+
+def test_krea2_rmsnorm_zero_centered():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2RMSNorm
+
+    norm = Krea2RMSNorm(32)
+    assert torch.allclose(norm.weight, torch.zeros(32))
+    x = torch.randn(2, 4, 32)
+    out = norm(x)
+    assert out.shape == x.shape
+
+
+def test_krea2_attention_separate_qkv():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2Attention
+
+    attn = Krea2Attention(_HIDDEN, _HEADS, _KV_HEADS)
+    params = _param_names(attn)
+
+    assert "to_q.weight" in params
+    assert "to_k.weight" in params
+    assert "to_v.weight" in params
+    assert "to_gate.weight" in params
+    assert "norm_q.weight" in params
+    assert "norm_k.weight" in params
+    assert "to_out.0.weight" in params
+    assert "to_q.bias" not in params
+    assert "to_k.bias" not in params
+
+
+def test_krea2_swiglu_no_bias():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2SwiGLU
+
+    ff = Krea2SwiGLU(_HIDDEN, _INTERMEDIATE)
+    params = _param_names(ff)
+
+    assert "gate.weight" in params
+    assert "up.weight" in params
+    assert "down.weight" in params
+    assert "gate.bias" not in params
+
+
+def test_krea2_text_fusion_block_structure():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2TextFusionBlock
+
+    block = Krea2TextFusionBlock(
+        _TEXT_DIM, _TEXT_HEADS, _TEXT_KV_HEADS, _TEXT_INTERMEDIATE, eps=1e-5
+    )
+    params = _param_names(block)
+
+    assert "norm1.weight" in params
+    assert "norm2.weight" in params
+    assert "attn.to_q.weight" in params
+    assert "ff.gate.weight" in params
+
+
+def test_krea2_text_fusion_forward():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2TextFusion
+
+    fusion = Krea2TextFusion(
+        num_text_layers=_TEXT_LAYERS,
+        dim=_TEXT_DIM,
+        num_heads=_TEXT_HEADS,
+        num_kv_heads=_TEXT_KV_HEADS,
+        intermediate_size=_TEXT_INTERMEDIATE,
+        num_layerwise_blocks=1,
+        num_refiner_blocks=1,
+        eps=1e-5,
+    )
+    B, S = 2, 8
+    x = torch.randn(B, S, _TEXT_LAYERS, _TEXT_DIM)
+    out = fusion(x)
+    assert out.shape == (B, S, _TEXT_DIM)
+
+    params = _param_names(fusion)
+    assert "projector.weight" in params
+    assert "layerwise_blocks.0.norm1.weight" in params
+    assert "refiner_blocks.0.norm1.weight" in params
+
+
+def test_krea2_transformer_block_params():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2TransformerBlock
+
+    block = Krea2TransformerBlock(
+        hidden_size=_HIDDEN,
+        intermediate_size=_INTERMEDIATE,
+        num_heads=_HEADS,
+        num_kv_heads=_KV_HEADS,
+        norm_eps=1e-5,
+    )
+    params = _param_names(block)
+
+    assert "scale_shift_table" in params
+    assert "norm1.weight" in params
+    assert "norm2.weight" in params
+    assert "attn.to_q.weight" in params
+    assert "ff.gate.weight" in params
+
+
+def test_krea2_final_layer_has_bias():
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2FinalLayer
+
+    final = Krea2FinalLayer(_HIDDEN, _IN_CHANNELS, eps=1e-5)
+    params = _param_names(final)
+
+    assert "linear.weight" in params
+    assert "linear.bias" in params
+    assert "scale_shift_table" in params
+    assert "norm.weight" in params
+
+
+def test_krea2_transformer_full_param_names():
+    """All parameter names in the full model should match diffusers checkpoint keys."""
+    from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2Transformer2DModel
+
+    model = Krea2Transformer2DModel(
+        in_channels=_IN_CHANNELS,
+        num_layers=_NUM_BLOCKS,
+        attention_head_dim=_HEAD_DIM,
+        num_attention_heads=_HEADS,
+        num_key_value_heads=_KV_HEADS,
+        intermediate_size=_INTERMEDIATE,
+        timestep_embed_dim=32,
+        text_hidden_dim=_TEXT_DIM,
+        num_text_layers=_TEXT_LAYERS,
+        text_num_attention_heads=_TEXT_HEADS,
+        text_num_key_value_heads=_TEXT_KV_HEADS,
+        text_intermediate_size=_TEXT_INTERMEDIATE,
+        num_layerwise_text_blocks=1,
+        num_refiner_text_blocks=1,
+        axes_dims_rope=(8, 12, 12),
+        rope_theta=1000.0,
+    )
+    params = _param_names(model)
+
+    expected_prefixes = [
+        "img_in.weight",
+        "img_in.bias",
+        "time_embed.linear_1.weight",
+        "time_embed.linear_1.bias",
+        "time_embed.linear_2.weight",
+        "time_embed.linear_2.bias",
+        "time_mod_proj.weight",
+        "time_mod_proj.bias",
+        "text_fusion.layerwise_blocks.0.norm1.weight",
+        "text_fusion.layerwise_blocks.0.attn.to_q.weight",
+        "text_fusion.layerwise_blocks.0.attn.to_out.0.weight",
+        "text_fusion.layerwise_blocks.0.ff.gate.weight",
+        "text_fusion.projector.weight",
+        "text_fusion.refiner_blocks.0.norm1.weight",
+        "txt_in.norm.weight",
+        "txt_in.linear_1.weight",
+        "txt_in.linear_1.bias",
+        "txt_in.linear_2.weight",
+        "txt_in.linear_2.bias",
+        "transformer_blocks.0.scale_shift_table",
+        "transformer_blocks.0.norm1.weight",
+        "transformer_blocks.0.attn.to_q.weight",
+        "transformer_blocks.0.attn.to_k.weight",
+        "transformer_blocks.0.attn.to_v.weight",
+        "transformer_blocks.0.attn.to_gate.weight",
+        "transformer_blocks.0.attn.norm_q.weight",
+        "transformer_blocks.0.attn.norm_k.weight",
+        "transformer_blocks.0.attn.to_out.0.weight",
+        "transformer_blocks.0.ff.gate.weight",
+        "transformer_blocks.0.ff.up.weight",
+        "transformer_blocks.0.ff.down.weight",
+        "final_layer.scale_shift_table",
+        "final_layer.norm.weight",
+        "final_layer.linear.weight",
+        "final_layer.linear.bias",
+    ]
+    for name in expected_prefixes:
+        assert name in params, f"Expected param '{name}' not found in model. Got: {sorted(params)}"
+
+
+def test_preprocess_pack_unpack_roundtrip():
+    from vllm_omni.diffusion.models.krea2.preprocess_krea2 import (
+        pack_latents,
+        unpack_latents,
+    )
+
+    B, C, H, W = 2, 4, 8, 8
+    latents = torch.randn(B, C, H, W)
+    packed = pack_latents(latents, B, C, H, W, patch_size=2)
+    assert packed.shape == (B, (H // 2) * (W // 2), C * 4)
+
+    unpacked = unpack_latents(packed, H * 8, W * 8, vae_scale_factor=8, patch_size=2)
+    assert unpacked.shape == (B, C, 1, H, W)
+
+
+def test_prepare_position_ids_shape():
+    from vllm_omni.diffusion.models.krea2.preprocess_krea2 import prepare_position_ids
+
+    text_len = 10
+    gh, gw = 4, 6
+    ids = prepare_position_ids(text_len, gh, gw, device=torch.device("cpu"))
+    assert ids.shape == (text_len + gh * gw, 3)
+    assert torch.all(ids[:text_len] == 0)
+
+
+def test_registry_has_krea2():
+    from vllm_omni.diffusion.registry import _DIFFUSION_MODELS, _DIFFUSION_POST_PROCESS_FUNCS
+
+    assert "Krea2Pipeline" in _DIFFUSION_MODELS
+    assert "Krea2Pipeline" in _DIFFUSION_POST_PROCESS_FUNCS

--- a/tests/diffusion/models/krea2/test_krea2_structure.py
+++ b/tests/diffusion/models/krea2/test_krea2_structure.py
@@ -94,9 +94,7 @@ def test_krea2_swiglu_no_bias():
 def test_krea2_text_fusion_block_structure():
     from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2TextFusionBlock
 
-    block = Krea2TextFusionBlock(
-        _TEXT_DIM, _TEXT_HEADS, _TEXT_KV_HEADS, _TEXT_INTERMEDIATE, eps=1e-5
-    )
+    block = Krea2TextFusionBlock(_TEXT_DIM, _TEXT_HEADS, _TEXT_KV_HEADS, _TEXT_INTERMEDIATE, eps=1e-5)
     params = _param_names(block)
 
     assert "norm1.weight" in params

--- a/tests/diffusion/models/krea2/test_krea2_structure.py
+++ b/tests/diffusion/models/krea2/test_krea2_structure.py
@@ -253,3 +253,42 @@ def test_registry_has_krea2():
 
     assert "Krea2Pipeline" in _DIFFUSION_MODELS
     assert "Krea2Pipeline" in _DIFFUSION_POST_PROCESS_FUNCS
+
+
+def test_krea2_imports():
+    from vllm_omni.diffusion.models.krea2 import Krea2Pipeline, Krea2Transformer2DModel, get_krea2_post_process_func
+
+    assert Krea2Pipeline is not None
+    assert Krea2Transformer2DModel is not None
+    assert callable(get_krea2_post_process_func)
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("krea/Krea-2-Raw", False),
+        ("krea/Krea-2-Turbo", True),
+        ("krea-ai/krea-2-medium", False),
+        ("krea-ai/krea-2-medium-tdm", True),
+        ("/local/path/krea-distilled", True),
+        ("krea/some-other-model", False),
+    ],
+)
+def test_distilled_name_detection(model_name, expected):
+    tags = ("turbo", "tdm", "distill")
+    detected = any(tag in model_name.lower() for tag in tags)
+    assert detected == expected, f"{model_name} should{'not' if not expected else ''} be detected as distilled"
+
+
+def test_denormalize_latents_no_reciprocal():
+    from vllm_omni.diffusion.models.krea2.preprocess_krea2 import denormalize_latents
+
+    latents = torch.ones(1, 4, 1, 2, 2)
+    mean = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    std = torch.tensor([2.0, 3.0, 4.0, 5.0])
+    result = denormalize_latents(latents, mean, std)
+    assert result.shape == latents.shape
+    assert torch.allclose(result[0, 0], torch.tensor(3.0))  # 1*2 + 1 = 3
+    assert torch.allclose(result[0, 1], torch.tensor(5.0))  # 1*3 + 2 = 5
+    assert torch.allclose(result[0, 2], torch.tensor(7.0))  # 1*4 + 3 = 7
+    assert torch.allclose(result[0, 3], torch.tensor(9.0))  # 1*5 + 4 = 9

--- a/tests/e2e/offline_inference/test_krea2.py
+++ b/tests/e2e/offline_inference/test_krea2.py
@@ -39,7 +39,7 @@ pytestmark_raw = [
 
 
 @pytest.mark.parametrize("omni_runner", [_RAW_RUNNER_PARAM], indirect=True)
-@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 @pytest.mark.full_model
 @pytest.mark.diffusion
 def test_krea2_raw_text_to_image(omni_runner_handler: OmniRunnerHandler):
@@ -65,7 +65,7 @@ _TURBO_RUNNER_PARAM = (MODEL_TURBO, {"model_config": {"is_distilled": True}})
 
 
 @pytest.mark.parametrize("omni_runner", [_TURBO_RUNNER_PARAM], indirect=True)
-@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 @pytest.mark.full_model
 @pytest.mark.diffusion
 def test_krea2_turbo_text_to_image(omni_runner_handler: OmniRunnerHandler):
@@ -86,7 +86,7 @@ def test_krea2_turbo_text_to_image(omni_runner_handler: OmniRunnerHandler):
 
 
 @pytest.mark.parametrize("omni_runner", [_TURBO_RUNNER_PARAM], indirect=True)
-@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 @pytest.mark.full_model
 @pytest.mark.diffusion
 def test_krea2_deterministic_seed(omni_runner_handler: OmniRunnerHandler):

--- a/tests/e2e/offline_inference/test_krea2.py
+++ b/tests/e2e/offline_inference/test_krea2.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""End-to-end tests for Krea 2 text-to-image generation.
+
+Tests both the base (Krea-2-Raw, 28-step) and distilled (Krea-2-Turbo, 8-step)
+checkpoints via the OmniRunner offline path.
+"""
+
+import pytest
+import torch
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import DiffusionResponse, OmniRunnerHandler
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.platforms import current_omni_platform
+
+MODEL_RAW = "krea/Krea-2-Raw"
+MODEL_TURBO = "krea/Krea-2-Turbo"
+
+_HEIGHT = 512
+_WIDTH = 512
+
+
+def _images_from_response(response: DiffusionResponse) -> list:
+    if isinstance(response.images[0], list):
+        return [f for fr in response.images for f in fr]
+    return list(response.images)
+
+
+# --- Base model (Krea-2-Raw) ---
+
+_RAW_RUNNER_PARAM = (MODEL_RAW, {"model_config": {}})
+
+pytestmark_raw = [
+    pytest.mark.full_model,
+    pytest.mark.diffusion,
+]
+
+
+@pytest.mark.parametrize("omni_runner", [_RAW_RUNNER_PARAM], indirect=True)
+@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@pytest.mark.full_model
+@pytest.mark.diffusion
+def test_krea2_raw_text_to_image(omni_runner_handler: OmniRunnerHandler):
+    """Test Krea-2-Raw base model text-to-image generation."""
+    omni_runner_handler.send_diffusion_request(
+        {
+            "model": MODEL_RAW,
+            "prompt": "a serene Vermont mountain lake at dawn",
+            "sampling_params": OmniDiffusionSamplingParams(
+                height=_HEIGHT,
+                width=_WIDTH,
+                num_inference_steps=28,
+                guidance_scale=4.5,
+                seed=42,
+            ),
+        }
+    )
+
+
+# --- Distilled model (Krea-2-Turbo) ---
+
+_TURBO_RUNNER_PARAM = (MODEL_TURBO, {"model_config": {"is_distilled": True}})
+
+
+@pytest.mark.parametrize("omni_runner", [_TURBO_RUNNER_PARAM], indirect=True)
+@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@pytest.mark.full_model
+@pytest.mark.diffusion
+def test_krea2_turbo_text_to_image(omni_runner_handler: OmniRunnerHandler):
+    """Test Krea-2-Turbo distilled model text-to-image generation."""
+    omni_runner_handler.send_diffusion_request(
+        {
+            "model": MODEL_TURBO,
+            "prompt": "a cup of coffee on the table",
+            "sampling_params": OmniDiffusionSamplingParams(
+                height=_HEIGHT,
+                width=_WIDTH,
+                num_inference_steps=8,
+                guidance_scale=0.0,
+                seed=42,
+            ),
+        }
+    )
+
+
+@pytest.mark.parametrize("omni_runner", [_TURBO_RUNNER_PARAM], indirect=True)
+@hardware_test(res={"cuda": "A100"}, num_cards=1)
+@pytest.mark.full_model
+@pytest.mark.diffusion
+def test_krea2_deterministic_seed(omni_runner_handler: OmniRunnerHandler):
+    """Same seed must produce pixel-identical output."""
+    seed = 12345
+
+    def _generate():
+        gen = torch.Generator(current_omni_platform.device_type).manual_seed(seed)
+        return omni_runner_handler.send_diffusion_request(
+            {
+                "model": MODEL_TURBO,
+                "prompt": "a red flower in a green field",
+                "sampling_params": OmniDiffusionSamplingParams(
+                    height=_HEIGHT,
+                    width=_WIDTH,
+                    num_inference_steps=8,
+                    guidance_scale=0.0,
+                    generator=gen,
+                    num_outputs_per_prompt=1,
+                ),
+            }
+        )
+
+    r1 = _generate()
+    r2 = _generate()
+
+    images1 = _images_from_response(r1)
+    images2 = _images_from_response(r2)
+
+    assert list(images1[0].getdata()) == list(images2[0].getdata()), (
+        "Same input with same seed should produce identical output."
+    )

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -77,6 +77,7 @@ EXCLUDED_MODELS = [
     "Gr00tN1d7Pipeline",
     "SoulXSingerPipeline",
     "SoulXSingerSVCPipeline",
+    "Krea2Pipeline",
 ]
 
 

--- a/vllm_omni/diffusion/models/krea2/__init__.py
+++ b/vllm_omni/diffusion/models/krea2/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Krea 2 diffusion model components."""
+
+from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2Transformer2DModel
+from vllm_omni.diffusion.models.krea2.pipeline_krea2 import (
+    Krea2Pipeline,
+    get_krea2_post_process_func,
+)
+
+__all__ = [
+    "Krea2Pipeline",
+    "Krea2Transformer2DModel",
+    "get_krea2_post_process_func",
+]

--- a/vllm_omni/diffusion/models/krea2/krea2_transformer.py
+++ b/vllm_omni/diffusion/models/krea2/krea2_transformer.py
@@ -33,9 +33,7 @@ class Krea2RMSNorm(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         dtype = hidden_states.dtype
-        hidden_states = F.rms_norm(
-            hidden_states.float(), (self.dim,), weight=self.weight + 1.0, eps=self.eps
-        )
+        hidden_states = F.rms_norm(hidden_states.float(), (self.dim,), weight=self.weight + 1.0, eps=self.eps)
         return hidden_states.to(dtype)
 
 
@@ -134,9 +132,7 @@ class Krea2TextFusionBlock(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = hidden_states + self.attn(
-            self.norm1(hidden_states), attention_mask=attention_mask
-        )
+        hidden_states = hidden_states + self.attn(self.norm1(hidden_states), attention_mask=attention_mask)
         hidden_states = hidden_states + self.ff(self.norm2(hidden_states))
         return hidden_states
 
@@ -186,9 +182,7 @@ class Krea2TextFusion(nn.Module):
         for block in self.layerwise_blocks:
             hidden_states = block(hidden_states.contiguous())
 
-        hidden_states = hidden_states.reshape(batch_size, seq_len, num_text_layers, dim).permute(
-            0, 1, 3, 2
-        )
+        hidden_states = hidden_states.reshape(batch_size, seq_len, num_text_layers, dim).permute(0, 1, 3, 2)
         hidden_states = self.projector(hidden_states).squeeze(-1)
 
         for block in self.refiner_blocks:
@@ -247,9 +241,7 @@ class Krea2TimestepEmbedding(nn.Module):
 
     def forward(self, timestep: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
         half = self.embed_dim // 2
-        freqs = torch.exp(
-            -math.log(1e4) * torch.arange(half, dtype=torch.float32, device=timestep.device) / half
-        )
+        freqs = torch.exp(-math.log(1e4) * torch.arange(half, dtype=torch.float32, device=timestep.device) / half)
         args = (timestep.float() * 1e3)[:, None, None] * freqs
         emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1).to(dtype)
         return self.linear_2(F.gelu(self.linear_1(emb), approximate="tanh"))
@@ -412,9 +404,7 @@ class Krea2Transformer2DModel(nn.Module):
             image_mask = encoder_attention_mask.new_ones((batch_size, image_seq_len))
             attention_mask = torch.cat([encoder_attention_mask, image_mask], dim=1)
 
-        encoder_hidden_states = self.text_fusion(
-            encoder_hidden_states, attention_mask=text_attention_mask
-        )
+        encoder_hidden_states = self.text_fusion(encoder_hidden_states, attention_mask=text_attention_mask)
         encoder_hidden_states = self.txt_in(encoder_hidden_states)
 
         hidden_states = self.img_in(hidden_states)

--- a/vllm_omni/diffusion/models/krea2/krea2_transformer.py
+++ b/vllm_omni/diffusion/models/krea2/krea2_transformer.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Krea 2 single-stream MMDiT transformer for vLLM-Omni."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.models.embeddings import get_1d_rotary_pos_embed
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.layers.rope import RotaryEmbedding, apply_rope_to_qk
+
+logger = init_logger(__name__)
+
+
+class Krea2RMSNorm(nn.Module):
+    """Zero-centered RMSNorm: effective multiplier is ``1 + weight``."""
+
+    def __init__(self, dim: int, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        dtype = hidden_states.dtype
+        hidden_states = F.rms_norm(
+            hidden_states.float(), (self.dim,), weight=self.weight + 1.0, eps=self.eps
+        )
+        return hidden_states.to(dtype)
+
+
+class Krea2Attention(nn.Module):
+    """GQA self-attention with RMSNorm on Q/K, optional RoPE, and sigmoid output gate."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int | None = None,
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.to_q = nn.Linear(hidden_size, self.head_dim * self.num_heads, bias=False)
+        self.to_k = nn.Linear(hidden_size, self.head_dim * self.num_kv_heads, bias=False)
+        self.to_v = nn.Linear(hidden_size, self.head_dim * self.num_kv_heads, bias=False)
+        self.to_gate = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.norm_q = Krea2RMSNorm(self.head_dim, eps=eps)
+        self.norm_k = Krea2RMSNorm(self.head_dim, eps=eps)
+        self.to_out = nn.ModuleList([nn.Linear(hidden_size, hidden_size, bias=False)])
+
+        self.rope = RotaryEmbedding(is_neox_style=False)
+        self.attn = Attention(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            softmax_scale=1.0 / (self.head_dim**0.5),
+            causal=False,
+            num_kv_heads=self.num_kv_heads,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        query = self.to_q(hidden_states).unflatten(-1, (self.num_heads, self.head_dim))
+        key = self.to_k(hidden_states).unflatten(-1, (self.num_kv_heads, self.head_dim))
+        value = self.to_v(hidden_states).unflatten(-1, (self.num_kv_heads, self.head_dim))
+        gate = self.to_gate(hidden_states)
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        query, key = apply_rope_to_qk(self.rope, query, key, image_rotary_emb)
+
+        attn_metadata = None
+        if attention_mask is not None:
+            attn_metadata = AttentionMetadata(attn_mask=attention_mask)
+
+        hidden_states = self.attn(query, key, value, attn_metadata)
+        hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.to(query.dtype)
+        hidden_states = hidden_states * torch.sigmoid(gate)
+        return self.to_out[0](hidden_states)
+
+
+class Krea2SwiGLU(nn.Module):
+    """SwiGLU feed-forward network."""
+
+    def __init__(self, dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.gate = nn.Linear(dim, hidden_dim, bias=False)
+        self.up = nn.Linear(dim, hidden_dim, bias=False)
+        self.down = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down(F.silu(self.gate(hidden_states)) * self.up(hidden_states))
+
+
+class Krea2TextFusionBlock(nn.Module):
+    """Pre-norm transformer block for text fusion (no RoPE, no timestep modulation)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        intermediate_size: int,
+        eps: float,
+    ) -> None:
+        super().__init__()
+        self.norm1 = Krea2RMSNorm(dim, eps=eps)
+        self.norm2 = Krea2RMSNorm(dim, eps=eps)
+        self.attn = Krea2Attention(dim, num_heads, num_kv_heads, eps=eps)
+        self.ff = Krea2SwiGLU(dim, intermediate_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states), attention_mask=attention_mask
+        )
+        hidden_states = hidden_states + self.ff(self.norm2(hidden_states))
+        return hidden_states
+
+
+class Krea2TextFusion(nn.Module):
+    """Fuses stacked text-encoder hidden states into a single sequence.
+
+    Two layerwise blocks attend across the tapped-layer axis per token,
+    a linear projector collapses that axis, then two refiner blocks attend
+    across the token sequence.
+    """
+
+    def __init__(
+        self,
+        num_text_layers: int,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        intermediate_size: int,
+        num_layerwise_blocks: int,
+        num_refiner_blocks: int,
+        eps: float,
+    ) -> None:
+        super().__init__()
+        self.layerwise_blocks = nn.ModuleList(
+            [
+                Krea2TextFusionBlock(dim, num_heads, num_kv_heads, intermediate_size, eps)
+                for _ in range(num_layerwise_blocks)
+            ]
+        )
+        self.projector = nn.Linear(num_text_layers, 1, bias=False)
+        self.refiner_blocks = nn.ModuleList(
+            [
+                Krea2TextFusionBlock(dim, num_heads, num_kv_heads, intermediate_size, eps)
+                for _ in range(num_refiner_blocks)
+            ]
+        )
+
+    def forward(
+        self,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch_size, seq_len, num_text_layers, dim = encoder_hidden_states.shape
+
+        hidden_states = encoder_hidden_states.reshape(batch_size * seq_len, num_text_layers, dim)
+        for block in self.layerwise_blocks:
+            hidden_states = block(hidden_states.contiguous())
+
+        hidden_states = hidden_states.reshape(batch_size, seq_len, num_text_layers, dim).permute(
+            0, 1, 3, 2
+        )
+        hidden_states = self.projector(hidden_states).squeeze(-1)
+
+        for block in self.refiner_blocks:
+            hidden_states = block(hidden_states, attention_mask=attention_mask)
+
+        return hidden_states
+
+
+class Krea2TransformerBlock(nn.Module):
+    """Main DiT block with 6-channel AdaLN modulation."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.scale_shift_table = nn.Parameter(torch.zeros(6, hidden_size))
+        self.norm1 = Krea2RMSNorm(hidden_size, eps=norm_eps)
+        self.norm2 = Krea2RMSNorm(hidden_size, eps=norm_eps)
+        self.attn = Krea2Attention(hidden_size, num_heads, num_kv_heads, eps=norm_eps)
+        self.ff = Krea2SwiGLU(hidden_size, intermediate_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        modulation = temb.unflatten(-1, (6, -1)) + self.scale_shift_table
+        prescale, preshift, pregate, postscale, postshift, postgate = modulation.unbind(-2)
+
+        attn_out = self.attn(
+            (1.0 + prescale) * self.norm1(hidden_states) + preshift,
+            attention_mask=attention_mask,
+            image_rotary_emb=image_rotary_emb,
+        )
+        hidden_states = hidden_states + pregate * attn_out
+        ff_out = self.ff((1.0 + postscale) * self.norm2(hidden_states) + postshift)
+        hidden_states = hidden_states + postgate * ff_out
+        return hidden_states
+
+
+class Krea2TimestepEmbedding(nn.Module):
+    """Sinusoidal flow-time embedding (scale 1000) followed by a two-layer MLP."""
+
+    def __init__(self, embed_dim: int, hidden_size: int) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.linear_1 = nn.Linear(embed_dim, hidden_size, bias=True)
+        self.linear_2 = nn.Linear(hidden_size, hidden_size, bias=True)
+
+    def forward(self, timestep: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        half = self.embed_dim // 2
+        freqs = torch.exp(
+            -math.log(1e4) * torch.arange(half, dtype=torch.float32, device=timestep.device) / half
+        )
+        args = (timestep.float() * 1e3)[:, None, None] * freqs
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1).to(dtype)
+        return self.linear_2(F.gelu(self.linear_1(emb), approximate="tanh"))
+
+
+class Krea2TextProjection(nn.Module):
+    """Projects fused text features into the transformer width."""
+
+    def __init__(self, text_dim: int, hidden_size: int, eps: float) -> None:
+        super().__init__()
+        self.norm = Krea2RMSNorm(text_dim, eps=eps)
+        self.linear_1 = nn.Linear(text_dim, hidden_size, bias=True)
+        self.linear_2 = nn.Linear(hidden_size, hidden_size, bias=True)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_1(self.norm(hidden_states))
+        return self.linear_2(F.gelu(hidden_states, approximate="tanh"))
+
+
+class Krea2FinalLayer(nn.Module):
+    """Final adaptive RMSNorm and output projection."""
+
+    def __init__(self, hidden_size: int, out_channels: int, eps: float) -> None:
+        super().__init__()
+        self.scale_shift_table = nn.Parameter(torch.zeros(2, hidden_size))
+        self.norm = Krea2RMSNorm(hidden_size, eps=eps)
+        self.linear = nn.Linear(hidden_size, out_channels, bias=True)
+
+    def forward(self, hidden_states: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        modulation = temb + self.scale_shift_table
+        scale, shift = modulation.chunk(2, dim=1)
+        hidden_states = (1.0 + scale) * self.norm(hidden_states) + shift
+        return self.linear(hidden_states)
+
+
+class Krea2PosEmbed(nn.Module):
+    """3-axis RoPE position embedding for the combined [text, image] sequence."""
+
+    def __init__(self, theta: float, axes_dim: list[int]) -> None:
+        super().__init__()
+        self.theta = theta
+        self.axes_dim = axes_dim
+
+    def forward(self, ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        n_axes = ids.shape[-1]
+        cos_out = []
+        sin_out = []
+        pos = ids.float()
+        freqs_dtype = torch.float32 if ids.device.type == "mps" else torch.float64
+        for i in range(n_axes):
+            freqs_cis = get_1d_rotary_pos_embed(
+                self.axes_dim[i],
+                pos[:, i],
+                theta=self.theta,
+                use_real=False,
+                freqs_dtype=freqs_dtype,
+            )
+            cos_out.append(freqs_cis.real)
+            sin_out.append(freqs_cis.imag)
+        freqs_cos = torch.cat(cos_out, dim=-1).to(ids.device)
+        freqs_sin = torch.cat(sin_out, dim=-1).to(ids.device)
+        return freqs_cos, freqs_sin
+
+
+class Krea2Transformer2DModel(nn.Module):
+    """Krea 2 single-stream MMDiT flow-matching backbone.
+
+    Ported from the diffusers ``Krea2Transformer2DModel`` to vLLM-Omni
+    conventions: plain ``nn.Module``, vLLM-Omni attention layer, and
+    ``load_weights`` for checkpoint loading.
+    """
+
+    _repeated_blocks = ["Krea2TransformerBlock"]
+
+    def __init__(
+        self,
+        od_config: OmniDiffusionConfig | None = None,
+        in_channels: int = 64,
+        num_layers: int = 28,
+        attention_head_dim: int = 128,
+        num_attention_heads: int = 48,
+        num_key_value_heads: int = 12,
+        intermediate_size: int = 16384,
+        timestep_embed_dim: int = 256,
+        text_hidden_dim: int = 2560,
+        num_text_layers: int = 12,
+        text_num_attention_heads: int = 20,
+        text_num_key_value_heads: int = 20,
+        text_intermediate_size: int = 6912,
+        num_layerwise_text_blocks: int = 2,
+        num_refiner_text_blocks: int = 2,
+        axes_dims_rope: tuple[int, int, int] = (32, 48, 48),
+        rope_theta: float = 1000.0,
+        norm_eps: float = 1e-5,
+        quant_config: object | None = None,
+    ) -> None:
+        super().__init__()
+
+        if od_config is not None:
+            model_config = od_config.tf_model_config
+            num_layers = getattr(model_config, "num_layers", num_layers)
+
+        hidden_size = attention_head_dim * num_attention_heads
+
+        self.in_channels = in_channels
+        self.out_channels = in_channels
+        self.hidden_size = hidden_size
+
+        self.img_in = nn.Linear(in_channels, hidden_size, bias=True)
+        self.time_embed = Krea2TimestepEmbedding(timestep_embed_dim, hidden_size)
+        self.time_mod_proj = nn.Linear(hidden_size, 6 * hidden_size, bias=True)
+
+        self.text_fusion = Krea2TextFusion(
+            num_text_layers=num_text_layers,
+            dim=text_hidden_dim,
+            num_heads=text_num_attention_heads,
+            num_kv_heads=text_num_key_value_heads,
+            intermediate_size=text_intermediate_size,
+            num_layerwise_blocks=num_layerwise_text_blocks,
+            num_refiner_blocks=num_refiner_text_blocks,
+            eps=norm_eps,
+        )
+        self.txt_in = Krea2TextProjection(text_hidden_dim, hidden_size, eps=norm_eps)
+        self.rotary_emb = Krea2PosEmbed(theta=rope_theta, axes_dim=list(axes_dims_rope))
+
+        self.transformer_blocks = nn.ModuleList(
+            [
+                Krea2TransformerBlock(
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    num_heads=num_attention_heads,
+                    num_kv_heads=num_key_value_heads,
+                    norm_eps=norm_eps,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.final_layer = Krea2FinalLayer(hidden_size, out_channels=in_channels, eps=norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        position_ids: torch.Tensor,
+        encoder_attention_mask: torch.Tensor | None = None,
+        return_dict: bool = True,
+    ) -> tuple[torch.Tensor]:
+        batch_size, image_seq_len, _ = hidden_states.shape
+        text_seq_len = encoder_hidden_states.shape[1]
+
+        temb = self.time_embed(timestep, dtype=hidden_states.dtype)
+        temb_mod = self.time_mod_proj(F.gelu(temb, approximate="tanh"))
+
+        text_attention_mask = None
+        attention_mask = None
+        if encoder_attention_mask is not None:
+            text_attention_mask = encoder_attention_mask
+            image_mask = encoder_attention_mask.new_ones((batch_size, image_seq_len))
+            attention_mask = torch.cat([encoder_attention_mask, image_mask], dim=1)
+
+        encoder_hidden_states = self.text_fusion(
+            encoder_hidden_states, attention_mask=text_attention_mask
+        )
+        encoder_hidden_states = self.txt_in(encoder_hidden_states)
+
+        hidden_states = self.img_in(hidden_states)
+        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+
+        image_rotary_emb = self.rotary_emb(position_ids)
+
+        for block in self.transformer_blocks:
+            hidden_states = block(hidden_states, temb_mod, image_rotary_emb, attention_mask)
+
+        hidden_states = hidden_states[:, text_seq_len:]
+        output = self.final_layer(hidden_states, temb)
+
+        return (output,)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if name not in params_dict and ".to_out.0." in name:
+                name = name.replace(".to_out.0.", ".to_out.")
+            if name not in params_dict:
+                logger.warning("Skipping unknown weight: %s", name)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params

--- a/vllm_omni/diffusion/models/krea2/krea2_transformer.py
+++ b/vllm_omni/diffusion/models/krea2/krea2_transformer.py
@@ -336,7 +336,6 @@ class Krea2Transformer2DModel(nn.Module):
         axes_dims_rope: tuple[int, int, int] = (32, 48, 48),
         rope_theta: float = 1000.0,
         norm_eps: float = 1e-5,
-        quant_config: object | None = None,
     ) -> None:
         super().__init__()
 
@@ -425,8 +424,6 @@ class Krea2Transformer2DModel(nn.Module):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
-            if name not in params_dict and ".to_out.0." in name:
-                name = name.replace(".to_out.0.", ".to_out.")
             if name not in params_dict:
                 logger.warning("Skipping unknown weight: %s", name)
                 continue

--- a/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Krea 2 text-to-image pipeline for vLLM-Omni."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Iterable
+from typing import Any, ClassVar
+
+import numpy as np
+import torch
+import torch.nn as nn
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.models.autoencoders.autoencoder_kl_qwenimage import AutoencoderKLQwenImage
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from diffusers.utils.torch_utils import randn_tensor
+from transformers import AutoTokenizer, Qwen3VLModel
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2Transformer2DModel
+from vllm_omni.diffusion.models.krea2.preprocess_krea2 import (
+    denormalize_latents,
+    pack_latents,
+    prepare_position_ids,
+    unpack_latents,
+)
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TEXT_ENCODER_SELECT_LAYERS = (2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35)
+
+PROMPT_TEMPLATE_PREFIX = (
+    "<|im_start|>system\nDescribe the image by detailing the color, shape, size, texture, "
+    "quantity, text, spatial relationships of the objects and background:<|im_end|>\n"
+    "<|im_start|>user\n"
+)
+PROMPT_TEMPLATE_SUFFIX = "<|im_end|>\n<|im_start|>assistant\n"
+PROMPT_TEMPLATE_START_IDX = 34
+PROMPT_TEMPLATE_NUM_SUFFIX_TOKENS = 5
+
+
+def calculate_shift(
+    image_seq_len: int,
+    base_seq_len: int = 256,
+    max_seq_len: int = 6400,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+) -> float:
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    return image_seq_len * m + b
+
+
+def get_krea2_post_process_func(od_config: OmniDiffusionConfig):
+    if od_config.output_type == "latent":
+        return lambda x: x
+
+    model_name = od_config.model
+    if os.path.exists(model_name):
+        model_path = model_name
+    else:
+        model_path = download_weights_from_hf_specific(model_name, None, ["*"])
+
+    vae_config_path = os.path.join(model_path, "vae/config.json")
+    with open(vae_config_path) as f:
+        vae_config = json.load(f)
+        vae_scale_factor = (
+            2 ** len(vae_config["temporal_downsample"])
+            if "temporal_downsample" in vae_config
+            else 8
+        )
+
+    image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor * 2)
+
+    def post_process_func(images: torch.Tensor):
+        return image_processor.postprocess(images)
+
+    return post_process_func
+
+
+class Krea2Pipeline(
+    nn.Module,
+    CFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
+):
+    """Krea 2 text-to-image pipeline for vLLM-Omni."""
+
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.od_config = od_config
+        self._execution_device = get_local_device()
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        krea2_subfolders = ["scheduler", "text_encoder", "tokenizer", "vae"]
+        prefetch_subfolders(model, krea2_subfolders, local_files_only=local_files_only)
+
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model, subfolder="scheduler", local_files_only=local_files_only
+        )
+
+        self.text_encoder = from_pretrained_with_prefetch(
+            Qwen3VLModel.from_pretrained,
+            model,
+            subfolder="text_encoder",
+            prefetch_list=krea2_subfolders,
+            local_files_only=local_files_only,
+        ).to(self._execution_device)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model, subfolder="tokenizer", local_files_only=local_files_only
+        )
+
+        self.vae = from_pretrained_with_prefetch(
+            AutoencoderKLQwenImage.from_pretrained,
+            model,
+            subfolder="vae",
+            prefetch_list=krea2_subfolders,
+            local_files_only=local_files_only,
+        ).to(self._execution_device)
+
+        transformer_kwargs = get_transformer_config_kwargs(
+            od_config.tf_model_config, Krea2Transformer2DModel
+        )
+        self.transformer = Krea2Transformer2DModel(
+            od_config=od_config,
+            quant_config=od_config.quantization_config,
+            **transformer_kwargs,
+        )
+
+        self.text_encoder_select_layers = DEFAULT_TEXT_ENCODER_SELECT_LAYERS
+
+        model_config = od_config.model_config or {}
+        self.is_distilled = model_config.get("is_distilled", False)
+        self.patch_size = 2
+
+        self.vae_scale_factor = (
+            2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
+        )
+
+        self._guidance_scale = 0.0
+        self._current_timestep = None
+        self._num_timesteps = None
+        self._interrupt = False
+
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    def get_text_hidden_states(
+        self,
+        prompt: str | list[str],
+        max_sequence_length: int = 512,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode prompt using the Krea 2 chat-template layout.
+
+        Returns (hidden_states, attention_mask) of shapes
+        (B, text_seq_len, num_text_layers, text_hidden_dim) and (B, text_seq_len).
+        """
+        device = self._execution_device
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        prefix_idx = PROMPT_TEMPLATE_START_IDX
+
+        text = [PROMPT_TEMPLATE_PREFIX + p for p in prompt]
+        text_tokens = self.tokenizer(
+            text,
+            truncation=True,
+            padding="max_length",
+            max_length=max_sequence_length + prefix_idx - PROMPT_TEMPLATE_NUM_SUFFIX_TOKENS,
+            return_tensors="pt",
+        ).to(device)
+
+        suffix_tokens = self.tokenizer(
+            [PROMPT_TEMPLATE_SUFFIX] * len(text), return_tensors="pt"
+        ).to(device)
+
+        input_ids = torch.cat([text_tokens.input_ids, suffix_tokens.input_ids], dim=1)
+        attention_mask = torch.cat(
+            [text_tokens.attention_mask, suffix_tokens.attention_mask], dim=1
+        ).bool()
+
+        position_ids = (attention_mask.long().cumsum(dim=-1) - 1).clamp(min=0)
+        position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+        outputs = self.text_encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            output_hidden_states=True,
+        )
+        hidden_states = torch.stack(
+            [outputs.hidden_states[i] for i in self.text_encoder_select_layers], dim=2
+        )
+
+        hidden_states = hidden_states[:, prefix_idx:]
+        attention_mask = attention_mask[:, prefix_idx:]
+        return hidden_states, attention_mask
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        num_images_per_prompt: int = 1,
+        max_sequence_length: int = 512,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prompt_embeds, prompt_embeds_mask = self.get_text_hidden_states(
+            prompt, max_sequence_length
+        )
+        batch_size, seq_len, num_text_layers, dim = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1, 1)
+        prompt_embeds = prompt_embeds.view(
+            batch_size * num_images_per_prompt, seq_len, num_text_layers, dim
+        )
+        prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt)
+        prompt_embeds_mask = prompt_embeds_mask.view(
+            batch_size * num_images_per_prompt, seq_len
+        )
+        return prompt_embeds, prompt_embeds_mask
+
+    def prepare_latents(
+        self,
+        batch_size: int,
+        num_channels_latents: int,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+    ) -> torch.Tensor:
+        latent_height = height // self.vae_scale_factor
+        latent_width = width // self.vae_scale_factor
+        shape = (batch_size, num_channels_latents, latent_height, latent_width)
+        latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        return pack_latents(
+            latents, batch_size, num_channels_latents, latent_height, latent_width, self.patch_size
+        )
+
+    def prepare_timesteps(
+        self,
+        num_inference_steps: int,
+        sigmas: list[float] | None,
+        image_seq_len: int,
+    ) -> tuple[torch.Tensor, int]:
+        if sigmas is None:
+            sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+
+        if self.is_distilled:
+            mu = 1.15
+        else:
+            mu = calculate_shift(
+                image_seq_len,
+                self.scheduler.config.get("base_image_seq_len", 256),
+                self.scheduler.config.get("max_image_seq_len", 6400),
+                self.scheduler.config.get("base_shift", 0.5),
+                self.scheduler.config.get("max_shift", 1.15),
+            )
+
+        accepts_sigmas = "sigmas" in set(
+            __import__("inspect").signature(self.scheduler.set_timesteps).parameters.keys()
+        )
+        if accepts_sigmas:
+            self.scheduler.set_timesteps(sigmas=sigmas, mu=mu)
+        else:
+            self.scheduler.set_timesteps(num_inference_steps, mu=mu)
+        timesteps = self.scheduler.timesteps
+        return timesteps, len(timesteps)
+
+    def combine_cfg_noise(
+        self,
+        positive_noise_pred: torch.Tensor | tuple[torch.Tensor, ...],
+        negative_noise_pred: torch.Tensor | tuple[torch.Tensor, ...],
+        true_cfg_scale: float,
+        cfg_normalize: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        """Krea 2 non-standard CFG: v_cond + scale * (v_cond - v_uncond)."""
+        if isinstance(positive_noise_pred, tuple):
+            pos = positive_noise_pred[0]
+            neg = negative_noise_pred[0] if isinstance(negative_noise_pred, tuple) else negative_noise_pred
+        else:
+            pos = positive_noise_pred
+            neg = negative_noise_pred[0] if isinstance(negative_noise_pred, tuple) else negative_noise_pred
+        result = pos + true_cfg_scale * (pos - neg)
+        if isinstance(positive_noise_pred, tuple):
+            return (result,)
+        return result
+
+    def diffuse(
+        self,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        negative_prompt_embeds_mask: torch.Tensor | None,
+        latents: torch.Tensor,
+        position_ids: torch.Tensor,
+        timesteps: torch.Tensor,
+        do_cfg: bool,
+        guidance_scale: float,
+    ) -> torch.Tensor:
+        self.scheduler.set_begin_index(0)
+
+        for i, t in enumerate(timesteps):
+            if self._interrupt:
+                continue
+
+            self._current_timestep = t
+            timestep = (t / self.scheduler.config.num_train_timesteps).expand(
+                latents.shape[0]
+            ).to(dtype=latents.dtype, device=latents.device)
+
+            positive_kwargs = {
+                "hidden_states": latents,
+                "encoder_hidden_states": prompt_embeds,
+                "timestep": timestep,
+                "position_ids": position_ids,
+                "encoder_attention_mask": prompt_embeds_mask,
+                "return_dict": False,
+            }
+
+            if do_cfg:
+                negative_kwargs = {
+                    "hidden_states": latents,
+                    "encoder_hidden_states": negative_prompt_embeds,
+                    "timestep": timestep,
+                    "position_ids": position_ids,
+                    "encoder_attention_mask": negative_prompt_embeds_mask,
+                    "return_dict": False,
+                }
+            else:
+                negative_kwargs = None
+
+            noise_pred = self.predict_noise_maybe_with_cfg(
+                do_cfg,
+                guidance_scale,
+                positive_kwargs,
+                negative_kwargs,
+            )
+            if isinstance(noise_pred, tuple):
+                noise_pred = noise_pred[0]
+
+            latents_dtype = latents.dtype
+            latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+            if latents.dtype != latents_dtype:
+                latents = latents.to(latents_dtype)
+
+        return latents
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    @property
+    def interrupt(self):
+        return self._interrupt
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        prompt: str | list[str] | None = None,
+        negative_prompt: str | list[str] | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        num_inference_steps: int = 28,
+        sigmas: list[float] | None = None,
+        guidance_scale: float = 4.5,
+        num_images_per_prompt: int = 1,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        max_sequence_length: int = 512,
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        prompt = (
+            [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts]
+            or prompt
+        )
+        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
+            negative_prompt = None
+        elif req.prompts:
+            negative_prompt = [
+                "" if isinstance(p, str) else (p.get("negative_prompt") or "")
+                for p in req.prompts
+            ]
+
+        default_size = 1024
+        height = req.sampling_params.height or height or default_size
+        width = req.sampling_params.width or width or default_size
+        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        sigmas = req.sampling_params.sigmas or sigmas
+        guidance_scale = (
+            req.sampling_params.guidance_scale
+            if req.sampling_params.guidance_scale_provided
+            else guidance_scale
+        )
+        generator = req.sampling_params.generator or generator
+        num_images_per_prompt = (
+            req.sampling_params.num_outputs_per_prompt
+            if req.sampling_params.num_outputs_per_prompt > 0
+            else num_images_per_prompt
+        )
+
+        multiple = self.vae_scale_factor * self.patch_size
+        if height % multiple != 0 or width % multiple != 0:
+            height = ((height + multiple - 1) // multiple) * multiple
+            width = ((width + multiple - 1) // multiple) * multiple
+
+        self._guidance_scale = guidance_scale
+        self._current_timestep = None
+        self._interrupt = False
+
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = 1
+
+        do_cfg = guidance_scale > 0
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        negative_prompt_embeds = None
+        negative_prompt_embeds_mask = None
+        if do_cfg:
+            if negative_prompt is None:
+                negative_prompt = [""] * batch_size
+            elif isinstance(negative_prompt, str):
+                negative_prompt = [negative_prompt] * batch_size
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+            )
+
+        num_channels_latents = self.transformer.in_channels // (self.patch_size**2)
+        latents = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self._execution_device,
+            generator,
+        )
+
+        grid_height = height // (self.vae_scale_factor * self.patch_size)
+        grid_width = width // (self.vae_scale_factor * self.patch_size)
+        position_ids = prepare_position_ids(
+            prompt_embeds.shape[1], grid_height, grid_width, self._execution_device
+        )
+
+        timesteps, num_inference_steps = self.prepare_timesteps(
+            num_inference_steps, sigmas, latents.shape[1]
+        )
+        self._num_timesteps = len(timesteps)
+
+        latents = self.diffuse(
+            prompt_embeds,
+            prompt_embeds_mask,
+            negative_prompt_embeds,
+            negative_prompt_embeds_mask,
+            latents,
+            position_ids,
+            timesteps,
+            do_cfg,
+            guidance_scale,
+        )
+
+        self._current_timestep = None
+
+        latents = unpack_latents(latents, height, width, self.vae_scale_factor, self.patch_size)
+        latents = latents.to(self.vae.dtype)
+
+        latents_mean = torch.tensor(self.vae.config.latents_mean)
+        latents_std = torch.tensor(self.vae.config.latents_std)
+        latents = denormalize_latents(latents, latents_mean, latents_std)
+
+        image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+
+        return DiffusionOutput(output=image)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
@@ -158,7 +158,10 @@ class Krea2Pipeline(
         self.text_encoder_select_layers = DEFAULT_TEXT_ENCODER_SELECT_LAYERS
 
         model_config = od_config.model_config or {}
-        self.is_distilled = model_config.get("is_distilled", False)
+        self.is_distilled = model_config.get(
+            "is_distilled",
+            any(tag in model.lower() for tag in ("turbo", "tdm", "distill")),
+        )
         self.patch_size = 2
 
         self.vae_scale_factor = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8

--- a/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
@@ -79,11 +79,7 @@ def get_krea2_post_process_func(od_config: OmniDiffusionConfig):
     vae_config_path = os.path.join(model_path, "vae/config.json")
     with open(vae_config_path) as f:
         vae_config = json.load(f)
-        vae_scale_factor = (
-            2 ** len(vae_config["temporal_downsample"])
-            if "temporal_downsample" in vae_config
-            else 8
-        )
+        vae_scale_factor = 2 ** len(vae_config["temporal_downsample"]) if "temporal_downsample" in vae_config else 8
 
     image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor * 2)
 
@@ -142,9 +138,7 @@ class Krea2Pipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model, subfolder="tokenizer", local_files_only=local_files_only
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
 
         self.vae = from_pretrained_with_prefetch(
             AutoencoderKLQwenImage.from_pretrained,
@@ -154,9 +148,7 @@ class Krea2Pipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        transformer_kwargs = get_transformer_config_kwargs(
-            od_config.tf_model_config, Krea2Transformer2DModel
-        )
+        transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, Krea2Transformer2DModel)
         self.transformer = Krea2Transformer2DModel(
             od_config=od_config,
             quant_config=od_config.quantization_config,
@@ -169,9 +161,7 @@ class Krea2Pipeline(
         self.is_distilled = model_config.get("is_distilled", False)
         self.patch_size = 2
 
-        self.vae_scale_factor = (
-            2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
-        )
+        self.vae_scale_factor = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
 
         self._guidance_scale = 0.0
         self._current_timestep = None
@@ -205,14 +195,10 @@ class Krea2Pipeline(
             return_tensors="pt",
         ).to(device)
 
-        suffix_tokens = self.tokenizer(
-            [PROMPT_TEMPLATE_SUFFIX] * len(text), return_tensors="pt"
-        ).to(device)
+        suffix_tokens = self.tokenizer([PROMPT_TEMPLATE_SUFFIX] * len(text), return_tensors="pt").to(device)
 
         input_ids = torch.cat([text_tokens.input_ids, suffix_tokens.input_ids], dim=1)
-        attention_mask = torch.cat(
-            [text_tokens.attention_mask, suffix_tokens.attention_mask], dim=1
-        ).bool()
+        attention_mask = torch.cat([text_tokens.attention_mask, suffix_tokens.attention_mask], dim=1).bool()
 
         position_ids = (attention_mask.long().cumsum(dim=-1) - 1).clamp(min=0)
         position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
@@ -223,9 +209,7 @@ class Krea2Pipeline(
             position_ids=position_ids,
             output_hidden_states=True,
         )
-        hidden_states = torch.stack(
-            [outputs.hidden_states[i] for i in self.text_encoder_select_layers], dim=2
-        )
+        hidden_states = torch.stack([outputs.hidden_states[i] for i in self.text_encoder_select_layers], dim=2)
 
         hidden_states = hidden_states[:, prefix_idx:]
         attention_mask = attention_mask[:, prefix_idx:]
@@ -237,18 +221,12 @@ class Krea2Pipeline(
         num_images_per_prompt: int = 1,
         max_sequence_length: int = 512,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        prompt_embeds, prompt_embeds_mask = self.get_text_hidden_states(
-            prompt, max_sequence_length
-        )
+        prompt_embeds, prompt_embeds_mask = self.get_text_hidden_states(prompt, max_sequence_length)
         batch_size, seq_len, num_text_layers, dim = prompt_embeds.shape
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1, 1)
-        prompt_embeds = prompt_embeds.view(
-            batch_size * num_images_per_prompt, seq_len, num_text_layers, dim
-        )
+        prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, num_text_layers, dim)
         prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt)
-        prompt_embeds_mask = prompt_embeds_mask.view(
-            batch_size * num_images_per_prompt, seq_len
-        )
+        prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_images_per_prompt, seq_len)
         return prompt_embeds, prompt_embeds_mask
 
     def prepare_latents(
@@ -265,9 +243,7 @@ class Krea2Pipeline(
         latent_width = width // self.vae_scale_factor
         shape = (batch_size, num_channels_latents, latent_height, latent_width)
         latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
-        return pack_latents(
-            latents, batch_size, num_channels_latents, latent_height, latent_width, self.patch_size
-        )
+        return pack_latents(latents, batch_size, num_channels_latents, latent_height, latent_width, self.patch_size)
 
     def prepare_timesteps(
         self,
@@ -337,9 +313,11 @@ class Krea2Pipeline(
                 continue
 
             self._current_timestep = t
-            timestep = (t / self.scheduler.config.num_train_timesteps).expand(
-                latents.shape[0]
-            ).to(dtype=latents.dtype, device=latents.device)
+            timestep = (
+                (t / self.scheduler.config.num_train_timesteps)
+                .expand(latents.shape[0])
+                .to(dtype=latents.dtype, device=latents.device)
+            )
 
             positive_kwargs = {
                 "hidden_states": latents,
@@ -409,17 +387,11 @@ class Krea2Pipeline(
         max_sequence_length: int = 512,
         **kwargs: Any,
     ) -> DiffusionOutput:
-        prompt = (
-            [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts]
-            or prompt
-        )
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
         if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
             negative_prompt = None
         elif req.prompts:
-            negative_prompt = [
-                "" if isinstance(p, str) else (p.get("negative_prompt") or "")
-                for p in req.prompts
-            ]
+            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
 
         default_size = 1024
         height = req.sampling_params.height or height or default_size
@@ -427,9 +399,7 @@ class Krea2Pipeline(
         num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         guidance_scale = (
-            req.sampling_params.guidance_scale
-            if req.sampling_params.guidance_scale_provided
-            else guidance_scale
+            req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
         )
         generator = req.sampling_params.generator or generator
         num_images_per_prompt = (
@@ -488,13 +458,9 @@ class Krea2Pipeline(
 
         grid_height = height // (self.vae_scale_factor * self.patch_size)
         grid_width = width // (self.vae_scale_factor * self.patch_size)
-        position_ids = prepare_position_ids(
-            prompt_embeds.shape[1], grid_height, grid_width, self._execution_device
-        )
+        position_ids = prepare_position_ids(prompt_embeds.shape[1], grid_height, grid_width, self._execution_device)
 
-        timesteps, num_inference_steps = self.prepare_timesteps(
-            num_inference_steps, sigmas, latents.shape[1]
-        )
+        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
         self._num_timesteps = len(timesteps)
 
         latents = self.diffuse(

--- a/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -151,7 +152,6 @@ class Krea2Pipeline(
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, Krea2Transformer2DModel)
         self.transformer = Krea2Transformer2DModel(
             od_config=od_config,
-            quant_config=od_config.quantization_config,
             **transformer_kwargs,
         )
 
@@ -268,9 +268,7 @@ class Krea2Pipeline(
                 self.scheduler.config.get("max_shift", 1.15),
             )
 
-        accepts_sigmas = "sigmas" in set(
-            __import__("inspect").signature(self.scheduler.set_timesteps).parameters.keys()
-        )
+        accepts_sigmas = "sigmas" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
         if accepts_sigmas:
             self.scheduler.set_timesteps(sigmas=sigmas, mu=mu)
         else:
@@ -293,6 +291,8 @@ class Krea2Pipeline(
             pos = positive_noise_pred
             neg = negative_noise_pred[0] if isinstance(negative_noise_pred, tuple) else negative_noise_pred
         result = pos + true_cfg_scale * (pos - neg)
+        if cfg_normalize:
+            result = self.cfg_normalize_function(pos, result)
         if isinstance(positive_noise_pred, tuple):
             return (result,)
         return result
@@ -480,16 +480,22 @@ class Krea2Pipeline(
 
         self._current_timestep = None
 
-        latents = unpack_latents(latents, height, width, self.vae_scale_factor, self.patch_size)
-        latents = latents.to(self.vae.dtype)
+        if self.od_config.output_type == "latent":
+            image = latents
+        else:
+            latents = unpack_latents(latents, height, width, self.vae_scale_factor, self.patch_size)
+            latents = latents.to(self.vae.dtype)
 
-        latents_mean = torch.tensor(self.vae.config.latents_mean)
-        latents_std = torch.tensor(self.vae.config.latents_std)
-        latents = denormalize_latents(latents, latents_mean, latents_std)
+            latents_mean = torch.tensor(self.vae.config.latents_mean)
+            latents_std = torch.tensor(self.vae.config.latents_std)
+            latents = denormalize_latents(latents, latents_mean, latents_std)
 
-        image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+            image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
 
-        return DiffusionOutput(output=image)
+        return DiffusionOutput(
+            output=image,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm_omni/diffusion/models/krea2/preprocess_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/preprocess_krea2.py
@@ -71,5 +71,5 @@ def denormalize_latents(
     """Denormalize VAE latents using per-channel mean/std from VAE config."""
     z_dim = latents.shape[1]
     mean = latents_mean.view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
-    std = (1.0 / latents_std).view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
+    std = latents_std.view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
     return latents * std + mean

--- a/vllm_omni/diffusion/models/krea2/preprocess_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/preprocess_krea2.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Krea 2 pre/post-processing utilities for vLLM-Omni."""
+
+from __future__ import annotations
+
+import torch
+
+
+def pack_latents(
+    latents: torch.Tensor,
+    batch_size: int,
+    num_channels: int,
+    height: int,
+    width: int,
+    patch_size: int = 2,
+) -> torch.Tensor:
+    """Pack latents into patch tokens: (B,C,H,W) -> (B, H/p*W/p, C*p*p)."""
+    p = patch_size
+    latents = latents.view(batch_size, num_channels, height // p, p, width // p, p)
+    latents = latents.permute(0, 2, 4, 1, 3, 5)
+    latents = latents.reshape(batch_size, (height // p) * (width // p), num_channels * p * p)
+    return latents
+
+
+def unpack_latents(
+    latents: torch.Tensor,
+    height: int,
+    width: int,
+    vae_scale_factor: int,
+    patch_size: int = 2,
+) -> torch.Tensor:
+    """Unpack patch tokens back to spatial: (B, S, C*p*p) -> (B, C, 1, H, W)."""
+    if latents.dim() == 4:
+        return latents
+    batch_size, _, channels = latents.shape
+    p = patch_size
+
+    lat_h = p * (int(height) // (vae_scale_factor * p))
+    lat_w = p * (int(width) // (vae_scale_factor * p))
+
+    latents = latents.view(batch_size, lat_h // p, lat_w // p, channels // (p * p), p, p)
+    latents = latents.permute(0, 3, 1, 4, 2, 5)
+    latents = latents.reshape(batch_size, channels // (p * p), 1, lat_h, lat_w)
+    return latents
+
+
+def prepare_position_ids(
+    text_seq_len: int,
+    grid_height: int,
+    grid_width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build (text_seq + image_seq, 3) rotary coordinates.
+
+    Text tokens sit at the origin; image tokens carry (0, h, w) grid coords.
+    """
+    text_ids = torch.zeros(text_seq_len, 3, device=device)
+    image_ids = torch.zeros(grid_height, grid_width, 3, device=device)
+    image_ids[..., 1] = torch.arange(grid_height, device=device)[:, None]
+    image_ids[..., 2] = torch.arange(grid_width, device=device)[None, :]
+    image_ids = image_ids.reshape(grid_height * grid_width, 3)
+    return torch.cat([text_ids, image_ids], dim=0)
+
+
+def denormalize_latents(
+    latents: torch.Tensor,
+    latents_mean: torch.Tensor,
+    latents_std: torch.Tensor,
+) -> torch.Tensor:
+    """Denormalize VAE latents using per-channel mean/std from VAE config."""
+    z_dim = latents.shape[1]
+    mean = latents_mean.view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
+    std = (1.0 / latents_std).view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
+    return latents * std + mean

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -306,6 +306,11 @@ _DIFFUSION_MODELS = {
         "pipeline_sdxl",
         "StableDiffusionXLPipeline",
     ),
+    "Krea2Pipeline": (
+        "krea2",
+        "pipeline_krea2",
+        "Krea2Pipeline",
+    ),
 }
 
 
@@ -533,6 +538,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_post_process_func",
     "HiDreamImagePipeline": "get_hidream_image_post_process_func",
     "StableDiffusionXLPipeline": "get_sdxl_image_post_process_func",
+    "Krea2Pipeline": "get_krea2_post_process_func",
 }
 
 _DIFFUSION_ACTION_POST_PROCESS_FUNCS = {


### PR DESCRIPTION
## Summary

Add support for the [Krea 2](https://github.com/krea-ai/krea-2) flow-matching text-to-image model family. Both base (`krea/Krea-2-Raw`, 28 steps, guidance_scale=4.5) and distilled (`krea/Krea-2-Turbo`, 8 steps, guidance_scale=0) checkpoints are supported.

- **8 new files, ~1,470 lines** — transformer, pipeline, preprocessing utilities, registry entries, structural tests, and an example CLI script
- **Architecture**: single-stream MMDiT with GQA (48 Q / 12 KV heads), 3-stage Qwen3VL text fusion, 3-axis RoPE, AdaLN modulation, SwiGLU FFN, per-channel VAE denormalization
- **Verified end-to-end** on A100-80GB generating 1024x1024 images via `/v1/images/generations`

### Files

| File | Lines | Purpose |
|------|------:|---------|
| `vllm_omni/diffusion/models/krea2/krea2_transformer.py` | 448 | Full transformer port — 10 nn.Module classes |
| `vllm_omni/diffusion/models/krea2/pipeline_krea2.py` | 527 | Pipeline: text encoding, CFG, denoising loop, VAE decode |
| `vllm_omni/diffusion/models/krea2/preprocess_krea2.py` | 75 | Latent packing, position IDs, VAE denormalization |
| `vllm_omni/diffusion/models/krea2/__init__.py` | 15 | Module exports |
| `vllm_omni/diffusion/registry.py` | +6 | Registry entries for model + post-process |
| `tests/diffusion/models/krea2/test_krea2_structure.py` | 257 | 12 structural/param-name tests |
| `examples/.../krea2_generate.py` | 140 | CLI example with auto distilled detection |

### Key design decisions

- **Separate Q/K/V linears** (not fused) — matches checkpoint weight names 1:1, no stacked_params_mapping needed
- **RoPE compatibility** — uses `use_real=False` + `RotaryEmbedding(is_neox_style=False)` to match the existing Flux pattern
- **Non-standard CFG** — `v_cond + scale * (v_cond - v_uncond)` instead of standard `v_uncond + scale * (v_cond - v_uncond)`, handled via `combine_cfg_noise` override
- **2D attention masks** throughout for flash attention backend compatibility

## Test plan

- [x] Structural tests pass (`pytest tests/diffusion/models/krea2/ -v`) — param names match diffusers checkpoint, shapes roundtrip correctly, registry entries present
- [x] Model loads on A100-80GB (713 weights, 32.4 GiB, ~12s)
- [x] Warmup dummy run completes successfully
- [x] Image generation via OpenAI-compatible API produces valid 1024x1024 PNGs
- [x] Tested with `krea/Krea-2-Turbo` (distilled) checkpoint
- [ ] Test with `krea/Krea-2-Raw` (base) checkpoint
- [ ] Tensor parallelism validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)