### PR TITLE
[Test] Skip MOSS TTS offline E2E tests (issue #4700)

### DIFF
--- a/tests/e2e/offline_inference/test_moss_tts.py
+++ b/tests/e2e/offline_inference/test_moss_tts.py
@@ -88,6 +88,7 @@ def _get_test_config() -> str:
 # ---------------------------------------------------------------------------
 
 pytestmark = [
+    pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/4700"),
     pytest.mark.full_model,
     pytest.mark.tts,
     pytest.mark.parametrize("omni_runner", [(MODEL, _get_test_config())], indirect=True),

--- a/tests/e2e/offline_inference/test_moss_tts_realtime.py
+++ b/tests/e2e/offline_inference/test_moss_tts_realtime.py
@@ -95,6 +95,7 @@ def _get_test_config() -> str:
 # ---------------------------------------------------------------------------
 
 pytestmark = [
+    pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/4700"),
     pytest.mark.full_model,
     pytest.mark.tts,
     pytest.mark.parametrize("omni_runner", [(MODEL, _get_test_config())], indirect=True),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

MOSS TTS offline E2E tests fail during orchestrator initialization on CI:

- `test_moss_tts.py`: `OpenMOSS-Team/MOSS-VoiceGenerator` requires `trust_remote_code=True` at ModelConfig validation time.
- `test_moss_tts_realtime.py`: Transformers does not recognize architecture `moss_tts_realtime`.

Skip the affected modules at collection time until the underlying loading/config issues are fixed.

## Test Plan

- No new tests; CI-only skip markers on existing modules.
- Local collection (with full deps):

```bash
pytest tests/e2e/offline_inference/test_moss_tts.py \
       tests/e2e/offline_inference/test_moss_tts_realtime.py --collect-only -q
```

Expected: 5 tests reported as skipped with reason `issues/4700`.

**vLLM Version:** N/A (test-only change)

**vLLM-Omni Commit:** `d6966b12`

## Test Result

- Pending CI (Buildkite L2/L3 merge jobs that include MOSS TTS offline inference).
- Skip markers follow existing offline_inference convention (module-level `pytestmark.skip` with issue URL).

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
