### PR TITLE
[Bugfix] Fix hardcoded bfloat16 dtype in Voxtral TTS Stage-1 audio tokenizer decode

### DIFF
--- a/tests/model_executor/models/voxtral_tts/test_audio_tokenizer_parsing.py
+++ b/tests/model_executor/models/voxtral_tts/test_audio_tokenizer_parsing.py
@@ -185,3 +185,77 @@ def test_cut_all_frames_returns_empty():
     result = apply_ctx_frames_cutting([audio], [ctx_frames], downsample_factor)
 
     assert result[0].numel() == 0
+
+
+# ──────────────────────────────────────────────────────────────────
+# decode_helper_batch_async dtype regression test (#4838)
+# ──────────────────────────────────────────────────────────────────
+
+
+@functools.lru_cache(maxsize=1)
+def _voxtral_tts_audio_tokenizer_cls():
+    from tests.model_executor.helpers import bootstrap_vllm_layer_custom_op_modules
+
+    bootstrap_vllm_layer_custom_op_modules()
+    import vllm.model_executor.models.utils  # noqa: F401
+
+    from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_tokenizer import (
+        VoxtralTTSAudioTokenizer,
+    )
+
+    return VoxtralTTSAudioTokenizer
+
+
+def _make_bare_audio_tokenizer(param_dtype: torch.dtype):
+    """Build a VoxtralTTSAudioTokenizer without running __init__.
+
+    __init__ requires a full VllmConfig + checkpoint, which is too heavy
+    for a CPU unit test. Instead we bypass it and set only the state
+    needed to exercise decode_helper_batch_async.
+    """
+    cls = _voxtral_tts_audio_tokenizer_cls()
+    tokenizer = cls.__new__(cls)
+    torch.nn.Module.__init__(tokenizer)
+    tokenizer.register_parameter("_dummy_param", torch.nn.Parameter(torch.zeros(1, dtype=param_dtype)))
+    tokenizer._sampling_rate = 24000
+    tokenizer._frame_rate = 24000 / 240  # -> downsample_factor == 240
+    return tokenizer
+
+
+def test_dtype_property_reflects_param_dtype():
+    """VoxtralTTSAudioTokenizer.dtype reflects the actual loaded parameter dtype."""
+    tokenizer = _make_bare_audio_tokenizer(torch.float16)
+    assert tokenizer.dtype == torch.float16
+
+
+def test_decode_helper_batch_async_uses_resolved_dtype_not_hardcoded(monkeypatch):
+    """Regression test for #4838.
+
+    decode_helper_batch_async previously hardcoded dtype=torch.bfloat16
+    when calling self.decode(...). This mismatched the tokenizer's actual
+    (e.g. float16) parameter dtype on GPUs without bfloat16 support, such
+    as Tesla T4, causing:
+        RuntimeError: expected scalar type BFloat16 but found Half
+
+    This verifies decode_helper_batch_async passes the tokenizer's
+    resolved `dtype` property to decode(), instead of a hardcoded value.
+    """
+    tokenizer = _make_bare_audio_tokenizer(torch.float16)
+    seen_dtypes = []
+
+    def fake_decode(codes, dtype=torch.float32):
+        seen_dtypes.append(dtype)
+        b, _, t = codes.shape
+        return torch.zeros(b, 1, t * tokenizer.downsample_factor)
+
+    monkeypatch.setattr(tokenizer, "decode", fake_decode)
+
+    num_codebooks = 4
+    non_eoa_row = torch.zeros(num_codebooks, dtype=torch.long)
+    eoa_row = torch.zeros(num_codebooks, dtype=torch.long)
+    eoa_row[0] = 1
+    codes = torch.stack([non_eoa_row, eoa_row])  # [T=2, K]
+
+    tokenizer.decode_helper_batch_async([codes])
+
+    assert seen_dtypes == [torch.float16]

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_tokenizer.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_tokenizer.py
@@ -897,6 +897,17 @@ class VoxtralTTSAudioTokenizer(nn.Module):
         """List of size of each codebook"""
         return self.quantizer.codebook_sizes
 
+    @property
+    def dtype(self) -> torch.dtype:
+        """Actual dtype of the loaded model parameters.
+
+        Used instead of a hardcoded dtype so decode-time casts stay
+        consistent with whatever dtype the weights were loaded/cast to
+        (e.g. the float16 fallback on GPUs without bfloat16 support,
+        such as Tesla T4 / compute capability < 8.0). See #4838.
+        """
+        return next(self.parameters()).dtype
+
     def load_weight(self, weight: tuple[str, torch.Tensor]) -> str:
         params_dict = dict(self.named_parameters())
         name, loaded_weight = weight
@@ -1100,7 +1111,7 @@ class VoxtralTTSAudioTokenizer(nn.Module):
             padded[i, : len(chunk)] = chunk
 
         audio_codes = padded.to(device=current_omni_platform.device_type)  # [B, T, K]
-        audio_values = self.decode(audio_codes.transpose(1, 2), dtype=torch.bfloat16)  # [B, 1, T_out]
+        audio_values = self.decode(audio_codes.transpose(1, 2), dtype=self.dtype)  # [B, 1, T_out]
         audio_values = audio_values.detach().cpu().float().squeeze(1)  # [B, T_out]
         if torch.min(audio_values) < -1.0:
             logger.warning("Min value of decoded waveform signal is %s", torch.min(audio_values))


### PR DESCRIPTION
Fixes #4838

## Purpose
Voxtral TTS (`mistralai/Voxtral-4B-TTS-2603`) crashes during Stage-1 warmup on GPUs with compute capability < 8.0 (e.g. Tesla T4) with:
```
RuntimeError: expected scalar type BFloat16 but found Half
```

Stage-0 correctly detects unsupported bfloat16 hardware and falls back to float16, but `VoxtralTTSAudioTokenizer.decode_helper_batch_async` hardcoded `dtype=torch.bfloat16` when calling `self.decode(...)`, mismatching the actual (float16) dtype of the loaded model weights and causing a dtype mismatch in the decoder's conv1d layers.

This PR adds a `dtype` property to `VoxtralTTSAudioTokenizer` that reads the actual dtype of the loaded parameters (`next(self.parameters()).dtype`), mirroring the existing `Transformer.dtype()` pattern already used elsewhere in this file, and replaces the hardcoded `dtype=torch.bfloat16` with `dtype=self.dtype` at the affected call site.

There is a second hardcoded `dtype=torch.bfloat16` in `_tokenize_audio` (inside a `torch.autocast` block, used for the encoder/voice-cloning path via `encode_waveforms`). This is left untouched in this PR since it's tied to flash-attn's alibi bias requirements and isn't on the path that caused the reported crash — flagging as a possible follow-up.

## Test Plan
**vLLM Version:** 0.24.0
**vLLM-Omni Commit:** 5c51782c

Ran the repro command from #4838 on 2x Tesla T4 (compute capability 7.5):
```
python examples/offline_inference/text_to_speech/voxtral_tts/end2end.py \
    --write-audio --voice casual_male \
    --model mistralai/Voxtral-4B-TTS-2603 \
    --text "This is a test message."
```

## Test Result
**Before:** crashes during Stage-1 warmup with:
```
RuntimeError: expected scalar type BFloat16 but found Half
```

**After:** completes successfully:
```
Stage 1 engine startup completed
Audio saved to output_audio/tts_output_0.wav
Total audio duration: 4.80s
RTF: 0.9384
```