### PR TITLE
[Bugfix] Fix /v1/chat/completions nonstreaming response structure

### DIFF
--- a/tests/entrypoints/openai_api/test_full_generator_choices.py
+++ b/tests/entrypoints/openai_api/test_full_generator_choices.py
@@ -6,32 +6,23 @@ number of choices and merges text+audio into a single choice per the
 OpenAI API spec.
 """
 
-import enum
 from unittest.mock import MagicMock
 
 import pytest
-
-if not hasattr(enum, "StrEnum"):
-
-    class _StrEnum(str, enum.Enum):
-        pass
-
-    enum.StrEnum = _StrEnum  # type: ignore[attr-defined]
-
 from openai.types.chat.chat_completion_audio import (
     ChatCompletionAudio as OpenAIChatCompletionAudio,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
     ChatCompletionResponseChoice,
     ChatMessage,
 )
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.outputs import CompletionOutput, RequestOutput
 
-from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
-from vllm_omni.outputs import OmniRequestOutput
+from tests.helpers.serving_chat import (
+    build_serving_chat,
+    make_audio_omni_output,
+    make_text_omni_output,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -43,65 +34,7 @@ FAKE_AUDIO = OpenAIChatCompletionAudio(
 )
 
 
-def _make_text_omni_output(
-    text="hello",
-    finish_reason="stop",
-    index=0,
-):
-    res = RequestOutput(
-        request_id="req",
-        prompt="test",
-        prompt_token_ids=[1, 2, 3],
-        prompt_logprobs=None,
-        outputs=[
-            CompletionOutput(
-                index=index,
-                text=text,
-                token_ids=[10, 11, 12],
-                cumulative_logprob=0.0,
-                logprobs=None,
-                finish_reason=finish_reason,
-                stop_reason=None,
-            )
-        ],
-        finished=True,
-    )
-    return OmniRequestOutput(
-        request_id="req",
-        final_output_type="text",
-        request_output=res,
-        finished=True,
-    )
-
-
-def _make_audio_omni_output():
-    res = RequestOutput(
-        request_id="req",
-        prompt="test",
-        prompt_token_ids=[1, 2, 3],
-        prompt_logprobs=None,
-        outputs=[
-            CompletionOutput(
-                index=0,
-                text="",
-                token_ids=[],
-                cumulative_logprob=0.0,
-                logprobs=None,
-                finish_reason="stop",
-                stop_reason=None,
-            )
-        ],
-        finished=True,
-    )
-    return OmniRequestOutput(
-        request_id="req",
-        final_output_type="audio",
-        request_output=res,
-        finished=True,
-    )
-
-
-def _mock_audio_choices(role="assistant"):
+def _mock_full_audio_choices(role="assistant"):
     return [
         ChatCompletionResponseChoice(
             index=0,
@@ -123,65 +56,31 @@ def _mock_text_choice_result(choices):
     )
 
 
-def _build_serving_chat():
-    mock_engine = MagicMock()
-    mock_engine.errored = False
-
-    models = OpenAIServingModels(
-        engine_client=mock_engine,
-        base_model_paths=[],
-    )
-
-    instance = OmniOpenAIServingChat(
-        engine_client=mock_engine,
-        models=models,
-        response_role="assistant",
-        openai_serving_render=MagicMock(),
-        request_logger=None,
-        chat_template=None,
-        chat_template_content_format="auto",
-    )
-    instance._create_audio_choice = MagicMock(
-        side_effect=lambda *a, **kw: _mock_audio_choices()
-    )
-    return instance
-
-
-def _make_request(modalities, stream=False):
-    req = ChatCompletionRequest(
-        model="test-model",
-        messages=[{"role": "user", "content": "hello"}],
-        stream=stream,
-    )
-    req.modalities = modalities
-    return req
-
-
 async def _async_iter(items):
     for item in items:
         yield item
 
 
 async def _call_full_generator(serving, outputs, modalities):
-    request = _make_request(modalities)
-    tokenizer = MagicMock()
-    metadata = MagicMock()
+    from tests.helpers.serving_chat import make_request
+
+    request = make_request(modalities, stream=False)
     result = await serving.chat_completion_full_generator(
         request=request,
         result_generator=_async_iter(outputs),
         request_id="chatcmpl-test",
         model_name="test-model",
         conversation=[],
-        tokenizer=tokenizer,
-        request_metadata=metadata,
+        tokenizer=MagicMock(),
+        request_metadata=MagicMock(),
     )
     return result
 
 
 @pytest.mark.asyncio
 async def test_text_only():
-    serving = _build_serving_chat()
-    text_output = _make_text_omni_output(text="hello world")
+    serving = build_serving_chat()
+    text_output = make_text_omni_output(text="hello world", finish_reason="stop")
 
     text_choice = ChatCompletionResponseChoice(
         index=0,
@@ -190,9 +89,7 @@ async def test_text_only():
         finish_reason="stop",
         stop_reason=None,
     )
-    serving._create_text_choice = MagicMock(
-        return_value=_mock_text_choice_result([text_choice])
-    )
+    serving._create_text_choice = MagicMock(return_value=_mock_text_choice_result([text_choice]))
 
     response = await _call_full_generator(serving, [text_output], ["text"])
 
@@ -203,8 +100,9 @@ async def test_text_only():
 
 @pytest.mark.asyncio
 async def test_audio_only():
-    serving = _build_serving_chat()
-    audio_output = _make_audio_omni_output()
+    serving = build_serving_chat()
+    serving._create_audio_choice = MagicMock(side_effect=lambda *a, **kw: _mock_full_audio_choices())
+    audio_output = make_audio_omni_output()
 
     response = await _call_full_generator(serving, [audio_output], ["audio"])
 
@@ -214,9 +112,10 @@ async def test_audio_only():
 
 @pytest.mark.asyncio
 async def test_text_and_audio_merged():
-    serving = _build_serving_chat()
-    text_output = _make_text_omni_output(text="hello")
-    audio_output = _make_audio_omni_output()
+    serving = build_serving_chat()
+    serving._create_audio_choice = MagicMock(side_effect=lambda *a, **kw: _mock_full_audio_choices())
+    text_output = make_text_omni_output(text="hello", finish_reason="stop")
+    audio_output = make_audio_omni_output()
 
     text_choice = ChatCompletionResponseChoice(
         index=0,
@@ -225,51 +124,10 @@ async def test_text_and_audio_merged():
         finish_reason="stop",
         stop_reason=None,
     )
-    serving._create_text_choice = MagicMock(
-        return_value=_mock_text_choice_result([text_choice])
-    )
+    serving._create_text_choice = MagicMock(return_value=_mock_text_choice_result([text_choice]))
 
-    response = await _call_full_generator(
-        serving, [text_output, audio_output], ["text", "audio"]
-    )
+    response = await _call_full_generator(serving, [text_output, audio_output], ["text", "audio"])
 
     assert len(response.choices) == 1
     assert response.choices[0].message.content == "hello"
     assert response.choices[0].message.audio is FAKE_AUDIO
-
-
-@pytest.mark.asyncio
-async def test_text_and_audio_merged_n2():
-    serving = _build_serving_chat()
-    text_output = _make_text_omni_output(text="first")
-    audio_output = _make_audio_omni_output()
-
-    choice_0 = ChatCompletionResponseChoice(
-        index=0,
-        message=ChatMessage(role="assistant", content="first"),
-        logprobs=None,
-        finish_reason="stop",
-        stop_reason=None,
-    )
-    choice_1 = ChatCompletionResponseChoice(
-        index=1,
-        message=ChatMessage(role="assistant", content="second"),
-        logprobs=None,
-        finish_reason="stop",
-        stop_reason=None,
-    )
-    serving._create_text_choice = MagicMock(
-        return_value=_mock_text_choice_result([choice_0, choice_1])
-    )
-
-    response = await _call_full_generator(
-        serving, [text_output, audio_output], ["text", "audio"]
-    )
-
-    assert len(response.choices) == 2
-    assert response.choices[0].index == 0
-    assert response.choices[0].message.content == "first"
-    assert response.choices[0].message.audio is FAKE_AUDIO
-    assert response.choices[1].index == 1
-    assert response.choices[1].message.content == "second"
-    assert response.choices[1].message.audio is FAKE_AUDIO

--- a/tests/entrypoints/openai_api/test_full_generator_choices.py
+++ b/tests/entrypoints/openai_api/test_full_generator_choices.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for non-streaming choice merging in chat_completion_full_generator.
+
+Verifies that /v1/chat/completions with stream=False produces the correct
+number of choices and merges text+audio into a single choice per the
+OpenAI API spec.
+"""
+
+import enum
+from unittest.mock import MagicMock
+
+import pytest
+
+if not hasattr(enum, "StrEnum"):
+
+    class _StrEnum(str, enum.Enum):
+        pass
+
+    enum.StrEnum = _StrEnum  # type: ignore[attr-defined]
+
+from openai.types.chat.chat_completion_audio import (
+    ChatCompletionAudio as OpenAIChatCompletionAudio,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.engine.protocol import UsageInfo
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.outputs import CompletionOutput, RequestOutput
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+from vllm_omni.outputs import OmniRequestOutput
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+FAKE_AUDIO = OpenAIChatCompletionAudio(
+    id="audio-test",
+    data="dGVzdA==",
+    expires_at=9999999999,
+    transcript="",
+)
+
+
+def _make_text_omni_output(
+    text="hello",
+    finish_reason="stop",
+    index=0,
+):
+    res = RequestOutput(
+        request_id="req",
+        prompt="test",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=index,
+                text=text,
+                token_ids=[10, 11, 12],
+                cumulative_logprob=0.0,
+                logprobs=None,
+                finish_reason=finish_reason,
+                stop_reason=None,
+            )
+        ],
+        finished=True,
+    )
+    return OmniRequestOutput(
+        request_id="req",
+        final_output_type="text",
+        request_output=res,
+        finished=True,
+    )
+
+
+def _make_audio_omni_output():
+    res = RequestOutput(
+        request_id="req",
+        prompt="test",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="",
+                token_ids=[],
+                cumulative_logprob=0.0,
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=None,
+            )
+        ],
+        finished=True,
+    )
+    return OmniRequestOutput(
+        request_id="req",
+        final_output_type="audio",
+        request_output=res,
+        finished=True,
+    )
+
+
+def _mock_audio_choices(role="assistant"):
+    return [
+        ChatCompletionResponseChoice(
+            index=0,
+            message=ChatMessage(role=role, audio=FAKE_AUDIO),
+            logprobs=None,
+            finish_reason="stop",
+            stop_reason=None,
+        )
+    ]
+
+
+def _mock_text_choice_result(choices):
+    return (
+        choices,
+        UsageInfo(prompt_tokens=3, completion_tokens=3, total_tokens=6),
+        None,
+        [1, 2, 3],
+        None,
+    )
+
+
+def _build_serving_chat():
+    mock_engine = MagicMock()
+    mock_engine.errored = False
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=[],
+    )
+
+    instance = OmniOpenAIServingChat(
+        engine_client=mock_engine,
+        models=models,
+        response_role="assistant",
+        openai_serving_render=MagicMock(),
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+    instance._create_audio_choice = MagicMock(
+        side_effect=lambda *a, **kw: _mock_audio_choices()
+    )
+    return instance
+
+
+def _make_request(modalities, stream=False):
+    req = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=stream,
+    )
+    req.modalities = modalities
+    return req
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+async def _call_full_generator(serving, outputs, modalities):
+    request = _make_request(modalities)
+    tokenizer = MagicMock()
+    metadata = MagicMock()
+    result = await serving.chat_completion_full_generator(
+        request=request,
+        result_generator=_async_iter(outputs),
+        request_id="chatcmpl-test",
+        model_name="test-model",
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=metadata,
+    )
+    return result
+
+
+@pytest.mark.asyncio
+async def test_text_only():
+    serving = _build_serving_chat()
+    text_output = _make_text_omni_output(text="hello world")
+
+    text_choice = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(role="assistant", content="hello world"),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    serving._create_text_choice = MagicMock(
+        return_value=_mock_text_choice_result([text_choice])
+    )
+
+    response = await _call_full_generator(serving, [text_output], ["text"])
+
+    assert len(response.choices) == 1
+    assert response.choices[0].message.content == "hello world"
+    assert response.choices[0].message.audio is None
+
+
+@pytest.mark.asyncio
+async def test_audio_only():
+    serving = _build_serving_chat()
+    audio_output = _make_audio_omni_output()
+
+    response = await _call_full_generator(serving, [audio_output], ["audio"])
+
+    assert len(response.choices) == 1
+    assert response.choices[0].message.audio is FAKE_AUDIO
+
+
+@pytest.mark.asyncio
+async def test_text_and_audio_merged():
+    serving = _build_serving_chat()
+    text_output = _make_text_omni_output(text="hello")
+    audio_output = _make_audio_omni_output()
+
+    text_choice = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(role="assistant", content="hello"),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    serving._create_text_choice = MagicMock(
+        return_value=_mock_text_choice_result([text_choice])
+    )
+
+    response = await _call_full_generator(
+        serving, [text_output, audio_output], ["text", "audio"]
+    )
+
+    assert len(response.choices) == 1
+    assert response.choices[0].message.content == "hello"
+    assert response.choices[0].message.audio is FAKE_AUDIO
+
+
+@pytest.mark.asyncio
+async def test_text_and_audio_merged_n2():
+    serving = _build_serving_chat()
+    text_output = _make_text_omni_output(text="first")
+    audio_output = _make_audio_omni_output()
+
+    choice_0 = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(role="assistant", content="first"),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    choice_1 = ChatCompletionResponseChoice(
+        index=1,
+        message=ChatMessage(role="assistant", content="second"),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    serving._create_text_choice = MagicMock(
+        return_value=_mock_text_choice_result([choice_0, choice_1])
+    )
+
+    response = await _call_full_generator(
+        serving, [text_output, audio_output], ["text", "audio"]
+    )
+
+    assert len(response.choices) == 2
+    assert response.choices[0].index == 0
+    assert response.choices[0].message.content == "first"
+    assert response.choices[0].message.audio is FAKE_AUDIO
+    assert response.choices[1].index == 1
+    assert response.choices[1].message.content == "second"
+    assert response.choices[1].message.audio is FAKE_AUDIO

--- a/tests/entrypoints/test_stream_finish_reason.py
+++ b/tests/entrypoints/test_stream_finish_reason.py
@@ -16,30 +16,20 @@ Key invariants tested:
   - voice/speaker parameter compatibility in chat completions
 """
 
-import enum
 import json
 from unittest.mock import MagicMock
 
 import pytest
-
-# Python 3.10 compat: StrEnum was added in 3.11
-if not hasattr(enum, "StrEnum"):
-
-    class _StrEnum(str, enum.Enum):
-        """Minimal StrEnum backport for Python 3.10."""
-
-    enum.StrEnum = _StrEnum  # type: ignore[attr-defined]
-
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
-    ChatCompletionResponseStreamChoice,
 )
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage
-from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.outputs import CompletionOutput, RequestOutput
 
-from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
-from vllm_omni.outputs import OmniRequestOutput
+from tests.helpers.serving_chat import (
+    build_serving_chat,
+    make_audio_omni_output,
+    make_request,
+    make_text_omni_output,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -47,126 +37,6 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_text_omni_output(
-    request_id: str = "test-req",
-    text: str = "hello",
-    token_ids: list[int] | None = None,
-    finish_reason: str | None = None,
-    index: int = 0,
-    num_prompt_tokens: int = 3,
-) -> OmniRequestOutput:
-    """Build an OmniRequestOutput wrapping a text RequestOutput."""
-    if token_ids is None:
-        token_ids = [10, 11, 12]
-    res = RequestOutput(
-        request_id=request_id,
-        prompt="test",
-        prompt_token_ids=list(range(num_prompt_tokens)),
-        prompt_logprobs=None,
-        outputs=[
-            CompletionOutput(
-                index=index,
-                text=text,
-                token_ids=token_ids,
-                cumulative_logprob=0.0,
-                logprobs=None,
-                finish_reason=finish_reason,
-                stop_reason=None,
-            )
-        ],
-        finished=finish_reason is not None,
-    )
-    return OmniRequestOutput(
-        request_id=request_id,
-        final_output_type="text",
-        request_output=res,
-        finished=finish_reason is not None,
-    )
-
-
-def _make_audio_omni_output(
-    request_id: str = "test-req",
-    index: int = 0,
-    num_prompt_tokens: int = 3,
-) -> OmniRequestOutput:
-    """Build an OmniRequestOutput for audio (no torch dependency)."""
-    res = RequestOutput(
-        request_id=request_id,
-        prompt="test",
-        prompt_token_ids=list(range(num_prompt_tokens)),
-        prompt_logprobs=None,
-        outputs=[
-            CompletionOutput(
-                index=index,
-                text="",
-                token_ids=[],
-                cumulative_logprob=0.0,
-                logprobs=None,
-                finish_reason="stop",
-                stop_reason=None,
-            )
-        ],
-        finished=True,
-    )
-    return OmniRequestOutput(
-        request_id=request_id,
-        final_output_type="audio",
-        request_output=res,
-        finished=True,
-    )
-
-
-def _mock_audio_choices(index: int = 0, role: str = "assistant"):
-    return [
-        ChatCompletionResponseStreamChoice(
-            index=index,
-            delta=DeltaMessage(role=role, content="dGVzdA=="),
-            logprobs=None,
-            finish_reason="stop",
-        )
-    ]
-
-
-def _build_serving_chat():
-    """Create a minimal OmniOpenAIServingChat for testing."""
-    mock_engine = MagicMock()
-    mock_engine.errored = False
-
-    models = OpenAIServingModels(
-        engine_client=mock_engine,
-        base_model_paths=[],
-    )
-    mock_render = MagicMock()
-
-    instance = OmniOpenAIServingChat(
-        engine_client=mock_engine,
-        models=models,
-        response_role="assistant",
-        online_renderer=mock_render,
-        request_logger=None,
-        chat_template=None,
-        chat_template_content_format="auto",
-    )
-    instance._create_audio_choice = MagicMock(
-        side_effect=lambda omni_res, role, request, stream=False: _mock_audio_choices(
-            index=omni_res.request_output.outputs[0].index,
-            role=role,
-        )
-    )
-    return instance
-
-
-def _make_request(modalities: list[str], n: int = 1) -> ChatCompletionRequest:
-    req = ChatCompletionRequest(
-        model="test-model",
-        messages=[{"role": "user", "content": "hello"}],
-        n=n,
-        stream=True,
-    )
-    req.modalities = modalities  # type: ignore[attr-defined]
-    return req
 
 
 def _parse_sse_chunks(lines: list[str]) -> list[dict]:
@@ -202,12 +72,12 @@ async def _collect_stream(gen):
 @pytest.mark.asyncio
 async def test_single_modality_text_only_one_stop():
     """Text-only streaming: exactly one chunk has finish_reason='stop'."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["text"])
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["text"])
 
     async def result_generator():
-        yield _make_text_omni_output(text="he", token_ids=[10, 11], finish_reason=None)
-        yield _make_text_omni_output(text="llo", token_ids=[12], finish_reason="stop")
+        yield make_text_omni_output(text="he", token_ids=[10, 11], finish_reason=None)
+        yield make_text_omni_output(text="llo", token_ids=[12], finish_reason="stop")
 
     raw_lines = await _collect_stream(
         serving_chat.chat_completion_stream_generator(
@@ -233,13 +103,13 @@ async def test_single_modality_text_only_one_stop():
 @pytest.mark.asyncio
 async def test_multi_modal_text_audio_only_last_stop():
     """text+audio: text finish sends finish_reason=null, audio sends stop."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["text", "audio"])
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["text", "audio"])
 
     async def result_generator():
-        yield _make_text_omni_output(text="he", token_ids=[10, 11], finish_reason=None)
-        yield _make_text_omni_output(text="llo", token_ids=[12], finish_reason="stop")
-        yield _make_audio_omni_output()
+        yield make_text_omni_output(text="he", token_ids=[10, 11], finish_reason=None)
+        yield make_text_omni_output(text="llo", token_ids=[12], finish_reason="stop")
+        yield make_audio_omni_output()
 
     raw_lines = await _collect_stream(
         serving_chat.chat_completion_stream_generator(
@@ -269,16 +139,16 @@ async def test_multi_modal_text_audio_only_last_stop():
 @pytest.mark.asyncio
 async def test_multi_modal_n2_independent_per_choice():
     """n=2 with text+audio: each choice gets exactly one stop, at the end."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["text", "audio"], n=2)
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["text", "audio"], n=2)
 
     async def result_generator():
-        yield _make_text_omni_output(text="A", token_ids=[10], finish_reason=None, index=0)
-        yield _make_text_omni_output(text="B", token_ids=[20], finish_reason=None, index=1)
-        yield _make_text_omni_output(text="", token_ids=[11], finish_reason="stop", index=0)
-        yield _make_text_omni_output(text="", token_ids=[21], finish_reason="stop", index=1)
-        yield _make_audio_omni_output(index=0)
-        yield _make_audio_omni_output(index=1)
+        yield make_text_omni_output(text="A", token_ids=[10], finish_reason=None, index=0)
+        yield make_text_omni_output(text="B", token_ids=[20], finish_reason=None, index=1)
+        yield make_text_omni_output(text="", token_ids=[11], finish_reason="stop", index=0)
+        yield make_text_omni_output(text="", token_ids=[21], finish_reason="stop", index=1)
+        yield make_audio_omni_output(index=0)
+        yield make_audio_omni_output(index=1)
 
     raw_lines = await _collect_stream(
         serving_chat.chat_completion_stream_generator(
@@ -306,11 +176,11 @@ async def test_multi_modal_n2_independent_per_choice():
 @pytest.mark.asyncio
 async def test_single_modality_audio_only_one_stop():
     """Audio-only streaming: the audio chunk carries finish_reason='stop'."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["audio"])
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["audio"])
 
     async def result_generator():
-        yield _make_audio_omni_output()
+        yield make_audio_omni_output()
 
     raw_lines = await _collect_stream(
         serving_chat.chat_completion_stream_generator(
@@ -340,13 +210,13 @@ async def test_single_modality_audio_only_one_stop():
 async def test_declared_modality_not_produced_emits_fallback_stop():
     """If request.modalities declares ["text","audio"] but engine only produces
     text, a fallback stop chunk is emitted at stream end."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["text", "audio"])
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["text", "audio"])
 
     async def result_generator():
         # Engine only produces text, no audio output at all
-        yield _make_text_omni_output(text="hi", token_ids=[10], finish_reason=None)
-        yield _make_text_omni_output(text="!", token_ids=[11], finish_reason="stop")
+        yield make_text_omni_output(text="hi", token_ids=[10], finish_reason=None)
+        yield make_text_omni_output(text="!", token_ids=[11], finish_reason="stop")
 
     raw_lines = await _collect_stream(
         serving_chat.chat_completion_stream_generator(
@@ -373,12 +243,12 @@ async def test_declared_modality_not_produced_emits_fallback_stop():
 async def test_declared_modality_not_produced_text_finish_suppressed():
     """When text finishes but audio (declared in modalities) never appears,
     the text finish chunk has finish_reason=null (suppressed)."""
-    serving_chat = _build_serving_chat()
-    request = _make_request(modalities=["text", "audio"])
+    serving_chat = build_serving_chat()
+    request = make_request(modalities=["text", "audio"])
 
     async def result_generator():
-        yield _make_text_omni_output(text="hi", token_ids=[10], finish_reason=None)
-        yield _make_text_omni_output(text="!", token_ids=[11], finish_reason="stop")
+        yield make_text_omni_output(text="hi", token_ids=[10], finish_reason=None)
+        yield make_text_omni_output(text="!", token_ids=[11], finish_reason="stop")
         # No audio output — stream ends
 
     raw_lines = await _collect_stream(

--- a/tests/helpers/serving_chat.py
+++ b/tests/helpers/serving_chat.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory functions and helpers for OmniOpenAIServingChat tests."""
+
+import enum
+from unittest.mock import MagicMock
+
+if not hasattr(enum, "StrEnum"):
+
+    class _StrEnum(str, enum.Enum):
+        pass
+
+    enum.StrEnum = _StrEnum  # type: ignore[attr-defined]
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponseStreamChoice,
+)
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.outputs import CompletionOutput, RequestOutput
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+from vllm_omni.outputs import OmniRequestOutput
+
+
+def make_text_omni_output(
+    request_id: str = "test-req",
+    text: str = "hello",
+    token_ids: list[int] | None = None,
+    finish_reason: str | None = None,
+    index: int = 0,
+    num_prompt_tokens: int = 3,
+) -> OmniRequestOutput:
+    if token_ids is None:
+        token_ids = [10, 11, 12]
+    res = RequestOutput(
+        request_id=request_id,
+        prompt="test",
+        prompt_token_ids=list(range(num_prompt_tokens)),
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=index,
+                text=text,
+                token_ids=token_ids,
+                cumulative_logprob=0.0,
+                logprobs=None,
+                finish_reason=finish_reason,
+                stop_reason=None,
+            )
+        ],
+        finished=finish_reason is not None,
+    )
+    return OmniRequestOutput(
+        request_id=request_id,
+        final_output_type="text",
+        request_output=res,
+        finished=finish_reason is not None,
+    )
+
+
+def make_audio_omni_output(
+    request_id: str = "test-req",
+    index: int = 0,
+    num_prompt_tokens: int = 3,
+) -> OmniRequestOutput:
+    res = RequestOutput(
+        request_id=request_id,
+        prompt="test",
+        prompt_token_ids=list(range(num_prompt_tokens)),
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=index,
+                text="",
+                token_ids=[],
+                cumulative_logprob=0.0,
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=None,
+            )
+        ],
+        finished=True,
+    )
+    return OmniRequestOutput(
+        request_id=request_id,
+        final_output_type="audio",
+        request_output=res,
+        finished=True,
+    )
+
+
+def mock_stream_audio_choices(index: int = 0, role: str = "assistant"):
+    return [
+        ChatCompletionResponseStreamChoice(
+            index=index,
+            delta=DeltaMessage(role=role, content="dGVzdA=="),
+            logprobs=None,
+            finish_reason="stop",
+        )
+    ]
+
+
+def build_serving_chat() -> OmniOpenAIServingChat:
+    mock_engine = MagicMock()
+    mock_engine.errored = False
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=[],
+    )
+
+    instance = OmniOpenAIServingChat(
+        engine_client=mock_engine,
+        models=models,
+        response_role="assistant",
+        openai_serving_render=MagicMock(),
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+    instance._create_audio_choice = MagicMock(
+        side_effect=lambda omni_res, role, request, stream=False: mock_stream_audio_choices(
+            index=omni_res.request_output.outputs[0].index,
+            role=role,
+        )
+    )
+    return instance
+
+
+def make_request(
+    modalities: list[str],
+    n: int = 1,
+    stream: bool = True,
+) -> ChatCompletionRequest:
+    req = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        n=n,
+        stream=stream,
+    )
+    req.modalities = modalities  # type: ignore[attr-defined]
+    return req

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2153,7 +2153,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         # Collect modality outputs to merge into a single choice
         text_choices: list[ChatCompletionResponseChoice] = []
-        audio_obj: OpenAIChatCompletionAudio | None = None
+        audio_choices: list[ChatCompletionResponseChoice] = []
         image_choices: list[ChatCompletionResponseChoice] = []
 
         for omni_outputs in final_outputs:
@@ -2199,9 +2199,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         )
                     )
             elif omni_outputs.final_output_type == "audio":
-                audio_choices = self._create_audio_choice(omni_outputs, role, request, stream=False)
-                if audio_choices:
-                    audio_obj = audio_choices[0].message.audio
+                audio_choices.extend(self._create_audio_choice(omni_outputs, role, request, stream=False))
             elif omni_outputs.final_output_type == "image":
                 image_choices.extend(self._create_image_choice(omni_outputs, role, request, stream=False))
             else:
@@ -2221,38 +2219,15 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         # Merge text and audio into a single choice per the OpenAI spec
         choices: list[ChatCompletionResponseChoice] = []
-        if text_choices and audio_obj:
+        if text_choices and audio_choices:
+            audio_obj = audio_choices[0].message.audio
             for tc in text_choices:
-                merged_message = ChatMessage(
-                    role=tc.message.role,
-                    content=tc.message.content,
-                    audio=audio_obj,
-                    reasoning=tc.message.reasoning,
-                    refusal=tc.message.refusal,
-                    function_call=tc.message.function_call,
-                    tool_calls=tc.message.tool_calls,
-                )
-                choices.append(
-                    ChatCompletionResponseChoice(
-                        index=tc.index,
-                        message=merged_message,
-                        logprobs=tc.logprobs,
-                        finish_reason=tc.finish_reason,
-                        stop_reason=tc.stop_reason,
-                    )
-                )
+                tc.message.audio = audio_obj
+            choices.extend(text_choices)
         elif text_choices:
             choices.extend(text_choices)
-        elif audio_obj:
-            choices.append(
-                ChatCompletionResponseChoice(
-                    index=0,
-                    message=ChatMessage(role=role, audio=audio_obj),
-                    logprobs=None,
-                    finish_reason="stop",
-                    stop_reason=None,
-                )
-            )
+        elif audio_choices:
+            choices.extend(audio_choices)
         choices.extend(image_choices)
 
         response_metrics = self._filter_stage_metrics_detail(response_metrics, request)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2139,8 +2139,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         assert final_outputs is not None
 
-        choices: list[ChatCompletionResponseChoice] = []
-
         usage = UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0)
         role = self.get_chat_request_role(request)
         prompt_logprobs = None
@@ -2153,8 +2151,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             set(request.modalities) if hasattr(request, "modalities") and request.modalities else None
         )
 
+        # Collect modality outputs to merge into a single choice
+        text_choices: list[ChatCompletionResponseChoice] = []
+        audio_obj: OpenAIChatCompletionAudio | None = None
+        image_choices: list[ChatCompletionResponseChoice] = []
+
         for omni_outputs in final_outputs:
-            choices_data = []
             if omni_outputs.request_output is not None and not getattr(omni_outputs.request_output, "finished", False):
                 continue
 
@@ -2179,6 +2181,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         role,
                         reasoning_parser,
                     )
+                    text_choices.extend(choices_data)
                     final_res = omni_outputs.request_output
                 else:
                     # Diffusion pipeline text output (e.g. single-stage
@@ -2186,7 +2189,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     # a simple text choice from diffusion multimodal output.
                     text_body = self._get_diffusion_text_output(omni_outputs)
                     message = ChatMessage(role=role, content=text_body)
-                    choices_data = [
+                    text_choices.append(
                         ChatCompletionResponseChoice(
                             index=0,
                             message=message,
@@ -2194,11 +2197,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             finish_reason="stop",
                             stop_reason=None,
                         )
-                    ]
+                    )
             elif omni_outputs.final_output_type == "audio":
-                choices_data = self._create_audio_choice(omni_outputs, role, request, stream=False)
+                audio_choices = self._create_audio_choice(omni_outputs, role, request, stream=False)
+                if audio_choices:
+                    audio_obj = audio_choices[0].message.audio
             elif omni_outputs.final_output_type == "image":
-                choices_data = self._create_image_choice(omni_outputs, role, request, stream=False)
+                image_choices.extend(self._create_image_choice(omni_outputs, role, request, stream=False))
             else:
                 logger.warning(f"Unsupported final output type: {omni_outputs.final_output_type}")
                 continue
@@ -2213,7 +2218,42 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 extra = self._get_diffusion_extra_output_params(omni_outputs)
                 if extra:
                     response_metrics.update(extra)
-            choices.extend(choices_data)
+
+        # Merge text and audio into a single choice per the OpenAI spec
+        choices: list[ChatCompletionResponseChoice] = []
+        if text_choices and audio_obj:
+            for tc in text_choices:
+                merged_message = ChatMessage(
+                    role=tc.message.role,
+                    content=tc.message.content,
+                    audio=audio_obj,
+                    reasoning=tc.message.reasoning,
+                    refusal=tc.message.refusal,
+                    function_call=tc.message.function_call,
+                    tool_calls=tc.message.tool_calls,
+                )
+                choices.append(
+                    ChatCompletionResponseChoice(
+                        index=tc.index,
+                        message=merged_message,
+                        logprobs=tc.logprobs,
+                        finish_reason=tc.finish_reason,
+                        stop_reason=tc.stop_reason,
+                    )
+                )
+        elif text_choices:
+            choices.extend(text_choices)
+        elif audio_obj:
+            choices.append(
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role=role, audio=audio_obj),
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            )
+        choices.extend(image_choices)
 
         response_metrics = self._filter_stage_metrics_detail(response_metrics, request)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

Reimplement https://github.com/vllm-project/vllm-omni/pull/4450

## Purpose
`/v1/chat/completions` for audio-generating models with `"stream": False` currently returns a response with two `choices`: one with text and another with audio. This is inconsistent with both vLLM-Omni's own `"stream": True` behavior  and the OpenAI API specification, which have the server returning a single `ChatCompletionResponseChoice` with both text and audio.

This PR edits the handling logic to cause `/v1/chat/completions` with `"modalities": ["text", "audio"]` to correctly merge responses in `choices`.

## Test Plan
### Unit tests
* `test_text_only`: Test `modalities: ["text"]`
* `test_audio_only`: Test `modalities: ["audio"]`
* `test_text_and_audio_merge`: Test `modalities: ["text", "audio"]`

### E2E tests
Deploy Qwen3-Omni and Qwen-Image-2512 and observe structure of response from `POST /v1/chat/completions` with `"stream": "false"`

**vLLM Version:**
`v0.23.0`

**vLLM-Omni Commit:**
`67bd02f76782e75680e12d37a2241dc030ec3004`

## Test Result
### Unit tests
* `test_text_only`: PASSED (previously PASSED)
* `test_audio_only`: PASSED (previously PASSED)
* `test_text_and_audio_merge`: PASSED (previously FAILED)

### E2E tests
Qwen3-Omni "text":
[qwen3-text.json](https://github.com/user-attachments/files/29310490/qwen3-text.json)

Qwen3-Omni "audio":
[qwen3-audio.json](https://github.com/user-attachments/files/29310494/qwen3-audio.json)

Qwen3-Omni "text" and "audio":
[qwen3-text-and-audio.json](https://github.com/user-attachments/files/29310502/qwen3-text-and-audio.json)

Qwen-Image-2512 "image":
[qwen-image.json](https://github.com/user-attachments/files/29310541/qwen-image.json)

All have expected structure.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
