### PR TITLE
[Bugfix][NPU] Register vllm-ascend custom ops in NPUOmniPlatform.set_device

### DIFF
--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -44,6 +44,12 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
     @classmethod
     def set_device(cls, device: torch.device) -> None:
         super().set_device(device)
+
+        # Register vllm_ascend custom ops (torch.ops._C_ascend.*).
+        from vllm_ascend.utils import enable_custom_op
+
+        enable_custom_op()
+
         # Ascend quantized weights are converted from ND to FRACTAL_NZ
         # after loading. Enable internal format so the NZ storage layout
         # is preserved for fused NPU kernels.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fixes #4702.

## Root cause
DiffusionWorker doesn't inherit NPUWorker and HunyuanImage's MoE path calls torch.ops._C_ascend.moe_gating_top_k directly. vllm-ascend registers _C_ascend.* lazily via op wrappers (AscendRMSNorm), which the diffusion path never hits (it uses its own norm), so the gating op is unregistered and crashes with AttributeError: `AttributeError: '_OpNamespace' '_C_ascend' object has no attribute 'moe_gating_top_k'`.

## Test Plan

Run 
```shell
pytest -s tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_hunyuan_image_tp4.json
```



**vLLM Version:** v0.23.0

**vLLM-Omni Commit:** main

## Test Result

```shell
--- Running Summary
=================================== 1 passed, 18 warnings in 348.28s (0:05:48) ====================================

```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
