### PR TITLE
[Fix] remove default Qwen3-TTS seeds

### DIFF
--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -54,7 +54,6 @@ stages:
       temperature: 0.9
       top_k: 50
       max_tokens: 4096
-      seed: 42
       repetition_penalty: 1.05
     subtalker_sampling_params:
       do_sample: true
@@ -85,7 +84,6 @@ stages:
       top_p: 1.0
       top_k: -1
       max_tokens: 65536
-      seed: 42
       repetition_penalty: 1.0
 
 platforms:


### PR DESCRIPTION
## Purpose
Remove the default `seed: 42` entries from the Qwen3-TTS deploy config so default serving does not force seeded sampling for every request.

Temporary Fix and detailed fix is under validation.

## Test Plan
- `python3 - <<'PY' ... yaml.safe_load(...)`
- `ruff check .`

**vLLM Version:** N/A

**vLLM-Omni Commit:** d61ad3ff

## Test Result
- YAML parsed successfully; stage 0 and stage 1 default sampling params no longer include `seed`.
- `ruff check .` passed.

cc @Gaohan123 