### PR TITLE
[Bugfix] Sync JoyVL interaction layer with upstream reference fixes

### DIFF
--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -14,10 +14,10 @@
 
 ## Quick start
 
-Three commands: serve the model, start the interaction server, try it on a video.
+Serve the model in fp8 (fits small GPUs without OOM), then put JD's official WebUI on top.
 
 ```bash
-# 1. Serve the model — fp8 shrinks the 8B to ~10 GiB of weights so it fits small cards
+# 1. Serve the model — fp8 shrinks the 8B to ~10 GiB of weights
 #    (drop `--quantization fp8` on 48GB+ GPUs for full precision)
 vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
   --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
@@ -28,15 +28,21 @@ vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
 python -m vllm_omni.experimental.fullduplex.joyvl.serving.server --port 8070 \
   --main-backend-url http://127.0.0.1:8061/v1 --main-model JoyAI-VL-Interaction-Preview
 
-# 3. Stream a video through it and watch the per-second decisions
-#    (frame reading needs: uv pip install opencv-python)
-python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
-  path/to/video.mp4 --query "Alert me if a fire breaks out"
+# 3. Run JD's official WebUI, pointed at the interaction server
+git clone https://github.com/jd-opensource/JoyAI-VL-Interaction.git
+cd JoyAI-VL-Interaction/services/webui
+uv venv && uv pip install -e .
+bash scripts/start_server.sh --api-base http://127.0.0.1:8070/v1
 ```
 
-For the browser demo (live webcam, voice in/out) see
-[Host the WebUI demo](#host-the-webui-demo), or launch everything at once with
-`bash examples/online_serving/joyvl_interaction/scripts/start_all.sh`.
+Open the printed HTTPS URL, allow the camera (or enter an RTSP URL), and type a standing
+instruction — e.g. "Alert me if a fire breaks out". The model then decides each second on
+its own to stay silent, speak, or delegate a hard question.
+
+One-shot alternative for steps 1–3:
+`bash examples/online_serving/joyvl_interaction/scripts/start_all.sh` (set `WEBUI_DIR`
+to your WebUI clone). For webui-side issues, see the upstream
+[Troubleshooting Guide](https://github.com/jd-opensource/JoyAI-VL-Interaction/blob/main/doc/troubleshooting.md).
 
 ## Environment
 
@@ -121,26 +127,14 @@ off**. The brain is bring-your-own: a larger vLLM you serve, or any OpenAI-compa
 API (e.g. `--delegation-backend-url https://api.anthropic.com/v1/
 --delegation-model claude-... --delegation-api-key …`).
 
-## Host the WebUI demo
-
-For the full browser experience — live webcam / RTSP input, voice (ASR/TTS), and the
-per-tick decision stream — run JD's official WebUI in front of the orchestrator. Clone the
-model repo and start its WebUI pointed at the orchestrator (`:8070`):
-
-```bash
-git clone https://github.com/jd-opensource/JoyAI-VL-Interaction.git
-cd JoyAI-VL-Interaction/services/webui
-uv venv && uv pip install -e .
-bash scripts/start_server.sh --api-base http://127.0.0.1:8070/v1
-```
-
-Open the printed HTTPS URL, allow the camera (or enter an RTSP URL), and give a standing
-instruction. For webui-side deployment issues, see the upstream
-[Troubleshooting Guide](https://github.com/jd-opensource/JoyAI-VL-Interaction/blob/main/doc/troubleshooting.md).
-
 ## Verification
 
 ```bash
+# headless smoke test: stream a clip and print the per-second decisions
+# (needs: uv pip install opencv-python)
+python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
+  path/to/video.mp4 --query "Alert me if a fire breaks out"
+
 pytest tests/fullduplex   # framework + JoyVL unit tests
 ```
 

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -158,7 +158,13 @@ bash scripts/start_server.sh --api-base http://127.0.0.1:8070/v1
 
 Open the printed HTTPS URL, allow the camera (or enter an RTSP URL), and give a standing
 instruction. `examples/online_serving/joyvl_interaction/scripts/start_all.sh` can launch
-the model + orchestrator + WebUI together — point `WEBUI_DIR` at your clone.
+the model + orchestrator + WebUI together — point `WEBUI_DIR` at your clone. For webui-side
+deployment issues, see the upstream
+[Troubleshooting Guide](https://github.com/jd-opensource/JoyAI-VL-Interaction/blob/main/doc/troubleshooting.md).
+
+The webui attaches per-turn frame timestamps (`frame_time_range(s)` in the request body);
+the orchestrator honors them and falls back to its own 1 fps clock when absent, so older
+clients keep working unchanged.
 
 ## Verification
 

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -34,19 +34,9 @@ python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
   path/to/video.mp4 --query "Alert me if a fire breaks out"
 ```
 
-That's it — the model watches the video and decides each second whether to stay silent,
-speak up, or hand a hard question to a background brain. For the full browser demo
-(live webcam, voice in/out) see [Host the WebUI demo](#host-the-webui-demo), or launch
-everything at once with
+For the browser demo (live webcam, voice in/out) see
+[Host the WebUI demo](#host-the-webui-demo), or launch everything at once with
 `bash examples/online_serving/joyvl_interaction/scripts/start_all.sh`.
-
-## When to use this recipe
-
-Use this to stand up the streaming-interaction serving layer (`vllm_omni/experimental/fullduplex/`).
-The model is served unchanged by `vllm serve`; this layer adds session state, 3-tier
-summary memory, the per-tick decision, and pluggable ASR / TTS / delegation. For the
-framework internals and how to add another full-duplex model, see
-[`vllm_omni/experimental/fullduplex/README.md`](../../vllm_omni/experimental/fullduplex/README.md).
 
 ## Environment
 
@@ -59,18 +49,12 @@ framework internals and how to add another full-duplex model, see
 
 ## Serving notes
 
-- Plain `vllm serve`, **not** `--omni` — the model keeps the Qwen3-VL architecture,
-  so stock vLLM runs the forward pass; this recipe only adds the interaction layer.
-- The quick start loads the weights in fp8 **online from the bf16 checkpoint** — no
-  separate quantized checkpoint needed (standard Qwen3-VL, so vLLM's generic fp8 path
-  applies). Measured here: **9.9 GiB** weights vs **16.8 GiB** bf16 (**−41%**).
-- fp8 is a **memory** option, not a speed one: at one request per tick (the streaming
-  regime) it was not faster in our test — single-stream decode is memory-latency-bound
-  and pays fp8's dynamic-scale overhead. Decisions stay coherent, but fp8 can shift the
-  speak/silence boundary, so for timing-critical alerting validate output against bf16 first.
-- The `--limit-mm-per-prompt` image limit must cover the short-term frame window
-  (`--chunk-frames`, default 100); prefix caching keeps the accumulating window cheap.
-  On smaller GPUs lower `--chunk-frames`, `--max-model-len`, and the image limit together.
+- Use plain `vllm serve`, **not** `--omni`.
+- fp8 loads online from the bf16 checkpoint — nothing extra to download. It saves
+  memory (~10 GiB vs 16.8 GiB weights), not speed; for timing-critical alerting,
+  validate output against bf16 first.
+- Keep the `--limit-mm-per-prompt` image limit ≥ `--chunk-frames` (default 100).
+  On small GPUs lower `--chunk-frames`, `--max-model-len`, and the image limit together.
 
 ## Using the model
 
@@ -133,13 +117,9 @@ python -m vllm_omni.experimental.fullduplex.joyvl.serving.server --port 8070 \
 - `stub` — canned answers for tests/demos only (no backend needed)
 
 `chat`/`image`/`edit`/`router` each need a backend URL — **without one, delegation stays
-off** (the model's delegate note is still spoken, but nothing is folded back). The brain is
-**bring-your-own**: a larger vLLM you serve, or any OpenAI-compatible API (e.g.
-`--delegation-backend-url https://api.anthropic.com/v1/ --delegation-model claude-...
---delegation-api-key …`). The reference deployment instead drives the `codex` CLI as the
-brain via a separate background-agent service; that agent runs with its own credentials
-and bypasses its sandbox, so it is **not bundled here** — self-host a plain
-OpenAI-compatible endpoint instead.
+off**. The brain is bring-your-own: a larger vLLM you serve, or any OpenAI-compatible
+API (e.g. `--delegation-backend-url https://api.anthropic.com/v1/
+--delegation-model claude-... --delegation-api-key …`).
 
 ## Host the WebUI demo
 
@@ -155,31 +135,19 @@ bash scripts/start_server.sh --api-base http://127.0.0.1:8070/v1
 ```
 
 Open the printed HTTPS URL, allow the camera (or enter an RTSP URL), and give a standing
-instruction. `examples/online_serving/joyvl_interaction/scripts/start_all.sh` can launch
-the model + orchestrator + WebUI together — point `WEBUI_DIR` at your clone. For webui-side
-deployment issues, see the upstream
+instruction. For webui-side deployment issues, see the upstream
 [Troubleshooting Guide](https://github.com/jd-opensource/JoyAI-VL-Interaction/blob/main/doc/troubleshooting.md).
-
-The webui attaches per-turn frame timestamps (`frame_time_range(s)` in the request body);
-the orchestrator honors them and falls back to its own 1 fps clock when absent, so older
-clients keep working unchanged.
 
 ## Verification
 
 ```bash
-# headless: stream a clip and print the per-tick decision timeline
-# (the CLI reads video frames via OpenCV: `uv pip install opencv-python`)
-python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
-  path/to/video.mp4 --query "Alert me if a fire breaks out"
-
 pytest tests/fullduplex   # framework + JoyVL unit tests
 ```
 
 ## Testing with an RTSP stream (optional)
 
-RTSP is a **webui-side input** — the browser pulls the stream and feeds frames to the
-orchestrator over the normal API; no serving-layer code is involved. To simulate an RTSP
-camera from a local video file (no physical IP camera needed), use the helper scripts in
+To simulate an RTSP camera from a local video file (no physical IP camera needed),
+enter its stream URL in the WebUI RTSP box, using the helper scripts in
 [`examples/online_serving/joyvl_interaction/rtsp/`](../../examples/online_serving/joyvl_interaction/rtsp/),
 which wrap [MediaMTX](https://github.com/bluenviron/mediamtx/releases) + `ffmpeg`:
 
@@ -201,22 +169,12 @@ the audio-track caveat.
 
 ## Notes
 
-- On a host without `nvcc` / `ninja`, `vllm serve` of the 8B can crash engine-core in the
-  FlashInfer sampler JIT (`FileNotFoundError: 'ninja'`) during `profile_run`. Set
-  `VLLM_USE_FLASHINFER_SAMPLER=0` (or install `ninja`) to work around it.
-- `force_silence_before_query` is on by default — the model stays silent until an
-  instruction arrives; give a standing task (e.g. "translate the on-screen text")
-  to arm proactive output.
-- **Frame resolution is the main latency knob.** The system/memory prefix is prefix-cached,
-  so per-tick *new* compute is dominated by the new frame's vision tokens. Measured on the
-  8B: ~256×192 frames hit Qwen3-VL's min-pixel floor (~72 vision tokens, ~17 ms/tick) vs
-  ~302 tokens / ~38 ms at 640×480 — about 2× cheaper. Downsample frames to ~256×192 for the
-  tightest latency / highest concurrency; one GPU then sustains ~150–180 concurrent 1 fps
-  streams with p95 < 200 ms. Per-tick latency is already far inside the 1 fps budget, so
-  serving is rarely the bottleneck — resolution is the lever if you need more headroom.
-- Speech is external and pluggable: point `ASR_URL` / `TTS_URL` at the bridges in
+- If `vllm serve` crashes with `FileNotFoundError: 'ninja'` (FlashInfer sampler JIT),
+  set `VLLM_USE_FLASHINFER_SAMPLER=0` or install `ninja`.
+- The model stays silent until the first instruction arrives — give a standing task
+  (e.g. "translate the on-screen text") to arm proactive output.
+- Downsample frames to ~256×192 for the lowest latency and highest concurrency
+  (~2× cheaper per tick than 640×480; one GPU sustains ~150–180 concurrent 1 fps
+  streams with p95 < 200 ms).
+- Speech is pluggable: point `ASR_URL` / `TTS_URL` at the bridges in
   `examples/online_serving/joyvl_interaction/bridges/` or any compatible service.
-- The decision prompts, sampling, and 3-tier summary memory (`T_s=100`, mid→long every
-  5 chunks, `key_frames=0` = summarize all chunk frames) are aligned to the JoyVL
-  reference adapter so per-tick behavior matches the released model; the framework only
-  supplies the serving structure.

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -12,6 +12,34 @@
   a plain `vllm serve` backend
 - Maintainer: Community
 
+## Quick start
+
+Three commands: serve the model, start the interaction server, try it on a video.
+
+```bash
+# 1. Serve the model — fp8 shrinks the 8B to ~10 GiB of weights so it fits small cards
+#    (drop `--quantization fp8` on 48GB+ GPUs for full precision)
+vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
+  --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
+  --quantization fp8 --max-model-len 131072 --enable-prefix-caching \
+  --limit-mm-per-prompt '{"image":256,"video":1}'
+
+# 2. Start the interaction server (OpenAI-compatible, port 8070)
+python -m vllm_omni.experimental.fullduplex.joyvl.serving.server --port 8070 \
+  --main-backend-url http://127.0.0.1:8061/v1 --main-model JoyAI-VL-Interaction-Preview
+
+# 3. Stream a video through it and watch the per-second decisions
+#    (frame reading needs: uv pip install opencv-python)
+python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
+  path/to/video.mp4 --query "Alert me if a fire breaks out"
+```
+
+That's it — the model watches the video and decides each second whether to stay silent,
+speak up, or hand a hard question to a background brain. For the full browser demo
+(live webcam, voice in/out) see [Host the WebUI demo](#host-the-webui-demo), or launch
+everything at once with
+`bash examples/online_serving/joyvl_interaction/scripts/start_all.sh`.
+
 ## When to use this recipe
 
 Use this to stand up the streaming-interaction serving layer (`vllm_omni/experimental/fullduplex/`).
@@ -24,55 +52,25 @@ framework internals and how to add another full-duplex model, see
 
 - OS: Linux
 - Python: 3.10+
-- Hardware: 1x GPU. The default `T_s=100` frame window + `--max-model-len 131072` wants
-  ≈48GB+; for ~24GB, lower `--chunk-frames`, `--max-model-len`, and the image limit together,
-  and/or load the weights in fp8 (see "Smaller GPU: fp8 weights" below — ~9.9 GiB vs 16.8 GiB)
+- Hardware: 1x GPU. The fp8 quick start fits much smaller cards (~10 GiB weights vs
+  16.8 GiB bf16); bf16 at the default settings wants ≈48GB+. On small cards also lower
+  `--chunk-frames`, `--max-model-len`, and the image limit together (see "Serving notes")
 - vLLM / vLLM-Omni: versions from your current checkout
 
-## Start server
+## Serving notes
 
-From repository root:
-
-```bash
-# 1. Serve the model (plain `vllm serve`, NOT --omni; it uses the Qwen3-VL architecture).
-#    The image limit must cover the short-term frame window (chunk_frames, default 100 = T_s);
-#    prefix caching keeps the accumulating window cheap. Lower both for smaller GPUs.
-vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
-  --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
-  --max-model-len 131072 --enable-prefix-caching \
-  --limit-mm-per-prompt '{"image":256,"video":1}'
-
-# 2. Interaction orchestrator (OpenAI-compatible, :8070)
-python -m vllm_omni.experimental.fullduplex.joyvl.serving.server --port 8070 \
-  --main-backend-url http://127.0.0.1:8061/v1 --main-model JoyAI-VL-Interaction-Preview
-```
-
-### Smaller GPU: fp8 weights
-
-Add `--quantization fp8` to the step-1 `vllm serve` to load the weights in fp8 online
-from the bf16 checkpoint (no separate quantized checkpoint needed; uses vLLM's generic
-fp8 path, since the model is a standard Qwen3-VL VLM):
-
-```bash
-vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
-  --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
-  --quantization fp8 --max-model-len 131072 --enable-prefix-caching \
-  --limit-mm-per-prompt '{"image":256,"video":1}'
-```
-
-Measured here: model weights **9.9 GiB** vs **16.8 GiB** bf16 (**−41%**), which lets the 8B
-fit a much smaller card. This is a **memory** option, not a speed one: at one request per
-tick (the streaming regime) fp8 was **not** faster (≈19% slower in our test) because
-single-stream decode is memory-latency-bound and pays fp8's dynamic-scale overhead; its
-throughput gain needs batching. Decisions stay coherent, but fp8 can shift the
-speak/silence boundary, so for timing-critical alerting validate output against bf16 first.
-
-Optional one-shot launch (model + orchestrator + JD webui + ASR/TTS/background,
-all env-configurable). The JD webui frontend is external — set `WEBUI_DIR` to point at it:
-
-```bash
-bash examples/online_serving/joyvl_interaction/scripts/start_all.sh
-```
+- Plain `vllm serve`, **not** `--omni` — the model keeps the Qwen3-VL architecture,
+  so stock vLLM runs the forward pass; this recipe only adds the interaction layer.
+- The quick start loads the weights in fp8 **online from the bf16 checkpoint** — no
+  separate quantized checkpoint needed (standard Qwen3-VL, so vLLM's generic fp8 path
+  applies). Measured here: **9.9 GiB** weights vs **16.8 GiB** bf16 (**−41%**).
+- fp8 is a **memory** option, not a speed one: at one request per tick (the streaming
+  regime) it was not faster in our test — single-stream decode is memory-latency-bound
+  and pays fp8's dynamic-scale overhead. Decisions stay coherent, but fp8 can shift the
+  speak/silence boundary, so for timing-critical alerting validate output against bf16 first.
+- The `--limit-mm-per-prompt` image limit must cover the short-term frame window
+  (`--chunk-frames`, default 100); prefix caching keeps the accumulating window cheap.
+  On smaller GPUs lower `--chunk-frames`, `--max-model-len`, and the image limit together.
 
 ## Using the model
 
@@ -203,9 +201,6 @@ the audio-track caveat.
 
 ## Notes
 
-- `--omni` is **not** used: the model keeps the Qwen3-VL architecture (only the
-  weights are retrained), so stock `vllm serve` runs the forward pass; this recipe
-  only adds the interaction/serving layer.
 - On a host without `nvcc` / `ninja`, `vllm serve` of the 8B can crash engine-core in the
   FlashInfer sampler JIT (`FileNotFoundError: 'ninja'`) during `profile_run`. Set
   `VLLM_USE_FLASHINFER_SAMPLER=0` (or install `ninja`) to work around it.

--- a/tests/fullduplex/test_joyvl_brain.py
+++ b/tests/fullduplex/test_joyvl_brain.py
@@ -65,6 +65,8 @@ async def test_flush_archives_qa_and_summarizes():
     b = InteractionBrain(summarizer=summ, chunk_frames=3, long_term_every_n_chunks=2, frame_seconds=1.0)
     b.update_query("watch the room")
     b.tick(3)
+    for _ in range(3):
+        b.tick_turn()
     assert b.should_flush() is True
     b.record_response("a person enters")
     await b.flush([("0.0s", "u0"), ("2.0s", "u2")])
@@ -73,6 +75,19 @@ async def test_flush_archives_qa_and_summarizes():
     assert b.should_flush() is False
     assert b.memory.qa_history[-1].responses == [("2.0 seconds", "a person enters")]
     assert len(b.memory.mid_term_summaries) == 1
+
+
+def test_chunk_window_counts_turns_not_frames():
+    # A batch turn carrying several frames advances the chunk window by one
+    # (reference fix 9d07596b), so multi-frame requests don't burn the window early.
+    b = InteractionBrain(chunk_frames=2, frame_seconds=1.0)
+    b.tick(3)  # 3 frames arrive in one turn
+    b.tick_turn()
+    assert b.should_flush() is False
+    b.tick_turn()
+    assert b.should_flush() is True
+    b.close_chunk()
+    assert b.should_flush() is False
 
 
 @pytest.mark.asyncio

--- a/tests/fullduplex/test_joyvl_serving.py
+++ b/tests/fullduplex/test_joyvl_serving.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_omni.experimental.fullduplex.joyvl.serving.config import InteractionConfig
+from vllm_omni.experimental.fullduplex.joyvl.serving.server import (
+    _extract_frames_and_query,
+    _incoming_time_ranges,
+    _normalize_time_range,
+)
+from vllm_omni.experimental.fullduplex.joyvl.serving.session import InteractionSession
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+FRAME = "data:image/jpeg;base64,AAA"
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.requests = []
+
+    async def generate(self, messages, **kwargs):
+        self.requests.append(messages)
+        return "</silence>", None
+
+    async def aclose(self):
+        pass
+
+
+class _FakeRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+def _payload(parts):
+    return {"messages": [{"role": "user", "content": parts}]}
+
+
+def test_normalize_time_range_variants():
+    assert _normalize_time_range("3.0 seconds") == "3.0 seconds"
+    assert _normalize_time_range("3s") == "3.0 seconds"
+    assert _normalize_time_range("<12.34 seconds>") == "12.3 seconds"
+    assert _normalize_time_range("1s~2s") == "1.0 seconds ~ 2.0 seconds"
+    assert _normalize_time_range("1.0 seconds-2.0 seconds") == "1.0 seconds-2.0 seconds"
+    assert _normalize_time_range("not a time") is None
+    assert _normalize_time_range(None) is None
+
+
+def test_time_markers_stripped_from_query():
+    frames, query, markers = _extract_frames_and_query(
+        _payload(
+            [
+                {"type": "text", "text": "<3.0 seconds>"},
+                {"type": "text", "text": "Alert me if a fire breaks out"},
+                {"type": "image_url", "image_url": {"url": FRAME}},
+            ]
+        )
+    )
+    assert frames == [FRAME]
+    assert query == "Alert me if a fire breaks out"
+    assert markers == ["3.0 seconds"]
+
+
+def test_incoming_time_ranges_priority():
+    payload = _payload([{"type": "image_url", "image_url": {"url": FRAME}}])
+    payload["frame_time_ranges"] = ["5s", "6s"]
+    payload["frame_time_range"] = "9s"
+    assert _incoming_time_ranges(_FakeRequest(), payload, []) == ["5.0 seconds", "6.0 seconds"]
+
+    del payload["frame_time_ranges"]
+    assert _incoming_time_ranges(_FakeRequest(), payload, []) == ["9.0 seconds"]
+
+    del payload["frame_time_range"]
+    request = _FakeRequest({"x-frame-time-range": "7s"})
+    assert _incoming_time_ranges(request, payload, []) == ["7.0 seconds"]
+
+    assert _incoming_time_ranges(_FakeRequest(), payload, ["3.0 seconds"]) == ["3.0 seconds"]
+
+
+@pytest.mark.asyncio
+async def test_step_emits_one_time_marker_per_turn():
+    config = InteractionConfig(enable_memory=False, force_silence_before_query=False)
+    session = InteractionSession("s", config, _FakeBackend())
+    await session.step([FRAME, FRAME, FRAME], time_ranges=["4.0 seconds"])
+    content = session.chunk.messages[0]["content"]
+    text_parts = [p["text"] for p in content if p["type"] == "text"]
+    assert text_parts == ["<4.0 seconds>"]
+    assert sum(1 for p in content if p["type"] == "image_url") == 3
+
+
+@pytest.mark.asyncio
+async def test_step_counts_turns_for_chunk_window():
+    config = InteractionConfig(enable_memory=False, force_silence_before_query=False, chunk_frames=2)
+    session = InteractionSession("s", config, _FakeBackend())
+    result = await session.step([FRAME, FRAME, FRAME])  # one turn, three frames
+    assert result.turn_index == 1
+    assert session._policy.needs_flush() is False
+    result = await session.step([FRAME])
+    assert result.turn_index == 2
+    assert session._policy.needs_flush() is True

--- a/vllm_omni/experimental/fullduplex/joyvl/adapter.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/adapter.py
@@ -58,6 +58,7 @@ class JoyVLDuplexAdapter(DuplexAdapter):
 
         parts = [{"type": "image_url", "image_url": {"url": f}} for f in sample_frames(self._frames, policy.num_frames)]
         messages, _ = policy.build_messages(parts)
+        policy.tick_turn()
         action = policy.commit(await self._generate(messages))
 
         frames = [(str(i), f) for i, f in enumerate(self._frames)]

--- a/vllm_omni/experimental/fullduplex/joyvl/decision/policy.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/decision/policy.py
@@ -56,6 +56,9 @@ class JoyVLPolicy:
     def tick(self, n: int = 1) -> None:
         self.brain.tick(n)
 
+    def tick_turn(self) -> None:
+        self.brain.tick_turn()
+
     def observe(self, time_range: str, data_url: str) -> None:
         self.brain.observe(time_range, data_url)
 
@@ -66,8 +69,8 @@ class JoyVLPolicy:
     def take_working_frames(self) -> list[tuple[str, str]]:
         return self.brain.take_working_frames()
 
-    def set_query(self, query: str | None) -> bool:
-        return self.brain.update_query(query)
+    def set_query(self, query: str | None, at: str | None = None) -> bool:
+        return self.brain.update_query(query, at)
 
     def should_respond(self) -> bool:
         return True

--- a/vllm_omni/experimental/fullduplex/joyvl/memory/brain.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/memory/brain.py
@@ -51,8 +51,9 @@ class InteractionBrain:
         self.query_time: str | None = None
         self.query_in_current_chunk = False
         self.frame_index = 0
+        self.turn_index = 0
         self.chunk_index = 1
-        self._chunk_frame_count = 0
+        self._chunk_turn_count = 0
         self.working_frames: list[tuple[str, str]] = []
         self.last_response_text = ""
         self.response_records: list[tuple[str, str]] = []
@@ -67,7 +68,10 @@ class InteractionBrain:
 
     def tick(self, n: int = 1) -> None:
         self.frame_index += n
-        self._chunk_frame_count += n
+
+    def tick_turn(self) -> None:
+        self.turn_index += 1
+        self._chunk_turn_count += 1
 
     def observe(self, time_range: str, data_url: str) -> None:
         self.tick()
@@ -79,16 +83,18 @@ class InteractionBrain:
         return frames
 
     def should_flush(self) -> bool:
-        return self._chunk_frames > 0 and self._chunk_frame_count >= self._chunk_frames
+        # The chunk window counts inference turns, not frames (reference fix 9d07596b);
+        # at 1 fps with one frame per turn the two are identical.
+        return self._chunk_frames > 0 and self._chunk_turn_count >= self._chunk_frames
 
-    def update_query(self, query: str | None) -> bool:
+    def update_query(self, query: str | None, at: str | None = None) -> bool:
         q = (query or "").strip()
         if not q or q == self.current_query:
             return False
         if self.current_query is not None:
             self.archive_query()
         self.current_query = q
-        self.query_time = self.now()
+        self.query_time = at or self.now()
         self.query_in_current_chunk = True
         return True
 
@@ -121,7 +127,7 @@ class InteractionBrain:
         self.archive_query()
         closed = self.chunk_index
         self.chunk_index += 1
-        self._chunk_frame_count = 0
+        self._chunk_turn_count = 0
         self.query_in_current_chunk = False
         return closed
 

--- a/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import math
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -114,14 +116,16 @@ class SessionManager:
             self._locks[session_id] = asyncio.Lock()
         return session
 
-    async def step(self, session_id: str, frames: list[str], query: str | None) -> StepResult:
+    async def step(
+        self, session_id: str, frames: list[str], query: str | None, time_ranges: list[str] | None = None
+    ) -> StepResult:
         await self._evict_expired()
         # capture session + lock together (no await between) so a concurrent reset cannot
         # swap them out from under us; the lock then serializes step against reset.
         session = self._get(session_id)
         lock = self._locks[session_id]
         async with lock:
-            return await session.step(frames, query)
+            return await session.step(frames, query, time_ranges=time_ranges)
 
     async def reset(self, session_id: str) -> None:
         # Acquire the per-session lock so reset waits for any in-flight step() to finish
@@ -170,10 +174,38 @@ class SessionManager:
             await self._delegation.aclose()
 
 
-def _extract_frames_and_query(payload: dict[str, Any]) -> tuple[list[str], str | None]:
+# Time markers as embedded by the JD reference clients: <3.0 seconds>, <3s>,
+# or a range with "-" / "~" between two values.
+_TIME_VALUE_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*(?:seconds?|s)$")
+_TIME_MARKER_RE = re.compile(r"^<\d+(?:\.\d+)?\s*(?:seconds?|s)(?:\s*[~-]\s*\d+(?:\.\d+)?\s*(?:seconds?|s))?>$")
+
+
+def _format_seconds_words(value: float) -> str:
+    return f"{math.floor(value * 10 + 0.5) / 10:.1f} seconds"
+
+
+def _normalize_time_range(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if text.startswith("<") and text.endswith(">"):
+        text = text[1:-1].strip()
+    match = _TIME_VALUE_RE.fullmatch(text)
+    if match:
+        return _format_seconds_words(float(match.group(1)))
+    parts = re.split(r"\s*([~-])\s*", text, maxsplit=1)
+    if len(parts) == 3:
+        start = _TIME_VALUE_RE.fullmatch(parts[0].strip())
+        end = _TIME_VALUE_RE.fullmatch(parts[2].strip())
+        if start and end:
+            sep = " ~ " if parts[1] == "~" else "-"
+            return f"{_format_seconds_words(float(start.group(1)))}{sep}{_format_seconds_words(float(end.group(1)))}"
+    return None
+
+
+def _extract_frames_and_query(payload: dict[str, Any]) -> tuple[list[str], str | None, list[str]]:
     messages = payload.get("messages") or []
     frames: list[str] = []
     texts: list[str] = []
+    markers: list[str] = []
     for message in messages:
         if message.get("role") != "user":
             continue
@@ -189,8 +221,38 @@ def _extract_frames_and_query(payload: dict[str, Any]) -> tuple[list[str], str |
                     frames.append(url)
             elif ptype == "text" and part.get("text"):
                 texts.append(part["text"])
-    query = "\n".join(t.strip() for t in texts if t.strip()) or None
-    return frames, query
+    # Pull <time> marker lines out of the text: they are frame timestamps,
+    # not part of the standing instruction.
+    query_lines: list[str] = []
+    for text in texts:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if _TIME_MARKER_RE.fullmatch(stripped):
+                normalized = _normalize_time_range(stripped)
+                if normalized:
+                    markers.append(normalized)
+            elif stripped:
+                query_lines.append(stripped)
+    query = "\n".join(query_lines) or None
+    return frames, query, markers
+
+
+def _incoming_time_ranges(request: Request, payload: dict[str, Any], markers: list[str]) -> list[str]:
+    ranges = payload.get("frame_time_ranges")
+    if isinstance(ranges, list):
+        parsed = [normalized for normalized in (_normalize_time_range(r) for r in ranges) if normalized]
+        if parsed:
+            return parsed
+    for candidate in (
+        request.headers.get("x-frame-time-range"),
+        request.headers.get("x-streaming-time-range"),
+        payload.get("frame_time_range"),
+        payload.get("x_frame_time_range"),
+    ):
+        normalized = _normalize_time_range(candidate)
+        if normalized:
+            return [normalized]
+    return markers
 
 
 def _session_id(request: Request, payload: dict[str, Any]) -> str:
@@ -227,6 +289,7 @@ def _completion_response(model: str, result: StepResult) -> dict[str, Any]:
             "delegation": result.delegation,
             "chunk_index": result.chunk_index,
             "frame_index": result.frame_index,
+            "turn_index": result.turn_index,
             "inference_skipped": result.inference_skipped,
             "latency_ms": result.latency_ms,
             "memory": memory,
@@ -258,10 +321,11 @@ def create_app(config: InteractionConfig) -> FastAPI:
     @app.post("/v1/chat/completions")
     async def chat_completions(request: Request) -> JSONResponse:
         payload = await request.json()
-        frames, query = _extract_frames_and_query(payload)
+        frames, query, markers = _extract_frames_and_query(payload)
         if not frames:
             return JSONResponse({"error": "interaction server requires at least one image_url frame"}, status_code=400)
-        result = await manager.step(_session_id(request, payload), frames, query)
+        time_ranges = _incoming_time_ranges(request, payload, markers)
+        result = await manager.step(_session_id(request, payload), frames, query, time_ranges)
         return JSONResponse(_completion_response(config.main_model, result))
 
     @app.post("/reset")

--- a/vllm_omni/experimental/fullduplex/joyvl/serving/session.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/serving/session.py
@@ -25,6 +25,7 @@ class StepResult:
     action: ParsedAction
     chunk_index: int
     frame_index: int
+    turn_index: int
     inference_skipped: bool
     latency_ms: float
     long_term_memory: str
@@ -68,14 +69,22 @@ class InteractionSession:
         self._system_prompt = prompt
         return True
 
-    async def step(self, frames: list[str], query: str | None = None, t: float | None = None) -> StepResult:
+    async def step(
+        self, frames: list[str], query: str | None = None, time_ranges: list[str] | None = None
+    ) -> StepResult:
         self.last_access = time.monotonic()
         started = time.perf_counter()
         policy = self._policy
         brain = policy.brain
 
-        base = t if t is not None else brain.frame_index * self.config.frame_seconds
-        time_ranges = [f"{base + i * self.config.frame_seconds:.1f} seconds" for i in range(len(frames))]
+        # Client-supplied per-frame times (the JD webui sends turn-based ones) win;
+        # otherwise fall back to the local 1 fps frame clock.
+        incoming = list(time_ranges or [])
+        base = brain.frame_index * self.config.frame_seconds
+        time_ranges = [
+            incoming[i] if i < len(incoming) and incoming[i] else f"{base + i * self.config.frame_seconds:.1f} seconds"
+            for i in range(len(frames))
+        ]
 
         delegation_info = await policy.fold_delegations()
 
@@ -83,7 +92,8 @@ class InteractionSession:
             self._spawn_consolidation(policy.close_chunk(), policy.take_working_frames())
             self.chunk = WorkingChunk()
 
-        query_is_fresh = policy.set_query(query)
+        policy.tick_turn()
+        query_is_fresh = policy.set_query(query, at=time_ranges[0] if time_ranges else None)
 
         for tr, url in zip(time_ranges, frames):
             policy.observe(tr, url)
@@ -105,6 +115,7 @@ class InteractionSession:
             action=action,
             chunk_index=brain.chunk_index,
             frame_index=brain.frame_index,
+            turn_index=brain.turn_index,
             inference_skipped=skipped,
             latency_ms=round((time.perf_counter() - started) * 1000, 1),
             long_term_memory=brain.memory.long_term_memory,
@@ -174,7 +185,10 @@ class InteractionSession:
         query = self._policy.brain.current_query
         if include_query and query:
             content.append({"type": "text", "text": f"{USER_QUERY_HEADER}\n{query.strip()}"})
-        for tr, url in zip(time_ranges, frames):
-            content.append({"type": "text", "text": f"<{tr}>"})
+        # One time marker per turn, before all of the turn's frames (reference fix 9d07596b).
+        marker = next((tr for tr in time_ranges if tr), None)
+        if marker:
+            content.append({"type": "text", "text": f"<{marker}>"})
+        for url in frames:
             content.append({"type": "image_url", "image_url": {"url": url}, "max_pixels": self.config.max_pixels})
         return {"role": "user", "content": content}


### PR DESCRIPTION
Syncs the JoyVL streaming-interaction layer with the reference fixes that landed upstream after the initial port ([jd-opensource/JoyAI-VL-Interaction@9d07596b](https://github.com/jd-opensource/JoyAI-VL-Interaction/commit/9d07596b) "Fix existing bugs"), and reworks the recipe into an fp8-first quick start for small-GPU deployment behind JD's official WebUI.

## What changed upstream

The reference adapter and WebUI moved to turn-based time handling:

- The WebUI now sends per-turn frame timestamps with each request (`frame_time_range` / `frame_time_ranges` payload keys, plus `<X.X seconds>` markers in the message text).
- The reference adapter emits **one** time marker per inference turn (before all of the turn's frames) instead of one marker per frame.
- The chunk window (`T_s`) counts **inference turns**, not frames, so batch turns (WebUI `frames_per_batch > 1`) don't burn the short-term window early.
- Time-range parsing accepts both `3s` and `3.0 seconds` forms and `-` / `~` range separators.

## User-facing impact without this sync

With JD's current WebUI in front of the orchestrator, each turn's `<time>` marker was treated as query text and **overwrote the standing instruction** — proactive alerting broke after the first turn. With `frames_per_batch > 1`, memory flushed N× too early and the message layout diverged from the trained format. Clients that send no timestamps (e.g. the CLI demo) were and remain unaffected.

## What this PR does

Mirrors the reference semantics in `vllm_omni/experimental/fullduplex/joyvl`:

- **Server**: extracts client-supplied timestamps (payload keys, `x-frame-time-range` / `x-streaming-time-range` headers, or embedded `<time>` markers) with the broadened normalization, and strips marker lines from the standing query.
- **Session**: client timestamps win over the local 1 fps clock; the turn's frames share a single leading time marker.
- **Brain/policy**: chunk flush and QA timing are turn-based (`turn_index` also surfaced in the `interaction` response block). At 1 fps with one frame per turn — the default regime — behavior is unchanged.
- **Recipe**: restructured around the intended deployment — a copy-paste quick start (fp8 `vllm serve` → interaction server → official JD WebUI), with background prose trimmed to actionable notes and the upstream troubleshooting guide linked.

## Test

`pytest tests/fullduplex` — 34 passed (new coverage: marker stripping, timestamp priority/normalization, single marker per turn, turn-based chunk window).
