### PR TITLE
[CI][Bugfix]Split nightly Diffusion X2V function tests by T2V/I2V to fix timeout

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -1276,13 +1276,10 @@ steps:
       build.pull_request.labels includes "nightly-test" ||
       build.pull_request.labels includes "diffusion-x2v-test"
     steps:
-      - label: ":full_moon: Diffusion X2V · T2V Function Test"
+      - label: ":full_moon: Diffusion X2V · Wan2.2 T2V Function Test"
         timeout_in_minutes: 90
         commands:
-          - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py -k "t2v and not ti2v" -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_hunyuan_video_15_expansion.py -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "t2v and not i2v" -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/online_serving/test_ltx2_expansion.py -k "t2v" -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py -k "t2v" -m "full_model and cuda" --run-level "full_model"
         agents:
           queue: "mithril-h100-pool"
         plugins:
@@ -1317,12 +1314,10 @@ steps:
                       path: /mnt/hf-cache
                       type: DirectoryOrCreate
 
-      - label: ":full_moon: Diffusion X2V · I2V Function Test"
+      - label: ":full_moon: Diffusion X2V · Wan2.2 I2V/TI2V Function Test"
         timeout_in_minutes: 90
         commands:
           - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/online_serving/test_ltx2_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
         agents:
           queue: "mithril-h100-pool"
         plugins:
@@ -1357,14 +1352,90 @@ steps:
                       path: /mnt/hf-cache
                       type: DirectoryOrCreate
 
-      - label: ":full_moon: Diffusion X2V · Accuracy Test"
+      - label: ":full_moon: Diffusion X2V · Other Function Test"
+        timeout_in_minutes: 90
+        commands:
+          - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_hunyuan_video_15_expansion.py tests/e2e/online_serving/test_ltx2_expansion.py -m "full_model and cuda" --run-level "full_model"
+        agents:
+          queue: "mithril-h100-pool"
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 2
+                    volumeMounts:
+                      - name: devshm
+                        mountPath: /dev/shm
+                      - name: hf-cache
+                        mountPath: /root/.cache/huggingface
+                    env:
+                      - name: HF_HOME
+                        value: /root/.cache/huggingface
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+                nodeSelector:
+                  node.kubernetes.io/instance-type: gpu-h100-sxm
+                volumes:
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+                  - name: hf-cache
+                    hostPath:
+                      path: /mnt/hf-cache
+                      type: DirectoryOrCreate
+
+      - label: ":full_moon: Diffusion X2V · Wan2.2 Accuracy Test"
         timeout_in_minutes: 180
         commands:
           - pytest -s -v tests/e2e/accuracy/wan22_i2v/test_wan22_i2v_video_similarity.py -m full_model --run-level full_model
+          - pytest -s -v tests/e2e/accuracy/test_diffusers_backend_similarity.py -k '2v_matches_diffusers' -m full_model --run-level full_model
+        agents:
+          queue: "mithril-h100-pool"
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 2
+                    volumeMounts:
+                      - name: devshm
+                        mountPath: /dev/shm
+                      - name: hf-cache
+                        mountPath: /root/.cache/huggingface
+                    env:
+                      - name: HF_HOME
+                        value: /root/.cache/huggingface
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+                nodeSelector:
+                  node.kubernetes.io/instance-type: gpu-h100-sxm
+                volumes:
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+                  - name: hf-cache
+                    hostPath:
+                      path: /mnt/hf-cache
+                      type: DirectoryOrCreate
+
+      - label: ":full_moon: Diffusion X2V · Other Accuracy Test"
+        timeout_in_minutes: 180
+        commands:
           - pytest -s -v tests/e2e/accuracy/hunyuanvideo15_t2v/test_hunyuanvideo15_t2v_video_similarity.py -m full_model --run-level full_model
           - pytest -s -v tests/e2e/accuracy/hunyuanvideo15_i2v/test_hunyuanvideo15_i2v_video_similarity.py -m full_model --run-level full_model
           - pytest -s -v tests/e2e/accuracy/test_ltx2_3_video_similarity.py -m full_model --run-level full_model
-          - pytest -s -v tests/e2e/accuracy/test_diffusers_backend_similarity.py -k '2v_matches_diffusers' -m full_model --run-level full_model
           - pytest -s -v tests/e2e/accuracy/test_video_streaming_output_similarity.py -m full_model --run-level full_model
         agents:
           queue: "mithril-h100-pool"

--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -1276,10 +1276,53 @@ steps:
       build.pull_request.labels includes "nightly-test" ||
       build.pull_request.labels includes "diffusion-x2v-test"
     steps:
-      - label: ":full_moon: Diffusion X2V · Function Test"
+      - label: ":full_moon: Diffusion X2V · T2V Function Test"
         timeout_in_minutes: 90
         commands:
-          - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_hunyuan_video_15_expansion.py tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py tests/e2e/online_serving/test_ltx2_expansion.py -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py -k "t2v and not ti2v" -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_hunyuan_video_15_expansion.py -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "t2v and not i2v" -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_ltx2_expansion.py -k "t2v" -m "full_model and cuda" --run-level "full_model"
+        agents:
+          queue: "mithril-h100-pool"
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 2
+                    volumeMounts:
+                      - name: devshm
+                        mountPath: /dev/shm
+                      - name: hf-cache
+                        mountPath: /root/.cache/huggingface
+                    env:
+                      - name: HF_HOME
+                        value: /root/.cache/huggingface
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+                nodeSelector:
+                  node.kubernetes.io/instance-type: gpu-h100-sxm
+                volumes:
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+                  - name: hf-cache
+                    hostPath:
+                      path: /mnt/hf-cache
+                      type: DirectoryOrCreate
+
+      - label: ":full_moon: Diffusion X2V · I2V Function Test"
+        timeout_in_minutes: 90
+        commands:
+          - pytest -s -v tests/e2e/online_serving/test_wan22_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_ltx2_expansion.py -k "i2v" -m "full_model and cuda" --run-level "full_model"
         agents:
           queue: "mithril-h100-pool"
         plugins:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix nightly CI timeouts in the **Diffusion X2V · Function Test** job (L4, `.buildkite/test-nightly.yml`).
https://buildkite.com/vllm/vllm-omni/builds/11810/canvas?sid=019efffb-5bfa-4279-aba6-1d7670898906&tab=output

The previous single job ran all T2V and I2V expansion tests sequentially in one 90-minute step (Wan2.2, Wan VACE, HunyuanVideo-1.5, Wan2.2 AutoRound, LTX-2). As the X2V model matrix grew, the combined runtime exceeded the step timeout and caused nightly builds to fail.

This PR splits that job into two parallel Buildkite steps by model type:

- **Diffusion X2V · T2V Function Test** — text-to-video cases (Wan2.2 T2V, VACE, HunyuanVideo-1.5 T2V, Wan2.2 AutoRound T2V, LTX-2 T2V)
- **Diffusion X2V · I2V Function Test** — image-to-video cases (Wan2.2 I2V/TI2V, Wan2.2 AutoRound I2V, LTX-2 I2V)

Mixed test files use separate `pytest` invocations with `-k` filters so each modality keeps the correct subset. Total coverage is unchanged; T2V and I2V now run in parallel on separate agents (each still 90 min, 2×H100).

## Test Plan

No new pytest files — CI pipeline change only.

**Dry-run: verify collected tests match T2V vs I2V split**

```bash
# T2V subset
pytest --collect-only -q tests/e2e/online_serving/test_wan22_expansion.py -k "t2v and not ti2v" -m "full_model and cuda"
pytest --collect-only -q tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_hunyuan_video_15_expansion.py -m "full_model and cuda"
pytest --collect-only -q tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "t2v and not i2v" -m "full_model and cuda"
pytest --collect-only -q tests/e2e/online_serving/test_ltx2_expansion.py -k "t2v" -m "full_model and cuda"

# I2V subset
pytest --collect-only -q tests/e2e/online_serving/test_wan22_expansion.py -k "i2v" -m "full_model and cuda"
pytest --collect-only -q tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -k "i2v" -m "full_model and cuda"
pytest --collect-only -q tests/e2e/online_serving/test_ltx2_expansion.py -k "i2v" -m "full_model and cuda"
```

**CI validation:** trigger nightly with `NIGHTLY=1` on `main`, or add PR label `diffusion-x2v-test`, and confirm both new steps complete within timeout.

**vLLM Version:** N/A (CI-only change)

**vLLM-Omni Commit:** `b3a50c8a`

## Test Result

- Local: `pytest --collect-only` confirms T2V/I2V filters select disjoint case sets from shared expansion files.
Before:
**Function job**
```
 <Module test_wan22_expansion.py>
          <Function test_wan22_diffusion_features[t2v_cpu_offload]>
          <Function test_wan22_diffusion_features[i2v_cpu_offload]>
          <Function test_wan22_diffusion_features[ti2v_cpu_offload]>
          <Function test_wan22_diffusion_features[cuda_t2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_i2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_ti2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_t2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_t2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_t2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_t2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_t2v_ring_atten]>
          <Function test_wan22_diffusion_features[cuda_i2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_i2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_i2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_i2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_i2v_ring_atten]>
          <Function test_wan22_diffusion_features[cuda_ti2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_ti2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_ti2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_ti2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_ti2v_ring_atten]>

 <Module test_wan22_autoround_w4a16_expansion.py>
          <Function test_wan22_i2v_autoround_w4a16_generates_video[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_generates_video[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_quant_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_baseline_peak[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_quant_peak[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_baseline_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_memory_savings>
          <Function test_wan22_t2v_autoround_w4a16_memory_savings>
<Module test_ltx2_expansion.py>
        <Function test_ltx2_two_stage_hsdp[t2v_hsdp]>
        <Function test_ltx2_two_stage_hsdp[i2v_hsdp]>
<Module test_wan_2_1_vace_expansion.py>
          <Function test_wan_2_1_vace[single_card_cpu_offload]>
          <Function test_wan_2_1_vace[single_card_001]>
          <Function test_wan_2_1_vace[parallel_001]>
          <Function test_wan_2_1_vace[parallel_002]>
          <Function test_wan_2_1_vace[parallel_003]>
          <Function test_wan_2_1_vace[parallel_004]>
          <Function test_wan_2_1_vace[parallel_005]>
<Module test_hunyuan_video_15_expansion.py>
          <Function test_hunyuan_video_15_t2v[single_card_cpu_offload]>
          <Function test_hunyuan_video_15_t2v[single_card_cachedit_layerwise]>
          <Function test_hunyuan_video_15_t2v[parallel_cachedit_tp2_vae2]>
```

After
**Function job**
T2V job
```
<Module test_wan22_expansion.py>
          <Function test_wan22_diffusion_features[t2v_cpu_offload]>
          <Function test_wan22_diffusion_features[cuda_t2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_t2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_t2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_t2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_t2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_t2v_ring_atten]>
```

I2V/TI2V job
```
<Module test_wan22_expansion.py>
          <Function test_wan22_diffusion_features[i2v_cpu_offload]>
          <Function test_wan22_diffusion_features[ti2v_cpu_offload]>
          <Function test_wan22_diffusion_features[cuda_i2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_ti2v_cache_dit]>
          <Function test_wan22_diffusion_features[cuda_i2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_i2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_i2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_i2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_i2v_ring_atten]>
          <Function test_wan22_diffusion_features[cuda_ti2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[cuda_ti2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[cuda_ti2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[cuda_ti2v_hsdp]>
          <Function test_wan22_diffusion_features[cuda_ti2v_ring_atten]>
<Module test_wan22_autoround_w4a16_expansion.py>
          <Function test_wan22_i2v_autoround_w4a16_generates_video[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_quant_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_baseline_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_memory_savings>
<Module test_ltx2_expansion.py>
      <Function test_ltx2_two_stage_hsdp[i2v_hsdp]>
```

Other job
```
<Module test_wan22_autoround_w4a16_expansion.py>
          <Function test_wan22_i2v_autoround_w4a16_generates_video[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_generates_video[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_quant_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_baseline_peak[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_quant_peak[omni_runner0]>
          <Function test_wan22_t2v_autoround_w4a16_baseline_peak[omni_runner0]>
          <Function test_wan22_i2v_autoround_w4a16_memory_savings>
          <Function test_wan22_t2v_autoround_w4a16_memory_savings>
<Module test_wan_2_1_vace_expansion.py>
          <Function test_wan_2_1_vace[single_card_cpu_offload]>
          <Function test_wan_2_1_vace[single_card_001]>
          <Function test_wan_2_1_vace[parallel_001]>
          <Function test_wan_2_1_vace[parallel_002]>
          <Function test_wan_2_1_vace[parallel_003]>
          <Function test_wan_2_1_vace[parallel_004]>
          <Function test_wan_2_1_vace[parallel_005]>
 <Module test_hunyuan_video_15_expansion.py>
          <Function test_hunyuan_video_15_t2v[single_card_cpu_offload]>
          <Function test_hunyuan_video_15_t2v[single_card_cachedit_layerwise]>
          <Function test_hunyuan_video_15_t2v[parallel_cachedit_tp2_vae2]>
 <Module test_ltx2_expansion.py>
          <Function test_ltx2_two_stage_hsdp[t2v_hsdp]>
          <Function test_ltx2_two_stage_hsdp[i2v_hsdp]>
```

**Acc Job**
Before
```
<Module test_wan22_i2v_video_similarity.py>
            <Function test_parse_video_metadata_extracts_dimensions_and_fps>
            <Function test_parse_ssim_summary_extracts_all_score>
            <Function test_parse_psnr_summary_extracts_average_score>
            <Function test_build_diffusers_command_uses_python_runner_path>
            <Function test_resolve_image_source_prefers_existing_local_path>
            <Function test_build_online_image_reference_uses_data_url_for_local_path>
            <Function test_send_video_request_with_timeout_uses_requested_timeout>
            <Function test_online_timeout_defaults_to_1200>
            <Function test_artifact_dir_is_under_repo_result_folder>
            <Function test_offline_cuda_device_uses_indexed_cuda_device>
            <Function test_ensure_wan_ftfy_fallback_sets_identity>
            <Function test_resize_to_target_matches_requested_dimensions>
            <Function test_configure_scheduler_switches_to_unipc>
            <Function test_wan22_i2v_diffusers_offline_generates_video>
            <Function test_wan22_i2v_online_serving_generates_video[wan22_i2v_usp2_hsdp2]>
            <Function test_wan22_i2v_serving_matches_diffusers_video_similarity>
<Module test_diffusers_backend_similarity.py>
          <Function test_diffusers_backend_i2v_matches_diffusers[Wan-AI/Wan2.2-I2V-A14B-Diffusers]>
<Module test_hunyuanvideo15_t2v_video_similarity.py>
            <Function test_hunyuanvideo15_t2v_diffusers_offline_generates_video>
            <Function test_hunyuanvideo15_t2v_online_serving_generates_video[hunyuanvideo15_t2v_default]>
            <Function test_hunyuanvideo15_t2v_serving_matches_offline_video_similarity>
 <Module test_hunyuanvideo15_i2v_video_similarity.py>
            <Function test_hunyuanvideo15_i2v_diffusers_offline_generates_video>
            <Function test_hunyuanvideo15_i2v_online_serving_generates_video[hunyuanvideo15_i2v_default]>
            <Function test_hunyuanvideo15_i2v_serving_matches_offline_video_similarity>
 <Module test_ltx2_3_video_similarity.py>
          <Function test_ltx2_3_transformer_matches_diffusers>
          <Function test_ltx2_3_pipeline_matches_diffusers>
 <Module test_video_streaming_output_similarity.py>
          <Function test_helios_streaming_output_matches_non_streaming[helios_distilled]>
```

After
Wan 2.2 Job
```
<Module test_wan22_i2v_video_similarity.py>
            <Function test_parse_video_metadata_extracts_dimensions_and_fps>
            <Function test_parse_ssim_summary_extracts_all_score>
            <Function test_parse_psnr_summary_extracts_average_score>
            <Function test_build_diffusers_command_uses_python_runner_path>
            <Function test_resolve_image_source_prefers_existing_local_path>
            <Function test_build_online_image_reference_uses_data_url_for_local_path>
            <Function test_send_video_request_with_timeout_uses_requested_timeout>
            <Function test_online_timeout_defaults_to_1200>
            <Function test_artifact_dir_is_under_repo_result_folder>
            <Function test_offline_cuda_device_uses_indexed_cuda_device>
            <Function test_ensure_wan_ftfy_fallback_sets_identity>
            <Function test_resize_to_target_matches_requested_dimensions>
            <Function test_configure_scheduler_switches_to_unipc>
            <Function test_wan22_i2v_diffusers_offline_generates_video>
            <Function test_wan22_i2v_online_serving_generates_video[wan22_i2v_usp2_hsdp2]>
            <Function test_wan22_i2v_serving_matches_diffusers_video_similarity>
<Module test_diffusers_backend_similarity.py>
          <Function test_diffusers_backend_i2v_matches_diffusers[Wan-AI/Wan2.2-I2V-A14B-Diffusers]>
```

other job
```
<Module test_hunyuanvideo15_t2v_video_similarity.py>
            <Function test_hunyuanvideo15_t2v_diffusers_offline_generates_video>
            <Function test_hunyuanvideo15_t2v_online_serving_generates_video[hunyuanvideo15_t2v_default]>
            <Function test_hunyuanvideo15_t2v_serving_matches_offline_video_similarity>
 <Module test_hunyuanvideo15_i2v_video_similarity.py>
            <Function test_hunyuanvideo15_i2v_diffusers_offline_generates_video>
            <Function test_hunyuanvideo15_i2v_online_serving_generates_video[hunyuanvideo15_i2v_default]>
            <Function test_hunyuanvideo15_i2v_serving_matches_offline_video_similarity>
 <Module test_ltx2_3_video_similarity.py>
          <Function test_ltx2_3_transformer_matches_diffusers>
          <Function test_ltx2_3_pipeline_matches_diffusers>
 <Module test_video_streaming_output_similarity.py>
          <Function test_helios_streaming_output_matches_non_streaming[helios_distilled]>
```

- Buildkite: Pending — expect the two parallel Function Test steps to finish within 90 min each where the monolithic job previously timed out.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
