### PR TITLE
[Bugfix] Free CosyVoice3 process-wide GPU caches on engine shutdown

### DIFF
--- a/tests/entrypoints/test_omni_base_shutdown_cache.py
+++ b/tests/entrypoints/test_omni_base_shutdown_cache.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for OmniBase shutdown dispatching CosyVoice3 cache cleanup.
+
+``OmniBase._shutdown_base`` releases model-side process-wide caches after the
+engine stops, but only for model modules that were actually imported — it looks
+them up via ``sys.modules`` so shutdown never forces a heavy optional import.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.entrypoints.omni_base import OmniBase
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_COSYVOICE3_MOD = "vllm_omni.model_executor.models.cosyvoice3.cosyvoice3"
+
+
+def _fake_self(engine):
+    """Minimal stand-in carrying only the attributes _shutdown_base reads."""
+    return SimpleNamespace(_shutdown_called=False, _weak_finalizer=None, engine=engine)
+
+
+class TestShutdownCacheDispatch:
+    def test_calls_cleanup_when_module_imported(self, mocker):
+        engine = mocker.MagicMock()
+        cleanup = mocker.MagicMock()
+        fake_mod = SimpleNamespace(clear_process_runtime_caches=cleanup)
+        mocker.patch.dict(sys.modules, {_COSYVOICE3_MOD: fake_mod})
+
+        OmniBase._shutdown_base(_fake_self(engine))
+
+        engine.shutdown.assert_called_once()
+        cleanup.assert_called_once_with()
+
+    def test_skips_when_module_not_imported(self, mocker):
+        engine = mocker.MagicMock()
+        # Ensure the module is absent; shutdown must not import it.
+        mocker.patch.dict(sys.modules)
+        sys.modules.pop(_COSYVOICE3_MOD, None)
+
+        OmniBase._shutdown_base(_fake_self(engine))
+
+        engine.shutdown.assert_called_once()
+        assert _COSYVOICE3_MOD not in sys.modules
+
+    def test_cleanup_failure_does_not_propagate(self, mocker):
+        engine = mocker.MagicMock()
+        cleanup = mocker.MagicMock(side_effect=RuntimeError("cleanup boom"))
+        fake_mod = SimpleNamespace(clear_process_runtime_caches=cleanup)
+        mocker.patch.dict(sys.modules, {_COSYVOICE3_MOD: fake_mod})
+
+        # Must not raise even though the model cleanup blew up.
+        OmniBase._shutdown_base(_fake_self(engine))
+        cleanup.assert_called_once_with()
+
+    def test_second_call_is_a_noop(self, mocker):
+        engine = mocker.MagicMock()
+        cleanup = mocker.MagicMock()
+        fake_mod = SimpleNamespace(clear_process_runtime_caches=cleanup)
+        mocker.patch.dict(sys.modules, {_COSYVOICE3_MOD: fake_mod})
+
+        slf = _fake_self(engine)
+        OmniBase._shutdown_base(slf)
+        OmniBase._shutdown_base(slf)
+
+        # _shutdown_called guard prevents a second engine.shutdown / cleanup.
+        engine.shutdown.assert_called_once()
+        cleanup.assert_called_once_with()

--- a/tests/model_executor/models/cosyvoice3/test_cosyvoice3_cache_cleanup.py
+++ b/tests/model_executor/models/cosyvoice3/test_cosyvoice3_cache_cleanup.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for CosyVoice3 process-wide cache cleanup.
+
+CosyVoice3 keeps several process-wide caches in the main process (keyed by
+``model_dir`` and never evicted). ``clear_process_runtime_caches`` releases them
+on engine shutdown to bound memory growth; these tests verify it empties every
+cache, is resilient to a failing release, and is idempotent.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import vllm_omni.model_executor.models.cosyvoice3.cosyvoice3 as c3
+import vllm_omni.model_executor.models.cosyvoice3.speaker_embedding_trt as trt
+from vllm_omni.utils.speaker_cache import SpeakerEmbeddingCache, get_speaker_cache
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _StubCampplus:
+    """Stand-in for CampplusTRT that records close() without building an engine."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches(fresh_speaker_cache):
+    """Snapshot and restore the process-wide caches around each test.
+
+    ``fresh_speaker_cache`` resets the speaker-cache singleton; here we also
+    save/restore the cosyvoice3 module globals and the class-level s3 model so a
+    test never leaks cache state into the rest of the suite.
+    """
+    saved_runtime = dict(c3._RUNTIME_COMPONENTS_CACHE)
+    saved_campplus = dict(trt._CAMPPLUS_CACHE)
+    saved_s3 = c3.CosyVoice3MultiModalProcessor._s3_model
+
+    c3._RUNTIME_COMPONENTS_CACHE.clear()
+    trt._CAMPPLUS_CACHE.clear()
+    c3.CosyVoice3MultiModalProcessor._s3_model = None
+    try:
+        yield
+    finally:
+        c3._RUNTIME_COMPONENTS_CACHE.clear()
+        c3._RUNTIME_COMPONENTS_CACHE.update(saved_runtime)
+        trt._CAMPPLUS_CACHE.clear()
+        trt._CAMPPLUS_CACHE.update(saved_campplus)
+        c3.CosyVoice3MultiModalProcessor._s3_model = saved_s3
+
+
+def _populate_all_caches() -> _StubCampplus:
+    """Fill every process-wide cache and return the stub campplus instance."""
+    stub = _StubCampplus()
+    c3.CosyVoice3MultiModalProcessor._s3_model = ("model", "s3module", "cuda")
+    c3._RUNTIME_COMPONENTS_CACHE["/some/model_dir"] = {
+        "tokenizer": object(),
+        "campplus_trt": stub,
+    }
+    trt._CAMPPLUS_CACHE[("/some/campplus.onnx", "cuda")] = stub
+    get_speaker_cache().put(
+        SpeakerEmbeddingCache.make_cache_key("alice", model_type="cosyvoice3"),
+        {"emb": object()},
+    )
+    return stub
+
+
+class TestClearProcessRuntimeCaches:
+    def test_clears_all_four_caches(self):
+        stub = _populate_all_caches()
+        speaker_key = SpeakerEmbeddingCache.make_cache_key("alice", model_type="cosyvoice3")
+        # Sanity: everything is populated before the call.
+        assert c3.CosyVoice3MultiModalProcessor._s3_model is not None
+        assert c3._RUNTIME_COMPONENTS_CACHE
+        assert trt._CAMPPLUS_CACHE
+        assert get_speaker_cache().get(speaker_key) is not None
+
+        c3.clear_process_runtime_caches()
+
+        assert c3.CosyVoice3MultiModalProcessor._s3_model is None
+        assert c3._RUNTIME_COMPONENTS_CACHE == {}
+        assert trt._CAMPPLUS_CACHE == {}
+        assert get_speaker_cache().get(speaker_key) is None
+        # The campplus engine was released via close().
+        assert stub.closed is True
+
+    def test_idempotent_on_empty_caches(self):
+        # Caches start empty (autouse fixture). Calling twice must not raise.
+        c3.clear_process_runtime_caches()
+        c3.clear_process_runtime_caches()
+        assert c3.CosyVoice3MultiModalProcessor._s3_model is None
+        assert c3._RUNTIME_COMPONENTS_CACHE == {}
+        assert trt._CAMPPLUS_CACHE == {}
+
+    def test_speaker_cache_clear_failure_is_swallowed(self, monkeypatch):
+        """A failing speaker-cache clear must not abort the shutdown path."""
+        _populate_all_caches()
+
+        class _Boom:
+            def clear(self, *a, **k):
+                raise RuntimeError("speaker cache boom")
+
+        monkeypatch.setattr(c3, "get_speaker_cache", lambda: _Boom())
+
+        # Must not raise, and the caches cleared before the speaker step are
+        # still released.
+        c3.clear_process_runtime_caches()
+        assert c3.CosyVoice3MultiModalProcessor._s3_model is None
+        assert c3._RUNTIME_COMPONENTS_CACHE == {}
+        assert trt._CAMPPLUS_CACHE == {}
+
+    def test_release_s3_model_classmethod(self):
+        c3.CosyVoice3MultiModalProcessor._s3_model = ("m", "s3", "cuda")
+        c3.CosyVoice3MultiModalProcessor._release_s3_model()
+        assert c3.CosyVoice3MultiModalProcessor._s3_model is None
+
+
+class TestClearCampplusTrtCache:
+    def test_returns_count_and_closes_each(self):
+        a, b = _StubCampplus(), _StubCampplus()
+        trt._CAMPPLUS_CACHE[("a", "cuda")] = a
+        trt._CAMPPLUS_CACHE[("b", "cuda")] = b
+
+        n = trt.clear_campplus_trt_cache()
+
+        assert n == 2
+        assert a.closed and b.closed
+        assert trt._CAMPPLUS_CACHE == {}
+
+    def test_failing_close_is_swallowed_and_cache_still_cleared(self):
+        class _BadClose:
+            def close(self):
+                raise RuntimeError("close boom")
+
+        good = _StubCampplus()
+        trt._CAMPPLUS_CACHE[("bad", "cuda")] = _BadClose()
+        trt._CAMPPLUS_CACHE[("good", "cuda")] = good
+
+        # Must not raise; the dict is emptied and the well-behaved engine closed.
+        n = trt.clear_campplus_trt_cache()
+        assert n == 2
+        assert trt._CAMPPLUS_CACHE == {}
+        assert good.closed is True
+
+    def test_empty_cache_returns_zero(self):
+        assert trt.clear_campplus_trt_cache() == 0
+
+
+class TestCampplusTrtClose:
+    def test_close_drops_context_and_engine(self):
+        # Build a bare CampplusTRT without deserializing a real engine.
+        inst = trt.CampplusTRT.__new__(trt.CampplusTRT)
+        inst._lock = threading.Lock()
+        inst.context = object()
+        inst.engine = object()
+
+        inst.close()
+
+        assert inst.context is None
+        assert inst.engine is None

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 import weakref
 from collections.abc import Sequence
@@ -652,3 +653,13 @@ class OmniBase(PDDisaggregationMixin):
         if finalizer is not None and finalizer.alive:
             finalizer.detach()
         self.engine.shutdown()
+        # Release model-side process-wide caches built in this (main) process,
+        # e.g. CosyVoice3's mm-processor / TensorRT / s3tokenizer caches. Only
+        # touch a model module if it was actually imported, so shutdown never
+        # forces a heavy optional import.
+        cosyvoice3 = sys.modules.get("vllm_omni.model_executor.models.cosyvoice3.cosyvoice3")
+        if cosyvoice3 is not None:
+            try:
+                cosyvoice3.clear_process_runtime_caches()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("CosyVoice3 process cache cleanup failed: %s", exc)

--- a/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
@@ -204,6 +204,11 @@ class CosyVoice3MultiModalProcessor(BaseMultiModalProcessor[CosyVoice3MultiModal
         cls._s3_model = (model, _s3, device)
         return cls._s3_model
 
+    @classmethod
+    def _release_s3_model(cls) -> None:
+        """Drop the class-level s3tokenizer model (largest GPU consumer)."""
+        cls._s3_model = None
+
     def _extract_speech_token_via_s3(self, audio, return_device):
         """Drop-in replacement for ``extract_speech_token`` that uses the
         S3Tokenizer PyTorch model on GPU. Returns the same
@@ -392,6 +397,43 @@ class CosyVoice3MultiModalProcessor(BaseMultiModalProcessor[CosyVoice3MultiModal
                 insertion=insertion_end,
             ),
         ]
+
+
+def clear_process_runtime_caches() -> None:
+    """Release CosyVoice3's process-wide caches built in the main process.
+
+    These caches (keyed by ``model_dir``, never evicted) keep GPU/host memory
+    pinned for the lifetime of the process, so a server that swaps models or a
+    test worker that runs several models in one PID grows monotonically. This
+    drops them so memory falls back to the irreducible CUDA-context floor; it is
+    invoked from the engine shutdown path (``OmniBase._shutdown_base``).
+    """
+    # Largest GPU consumer first: the class-level s3tokenizer model.
+    CosyVoice3MultiModalProcessor._release_s3_model()
+
+    # TensorRT campplus engines + execution contexts.
+    try:
+        from vllm_omni.model_executor.models.cosyvoice3.speaker_embedding_trt import (
+            clear_campplus_trt_cache,
+        )
+
+        clear_campplus_trt_cache()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("CosyVoice3: campplus TRT cache clear failed: %s", exc)
+
+    # Per-model runtime components (tokenizer, feat_extractor, ONNX session).
+    # campplus_trt entries are already released above; drop the dict so the
+    # remaining CPU-side objects are freed too.
+    _RUNTIME_COMPONENTS_CACHE.clear()
+
+    # Speaker-embedding artifact cache (shared singleton).
+    try:
+        get_speaker_cache().clear()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("CosyVoice3: speaker cache clear failed: %s", exc)
+
+    if torch.cuda.is_available():
+        torch.accelerator.empty_cache()
 
 
 class CosyVoice3DummyInputsBuilder(BaseDummyInputsBuilder[CosyVoice3MultiModalProcessingInfo]):

--- a/vllm_omni/model_executor/models/cosyvoice3/speaker_embedding_trt.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/speaker_embedding_trt.py
@@ -137,6 +137,13 @@ class CampplusTRT:
             stream.synchronize()
         return out
 
+    def close(self) -> None:
+        """Release the TensorRT execution context and engine (GPU memory)."""
+        with self._lock:
+            # Drop the execution context before the engine it was created from.
+            self.context = None
+            self.engine = None
+
 
 # Process-wide cache: the mm processor is re-created per request (the deploy
 # config disables the mm-processor object cache), so building a fresh
@@ -155,3 +162,15 @@ def get_campplus_trt(onnx_path: str, device: str | torch.device) -> CampplusTRT:
         inst = CampplusTRT(onnx_path, device)
         _CAMPPLUS_CACHE[key] = inst
     return inst
+
+
+def clear_campplus_trt_cache() -> int:
+    """Release every cached TensorRT campplus engine. Returns count cleared."""
+    insts = list(_CAMPPLUS_CACHE.values())
+    _CAMPPLUS_CACHE.clear()
+    for inst in insts:
+        try:
+            inst.close()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("campplus TRT close failed: %s", exc)
+    return len(insts)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Follow-up to the discussion in #4354 (CI optimization). While moving the TTS·L4
E2E job, @linyueqian and @yenuo26 found that CosyVoice3 leaves a **~1.7 GiB GPU
memory residue** between test cases, which trips the per-test GPU health-check
gate (`threshold_ratio=0.05` ≈ 1.2 GiB on a 24 GB L4) and eventually times the
job out. See https://github.com/vllm-project/vllm-omni/pull/4354#issuecomment-4791501205 —
@linyueqian asked me to handle the **model-side cleanup** for the caches the
TensorRT path (#4168) introduced.

### Root cause

CosyVoice3 runs Stage-0 work in the **main process** and keeps several
process-wide caches that are **keyed by `model_dir` and never evicted**:

| Cache | Location | GPU |
| --- | --- | --- |
| `_RUNTIME_COMPONENTS_CACHE` | `cosyvoice3.py` (module-level dict) | mostly CPU; holds the TRT ref |
| `_CAMPPLUS_CACHE` | `speaker_embedding_trt.py` (module-level dict) | yes (TRT engine + context) |
| `_s3_model` | `CosyVoice3MultiModalProcessor` (class attr) | yes — largest consumer |
| speaker cache | `get_speaker_cache()` singleton | tensors |

A process that serves several `model_dir` values over its lifetime (a server
that swaps models, or a pytest worker that runs multiple model cases in one PID)
therefore grows GPU/host memory monotonically.

### Fix

- Add `clear_process_runtime_caches()` in `cosyvoice3.py` that releases all four
  caches — `_s3_model` first (largest GPU consumer, missing from the original
  proposal), then the TRT engines via `CampplusTRT.close()` +
  `clear_campplus_trt_cache()`, then `_RUNTIME_COMPONENTS_CACHE`, then the
  speaker cache — and calls `torch.cuda.empty_cache()`.
- Add `CampplusTRT.close()` and `clear_campplus_trt_cache()` in
  `speaker_embedding_trt.py` to free the TRT execution context + engine.
- Invoke it from `OmniBase._shutdown_base` via a `sys.modules` lookup, so engine
  shutdown never forces the heavy optional CosyVoice3 import when the model was
  not used.

This bounds multi-`model_dir` growth and helps long-running servers. As
@linyueqian noted, it cannot clear the irreducible ~1.2 GiB CUDA-context floor
on its own — the L4 health-check timeout is primarily addressed on the CI side
(separate processes per script); this is the complementary model-side cleanup.

## Test Plan

```bash
# Existing speaker-cache regression
.venv/bin/python -m pytest tests/test_speaker_cache.py -q

# Functional check: populate all four caches, call clear, assert empty
```

**vLLM Version:** 0.22.0

**vLLM-Omni Commit:** 940e1a49

## Test Result

- `tests/test_speaker_cache.py`: **19 passed**.
- Functional check (in `.venv`): after populating `_s3_model`,
  `_RUNTIME_COMPONENTS_CACHE`, `_CAMPPLUS_CACHE`, and the speaker cache,
  `clear_process_runtime_caches()` empties all four; `clear_campplus_trt_cache()`
  returns the cleared count and calls `close()` on each engine; the
  `OmniBase._shutdown_base` `sys.modules` lookup skips when CosyVoice3 is not
  imported and dispatches when it is.

> Note: this is logic/unit-level verification. The end-to-end L4 residue
> reduction must be confirmed in a weighted E2E run.
