### PR TITLE
[Bugfix] Add back resolving from deploy config written pipeline in StageConfigFactory

### DIFF
--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -655,6 +655,16 @@ class TestPipelineRegistration:
         assert isinstance(pipeline_cfg, PipelineConfig)
         assert pipeline_cfg.model_type == resolved_type
 
+    def test_resolve_when_autodetect_resolves_none(self):
+        """Regression test for: https://github.com/vllm-project/vllm-omni/issues/4726"""
+        deploy_path = get_deploy_config_path("ming_tts.yaml")
+        resolved_config = StageConfigFactory.create_from_model(
+            model="inclusionAI/Ming-omni-tts-0.5B",
+            deploy_config_path=deploy_path,
+        )
+        assert resolved_config is not None
+        assert len(resolved_config) > 0
+
 
 class TestResolveScheduler:
     def test_all_execution_types_handled(self):

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -83,6 +83,10 @@ class StageConfigFactory:
                     deploy_config_path,
                 )
 
+        print(" >>> create_from_model: ")
+        print(f"    >>> model_type: {type(model_type)}, {model_type}")
+        print(f"    >>> hf_config: {type(hf_config)}, {hf_config}")
+
         # --- HF architecture fallback: some models report a generic
         # model_type that collides with another model. Match by the
         # hf_architectures declared on each registered PipelineConfig.
@@ -123,6 +127,23 @@ class StageConfigFactory:
                             cli_overrides,
                             deploy_config_path,
                         )
+        # --- Explicit deploy-config pipeline ---
+        # When auto-detection above resolves nothing (generic/missing HF model_type
+        # and no matching architecture), honor an explicit pipeline key in the deploy config
+        if deploy_config_path is not None:
+            deploy_path = Path(deploy_config_path)
+            if deploy_path.exists():
+                deploy_cfg = load_deploy_config(deploy_path)
+                if deploy_cfg.pipeline:
+                    pipeline_cfg = cls.resolve_pipeline_config(deploy_cfg.pipeline, hf_config)
+                    if pipeline_cfg is not None:
+                        return cls._create_from_registry(
+                            pipeline_cfg.model_type,
+                            pipeline_cfg,
+                            cli_overrides,
+                            deploy_config_path,
+                        )
+
         # Not in the pipeline registry — let the caller fall back to the
         # legacy ``stage_configs/*.yaml`` path (resolve_model_config_path).
         return None

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -83,10 +83,6 @@ class StageConfigFactory:
                     deploy_config_path,
                 )
 
-        print(" >>> create_from_model: ")
-        print(f"    >>> model_type: {type(model_type)}, {model_type}")
-        print(f"    >>> hf_config: {type(hf_config)}, {hf_config}")
-
         # --- HF architecture fallback: some models report a generic
         # model_type that collides with another model. Match by the
         # hf_architectures declared on each registered PipelineConfig.
@@ -127,6 +123,7 @@ class StageConfigFactory:
                             cli_overrides,
                             deploy_config_path,
                         )
+
         # --- Explicit deploy-config pipeline ---
         # When auto-detection above resolves nothing (generic/missing HF model_type
         # and no matching architecture), honor an explicit pipeline key in the deploy config


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Resolves #4726

I didn't refactor or move the orders of the previous paths in `StageConfigFactory.create_from_model`, as we don't want to import significant changes which require a lot of testing. Instead, I added the user written deploy-config pipeline path (pipeline key in deploy yaml) at the end of `StageConfigFactory.create_from_model`, so that models fail for the other resolutions (e.g., model type none or generic, etc) will get into this path as an additional try.

## Test Plan

Serve `inclusionAI/Ming-omni-tts-0.5B`
```bash
vllm-omni serve inclusionAI/Ming-omni-tts-0.5B \
    --deploy-config vllm_omni/deploy/ming_tts.yaml \
    --omni \
    --port 8091 \
    --enforce-eager

vllm-omni serve inclusionAI/Ming-omni-tts-0.5B \
    --omni \
    --port 8091 \
    --enforce-eager
```

Serve `inclusionAI/Ming-omni-tts-16.8B-A3B`

```bash
vllm-omni serve inclusionAI/Ming-omni-tts-16.8B-A3B --deploy-config vllm_omni/deploy/ming_tts_moe.yaml --omni --port 8091

vllm-omni serve inclusionAI/Ming-omni-tts-16.8B-A3B --omni --port 8091
```

**vLLM Version:** 0.23

**vLLM-Omni Commit:** on top of f8815857

## Test Result

I run serve and simple request on all the above four commands (Ming-omni-tts-0.5B and Ming-omni-tts-16.8B-A3B; with and without deploy-config arg). Servers get launched and configs get resolved correctly.



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
