### PR TITLE
[NPU] Optimize the code_predictor in Qwen3-Omni Talker for NPU.

### DIFF
--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -157,57 +157,26 @@ class CodePredictorAttention(nn.Module):
             )
             self.register_buffer("_fusion_causal_mask", fusion_mask, persistent=False)
 
-    def _forward_npu_attention(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        bsz: int,
-        seq_len: int,
-    ) -> torch.Tensor:
+    def _forward_npu_attention(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         import torch_npu
 
-        q_f, k_f, v_f = q, k, v
-        if self.is_gqa:
-            k_f = (
-                k[:, :, None, :, :]
-                .expand(bsz, self.num_kv_heads, self.num_queries_per_kv, seq_len, self.head_dim)
-                .reshape(bsz, self.num_heads, seq_len, self.head_dim)
-            )
-            v_f = (
-                v[:, :, None, :, :]
-                .expand(bsz, self.num_kv_heads, self.num_queries_per_kv, seq_len, self.head_dim)
-                .reshape(bsz, self.num_heads, seq_len, self.head_dim)
-            )
-
-        mask = self._fusion_causal_mask
-        mask = mask.contiguous()
-        q_f = q_f.contiguous()
-        k_f = k_f.contiguous()
-        v_f = v_f.contiguous()
-        return torch_npu.npu_fusion_attention(
-            q_f,
-            k_f,
-            v_f,
-            self.num_heads,
-            "BNSD",
-            pse=None,
-            padding_mask=None,
-            atten_mask=mask,
+        v = v.contiguous()
+        return torch_npu.npu_fused_infer_attention_score(
+            q,
+            k,
+            v,
+            pse_shift=None,
+            atten_mask=self._fusion_causal_mask,
+            actual_seq_lengths=None,
+            actual_seq_lengths_kv=None,
+            block_table=None,
+            num_heads=self.num_heads,
+            num_key_value_heads=self.num_kv_heads,
             scale=float(self.scaling),
-            keep_prob=1.0,
-            # Keep torch_npu's API spelling.
-            pre_tockens=2147483647,
-            next_tockens=2147483647,
-            inner_precise=0,
-            prefix=None,
-            actual_seq_qlen=None,
-            actual_seq_kvlen=None,
-            # Ascend SDPA is_causal migration example uses sparse_mode=2.
+            input_layout="BNSD",
             sparse_mode=2,
-            gen_mask_parallel=True,
-            # Keep sync=True for the NPU fused attention path.
-            sync=True,
+            block_size=0,
+            softmax_lse_flag=False,
         )[0]
 
     def forward(
@@ -240,7 +209,7 @@ class CodePredictorAttention(nn.Module):
                 enable_gqa=self.is_gqa,
             )
         else:
-            attn_out = self._forward_npu_attention(q, k, v, bsz, seq_len)
+            attn_out = self._forward_npu_attention(q, k, v)
 
         attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
         return self.o_proj(attn_out)
@@ -843,7 +812,7 @@ class CodePredictorWrapper(nn.Module):
                     sorted_probs = F.softmax(sorted_logits, dim=-1, dtype=torch.float32)
                     cumulative_probs = sorted_probs.cumsum(dim=-1)
                     remove_mask = (cumulative_probs - sorted_probs) >= s_top_p
-                    sorted_logits[remove_mask] = float("-inf")
+                    sorted_logits = sorted_logits.masked_fill(remove_mask, float("-inf"))
                     logits = sorted_logits.scatter(1, sorted_idx, sorted_logits)
                 probs = F.softmax(logits, dim=-1, dtype=torch.float32)
                 code = torch.multinomial(probs, num_samples=1, generator=generator)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
### Objective:
This PR aims to optimize the inference performance of the Qwen3-Omni Talker `code_predictor`.

### Key Changes:

- Inspired by vLLM's NPU attention computation, replaced `npu_fusion_attention` with `npu_fused_infer_attention_score` in the forward pass of the `code_predictor` Attention layer.
- Replaced the `Tensor[mask]` operation in Top-P sampling with the `masked_fill` function for better efficiency.

## Test Plan
### Functional Test
Deploy the model using the following command, and compare the text and audio generated by the model before and after the modifications.

- Service startup
```
vllm serve /workspace/user_data/models/ \
--omni \
--host 0.0.0.0 \
--port 8080 \
--served-model-name Qwen3-Omni \
--dtype bfloat16 \
--stage-init-timeout 3600 \
--init-timeout 3600 \
--deploy-config /workspace/user_data/vllm-omni-0.22.0/qwen3_omni_moe.yaml
```

- deploy-config
Use `vllm_omni/deploy/qwen3_omni_moe.yaml` as the deploy config, and add `enforce_eager: true` to stages 1 and 2 under `platforms.npu` to prevent the model from failing to start.
```
async_chunk: true

connectors:
  connector_of_shared_memory:
    name: SharedMemoryConnector
    extra:
      initial_codec_chunk_frames: 4
      codec_chunk_frames: 25
      codec_left_context_frames: 25

stages:
  - stage_id: 0
    max_num_batched_tokens: 32768
    max_num_seqs: 64
    gpu_memory_utilization: 0.9
    trust_remote_code: true
    enable_prefix_caching: false
    devices: "0"
    default_sampling_params:
      temperature: 0.0
      max_tokens: 2048

  - stage_id: 1
    max_num_batched_tokens: 32768
    max_num_seqs: 64
    gpu_memory_utilization: 0.6
    trust_remote_code: true
    enable_prefix_caching: false
    devices: "1"
    input_connectors:
      from_stage_0: connector_of_shared_memory
    default_sampling_params:
      temperature: 0.9
      top_k: 50
      max_tokens: 4096
      seed: 42
      repetition_penalty: 1.05

  - stage_id: 2
    max_num_batched_tokens: 65536
    max_num_seqs: 64
    gpu_memory_utilization: 0.1
    enforce_eager: false
    trust_remote_code: true
    enable_prefix_caching: false
    enable_chunked_prefill: false
    async_scheduling: false
    devices: "1"
    input_connectors:
      from_stage_1: connector_of_shared_memory
    default_sampling_params:
      temperature: 0.0
      top_p: 1.0
      top_k: -1
      max_tokens: 65536
      seed: 42
      repetition_penalty: 1.1

platforms:
  npu:
    stages:
      - stage_id: 0
        gpu_memory_utilization: 0.6
        tensor_parallel_size: 2
        max_num_batched_tokens: 8192
        devices: "0,1"
      - stage_id: 1
        gpu_memory_utilization: 0.6
        max_num_batched_tokens: 8192
        devices: "2"
        enforce_eager: true
      - stage_id: 2
        gpu_memory_utilization: 0.3
        devices: "2"
        enforce_eager: true

  rocm:
    stages:
      - stage_id: 2
        enforce_eager: true

  xpu:
    stages:
      - stage_id: 0
        tensor_parallel_size: 4
        enforce_eager: true
        max_cudagraph_capture_size: 0
        devices: "0,1,2,3"
      - stage_id: 1
        enforce_eager: true
        max_cudagraph_capture_size: 0
        devices: "4"
      - stage_id: 2
        gpu_memory_utilization: 0.3
        max_cudagraph_capture_size: 0
        devices: "4"
```
- Functional request
```
curl -s http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen3-Omni",
    "messages": [{"role": "user", "content": "Describe vLLM in brief"}],
    "modalities": ["text", "audio"]
  }' > response.txt
```

**vLLM Version: 0.22.1**

**vLLM-Ascend Version: 0.22.1rc1**

**vLLM-Omni Commit:963ba1a**

### Test Result

Audio output of the original model:
[output.wav](https://github.com/user-attachments/files/29630585/output.wav)


Audio output of the modified model:
[output_modify.wav](https://github.com/user-attachments/files/29630586/output_modify.wav)

### Performance Test
Run the following command for performance testing. Execute each scenario 2 times and take the average as the result.
```
vllm bench serve \
--omni \
--backend openai-chat-omni \
--model /workspace/user_data/models/ \
--served-model-name Qwen3-Omni \
--endpoint /v1/chat/completions \
--dataset-name random-mm \
--num-prompts 10 \
--request-rate 1|4|10 \
--max-concurrency 1|4|10 \
--ignore-eos \
--percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
--random-input-len 1024 \
--random-output-len 100 \
--random-mm-base-items-per-request 1 \
--random-mm-limit-mm-per-prompt '{"image": 1}' \
--random-mm-bucket-config '{(512,512,1): 1}' \
--base-url http://127.0.0.1:8080 \
--host 127.0.0.1 \
--port 8000 \
--seed 1000 \
--trust-remote-code \
--skip-chat-template \
--save-result
```

### Test Result

Concurrency = 1
| Metric | main | Current PR |Summary|
|  ----  | ----  |----  |----  |
| Successful requests | 10 | 10 | - |
| Failed requests | 0 | 0 | - |
| Maximum request concurrency | 1 | 1 | - |
| Benchmark duration (s) | 472.755 | 351.61 |-25.63%|
| Request throughput (req/s) | 0.02 | 0.03 |+50%|
| Mean E2EL (ms) | 47166.125 | 35051.74 |-25.68%|
| Median E2EL (ms) | 50171.48 | 37968.54 |-24.32%|
| P99 E2EL (ms) | 62851.515 | 42030.55 |-33.13%|
| Output token throughput (tok/s) | 1.98 | 2.665 |+34.6%|
| Total token throughput (tok/s) | 29.27 | 39.355 |+34.46%|
| Mean TTFT (ms) | 412.755 | 407.475 |-1.28% |
| Median TTFT (ms) | 416.215 | 411.51 | -1.13% |
| P99 TTFT (ms) | 432.305 | 420.88| -2.64% |
| Mean TPOT (ms) | 39.425 | 39.12 | -0.77% |
| Median TPOT (ms) | 34.08 | 33.775 |-0.89% |
| P99 TPOT (ms) | 82.075 | 81.59 |-0.59% |
| Mean ITL (ms) | 33.755 | 33.485 |-0.8% |
| Median ITL (ms) | 33.905 | 33.83 | -0.22% |
| P99 ITL (ms) | 69.33 | 69.265 | -0.09% |
| Audio throughput (audio duration/s) | 0.61 | 0.775 | +27.05%|
| Mean AUDIO_TTFP (ms) | 1151.19 | 1020.53 |-11.35%  |
| Median AUDIO_TTFP (ms) | 1152.96 | 1024.42 |-11.15% |
| P99 AUDIO_TTFP (ms) | 1188.36 | 1056.31 |-11.11%|
| Mean AUDIO_RTF | 1.645 | 1.29 |-21.58%|
| Median AUDIO_RTF | 1.63 | 1.285 |-21.17%|
| P99 AUDIO_RTF | 1.73 | 1.36 |-21.39%|

###Summary
At a concurrency of 1, E2EL decreased by approximately 25.68%, audio token throughput improved by about 27.05%, TTFP dropped by roughly 11.35%, and RTF decreased by around 21.58%. Metrics related to text token generation, such as TTFT, TPOT, and ITL, showed no significant changes.

Concurrency = 4
| Metric | main | Current PR |Summary|
|  ----  | ----  |----  |----  |
| Successful requests | 10 | 10 | - |
| Failed requests | 0 | 0 | - |
| Maximum request concurrency | 4 | 4 | - |
| Benchmark duration (s) | 212.135 | 155.06 |-26.91%|
| Request throughput (req/s) | 0.05 | 0.065 |+30%|
| Mean E2EL (ms) | 73544.78 | 52199.78 |-29.02%|
| Median E2EL (ms) | 73993.535 | 53761.94 |-27.34%|
| P99 E2EL (ms) | 89942.9 | 60562.22 |-32.67%|
| Output token throughput (tok/s) | 4.695 | 6.42 |+36.74%|
| Total token throughput (tok/s) | 65.55 | 89.655 |+36.77%|
| Mean TTFT (ms) | 562.265 | 553.735 |-1.52% |
| Median TTFT (ms) | 454.385 | 493.255 | +8.55% |
| P99 TTFT (ms) | 821.52 |762.05 | -7.24% |
| Mean TPOT (ms) | 42.695 | 42.045 | -1.52% |
| Median TPOT (ms) | 41.93 | 39.77 |-5.15% |
| P99 TPOT (ms) | 55.595 | 54.72 |-1.57% |
| Mean ITL (ms) | 42.025 | 41.385 |-1.52% |
| Median ITL (ms) | 37.62 | 36.73 | -2.37% |
| P99 ITL (ms) | 128.545 | 133.63 | +3.96% |
| Audio throughput (audio duration/s) | 1.575 | 1.945 | +23.49%|
| Mean AUDIO_TTFP (ms) | 2072.4 | 1809.94 |-12.66%  |
| Median AUDIO_TTFP (ms) | 2061.99 | 1707.49 |-17.19% |
| P99 AUDIO_TTFP (ms) | 2333.37 | 2311.19 |-0.95%|
| Mean AUDIO_RTF | 2.215 | 1.755 |-20.77%|
| Median AUDIO_RTF | 2.21 | 1.725 |-21.95%|
| P99 AUDIO_RTF | 2.425 | 2.075 |-14.43%|

###Summary
At a concurrency of 4, E2EL decreased by approximately 29.02%, audio token throughput improved by about 23.49%, TTFP dropped by roughly 12.66%, and RTF decreased by around 20.77%.

Concurrency = 10
| Metric | main | Current PR |Summary|
|  ----  | ----  |----  |----  |
| Successful requests | 10 | 10 | - |
| Failed requests | 0 | 0 | - |
| Maximum request concurrency | 10 | 10 | - |
| Benchmark duration (s) | 91.005 | 70.06 |-23.02%|
| Request throughput (req/s) | 0.11 | 0.14 |+27.27%|
| Mean E2EL (ms) | 77378.85 | 56.145.945 |-27.44%|
| Median E2EL (ms) | 80971.22 | 58040.78 |-28.32%|
| P99 E2EL (ms) | 90205.735 | 68941.135 |-23.57%|
| Output token throughput (tok/s) | 10.705 | 14.02 |+30.97%|
| Total token throughput (tok/s) | 152.46 | 198.95 |+30.49%|
| Mean TTFT (ms) | 2630.535 | 1874.84 |-28.73% |
| Median TTFT (ms) | 3324.035 | 2168.965 | -34.75% |
| P99 TTFT (ms) | 3594.605 |2568.995 | -28.53% |
| Mean TPOT (ms) | 91.965 | 88.815 | -3.43% |
| Median TPOT (ms) | 79.19 | 80.81 |+2.05% |
| P99 TPOT (ms) | 142.285 | 130.04 |-8.61% |
| Mean ITL (ms) | 87.06 | 84.33 |-3.14% |
| Median ITL (ms) | 85.665 | 83.535 | -2.49% |
| P99 ITL (ms) | 192.615 | 422.53 | +119.37% |
| Audio throughput (audio duration/s) | 3.265 | 4.275 | +30.93%|
| Mean AUDIO_TTFP (ms) | 5041.1 | 3751.88 |-25.57%  |
| Median AUDIO_TTFP (ms) | 5107.03 | 3800.06 |-25.59% |
| P99 AUDIO_TTFP (ms) | 5310.67 | 3934.52 |-25.91%|
| Mean AUDIO_RTF | 2.66 | 1.95 |-26.69%|
| Median AUDIO_RTF | 2.585 | 1.875 |-27.47%|
| P99 AUDIO_RTF | 3.25 | 2.555 |-21.38%|

###Summary
At a concurrency of 10, E2EL decreased by approximately 27.44%, audio token throughput improved by about 30.93%, TTFP dropped by roughly 25.57%, and RTF decreased by around 26.69%.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
