### PR TITLE
[ROCm] [CI] Fix AMD CI after v0.24.0 rebase

### DIFF
--- a/.buildkite/test-amd-merge.yml
+++ b/.buildkite/test-amd-merge.yml
@@ -182,10 +182,10 @@ steps:
       depends_on: amd-build
       mirror_hardwares: [amdproduction]
       grade: Blocking
-      timeout_in_minutes: 70
+      timeout_in_minutes: 50
       commands:
         - |
-          timeout 60m bash -c '
+          timeout 40m bash -c '
             export VLLM_LOGGING_LEVEL=DEBUG
             export VLLM_WORKER_MULTIPROC_METHOD=spawn
             export VLLM_ALLOW_LONG_MAX_MODEL_LEN="1"

--- a/.buildkite/test-amd-merge.yml
+++ b/.buildkite/test-amd-merge.yml
@@ -7,7 +7,7 @@ steps:
 
 - group: ":card_index_dividers: Simple Test"
   steps:
-    - label: "Simple · Diffusion & Model Executor Test"
+    - label: "Simple · Diffusion & Model Executor Test (1/2)"
       agent_pool: mi325_1
       depends_on: amd-build
       timeout_in_minutes: 70
@@ -18,7 +18,18 @@ steps:
         # ignore test_teacache_extractors.py because it use rocm gemm kernel from vLLM
         # that is not supported on CPU
         # CPU tests on ROCm gpu machines are very slow, so we give them more time.
-        - "timeout 60m pytest -sv tests/diffusion tests/model_executor -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
+        - "timeout 60m pytest -sv tests/diffusion -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
+
+    - label: "Simple · Diffusion & Model Executor Test (2/2)"
+      agent_pool: mi325_1
+      depends_on: amd-build
+      timeout_in_minutes: 70
+      mirror_hardwares: [amdproduction]
+      grade: Blocking
+      commands:
+        - export VLLM_ROCM_USE_AITER=0
+        # CPU tests on ROCm gpu machines are very slow, so we give them more time.
+        - "timeout 60m pytest -sv tests/model_executor -m 'core_model and cpu' --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
 
     - label: "Simple · Other Test"
       agent_pool: mi325_1
@@ -159,7 +170,7 @@ steps:
       grade: Blocking
       commands:
         - |
-          timeout 20m bash -c '
+          timeout 50m bash -c '
             export VLLM_LOGGING_LEVEL=DEBUG
             export VLLM_WORKER_MULTIPROC_METHOD=spawn
             export VLLM_ALLOW_LONG_MAX_MODEL_LEN="1"
@@ -178,7 +189,7 @@ steps:
             export VLLM_LOGGING_LEVEL=DEBUG
             export VLLM_WORKER_MULTIPROC_METHOD=spawn
             export VLLM_ALLOW_LONG_MAX_MODEL_LEN="1"
-            pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py tests/e2e/offline_inference/test_qwen3_tts_base.py -m "advanced_model" --run-level "advanced_model"
+            pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py tests/e2e/offline_inference/test_qwen3_tts_base.py -m 'advanced_model and cuda' --run-level 'advanced_model'
           '
 
 # TODO: Bagel test on ROCm is very unstable. @tjtanaa

--- a/.buildkite/test-amd-merge.yml
+++ b/.buildkite/test-amd-merge.yml
@@ -10,14 +10,15 @@ steps:
     - label: "Simple · Diffusion & Model Executor Test"
       agent_pool: mi325_1
       depends_on: amd-build
-      timeout_in_minutes: 50
+      timeout_in_minutes: 70
       mirror_hardwares: [amdproduction]
       grade: Blocking
       commands:
         - export VLLM_ROCM_USE_AITER=0
         # ignore test_teacache_extractors.py because it use rocm gemm kernel from vLLM
         # that is not supported on CPU
-        - "timeout 40m pytest -sv tests/diffusion tests/model_executor -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
+        # CPU tests on ROCm gpu machines are very slow, so we give them more time.
+        - "timeout 60m pytest -sv tests/diffusion tests/model_executor -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
 
     - label: "Simple · Other Test"
       agent_pool: mi325_1
@@ -170,9 +171,10 @@ steps:
       depends_on: amd-build
       mirror_hardwares: [amdproduction]
       grade: Blocking
+      timeout_in_minutes: 70
       commands:
         - |
-          timeout 30m bash -c '
+          timeout 60m bash -c '
             export VLLM_LOGGING_LEVEL=DEBUG
             export VLLM_WORKER_MULTIPROC_METHOD=spawn
             export VLLM_ALLOW_LONG_MAX_MODEL_LEN="1"


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix `label: "Simple · Diffusion & Model Executor Test"`
The CPU core count is fewer on ROCm GPU machine, so I have split them into two parts to speed up the test and also increase the timeout to provide some buffer.

Fix `Qwen3-TTS CustomVoice E2E Test` timeout by updating the pytest marker filter and timeout duration based on CUDA's `test-merge.yaml`

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

test-ready.yaml (passing on main already): https://buildkite.com/vllm/vllm-omni-amd-ci/builds/9207/list

test-merge.yaml (passing after this PR fixes): https://buildkite.com/vllm/vllm-omni-amd-ci/builds/9228/list?jid=019f1d1c-4809-45b7-aff9-808decf06a8d&tab=output

NOTE: `mi325_4: Diffusion Sequence Parallelism Test (Need 4 GPUs)` occasionally can be flaky, usually just restart once will pass the tests. I don't have a clear understanding of this flakiness at the time of this PR is opened.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
