### PR TITLE
[BugFix]: Add vae_use_tiling in magi_human test

### DIFF
--- a/tests/e2e/offline_inference/test_magi_human_expansion.py
+++ b/tests/e2e/offline_inference/test_magi_human_expansion.py
@@ -22,6 +22,7 @@ _OMNI_RUNNER_PARAM = (
     {
         "init_timeout": 1200,
         "tensor_parallel_size": 2,
+        "vae_use_tiling": True,
     },
 )
 
@@ -32,6 +33,7 @@ _OMNI_RUNNER_PARAM_OFFLOAD = (
         "init_timeout": 1200,
         "tensor_parallel_size": 2,
         "enable_cpu_offload": True,
+        "vae_use_tiling": True,
     },
 )
 

--- a/tests/e2e/offline_inference/test_magi_human_expansion.py
+++ b/tests/e2e/offline_inference/test_magi_human_expansion.py
@@ -45,10 +45,6 @@ pytestmark = [
     ),
 ]
 
-_SKIP_ISSUE_3236 = pytest.mark.skip(
-    reason="https://github.com/vllm-project/vllm-omni/issues/3236",
-)
-
 
 def _validate_mp4(video_bytes: bytes, min_frames: int = 10) -> None:
     """Validate that the MP4 contains meaningful video and audio tracks."""
@@ -74,7 +70,6 @@ def _validate_mp4(video_bytes: bytes, min_frames: int = 10) -> None:
     container.close()
 
 
-@_SKIP_ISSUE_3236
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_magi_human_e2e(omni_runner: OmniRunner):
     """End-to-end test for MagiHuman generating video and audio."""

--- a/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
+++ b/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
@@ -1686,6 +1686,10 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae", "audio_vae"]
 
+    # Frames whose longer side exceeds this are VAE-decoded in tiles;
+    # above base-rate (<=512px), below SR (1080p), so only SR decodes tile.
+    _VAE_TILING_MIN_FRAME: ClassVar[int] = 720
+
     def __init__(self, od_config: OmniDiffusionConfig, **kwargs):
         super().__init__()
         model_path = od_config.model
@@ -2119,6 +2123,13 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
         mean = self.vae_latent_mean.to(latent.device, dtype=latent.dtype).view(1, -1, 1, 1, 1)
         std = self.vae_latent_std.to(latent.device, dtype=latent.dtype).view(1, -1, 1, 1, 1)
         latent = latent * std + mean
+
+        # Tile the VAE decode for SR-resolution frames to bound peak memory.
+        _, _, _, latent_h, latent_w = latent.shape
+        frame_h = latent_h * self.vae_stride[1]
+        frame_w = latent_w * self.vae_stride[2]
+        if max(frame_h, frame_w) > self._VAE_TILING_MIN_FRAME and hasattr(self.vae, "enable_tiling"):
+            self.vae.enable_tiling()
 
         videos = self.vae.decode(latent.to(self.dtype))
         if hasattr(videos, "sample"):

--- a/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
+++ b/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
@@ -1686,10 +1686,6 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae", "audio_vae"]
 
-    # Frames whose longer side exceeds this are VAE-decoded in tiles;
-    # above base-rate (<=512px), below SR (1080p), so only SR decodes tile.
-    _VAE_TILING_MIN_FRAME: ClassVar[int] = 720
-
     def __init__(self, od_config: OmniDiffusionConfig, **kwargs):
         super().__init__()
         model_path = od_config.model
@@ -2123,13 +2119,6 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
         mean = self.vae_latent_mean.to(latent.device, dtype=latent.dtype).view(1, -1, 1, 1, 1)
         std = self.vae_latent_std.to(latent.device, dtype=latent.dtype).view(1, -1, 1, 1, 1)
         latent = latent * std + mean
-
-        # Tile the VAE decode for SR-resolution frames to bound peak memory.
-        _, _, _, latent_h, latent_w = latent.shape
-        frame_h = latent_h * self.vae_stride[1]
-        frame_w = latent_w * self.vae_stride[2]
-        if max(frame_h, frame_w) > self._VAE_TILING_MIN_FRAME and hasattr(self.vae, "enable_tiling"):
-            self.vae.enable_tiling()
 
         videos = self.vae.decode(latent.to(self.dtype))
         if hasattr(videos, "sample"):


### PR DESCRIPTION
## Purpose

Fixes #3236 

## Test Plan

```
pytest -s -v tests/e2e/offline_inference/test_magi_human_expansion.py::test_magi_human_e2e[omni_runner0]  --run-level full_model
```

## Test Result

Sorry, my device's memory is so large, can't easily trigger this error