### PR TITLE
[RFC203] Add deterministic inference controls

### DIFF
--- a/tests/core/sched/test_omni_scheduler_mixin.py
+++ b/tests/core/sched/test_omni_scheduler_mixin.py
@@ -1,0 +1,139 @@
+"""Unit tests for batch-invariant scheduler mixin behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.request_queue import SchedulingPolicy
+
+# Import vllm_omni first so its vLLM request patches are applied before vLLM
+# classes are bound in this module.
+import vllm_omni  # noqa: F401
+from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
+from vllm_omni.core.sched.output import OmniNewRequestData
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _MockQueue:
+    def __init__(self, requests):
+        self._requests = list(requests)
+        self.add_requests_called = False
+
+    def __iter__(self):
+        return iter(self._requests)
+
+    def __len__(self):
+        return len(self._requests)
+
+    def add_request(self, request):
+        self._requests.append(request)
+
+    def add_requests(self, requests):
+        self.add_requests_called = True
+        self._requests.extend(requests)
+
+    def remove_requests(self, requests):
+        remove_ids = {id(request) for request in requests}
+        self._requests = [request for request in self._requests if id(request) not in remove_ids]
+
+
+class _OrderingSchedulerStub(OmniSchedulerMixin):
+    def __init__(self, requests):
+        self.waiting = _MockQueue(requests)
+        self.max_num_running_reqs = 8
+        self.policy = SchedulingPolicy.PRIORITY
+
+
+def _priority_request(request_id: str, priority: int):
+    return SimpleNamespace(request_id=request_id, priority=priority)
+
+
+def test_waiting_order_is_unchanged_by_default(monkeypatch):
+    monkeypatch.delenv("VLLM_BATCH_INVARIANT", raising=False)
+    scheduler = _OrderingSchedulerStub(
+        [
+            _priority_request("b", 20),
+            _priority_request("a", 10),
+            _priority_request("c", 10),
+        ]
+    )
+
+    scheduler._order_waiting_for_batch_invariance()
+
+    assert [request.request_id for request in scheduler.waiting] == ["b", "a", "c"]
+    assert scheduler.waiting.add_requests_called is False
+
+
+def test_waiting_order_uses_priority_then_request_id_in_batch_invariant_mode(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    scheduler = _OrderingSchedulerStub(
+        [
+            _priority_request("b", 20),
+            _priority_request("c", 10),
+            _priority_request("a", 10),
+        ]
+    )
+
+    scheduler._order_waiting_for_batch_invariance()
+
+    assert [request.request_id for request in scheduler.waiting] == ["a", "c", "b"]
+    assert scheduler.waiting.add_requests_called is True
+
+
+def test_batch_invariant_limits_running_requests(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    scheduler = _OrderingSchedulerStub([])
+
+    scheduler._apply_batch_invariant_limits()
+
+    assert scheduler.max_num_running_reqs == 1
+
+
+def test_batch_invariant_limits_use_fcfs_waiting_queue(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    scheduler = _OrderingSchedulerStub(
+        [
+            _priority_request("b", 20),
+            _priority_request("a", 10),
+        ]
+    )
+
+    scheduler._apply_batch_invariant_limits()
+
+    assert scheduler.policy == SchedulingPolicy.FCFS
+    assert scheduler.waiting.__class__.__name__ == "FCFSRequestQueue"
+    assert [request.request_id for request in scheduler.waiting] == ["b", "a"]
+
+
+def test_running_request_limit_is_unchanged_by_default(monkeypatch):
+    monkeypatch.delenv("VLLM_BATCH_INVARIANT", raising=False)
+    scheduler = _OrderingSchedulerStub([])
+
+    scheduler._apply_batch_invariant_limits()
+
+    assert scheduler.max_num_running_reqs == 8
+
+
+def test_omni_new_request_data_preserves_sampling_seed():
+    sampling_params = SamplingParams(max_tokens=4, seed=123)
+    request = SimpleNamespace(
+        request_id="seeded-req",
+        external_req_id="seeded-req",
+        prompt_token_ids=[1, 2],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        num_computed_tokens=0,
+        lora_request=None,
+        prompt_embeds=None,
+        prompt_is_token_ids=True,
+        additional_information=None,
+    )
+
+    data = OmniNewRequestData.from_request(request, block_ids=([0],))
+
+    assert data.sampling_params is sampling_params
+    assert data.sampling_params.seed == 123

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -342,6 +342,25 @@ class _BatchSingleOutputPipeline:
         return DiffusionOutput(output=batch.prompts[0])
 
 
+class _GeneratorDrivenBatchPipeline:
+    supports_request_batch = True
+
+    def forward(self, batch):
+        outputs = []
+        for sampling_params in batch.sampling_params_list:
+            generator = sampling_params.generator
+            assert isinstance(generator, torch.Generator)
+            outputs.append(
+                DiffusionOutput(
+                    output=(
+                        generator.initial_seed(),
+                        int(torch.randint(0, 2**31, (1,), generator=generator).item()),
+                    )
+                )
+            )
+        return outputs
+
+
 def _make_batch_runner(pipeline):
     runner = object.__new__(DiffusionModelRunner)
     runner.vllm_config = object()
@@ -364,6 +383,17 @@ def _make_scheduler_output(num_reqs: int):
     reqs = [_make_request() for _ in range(num_reqs)]
     for i, req in enumerate(reqs):
         req.request_id = f"req-{i}"
+    return SimpleNamespace(scheduled_new_reqs=[SimpleNamespace(req=req) for req in reqs])
+
+
+def _make_scheduler_output_for_request_ids(request_ids: list[str], *, seed: int):
+    reqs = []
+    for request_id in request_ids:
+        req = _make_request()
+        req.request_id = request_id
+        req.sampling_params.seed = seed
+        req.sampling_params.generator = None
+        reqs.append(req)
     return SimpleNamespace(scheduled_new_reqs=[SimpleNamespace(req=req) for req in reqs])
 
 
@@ -419,6 +449,78 @@ def test_execute_model_batch_preserves_per_request_sampling_and_seeds_generators
     assert [sp.generator.initial_seed() for sp in pipeline.last_batch.sampling_params_list] == [111, 222]
     with pytest.raises(AssertionError, match="multiple requests"):
         _ = pipeline.last_batch.sampling_params
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_batch_outputs_are_request_stable_in_batch_invariant_mode(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    monkeypatch.setattr(model_runner_module, "current_omni_platform", _fake_platform_for_peak_memory())
+
+    def run_batch(request_ids: list[str]) -> dict[str, tuple[int, int]]:
+        runner = _make_batch_runner(_GeneratorDrivenBatchPipeline())
+        sched = _make_scheduler_output_for_request_ids(request_ids, seed=123)
+        result = DiffusionModelRunner.execute_model_batch(runner, sched, runner.od_config)
+        return {runner_output.request_id: runner_output.result.output for runner_output in result.runner_outputs}
+
+    canonical = run_batch(["req-a", "req-b"])
+    shuffled = run_batch(["req-b", "req-a"])
+    with_neighbor = run_batch(["req-extra", "req-a", "req-b"])
+
+    assert canonical["req-a"] == shuffled["req-a"] == with_neighbor["req-a"]
+    assert canonical["req-b"] == shuffled["req-b"] == with_neighbor["req-b"]
+    assert canonical["req-a"][0] == model_runner_module.deterministic_sample_seed(123, "req-a")
+    assert canonical["req-b"][0] == model_runner_module.deterministic_sample_seed(123, "req-b")
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_sampling_generator_derives_per_request_generators_in_batch_invariant_mode(monkeypatch):
+    runner = _make_runner(cache_backend=None, cache_backend_name="cache_dit")
+    sampling_params = SimpleNamespace(generator=None, seed=123, generator_device=None)
+
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+
+    runner._ensure_sampling_generator(sampling_params, request_ids=["req-b", "req-a"])
+
+    generators = sampling_params.generator
+    assert isinstance(generators, list)
+    assert len(generators) == 2
+    assert [generator.initial_seed() for generator in generators] == [
+        model_runner_module.deterministic_sample_seed(123, "req-b"),
+        model_runner_module.deterministic_sample_seed(123, "req-a"),
+    ]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_sampling_generator_derives_single_request_generator_in_batch_invariant_mode(monkeypatch):
+    runner = _make_runner(cache_backend=None, cache_backend_name="cache_dit")
+    sampling_params = SimpleNamespace(generator=None, seed=123, generator_device=None)
+
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+
+    runner._ensure_sampling_generator(sampling_params, request_ids=["req-a"])
+
+    generator = sampling_params.generator
+    assert isinstance(generator, torch.Generator)
+    assert generator.initial_seed() == model_runner_module.deterministic_sample_seed(123, "req-a")
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_sampling_generator_keeps_single_generator_by_default(monkeypatch):
+    runner = _make_runner(cache_backend=None, cache_backend_name="cache_dit")
+    sampling_params = SimpleNamespace(generator=None, seed=123, generator_device=None)
+
+    monkeypatch.delenv("VLLM_BATCH_INVARIANT", raising=False)
+
+    runner._ensure_sampling_generator(sampling_params, request_ids=["req-b", "req-a"])
+
+    generator = sampling_params.generator
+    assert isinstance(generator, torch.Generator)
+    assert generator.initial_seed() == 123
 
 
 @pytest.mark.core_model

--- a/tests/diffusion/test_diffusion_request.py
+++ b/tests/diffusion/test_diffusion_request.py
@@ -72,3 +72,22 @@ def test_tp_seed_same_across_ranks_and_varies_across_requests():
 
     # Seeds must vary across requests (non-determinism preserved).
     assert len(set(seeds)) == n_requests, f"Expected {n_requests} unique seeds but got {len(set(seeds))}: {seeds}"
+
+
+def test_batch_invariant_mode_rejects_missing_diffusion_seed(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+
+    with pytest.raises(ValueError, match="sampling_params.seed"):
+        _make_request()
+
+
+def test_batch_invariant_mode_accepts_explicit_diffusion_seed(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+
+    request = OmniDiffusionRequest(
+        prompt={"prompt": "a cup of coffee on a table"},
+        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1, seed=42),
+        request_id="seeded-request",
+    )
+
+    assert request.sampling_params.seed == 42

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -27,11 +27,12 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
 
-def _make_request(req_id: str) -> OmniDiffusionRequest:
+def _make_request(req_id: str, *, priority: int = 0, seed: int | None = None) -> OmniDiffusionRequest:
     return OmniDiffusionRequest(
         prompt=f"prompt_{req_id}",
-        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1),
+        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1, seed=seed),
         request_id=req_id,
+        priority=priority,
     )
 
 
@@ -400,6 +401,41 @@ class TestRequestScheduler:
         assert _new_ids(first) == [req_id_a, req_id_b]
         assert first.num_running_reqs == 2
         assert first.num_waiting_reqs == 0
+
+    def test_batch_invariant_orders_waiting_by_priority_then_request_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+        scheduler = RequestScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=3))
+
+        scheduler.add_request(_make_request("b", priority=20, seed=1))
+        scheduler.add_request(_make_request("c", priority=10, seed=2))
+        scheduler.add_request(_make_request("a", priority=10, seed=3))
+
+        first = scheduler.schedule()
+        assert _new_ids(first) == ["a"]
+        assert first.num_running_reqs == 1
+        assert first.num_waiting_reqs == 2
+
+        scheduler.update_from_output(first, _make_request_output("a"))
+
+        second = scheduler.schedule()
+        assert _new_ids(second) == ["c"]
+        assert second.num_running_reqs == 1
+        assert second.num_waiting_reqs == 1
+
+        scheduler.update_from_output(second, _make_request_output("c"))
+
+        third = scheduler.schedule()
+        assert _new_ids(third) == ["b"]
+        assert third.num_running_reqs == 1
+        assert third.num_waiting_reqs == 0
+
+    def test_batch_invariant_limits_running_requests_to_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+        scheduler = RequestScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=4))
+
+        assert scheduler.max_num_running_reqs == 1
 
     def test_incompatible_waiting_head_blocks_later_compatible_request(self) -> None:
         scheduler = RequestScheduler()

--- a/tests/diffusion/test_inline_stage_diffusion_client.py
+++ b/tests/diffusion/test_inline_stage_diffusion_client.py
@@ -74,6 +74,34 @@ async def test_inline_dispatch_request_success(client, mock_engine):
 
 
 @pytest.mark.asyncio
+async def test_inline_dispatch_request_preserves_priority(client, mock_engine):
+    captured = {}
+
+    async def _step(request):
+        captured["request"] = request
+        return [OmniRequestOutput.from_diffusion(request_id=request.request_id, images=[])]
+
+    mock_engine.step.side_effect = _step
+
+    await client.add_request_async(
+        "req-priority",
+        "A test prompt",
+        OmniDiffusionSamplingParams(),
+        priority=29,
+    )
+
+    for _ in range(10):
+        output = client.get_diffusion_output_nowait()
+        if output is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    assert output is not None
+    assert output.request_id == "req-priority"
+    assert captured["request"].priority == 29
+
+
+@pytest.mark.asyncio
 async def test_inline_dispatch_request_streaming_success(client, mock_engine):
     """Inline StageDiffusionClient correctly receives streaming chunk output from Diffusion Engine"""
     chunks = [

--- a/tests/diffusion/test_multiproc_engine_concurrency.py
+++ b/tests/diffusion/test_multiproc_engine_concurrency.py
@@ -773,6 +773,21 @@ class TestStageDiffusionClientErrorPropagation:
         with pytest.raises(EngineDeadError):
             await client.add_request_async("req-3", "test prompt", None)
 
+    @pytest.mark.asyncio
+    async def test_add_request_payload_includes_priority(self):
+        client = self._make_client()
+        client._encoder.encode.side_effect = lambda payload: payload
+
+        await client.add_request_async(
+            "req-priority",
+            "test prompt",
+            OmniDiffusionSamplingParams(),
+            priority=31,
+        )
+
+        payload = client._request_socket.send.call_args.args[0]
+        assert payload["priority"] == 31
+
     def test_check_health_raises_when_dead(self):
         client = self._make_client(engine_dead=True)
 

--- a/tests/diffusion/test_stage_diffusion_proc.py
+++ b/tests/diffusion/test_stage_diffusion_proc.py
@@ -75,6 +75,29 @@ async def test_proc_streaming_request_yields_each_engine_chunk():
 
 
 @pytest.mark.asyncio
+async def test_process_request_preserves_priority():
+    captured = {}
+
+    class _Engine:
+        async def step(self, request):
+            captured["request"] = request
+            return [MockOmniRequestOutput(request_id=request.request_id)]
+
+    stage_proc = object.__new__(StageDiffusionProc)
+    stage_proc._engine = _Engine()
+
+    result = await stage_proc._process_request(
+        request_id="req-priority",
+        prompt="prompt",
+        sampling_params_dict=asdict(OmniDiffusionSamplingParams()),
+        priority=23,
+    )
+
+    assert result.request_id == "req-priority"
+    assert captured["request"].priority == 23
+
+
+@pytest.mark.asyncio
 async def test_proc_process_request_with_batching_async_output():
     stage_proc = object.__new__(StageDiffusionProc)
     stage_proc._engine = MockDiffusionEngine()

--- a/tests/engine/test_orchestrator_kv_sender_info.py
+++ b/tests/engine/test_orchestrator_kv_sender_info.py
@@ -34,13 +34,14 @@ class _DummyDiffusionStage:
         self.engine_input_source = engine_input_source or [0]
         self.calls = []
 
-    async def add_request_async(self, request_id, prompt, sampling_params, kv_sender_info=None):
+    async def add_request_async(self, request_id, prompt, sampling_params, kv_sender_info=None, priority=0):
         self.calls.append(
             {
                 "request_id": request_id,
                 "prompt": prompt,
                 "sampling_params": sampling_params,
                 "kv_sender_info": kv_sender_info,
+                "priority": priority,
             }
         )
 
@@ -151,6 +152,7 @@ def test_forward_to_diffusion_attaches_kv_sender_info():
         prompt={"prompt": "hello"},
         sampling_params_list=[SamplingParams(max_tokens=4), params],
         final_stage_id=1,
+        priority=13,
     )
 
     output = SimpleNamespace(request_id="req-1", finished=True)
@@ -160,6 +162,7 @@ def test_forward_to_diffusion_attaches_kv_sender_info():
     assert diffusion_stage.calls[0]["kv_sender_info"] == {
         0: {"host": "10.0.0.2", "zmq_port": 50151},
     }
+    assert diffusion_stage.calls[0]["priority"] == 13
     assert req_state.stage_submit_ts[1] > 0
 
 

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -93,6 +93,30 @@ def test_generate_submits_randomized_id_to_engine():
 
 
 @pytest.mark.cpu
+def test_generate_forwards_priority_to_engine():
+    async def run():
+        captured = {}
+
+        async def fake_add_request_async(**kwargs):
+            captured.update(kwargs)
+
+        omni = get_async_omni_instance(fake_add_request=fake_add_request_async)
+
+        async for _ in omni.generate(
+            prompt={"prompt": "test"},
+            request_id="priority-req",
+            sampling_params_list=[SimpleNamespace()],
+            output_modalities=["text"],
+            priority=17,
+        ):
+            pass
+
+        assert captured["priority"] == 17
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
 @pytest.mark.parametrize(
     "req_ids,cancel_prefix,expected_cancel_count",
     [

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -93,6 +93,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._latest_omni_connector_output: OmniConnectorOutput | None = None
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
+        self._apply_batch_invariant_limits()
 
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
@@ -221,6 +222,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             self.chunk_transfer_adapter.process_pending_chunks(
                 self.waiting, self.running, scheduler_requests=self.requests
             )
+        self._order_waiting_for_batch_invariance()
 
         try:
             scheduler_output = super().schedule(throttle_prefills)

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -55,6 +55,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 async_chunk=False,
             )
         self._latest_omni_connector_output: OmniConnectorOutput | None = None
+        self._apply_batch_invariant_limits()
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         """Diffusion fast path:
@@ -90,6 +91,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             self.chunk_transfer_adapter.process_pending_chunks(
                 self.waiting, self.running, scheduler_requests=self.requests
             )
+        self._order_waiting_for_batch_invariance()
 
         # OMNI: Track requests that are already finished (e.g., marked by connector)
         # These should be removed from running and not scheduled

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -7,10 +7,12 @@ from typing import Any
 
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.request import RequestStatus
 
 from vllm_omni.core.sched.output import OmniChunkRecvHandle, OmniSchedulerOutput
+from vllm_omni.determinism import deterministic_request_key, is_batch_invariant_enabled
 
 logger = init_logger(__name__)
 
@@ -39,6 +41,35 @@ except ValueError:
 
 class OmniSchedulerMixin:
     """Shared scheduler helpers for omni-specific request handling."""
+
+    @staticmethod
+    def _append_waiting_requests(waiting_queue, requests) -> None:
+        add_requests = getattr(waiting_queue, "add_requests", None)
+        if add_requests is not None:
+            add_requests(requests)
+            return
+        for request in requests:
+            waiting_queue.add_request(request)
+
+    def _apply_batch_invariant_limits(self) -> None:
+        if not is_batch_invariant_enabled():
+            return
+        self.max_num_running_reqs = 1
+        self.policy = SchedulingPolicy.FCFS
+        waiting = getattr(self, "waiting", None)
+        if waiting is None:
+            return
+        replacement = create_request_queue(self.policy)
+        self._append_waiting_requests(replacement, list(waiting))
+        self.waiting = replacement
+
+    def _order_waiting_for_batch_invariance(self) -> None:
+        waiting = getattr(self, "waiting", None)
+        if not is_batch_invariant_enabled() or waiting is None or len(waiting) < 2:
+            return
+        ordered = sorted(list(waiting), key=deterministic_request_key)
+        waiting.remove_requests(ordered)
+        self._append_waiting_requests(waiting, ordered)
 
     def _free_input_coordinator_request(self, request_id: str) -> None:
         """Prune full-payload coordinator state for a completed request."""

--- a/vllm_omni/determinism.py
+++ b/vllm_omni/determinism.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_batch_invariant_enabled() -> bool:
+    """Return whether rollout scheduling should avoid arrival-order effects."""
+    return os.environ.get("VLLM_BATCH_INVARIANT", "").strip().lower() in _TRUE_VALUES
+
+
+def deterministic_request_key(request: Any) -> tuple[int, str]:
+    """Stable ordering key for deterministic scheduling."""
+    request_id = getattr(request, "request_id", None)
+    if request_id is None:
+        request_ids = getattr(request, "request_ids", None)
+        if request_ids:
+            request_id = request_ids[0]
+    return (int(getattr(request, "priority", 0) or 0), str(request_id or ""))
+
+
+def deterministic_sample_seed(base_seed: int, sample_id: str) -> int:
+    """Derive a stable per-sample seed from a request seed and sample id."""
+    payload = f"{int(base_seed)}:{sample_id}".encode()
+    digest = hashlib.blake2b(payload, digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="big", signed=False) % (2**63)

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -792,6 +792,7 @@ class DiffusionEngine:
                 # Disable CFG for warmup to avoid triggering CFG parallel
                 # validation when cfg_parallel_size > 1.
                 extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
+                seed=0,
             ),
         )
         logger.info("dummy run to warm up the model")

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -100,6 +100,7 @@ class InlineStageDiffusionClient(StageClientBase):
         prompt: OmniPromptType,
         sampling_params: OmniDiffusionSamplingParams,
         kv_sender_info: dict[int, dict[str, Any]] | None = None,
+        priority: int = 0,
     ) -> None:
         logger.debug(
             "[InlineStageDiffusionClient] stage-%s [rep-%s] add request: %s",
@@ -113,6 +114,7 @@ class InlineStageDiffusionClient(StageClientBase):
                 prompt,
                 sampling_params,
                 kv_sender_info,
+                priority,
             )
         )
         self._tasks[request_id] = task
@@ -123,6 +125,7 @@ class InlineStageDiffusionClient(StageClientBase):
         prompt: Any,
         sampling_params: OmniDiffusionSamplingParams,
         kv_sender_info: dict[str, Any] | None = None,
+        priority: int = 0,
     ) -> None:
         try:
             request = OmniDiffusionRequest(
@@ -130,6 +133,7 @@ class InlineStageDiffusionClient(StageClientBase):
                 sampling_params=sampling_params,
                 request_id=request_id,
                 kv_sender_info=kv_sender_info,
+                priority=priority,
             )
 
             if self.od_config.streaming_output:

--- a/vllm_omni/diffusion/request.py
+++ b/vllm_omni/diffusion/request.py
@@ -5,6 +5,7 @@
 import random
 from dataclasses import dataclass
 
+from vllm_omni.determinism import is_batch_invariant_enabled
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniPromptType
 
 DUMMY_DIFFUSION_REQUEST_ID = "dummy_req_id"
@@ -29,6 +30,7 @@ class OmniDiffusionRequest:
     sampling_params: OmniDiffusionSamplingParams
     request_id: str
     kv_sender_info: dict | None = None
+    priority: int = 0
 
     def __post_init__(self):
         """Initialize dependent fields after dataclass initialization."""
@@ -38,6 +40,11 @@ class OmniDiffusionRequest:
         # When neither a generator nor a seed is provided, assign a random seed
         # so that all ranks derive the same generator state.
         if self.sampling_params.generator is None and self.sampling_params.seed is None:
+            if is_batch_invariant_enabled():
+                raise ValueError(
+                    "Diffusion requests must provide sampling_params.seed or "
+                    "sampling_params.generator when VLLM_BATCH_INVARIANT=1."
+                )
             self.sampling_params.seed = random.randint(0, 2**31 - 1)
 
         # Detect whether user explicitly provided guidance_scale.

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -8,6 +8,7 @@ from dataclasses import fields
 
 from vllm.logger import init_logger
 
+from vllm_omni.determinism import deterministic_request_key, is_batch_invariant_enabled
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import (
@@ -77,6 +78,8 @@ class _BaseScheduler(SchedulerInterface):
             self.max_num_running_reqs = max(1, int(max_num_seqs))
         except (TypeError, ValueError):
             self.max_num_running_reqs = 1
+        if is_batch_invariant_enabled():
+            self.max_num_running_reqs = 1
         omni_kv = getattr(od_config, "omni_kv_config", None) or {}
         self._prefetch_enabled = bool(omni_kv.get("enable_kv_async_prefetch", False))
         self._reset_scheduler_state()
@@ -102,6 +105,8 @@ class _BaseScheduler(SchedulerInterface):
             state = self._request_states.get(request_id)
             if state is not None:
                 scheduled_cached_request_ids.append(request_id)
+
+        self._order_waiting_for_batch_invariance()
 
         # Second, schedule WAITING requests while capacity remains.
         while self._waiting and len(self._running) < self.max_num_running_reqs:
@@ -287,3 +292,15 @@ class _BaseScheduler(SchedulerInterface):
         self, request: OmniDiffusionRequest
     ) -> SamplingParamsKey | RequestBatchSamplingParamsKey | None:
         return get_sampling_params_key(request)
+
+    def _order_waiting_for_batch_invariance(self) -> None:
+        if not is_batch_invariant_enabled() or len(self._waiting) < 2:
+            return
+
+        def key(request_id: str) -> tuple[int, str]:
+            state = self._request_states.get(request_id)
+            if state is None:
+                return (0, request_id)
+            return deterministic_request_key(state.req)
+
+        self._waiting = deque(sorted(self._waiting, key=key))

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -334,6 +334,7 @@ class StageDiffusionClient(StageClientBase):
         prompt: OmniPromptType,
         sampling_params: OmniDiffusionSamplingParams,
         kv_sender_info: dict[int, dict[str, Any]] | None = None,
+        priority: int = 0,
     ) -> None:
         if self._engine_dead:
             raise EngineDeadError()
@@ -351,6 +352,7 @@ class StageDiffusionClient(StageClientBase):
                     "prompt": prompt,
                     "sampling_params": self._sampling_params_to_dict(sampling_params),
                     "kv_sender_info": kv_sender_info,
+                    "priority": priority,
                 }
             )
         )

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -154,6 +154,7 @@ class StageDiffusionProc:
         prompt: Any,
         sampling_params_dict: dict,
         kv_sender_info: dict[str, Any] | None = None,
+        priority: int = 0,
     ) -> OmniRequestOutput:
         """Build a diffusion request and run DiffusionEngine.step()."""
         sampling_params = self._reconstruct_sampling_params(sampling_params_dict)
@@ -163,6 +164,7 @@ class StageDiffusionProc:
             sampling_params=sampling_params,
             request_id=request_id,
             kv_sender_info=kv_sender_info,
+            priority=priority,
         )
 
         results = await self._engine.step(request)
@@ -177,6 +179,7 @@ class StageDiffusionProc:
         prompt: Any,
         sampling_params_dict: dict,
         kv_sender_info: dict[str, Any] | None = None,
+        priority: int = 0,
     ) -> AsyncGenerator[OmniRequestOutput, None]:
         """Process a streaming diffusion request and yield the results from DiffusionEngine.step_streaming()."""
         sampling_params = self._reconstruct_sampling_params(sampling_params_dict)
@@ -186,6 +189,7 @@ class StageDiffusionProc:
             sampling_params=sampling_params,
             request_id=request_id,
             kv_sender_info=kv_sender_info,
+            priority=priority,
         )
 
         async for results in self._engine.step_streaming(request):  # pyright: ignore[reportOptionalMemberAccess]
@@ -331,6 +335,7 @@ class StageDiffusionProc:
             prompt: Any,
             sampling_params_dict: dict,
             kv_sender_info: dict[str, Any] | None = None,
+            priority: int = 0,
         ) -> None:
             """Process a single diffusion request and send the response."""
             try:
@@ -340,6 +345,7 @@ class StageDiffusionProc:
                         prompt,
                         sampling_params_dict,
                         kv_sender_info=kv_sender_info,
+                        priority=priority,
                     )
                     await response_socket.send(encoder.encode({"type": "result", "output": result}))
                 else:
@@ -348,6 +354,7 @@ class StageDiffusionProc:
                         prompt,
                         sampling_params_dict,
                         kv_sender_info=kv_sender_info,
+                        priority=priority,
                     ):
                         await response_socket.send(encoder.encode({"type": "result", "output": result}))
             except DiffusionRequestAbortedError as e:
@@ -415,6 +422,7 @@ class StageDiffusionProc:
                             msg["prompt"],
                             msg["sampling_params"],
                             msg.get("kv_sender_info"),
+                            msg.get("priority", 0),
                         )
                     )
                     tasks[request_id] = task

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -22,6 +22,7 @@ from vllm.config import LoadConfig
 from vllm.logger import init_logger
 from vllm.utils.mem_utils import DeviceMemoryProfiler, GiB_bytes
 
+from vllm_omni.determinism import deterministic_sample_seed, is_batch_invariant_enabled
 from vllm_omni.diffusion.cache.cache_dit_backend import cache_summary
 from vllm_omni.diffusion.cache.prompt_embed_cache import (
     install_prompt_embed_cache,
@@ -353,14 +354,30 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if use_prefetch and self._kv_prefetch_enabled and kv_prefetch_jobs is not None:
             self.kv_transfer_manager.start_prefetch(kv_prefetch_jobs, self.target_device)
 
-        if req.sampling_params.generator is None and req.sampling_params.seed is not None:
-            if req.sampling_params.generator_device is not None:
-                gen_device = req.sampling_params.generator_device
-            elif self.device.type == "cpu":
-                gen_device = "cpu"
-            else:
-                gen_device = self.device
-            req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(req.sampling_params.seed)
+        self._ensure_sampling_generator(
+            req.sampling_params,
+            request_ids=[req.request_id],
+        )
+
+    def _sampling_generator_device(self, sampling_params) -> torch.device | str:
+        if sampling_params.generator_device is not None:
+            return sampling_params.generator_device
+        if self.device.type == "cpu":
+            return "cpu"
+        return self.device
+
+    def _ensure_sampling_generator(self, sampling_params, *, request_ids: list[str]) -> None:
+        if sampling_params.generator is not None or sampling_params.seed is None:
+            return
+        gen_device = self._sampling_generator_device(sampling_params)
+        if is_batch_invariant_enabled() and request_ids:
+            seeds = [deterministic_sample_seed(sampling_params.seed, request_id) for request_id in request_ids]
+            if len(seeds) == 1:
+                sampling_params.generator = torch.Generator(device=gen_device).manual_seed(seeds[0])
+                return
+            sampling_params.generator = [torch.Generator(device=gen_device).manual_seed(seed) for seed in seeds]
+            return
+        sampling_params.generator = torch.Generator(device=gen_device).manual_seed(sampling_params.seed)
 
     def _refresh_cache_for_requests(
         self,
@@ -594,13 +611,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if state.request_id in new_request_ids:
                 # set generator
                 if state.sampling.generator is None and state.sampling.seed is not None:
-                    if state.sampling.generator_device is not None:
-                        gen_device = state.sampling.generator_device
-                    elif self.device.type == "cpu":
-                        gen_device = "cpu"
-                    else:
-                        gen_device = self.device
-                    state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
+                    self._ensure_sampling_generator(state.sampling, request_ids=[state.request_id])
                 # encode
                 self.pipeline.prepare_encode(state)
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -765,6 +765,7 @@ class AsyncOmniEngine:
             preprocess_ms=_preprocess_ms,
             request_timestamp=request_timestamp,
             enqueue_ts=time.perf_counter(),
+            priority=priority,
         )
 
     def _enqueue_cfg_companions(
@@ -773,6 +774,7 @@ class AsyncOmniEngine:
         original_prompt: Any,
         stage0_params: Any,
         sampling_params_list: list[Any],
+        priority: int = 0,
     ) -> None:
         """Expand prompt into CFG companions, process through InputProcessor, and enqueue."""
         try:
@@ -798,6 +800,7 @@ class AsyncOmniEngine:
                 prompt=companion_prompt,
                 params=companion_params,
                 supported_tasks=self.supported_tasks,
+                priority=priority,
             )
             request.external_req_id = cid
 
@@ -812,6 +815,7 @@ class AsyncOmniEngine:
                     prompt=request,
                     companion_prompt_text=companion_prompt,
                     sampling_params_list=companion_spl,
+                    priority=priority,
                 )
             )
 
@@ -1291,7 +1295,13 @@ class AsyncOmniEngine:
             effective_spl = msg.sampling_params_list
             stage0_params = effective_spl[0] if effective_spl else None
             if stage0_params is not None:
-                self._enqueue_cfg_companions(request_id, original_prompt, stage0_params, effective_spl)
+                self._enqueue_cfg_companions(
+                    request_id,
+                    original_prompt,
+                    stage0_params,
+                    effective_spl,
+                    priority=priority,
+                )
 
     async def add_request_async(
         self,
@@ -1338,6 +1348,7 @@ class AsyncOmniEngine:
         final_stage_id: int = 0,
         final_output_stage_ids: Sequence[int] | None = None,
         arrival_time: float | None = None,
+        priority: int = 0,
         *,
         resumable: bool = True,
     ) -> None:
@@ -1350,6 +1361,7 @@ class AsyncOmniEngine:
             final_stage_id=final_stage_id,
             final_output_stage_ids=final_output_stage_ids,
             arrival_time=arrival_time,
+            priority=priority,
             resumable=resumable,
             message_type="streaming_update",
         )
@@ -1364,6 +1376,7 @@ class AsyncOmniEngine:
         final_stage_id: int = 0,
         final_output_stage_ids: Sequence[int] | None = None,
         arrival_time: float | None = None,
+        priority: int = 0,
         *,
         resumable: bool = True,
     ) -> None:
@@ -1376,6 +1389,7 @@ class AsyncOmniEngine:
             final_stage_id=final_stage_id,
             final_output_stage_ids=final_output_stage_ids,
             arrival_time=arrival_time,
+            priority=priority,
             resumable=resumable,
         )
 

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -27,6 +27,7 @@ class StageSubmissionMessage(EngineQueueMessage, kw_only=True):
     request_timestamp: float
     enqueue_ts: float
     final_output_stage_ids: list[int] | None = None
+    priority: int = 0
 
 
 class AddCompanionRequestMessage(EngineQueueMessage, kw_only=True):
@@ -37,6 +38,7 @@ class AddCompanionRequestMessage(EngineQueueMessage, kw_only=True):
     prompt: EngineCoreRequest
     companion_prompt_text: object | None
     sampling_params_list: list[OmniSamplingParams]
+    priority: int = 0
 
 
 class AbortRequestMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -124,6 +124,7 @@ def build_engine_core_request_from_tokens(
     model_config: ModelConfig | None = None,
     resumable: bool = False,
     mm_features: list | None = None,
+    priority: int = 0,
 ) -> OmniEngineCoreRequest:
     """Build an OmniEngineCoreRequest directly from an OmniTokensPrompt."""
     if arrival_time is None:
@@ -156,6 +157,7 @@ def build_engine_core_request_from_tokens(
         lora_request=getattr(params, "lora_request", None),
         cache_salt=prompt.get("cache_salt"),
         data_parallel_rank=None,
+        priority=priority,
         prompt_embeds=prompt_embeds,
         resumable=resumable,
         additional_information=additional_info_payload,
@@ -172,6 +174,7 @@ class OrchestratorRequestState:
     final_stage_id: int = -1
     final_output_stage_ids: set[int] = field(default_factory=set)
     finished_final_output_stage_ids: set[int] = field(default_factory=set)
+    priority: int = 0
 
     # Wall-clock timestamp when the client-facing engine request was accepted.
     request_timestamp: float = 0.0
@@ -462,6 +465,7 @@ class Orchestrator:
             sampling_params_list=sampling_params_list,
             final_stage_id=final_stage_id,
             final_output_stage_ids=final_output_stage_ids,
+            priority=msg.priority,
             request_timestamp=float(msg.request_timestamp or _time.time()),
             mm_features=getattr(prompt, "mm_features", None),
         )
@@ -510,6 +514,7 @@ class Orchestrator:
                 preprocess_ms=msg.preprocess_ms,
                 request_timestamp=msg.request_timestamp,
                 enqueue_ts=msg.enqueue_ts,
+                priority=msg.priority,
             )
             await self._handle_add_request(fallback_msg)
             return
@@ -555,6 +560,7 @@ class Orchestrator:
             sampling_params_list=sampling_params_list,
             final_stage_id=0,
             final_output_stage_ids={0},
+            priority=msg.priority,
             request_timestamp=parent_state.request_timestamp,
         )
         self.request_states[companion_id] = companion_state
@@ -1014,6 +1020,8 @@ class Orchestrator:
         resumable: bool = False,
     ) -> Any:
         next_pool = self.stage_pools[next_stage_id]
+        req_state = self.request_states.get(req_id)
+        priority = req_state.priority if req_state is not None else 0
         if self._next_stage_input_is_tokens(next_input):
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
@@ -1022,6 +1030,7 @@ class Orchestrator:
                 model_config=next_pool.stage_vllm_config.model_config,
                 mm_features=mm_features,
                 resumable=resumable,
+                priority=priority,
             )
             request.external_req_id = request.request_id
             return request
@@ -1033,6 +1042,7 @@ class Orchestrator:
             params=params,
             supported_tasks=("generate",),
             arrival_time=_time.time(),
+            priority=priority,
             resumable=resumable,
         )
         request = self._upgrade_processed_stage_request(request, next_input)
@@ -1348,6 +1358,7 @@ class Orchestrator:
                     model_config=next_pool.stage_vllm_config.model_config,
                     mm_features=req_state.mm_features,
                     resumable=next_stage_resumable,
+                    priority=req_state.priority,
                 )
                 request.external_req_id = request.request_id
                 if already_submitted:
@@ -1524,6 +1535,7 @@ class Orchestrator:
                     params=params,
                     model_config=next_pool.stage_vllm_config.model_config,
                     resumable=downstream_resumable,
+                    priority=req_state.priority,
                 )
                 request.external_req_id = request.request_id
                 await next_pool.submit_initial(

--- a/vllm_omni/engine/stage_client.py
+++ b/vllm_omni/engine/stage_client.py
@@ -98,6 +98,7 @@ class StagePoolDiffusionClient(StagePoolClient, Protocol):
         prompt: OmniPromptType,
         sampling_params: OmniDiffusionSamplingParams,
         kv_sender_info: dict[int, dict[str, Any]] | None = None,
+        priority: int = 0,
     ) -> None: ...
 
     def get_diffusion_output_nowait(self) -> OmniRequestOutput | None: ...

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -958,6 +958,7 @@ class StagePool:
                 affinity_request_id=affinity_request_id,
             )
             client = self._diffusion_client(replica_id)
+            submit_kwargs.setdefault("priority", req_state.priority)
             await client.add_request_async(request_id, request, params, **submit_kwargs)
             return replica_id
 
@@ -1024,7 +1025,12 @@ class StagePool:
                     "Diffusion list-prompt batch requests are no longer supported. "
                     "Submit multiple independent requests to use scheduler batching."
                 )
-            await self._diffusion_client(replica_id).add_request_async(request_id, request, params)
+            await self._diffusion_client(replica_id).add_request_async(
+                request_id,
+                request,
+                params,
+                priority=req_state.priority,
+            )
         else:
             # Refresh the shared output-processor state before yielding to the
             # stage client so streaming segments are merged against the latest

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -386,6 +386,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     final_stage_id=final_stage_id_for_e2e,
                     final_output_stage_ids=final_output_stage_ids,
                     arrival_time=wall_start_ts,
+                    priority=priority,
                 )
             else:
                 await self.engine.add_request_async(
@@ -395,6 +396,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     final_stage_id=final_stage_id_for_e2e,
                     final_output_stage_ids=final_output_stage_ids,
                     arrival_time=wall_start_ts,
+                    priority=priority,
                 )
             submit_ts = time.time()
             req_state.metrics.stage_first_ts[0] = submit_ts
@@ -439,6 +441,7 @@ class AsyncOmni(EngineClient, OmniBase):
         final_stage_id: int,
         final_output_stage_ids: Sequence[int],
         arrival_time: float,
+        priority: int = 0,
     ) -> asyncio.Task:
         """Submit a streaming input generator as incremental stage-0 updates."""
         if not sampling_params_list:
@@ -477,6 +480,7 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_output_stage_ids=final_output_stage_ids,
                             arrival_time=arrival_time,
                             resumable=True,
+                            priority=priority,
                         )
                         has_submitted_first_chunk = True
                     else:
@@ -489,6 +493,7 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_output_stage_ids=final_output_stage_ids,
                             arrival_time=arrival_time,
                             resumable=True,
+                            priority=priority,
                         )
             except (asyncio.CancelledError, GeneratorExit):
                 cancelled = True
@@ -520,6 +525,7 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_output_stage_ids=final_output_stage_ids,
                             arrival_time=arrival_time,
                             resumable=False,
+                            priority=priority,
                         )
                     else:
                         await self.engine.add_request_async(
@@ -531,6 +537,7 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_output_stage_ids=final_output_stage_ids,
                             arrival_time=arrival_time,
                             resumable=False,
+                            priority=priority,
                         )
 
         input_stream_task = asyncio.create_task(handle_inputs())


### PR DESCRIPTION
 ## Purpose

This adds the vLLM-Omni side of deterministic rollout support for verl-omni issue [203](https://github.com/verl-project/verl-omni/issues/203)

This PR is intentionally scoped to the core execution owners only. It introduces an opt-in `VLLM_BATCH_INVARIANT=1` mode that:

- caps vLLM-stage and diffusion scheduling to one running request;
- orders waiting requests by `priority` and then stable request id;
- requires explicit diffusion seeds in deterministic mode instead of silently assigning random seeds;
- derives diffusion generators from `(base_seed, request_id)` so a request keeps the same generator-driven output across different batch orderings or co-batches.

Default behavior is unchanged when `VLLM_BATCH_INVARIANT` is unset.

Public API / IPC-wide priority propagation is deliberately left out of this PR to keep the change minimal. This patch honors `priority` when it is already present on scheduler-visible request objects; wiring additional priority sources can be done separately.

## Test Plan

On B1 (`/home/wzr/vllm0.23.0/bin/python`, vLLM 0.23.0), run the core deterministic tests covering scheduler order, seed fail-fast, per-request generator derivation, and batch-order/co-batch stable dummy diffusion outputs:

```bash
python -m pytest -q \
  tests/core/sched/test_omni_scheduler_mixin.py \
  tests/diffusion/test_diffusion_request.py \
  tests/diffusion/test_diffusion_scheduler.py \
  tests/diffusion/test_diffusion_model_runner.py
```

## Test Result

On B1 at commit `231dd5d0280bdc02702b9d19e5ee4fc00fdc215e`:

- core deterministic tests: `89 passed`
