### PR TITLE
[Feature] Add flash attention 4 

### DIFF
--- a/docs/user_guide/diffusion/attention_backends.md
+++ b/docs/user_guide/diffusion/attention_backends.md
@@ -10,19 +10,33 @@ This backend is used by diffusion attention layers such as the DiT attention in 
 
 The full set of backends and their platform defaults is in the **Backend Options** and **Platform Defaults** sections below. If no attention backend is configured, vLLM-Omni asks the current platform to choose the default.
 
-## Backend Options
+## Backend Feature Support
 
-| Value | Notes |
+### Legend
+
+| Column | Description |
 |---|---|
-| `FLASH_ATTN` | Wraps FlashAttention 2. Default on Hopper / Ada / Ampere when `flash-attn` is installed. |
-| `CUDNN_ATTN` | Pins `sdpa_kernel([CUDNN_ATTENTION])`. Default on Blackwell (sm_10x / sm_12x) with cuDNN ≥ 9.5. Wins on mask-heavy DiTs (HunyuanVideo-1.5: 2× e2e vs SDPA). |
-| `FLASHINFER_ATTN` | Calls FlashInfer's dense `single_prefill_with_kv_cache` directly with `custom_mask` for non-causal masked attention. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer`. |
-| `TORCH_SDPA` | PyTorch `scaled_dot_product_attention` with the default backend dispatcher. Most conservative; always available. |
-| `SAGE_ATTN` | SageAttention 2.2 — INT8-quantized attention with FP16 accumulation. Lossy but typically visually indistinguishable on diffusion outputs. Requires `sageattention`. |
-| `SAGE_ATTN_3` | Requires `sageattn3` from `SageAttention/sageattention3_blackwell`. CUDA only, intended for Blackwell GPUs, with GQA/MQA requests falling back to PyTorch SDPA. |
+| Requires | Extra package needed beyond a stock vLLM-Omni install |
+| Dtypes | Supported activation data types |
+| Lossless | Bit-accurate attention math at the model dtype (❌ = quantized/lossy kernels) |
+| Masks | Non-causal `attn_mask` / varlen support (needed by mask-heavy DiTs) |
+| Head Sizes | Supported attention head dimensions ("Any" = no backend-side restriction) |
+| Compute Cap. | Required CUDA compute capability |
+
+Symbols: ✅ = supported, ❌ = not supported.
+
+| Backend | Requires | Dtypes | Lossless | Masks | Head Sizes | Compute Cap. | Notes |
+|---|---|---|---|---|---|---|---|
+| `FLASH_ATTN` | `flash-attn` | fp16, bf16 | ✅ | ✅ | 64, 96, 128, 192, 256 | ≥ 8.0 | FlashAttention 2; auto-route default on pre-Blackwell |
+| `FLASH_ATTN_4` | `flash-attn-4` (pre-release) | fp16, bf16 | ✅ | ✅ | 64, 96, 128, 256 | ≥ 8.0 | Opt-in, never auto-routed — see [FlashAttention-4](#flashattention-4-datacenter-blackwell) |
+| `CUDNN_ATTN` | cuDNN ≥ 9.5 (in PyTorch 2.5+ wheels) | fp16, bf16 | ✅ | ✅ | Any (%8, ≤ 256) | Any | Pins `sdpa_kernel([CUDNN_ATTENTION])`; auto-route default on Blackwell; 2× e2e on mask-heavy DiTs (HV-1.5) |
+| `FLASHINFER_ATTN` | `flashinfer` | fp16, bf16 | ✅ | ✅ (`custom_mask`) | 64, 128, 256 | ≥ 8.0 | Dense `single_prefill_with_kv_cache`; Blackwell fallback when cuDNN < 9.5 |
+| `TORCH_SDPA` | — | fp16, bf16, fp32 | ✅ | ✅ | Any | Any | Default dispatcher; most conservative, always available; quality reference |
+| `SAGE_ATTN` | `sageattention` | fp16, bf16 | ❌ (INT8, fp16 accum) | ❌ | 32–256 | ≥ 8.0 | Typically visually indistinguishable on diffusion outputs |
+| `SAGE_ATTN_3` | `sageattn3` | fp16, bf16 | ❌ | ❌ | 64, 128, 256 | ≥ 10.0 | Blackwell only; GQA/MQA requests fall back to `TORCH_SDPA` |
 
 
-## Configuration
+## Setting the Diffusion Attention Backend
 
 Diffusion attention backends can be configured three ways, in priority order:
 
@@ -69,8 +83,8 @@ vllm-omni serve <model> \
 Backends may also accept backend-specific parameters via `extra`:
 
 ```bash
---diffusion-attention-config.per_role.self.backend SPARSE_BLOCK \
---diffusion-attention-config.per_role.self.extra.block_size 128
+--diffusion-attention-config.per_role.self.backend SAGE_ATTN \
+--diffusion-attention-config.per_role.self.extra.some_option value
 ```
 
 ### Programmatic API
@@ -93,29 +107,45 @@ config = OmniDiffusionConfig(
 
 A plain dict is also accepted and normalized to `AttentionConfig`.
 
-## Platform Defaults
+## Backend Selection Behavior
 
-### Blackwell (sm_100 / sm_103 / sm_120 / sm_121)
+### Manual Selection
 
-Auto-route preference, in order:
+When you explicitly set a backend via `--diffusion-attention-backend` or `--diffusion-attention-config`:
 
-1. `CUDNN_ATTN` — when cuDNN ≥ 9.5 is available (ships in PyTorch 2.5+ wheels)
-2. `FLASHINFER_ATTN` — when `flashinfer` is installed but cuDNN < 9.5
-3. `FLASH_ATTN` — when `flash-attn` is installed with the Blackwell CUTE kernel
-4. `TORCH_SDPA` — last resort
+1. The selection is validated against your environment (package installed, compute capability).
+2. If the backend is unavailable or unsupported, vLLM-Omni logs a warning with the specific reason and **falls back to `TORCH_SDPA`** — unlike core vLLM, it does not raise.
+3. If valid, the backend is used and the startup log prints `Using diffusion attention backend '<NAME>'`.
 
-The startup log line `Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_120, cuDNN 91002)` confirms the route.
+### Automatic Selection
+
+When no backend is configured, the platform picks the first compatible backend from the priority tables below. The startup log line `Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_120, cuDNN 91002)` confirms the route. If neither the `Using ...` nor the `Defaulting to ...` line appears, the model didn't reach diffusion stage init — check earlier logs for failures.
+
+`FLASH_ATTN_4`, `SAGE_ATTN`, and `SAGE_ATTN_3` are never auto-routed — they are opt-in only.
+
+## Backend Priority (CUDA)
+
+Priority is 1 = highest (tried first).
+
+**Blackwell (sm_100 / sm_103 / sm_120 / sm_121):**
+
+| Priority | Backend | Condition |
+|---|---|---|
+| 1 | `CUDNN_ATTN` | cuDNN ≥ 9.5 available (ships in PyTorch 2.5+ wheels) |
+| 2 | `FLASHINFER_ATTN` | `flashinfer` installed, cuDNN < 9.5 |
+| 3 | `FLASH_ATTN` | `flash-attn` installed with the Blackwell CUTE kernel |
+| 4 | `TORCH_SDPA` | always available |
 
 **Why CUDNN_ATTN by default**: on mask-heavy diffusion models (HunyuanVideo-1.5, Qwen-Image), cuDNN's pinned FMHA kernel sidesteps a PyTorch SDPA dispatch quirk where the unpinned dispatcher picks `EFFICIENT_ATTENTION` (~25 ms) for masked calls instead of cuDNN (~11 ms). The pin gives 2× e2e on HV-1.5 with no regression on lighter models.
 
-### Hopper (sm_90) / Ada (sm_89) / Ampere (sm_80–sm_86)
+**Hopper (sm_90) / Ada (sm_89) / Ampere (sm_80–sm_86):**
 
-Auto-route preference:
+| Priority | Backend | Condition |
+|---|---|---|
+| 1 | `FLASH_ATTN` | `flash-attn` installed |
+| 2 | `TORCH_SDPA` | always available |
 
-1. `FLASH_ATTN` — when `flash-attn` is installed
-2. `TORCH_SDPA` — fallback
-
-`CUDNN_ATTN` and `FLASHINFER_ATTN` are still selectable via env var on these GPUs but are not in the auto-route — FlashAttention 2 is the well-tuned path on pre-Blackwell hardware.
+`CUDNN_ATTN` and `FLASHINFER_ATTN` are still selectable explicitly on these GPUs but are not in the auto-route — FlashAttention 2 is the well-tuned path on pre-Blackwell hardware.
 
 ## End-to-End Benchmark (BF16, sm_120 RTX Pro 6000 Blackwell)
 
@@ -129,43 +159,6 @@ Same prompt and seed across runs. `Total generation time` from `text_to_video.py
 | FLUX.2-dev (T2I) | 1024² / 50 steps, TP=2 | 53.62 s | **53.30 s** | 54.94 s |
 
 Pattern: mask-heavy DiTs (HV-1.5, Qwen-Image) favor `CUDNN_ATTN`; lighter-mask DiTs and TP-saturated configs (Wan 2.2, FLUX.2 TP=2) tie within noise.
-
-## Known Limitations
-
-### LTX-2.0: `CUDNN_ATTN` crashes under torch.compile
-
-LTX-2's audio attention has a symbolic head_dim under torch.compile tracing. cuDNN's SDPA backend selector rejects symbolic dims and Dynamo aborts compilation. Tracked in [#3121](https://github.com/vllm-project/vllm-omni/issues/3121).
-
-**Workaround**: explicitly select `FLASHINFER_ATTN` or `TORCH_SDPA` for LTX-2.0:
-
-```bash
-DIFFUSION_ATTENTION_BACKEND=FLASHINFER_ATTN python examples/offline_inference/text_to_video/text_to_video.py \
-    --model Lightricks/LTX-2 ...
-```
-
-### FA4 not yet integrated
-
-FlashAttention-4 (released March 2026) targets Blackwell natively and reportedly beats cuDNN by ~20% on B200. As of this writing the `flash-attn-4 4.0.0b10` wheel crashes with `AttributeError: 'NoneType' object has no attribute '_trait'` during JIT on sm_120. Not yet wired into vLLM-Omni; revisit when stable lands.
-
-## Choosing a Backend Manually
-
-### When to override the default
-
-- **Quality validation**: compare a new backend against `TORCH_SDPA` as the reference, since SDPA's default dispatcher is the most extensively tested.
-- **Lossy speedup hunting**: try `SAGE_ATTN` (INT8 quantized) on diffusion outputs — typically indistinguishable visually but always validate.
-- **Workaround for known issues**: see Known Limitations above.
-
-### Verifying which backend is in use
-
-The startup log prints one of:
-
-```
-Using diffusion attention backend 'CUDNN_ATTN'           # explicit override
-Defaulting to diffusion attention backend CUDNN_ATTN ... # auto-route
-Defaulting to diffusion attention backend SDPA           # nothing else available
-```
-
-If you don't see one of these, the model didn't reach diffusion stage init — check earlier logs for failures.
 
 ## SageAttention Installation
 
@@ -236,6 +229,21 @@ DIFFUSION_ATTENTION_BACKEND=FLASHINFER_ATTN python examples/offline_inference/te
     --output ltx2.mp4
 ```
 
+### FlashAttention-4 (datacenter Blackwell)
+
+`FLASH_ATTN_4` is opt-in (never auto-routed). Requires `pip install --pre flash-attn-4` — the wheel publishes only the `flash_attn.cute` namespace; installing it alongside a `flash-attn` FA2 wheel in the same environment is not supported, since both own the `flash_attn` package directory. The backend covers dense, piecewise (mixed causal/full), and masked/varlen calls, works under torch.compile, and on sm_103 (B300) automatically selects the `sm_103a` compile target unless `CUTE_DSL_ARCH` is already set.
+
+BF16 FA4 is a drop-in selection:
+
+```bash
+DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN_4 python examples/offline_inference/text_to_video/text_to_video.py \
+    --model hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v \
+    --prompt "A dog running across a field of golden wheat." \
+    --height 480 --width 832 --num-frames 33 \
+    --num-inference-steps 50 --seed 42 --guidance-scale 6.0 \
+    --output hv15_fa4.mp4
+```
+
 ### SageAttention (lossy)
 
 ```bash
@@ -299,7 +307,7 @@ python examples/offline_inference/text_to_video/text_to_video.py \
     --height 704 --width 1280 --num-frames 49 \
     --num-inference-steps 30 --seed 42 --guidance-scale 5.0 \
     --tensor-parallel-size 2 \
-    --output outputs/wan22_fa3.mp4
+    --output outputs/wan22_fa2.mp4
 ```
 
 ## Validation Guidance

--- a/tests/diffusion/attention/test_flash_attn4.py
+++ b/tests/diffusion/attention/test_flash_attn4.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+
+import pytest
+import torch
+import torch.nn.functional as F
+from vllm.platforms import current_platform
+
+FLASH_ATTN4_MODULE = "vllm_omni.diffusion.attention.backends.flash_attn4"
+
+
+def _fa4_installed() -> bool:
+    try:
+        from flash_attn.cute import flash_attn_func  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+requires_fa4 = pytest.mark.skipif(
+    not (current_platform.is_cuda() and torch.cuda.is_available() and _fa4_installed()),
+    reason="requires CUDA and flash-attn-4 (pip install --pre flash-attn-4)",
+)
+
+
+def _sdpa_reference(query, key, value, softmax_scale, causal):
+    # (B, S, H, D) -> (B, H, S, D)
+    q, k, v = (t.transpose(1, 2).float() for t in (query, key, value))
+    out = F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=softmax_scale)
+    return out.transpose(1, 2)
+
+
+@requires_fa4
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("head_dim", [64, 128])
+def test_flash_attn4_matches_sdpa(causal: bool, head_dim: int):
+    backend_module = importlib.import_module(FLASH_ATTN4_MODULE)
+    torch.manual_seed(0)
+
+    batch, seq_len, num_heads = 2, 512, 4
+    softmax_scale = head_dim**-0.5
+    impl = backend_module.FlashAttention4Impl(
+        num_heads=num_heads,
+        head_size=head_dim,
+        softmax_scale=softmax_scale,
+        causal=causal,
+    )
+
+    query = torch.randn(batch, seq_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+
+    out = impl.forward_cuda(query, key, value)
+    ref = _sdpa_reference(query, key, value, softmax_scale, causal)
+
+    assert out.shape == query.shape
+    assert torch.allclose(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
+@requires_fa4
+def test_flash_attn4_cross_attention_shape():
+    """Cosmos3-style cross attention: kv longer than q, non-causal."""
+    backend_module = importlib.import_module(FLASH_ATTN4_MODULE)
+    torch.manual_seed(0)
+
+    batch, q_len, kv_len, num_heads, head_dim = 1, 256, 768, 8, 128
+    softmax_scale = head_dim**-0.5
+    impl = backend_module.FlashAttention4Impl(
+        num_heads=num_heads,
+        head_size=head_dim,
+        softmax_scale=softmax_scale,
+        causal=False,
+    )
+
+    query = torch.randn(batch, q_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn(batch, kv_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    value = torch.randn_like(key)
+
+    out = impl.forward_cuda(query, key, value)
+    ref = _sdpa_reference(query, key, value, softmax_scale, causal=False)
+
+    assert out.shape == query.shape
+    assert torch.allclose(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
+@requires_fa4
+def test_flash_attn4_masked_varlen_path():
+    from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+
+    backend_module = importlib.import_module(FLASH_ATTN4_MODULE)
+    torch.manual_seed(0)
+
+    batch, seq_len, num_heads, head_dim = 2, 128, 4, 64
+    softmax_scale = head_dim**-0.5
+    impl = backend_module.FlashAttention4Impl(
+        num_heads=num_heads,
+        head_size=head_dim,
+        softmax_scale=softmax_scale,
+        causal=False,
+    )
+
+    query = torch.randn(batch, seq_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    # Second sample only attends over its first 64 tokens.
+    attn_mask = torch.ones(batch, seq_len, dtype=torch.bool, device="cuda")
+    attn_mask[1, 64:] = False
+
+    out = impl.forward_cuda(query, key, value, AttentionMetadata(attn_mask=attn_mask))
+
+    ref0 = _sdpa_reference(query[:1], key[:1], value[:1], softmax_scale, causal=False)
+    ref1 = _sdpa_reference(
+        query[1:, :64],
+        key[1:, :64],
+        value[1:, :64],
+        softmax_scale,
+        causal=False,
+    )
+    assert torch.allclose(out[:1].float(), ref0, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(out[1:, :64].float(), ref1, atol=2e-2, rtol=2e-2)
+    # Padded (masked-out) query rows are zero-filled by _pad_input.
+    assert torch.all(out[1:, 64:] == 0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="platform selection tests require CUDA platform")
+def test_cuda_platform_selects_flash_attn4(monkeypatch: pytest.MonkeyPatch):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
+    monkeypatch.setattr(
+        CudaOmniPlatform,
+        "get_device_capability",
+        classmethod(lambda cls, device_id=0: DeviceCapability(10, 3)),
+    )
+    monkeypatch.setattr(PACKAGES_CHECKER, "get_packages_info", lambda: {"has_flash_attn": False})
+    from vllm_omni.diffusion.attention.backends.utils import fa as fa_utils
+
+    monkeypatch.setattr(fa_utils, "is_flash_attn_4_installed", lambda: True)
+
+    backend_path = CudaOmniPlatform.get_diffusion_attn_backend_cls("FLASH_ATTN_4", head_size=128)
+
+    assert backend_path == DiffusionAttentionBackendEnum.FLASH_ATTN_4.get_path()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="platform selection tests require CUDA platform")
+def test_cuda_platform_falls_back_when_flash_attn4_missing(monkeypatch: pytest.MonkeyPatch):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+    from vllm_omni.diffusion.attention.backends.utils import fa as fa_utils
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
+    monkeypatch.setattr(
+        CudaOmniPlatform,
+        "get_device_capability",
+        classmethod(lambda cls, device_id=0: DeviceCapability(10, 3)),
+    )
+    monkeypatch.setattr(PACKAGES_CHECKER, "get_packages_info", lambda: {"has_flash_attn": False})
+    monkeypatch.setattr(fa_utils, "is_flash_attn_4_installed", lambda: False)
+
+    backend_path = CudaOmniPlatform.get_diffusion_attn_backend_cls("FLASH_ATTN_4", head_size=128)
+
+    assert backend_path == DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()

--- a/vllm_omni/diffusion/attention/backends/flash_attn4.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn4.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashAttention-4 (CuTe DSL) diffusion attention backend.
+
+Install with ``pip install --pre flash-attn-4``. The wheel publishes only the
+``flash_attn.cute`` namespace, so this backend probes it directly instead of
+going through the FA2/FA3 detection chain in ``utils/fa.py``.
+"""
+
+import os
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.attention.backends.abstract import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadata,
+)
+from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
+    piecewise_attn,
+)
+
+logger = init_logger(__name__)
+
+try:
+    from flash_attn.cute import flash_attn_func, flash_attn_varlen_func  # noqa: F401
+except Exception as e:
+    logger.warning(
+        "FlashAttention4Backend is not available (%s). Install it with `pip install --pre flash-attn-4`.",
+        e,
+    )
+    raise ImportError from e
+
+
+def _unwrap_fa4_output(out: torch.Tensor | tuple[torch.Tensor, ...]) -> torch.Tensor:
+    # FA4 returns (out, lse); lse is None unless return_lse=True.
+    return out[0] if isinstance(out, tuple) else out
+
+
+# sm_103a codegen is up to ~14% faster than the sm_100 default at DiT shapes.
+if torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 3):
+    os.environ.setdefault("CUTE_DSL_ARCH", "sm_103a")
+
+
+# Custom ops keep the CuTe-DSL launchers opaque to torch.compile; the hasattr
+# guard keeps registration idempotent across re-imports.
+if not hasattr(torch.ops.vllm_omni, "flash_attn4"):
+
+    @torch.library.custom_op("vllm_omni::flash_attn4", mutates_args=())
+    def _flash_attn4_op(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        softmax_scale: float | None,
+        causal: bool,
+    ) -> torch.Tensor:
+        from flash_attn.cute import flash_attn_func as _kernel
+
+        return _unwrap_fa4_output(_kernel(query, key, value, softmax_scale=softmax_scale, causal=causal))
+
+    @_flash_attn4_op.register_fake
+    def _(query, key, value, softmax_scale, causal):
+        return query.new_empty(*query.shape[:-1], value.shape[-1])
+
+
+_flash_attn4_op = torch.ops.vllm_omni.flash_attn4
+
+
+class FlashAttention4Backend(AttentionBackend):
+    accept_output_buffer: bool = True
+
+    @classmethod
+    def supports_attention_mask(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
+        # sm_100/sm_103: head dims up to 128 plus a dedicated (256, 256) kernel.
+        return [64, 96, 128, 256]
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLASH_ATTN_4"
+
+    @staticmethod
+    def get_impl_cls() -> type["FlashAttention4Impl"]:
+        return FlashAttention4Impl
+
+
+class FlashAttention4Impl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        softmax_scale: float,
+        causal: bool = False,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        qkv_layout: str | None = None,
+        backend_kwargs: dict | None = None,
+        **extra_impl_args,
+    ) -> None:
+        self.num_heads = num_heads
+        self.causal = causal
+        self.softmax_scale = softmax_scale
+        if backend_kwargs:
+            logger.warning("FlashAttention4Impl ignoring backend_kwargs: %s", list(backend_kwargs.keys()))
+
+    @staticmethod
+    def _fa4_dense(q, k, v, *, softmax_scale, causal):
+        return _flash_attn4_op(q, k, v, softmax_scale, causal)
+
+    def _forward_varlen_masked(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        from vllm_omni.diffusion.attention.backends.utils.fa import (
+            _pad_input,
+            _unpad_input,
+            _upad_input,
+        )
+
+        assert attention_mask.ndim == 2, "attention_mask must be 2D, (batch_size, seq_len)"
+        query_length = query.size(1)
+        q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
+            query, key, value, attention_mask, query_length, _unpad_input
+        )
+
+        out_unpad = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seq_lens_q,
+            cu_seqlens_k=cu_seq_lens_k,
+            max_seqlen_q=max_length_q,
+            max_seqlen_k=max_length_k,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+        )
+        out_unpad = _unwrap_fa4_output(out_unpad)
+        return _pad_input(out_unpad, indices_q, query.size(0), query_length)
+
+    def forward_cuda(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata = None,
+    ) -> torch.Tensor:
+        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+        full_attn_spans = attn_metadata.full_attn_spans if attn_metadata is not None else None
+
+        if full_attn_spans is not None:
+            logger.debug("Using piecewise FlashAttention-4 for mixed causal/full mask")
+            return piecewise_attn(
+                query,
+                key,
+                value,
+                full_attn_spans,
+                self.softmax_scale,
+                FlashAttention4Impl._fa4_dense,
+            )
+
+        if attention_mask is not None and torch.any(~attention_mask):
+            return self._forward_varlen_masked(
+                query,
+                key,
+                value,
+                attention_mask,
+            )
+
+        return _flash_attn4_op(query, key, value, self.softmax_scale, self.causal)

--- a/vllm_omni/diffusion/attention/backends/registry.py
+++ b/vllm_omni/diffusion/attention/backends/registry.py
@@ -57,6 +57,7 @@ class DiffusionAttentionBackendEnum(Enum, metaclass=_DiffusionBackendEnumMeta):
 
     # Common backends (available on most platforms)
     FLASH_ATTN = "vllm_omni.diffusion.attention.backends.flash_attn.FlashAttentionBackend"
+    FLASH_ATTN_4 = "vllm_omni.diffusion.attention.backends.flash_attn4.FlashAttention4Backend"
     TORCH_SDPA = "vllm_omni.diffusion.attention.backends.sdpa.SDPABackend"
     SAGE_ATTN = "vllm_omni.diffusion.attention.backends.sage_attn.SageAttentionBackend"
     SAGE_ATTN_3 = "vllm_omni.diffusion.attention.backends.sage_attn3.SageAttention3Backend"

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -138,6 +138,25 @@ def is_flash_attn_installed() -> bool:
         return False
 
 
+@lru_cache(maxsize=1)
+def is_flash_attn_4_installed() -> bool:
+    """Return whether FlashAttention-4 (``flash_attn.cute``) is importable.
+
+    Kept separate from the FA2/FA3 chain above: the ``flash-attn-4`` wheel
+    publishes only the ``flash_attn.cute`` namespace (no ``flash_attn.ops`` /
+    ``flash_attn_interface``), and conversely older ``flash-attn`` wheels ship
+    a ``flash_attn/cute`` directory whose imports fail against current
+    ``nvidia-cutlass-dsl`` — so only a real import (not ``find_spec``) is a
+    reliable probe, and any failure means unavailable.
+    """
+    try:
+        from flash_attn.cute import flash_attn_func  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
 def _index_first_axis(tensor, indices):
     """
     A local implementation of the PyTorch indexing operation `tensor[indices]` on the first axis,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -524,7 +524,7 @@ class OmniServeCommand(CLISubcommand):
             help="Diffusion attention config. Accepts JSON or vLLM-style dotted flags. "
             "Examples: "
             "--diffusion-attention-config.default.backend FLASH_ATTN, "
-            "--diffusion-attention-config.per_role.self.backend SPARSE_BLOCK, "
+            "--diffusion-attention-config.per_role.self.backend FLASH_ATTN_4, "
             "--diffusion-attention-config.per_role.cross.backend SAGE_ATTN, "
             '--diffusion-attention-config \'{"default": {"backend": "FLASH_ATTN"}, '
             '"per_role": {"cross": {"backend": "SAGE_ATTN"}}}\'.',

--- a/vllm_omni/platforms/cuda/platform.py
+++ b/vllm_omni/platforms/cuda/platform.py
@@ -131,6 +131,23 @@ class CudaOmniPlatform(OmniPlatform, CudaPlatformBase):
                     logger.warning("Flash Attention packages not available. Falling back to TORCH_SDPA backend.")
                 logger.debug("Defaulting to diffusion attention backend SDPA")
                 return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
+            if backend_upper == "FLASH_ATTN_4":
+                # FA4 (CuTe DSL) ships sm_80/sm_90/sm_100/sm_120 kernel paths;
+                # its Blackwell (sm_10x) kernels are the reason to pick it.
+                if not compute_supported:
+                    logger.warning(
+                        "FlashAttention-4 requires GPU with compute capability >= 8.0. "
+                        "Falling back to TORCH_SDPA backend."
+                    )
+                    return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
+                from vllm_omni.diffusion.attention.backends.utils.fa import is_flash_attn_4_installed
+
+                if not is_flash_attn_4_installed():
+                    logger.warning(
+                        "FlashAttention-4 package not available. Install it with "
+                        "`pip install --pre flash-attn-4`. Falling back to TORCH_SDPA backend."
+                    )
+                    return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
             if backend_upper == "SAGE_ATTN_3":
                 sage_attn3_supported = compute_capability is not None and compute_capability.major >= 10
                 if not sage_attn3_supported:


### PR DESCRIPTION
We are currently benchmarking long video generation models, specifically Cosmos 3 Super and Wan 2.2 14B, to assess the viability of FlashAttention 4 as our primary attention kernel for DC Blackwell architectures (SM100/SM103).

This PR adds `FLASH_ATTN_4` as an opt-in BF16 diffusion attention backend (dense, piecewise mixed causal/full, and masked/varlen paths; torch.compile-safe via custom ops; automatic `sm_103a` codegen pin on B300).

## Scope

**BF16 only.** We extensively measured FA4's FP8 path and root-caused its video-DiT quality loss to an upstream kernel bug: the pipelined softmax's delayed-running-max overshoot saturates the fp8 P matrix (`max_offset=8` leaves only 1.75x e4m3 headroom), silently clipping attention weights whenever logits are wide — the video-DiT regime; LLM-sharp attention never triggers it. We have submitted the one-constant fix upstream ([Dao-AILab/flash-attention#2694](https://github.com/Dao-AILab/flash-attention/pull/2694)). With that fix plus Hadamard input conditioning, FP8 reaches same-seed SSIM 0.965 (i2v) / 0.951 (t2v) vs the cuDNN baseline — at FP8's native 1.49x kernel speed (measured e2e: 2.00 s/step vs the 2.45-2.55 cuDNN baseline at 189 frames, 1.23-1.28x). An FP8 knob for this backend will follow as a stacked PR once the fixed kernel is available in a released flash-attn-4.

Results-only summary with same-seed videos: **https://lishunyang12.github.io/blog/fa4-blackwell-cosmos3** · full kernel working set: [lishunyang12/flash-attention#1](https://github.com/lishunyang12/flash-attention/pull/1)

## Results (Cosmos3-Nano, 1x B300, idle-verified)

Kernel-level: parity with cuDNN (1.00-1.03x across DiT shapes 14k-86k tokens). End-to-end, steady-state per denoising step:

| Task | Frames | cuDNN | FA4 bf16 | Speedup |
|---|---|---|---|---|
| t2v 1280x720 | 189 | 2.45-2.55 s/step | 2.36 s/step | 1.04-1.08x |
| i2v 1280x704 | 189 | 2.36-2.45 s/step | 2.27 s/step | 1.04-1.08x |
| t2v 1280x720 | 33 | 267 ms/step | 260 ms/step | 1.03x |
| i2v 1280x720 | 33 | 268 ms/step | 263 ms/step | 1.02x |

189-frame rows: 12 denoising steps, measured from unsmoothed progress-bar elapsed deltas (first-step compile/JIT excluded). 33-frame rows: official 35-step config, per-step walls from torch-profiler trace timelines (progress-bar granularity cannot resolve ms-level deltas). The gain tracks attention's share of step time: ~86k tokens at 189 frames vs ~15k at 33.

Same-seed output quality is at the kernel-noise floor (SSIM 0.97 vs the cuDNN baseline at 35 steps). cuDNN remains the platform default; FA4 is opt-in:

```bash
DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN_4 python examples/offline_inference/text_to_video/text_to_video.py \
  --model nvidia/Cosmos3-Nano --num-frames 189 --num-inference-steps 35 --seed 42 ...
```


Next MR: FA FP8
