### PR TITLE
[CI][Bugfix] Fix nightly L2/L3 E2E-only upload and Buildkite EXTRA escaping

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
         if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
           EXTRA="--e2e"
         fi
-        python3 .buildkite/scripts/upload_pipeline.py --upload $EXTRA .buildkite/test-ready.yml
+        python3 .buildkite/scripts/upload_pipeline.py --upload $$EXTRA .buildkite/test-ready.yml
     agents:
       queue: "cpu_queue_premerge"
 
@@ -52,7 +52,7 @@ steps:
         if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
           EXTRA="--e2e"
         fi
-        python3 .buildkite/scripts/upload_pipeline.py --upload $EXTRA .buildkite/test-merge.yml
+        python3 .buildkite/scripts/upload_pipeline.py --upload $$EXTRA .buildkite/test-merge.yml
     agents:
       queue: "cpu_queue_premerge"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,23 +26,33 @@ steps:
     agents:
       queue: "cpu_queue_premerge"
 
-  # L2 Test
+  # L2 Test — PR ready label (diff-aware) or main+NIGHTLY=1 (--e2e, full E2E group)
   - label: "Upload Ready Pipeline"
     depends_on: image-build
     key: upload-ready-pipeline
     if: __UPLOAD_READY_IF__
     commands:
-      - python3 .buildkite/scripts/upload_pipeline.py --upload .buildkite/test-ready.yml
+      - |
+        EXTRA=""
+        if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
+          EXTRA="--e2e"
+        fi
+        python3 .buildkite/scripts/upload_pipeline.py --upload $EXTRA .buildkite/test-ready.yml
     agents:
       queue: "cpu_queue_premerge"
 
-  # L3 Test
+  # L3 Test — PR merge-test label (diff-aware) or main+NIGHTLY=1 (--e2e, full E2E group)
   - label: "Upload Merge Pipeline"
     depends_on: image-build
     key: upload-merge-pipeline
     if: __UPLOAD_MERGE_IF__
     commands:
-      - python3 .buildkite/scripts/upload_pipeline.py --upload .buildkite/test-merge.yml
+      - |
+        EXTRA=""
+        if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
+          EXTRA="--e2e"
+        fi
+        python3 .buildkite/scripts/upload_pipeline.py --upload $EXTRA .buildkite/test-merge.yml
     agents:
       queue: "cpu_queue_premerge"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - |
         EXTRA=""
-        if ! { [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; }; then
+        if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
           EXTRA="--e2e"
         fi
         python3 .buildkite/scripts/upload_pipeline.py --upload $$EXTRA .buildkite/test-ready.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - |
         EXTRA=""
-        if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
+        if ! { [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; }; then
           EXTRA="--e2e"
         fi
         python3 .buildkite/scripts/upload_pipeline.py --upload $$EXTRA .buildkite/test-ready.yml

--- a/.buildkite/scripts/upload_pipeline.py
+++ b/.buildkite/scripts/upload_pipeline.py
@@ -13,7 +13,7 @@ Test pipeline mode (e.g. test-merge.yml):
     recognize this uploader-only key).
 
 Usage:
-  python3 upload_pipeline.py [--upload] [--all] <pipeline.yml>
+  python3 upload_pipeline.py [--upload] [--all | --e2e] <pipeline.yml>
 
   # Bootstrap (replaces upload_pipeline_with_skip_ci.sh):
   python3 upload_pipeline.py --upload .buildkite/pipeline.yml
@@ -23,6 +23,9 @@ Usage:
 
   # Full suite (rebase pipeline): keep all steps, still strip the uploader-only key:
   python3 upload_pipeline.py --upload --all .buildkite/test-merge.yml
+
+  # Nightly L2 E2E only: keep the E2E Test group, ignore source_file_dependencies:
+  python3 upload_pipeline.py --upload --e2e .buildkite/test-ready.yml
 """
 
 from __future__ import annotations
@@ -47,6 +50,7 @@ LOG = "upload_pipeline"
 ROOT = Path(__file__).resolve().parent.parent.parent
 DOC_SEP = "\n---\n"
 BOOTSTRAP_MARKER = "__IMAGE_BUILD_IF__"
+E2E_GROUP_MARKER = "E2E Test"
 
 
 def _log(message: str) -> None:
@@ -322,18 +326,18 @@ def render_bootstrap_pipeline(text: str, *, skip_ci: bool) -> str:
     nightly_only = (
         '(build.pull_request.labels includes "nightly-test") || (build.branch == "main" && build.env("NIGHTLY") == "1")'
     )
+    nightly_main = 'build.branch == "main" && build.env("NIGHTLY") == "1"'
+    ready_pr = 'build.branch != "main" && build.pull_request.labels includes "ready"'
+    merge_main = 'build.branch == "main" && build.env("NIGHTLY") != "1" && build.env("WEEKLY") != "1"'
+    merge_pr = 'build.branch != "main" && build.pull_request.labels includes "merge-test"'
     if skip_ci:
         image_if = f"'{nightly_only}'"
-        ready_if = "'false'"
-        merge_if = "'false'"
+        ready_if = f"'({nightly_main})'"
+        merge_if = f"'({nightly_main})'"
     else:
         image_if = "'true'"
-        ready_if = '\'build.branch != "main" && build.pull_request.labels includes "ready"\''
-        merge_if = (
-            '\'(build.branch == "main" && build.env("NIGHTLY") != "1" '
-            '&& build.env("WEEKLY") != "1") || '
-            '(build.branch != "main" && build.pull_request.labels includes "merge-test")\''
-        )
+        ready_if = f"'(({nightly_main}) || ({ready_pr}))'"
+        merge_if = f"'(({nightly_main}) || (({merge_main}) || ({merge_pr})))'"
 
     return (
         continuation.replace("__IMAGE_BUILD_IF__", image_if)
@@ -396,6 +400,20 @@ def _filter_steps(steps: list[Any], changed_files: list[str]) -> list[Any]:
     return filtered
 
 
+def _is_e2e_group(step: dict[str, Any]) -> bool:
+    group = step.get("group")
+    return isinstance(group, str) and E2E_GROUP_MARKER in group
+
+
+def _select_e2e_group_steps(steps: list[Any]) -> list[Any]:
+    selected = [step for step in steps if isinstance(step, dict) and _is_e2e_group(step)]
+    if not selected:
+        _log(f"no group matching {E2E_GROUP_MARKER!r} found")
+    else:
+        _log(f"keep {len(selected)} group(s) matching {E2E_GROUP_MARKER!r}")
+    return selected
+
+
 def _strip_uploader_metadata_from_steps(steps: list[Any]) -> list[Any]:
     """Remove uploader-only keys while keeping all steps (no diff filtering)."""
     stripped: list[Any] = []
@@ -422,11 +440,16 @@ def _strip_uploader_metadata_from_steps(steps: list[Any]) -> list[Any]:
 def render_test_pipeline(
     doc: dict[str, Any],
     changed_files: list[str] | None,
+    *,
+    e2e_only: bool = False,
 ) -> dict[str, Any]:
     steps = doc.get("steps")
     if not isinstance(steps, list):
         return doc
-    if changed_files is not None:
+    if e2e_only:
+        steps = _select_e2e_group_steps(steps)
+        steps = _strip_uploader_metadata_from_steps(steps)
+    elif changed_files is not None:
         steps = _filter_steps(steps, changed_files)
     else:
         steps = _strip_uploader_metadata_from_steps(steps)
@@ -440,7 +463,12 @@ def resolve_pipeline_path(arg: str) -> Path:
     return ROOT / path
 
 
-def render_pipeline(path: Path, *, force_all: bool = False) -> str:
+def render_pipeline(
+    path: Path,
+    *,
+    force_all: bool = False,
+    e2e_only: bool = False,
+) -> str:
     text = path.read_text(encoding="utf-8")
     diff_range = resolve_diff_range()
     changed_files = resolve_changed_files()
@@ -448,7 +476,7 @@ def render_pipeline(path: Path, *, force_all: bool = False) -> str:
     # ``--all`` forces the keep-all-steps path (no diff-aware skipping) while still
     # stripping ``source_file_dependencies``. Used by the rebase pipeline so main builds
     # run the full e2e suite (see .buildkite/rebase-pipeline.yaml).
-    if force_all:
+    if force_all or e2e_only:
         changed_files = None
 
     if BOOTSTRAP_MARKER in text:
@@ -462,7 +490,7 @@ def render_pipeline(path: Path, *, force_all: bool = False) -> str:
     if not isinstance(doc, dict):
         raise ValueError(f"invalid pipeline YAML: {path}")
 
-    doc = render_test_pipeline(doc, changed_files)
+    doc = render_test_pipeline(doc, changed_files, e2e_only=e2e_only)
 
     return yaml.safe_dump(doc, sort_keys=False)
 
@@ -489,10 +517,16 @@ def main() -> int:
         action="store_true",
         help="Pipe rendered YAML to buildkite-agent pipeline upload",
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--all",
         action="store_true",
         help="Keep all steps (disable diff-aware skipping); still strips source_file_dependencies",
+    )
+    mode.add_argument(
+        "--e2e",
+        action="store_true",
+        help="Keep only the E2E Test group; disable diff-aware skipping for those steps",
     )
     args = parser.parse_args()
 
@@ -501,7 +535,7 @@ def main() -> int:
         _log(f"missing pipeline file: {path}")
         return 1
 
-    rendered = render_pipeline(path, force_all=args.all)
+    rendered = render_pipeline(path, force_all=args.all, e2e_only=args.e2e)
     if args.upload:
         upload_to_buildkite(rendered)
     else:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix nightly L2/L3 Buildkite uploads on `main` when `NIGHTLY=1` so only the **E2E Test** group from `test-ready.yml` / `test-merge.yml` is uploaded, instead of the full ready/merge pipelines.

Changes:

1. **`upload_pipeline.py`**: add `--e2e` flag to keep only the `:card_index_dividers: E2E Test` group and skip diff-aware filtering for those steps.
2. **`pipeline.yml`**: on `main + NIGHTLY=1`, pass `--e2e` when uploading L2/L3 pipelines.
3. **Bootstrap `if` expressions**: allow L2/L3 upload on `main + NIGHTLY=1` (including skip-ci docs-only builds).
4. **Bug fix**: use `$$EXTRA` (not `$EXTRA`) in pipeline YAML so Buildkite does not interpolate the shell variable at pipeline upload time. Without this, `EXTRA="--e2e"` was set in shell but the python command still ran without `--e2e` (observed in Buildkite log as `--upload  .buildkite/...` with a double space).

## Test Plan

No new pytest files — CI plumbing only. Local dry-run verification on Linux:

### 1. Verify shell assigns `--e2e` on `main + NIGHTLY=1`

```bash
cd /path/to/vllm-omni

export NIGHTLY=1
export BUILDKITE_BRANCH=main

EXTRA=""
if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then
  EXTRA="--e2e"
fi
echo "python3 .buildkite/scripts/upload_pipeline.py --upload $EXTRA .buildkite/test-ready.yml"
```

Expected: command includes `--upload --e2e .buildkite/test-ready.yml`.

Without `NIGHTLY=1`, expected: no `--e2e` in the echoed command.

### 2. Dry-run `upload_pipeline.py --e2e` filters to one group

```bash
python3 .buildkite/scripts/upload_pipeline.py --e2e .buildkite/test-ready.yml 2>&1 >/dev/null | grep upload_pipeline:
python3 .buildkite/scripts/upload_pipeline.py --e2e .buildkite/test-ready.yml 2>/dev/null | grep -E '^- (group|label):'
```

Expected stderr: `upload_pipeline: keep 1 group(s) matching 'E2E Test'`.

Expected stdout: only `- group: ':card_index_dividers: E2E Test'`.

Compare step count:

```bash
echo -n "without --e2e: "
python3 .buildkite/scripts/upload_pipeline.py .buildkite/test-ready.yml 2>/dev/null | grep -cE '^- (group|label):'
echo -n "with    --e2e: "
python3 .buildkite/scripts/upload_pipeline.py --e2e .buildkite/test-ready.yml 2>/dev/null | grep -cE '^- (group|label):'
```

Expected: `7` vs `1`.

### 3. End-to-end shell + python (no Buildkite upload)

```bash
export NIGHTLY=1 BUILDKITE_BRANCH=main
EXTRA=""
if [ "${NIGHTLY:-}" = "1" ] && [ "${BUILDKITE_BRANCH}" = "main" ]; then EXTRA="--e2e"; fi
python3 .buildkite/scripts/upload_pipeline.py $EXTRA .buildkite/test-ready.yml 2>&1 | tee /tmp/ready-pipeline.yml
grep upload_pipeline: /tmp/ready-pipeline.yml
grep -E '^- (group|label):' /tmp/ready-pipeline.yml | wc -l
```

Expected: log contains `keep 1 group`; step count is `1`.

**vLLM Version:** N/A (CI-only change)

**vLLM-Omni Commit:** `b8a78055`

## Test Result

Local dry-run (Linux):

- `NIGHTLY=1` + `BUILDKITE_BRANCH=main` → echoed command includes `--e2e`.
<img width="1656" height="84" alt="2dd6a92d-9185-4eec-bb2e-018c48b102fe" src="https://github.com/user-attachments/assets/a5f6801a-0ecd-4d94-970e-6d2d4e5e59f3" />

- `--e2e .buildkite/test-ready.yml` → stderr: `keep 1 group(s) matching 'E2E Test'`; only one top-level group in rendered YAML.
<img width="2306" height="196" alt="50fe7796-ada3-40a4-81a4-6b252b6486a5" src="https://github.com/user-attachments/assets/d89f40e4-274f-413e-a85c-5006408a4d4d" />
<img width="2308" height="112" alt="70cb2996-dfd5-44b3-b72b-3aadd83b8786" src="https://github.com/user-attachments/assets/189d2eb4-b944-4181-9ed4-c51ae031c482" />


```
upload_pipeline: main commit has no parent; using safe defaults
upload_pipeline: main commit has no parent; using safe defaults
upload_pipeline: keep 1 group(s) matching 'E2E Test'
env:
  VLLM_WORKER_MULTIPROC_METHOD: spawn
  VLLM_USE_FLASHINFER_MOE_FP16: 0
  HF_HUB_DOWNLOAD_TIMEOUT: 300
  HF_HUB_ETAG_TIMEOUT: 60
steps:
- group: ':card_index_dividers: E2E Test'
  depends_on: upload-ready-pipeline
  steps:
  - label: "RLHF \xB7 VeRL-Omni E2E Test"
    commands:
    - "timeout 20m bash -c \"\n  pytest -s -v tests/e2e/offline_inference/rlhf_test/test_verl_omni_e2e.py\n\
      \"\n"
    agents:
      queue: gpu_1_queue
    plugins:
    - docker#v5.2.0:
        image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
        always-pull: true
        propagate-environment: true
        shm-size: 8gb
        environment:
        - HF_HOME=/fsx/hf_cache
        - HF_TOKEN
        volumes:
        - /fsx/hf_cache:/fsx/hf_cache
  - label: "Omni \xB7 Qwen3-Omni Test"
    commands:
    - "timeout 20m bash -c \"\n  pytest -s -v tests/e2e/online_serving/test_qwen3_omni.py\
      \ -m 'core_model' --run-level 'core_model'\n\"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 2
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
  - label: "TTS \xB7 VoxCPM2 Test"
    timeout_in_minutes: 30
    commands:
    - "timeout 30m bash -c \"\n  export VLLM_LOGGING_LEVEL=DEBUG\n  export VLLM_WORKER_MULTIPROC_METHOD=spawn\n\
      \  pytest -s -v tests/e2e/online_serving/test_voxcpm2_tts.py -m 'core_model'\
      \ --run-level 'core_model'\n\"\n"
    agents:
      queue: gpu_1_queue
    plugins:
    - docker#v5.2.0:
        image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
        always-pull: true
        propagate-environment: true
        shm-size: 8gb
        environment:
        - HF_HOME=/fsx/hf_cache
        - HF_TOKEN
        volumes:
        - /fsx/hf_cache:/fsx/hf_cache
  - label: "TTS \xB7 Qwen3-TTS CustomVoice Test"
    commands:
    - "timeout 20m bash -c \"\n  export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\n  pytest\
      \ -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model'\
      \ --run-level 'core_model'\n\"\n"
    agents:
      queue: gpu_1_queue
    plugins:
    - docker#v5.2.0:
        image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
        always-pull: true
        propagate-environment: true
        shm-size: 8gb
        environment:
        - HF_HOME=/fsx/hf_cache
        - HF_TOKEN
        volumes:
        - /fsx/hf_cache:/fsx/hf_cache
  - label: "TTS \xB7 Qwen3-TTS Base Test"
    commands:
    - "timeout 20m bash -c \"\n  export VLLM_WORKER_MULTIPROC_METHOD=spawn\n  export\
      \ VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\n  export VLLM_OMNI_USE_V2_RUNNER=1\n  pytest\
      \ -s -v tests/e2e/online_serving/test_qwen3_tts_base.py -m 'core_model' --run-level\
      \ 'core_model'\n\"\n"
    agents:
      queue: gpu_1_queue
    plugins:
    - docker#v5.2.0:
        image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
        always-pull: true
        propagate-environment: true
        shm-size: 8gb
        environment:
        - HF_HOME=/fsx/hf_cache
        - HF_TOKEN
        volumes:
        - /fsx/hf_cache:/fsx/hf_cache
  - label: "TTS \xB7 Higgs-Audio-V3 Test"
    commands:
    - "timeout 20m bash -c \"\n  export VLLM_WORKER_MULTIPROC_METHOD=spawn\n  export\
      \ VLLM_USE_DEEP_GEMM=0\n  export VLLM_MOE_USE_DEEP_GEMM=0\n  pytest -s -v tests/e2e/online_serving/test_higgs_audio_v3.py\
      \ -m 'core_model' --run-level 'core_model'\n\"\n"
    agents:
      queue: gpu_1_queue
    plugins:
    - docker#v5.2.0:
        image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
        always-pull: true
        propagate-environment: true
        shm-size: 8gb
        environment:
        - HF_HOME=/fsx/hf_cache
        - HF_TOKEN
        volumes:
        - /fsx/hf_cache:/fsx/hf_cache
  - label: "Diffusion \xB7 Qwen Image Edit Test"
    commands:
    - "timeout 20m bash -c \"\n  pytest -s -v tests/e2e/online_serving/test_qwen_image_edit.py\
      \ -m 'core_model' --run-level 'core_model'\n\"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 1
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
  - label: "Diffusion \xB7 Bagel Test"
    commands:
    - "timeout 40m bash -c \"\n  export VLLM_IMAGE_FETCH_TIMEOUT=60\n  pytest -s -v\
      \ tests/e2e/online_serving/test_bagel.py -m 'core_model' --run-level 'core_model'\n\
      \"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 1
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
            - name: HF_TOKEN
              valueFrom:
                secretKeyRef:
                  name: hf-token-secret
                  key: token
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
  - label: "Diffusion \xB7 Wan22 Test"
    commands:
    - "timeout 40m bash -c \"\n  export VLLM_IMAGE_FETCH_TIMEOUT=60\n  pytest -s -v\
      \ tests/e2e/online_serving/test_wan22_t2v.py -m 'core_model' --run-level 'core_model'\n\
      \"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 1
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
            - name: HF_TOKEN
              valueFrom:
                secretKeyRef:
                  name: hf-token-secret
                  key: token
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
  - label: "Diffusion \xB7 Qwen Image Test"
    commands:
    - "timeout 40m bash -c \"\n  export VLLM_IMAGE_FETCH_TIMEOUT=60\n  pytest -s -v\
      \ tests/e2e/online_serving/test_qwen_image.py -m 'core_model' --run-level 'core_model'\n\
      \"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 1
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
            - name: HF_TOKEN
              valueFrom:
                secretKeyRef:
                  name: hf-token-secret
                  key: token
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
  - label: "Diffusion \xB7 Qwen Image Layered Test"
    commands:
    - "timeout 40m bash -c \"\n  export VLLM_IMAGE_FETCH_TIMEOUT=60\n  pytest -s -v\
      \ tests/e2e/online_serving/test_qwen_image_layered.py -m 'core_model' --run-level\
      \ 'core_model'\n\"\n"
    agents:
      queue: mithril-h100-pool
    plugins:
    - kubernetes:
        podSpec:
          containers:
          - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
            resources:
              limits:
                nvidia.com/gpu: 1
            volumeMounts:
            - name: devshm
              mountPath: /dev/shm
            - name: hf-cache
              mountPath: /root/.cache/huggingface
            env:
            - name: HF_HOME
              value: /root/.cache/huggingface
            - name: HF_TOKEN
              valueFrom:
                secretKeyRef:
                  name: hf-token-secret
                  key: token
          nodeSelector:
            node.kubernetes.io/instance-type: gpu-h100-sxm
          volumes:
          - name: devshm
            emptyDir:
              medium: Memory
          - name: hf-cache
            hostPath:
              path: /mnt/hf-cache
              type: DirectoryOrCreate
upload_pipeline: main commit has no parent; using safe defaults
upload_pipeline: main commit has no parent; using safe defaults
upload_pipeline: keep 1 group(s) matching 'E2E Test'
```
Buildkite: Pending — will confirm on `main + NIGHTLY=1` that Upload Ready Pipeline log shows `--upload --e2e` (not `--upload  .buildkite/...`).
<img width="2446" height="724" alt="aa876bc1-8be9-4006-994f-bbc8427ce5a1" src="https://github.com/user-attachments/assets/7f06da04-b11f-4a58-ab9e-d132d2402436" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
