### PR TITLE
Bump safetensors to the 0.8.0 release

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -13,7 +13,7 @@ transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5
 av>=14.0.0
 omegaconf>=2.3.0
 diffusers==0.38.0
-safetensors>=0.8.0rc0
+safetensors>=0.8.0
 accelerate==1.12.0
 soundfile>=0.13.1
 cache-dit==1.3.0


### PR DESCRIPTION
<!-- markdownlint-disable -->
Bump the safetensors dependency from the release candidate (`>=0.8.0rc0`) to the stable release (`>=0.8.0`).

## Purpose

The safetensors 0.8.0 stable release is now available. This PR updates `requirements/common.txt` to pin against the stable version instead of the release candidate, ensuring users install the final release rather than a pre-release build.

## Test Plan

No functional changes — this is a dependency version bump only. Existing CI tests validate compatibility.

**vLLM Version:** N/A

**vLLM-Omni Commit:** e9096ade

## Test Result

N/A (dependency version bump only)

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)