### PR TITLE
[NPU][Quant] Add MXFP8/MXFP4 online Linear quantization support for Hunyuanimage3.0 AR inference on Ascend NPU

### DIFF
--- a/tests/diffusion/quantization/test_mxfp4_config.py
+++ b/tests/diffusion/quantization/test_mxfp4_config.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for MXFP4 quantization configs and the MXFP4 DualScale + BF16 mixed config."""
 
+import sys
+import types
+
 import pytest
 import torch
 
@@ -14,6 +17,27 @@ def _patch_tp_state(monkeypatch):
     without an initialized distributed group.  Returns TP=1 rank=0 for all tests."""
     monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0)
     monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", lambda: 1)
+
+
+def _install_ascend_fused_moe_fake(monkeypatch: pytest.MonkeyPatch):
+    """Stub vllm_ascend.ops.fused_moe.fused_moe.AscendUnquantizedFusedMoEMethod
+    so get_quant_method's FusedMoE branch can be exercised without the real
+    vllm-ascend package. Returns the fake class so tests can inspect calls."""
+    calls: list[tuple] = []
+
+    class _FakeAscendUnquantizedFusedMoEMethod:
+        def __init__(self, moe_config, *, tid2eid=None):
+            self.moe_config = moe_config
+            self.tid2eid = tid2eid
+            calls.append((moe_config, {"tid2eid": tid2eid}))
+
+    for name in ("vllm_ascend", "vllm_ascend.ops", "vllm_ascend.ops.fused_moe"):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    fused_moe_module = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
+    fused_moe_module.AscendUnquantizedFusedMoEMethod = _FakeAscendUnquantizedFusedMoEMethod
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_module)
+
+    return _FakeAscendUnquantizedFusedMoEMethod, calls
 
 
 # ---------------------------------------------------------------------------
@@ -652,3 +676,149 @@ def test_rocm_create_weights_row_parallel_tp2(_rocm_platform):
     assert layer.weight.shape == (_TP2_N, _TP2_K // _TP2)
     assert layer.input_size_per_partition == _TP2_K // _TP2
     assert layer.output_size_per_partition == _TP2_N
+
+
+# ---------------------------------------------------------------------------
+# OmniNPUMxfp4Config — NPU AR-stage identity, distinct from vLLM's own "mxfp4"
+# ---------------------------------------------------------------------------
+
+
+def test_omni_npu_mxfp4_config_get_name():
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    assert OmniNPUMxfp4Config.get_name() == "omni_npu_mxfp4"
+
+
+def test_build_quant_config_omni_npu_mxfp4_registered():
+    """omni_npu_mxfp4 must resolve through vLLM's quantization registry,
+    the same lifecycle vLLM's own ModelConfig uses for "mxfp4"."""
+    from vllm_omni.quantization import build_quant_config
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    cfg = build_quant_config("omni_npu_mxfp4")
+    assert isinstance(cfg, OmniNPUMxfp4Config)
+    assert cfg.is_checkpoint_mxfp4_serialized is False
+
+
+def test_build_quant_config_omni_npu_mxfp4_local_serialized_checkpoint():
+    """A local pre-quantized checkpoint's config.json (quant_method="omni_npu_mxfp4",
+    is_checkpoint_mxfp4_serialized=True) must build the offline variant."""
+    from vllm_omni.quantization import build_quant_config
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    cfg = build_quant_config(
+        {"method": "omni_npu_mxfp4", "is_checkpoint_mxfp4_serialized": True, "ignored_layers": ["proj_out"]}
+    )
+    assert isinstance(cfg, OmniNPUMxfp4Config)
+    assert cfg.is_checkpoint_mxfp4_serialized is True
+    assert cfg.ignored_layers == ["proj_out"]
+
+
+@pytest.mark.parametrize("quant_method", ["mxfp4", "omni_npu_mxfp4"])
+def test_omni_npu_mxfp4_override_quantization_method_on_npu(quant_method: str, monkeypatch: pytest.MonkeyPatch):
+    """On NPU, a checkpoint declaring either the vLLM-reserved "mxfp4" name (e.g. a
+    Hugging Face checkpoint uploaded before the remap existed) or the already-remapped
+    "omni_npu_mxfp4" (a checkpoint saved locally by this integration) must both resolve
+    to "omni_npu_mxfp4" so vLLM's ModelConfig loads the Omni-specific config class."""
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    result = OmniNPUMxfp4Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": quant_method},
+        user_quant=None,
+    )
+    assert result == "omni_npu_mxfp4"
+
+
+def test_omni_npu_mxfp4_override_quantization_method_off_npu_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """The remap must not apply on non-NPU platforms, even with a matching config."""
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: False)
+
+    result = OmniNPUMxfp4Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": "mxfp4"},
+        user_quant=None,
+    )
+    assert result is None
+
+
+def test_omni_npu_mxfp4_override_quantization_method_mismatched_method_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An unrelated quant_method in the checkpoint config must not be hijacked."""
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    result = OmniNPUMxfp4Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": "mxfp4_dualscale"},
+        user_quant=None,
+    )
+    assert result is None
+
+
+def test_omni_npu_mxfp4_override_quantization_method_non_dict_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """hf_quant_cfg may be None (unquantized model) or a non-dict; must not raise."""
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    assert OmniNPUMxfp4Config.override_quantization_method(hf_quant_cfg=None, user_quant=None) is None
+    assert OmniNPUMxfp4Config.override_quantization_method(hf_quant_cfg="mxfp4", user_quant=None) is None
+
+
+# ---------------------------------------------------------------------------
+# get_quant_method — FusedMoE / tid2eid forwarding (NPU AR-stage MoE routing)
+# ---------------------------------------------------------------------------
+
+
+def test_get_quant_method_fused_moe_forwards_tid2eid(monkeypatch: pytest.MonkeyPatch, mocker):
+    """tid2eid (logical-to-physical expert id mapping) must be forwarded explicitly
+    to AscendUnquantizedFusedMoEMethod, not silently dropped via **kwargs."""
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import DiffusionMXFP4Config
+
+    fake_cls, calls = _install_ascend_fused_moe_fake(monkeypatch)
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    config = DiffusionMXFP4Config()
+    layer = mocker.Mock(spec=FusedMoE)
+    layer.moe_config = mocker.sentinel.moe_config
+    sentinel_tid2eid = mocker.sentinel.tid2eid
+
+    method = config.get_quant_method(layer, "blocks.0.ffn.experts", tid2eid=sentinel_tid2eid)
+
+    assert isinstance(method, fake_cls)
+    assert len(calls) == 1
+    moe_config_arg, kwargs = calls[0]
+    assert moe_config_arg is mocker.sentinel.moe_config
+    assert kwargs["tid2eid"] is sentinel_tid2eid
+
+
+def test_get_quant_method_fused_moe_without_tid2eid_passes_none(monkeypatch: pytest.MonkeyPatch, mocker):
+    """When no logical-to-physical mapping is active, tid2eid must default to None
+    rather than being omitted or raising."""
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+
+    from vllm_omni.platforms import current_omni_platform
+    from vllm_omni.quantization.mxfp4_config import DiffusionMXFP4Config
+
+    fake_cls, calls = _install_ascend_fused_moe_fake(monkeypatch)
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    config = DiffusionMXFP4Config()
+    layer = mocker.Mock(spec=FusedMoE)
+    layer.moe_config = mocker.sentinel.moe_config
+
+    method = config.get_quant_method(layer, "blocks.0.ffn.experts")
+
+    assert isinstance(method, fake_cls)
+    assert calls[0][1]["tid2eid"] is None

--- a/tests/diffusion/quantization/test_mxfp8_config.py
+++ b/tests/diffusion/quantization/test_mxfp8_config.py
@@ -11,9 +11,14 @@ Coverage:
 - MXFP8_QUANT_CONFIG structure as the auto-detection contract
 """
 
+import sys
+import types
+from typing import Any
+
 import pytest
 import torch
 from pytest_mock import MockerFixture
+from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
 from vllm_omni.platforms import current_omni_platform
@@ -22,6 +27,27 @@ from vllm_omni.quantization import build_quant_config
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 npu_available = pytest.mark.skipif(not current_omni_platform.is_npu(), reason="NPU platform not available")
+
+
+def _install_ascend_fused_moe_fake(monkeypatch: pytest.MonkeyPatch):
+    """Stub vllm_ascend.ops.fused_moe.fused_moe.AscendUnquantizedFusedMoEMethod
+    so get_quant_method's FusedMoE branch can be exercised without the real
+    vllm-ascend package. Returns the fake class so tests can inspect calls."""
+    calls: list[tuple[Any, dict]] = []
+
+    class _FakeAscendUnquantizedFusedMoEMethod:
+        def __init__(self, moe_config, *, tid2eid=None):
+            self.moe_config = moe_config
+            self.tid2eid = tid2eid
+            calls.append((moe_config, {"tid2eid": tid2eid}))
+
+    for name in ("vllm_ascend", "vllm_ascend.ops", "vllm_ascend.ops.fused_moe"):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    fused_moe_module = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
+    fused_moe_module.AscendUnquantizedFusedMoEMethod = _FakeAscendUnquantizedFusedMoEMethod
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_module)
+
+    return _FakeAscendUnquantizedFusedMoEMethod, calls
 
 
 # ---------------------------------------------------------------------------
@@ -335,3 +361,137 @@ def test_supported_methods_include_mxfp8():
     from vllm_omni.quantization import SUPPORTED_QUANTIZATION_METHODS
 
     assert "mxfp8" in SUPPORTED_QUANTIZATION_METHODS
+
+
+# ---------------------------------------------------------------------------
+# OmniNPUMxfp8Config — NPU AR-stage identity, distinct from vLLM's own "mxfp8"
+# ---------------------------------------------------------------------------
+
+
+def test_omni_npu_mxfp8_config_get_name():
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    assert OmniNPUMxfp8Config.get_name() == "omni_npu_mxfp8"
+
+
+def test_build_quant_config_omni_npu_mxfp8_registered():
+    """omni_npu_mxfp8 must resolve through vLLM's quantization registry,
+    the same lifecycle vLLM's own ModelConfig uses for "mxfp8"."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    cfg = build_quant_config("omni_npu_mxfp8")
+    assert isinstance(cfg, OmniNPUMxfp8Config)
+    assert cfg.is_checkpoint_mxfp8_serialized is False
+
+
+def test_build_quant_config_omni_npu_mxfp8_local_serialized_checkpoint():
+    """A local pre-quantized checkpoint's config.json (quant_method="omni_npu_mxfp8",
+    is_checkpoint_mxfp8_serialized=True) must build the offline variant."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    cfg = build_quant_config(
+        {"method": "omni_npu_mxfp8", "is_checkpoint_mxfp8_serialized": True, "ignored_layers": ["proj_out"]}
+    )
+    assert isinstance(cfg, OmniNPUMxfp8Config)
+    assert cfg.is_checkpoint_mxfp8_serialized is True
+    assert cfg.ignored_layers == ["proj_out"]
+
+
+@pytest.mark.parametrize("quant_method", ["mxfp8", "omni_npu_mxfp8"])
+def test_omni_npu_mxfp8_override_quantization_method_on_npu(quant_method: str, monkeypatch: pytest.MonkeyPatch):
+    """On NPU, a checkpoint declaring either the vLLM-reserved "mxfp8" name (e.g. a
+    Hugging Face checkpoint uploaded before the remap existed) or the already-remapped
+    "omni_npu_mxfp8" (a checkpoint saved locally by this integration) must both resolve
+    to "omni_npu_mxfp8" so vLLM's ModelConfig loads the Omni-specific config class."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    result = OmniNPUMxfp8Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": quant_method},
+        user_quant=None,
+    )
+    assert result == "omni_npu_mxfp8"
+
+
+def test_omni_npu_mxfp8_override_quantization_method_off_npu_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """The remap must not apply on non-NPU platforms, even with a matching config."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: False)
+
+    result = OmniNPUMxfp8Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": "mxfp8"},
+        user_quant=None,
+    )
+    assert result is None
+
+
+def test_omni_npu_mxfp8_override_quantization_method_mismatched_method_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An unrelated quant_method in the checkpoint config must not be hijacked."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    result = OmniNPUMxfp8Config.override_quantization_method(
+        hf_quant_cfg={"quant_method": "int8"},
+        user_quant=None,
+    )
+    assert result is None
+
+
+def test_omni_npu_mxfp8_override_quantization_method_non_dict_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """hf_quant_cfg may be None (unquantized model) or a non-dict; must not raise."""
+    from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
+
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    assert OmniNPUMxfp8Config.override_quantization_method(hf_quant_cfg=None, user_quant=None) is None
+    assert OmniNPUMxfp8Config.override_quantization_method(hf_quant_cfg="mxfp8", user_quant=None) is None
+
+
+# ---------------------------------------------------------------------------
+# get_quant_method — FusedMoE / tid2eid forwarding (NPU AR-stage MoE routing)
+# ---------------------------------------------------------------------------
+
+
+def test_get_quant_method_fused_moe_forwards_tid2eid(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+    """tid2eid (logical-to-physical expert id mapping) must be forwarded explicitly
+    to AscendUnquantizedFusedMoEMethod, not silently dropped via **kwargs."""
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    fake_cls, calls = _install_ascend_fused_moe_fake(monkeypatch)
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    config = DiffusionMXFP8Config()
+    layer = mocker.Mock(spec=FusedMoE)
+    layer.moe_config = mocker.sentinel.moe_config
+    sentinel_tid2eid = mocker.sentinel.tid2eid
+
+    method = config.get_quant_method(layer, "blocks.0.ffn.experts", tid2eid=sentinel_tid2eid)
+
+    assert isinstance(method, fake_cls)
+    assert len(calls) == 1
+    moe_config_arg, kwargs = calls[0]
+    assert moe_config_arg is mocker.sentinel.moe_config
+    assert kwargs["tid2eid"] is sentinel_tid2eid
+
+
+def test_get_quant_method_fused_moe_without_tid2eid_passes_none(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture):
+    """When no logical-to-physical mapping is active, tid2eid must default to None
+    rather than being omitted or raising."""
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    fake_cls, calls = _install_ascend_fused_moe_fake(monkeypatch)
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    config = DiffusionMXFP8Config()
+    layer = mocker.Mock(spec=FusedMoE)
+    layer.moe_config = mocker.sentinel.moe_config
+
+    method = config.get_quant_method(layer, "blocks.0.ffn.experts")
+
+    assert isinstance(method, fake_cls)
+    assert calls[0][1]["tid2eid"] is None

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -20,6 +20,9 @@ from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import build_engine_args_dict
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.quantization import build_quant_config
+from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config
+from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -357,3 +360,29 @@ def test_quantization_untouched_for_other_methods(monkeypatch: pytest.MonkeyPatc
     engine_args = OmniEngineArgs(quantization="mxfp4_dualscale", worker_type="ar")
 
     assert engine_args.quantization == "mxfp4_dualscale"
+
+
+@pytest.mark.parametrize(
+    ("resolved_method", "expected_cls"),
+    [
+        ("omni_npu_mxfp8", OmniNPUMxfp8Config),
+        ("omni_npu_mxfp4", OmniNPUMxfp4Config),
+    ],
+)
+def test_hf_config_only_npu_ar_registers_mxfp_configs_before_parent_post_init(
+    monkeypatch: pytest.MonkeyPatch,
+    resolved_method: str,
+    expected_cls: type,
+):
+    """HF-config-only AR startup must see Omni MXFP configs even when CLI quantization is unset."""
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    def fake_parent_post_init(self):
+        cfg = build_quant_config(resolved_method)
+        assert isinstance(cfg, expected_cls)
+
+    monkeypatch.setattr(EngineArgs, "__post_init__", fake_parent_post_init)
+
+    engine_args = OmniEngineArgs(quantization=None, worker_type="ar")
+
+    assert engine_args.quantization is None

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -19,6 +19,7 @@ from vllm_omni.config.model import OmniModelConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import build_engine_args_dict
+from vllm_omni.platforms import current_omni_platform
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -309,4 +310,50 @@ def test_tensor_parallel_size_none_is_handled():
         model="snu-aidas/Dynin-Omni",
     )
     assert isinstance(args, dict)
-    assert "tensor_parallel_size" not in args
+
+
+# ---------------------------------------------------------------------------
+# NPU AR-stage mxfp8/mxfp4 -> omni_npu_mxfp8/omni_npu_mxfp4 remap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["mxfp8", "mxfp4"])
+def test_npu_ar_quantization_remapped_to_omni_npu_name(monkeypatch: pytest.MonkeyPatch, method: str):
+    """NPU AR stages requesting mxfp8/mxfp4 must be remapped to a distinct,
+    registered method name before vLLM's own EngineArgs.__post_init__ runs,
+    so vLLM never resolves the reserved "mxfp8"/"mxfp4" built-in methods."""
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    engine_args = OmniEngineArgs(quantization=method, worker_type="ar")
+
+    assert engine_args.quantization == f"omni_npu_{method}"
+
+
+@pytest.mark.parametrize("method", ["mxfp8", "mxfp4"])
+def test_quantization_untouched_for_non_ar_worker_type(monkeypatch: pytest.MonkeyPatch, method: str):
+    """The remap must not apply to diffusion/generation stages, which resolve
+    their own quantization_config independently (OmniDiffusionConfig)."""
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    engine_args = OmniEngineArgs(quantization=method, worker_type="generation")
+
+    assert engine_args.quantization == method
+
+
+@pytest.mark.parametrize("method", ["mxfp8", "mxfp4"])
+def test_quantization_untouched_off_npu(monkeypatch: pytest.MonkeyPatch, method: str):
+    """The remap must not apply on non-NPU platforms."""
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: False)
+
+    engine_args = OmniEngineArgs(quantization=method, worker_type="ar")
+
+    assert engine_args.quantization == method
+
+
+def test_quantization_untouched_for_other_methods(monkeypatch: pytest.MonkeyPatch):
+    """Only mxfp8/mxfp4 are remapped; other quantization methods pass through."""
+    monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
+
+    engine_args = OmniEngineArgs(quantization="mxfp4_dualscale", worker_type="ar")
+
+    assert engine_args.quantization == "mxfp4_dualscale"

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -202,6 +202,19 @@ class OmniEngineArgs(EngineArgs):
     has_sampling_extra_args: bool = False
 
     def __post_init__(self) -> None:
+        # NPU AR stages requesting mxfp8/mxfp4 must be remapped to a distinct,
+        # registered method name *before* super().__post_init__() runs: vLLM
+        # reserves "mxfp8"/"mxfp4" as its own built-in quantization methods
+        # (an online-quant shorthand and a native Triton MXFP4 config,
+        # respectively), unrelated to vllm-omni's Ascend diffusion configs.
+        # Remapping early lets vLLM's normal ModelConfig lifecycle validate,
+        # detect serialized checkpoints, and hash this method like any other.
+        if current_omni_platform.is_npu() and self.worker_type == "ar" and self.quantization in ("mxfp8", "mxfp4"):
+            if self.quantization == "mxfp8":
+                from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config  # noqa: F401
+            else:
+                from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config  # noqa: F401
+            self.quantization = f"omni_npu_{self.quantization}"
         if self.worker_cls is None:
             if self.worker_type == "ar":
                 self.worker_cls = current_omni_platform.get_omni_ar_worker_cls()

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -201,7 +201,17 @@ class OmniEngineArgs(EngineArgs):
     custom_pipeline_args: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
 
+    def _register_omni_npu_quant_configs(self) -> None:
+        if not (current_omni_platform.is_npu() and self.worker_type == "ar"):
+            return
+        # HF-config-only AR startup still needs both Omni MXFP configs loaded
+        # before the parent EngineArgs lifecycle resolves quantization.
+        from vllm_omni.quantization.mxfp4_config import OmniNPUMxfp4Config  # noqa: F401
+        from vllm_omni.quantization.mxfp8_config import OmniNPUMxfp8Config  # noqa: F401
+
     def __post_init__(self) -> None:
+        self._register_omni_npu_quant_configs()
+
         # NPU AR stages requesting mxfp8/mxfp4 must be remapped to a distinct,
         # registered method name *before* super().__post_init__() runs: vLLM
         # reserves "mxfp8"/"mxfp4" as its own built-in quantization methods

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -797,6 +797,7 @@ def build_vllm_config(
         usage_context=UsageContext.LLM_CLASS,
         headless=headless,
     )
+
     executor_class = Executor.get_class(vllm_config)
 
     # Upgrade vanilla INCConfig to OmniINCConfig for multi-stage models.

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -61,7 +61,10 @@ from vllm.model_executor.layers.linear import (
     LinearBase,
     UnquantizedLinearMethod,
 )
-from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization import (
+    QuantizationMethods,
+    register_quantization_config,
+)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -107,6 +110,7 @@ class DiffusionMXFP4Config(QuantizationConfig):
         super().__init__()
         self.is_checkpoint_mxfp4_serialized = is_checkpoint_mxfp4_serialized
         self.ignored_layers = ignored_layers or []
+        self.quant_description = []
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
@@ -143,7 +147,33 @@ class DiffusionMXFP4Config(QuantizationConfig):
         self,
         layer: torch.nn.Module,
         prefix: str,
+        **kwargs,
     ) -> QuantizeMethodBase | None:
+        fused_moe_type: type[torch.nn.Module] | None = None
+        try:
+            from vllm.model_executor.layers.fused_moe import FusedMoE
+
+            if isinstance(FusedMoE, type):
+                fused_moe_type = FusedMoE
+        except Exception:
+            fused_moe_type = None
+
+        is_fused_moe_layer = False
+        if fused_moe_type is not None:
+            is_fused_moe_layer = isinstance(layer, fused_moe_type)
+        elif hasattr(layer, "moe_config"):
+            layer_cls = layer.__class__
+            layer_cls_name = getattr(layer_cls, "__name__", "")
+            layer_cls_mod = getattr(layer_cls, "__module__", "")
+            is_fused_moe_layer = layer_cls_name == "FusedMoE" or "fused_moe" in layer_cls_mod
+
+        if current_omni_platform.is_npu():
+            if is_fused_moe_layer:
+                from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+
+                tid2eid = kwargs.get("tid2eid")
+                return AscendUnquantizedFusedMoEMethod(layer.moe_config, tid2eid=tid2eid)
+
         if isinstance(layer, LinearBase):
             if is_layer_skipped(
                 prefix=prefix,
@@ -166,6 +196,28 @@ class DiffusionMXFP4Config(QuantizationConfig):
                 "DiffusionMXFP4Config (W4A4 MXFP4) is currently only supported "
                 "on NPU (Ascend) and ROCm (AMD, gfx950) platforms."
             )
+        return None
+
+
+@register_quantization_config("omni_npu_mxfp4")
+class OmniNPUMxfp4Config(DiffusionMXFP4Config):
+    """NPU AR-stage identity for online/offline MXFP4, distinct from vLLM's
+    own built-in "mxfp4" quantization method (native Triton MXFP4, e.g. for
+    GPT-OSS). See OmniNPUMxfp8Config in mxfp8_config.py for the rationale.
+    """
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "omni_npu_mxfp4"
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg: Any, user_quant: Any, hf_config: Any = None) -> Any:
+        if (
+            current_omni_platform.is_npu()
+            and isinstance(hf_quant_cfg, dict)
+            and hf_quant_cfg.get("quant_method") in ("mxfp4", "omni_npu_mxfp4")
+        ):
+            return "omni_npu_mxfp4"
         return None
 
 

--- a/vllm_omni/quantization/mxfp8_config.py
+++ b/vllm_omni/quantization/mxfp8_config.py
@@ -44,7 +44,10 @@ from vllm.model_executor.layers.linear import (
     LinearMethodBase,
     UnquantizedLinearMethod,
 )
-from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization import (
+    QuantizationMethods,
+    register_quantization_config,
+)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -85,6 +88,7 @@ class DiffusionMXFP8Config(QuantizationConfig):
         super().__init__()
         self.is_checkpoint_mxfp8_serialized = is_checkpoint_mxfp8_serialized
         self.ignored_layers = ignored_layers or []
+        self.quant_description = []
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
@@ -121,7 +125,33 @@ class DiffusionMXFP8Config(QuantizationConfig):
         self,
         layer: torch.nn.Module,
         prefix: str,
+        **kwargs,
     ) -> QuantizeMethodBase | None:
+        fused_moe_type: type[torch.nn.Module] | None = None
+        try:
+            from vllm.model_executor.layers.fused_moe import FusedMoE
+
+            if isinstance(FusedMoE, type):
+                fused_moe_type = FusedMoE
+        except Exception:
+            fused_moe_type = None
+
+        is_fused_moe_layer = False
+        if fused_moe_type is not None:
+            is_fused_moe_layer = isinstance(layer, fused_moe_type)
+        elif hasattr(layer, "moe_config"):
+            layer_cls = layer.__class__
+            layer_cls_name = getattr(layer_cls, "__name__", "")
+            layer_cls_mod = getattr(layer_cls, "__module__", "")
+            is_fused_moe_layer = layer_cls_name == "FusedMoE" or "fused_moe" in layer_cls_mod
+
+        if current_omni_platform.is_npu():
+            if is_fused_moe_layer:
+                from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+
+                tid2eid = kwargs.get("tid2eid")
+                return AscendUnquantizedFusedMoEMethod(layer.moe_config, tid2eid=tid2eid)
+
         if isinstance(layer, LinearBase):
             if is_layer_skipped(
                 prefix=prefix,
@@ -145,6 +175,35 @@ class DiffusionMXFP8Config(QuantizationConfig):
                 "DiffusionMXFP8Config (W8A8 MXFP8) is currently only supported "
                 "on NPU (Ascend) and XPU (Intel) platforms."
             )
+        return None
+
+
+@register_quantization_config("omni_npu_mxfp8")
+class OmniNPUMxfp8Config(DiffusionMXFP8Config):
+    """NPU AR-stage identity for online/offline MXFP8, distinct from vLLM's
+    own reserved "mxfp8" online-quant shorthand and built-in method name.
+
+    Registered under a separate method name so that vLLM's native
+    ModelConfig/quantization lifecycle (validation, platform checks, config
+    hashing) can resolve, validate, and hash this NPU AR-stage quantization
+    method directly, instead of vllm-omni stashing/restoring EngineArgs
+    fields around create_engine_config(). See override_quantization_method()
+    for serialized-checkpoint auto-detection from the HF config vLLM already
+    parses (replaces a manual config.json download).
+    """
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "omni_npu_mxfp8"
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg: Any, user_quant: Any, hf_config: Any = None) -> Any:
+        if (
+            current_omni_platform.is_npu()
+            and isinstance(hf_quant_cfg, dict)
+            and hf_quant_cfg.get("quant_method") in ("mxfp8", "omni_npu_mxfp8")
+        ):
+            return "omni_npu_mxfp8"
         return None
 
 


### PR DESCRIPTION


## Purpose
This PR introduces W8A8 MXFP8 online quantization support for Hunyuan-image-3.0 model inference on Ascend NPU platforms. The main goals are:

Enable online quantization: During model forward pass, dynamically quantize weights and activations to MXFP8 format (W8A8) to reduce memory footprint and improve inference performance on Ascend NPUs.

Support Hunyuan-image-3.0: Specifically adapt the quantization pipeline for the Hunyuan-image-3.0 model architecture, ensuring compatibility with its unique layer structures and computation patterns.

## Test Plan

vLLM Version: v0.25.1

vLLM-Omni Commit: main

## Test Result
**NPU Device:** Ascend950

**vllm command:** `vllm serve /home/weights/HunyuanImage-3.0-Instruct/ --omni --deploy-config /home/k00930897/vllm-omni/vllm_omni/deploy/hunyuan_image3_ar.yaml --trust-remote-code  --max-num-seqs 32 --quantization mxfp4/mxfp8/None`

**Accuracy**: Returns reasonable answer to text2text request
curl -X POST http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
    "prompt": "whats the capital of france",
    "max_tokens": 7,
    "temperature": 0.7
  }'
{"id":"cmpl-abccb24288e7cd27","object":"text_completion","created":946730247,"model":"/home/weights/Qwen3-0.6B/","choices":[{"index":0,"text":"?\n\nThe capital of France is Paris","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.25.1-f3ed1b9d","usage":{"prompt_tokens":6,"total_tokens":13,"completion_tokens":7,"prompt_tokens_details":null},"kv_transfer_params":null,"metrics":null}

**Benchmark:**
1K input + BS=32:
**bf16**
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  7.61      
Total input tokens:                      32000     
Total generated tokens:                  3200      
Request throughput (req/s):              4.21      
Output token throughput (tok/s):         420.58    
Peak output token throughput (tok/s):    544.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4626.42   
---------------Time to First Token----------------
Mean TTFT (ms):                          917.51    
Median TTFT (ms):                        850.60    
P99 TTFT (ms):                           1222.51   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          66.53     
Median TPOT (ms):                        66.99     
P99 TPOT (ms):                           69.85     
---------------Inter-token Latency----------------
Mean ITL (ms):                           66.53     
Median ITL (ms):                         61.97     
P99 ITL (ms):                            163.17   

**mxfp8**
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  7.28      
Total input tokens:                      32000     
Total generated tokens:                  3200      
Request throughput (req/s):              4.39      
Output token throughput (tok/s):         439.44    
Peak output token throughput (tok/s):    544.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4833.83   
---------------Time to First Token----------------
Mean TTFT (ms):                          735.66    
Median TTFT (ms):                        670.17    
P99 TTFT (ms):                           1040.32   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          65.05     
Median TPOT (ms):                        65.52     
P99 TPOT (ms):                           67.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           65.05     
Median ITL (ms):                         60.92     
P99 ITL (ms):                            164.80   

**mxfp4**
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  7.42      
Total input tokens:                      32000     
Total generated tokens:                  3200      
Request throughput (req/s):              4.32      
Output token throughput (tok/s):         431.50    
Peak output token throughput (tok/s):    512.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4746.50   
---------------Time to First Token----------------
Mean TTFT (ms):                          873.39    
Median TTFT (ms):                        869.75    
P99 TTFT (ms):                           1180.20   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          64.82     
Median TPOT (ms):                        64.80     
P99 TPOT (ms):                           68.17     
---------------Inter-token Latency----------------
Mean ITL (ms):                           64.82     
Median ITL (ms):                         61.82     
P99 ITL (ms):                            196.85  


Online quantization has improvement in computation-bound scenerio 


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
