### PR TITLE
[Draft][WIP][New Model] Add ideogram fp8

### DIFF
--- a/vllm_omni/diffusion/models/ideogram4/__init__.py
+++ b/vllm_omni/diffusion/models/ideogram4/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.diffusion.models.ideogram4.pipeline_ideogram4 import (
+    Ideogram4Pipeline,
+    get_ideogram4_post_process_func,
+)
+from vllm_omni.diffusion.models.ideogram4.transformer_ideogram4 import (
+    IMAGE_POSITION_OFFSET,
+    LLM_TOKEN_INDICATOR,
+    OUTPUT_IMAGE_INDICATOR,
+    SEQUENCE_PADDING_INDICATOR,
+    Ideogram4Transformer2DModel,
+)
+
+__all__ = [
+    "Ideogram4Pipeline",
+    "Ideogram4Transformer2DModel",
+    "get_ideogram4_post_process_func",
+    "IMAGE_POSITION_OFFSET",
+    "LLM_TOKEN_INDICATOR",
+    "OUTPUT_IMAGE_INDICATOR",
+    "SEQUENCE_PADDING_INDICATOR",
+]

--- a/vllm_omni/diffusion/models/ideogram4/ideogram_fp8.py
+++ b/vllm_omni/diffusion/models/ideogram4/ideogram_fp8.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Weight-only FP8 support for Ideogram-4 models.
+
+This module provides FP8 (E4M3FN) weight-only quantization support that matches
+Ideogram-4's offline quantization format:
+    weight:      (out_features, in_features) float8_e4m3fn
+    weight_scale: (out_features,) float32  (per-row / per-output-channel)
+    bias:        (out_features,) compute_dtype (optional)
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    pass
+
+FP8_E4M3_MAX = 448.0
+FP8_WEIGHT_DTYPE = torch.float8_e4m3fn
+FP8_SCALE_SUFFIX = ".weight_scale"
+
+
+class Ideogram4Fp8Linear(nn.Module):
+    """Linear layer with weight-only FP8 (E4M3FN) + per-row scale.
+
+    Weight and scale are registered as buffers (not parameters) so they load
+    via load_state_dict and are excluded from optimizer/grad machinery.
+
+    The dequantized matmul runs in compute_dtype (e.g. bfloat16), so this
+    needs no FP8 tensor-core hardware and works on any device that can
+    store float8.
+    """
+
+    weight: torch.Tensor
+    weight_scale: torch.Tensor
+    bias: torch.Tensor | None
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        compute_dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.compute_dtype = compute_dtype
+
+        # Weight stored as FP8 E4M3FN
+        self.register_buffer(
+            "weight",
+            torch.empty(out_features, in_features, dtype=FP8_WEIGHT_DTYPE),
+        )
+        # Per-row scale (per-output-channel)
+        self.register_buffer(
+            "weight_scale",
+            torch.empty(out_features, dtype=torch.float32),
+        )
+        if bias:
+            self.register_buffer("bias", torch.empty(out_features, dtype=compute_dtype))
+        else:
+            self.bias = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Dequantize: weight_fp8 * scale
+        # weight: (out, in), weight_scale: (out,)
+        # Move weights to the same device as input
+        w = self.weight.to(device=x.device, dtype=x.dtype)
+        scale = self.weight_scale.to(device=x.device, dtype=x.dtype).unsqueeze(1)
+        w = w * scale
+        bias = self.bias.to(device=x.device, dtype=x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"weight_dtype={FP8_WEIGHT_DTYPE}, compute_dtype={self.compute_dtype}"
+        )
+
+
+def is_ideogram_fp8_state_dict(state_dict: dict[str, torch.Tensor]) -> bool:
+    """Check if checkpoint uses Ideogram-4's FP8 format.
+
+    Returns True if any key ends with .weight_scale or any tensor has FP8 dtype.
+    """
+    return any(k.endswith(FP8_SCALE_SUFFIX) for k in state_dict) or any(
+        v.dtype == FP8_WEIGHT_DTYPE for v in state_dict.values()
+    )
+
+
+def swap_linears_to_fp8(
+    module: nn.Module,
+    state_dict: dict[str, torch.Tensor],
+    compute_dtype: torch.dtype = torch.bfloat16,
+    prefix: str = "",
+) -> None:
+    """Replace each nn.Linear that has a saved FP8 scale with Ideogram4Fp8Linear.
+
+    Gating on the presence of <name>.weight_scale means only layers that were
+    actually quantized at save time are swapped; everything else loads normally.
+    """
+    for name, child in list(module.named_children()):
+        child_prefix = f"{prefix}{name}"
+
+        if isinstance(child, nn.Linear):
+            scale_key = f"{child_prefix}{FP8_SCALE_SUFFIX}"
+            if scale_key in state_dict:
+                fp8_linear = Ideogram4Fp8Linear(
+                    child.in_features,
+                    child.out_features,
+                    bias=child.bias is not None,
+                    compute_dtype=compute_dtype,
+                )
+                setattr(module, name, fp8_linear)
+        else:
+            swap_linears_to_fp8(child, state_dict, compute_dtype, prefix=f"{child_prefix}.")
+
+
+def load_ideogram_fp8_state_dict(
+    model: nn.Module,
+    state_dict: dict[str, torch.Tensor],
+    device: torch.device,
+    dtype: torch.dtype,
+    assign: bool = True,
+    strict: bool = True,
+) -> None:
+    """Load Ideogram-4 FP8 checkpoint into model.
+
+    Model must already have its FP8 Linear layers swapped in (see swap_linears_to_fp8).
+    FP8 weights are kept as float8, scales stay float32, and every other floating
+    tensor is cast to dtype.
+
+    Args:
+        assign: Replace the module's tensors with the prepared ones rather than
+                copying into them. Use True when model was built with from_config.
+        strict: If True, raise on missing keys. If False, downgrade to warning.
+    """
+    prepared: dict[str, torch.Tensor] = {}
+    for k, v in state_dict.items():
+        if v.dtype == FP8_WEIGHT_DTYPE:
+            prepared[k] = v.to(device=device)
+        elif k.endswith(FP8_SCALE_SUFFIX):
+            prepared[k] = v.to(device=device, dtype=torch.float32)
+        elif v.is_floating_point():
+            prepared[k] = v.to(device=device, dtype=dtype)
+        else:
+            prepared[k] = v.to(device=device)
+
+    missing, unexpected = model.load_state_dict(prepared, strict=False, assign=assign)
+    if unexpected:
+        raise RuntimeError(f"unexpected keys after fp8 load: {unexpected[:10]}")
+    if missing and strict:
+        raise RuntimeError(f"missing keys after fp8 load: {missing[:10]}")
+    elif missing:
+        warnings.warn(f"missing keys after fp8 load: {missing[:10]}", stacklevel=2)
+
+    model.to(device)
+
+
+def quantize_weight_to_fp8(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2-D Linear weight to e4m3 float8 with per-row scales.
+
+    Returns (weight_fp8, scale) where weight_fp8 has shape (out, in) in
+    float8_e4m3fn and scale has shape (out,) in float32 such that
+    weight ≈ weight_fp8.to(dtype) * scale[:, None].
+    """
+    w = weight.detach().to(torch.float32)
+    amax = w.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
+    scale = amax / FP8_E4M3_MAX
+    q = (w / scale).clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX).to(FP8_WEIGHT_DTYPE)
+    return q, scale.squeeze(1).to(torch.float32)

--- a/vllm_omni/diffusion/models/ideogram4/pipeline_ideogram4.py
+++ b/vllm_omni/diffusion/models/ideogram4/pipeline_ideogram4.py
@@ -1,0 +1,684 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from diffusers.pipelines.ideogram4.pipeline_ideogram4
+
+import json
+import logging
+import math
+import os
+from collections.abc import Iterable
+from typing import ClassVar
+
+import torch
+import torch.nn as nn
+from diffusers import AutoencoderKLFlux2, FlowMatchEulerDiscreteScheduler
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.utils.torch_utils import randn_tensor
+from transformers import AutoTokenizer
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.model_loader.hub_prefetch import (
+    from_pretrained_with_prefetch,
+    prefetch_subfolders,
+)
+from vllm_omni.diffusion.models.ideogram4.transformer_ideogram4 import (
+    IMAGE_POSITION_OFFSET,
+    LLM_TOKEN_INDICATOR,
+    OUTPUT_IMAGE_INDICATOR,
+    SEQUENCE_PADDING_INDICATOR,
+    Ideogram4Transformer2DModel,
+)
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+
+logger = logging.getLogger(__name__)
+
+
+# Hidden states of these Qwen3-VL decoder layers are concatenated to form the per-token
+# text conditioning consumed by the Ideogram4 transformer.
+QWEN3_VL_ACTIVATION_LAYERS = (0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 35)
+
+# Subfolders to prefetch for Ideogram4
+IDEOGRAM4_SUBFOLDERS = [
+    "text_encoder",
+    "tokenizer",
+    "vae",
+    "scheduler",
+    "transformer",
+    "unconditional_transformer",
+]
+
+
+def _logit_normal_sigmas(
+    num_inference_steps: int,
+    mu: float,
+    std: float = 1.0,
+    logsnr_min: float = -15.0,
+    logsnr_max: float = 18.0,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Build a length-`num_inference_steps` sigma schedule using the Ideogram4 logit-normal flow-matching schedule."""
+    intervals = torch.linspace(0.0, 1.0, num_inference_steps + 1, dtype=torch.float64)
+    z = torch.special.ndtri(intervals)
+    y = mu + std * z
+    t = 1.0 - torch.special.expit(y)
+    t_min = 1.0 / (1.0 + math.exp(0.5 * logsnr_max))
+    t_max = 1.0 / (1.0 + math.exp(0.5 * logsnr_min))
+    t = t.clamp(t_min, t_max)
+    sigmas = (1.0 - t).flip(0)
+    sigmas = sigmas[:-1].to(dtype=torch.float32, device=device)
+    return sigmas
+
+
+def _resolution_aware_mu(
+    height: int,
+    width: int,
+    base_mu: float,
+    base_resolution: tuple[int, int] = (512, 512),
+) -> float:
+    """Shift the schedule mean as a function of image resolution."""
+    num_pixels = height * width
+    base_pixels = base_resolution[0] * base_resolution[1]
+    return base_mu + 0.5 * math.log(num_pixels / base_pixels)
+
+
+def _expand_tensor_to_effective_batch(
+    tensor: torch.Tensor,
+    batch_size: int,
+    num_per_prompt: int,
+    tensor_name: str | None = None,
+) -> torch.Tensor:
+    """Replicate `tensor` along dim 0 from `batch_size` (or 1) to `batch_size * num_per_prompt`."""
+    target_batch_size = batch_size * num_per_prompt
+
+    if tensor.shape[0] == target_batch_size:
+        return tensor
+
+    if tensor.shape[0] == 1:
+        repeat_by = target_batch_size
+    elif tensor.shape[0] == batch_size:
+        repeat_by = num_per_prompt
+    else:
+        tensor_name = f"`{tensor_name}`" if tensor_name is not None else "Tensor"
+        raise ValueError(
+            f"{tensor_name} batch size must be 1, `batch_size` ({batch_size}), or "
+            f"`batch_size * num_*_per_prompt` ({target_batch_size}), but got {tensor.shape[0]}."
+        )
+
+    return torch.repeat_interleave(tensor, repeats=repeat_by, dim=0, output_size=tensor.shape[0] * repeat_by)
+
+
+def get_ideogram4_post_process_func(od_config: OmniDiffusionConfig):
+    """Get post-processing function for Ideogram4 output."""
+    if od_config.output_type == "latent":
+        return lambda x: x
+
+    model_name = od_config.model
+    if os.path.exists(model_name):
+        model_path = model_name
+    else:
+        model_path = download_weights_from_hf_specific(model_name, None, ["*"])
+
+    vae_config_path = os.path.join(model_path, "vae/config.json")
+    with open(vae_config_path) as f:
+        vae_config = json.load(f)
+        vae_scale_factor = 2 ** (len(vae_config.get("block_out_channels", [])) - 1)
+
+    image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor * 2)
+
+    def post_process_func(images: torch.Tensor):
+        return image_processor.postprocess(images)
+
+    return post_process_func
+
+
+class Ideogram4Pipeline(
+    nn.Module,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
+):
+    """Text-to-image pipeline for Ideogram4.
+
+    Ideogram4 is a flow-matching model trained with asymmetric classifier-free guidance:
+    a `transformer` consumes text-conditioned features alongside the image latents,
+    while a separate `unconditional_transformer` denoises with zeroed text features.
+    """
+
+    _dit_modules: ClassVar[list[str]] = ["transformer", "unconditional_transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.od_config = od_config
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="unconditional_transformer",
+                revision=None,
+                prefix="unconditional_transformer.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        self._execution_device = get_local_device()
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        # Prefetch all subfolders to avoid race conditions with gated repos
+        prefetch_subfolders(model, IDEOGRAM4_SUBFOLDERS, local_files_only=local_files_only)
+
+        # Scheduler
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model, subfolder="scheduler", local_files_only=local_files_only
+        )
+
+        # VAE
+        self.vae = from_pretrained_with_prefetch(
+            AutoencoderKLFlux2.from_pretrained,
+            model,
+            subfolder="vae",
+            prefetch_list=IDEOGRAM4_SUBFOLDERS,
+            local_files_only=local_files_only,
+        ).to(self._execution_device)
+
+        # Text encoder (Qwen3-VL)
+        if "ideogram-4-fp8" in model:
+            self.text_encoder = self._load_text_encoder_ideogram_fp8(
+                model, self._execution_device, od_config.dtype, local_files_only
+            )
+        else:
+            raise NotImplementedError(
+                f"Model {model} is not supported. Only ideogram-ai/ideogram-4-fp8 is currently supported."
+            )
+
+        # Tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
+
+        # Ideogram4 uses head_dim=256 which is not supported by cuDNN attention kernels.
+        # Default to TORCH_SDPA backend if not specified.
+        from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
+
+        if od_config.diffusion_attention_config is None:
+            od_config.diffusion_attention_config = AttentionConfig()
+        if od_config.diffusion_attention_config.default is None:
+            od_config.diffusion_attention_config.default = AttentionSpec(backend="TORCH_SDPA")
+            logger.info(
+                "Ideogram4: using TORCH_SDPA as default attention backend (cuDNN does not support head_dim=256)"
+            )
+
+        # Transformer (conditional)
+        transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, Ideogram4Transformer2DModel)
+        self.transformer = Ideogram4Transformer2DModel(
+            od_config=od_config,
+            **transformer_kwargs,
+        )
+
+        # Unconditional transformer
+        self.unconditional_transformer = Ideogram4Transformer2DModel(
+            od_config=od_config,
+            **transformer_kwargs,
+        )
+
+        # VAE scale factor
+        self.vae_scale_factor = (
+            2 ** (len(self.vae.config.block_out_channels) - 1) if hasattr(self, "vae") and self.vae is not None else 8
+        )
+        # Ideogram4 patchifies the VAE output by a factor of 2
+        self.patch_size = 2
+        self.image_processor = VaeImageProcessor(vae_scale_factor=self.vae_scale_factor * self.patch_size)
+
+        self._guidance_scale = None
+        _num_timesteps = None
+        self._interrupt = False
+
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    def _load_text_encoder_ideogram_fp8(
+        self,
+        model: str,
+        device: torch.device,
+        dtype: torch.dtype,
+        local_files_only: bool,
+    ):
+        """Load Qwen3-VL text encoder with Ideogram-4's weight-only FP8 format.
+
+        transformers' from_pretrained can't read Ideogram's float8 layout, so we:
+        1. Instantiate the architecture with from_config
+        2. Swap the quantized Linears for Ideogram4Fp8Linear
+        3. Load the FP8 state dict with assign=True
+        """
+        from transformers import AutoConfig, AutoModel
+
+        from vllm_omni.diffusion.models.ideogram4.ideogram_fp8 import (
+            is_ideogram_fp8_state_dict,
+            load_ideogram_fp8_state_dict,
+            swap_linears_to_fp8,
+        )
+
+        # 1. Load config and create model architecture
+        config = AutoConfig.from_pretrained(
+            model, subfolder="text_encoder", local_files_only=local_files_only, trust_remote_code=True
+        )
+        text_encoder = AutoModel.from_config(config, trust_remote_code=True)
+
+        # 2. Load state dict
+        state_dict = self._load_text_encoder_state_dict(model, local_files_only)
+
+        # 3. Swap Linears to FP8 if needed
+        if is_ideogram_fp8_state_dict(state_dict):
+            swap_linears_to_fp8(text_encoder, state_dict, compute_dtype=dtype)
+
+        # 4. Load FP8 weights
+        load_ideogram_fp8_state_dict(text_encoder, state_dict, device=device, dtype=dtype, assign=True)
+
+        return text_encoder.eval()
+
+    def _load_text_encoder_state_dict(self, model: str, local_files_only: bool) -> dict[str, torch.Tensor]:
+        """Load text encoder state dict from safetensors (handles sharded and single file)."""
+        from huggingface_hub import hf_hub_download
+        from safetensors.torch import load_file
+
+        # Check for sharded checkpoint
+        try:
+            index_path = hf_hub_download(
+                model, "text_encoder/model.safetensors.index.json", local_files_only=local_files_only
+            )
+            with open(index_path) as f:
+                index = json.load(f)
+            weight_map = index["weight_map"]
+
+            # Load all shards
+            state_dict = {}
+            shards = sorted(set(weight_map.values()))
+            for shard in shards:
+                shard_path = hf_hub_download(model, f"text_encoder/{shard}", local_files_only=local_files_only)
+                state_dict.update(load_file(shard_path))
+            return state_dict
+        except Exception:
+            # Single file
+            model_path = hf_hub_download(model, "text_encoder/model.safetensors", local_files_only=local_files_only)
+            return load_file(model_path)
+
+    @staticmethod
+    def _prepare_ids(
+        text_lengths: list[int],
+        grid_h: int,
+        grid_w: int,
+        max_text_tokens: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build the packed `[left-pad][text][image]` layout."""
+        batch_size = len(text_lengths)
+        num_image_tokens = grid_h * grid_w
+        total_seq_len = max_text_tokens + num_image_tokens
+
+        # Image position ids (t=0, h, w); offset keeps them disjoint from text positions.
+        h_idx = torch.arange(grid_h).view(-1, 1).expand(grid_h, grid_w).reshape(-1)
+        w_idx = torch.arange(grid_w).view(1, -1).expand(grid_h, grid_w).reshape(-1)
+        t_idx = torch.zeros_like(h_idx)
+        image_pos = torch.stack([t_idx, h_idx, w_idx], dim=1) + IMAGE_POSITION_OFFSET
+
+        position_ids = torch.zeros(batch_size, total_seq_len, 3, dtype=torch.long)
+        segment_ids = torch.full((batch_size, total_seq_len), SEQUENCE_PADDING_INDICATOR, dtype=torch.long)
+        indicator = torch.zeros(batch_size, total_seq_len, dtype=torch.long)
+
+        for b, num_text in enumerate(text_lengths):
+            offset = max_text_tokens - num_text
+
+            text_pos = torch.arange(num_text)
+            text_pos_3d = torch.stack([text_pos, text_pos, text_pos], dim=1)
+            position_ids[b, offset : offset + num_text] = text_pos_3d
+            position_ids[b, offset + num_text :] = image_pos
+
+            indicator[b, offset : offset + num_text] = LLM_TOKEN_INDICATOR
+            indicator[b, offset + num_text :] = OUTPUT_IMAGE_INDICATOR
+
+            segment_ids[b, offset : offset + num_text + num_image_tokens] = 1
+
+        return position_ids.to(device), segment_ids.to(device), indicator.to(device)
+
+    @staticmethod
+    def _get_text_encoder_hidden_states(
+        text_encoder,
+        token_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        pos_2d: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """Run the text encoder's decoder layers, returning hidden states from activation layers."""
+        language_model = text_encoder.language_model
+
+        inputs_embeds = language_model.embed_tokens(token_ids)
+
+        position_ids_4d = pos_2d[None, ...].expand(4, pos_2d.shape[0], -1)
+        text_position_ids = position_ids_4d[0]
+        mrope_position_ids = position_ids_4d[1:]
+
+        from transformers.masking_utils import create_causal_mask
+
+        causal_mask = create_causal_mask(
+            config=language_model.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=None,
+            position_ids=text_position_ids,
+        )
+        position_embeddings = language_model.rotary_emb(inputs_embeds, mrope_position_ids)
+
+        tap_set = set(QWEN3_VL_ACTIVATION_LAYERS)
+        captured: dict[int, torch.Tensor] = {}
+        hidden_states = inputs_embeds
+        for layer_idx, decoder_layer in enumerate(language_model.layers):
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_ids=text_position_ids,
+                past_key_values=None,
+                position_embeddings=position_embeddings,
+            )
+            if layer_idx in tap_set:
+                captured[layer_idx] = hidden_states
+
+        return [captured[i] for i in QWEN3_VL_ACTIVATION_LAYERS]
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        grid_h: int,
+        grid_w: int,
+        max_sequence_length: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Prepare the conditioning for the packed text+image sequence."""
+        prompts = [prompt] if isinstance(prompt, str) else list(prompt)
+        batch_size = len(prompts)
+        num_image_tokens = grid_h * grid_w
+
+        # Tokenize each chat-formatted prompt and left-pad to `max_sequence_length`.
+        token_ids = torch.zeros(batch_size, max_sequence_length, dtype=torch.long)
+        attention_mask = torch.zeros(batch_size, max_sequence_length, dtype=torch.long)
+        text_position_ids = torch.zeros(batch_size, max_sequence_length, dtype=torch.long)
+        text_lengths = []
+        for b, text_prompt in enumerate(prompts):
+            messages = [{"role": "user", "content": [{"type": "text", "text": text_prompt}]}]
+            text = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+            toks = self.tokenizer(text, return_tensors="pt", add_special_tokens=False)["input_ids"][0]
+            n = int(toks.shape[0])
+            if n > max_sequence_length:
+                raise ValueError(f"prompt has {n} tokens, exceeds max_sequence_length={max_sequence_length}")
+            text_lengths.append(n)
+            offset = max_sequence_length - n
+            token_ids[b, offset:] = toks
+            attention_mask[b, offset:] = 1
+            text_position_ids[b, offset:] = torch.arange(n)
+
+        te_device = self.text_encoder.device
+        token_ids = token_ids.to(te_device)
+        attention_mask = attention_mask.to(te_device)
+        text_position_ids = text_position_ids.to(te_device)
+
+        # Concatenate the tapped activation-layer hidden states into per-token text features.
+        selected = self._get_text_encoder_hidden_states(self.text_encoder, token_ids, attention_mask, text_position_ids)
+        text_features = torch.stack(selected, dim=0).permute(1, 2, 3, 0).reshape(batch_size, max_sequence_length, -1)
+        text_features = (text_features * attention_mask.to(text_features.dtype).unsqueeze(-1)).to(torch.float32)
+        text_features = text_features.to(device)
+
+        position_ids, segment_ids, indicator = self._prepare_ids(
+            text_lengths, grid_h, grid_w, max_sequence_length, device
+        )
+
+        # Pack the text features into the full sequence; image positions carry no text features.
+        image_feature_padding = torch.zeros(
+            batch_size, num_image_tokens, text_features.shape[-1], dtype=text_features.dtype, device=device
+        )
+        prompt_embeds = torch.cat([text_features, image_feature_padding], dim=1)
+
+        return prompt_embeds, position_ids, segment_ids, indicator
+
+    def prepare_latents(
+        self,
+        batch_size: int,
+        num_image_tokens: int,
+        latent_dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | list[torch.Generator] | None,
+        latents: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        shape = (batch_size, num_image_tokens, latent_dim)
+        if latents is None:
+            latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        else:
+            if latents.shape != shape:
+                raise ValueError(f"Unexpected latents shape, got {latents.shape}, expected {shape}")
+            latents = latents.to(device=device, dtype=dtype)
+        return latents
+
+    @property
+    def guidance_scale(self) -> float | None:
+        return self._guidance_scale
+
+    @property
+    def num_timesteps(self) -> int:
+        return self._num_timesteps
+
+    @property
+    def interrupt(self) -> bool:
+        return self._interrupt
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        height: int = 2048,
+        width: int = 2048,
+        num_inference_steps: int = 48,
+        guidance_scale: float | None = None,
+        guidance_schedule: list[float] | torch.Tensor | None = None,
+        mu: float = 0.0,
+        std: float = 1.5,
+        max_sequence_length: int = 2048,
+        num_images_per_prompt: int = 1,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+        output_type: str | None = "pil",
+        return_dict: bool = True,
+    ) -> DiffusionOutput:
+        # Extract prompt from request
+        if len(req.prompts) > 1:
+            logger.warning("Ideogram4 only supports a single prompt. Using the first one.")
+        first_prompt = req.prompts[0]
+        prompt = first_prompt if isinstance(first_prompt, str) else (first_prompt.get("prompt") or "")
+
+        # Get parameters from request or use defaults
+        height = req.sampling_params.height or height
+        width = req.sampling_params.width or width
+        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        guidance_scale = (
+            req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
+        )
+        generator = req.sampling_params.generator or generator
+        num_images_per_prompt = (
+            req.sampling_params.num_outputs_per_prompt
+            if req.sampling_params.num_outputs_per_prompt > 0
+            else num_images_per_prompt
+        )
+        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+
+        if isinstance(prompt, str):
+            batch_size = 1
+        elif isinstance(prompt, list):
+            batch_size = len(prompt)
+
+        device = self._execution_device
+        self._interrupt = False
+
+        # Default guidance schedule (recommended by Ideogram4)
+        if guidance_scale is not None and guidance_schedule is None:
+            guidance_schedule = [guidance_scale] * num_inference_steps
+        elif guidance_scale is None and guidance_schedule is None:
+            guidance_schedule = (7.0,) * 45 + (3.0,) * 3
+
+        # 1. Image grid
+        grid_h, grid_w = (
+            height // (self.vae_scale_factor * self.patch_size),
+            width // (self.vae_scale_factor * self.patch_size),
+        )
+        num_image_tokens = grid_h * grid_w
+
+        # 2. Encode prompts
+        llm_features, position_ids, segment_ids, indicator = self.encode_prompt(
+            prompt=prompt,
+            grid_h=grid_h,
+            grid_w=grid_w,
+            max_sequence_length=max_sequence_length,
+            device=device,
+        )
+
+        # 3. Replicate for num_images_per_prompt
+        llm_features = _expand_tensor_to_effective_batch(llm_features, batch_size, num_images_per_prompt)
+        position_ids = _expand_tensor_to_effective_batch(position_ids, batch_size, num_images_per_prompt)
+        segment_ids = _expand_tensor_to_effective_batch(segment_ids, batch_size, num_images_per_prompt)
+        indicator = _expand_tensor_to_effective_batch(indicator, batch_size, num_images_per_prompt)
+
+        # 4. Unconditional branch
+        neg_llm_features = torch.zeros(
+            batch_size * num_images_per_prompt,
+            num_image_tokens,
+            llm_features.shape[-1],
+            dtype=llm_features.dtype,
+            device=device,
+        )
+        neg_position_ids = position_ids[:, max_sequence_length:]
+        neg_segment_ids = segment_ids[:, max_sequence_length:]
+        neg_indicator = indicator[:, max_sequence_length:]
+
+        # 5. Set up sigma schedule
+        schedule_mu = _resolution_aware_mu(height=height, width=width, base_mu=mu)
+        sigmas = _logit_normal_sigmas(num_inference_steps, schedule_mu, std=std, device=device)
+        self.scheduler.set_timesteps(sigmas=sigmas.tolist(), device=device)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        # 6. Guidance weights
+        gw = torch.as_tensor(guidance_schedule, dtype=torch.float32, device=device)
+
+        # 7. Prepare latents
+        latent_dim = self.transformer.config.in_channels
+        latents = self.prepare_latents(
+            batch_size=batch_size * num_images_per_prompt,
+            num_image_tokens=num_image_tokens,
+            latent_dim=latent_dim,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+            latents=latents,
+        )
+
+        # 8. Padding for text region
+        max_text_tokens = max_sequence_length
+        text_z_padding = torch.zeros(
+            batch_size * num_images_per_prompt,
+            max_text_tokens,
+            latent_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        # Cast text features to transformer dtype
+        llm_features = llm_features.to(self.transformer.dtype)
+        neg_llm_features = neg_llm_features.to(self.unconditional_transformer.dtype)
+
+        # 9. Denoising loop
+        num_train_timesteps = self.scheduler.config.num_train_timesteps
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                if self.interrupt:
+                    continue
+
+                # Map sigma-domain timestep to model time `t` in [0, 1]
+                t_model = 1.0 - (t.float() / num_train_timesteps)
+                t_model = t_model.expand(batch_size * num_images_per_prompt).to(self.transformer.dtype)
+
+                # Conditional pass
+                pos_z = torch.cat([text_z_padding, latents], dim=1).to(self.transformer.dtype)
+                pos_out = self.transformer(
+                    hidden_states=pos_z,
+                    timestep=t_model,
+                    encoder_hidden_states=llm_features,
+                    position_ids=position_ids,
+                    segment_ids=segment_ids,
+                    indicator=indicator,
+                    return_dict=False,
+                )[0]
+                pos_v = pos_out[:, max_text_tokens:].to(torch.float32)
+
+                # Unconditional pass
+                neg_v = self.unconditional_transformer(
+                    hidden_states=latents.to(self.unconditional_transformer.dtype),
+                    timestep=t_model,
+                    encoder_hidden_states=neg_llm_features,
+                    position_ids=neg_position_ids,
+                    segment_ids=neg_segment_ids,
+                    indicator=neg_indicator,
+                    return_dict=False,
+                )[0].to(torch.float32)
+
+                # CFG blending
+                self._guidance_scale = guidance_schedule[i]
+                gw_i = gw[i]
+                v = gw_i * pos_v + (1.0 - gw_i) * neg_v
+
+                latents = self.scheduler.step(-v, t, latents, return_dict=False)[0]
+
+                progress_bar.update()
+
+        # 10. Decode
+        if output_type == "latent":
+            image = latents
+        else:
+            z = latents
+            # VAE batch-norm denormalization
+            bn_mean = self.vae.bn.running_mean.view(1, 1, -1).to(device=z.device, dtype=z.dtype)
+            bn_std = torch.sqrt(self.vae.bn.running_var + self.vae.config.batch_norm_eps).view(1, 1, -1)
+            bn_std = bn_std.to(device=z.device, dtype=z.dtype)
+            z = z * bn_std + bn_mean
+
+            # Unpatchify
+            patch = self.patch_size
+            ae_channels = z.shape[-1] // (patch * patch)
+            z = z.view(batch_size * num_images_per_prompt, grid_h, grid_w, patch, patch, ae_channels)
+            z = z.permute(0, 5, 1, 3, 2, 4).contiguous()
+            z = z.view(batch_size * num_images_per_prompt, ae_channels, grid_h * patch, grid_w * patch)
+
+            decoded = self.vae.decode(z.to(self.vae.dtype), return_dict=False)[0]
+            # Return tensor for post_process_func, not PIL images
+            image = decoded.float()
+
+        return DiffusionOutput(output=image)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/ideogram4/transformer_ideogram4.py
+++ b/vllm_omni/diffusion/models/ideogram4/transformer_ideogram4.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from diffusers.models.transformers.transformer_ideogram4
+
+import math
+from collections.abc import Iterable
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.models.normalization import RMSNorm as DiffusersRMSNorm
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
+
+# Per-token role indicators used to label entries of the packed text+image sequence.
+SEQUENCE_PADDING_INDICATOR = -1
+OUTPUT_IMAGE_INDICATOR = 2
+LLM_TOKEN_INDICATOR = 3
+
+# Image grid coordinates start at this offset so they never collide with text token indices.
+IMAGE_POSITION_OFFSET = 65536
+
+
+def _join_prefix(prefix: str, name: str) -> str:
+    return f"{prefix}.{name}" if prefix else name
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+
+class Ideogram4MRoPE(nn.Module):
+    """Multi-axis (t, h, w) interleaved rotary position embedding."""
+
+    inv_freq: torch.Tensor
+
+    def __init__(
+        self,
+        head_dim: int,
+        base: int,
+        mrope_section: tuple[int, ...],
+    ) -> None:
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.mrope_section = tuple(mrope_section)
+        self.head_dim = head_dim
+
+    def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # position_ids: (B, L, 3) of int (axes are t, h, w).
+        if position_ids.ndim != 3 or position_ids.shape[-1] != 3:
+            raise ValueError(f"`position_ids` must have shape (B, L, 3), got {tuple(position_ids.shape)}.")
+        batch_size, seq_len, _ = position_ids.shape
+
+        # Ideogram4's image position ids start at IMAGE_POSITION_OFFSET (65536).
+        # Disable autocast to avoid bfloat16 collapse at large position values.
+        pos = position_ids.permute(2, 0, 1).to(dtype=torch.float32)
+        inv_freq = self.inv_freq.to(dtype=torch.float32)[None, None, :, None].expand(3, batch_size, -1, 1)
+        with torch.autocast(device_type=position_ids.device.type, enabled=False):
+            freqs = inv_freq @ pos.unsqueeze(2)
+        freqs = freqs.transpose(2, 3)  # (3, B, L, inv_freq_size)
+
+        # Interleaved mrope: pull H freqs into idx 1 mod 3, W freqs into idx 2 mod 3.
+        freqs_t = freqs[0].clone()
+        for axis, offset in ((1, 1), (2, 2)):
+            length = self.mrope_section[axis] * 3
+            idx = torch.arange(offset, length, 3, device=freqs_t.device)
+            freqs_t[..., idx] = freqs[axis][..., idx]
+
+        emb = torch.cat((freqs_t, freqs_t), dim=-1)
+        return emb.cos().float(), emb.sin().float()
+
+
+class Ideogram4MLP(nn.Module):
+    """SwiGLU feed-forward network."""
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+    ) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x1 = self.w1(x)
+        x3 = self.w3(x)
+        x = F.silu(x1) * x3
+        x = self.w2(x)
+        return x
+
+
+class Ideogram4Attention(nn.Module):
+    """Self-attention with merged QKV projection, q/k RMSNorm, and MRoPE.
+
+    Note: This uses merged QKV projection (matching the checkpoint format)
+    instead of separate to_q/to_k/to_v projections.
+    """
+
+    def __init__(self, hidden_size: int, num_heads: int, eps: float = 1e-5) -> None:
+        super().__init__()
+        if hidden_size % num_heads != 0:
+            raise ValueError(f"hidden_size={hidden_size} must be divisible by num_heads={num_heads}")
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        # Merged QKV projection (matches checkpoint: attention.qkv.weight)
+        self.qkv = nn.Linear(hidden_size, 3 * hidden_size, bias=False)
+
+        # Q/K normalization (per-head RMSNorm)
+        self.norm_q = RMSNorm(self.head_dim, eps=eps)
+        self.norm_k = RMSNorm(self.head_dim, eps=eps)
+
+        # Output projection (matches checkpoint: attention.o.weight)
+        self.o = nn.Linear(hidden_size, hidden_size, bias=False)
+
+        self.attn = Attention(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            softmax_scale=1.0 / (self.head_dim**0.5),
+            causal=False,
+            num_kv_heads=self.num_heads,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        B, S, _ = hidden_states.shape
+
+        # Merged QKV projection
+        qkv = self.qkv(hidden_states)
+        qkv = qkv.view(B, S, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=2)  # Each: (B, S, num_heads, head_dim)
+
+        # Q/K normalization
+        q = self.norm_q(q)
+        k = self.norm_k(k)
+
+        # Apply MRoPE
+        if image_rotary_emb is not None:
+            cos, sin = image_rotary_emb
+            cos = cos.unsqueeze(2)  # (B, L, 1, head_dim)
+            sin = sin.unsqueeze(2)
+            q = (q * cos) + (_rotate_half(q) * sin)
+            k = (k * cos) + (_rotate_half(k) * sin)
+
+        # Q/K/V shape: (B, S, num_heads, head_dim) - keep this format for SDPA
+
+        # Attention
+        attn_metadata = None
+        if attention_mask is not None:
+            if attention_mask.dim() == 3:
+                attention_mask = attention_mask.unsqueeze(1)
+            # Keep mask as [B, 1, S, S] for SDPA to broadcast
+            attn_metadata = AttentionMetadata(attn_mask=attention_mask)
+
+        hidden_states = self.attn(q, k, v, attn_metadata)
+        hidden_states = hidden_states.reshape(B, S, self.hidden_size)
+
+        # Output projection
+        hidden_states = self.o(hidden_states.contiguous())
+        return hidden_states
+
+
+class Ideogram4TransformerBlock(nn.Module):
+    def __init__(
+        self, hidden_size: int, intermediate_size: int, num_heads: int, norm_eps: float, adaln_dim: int
+    ) -> None:
+        super().__init__()
+        self.attention = Ideogram4Attention(hidden_size, num_heads, eps=1e-5)
+        self.feed_forward = Ideogram4MLP(hidden_size, intermediate_size)
+
+        self.attention_norm1 = RMSNorm(hidden_size, eps=norm_eps)
+        self.ffn_norm1 = RMSNorm(hidden_size, eps=norm_eps)
+        self.attention_norm2 = RMSNorm(hidden_size, eps=norm_eps)
+        self.ffn_norm2 = RMSNorm(hidden_size, eps=norm_eps)
+
+        self.adaln_modulation = nn.Linear(adaln_dim, 4 * hidden_size, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        adaln_input: torch.Tensor,
+    ) -> torch.Tensor:
+        mod = self.adaln_modulation(adaln_input)
+        scale_msa, gate_msa, scale_mlp, gate_mlp = mod.chunk(4, dim=-1)
+        gate_msa = torch.tanh(gate_msa)
+        gate_mlp = torch.tanh(gate_mlp)
+        scale_msa = 1.0 + scale_msa
+        scale_mlp = 1.0 + scale_mlp
+
+        attn_out = self.attention(
+            self.attention_norm1(hidden_states) * scale_msa,
+            attention_mask=attention_mask,
+            image_rotary_emb=image_rotary_emb,
+        )
+        hidden_states = hidden_states + gate_msa * self.attention_norm2(attn_out)
+        hidden_states = hidden_states + gate_mlp * self.ffn_norm2(
+            self.feed_forward(self.ffn_norm1(hidden_states) * scale_mlp)
+        )
+        return hidden_states
+
+
+def _sinusoidal_embedding(t: torch.Tensor, dim: int, scale: float = 1e4) -> torch.Tensor:
+    t = t.to(torch.float32)
+    half = dim // 2
+    freq = math.log(scale) / (half - 1)
+    freq = torch.exp(torch.arange(half, dtype=torch.float32, device=t.device) * -freq)
+    emb = t.unsqueeze(-1) * freq
+    emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+    if dim % 2 == 1:
+        emb = F.pad(emb, (0, 1))
+    return emb
+
+
+class Ideogram4EmbedScalar(nn.Module):
+    """Sinusoidal scalar embedding followed by a small MLP."""
+
+    def __init__(self, dim: int, input_range: tuple[float, float]) -> None:
+        super().__init__()
+        self.dim = dim
+        self.range_min, self.range_max = input_range
+        if self.range_max <= self.range_min:
+            raise ValueError("input_range[1] must be greater than input_range[0]")
+        self.mlp_in = nn.Linear(dim, dim, bias=True)
+        self.mlp_out = nn.Linear(dim, dim, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        x = x.to(torch.float32)
+        scaled = 1e4 * (x - self.range_min) / (self.range_max - self.range_min)
+        emb = _sinusoidal_embedding(scaled, self.dim)
+        emb = emb.to(in_dtype)
+        emb = F.silu(self.mlp_in(emb))
+        return self.mlp_out(emb)
+
+
+class Ideogram4FinalLayer(nn.Module):
+    def __init__(self, hidden_size: int, out_channels: int, adaln_dim: int) -> None:
+        super().__init__()
+        self.norm_final = nn.LayerNorm(hidden_size, eps=1e-6, elementwise_affine=False)
+        self.linear = nn.Linear(hidden_size, out_channels, bias=True)
+        self.adaln_modulation = nn.Linear(adaln_dim, hidden_size, bias=True)
+
+    def forward(self, hidden_states: torch.Tensor, conditioning: torch.Tensor) -> torch.Tensor:
+        scale = 1.0 + self.adaln_modulation(F.silu(conditioning))
+        output = self.linear(self.norm_final(hidden_states) * scale)
+        return output
+
+
+class Ideogram4Transformer2DModel(nn.Module):
+    """The flow-matching transformer backbone used by the Ideogram 4 pipeline."""
+
+    _repeated_blocks = ["Ideogram4TransformerBlock"]
+    _skip_layerwise_casting_patterns = ["t_embedding", "adaln_proj", "embed_image_indicator"]
+
+    @staticmethod
+    def _is_transformer_block(name: str, module) -> bool:
+        return "layers" in name and name.split(".")[-1].isdigit()
+
+    _hsdp_shard_conditions = [_is_transformer_block]
+
+    def __init__(
+        self,
+        in_channels: int = 128,
+        num_layers: int = 34,
+        attention_head_dim: int = 256,
+        num_attention_heads: int = 18,
+        intermediate_size: int = 12288,
+        adaln_dim: int = 512,
+        llm_features_dim: int = 53248,
+        rope_theta: int = 5_000_000,
+        mrope_section: tuple[int, int, int] = (24, 20, 20),
+        norm_eps: float = 1e-5,
+        od_config: OmniDiffusionConfig | None = None,
+    ) -> None:
+        super().__init__()
+
+        hidden_size = attention_head_dim * num_attention_heads
+        head_dim = attention_head_dim
+
+        self.in_channels = in_channels
+        self.out_channels = in_channels
+        self.hidden_size = hidden_size
+        self.gradient_checkpointing = False
+
+        self.config = SimpleNamespace(
+            in_channels=in_channels,
+            out_channels=in_channels,
+            num_layers=num_layers,
+            attention_head_dim=attention_head_dim,
+            num_attention_heads=num_attention_heads,
+            intermediate_size=intermediate_size,
+            adaln_dim=adaln_dim,
+            llm_features_dim=llm_features_dim,
+            rope_theta=rope_theta,
+            mrope_section=mrope_section,
+            norm_eps=norm_eps,
+        )
+
+        if od_config is not None:
+            self.parallel_config = od_config.parallel_config
+        else:
+            self.parallel_config = DiffusionParallelConfig()
+
+        self.input_proj = nn.Linear(in_channels, hidden_size, bias=True)
+        self.llm_cond_norm = DiffusersRMSNorm(llm_features_dim, eps=1e-6, elementwise_affine=True)
+        self.llm_cond_proj = nn.Linear(llm_features_dim, hidden_size, bias=True)
+        self.t_embedding = Ideogram4EmbedScalar(hidden_size, input_range=(0.0, 1.0))
+        self.adaln_proj = nn.Linear(hidden_size, adaln_dim, bias=True)
+
+        self.embed_image_indicator = nn.Embedding(2, hidden_size)
+
+        self.rotary_emb = Ideogram4MRoPE(
+            head_dim=head_dim,
+            base=rope_theta,
+            mrope_section=mrope_section,
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                Ideogram4TransformerBlock(
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    num_heads=num_attention_heads,
+                    norm_eps=norm_eps,
+                    adaln_dim=adaln_dim,
+                )
+                for i in range(num_layers)
+            ]
+        )
+
+        self.final_layer = Ideogram4FinalLayer(hidden_size=hidden_size, out_channels=in_channels, adaln_dim=adaln_dim)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        segment_ids: torch.Tensor,
+        indicator: torch.Tensor,
+        attention_kwargs: dict | None = None,
+        return_dict: bool = True,
+    ) -> Transformer2DModelOutput | tuple[torch.Tensor]:
+        batch_size, seq_len, in_channels = hidden_states.shape
+        if in_channels != self.in_channels:
+            raise ValueError(f"Expected last dim {self.in_channels}, got {in_channels}.")
+
+        llm_token_mask = (indicator == LLM_TOKEN_INDICATOR).to(hidden_states.dtype).unsqueeze(-1)
+        output_image_mask = (indicator == OUTPUT_IMAGE_INDICATOR).to(hidden_states.dtype).unsqueeze(-1)
+
+        encoder_hidden_states = encoder_hidden_states * llm_token_mask
+        hidden_states = hidden_states * output_image_mask
+        hidden_states = self.input_proj(hidden_states) * output_image_mask
+
+        t_cond = self.t_embedding(timestep)
+        if timestep.dim() == 1:
+            t_cond = t_cond.unsqueeze(1)
+        adaln_input = F.silu(self.adaln_proj(t_cond))
+
+        encoder_hidden_states = self.llm_cond_norm(encoder_hidden_states)
+        encoder_hidden_states = self.llm_cond_proj(encoder_hidden_states) * llm_token_mask
+
+        hidden_states = hidden_states + encoder_hidden_states
+
+        image_indicator_embedding = self.embed_image_indicator((indicator == OUTPUT_IMAGE_INDICATOR).to(torch.long))
+        hidden_states = hidden_states + image_indicator_embedding
+
+        cos, sin = self.rotary_emb(position_ids)
+        cos = cos.to(hidden_states.dtype)
+        sin = sin.to(hidden_states.dtype)
+        image_rotary_emb = (cos, sin)
+
+        # Block-diagonal mask from segment ids: tokens only attend within their segment.
+        attention_mask = (segment_ids.unsqueeze(2) == segment_ids.unsqueeze(1)).unsqueeze(1)
+
+        for block in self.layers:
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states = self._gradient_checkpointing_func(
+                    block, hidden_states, attention_mask, image_rotary_emb, adaln_input
+                )
+            else:
+                hidden_states = block(hidden_states, attention_mask, image_rotary_emb, adaln_input)
+
+        output = self.final_layer(hidden_states, conditioning=adaln_input)
+
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Convert to list to allow multiple passes (FP8 detection + actual loading)
+        weights_list = list(weights)
+
+        # Check if checkpoint uses Ideogram's weight-only FP8 format
+        from vllm_omni.diffusion.models.ideogram4.ideogram_fp8 import (
+            is_ideogram_fp8_state_dict,
+            swap_linears_to_fp8,
+        )
+
+        # Build state dict for FP8 detection
+        state_dict = {name: tensor for name, tensor in weights_list}
+
+        if is_ideogram_fp8_state_dict(state_dict):
+            # Swap nn.Linear to Ideogram4Fp8Linear before loading
+            # This must happen before we try to load weight_scale buffers
+            swap_linears_to_fp8(self, state_dict, compute_dtype=self.dtype)
+
+        # Now load the weights
+        params_dict = dict(self.named_parameters())
+        buffers_dict = dict(self.named_buffers())
+
+        loaded_params: set[str] = set()
+        for original_name, loaded_weight in weights_list:
+            # AutoWeightsLoader passes names with prefix like "transformer.layers.0..."
+            # We need to strip the prefix to match params_dict
+            name = original_name
+            if name.startswith("transformer."):
+                name = name[len("transformer.") :]
+            elif name.startswith("unconditional_transformer."):
+                name = name[len("unconditional_transformer.") :]
+
+            # Check if it's a parameter or buffer
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(original_name)
+            elif name in buffers_dict:
+                # For weight_scale and other buffers
+                buffer = buffers_dict[name]
+                buffer.copy_(loaded_weight)
+                loaded_params.add(original_name)
+
+        return loaded_params

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -306,6 +306,11 @@ _DIFFUSION_MODELS = {
         "pipeline_sdxl",
         "StableDiffusionXLPipeline",
     ),
+    "Ideogram4Pipeline": (
+        "ideogram4",
+        "pipeline_ideogram4",
+        "Ideogram4Pipeline",
+    ),
 }
 
 
@@ -533,6 +538,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_post_process_func",
     "HiDreamImagePipeline": "get_hidream_image_post_process_func",
     "StableDiffusionXLPipeline": "get_sdxl_image_post_process_func",
+    "Ideogram4Pipeline": "get_ideogram4_post_process_func",
 }
 
 _DIFFUSION_ACTION_POST_PROCESS_FUNCS = {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Draft of #4787 

## FIle changed

  vllm_omni/diffusion/models/ideogram4/
  ├── __init__.py            # Pipeline exports and registry
  ├── transformer_ideogram4.py   # DiT transformer with MRoPE
  ├── pipeline_ideogram4.py      # Pipeline with Qwen3-VL encoder, asymmetric CFG
  └── ideogram_fp8.py           # FP8 Linear layer and loading utilities

## Todo list and furture plan

- [ ]  Add unit tests
- [ ] Add documentation and usage recipes
- [ ] Add deploy.yaml configuration
- [ ] Add performance benchmarks

Future Optimization Plan

The current implementation supports single-GPU inference and CPU offload. Future work will progressively enable Tensor Parallel (TP), Sequence Parallel (USP), CFG Parallel, and Cache-DiT acceleration for improved multi-GPU scaling and inference throughput.

## Test Plan

**vLLM Version:**
0.23.0

**vLLM-Omni Commit:**

```
python examples/offline_inference/text_to_image/text_to_image.py \
  --model ideogram-ai/ideogram-4-fp8 \
  --prompt "A photo of a cat" \
  --height 512 --width 512 \
  --num-inference-steps 5 \
  --out output.png  2>&1 | tee running.log
```

## Test Result

<img width="512" height="512" alt="output" src="https://github.com/user-attachments/assets/de5940c4-7854-47e5-a35e-e7e8e26dd290" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
