### PR TITLE
feat: incorporate file metadata into local ref_audio cache keys to su…

### DIFF
--- a/tests/test_ref_audio_cache.py
+++ b/tests/test_ref_audio_cache.py
@@ -1,0 +1,56 @@
+import os
+import time
+import tempfile
+import pathlib
+import hashlib
+from vllm_omni.entrypoints.openai.serving_speech import OmniOpenAIServingSpeech
+
+def test_local_file_cache_key_invalidation():
+    print("Testing local file cache key invalidation...")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = pathlib.Path(tmp_dir)
+        test_file = tmp_path / "test_audio.wav"
+        
+        # 1. Create a dummy file and get its cache key
+        test_file.write_text("dummy audio data 1")
+        file_uri = f"file://{test_file}"
+        
+        key1 = OmniOpenAIServingSpeech._get_ref_audio_cache_key(file_uri)
+        print(f"  [1] Key for original file: {key1}")
+        
+        # Wait slightly to ensure the mtime changes on the filesystem
+        time.sleep(0.01)
+        
+        # 2. Modify the file
+        test_file.write_text("dummy audio data 2 modified")
+        
+        # 3. Get the new cache key
+        key2 = OmniOpenAIServingSpeech._get_ref_audio_cache_key(file_uri)
+        print(f"  [2] Key for modified file: {key2}")
+        
+        assert key1 != key2, "Cache key should change when file is modified!"
+        print("  ✓ Passed: Keys are correctly invalidated based on file metadata.")
+
+def test_remote_url_cache_key():
+    print("\nTesting remote URL cache key stability...")
+    url = "https://example.com/audio.wav"
+    key1 = OmniOpenAIServingSpeech._get_ref_audio_cache_key(url)
+    key2 = OmniOpenAIServingSpeech._get_ref_audio_cache_key(url)
+    
+    assert key1 == key2, "Cache key for URLs should remain constant!"
+    print("  ✓ Passed: URLs correctly maintain a constant cache key.")
+
+def test_missing_file_cache_key():
+    print("\nTesting missing file fallback...")
+    file_uri = "file:///path/to/nonexistent/file.wav"
+    key = OmniOpenAIServingSpeech._get_ref_audio_cache_key(file_uri)
+    expected_key = hashlib.sha1(file_uri.encode("utf-8")).hexdigest()
+    
+    assert key == expected_key, "Missing files should fallback to the string hash."
+    print("  ✓ Passed: Missing files are handled gracefully.")
+
+if __name__ == "__main__":
+    test_local_file_cache_key_invalidation()
+    test_remote_url_cache_key()
+    test_missing_file_cache_key()
+    print("\nAll unit tests passed successfully!")

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -2439,14 +2439,31 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
 
         return None
 
+    @staticmethod
+    def _get_ref_audio_cache_key(ref_audio_str: str) -> str:
+        """Compute the cache key hash for a given ref_audio string, incorporating file metadata for local files."""
+        cache_key_source = ref_audio_str
+        if not ref_audio_str.startswith(("http://", "https://", "data:")):
+            try:
+                path = ref_audio_str[7:] if ref_audio_str.startswith("file://") else ref_audio_str
+                st = os.stat(path)
+                cache_key_source = f"{ref_audio_str}:{st.st_mtime}:{st.st_size}"
+            except Exception:
+                pass
+        return hashlib.sha1(cache_key_source.encode("utf-8")).hexdigest()
+
     async def _resolve_ref_audio(self, ref_audio_str: str) -> tuple[list[float], int]:
         """Resolve ref_audio to (wav_samples, sample_rate).
 
         Delegates to upstream vLLM's MediaConnector which handles http(s)
         URLs, ``data:`` base64 URIs, and ``file:`` local paths (the latter
         gated by ``--allowed-local-media-path``).
+
+        Local file references incorporate mtime and size into the cache key
+        so that modified files are automatically reloaded without a server
+        restart. Remote URLs remain cached by their original string locator.
         """
-        cache_key = hashlib.sha1(ref_audio_str.encode("utf-8")).hexdigest()
+        cache_key = self._get_ref_audio_cache_key(ref_audio_str)
         cached = self._ref_audio_resolve_cache.get(cache_key)
         if cached is not None:
             self._ref_audio_resolve_cache.move_to_end(cache_key)
@@ -2511,7 +2528,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         return h.hexdigest()
 
     def _get_resolved_ref_audio_artifact_key(self, ref_audio_str: str) -> str | None:
-        source_key = hashlib.sha1(ref_audio_str.encode("utf-8")).hexdigest()
+        source_key = self._get_ref_audio_cache_key(ref_audio_str)
         cached = self._ref_audio_resolve_cache.get(source_key)
         if cached is None:
             return None


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #4873

## Purpose

When a user updates a local reference audio file but keeps the same file path, `_resolve_ref_audio()` was previously returning a stale decoded audio waveform because the cache key was only hashing the `ref_audio_str` locator path.

This PR implements Option 1 from the issue discussion by updating `_get_ref_audio_cache_key` to be content-aware for local files. The cache key now incorporates the file's `mtime` and `size`, automatically detecting file modifications without needing a server restart, while preserving the existing string-hash behavior for URLs and immutable data.

## Test Plan

- Created unit tests in `tests/test_ref_audio_cache.py` verifying cache invalidation behavior using temporary files.
- Ran an end-to-end integration test locally with `OpenMOSS-Team/MOSS-TTS-Nano` in `voice_clone` mode by downloading a sample reference audio, querying the `/v1/audio/speech` endpoint, overwriting the audio file on disk, and querying the endpoint again.

**vLLM Version:**
0.24.0

**vLLM-Omni Commit:**
32032b87b7c103f2c7d3ab0454ed9de5c7de5f84

## Test Result

- **Unit test**: Passed (asserted cache keys correctly mismatch upon file edit).
- **End-to-End**: Passed (Server dynamically invalidated the `_ref_audio_resolve_cache`, reloaded the decoded waveform, and generated the second audio request with the new cloned speaker voice).
