### PR TITLE
[Refactor] Output Processor Phase 3-5: Integrate images, traj_latents etc into multimodal_output

### DIFF
--- a/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
+++ b/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
@@ -282,7 +282,7 @@ class QwenImagePipelineWithLogProbForTest(QwenImagePipeline):
         else:
             # Both prompt_ids and prompt_embeds are None (e.g. during warmup/dummy run).
             # Return a minimal dummy output to avoid crashing.
-            return DiffusionOutput(output=None, custom_output={})
+            return DiffusionOutput(multimodal_output={}, custom_output={})
 
         if isinstance(negative_prompt_ids, list):
             negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
@@ -393,10 +393,13 @@ class QwenImagePipelineWithLogProbForTest(QwenImagePipeline):
             image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
 
         return DiffusionOutput(
-            output=_maybe_to_cpu(image),
-            trajectory_latents=_maybe_to_cpu(all_latents),
-            trajectory_log_probs=_maybe_to_cpu(all_log_probs),
-            trajectory_timesteps=_maybe_to_cpu(all_timesteps),
+            multimodal_output={
+                "images": _maybe_to_cpu(image),
+                "trajectory_latents": [_maybe_to_cpu(all_latents)],
+                "trajectory_log_probs": [_maybe_to_cpu(all_log_probs)],
+                "trajectory_timesteps": [_maybe_to_cpu(all_timesteps)],
+
+            },
             custom_output={
                 "prompt_embeds": _maybe_to_cpu(prompt_embeds),
                 "prompt_embeds_mask": _maybe_to_cpu(prompt_embeds_mask),

--- a/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
+++ b/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
@@ -398,7 +398,6 @@ class QwenImagePipelineWithLogProbForTest(QwenImagePipeline):
                 "trajectory_latents": [_maybe_to_cpu(all_latents)],
                 "trajectory_log_probs": [_maybe_to_cpu(all_log_probs)],
                 "trajectory_timesteps": [_maybe_to_cpu(all_timesteps)],
-
             },
             custom_output={
                 "prompt_embeds": _maybe_to_cpu(prompt_embeds),

--- a/tests/e2e/offline_inference/rlhf_test/test_verl_omni_e2e.py
+++ b/tests/e2e/offline_inference/rlhf_test/test_verl_omni_e2e.py
@@ -388,7 +388,7 @@ class vLLMOmniHttpServerLocal:
             final_res = output
         assert final_res is not None
 
-        diffusion_output = self._to_tensor(final_res.images[0]).float() / 255.0
+        diffusion_output = self._to_tensor(final_res.multimodal_output["images"][0]).float() / 255.0
 
         mm_output = final_res.custom_output or {}
 

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -37,7 +37,7 @@ def _make_llm_metadata(
         default_sampling_params=types.SimpleNamespace(name=f"sp-{stage_id}-{replica_id}"),
         custom_process_input_func=None,
         engine_input_source=[] if stage_id == 0 else [stage_id - 1],
-        engine_output_type="token_ids",
+        engine_output_type="text",
         replica_id=replica_id,
         is_comprehension=is_comprehension,
     )

--- a/tests/engine/test_output_modality.py
+++ b/tests/engine/test_output_modality.py
@@ -42,7 +42,7 @@ MultimodalCompletionOutput = _mm_mod.MultimodalCompletionOutput
 
 
 def test_output_modality_parsing_and_flags():
-    """Test OutputModality enum: from_string, aliases, compounds, properties, and accumulation strategy."""
+    """Test OutputModality enum: from_string, compounds, properties, and accumulation strategy."""
     # Defaults
     assert OutputModality.from_string(None) == OutputModality.TEXT
     assert OutputModality.from_string("") == OutputModality.TEXT
@@ -50,11 +50,6 @@ def test_output_modality_parsing_and_flags():
     # Direct names and case insensitivity
     assert OutputModality.from_string("image") == OutputModality.IMAGE
     assert OutputModality.from_string("Audio") == OutputModality.AUDIO
-
-    # Aliases
-    assert OutputModality.from_string("speech") == OutputModality.AUDIO
-    assert OutputModality.from_string("latents") == OutputModality.LATENT
-    assert OutputModality.from_string("pixel_values") == OutputModality.IMAGE
 
     # Compound
     compound = OutputModality.from_string("text+image")
@@ -102,7 +97,7 @@ def test_multimodal_payload_and_completion_output():
 def test_output_modality_printed_examples(capsys):
     """Printed examples for output modality types."""
     print("\n=== OutputModality Parsing ===")
-    for s in [None, "", "image", "Audio", "speech", "latents", "pixel_values", "text+image"]:
+    for s in [None, "", "image", "latent", "Audio", "text+image"]:
         print(f"  from_string({s!r:20s}) -> {OutputModality.from_string(s)}")
 
     print("\n=== Flag Properties ===")

--- a/tests/engine/test_output_processor.py
+++ b/tests/engine/test_output_processor.py
@@ -11,18 +11,17 @@ from vllm.outputs import PoolingRequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine import FinishReason
 
-from vllm_omni.engine.output_modality import OutputModalityNames
 from vllm_omni.engine.output_processor import OmniRequestState
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 # Audio is explicitly listed as a drainable modality
-AUDIO = OutputModalityNames.AUDIO
+AUDIO = "audio"
 
 # Latent is explicitly not drainable, but the choice doesn't matter here as
 # long as isn't listed as drainable. I.e., could also be arbitrary keys for
 # the purposes of these tests
-LATENT = OutputModalityNames.LATENT
+LATENT = "latent"
 
 # NOTE: detokenizer and logprobs aren't really used here, but we mock them since
 # some of the utils called in vLLM superclass assert require them to be None.

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -61,7 +61,7 @@ def _make_llm_plan(
         default_sampling_params=SimpleNamespace(),
         custom_process_input_func=None,
         engine_input_source=[],
-        engine_output_type="token_ids",
+        engine_output_type="text",
         replica_id=0,
     )
     return LogicalStageInitPlan(

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -14,6 +14,7 @@ from vllm.transformers_utils.model_arch_config_convertor import (
 )
 
 import vllm_omni.model_executor.models as me_models
+from vllm_omni.engine.output_modality import EngineOutputType
 
 logger = init_logger(__name__)
 
@@ -124,7 +125,7 @@ class OmniModelConfig(ModelConfig):
     model_stage: str = "thinker"
     model_arch: str | None = None
     worker_type: str | None = None
-    engine_output_type: str | None = None
+    engine_output_type: EngineOutputType | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_config: dict[str, Any] = field(

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -21,6 +21,7 @@ from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
 from vllm_omni.config.yaml_util import create_config, load_yaml_config, to_dict
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARAsyncScheduler, OmniARScheduler
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+from vllm_omni.engine.output_modality import EngineOutputType
 
 logger = init_logger(__name__)
 
@@ -212,7 +213,7 @@ class StagePipelineConfig:
     owns_tokenizer: bool = False
     requires_multimodal_data: bool = False
     hf_config_name: str | None = None
-    engine_output_type: str | None = None
+    engine_output_type: EngineOutputType | None = None
     model_arch: str | None = None
     sampling_constraints: dict[str, Any] = field(default_factory=dict)
     custom_process_input_func: str | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 import diffusers
 import torch
-from PIL import Image
 from pydantic import Field, model_validator
 from typing_extensions import Self
 from vllm.config.utils import config

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1145,8 +1145,6 @@ class DiffusionOutput:
     """
     Final output (after pipeline completion)
     """
-    # Not used in the new multimodal output format, but kept for backwards compatibility
-    outputs: list[torch.Tensor] | None = None
 
     # Fields may be replaced with SHM handle dicts by ipc.pack_diffusion_output_shm
     multimodal_output: dict[str, Any] | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1145,13 +1145,11 @@ class DiffusionOutput:
     """
     Final output (after pipeline completion)
     """
+    # Not used in the new multimodal output format, but kept for backwards compatibility
+    outputs: list[torch.Tensor] | None = None
 
     # Fields may be replaced with SHM handle dicts by ipc.pack_diffusion_output_shm
-    output: torch.Tensor | tuple[Any, ...] | dict[str, Any] | None = None
-    trajectory_timesteps: torch.Tensor | dict[str, Any] | None = None
-    trajectory_latents: torch.Tensor | dict[str, Any] | None = None
-    trajectory_log_probs: torch.Tensor | dict[str, Any] | None = None
-    trajectory_decoded: list[Image.Image] | None = None
+    multimodal_output: dict[str, Any] | None = None
     error: str | None = None
     error_status_code: int | None = None
     error_type: str | None = None
@@ -1193,10 +1191,9 @@ class DiffusionOutput:
                 return value.detach().cpu()
             return value
 
-        self.output = _maybe_to_cpu(self.output)
-        self.trajectory_timesteps = _maybe_to_cpu(self.trajectory_timesteps)
-        self.trajectory_latents = _maybe_to_cpu(self.trajectory_latents)
-        self.trajectory_log_probs = _maybe_to_cpu(self.trajectory_log_probs)
+        for k in self.multimodal_output.keys() if self.multimodal_output else []:
+            self.multimodal_output[k] = _maybe_to_cpu(self.multimodal_output[k])
+
         if self.custom_output:
             self.custom_output = {k: _maybe_to_cpu(v) for k, v in self.custom_output.items()}
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -249,14 +249,14 @@ class DiffusionEngine:
             raise RuntimeError(output.error)
         logger.debug("Generation completed successfully.")
 
-        if output.output is None:
+        if output.multimodal_output is None or output.multimodal_output == {}:
             logger.warning("Output is None, returning empty OmniRequestOutput")
             return format_empty_diffusion_outputs(request, finished=output.finished)
 
         # When CPU offload is enabled, move output to CPU before
         # post-processing to avoid device OOM — model weights may still
         # reside on the device and leave no headroom for intermediates.
-        output_data = output.output
+        output_data = output.multimodal_output
         if self.od_config.enable_cpu_offload:
             output_data = _move_tensor_tree_to_cpu(output_data)
 

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -857,11 +857,13 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
         custom["image"] = img
 
         return DiffusionOutput(
-            output=img,
-            trajectory_latents=trajectory_latents_stacked,
-            trajectory_timesteps=trajectory_timesteps_stacked,
-            trajectory_log_probs=trajectory_log_probs_stacked,
-            trajectory_decoded=trajectory_decoded,
+            multimodal_output={
+                "image": img,
+                "trajectory_latents": trajectory_latents_stacked,
+                "trajectory_timesteps": trajectory_timesteps_stacked,
+                "trajectory_log_probs": trajectory_log_probs_stacked,
+                "trajectory_decoded": trajectory_decoded,
+            }, 
             custom_output=custom,
             stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -863,7 +863,7 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                 "trajectory_timesteps": trajectory_timesteps_stacked,
                 "trajectory_log_probs": trajectory_log_probs_stacked,
                 "trajectory_decoded": trajectory_decoded,
-            }, 
+            },
             custom_output=custom,
             stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -73,9 +73,11 @@ def get_qwen_image_post_process_func(
     image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor * 2)
 
     def post_process_func(
-        images: torch.Tensor,
+        multimodal_output: dict[str, Any],
     ):
-        return image_processor.postprocess(images)
+        processed_images = image_processor.postprocess(multimodal_output["images"])
+        multimodal_output["images"] = processed_images
+        return multimodal_output
 
     return post_process_func
 

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -66,9 +66,11 @@ def get_post_process_func(
     image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor * 2, do_convert_rgb=True)
 
     def post_process_func(
-        images: torch.Tensor,
+        multimodal_output: dict[str, Any],
     ):
-        return image_processor.postprocess(images)
+        processed_images = image_processor.postprocess(multimodal_output["images"])
+        multimodal_output["images"] = processed_images
+        return multimodal_output
 
     return post_process_func
 
@@ -829,7 +831,7 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
             # image = self.image_processor.postprocess(image, output_type=output_type)
 
         return DiffusionOutput(
-            output=image, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
+            multimodal_output={"images": image}, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -831,7 +831,8 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
             # image = self.image_processor.postprocess(image, output_type=output_type)
 
         return DiffusionOutput(
-            multimodal_output={"images": image}, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
+            multimodal_output={"images": image},
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -130,7 +130,7 @@ def format_diffusion_outputs(
             # outputs=outputs,
             metrics=metrics,
             postprocess_output=postprocess_output,
-            is_images_output=is_images_output, 
+            is_images_output=is_images_output,
             is_text_output=is_text_output,
             is_audio_output=is_audio_output,
             audio_sample_rate=audio_sample_rate,
@@ -160,6 +160,7 @@ def _format_audio_multimodal_output(payload: Any, audio_sample_rate: int | None)
     if audio_sample_rate is not None:
         mm_output["audio_sample_rate"] = audio_sample_rate
     return mm_output
+
 
 def _has_non_audio_postprocess_payload(postprocess_output: DiffusionPostprocessOutput) -> bool:
     return (
@@ -193,7 +194,7 @@ def _format_single_prompt_output(
     diffusion_output: DiffusionOutput,
     metrics: dict[str, Any],
     postprocess_output: DiffusionPostprocessOutput,
-    is_images_output: bool, 
+    is_images_output: bool,
     is_text_output: bool,
     is_audio_output: bool,
     audio_sample_rate: int | None,
@@ -201,7 +202,7 @@ def _format_single_prompt_output(
 ) -> list[OmniRequestOutput]:
     prompt = request.prompts[0]
     request_id = request.request_id
-    
+
     mm_output = _build_multimodal_output(postprocess_output, audio_sample_rate)
 
     if is_images_output:
@@ -210,7 +211,7 @@ def _format_single_prompt_output(
                 request_id=request_id,
                 prompt=prompt,
                 metrics=metrics,
-                multimodal_output=mm_output, 
+                multimodal_output=mm_output,
                 final_output_type="image",
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,
@@ -239,7 +240,7 @@ def _format_single_prompt_output(
                 request_id=request_id,
                 prompt=prompt,
                 metrics=metrics,
-                multimodal_output=mm_output, 
+                multimodal_output=mm_output,
                 final_output_type="audio",
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -25,6 +25,7 @@ class DiffusionStepTimings:
 class DiffusionPostprocessOutput:
     outputs: Any
     custom_output: dict[str, Any]
+    images_payload: Any | None = None
     audio_payload: Any | None = None
     action_payload: Any | None = None
     audio_sample_rate: int | None = None
@@ -54,6 +55,7 @@ def normalize_diffusion_postprocess_output(
         has_video_payload = "video" in outputs
         audio_payload = outputs.get("audio")
         action_payload = outputs.get("actions")
+        images_payload = outputs.get("images")
         merged_custom_output.update(outputs.get("custom_output") or {})
         audio_sample_rate = outputs.get("audio_sample_rate")
         fps = outputs.get("fps")
@@ -64,6 +66,7 @@ def normalize_diffusion_postprocess_output(
         custom_output=merged_custom_output,
         audio_payload=audio_payload,
         action_payload=action_payload,
+        images_payload=images_payload,
         audio_sample_rate=audio_sample_rate,
         fps=fps,
         has_video_payload=has_video_payload,
@@ -78,10 +81,9 @@ def format_empty_diffusion_outputs(
     return [
         OmniRequestOutput.from_diffusion(
             request_id=request.request_id,
-            images=[],
             prompt=prompt,
             metrics={},
-            latents=None,
+            multimodal_output=None,
             finished=finished,
         )
         for prompt in request.prompts
@@ -99,7 +101,7 @@ def format_diffusion_outputs(
 ) -> list[OmniRequestOutput]:
     """Convert a finished diffusion model output into API-facing outputs."""
 
-    outputs = _ensure_list(postprocess_output.outputs)
+    # outputs = _ensure_list(postprocess_output.outputs)
     metrics = {
         "preprocess_time_ms": timings.preprocess_time_s * 1000,
         "diffusion_engine_exec_time_ms": timings.exec_time_s * 1000,
@@ -114,6 +116,7 @@ def format_diffusion_outputs(
     # as a text-type response instead of an image.
     is_text_output = isinstance(output_data, str) and postprocess_output.custom_output.get("text_output") is not None
 
+    is_images_output = postprocess_output.images_payload is not None
     is_audio_output = supports_audio_output(od_config.model_class_name)
     audio_sample_rate = postprocess_output.audio_sample_rate
     if is_audio_output and audio_sample_rate is None:
@@ -124,9 +127,10 @@ def format_diffusion_outputs(
         return _format_single_prompt_output(
             request=request,
             diffusion_output=diffusion_output,
-            outputs=outputs,
+            # outputs=outputs,
             metrics=metrics,
             postprocess_output=postprocess_output,
+            is_images_output=is_images_output, 
             is_text_output=is_text_output,
             is_audio_output=is_audio_output,
             audio_sample_rate=audio_sample_rate,
@@ -136,7 +140,7 @@ def format_diffusion_outputs(
     return _format_multi_prompt_outputs(
         request=request,
         diffusion_output=diffusion_output,
-        outputs=outputs,
+        # outputs=outputs,
         metrics=metrics,
         postprocess_output=postprocess_output,
         is_audio_output=is_audio_output,
@@ -156,7 +160,6 @@ def _format_audio_multimodal_output(payload: Any, audio_sample_rate: int | None)
     if audio_sample_rate is not None:
         mm_output["audio_sample_rate"] = audio_sample_rate
     return mm_output
-
 
 def _has_non_audio_postprocess_payload(postprocess_output: DiffusionPostprocessOutput) -> bool:
     return (
@@ -179,6 +182,8 @@ def _build_multimodal_output(
         mm_output["fps"] = postprocess_output.fps
     if postprocess_output.action_payload is not None:
         mm_output["actions"] = postprocess_output.action_payload
+    if postprocess_output.images_payload is not None:
+        mm_output["images"] = postprocess_output.images_payload
     return mm_output
 
 
@@ -186,9 +191,9 @@ def _format_single_prompt_output(
     *,
     request: OmniDiffusionRequest,
     diffusion_output: DiffusionOutput,
-    outputs: list[Any],
     metrics: dict[str, Any],
     postprocess_output: DiffusionPostprocessOutput,
+    is_images_output: bool, 
     is_text_output: bool,
     is_audio_output: bool,
     audio_sample_rate: int | None,
@@ -196,13 +201,27 @@ def _format_single_prompt_output(
 ) -> list[OmniRequestOutput]:
     prompt = request.prompts[0]
     request_id = request.request_id
+    
     mm_output = _build_multimodal_output(postprocess_output, audio_sample_rate)
+
+    if is_images_output:
+        return [
+            OmniRequestOutput.from_diffusion(
+                request_id=request_id,
+                prompt=prompt,
+                metrics=metrics,
+                multimodal_output=mm_output, 
+                final_output_type="image",
+                stage_durations=diffusion_output.stage_durations,
+                peak_memory_mb=diffusion_output.peak_memory_mb,
+                finished=finished,
+            ),
+        ]
 
     if is_text_output:
         return [
             OmniRequestOutput.from_diffusion(
                 request_id=request_id,
-                images=[],
                 prompt=prompt,
                 metrics=metrics,
                 custom_output=postprocess_output.custom_output,
@@ -214,25 +233,13 @@ def _format_single_prompt_output(
             ),
         ]
 
-    if is_audio_output and not _has_non_audio_postprocess_payload(postprocess_output):
-        request_audio_payload = postprocess_output.audio_payload
-        if request_audio_payload is None:
-            request_audio_payload = outputs[0] if len(outputs) == 1 else outputs
+    if is_audio_output:
         return [
             OmniRequestOutput.from_diffusion(
                 request_id=request_id,
-                images=[],
                 prompt=prompt,
                 metrics=metrics,
-                latents=diffusion_output.trajectory_latents,
-                trajectory_latents=diffusion_output.trajectory_latents,
-                trajectory_timesteps=diffusion_output.trajectory_timesteps,
-                trajectory_log_probs=diffusion_output.trajectory_log_probs,
-                trajectory_decoded=diffusion_output.trajectory_decoded,
-                multimodal_output=_format_audio_multimodal_output(
-                    request_audio_payload,
-                    audio_sample_rate,
-                ),
+                multimodal_output=mm_output, 
                 final_output_type="audio",
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,
@@ -243,14 +250,8 @@ def _format_single_prompt_output(
     return [
         OmniRequestOutput.from_diffusion(
             request_id=request_id,
-            images=outputs,
             prompt=prompt,
             metrics=metrics,
-            latents=diffusion_output.trajectory_latents,
-            trajectory_latents=diffusion_output.trajectory_latents,
-            trajectory_timesteps=diffusion_output.trajectory_timesteps,
-            trajectory_log_probs=diffusion_output.trajectory_log_probs,
-            trajectory_decoded=diffusion_output.trajectory_decoded,
             custom_output=postprocess_output.custom_output,
             multimodal_output=mm_output,
             stage_durations=diffusion_output.stage_durations,
@@ -295,7 +296,6 @@ def _format_multi_prompt_outputs(
             results.append(
                 OmniRequestOutput.from_diffusion(
                     request_id=request_id,
-                    images=[],
                     prompt=prompt,
                     metrics=metrics,
                     latents=diffusion_output.trajectory_latents,

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Mapping
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, fields, is_dataclass
 from typing import Any
 
 import msgspec
@@ -11,6 +11,8 @@ import torch
 from msgspec import msgpack
 from PIL import Image
 from vllm.outputs import CompletionOutput, RequestOutput
+
+from vllm_omni.engine.mm_outputs import MultimodalCompletionOutput, MultimodalPayload
 
 # Type markers for custom serialization
 _TENSOR_MARKER = "__tensor__"
@@ -161,15 +163,20 @@ class OmniMsgpackEncoder:
         return result
 
     def _encode_completion_output(self, obj: CompletionOutput) -> dict[str, Any]:
-        """Encode CompletionOutput to dict, preserving multimodal payloads."""
-        result = asdict(obj)
+        """Encode CompletionOutput to dict, preserving multimodal payloads.
+
+        Build from CompletionOutput's base fields explicitly (avoid asdict()
+        deep-copying tensors). MultimodalPayload is written in its native
+        ``{tensors, metadata}`` shape so this matches what msgspec produces
+        when encoding a MultimodalCompletionOutput dataclass directly.
+        """
+        result = {f.name: getattr(obj, f.name) for f in fields(CompletionOutput)}
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
-            # Convert MultimodalPayload to plain dict for wire format
-            if isinstance(mm_output, Mapping):
-                result["multimodal_output"] = dict(mm_output)
-            else:
-                result["multimodal_output"] = mm_output
+            if not isinstance(mm_output, MultimodalPayload):
+                # Legacy plain dict: normalize through MultimodalPayload.
+                mm_output = MultimodalPayload.from_dict(mm_output) or MultimodalPayload()
+            result["multimodal_output"] = {"tensors": mm_output.tensors, "metadata": mm_output.metadata}
         return result
 
 
@@ -300,12 +307,27 @@ class OmniMsgpackDecoder:
         return Image.fromarray(arr, mode=mode)
 
     def _decode_completion_output(self, obj: dict[str, Any]) -> CompletionOutput:
-        """Decode dict to CompletionOutput using msgspec.convert."""
+        """Decode dict to CompletionOutput, promoting to MultimodalCompletionOutput
+        when a multimodal payload is present."""
         mm_output = obj.pop("multimodal_output", None)
-        co = msgspec.convert(obj, CompletionOutput)
-        if mm_output is not None:
-            setattr(co, "multimodal_output", mm_output)
-        return co
+        if mm_output is None:
+            return msgspec.convert(obj, CompletionOutput)
+        if not isinstance(mm_output, MultimodalPayload):
+            # Wire format is the native MultimodalPayload shape
+            # ``{tensors, metadata}``; fall back to flat dict reconstruction
+            # for any legacy producer that wrote a plain dict.
+            if isinstance(mm_output, dict) and set(mm_output.keys()) <= {"tensors", "metadata"}:
+                mm_output = MultimodalPayload(
+                    tensors=mm_output.get("tensors") or {},
+                    metadata=mm_output.get("metadata") or {},
+                )
+            else:
+                mm_output = MultimodalPayload.from_dict(mm_output) or MultimodalPayload()
+        base = msgspec.convert(obj, CompletionOutput)
+        return MultimodalCompletionOutput(
+            **{f.name: getattr(base, f.name) for f in fields(CompletionOutput)},
+            multimodal_output=mm_output,
+        )
 
     def _decode_request_output(self, obj: dict[str, Any]) -> RequestOutput:
         """Decode dict to RequestOutput.

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -9,7 +9,7 @@ from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.logger import init_logger
 
 from vllm_omni.config import OmniModelConfig
-from vllm_omni.engine.output_modality import OutputModality
+from vllm_omni.engine.output_modality import EngineOutputType, OutputModality
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.plugins import load_omni_general_plugins
 
@@ -143,7 +143,7 @@ class OmniEngineArgs(EngineArgs):
     stage_id: int = 0
     model_stage: str = "thinker"
     model_arch: str | None = None
-    engine_output_type: str | None = None
+    engine_output_type: EngineOutputType | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_spec: dict[str, Any] = field(default_factory=dict)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -111,7 +111,7 @@ class OmniEngineArgs(EngineArgs):
             (default: "Qwen2_5OmniForConditionalGeneration")
         engine_output_type: Optional output type specification for the engine.
             Used to route outputs to appropriate processors (e.g., "image",
-            "audio", "latents"). If None, output type is inferred.
+            "audio", "latent"). If None, output type is inferred.
         hf_config_name: Optional key for HF config subkey to be extracted
             for this stage, e.g., talker_config; If None, the default
             HF config will be used.

--- a/vllm_omni/engine/output_modality.py
+++ b/vllm_omni/engine/output_modality.py
@@ -8,31 +8,18 @@ for type-safe multimodal output routing and tensor merging.
 from __future__ import annotations
 
 import re
-from enum import Enum, Flag, StrEnum, auto
+from enum import Enum, Flag, auto
 from typing import Literal, TypeAlias
 
 FinalOutputModalityType: TypeAlias = Literal["text", "image", "audio", "video"]
 
+EngineOutputType: TypeAlias = Literal["text", "image", "audio", "latent"]
 
-class OutputModalityNames(StrEnum):
-    """Keys for output modalities.
-
-    TODO: (Alex) Integrate this with the big-flag enum below + throughout the code
-    for better type safety (currently only used for output processor).
-    """
-
-    TEXT = "text"
-    IMAGE = "image"
-    AUDIO = "audio"
-    LATENT = "latent"
-
-
-# Specify which output modalities may be drained when handling delta messages.
-# For some types, e.g., latents, we need to be careful to ensure the full context
-# is passed as the stream yields due to assumptions in the I/O processing and model
-# when async chunk isn't enabled.
-NON_DRAINABLE_MODALITIES = {OutputModalityNames.TEXT, OutputModalityNames.LATENT}
-DRAINABLE_MODALITIES = {mod for mod in OutputModalityNames if mod not in NON_DRAINABLE_MODALITIES}
+# Modalities whose accumulated tensors are drained per DELTA emission. TEXT is
+# handled by the base detokenizer path (never lands in mm_accumulated), and
+# LATENT needs full-history context for downstream model assumptions, so both
+# stay out of this set.
+DRAINABLE_MODALITIES: frozenset[str] = frozenset({"image", "audio"})
 
 
 class OutputModality(Flag):

--- a/vllm_omni/engine/output_modality.py
+++ b/vllm_omni/engine/output_modality.py
@@ -13,18 +13,6 @@ from typing import Literal, TypeAlias
 
 FinalOutputModalityType: TypeAlias = Literal["text", "image", "audio", "video"]
 
-_MODALITY_ALIASES: dict[str, str] = {
-    "speech": "audio",
-    "images": "image",
-    "latents": "latent",
-    "wav": "audio",
-    "waveform": "audio",
-    "pixel_values": "image",
-    "pixels": "image",
-    "token_ids": "text",
-    "tokens": "text",
-}
-
 
 class OutputModalityNames(StrEnum):
     """Keys for output modalities.
@@ -69,7 +57,7 @@ class OutputModality(Flag):
     def from_string(cls, s: str | None) -> OutputModality:
         """Parse a free-text modality string into an OutputModality flag.
 
-        Handles common aliases and compound strings separated by + or ,.
+        Handles compound strings separated by + or ,.
 
         Examples::
 
@@ -82,7 +70,6 @@ class OutputModality(Flag):
         parts = [p.strip().lower() for p in re.split(r"[+,]", s.strip())]
         result = cls(0)
         for p in parts:
-            p = _MODALITY_ALIASES.get(p, p)
             try:
                 result |= cls[p.upper()]
             except KeyError:

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -24,7 +24,6 @@ from vllm_omni.engine.output_modality import (
     TensorAccumulationStrategy,
     get_accumulation_strategy,
 )
-from vllm_omni.outputs import OmniRequestOutput
 
 logger = init_logger(__name__)
 
@@ -251,7 +250,7 @@ class OmniRequestState(RequestState):
         stop_reason: int | str | None,
         kv_transfer_params: dict[str, Any] | None = None,
         routed_experts: Any = None,
-    ) -> OmniRequestOutput | PoolingRequestOutput | None:
+    ) -> RequestOutput | PoolingRequestOutput | None:
         """Create a request output from generation results.
 
         Creates a RequestOutput or PoolingRequestOutput from the generated
@@ -268,7 +267,7 @@ class OmniRequestState(RequestState):
                 attached to the completion output for generation stages
 
         Returns:
-            OmniRequestOutput or PoolingRequestOutput if output should be
+            RequestOutput or PoolingRequestOutput if output should be
             emitted (based on finish status and output kind), None otherwise
         """
         # Pooling-only requests should follow base behavior.

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -27,6 +27,7 @@ from vllm.v1.executor import Executor
 
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
+from vllm_omni.engine.output_modality import EngineOutputType
 from vllm_omni.engine.output_processor import MultimodalOutputProcessor
 from vllm_omni.entrypoints.stage_utils import _to_dict, set_stage_devices
 from vllm_omni.entrypoints.utils import filter_dataclass_kwargs, resolve_model_config_path
@@ -329,7 +330,7 @@ class StageMetadata:
 
     stage_id: int
     stage_type: Literal["llm", "diffusion"]
-    engine_output_type: str | None
+    engine_output_type: EngineOutputType | None
     is_comprehension: bool
     requires_multimodal_data: bool
     engine_input_source: list[int]

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -564,7 +564,6 @@ class OmniBase(PDDisaggregationMixin):
         self.prom_metrics.set_running(running)
         self.prom_metrics.set_waiting(max(0, total - running))
 
-        images = getattr(engine_outputs, "images", []) if output_type == "image" else []
         response_metrics: dict[str, Any] = {}
         stage_metrics: dict[str, dict[str, Any]] = {}
         rid_key = str(req_id)
@@ -594,11 +593,7 @@ class OmniBase(PDDisaggregationMixin):
             stage_id=stage_id,
             final_output_type=output_type,
             request_output=engine_outputs,
-            images=images,
-            trajectory_latents=getattr(engine_outputs, "trajectory_latents", None),
-            trajectory_timesteps=getattr(engine_outputs, "trajectory_timesteps", None),
-            trajectory_log_probs=getattr(engine_outputs, "trajectory_log_probs", None),
-            trajectory_decoded=getattr(engine_outputs, "trajectory_decoded", None),
+            _multimodal_output=getattr(engine_outputs, "_multimodal_output", {}),
             _custom_output=getattr(engine_outputs, "_custom_output", {}),
             metrics=response_metrics,
             stage_durations=stage_durations,

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -588,17 +588,41 @@ class OmniBase(PDDisaggregationMixin):
                 response_metrics["final_output_type"] = current_stage_metrics["final_output_type"]
                 response_metrics["num_tokens_in"] = current_stage_metrics["num_tokens_in"]
                 response_metrics["num_tokens_out"] = current_stage_metrics["num_tokens_out"]
+        # Diffusion stages emit an OmniRequestOutput directly. Unwrap it so the
+        # outer `request_output` field holds a vLLM RequestOutput (or None) per
+        # its annotation, instead of nesting OmniRequestOutput inside itself.
+        # Inner-only fields (prompt, error, diffusion perf metrics) are merged
+        # into the outer so no data is lost in the unwrap.
+        if isinstance(engine_outputs, OmniRequestOutput):
+            inner_request_output = engine_outputs.request_output
+            prompt = engine_outputs.prompt
+            error = engine_outputs.error
+            error_status_code = engine_outputs.error_status_code
+            error_type = engine_outputs.error_type
+            for k, v in (engine_outputs.metrics or {}).items():
+                response_metrics.setdefault(k, v)
+        else:
+            inner_request_output = engine_outputs
+            prompt = None
+            error = None
+            error_status_code = None
+            error_type = None
+
         return OmniRequestOutput(
             request_id=req_id or "",
             stage_id=stage_id,
             final_output_type=output_type,
-            request_output=engine_outputs,
+            request_output=inner_request_output,
+            prompt=prompt,
             _multimodal_output=getattr(engine_outputs, "_multimodal_output", {}),
             _custom_output=getattr(engine_outputs, "_custom_output", {}),
             metrics=response_metrics,
             stage_durations=stage_durations,
             peak_memory_mb=peak_memory_mb,
             finished=finished,
+            error=error,
+            error_status_code=error_status_code,
+            error_type=error_type,
         )
 
     def shutdown(self, timeout: float | None = None) -> None:

--- a/vllm_omni/model_executor/models/glm_image/pipeline.py
+++ b/vllm_omni/model_executor/models/glm_image/pipeline.py
@@ -27,7 +27,7 @@ GLM_IMAGE_PIPELINE = PipelineConfig(
             final_output=False,
             owns_tokenizer=True,
             model_arch="GlmImageForConditionalGeneration",
-            engine_output_type="token_ids",
+            engine_output_type="text",
             model_subdir="vision_language_encoder",
             tokenizer_subdir="processor",
         ),

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-import torch
-from PIL import Image
 from vllm.outputs import RequestOutput
 from vllm.v1.outputs import ModelRunnerOutput
 
@@ -394,8 +392,6 @@ class OmniRequestOutput:
 
     def __repr__(self) -> str:
         """Custom repr to properly show image count instead of image objects."""
-        # For images, show count instead of full list
-        images_repr = f"[{len(self.images)} PIL Images]" if self.images else "[]"
 
         # Build repr string
         parts = [

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -70,9 +70,10 @@ class OmniRequestOutput:
         stage_id: Identifier of the stage that produced this output (pipeline mode)
         final_output_type: Type of output ("text", "image", "audio", "latents")
         request_output: The underlying RequestOutput from the stage (pipeline mode)
-        images: List of generated PIL images (diffusion mode)
         prompt: The prompt used for generation (diffusion mode)
         latents: Optional tensor of latent representations (diffusion mode)
+        _multimodal_output: Optional multimodal output dict (diffusion mode)
+        _custom_output: Optional custom output dict (diffusion mode)
         metrics: Optional dictionary of generation metrics
     """
 
@@ -85,13 +86,7 @@ class OmniRequestOutput:
     request_output: RequestOutput | None = None
 
     # Diffusion model fields
-    images: list[Image.Image] = field(default_factory=list)
     prompt: OmniPromptType | None = None
-    latents: torch.Tensor | None = None
-    trajectory_latents: torch.Tensor | None = None
-    trajectory_timesteps: torch.Tensor | None = None
-    trajectory_log_probs: torch.Tensor | None = None
-    trajectory_decoded: list | None = None
     metrics: dict[str, Any] = field(default_factory=dict)
     _multimodal_output: dict[str, Any] = field(default_factory=dict)
     _custom_output: dict[str, Any] = field(default_factory=dict)
@@ -162,14 +157,8 @@ class OmniRequestOutput:
     def from_diffusion(
         cls,
         request_id: str,
-        images: list[Image.Image],
         prompt: OmniPromptType | None = None,
         metrics: dict[str, Any] | None = None,
-        latents: torch.Tensor | None = None,
-        trajectory_latents: torch.Tensor | None = None,
-        trajectory_timesteps: torch.Tensor | None = None,
-        trajectory_log_probs: torch.Tensor | None = None,
-        trajectory_decoded: list | None = None,
         multimodal_output: dict[str, Any] | None = None,
         custom_output: dict[str, Any] | None = None,
         final_output_type: str = "image",
@@ -181,14 +170,8 @@ class OmniRequestOutput:
 
         Args:
             request_id: Request identifier
-            images: Generated images
             prompt: The prompt used
             metrics: Generation metrics
-            latents: Optional latent tensors
-            trajectory_latents: Optional stacked trajectory latent tensors
-            trajectory_timesteps: Optional stacked trajectory timestep tensors
-            trajectory_log_probs: Optional stacked trajectory log-probability tensors
-            trajectory_decoded: Optional list of decoded trajectory images
             multimodal_output: Optional multimodal output dict
             custom_output: Optional custom output dict (e.g. prompt embeds)
             stage_durations: Optional stage durations (execution time of each stage) dict
@@ -200,13 +183,7 @@ class OmniRequestOutput:
         return cls(
             request_id=request_id,
             final_output_type=final_output_type,
-            images=images,
             prompt=prompt,
-            latents=latents,
-            trajectory_latents=trajectory_latents,
-            trajectory_timesteps=trajectory_timesteps,
-            trajectory_log_probs=trajectory_log_probs,
-            trajectory_decoded=trajectory_decoded,
             metrics=metrics or {},
             _multimodal_output=multimodal_output or {},
             _custom_output=custom_output or {},
@@ -255,7 +232,10 @@ class OmniRequestOutput:
     @property
     def num_images(self) -> int:
         """Return the number of generated images."""
-        return len(self.images)
+        assert self.final_output_type == "image", "num_images is only valid for image outputs"
+        assert "images" in self.multimodal_output, "multimodal_output must contain 'images' key for image outputs"
+        assert isinstance(self.multimodal_output["images"], list), "multimodal_output['images'] must be a list"
+        return len(self.multimodal_output["images"])
 
     # Pass-through properties keep vLLM serving codepaths compatible with
     # OmniRequestOutput for pipeline outputs (Issue #345).
@@ -312,7 +292,8 @@ class OmniRequestOutput:
     @property
     def is_diffusion_output(self) -> bool:
         """Check if this is a diffusion model output."""
-        return len(self.images) > 0 or self.final_output_type == "image"
+        raise NotImplementedError("is_diffusion_output is not implemented yet")
+        # return len(self.images) > 0 or self.final_output_type == "image"
 
     @property
     def is_pipeline_output(self) -> bool:
@@ -423,9 +404,7 @@ class OmniRequestOutput:
             f"stage_id={self.stage_id}",
             f"final_output_type={self.final_output_type!r}",
             f"request_output={self.request_output}",
-            f"images={images_repr}",
             f"prompt={self.prompt!r}",
-            f"latents={self.latents}",
             f"metrics={self.metrics}",
             f"multimodal_output={self._multimodal_output}",
             f"custom_output={self._custom_output}",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Resovles Phase 3-5 and address several historical problems of [RFC1601](https://github.com/vllm-project/vllm-
omni/issues/1601)
#1601 #2744 

### Refactor 1
In OmniRequestOutput, integrate images, trajectory_timesteps, trajectory_log_probs, trajectory_decoded, trajectory_latents into OmniRequestOutput._multimodal_output

### Refactor 2
refactor redundent and unnecessary _MODALITY_ALIASES. Delete all of them and adapt inference pipeline
```
_MODALITY_ALIASES: dict[str, str] = {
    "speech": "audio",
    "images": "image",
    "latents": "latent",
    "wav": "audio",
    "waveform": "audio",
    "pixel_values": "image",
    "pixels": "image",
    "token_ids": "text",
    "tokens": "text",
}
```
`engine_output_type="token_ids"` -> `ngine_output_type="text"`

### Refactor 3
refactor the none-compile-time type safe `engine_output_type`
In the context of `engine_output_type`, it means the value is a plain `str` — any string typechecks, even nonsense. The mismatch is only caught at runtime when `OutputModality.from_string()` hits the `KeyError` branch.

Concretely, here's the field declaration ([vllm_omni/engine/arg_utils.py:146](vscode-webview://0v7p5i5tqk2su1nrk077u4q0me40llk4g4dvg6kmo7npp02qshgv/vllm-omni/vllm_omni/engine/arg_utils.py#L146)):

The type checker has no idea what set of strings is legal. The error only fires later, when something instantiates the engine and reaches `OutputModality.from_string(...)`:
`ValueError: Unknown modality: 'txet'. Supported: ['text', 'image', 'audio', 'latent']`
That can be at server boot, or — worse — only when a request of a certain modality actually arrives. Contrast with the type-safe alternative:
```
FinalOutputModalityType: TypeAlias = Literal["text", "image", "audio", "video"]
engine_output_type: FinalOutputModalityType | None = None
```
or directly the enum:
```
engine_output_type: OutputModality | None = None
```

### Refactor 4
Removed the redundant `OutputModalityNames` StrEnum and `NON_DRAINABLE_MODALITIES`
`OutputModalityNames` mirrored `OutputModality`'s members. Resolved the existing `TODO: (Alex) Integrate this with the big-flag enum` by eliminating the duplicate type.
`NON_DRAINABLE_MODALITIES` was only used to derive `DRAINABLE_MODALITIES` one line below.
Replaced both with a single direct definition: `DRAINABLE_MODALITIES: frozenset[str] = frozenset({"image", "audio"})` (semantics preserved — TEXT is handled by the base detokenizer path, LATENT needs full-history context).

### Refactor 5
vllm_omni/engine/output_processor.py
Fixed a lying type annotation on `OmniRequestState.make_request_output`:

Changed return annotation `OmniRequestOutput | PoolingRequestOutput | None → RequestOutput | PoolingRequestOutput | None`
Updated the matching docstring `Returns`:
Removed the now-unused `from vllm_omni.outputs import OmniRequestOutput` import

### Refactor 6
vllm_omni/entrypoints/omni_base.py
Eliminated `OmniRequestOutput-inside-OmniRequestOutput` nesting from the diffusion path in `_process_single_result`
If `engine_outputs` is already an `OmniRequestOutput`, set the outer's `request_output=` to its inner `request_output` (typically None) instead of nesting.
Promote inner-only fields (`prompt`, `error`, `error_status_code`, `error_type`) onto the outer.
Merge inner metrics (diffusion perf timings) into `response_metrics` via `setdefault` so orchestrator keys win, no data is lost on unwrap.


## Test Plan
`trajectory_*` is only used in `Qwen_images` and `Bagel` model. We test the correctness of inference of these two model
python -m pytest tests/e2e/offline_inference/rlhf_test/test_verl_omni_e2e.py -v
python -m pytest tests/e2e/offline_inference/test_bagel.py --run-level=advanced_model -v

**vLLM Version: 0.23.0**

**vLLM-Omni Commit:eb81914c644cbe785b3dbdd5e6efa390af7c5808**


## Test Result
### Refactor 1:
Passed
### Refactor 2: 
`python -m pytest tests/engine/test_output_modality.py -x -q`
3 passed, 17 warnings in 0.04s
### Refactor 3:
`python -m pytest tests/test_config_factory.py tests/engine/test_single_stage_mode.py` tests/engine/test_async_omni_engine_stage_init.py -x -q 2>&1 
179 passed, 17 warnings in 22.23s
### Refactor 4:
`python -m pytest tests/engine/test_output_modality.py tests/engine/test_output_processor.py -x -q 2>&1 | tail -10`
18 passed, 17 warnings in 0.07s

`pytest tests/test_outputs.py -x`
11 passed, 16 warnings in 0.05s

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
