### PR TITLE
[ROCm] [CI] Make Simple · Other Test run remaining tests instead of duplicating diffusion/model_executor suites

### DIFF
--- a/.buildkite/amd/test-amd-merge.yml
+++ b/.buildkite/amd/test-amd-merge.yml
@@ -39,9 +39,9 @@ steps:
       grade: Blocking
       commands:
         - export VLLM_ROCM_USE_AITER=0
-        # ignore test_teacache_extractors.py because it use rocm gemm kernel from vLLM
-        # that is not supported on CPU
-        - "timeout 40m pytest -sv tests/diffusion tests/model_executor -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
+        # tests/diffusion and tests/model_executor are covered by the (1/2) and (2/2)
+        # steps above; run the remaining tests here, same as the non-AMD pipeline.
+        - "timeout 40m pytest -sv -m 'core_model and cpu' --ignore=tests/diffusion --ignore=tests/model_executor --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
 
 - group: ":card_index_dividers: Diffusion Test"
   steps:

--- a/.buildkite/amd/test-amd-ready.yml
+++ b/.buildkite/amd/test-amd-ready.yml
@@ -25,9 +25,9 @@ steps:
       grade: Blocking
       commands:
         - export VLLM_ROCM_USE_AITER=0
-        # ignore test_teacache_extractors.py because it use rocm gemm kernel from vLLM
-        # that is not supported on CPU
-        - "timeout 40m pytest -sv tests/diffusion tests/model_executor -m 'core_model and cpu' --ignore=tests/diffusion/cache/test_teacache_extractors.py --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
+        # tests/diffusion and tests/model_executor are covered by the step above;
+        # run the remaining tests here, same as the non-AMD pipeline.
+        - "timeout 40m pytest -sv -m 'core_model and cpu' --ignore=tests/diffusion --ignore=tests/model_executor --cov=vllm_omni --cov-report=term-missing:skip-covered --cov-report=xml"
 
 - label: "Custom Pipeline Test"
   agent_pool: mi325_1


### PR DESCRIPTION
## Purpose

FIX #4886

The AMD `Simple · Other Test` step runs `pytest tests/diffusion tests/model_executor` — the exact same 2100 tests already covered by the `Simple · Diffusion & Model Executor Test` step(s) — instead of the *remaining* tests like the non-AMD pipeline (`test-merge.yml` / `test-ready.yml` use `--ignore=tests/diffusion --ignore=tests/model_executor`).

After #4821 split the main step into (1/2)/(2/2) with 60m budgets each, this duplicated step kept the old combined command with a 40m budget. The suite normally finishes in ~13–17m but slows ~3x under node contention (CPU-mode tests on shared GPU nodes) and hits the 40m timeout — 8 of the last 13 main builds failed with exit 124 (e.g. [build 9333](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/9333)).

This PR aligns `Simple · Other Test` in `test-amd-merge.yml` and `test-amd-ready.yaml` with the non-AMD pipeline: run everything except `tests/diffusion` and `tests/model_executor`. The `--ignore=tests/diffusion/cache/test_teacache_extractors.py` flag is dropped because `tests/diffusion` is now excluded entirely. `pyproject.toml` sets `testpaths = ["tests"]`, so the bare `pytest` invocation collects from `tests/` only, same as the non-AMD step.

## Test Plan

CI-config-only change; the AMD ready pipeline on this PR exercises the updated `Simple · Other Test` command directly. Both YAML files validated with `yaml.safe_load`.

**vLLM Version:** v0.24.0

**vLLM-Omni Commit:** 86bdcaf3

## Test Result

Pending AMD CI on this PR.
