### PR TITLE
[Feature]Inter request cache reuse in the DIT phase of the text-to-image model.

### DIFF
--- a/docs/user_guide/diffusion/cache_acceleration/inter_request.md
+++ b/docs/user_guide/diffusion/cache_acceleration/inter_request.md
@@ -1,0 +1,229 @@
+# Inter-Request Cache Reuse Guide
+
+
+## Table of Content
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Example Scripts](#example-scripts)
+- [Configuration Parameters](#configuration-parameters)
+- [Combined with Cache-DiT](#combined-with-cache-dit)
+- [Persistent Cache](#persistent-cache)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The **inter-request cache** (Chorus Stage-1) accelerates text-to-image generation by reusing
+DiT computation results across different requests. When multiple requests share the same or
+semantically similar prompts, previously computed denoising latents can be reused, avoiding
+redundant computation and providing significant end-to-end speedup.
+
+### Three Cache Tiers
+
+| Tier | Match Condition | Speedup | Quality |
+|------|----------------|---------|---------|
+| **Exact hit** | Identical prompt + seed + params | ~50× (skip all DiT steps) | Identical |
+| **Semantic hit** | CLIP text similarity > threshold | Partial (skip first N steps) | Near-identical |
+| **Miss** | No match | No speedup (compute & cache) | Normal |
+
+---
+
+## How It Works
+
+1. **Exact matching**: Each request's full parameter set (prompt, seed, dimensions, guidance
+   scale, steps, etc.) is hashed into a cache key. An exact match means the cached final latent
+   can be returned directly — skipping the entire DiT forward.
+
+2. **Semantic matching (optional)**: When CLIP is configured, a text embedding is computed for
+   the incoming prompt and compared (via vectorized cosine similarity) against all cached prompt
+   embeddings. If similarity exceeds the threshold, the cached entry's per-step latents are used
+   to **resume** denoising from an intermediate step rather than starting from scratch.
+
+3. **Hybrid similarity**: When image embeddings are available, the semantic score combines
+   text-to-text similarity with a sigmoid penalty based on text-to-image similarity, improving
+   match precision. This can be disabled with `inter_request_use_t2i_penalty=False`.
+
+---
+
+## Quick Start
+
+### Basic Usage
+
+```python
+from vllm_omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+omni = Omni(
+    model="Qwen/Qwen-Image",
+    cache_backend="inter_request",
+    cache_config={
+        "inter_request_max_entries": 1000,
+        "inter_request_max_memory_gb": 16.0,
+        "inter_request_persistent_cache_dir": "./persistent_cache",
+    },
+)
+
+# First request: cache miss, computes and stores
+outputs = omni.generate(
+    "a cup of coffee on the table",
+    OmniDiffusionSamplingParams(num_inference_steps=50, seed=142),
+)
+
+# Same prompt + params: exact hit, skips all DiT computation
+outputs = omni.generate(
+    "a cup of coffee on the table",
+    OmniDiffusionSamplingParams(num_inference_steps=50, seed=142),
+)
+```
+
+### With Semantic Matching (CLIP)
+
+```python
+omni = Omni(
+    model="Qwen/Qwen-Image",
+    cache_backend="inter_request",
+    cache_config={
+        "inter_request_max_entries": 1000,
+        "inter_request_max_memory_gb": 16.0,
+        "inter_request_persistent_cache_dir": "./persistent_cache",
+        "inter_request_clip_model_path": "/path/to/clip-vit-large-patch14",
+        "inter_request_clip_threshold": 0.65,
+        "inter_request_clip_min_skip": 5,
+        "inter_request_clip_max_skip_ratio": 0.5,
+    },
+)
+```
+
+---
+
+## Example Scripts
+
+### Offline Inference
+
+```bash
+python3 examples/offline_inference/text_to_image/text_to_image.py \
+    --model /path/to/Qwen-Image \
+    --cache-backend inter_request \
+    --persistent-cache-dir ./persistent_cache \
+    --max-entries 1000 \
+    --max-memory-gb 16.0 \
+    --clip-model-path /path/to/clip-vit-large-patch14 \
+    --clip-threshold 0.65
+```
+
+### Online Serving
+
+```bash
+python3 examples/online_serving/text_to_image/run_server_with_cache.py \
+    --model /path/to/Qwen-Image \
+    --cache-backend inter_request \
+    --persistent-cache-dir ./persistent_cache \
+    --max-entries 8000 \
+    --max-memory-gb 800.0 \
+    --clip-model-path /path/to/clip-vit-large-patch14 \
+    --clip-threshold 0.65
+```
+
+---
+
+## Configuration Parameters
+
+All parameters use the `inter_request_` prefix in the `cache_config` dictionary:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `inter_request_max_entries` | int | 100 | Maximum number of cached entries (LRU eviction) |
+| `inter_request_max_memory_gb` | float | 4.0 | Maximum total memory for cached latents (GB) |
+| `inter_request_persistent_cache_dir` | str \| None | None | Directory for disk persistence; if set, cache survives restarts |
+| `inter_request_clip_model_path` | str \| None | None | Path to CLIP model for semantic matching; if None, only exact matching is used |
+| `inter_request_clip_threshold` | float | 0.75 | CLIP text similarity threshold (τ) for semantic hit |
+| `inter_request_clip_min_skip` | int | 5 | Minimum denoising steps to skip on a semantic hit |
+| `inter_request_clip_max_skip_ratio` | float | 0.5 | Maximum skip ratio of total steps (when similarity ≈ 1.0) |
+| `inter_request_use_t2i_penalty` | bool | True | Enable t2i sigmoid penalty in hybrid similarity scoring |
+
+### CLI Flags (example scripts)
+
+| Flag | Maps to |
+|------|---------|
+| `--persistent-cache-dir` | `inter_request_persistent_cache_dir` |
+| `--max-entries` | `inter_request_max_entries` |
+| `--max-memory-gb` | `inter_request_max_memory_gb` |
+| `--clip-model-path` | `inter_request_clip_model_path` |
+| `--clip-threshold` | `inter_request_clip_threshold` |
+| `--clip-min-skip` | `inter_request_clip_min_skip` |
+| `--clip-max-skip-ratio` | `inter_request_clip_max_skip_ratio` |
+| `--no-t2i-penalty` | Sets `inter_request_use_t2i_penalty=False` |
+
+---
+
+## Combined with Cache-DiT
+
+For maximum acceleration, the inter-request cache can be combined with intra-request
+[Cache-DiT](cache_dit.md) using the `inter_request+cache_dit` backend:
+
+```bash
+python3 examples/offline_inference/text_to_image/text_to_image.py \
+    --model /path/to/Qwen-Image \
+    --cache-backend inter_request+cache_dit \
+    --persistent-cache-dir ./persistent_cache \
+    --clip-model-path /path/to/clip-vit-large-patch14 \
+    --clip-threshold 0.65
+```
+
+This applies cross-request reuse (exact/semantic hit) first, then intra-request
+cache-dit acceleration (DBCache + TaylorSeer + SCM) for the remaining denoising steps.
+
+---
+
+## Persistent Cache
+
+When `inter_request_persistent_cache_dir` is set, the cache is automatically:
+
+1. **Loaded** on engine startup — all entries (latents, step latents, embeddings, cache keys)
+   are restored and become immediately searchable.
+2. **Saved** periodically and on shutdown — new entries are persisted to disk.
+
+This enables cache reuse across server restarts, model reloads, or even different machines
+sharing a cache directory.
+
+---
+
+## Best Practices
+
+- **Start without CLIP**: Exact matching alone provides large speedup for repeated prompts
+  with zero quality loss. Add CLIP semantic matching only when prompt diversity is expected.
+- **Tune the threshold**: Lower `clip_threshold` → more semantic hits but potentially lower
+  quality. `0.60–0.75` is a good range for most use cases.
+- **Set `max_memory_gb` appropriately**: Cached latents can be large. Monitor memory usage
+  and adjust the limit to avoid OOM.
+- **Use persistent cache in production**: Set `persistent_cache_dir` to a stable path so the
+  cache survives restarts and warms up quickly.
+
+---
+
+## Troubleshooting
+
+### "CLIP model path does not exist" warning
+
+The CLIP model path must be a local directory (not a HuggingFace repo ID). Download the model
+first:
+
+```bash
+huggingface-cli download openai/clip-vit-large-patch14 --local-dir /path/to/clip-vit-large-patch14
+```
+
+### Semantic hits never trigger
+
+- Verify the CLIP model loaded successfully (check logs for "CLIP model loaded successfully").
+- Lower the `clip_threshold` value.
+- Ensure cached entries have `clip_embedding` (entries cached before CLIP was configured will
+  not be semantically searchable; clear the cache and re-populate).
+
+### Cache not persisting across restarts
+
+Ensure `inter_request_persistent_cache_dir` points to a writable directory and that the
+process has permission to create files there.

--- a/examples/offline_inference/text_to_image/text_to_image.py
+++ b/examples/offline_inference/text_to_image/text_to_image.py
@@ -101,10 +101,13 @@ def parse_args() -> argparse.Namespace:
         "--cache-backend",
         type=str,
         default=None,
-        choices=["cache_dit", "tea_cache"],
+        choices=["cache_dit", "tea_cache", "inter_request", "inter_request+cache_dit"],
         help=(
             "Cache backend to use for acceleration. "
-            "Options: 'cache_dit' (DBCache + SCM + TaylorSeer), 'tea_cache' (Timestep Embedding Aware Cache). "
+            "Options: 'cache_dit' (DBCache + SCM + TaylorSeer), "
+            "'tea_cache' (Timestep Embedding Aware Cache), "
+            "'inter_request' (cross-request DiT cache reuse), "
+            "'inter_request+cache_dit' (cross-request + intra-request cache_dit). "
             "Default: None (no cache acceleration)."
         ),
     )
@@ -112,6 +115,54 @@ def parse_args() -> argparse.Namespace:
         "--enable-cache-dit-summary",
         action="store_true",
         help="Enable cache-dit summary logging after diffusion forward passes.",
+    )
+    # Inter-request cache parameters [inter_request only]
+    parser.add_argument(
+        "--persistent-cache-dir",
+        type=str,
+        default="./persistent_cache",
+        help="Directory for persistent cross-request cache storage.",
+    )
+    parser.add_argument(
+        "--max-entries",
+        type=int,
+        default=8000,
+        help="Maximum number of cached entries in the inter-request cache.",
+    )
+    parser.add_argument(
+        "--max-memory-gb",
+        type=float,
+        default=800.0,
+        help="Maximum GPU/CPU memory (GB) for the inter-request cache.",
+    )
+    parser.add_argument(
+        "--clip-model-path",
+        type=str,
+        default=None,
+        help="Path to CLIP model for semantic prompt matching.",
+    )
+    parser.add_argument(
+        "--clip-threshold",
+        type=float,
+        default=0.75,
+        help="CLIP text similarity threshold for semantic cache hit.",
+    )
+    parser.add_argument(
+        "--clip-min-skip",
+        type=int,
+        default=5,
+        help="Minimum denoising steps to skip on a semantic hit.",
+    )
+    parser.add_argument(
+        "--clip-max-skip-ratio",
+        type=float,
+        default=0.5,
+        help="Maximum skip ratio of total steps when similarity is 1.0.",
+    )
+    parser.add_argument(
+        "--no-t2i-penalty",
+        action="store_true",
+        help="Disable t2i sigmoid penalty (use text-only similarity).",
     )
     parser.add_argument(
         "--ulysses-degree",
@@ -344,6 +395,30 @@ def main():
             # Note: coefficients will use model-specific defaults based on model_type
             #       (e.g., QwenImagePipeline or FluxPipeline)
         }
+    elif cache_backend and "inter_request" in cache_backend:
+        # Inter-request DiT cache reuse configuration
+        cache_config = {
+            "inter_request_max_entries": args.max_entries,
+            "inter_request_max_memory_gb": args.max_memory_gb,
+            "inter_request_persistent_cache_dir": args.persistent_cache_dir,
+        }
+        if args.clip_model_path:
+            cache_config["inter_request_clip_model_path"] = args.clip_model_path
+            cache_config["inter_request_clip_threshold"] = args.clip_threshold
+            cache_config["inter_request_clip_min_skip"] = args.clip_min_skip
+            cache_config["inter_request_clip_max_skip_ratio"] = args.clip_max_skip_ratio
+        cache_config["inter_request_use_t2i_penalty"] = not args.no_t2i_penalty
+        # When combined with cache_dit, also add cache_dit parameters
+        if "cache_dit" in cache_backend:
+            cache_config["Fn_compute_blocks"] = 1
+            cache_config["Bn_compute_blocks"] = 0
+            cache_config["max_warmup_steps"] = 4
+            cache_config["residual_diff_threshold"] = 0.24
+            cache_config["max_continuous_cached_steps"] = 3
+            cache_config["enable_taylorseer"] = False
+            cache_config["taylorseer_order"] = 1
+            cache_config["scm_steps_mask_policy"] = None
+            cache_config["scm_steps_policy"] = "dynamic"
 
     profiler_enabled = args.profiler_config is not None
 

--- a/examples/online_serving/text_to_image/README.md
+++ b/examples/online_serving/text_to_image/README.md
@@ -273,3 +273,4 @@ cat response.json | jq -r '.choices[0].message.content[0].image_url.url' | cut -
 | `run_curl_text_to_image.sh` | curl example                 |
 | `openai_chat_client.py`     | Python client                |
 | `gradio_demo.py`            | Gradio interactive interface |
+| `run_server_with_cache.py`  | Server with inter-request DiT cache reuse (see [Inter-Request Cache Guide](../../../docs/user_guide/diffusion/cache_acceleration/inter_request.md)) |

--- a/examples/online_serving/text_to_image/run_server_with_cache.py
+++ b/examples/online_serving/text_to_image/run_server_with_cache.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Simple HTTP server wrapping Omni with inter-request cache support.
+
+This bypasses the vllm serve CLI to avoid version compatibility issues.
+
+Usage:
+    ASCEND_RT_VISIBLE_DEVICES=0,1 python run_server_with_cache.py
+
+Endpoints:
+    POST /v1/images/generations  - Generate image (with cache support)
+    GET  /health                  - Health check
+"""
+
+import argparse
+import base64
+import io
+import json
+import logging
+import os
+import random
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+# Force unbuffered stdout so logs show immediately
+sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    force=True,
+)
+logger = logging.getLogger(__name__)
+
+omni = None
+SAMPLING_PARAMS_CLS = None
+
+
+class CacheAwareHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        logger.info("%s - %s", self.client_address[0], format % args)
+
+    def _send_json(self, code, data):
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._send_json(200, {"status": "ok"})
+        elif self.path == "/similarity_stats":
+            self._handle_similarity_stats()
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path == "/v1/images/generations":
+            self._handle_generate()
+        elif self.path == "/reset_similarity_stats":
+            self._handle_reset_similarity_stats()
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def _handle_similarity_stats(self):
+        try:
+            import json as _json
+
+            with open("/tmp/cache_sim_stats.json") as f:
+                stats = _json.load(f)
+            self._send_json(200, stats)
+        except FileNotFoundError:
+            self._send_json(200, {"final_sim": {"total_comparisons": 0}, "t2t_sim": {"total_comparisons": 0}})
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
+    def _handle_reset_similarity_stats(self):
+        try:
+            import json as _json
+
+            with open("/tmp/cache_sim_stats.json", "w") as f:
+                _json.dump({"final_sim": {"total_comparisons": 0}, "t2t_sim": {"total_comparisons": 0}}, f)
+            self._send_json(200, {"status": "ok"})
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
+    def _handle_generate(self):
+        global omni, SAMPLING_PARAMS_CLS
+        content_len = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_len)
+        try:
+            req = json.loads(body)
+        except json.JSONDecodeError as e:
+            self._send_json(400, {"error": f"invalid JSON: {e}"})
+            return
+
+        prompt = req.get("prompt", "")
+        negative_prompt = req.get("negative_prompt")
+        seed = req.get("seed", random.randint(0, 2**32 - 1))
+        width = req.get("width")
+        height = req.get("height")
+        size_str = req.get("size")
+        if size_str and "x" in str(size_str):
+            parts = str(size_str).split("x")
+            if width is None:
+                width = int(parts[0])
+            if height is None:
+                height = int(parts[1])
+        steps = req.get("num_inference_steps", 50)
+        true_cfg_scale = req.get("true_cfg_scale", 4.0)
+        resume_from_step = req.get("resume_from_step", 0) or 0
+
+        prompt_dict = {"prompt": prompt}
+        if negative_prompt:
+            prompt_dict["negative_prompt"] = negative_prompt
+
+        sampling_params = SAMPLING_PARAMS_CLS(
+            height=height,
+            width=width,
+            seed=seed,
+            true_cfg_scale=true_cfg_scale,
+            num_inference_steps=steps,
+            num_outputs_per_prompt=1,
+            resume_from_step=resume_from_step,
+        )
+
+        start = time.perf_counter()
+        logger.info("=" * 60)
+        logger.info("REQUEST: prompt=%r seed=%d steps=%d", prompt[:80], seed, steps)
+        try:
+            outputs = omni.generate(prompt_dict, sampling_params)
+        except Exception as e:
+            logger.error("Generation failed: %s", e, exc_info=True)
+            self._send_json(500, {"error": str(e)})
+            return
+        elapsed = time.perf_counter() - start
+        logger.info("COMPLETED in %.2fs", elapsed)
+        logger.info("=" * 60)
+
+        images = []
+        for out in outputs:
+            inner = out.request_output
+            if inner and inner.images:
+                for img in inner.images:
+                    buf = io.BytesIO()
+                    img.save(buf, format="PNG")
+                    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+                    images.append({"b64_json": b64})
+
+        self._send_json(
+            200,
+            {
+                "created": int(time.time()),
+                "data": images,
+                "time_ms": elapsed * 1000,
+            },
+        )
+
+
+def main():
+    global omni, SAMPLING_PARAMS_CLS
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="/mnt/shared/models/Qwen-Image")
+    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--cache-backend", default="inter_request")
+    parser.add_argument("--persistent-cache-dir", default="./persistent_cache")
+    parser.add_argument("--tensor-parallel-size", type=int, default=2)
+    parser.add_argument("--max-entries", type=int, default=8000)
+    parser.add_argument("--max-memory-gb", type=float, default=800.0)
+    parser.add_argument("--clip-model-path", default=None, help="Path to CLIP model for semantic matching")
+    parser.add_argument("--clip-threshold", type=float, default=0.75, help="CLIP similarity threshold (tau)")
+    parser.add_argument(
+        "--clip-min-skip", type=int, default=5, help="Minimum skip steps when similarity just exceeds threshold"
+    )
+    parser.add_argument(
+        "--clip-max-skip-ratio", type=float, default=0.5, help="Max skip ratio of total steps when similarity=1.0"
+    )
+    parser.add_argument(
+        "--no-t2i-penalty", action="store_true", help="Disable t2i sigmoid penalty (use text-only similarity)"
+    )
+    # cache_dit parameters (used when cache-backend contains "cache_dit")
+    parser.add_argument(
+        "--fn-compute-blocks", type=int, default=1, help="cache_dit: number of blocks to fully compute each step"
+    )
+    parser.add_argument("--bn-compute-blocks", type=int, default=0, help="cache_dit: number of backward compute blocks")
+    parser.add_argument("--max-warmup-steps", type=int, default=4, help="cache_dit: warmup steps before caching begins")
+    parser.add_argument(
+        "--residual-diff-threshold", type=float, default=0.24, help="cache_dit: residual difference threshold"
+    )
+    args = parser.parse_args()
+
+    from vllm_omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    SAMPLING_PARAMS_CLS = OmniDiffusionSamplingParams
+
+    cache_config = {
+        "inter_request_max_entries": args.max_entries,
+        "inter_request_max_memory_gb": args.max_memory_gb,
+        "inter_request_persistent_cache_dir": args.persistent_cache_dir,
+    }
+    if args.clip_model_path:
+        cache_config["inter_request_clip_model_path"] = args.clip_model_path
+        cache_config["inter_request_clip_threshold"] = args.clip_threshold
+        cache_config["inter_request_clip_min_skip"] = args.clip_min_skip
+        cache_config["inter_request_clip_max_skip_ratio"] = args.clip_max_skip_ratio
+    cache_config["inter_request_use_t2i_penalty"] = not args.no_t2i_penalty
+
+    # Add cache_dit parameters when backend contains cache_dit
+    if "cache_dit" in args.cache_backend:
+        cache_config["Fn_compute_blocks"] = args.fn_compute_blocks
+        cache_config["Bn_compute_blocks"] = args.bn_compute_blocks
+        cache_config["max_warmup_steps"] = args.max_warmup_steps
+        cache_config["residual_diff_threshold"] = args.residual_diff_threshold
+
+    logger.info("Initializing Omni engine...")
+    logger.info("  Model: %s", args.model)
+    logger.info("  Cache backend: %s", args.cache_backend)
+    logger.info("  Persistent cache dir: %s", args.persistent_cache_dir)
+
+    omni = Omni(
+        model=args.model,
+        cache_backend=args.cache_backend,
+        cache_config=cache_config,
+        tensor_parallel_size=args.tensor_parallel_size,
+        mode="text-to-image",
+        init_timeout=3600,
+        enable_cache_dit_summary=True,
+    )
+
+    server = HTTPServer((args.host, args.port), CacheAwareHandler)
+    logger.info("Server listening on %s:%d", args.host, args.port)
+    logger.info("POST /v1/images/generations - Generate image")
+    logger.info("GET  /health - Health check")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+        server.server_close()
+        omni.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_omni/diffusion/cache/base.py
+++ b/vllm_omni/diffusion/cache/base.py
@@ -73,7 +73,13 @@ class CacheBackend(ABC):
         raise NotImplementedError("Subclasses must implement enable()")
 
     @abstractmethod
-    def refresh(self, pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh(
+        self,
+        pipeline: Any,
+        num_inference_steps: int,
+        verbose: bool = True,
+        **kwargs: Any,
+    ) -> None:
         """
         Refresh cache state for new generation.
 
@@ -86,6 +92,8 @@ class CacheBackend(ABC):
             num_inference_steps: Number of inference steps for the current generation.
                                 May be used for cache context updates.
             verbose: Whether to log refresh operations (default: True)
+            **kwargs: Additional keyword arguments (e.g., resume_from_step for
+                     composite backends that need to adjust effective step count).
         """
         raise NotImplementedError("Subclasses must implement refresh()")
 

--- a/vllm_omni/diffusion/cache/composite_backend.py
+++ b/vllm_omni/diffusion/cache/composite_backend.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Composite cache backend combining inter_request and cache_dit.
+
+This allows both cross-request latent reuse (inter_request) and intra-request
+block-level caching (cache_dit) to work together. When inter_request resumes
+from step N, cache_dit operates on the remaining (total - N) steps.
+
+Usage:
+    omni = Omni(
+        model="Qwen/Qwen-Image",
+        cache_backend="inter_request+cache_dit",
+        cache_config={
+            # inter_request params
+            "inter_request_clip_model_path": "/path/to/clip",
+            "inter_request_clip_threshold": 0.65,
+            # cache_dit params
+            "Fn_compute_blocks": 1,
+            "max_warmup_steps": 4,
+        },
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from vllm_omni.diffusion.cache.inter_request.backend import InterRequestCacheBackend
+
+logger = logging.getLogger(__name__)
+
+
+class CompositeCacheBackend(InterRequestCacheBackend):
+    """
+    Composite backend that combines inter_request with cache_dit.
+
+    Inherits from InterRequestCacheBackend so all isinstance() checks in the
+    runner work transparently. Internally creates and manages a CacheDiTBackend
+    for block-level caching within each denoising step.
+
+    Coordination logic:
+    - enable(): enables cache_dit on transformer first, then inter_request recorder
+    - refresh(): when resume_from_step > 0, tells cache_dit to use (total - resume) steps
+    - All other methods (lookup, store, before_forward, after_forward) inherit from
+      InterRequestCacheBackend unchanged - cache_dit operates automatically via
+      transformer hooks.
+    """
+
+    def __init__(self, config: Any):
+        super().__init__(config)
+        from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTBackend
+        self._cache_dit_backend = CacheDiTBackend(config)
+        logger.info(
+            "CompositeCacheBackend initialized: inter_request + cache_dit "
+            "(Fn=%d, Bn=%d, warmup=%d)",
+            config.Fn_compute_blocks,
+            config.Bn_compute_blocks,
+            config.max_warmup_steps,
+        )
+
+    def enable(self, pipeline: Any) -> None:
+        # Enable cache_dit first (modifies transformer forward behavior)
+        self._cache_dit_backend.enable(pipeline)
+        logger.info("cache_dit enabled on transformer within composite backend")
+
+        # Then enable inter_request (attaches StepLatentsRecorder)
+        super().enable(pipeline)
+
+    def refresh(
+        self,
+        pipeline: Any,
+        num_inference_steps: int,
+        verbose: bool = True,
+        resume_from_step: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        """Refresh cache context for both backends.
+
+        For cache_dit: when inter_request resumes from step N, only
+        (num_inference_steps - N) steps will actually execute through the
+        transformer. cache_dit must be configured for this effective step count
+        so its warmup and caching intervals are correct.
+
+        For inter_request: no-op (inherited from InterRequestCacheBackend).
+        """
+        effective_steps = max(1, num_inference_steps - resume_from_step)
+        if resume_from_step > 0:
+            logger.info(
+                "CompositeCacheBackend refresh: total_steps=%d, resume_from_step=%d, "
+                "cache_dit effective_steps=%d",
+                num_inference_steps,
+                resume_from_step,
+                effective_steps,
+            )
+        self._cache_dit_backend.refresh(pipeline, effective_steps, verbose)
+
+    @property
+    def cache_dit_backend(self):
+        """Access the internal cache_dit backend for summary/debugging."""
+        return self._cache_dit_backend

--- a/vllm_omni/diffusion/cache/inter_request/__init__.py
+++ b/vllm_omni/diffusion/cache/inter_request/__init__.py
@@ -1,0 +1,13 @@
+from vllm_omni.diffusion.cache.inter_request.cache_store import (
+    DiTCacheStore,
+    CacheKey,
+)
+from vllm_omni.diffusion.cache.inter_request.backend import InterRequestCacheBackend
+from vllm_omni.diffusion.cache.inter_request.step_recorder import StepLatentsRecorder
+
+__all__ = [
+    "DiTCacheStore",
+    "CacheKey",
+    "InterRequestCacheBackend",
+    "StepLatentsRecorder",
+]

--- a/vllm_omni/diffusion/cache/inter_request/backend.py
+++ b/vllm_omni/diffusion/cache/inter_request/backend.py
@@ -78,6 +78,14 @@ class InterRequestCacheBackend(CacheBackend):
         self._clip_tokenizer = None
         self._clip_model = None
         self._clip_device = None
+        # CLIP sub-attributes are only fully populated inside _init_clip_encoder().
+        # Pre-initialize them here so that update_image_embedding / encode_image
+        # can safely short-circuit when CLIP is not configured (otherwise they
+        # would raise AttributeError on the never-set attributes).
+        self._full_clip_model = None
+        self._clip_processor = None
+        self._clip_image_processor = None
+        self._use_fgclip = False
 
         logger.info(
             "InterRequestCacheBackend initialized: "

--- a/vllm_omni/diffusion/cache/inter_request/backend.py
+++ b/vllm_omni/diffusion/cache/inter_request/backend.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from vllm_omni.diffusion.cache.base import CacheBackend
+from vllm_omni.diffusion.cache.inter_request.cache_store import (
+    DiTCacheStore,
+    StepLatentData,
+    build_cache_key_from_request,
+)
+from vllm_omni.diffusion.cache.inter_request.step_recorder import StepLatentsRecorder
+from vllm_omni.diffusion.data import DiffusionCacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+class InterRequestCacheBackend(CacheBackend):
+    """
+    Inter-request cache backend for DiT full reuse (Chorus Stage-1).
+
+    This backend implements the Stage-1 caching strategy from the Chorus paper:
+    when two requests have identical inputs (same prompt, dimensions, seed, etc.),
+    the DiT computation can be entirely skipped by reusing cached latent features
+    from a previous request.
+
+    Unlike intra-request caching backends (cache_dit, TeaCache) that optimize
+    within a single denoising process, this backend caches the final latents
+    across different requests, enabling complete DiT computation reuse.
+
+    The cache stores:
+    - Key: Hash of all inputs that determine the DiT output (prompt, seed, etc.)
+    - Value: Final latents after all denoising steps (before VAE decode)
+    - Step latents: Intermediate latents at every denoising step (for future
+      partial-resume capability)
+
+    A :class:`StepLatentsRecorder` is always attached to the pipeline to capture
+    intermediate latents during denoising.  These are stored in the in-memory
+    cache alongside the final latent.  When ``record_step_latents`` is enabled,
+    the step latents are additionally saved to disk.
+
+    Usage:
+        omni = Omni(
+            model="Qwen/Qwen-Image",
+            cache_backend="inter_request",
+            cache_config={
+                "inter_request_max_entries": 100,
+                "inter_request_max_memory_gb": 4.0,
+                "inter_request_record_step_latents": True,
+                "inter_request_step_latents_dir": "./step_latents",
+            }
+        )
+    """
+
+    def __init__(self, config: DiffusionCacheConfig):
+        super().__init__(config)
+        max_entries = getattr(config, "inter_request_max_entries", 100)
+        max_memory_gb = getattr(config, "inter_request_max_memory_gb", 4.0)
+        self._cache_store = DiTCacheStore(
+            max_entries=max_entries,
+            max_memory_gb=max_memory_gb,
+        )
+        self._pipeline = None
+
+        self._record_step_latents = getattr(config, "inter_request_record_step_latents", False)
+        self._step_latents_dir = getattr(config, "inter_request_step_latents_dir", "./step_latents")
+        self._persistent_cache_dir = getattr(config, "inter_request_persistent_cache_dir", None)
+
+        self._clip_model_path = getattr(config, "inter_request_clip_model_path", None)
+        self._clip_threshold = float(getattr(config, "inter_request_clip_threshold", 0.75))
+        self._clip_min_skip = int(getattr(config, "inter_request_clip_min_skip", 5))
+        self._clip_max_skip_ratio = float(getattr(config, "inter_request_clip_max_skip_ratio", 0.5))
+        self._use_t2i_penalty = bool(getattr(config, "inter_request_use_t2i_penalty", True))
+        self._cache_store.set_t2i_penalty(self._use_t2i_penalty)
+        self._clip_tokenizer = None
+        self._clip_model = None
+        self._clip_device = None
+
+        logger.info(
+            "InterRequestCacheBackend initialized: "
+            "max_entries=%d, max_memory_gb=%.1f, record_step_latents=%s, "
+            "persistent_cache_dir=%s, clip_model_path=%s, "
+            "clip_threshold=%.2f, clip_min_skip=%d, clip_max_skip_ratio=%.2f",
+            max_entries,
+            max_memory_gb,
+            self._record_step_latents,
+            self._persistent_cache_dir,
+            self._clip_model_path,
+            self._clip_threshold,
+            self._clip_min_skip,
+            self._clip_max_skip_ratio,
+        )
+
+    def enable(self, pipeline: Any) -> None:
+        self._pipeline = pipeline
+        self.enabled = True
+        self._recorder = StepLatentsRecorder()
+        pipeline._step_latents_recorder = self._recorder
+
+        if self._clip_model_path is not None:
+            self._init_clip_encoder()
+
+        if self._persistent_cache_dir is not None:
+            loaded = self._cache_store.load_from_disk(self._persistent_cache_dir)
+            if loaded > 0:
+                logger.info(
+                    "Loaded %d cache entries from persistent storage %s",
+                    loaded,
+                    self._persistent_cache_dir,
+                )
+
+        logger.info(
+            "InterRequestCacheBackend enabled on pipeline %s (save_step_latents_to_disk=%s)",
+            pipeline.__class__.__name__,
+            self._record_step_latents,
+        )
+
+    def _init_clip_encoder(self) -> None:
+        try:
+            self._clip_device = torch.device("cpu")
+            logger.info("Loading CLIP model from %s on %s", self._clip_model_path, self._clip_device)
+
+            # Verify the path exists before passing to from_pretrained,
+            # otherwise transformers treats it as a repo id and fails confusingly.
+            config_path = Path(self._clip_model_path)
+            if not config_path.exists():
+                logger.warning("CLIP model path does not exist: %s, semantic matching disabled", self._clip_model_path)
+                self._clip_model = None
+                self._clip_tokenizer = None
+                return
+
+            config_path = Path(self._clip_model_path)
+            fgclip_config = config_path / "modeling_fgclip.py"
+            if fgclip_config.exists():
+                from transformers import AutoModelForCausalLM, AutoTokenizer
+
+                self._clip_tokenizer = AutoTokenizer.from_pretrained(self._clip_model_path)
+                self._clip_model = AutoModelForCausalLM.from_pretrained(self._clip_model_path, trust_remote_code=True)
+                self._clip_model.to(self._clip_device)
+                self._clip_model.eval()
+                self._use_fgclip = True
+                self._clip_image_processor = None
+                self._full_clip_model = None
+                logger.info("FG-CLIP text encoder loaded successfully (text-only mode)")
+            else:
+                from transformers import CLIPModel, CLIPProcessor
+
+                self._full_clip_model = CLIPModel.from_pretrained(self._clip_model_path)
+                self._full_clip_model.to(self._clip_device)
+                self._full_clip_model.eval()
+                self._clip_processor = CLIPProcessor.from_pretrained(self._clip_model_path)
+                self._clip_model = self._full_clip_model
+                self._clip_tokenizer = self._clip_processor.tokenizer
+                self._clip_image_processor = self._clip_processor.image_processor
+                self._use_fgclip = False
+                logger.info("CLIP model loaded successfully (text+image mode)")
+        except Exception as e:
+            logger.warning("Failed to load CLIP encoder: %s, semantic matching disabled", e)
+            self._clip_model = None
+            self._clip_tokenizer = None
+
+    def encode_prompt(self, prompt: str) -> torch.Tensor | None:
+        if self._clip_model is None or self._clip_tokenizer is None:
+            return None
+        try:
+            if getattr(self, "_use_fgclip", False):
+                inputs = self._clip_tokenizer(
+                    [prompt], max_length=77, padding="max_length", truncation=True, return_tensors="pt"
+                ).to(self._clip_device)
+                with torch.no_grad():
+                    text_features = self._clip_model.get_text_features(
+                        input_ids=inputs["input_ids"],
+                        attention_mask=inputs.get("attention_mask"),
+                        walk_short_pos=True,
+                    )
+                feat = text_features.squeeze(0)
+                feat = feat / feat.norm(dim=-1, keepdim=True)
+                return feat
+            else:
+                inputs = self._clip_tokenizer([prompt], padding=True, return_tensors="pt").to(self._clip_device)
+                with torch.no_grad():
+                    text_features = self._full_clip_model.get_text_features(**inputs)
+                feat = text_features.squeeze(0)
+                feat = feat / feat.norm(dim=-1, keepdim=True)
+                return feat
+        except Exception as e:
+            logger.warning("CLIP encoding failed: %s", e)
+            return None
+
+    def encode_image(self, image_tensor: torch.Tensor) -> torch.Tensor | None:
+        # Video tensors are 5D [B, C, T, H, W] — skip image embedding for video
+        if image_tensor.dim() == 5:
+            return None
+        if getattr(self, "_use_fgclip", False) or self._full_clip_model is None:
+            return None
+        if self._clip_image_processor is None:
+            return None
+        try:
+            from PIL import Image
+
+            img = image_tensor.float().cpu()
+            if img.dim() == 4:
+                img = img[0]
+            if img.shape[0] == 3:
+                img = img.permute(1, 2, 0)
+            img = (img - img.min()) / (img.max() - img.min() + 1e-8)
+            img = (img * 255).clamp(0, 255).to(torch.uint8).numpy()
+            pil_image = Image.fromarray(img)
+            inputs = self._clip_image_processor(images=[pil_image], return_tensors="pt").to(self._clip_device)
+            with torch.no_grad():
+                image_features = self._full_clip_model.get_image_features(**inputs)
+            feat = image_features.squeeze(0)
+            feat = feat / feat.norm(dim=-1, keepdim=True)
+            return feat
+        except Exception as e:
+            logger.warning("CLIP image encoding failed: %s", e)
+            return None
+
+    def update_image_embedding(self, cache_key_hash: str | None, image_tensor: torch.Tensor) -> None:
+        if cache_key_hash is None:
+            return
+        if getattr(self, "_use_fgclip", False) or self._full_clip_model is None:
+            return
+        image_emb = self.encode_image(image_tensor)
+        if image_emb is not None:
+            self._cache_store.update_image_embedding(cache_key_hash, image_emb)
+
+    def semantic_lookup(
+        self, req: Any, target_device: torch.device | str | None = None
+    ) -> tuple[torch.Tensor | None, list[StepLatentData] | None, float, str | None, str | None]:
+        if not self.enabled or self._clip_model is None:
+            return None, None, 0.0, None, None
+
+        cache_key = build_cache_key_from_request(req, self._pipeline)
+        if cache_key is None:
+            return None, None, 0.0, None, None
+
+        query_emb = self.encode_prompt(cache_key.prompt)
+        if query_emb is None:
+            return None, None, 0.0, None, None
+
+        latents, step_latents, sim, cached_prompt, match_type = self._cache_store.semantic_search(
+            query_emb,
+            threshold=self._clip_threshold,
+            target_device=target_device,
+            required_height=cache_key.height,
+            required_width=cache_key.width,
+            required_num_inference_steps=cache_key.num_inference_steps,
+            required_num_frames=cache_key.num_frames,
+        )
+        return latents, step_latents, sim, cached_prompt, match_type
+
+    def compute_skip_steps(
+        self,
+        similarity: float,
+        total_steps: int,
+        query_prompt: str | None = None,
+        cached_prompt: str | None = None,
+        match_type: str | None = None,
+    ) -> int:
+        if similarity < self._clip_threshold:
+            return 0
+        max_skip = int(total_steps * self._clip_max_skip_ratio)
+        if max_skip <= self._clip_min_skip:
+            return self._clip_min_skip
+
+        ratio = (similarity - self._clip_threshold) / (1.0 - self._clip_threshold)
+        ratio = min(max(ratio, 0.0), 1.0)
+
+        skip = self._clip_min_skip + int(ratio * (max_skip - self._clip_min_skip))
+        return skip
+
+    @property
+    def clip_enabled(self) -> bool:
+        return self._clip_model is not None
+
+    def shutdown(self) -> None:
+        logger.info(
+            "InterRequestCacheBackend shutdown: persistent_cache_dir=%s, cache_size=%d",
+            self._persistent_cache_dir,
+            self._cache_store.size,
+        )
+        if self._persistent_cache_dir is not None and self._cache_store.size > 0:
+            saved = self._cache_store.save_to_disk(self._persistent_cache_dir)
+            logger.info(
+                "Persisted %d cache entries to %s",
+                saved,
+                self._persistent_cache_dir,
+            )
+
+    def refresh(self, pipeline: Any, num_inference_steps: int, verbose: bool = True, **kwargs: Any) -> None:
+        pass
+
+    def before_forward(self, is_dummy: bool = False) -> None:
+        if self._recorder is not None and not is_dummy:
+            self._recorder.clear()
+            self._recorder.enable()
+
+    def after_forward(self, cache_key_hash: str | None = None, is_dummy: bool = False) -> list[str] | None:
+        if self._recorder is None or is_dummy:
+            return None
+
+        self._recorder.disable()
+
+        if not self._record_step_latents:
+            self._recorder.clear()
+            return None
+
+        if self._recorder.num_steps == 0:
+            return None
+
+        save_dir = Path(self._step_latents_dir)
+        if cache_key_hash is not None:
+            save_dir = save_dir / cache_key_hash
+
+        saved_paths = self._recorder.save(save_dir)
+        self._recorder.clear()
+        return saved_paths
+
+    def lookup(self, req: Any, target_device: torch.device | str | None = None) -> torch.Tensor | None:
+        if not self.enabled or self._pipeline is None:
+            return None
+
+        cache_key = build_cache_key_from_request(req, self._pipeline)
+        if cache_key is None:
+            return None
+
+        return self._cache_store.get(cache_key, target_device=target_device)
+
+    def lookup_step_latents(
+        self, req: Any, target_device: torch.device | str | None = None
+    ) -> list[StepLatentData] | None:
+        if not self.enabled or self._pipeline is None:
+            return None
+
+        cache_key = build_cache_key_from_request(req, self._pipeline)
+        if cache_key is None:
+            return None
+
+        return self._cache_store.get_step_latents(cache_key, target_device=target_device)
+
+    def store(
+        self,
+        req: Any,
+        latents: torch.Tensor,
+        step_latents: list[StepLatentData] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str | None:
+        if not self.enabled or self._pipeline is None:
+            return None
+
+        cache_key = build_cache_key_from_request(req, self._pipeline)
+        if cache_key is None:
+            return None
+
+        clip_emb = None
+        if self._clip_model is not None:
+            prompt = cache_key.prompt
+            clip_emb = self.encode_prompt(prompt)
+
+        self._cache_store.put(cache_key, latents, step_latents=step_latents, metadata=metadata, clip_embedding=clip_emb)
+        return cache_key.to_hash()
+
+    @property
+    def cache_store(self) -> DiTCacheStore:
+        return self._cache_store
+
+    @property
+    def recorder(self) -> StepLatentsRecorder | None:
+        return self._recorder
+
+    def stats(self) -> dict[str, Any]:
+        return self._cache_store.stats()
+
+    def similarity_stats(self) -> dict:
+        return self._cache_store.get_similarity_stats()
+
+    def reset_similarity_stats(self) -> None:
+        self._cache_store.reset_similarity_stats()
+
+    def clear(self) -> None:
+        self._cache_store.clear()

--- a/vllm_omni/diffusion/cache/inter_request/cache_store.py
+++ b/vllm_omni/diffusion/cache/inter_request/cache_store.py
@@ -1,0 +1,799 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+# ---- Module constants ----
+_MB = 1024**2
+_GB = 1024**3
+_SIM_STATS_PATH = "/tmp/cache_sim_stats.json"
+_SIM_STATS_FLUSH_INTERVAL = 50  # flush similarity stats to file every N searches
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    prompt: str
+    negative_prompt: str
+    height: int
+    width: int
+    num_inference_steps: int
+    guidance_scale: float
+    true_cfg_scale: float
+    seed: int
+    sigmas: tuple[float, ...] | None
+    max_sequence_length: int | None
+    num_images_per_prompt: int
+    num_frames: int = 1
+
+    def to_hash(self) -> str:
+        data = {
+            "prompt": self.prompt,
+            "negative_prompt": self.negative_prompt,
+            "height": self.height,
+            "width": self.width,
+            "num_inference_steps": self.num_inference_steps,
+            "guidance_scale": self.guidance_scale,
+            "true_cfg_scale": self.true_cfg_scale,
+            "seed": self.seed,
+            "sigmas": list(self.sigmas) if self.sigmas is not None else None,
+            "max_sequence_length": self.max_sequence_length,
+            "num_images_per_prompt": self.num_images_per_prompt,
+            "num_frames": self.num_frames,
+        }
+        serialized = json.dumps(data, sort_keys=True)
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+@dataclass
+class StepLatentData:
+    step_index: int
+    timestep: float
+    latent: torch.Tensor
+
+
+@dataclass
+class CacheEntry:
+    latents: torch.Tensor
+    cache_key_hash: str
+    step_latents: list[StepLatentData] | None = None
+    metadata: dict[str, Any] | None = None
+    clip_embedding: torch.Tensor | None = None
+    cache_key: CacheKey | None = None
+    image_embedding: torch.Tensor | None = None
+
+
+class DiTCacheStore:
+    def __init__(self, max_entries: int = 100, max_memory_gb: float = 4.0):
+        self._store: OrderedDict[str, CacheEntry] = OrderedDict()
+        self._max_entries = max_entries
+        self._max_memory_bytes = max_memory_gb * _GB
+        self._current_memory_bytes = 0
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._misses = 0
+        self._all_sims: list[float] = []  # all final_sim values across all queries
+        self._all_t2t_sims: list[float] = []  # all t2t_sim values across all queries
+        self._search_count: int = 0  # throttle for _flush_sim_stats_to_file
+        self._use_t2i_penalty: bool = True  # enable t2i sigmoid penalty in hybrid matching
+
+        # ---- Pre-stacked embedding matrices for fast vectorized retrieval ----
+        # Instead of torch.stack()-ing all embeddings on every semantic_search()
+        # call (O(N) copy each time), we maintain two growable matrices that are
+        # updated incrementally on put()/update/evict.  Rows are lazily freed:
+        # evicted rows are marked invalid and skipped during search, avoiding
+        # costly matrix rebuilds on every eviction.
+        self._emb_dim: int | None = None  # embedding dim (set on first put)
+        self._txt_matrix: torch.Tensor | None = None  # [rows, dim] text embeddings
+        self._img_matrix: torch.Tensor | None = None  # [rows, dim] image embeddings (None row = absent)
+        self._row_keys: list[str | None] = []  # row_idx -> key_hash (None = freed row)
+        self._key_rows: dict[str, int] = {}  # key_hash -> row_idx
+        self._next_row: int = 0  # next free row to append to
+        self._capacity: int = 0  # allocated row capacity (grows in chunks)
+
+    def set_t2i_penalty(self, enabled: bool) -> None:
+        """Enable or disable t2i sigmoid penalty in hybrid matching."""
+        self._use_t2i_penalty = enabled
+        logger.info("t2i penalty %s", "enabled" if enabled else "disabled")
+
+    # ---- Matrix maintenance helpers ----
+    _ROW_CHUNK = 512  # rows to allocate per growth event
+
+    def _ensure_capacity(self, extra: int = 1) -> None:
+        """Grow the embedding matrices if needed to hold at least _next_row+extra rows."""
+        needed = self._next_row + extra
+        if needed <= self._capacity:
+            return
+        new_cap = max(needed, self._capacity + self._ROW_CHUNK)
+        if self._txt_matrix is None:
+            # first allocation
+            self._txt_matrix = torch.zeros(new_cap, self._emb_dim)
+            self._img_matrix = torch.zeros(new_cap, self._emb_dim)
+        else:
+            pad = new_cap - self._capacity
+            self._txt_matrix = torch.cat([self._txt_matrix, torch.zeros(pad, self._emb_dim)], dim=0)
+            self._img_matrix = torch.cat([self._img_matrix, torch.zeros(pad, self._emb_dim)], dim=0)
+            # extend row_keys list
+            self._row_keys.extend([None] * pad)
+        self._capacity = new_cap
+
+    def _matrix_add(self, key_hash: str, clip_embedding: torch.Tensor | None) -> None:
+        """Add/overwrite a row in the text embedding matrix for key_hash."""
+        if clip_embedding is None:
+            self._key_rows.pop(key_hash, None)
+            return
+        emb = clip_embedding.detach().cpu()
+        if emb.dim() == 2:
+            emb = emb.squeeze(0)
+        if self._emb_dim is None:
+            self._emb_dim = emb.shape[0]
+        elif emb.shape[0] != self._emb_dim:
+            logger.warning("Embedding dim mismatch: got %d, expected %d, skipping", emb.shape[0], self._emb_dim)
+            return
+        self._ensure_capacity(1)
+        row = self._next_row
+        self._txt_matrix[row] = emb
+        self._row_keys.append(key_hash)
+        self._key_rows[key_hash] = row
+        self._next_row += 1
+
+    def _matrix_update_image(self, key_hash: str, image_embedding: torch.Tensor) -> bool:
+        """Set the image embedding for an existing row. Returns False if key absent."""
+        row = self._key_rows.get(key_hash)
+        if row is None:
+            return False
+        emb = image_embedding.detach().cpu()
+        if emb.dim() == 2:
+            emb = emb.squeeze(0)
+        self._img_matrix[row] = emb
+        return True
+
+    def _matrix_free(self, key_hash: str) -> None:
+        """Lazily free a row (mark invalid); no matrix rebuild."""
+        row = self._key_rows.pop(key_hash, None)
+        if row is not None:
+            self._row_keys[row] = None  # mark as freed
+
+    def _estimate_tensor_bytes(self, tensor: torch.Tensor) -> int:
+        return tensor.nelement() * tensor.element_size()
+
+    def _estimate_step_latents_bytes(self, step_latents: list[StepLatentData]) -> int:
+        return sum(self._estimate_tensor_bytes(s.latent) for s in step_latents)
+
+    def _estimate_entry_bytes(self, entry: CacheEntry) -> int:
+        total = self._estimate_tensor_bytes(entry.latents)
+        if entry.step_latents is not None:
+            total += self._estimate_step_latents_bytes(entry.step_latents)
+        return total
+
+    def _evict_if_needed(self, required_bytes: int):
+        while len(self._store) >= self._max_entries or (
+            self._current_memory_bytes + required_bytes > self._max_memory_bytes and len(self._store) > 0
+        ):
+            oldest_key, oldest_entry = self._store.popitem(last=False)
+            freed = self._estimate_entry_bytes(oldest_entry)
+            self._current_memory_bytes -= freed
+            self._matrix_free(oldest_key)
+            logger.debug(
+                "Evicted cache entry %s, freed %.2f MB",
+                oldest_key[:8],
+                freed / _MB,
+            )
+
+    def put(
+        self,
+        key: CacheKey,
+        latents: torch.Tensor,
+        step_latents: list[StepLatentData] | None = None,
+        metadata: dict[str, Any] | None = None,
+        clip_embedding: torch.Tensor | None = None,
+    ):
+        key_hash = key.to_hash()
+        tensor_bytes = self._estimate_tensor_bytes(latents)
+        if step_latents is not None:
+            tensor_bytes += self._estimate_step_latents_bytes(step_latents)
+
+        with self._lock:
+            if key_hash in self._store:
+                old_entry = self._store[key_hash]
+                self._current_memory_bytes -= self._estimate_entry_bytes(old_entry)
+                self._matrix_free(key_hash)
+                del self._store[key_hash]
+
+            self._evict_if_needed(tensor_bytes)
+
+            cached_latents = latents.detach().clone().cpu()
+            cached_step_latents = None
+            if step_latents is not None:
+                cached_step_latents = [
+                    StepLatentData(
+                        step_index=s.step_index,
+                        timestep=s.timestep,
+                        latent=s.latent.detach().clone().cpu(),
+                    )
+                    for s in step_latents
+                ]
+            cached_clip = clip_embedding.detach().clone().cpu() if clip_embedding is not None else None
+            entry = CacheEntry(
+                latents=cached_latents,
+                cache_key_hash=key_hash,
+                step_latents=cached_step_latents,
+                metadata=metadata,
+                clip_embedding=cached_clip,
+                cache_key=key,
+            )
+            self._store[key_hash] = entry
+            self._matrix_add(key_hash, cached_clip)
+            self._current_memory_bytes += tensor_bytes
+
+            num_steps = len(cached_step_latents) if cached_step_latents is not None else 0
+            logger.info(
+                "Cached DiT state for key %s, size %.2f MB (final + %d steps), total cache %.2f MB / %d entries",
+                key_hash[:8],
+                tensor_bytes / _MB,
+                num_steps,
+                self._current_memory_bytes / _MB,
+                len(self._store),
+            )
+
+    def get(self, key: CacheKey, target_device: torch.device | str | None = None) -> torch.Tensor | None:
+        key_hash = key.to_hash()
+
+        with self._lock:
+            entry = self._store.get(key_hash)
+            if entry is None:
+                self._misses += 1
+                logger.debug("Cache MISS for key %s", key_hash[:8])
+                return None
+
+            self._store.move_to_end(key_hash)
+            self._hits += 1
+
+            latents = entry.latents
+            if target_device is not None:
+                latents = latents.to(device=target_device)
+            else:
+                latents = latents.clone()
+
+            logger.info(
+                "Cache HIT for key %s (hits=%d, misses=%d, hit_rate=%.2f%%)",
+                key_hash[:8],
+                self._hits,
+                self._misses,
+                self.hit_rate * 100,
+            )
+            return latents
+
+    def update_image_embedding(self, key_hash: str, image_embedding: torch.Tensor) -> bool:
+        with self._lock:
+            entry = self._store.get(key_hash)
+            if entry is None:
+                return False
+            img_emb = image_embedding.detach().clone().cpu()
+            entry.image_embedding = img_emb
+            self._matrix_update_image(key_hash, img_emb)
+            logger.info("Updated image embedding for cache entry %s", key_hash[:8])
+            return True
+
+    def semantic_search(
+        self,
+        query_embedding: torch.Tensor,
+        threshold: float = 0.75,
+        target_device: torch.device | str | None = None,
+        required_height: int | None = None,
+        required_width: int | None = None,
+        required_num_inference_steps: int | None = None,
+        required_num_frames: int | None = None,
+    ) -> tuple[torch.Tensor | None, list[StepLatentData] | None, float, str | None, str | None]:
+        if query_embedding.dim() == 1:
+            query_embedding = query_embedding.unsqueeze(0)
+        query_norm = query_embedding / query_embedding.norm(dim=-1, keepdim=True)
+        best_sim = 0.0
+        best_key_hash = None
+        best_t2t = 0.0
+        best_t2i = 0.0
+        best_penalty = 1.0
+
+        with self._lock:
+            # ---- Vectorized retrieval using pre-stacked matrices ----
+            # The text embedding matrix (_txt_matrix) is maintained incrementally
+            # on put()/evict(), so we avoid torch.stack() on every search.
+            # We iterate over rows to build dimension/step-filtered index lists,
+            # then slice the matrices and compute all similarities in batch.
+            # Rows fall into:
+            #   hybrid: has image embedding -> sim = t2t * sigmoid_penalty(t2i)
+            #   text_only: no image embedding -> sim = t2t
+            if self._txt_matrix is None or self._next_row == 0:
+                # empty cache
+                self._misses += 1
+                logger.info(
+                    "CLIP semantic search: no match (cache empty, threshold=%.2f)",
+                    threshold,
+                )
+                return None, None, 0.0, None, None
+
+            # Build filtered index lists (row indices) + track which are hybrid
+            hybrid_row_idxs: list[int] = []
+            text_row_idxs: list[int] = []
+            for row_idx in range(self._next_row):
+                kh = self._row_keys[row_idx]
+                if kh is None:
+                    continue  # freed row
+                entry = self._store.get(kh)
+                if entry is None:
+                    continue
+                if entry.cache_key is not None:
+                    if required_height is not None and entry.cache_key.height != required_height:
+                        continue
+                    if required_width is not None and entry.cache_key.width != required_width:
+                        continue
+                    if (
+                        required_num_inference_steps is not None
+                        and entry.cache_key.num_inference_steps < required_num_inference_steps
+                    ):
+                        continue
+                    if (
+                        required_num_frames is not None
+                        and entry.cache_key.num_frames != required_num_frames
+                    ):
+                        continue
+                if entry.image_embedding is not None and entry.clip_embedding is not None:
+                    hybrid_row_idxs.append(row_idx)
+                elif entry.clip_embedding is not None:
+                    text_row_idxs.append(row_idx)
+
+            q_cpu = query_norm.cpu()  # [1, dim]
+
+            # --- Hybrid group: sim = t2t * sigmoid_penalty(t2i) ---
+            # Embeddings already L2-normalized at encode time (backend.py),
+            # so cosine similarity = dot product directly — no re-normalization.
+            if hybrid_row_idxs:
+                idx_t = torch.tensor(hybrid_row_idxs, dtype=torch.long)
+                txt_sub = self._txt_matrix.index_select(0, idx_t)  # [M, dim]
+                img_sub = self._img_matrix.index_select(0, idx_t)  # [M, dim]
+                t2t = (q_cpu * txt_sub).sum(dim=-1)  # [M]
+                t2i = (q_cpu * img_sub).sum(dim=-1)  # [M]
+                if self._use_t2i_penalty:
+                    penalty = torch.sigmoid((t2i - 0.10) * 10)  # [M]
+                else:
+                    penalty = torch.ones_like(t2t)  # no t2i penalty
+                sims = t2t * penalty  # [M]
+
+                self._all_sims.extend(sims.tolist())
+                self._all_t2t_sims.extend(t2t.tolist())
+                best_local = int(torch.argmax(sims).item())
+                best_sim = float(sims[best_local].item())
+                best_row = hybrid_row_idxs[best_local]
+                best_key_hash = self._row_keys[best_row]
+                best_t2t = float(t2t[best_local].item())
+                best_t2i = float(t2i[best_local].item())
+                best_penalty = float(penalty[best_local].item())
+
+            # --- Text-only group: sim = t2t ---
+            if text_row_idxs:
+                idx_t = torch.tensor(text_row_idxs, dtype=torch.long)
+                txt_sub = self._txt_matrix.index_select(0, idx_t)  # [K, dim]
+                t2t = (q_cpu * txt_sub).sum(dim=-1)  # [K]
+                sims = t2t  # sim == t2t for text-only
+
+                self._all_sims.extend(sims.tolist())
+                self._all_t2t_sims.extend(t2t.tolist())
+                best_local = int(torch.argmax(sims).item())
+                top_sim = float(sims[best_local].item())
+                if top_sim > best_sim:
+                    best_sim = top_sim
+                    best_row = text_row_idxs[best_local]
+                    best_key_hash = self._row_keys[best_row]
+                    best_t2t = float(t2t[best_local].item())
+                    best_t2i = 0.0
+                    best_penalty = 1.0
+
+            # Original loop initialized best_sim=0.0 and only updated on strictly
+            # greater values, so an all-negative result left best_key_hash=None.
+            # argmax can pick a negative winner; clamp to match original behavior
+            # (all-negative -> no match, consistent best_sim=0.0 in logs/stats).
+            if best_sim < 0.0:
+                best_sim = 0.0
+                best_key_hash = None
+                best_t2t = 0.0
+                best_t2i = 0.0
+                best_penalty = 1.0
+
+            # Throttle stats flushing: only every N searches to avoid O(total)
+            # numpy computation + disk write on every single query.
+            self._search_count += 1
+            if self._search_count % _SIM_STATS_FLUSH_INTERVAL == 0:
+                self._flush_sim_stats_to_file()
+
+            if best_key_hash is not None and self._store[best_key_hash].image_embedding is not None:
+                match_type = "hybrid"
+            else:
+                match_type = "text-text"
+
+            if best_key_hash is None or best_sim < threshold:
+                self._misses += 1
+                logger.info(
+                    "CLIP semantic search: no match (t2t=%.4f, t2i=%.4f, penalty=%.4f, final=%.4f, threshold=%.2f)",
+                    best_t2t,
+                    best_t2i,
+                    best_penalty,
+                    best_sim,
+                    threshold,
+                )
+                return None, None, best_sim, None, None
+
+            self._store.move_to_end(best_key_hash)
+            self._hits += 1
+            entry = self._store[best_key_hash]
+            cached_prompt = entry.cache_key.prompt if entry.cache_key is not None else None
+
+            latents = entry.latents
+            if target_device is not None:
+                latents = latents.to(device=target_device)
+            else:
+                latents = latents.clone()
+
+            step_latents = None
+            if entry.step_latents is not None and target_device is not None:
+                step_latents = [
+                    StepLatentData(
+                        step_index=s.step_index,
+                        timestep=s.timestep,
+                        latent=s.latent.to(device=target_device),
+                    )
+                    for s in entry.step_latents
+                ]
+            elif entry.step_latents is not None:
+                step_latents = [
+                    StepLatentData(
+                        step_index=s.step_index,
+                        timestep=s.timestep,
+                        latent=s.latent.clone(),
+                    )
+                    for s in entry.step_latents
+                ]
+
+            logger.info(
+                "CLIP semantic HIT [%s]: key=%s "
+                "t2t=%.4f t2i=%.4f penalty=%.4f final=%.4f "
+                "(threshold=%.2f, hits=%d, misses=%d)",
+                match_type,
+                best_key_hash[:8],
+                best_t2t,
+                best_t2i,
+                best_penalty,
+                best_sim,
+                threshold,
+                self._hits,
+                self._misses,
+            )
+            return latents, step_latents, best_sim, cached_prompt, match_type
+
+    def get_step_latents(
+        self, key: CacheKey, target_device: torch.device | str | None = None
+    ) -> list[StepLatentData] | None:
+        key_hash = key.to_hash()
+
+        with self._lock:
+            entry = self._store.get(key_hash)
+            if entry is None or entry.step_latents is None:
+                return None
+
+            self._store.move_to_end(key_hash)
+
+            if target_device is not None:
+                return [
+                    StepLatentData(
+                        step_index=s.step_index,
+                        timestep=s.timestep,
+                        latent=s.latent.to(device=target_device),
+                    )
+                    for s in entry.step_latents
+                ]
+            return [
+                StepLatentData(
+                    step_index=s.step_index,
+                    timestep=s.timestep,
+                    latent=s.latent.clone(),
+                )
+                for s in entry.step_latents
+            ]
+
+    @property
+    def hit_rate(self) -> float:
+        total = self._hits + self._misses
+        if total == 0:
+            return 0.0
+        return self._hits / total
+
+    def get_similarity_stats(self) -> dict:
+        """Return distribution stats of all similarity values collected.
+        Reads from a shared file so it can be called from any process."""
+        try:
+            with open(_SIM_STATS_PATH) as f:
+                return json.load(f)
+        except Exception:
+            return {"final_sim": {"total_comparisons": 0}, "t2t_sim": {"total_comparisons": 0}}
+
+    def reset_similarity_stats(self) -> None:
+        """Clear collected similarity values and reset the shared file."""
+        with self._lock:
+            self._all_sims.clear()
+            self._all_t2t_sims.clear()
+        try:
+            with open(_SIM_STATS_PATH, "w") as f:
+                json.dump({"final_sim": {"total_comparisons": 0}, "t2t_sim": {"total_comparisons": 0}}, f)
+        except Exception:
+            pass
+
+    def _flush_sim_stats_to_file(self) -> None:
+        """Write current sim stats to a shared file (called from within lock)."""
+
+        def _compute_stats(values):
+            if not values:
+                return {"total_comparisons": 0}
+            arr = np.array(values)
+            return {
+                "total_comparisons": len(values),
+                "mean": float(np.mean(arr)),
+                "std": float(np.std(arr)),
+                "min": float(np.min(arr)),
+                "max": float(np.max(arr)),
+                "median": float(np.median(arr)),
+                "gte_0.9": int(np.sum(arr >= 0.9)),
+                "gte_0.8": int(np.sum(arr >= 0.8)),
+                "gte_0.7": int(np.sum(arr >= 0.7)),
+                "gte_0.6": int(np.sum(arr >= 0.6)),
+                "gte_0.5": int(np.sum(arr >= 0.5)),
+            }
+
+        result = {
+            "final_sim": _compute_stats(self._all_sims),
+            "t2t_sim": _compute_stats(self._all_t2t_sims),
+        }
+        try:
+            with open(_SIM_STATS_PATH, "w") as f:
+                json.dump(result, f)
+        except Exception:
+            pass
+
+    @property
+    def size(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    @property
+    def memory_usage_mb(self) -> float:
+        with self._lock:
+            return self._current_memory_bytes / _MB
+
+    def clear(self):
+        with self._lock:
+            self._store.clear()
+            self._current_memory_bytes = 0
+            self._hits = 0
+            self._misses = 0
+            # reset embedding matrices
+            self._emb_dim = None
+            self._txt_matrix = None
+            self._img_matrix = None
+            self._row_keys = []
+            self._key_rows = {}
+            self._next_row = 0
+            self._capacity = 0
+            logger.info("DiT cache store cleared")
+
+    def stats(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "entries": len(self._store),
+                "max_entries": self._max_entries,
+                "memory_mb": self._current_memory_bytes / _MB,
+                "max_memory_gb": self._max_memory_bytes / _GB,
+                "hits": self._hits,
+                "misses": self._misses,
+                "hit_rate": self.hit_rate,
+            }
+
+    def save_to_disk(self, cache_dir: str | Path) -> int:
+        cache_dir = Path(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        saved_count = 0
+        with self._lock:
+            for key_hash, entry in self._store.items():
+                entry_dir = cache_dir / key_hash
+                try:
+                    entry_dir.mkdir(parents=True, exist_ok=True)
+
+                    torch.save(
+                        entry.latents.cpu(),
+                        entry_dir / "final_latent.pt",
+                    )
+
+                    meta = {
+                        "cache_key_hash": entry.cache_key_hash,
+                        "metadata": entry.metadata,
+                    }
+
+                    if entry.step_latents is not None:
+                        step_data = []
+                        for s in entry.step_latents:
+                            step_file = entry_dir / f"step_{s.step_index:04d}.pt"
+                            torch.save(
+                                {
+                                    "step_index": s.step_index,
+                                    "timestep": s.timestep,
+                                    "latent": s.latent.cpu(),
+                                },
+                                step_file,
+                            )
+                            step_data.append(
+                                {
+                                    "step_index": s.step_index,
+                                    "timestep": s.timestep,
+                                    "file": step_file.name,
+                                }
+                            )
+                        meta["step_latents"] = step_data
+                        meta["num_steps"] = len(step_data)
+
+                    with open(entry_dir / "meta.json", "w") as f:
+                        json.dump(meta, f, indent=2)
+
+                    saved_count += 1
+                except Exception as e:
+                    logger.warning(
+                        "Failed to save cache entry %s to disk: %s",
+                        key_hash[:8],
+                        e,
+                    )
+
+        logger.info(
+            "Saved %d cache entries to %s (%.2f MB)",
+            saved_count,
+            cache_dir,
+            self._current_memory_bytes / _MB,
+        )
+        return saved_count
+
+    def load_from_disk(self, cache_dir: str | Path) -> int:
+        cache_dir = Path(cache_dir)
+        if not cache_dir.exists():
+            logger.info("Cache directory %s does not exist, skipping load", cache_dir)
+            return 0
+
+        loaded_count = 0
+        with self._lock:
+            for entry_dir in sorted(cache_dir.iterdir()):
+                if not entry_dir.is_dir():
+                    continue
+                meta_file = entry_dir / "meta.json"
+                latent_file = entry_dir / "final_latent.pt"
+                if not meta_file.exists() or not latent_file.exists():
+                    continue
+
+                try:
+                    key_hash = entry_dir.name
+
+                    with open(meta_file) as f:
+                        meta = json.load(f)
+
+                    latents = torch.load(latent_file, map_location="cpu", weights_only=True)
+
+                    step_latents = None
+                    if "step_latents" in meta and meta["step_latents"]:
+                        step_latents = []
+                        for step_info in meta["step_latents"]:
+                            step_file = entry_dir / step_info["file"]
+                            if step_file.exists():
+                                step_data = torch.load(step_file, map_location="cpu", weights_only=True)
+                                step_latents.append(
+                                    StepLatentData(
+                                        step_index=step_data["step_index"],
+                                        timestep=step_data["timestep"],
+                                        latent=step_data["latent"],
+                                    )
+                                )
+
+                    if key_hash in self._store:
+                        old_entry = self._store[key_hash]
+                        self._current_memory_bytes -= self._estimate_entry_bytes(old_entry)
+
+                    entry = CacheEntry(
+                        latents=latents,
+                        cache_key_hash=meta.get("cache_key_hash", key_hash),
+                        step_latents=step_latents,
+                        metadata=meta.get("metadata"),
+                    )
+                    self._store[key_hash] = entry
+                    self._current_memory_bytes += self._estimate_entry_bytes(entry)
+                    loaded_count += 1
+
+                except Exception as e:
+                    logger.warning(
+                        "Failed to load cache entry from %s: %s",
+                        entry_dir,
+                        e,
+                    )
+
+        logger.info(
+            "Loaded %d cache entries from %s (%.2f MB)",
+            loaded_count,
+            cache_dir,
+            self._current_memory_bytes / _MB,
+        )
+        return loaded_count
+
+
+def build_cache_key_from_request(
+    req: Any,
+    pipeline: Any,
+) -> CacheKey | None:
+    try:
+        prompts = req.prompts
+        if not prompts:
+            return None
+
+        prompt_text = ""
+        negative_prompt_text = ""
+        if isinstance(prompts[0], str):
+            prompt_text = prompts[0]
+        elif isinstance(prompts[0], dict):
+            prompt_text = prompts[0].get("prompt", "")
+            negative_prompt_text = prompts[0].get("negative_prompt", "") or ""
+
+        sampling = req.sampling_params
+
+        height = sampling.height
+        width = sampling.width
+        if height is None and hasattr(pipeline, "default_sample_size"):
+            vae_sf = getattr(pipeline, "vae_scale_factor", 8)
+            height = pipeline.default_sample_size * vae_sf
+        if width is None and hasattr(pipeline, "default_sample_size"):
+            vae_sf = getattr(pipeline, "vae_scale_factor", 8)
+            width = pipeline.default_sample_size * vae_sf
+
+        num_inference_steps = sampling.num_inference_steps or 50
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
+        true_cfg_scale = sampling.true_cfg_scale or 1.0
+        seed = sampling.seed if sampling.seed is not None else -1
+        if seed == -1 and sampling.generator is not None:
+            try:
+                if isinstance(sampling.generator, torch.Generator):
+                    seed = sampling.generator.initial_seed()
+            except Exception:
+                pass
+
+        sigmas = tuple(sampling.sigmas) if sampling.sigmas is not None else None
+        max_sequence_length = sampling.max_sequence_length
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        num_frames = getattr(sampling, "num_frames", 1) or 1
+
+        return CacheKey(
+            prompt=prompt_text,
+            negative_prompt=negative_prompt_text,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            true_cfg_scale=true_cfg_scale,
+            seed=seed,
+            sigmas=sigmas,
+            max_sequence_length=max_sequence_length,
+            num_images_per_prompt=num_images_per_prompt,
+            num_frames=num_frames,
+        )
+    except Exception as e:
+        logger.warning("Failed to build cache key: %s", e)
+        return None

--- a/vllm_omni/diffusion/cache/inter_request/cache_store.py
+++ b/vllm_omni/diffusion/cache/inter_request/cache_store.py
@@ -174,6 +174,10 @@ class DiTCacheStore:
         total = self._estimate_tensor_bytes(entry.latents)
         if entry.step_latents is not None:
             total += self._estimate_step_latents_bytes(entry.step_latents)
+        if entry.clip_embedding is not None:
+            total += self._estimate_tensor_bytes(entry.clip_embedding)
+        if entry.image_embedding is not None:
+            total += self._estimate_tensor_bytes(entry.image_embedding)
         return total
 
     def _evict_if_needed(self, required_bytes: int):
@@ -626,6 +630,38 @@ class DiTCacheStore:
                         "metadata": entry.metadata,
                     }
 
+                    # Persist cache_key so that semantic_search dimension filters
+                    # (height/width/steps/frames) survive a restart.
+                    if entry.cache_key is not None:
+                        ck = entry.cache_key
+                        meta["cache_key"] = {
+                            "prompt": ck.prompt,
+                            "negative_prompt": ck.negative_prompt,
+                            "height": ck.height,
+                            "width": ck.width,
+                            "num_inference_steps": ck.num_inference_steps,
+                            "guidance_scale": ck.guidance_scale,
+                            "true_cfg_scale": ck.true_cfg_scale,
+                            "seed": ck.seed,
+                            "sigmas": list(ck.sigmas) if ck.sigmas is not None else None,
+                            "max_sequence_length": ck.max_sequence_length,
+                            "num_images_per_prompt": ck.num_images_per_prompt,
+                            "num_frames": ck.num_frames,
+                        }
+
+                    # Persist text/image embeddings so loaded entries remain
+                    # searchable by semantic_search without re-encoding.
+                    if entry.clip_embedding is not None:
+                        torch.save(
+                            entry.clip_embedding.cpu(),
+                            entry_dir / "clip_embedding.pt",
+                        )
+                    if entry.image_embedding is not None:
+                        torch.save(
+                            entry.image_embedding.cpu(),
+                            entry_dir / "image_embedding.pt",
+                        )
+
                     if entry.step_latents is not None:
                         step_data = []
                         for s in entry.step_latents:
@@ -710,13 +746,53 @@ class DiTCacheStore:
                         old_entry = self._store[key_hash]
                         self._current_memory_bytes -= self._estimate_entry_bytes(old_entry)
 
+                    # Restore CacheKey so semantic_search dimension filters work.
+                    cache_key = None
+                    ck_meta = meta.get("cache_key")
+                    if ck_meta is not None:
+                        try:
+                            cache_key = CacheKey(
+                                prompt=ck_meta["prompt"],
+                                negative_prompt=ck_meta.get("negative_prompt", ""),
+                                height=ck_meta["height"],
+                                width=ck_meta["width"],
+                                num_inference_steps=ck_meta["num_inference_steps"],
+                                guidance_scale=ck_meta["guidance_scale"],
+                                true_cfg_scale=ck_meta["true_cfg_scale"],
+                                seed=ck_meta["seed"],
+                                sigmas=tuple(ck_meta["sigmas"]) if ck_meta.get("sigmas") is not None else None,
+                                max_sequence_length=ck_meta.get("max_sequence_length"),
+                                num_images_per_prompt=ck_meta["num_images_per_prompt"],
+                                num_frames=ck_meta.get("num_frames", 1),
+                            )
+                        except (KeyError, TypeError) as e:
+                            logger.debug("Could not restore CacheKey for %s: %s", key_hash[:8], e)
+
+                    # Restore embeddings so loaded entries stay semantically searchable.
+                    clip_embedding = None
+                    image_embedding = None
+                    clip_file = entry_dir / "clip_embedding.pt"
+                    img_file = entry_dir / "image_embedding.pt"
+                    if clip_file.exists():
+                        clip_embedding = torch.load(clip_file, map_location="cpu", weights_only=True)
+                    if img_file.exists():
+                        image_embedding = torch.load(img_file, map_location="cpu", weights_only=True)
+
                     entry = CacheEntry(
                         latents=latents,
                         cache_key_hash=meta.get("cache_key_hash", key_hash),
                         step_latents=step_latents,
                         metadata=meta.get("metadata"),
+                        clip_embedding=clip_embedding,
+                        cache_key=cache_key,
+                        image_embedding=image_embedding,
                     )
                     self._store[key_hash] = entry
+                    # Register in the semantic-search matrices so loaded entries
+                    # are visible to vectorized semantic_search.
+                    self._matrix_add(key_hash, clip_embedding)
+                    if image_embedding is not None:
+                        self._matrix_update_image(key_hash, image_embedding)
                     self._current_memory_bytes += self._estimate_entry_bytes(entry)
                     loaded_count += 1
 

--- a/vllm_omni/diffusion/cache/inter_request/step_recorder.py
+++ b/vllm_omni/diffusion/cache/inter_request/step_recorder.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StepLatentRecord:
+    step_index: int
+    timestep: float
+    latent: torch.Tensor
+
+
+class StepLatentsRecorder:
+    """
+    Records latent tensors at each denoising step during the first request.
+
+    When attached to a pipeline as ``pipeline._step_latents_recorder``, the
+    diffuse loop will call ``record()`` after every scheduler step.  After the
+    forward pass completes, call ``save()`` to persist all step latents to disk
+    or ``clear()`` to discard them.
+    """
+
+    def __init__(self) -> None:
+        self._records: list[StepLatentRecord] = []
+        self._enabled: bool = True
+
+    def record(self, step_index: int, timestep: float, latent: torch.Tensor) -> None:
+        if not self._enabled:
+            return
+        self._records.append(
+            StepLatentRecord(
+                step_index=step_index,
+                timestep=timestep,
+                latent=latent.detach().clone().cpu(),
+            )
+        )
+
+    @property
+    def records(self) -> list[StepLatentRecord]:
+        return self._records
+
+    @property
+    def num_steps(self) -> int:
+        return len(self._records)
+
+    def save(self, save_dir: str | Path, prefix: str = "step") -> list[str]:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+        saved_paths: list[str] = []
+        for rec in self._records:
+            filename = f"{prefix}_step{rec.step_index:04d}_t{rec.timestep:.1f}.pt"
+            filepath = save_dir / filename
+            torch.save(
+                {"step_index": rec.step_index, "timestep": rec.timestep, "latent": rec.latent},
+                filepath,
+            )
+            saved_paths.append(str(filepath))
+        logger.info(
+            "Saved %d step latents to %s (%.2f MB total)",
+            len(saved_paths),
+            save_dir,
+            sum(os.path.getsize(p) for p in saved_paths) / 1024**2,
+        )
+        return saved_paths
+
+    def clear(self) -> None:
+        self._records.clear()
+
+    def disable(self) -> None:
+        self._enabled = False
+
+    def enable(self) -> None:
+        self._enabled = True

--- a/vllm_omni/diffusion/cache/selector.py
+++ b/vllm_omni/diffusion/cache/selector.py
@@ -1,9 +1,6 @@
 from typing import Any
 
 from vllm_omni.diffusion.cache.base import CacheBackend
-from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTBackend
-from vllm_omni.diffusion.cache.magcache.backend import MagCacheBackend
-from vllm_omni.diffusion.cache.teacache.backend import TeaCacheBackend
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 
 
@@ -14,14 +11,17 @@ def get_cache_backend(cache_backend: str | None, cache_config: Any) -> CacheBack
     - cache_dit: Uses CacheDiTBackend with enable()/refresh() interface
     - tea_cache: Uses TeaCacheBackend with enable()/refresh() interface
     - mag_cache: Uses MagCacheBackend with enable()/refresh() interface
+    - inter_request: Uses InterRequestCacheBackend for cross-request DiT state reuse
+    - inter_request+cache_dit: CompositeCacheBackend combining both
 
     Args:
-        cache_backend: Cache backend name ("cache_dit", "tea_cache", "mag_cache", or None).
+        cache_backend: Cache backend name. Supported values:
+            "cache_dit", "tea_cache", "mag_cache", "inter_request",
+            "inter_request+cache_dit" (or "cache_dit+inter_request"), or None.
         cache_config: Cache configuration (dict or DiffusionCacheConfig instance).
 
     Returns:
-        Cache backend instance (CacheDiTBackend, TeaCacheBackend, or MagCacheBackend)
-        if cache_backend is set, None otherwise.
+        Cache backend instance if cache_backend is set, None otherwise.
 
     Raises:
         ValueError: If cache_backend is unsupported.
@@ -33,12 +33,27 @@ def get_cache_backend(cache_backend: str | None, cache_config: Any) -> CacheBack
         cache_config = DiffusionCacheConfig.from_dict(cache_config)
 
     if cache_backend == "cache_dit":
+        from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTBackend
+
         return CacheDiTBackend(cache_config)
     elif cache_backend == "tea_cache":
+        from vllm_omni.diffusion.cache.teacache.backend import TeaCacheBackend
+
         return TeaCacheBackend(cache_config)
     elif cache_backend == "mag_cache":
+        from vllm_omni.diffusion.cache.magcache.backend import MagCacheBackend
+
         return MagCacheBackend(cache_config)
+    elif cache_backend == "inter_request":
+        from vllm_omni.diffusion.cache.inter_request.backend import InterRequestCacheBackend
+
+        return InterRequestCacheBackend(cache_config)
+    elif cache_backend in ("inter_request+cache_dit", "cache_dit+inter_request"):
+        from vllm_omni.diffusion.cache.composite_backend import CompositeCacheBackend
+
+        return CompositeCacheBackend(cache_config)
     else:
         raise ValueError(
-            f"Unsupported cache backend: {cache_backend}. Supported: 'cache_dit', 'tea_cache', 'mag_cache'"
+            f"Unsupported cache backend: {cache_backend}. "
+            "Supported: 'cache_dit', 'tea_cache', 'mag_cache', 'inter_request', 'inter_request+cache_dit'"
         )

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -380,6 +380,12 @@ class DiffusionCacheConfig:
     inter_request_record_step_latents: bool = False
     inter_request_step_latents_dir: str = "./step_latents"
     inter_request_persistent_cache_dir: str | None = None
+    # CLIP-based semantic matching parameters [inter_request only]
+    inter_request_clip_model_path: str | None = None
+    inter_request_clip_threshold: float = 0.75
+    inter_request_clip_min_skip: int = 5
+    inter_request_clip_max_skip_ratio: float = 0.5
+    inter_request_use_t2i_penalty: bool = True
 
     # Additional parameters that may be passed but not explicitly defined
     _extra_params: dict[str, Any] = field(default_factory=dict, repr=False)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -374,6 +374,12 @@ class DiffusionCacheConfig:
     # Policy for force refresh: "once" refreshes only at the hint step,
     # "repeat" refreshes every force_refresh_step_hint steps.
     force_refresh_step_policy: str = "once"
+    # Inter-request cache parameters [inter_request only]
+    inter_request_max_entries: int = 100
+    inter_request_max_memory_gb: float = 4.0
+    inter_request_record_step_latents: bool = False
+    inter_request_step_latents_dir: str = "./step_latents"
+    inter_request_persistent_cache_dir: str | None = None
 
     # Additional parameters that may be passed but not explicitly defined
     _extra_params: dict[str, Any] = field(default_factory=dict, repr=False)

--- a/vllm_omni/diffusion/models/qwen_image/cfg_parallel.py
+++ b/vllm_omni/diffusion/models/qwen_image/cfg_parallel.py
@@ -42,6 +42,8 @@ class QwenImageCFGParallelMixin(CFGParallelMixin, ProgressBarMixin):
         image_latents: torch.Tensor | None = None,
         cfg_normalize: bool = True,
         additional_transformer_kwargs: dict[str, Any] | None = None,
+        resume_from_step: int = 0,
+        resume_latents: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Diffusion loop with optional classifier-free guidance.
@@ -70,16 +72,30 @@ class QwenImageCFGParallelMixin(CFGParallelMixin, ProgressBarMixin):
         self.transformer.do_true_cfg = do_true_cfg
         additional_transformer_kwargs = additional_transformer_kwargs or {}
 
+        step_latents_recorder = getattr(self, "_step_latents_recorder", None)
+
+        if resume_from_step > 0 and resume_latents is not None:
+            latents = resume_latents.to(device=latents.device, dtype=latents.dtype)
+            self.scheduler._step_index = resume_from_step
+            self.scheduler.set_begin_index(resume_from_step)
+            logger.info(
+                "Resuming denoising from step %d/%d (timestep=%.1f)",
+                resume_from_step,
+                len(timesteps),
+                timesteps[resume_from_step].item() if resume_from_step < len(timesteps) else -1,
+            )
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):
+                if i < resume_from_step:
+                    pbar.update()
+                    continue
                 if self.interrupt:
                     continue
                 self._current_timestep = t
 
-                # Broadcast timestep to match batch size
                 timestep = t.expand(latents.shape[0]).to(device=latents.device, dtype=latents.dtype)
 
-                # Concatenate image latents with noise latents if available (for editing pipelines)
                 latent_model_input = latents
                 if image_latents is not None:
                     latent_model_input = torch.cat([latents, image_latents], dim=1)
@@ -108,10 +124,8 @@ class QwenImageCFGParallelMixin(CFGParallelMixin, ProgressBarMixin):
                 else:
                     negative_kwargs = None
 
-                # For editing pipelines, we need to slice the output to remove condition latents
                 output_slice = latents.size(1) if image_latents is not None else None
 
-                # Predict noise with automatic CFG parallel handling
                 noise_pred = self.predict_noise_maybe_with_cfg(
                     do_true_cfg,
                     true_cfg_scale,
@@ -121,8 +135,10 @@ class QwenImageCFGParallelMixin(CFGParallelMixin, ProgressBarMixin):
                     output_slice,
                 )
 
-                # Compute the previous noisy sample x_t -> x_t-1 with automatic CFG sync
                 latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+
+                if step_latents_recorder is not None:
+                    step_latents_recorder.record(i, t.item(), latents)
 
                 pbar.update()
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -1055,6 +1055,8 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 "return_dict": False,
                 "attention_kwargs": self.attention_kwargs,
             },
+            resume_from_step=getattr(req.sampling_params, "resume_from_step", 0) or 0,
+            resume_latents=getattr(req.sampling_params, "resume_latents", None),
         )
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -864,6 +864,8 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
                 "return_dict": False,
                 "attention_kwargs": self.attention_kwargs,
             },
+            resume_from_step=getattr(req.sampling_params, "resume_from_step", 0) or 0,
+            resume_latents=getattr(req.sampling_params, "resume_latents", None),
         )
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -836,6 +836,8 @@ class QwenImageEditPlusPipeline(
                 "return_dict": False,
                 "attention_kwargs": self.attention_kwargs,
             },
+            resume_from_step=getattr(req.sampling_params, "resume_from_step", 0) or 0,
+            resume_latents=getattr(req.sampling_params, "resume_latents", None),
         )
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -874,6 +874,8 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 "additional_t_cond": is_rgb,
                 "attention_kwargs": self.attention_kwargs,
             },
+            resume_from_step=getattr(req.sampling_params, "resume_from_step", 0) or 0,
+            resume_latents=getattr(req.sampling_params, "resume_latents", None),
         )
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -570,11 +570,6 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             input_batch = self._prepare_batch_inputs(states, new_request_ids)
             attn_metadata = self._prepare_attn_metadata(input_batch)
 
-            is_dummy = "dummy" in req.request_ids[0] if req.request_ids else False
-
-            if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
-                self.cache_backend.before_forward(is_dummy=is_dummy)
-
             with set_forward_context(
                 vllm_config=self.vllm_config,
                 omni_diffusion_config=self.od_config,

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -392,7 +392,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if is_primary:
                 current_omni_platform.reset_peak_memory_stats()
 
-            is_dummy = "dummy" in req.request_ids[0] if req.request_ids else False
+            is_dummy = req.is_dummy_run
 
             if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
                 self.cache_backend.before_forward(is_dummy=is_dummy)

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -22,7 +22,11 @@ from vllm.config import LoadConfig
 from vllm.logger import init_logger
 from vllm.utils.mem_utils import DeviceMemoryProfiler, GiB_bytes
 
+import threading
+
 from vllm_omni.diffusion.cache.cache_dit_backend import cache_summary
+from vllm_omni.diffusion.cache.inter_request.backend import InterRequestCacheBackend
+from vllm_omni.diffusion.cache.inter_request.cache_store import StepLatentData
 from vllm_omni.diffusion.cache.prompt_embed_cache import (
     install_prompt_embed_cache,
     resolve_prompt_embed_cache_config,
@@ -223,6 +227,22 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             return None
         return self.prompt_embed_cache.stats()
 
+    def _update_cache_image_embedding(self, cache_key_hash: str, image_tensor: torch.Tensor) -> None:
+        # Skip image embedding update for video (5D tensor [B,C,T,H,W])
+        if image_tensor.dim() == 5:
+            return
+        # Copy tensor to CPU before async to avoid NPU synchronization issues
+        image_tensor_cpu = image_tensor.detach().clone().cpu()
+
+        def _worker():
+            try:
+                self.cache_backend.update_image_embedding(cache_key_hash, image_tensor_cpu)
+            except Exception as e:
+                logger.debug("Failed to update image embedding: %s", e)
+
+        t_thread = threading.Thread(target=_worker, daemon=True)
+        t_thread.start()
+
     def _record_peak_memory(self, output: DiffusionOutput) -> None:
         """Record peak GPU memory for the current forward pass into output.
 
@@ -290,6 +310,51 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                     gen_device = self.device
                 req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(req.sampling_params.seed)
 
+
+            # Inter-request cache: check for cached DiT output before computation
+            if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
+                resume_from_step = getattr(req.sampling_params, "resume_from_step", 0) or 0
+                if resume_from_step > 0:
+                    step_latents_list = self.cache_backend.lookup_step_latents(req, target_device=self.device)
+                    if step_latents_list is not None and len(step_latents_list) >= resume_from_step:
+                        resume_data = step_latents_list[resume_from_step - 1]
+                        req.sampling_params.resume_latents = resume_data.latent
+                        logger.info(
+                            "Inter-request cache: resuming from step %d", resume_from_step,
+                        )
+                    else:
+                        req.sampling_params.resume_from_step = 0
+                else:
+                    cached_output = self.cache_backend.lookup(req, target_device=self.device)
+                    if cached_output is not None:
+                        logger.info("Inter-request cache HIT: skipping DiT computation entirely")
+                        return DiffusionOutput(output=cached_output)
+
+                    if self.cache_backend.clip_enabled:
+                        clip_result = self.cache_backend.semantic_lookup(req, target_device=self.device)
+                        clip_latents, clip_step_latents, clip_sim, clip_cached_prompt, clip_match_type = clip_result
+                        if clip_latents is not None and clip_step_latents is not None:
+                            total_steps = req.sampling_params.num_inference_steps or len(clip_step_latents)
+                            current_prompt = ""
+                            if req.prompts and isinstance(req.prompts[0], dict):
+                                current_prompt = req.prompts[0].get("prompt", "")
+                            elif req.prompts and isinstance(req.prompts[0], str):
+                                current_prompt = req.prompts[0]
+                            clip_resume_step = self.cache_backend.compute_skip_steps(
+                                clip_sim, total_steps,
+                                query_prompt=current_prompt,
+                                cached_prompt=clip_cached_prompt,
+                                match_type=clip_match_type,
+                            )
+                            if clip_resume_step > 0 and len(clip_step_latents) >= clip_resume_step:
+                                resume_data = clip_step_latents[clip_resume_step - 1]
+                                req.sampling_params.resume_latents = resume_data.latent
+                                req.sampling_params.resume_from_step = clip_resume_step
+                                logger.info(
+                                    "CLIP semantic match: similarity=%.4f, resuming from step %d/%d",
+                                    clip_sim, clip_resume_step, total_steps,
+                                )
+
             # Refresh cache context if needed
             if (
                 not getattr(req, "skip_cache_refresh", False)
@@ -310,7 +375,12 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                     num_inference_steps = 0
 
                 if num_inference_steps is not None:
-                    self.cache_backend.refresh(self.pipeline, num_inference_steps)
+                    _resume_step = getattr(req.sampling_params, "resume_from_step", 0) or 0
+                    self.cache_backend.refresh(
+                        self.pipeline,
+                        num_inference_steps,
+                        resume_from_step=_resume_step,
+                    )
                 else:
                     logger.warning(
                         "Failed to refresh the diffusion transformer cache; backend %s "
@@ -322,12 +392,48 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if is_primary:
                 current_omni_platform.reset_peak_memory_stats()
 
+            is_dummy = "dummy" in req.request_ids[0] if req.request_ids else False
+
+            if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
+                self.cache_backend.before_forward(is_dummy=is_dummy)
+
             with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
                 with record_function("pipeline_forward"):
                     output = self.pipeline.forward(req)
 
             if is_primary:
                 self._record_peak_memory(output)
+
+            cache_key_hash = None
+            resume_from_step = getattr(req.sampling_params, "resume_from_step", 0) or 0
+            if (
+                isinstance(self.cache_backend, InterRequestCacheBackend)
+                and self.cache_backend.is_enabled()
+                and output.output is not None
+                and not is_dummy
+                and resume_from_step == 0
+            ):
+                step_latents_data = None
+                recorder = self.cache_backend.recorder
+                if recorder is not None and recorder.num_steps > 0:
+                    step_latents_data = [
+                        StepLatentData(
+                            step_index=r.step_index,
+                            timestep=r.timestep,
+                            latent=r.latent,
+                        )
+                        for r in recorder.records
+                    ]
+                cache_key_hash = self.cache_backend.store(
+                    req, output.output, step_latents=step_latents_data
+                )
+                if cache_key_hash is not None:
+                    output.custom_output["cache_key_hash"] = cache_key_hash
+                    self._update_cache_image_embedding(cache_key_hash, output.output)
+                logger.info("Inter-request cache: stored DiT output for future reuse")
+
+            if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
+                self.cache_backend.after_forward(cache_key_hash=cache_key_hash, is_dummy=is_dummy)
 
             # Log prompt-embed cache activity (hits/misses accumulate across requests).
             if is_primary and self.prompt_embed_cache is not None:
@@ -337,7 +443,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if (
                 self.cache_backend is not None
                 and self.cache_backend.is_enabled()
-                and self.od_config.cache_backend == "cache_dit"
+                and self.od_config.cache_backend in ("cache_dit", "inter_request+cache_dit", "cache_dit+inter_request")
                 and self.od_config.enable_cache_dit_summary
             ):
                 cache_summary(self.pipeline, details=True)
@@ -464,6 +570,11 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             input_batch = self._prepare_batch_inputs(states, new_request_ids)
             attn_metadata = self._prepare_attn_metadata(input_batch)
 
+            is_dummy = "dummy" in req.request_ids[0] if req.request_ids else False
+
+            if isinstance(self.cache_backend, InterRequestCacheBackend) and self.cache_backend.is_enabled():
+                self.cache_backend.before_forward(is_dummy=is_dummy)
+
             with set_forward_context(
                 vllm_config=self.vllm_config,
                 omni_diffusion_config=self.od_config,
@@ -514,3 +625,15 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 self._update_states_after(states, input_batch, pipeline_interrupted)
 
                 return BatchRunnerOutput.from_list(runner_output_list)
+
+    def shutdown(self) -> None:
+        logger.info(
+            "DiffusionModelRunner shutdown: cache_backend=%s, type=%s",
+            self.cache_backend,
+            type(self.cache_backend).__name__ if self.cache_backend else None,
+        )
+        if (
+            isinstance(self.cache_backend, InterRequestCacheBackend)
+            and self.cache_backend.is_enabled()
+        ):
+            self.cache_backend.shutdown()

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -303,6 +303,9 @@ class OmniDiffusionSamplingParams:
 
     # VSA parameters
     VSA_sparsity: float = 0.0
+    # Inter-request cache: resume from a cached denoising step
+    resume_from_step: int = 0
+    resume_latents: torch.Tensor | None = None
     # perf_logger: PerformanceLogger | None = None
 
     # stage logging


### PR DESCRIPTION
## Purpose
Implement #3978 .
Accelerate text-to-image diffusion serving by reusing cached DiT denoising states across requests with similar or identical prompts. When multiple requests share the same prompt, seed, and sampling parameters, the full denoising trajectory (or a prefix of it) can be reused, skipping redundant transformer computation entirely or partially.

This implements Chorus Stage-1 inter-request cache reuse on vllm-omni's Qwen-Image pipeline, with three reuse tiers:

1. Exact hit — identical prompt+seed+params → return cached final latent, skip all DiT steps (~50× faster).
2. Semantic hit — CLIP text-similarity above threshold → resume from a cached intermediate step, skipping the first N denoising steps.
3. Miss — full inference, record per-step latents for future reuse.

Additionally, a composite backend (`inter_request+cache_dit`) combines cross-request reuse with intra-request block-level caching (cache_dit), so even cache-miss requests benefit from transformer compression, and the long-tail latency of semantic-hit requests is further reduced.

**Key engineering contributions**

- Vectorized semantic search: Rewrote `semantic_search()` from a per-entry Python loop to batch matrix multiplication over a pre-stacked embedding matrix maintained incrementally on put/evict. Benchmark on 7,000 real CLIP embeddings: 284 ms → 13 ms per query (22× speedup), with the "latency grows linearly with cache size" pathology eliminated.
- Hybrid similarity matching: `sim = t2t × sigmoid_penalty(t2i)`, where text-text similarity is the primary signal and text-image similarity acts as a sigmoid penalty. A `--no-t2i-penalty` flag allows disabling the penalty for use cases where image embeddings are unavailable (e.g., video)
- Persistent cache: Cross-restart cache persistence via `save_to_disk/load_from_disk`; step latents are recorded by `StepLatentsRecorder` and stored alongside final latents.
- CompositeCacheBackend: Inherits `InterRequestCacheBackend`, holds an internal `CacheDiTBackend`, and performs step-count correction (`effective_steps = total - resume_from_step`) so cache_dit's warmup intervals remain correct after a semantic-hit resume.
- There are no API changes to the Omni engine interface. The cache is activated via `cache_backend="inter_request"` (or `"inter_request+cache_dit"` for composite) in `OmniDiffusionConfig`. All existing pipelines and sampling parameters are unchanged.

## Usage

**Online serving (HTTP server)**

```
python3 examples/online_serving/text_to_image/run_server_with_cache.py \
    --model /path/to/Qwen-Image \
    --port 8091 \
    --cache-backend inter_request+cache_dit \
    --clip-model-path /path/to/clip-vit-large-patch14 \
    --clip-threshold 0.65 \
    --clip-min-skip 0 \
    --clip-max-skip-ratio 0.5 \
    --persistent-cache-dir ./persistent_cache \
    --fn-compute-blocks 1 --max-warmup-steps 4 --residual-diff-threshold 0.24
```
Request (identical or similar prompt):

```
# First request: cache miss, full inference, writes to cache
curl -X POST http://localhost:8091/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{"prompt":"a cat on a table","seed":42,"num_inference_steps":50}'

# Second request (identical): exact cache hit, skips all DiT
curl -X POST http://localhost:8091/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{"prompt":"a cat on a table","seed":42,"num_inference_steps":50}'

# Third request (similar): semantic hit, resume from step N
curl -X POST http://localhost:8091/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{"prompt":"a kitten on a desk","seed":42,"num_inference_steps":50}'
```

**Offline inference**

Method 1: Semantic Matching
```
python3 examples/offline_inference/text_to_image/text_to_image.py \
    --model /path/to/Qwen-Image \
    --cache-backend inter_request \
    --persistent-cache-dir ./persistent_cache \
    --max-entries 1000 \
    --max-memory-gb 16.0 \
    --clip-model-path /path/to/clip-vit-large-patch14 \
    --clip-threshold 0.65 \
    --clip-min-skip 5 \
    --clip-max-skip-ratio 0.5
```

Method 2: Joint Acceleration
```
python3 examples/offline_inference/text_to_image/text_to_image.py \
    --model /path/to/Qwen-Image \
    --cache-backend inter_request+cache_dit \
    --persistent-cache-dir ./persistent_cache \
    --clip-model-path /path/to/clip-vit-large-patch14 \
    --clip-threshold 0.65
```

**Configuration parameters**

- --cache-backend: inter_request, inter_request+cache_dit, cache_dit, tea_cache
- --clip-model-path: Path to CLIP model (enables semantic matching)
- --clip-threshold: Similarity threshold τ for semantic hit
- --clip-min-skip: Minimum skip steps when similarity just exceeds τ
- --clip-max-skip-ratio: Max fraction of total steps to skip at similarity=1.0
- --no-t2i-penalty: Disable t2i sigmoid penalty (text-only similarity)
- --persistent-cache-dir: Directory for disk persistence (survives restart)
- --max-entries: Maximum cache entries (LRU eviction)
- --max-memory-gb: Maximum memory for cached latents
- --fn-compute-blocks: cache_dit: fully-compute blocks per step
- --max-warmup-steps: cache_dit: warmup steps before caching
- --residual-diff-threshold: cache_dit: residual diff threshold

## Test Plan

Correctness was validated via:

1. 8-case boundary tests for vectorized semantic_search (empty cache, single-entry, all-hybrid, all-text, mixed groups, all-negative similarity).
2. Real-CLIP benchmark: 7,000 actual CLIP-encoded prompts from T2I-CompBench, verifying identical best-match indices and similarity values between the old loop and new matrix implementation (max numerical difference < 1e-5).
3. End-to-end serving with 7,975 unique prompts (T2I-CompBench combine.txt), three-stage protocol (baseline → cache warmup → cache hit).
4. CLIP image quality: measured CLIP score per generated image, confirming no degradation.

**Clean NPU Validation**
The change was validated on Huawei Ascend NPU (Atlas A3) using the Qwen-Image checkpoint.

Environment:

- vllm-ascend v0.18.0; BF16; tensor-parallel = 2 (NPU 0+1);
- CLIP-ViT-Large/14 for semantic matching (loaded on CPU);
- 7,975 unique prompts from T2I-CompBench (color, spatial, numeracy, texture, complex);
- Qwen-Image, 1024×1024, 50 steps, seed 42, concurrency 1;
- cache_dit: Fn=1, Bn=0, warmup=4, residual=0.24;
- inter_request: threshold=0.65, min_skip=0, max_skip_ratio=0.5, t2i penalty enabled.

## Test Result

The original loop-based search caused linear latency growth as cache filled (median rose from 0.79 s at entries 1-1000 to 11.84 s at entries 7001-7975). The vectorized matrix search eliminates this: median remains flat at 0.74-0.78 s throughout.

CLIP image quality: 26.22 mean (baseline 27.90, -6.0%). The slight decrease is expected — semantic-hit resume reuses latents from similar-but-not-identical prompts. With --no-t2i-penalty the quality trade-off can be tuned.