### PR TITLE
[Perf] Skip LTX-2.3 denoise masks when connectors use learned registers

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
@@ -105,6 +105,63 @@ class TestPipelineIndependence:
         assert issubclass(LTX23Pipeline, DiffusionPipelineProfilerMixin)
 
 
+class TestConnectorMaskElision:
+    """Test LTX-2.3 connector-mask handling without loading weights."""
+
+    @pytest.mark.parametrize(
+        "connectors",
+        [
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    video_connector_num_learnable_registers=128,
+                    audio_connector_num_learnable_registers=128,
+                )
+            ),
+            SimpleNamespace(
+                config={
+                    "video_connector_num_learnable_registers": 128,
+                    "audio_connector_num_learnable_registers": 128,
+                }
+            ),
+        ],
+    )
+    def test_elides_denoise_mask_when_connectors_use_learned_registers(self, connectors):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23Pipeline
+
+        pipe = object.__new__(LTX23Pipeline)
+        object.__setattr__(pipe, "connectors", connectors)
+        mask = torch.ones(2, 4, dtype=torch.int64)
+
+        assert pipe._get_denoise_connector_attention_mask(mask) is None
+
+    @pytest.mark.parametrize(
+        "connectors",
+        [
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    video_connector_num_learnable_registers=None,
+                    audio_connector_num_learnable_registers=128,
+                )
+            ),
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    video_connector_num_learnable_registers=128,
+                    audio_connector_num_learnable_registers=None,
+                )
+            ),
+            SimpleNamespace(config=SimpleNamespace()),
+        ],
+    )
+    def test_keeps_denoise_mask_without_learned_registers(self, connectors):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23Pipeline
+
+        pipe = object.__new__(LTX23Pipeline)
+        object.__setattr__(pipe, "connectors", connectors)
+        mask = torch.ones(2, 4, dtype=torch.int64)
+
+        assert pipe._get_denoise_connector_attention_mask(mask) is mask
+
+
 class TestLTX23VaeDecodeParallel:
     """Test LTX-2.3 video VAE tiled parallel helpers without loading weights."""
 
@@ -646,6 +703,11 @@ class TestCFGParallelForwardPath:
                 return (latents - noise_pred,)
 
         class FakeConnectors:
+            config = SimpleNamespace(
+                video_connector_num_learnable_registers=128,
+                audio_connector_num_learnable_registers=128,
+            )
+
             def to(self, device):
                 return self
 
@@ -676,6 +738,8 @@ class TestCFGParallelForwardPath:
                 expected_prompt = torch.full((1, 1, 1), expected_prompt_value)
                 torch.testing.assert_close(kwargs["encoder_hidden_states"], expected_prompt)
                 torch.testing.assert_close(kwargs["audio_encoder_hidden_states"], expected_prompt)
+                assert kwargs["encoder_attention_mask"] is None
+                assert kwargs["audio_encoder_attention_mask"] is None
                 assert kwargs["hidden_states"].shape == (1, 1, 2)
                 assert kwargs["audio_hidden_states"].shape == (1, 1, 2)
                 if cfg_rank == 0:

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -299,6 +299,44 @@ class LTX23Pipeline(
         for module in (*modules.encoders, *modules.vaes, *modules.resident_modules):
             module.to(self.device)
 
+    @staticmethod
+    def _connectors_use_learned_registers(connectors: Any) -> bool:
+        """Return whether both LTX-2.3 connectors replace padding with registers."""
+
+        def has_registers(value: Any) -> bool:
+            if isinstance(value, int):
+                return value > 0
+            return value is not None
+
+        def get_config_value(config: Any, key: str) -> Any:
+            if config is None:
+                return None
+            if isinstance(config, dict):
+                return config.get(key)
+            return getattr(config, key, None)
+
+        config = getattr(connectors, "config", None)
+        video_registers = get_config_value(config, "video_connector_num_learnable_registers")
+        audio_registers = get_config_value(config, "audio_connector_num_learnable_registers")
+        if video_registers is not None or audio_registers is not None:
+            return has_registers(video_registers) and has_registers(audio_registers)
+
+        video_connector = getattr(connectors, "video_connector", None)
+        audio_connector = getattr(connectors, "audio_connector", None)
+        return (
+            getattr(video_connector, "learnable_registers", None) is not None
+            and getattr(audio_connector, "learnable_registers", None) is not None
+        )
+
+    def _get_denoise_connector_attention_mask(
+        self, connector_attention_mask: torch.Tensor | None
+    ) -> torch.Tensor | None:
+        if connector_attention_mask is None:
+            return None
+        if self._connectors_use_learned_registers(self.connectors):
+            return None
+        return connector_attention_mask
+
     # ------------------------------------------------------------------
     # Text Encoding (LTX-2.3 specific)
     # ------------------------------------------------------------------
@@ -999,10 +1037,11 @@ class LTX23Pipeline(
         connector_prompt_embeds, connector_audio_prompt_embeds, connector_attention_mask = self.connectors(
             prompt_embeds, prompt_attention_mask, padding_side=tokenizer_padding_side
         )
+        denoise_connector_attention_mask = self._get_denoise_connector_attention_mask(connector_attention_mask)
 
         positive_connector_prompt_embeds = connector_prompt_embeds
         positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds
-        positive_connector_attention_mask = connector_attention_mask
+        positive_connector_attention_mask = denoise_connector_attention_mask
         negative_connector_prompt_embeds = None
         negative_connector_audio_prompt_embeds = None
         negative_connector_attention_mask = None
@@ -1012,8 +1051,9 @@ class LTX23Pipeline(
             positive_connector_prompt_embeds = connector_prompt_embeds[split_batch:]
             negative_connector_audio_prompt_embeds = connector_audio_prompt_embeds[:split_batch]
             positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds[split_batch:]
-            negative_connector_attention_mask = connector_attention_mask[:split_batch]
-            positive_connector_attention_mask = connector_attention_mask[split_batch:]
+            if denoise_connector_attention_mask is not None:
+                negative_connector_attention_mask = denoise_connector_attention_mask[:split_batch]
+                positive_connector_attention_mask = denoise_connector_attention_mask[split_batch:]
 
         # ---- Prepare latents ----
         latent_num_frames = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
@@ -1183,8 +1223,8 @@ class LTX23Pipeline(
                             audio_encoder_hidden_states=connector_audio_prompt_embeds,
                             timestep=ts,
                             sigma=ts,  # LTX-2.3: sigma for prompt_adaln
-                            encoder_attention_mask=connector_attention_mask,
-                            audio_encoder_attention_mask=connector_attention_mask,
+                            encoder_attention_mask=denoise_connector_attention_mask,
+                            audio_encoder_attention_mask=denoise_connector_attention_mask,
                             num_frames=latent_num_frames,
                             height=latent_height,
                             width=latent_width,


### PR DESCRIPTION
<!-- markdownlint-disable -->
# [Perf] Skip LTX-2.3 denoise masks when connectors use learned registers

## Purpose

Improve LTX-2.3 text-to-video compile performance by skipping the connector attention mask in the denoise transformer when the LTX-2.3 connectors replace padding tokens with learned registers.

This follows up on the graph-break investigation from #4790, but uses a smaller LTX-2.3-local implementation instead of changing `setup_compile()` or process-wide Dynamo settings.

LTX-2.3 connectors expose learned registers for both video and audio conditioning:

- `video_connector_num_learnable_registers`
- `audio_connector_num_learnable_registers`

With those registers enabled, padded prompt positions are converted into learned conditioning tokens by the connector. The denoise transformer no longer needs the original text padding mask for `attn2` / `audio_attn2`.

This is not just a compile workaround. In the learned-register connector path, padding positions are first replaced by learned register embeddings and the connector returns an all-valid downstream mask. Passing `None` to the denoise transformer is therefore equivalent to passing that all-valid mask, while avoiding the masked-attention bookkeeping.

Keeping the mask forces the FlashAttention masked varlen path inside the compiled LTX-2.3 transformer block. That path performs tensor-value-dependent mask classification and varlen metadata work, which prevents the repeated block from being captured as a cleaner compiled region and adds extra work in every denoise step.

This change keeps the optimization local to LTX-2.3:

- Detect whether both LTX-2.3 connectors use learned registers.
- Pass `None` as the denoise `encoder_attention_mask` /
  `audio_encoder_attention_mask` when learned registers are present.
- Preserve the old masked behavior when connectors do not expose learned
  registers.
- Keep the diffusion attention backends and shared attention metadata unchanged.

The safety boundary is intentionally narrow: if either connector does not expose
learned registers, the previous mask path is kept unchanged.

## Test Plan

Platform:

- 4xA100 80GB

Model:

- LTX-2.3 Diffusers

Workload:

```bash
export PROMPT="Floating crystal islands in cosmic starry sky, glowing nebula, soft luminous particles flowing around, slow camera rotation"
export NEG_PROMPT="low quality, blurry, noise, watermark, text, deformed figures, cartoon style, over-saturated color, frame jump"
```

Benchmark command:

```bash
cd /root/vllm-omni

# Baseline commit / branch without this change.
LABEL=before MODEL=/data/models/Lightricks/LTX-2.3-diffusers \
bash ./run_ltx23_mask_elision_sweep_a100.sh

# Patched commit / branch with this change.
LABEL=after MODEL=/data/models/Lightricks/LTX-2.3-diffusers \
bash ./run_ltx23_mask_elision_sweep_a100.sh
```

Benchmark settings:

- `exec=compile`
- `profile=base,cfg2`
- `cases=512x384x25f,1024x576x81f`
- `num_inference_steps=10`
- same-shape warmup before measured requests
- 10 measured requests per cell
- `--enable-diffusion-pipeline-profiler` disabled
- primary metric: `stage_0_gen_ms`

**vLLM Version:**

0.23.0

**vLLM-Omni Commit:**

fe04c217a4b53719844b2c624143f87861e5e172

## Test Result

Stage-0 generation time:

| exec | profile | case | before mean ms | after mean ms | delta ms | delta % | before peak MB | after peak MB | completed | failed |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| compile | base | 512x384_25f | 4017.23 | 3436.99 | -580.23 | -14.44% | 73258.0 | 73258.0 | 10 | 0 |
| compile | cfg2 | 512x384_25f | 3208.70 | 2419.56 | -789.14 | -24.59% | 73258.0 | 73258.0 | 10 | 0 |
| compile | base | 1024x576_81f | 21873.91 | 21488.61 | -385.30 | -1.76% | 76622.0 | 76619.4 | 10 | 0 |
| compile | cfg2 | 1024x576_81f | 12524.78 | 12087.01 | -437.77 | -3.50% | 76616.0 | 76616.0 | 10 | 0 |

Peak memory is effectively unchanged across the measured cells.

Trace validation:
---

<img width="1387" height="771" alt="8f0a6e27-e781-49bc-9674-be552efdb61c" src="https://github.com/user-attachments/assets/fcb03997-3a2c-4e2c-83de-1fca16de43f1" />


Before: LTX-2.3 repeated transformer block enters the masked FlashAttention varlen path for prompt cross-attention.

---

<img width="1084" height="792" alt="{4A5FD8E8-A239-4B87-9C43-5E916BFC1676}" src="https://github.com/user-attachments/assets/aa43dc91-9994-4793-8d31-3f26742e18e1" />

After: the denoise transformer receives no connector attention mask when learned registers are enabled, avoiding the masked varlen path for those prompt cross-attention calls.

---


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
