### PR TITLE
[Perf] Fuse LTX-2.3 compile regions for masked FlashAttention cross-attention

### DIFF
--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -49,10 +49,12 @@ from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTAdapterConfig
 from vllm_omni.diffusion.distributed.hsdp_utils import is_transformer_block_module
 from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput, SequenceParallelOutput
 from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
 _RMSNORM_INIT_PARAMS = inspect.signature(RMSNorm.__init__).parameters
+_LTX2_FORCE_VARLEN_MASK_KEY = "ltx2_force_varlen_mask"
 
 
 def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) -> nn.Module:
@@ -75,6 +77,27 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
         delattr(norm, "weight")
         norm.register_buffer("weight", weight, persistent=False)
     return norm
+
+
+class LTX2AttentionLayer(Attention):
+    def _run_local_attention(self, query, key, value, attn_metadata):
+        if (
+            query.dtype != torch.float32
+            and attn_metadata is not None
+            and attn_metadata.attn_mask is not None
+            and attn_metadata.extra.get(_LTX2_FORCE_VARLEN_MASK_KEY, False)
+            and self.attn_backend.get_name() == "FLASH_ATTN"
+            and (
+                current_omni_platform.is_cuda()
+                or current_omni_platform.is_rocm()
+                or current_omni_platform.is_musa()
+                or current_omni_platform.is_xpu()
+            )
+            and hasattr(self.attention, "_forward_varlen_masked")
+        ):
+            return self.attention._forward_varlen_masked(query, key, value, attn_metadata.attn_mask)
+
+        return super()._run_local_attention(query, key, value, attn_metadata)
 
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
@@ -516,7 +539,12 @@ class LTX2AudioVideoAttnProcessor:
         key = key.unflatten(2, (attn.heads, attn.head_dim))
         value = value.unflatten(2, (attn.heads, attn.head_dim))
 
-        attn_metadata = AttentionMetadata(attn_mask=attention_mask) if attention_mask is not None else None
+        attn_metadata = None
+        if attention_mask is not None:
+            extra = {}
+            if attn.force_flash_varlen_mask and torch.compiler.is_compiling():
+                extra[_LTX2_FORCE_VARLEN_MASK_KEY] = True
+            attn_metadata = AttentionMetadata(attn_mask=attention_mask, extra=extra)
         hidden_states = attn.attn(query, key, value, attn_metadata)
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
@@ -564,6 +592,7 @@ class LTX2Attention(torch.nn.Module):
         quant_config: "QuantizationConfig | None" = None,
         prefix: str = "",
         disable_kv_quant: bool = False,
+        force_flash_varlen_mask: bool = False,
     ):
         super().__init__()
         # LTX-2 uses "rms_norm_across_heads", LTX-2.3 uses "rms_norm" -- both
@@ -586,6 +615,7 @@ class LTX2Attention(torch.nn.Module):
         self.total_num_heads = heads
         self.total_num_kv_heads = kv_heads
         self.rope_type = rope_type
+        self.force_flash_varlen_mask = force_flash_varlen_mask
 
         self.to_qkv = None
         self.to_q = None
@@ -680,7 +710,7 @@ class LTX2Attention(torch.nn.Module):
                 torch.nn.Dropout(dropout) if dropout > 0 else torch.nn.Identity(),
             ]
         )
-        self.attn = Attention(
+        self.attn = LTX2AttentionLayer(
             num_heads=self.query_num_heads,
             head_size=dim_head,
             num_kv_heads=self.kv_num_heads,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -75,6 +75,27 @@ except ImportError:
     LTX2VocoderWithBWE = None
 
 
+def _setup_ltx23_regional_compile(pipeline: nn.Module) -> None:
+    # LTX-2.3 prompt cross-attention uses FlashAttention varlen unpadding.
+    # Capturing dynamic output shape ops keeps the repeated transformer block
+    # in one compiled region instead of splitting around nonzero()/item().
+    torch._dynamo.config.capture_dynamic_output_shape_ops = True
+    torch._dynamo.config.capture_scalar_outputs = True
+
+    from vllm_omni.diffusion.compile import regionally_compile
+
+    transformer = getattr(pipeline, "transformer", None)
+    if transformer is None:
+        return
+    for block in getattr(transformer, "transformer_blocks", []):
+        for attr in ("attn2", "audio_attn2"):
+            attention = getattr(block, attr, None)
+            if attention is not None:
+                attention.force_flash_varlen_mask = True
+    pipeline.transformer = regionally_compile(transformer, dynamic=True)
+    logger.info("LTX-2.3 transformer compiled with dynamic output shape capture.")
+
+
 def _detect_vocoder_output_sample_rate(model: str) -> int | None:
     """Detect the vocoder output sample rate from vocoder/config.json.
 
@@ -144,6 +165,9 @@ class LTX23Pipeline(
     _encoder_modules: ClassVar[list[str]] = ["text_encoder", "connectors"]
     _vae_modules: ClassVar[list[str]] = ["vae", "audio_vae"]
     _resident_modules: ClassVar[list[str]] = ["vocoder"]
+
+    def setup_compile(self) -> None:
+        _setup_ltx23_regional_compile(self)
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->
# [Perf] Fuse LTX-2.3 compile regions for masked FlashAttention cross-attention

## Purpose

Fuse the compiled LTX-2.3 repeated transformer block into a larger TorchDynamo region when using FlashAttention masked varlen cross-attention.

LTX-2.3 already uses regional compile through the diffusion model runner, but the real pipeline trace showed the compiled block being split around the prompt cross-attention path. The split was not reproduced by a simplified block mock because the real pipeline exercises the masked FlashAttention varlen path.

The graph breaks came from two places:

- FlashAttention backend mask classification branches on `torch.any(~attention_mask)`.
- FlashAttention varlen unpadding uses dynamic shape / scalar ops such as `nonzero()` and `.item()`.

This PR keeps the change local to LTX-2.3:

- Add an LTX2-local `Attention` subclass that can bypass the tensor-valued mask classification branch for marked LTX2 attention layers.
- Add `LTX23Pipeline.setup_compile()` as the pipeline-specific compile entrypoint.
- In LTX-2.3 compile setup, enable Dynamo capture for dynamic output shape ops and scalar outputs before regional compile.
- Mark only LTX-2.3 prompt cross-attention layers (`attn2`, `audio_attn2`) for the local varlen masked path during compile.

The default diffusion attention backend and `AttentionMetadata` are unchanged. Other models keep the existing default compile path.

## Test Plan

Platform:

- 4xA100 80GB

Model:

- LTX-2.3 Diffusers

Workload:

```bash
export PROMPT="Floating crystal islands in cosmic starry sky, glowing nebula, soft luminous particles flowing around, slow camera rotation"
export NEG_PROMPT="low quality, blurry, noise, watermark, text, deformed figures, cartoon style, over-saturated color, frame jump"
```

Compile A/B:

- baseline split: LTX-2.3 compile without dynamic-output capture / local force-varlen path
- fused: LTX-2.3 compile with this PR

Cases:

- `512x384`, 25 frames
- `1024x576`, 81 frames

Each cell:

- warmup with the same shape
- 10 measured requests
- compare `stage_0_gen_ms`

**vLLM Version:**

0.23.0

**vLLM-Omni Commit:**

346bb61eaab1a58fb9faafc9e7d2c6f07ddefd96

## Test Result

Stage-0 generation time:

| attention | exec | graph | case | stage_0_gen_ms_mean | stage_0_gen_ms_p50 | stage_0_gen_ms_p99 | peak_memory_mb_mean | completed | failed |
|---|---|---|---|---:|---:|---:|---:|---:|---:|
| default FLASH_ATTN | compile | fused | 1024x576_81f | 21291.08 | 21276.30 | 21469.63 | 76619.4 | 10 | 0 |
| default FLASH_ATTN | compile | split | 1024x576_81f | 21980.61 | 21978.05 | 22002.86 | 76622.0 | 10 | 0 |
| default FLASH_ATTN | compile | fused | 512x384_25f | 3914.43 | 3888.54 | 4114.49 | 73259.0 | 10 | 0 |
| default FLASH_ATTN | compile | split | 512x384_25f | 4841.15 | 4815.68 | 4998.12 | 73259.4 | 10 | 0 |

Observed improvement:

| case | mean delta | relative |
|---|---:|---:|
| 1024x576_81f | -689.54 ms | -3.1% |
| 512x384_25f | -926.72 ms | -19.1% |

Peak memory was effectively unchanged.
---
Trace comparison:

<img width="1387" height="771" alt="8f0a6e27-e781-49bc-9674-be552efdb61c" src="https://github.com/user-attachments/assets/c9385715-f125-4bdb-bcaf-069823b954a3" />
- Before: the block is split into several Torch-Compiled Regions around the prompt cross-attention path.

---

<img width="1081" height="790" alt="91b42093-0e24-4074-832c-f05969bcf735" src="https://github.com/user-attachments/assets/ebbd3e91-d962-4ddc-84df-5997e23027c0" />
- After: the same block is captured as a larger continuous Torch-Compiled Region, reducing the CPU-side gaps between compiled fragments.

---

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
