### PR TITLE
[Bugfix] Fix audio.format parameter silently ignored in chat completions

### DIFF
--- a/docs/serving/audio_generate_api.md
+++ b/docs/serving/audio_generate_api.md
@@ -66,7 +66,7 @@ Content-Type: application/json
 |-----------|------|---------|-------------|
 | `input` | string | **required** | Text prompt describing the audio to generate |
 | `model` | string | server's model | Model to use (optional, should match server if specified) |
-| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, aac, opus |
+| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, opus |
 | `speed` | float | 1.0 | Playback speed (0.25 - 4.0) |
 
 #### Diffusion Parameters
@@ -90,8 +90,7 @@ Returns binary audio data with the appropriate `Content-Type` header:
 | `mp3` | `audio/mpeg` |
 | `flac` | `audio/flac` |
 | `pcm` | `audio/pcm` |
-| `aac` | `audio/aac` |
-| `opus` | `audio/opus` |
+| `opus` | `audio/ogg` |
 
 ## Examples
 
@@ -285,7 +284,7 @@ Pydantic validation failure (e.g. invalid `response_format`, `speed` out of rang
     "detail": [
         {
             "type": "literal_error",
-            "msg": "Input should be 'wav', 'pcm', 'flac', 'mp3', 'aac' or 'opus'",
+            "msg": "Input should be 'wav', 'pcm', 'flac', 'mp3' or 'opus'",
             ...
         }
     ]

--- a/docs/serving/audio_generate_api.md
+++ b/docs/serving/audio_generate_api.md
@@ -90,7 +90,7 @@ Returns binary audio data with the appropriate `Content-Type` header:
 | `mp3` | `audio/mpeg` |
 | `flac` | `audio/flac` |
 | `pcm` | `audio/pcm` |
-| `opus` | `audio/ogg` |
+| `opus` | `audio/opus` |
 
 ## Examples
 

--- a/docs/serving/speech_api.md
+++ b/docs/serving/speech_api.md
@@ -109,7 +109,7 @@ Content-Type: application/json
 | `input` | string | **required** | The text to synthesize into speech |
 | `model` | string | server's model | Model to use (optional, should match server if specified) |
 | `voice` | string | "vivian" | Speaker name (e.g., vivian, ryan, aiden) |
-| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, aac, opus |
+| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, opus |
 | `speed` | float | 1.0 | Playback speed (0.25-4.0) |
 
 #### vLLM-Omni Extension Parameters

--- a/docs/user_guide/examples/online_serving/text_to_audio.md
+++ b/docs/user_guide/examples/online_serving/text_to_audio.md
@@ -139,7 +139,7 @@ Content-Type: application/json
 |-----------|------|---------|-------------|
 | `input` | string | **required** | Text prompt describing the audio to generate |
 | `model` | string | server's model | Model to use (optional, should match server if specified) |
-| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, aac, opus |
+| `response_format` | string | "wav" | Audio format: wav, mp3, flac, pcm, opus |
 | `speed` | float | 1.0 | Playback speed (0.25 - 4.0) |
 | `audio_length` | float | null | Audio duration in seconds (max ~47s for `stable-audio-open-1.0`) |
 | `audio_start` | float | 0.0 | Audio start time in seconds |

--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -7,6 +7,7 @@ E2E Online tests for Qwen3-Omni model.
 import os
 
 import pytest
+from openai import BadRequestError
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
@@ -562,3 +563,21 @@ def test_text_to_audio_long_output_001(omni_server, openai_client) -> None:
     text = responses[0].text_content if responses else ""
     word_count = len(text.split())
     assert word_count >= 200, f"Expected at least 200 words in long output, got {word_count}"
+
+
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", test_params[:1], indirect=True)
+def test_invalid_audio_format_rejected(omni_server, openai_client) -> None:
+    """Ensure invalid audio format is rejected with 400 before streaming starts."""
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        content_text=get_prompt(),
+    )
+    with pytest.raises(BadRequestError, match="audio format"):
+        openai_client.client.chat.completions.create(
+            model=omni_server.model,
+            messages=messages,
+            modalities=["text", "audio"],
+            audio={"voice": "alloy", "format": "aac"},
+            stream=True,
+        )

--- a/tests/entrypoints/openai_api/test_audio_format.py
+++ b/tests/entrypoints/openai_api/test_audio_format.py
@@ -133,7 +133,7 @@ class TestResolveAudioFormat:
         return object.__new__(OmniOpenAIServingChat)
 
     def _make_request(self, audio_params=None):
-        from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 
         req = ChatCompletionRequest(
             model="test-model",
@@ -159,7 +159,7 @@ class TestResolveAudioFormat:
         assert result == "pcm"
 
     def test_invalid_format_returns_error(self, serving_chat):
-        from vllm.entrypoints.openai.protocol import ErrorResponse
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 
         request = self._make_request({"format": "aac", "voice": "alloy"})
         result = serving_chat._resolve_audio_format(request)
@@ -167,7 +167,7 @@ class TestResolveAudioFormat:
         assert "aac" in result.error.message
 
     def test_all_supported_formats_accepted(self, serving_chat):
-        from vllm.entrypoints.openai.protocol import ErrorResponse
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 
         for fmt in SUPPORTED_CHAT_AUDIO_FORMATS:
             request = self._make_request({"format": fmt, "voice": "alloy"})

--- a/tests/entrypoints/openai_api/test_audio_format.py
+++ b/tests/entrypoints/openai_api/test_audio_format.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for audio output format handling in chat completions.
+
+Covers:
+- #4716: audio.format parameter must be respected, not hardcoded to WAV
+- Format validation rejects unsupported formats
+- pcm16 is mapped to pcm for soundfile compatibility
+- Default format is WAV when not specified
+- create_audio encodes correctly for each supported format
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
+from vllm_omni.entrypoints.openai.protocol.audio import (
+    DEFAULT_AUDIO_FORMAT,
+    SUPPORTED_AUDIO_FORMATS,
+    SUPPORTED_CHAT_AUDIO_FORMATS,
+    CreateAudio,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestAudioFormatConstants:
+    def test_default_format_is_wav(self):
+        assert DEFAULT_AUDIO_FORMAT == "wav"
+
+    def test_supported_formats_no_aac(self):
+        assert "aac" not in SUPPORTED_AUDIO_FORMATS
+
+    def test_chat_formats_include_pcm16(self):
+        assert "pcm16" in SUPPORTED_CHAT_AUDIO_FORMATS
+
+    def test_chat_formats_superset_of_audio_formats(self):
+        assert SUPPORTED_AUDIO_FORMATS <= SUPPORTED_CHAT_AUDIO_FORMATS
+
+
+class TestCreateAudio:
+    @pytest.fixture
+    def mixin(self):
+        return AudioMixin()
+
+    @pytest.fixture
+    def audio_tensor(self):
+        return np.sin(np.linspace(0, 2 * np.pi, 24000)).astype(np.float32)
+
+    @pytest.mark.parametrize("fmt", ["wav", "mp3", "flac", "opus", "pcm"])
+    def test_create_audio_supported_formats(self, mixin, audio_tensor, fmt):
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format=fmt,
+            speed=1.0,
+            base64_encode=False,
+        )
+        response = mixin.create_audio(audio_obj)
+        assert len(response.audio_data) > 0
+
+    def test_wav_magic_bytes(self, mixin, audio_tensor):
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format="wav",
+            speed=1.0,
+            base64_encode=False,
+        )
+        response = mixin.create_audio(audio_obj)
+        assert response.audio_data[:4] == b"RIFF"
+        assert response.media_type == "audio/wav"
+
+    def test_mp3_encoding(self, mixin, audio_tensor):
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format="mp3",
+            speed=1.0,
+            base64_encode=False,
+        )
+        response = mixin.create_audio(audio_obj)
+        assert response.media_type == "audio/mpeg"
+        assert response.audio_data[:4] != b"RIFF"
+
+    def test_flac_magic_bytes(self, mixin, audio_tensor):
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format="flac",
+            speed=1.0,
+            base64_encode=False,
+        )
+        response = mixin.create_audio(audio_obj)
+        assert response.audio_data[:4] == b"fLaC"
+        assert response.media_type == "audio/flac"
+
+    def test_unsupported_format_falls_back_to_default(self, mixin, audio_tensor):
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format="aac",
+            speed=1.0,
+            base64_encode=False,
+        )
+        response = mixin.create_audio(audio_obj)
+        assert response.audio_data[:4] == b"RIFF"
+        assert response.media_type == "audio/wav"
+
+    def test_base64_encoding(self, mixin, audio_tensor):
+        import base64
+
+        audio_obj = CreateAudio(
+            audio_tensor=audio_tensor,
+            sample_rate=24000,
+            response_format="wav",
+            speed=1.0,
+            base64_encode=True,
+        )
+        response = mixin.create_audio(audio_obj)
+        decoded = base64.b64decode(response.audio_data)
+        assert decoded[:4] == b"RIFF"
+
+
+class TestResolveAudioFormat:
+    """Test _resolve_audio_format via the serving chat class."""
+
+    @pytest.fixture
+    def serving_chat(self):
+        from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+        return object.__new__(OmniOpenAIServingChat)
+
+    def _make_request(self, audio_params=None):
+        from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        if audio_params is not None:
+            req.audio = audio_params
+        return req
+
+    def test_default_format_when_no_audio_params(self, serving_chat):
+        request = self._make_request()
+        result = serving_chat._resolve_audio_format(request)
+        assert result == "wav"
+
+    def test_extracts_mp3_format(self, serving_chat):
+        request = self._make_request({"format": "mp3", "voice": "alloy"})
+        result = serving_chat._resolve_audio_format(request)
+        assert result == "mp3"
+
+    def test_pcm16_mapped_to_pcm(self, serving_chat):
+        request = self._make_request({"format": "pcm16", "voice": "alloy"})
+        result = serving_chat._resolve_audio_format(request)
+        assert result == "pcm"
+
+    def test_invalid_format_returns_error(self, serving_chat):
+        from vllm.entrypoints.openai.protocol import ErrorResponse
+
+        request = self._make_request({"format": "aac", "voice": "alloy"})
+        result = serving_chat._resolve_audio_format(request)
+        assert isinstance(result, ErrorResponse)
+        assert "aac" in result.error.message
+
+    def test_all_supported_formats_accepted(self, serving_chat):
+        from vllm.entrypoints.openai.protocol import ErrorResponse
+
+        for fmt in SUPPORTED_CHAT_AUDIO_FORMATS:
+            request = self._make_request({"format": fmt, "voice": "alloy"})
+            result = serving_chat._resolve_audio_format(request)
+            assert not isinstance(result, ErrorResponse), f"Format {fmt} should be accepted"

--- a/vllm_omni/entrypoints/openai/audio_utils_mixin.py
+++ b/vllm_omni/entrypoints/openai/audio_utils_mixin.py
@@ -5,7 +5,7 @@ import torch
 import torchaudio
 from vllm.logger import init_logger
 
-from vllm_omni.entrypoints.openai.protocol.audio import AudioResponse, CreateAudio
+from vllm_omni.entrypoints.openai.protocol.audio import DEFAULT_AUDIO_FORMAT, AudioResponse, CreateAudio
 
 try:
     import soundfile
@@ -53,8 +53,8 @@ class AudioMixin:
         }
 
         if response_format not in supported_formats:
-            logger.warning(f"Unsupported response format '{response_format}', defaulting to 'wav'.")
-            response_format = "wav"
+            logger.warning(f"Unsupported response format '{response_format}', defaulting to '{DEFAULT_AUDIO_FORMAT}'.")
+            response_format = DEFAULT_AUDIO_FORMAT
 
         soundfile_format, media_type, kwargs = supported_formats[response_format]
 

--- a/vllm_omni/entrypoints/openai/audio_utils_mixin.py
+++ b/vllm_omni/entrypoints/openai/audio_utils_mixin.py
@@ -49,7 +49,6 @@ class AudioMixin:
             "pcm": ("RAW", "audio/pcm", {"subtype": "PCM_16"}),
             "flac": ("FLAC", "audio/flac", {}),
             "mp3": ("MP3", "audio/mpeg", {}),
-            "aac": ("AAC", "audio/aac", {}),
             "opus": ("OGG", "audio/ogg", {"subtype": "OPUS"}),
         }
 
@@ -59,22 +58,9 @@ class AudioMixin:
 
         soundfile_format, media_type, kwargs = supported_formats[response_format]
 
-        try:
-            with BytesIO() as buffer:
-                soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
-                audio_data = buffer.getvalue()
-        except Exception:
-            if response_format == "wav":
-                raise
-            logger.warning(
-                "Failed to encode audio as '%s' (libsndfile may lack codec support), falling back to 'wav'.",
-                response_format,
-            )
-            response_format = "wav"
-            soundfile_format, media_type, kwargs = supported_formats["wav"]
-            with BytesIO() as buffer:
-                soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
-                audio_data = buffer.getvalue()
+        with BytesIO() as buffer:
+            soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
+            audio_data = buffer.getvalue()
 
         if base64_encode:
             import base64

--- a/vllm_omni/entrypoints/openai/audio_utils_mixin.py
+++ b/vllm_omni/entrypoints/openai/audio_utils_mixin.py
@@ -59,9 +59,22 @@ class AudioMixin:
 
         soundfile_format, media_type, kwargs = supported_formats[response_format]
 
-        with BytesIO() as buffer:
-            soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
-            audio_data = buffer.getvalue()
+        try:
+            with BytesIO() as buffer:
+                soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
+                audio_data = buffer.getvalue()
+        except Exception:
+            if response_format == "wav":
+                raise
+            logger.warning(
+                "Failed to encode audio as '%s' (libsndfile may lack codec support), falling back to 'wav'.",
+                response_format,
+            )
+            response_format = "wav"
+            soundfile_format, media_type, kwargs = supported_formats["wav"]
+            with BytesIO() as buffer:
+                soundfile.write(buffer, audio_tensor, sample_rate, format=soundfile_format, **kwargs)
+                audio_data = buffer.getvalue()
 
         if base64_encode:
             import base64

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -6,6 +6,10 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator, model_vali
 
 _MAX_EMBEDDING_DIM = 8192
 
+SUPPORTED_AUDIO_FORMATS: frozenset[str] = frozenset({"wav", "pcm", "flac", "mp3", "opus"})
+SUPPORTED_CHAT_AUDIO_FORMATS: frozenset[str] = SUPPORTED_AUDIO_FORMATS | {"pcm16"}
+DEFAULT_AUDIO_FORMAT: str = "wav"
+
 
 def _normalize_ref_audio_value(value):
     if value is None:
@@ -59,7 +63,7 @@ class OpenAICreateSpeechRequest(BaseModel):
         default=None,
         description="Instructions for voice style/emotion (maps to 'instruct' for Qwen3-TTS)",
     )
-    response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] = "wav"
+    response_format: Literal["wav", "pcm", "flac", "mp3", "opus"] = DEFAULT_AUDIO_FORMAT
     speed: float | None = Field(
         default=1.0,
         ge=0.25,
@@ -323,7 +327,7 @@ class OpenAICreateAudioGenerateRequest(BaseModel):
         description="Text prompt describing the audio to generate",
     )
     model: str | None = None
-    response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] = "wav"
+    response_format: Literal["wav", "pcm", "flac", "mp3", "opus"] = DEFAULT_AUDIO_FORMAT
     speed: float | None = Field(
         default=1.0,
         ge=0.25,
@@ -389,7 +393,7 @@ class SpeechBatchItem(BaseModel):
     input: str
     voice: str | None = Field(default=None, validation_alias=AliasChoices("voice", "speaker"))
     instructions: str | None = None
-    response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] | None = None
+    response_format: Literal["wav", "pcm", "flac", "mp3", "opus"] | None = None
     speed: float | None = Field(default=None, ge=0.25, le=4.0)
     task_type: Literal["CustomVoice", "VoiceDesign", "Base"] | None = None
     language: str | None = None
@@ -409,7 +413,7 @@ class BatchSpeechRequest(BaseModel):
     items: list[SpeechBatchItem] = Field(..., min_length=1)
     voice: str | None = Field(default=None, validation_alias=AliasChoices("voice", "speaker"))
     instructions: str | None = None
-    response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] = "wav"
+    response_format: Literal["wav", "pcm", "flac", "mp3", "opus"] = DEFAULT_AUDIO_FORMAT
     speed: float | None = Field(default=1.0, ge=0.25, le=4.0)
     task_type: Literal["CustomVoice", "VoiceDesign", "Base"] | None = None
     language: str | None = None
@@ -445,7 +449,7 @@ class StreamingSpeechSessionConfig(BaseModel):
     task_type: Literal["CustomVoice", "VoiceDesign", "Base"] | None = None
     language: str | None = None
     instructions: str | None = None
-    response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] = "wav"
+    response_format: Literal["wav", "pcm", "flac", "mp3", "opus"] = DEFAULT_AUDIO_FORMAT
     speed: float | None = Field(default=1.0, ge=0.25, le=4.0)
     max_new_tokens: int | None = Field(default=None, ge=1)
     initial_codec_chunk_frames: int | None = Field(

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -412,6 +412,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         output_modalities = getattr(request, "modalities", engine_output_modalities)
         request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
 
+        if request.modalities and "audio" in request.modalities:
+            audio_format_check = self._resolve_audio_format(request)
+            if isinstance(audio_format_check, ErrorResponse):
+                return audio_format_check
+
         num_inference_steps = None
         extra_body: dict[str, Any] = {}
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
@@ -1882,8 +1887,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
                     role = self.get_chat_request_role(request)
                     choices_data = self._create_audio_choice(omni_res, role, request, stream=True)
-                    if isinstance(choices_data, ErrorResponse):
-                        return
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
                     for choice in choices_data:
@@ -2156,8 +2159,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     ]
             elif omni_outputs.final_output_type == "audio":
                 choices_data = self._create_audio_choice(omni_outputs, role, request, stream=False)
-                if isinstance(choices_data, ErrorResponse):
-                    return choices_data
             elif omni_outputs.final_output_type == "image":
                 choices_data = self._create_image_choice(omni_outputs, role, request, stream=False)
             else:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1882,6 +1882,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
                     role = self.get_chat_request_role(request)
                     choices_data = self._create_audio_choice(omni_res, role, request, stream=True)
+                    if isinstance(choices_data, ErrorResponse):
+                        return
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
                     for choice in choices_data:
@@ -2154,6 +2156,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     ]
             elif omni_outputs.final_output_type == "audio":
                 choices_data = self._create_audio_choice(omni_outputs, role, request, stream=False)
+                if isinstance(choices_data, ErrorResponse):
+                    return choices_data
             elif omni_outputs.final_output_type == "image":
                 choices_data = self._create_image_choice(omni_outputs, role, request, stream=False)
             else:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -96,7 +96,12 @@ from vllm.v1.engine.exceptions import EngineDeadError
 from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
 from vllm_omni.entrypoints.openai.image_api_utils import encode_image_base64_with_compression, validate_layered_layers
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
-from vllm_omni.entrypoints.openai.protocol.audio import AudioResponse, CreateAudio
+from vllm_omni.entrypoints.openai.protocol.audio import (
+    DEFAULT_AUDIO_FORMAT,
+    SUPPORTED_CHAT_AUDIO_FORMATS,
+    AudioResponse,
+    CreateAudio,
+)
 from vllm_omni.entrypoints.openai.protocol.images import (
     ImageData,
     ImageEditARDeltaChunk,
@@ -2500,18 +2505,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         else:
             sample_rate = int(sr_raw)
 
-        _valid_audio_formats = {"wav", "mp3", "flac", "opus", "pcm16", "pcm"}
-        audio_params = getattr(request, "audio", None)
-        if isinstance(audio_params, dict):
-            audio_format = audio_params.get("format", "wav")
-        else:
-            audio_format = "wav"
-        if audio_format not in _valid_audio_formats:
-            return self._create_error_response(
-                f"Invalid audio format '{audio_format}'. Supported formats: {sorted(_valid_audio_formats)}",
-            )
-        if audio_format == "pcm16":
-            audio_format = "pcm"
+        audio_format = self._resolve_audio_format(request)
+        if isinstance(audio_format, ErrorResponse):
+            return audio_format
 
         audio_obj = CreateAudio(
             audio_tensor=audio_tensor,
@@ -3467,10 +3463,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     raise ValueError(f"Unexpected audio tensor rank {audio_tensor.ndim}; expected 1-3 dims.")
                 audio_array = audio_tensor.numpy()
 
+                audio_format = self._resolve_audio_format(request)
+                if isinstance(audio_format, ErrorResponse):
+                    return audio_format
+
                 audio_obj = CreateAudio(
                     audio_tensor=audio_array,
                     sample_rate=sample_rate,
-                    response_format="wav",
+                    response_format=audio_format,
                     speed=1.0,
                     base64_encode=True,
                 )
@@ -3685,6 +3685,21 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 logger.warning("Invalid size format: %s", extra_body.get("size"))
 
         return height, width
+
+    def _resolve_audio_format(self, request: ChatCompletionRequest) -> str | ErrorResponse:
+        """Extract and validate the audio output format from a chat completion request."""
+        audio_params = getattr(request, "audio", None)
+        if isinstance(audio_params, dict):
+            audio_format = audio_params.get("format", DEFAULT_AUDIO_FORMAT)
+        else:
+            audio_format = DEFAULT_AUDIO_FORMAT
+        if audio_format not in SUPPORTED_CHAT_AUDIO_FORMATS:
+            return self._create_error_response(
+                f"Invalid audio format '{audio_format}'. Supported formats: {sorted(SUPPORTED_CHAT_AUDIO_FORMATS)}",
+            )
+        if audio_format == "pcm16":
+            audio_format = "pcm"
+        return audio_format
 
     def _create_error_response(
         self,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2500,11 +2500,16 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         else:
             sample_rate = int(sr_raw)
 
+        _valid_audio_formats = {"wav", "mp3", "flac", "opus", "pcm16", "pcm"}
         audio_params = getattr(request, "audio", None)
         if isinstance(audio_params, dict):
             audio_format = audio_params.get("format", "wav")
         else:
             audio_format = "wav"
+        if audio_format not in _valid_audio_formats:
+            return self._create_error_response(
+                f"Invalid audio format '{audio_format}'. Supported formats: {sorted(_valid_audio_formats)}",
+            )
         if audio_format == "pcm16":
             audio_format = "pcm"
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2500,10 +2500,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         else:
             sample_rate = int(sr_raw)
 
+        audio_params = getattr(request, "audio", None)
+        if isinstance(audio_params, dict):
+            audio_format = audio_params.get("format", "wav")
+        else:
+            audio_format = "wav"
+        if audio_format == "pcm16":
+            audio_format = "pcm"
+
         audio_obj = CreateAudio(
             audio_tensor=audio_tensor,
             sample_rate=sample_rate,
-            response_format="wav",
+            response_format=audio_format,
             speed=1.0,
             base64_encode=True,
         )


### PR DESCRIPTION
## Purpose

Fix #4716 — The `audio.format` field in chat completion requests was silently ignored. The server always returned WAV audio regardless of the requested format (mp3, flac, opus, etc.).

**Root cause:** `_create_audio_choice()` in `serving_chat.py` hardcoded `response_format="wav"` when constructing the `CreateAudio` object. The encoding infrastructure in `audio_utils_mixin.py` already supports all formats — it was just never wired up.

**Changes:**
- `serving_chat.py`: Extract `audio.format` from the request and pass it to `CreateAudio` instead of hardcoding `"wav"`. Maps OpenAI's `"pcm16"` to soundfile's `"pcm"`. Defaults to `"wav"` when not specified.
- `audio_utils_mixin.py`: Add fallback to WAV with a warning when `soundfile.write` fails for the requested codec (e.g. MP3 on systems where `libsndfile` lacks LAME support).

## Test Plan

**vLLM Version:** latest

**vLLM-Omni Commit:** 2e6c83c8

1. Serve Qwen3-Omni and send chat completion requests with `audio.format` set to `"mp3"`, `"flac"`, and `"wav"`
2. Verify response audio magic bytes match the requested format (e.g. MP3 frame sync, fLaC header, RIFF header)
3. Verify backward compatibility: requests without `audio.format` still return WAV

## Test Result

- `ruff check` and `ruff format` pass on both modified files
- Manual verification confirms the format parameter is now respected