### PR TITLE
[Perf][Qwen3-TTS] Skip per-step hidden-state D2H via hidden pooler payload opt-out

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -309,6 +309,12 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # tensor read; postprocess receives the tail-only slice instead, which
         # avoids ~18 ms merge + ~6 ms write per step (Sy0307 profile, #3665).
         self.requires_full_prefix_cached_hidden_states = False
+        # Stage 1 (code2wav) consumes runtime audio codes, not hidden states,
+        # so the inter-stage pooler payload never needs a CPU hidden-states
+        # view. Opting out lets the runner skip the per-step blocking
+        # ``hidden_states[:n].to("cpu")`` (measured at 24% of stage-0 on-CPU
+        # samples at c=64 on H20).
+        self.omni_pooler_payload_include_hidden = False
         # ``codes.audio`` is only needed for future prefix-hit reconstruction
         # after a request has produced codec rows. Keep per-step rows on GPU and
         # materialize the CPU OmniTensorPrefixCache entry once at completion.

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1308,7 +1308,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 # prefix caching but the downstream pooler payload path still
                 # needs a CPU hidden-states view. Materialize it synchronously
                 # in that case; the legacy behavior is preserved.
-                if hs_for_cache is None:
+                if hs_for_cache is None and self._model_omni_pooler_payload_include_hidden():
                     hidden_states_cpu = hidden_states[:num_tokens_unpadded].detach().to("cpu").contiguous()
                 slot_mapping_gpu = self.input_batch.block_table[0].slot_mapping.gpu
                 self.omni_prefix_cache.schedule_async_write(


### PR DESCRIPTION
## Purpose

W1 of #4855. Qwen3-TTS stage 1 (code2wav) consumes runtime audio codes, not hidden states, but the runner still materializes a synchronous CPU copy of the full hidden states **every decode step** for the inter-stage pooler payload:

```python
# vllm_omni/worker/gpu_ar_model_runner.py
if hs_for_cache is None:
    hidden_states_cpu = hidden_states[:num_tokens_unpadded].detach().to("cpu").contiguous()
```

py-spy at c=64 attributes 24% of stage-0 on-CPU samples to this line. The opt-out flag and its payload-builder gates already exist (`omni_pooler_payload_include_hidden`, set by qwen3_omni, honored by `_model_omni_pooler_payload_include_hidden()` in the output builder); qwen3_tts just never set it, and this one materialization site did not check it.

This PR (2 files, ~8 lines): the talker declares `omni_pooler_payload_include_hidden = False`, and the copy site gates on the existing flag. Models that do not opt out keep the default `include_hidden=True` path byte-for-byte unchanged.

## Test Plan

A/B on 1x H20, Qwen3-TTS-12Hz-1.7B-CustomVoice, c=64, `max_num_seqs=64`, seed-tts-text en, 300 requests per arm, both arms completing 300/300 with audio (streaming and non-streaming verified):

| | throughput (audio-s/s) | mean TTFP | p99 TTFP | stage-0 host CPU | copy in py-spy profile |
|---|---|---|---|---|---|
| main | 45.7 | 1056 ms | 3270 ms | 59% of a core | 24.1% of samples |
| this PR | 51.7 (+13%) | 479 ms (-55%) | 1067 ms (-67%) | 24% of a core | gone |

Unit suites, run on the PR head (`ef13bdae`, includes the merge of main) on H20 with vLLM 0.24:

```
pytest -q tests/entrypoints/openai_api/test_serving_speech.py tests/entrypoints/openai_api/test_tts_adapter.py
202 passed, 19 warnings in 4.83s
```

**vLLM Version:** 0.24.0
