### PR TITLE
[Bugfix][Quant] Gate quack FP8 to datacenter Blackwell (sm_100.x) only

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -44,10 +44,16 @@ pip install vllm-omni[quack]
 pip install 'quack-kernels[cu13]' --extra-index-url https://download.pytorch.org/whl/cu130
 ```
 
-It is enabled automatically once installed (no flag needed) and is **Blackwell-only**:
-on Hopper/Ada the CUTLASS FP8 kernel already fuses bias, so quack is not used there.
-Set `VLLM_OMNI_USE_QUACK_FP8=0` to force the FlashInfer path. If `quack-kernels` is
-not installed, FP8 still works — it just keeps the unfused FlashInfer path.
+It is enabled automatically once installed (no flag needed) and is **datacenter
+Blackwell only** (`sm_100` / `sm_101` / `sm_103`, compute capability `10.x`, e.g.
+B200): quack's CuteDSL GEMM uses the 5th-gen `tcgen05` tensor-core MMA, which exists
+only on those parts. On Hopper/Ada the CUTLASS FP8 kernel already fuses bias, and on
+workstation/consumer Blackwell (`sm_120` / `sm_121`, compute capability `12.x`, e.g.
+RTX PRO 6000 / RTX 50-series) `tcgen05` is absent — so quack is **not** auto-enabled
+there and FlashInfer's native FP8 path is used instead. Set
+`VLLM_OMNI_USE_QUACK_FP8=1` to force quack on, or `VLLM_OMNI_USE_QUACK_FP8=0` to force
+the FlashInfer path. If `quack-kernels` is not installed, FP8 still works — it just
+keeps the unfused FlashInfer path.
 
 #### Compile cache and warmup
 

--- a/tests/quantization/test_quack_fp8_gate.py
+++ b/tests/quantization/test_quack_fp8_gate.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the quack FP8 auto-enable gate.
+
+quack's CuteDSL FP8 GEMM uses the 5th-gen ``tcgen05`` tensor-core MMA, which
+exists only on datacenter Blackwell (``sm_100a`` / ``sm_101a`` / ``sm_103a``,
+compute capability ``10.x``). It must NOT auto-enable on workstation/consumer
+Blackwell (``sm_120`` / ``sm_121``, cc ``12.x``, e.g. RTX PRO 6000 / RTX
+50-series), where ``tcgen05`` is absent and every FP8 GEMM would fall back to
+FlashInfer one call at a time (catastrophically slow). See
+``vllm_omni/quantization/quack_fp8.py``.
+
+Regression guard for the ``>= 10`` gate that matched cc ``12.x`` too. These
+tests are hardware-free: the ``torch.cuda`` probes are monkeypatched, so no GPU
+is required.
+"""
+
+import pytest
+import torch
+
+from vllm_omni.quantization import quack_fp8
+
+_ENV = "VLLM_OMNI_USE_QUACK_FP8"
+
+
+def _fake_cuda(monkeypatch: pytest.MonkeyPatch, capability: tuple[int, int]) -> None:
+    """Pretend a CUDA device with the given (major, minor) capability is present."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: capability)
+
+
+@pytest.mark.parametrize(
+    "capability, expected",
+    [
+        ((10, 0), True),  # sm_100 datacenter Blackwell — tcgen05 present
+        ((10, 3), True),  # sm_103 datacenter Blackwell
+        ((12, 0), False),  # sm_120 workstation Blackwell — the regression
+        ((12, 1), False),  # sm_121 consumer Blackwell
+        ((9, 0), False),  # Hopper — CUTLASS already fuses bias, quack unused
+        ((8, 9), False),  # Ada
+    ],
+)
+def test_auto_enable_only_on_datacenter_blackwell(
+    monkeypatch: pytest.MonkeyPatch,
+    capability: tuple[int, int],
+    expected: bool,
+) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    _fake_cuda(monkeypatch, capability)
+    assert quack_fp8._is_quack_capable() is expected
+    assert quack_fp8.quack_enabled() is expected
+
+
+def test_no_cuda_disables_quack(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert quack_fp8._is_quack_capable() is False
+    assert quack_fp8.quack_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "On"])
+def test_env_override_forces_on_even_on_sm120(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    # sm_120 auto-disables, but an explicit truthy override forces quack on
+    # (e.g. once CuteDSL ships sm_120a support).
+    _fake_cuda(monkeypatch, (12, 0))
+    monkeypatch.setenv(_ENV, value)
+    assert quack_fp8.quack_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_env_override_forces_off_even_on_datacenter_blackwell(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    # sm_100 auto-enables, but an explicit non-truthy override forces quack off.
+    _fake_cuda(monkeypatch, (10, 0))
+    monkeypatch.setenv(_ENV, value)
+    assert quack_fp8.quack_enabled() is False

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -15,11 +15,21 @@ _TRUTHY = {"1", "true", "yes", "on"}
 _gemm_interface = None
 
 
-def _is_blackwell() -> bool:
+def _is_quack_capable() -> bool:
+    """quack's CuteDSL FP8 / block-scaled MMA is built on the 5th-gen tensor-core
+    ``tcgen05`` instruction family, which is datacenter-Blackwell only
+    (``sm_100a`` / ``sm_101a`` / ``sm_103a``, compute capability ``10.x``).
+
+    Workstation/consumer Blackwell (``sm_120`` / ``sm_121``, compute capability
+    ``12.x``, e.g. RTX PRO 6000 / RTX 50-series) lacks ``tcgen05``, so quack can
+    never run there — CuteDSL rejects the arch and every GEMM falls back to
+    FlashInfer one call at a time, which is catastrophically slow. Those GPUs
+    have working native FlashInfer FP8 kernels, so default quack off for them.
+    """
     try:
         if not torch.cuda.is_available():
             return False
-        return torch.cuda.get_device_capability()[0] >= 10
+        return torch.cuda.get_device_capability()[0] == 10
     except Exception:  # noqa: BLE001
         return False
 
@@ -28,7 +38,7 @@ def quack_enabled() -> bool:
     override = os.environ.get("VLLM_OMNI_USE_QUACK_FP8")
     if override is not None:
         return override.lower() in _TRUTHY
-    return _is_blackwell()
+    return _is_quack_capable()
 
 
 def _set_persistent_cache_dir() -> None:


### PR DESCRIPTION
# [Bugfix][Quant] Gate quack FP8 to datacenter Blackwell (sm_100.x) only

## Summary

`quack_enabled()` currently turns the quack CuteDSL FP8 fused-bias GEMM **on for every
Blackwell GPU** (`get_device_capability()[0] >= 10`). That includes **workstation/consumer
Blackwell — `sm_120` / `sm_121` (compute capability 12.x), e.g. RTX PRO 6000 and the RTX 50
series** — where quack **cannot** run. The result there is a catastrophic per-GEMM fallback that
makes FP8/NVFP4 serving effectively unusable (a HunyuanImage-3.0 request that should take a few
seconds runs > 400 s and hits the client timeout).

This PR narrows the gate to **datacenter Blackwell only (`== 10`, i.e. `sm_100a` / `sm_101a` /
`sm_103a`)**, so `sm_120` / `sm_121` default to the working native FlashInfer FP8 path and no
longer need the `VLLM_OMNI_USE_QUACK_FP8=0` workaround.

## Root cause: quack can't run on sm_120/121

quack's CuteDSL FP8 / block-scaled MMA is built on the 5th-gen tensor-core **`tcgen05`**
instruction family, which is **datacenter-Blackwell only**:

- PTX `tcgen05.mma` targets `sm_100a / sm_101a / sm_103a / sm_110a`; `ptxas` rejects `tcgen05`
  on `sm_120`.
- CUTLASS [#2800](https://github.com/NVIDIA/cutlass/issues/2800): the CuteDSL `BlockScaledMmaOp`
  hardcodes `admissible_archs = [Arch.sm_100a]`, so on 12.x it raises
  `OpError: expects arch to be one of [Arch.sm_100a], but got Arch.sm_121a`.
- `sm_100` (cc 10.x) and `sm_120` (cc 12.x) are **separate, non-cross-compatible families**.

On `sm_120`, CuteDSL rejects the arch and **every FP8 GEMM falls back to FlashInfer one call at a
time** — the `try quack / except → FlashInfer` path runs on the hot loop of an 80B-MoE diffusion
forward × N denoising steps. These GPUs have **working native FlashInfer FP8/NVFP4 kernels**
(`compute_120f`, cf. CUTLASS [#3096](https://github.com/NVIDIA/cutlass/issues/3096), vLLM
[#31085](https://github.com/vllm-project/vllm/issues/31085)), so the correct default is
**quack off** for them.

## The fix

`vllm_omni/quantization/quack_fp8.py` — tighten the capability check from `>= 10` to `== 10`
(renamed `_is_blackwell` → `_is_quack_capable` to reflect the real constraint):

```diff
-def _is_blackwell() -> bool:
+def _is_quack_capable() -> bool:
     try:
         if not torch.cuda.is_available():
             return False
-        return torch.cuda.get_device_capability()[0] >= 10
+        return torch.cuda.get_device_capability()[0] == 10
     except Exception:  # noqa: BLE001
         return False

 def quack_enabled() -> bool:
     override = os.environ.get("VLLM_OMNI_USE_QUACK_FP8")
     if override is not None:
         return override.lower() in _TRUTHY
-    return _is_blackwell()
+    return _is_quack_capable()
```

- `sm_100 / 101 / 103` (10.x, datacenter): **unchanged** — quack still enabled.
- `sm_120 / 121` (12.x, RTX PRO 6000 / RTX 50-series): **quack off by default** → native FlashInfer FP8.
- The `VLLM_OMNI_USE_QUACK_FP8` env escape hatch is preserved (env is checked first), so either
  default can still be overridden — e.g. `=1` to force quack on once CuteDSL ships `sm_120a` support.

Also updates `docs/user_guide/quantization/fp8.md` to say quack auto-enables on **datacenter
Blackwell only** and documents the `=1` force-on override.

## Reproduction

On any `sm_120` GPU (RTX PRO 6000 / RTX 5090), serving an FP8/NVFP4 HunyuanImage-3.0 checkpoint on
`main`:

```bash
vllm serve feizhai123/hunyuan-image3-modelopt-mixed-experts-nvfp4-dense-fp8 \
  --omni --linear-backend cutlass --force-cutlass-fp8
# then send one image request (512x512, 50 steps)
```

Server logs at startup:

```
[quack_fp8.py] Quack FP8 fused-bias GEMM enabled (CuteDSL).
[quack_fp8.py] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
```

and during generation the request never returns in time (> 400 s), with the log flooded by:

```
Quack FP8 GEMM failed (...); using FlashInfer.
```

## Test plan

**Unit — `tests/quantization/test_quack_fp8_gate.py` (new, hardware-free).** Monkeypatches the
`torch.cuda` capability probe, so it runs on CI without a Blackwell GPU. Covers:

- default gate: `(10, 0)` / `(10, 3)` → on; `(12, 0)` / `(12, 1)` → off (the regression); Hopper `(9, 0)` / Ada `(8, 9)` → off
- no CUDA → off
- `VLLM_OMNI_USE_QUACK_FP8` override both ways (truthy forces on even on `sm_120`; falsy forces off even on `sm_100`)

This test **fails on the old `>= 10` gate and passes on this fix**.

**End-to-end.** RTX PRO 6000 Blackwell Server Edition (`sm_120`,
`torch.cuda.get_device_capability() == (12, 0)`), vLLM 0.23 + vLLM-omni, HunyuanImage-3.0 mixed
FP8-dense + NVFP4-experts, default config (no `VLLM_OMNI_USE_QUACK_FP8` set). The gate logic is
independent of the vLLM version.

| | Before (quack force-enabled) | After (this PR) |
|---|---|---|
| `Patched FlashInfer FP8 ScaledMM` at startup | yes | **no** |
| `Quack FP8 GEMM failed (...)` during generation | thousands (per-GEMM fallback) | **0** |
| 512×512 / 50 steps | **> 400 s → client timeout** (unusable) | **9.7 s** |
| Output | n/a (timeout) | normal image |

No change observed on the `sm_100` path (quack remains enabled).

## Environment (validation)

- GPU: NVIDIA RTX PRO 6000 Blackwell Server Edition — `sm_120`, cc `(12, 0)`
- vLLM 0.23 + vllm-omni; `nvidia-cutlass-dsl` 4.5.2; FlashInfer 0.6.12 (CUDA 13)
- Model: `feizhai123/hunyuan-image3-modelopt-mixed-experts-nvfp4-dense-fp8` (FP8 dense/attention + NVFP4 experts)

## Notes for reviewers

- Focused change: 3 files (`quack_fp8.py`, the FP8 doc, and the new test) — `102 insertions(+), 7 deletions(-)`.
- No behavior change on datacenter Blackwell (`sm_100.x`); the escape hatch env var is unchanged.
