### PR TITLE
[Test] Un-skip Qwen3-TTS batch E2E; match documented omit-null response shape (#4757)

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech_batch.py
+++ b/tests/entrypoints/openai_api/test_serving_speech_batch.py
@@ -88,7 +88,6 @@ class TestSpeechBatchE2E:
 
     @pytest.mark.advanced_model
     @pytest.mark.tts
-    @pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/4757")
     @hardware_test(res={"cuda": "H100"}, num_cards=1)
     @pytest.mark.parametrize("omni_server", default_server_params, indirect=True)
     def test_batch_basic_two_items(self, omni_server) -> None:
@@ -116,7 +115,10 @@ class TestSpeechBatchE2E:
             assert result["index"] == i
             assert result["status"] == "success"
             assert result["audio_data"] is not None
-            assert result["error"] is None
+            # Successful items omit `error` entirely (the batch response is
+            # serialized with exclude_none), so probe with .get rather than
+            # indexing a key that is only present on errored items.
+            assert result.get("error") is None
             audio_bytes = base64.b64decode(result["audio_data"])
             assert verify_wav_bytes(audio_bytes), f"Item {i}: invalid WAV"
             assert len(audio_bytes) > MIN_AUDIO_BYTES, f"Item {i}: audio too small ({len(audio_bytes)} bytes)"


### PR DESCRIPTION
## Summary

PR #4673 switched the `/v1/audio/speech/batch` serializer to `model_dump(exclude_none=True)`. Successful items now carry a `usage` object and leave `error=None`, so under `exclude_none` a successful item serializes **without** the `error` key (errored items likewise drop `usage`/`audio_data`/`media_type`). This omit-null shape is the intended contract: it is locked by the unit test `test_api_server_create_speech_batch_omits_null_fields` (asserts `"error" not in success`) and documented in `docs/serving/speech_api.md`.

The pre-existing E2E test `test_batch_basic_two_items` still indexed `result["error"]`, which raises `KeyError` on a successful item. #4673 updated the unit test and docs to the new shape but missed this older assertion; since the E2E test is H100-gated, it only surfaced at merge CI (#4757). #4758 skipped it as a stopgap.

## Fix

Test-only change:
- Probe with `result.get("error") is None` instead of `result["error"] is None` — successful items legitimately omit the key under the documented omit-null shape.
- Remove the `@pytest.mark.skip` added in #4758.

A source-side revert to plain `model_dump()` was considered and rejected: it would re-introduce null `error`/`audio_data`/`media_type`/`usage` keys and **break** the existing `test_api_server_create_speech_batch_omits_null_fields` unit test, contradicting the documented response shape.

## Verification

- Serialization repro against the real protocol models: old `result["error"]` → `KeyError`; new `result.get("error")` → `None`; a real error string still fails the assertion correctly (no silent pass).
- End-to-end on a single Hopper-class GPU (vLLM 0.23.0, `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`): `test_batch_basic_two_items[qwen3-tts-batch-default]` — **1 passed in 284.56s** (2 items → 2 valid WAVs > 10 KB).
- `ruff` (v0.14.10) check + format clean on the touched file.

Fixes #4757.
Un-skips the test skipped in #4758.
