### PR TITLE
[Bugfix] Fix broken FrameSimilarityFilter threshold test

### DIFF
--- a/tests/entrypoints/openai_api/test_video_frame_filter.py
+++ b/tests/entrypoints/openai_api/test_video_frame_filter.py
@@ -29,8 +29,8 @@ class TestFrameSimilarityFilter:
         assert f.should_retain(make_jpeg(255, 255, 255)) is True
         assert f.should_retain(make_jpeg(0, 0, 0)) is True
 
-    def test_low_threshold_keeps_slightly_different(self):
-        f = FrameSimilarityFilter(threshold=0.50)
+    def test_high_threshold_keeps_slightly_different(self):
+        f = FrameSimilarityFilter(threshold=0.999)
         assert f.should_retain(make_jpeg(100, 100, 100)) is True
         assert f.should_retain(make_jpeg(110, 110, 110)) is True
 


### PR DESCRIPTION
## Purpose

The test used threshold=0.50 expecting slightly different frames (RGB 100 vs 110) to be retained, but the MSE-based similarity for those values is 0.998 — well above 0.50 — so the frame was always dropped. Use threshold=0.999 to match the test intent: near-but-not-identical frames should pass a permissive threshold.

## Test Plan

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** 9972236c3786ae07e837376e56f38b56acbe85dd

```
pytest tests/entrypoints/openai_api/test_video_frame_filter.py
```

## Test Result

12 passed, 18 warnings in 2.80s