### PR TITLE
[Feature] Add audio tuple support to serialize_additional_information

### DIFF
--- a/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import os
 import urllib.request
+from pathlib import Path
 
 import pytest
 import torch
 from vllm import SamplingParams
+from vllm.multimodal.utils import fetch_audio
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniRunner
@@ -90,10 +92,11 @@ def _build_request(
     Upstream forbids ``prompt_text`` in ``voice_clone`` mode; only forward
     it when explicitly supplied (and typically with ``mode='continuation'``).
     """
+    audio, sr = fetch_audio(Path(prompt_audio_path).resolve().as_uri())
     additional: dict = {
         "text": [text],
         "mode": [mode],
-        "prompt_audio_path": [prompt_audio_path],
+        "prompt_audio_array": [(audio, sr)],
         "max_new_frames": [max_new_frames],
         "seed": [seed],
     }

--- a/tests/engine/test_data_entry_keys.py
+++ b/tests/engine/test_data_entry_keys.py
@@ -1,6 +1,7 @@
 """Tests for data_entry_keys."""
 
 import msgspec
+import numpy as np
 import pytest
 import torch
 
@@ -386,6 +387,40 @@ class TestSerializeDeserializePayload:
         restored = deserialize_payload(wire)
         assert restored["hidden_states"]["output"].shape == (3, 4, 5)
         assert torch.allclose(restored["hidden_states"]["output"], t)
+
+    def test_audio_round_trip(self):
+        wav = np.random.randn(16000).astype(np.float32)
+        sr = 16000
+        original = {"ref_audio": [(wav, sr)]}
+        wire = serialize_payload(original)
+        assert isinstance(wire, AdditionalInformationPayload)
+        restored = deserialize_payload(wire)
+        assert isinstance(restored["ref_audio"], list)
+        assert len(restored["ref_audio"]) == 1
+        assert isinstance(restored["ref_audio"][0], tuple)
+        np.testing.assert_array_equal(restored["ref_audio"][0][0], wav)
+        assert restored["ref_audio"][0][1] == sr
+
+    def test_audio_dtype_preserved(self):
+        wav = np.zeros(100, dtype=np.float64)
+        original = {"audio": [(wav, 44100)]}
+        wire = serialize_payload(original)
+        restored = deserialize_payload(wire)
+        assert restored["audio"][0][0].dtype == np.float64
+
+    def test_audio_shape_preserved(self):
+        wav = np.zeros((2, 8000), dtype=np.float32)
+        original = {"audio": [(wav, 24000)]}
+        wire = serialize_payload(original)
+        restored = deserialize_payload(wire)
+        assert restored["audio"][0][0].shape == (2, 8000)
+
+    def test_audio_float_sr(self):
+        wav = np.zeros(100, dtype=np.float32)
+        original = {"audio": [(wav, 22050.0)]}
+        wire = serialize_payload(original)
+        restored = deserialize_payload(wire)
+        assert restored["audio"][0][1] == 22050.0
 
     def test_empty_payload_returns_none(self):
         assert serialize_payload({}) is None

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -359,11 +359,29 @@ def _serialize_tensor(t: torch.Tensor) -> AdditionalInformationEntry:
     )
 
 
+def _serialize_audio(wav: np.ndarray, sr: int | float) -> AdditionalInformationEntry:
+    from vllm_omni.engine import AdditionalInformationEntry
+
+    return AdditionalInformationEntry(
+        audio_data=wav.tobytes(),
+        audio_shape=list(wav.shape),
+        audio_dtype=wav.dtype.str,
+        audio_sr=sr,
+    )
+
+
 def _deserialize_tensor(entry: AdditionalInformationEntry) -> torch.Tensor:
     dt = np.dtype(entry.tensor_dtype or "float32")
     arr = np.frombuffer(entry.tensor_data, dtype=dt)  # type: ignore[arg-type]
     arr = arr.reshape(entry.tensor_shape)
     return torch.from_numpy(arr.copy())
+
+
+def _deserialize_audio(entry: AdditionalInformationEntry) -> list[tuple[np.ndarray, int | float]]:
+    dt = np.dtype(entry.audio_dtype)
+    arr = np.frombuffer(entry.audio_data, dtype=dt)  # type: ignore[arg-type]
+    arr = arr.reshape(entry.audio_shape).copy()
+    return [(arr, entry.audio_sr)]  # type: ignore[return-value]
 
 
 def serialize_payload(
@@ -385,6 +403,15 @@ def serialize_payload(
     for key, value in flat.items():
         if isinstance(value, torch.Tensor):
             entries[key] = _serialize_tensor(value)
+        elif (
+            isinstance(value, list)
+            and len(value) == 1
+            and isinstance(value[0], tuple)
+            and len(value[0]) == 2
+            and isinstance(value[0][0], np.ndarray)
+            and isinstance(value[0][1], (int, float))
+        ):
+            entries[key] = _serialize_audio(value[0][0], value[0][1])
         elif isinstance(value, list):
             entries[key] = AdditionalInformationEntry(list_data=value)
         elif value is not None:
@@ -404,7 +431,9 @@ def deserialize_payload(
     flat: dict[str, Any] = {}
 
     for key, entry in wire.entries.items():
-        if entry.tensor_data is not None:
+        if entry.audio_data is not None:
+            flat[key] = _deserialize_audio(entry)
+        elif entry.tensor_data is not None:
             flat[key] = _deserialize_tensor(entry)
         elif entry.list_data is not None:
             flat[key] = entry.list_data

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -29,17 +29,24 @@ class PromptEmbedsPayload(msgspec.Struct):
 class AdditionalInformationEntry(msgspec.Struct):
     """One entry of additional_information.
 
-    Three supported forms are encoded:
-      - tensor: data/shape/dtype
+    Four supported forms are encoded:
+      - tensor: tensor_data/tensor_shape/tensor_dtype
+      - audio: audio_data/audio_shape/audio_dtype/audio_sr (as [(np.ndarray, sr)])
       - list: a Python list (msgspec-serializable)
       - scalar: a Python scalar (msgspec-serializable)
-    Exactly one of (tensor_data, list_data, scalar_data) should be non-None.
+    Exactly one of (tensor_data, audio_data, list_data, scalar_data) should be non-None.
     """
 
     # Tensor form
     tensor_data: bytes | None = None
     tensor_shape: list[int] | None = None
     tensor_dtype: str | None = None
+
+    # Audio form (decoded as (np.ndarray, sample_rate) tuple)
+    audio_data: bytes | None = None
+    audio_shape: list[int] | None = None
+    audio_dtype: str | None = None
+    audio_sr: int | float | None = None
 
     # List form
     list_data: list[Any] | None = None


### PR DESCRIPTION
## Purpose

Add an audio entry type to AdditionalInformationEntry that serializes
(np.ndarray, sample_rate) tuples — the return type of fetch_audio.

This allows passing decoded audio data through additional_information.

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** bd9ce77c552bc6fbe8e3644b6592f7c8403ab99f

```
pytest tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
```

## Test Result

PASSED
