### PR TITLE
[Bugfix][Qwen3-TTS] Seed residual MTP sampling

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -3343,6 +3343,27 @@ class TestTTSAsyncOffloading:
         qwen3_tts_server._build_tts_params.assert_called_once()
         qwen3_tts_server._estimate_prompt_len_async.assert_awaited_once()
 
+    def test_prepare_speech_generation_qwen3_default_seed_sets_tts_local_seed(
+        self, qwen3_tts_server, mocker: MockerFixture
+    ):
+        """Deploy default seed should seed Qwen3 TTS residual MTP sampling."""
+        qwen3_tts_server.engine_client.default_sampling_params_list = [
+            SimpleNamespace(max_tokens=2048, seed=42, extra_args=None)
+        ]
+        qwen3_tts_server._validate_tts_request = mocker.MagicMock(return_value=None)
+        qwen3_tts_server._build_tts_params = mocker.MagicMock(
+            return_value={"text": ["hello"], "task_type": ["CustomVoice"], "speaker": ["Vivian"]}
+        )
+        qwen3_tts_server._estimate_prompt_len_async = mocker.AsyncMock(return_value=512)
+        request = OpenAICreateSpeechRequest(input="hello")
+
+        asyncio.run(qwen3_tts_server._prepare_speech_generation(request))
+
+        stage0_params = qwen3_tts_server.engine_client.generate.call_args.kwargs["sampling_params_list"][0]
+        assert stage0_params.seed == 42
+        assert stage0_params.extra_args["tts_local_seed"] == 42
+        assert qwen3_tts_server.engine_client.default_sampling_params_list[0].extra_args is None
+
     def test_prepare_speech_generation_treats_sse_as_streaming(self, qwen3_tts_server, mocker: MockerFixture):
         """stream_format=sse should request delta-style multimodal outputs."""
         qwen3_tts_server._validate_tts_request = mocker.MagicMock(return_value=None)

--- a/vllm_omni/deploy/qwen3_tts_high_concurrency.yaml
+++ b/vllm_omni/deploy/qwen3_tts_high_concurrency.yaml
@@ -60,7 +60,6 @@ stages:
       temperature: 0.9
       top_k: 50
       max_tokens: 4096
-      seed: 42
       repetition_penalty: 1.05
     subtalker_sampling_params:
       do_sample: true
@@ -85,7 +84,6 @@ stages:
       top_p: 1.0
       top_k: -1
       max_tokens: 65536
-      seed: 42
       repetition_penalty: 1.0
 
 platforms:

--- a/vllm_omni/deploy/voxcpm2.yaml
+++ b/vllm_omni/deploy/voxcpm2.yaml
@@ -28,20 +28,21 @@ stages:
     max_num_batched_tokens: 4096
     max_model_len: 4096
     devices: "0"
-    hf_overrides:
-      voxcpm2_runtime_config:
-        audio_emit_every: 1
-        vae_decode_every: 3
-        enable_batched_cfm: true
-        enable_batched_vae_decode: true
-        coalesce_audio_d2h: true
-        enable_loc_dit_fused_qkv: true
-        enable_loc_dit_fused_mlp: true
-        enable_loc_dit_zero_dt_cache: true
-        enable_loc_dit_skip_qkv_contig: true
-        enable_loc_dit_reduce_overhead_no_cg: true
-        enable_unified_decode_graph: true
-        unified_decode_graph_max_batch_size: 8
+    engine_extras:
+      hf_overrides:
+        voxcpm2_runtime_config:
+          audio_emit_every: 1
+          vae_decode_every: 3
+          enable_batched_cfm: true
+          enable_batched_vae_decode: true
+          coalesce_audio_d2h: true
+          enable_loc_dit_fused_qkv: true
+          enable_loc_dit_fused_mlp: true
+          enable_loc_dit_zero_dt_cache: true
+          enable_loc_dit_skip_qkv_contig: true
+          enable_loc_dit_reduce_overhead_no_cg: true
+          enable_unified_decode_graph: true
+          unified_decode_graph_max_batch_size: 8
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -3709,6 +3709,18 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 stage0_params.extra_args = {}
             stage0_params.extra_args["tts_local_seed"] = request.seed
 
+        if self._tts_model_type == "qwen3_tts" and sampling_params_list:
+            stage0_params = sampling_params_list[0]
+            default_seed = getattr(stage0_params, "seed", None)
+            if default_seed is not None:
+                import copy
+
+                sampling_params_list = copy.deepcopy(sampling_params_list)
+                stage0_params = sampling_params_list[0]
+                if stage0_params.extra_args is None:
+                    stage0_params.extra_args = {}
+                stage0_params.extra_args.setdefault("tts_local_seed", int(default_seed))
+
         generator = self.engine_client.generate(
             prompt=prompt,
             request_id=request_id,


### PR DESCRIPTION
Fix #4850.

## Purpose

Qwen3-TTS deploy defaults can set `SamplingParams.seed=42`, but the residual MTP codec sampler only creates a per-request `torch.Generator` from `extra_args["tts_local_seed"]`. When the request does not explicitly provide `seed`, the deploy default seed stayed on `sampling_params.seed` and never reached `tts_local_seed`.

Under concurrent `async_chunk` requests, MTP residual sampling then falls back to the global PyTorch RNG. Multiple requests can interleave consumption of that global RNG, which can drift one request's residual codec sequence and produce long-tail audio text.

This PR propagates the stage-0 default seed into `tts_local_seed` for Qwen3-TTS, while preserving explicit request seed behavior and without changing `max_tokens`.

## Test Plan

- [x] Add unit coverage that a Qwen3-TTS deploy default `seed=42` sets stage-0 `extra_args["tts_local_seed"]`.
- [x] Run targeted ruff check and format check for changed files.
- [x] Run Python syntax check for changed files.
- [x] Reproduce the original async_chunk e2e failure on remote H20 without the fix.
- [x] Validate the same async_chunk e2e test on remote H20 with the seed propagation fix.

**vLLM Version:**

0.24.0 on remote H20 validation environment.

**vLLM-Omni Commit:**

0a4d3976

## E2E Test Result

### Before this PR: original bug reproduced on remote H20

Command:

```bash
CUDA_VISIBLE_DEVICES=1 VLLM_WORKER_MULTIPROC_METHOD=spawn PATH=/tmp/bugfix4850/bin:$PATH   /home/admin/miniconda3/bin/python3 -m pytest -s -vv   tests/e2e/online_serving/test_qwen3_tts_customvoice.py::test_text_to_audio_001   --run-level advanced_model --tb=short
```

Result:

```text
Task: 58b391a3
Log: /tmp/bugfix4850/seedrca_base_no_seedprop_run1.log
Result: FAILED

BUG4850_SERVING_STAGE0_PARAMS ... seed=42 extra_args=None max_tokens=500 stop_ids=[2150]
BUG4850_MTP_SEED ... sampling_seed=42 extra_args=None explicit_tts_local_seed=None generator_enabled=False
BUG4850_STAGE0_STOP ... out_len=241 ... stop_ids=[2150] max_tokens=500 status=FINISHED_STOPPED

AssertionError: Transcript doesn't match input: similarity=0.89,
transcript='... endless exploration opportunities. Eurasian Opportunities'
```

This shows the original bad case with deploy default `seed=42`, no `tts_local_seed`, MTP generator disabled, and a long-tail output. The request still stopped normally on `[2150]` with `max_tokens=500`, so this is not a max-token cap or missing-stop-token issue.

### After this PR: same e2e test passes on remote H20

Command:

```bash
CUDA_VISIBLE_DEVICES=1 VLLM_WORKER_MULTIPROC_METHOD=spawn PATH=/tmp/bugfix4850/bin:$PATH   /home/admin/miniconda3/bin/python3 -m pytest -s -vv   tests/e2e/online_serving/test_qwen3_tts_customvoice.py::test_text_to_audio_001   --run-level advanced_model --tb=short
```

Result:

```text
Task: 96fb50af
Log: /tmp/bugfix4850/seedrca_seedprop_only_run1.log
Result: PASSED

BUG4850_SERVING_STAGE0_PARAMS ... seed=42 extra_args={'tts_local_seed': 42} max_tokens=500 stop_ids=[2150]
BUG4850_MTP_SEED ... explicit_tts_local_seed=42 generator_enabled=True
BUG4850_STAGE0_STOP ... out_len=192 / 198 / 198 / 198 / 198 ... max_tokens=500

1 passed, 17 warnings in 145.48s
```

## Unit / Static Test Result

```text
ruff check tests/entrypoints/openai_api/test_serving_speech.py vllm_omni/entrypoints/openai/serving_speech.py: passed
ruff format --check tests/entrypoints/openai_api/test_serving_speech.py vllm_omni/entrypoints/openai/serving_speech.py: passed
python3 -m py_compile vllm_omni/entrypoints/openai/serving_speech.py tests/entrypoints/openai_api/test_serving_speech.py: passed
```

cc @linyueqian @Gaohan123 
