### PR TITLE
[BugFix][Qwen3-Omni]Repair async Code2Wav streaming chunk boundary sample loss

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_code2wav.py
@@ -327,7 +327,9 @@ class Qwen3OmniMoeCode2Wav(nn.Module):
             # (_trim_replay_output -> actual*upsample - 555) are short, so it applies to both.
             tail = max(0, int(code_seq_len * self.total_upsample) - batch_wav.shape[-1])
             start = max(0, left_context_size[idx] * self.total_upsample - tail)
-            wav_chunk = batch_wav[idx, :, start : code_seq_len * self.total_upsample]
+            new_frames = max(0, code_seq_len - left_context_size[idx])
+            end = min(batch_wav.shape[-1], start + new_frames * self.total_upsample)
+            wav_chunk = batch_wav[idx, :, start:end]
             wavs.append(wav_chunk)
         return wavs
 


### PR DESCRIPTION
## Purpose

### Summary

Fix silent per-chunk audio sample loss in `chunked_decode_streaming` when `async_chunk` is enabled. The causal Code2Wav decoder outputs `frames × total_upsample − C` samples (C ≈ 555 for Qwen3-Omni), but the streaming slice assumed nominal full length. Each chunk boundary dropped ~555 samples (~23 ms), causing cumulative duration drift (~1.2% on long audio) and audible gaps/clicks at chunk boundaries.

### Problem

With `async_chunk=true`, Code2Wav decodes overlapping codec windows incrementally via `chunked_decode_streaming`. 
This assumes decoder output length equals code_seq_len × total_upsample. In practice, the causal conv / transposed-conv stack trims the right edge due to missing future context, so actual output is shorter by a fixed constant C.

Symptoms on long audio:

Each internal chunk boundary loses C samples
Concatenated stream is progressively shorter than single-shot decode
Audible clicks/gaps at chunk boundaries
~1.2% time compression for a typical 4/25/25 chunk schedule (116 frames → 5 internal boundaries)

Item | Detail
-- | --
Nominal length | code_seq_len × 1280
Actual length | code_seq_len × 1280 − 555
Old slice start | left_context × 1280
Old slice end | code_seq_len × 1280 (implicit clamp to actual end)
Per-chunk output | (new_frames × 1280) − 555 instead of new_frames × 1280

###Solution
Measure tail from actual decoder output and shift slice start back by tail so each chunk refills the gap left by the previous chunk. Use an explicit end bound derived from the number of new frames:
```
tail = max(0, code_seq_len * total_upsample - batch_wav.shape[-1])
start = max(0, left_context * total_upsample - tail)
new_frames = max(0, code_seq_len - left_context)
end = min(batch_wav.shape[-1], start + new_frames * total_upsample)
wav_chunk = batch_wav[idx, :, start:end]
```
Resulting chunk length: (code_seq_len − left_context) × total_upsample. The trim constant C cancels across chunk boundaries; only the final utterance end loses C once, matching single-shot decode.

## Test Plan

```
python /data/why/vllm-omni/examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model /data/why/Qwen3-Omni-30B-A3B-Instruct \
    --query-type use_mixed_modalities  --port 28889 --speaker ethan --num-concurrent-requests 20
```
**vLLM Version:** v0.24.0

**vLLM-Omni Commit:**

## Test  Result

`Before:`
[audio_chatcmpl-b2ce9e15f08ed57a_19.wav](https://github.com/user-attachments/files/29584735/audio_chatcmpl-b2ce9e15f08ed57a_19.wav)

`After:`
[audio_chatcmpl-98958db77d96d931_19.wav](https://github.com/user-attachments/files/29584748/audio_chatcmpl-98958db77d96d931_19.wav)

