### PR TITLE
[Bugfix] Realign Serving Tokenization Name to Fix Error Handling Routes

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -2530,7 +2530,7 @@ def test_api_server_delete_voice_exception_returns_500(mocker: MockerFixture):
 def test_api_server_create_speech_without_handler_returns_404(mocker: MockerFixture):
     fake_base = _patch_api_server_base(mocker)
     raw_request = _make_api_server_request(None, path="/v1/audio/speech")
-    raw_request.app.state.openai_serving_tokenization = fake_base
+    raw_request.app.state.serving_tokenization = fake_base
     request = OpenAICreateSpeechRequest(input="Hello")
 
     response = asyncio.run(api_server_module.create_speech(request, raw_request))
@@ -2543,7 +2543,7 @@ def test_api_server_create_speech_without_handler_returns_404(mocker: MockerFixt
 def test_api_server_create_speech_batch_without_handler_returns_404(mocker: MockerFixture):
     fake_base = _patch_api_server_base(mocker)
     raw_request = _make_api_server_request(None, path="/v1/audio/speech/batch")
-    raw_request.app.state.openai_serving_tokenization = fake_base
+    raw_request.app.state.serving_tokenization = fake_base
     request = BatchSpeechRequest(items=[SpeechBatchItem(input="hi")])
 
     response = asyncio.run(api_server_module.create_speech_batch(request, raw_request))
@@ -2612,7 +2612,7 @@ def test_api_server_create_audio_generate_without_handler_returns_404(mocker: Mo
     fake_base = _patch_api_server_base(mocker)
     raw_request = _make_api_server_request(None, path="/v1/audio/generate")
     raw_request.app.state.openai_serving_audio_generate = None
-    raw_request.app.state.openai_serving_tokenization = fake_base
+    raw_request.app.state.serving_tokenization = fake_base
     request = OpenAICreateAudioGenerateRequest(input="a bird singing")
 
     response = asyncio.run(api_server_module.create_audio_generate(request, raw_request))

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -751,7 +751,7 @@ async def omni_init_app_state(
         state.diffusion_engine = engine_client
         state.openai_serving_models = _DiffusionServingModels(base_model_paths)
         # OMNI: tokenization endpoints are not supported in pure diffusion mode.
-        state.openai_serving_tokenization = None
+        state.serving_tokenization = None
 
         # Use for_diffusion method to create chat handler
         state.openai_serving_chat = OmniOpenAIServingChat.for_diffusion(
@@ -1014,7 +1014,7 @@ async def omni_init_app_state(
         if any(t in supported_tasks for t in ("embed", "score", "token_embed"))
         else None
     )
-    state.openai_serving_tokenization = ServingTokenization(
+    state.serving_tokenization = ServingTokenization(
         state.openai_serving_models,
         state.openai_serving_render,
         request_logger=request_logger,
@@ -1154,7 +1154,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     metrics_header_format = raw_request.headers.get(ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, "")
     handler = Omnichat(raw_request)
     if handler is None:
-        base_server = getattr(raw_request.app.state, "openai_serving_tokenization", None)
+        base_server = getattr(raw_request.app.state, "serving_tokenization", None)
         if base_server is None:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND.value,
@@ -1245,7 +1245,7 @@ async def create_speech(request: OpenAICreateSpeechRequest, raw_request: Request
     """
     handler = Omnispeech(raw_request)
     if handler is None:
-        base_server = getattr(raw_request.app.state, "openai_serving_tokenization", None)
+        base_server = getattr(raw_request.app.state, "serving_tokenization", None)
         if base_server is None:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND.value,
@@ -1283,7 +1283,7 @@ async def create_speech(request: OpenAICreateSpeechRequest, raw_request: Request
 async def create_speech_batch(request: BatchSpeechRequest, raw_request: Request):
     handler = Omnispeech(raw_request)
     if handler is None:
-        base_server = getattr(raw_request.app.state, "openai_serving_tokenization", None)
+        base_server = getattr(raw_request.app.state, "serving_tokenization", None)
         if base_server is None:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND.value,
@@ -1326,7 +1326,7 @@ async def create_speech_batch(request: BatchSpeechRequest, raw_request: Request)
 async def create_audio_generate(request: OpenAICreateAudioGenerateRequest, raw_request: Request):
     handler = OmniAudioGenerate(raw_request)
     if handler is None:
-        base_server = getattr(raw_request.app.state, "openai_serving_tokenization", None)
+        base_server = getattr(raw_request.app.state, "serving_tokenization", None)
         if base_server is None:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND.value,


### PR DESCRIPTION
## Purpose
There is now a misalignment between vLLM Omni and upstream vLLM in the app state as a result of the recent tokenization entrypoint refactor (https://github.com/vllm-project/vllm/pull/46022/). See `vllm/entrypoints/serve/instrumentator/basic.py`, where 

```python
def base(request: Request) -> OpenAIServing:
    return tokenization(request)

def tokenization(request: Request) -> OpenAIServingTokenization:
    return request.app.state.openai_serving_tokenization
```

has now been changed to
```python
def base(request: Request) -> ServingTokenization:
    return tokenization(request)

def tokenization(request: Request) -> ServingTokenization:
    return request.app.state.serving_tokenization
```

We need to switch Omni from`state.openai_serving_tokenization` -> `state.serving_tokenization`, otherwise calling `base` in the entrypoint will cause caught errors to turn into 500s if they go through `_create_speech_error_json_response`, since it calls that `base`  ([here](https://github.com/vllm-project/vllm-omni/blob/main/vllm_omni/entrypoints/openai/api_server.py#L376)).

You can see an example of this for some cases like the following:
```bash
vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni  --port 8998 
```

Then send a sad request to POST request to `v1/audio/voices`
```bash
 curl -s -X POST http://localhost:8998/v1/audio/voices \
  -F "name=test_voice" \
  -F "consent=test" \
  -F "audio_sample=@/dev/null;type=audio/wav"
```

The trace is pretty long, but you can see the important parts below
```
(APIServer pid=2502274) INFO:     127.0.0.1:40148 - "POST /v1/audio/voices HTTP/1.1" 500 Internal Server Error
...
(APIServer pid=2502274) Traceback (most recent call last):
(APIServer pid=2502274)   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/entrypoints/openai/api_server.py", line 1468, in upload_voice
(APIServer pid=2502274)     result = await handler.upload_voice(
(APIServer pid=2502274)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2502274)   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/entrypoints/openai/serving_speech.py", line 1301, in upload_voice
(APIServer pid=2502274)     raise ValueError(f"Could not decode audio file: {e}")
(APIServer pid=2502274) ValueError: Could not decode audio file: Error opening <_io.BytesIO object at 0x7fb66e71d8a0>: 
....
(APIServer pid=2502274)   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/entrypoints/openai/api_server.py", line 376, in _create_speech_error_json_response
(APIServer pid=2502274)     err = base(raw_request).create_error_response(
(APIServer pid=2502274)           ^^^^^^^^^^^^^^^^^
(APIServer pid=2502274)   File "/home/alex-jw-brooks/venvs/vllm_omni/lib/python3.12/site-packages/vllm/entrypoints/serve/instrumentator/basic.py", line 19, in base
(APIServer pid=2502274)     return tokenization(request)
(APIServer pid=2502274)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2502274)   File "/home/alex-jw-brooks/venvs/vllm_omni/lib/python3.12/site-packages/vllm/entrypoints/serve/instrumentator/basic.py", line 23, in tokenization
(APIServer pid=2502274)     return request.app.state.serving_tokenization
(APIServer pid=2502274)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2502274)   File "/home/alex-jw-brooks/venvs/vllm_omni/lib/python3.12/site-packages/starlette/datastructures.py", line 686, in __getattr__
(APIServer pid=2502274)     raise AttributeError(message.format(self.__class__.__name__, key))
(APIServer pid=2502274) AttributeError: 'State' object has no attribute 'serving_tokenization'
```

This updates the names to realign with the recent refactor, which avoids the AttributeError and keeps things from turning into a 500.