### PR TITLE
fix: ensure joint tensors are concatenated on all steps in ring attention (closes #4671)

### DIFF
--- a/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py
+++ b/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py
@@ -100,11 +100,12 @@ class RingAttentionFunc(torch.autograd.Function):
             if not is_causal or step <= comm.rank:
                 step_k = k
                 step_v = v
-                if step == 0 and joint_tensor_key is not None:
+                # Always concatenate joint tensors when present (both strategies)
+                if joint_tensor_key is not None:
                     if joint_strategy == "front":
                         step_k = torch.cat([joint_tensor_key, step_k], dim=1)
                         step_v = torch.cat([joint_tensor_value, step_v], dim=1)
-                    else:
+                    else:  # rear
                         step_k = torch.cat([step_k, joint_tensor_key], dim=1)
                         step_v = torch.cat([step_v, joint_tensor_value], dim=1)
 


### PR DESCRIPTION
## What
When using joint tensor key/value with `joint_strategy='rear'` in Ring Attention, the joint tensors were only being concatenated at step 0, causing all subsequent steps to miss the joint context. This broke inference for models like Qwen3-Omni that rely on joint conditioning tokens being visible throughout the entire sequence processing.

## Fix
Remove the `step == 0` condition from joint tensor concatenation logic so that joint tensors are always prepended/appended regardless of which step in the ring communication is being processed. This ensures the joint tokens are consistently available to all local query tokens on every step, maintaining the correct conditioning semantics.

Closes #4671