### PR TITLE
[BugFix][Qwen2.5-Omni] Guard talker prompt_token_ids being None on vllm 0.24.0

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -345,7 +345,11 @@ class Qwen2_5OmniForConditionalGeneration(
                     inputs_embeds=inputs_embeds,
                 )
 
-            if sampling_metadata is not None:
+            # ``SamplingMetadata.prompt_token_ids`` is populated lazily since
+            # vLLM v1 (only when a sampler needs it, e.g. penalties) and is
+            # ``None`` otherwise (surfaced as a crash on vllm 0.24.0). Guard the
+            # attribute, not just ``sampling_metadata``.
+            if sampling_metadata is not None and sampling_metadata.prompt_token_ids is not None:
                 # the padding token id is set to text model's pad token id,
                 # which do not match with the talker model's word embedding size
                 sampling_metadata.prompt_token_ids[sampling_metadata.prompt_token_ids == 152064] = 8448


### PR DESCRIPTION
## Purpose

Qwen2.5-Omni audio generation crashes on vllm 0.24.0 with:

```
TypeError: 'NoneType' object does not support item assignment
  File ".../qwen2_5_omni/qwen2_5_omni.py", line 351, in forward
    sampling_metadata.prompt_token_ids[sampling_metadata.prompt_token_ids == 152064] = 8448
```

The talker `forward` remaps the text model's pad token id to the talker vocab by
indexing into `sampling_metadata.prompt_token_ids`, but only guards on
`sampling_metadata is not None`.

Since vLLM v1, `SamplingMetadata.prompt_token_ids` is populated **lazily** — only
when a sampler actually needs it (e.g. repetition/presence/frequency penalties) —
and is `None` otherwise. On vllm 0.24.0 this path is hit during Qwen2.5-Omni
talker decode, so the assignment dereferences `None` and the engine dies.

## Fix

Guard the attribute itself, not just the container:

```python
if sampling_metadata is not None and sampling_metadata.prompt_token_ids is not None:
    sampling_metadata.prompt_token_ids[sampling_metadata.prompt_token_ids == 152064] = 8448
```

When `prompt_token_ids` is `None` there is nothing to remap, so skipping is safe.

## Test Plan / Result

Serve Qwen2.5-Omni-3B on vllm 0.24.0 (2×RTX A6000, default deploy config) and
request text+audio:

```bash
vllm serve Qwen/Qwen2.5-Omni-3B --omni --port 8902
curl .../v1/chat/completions -d '{"model":"Qwen/Qwen2.5-Omni-3B",
  "messages":[{"role":"user","content":"Say hello and count to three."}],
  "max_tokens":64,"modalities":["text","audio"]}'
```

- Before: engine dies in talker `forward` (`NoneType ... item assignment`).
- After: `HTTP 200`, text `"Hello\! 1, 2, 3."` + an `audio` object in the response; full thinker→talker→code2wav pipeline completes.
