### PR TITLE
[Core] Optimize SHM connector and OmniSerializer

### DIFF
--- a/benchmarks/tts/model_configs.yaml
+++ b/benchmarks/tts/model_configs.yaml
@@ -24,6 +24,20 @@ models:
         task_type: VoiceDesign
         language: English
 
+  Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice:
+    supported_tasks: [default_voice, voice_design]
+    backend: openai-audio-speech
+    endpoint: /v1/audio/speech
+    trust_remote_code: true
+    task_extra_body:
+      default_voice:
+        voice: Vivian
+        language: English
+        task_type: CustomVoice
+      voice_design:
+        task_type: VoiceDesign
+        language: English
+
   Qwen/Qwen3-TTS-12Hz-1.7B-Base:
     supported_tasks: [voice_clone]
     backend: openai-audio-speech

--- a/tests/distributed/omni_connectors/test_basic_connectors.py
+++ b/tests/distributed/omni_connectors/test_basic_connectors.py
@@ -102,15 +102,24 @@ def test_put_get_shm(mocker: MockerFixture, shm_connector, monkeypatch: pytest.M
     # Create data larger than 100 bytes
     data = {"large": "x" * 200}
 
-    # Mock SHM return values
-    mock_handle = {"name": "req_2", "size": 200}
+    # Pre-serialize to know the exact size the mock SHM should report
+    serialized_data = shm_connector.serialize_obj(data)
+    actual_size = len(serialized_data)
+
+    # Mock shm_write_bytes — no real SHM segment is created
+    mock_handle = {"name": "req_2", "size": actual_size}
     mock_write = mocker.MagicMock(return_value=mock_handle)
     monkeypatch.setattr("vllm_omni.distributed.omni_connectors.connectors.shm_connector.shm_write_bytes", mock_write)
 
-    # When reading, return the serialized bytes of the data
-    serialized_data = shm_connector.serialize_obj(data)
-    mock_read = mocker.MagicMock(return_value=serialized_data)
-    monkeypatch.setattr("vllm_omni.distributed.omni_connectors.connectors.shm_connector.shm_read_bytes", mock_read)
+    # Mock SharedMemory to return a buffer containing the serialized payload.
+    # _get_data_with_lock maps the segment directly via shm_pkg.SharedMemory;
+    # .buf must support the buffer protocol (bytearray satisfies this).
+    mock_shm = mocker.MagicMock()
+    mock_shm.buf = bytearray(serialized_data)
+    mocker.patch(
+        "vllm_omni.distributed.omni_connectors.connectors.shm_connector.shm_pkg.SharedMemory",
+        return_value=mock_shm,
+    )
 
     # Put
     success, size, metadata = shm_connector.put("stage_0", "stage_1", "req_2", data)
@@ -127,7 +136,6 @@ def test_put_get_shm(mocker: MockerFixture, shm_connector, monkeypatch: pytest.M
     retrieved_data, ret_size = shm_connector.get("stage_0", "stage_1", "req_2", metadata)
 
     assert data == retrieved_data
-    mock_read.assert_called_once_with(mock_handle)
 
 
 def test_get_invalid_metadata(shm_connector):

--- a/vllm_omni/distributed/omni_connectors/connectors/base.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/base.py
@@ -93,10 +93,10 @@ class OmniConnectorBase(ABC):
         """Serialize a Python object to bytes using centralized serializer."""
         from ..utils.serialization import OmniSerializer
 
-        return OmniSerializer.serialize(obj)
+        return bytes(OmniSerializer.serialize(obj))
 
     @staticmethod
-    def deserialize_obj(data: bytes) -> Any:
+    def deserialize_obj(data: bytes | bytearray | memoryview) -> Any:
         """Deserialize bytes to Python object using centralized serializer."""
         from ..utils.serialization import OmniSerializer
 

--- a/vllm_omni/distributed/omni_connectors/connectors/base.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/base.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC, abstractmethod
+from collections.abc import Buffer
 from typing import Any
 
 from ..utils.logging import get_connector_logger
@@ -89,14 +90,14 @@ class OmniConnectorBase(ABC):
         self.close()
 
     @staticmethod
-    def serialize_obj(obj: Any) -> bytes:
+    def serialize_obj(obj: Any) -> Buffer:
         """Serialize a Python object to bytes using centralized serializer."""
         from ..utils.serialization import OmniSerializer
 
-        return bytes(OmniSerializer.serialize(obj))
+        return OmniSerializer.serialize(obj)
 
     @staticmethod
-    def deserialize_obj(data: bytes | bytearray | memoryview) -> Any:
+    def deserialize_obj(data: Buffer) -> Any:
         """Deserialize bytes to Python object using centralized serializer."""
         from ..utils.serialization import OmniSerializer
 

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import fcntl
+import json
 import os
+import threading
+import time
 from multiprocessing import shared_memory as shm_pkg
 from typing import Any
 
@@ -12,6 +15,10 @@ from ..utils.logging import get_connector_logger
 from .base import OmniConnectorBase
 
 logger = get_connector_logger(__name__)
+
+PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
+PROFILE = PROFILE_ENV != "0"
+_PID = os.getpid()
 
 
 class SharedMemoryConnector(OmniConnectorBase):
@@ -51,7 +58,9 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Note: For extremely large objects in "inline" mode (e.g. Ray),
             # we might double-serialize if we're not careful, but here we assume
             # if it's huge we use SHM, or if Ray, threshold is maxsize.
+            t_serialize_start = time.perf_counter()
             payload = self.serialize_obj(data)
+            t_serialize_end = time.perf_counter()
             size = len(payload)
 
             # The legacy async-chunk adapter transfers only the connector key
@@ -59,24 +68,51 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Keep key-addressed SHM as the default and only inline payloads
             # when the caller explicitly enables the metadata-aware path.
             if size >= self.threshold or not self.inline_small_payloads:
+                t_write_start = time.perf_counter()
                 lock_file = f"/dev/shm/shm_{put_key}_lockfile.lock"
                 with open(lock_file, "wb+") as lockf:
                     fcntl.flock(lockf, fcntl.LOCK_EX)
                     meta = shm_write_bytes(payload, name=put_key)
                     fcntl.flock(lockf, fcntl.LOCK_UN)
+                t_write_end = time.perf_counter()
 
                 # meta contains {'name': ..., 'size': ...}
                 metadata = {"shm": meta, "size": size}
                 self._pending_keys.add(put_key)
                 self._metrics["shm_writes"] += 1
+                path = "shm"
             else:
+                t_write_start = t_write_end = t_serialize_end
                 # Inline small payloads to avoid the mmap + file-lock overhead
                 # that dominates codec chunk transfers.
                 metadata = {"inline_bytes": payload, "size": size}
                 self._metrics["inline_writes"] += 1
+                path = "inline"
 
             self._metrics["puts"] += 1
             self._metrics["bytes_transferred"] += size
+
+            if PROFILE:
+                print(
+                    "SHM_PROFILE",
+                    json.dumps(
+                        {
+                            "name": "shm_put",
+                            "ph": "X",
+                            "ts": t_serialize_start * 1_000_000,
+                            "dur": (t_write_end - t_serialize_start) * 1_000_000,
+                            "pid": _PID,
+                            "tid": threading.get_ident(),
+                            "args": {
+                                "put_key": put_key,
+                                "size": size,
+                                "path": path,
+                                "serialize_us": (t_serialize_end - t_serialize_start) * 1_000_000,
+                                "write_us": (t_write_end - t_write_start) * 1_000_000,
+                            },
+                        }
+                    ),
+                )
 
             return True, size, metadata
 
@@ -87,11 +123,34 @@ class SharedMemoryConnector(OmniConnectorBase):
     def _get_data_with_lock(self, lock_file: str, shm_handle: dict):
         obj = None
         try:
+            t_read_start = time.perf_counter()
             with open(lock_file, "rb+") as lockf:
                 fcntl.flock(lockf, fcntl.LOCK_EX)
                 data_bytes = shm_read_bytes(shm_handle)
                 fcntl.flock(lockf, fcntl.LOCK_UN)
+            t_read_end = time.perf_counter()
             obj = self.deserialize_obj(data_bytes)
+            t_deserialize_end = time.perf_counter()
+            if PROFILE:
+                print(
+                    "SHM_PROFILE",
+                    json.dumps(
+                        {
+                            "name": "shm_get",
+                            "ph": "X",
+                            "ts": t_read_start * 1_000_000,
+                            "dur": (t_deserialize_end - t_read_start) * 1_000_000,
+                            "pid": _PID,
+                            "tid": threading.get_ident(),
+                            "args": {
+                                "shm_name": shm_handle.get("name"),
+                                "size": shm_handle.get("size", 0),
+                                "shm_read_us": (t_read_end - t_read_start) * 1_000_000,
+                                "deserialize_us": (t_deserialize_end - t_read_end) * 1_000_000,
+                            },
+                        }
+                    ),
+                )
             return obj, int(shm_handle.get("size", 0))
         except Exception as e:
             logger.error(f"SharedMemoryConnector shm get failed for req : {e}")
@@ -138,6 +197,18 @@ class SharedMemoryConnector(OmniConnectorBase):
         get_key: str,
         metadata=None,
     ) -> tuple[Any, int] | None:
+        result = self._get_impl(from_stage, to_stage, get_key, metadata)
+        if result is not None:
+            self._metrics["gets"] += 1
+        return result
+
+    def _get_impl(
+        self,
+        from_stage: str,
+        to_stage: str,
+        get_key: str,
+        metadata=None,
+    ) -> tuple[Any, int] | None:
         if metadata is not None:
             if isinstance(metadata, dict) and get_key in metadata:
                 metadata = metadata.get(get_key)
@@ -147,7 +218,27 @@ class SharedMemoryConnector(OmniConnectorBase):
 
             if "inline_bytes" in metadata:
                 try:
+                    t_deserialize_start = time.perf_counter()
                     obj = self.deserialize_obj(metadata["inline_bytes"])
+                    t_deserialize_end = time.perf_counter()
+                    if PROFILE:
+                        print(
+                            "SHM_PROFILE",
+                            json.dumps(
+                                {
+                                    "name": "shm_get_inline",
+                                    "ph": "X",
+                                    "ts": t_deserialize_start * 1_000_000,
+                                    "dur": (t_deserialize_end - t_deserialize_start) * 1_000_000,
+                                    "pid": _PID,
+                                    "tid": threading.get_ident(),
+                                    "args": {
+                                        "get_key": get_key,
+                                        "size": int(metadata.get("size", 0)),
+                                    },
+                                }
+                            ),
+                        )
                     self._pending_keys.discard(get_key)
                     return obj, int(metadata.get("size", 0))
                 except Exception as e:
@@ -176,6 +267,20 @@ class SharedMemoryConnector(OmniConnectorBase):
         If ``get()`` was never called, we unlink it here so /dev/shm
         doesn't leak.
         """
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "shm_metrics",
+                        "ph": "i",
+                        "ts": time.perf_counter() * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {"request_id": request_id, **self._metrics},
+                    }
+                ),
+            )
         stale = [
             k
             for k in self._pending_keys

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -9,7 +9,7 @@ import time
 from multiprocessing import shared_memory as shm_pkg
 from typing import Any
 
-from vllm_omni.entrypoints.stage_utils import shm_read_bytes, shm_write_bytes
+from vllm_omni.entrypoints.stage_utils import shm_write_bytes
 
 from ..utils.logging import get_connector_logger
 from .base import OmniConnectorBase
@@ -45,6 +45,19 @@ class SharedMemoryConnector(OmniConnectorBase):
             "shm_writes": 0,
             "inline_writes": 0,
         }
+
+    @staticmethod
+    def serialize_obj(obj: Any) -> memoryview:
+        """Return a memoryview into the thread-local encode buffer — zero allocation.
+
+        Valid until the next serialize_obj() call on the same thread.  The SHM
+        write path (shm_write_bytes) consumes this synchronously before returning,
+        so the view is always released before re-encoding.  The inline path copies
+        to bytes explicitly since that metadata travels via IPC.
+        """
+        from ..utils.serialization import OmniSerializer
+
+        return OmniSerializer.serialize(obj)
 
     def put(
         self,
@@ -85,7 +98,9 @@ class SharedMemoryConnector(OmniConnectorBase):
                 t_write_start = t_write_end = t_serialize_end
                 # Inline small payloads to avoid the mmap + file-lock overhead
                 # that dominates codec chunk transfers.
-                metadata = {"inline_bytes": payload, "size": size}
+                # payload is a memoryview into a thread-local buffer; copy to
+                # bytes here since inline_bytes travels via IPC metadata.
+                metadata = {"inline_bytes": bytes(payload), "size": size}
                 self._metrics["inline_writes"] += 1
                 path = "inline"
 
@@ -122,14 +137,29 @@ class SharedMemoryConnector(OmniConnectorBase):
 
     def _get_data_with_lock(self, lock_file: str, shm_handle: dict):
         obj = None
+        shm = None
         try:
             t_read_start = time.perf_counter()
             with open(lock_file, "rb+") as lockf:
                 fcntl.flock(lockf, fcntl.LOCK_EX)
-                data_bytes = shm_read_bytes(shm_handle)
+                # Map the SHM segment inside the lock to guarantee the write is
+                # complete before we read.  We hold a memoryview into the
+                # mapping for decoding; msgspec copies binary fields (tensor
+                # data etc.) into bytes during decode, so the view can be
+                # released immediately after decode() returns.
+                shm = shm_pkg.SharedMemory(name=shm_handle["name"])
+                mv = memoryview(shm.buf)[: shm_handle["size"]]
                 fcntl.flock(lockf, fcntl.LOCK_UN)
             t_read_end = time.perf_counter()
-            obj = self.deserialize_obj(data_bytes)
+            # Decode directly from the SHM mapping — no intermediate bytes copy.
+            obj = self.deserialize_obj(mv)
+            del mv
+            shm.close()
+            try:
+                shm.unlink()
+            except Exception:
+                pass
+            shm = None
             t_deserialize_end = time.perf_counter()
             if PROFILE:
                 print(
@@ -145,7 +175,7 @@ class SharedMemoryConnector(OmniConnectorBase):
                             "args": {
                                 "shm_name": shm_handle.get("name"),
                                 "size": shm_handle.get("size", 0),
-                                "shm_read_us": (t_read_end - t_read_start) * 1_000_000,
+                                "shm_map_us": (t_read_end - t_read_start) * 1_000_000,
                                 "deserialize_us": (t_deserialize_end - t_read_end) * 1_000_000,
                             },
                         }
@@ -156,7 +186,12 @@ class SharedMemoryConnector(OmniConnectorBase):
             logger.error(f"SharedMemoryConnector shm get failed for req : {e}")
             return None
         finally:
-            # If data has been received, delete lock_file.
+            if shm is not None:
+                shm.close()
+                try:
+                    shm.unlink()
+                except Exception:
+                    pass
             if obj and os.path.exists(lock_file):
                 os.remove(lock_file)
 

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -57,7 +57,7 @@ class SharedMemoryConnector(OmniConnectorBase):
         """
         from ..utils.serialization import OmniSerializer
 
-        return OmniSerializer.serialize(obj)
+        return OmniSerializer.serialize_view(obj)
 
     def put(
         self,
@@ -154,7 +154,10 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Decode directly from the SHM mapping — no intermediate bytes copy.
             obj = self.deserialize_obj(mv)
             del mv
-            shm.close()
+            try:
+                shm.close()
+            except Exception:
+                pass
             try:
                 shm.unlink()
             except Exception:

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -31,12 +31,16 @@ class SharedMemoryConnector(OmniConnectorBase):
     the connector silently falls back to key-based lookup.
     """
 
+    # Initial buffer size for thread-local encode buffer
+    _INITIAL_BUF = 65536
+
     def __init__(self, config: dict[str, Any]):
         self.config = config
         self.stage_id = config.get("stage_id", -1)
         self.device = config.get("device", "cuda:0")
         self.threshold = int(config.get("shm_threshold_bytes", 65536))
         self.inline_small_payloads = bool(config.get("inline_small_payloads", False))
+        self._local = threading.local()
         self._pending_keys: set[str] = set()
         self._metrics = {
             "puts": 0,
@@ -46,18 +50,21 @@ class SharedMemoryConnector(OmniConnectorBase):
             "inline_writes": 0,
         }
 
-    @staticmethod
-    def serialize_obj(obj: Any) -> memoryview:
-        """Return a memoryview into the thread-local encode buffer — zero allocation.
+    def _serialize(self, obj: Any) -> memoryview:
+        """Serialize obj into the connector's thread-local buffer and return a view.
 
-        Valid until the next serialize_obj() call on the same thread.  The SHM
-        write path (shm_write_bytes) consumes this synchronously before returning,
-        so the view is always released before re-encoding.  The inline path copies
-        to bytes explicitly since that metadata travels via IPC.
+        The returned memoryview is valid only until the next _serialize() call
+        on the same thread.  The SHM write path (shm_write_bytes) consumes the
+        view synchronously before returning, so the invariant holds in put().
+        The inline path copies to bytes explicitly before storing in metadata.
         """
         from ..utils.serialization import OmniSerializer
 
-        return OmniSerializer.serialize_view(obj)
+        if not hasattr(self._local, "encode_buf"):
+            self._local.encode_buf = bytearray(self._INITIAL_BUF)
+        buf = self._local.encode_buf
+        OmniSerializer.serialize_into(obj, buf)
+        return memoryview(buf)
 
     def put(
         self,
@@ -72,7 +79,7 @@ class SharedMemoryConnector(OmniConnectorBase):
             # we might double-serialize if we're not careful, but here we assume
             # if it's huge we use SHM, or if Ray, threshold is maxsize.
             t_serialize_start = time.perf_counter()
-            payload = self.serialize_obj(data)
+            payload = self._serialize(data)
             t_serialize_end = time.perf_counter()
             size = len(payload)
 

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -2,10 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import fcntl
-import json
 import os
 import threading
-import time
 from multiprocessing import shared_memory as shm_pkg
 from typing import Any
 
@@ -15,10 +13,6 @@ from ..utils.logging import get_connector_logger
 from .base import OmniConnectorBase
 
 logger = get_connector_logger(__name__)
-
-PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
-PROFILE = PROFILE_ENV != "0"
-_PID = os.getpid()
 
 
 class SharedMemoryConnector(OmniConnectorBase):
@@ -78,9 +72,7 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Note: For extremely large objects in "inline" mode (e.g. Ray),
             # we might double-serialize if we're not careful, but here we assume
             # if it's huge we use SHM, or if Ray, threshold is maxsize.
-            t_serialize_start = time.perf_counter()
             payload = self._serialize(data)
-            t_serialize_end = time.perf_counter()
             size = len(payload)
 
             # The legacy async-chunk adapter transfers only the connector key
@@ -88,53 +80,26 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Keep key-addressed SHM as the default and only inline payloads
             # when the caller explicitly enables the metadata-aware path.
             if size >= self.threshold or not self.inline_small_payloads:
-                t_write_start = time.perf_counter()
                 lock_file = f"/dev/shm/shm_{put_key}_lockfile.lock"
                 with open(lock_file, "wb+") as lockf:
                     fcntl.flock(lockf, fcntl.LOCK_EX)
                     meta = shm_write_bytes(payload, name=put_key)
                     fcntl.flock(lockf, fcntl.LOCK_UN)
-                t_write_end = time.perf_counter()
 
                 # meta contains {'name': ..., 'size': ...}
                 metadata = {"shm": meta, "size": size}
                 self._pending_keys.add(put_key)
                 self._metrics["shm_writes"] += 1
-                path = "shm"
             else:
-                t_write_start = t_write_end = t_serialize_end
                 # Inline small payloads to avoid the mmap + file-lock overhead
                 # that dominates codec chunk transfers.
                 # payload is a memoryview into a thread-local buffer; copy to
                 # bytes here since inline_bytes travels via IPC metadata.
                 metadata = {"inline_bytes": bytes(payload), "size": size}
                 self._metrics["inline_writes"] += 1
-                path = "inline"
 
             self._metrics["puts"] += 1
             self._metrics["bytes_transferred"] += size
-
-            if PROFILE:
-                print(
-                    "SHM_PROFILE",
-                    json.dumps(
-                        {
-                            "name": "shm_put",
-                            "ph": "X",
-                            "ts": t_serialize_start * 1_000_000,
-                            "dur": (t_write_end - t_serialize_start) * 1_000_000,
-                            "pid": _PID,
-                            "tid": threading.get_ident(),
-                            "args": {
-                                "put_key": put_key,
-                                "size": size,
-                                "path": path,
-                                "serialize_us": (t_serialize_end - t_serialize_start) * 1_000_000,
-                                "write_us": (t_write_end - t_write_start) * 1_000_000,
-                            },
-                        }
-                    ),
-                )
 
             return True, size, metadata
 
@@ -146,7 +111,6 @@ class SharedMemoryConnector(OmniConnectorBase):
         obj = None
         shm = None
         try:
-            t_read_start = time.perf_counter()
             with open(lock_file, "rb+") as lockf:
                 fcntl.flock(lockf, fcntl.LOCK_EX)
                 # Map the SHM segment inside the lock to guarantee the write is
@@ -157,7 +121,6 @@ class SharedMemoryConnector(OmniConnectorBase):
                 shm = shm_pkg.SharedMemory(name=shm_handle["name"])
                 mv = memoryview(shm.buf)[: shm_handle["size"]]
                 fcntl.flock(lockf, fcntl.LOCK_UN)
-            t_read_end = time.perf_counter()
             # Decode directly from the SHM mapping — no intermediate bytes copy.
             obj = self.deserialize_obj(mv)
             del mv
@@ -170,27 +133,6 @@ class SharedMemoryConnector(OmniConnectorBase):
             except Exception:
                 pass
             shm = None
-            t_deserialize_end = time.perf_counter()
-            if PROFILE:
-                print(
-                    "SHM_PROFILE",
-                    json.dumps(
-                        {
-                            "name": "shm_get",
-                            "ph": "X",
-                            "ts": t_read_start * 1_000_000,
-                            "dur": (t_deserialize_end - t_read_start) * 1_000_000,
-                            "pid": _PID,
-                            "tid": threading.get_ident(),
-                            "args": {
-                                "shm_name": shm_handle.get("name"),
-                                "size": shm_handle.get("size", 0),
-                                "shm_map_us": (t_read_end - t_read_start) * 1_000_000,
-                                "deserialize_us": (t_deserialize_end - t_read_end) * 1_000_000,
-                            },
-                        }
-                    ),
-                )
             return obj, int(shm_handle.get("size", 0))
         except Exception as e:
             logger.error(f"SharedMemoryConnector shm get failed for req : {e}")
@@ -263,27 +205,7 @@ class SharedMemoryConnector(OmniConnectorBase):
 
             if "inline_bytes" in metadata:
                 try:
-                    t_deserialize_start = time.perf_counter()
                     obj = self.deserialize_obj(metadata["inline_bytes"])
-                    t_deserialize_end = time.perf_counter()
-                    if PROFILE:
-                        print(
-                            "SHM_PROFILE",
-                            json.dumps(
-                                {
-                                    "name": "shm_get_inline",
-                                    "ph": "X",
-                                    "ts": t_deserialize_start * 1_000_000,
-                                    "dur": (t_deserialize_end - t_deserialize_start) * 1_000_000,
-                                    "pid": _PID,
-                                    "tid": threading.get_ident(),
-                                    "args": {
-                                        "get_key": get_key,
-                                        "size": int(metadata.get("size", 0)),
-                                    },
-                                }
-                            ),
-                        )
                     self._pending_keys.discard(get_key)
                     return obj, int(metadata.get("size", 0))
                 except Exception as e:
@@ -312,20 +234,6 @@ class SharedMemoryConnector(OmniConnectorBase):
         If ``get()`` was never called, we unlink it here so /dev/shm
         doesn't leak.
         """
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "shm_metrics",
-                        "ph": "i",
-                        "ts": time.perf_counter() * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {"request_id": request_id, **self._metrics},
-                    }
-                ),
-            )
         stale = [
             k
             for k in self._pending_keys

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -156,11 +156,13 @@ class SharedMemoryConnector(OmniConnectorBase):
             del mv
             try:
                 shm.close()
-            except Exception:
+            except Exception as e:
+                logger.error(f"Failed to close SHM in _get_data_with_lock: {e}")
                 pass
             try:
                 shm.unlink()
-            except Exception:
+            except Exception as e:
+                logger.error(f"Failed to unlink SHM in _get_data_with_lock: {e}")
                 pass
             shm = None
             t_deserialize_end = time.perf_counter()
@@ -190,7 +192,16 @@ class SharedMemoryConnector(OmniConnectorBase):
             return None
         finally:
             if shm is not None:
-                shm.close()
+                # shm.close() (munmap) may fail with BufferError if the decoded
+                # struct holds memoryview fields that alias shm.buf — this is
+                # expected when the typed decoder returns zero-copy views.  Swallow
+                # the error; the mmap is cleaned up automatically by Python's GC
+                # when the last reference (via the tensor/array reference chain) is
+                # released.  Always unlink the name so /dev/shm is not leaked.
+                try:
+                    shm.close()
+                except Exception:
+                    pass
                 try:
                     shm.unlink()
                 except Exception:

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -156,13 +156,11 @@ class SharedMemoryConnector(OmniConnectorBase):
             del mv
             try:
                 shm.close()
-            except Exception as e:
-                logger.error(f"Failed to close SHM in _get_data_with_lock: {e}")
+            except Exception:
                 pass
             try:
                 shm.unlink()
-            except Exception as e:
-                logger.error(f"Failed to unlink SHM in _get_data_with_lock: {e}")
+            except Exception:
                 pass
             shm = None
             t_deserialize_end = time.perf_counter()
@@ -192,16 +190,7 @@ class SharedMemoryConnector(OmniConnectorBase):
             return None
         finally:
             if shm is not None:
-                # shm.close() (munmap) may fail with BufferError if the decoded
-                # struct holds memoryview fields that alias shm.buf — this is
-                # expected when the typed decoder returns zero-copy views.  Swallow
-                # the error; the mmap is cleaned up automatically by Python's GC
-                # when the last reference (via the tensor/array reference chain) is
-                # released.  Always unlink the name so /dev/shm is not leaked.
-                try:
-                    shm.close()
-                except Exception:
-                    pass
+                shm.close()
                 try:
                     shm.unlink()
                 except Exception:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -41,18 +41,40 @@ _OMNI_REQUEST_OUTPUT_KEYS = frozenset({"finished", "final_output_type"})
 class OmniMsgpackEncoder:
     """
     This implementation is adapted from vLLM’s MsgpackEncoder.
-    However, zero-copy support has not been implemented yet.
     Handles torch.Tensor, numpy.ndarray, PIL.Image, RequestOutput and
     CompletionOutput by converting them to serializable dict representations.
-    TODO: Enable zero-copy support.
+
+    Encoding is zero-copy for the caller: encode() returns a memoryview into a
+    thread-local bytearray that is reused across calls, avoiding a Python bytes
+    allocation per encode.  Callers that need to persist the result beyond the
+    next encode() call on the same thread must copy (bytes(view)).
     """
 
-    def __init__(self):
-        self.encoder = msgpack.Encoder(enc_hook=self._enc_hook)
+    # Initial per-thread encode buffer size; grows automatically via encode_into.
+    _INITIAL_BUF = 65536
 
-    def encode(self, obj: Any) -> bytes:
-        """Encode an object to bytes."""
-        return self.encoder.encode(obj)
+    def __init__(self):
+        self._local = threading.local()
+
+    def _get_encoder_and_buf(self) -> tuple[msgpack.Encoder, bytearray]:
+        """Return (or lazily create) the thread-local encoder + write buffer."""
+        loc = self._local
+        if not hasattr(loc, "encoder"):
+            loc.encoder = msgpack.Encoder(enc_hook=self._enc_hook)
+            loc.buf = bytearray(self._INITIAL_BUF)
+        return loc.encoder, loc.buf
+
+    def encode(self, obj: Any) -> memoryview:
+        """Encode an object.
+
+        Returns a memoryview into the thread-local buffer — zero allocation.
+        encode_into() truncates buf to the encoded length, so memoryview(buf)
+        is exactly the serialized bytes.  The view is valid until the next
+        encode() call on the same thread.
+        """
+        encoder, buf = self._get_encoder_and_buf()
+        encoder.encode_into(obj, buf)
+        return memoryview(buf)
 
     def _enc_hook(self, obj: Any) -> Any:
         """Custom encoding hook for non-standard types."""
@@ -341,11 +363,13 @@ class OmniMsgpackEncoder:
 class OmniMsgpackDecoder:
     """
     This implementation is adapted from vLLM’s MsgpackDecoder.
-    However, zero-copy support has not been implemented yet.
-
     Automatically reconstructs torch.Tensor, numpy.ndarray, PIL.Image,
     RequestOutput and CompletionOutput from their dict representations.
-    TODO: Enable zero-copy support.
+
+    decode() accepts bytes, bytearray, or memoryview — pass a memoryview of the
+    SHM buffer directly to avoid copying the full payload onto the Python heap.
+    Binary fields (tensor/ndarray data) are copied into bytes by msgspec during
+    decoding, so the input buffer can be released immediately after decode().
     """
 
     def __init__(self):
@@ -636,8 +660,13 @@ class OmniSerde:
         self.encoder = OmniMsgpackEncoder()
         self.decoder = OmniMsgpackDecoder()
 
-    def serialize(self, obj: Any) -> bytes:
-        """Serialize an object to bytes."""
+    def serialize(self, obj: Any) -> memoryview:
+        """Serialize an object.
+
+        Returns a memoryview into a thread-local buffer — zero allocation.
+        Valid until the next serialize() call on the same thread; callers that
+        need to persist the result must copy: bytes(view).
+        """
         return self.encoder.encode(obj)
 
     def deserialize(self, data: bytes | bytearray | memoryview) -> Any:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+import os
+import threading
+import time
 from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from typing import Any
@@ -11,6 +15,10 @@ import torch
 from msgspec import msgpack
 from PIL import Image
 from vllm.outputs import CompletionOutput, RequestOutput
+
+PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
+PROFILE = PROFILE_ENV != "0"
+_PID = os.getpid()
 
 # Type markers for custom serialization
 _TENSOR_MARKER = "__tensor__"
@@ -84,40 +92,121 @@ class OmniMsgpackEncoder:
     def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode torch.Tensor to dict."""
         t = tensor.detach().cpu()
+        start = time.perf_counter()
         # Handle 0-dimensional (scalar) tensors by reshaping to 1D first
+        called_reshape = False
+        called_contiguous = False
         if t.dim() == 0:
+            called_reshape = True
             t = t.reshape(1)
         if not t.is_contiguous():
+            called_contiguous = True
             t = t.contiguous()
         t = t.view(torch.uint8)
+        data = t.numpy().tobytes()
+        end = time.perf_counter()
+
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_encode_tensor",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "dtype": str(tensor.dtype).removeprefix("torch."),
+                            "shape": list(tensor.shape),
+                            "nbytes": tensor.nbytes,
+                            "device": str(tensor.device),
+                            "called_reshape": called_reshape,
+                            "called_contiguous": called_contiguous,
+                        },
+                    }
+                ),
+            )
+
         return {
             _TENSOR_MARKER: True,
             "dtype": str(tensor.dtype).removeprefix("torch."),
             "shape": list(tensor.shape),
-            "data": t.numpy().tobytes(),
+            "data": data,
         }
 
     def _encode_ndarray(self, arr: np.ndarray) -> dict[str, Any]:
         """Encode numpy.ndarray to dict."""
+        start = time.perf_counter()
+        called_contiguous = False
         if not arr.flags.c_contiguous:
+            called_contiguous = True
             arr = np.ascontiguousarray(arr)
+        data = arr.tobytes()
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_encode_ndarray",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "dtype": arr.dtype.str,
+                            "shape": list(arr.shape),
+                            "nbytes": arr.nbytes,
+                            "called_contiguous": called_contiguous,
+                        },
+                    }
+                ),
+            )
         return {
             _NDARRAY_MARKER: True,
             "dtype": arr.dtype.str,
             "shape": list(arr.shape),
-            "data": arr.tobytes(),
+            "data": data,
         }
 
     def _encode_pil_image(self, img: Image.Image) -> dict[str, Any]:
         """Encode PIL.Image to dict."""
+        start = time.perf_counter()
+        called_contiguous = False
         arr = np.asarray(img, dtype=np.uint8)
         if not arr.flags.c_contiguous:
+            called_contiguous = True
             arr = np.ascontiguousarray(arr)
+        data = arr.tobytes()
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_encode_pil_image",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "mode": img.mode,
+                            "shape": list(arr.shape),
+                            "nbytes": arr.nbytes,
+                            "called_contiguous": called_contiguous,
+                        },
+                    }
+                ),
+            )
         return {
             _PIL_IMAGE_MARKER: True,
             "mode": img.mode,
             "shape": list(arr.shape),
-            "data": arr.tobytes(),
+            "data": data,
         }
 
     def _encode_request_output(self, obj: RequestOutput) -> dict[str, Any]:
@@ -126,6 +215,7 @@ class OmniMsgpackEncoder:
         RequestOutput is not a dataclass, so we manually extract its attributes.
         Also handles dynamically added 'multimodal_output' attribute.
         """
+        start = time.perf_counter()
         # msgspec can serialize CompletionOutput dataclasses directly, but it
         # drops dynamic fields such as multimodal_output. Encode them manually
         # to preserve multimodal payloads across IPC.
@@ -158,10 +248,31 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_encode_request_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "request_id": obj.request_id,
+                            "num_outputs": len(obj.outputs),
+                            "has_multimodal_output": mm_output is not None,
+                        },
+                    }
+                ),
+            )
         return result
 
     def _encode_completion_output(self, obj: CompletionOutput) -> dict[str, Any]:
         """Encode CompletionOutput to dict, preserving multimodal payloads."""
+        start = time.perf_counter()
         result = asdict(obj)
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
@@ -170,6 +281,24 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_encode_completion_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "has_multimodal_output": mm_output is not None,
+                        },
+                    }
+                ),
+            )
         return result
 
 
@@ -257,18 +386,39 @@ class OmniMsgpackDecoder:
         """
         from vllm_omni.outputs import OmniRequestOutput
 
+        start = time.perf_counter()
         try:
             # Use msgspec.convert for dataclass reconstruction
-            return msgspec.convert(obj, OmniRequestOutput)
+            result = msgspec.convert(obj, OmniRequestOutput)
         except Exception:
             try:
                 # Fallback: construct directly if msgspec.convert fails
                 # (e.g., if some fields are missing or have wrong types)
-                return OmniRequestOutput(**obj)
+                result = OmniRequestOutput(**obj)
             except Exception:
                 # If both attempts fail, return dict as-is (defensive fallback)
                 # This should rarely happen if _is_omni_request_output is correct
-                return obj
+                result = obj
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_omni_request_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "finished": obj.get("finished"),
+                            "final_output_type": obj.get("final_output_type"),
+                        },
+                    }
+                ),
+            )
+        return result
 
     def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
         """Decode dict to torch.Tensor."""
@@ -276,35 +426,120 @@ class OmniMsgpackDecoder:
         shape = obj["shape"]
         data = obj["data"]
 
+        start = time.perf_counter()
         torch_dtype = getattr(torch, dtype_str)
         if not data:
-            return torch.empty(shape, dtype=torch_dtype)
-
-        buffer = bytearray(data) if isinstance(data, (bytes, memoryview)) else data
-        arr = torch.frombuffer(buffer, dtype=torch.uint8)
-        return arr.view(torch_dtype).reshape(shape)
+            result = torch.empty(shape, dtype=torch_dtype)
+        else:
+            buffer = bytearray(data) if isinstance(data, (bytes, memoryview)) else data
+            arr = torch.frombuffer(buffer, dtype=torch.uint8)
+            result = arr.view(torch_dtype).reshape(shape)
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_tensor",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "dtype": dtype_str,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
+                        },
+                    }
+                ),
+            )
+        return result
 
     def _decode_ndarray(self, obj: dict[str, Any]) -> np.ndarray:
         """Decode dict to numpy.ndarray."""
         dtype = obj["dtype"]
         shape = obj["shape"]
         data = obj["data"]
-        return np.frombuffer(data, dtype=dtype).reshape(shape)
+        start = time.perf_counter()
+        result = np.frombuffer(data, dtype=dtype).reshape(shape)
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_ndarray",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "dtype": dtype,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
+                        },
+                    }
+                ),
+            )
+        return result
 
     def _decode_pil_image(self, obj: dict[str, Any]) -> Image.Image:
         """Decode dict to PIL.Image."""
         mode = obj["mode"]
         shape = obj["shape"]
         data = obj["data"]
+        start = time.perf_counter()
         arr = np.frombuffer(data, dtype=np.uint8).reshape(shape)
-        return Image.fromarray(arr, mode=mode)
+        result = Image.fromarray(arr, mode=mode)
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_pil_image",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "mode": mode,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
+                        },
+                    }
+                ),
+            )
+        return result
 
     def _decode_completion_output(self, obj: dict[str, Any]) -> CompletionOutput:
         """Decode dict to CompletionOutput using msgspec.convert."""
         mm_output = obj.pop("multimodal_output", None)
+        start = time.perf_counter()
         co = msgspec.convert(obj, CompletionOutput)
         if mm_output is not None:
             setattr(co, "multimodal_output", mm_output)
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_completion_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "has_multimodal_output": mm_output is not None,
+                        },
+                    }
+                ),
+            )
         return co
 
     def _decode_request_output(self, obj: dict[str, Any]) -> RequestOutput:
@@ -322,6 +557,7 @@ class OmniMsgpackDecoder:
         mm_output = obj.pop("multimodal_output", None)
         multi_modal_placeholders = obj.pop("multi_modal_placeholders", None)
 
+        start = time.perf_counter()
         ro = RequestOutput(**obj)
 
         # Restore dynamic attributes that are not part of __init__.
@@ -329,6 +565,26 @@ class OmniMsgpackDecoder:
             setattr(ro, "multi_modal_placeholders", multi_modal_placeholders)
         if mm_output is not None:
             setattr(ro, "multimodal_output", mm_output)
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_request_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "request_id": obj.get("request_id"),
+                            "num_outputs": len(obj.get("outputs", [])),
+                            "has_multimodal_output": mm_output is not None,
+                        },
+                    }
+                ),
+            )
         return ro
 
 

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -22,6 +22,7 @@ _PID = os.getpid()
 
 # Type markers for custom serialization
 _TENSOR_MARKER = "__tensor__"
+_SCALAR_TENSOR_MARKER = "__scalar_tensor__"
 _NDARRAY_MARKER = "__ndarray__"
 _PIL_IMAGE_MARKER = "__pil_image__"
 
@@ -55,8 +56,10 @@ class OmniMsgpackEncoder:
 
     def _enc_hook(self, obj: Any) -> Any:
         """Custom encoding hook for non-standard types."""
-        # torch.Tensor
+        # torch.Tensor — single-element tensors skip the heavy encode path
         if isinstance(obj, torch.Tensor):
+            if obj.numel() == 1:
+                return self._encode_scalar_tensor(obj)
             return self._encode_tensor(obj)
 
         # numpy.ndarray (exclude object/void dtypes)
@@ -83,27 +86,50 @@ class OmniMsgpackEncoder:
         if isinstance(obj, slice):
             return (obj.start, obj.stop, obj.step)
 
+        # byte-like objects — modern msgspec encodes memoryview/bytearray natively
+        # as msgpack bin without reaching this hook; this is a compatibility fallback.
+        if isinstance(obj, (memoryview, bytearray)):
+            return bytes(obj)
+
         raise TypeError(
             f"Object of type {type(obj).__name__} is not serializable. "
             "Supported types: torch.Tensor, np.ndarray, PIL.Image, dataclass, "
             "RequestOutput, and standard Python types (dict, list, str, int, float, bool, None, bytes)."
         )
 
+    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
+        """Encode a single-element tensor as a Python scalar — avoids detach/cpu/view/numpy overhead."""
+        return {
+            _SCALAR_TENSOR_MARKER: True,
+            "dtype": str(tensor.dtype).removeprefix("torch."),
+            "shape": list(tensor.shape),
+            "value": tensor.item(),
+        }
+
     def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode torch.Tensor to dict."""
-        t = tensor.detach().cpu()
-        start = time.perf_counter()
-        # Handle 0-dimensional (scalar) tensors by reshaping to 1D first
         called_reshape = False
         called_contiguous = False
+
+        start = time.perf_counter()
+
+        t = tensor.detach()
+
+        # Perform contiguous on GPU if possible
+        if not t.is_contiguous():
+            t = t.contiguous()
+            called_contiguous = True
+
+        t = t.cpu()
+
+        # Handle 0-dimensional (scalar) tensors by reshaping to 1D first
         if t.dim() == 0:
             called_reshape = True
             t = t.reshape(1)
-        if not t.is_contiguous():
-            called_contiguous = True
-            t = t.contiguous()
+
         t = t.view(torch.uint8)
-        data = t.numpy().tobytes()
+        data = memoryview(t.numpy())
+
         end = time.perf_counter()
 
         if PROFILE:
@@ -138,12 +164,16 @@ class OmniMsgpackEncoder:
 
     def _encode_ndarray(self, arr: np.ndarray) -> dict[str, Any]:
         """Encode numpy.ndarray to dict."""
-        start = time.perf_counter()
         called_contiguous = False
+
+        start = time.perf_counter()
+
         if not arr.flags.c_contiguous:
-            called_contiguous = True
             arr = np.ascontiguousarray(arr)
-        data = arr.tobytes()
+            called_contiguous = True
+
+        data = memoryview(arr)
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -165,6 +195,7 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
+
         return {
             _NDARRAY_MARKER: True,
             "dtype": arr.dtype.str,
@@ -174,14 +205,19 @@ class OmniMsgpackEncoder:
 
     def _encode_pil_image(self, img: Image.Image) -> dict[str, Any]:
         """Encode PIL.Image to dict."""
-        start = time.perf_counter()
         called_contiguous = False
+
+        start = time.perf_counter()
+
         arr = np.asarray(img, dtype=np.uint8)
         if not arr.flags.c_contiguous:
-            called_contiguous = True
             arr = np.ascontiguousarray(arr)
-        data = arr.tobytes()
+            called_contiguous = True
+
+        data = memoryview(arr)
+
         end = time.perf_counter()
+
         if PROFILE:
             print(
                 "SHM_PROFILE",
@@ -324,6 +360,8 @@ class OmniMsgpackDecoder:
         """Recursively restore tensor/ndarray/image/RequestOutput/OmniRequestOutput from their dict representations."""
         if isinstance(obj, dict):
             # Check for type markers first
+            if obj.get(_SCALAR_TENSOR_MARKER):
+                return self._decode_scalar_tensor(obj)
             if obj.get(_TENSOR_MARKER):
                 return self._decode_tensor(obj)
             if obj.get(_NDARRAY_MARKER):
@@ -420,6 +458,10 @@ class OmniMsgpackDecoder:
             )
         return result
 
+    def _decode_scalar_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
+        """Decode a scalar-encoded tensor back to a torch.Tensor."""
+        return torch.tensor(obj["value"], dtype=getattr(torch, obj["dtype"])).reshape(obj["shape"])
+
     def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
         """Decode dict to torch.Tensor."""
         dtype_str = obj["dtype"]
@@ -431,8 +473,7 @@ class OmniMsgpackDecoder:
         if not data:
             result = torch.empty(shape, dtype=torch_dtype)
         else:
-            buffer = bytearray(data) if isinstance(data, (bytes, memoryview)) else data
-            arr = torch.frombuffer(buffer, dtype=torch.uint8)
+            arr = torch.frombuffer(data, dtype=torch.uint8)
             result = arr.view(torch_dtype).reshape(shape)
         end = time.perf_counter()
         if PROFILE:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -20,6 +20,12 @@ PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
 PROFILE = PROFILE_ENV != "0"
 _PID = os.getpid()
 
+# Type markers for custom serialization
+_TENSOR_MARKER = "__tensor__"
+_SCALAR_TENSOR_MARKER = "__scalar_tensor__"
+_NDARRAY_MARKER = "__ndarray__"
+_PIL_IMAGE_MARKER = "__pil_image__"
+
 # Keys that identify a RequestOutput dict (for reconstruction)
 _REQUEST_OUTPUT_KEYS = frozenset({"request_id", "prompt", "prompt_token_ids", "outputs", "finished"})
 
@@ -30,65 +36,6 @@ _COMPLETION_OUTPUT_KEYS = frozenset({"index", "text", "token_ids", "finish_reaso
 # OmniRequestOutput has 'final_output_type' which is unique, or can be identified by
 # having 'finished' and ('images' or 'final_output_type')
 _OMNI_REQUEST_OUTPUT_KEYS = frozenset({"finished", "final_output_type"})
-
-
-class ScalarTensorPayload(msgspec.Struct, tag=True):
-    """PyTorch tensor payload specialized to avoid overhead for scalar tensors."""
-
-    dtype: str
-    shape: list[int]
-    value: float | int | bool  # tensor.item() returns bool/int/float depending on dtype
-
-
-class TensorPayload(msgspec.Struct, tag=True):
-    """PyTorch tensor payload."""
-
-    dtype: str
-    shape: list[int]
-    data: memoryview
-
-
-class NdarrayPayload(msgspec.Struct, tag=True):
-    """NumPy ndarray payload."""
-
-    dtype: str
-    shape: list[int]
-    data: memoryview
-
-
-class ImagePayload(msgspec.Struct, tag=True):
-    """PIL image payload."""
-
-    mode: str
-    shape: list[int]
-    data: memoryview
-
-
-class SlicePayload(msgspec.Struct, tag=True):
-    """Slice object payload."""
-
-    start: int | None
-    stop: int | None
-    step: int | None
-
-
-class BytesPayload(msgspec.Struct, tag=True):
-    """Bytes payload."""
-
-    payload: bytes
-
-
-# TODO: add type hint
-class DictPayload(msgspec.Struct, tag=True):
-    """Fallback payload for encoding arbitrary dict-shaped data."""
-
-    # Need to wrap dict in a tagged Struct to enable tagged union optimizations
-    payload: dict[str, Any]
-
-
-OmniConnectorPayload = (
-    ScalarTensorPayload | TensorPayload | NdarrayPayload | ImagePayload | BytesPayload | SlicePayload | DictPayload
-)
 
 
 class OmniMsgpackEncoder:
@@ -126,25 +73,10 @@ class OmniMsgpackEncoder:
         encode() call on the same thread.
         """
         encoder, buf = self._get_encoder_and_buf()
-        # Native msgspec types bypass enc_hook and produce untagged roots.
-        # The typed decoder requires a tagged root.
-        #
-        # - Plain dict: wrap directly.
-        # - Untagged msgspec.Struct (e.g. OmniPayloadStruct, _StructBase subclasses):
-        #   extract fields into a plain dict preserving the original Python values,
-        #   then wrap.  Field values that are tensors/ndarrays will go through
-        #   enc_hook when msgspec encodes the DictPayload, so no special handling
-        #   is needed.  We cannot use msgspec.to_builtins() here because it cannot
-        #   convert torch.Tensor or numpy.ndarray.
-        if isinstance(obj, dict):
-            obj = DictPayload(obj)
-        elif isinstance(obj, msgspec.Struct) and not isinstance(obj, OmniConnectorPayload.__args__):
-            fields_dict = {fi.name: getattr(obj, fi.name) for fi in msgspec.structs.fields(obj)}
-            obj = DictPayload(fields_dict)
         encoder.encode_into(obj, buf)
         return memoryview(buf)
 
-    def _enc_hook(self, obj: Any) -> OmniConnectorPayload:
+    def _enc_hook(self, obj: Any) -> Any:
         """Custom encoding hook for non-standard types."""
         # torch.Tensor — single-element tensors skip the heavy encode path
         if isinstance(obj, torch.Tensor):
@@ -160,15 +92,6 @@ class OmniMsgpackEncoder:
         if isinstance(obj, Image.Image):
             return self._encode_pil_image(obj)
 
-        # byte-like objects — modern msgspec encodes memoryview/bytearray natively
-        # as msgpack bin without reaching this hook; this is a compatibility fallback.
-        if isinstance(obj, (memoryview, bytearray)):
-            return BytesPayload(bytes(obj))
-
-        # slice
-        if isinstance(obj, slice):
-            return SlicePayload(start=obj.start, stop=obj.stop, step=obj.step)
-
         # RequestOutput (not a dataclass, needs special handling)
         if isinstance(obj, RequestOutput):
             return self._encode_request_output(obj)
@@ -179,7 +102,16 @@ class OmniMsgpackEncoder:
 
         # Other dataclasses
         if is_dataclass(obj) and not isinstance(obj, type):
-            return DictPayload(asdict(obj))
+            return asdict(obj)
+
+        # slice
+        if isinstance(obj, slice):
+            return (obj.start, obj.stop, obj.step)
+
+        # byte-like objects — modern msgspec encodes memoryview/bytearray natively
+        # as msgpack bin without reaching this hook; this is a compatibility fallback.
+        if isinstance(obj, (memoryview, bytearray)):
+            return bytes(obj)
 
         raise TypeError(
             f"Object of type {type(obj).__name__} is not serializable. "
@@ -187,14 +119,16 @@ class OmniMsgpackEncoder:
             "RequestOutput, and standard Python types (dict, list, str, int, float, bool, None, bytes)."
         )
 
-    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> ScalarTensorPayload:
+    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode a single-element tensor as a Python scalar — avoids detach/cpu/view/numpy overhead."""
-        tensor = tensor.detach().cpu()
-        return ScalarTensorPayload(
-            dtype=str(tensor.dtype).removeprefix("torch."), shape=list(tensor.shape), value=tensor.item()
-        )
+        return {
+            _SCALAR_TENSOR_MARKER: True,
+            "dtype": str(tensor.dtype).removeprefix("torch."),
+            "shape": list(tensor.shape),
+            "value": tensor.item(),
+        }
 
-    def _encode_tensor(self, tensor: torch.Tensor) -> TensorPayload:
+    def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode torch.Tensor to dict."""
         called_reshape = False
         called_contiguous = False
@@ -243,13 +177,14 @@ class OmniMsgpackEncoder:
                 ),
             )
 
-        return TensorPayload(
-            dtype=str(tensor.dtype).removeprefix("torch."),
-            shape=list(tensor.shape),
-            data=data,
-        )
+        return {
+            _TENSOR_MARKER: True,
+            "dtype": str(tensor.dtype).removeprefix("torch."),
+            "shape": list(tensor.shape),
+            "data": data,
+        }
 
-    def _encode_ndarray(self, arr: np.ndarray) -> NdarrayPayload:
+    def _encode_ndarray(self, arr: np.ndarray) -> dict[str, Any]:
         """Encode numpy.ndarray to dict."""
         called_contiguous = False
 
@@ -283,13 +218,14 @@ class OmniMsgpackEncoder:
                 ),
             )
 
-        return NdarrayPayload(
-            dtype=arr.dtype.str,
-            shape=list(arr.shape),
-            data=data,
-        )
+        return {
+            _NDARRAY_MARKER: True,
+            "dtype": arr.dtype.str,
+            "shape": list(arr.shape),
+            "data": data,
+        }
 
-    def _encode_pil_image(self, img: Image.Image) -> ImagePayload:
+    def _encode_pil_image(self, img: Image.Image) -> dict[str, Any]:
         """Encode PIL.Image to dict."""
         called_contiguous = False
 
@@ -324,14 +260,14 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
+        return {
+            _PIL_IMAGE_MARKER: True,
+            "mode": img.mode,
+            "shape": list(arr.shape),
+            "data": data,
+        }
 
-        return ImagePayload(
-            mode=img.mode,
-            shape=list(arr.shape),
-            data=data,
-        )
-
-    def _encode_request_output(self, obj: RequestOutput) -> DictPayload:
+    def _encode_request_output(self, obj: RequestOutput) -> dict[str, Any]:
         """Encode RequestOutput to dict.
 
         RequestOutput is not a dataclass, so we manually extract its attributes.
@@ -367,10 +303,9 @@ class OmniMsgpackEncoder:
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
             if isinstance(mm_output, Mapping):
-                result["multimodal_output"] = DictPayload(dict(mm_output))
+                result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
-
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -391,22 +326,19 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
+        return result
 
-        return DictPayload(result)
-
-    def _encode_completion_output(self, obj: CompletionOutput) -> DictPayload:
+    def _encode_completion_output(self, obj: CompletionOutput) -> dict[str, Any]:
         """Encode CompletionOutput to dict, preserving multimodal payloads."""
         start = time.perf_counter()
-
         result = asdict(obj)
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
             # Convert MultimodalPayload to plain dict for wire format
             if isinstance(mm_output, Mapping):
-                result["multimodal_output"] = DictPayload(dict(mm_output))
+                result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
-
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -425,8 +357,7 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
-
-        return DictPayload(result)
+        return result
 
 
 class OmniMsgpackDecoder:
@@ -442,100 +373,132 @@ class OmniMsgpackDecoder:
     """
 
     def __init__(self):
-        # Typed decoder: the root is always an OmniConnectorPayload (the encoder
-        # wraps plain dicts in DictPayload).  Binary fields (TensorPayload.data
-        # etc.) are decoded as memoryview objects that ALIAS the input buffer.
-        # When decoding from SHM, the connector must not munmap the SHM segment
-        # while objects derived from the payload (tensors, arrays) are still alive.
-        # See SharedMemoryConnector._get_data_with_lock for the lifetime contract.
-        self.decoder = msgpack.Decoder(OmniConnectorPayload)
+        self.decoder = msgpack.Decoder()
 
     def decode(self, data: Buffer) -> Any:
         """Decode bytes to object."""
-        try:
-            return self._post_process(self.decoder.decode(data))
-        except msgspec.DecodeError:
-            # Root is not a tagged OmniConnectorPayload — most likely a bare
-            # msgspec.Struct (e.g. OmniPayloadStruct) which msgspec encodes
-            # natively as an untagged map without calling enc_hook.  Fall back
-            # to a generic decode and let _post_process handle the plain dict.
-            return self._post_process(msgpack.decode(data))
+        result = self.decoder.decode(data)
+        return self._post_process(result)
 
     def _post_process(self, obj: Any) -> Any:
-        """Recursively restore typed objects from their wire representations."""
-        # Root-level Struct instances from the typed decoder — direct dispatch.
-        if isinstance(obj, ScalarTensorPayload):
-            return self._decode_scalar_tensor(obj)
-        if isinstance(obj, TensorPayload):
-            return self._decode_tensor(obj)
-        if isinstance(obj, NdarrayPayload):
-            return self._decode_ndarray(obj)
-        if isinstance(obj, ImagePayload):
-            return self._decode_pil_image(obj)
-        if isinstance(obj, SlicePayload):
-            return slice(obj.start, obj.stop, obj.step)
-        if isinstance(obj, BytesPayload):
-            return obj.payload
-        if isinstance(obj, DictPayload):
-            return self._post_process_dict(obj.payload)
-
-        # Nested raw values from DictPayload.payload (typed as Any by msgspec).
+        """Recursively restore tensor/ndarray/image/RequestOutput/OmniRequestOutput from their dict representations."""
         if isinstance(obj, dict):
-            return self._post_process_dict(obj)
+            # Check for type markers first
+            if obj.get(_SCALAR_TENSOR_MARKER):
+                return self._decode_scalar_tensor(obj)
+            if obj.get(_TENSOR_MARKER):
+                return self._decode_tensor(obj)
+            if obj.get(_NDARRAY_MARKER):
+                return self._decode_ndarray(obj)
+            if obj.get(_PIL_IMAGE_MARKER):
+                return self._decode_pil_image(obj)
+
+            # Process values recursively first
+            processed = {k: self._post_process(v) for k, v in obj.items()}
+
+            # Check if this looks like an OmniRequestOutput (check before RequestOutput
+            # since OmniRequestOutput may also have some RequestOutput-like fields)
+            if self._is_omni_request_output(processed):
+                return self._decode_omni_request_output(processed)
+
+            # Check if this looks like a RequestOutput
+            if _REQUEST_OUTPUT_KEYS.issubset(processed.keys()):
+                return self._decode_request_output(processed)
+
+            # Check if this looks like a CompletionOutput
+            if _COMPLETION_OUTPUT_KEYS.issubset(processed.keys()):
+                return self._decode_completion_output(processed)
+
+            return processed
+
         if isinstance(obj, list):
             return [self._post_process(item) for item in obj]
+
         if isinstance(obj, tuple):
             return tuple(self._post_process(item) for item in obj)
+
         return obj
 
-    def _post_process_dict(self, d: dict) -> Any:
-        """Process the values of a plain dict and reconstruct typed objects."""
-        processed = {k: self._convert_value(v) for k, v in d.items()}
+    def _is_omni_request_output(self, obj: dict[str, Any]) -> bool:
+        """Check if a dict looks like an OmniRequestOutput.
 
-        # Heuristic reconstruction of complex types not represented as tagged structs.
-        if self._is_omni_request_output(processed):
-            return self._decode_omni_request_output(processed)
-        if _REQUEST_OUTPUT_KEYS.issubset(processed.keys()):
-            return self._decode_request_output(processed)
-        if _COMPLETION_OUTPUT_KEYS.issubset(processed.keys()):
-            return self._decode_completion_output(processed)
-        return processed
-
-    def _convert_value(self, v: Any) -> Any:
-        """Convert a single value from DictPayload.payload.
-
-        Uses msgspec.convert for tagged dicts so nested payloads (tensors,
-        images, nested DictPayloads, etc.) are reconstructed with type
-        validation rather than heuristic string matching.
+        OmniRequestOutput can be identified by:
+        - Having 'finished' and 'final_output_type' fields (unique to OmniRequestOutput)
+        - OR having 'finished' and 'images' fields (diffusion mode)
         """
-        if isinstance(v, dict):
-            if "type" in v:
-                try:
-                    return self._post_process(msgspec.convert(v, OmniConnectorPayload, strict=False))
-                except msgspec.ValidationError:
-                    pass
-            return self._post_process_dict(v)
-        if isinstance(v, list):
-            return [self._convert_value(item) for item in v]
-        return v
+        # Must have 'finished' field
+        if "finished" not in obj:
+            return False
 
-    # --- Struct-typed decode methods (primary path with typed decoder) ---
+        # Check for unique identifier: 'final_output_type'
+        if "final_output_type" in obj:
+            return True
 
-    def _decode_scalar_tensor(self, payload: ScalarTensorPayload) -> torch.Tensor:
-        """Decode a scalar-encoded tensor back to a torch.Tensor."""
-        return torch.tensor(payload.value, dtype=getattr(torch, payload.dtype)).reshape(payload.shape)
+        # Alternative: check for 'images' field (diffusion mode)
+        if "images" in obj:
+            return True
 
-    def _decode_tensor(self, payload: TensorPayload) -> torch.Tensor:
-        """Decode dict to torch.Tensor."""
+        return False
+
+    def _decode_omni_request_output(self, obj: dict[str, Any]) -> Any:
+        """Decode dict to OmniRequestOutput.
+
+        OmniRequestOutput is a dataclass, so we can use msgspec.convert
+        or construct it directly.
+        """
+        from vllm_omni.outputs import OmniRequestOutput
+
         start = time.perf_counter()
+        try:
+            # Use msgspec.convert for dataclass reconstruction
+            result = msgspec.convert(obj, OmniRequestOutput)
+        except Exception:
+            try:
+                # Fallback: construct directly if msgspec.convert fails
+                # (e.g., if some fields are missing or have wrong types)
+                result = OmniRequestOutput(**obj)
+            except Exception:
+                # If both attempts fail, return dict as-is (defensive fallback)
+                # This should rarely happen if _is_omni_request_output is correct
+                result = obj
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_omni_request_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "finished": obj.get("finished"),
+                            "final_output_type": obj.get("final_output_type"),
+                        },
+                    }
+                ),
+            )
+        return result
 
-        torch_dtype = getattr(torch, payload.dtype)
-        if not payload.data:
-            result = torch.empty(payload.shape, dtype=torch_dtype)
+    def _decode_scalar_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
+        """Decode a scalar-encoded tensor back to a torch.Tensor."""
+        return torch.tensor(obj["value"], dtype=getattr(torch, obj["dtype"])).reshape(obj["shape"])
+
+    def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
+        """Decode dict to torch.Tensor."""
+        dtype_str = obj["dtype"]
+        shape = obj["shape"]
+        data = obj["data"]
+
+        start = time.perf_counter()
+        torch_dtype = getattr(torch, dtype_str)
+        if not data:
+            result = torch.empty(shape, dtype=torch_dtype)
         else:
-            arr = torch.frombuffer(payload.data, dtype=torch.uint8)
-            result = arr.view(torch_dtype).reshape(payload.shape)
-
+            arr = torch.frombuffer(data, dtype=torch.uint8)
+            result = arr.view(torch_dtype).reshape(shape)
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -549,22 +512,22 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "dtype": payload.dtype,
-                            "shape": payload.shape,
-                            "nbytes": len(payload.data) if payload.data else 0,
+                            "dtype": dtype_str,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
                         },
                     }
                 ),
             )
-
         return result
 
-    def _decode_ndarray(self, payload: NdarrayPayload) -> np.ndarray:
+    def _decode_ndarray(self, obj: dict[str, Any]) -> np.ndarray:
         """Decode dict to numpy.ndarray."""
+        dtype = obj["dtype"]
+        shape = obj["shape"]
+        data = obj["data"]
         start = time.perf_counter()
-
-        result = np.frombuffer(payload.data, dtype=payload.dtype).reshape(payload.shape)
-
+        result = np.frombuffer(data, dtype=dtype).reshape(shape)
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -578,23 +541,23 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "dtype": payload.dtype,
-                            "shape": payload.shape,
-                            "nbytes": len(payload.data) if payload.data else 0,
+                            "dtype": dtype,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
                         },
                     }
                 ),
             )
-
         return result
 
-    def _decode_pil_image(self, payload: ImagePayload) -> Image.Image:
+    def _decode_pil_image(self, obj: dict[str, Any]) -> Image.Image:
         """Decode dict to PIL.Image."""
+        mode = obj["mode"]
+        shape = obj["shape"]
+        data = obj["data"]
         start = time.perf_counter()
-
-        arr = np.frombuffer(payload.data, dtype=np.uint8).reshape(payload.shape)
-        result = Image.fromarray(arr, mode=payload.mode)
-
+        arr = np.frombuffer(data, dtype=np.uint8).reshape(shape)
+        result = Image.fromarray(arr, mode=mode)
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -608,14 +571,13 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "mode": payload.mode,
-                            "shape": payload.shape,
-                            "nbytes": len(payload.data) if payload.data else 0,
+                            "mode": mode,
+                            "shape": shape,
+                            "nbytes": len(data) if data else 0,
                         },
                     }
                 ),
             )
-
         return result
 
     def _decode_completion_output(self, obj: dict[str, Any]) -> CompletionOutput:
@@ -689,65 +651,6 @@ class OmniMsgpackDecoder:
                 ),
             )
         return ro
-
-    def _is_omni_request_output(self, obj: dict[str, Any]) -> bool:
-        """Check if a dict looks like an OmniRequestOutput.
-
-        OmniRequestOutput can be identified by:
-        - Having 'finished' and 'final_output_type' fields (unique to OmniRequestOutput)
-        - OR having 'finished' and 'images' fields (diffusion mode)
-        """
-        # Must have 'finished' field
-        if "finished" not in obj:
-            return False
-
-        # Check for unique identifier: 'final_output_type'
-        if "final_output_type" in obj:
-            return True
-
-        # Alternative: check for 'images' field (diffusion mode)
-        if "images" in obj:
-            return True
-
-        return False
-
-    def _decode_omni_request_output(self, obj: dict[str, Any]) -> Any:
-        """Decode dict to OmniRequestOutput.
-
-        OmniRequestOutput is a dataclass, so we can use msgspec.convert
-        or construct it directly.
-        """
-        from vllm_omni.outputs import OmniRequestOutput
-
-        start = time.perf_counter()
-        try:
-            # The dict contains already-reconstructed Python objects (tensors,
-            # ndarrays, etc.) so msgspec.convert won't work here — go straight
-            # to direct construction.
-            result = OmniRequestOutput(**obj)
-        except Exception:
-            # If construction fails, return dict as-is (defensive fallback)
-            result = obj
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_omni_request_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "finished": obj.get("finished"),
-                            "final_output_type": obj.get("final_output_type"),
-                        },
-                    }
-                ),
-            )
-        return result
 
 
 class OmniSerde:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -5,7 +5,7 @@ import json
 import os
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Buffer, Mapping
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
@@ -375,7 +375,7 @@ class OmniMsgpackDecoder:
     def __init__(self):
         self.decoder = msgpack.Decoder()
 
-    def decode(self, data: bytes | bytearray | memoryview) -> Any:
+    def decode(self, data: Buffer) -> Any:
         """Decode bytes to object."""
         result = self.decoder.decode(data)
         return self._post_process(result)
@@ -660,16 +660,26 @@ class OmniSerde:
         self.encoder = OmniMsgpackEncoder()
         self.decoder = OmniMsgpackDecoder()
 
-    def serialize(self, obj: Any) -> memoryview:
+    def serialize(self, obj: Any) -> bytes:
         """Serialize an object.
 
+        This method allocates a bytes object from the buffer that the serializer
+        writes to, making it safe for general use.
+        """
+        return bytes(self.encoder.encode(obj))
+
+    def serialize_view(self, obj: Any) -> memoryview:
+        """Serialize an object into a memoryview.
+
         Returns a memoryview into a thread-local buffer — zero allocation.
-        Valid until the next serialize() call on the same thread; callers that
-        need to persist the result must copy: bytes(view).
+        Valid until the next serialize operation on the same thread.
+
+        If you need the object beyond this lifetime, use the serialize() method
+        instead.
         """
         return self.encoder.encode(obj)
 
-    def deserialize(self, data: bytes | bytearray | memoryview) -> Any:
+    def deserialize(self, data: Buffer) -> Any:
         """Deserialize bytes to an object."""
         return self.decoder.decode(data)
 

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -37,7 +37,7 @@ class ScalarTensorPayload(msgspec.Struct, tag=True):
 
     dtype: str
     shape: list[int]
-    value: float  # torch will truncate floats to integers on decode
+    value: float | int | bool  # tensor.item() returns bool/int/float depending on dtype
 
 
 class TensorPayload(msgspec.Struct, tag=True):
@@ -126,6 +126,21 @@ class OmniMsgpackEncoder:
         encode() call on the same thread.
         """
         encoder, buf = self._get_encoder_and_buf()
+        # Native msgspec types bypass enc_hook and produce untagged roots.
+        # The typed decoder requires a tagged root.
+        #
+        # - Plain dict: wrap directly.
+        # - Untagged msgspec.Struct (e.g. OmniPayloadStruct, _StructBase subclasses):
+        #   extract fields into a plain dict preserving the original Python values,
+        #   then wrap.  Field values that are tensors/ndarrays will go through
+        #   enc_hook when msgspec encodes the DictPayload, so no special handling
+        #   is needed.  We cannot use msgspec.to_builtins() here because it cannot
+        #   convert torch.Tensor or numpy.ndarray.
+        if isinstance(obj, dict):
+            obj = DictPayload(obj)
+        elif isinstance(obj, msgspec.Struct) and not isinstance(obj, OmniConnectorPayload.__args__):
+            fields_dict = {fi.name: getattr(obj, fi.name) for fi in msgspec.structs.fields(obj)}
+            obj = DictPayload(fields_dict)
         encoder.encode_into(obj, buf)
         return memoryview(buf)
 
@@ -165,10 +180,6 @@ class OmniMsgpackEncoder:
         # Other dataclasses
         if is_dataclass(obj) and not isinstance(obj, type):
             return DictPayload(asdict(obj))
-
-        # dict
-        if isinstance(obj, dict):
-            return DictPayload(obj)
 
         raise TypeError(
             f"Object of type {type(obj).__name__} is not serializable. "
@@ -356,7 +367,7 @@ class OmniMsgpackEncoder:
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
             if isinstance(mm_output, Mapping):
-                result["multimodal_output"] = dict(mm_output)
+                result["multimodal_output"] = DictPayload(dict(mm_output))
             else:
                 result["multimodal_output"] = mm_output
 
@@ -392,7 +403,7 @@ class OmniMsgpackEncoder:
         if mm_output is not None:
             # Convert MultimodalPayload to plain dict for wire format
             if isinstance(mm_output, Mapping):
-                result["multimodal_output"] = dict(mm_output)
+                result["multimodal_output"] = DictPayload(dict(mm_output))
             else:
                 result["multimodal_output"] = mm_output
 
@@ -431,149 +442,84 @@ class OmniMsgpackDecoder:
     """
 
     def __init__(self):
-        # Generic decoder: binary fields decode to bytes (copied, not referenced),
-        # so the input SHM buffer can be safely unmapped after decode() returns.
-        # A typed decoder (msgpack.Decoder(OmniConnectorPayload)) would return
-        # memoryview fields that alias the input buffer, causing BufferError on
-        # shm.close(), and would reject untagged root dicts with "missing field
-        # 'type'".  Tag-string dispatch in _post_process handles the Struct types.
-        self.decoder = msgpack.Decoder()
+        # Typed decoder: the root is always an OmniConnectorPayload (the encoder
+        # wraps plain dicts in DictPayload).  Binary fields (TensorPayload.data
+        # etc.) are decoded as memoryview objects that ALIAS the input buffer.
+        # When decoding from SHM, the connector must not munmap the SHM segment
+        # while objects derived from the payload (tensors, arrays) are still alive.
+        # See SharedMemoryConnector._get_data_with_lock for the lifetime contract.
+        self.decoder = msgpack.Decoder(OmniConnectorPayload)
 
     def decode(self, data: Buffer) -> Any:
         """Decode bytes to object."""
-        payload = self.decoder.decode(data)
-        return self._post_process(payload)
+        try:
+            return self._post_process(self.decoder.decode(data))
+        except msgspec.DecodeError:
+            # Root is not a tagged OmniConnectorPayload — most likely a bare
+            # msgspec.Struct (e.g. OmniPayloadStruct) which msgspec encodes
+            # natively as an untagged map without calling enc_hook.  Fall back
+            # to a generic decode and let _post_process handle the plain dict.
+            return self._post_process(msgpack.decode(data))
 
     def _post_process(self, obj: Any) -> Any:
         """Recursively restore typed objects from their wire representations."""
+        # Root-level Struct instances from the typed decoder — direct dispatch.
+        if isinstance(obj, ScalarTensorPayload):
+            return self._decode_scalar_tensor(obj)
+        if isinstance(obj, TensorPayload):
+            return self._decode_tensor(obj)
+        if isinstance(obj, NdarrayPayload):
+            return self._decode_ndarray(obj)
+        if isinstance(obj, ImagePayload):
+            return self._decode_pil_image(obj)
+        if isinstance(obj, SlicePayload):
+            return slice(obj.start, obj.stop, obj.step)
+        if isinstance(obj, BytesPayload):
+            return obj.payload
+        if isinstance(obj, DictPayload):
+            return self._post_process_dict(obj.payload)
+
+        # Nested raw values from DictPayload.payload (typed as Any by msgspec).
         if isinstance(obj, dict):
-            # Tagged-struct format: dispatch on the msgspec Struct tag field.
-            type_tag = obj.get("type")
-            if type_tag is not None:
-                if type_tag == "ScalarTensorPayload":
-                    return self._decode_scalar_tensor_dict(obj)
-                if type_tag == "TensorPayload":
-                    return self._decode_tensor_dict(obj)
-                if type_tag == "NdarrayPayload":
-                    return self._decode_ndarray_dict(obj)
-                if type_tag == "ImagePayload":
-                    return self._decode_pil_image_dict(obj)
-                if type_tag == "SlicePayload":
-                    return slice(obj["start"], obj["stop"], obj["step"])
-                if type_tag == "BytesPayload":
-                    return obj["payload"]
-                if type_tag == "DictPayload":
-                    return self._post_process(obj["payload"])
-                # Unknown tag: fall through to generic dict processing.
-
-            # Process values recursively first
-            processed = {k: self._post_process(v) for k, v in obj.items()}
-
-            # Check if this looks like an OmniRequestOutput (check before RequestOutput
-            # since OmniRequestOutput may also have some RequestOutput-like fields)
-            if self._is_omni_request_output(processed):
-                return self._decode_omni_request_output(processed)
-
-            # Check if this looks like a RequestOutput
-            if _REQUEST_OUTPUT_KEYS.issubset(processed.keys()):
-                return self._decode_request_output(processed)
-
-            # Check if this looks like a CompletionOutput
-            if _COMPLETION_OUTPUT_KEYS.issubset(processed.keys()):
-                return self._decode_completion_output(processed)
-
-            return processed
-
+            return self._post_process_dict(obj)
         if isinstance(obj, list):
             return [self._post_process(item) for item in obj]
-
         if isinstance(obj, tuple):
             return tuple(self._post_process(item) for item in obj)
-
         return obj
 
-    def _is_omni_request_output(self, obj: dict[str, Any]) -> bool:
-        """Check if a dict looks like an OmniRequestOutput.
+    def _post_process_dict(self, d: dict) -> Any:
+        """Process the values of a plain dict and reconstruct typed objects."""
+        processed = {k: self._convert_value(v) for k, v in d.items()}
 
-        OmniRequestOutput can be identified by:
-        - Having 'finished' and 'final_output_type' fields (unique to OmniRequestOutput)
-        - OR having 'finished' and 'images' fields (diffusion mode)
+        # Heuristic reconstruction of complex types not represented as tagged structs.
+        if self._is_omni_request_output(processed):
+            return self._decode_omni_request_output(processed)
+        if _REQUEST_OUTPUT_KEYS.issubset(processed.keys()):
+            return self._decode_request_output(processed)
+        if _COMPLETION_OUTPUT_KEYS.issubset(processed.keys()):
+            return self._decode_completion_output(processed)
+        return processed
+
+    def _convert_value(self, v: Any) -> Any:
+        """Convert a single value from DictPayload.payload.
+
+        Uses msgspec.convert for tagged dicts so nested payloads (tensors,
+        images, nested DictPayloads, etc.) are reconstructed with type
+        validation rather than heuristic string matching.
         """
-        # Must have 'finished' field
-        if "finished" not in obj:
-            return False
+        if isinstance(v, dict):
+            if "type" in v:
+                try:
+                    return self._post_process(msgspec.convert(v, OmniConnectorPayload, strict=False))
+                except msgspec.ValidationError:
+                    pass
+            return self._post_process_dict(v)
+        if isinstance(v, list):
+            return [self._convert_value(item) for item in v]
+        return v
 
-        # Check for unique identifier: 'final_output_type'
-        if "final_output_type" in obj:
-            return True
-
-        # Alternative: check for 'images' field (diffusion mode)
-        if "images" in obj:
-            return True
-
-        return False
-
-    def _decode_omni_request_output(self, obj: dict[str, Any]) -> Any:
-        """Decode dict to OmniRequestOutput.
-
-        OmniRequestOutput is a dataclass, so we can use msgspec.convert
-        or construct it directly.
-        """
-        from vllm_omni.outputs import OmniRequestOutput
-
-        start = time.perf_counter()
-        try:
-            # The dict contains already-reconstructed Python objects (tensors,
-            # ndarrays, etc.) so msgspec.convert won't work here — go straight
-            # to direct construction.
-            result = OmniRequestOutput(**obj)
-        except Exception:
-            # If construction fails, return dict as-is (defensive fallback)
-            result = obj
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_omni_request_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "finished": obj.get("finished"),
-                            "final_output_type": obj.get("final_output_type"),
-                        },
-                    }
-                ),
-            )
-        return result
-
-    # --- dict-based helpers (generic decoder returns raw dicts, not Struct instances) ---
-
-    def _decode_scalar_tensor_dict(self, obj: dict) -> torch.Tensor:
-        return torch.tensor(obj["value"], dtype=getattr(torch, obj["dtype"])).reshape(obj["shape"])
-
-    def _decode_tensor_dict(self, obj: dict) -> torch.Tensor:
-        dtype_str, shape, data = obj["dtype"], obj["shape"], obj["data"]
-        torch_dtype = getattr(torch, dtype_str)
-        if not data:
-            return torch.empty(shape, dtype=torch_dtype)
-        # Copy into bytearray is necessary as the tensor may be mutated, aliasing the memoryview
-        buffer = bytearray(data) if isinstance(data, bytes | memoryview) else data
-        arr = torch.frombuffer(buffer, dtype=torch.uint8)
-        return arr.view(torch_dtype).reshape(shape)
-
-    def _decode_ndarray_dict(self, obj: dict) -> np.ndarray:
-        return np.frombuffer(obj["data"], dtype=obj["dtype"]).reshape(obj["shape"])
-
-    def _decode_pil_image_dict(self, obj: dict) -> Image.Image:
-        arr = np.frombuffer(obj["data"], dtype=np.uint8).reshape(obj["shape"])
-        return Image.fromarray(arr, mode=obj["mode"])
-
-    # --- Struct-typed helpers (kept for direct use if a typed decoder is re-introduced) ---
+    # --- Struct-typed decode methods (primary path with typed decoder) ---
 
     def _decode_scalar_tensor(self, payload: ScalarTensorPayload) -> torch.Tensor:
         """Decode a scalar-encoded tensor back to a torch.Tensor."""
@@ -743,6 +689,65 @@ class OmniMsgpackDecoder:
                 ),
             )
         return ro
+
+    def _is_omni_request_output(self, obj: dict[str, Any]) -> bool:
+        """Check if a dict looks like an OmniRequestOutput.
+
+        OmniRequestOutput can be identified by:
+        - Having 'finished' and 'final_output_type' fields (unique to OmniRequestOutput)
+        - OR having 'finished' and 'images' fields (diffusion mode)
+        """
+        # Must have 'finished' field
+        if "finished" not in obj:
+            return False
+
+        # Check for unique identifier: 'final_output_type'
+        if "final_output_type" in obj:
+            return True
+
+        # Alternative: check for 'images' field (diffusion mode)
+        if "images" in obj:
+            return True
+
+        return False
+
+    def _decode_omni_request_output(self, obj: dict[str, Any]) -> Any:
+        """Decode dict to OmniRequestOutput.
+
+        OmniRequestOutput is a dataclass, so we can use msgspec.convert
+        or construct it directly.
+        """
+        from vllm_omni.outputs import OmniRequestOutput
+
+        start = time.perf_counter()
+        try:
+            # The dict contains already-reconstructed Python objects (tensors,
+            # ndarrays, etc.) so msgspec.convert won't work here — go straight
+            # to direct construction.
+            result = OmniRequestOutput(**obj)
+        except Exception:
+            # If construction fails, return dict as-is (defensive fallback)
+            result = obj
+        end = time.perf_counter()
+        if PROFILE:
+            print(
+                "SHM_PROFILE",
+                json.dumps(
+                    {
+                        "name": "_decode_omni_request_output",
+                        "ph": "X",
+                        "ts": start * 1_000_000,
+                        "dur": (end - start) * 1_000_000,
+                        "pid": _PID,
+                        "tid": threading.get_ident(),
+                        "args": {
+                            "finished": obj.get("finished"),
+                            "final_output_type": obj.get("final_output_type"),
+                        },
+                    }
+                ),
+            )
+        return result
 
 
 class OmniSerde:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -20,12 +20,6 @@ PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
 PROFILE = PROFILE_ENV != "0"
 _PID = os.getpid()
 
-# Type markers for custom serialization
-_TENSOR_MARKER = "__tensor__"
-_SCALAR_TENSOR_MARKER = "__scalar_tensor__"
-_NDARRAY_MARKER = "__ndarray__"
-_PIL_IMAGE_MARKER = "__pil_image__"
-
 # Keys that identify a RequestOutput dict (for reconstruction)
 _REQUEST_OUTPUT_KEYS = frozenset({"request_id", "prompt", "prompt_token_ids", "outputs", "finished"})
 
@@ -36,6 +30,65 @@ _COMPLETION_OUTPUT_KEYS = frozenset({"index", "text", "token_ids", "finish_reaso
 # OmniRequestOutput has 'final_output_type' which is unique, or can be identified by
 # having 'finished' and ('images' or 'final_output_type')
 _OMNI_REQUEST_OUTPUT_KEYS = frozenset({"finished", "final_output_type"})
+
+
+class ScalarTensorPayload(msgspec.Struct, tag=True):
+    """PyTorch tensor payload specialized to avoid overhead for scalar tensors."""
+
+    dtype: str
+    shape: list[int]
+    value: float  # torch will truncate floats to integers on decode
+
+
+class TensorPayload(msgspec.Struct, tag=True):
+    """PyTorch tensor payload."""
+
+    dtype: str
+    shape: list[int]
+    data: memoryview
+
+
+class NdarrayPayload(msgspec.Struct, tag=True):
+    """NumPy ndarray payload."""
+
+    dtype: str
+    shape: list[int]
+    data: memoryview
+
+
+class ImagePayload(msgspec.Struct, tag=True):
+    """PIL image payload."""
+
+    mode: str
+    shape: list[int]
+    data: memoryview
+
+
+class SlicePayload(msgspec.Struct, tag=True):
+    """Slice object payload."""
+
+    start: int | None
+    stop: int | None
+    step: int | None
+
+
+class BytesPayload(msgspec.Struct, tag=True):
+    """Bytes payload."""
+
+    payload: bytes
+
+
+# TODO: add type hint
+class DictPayload(msgspec.Struct, tag=True):
+    """Fallback payload for encoding arbitrary dict-shaped data."""
+
+    # Need to wrap dict in a tagged Struct to enable tagged union optimizations
+    payload: dict[str, Any]
+
+
+OmniConnectorPayload = (
+    ScalarTensorPayload | TensorPayload | NdarrayPayload | ImagePayload | BytesPayload | SlicePayload | DictPayload
+)
 
 
 class OmniMsgpackEncoder:
@@ -76,7 +129,7 @@ class OmniMsgpackEncoder:
         encoder.encode_into(obj, buf)
         return memoryview(buf)
 
-    def _enc_hook(self, obj: Any) -> Any:
+    def _enc_hook(self, obj: Any) -> OmniConnectorPayload:
         """Custom encoding hook for non-standard types."""
         # torch.Tensor — single-element tensors skip the heavy encode path
         if isinstance(obj, torch.Tensor):
@@ -92,6 +145,15 @@ class OmniMsgpackEncoder:
         if isinstance(obj, Image.Image):
             return self._encode_pil_image(obj)
 
+        # byte-like objects — modern msgspec encodes memoryview/bytearray natively
+        # as msgpack bin without reaching this hook; this is a compatibility fallback.
+        if isinstance(obj, (memoryview, bytearray)):
+            return BytesPayload(bytes(obj))
+
+        # slice
+        if isinstance(obj, slice):
+            return SlicePayload(start=obj.start, stop=obj.stop, step=obj.step)
+
         # RequestOutput (not a dataclass, needs special handling)
         if isinstance(obj, RequestOutput):
             return self._encode_request_output(obj)
@@ -102,16 +164,11 @@ class OmniMsgpackEncoder:
 
         # Other dataclasses
         if is_dataclass(obj) and not isinstance(obj, type):
-            return asdict(obj)
+            return DictPayload(asdict(obj))
 
-        # slice
-        if isinstance(obj, slice):
-            return (obj.start, obj.stop, obj.step)
-
-        # byte-like objects — modern msgspec encodes memoryview/bytearray natively
-        # as msgpack bin without reaching this hook; this is a compatibility fallback.
-        if isinstance(obj, (memoryview, bytearray)):
-            return bytes(obj)
+        # dict
+        if isinstance(obj, dict):
+            return DictPayload(obj)
 
         raise TypeError(
             f"Object of type {type(obj).__name__} is not serializable. "
@@ -119,16 +176,14 @@ class OmniMsgpackEncoder:
             "RequestOutput, and standard Python types (dict, list, str, int, float, bool, None, bytes)."
         )
 
-    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
+    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> ScalarTensorPayload:
         """Encode a single-element tensor as a Python scalar — avoids detach/cpu/view/numpy overhead."""
-        return {
-            _SCALAR_TENSOR_MARKER: True,
-            "dtype": str(tensor.dtype).removeprefix("torch."),
-            "shape": list(tensor.shape),
-            "value": tensor.item(),
-        }
+        tensor = tensor.detach().cpu()
+        return ScalarTensorPayload(
+            dtype=str(tensor.dtype).removeprefix("torch."), shape=list(tensor.shape), value=tensor.item()
+        )
 
-    def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
+    def _encode_tensor(self, tensor: torch.Tensor) -> TensorPayload:
         """Encode torch.Tensor to dict."""
         called_reshape = False
         called_contiguous = False
@@ -177,14 +232,13 @@ class OmniMsgpackEncoder:
                 ),
             )
 
-        return {
-            _TENSOR_MARKER: True,
-            "dtype": str(tensor.dtype).removeprefix("torch."),
-            "shape": list(tensor.shape),
-            "data": data,
-        }
+        return TensorPayload(
+            dtype=str(tensor.dtype).removeprefix("torch."),
+            shape=list(tensor.shape),
+            data=data,
+        )
 
-    def _encode_ndarray(self, arr: np.ndarray) -> dict[str, Any]:
+    def _encode_ndarray(self, arr: np.ndarray) -> NdarrayPayload:
         """Encode numpy.ndarray to dict."""
         called_contiguous = False
 
@@ -218,14 +272,13 @@ class OmniMsgpackEncoder:
                 ),
             )
 
-        return {
-            _NDARRAY_MARKER: True,
-            "dtype": arr.dtype.str,
-            "shape": list(arr.shape),
-            "data": data,
-        }
+        return NdarrayPayload(
+            dtype=arr.dtype.str,
+            shape=list(arr.shape),
+            data=data,
+        )
 
-    def _encode_pil_image(self, img: Image.Image) -> dict[str, Any]:
+    def _encode_pil_image(self, img: Image.Image) -> ImagePayload:
         """Encode PIL.Image to dict."""
         called_contiguous = False
 
@@ -260,14 +313,14 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
-        return {
-            _PIL_IMAGE_MARKER: True,
-            "mode": img.mode,
-            "shape": list(arr.shape),
-            "data": data,
-        }
 
-    def _encode_request_output(self, obj: RequestOutput) -> dict[str, Any]:
+        return ImagePayload(
+            mode=img.mode,
+            shape=list(arr.shape),
+            data=data,
+        )
+
+    def _encode_request_output(self, obj: RequestOutput) -> DictPayload:
         """Encode RequestOutput to dict.
 
         RequestOutput is not a dataclass, so we manually extract its attributes.
@@ -306,6 +359,7 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -326,11 +380,13 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
-        return result
 
-    def _encode_completion_output(self, obj: CompletionOutput) -> dict[str, Any]:
+        return DictPayload(result)
+
+    def _encode_completion_output(self, obj: CompletionOutput) -> DictPayload:
         """Encode CompletionOutput to dict, preserving multimodal payloads."""
         start = time.perf_counter()
+
         result = asdict(obj)
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
@@ -339,6 +395,7 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -357,7 +414,8 @@ class OmniMsgpackEncoder:
                     }
                 ),
             )
-        return result
+
+        return DictPayload(result)
 
 
 class OmniMsgpackDecoder:
@@ -373,25 +431,40 @@ class OmniMsgpackDecoder:
     """
 
     def __init__(self):
+        # Generic decoder: binary fields decode to bytes (copied, not referenced),
+        # so the input SHM buffer can be safely unmapped after decode() returns.
+        # A typed decoder (msgpack.Decoder(OmniConnectorPayload)) would return
+        # memoryview fields that alias the input buffer, causing BufferError on
+        # shm.close(), and would reject untagged root dicts with "missing field
+        # 'type'".  Tag-string dispatch in _post_process handles the Struct types.
         self.decoder = msgpack.Decoder()
 
     def decode(self, data: Buffer) -> Any:
         """Decode bytes to object."""
-        result = self.decoder.decode(data)
-        return self._post_process(result)
+        payload = self.decoder.decode(data)
+        return self._post_process(payload)
 
     def _post_process(self, obj: Any) -> Any:
-        """Recursively restore tensor/ndarray/image/RequestOutput/OmniRequestOutput from their dict representations."""
+        """Recursively restore typed objects from their wire representations."""
         if isinstance(obj, dict):
-            # Check for type markers first
-            if obj.get(_SCALAR_TENSOR_MARKER):
-                return self._decode_scalar_tensor(obj)
-            if obj.get(_TENSOR_MARKER):
-                return self._decode_tensor(obj)
-            if obj.get(_NDARRAY_MARKER):
-                return self._decode_ndarray(obj)
-            if obj.get(_PIL_IMAGE_MARKER):
-                return self._decode_pil_image(obj)
+            # Tagged-struct format: dispatch on the msgspec Struct tag field.
+            type_tag = obj.get("type")
+            if type_tag is not None:
+                if type_tag == "ScalarTensorPayload":
+                    return self._decode_scalar_tensor_dict(obj)
+                if type_tag == "TensorPayload":
+                    return self._decode_tensor_dict(obj)
+                if type_tag == "NdarrayPayload":
+                    return self._decode_ndarray_dict(obj)
+                if type_tag == "ImagePayload":
+                    return self._decode_pil_image_dict(obj)
+                if type_tag == "SlicePayload":
+                    return slice(obj["start"], obj["stop"], obj["step"])
+                if type_tag == "BytesPayload":
+                    return obj["payload"]
+                if type_tag == "DictPayload":
+                    return self._post_process(obj["payload"])
+                # Unknown tag: fall through to generic dict processing.
 
             # Process values recursively first
             processed = {k: self._post_process(v) for k, v in obj.items()}
@@ -450,17 +523,13 @@ class OmniMsgpackDecoder:
 
         start = time.perf_counter()
         try:
-            # Use msgspec.convert for dataclass reconstruction
-            result = msgspec.convert(obj, OmniRequestOutput)
+            # The dict contains already-reconstructed Python objects (tensors,
+            # ndarrays, etc.) so msgspec.convert won't work here — go straight
+            # to direct construction.
+            result = OmniRequestOutput(**obj)
         except Exception:
-            try:
-                # Fallback: construct directly if msgspec.convert fails
-                # (e.g., if some fields are missing or have wrong types)
-                result = OmniRequestOutput(**obj)
-            except Exception:
-                # If both attempts fail, return dict as-is (defensive fallback)
-                # This should rarely happen if _is_omni_request_output is correct
-                result = obj
+            # If construction fails, return dict as-is (defensive fallback)
+            result = obj
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -482,23 +551,45 @@ class OmniMsgpackDecoder:
             )
         return result
 
-    def _decode_scalar_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
-        """Decode a scalar-encoded tensor back to a torch.Tensor."""
+    # --- dict-based helpers (generic decoder returns raw dicts, not Struct instances) ---
+
+    def _decode_scalar_tensor_dict(self, obj: dict) -> torch.Tensor:
         return torch.tensor(obj["value"], dtype=getattr(torch, obj["dtype"])).reshape(obj["shape"])
 
-    def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
-        """Decode dict to torch.Tensor."""
-        dtype_str = obj["dtype"]
-        shape = obj["shape"]
-        data = obj["data"]
-
-        start = time.perf_counter()
+    def _decode_tensor_dict(self, obj: dict) -> torch.Tensor:
+        dtype_str, shape, data = obj["dtype"], obj["shape"], obj["data"]
         torch_dtype = getattr(torch, dtype_str)
         if not data:
-            result = torch.empty(shape, dtype=torch_dtype)
+            return torch.empty(shape, dtype=torch_dtype)
+        # Copy into bytearray is necessary as the tensor may be mutated, aliasing the memoryview
+        buffer = bytearray(data) if isinstance(data, bytes | memoryview) else data
+        arr = torch.frombuffer(buffer, dtype=torch.uint8)
+        return arr.view(torch_dtype).reshape(shape)
+
+    def _decode_ndarray_dict(self, obj: dict) -> np.ndarray:
+        return np.frombuffer(obj["data"], dtype=obj["dtype"]).reshape(obj["shape"])
+
+    def _decode_pil_image_dict(self, obj: dict) -> Image.Image:
+        arr = np.frombuffer(obj["data"], dtype=np.uint8).reshape(obj["shape"])
+        return Image.fromarray(arr, mode=obj["mode"])
+
+    # --- Struct-typed helpers (kept for direct use if a typed decoder is re-introduced) ---
+
+    def _decode_scalar_tensor(self, payload: ScalarTensorPayload) -> torch.Tensor:
+        """Decode a scalar-encoded tensor back to a torch.Tensor."""
+        return torch.tensor(payload.value, dtype=getattr(torch, payload.dtype)).reshape(payload.shape)
+
+    def _decode_tensor(self, payload: TensorPayload) -> torch.Tensor:
+        """Decode dict to torch.Tensor."""
+        start = time.perf_counter()
+
+        torch_dtype = getattr(torch, payload.dtype)
+        if not payload.data:
+            result = torch.empty(payload.shape, dtype=torch_dtype)
         else:
-            arr = torch.frombuffer(data, dtype=torch.uint8)
-            result = arr.view(torch_dtype).reshape(shape)
+            arr = torch.frombuffer(payload.data, dtype=torch.uint8)
+            result = arr.view(torch_dtype).reshape(payload.shape)
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -512,22 +603,22 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "dtype": dtype_str,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
+                            "dtype": payload.dtype,
+                            "shape": payload.shape,
+                            "nbytes": len(payload.data) if payload.data else 0,
                         },
                     }
                 ),
             )
+
         return result
 
-    def _decode_ndarray(self, obj: dict[str, Any]) -> np.ndarray:
+    def _decode_ndarray(self, payload: NdarrayPayload) -> np.ndarray:
         """Decode dict to numpy.ndarray."""
-        dtype = obj["dtype"]
-        shape = obj["shape"]
-        data = obj["data"]
         start = time.perf_counter()
-        result = np.frombuffer(data, dtype=dtype).reshape(shape)
+
+        result = np.frombuffer(payload.data, dtype=payload.dtype).reshape(payload.shape)
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -541,23 +632,23 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "dtype": dtype,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
+                            "dtype": payload.dtype,
+                            "shape": payload.shape,
+                            "nbytes": len(payload.data) if payload.data else 0,
                         },
                     }
                 ),
             )
+
         return result
 
-    def _decode_pil_image(self, obj: dict[str, Any]) -> Image.Image:
+    def _decode_pil_image(self, payload: ImagePayload) -> Image.Image:
         """Decode dict to PIL.Image."""
-        mode = obj["mode"]
-        shape = obj["shape"]
-        data = obj["data"]
         start = time.perf_counter()
-        arr = np.frombuffer(data, dtype=np.uint8).reshape(shape)
-        result = Image.fromarray(arr, mode=mode)
+
+        arr = np.frombuffer(payload.data, dtype=np.uint8).reshape(payload.shape)
+        result = Image.fromarray(arr, mode=payload.mode)
+
         end = time.perf_counter()
         if PROFILE:
             print(
@@ -571,13 +662,14 @@ class OmniMsgpackDecoder:
                         "pid": _PID,
                         "tid": threading.get_ident(),
                         "args": {
-                            "mode": mode,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
+                            "mode": payload.mode,
+                            "shape": payload.shape,
+                            "nbytes": len(payload.data) if payload.data else 0,
                         },
                     }
                 ),
             )
+
         return result
 
     def _decode_completion_output(self, obj: dict[str, Any]) -> CompletionOutput:

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -22,7 +22,6 @@ _PID = os.getpid()
 
 # Type markers for custom serialization
 _TENSOR_MARKER = "__tensor__"
-_SCALAR_TENSOR_MARKER = "__scalar_tensor__"
 _NDARRAY_MARKER = "__ndarray__"
 _PIL_IMAGE_MARKER = "__pil_image__"
 
@@ -84,8 +83,6 @@ class OmniMsgpackEncoder:
         """Custom encoding hook for non-standard types."""
         # torch.Tensor — single-element tensors skip the heavy encode path
         if isinstance(obj, torch.Tensor):
-            if obj.numel() == 1:
-                return self._encode_scalar_tensor(obj)
             return self._encode_tensor(obj)
 
         # numpy.ndarray (exclude object/void dtypes)
@@ -122,15 +119,6 @@ class OmniMsgpackEncoder:
             "Supported types: torch.Tensor, np.ndarray, PIL.Image, dataclass, "
             "RequestOutput, and standard Python types (dict, list, str, int, float, bool, None, bytes)."
         )
-
-    def _encode_scalar_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
-        """Encode a single-element tensor as a Python scalar — avoids detach/cpu/view/numpy overhead."""
-        return {
-            _SCALAR_TENSOR_MARKER: True,
-            "dtype": str(tensor.dtype).removeprefix("torch."),
-            "shape": list(tensor.shape),
-            "value": tensor.item(),
-        }
 
     def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode torch.Tensor to dict."""
@@ -388,8 +376,6 @@ class OmniMsgpackDecoder:
         """Recursively restore tensor/ndarray/image/RequestOutput/OmniRequestOutput from their dict representations."""
         if isinstance(obj, dict):
             # Check for type markers first
-            if obj.get(_SCALAR_TENSOR_MARKER):
-                return self._decode_scalar_tensor(obj)
             if obj.get(_TENSOR_MARKER):
                 return self._decode_tensor(obj)
             if obj.get(_NDARRAY_MARKER):
@@ -485,10 +471,6 @@ class OmniMsgpackDecoder:
                 ),
             )
         return result
-
-    def _decode_scalar_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
-        """Decode a scalar-encoded tensor back to a torch.Tensor."""
-        return torch.tensor(obj["value"], dtype=getattr(torch, obj["dtype"])).reshape(obj["shape"])
 
     def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
         """Decode dict to torch.Tensor."""

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import json
-import os
-import threading
-import time
 from collections.abc import Buffer, Mapping
 from dataclasses import asdict, is_dataclass
 from typing import Any
@@ -15,10 +11,6 @@ import torch
 from msgspec import msgpack
 from PIL import Image
 from vllm.outputs import CompletionOutput, RequestOutput
-
-PROFILE_ENV = os.getenv("SHM_PROFILE", "0")
-PROFILE = PROFILE_ENV != "0"
-_PID = os.getpid()
 
 # Type markers for custom serialization
 _TENSOR_MARKER = "__tensor__"
@@ -119,48 +111,16 @@ class OmniMsgpackEncoder:
 
     def _encode_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
         """Encode torch.Tensor to dict."""
-        called_reshape = False
-        called_contiguous = False
-
-        start = time.perf_counter()
-
         t = tensor.detach().cpu()
 
         # Handle 0-dimensional (scalar) tensors by reshaping to 1D first
         if t.dim() == 0:
-            called_reshape = True
             t = t.reshape(1)
         if not t.is_contiguous():
             t = t.contiguous()
-            called_contiguous = True
 
         t = t.view(torch.uint8)
         data = memoryview(t.numpy())
-
-        end = time.perf_counter()
-
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_encode_tensor",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "dtype": str(tensor.dtype).removeprefix("torch."),
-                            "shape": list(tensor.shape),
-                            "nbytes": tensor.nbytes,
-                            "device": str(tensor.device),
-                            "called_reshape": called_reshape,
-                            "called_contiguous": called_contiguous,
-                        },
-                    }
-                ),
-            )
 
         return {
             _TENSOR_MARKER: True,
@@ -171,37 +131,9 @@ class OmniMsgpackEncoder:
 
     def _encode_ndarray(self, arr: np.ndarray) -> dict[str, Any]:
         """Encode numpy.ndarray to dict."""
-        called_contiguous = False
-
-        start = time.perf_counter()
-
         if not arr.flags.c_contiguous:
             arr = np.ascontiguousarray(arr)
-            called_contiguous = True
-
         data = memoryview(arr)
-
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_encode_ndarray",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "dtype": arr.dtype.str,
-                            "shape": list(arr.shape),
-                            "nbytes": arr.nbytes,
-                            "called_contiguous": called_contiguous,
-                        },
-                    }
-                ),
-            )
 
         return {
             _NDARRAY_MARKER: True,
@@ -212,39 +144,11 @@ class OmniMsgpackEncoder:
 
     def _encode_pil_image(self, img: Image.Image) -> dict[str, Any]:
         """Encode PIL.Image to dict."""
-        called_contiguous = False
-
-        start = time.perf_counter()
-
         arr = np.asarray(img, dtype=np.uint8)
         if not arr.flags.c_contiguous:
             arr = np.ascontiguousarray(arr)
-            called_contiguous = True
-
         data = memoryview(arr)
 
-        end = time.perf_counter()
-
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_encode_pil_image",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "mode": img.mode,
-                            "shape": list(arr.shape),
-                            "nbytes": arr.nbytes,
-                            "called_contiguous": called_contiguous,
-                        },
-                    }
-                ),
-            )
         return {
             _PIL_IMAGE_MARKER: True,
             "mode": img.mode,
@@ -258,7 +162,6 @@ class OmniMsgpackEncoder:
         RequestOutput is not a dataclass, so we manually extract its attributes.
         Also handles dynamically added 'multimodal_output' attribute.
         """
-        start = time.perf_counter()
         # msgspec can serialize CompletionOutput dataclasses directly, but it
         # drops dynamic fields such as multimodal_output. Encode them manually
         # to preserve multimodal payloads across IPC.
@@ -291,31 +194,10 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_encode_request_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "request_id": obj.request_id,
-                            "num_outputs": len(obj.outputs),
-                            "has_multimodal_output": mm_output is not None,
-                        },
-                    }
-                ),
-            )
         return result
 
     def _encode_completion_output(self, obj: CompletionOutput) -> dict[str, Any]:
         """Encode CompletionOutput to dict, preserving multimodal payloads."""
-        start = time.perf_counter()
         result = asdict(obj)
         mm_output = getattr(obj, "multimodal_output", None)
         if mm_output is not None:
@@ -324,24 +206,6 @@ class OmniMsgpackEncoder:
                 result["multimodal_output"] = dict(mm_output)
             else:
                 result["multimodal_output"] = mm_output
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_encode_completion_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "has_multimodal_output": mm_output is not None,
-                        },
-                    }
-                ),
-            )
         return result
 
 
@@ -431,7 +295,6 @@ class OmniMsgpackDecoder:
         """
         from vllm_omni.outputs import OmniRequestOutput
 
-        start = time.perf_counter()
         try:
             # Use msgspec.convert for dataclass reconstruction
             result = msgspec.convert(obj, OmniRequestOutput)
@@ -444,25 +307,6 @@ class OmniMsgpackDecoder:
                 # If both attempts fail, return dict as-is (defensive fallback)
                 # This should rarely happen if _is_omni_request_output is correct
                 result = obj
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_omni_request_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "finished": obj.get("finished"),
-                            "final_output_type": obj.get("final_output_type"),
-                        },
-                    }
-                ),
-            )
         return result
 
     def _decode_tensor(self, obj: dict[str, Any]) -> torch.Tensor:
@@ -471,7 +315,6 @@ class OmniMsgpackDecoder:
         shape = obj["shape"]
         data = obj["data"]
 
-        start = time.perf_counter()
         torch_dtype = getattr(torch, dtype_str)
         if not data:
             result = torch.empty(shape, dtype=torch_dtype)
@@ -480,26 +323,6 @@ class OmniMsgpackDecoder:
             buffer = bytearray(data) if isinstance(data, (bytes, memoryview)) else data
             arr = torch.frombuffer(buffer, dtype=torch.uint8)
             result = arr.view(torch_dtype).reshape(shape)
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_tensor",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "dtype": dtype_str,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
-                        },
-                    }
-                ),
-            )
         return result
 
     def _decode_ndarray(self, obj: dict[str, Any]) -> np.ndarray:
@@ -507,28 +330,7 @@ class OmniMsgpackDecoder:
         dtype = obj["dtype"]
         shape = obj["shape"]
         data = obj["data"]
-        start = time.perf_counter()
         result = np.frombuffer(data, dtype=dtype).reshape(shape)
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_ndarray",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "dtype": dtype,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
-                        },
-                    }
-                ),
-            )
         return result
 
     def _decode_pil_image(self, obj: dict[str, Any]) -> Image.Image:
@@ -536,56 +338,16 @@ class OmniMsgpackDecoder:
         mode = obj["mode"]
         shape = obj["shape"]
         data = obj["data"]
-        start = time.perf_counter()
         arr = np.frombuffer(data, dtype=np.uint8).reshape(shape)
         result = Image.fromarray(arr, mode=mode)
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_pil_image",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "mode": mode,
-                            "shape": shape,
-                            "nbytes": len(data) if data else 0,
-                        },
-                    }
-                ),
-            )
         return result
 
     def _decode_completion_output(self, obj: dict[str, Any]) -> CompletionOutput:
         """Decode dict to CompletionOutput using msgspec.convert."""
         mm_output = obj.pop("multimodal_output", None)
-        start = time.perf_counter()
         co = msgspec.convert(obj, CompletionOutput)
         if mm_output is not None:
             setattr(co, "multimodal_output", mm_output)
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_completion_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "has_multimodal_output": mm_output is not None,
-                        },
-                    }
-                ),
-            )
         return co
 
     def _decode_request_output(self, obj: dict[str, Any]) -> RequestOutput:
@@ -603,7 +365,6 @@ class OmniMsgpackDecoder:
         mm_output = obj.pop("multimodal_output", None)
         multi_modal_placeholders = obj.pop("multi_modal_placeholders", None)
 
-        start = time.perf_counter()
         ro = RequestOutput(**obj)
 
         # Restore dynamic attributes that are not part of __init__.
@@ -611,26 +372,6 @@ class OmniMsgpackDecoder:
             setattr(ro, "multi_modal_placeholders", multi_modal_placeholders)
         if mm_output is not None:
             setattr(ro, "multimodal_output", mm_output)
-        end = time.perf_counter()
-        if PROFILE:
-            print(
-                "SHM_PROFILE",
-                json.dumps(
-                    {
-                        "name": "_decode_request_output",
-                        "ph": "X",
-                        "ts": start * 1_000_000,
-                        "dur": (end - start) * 1_000_000,
-                        "pid": _PID,
-                        "tid": threading.get_ident(),
-                        "args": {
-                            "request_id": obj.get("request_id"),
-                            "num_outputs": len(obj.get("outputs", [])),
-                            "has_multimodal_output": mm_output is not None,
-                        },
-                    }
-                ),
-            )
         return ro
 
 

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -44,37 +44,41 @@ class OmniMsgpackEncoder:
     Handles torch.Tensor, numpy.ndarray, PIL.Image, RequestOutput and
     CompletionOutput by converting them to serializable dict representations.
 
-    Encoding is zero-copy for the caller: encode() returns a memoryview into a
-    thread-local bytearray that is reused across calls, avoiding a Python bytes
-    allocation per encode.  Callers that need to persist the result beyond the
-    next encode() call on the same thread must copy (bytes(view)).
+    The encoder instance itself is shared; buffer ownership is left to the
+    caller.  Use encode_into() to write into a caller-owned buffer (e.g. a
+    connector’s thread-local bytearray) for zero-copy paths, or encode() for
+    a one-shot bytearray when convenience matters more than allocation count.
     """
 
-    # Initial per-thread encode buffer size; grows automatically via encode_into.
-    _INITIAL_BUF = 65536
-
     def __init__(self):
-        self._local = threading.local()
+        self.encoder = msgpack.Encoder(enc_hook=self._enc_hook)
 
-    def _get_encoder_and_buf(self) -> tuple[msgpack.Encoder, bytearray]:
-        """Return (or lazily create) the thread-local encoder + write buffer."""
-        loc = self._local
-        if not hasattr(loc, "encoder"):
-            loc.encoder = msgpack.Encoder(enc_hook=self._enc_hook)
-            loc.buf = bytearray(self._INITIAL_BUF)
-        return loc.encoder, loc.buf
+    def encode(self, obj: Any) -> bytes:
+        """Encode obj and return a new bytes object containing the result.
 
-    def encode(self, obj: Any) -> memoryview:
-        """Encode an object.
-
-        Returns a memoryview into the thread-local buffer — zero allocation.
-        encode_into() truncates buf to the encoded length, so memoryview(buf)
-        is exactly the serialized bytes.  The view is valid until the next
-        encode() call on the same thread.
+        Allocates a new bytes object. For a hot path use encode_into() with a
+        pre-allocated caller-owned buffer instead.
         """
-        encoder, buf = self._get_encoder_and_buf()
-        encoder.encode_into(obj, buf)
-        return memoryview(buf)
+        return self.encoder.encode(obj)
+
+    def encode_into(self, obj: Any, buf: bytearray) -> None:
+        """Encode obj into buf in-place.
+
+        buf is grown automatically if the encoded output exceeds its current
+        length, and truncated to the encoded length on success.  The caller
+        owns buf and controls its lifetime; a memoryview(buf) taken after this
+        call is valid as long as no further encode_into call on the same buf
+        occurs (which would resize it and invalidate open exports).
+
+        Thread safety: encode_into() must not be called concurrently on the
+        same OmniMsgpackEncoder instance from multiple threads — the underlying
+        msgpack.Encoder may have internal scratch state that is not protected by
+        the GIL when encoding large binary payloads.  encode() is safe to call
+        concurrently because each call allocates its own output buffer.  In
+        practice encode_into() is only called from the SHM connector's single
+        save_thread, so no additional synchronisation is required today.
+        """
+        self.encoder.encode_into(obj, buf)
 
     def _enc_hook(self, obj: Any) -> Any:
         """Custom encoding hook for non-standard types."""
@@ -661,23 +665,24 @@ class OmniSerde:
         self.decoder = OmniMsgpackDecoder()
 
     def serialize(self, obj: Any) -> bytes:
-        """Serialize an object.
+        """Serialize obj and return an owned bytes object.
 
-        This method allocates a bytes object from the buffer that the serializer
-        writes to, making it safe for general use.
+        Allocates a bytearray, encodes into it, then copies to bytes.  Safe for
+        general use: the result can be stored indefinitely.  One allocation per
+        call; prefer serialize_into() with a caller-owned buffer on hot paths.
         """
         return bytes(self.encoder.encode(obj))
 
-    def serialize_view(self, obj: Any) -> memoryview:
-        """Serialize an object into a memoryview.
+    def serialize_into(self, obj: Any, buf: bytearray) -> None:
+        """Serialize obj into caller-owned buf in-place.
 
-        Returns a memoryview into a thread-local buffer — zero allocation.
-        Valid until the next serialize operation on the same thread.
-
-        If you need the object beyond this lifetime, use the serialize() method
-        instead.
+        buf is grown automatically and truncated to the encoded length on
+        success.  The caller is responsible for buf's lifetime.  Taking a
+        memoryview(buf) after this call gives a zero-copy view of the encoded
+        bytes; that view is only valid until the next serialize_into call on
+        the same buf.
         """
-        return self.encoder.encode(obj)
+        self.encoder.encode_into(obj, buf)
 
     def deserialize(self, data: Buffer) -> Any:
         """Deserialize bytes to an object."""

--- a/vllm_omni/distributed/omni_connectors/utils/serialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/serialization.py
@@ -31,11 +31,6 @@ _REQUEST_OUTPUT_KEYS = frozenset({"request_id", "prompt", "prompt_token_ids", "o
 # Keys that identify a CompletionOutput dict (for reconstruction)
 _COMPLETION_OUTPUT_KEYS = frozenset({"index", "text", "token_ids", "finish_reason"})
 
-# Keys that identify an OmniRequestOutput dict (for reconstruction)
-# OmniRequestOutput has 'final_output_type' which is unique, or can be identified by
-# having 'finished' and ('images' or 'final_output_type')
-_OMNI_REQUEST_OUTPUT_KEYS = frozenset({"finished", "final_output_type"})
-
 
 class OmniMsgpackEncoder:
     """
@@ -73,9 +68,11 @@ class OmniMsgpackEncoder:
         same OmniMsgpackEncoder instance from multiple threads — the underlying
         msgpack.Encoder may have internal scratch state that is not protected by
         the GIL when encoding large binary payloads.  encode() is safe to call
-        concurrently because each call allocates its own output buffer.  In
-        practice encode_into() is only called from the SHM connector's single
-        save_thread, so no additional synchronisation is required today.
+        concurrently because each call allocates its own output buffer.  The
+        caller is responsible for ensuring at most one thread calls encode_into()
+        on a given instance at a time; SharedMemoryConnector upholds this by
+        holding one OmniSerde per connector instance and calling put() from a
+        single thread.
         """
         self.encoder.encode_into(obj, buf)
 
@@ -127,19 +124,15 @@ class OmniMsgpackEncoder:
 
         start = time.perf_counter()
 
-        t = tensor.detach()
-
-        # Perform contiguous on GPU if possible
-        if not t.is_contiguous():
-            t = t.contiguous()
-            called_contiguous = True
-
-        t = t.cpu()
+        t = tensor.detach().cpu()
 
         # Handle 0-dimensional (scalar) tensors by reshaping to 1D first
         if t.dim() == 0:
             called_reshape = True
             t = t.reshape(1)
+        if not t.is_contiguous():
+            t = t.contiguous()
+            called_contiguous = True
 
         t = t.view(torch.uint8)
         data = memoryview(t.numpy())
@@ -483,7 +476,9 @@ class OmniMsgpackDecoder:
         if not data:
             result = torch.empty(shape, dtype=torch_dtype)
         else:
-            arr = torch.frombuffer(data, dtype=torch.uint8)
+            # To prevent undefined behavior when downstream stages mutate the tensor, a copy is necessary.
+            buffer = bytearray(data) if isinstance(data, (bytes, memoryview)) else data
+            arr = torch.frombuffer(buffer, dtype=torch.uint8)
             result = arr.view(torch_dtype).reshape(shape)
         end = time.perf_counter()
         if PROFILE:

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -179,7 +179,7 @@ def serialize_obj(obj: Any) -> bytes:
     return OmniSerializer.serialize(obj)
 
 
-def shm_write_bytes(payload: bytes, name: str | None = None) -> dict[str, Any]:
+def shm_write_bytes(payload: bytes | bytearray | memoryview, name: str | None = None) -> dict[str, Any]:
     """Write bytes into SharedMemory and return meta dict {name,size}.
 
     Caller should close the segment; the receiver should unlink.

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Buffer
 from multiprocessing import shared_memory as _shm
 from typing import Any
 
@@ -179,7 +180,7 @@ def serialize_obj(obj: Any) -> bytes:
     return OmniSerializer.serialize(obj)
 
 
-def shm_write_bytes(payload: bytes | bytearray | memoryview, name: str | None = None) -> dict[str, Any]:
+def shm_write_bytes(payload: Buffer, name: str | None = None) -> dict[str, Any]:
     """Write bytes into SharedMemory and return meta dict {name,size}.
 
     Caller should close the segment; the receiver should unlink.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Optimizations for `SharedMemoryConnector` and `OmniSerializer`. Part of RFC #4796 -- this PR aims to land performance improvements that don't require design work (please see RFC for design discussion).

## Performance

This section was removed because the benchmarks were untrustworthy -- see comment below.

## Test Plan

L1-L2 tests relevant to the SHM connector and serializer.

```bash
# L1
pytest -svm 'core_model and cpu'

# L2
pytest -svm 'core_model and cuda' \
  tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py \
  tests/e2e/online_serving/test_qwen3_tts_base.py \
  tests/e2e/online_serving/test_qwen3_tts_customvoice.py \
  --run-level core_model
```

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** fc0416f

## Test Result

- L1: 3903 passed, 21 skipped, 2033 deselected, 63 warnings in 315.02s (0:05:15)
- L2: 5 passed, 1 deselected, 21 warnings in 1206.95s (0:20:06)

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
