### PR TITLE
[Core] Support single-file (Kohya/diffusers) LoRA adapters in the diffusion LoRA path

### DIFF
--- a/docs/user_guide/diffusion/lora.md
+++ b/docs/user_guide/diffusion/lora.md
@@ -8,7 +8,9 @@ LoRA adapters are lightweight, model-specific fine-tuning weights that can be dy
 
 ## LoRA Adapter Format
 
-LoRA adapters must be in **PEFT (Parameter-Efficient Fine-Tuning)** format. A typical LoRA adapter directory structure:
+LoRA adapters can be provided in either of two formats:
+
+**PEFT (Parameter-Efficient Fine-Tuning) format** — a directory:
 
 ```
 lora_adapter/
@@ -20,6 +22,16 @@ The `adapter_config.json` file contains metadata about the LoRA adapter, includi
 - `r`: LoRA rank
 - `lora_alpha`: LoRA alpha scaling factor
 - `target_modules`: List of module names to apply LoRA to
+
+**Single-file (Kohya/diffusers) format** — a bare `.safetensors` file with
+`{module}.lora_down/lora_up.weight` (or `lora_A/lora_B`) keys and optional
+per-module `alpha` scalars, and no `adapter_config.json`. This is the format
+most published diffusion LoRAs use (e.g.
+[`lightx2v/Qwen-Image-Lightning`](https://huggingface.co/lightx2v/Qwen-Image-Lightning)).
+Point `lora_path` at the `.safetensors` file (or a directory containing
+exactly one) and it is converted to the PEFT layout in memory at load time —
+see [`recipes/Qwen/Qwen-Image-Lightning.md`](https://github.com/vllm-project/vllm-omni/blob/main/recipes/Qwen/Qwen-Image-Lightning.md)
+for a complete example.
 
 ## Quick Start
 

--- a/recipes/Qwen/Qwen-Image-Lightning.md
+++ b/recipes/Qwen/Qwen-Image-Lightning.md
@@ -1,0 +1,129 @@
+# Qwen-Image-Lightning
+
+> 4/8-step text-to-image serving with the lightx2v step-distillation LoRA
+
+## Summary
+
+- Vendor: lightx2v (adapter) / Qwen (base model)
+- Model: `Qwen/Qwen-Image` + `lightx2v/Qwen-Image-Lightning`
+- Task: Text-to-image generation, accelerated to 4 or 8 denoising steps
+- Mode: Online serving with a per-request LoRA
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe when you want Qwen-Image latency reduced by roughly an order
+of magnitude: the Lightning adapter is a step-distillation LoRA that produces
+fully formed images in 4 or 8 steps with CFG disabled, instead of the ~50-step
+CFG schedule of the base model.
+
+The Lightning checkpoints are published as single Kohya-style safetensors
+files (`lora_down/lora_up` keys plus per-module `alpha` scalars, no
+`adapter_config.json`). vLLM-Omni converts this format to its PEFT layout
+in memory at load time, so the files can be used as downloaded.
+
+## References
+
+- Adapter weights: [`lightx2v/Qwen-Image-Lightning`](https://huggingface.co/lightx2v/Qwen-Image-Lightning)
+- Base model recipe: [`recipes/Qwen/Qwen-Image.md`](Qwen-Image.md)
+- LoRA guide: [`docs/user_guide/diffusion/lora.md`](../../docs/user_guide/diffusion/lora.md)
+
+## Hardware Support
+
+This recipe documents one CUDA GPU serving configuration. Extend it with more
+hardware sections as community validation lands.
+
+## GPU
+
+### 1x A100/A800 80GB
+
+#### Environment
+
+- OS: Linux
+- Python: 3.10+
+- Driver / runtime: NVIDIA CUDA environment with an 80 GB GPU
+- vLLM / vLLM-Omni: match the repository requirements for your checkout
+
+#### Assets
+
+Download one Lightning checkpoint next to the server, e.g.:
+
+```bash
+huggingface-cli download lightx2v/Qwen-Image-Lightning \
+  Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors \
+  --local-dir /path/to/qwen-image-lightning
+```
+
+#### Command
+
+Start the baseline server:
+
+```bash
+vllm serve Qwen/Qwen-Image --omni --port 8091
+```
+
+Request an image with the Lightning LoRA, 4 steps, CFG disabled:
+
+```bash
+curl http://localhost:8091/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen-Image",
+    "prompt": "a corgi wearing sunglasses on a beach, golden hour, photo",
+    "num_inference_steps": 4,
+    "true_cfg_scale": 1.0,
+    "seed": 42,
+    "lora": {
+      "name": "lightning-4steps",
+      "path": "/path/to/qwen-image-lightning/Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors",
+      "scale": 1.0
+    }
+  }'
+```
+
+For offline inference, set the LoRA on the sampling params:
+
+```python
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.lora.request import LoRARequest
+from vllm_omni.lora.utils import stable_lora_int_id
+
+lora_path = "/path/to/qwen-image-lightning/Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors"
+omni = Omni(model="Qwen/Qwen-Image", lora_path=lora_path)
+params = OmniDiffusionSamplingParams(
+    num_inference_steps=4,
+    true_cfg_scale=1.0,
+    seed=42,
+    lora_request=LoRARequest(
+        lora_name="lightning-4steps",
+        lora_int_id=stable_lora_int_id(lora_path),
+        lora_path=lora_path,
+    ),
+    lora_scale=1.0,
+)
+```
+
+#### Verification
+
+- With the LoRA: a 4-step request returns a clean, fully formed image.
+- Without the LoRA (same request minus the `lora` field): a 4-step request
+  returns a blurry, washed-out image — the undistilled base model cannot
+  converge in 4 steps. This contrast confirms the adapter is applied.
+- The server log shows the in-memory conversion and the adapter size:
+  `Detected single-file (non-PEFT) LoRA ...` and
+  `Loaded LoRA model: ... num_modules=720`.
+
+## Notes
+
+- Use `num_inference_steps: 8` with the 8-step checkpoint variants.
+- Keep `true_cfg_scale` at `1.0`: guidance is distilled into the adapter.
+  True CFG engages only when a negative prompt is also supplied; when it
+  does, it doubles per-step compute and visibly degrades output
+  (oversaturated, color-shifted results in our tests).
+- Extra steps buy nothing: in our tests a 50-step run produced a comparable
+  image at >10x the latency of the 4-step configuration — the point of the
+  adapter is that the 4/8-step schedule is sufficient.
+- The sibling repositories (`Qwen-Image-2512-Lightning`,
+  `Qwen-Image-Edit-*-Lightning`) publish the same file format for the newer
+  base models and should load the same way; validation results welcome.

--- a/tests/diffusion/lora/test_single_file_lora.py
+++ b/tests/diffusion/lora/test_single_file_lora.py
@@ -113,3 +113,34 @@ def test_find_single_file_lora(tmp_path):
     (tmp_path / "adapter_config.json").unlink()
     save_file({"x": torch.zeros(1)}, str(tmp_path / "other.safetensors"))
     assert find_single_file_lora(str(tmp_path)) is None
+
+
+def test_find_single_file_lora_case_insensitive(tmp_path):
+    ckpt = tmp_path / "ADAPTER.SAFETENSORS"
+    save_file({"x": torch.zeros(1)}, str(ckpt))
+    assert find_single_file_lora(str(ckpt)) == str(ckpt)
+    assert find_single_file_lora(str(tmp_path)) == str(ckpt)
+
+
+def test_convert_mixed_ranks_uses_max_and_keeps_per_module_scale():
+    sd = {
+        "transformer_blocks.0.attn.to_q.lora_down.weight": torch.randn(4, _DIM),
+        "transformer_blocks.0.attn.to_q.lora_up.weight": torch.randn(_DIM, 4),
+        "transformer_blocks.0.attn.to_q.alpha": torch.tensor(2.0),
+        "transformer_blocks.0.attn.to_k.lora_down.weight": torch.randn(8, _DIM),
+        "transformer_blocks.0.attn.to_k.lora_up.weight": torch.randn(_DIM, 8),
+        "transformer_blocks.0.attn.to_k.alpha": torch.tensor(2.0),
+    }
+    config, tensors = convert_single_file_lora(sd, _EXPECTED_MODULES | {"to_k"})
+    # The synthesized config advertises the max rank...
+    assert config["r"] == 8
+    assert config["lora_alpha"] == 8
+    # ...while each module keeps its exact alpha/rank scaling folded into lora_B.
+    torch.testing.assert_close(
+        tensors["base_model.model.transformer_blocks.0.attn.to_q.lora_B.weight"],
+        sd["transformer_blocks.0.attn.to_q.lora_up.weight"] * (2.0 / 4),
+    )
+    torch.testing.assert_close(
+        tensors["base_model.model.transformer_blocks.0.attn.to_k.lora_B.weight"],
+        sd["transformer_blocks.0.attn.to_k.lora_up.weight"] * (2.0 / 8),
+    )

--- a/tests/diffusion/lora/test_single_file_lora.py
+++ b/tests/diffusion/lora/test_single_file_lora.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from vllm.lora.peft_helper import PEFTHelper
+
+from vllm_omni.diffusion.lora.utils import (
+    convert_single_file_lora,
+    find_single_file_lora,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# Module layout mirroring the Qwen-Image transformer: plain projections,
+# a diffusers ModuleList indirection (`to_out.0`), and MLP linears whose
+# leaf names (`proj`, `2`) are how they appear in the pipeline module tree.
+_MODULE_PATHS = [
+    "transformer_blocks.0.attn.to_q",
+    "transformer_blocks.0.attn.to_out.0",
+    "transformer_blocks.0.img_mlp.net.0.proj",
+    "transformer_blocks.0.img_mlp.net.2",
+]
+_EXPECTED_MODULES = {"to_q", "to_out", "proj", "2"}
+_RANK = 4
+_DIM = 16
+
+
+def _kohya_state_dict(alpha: float | None = 2.0) -> dict[str, torch.Tensor]:
+    sd: dict[str, torch.Tensor] = {}
+    for path in _MODULE_PATHS:
+        sd[f"{path}.lora_down.weight"] = torch.randn(_RANK, _DIM)
+        sd[f"{path}.lora_up.weight"] = torch.randn(_DIM, _RANK)
+        if alpha is not None:
+            sd[f"{path}.alpha"] = torch.tensor(alpha)
+    return sd
+
+
+def test_convert_kohya_names_and_config():
+    sd = _kohya_state_dict()
+    config, tensors = convert_single_file_lora(sd, _EXPECTED_MODULES)
+
+    assert config["r"] == _RANK
+    # alpha is folded into lora_B, so the config keeps a 1.0 global scale.
+    assert config["lora_alpha"] == config["r"]
+    assert config["target_modules"] == [
+        "attn.to_out",
+        "attn.to_q",
+        "img_mlp.net.0.proj",
+        "img_mlp.net.2",
+    ]
+    # The config round-trips through vLLM's PEFT parsing.
+    helper = PEFTHelper.from_dict(config)
+    assert helper.vllm_lora_scaling_factor == 1.0
+
+    # ModuleList indirection is folded onto the pipeline module path.
+    assert "base_model.model.transformer_blocks.0.attn.to_out.lora_A.weight" in tensors
+    # Plain paths are preserved.
+    assert "base_model.model.transformer_blocks.0.img_mlp.net.0.proj.lora_B.weight" in tensors
+    assert len(tensors) == 2 * len(_MODULE_PATHS)
+
+
+def test_convert_folds_alpha_into_lora_b():
+    sd = _kohya_state_dict(alpha=2.0)
+    _, tensors = convert_single_file_lora(sd, _EXPECTED_MODULES)
+    expected = sd["transformer_blocks.0.attn.to_q.lora_up.weight"] * (2.0 / _RANK)
+    got = tensors["base_model.model.transformer_blocks.0.attn.to_q.lora_B.weight"]
+    torch.testing.assert_close(got, expected)
+
+
+def test_convert_accepts_peft_style_names_and_prefixes():
+    sd = {
+        "transformer.transformer_blocks.0.attn.to_q.lora_A.weight": torch.randn(_RANK, _DIM),
+        "transformer.transformer_blocks.0.attn.to_q.lora_B.weight": torch.randn(_DIM, _RANK),
+    }
+    config, tensors = convert_single_file_lora(sd, _EXPECTED_MODULES)
+    assert config["r"] == _RANK
+    assert "base_model.model.transformer_blocks.0.attn.to_q.lora_A.weight" in tensors
+
+
+def test_convert_rejects_unsupported_modules():
+    sd = {
+        "transformer_blocks.0.attn.unknown_proj.lora_down.weight": torch.randn(_RANK, _DIM),
+        "transformer_blocks.0.attn.unknown_proj.lora_up.weight": torch.randn(_DIM, _RANK),
+    }
+    with pytest.raises(ValueError, match="do not match any supported LoRA module"):
+        convert_single_file_lora(sd, _EXPECTED_MODULES)
+
+
+def test_convert_rejects_unknown_keys():
+    with pytest.raises(ValueError, match="Unrecognized key"):
+        convert_single_file_lora({"transformer_blocks.0.attn.to_q.weird": torch.zeros(1)}, _EXPECTED_MODULES)
+
+
+def test_find_single_file_lora(tmp_path):
+    ckpt = tmp_path / "adapter.safetensors"
+    save_file({"x": torch.zeros(1)}, str(ckpt))
+
+    # Direct file path and a directory holding exactly one safetensors file.
+    assert find_single_file_lora(str(ckpt)) == str(ckpt)
+    assert find_single_file_lora(str(tmp_path)) == str(ckpt)
+
+    # A PEFT directory keeps going through the PEFT loader.
+    (tmp_path / "adapter_config.json").write_text(json.dumps({"r": 4}))
+    assert find_single_file_lora(str(tmp_path)) is None
+
+    # Ambiguous directories (multiple safetensors) are not treated as single-file.
+    (tmp_path / "adapter_config.json").unlink()
+    save_file({"x": torch.zeros(1)}, str(tmp_path / "other.safetensors"))
+    assert find_single_file_lora(str(tmp_path)) is None

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -298,10 +298,13 @@ class DiffusionLoRAManager:
                 "Detected single-file (non-PEFT) LoRA at %s; converting to PEFT layout in memory",
                 single_file,
             )
+            raw_tensors = load_file(single_file)
             peft_config, single_file_tensors = convert_single_file_lora(
-                load_file(single_file),
+                raw_tensors,
                 self._expected_lora_modules,
             )
+            # Release the unconverted state dict early to reduce peak memory.
+            del raw_tensors
             peft_helper = PEFTHelper.from_dict(peft_config)
         else:
             peft_helper = PEFTHelper.from_local_dir(

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -8,6 +8,7 @@ from typing import get_args
 
 import torch
 import torch.nn as nn
+from safetensors.torch import load_file
 from vllm.config.lora import MaxLoRARanks
 from vllm.logger import init_logger
 from vllm.lora.layers import BaseLayerWithLoRA
@@ -26,6 +27,8 @@ from vllm_omni.config.lora import LoRAConfig
 from vllm_omni.diffusion.lora.utils import (
     _expand_expected_modules_for_packed_layers,
     _match_target_modules,
+    convert_single_file_lora,
+    find_single_file_lora,
     from_layer_diffusion,
 )
 from vllm_omni.lora.utils import stable_lora_int_id
@@ -284,11 +287,28 @@ class DiffusionLoRAManager:
         lora_path = get_adapter_absolute_path(lora_request.lora_path)
         logger.debug("Resolved LoRA path: %s", lora_path)
 
-        peft_helper = PEFTHelper.from_local_dir(
-            lora_path,
-            max_position_embeddings=None,  # no need in diffusion
-            tensorizer_config_dict=lora_request.tensorizer_config_dict,
-        )
+        # Single-file (Kohya/diffusers) checkpoints — the format used by most
+        # published diffusion LoRAs (e.g. lightx2v/Qwen-Image-Lightning) —
+        # carry no adapter_config.json, so they are converted to the PEFT
+        # layout in memory instead of going through PEFTHelper.from_local_dir.
+        single_file = find_single_file_lora(lora_path)
+        single_file_tensors = None
+        if single_file is not None:
+            logger.info(
+                "Detected single-file (non-PEFT) LoRA at %s; converting to PEFT layout in memory",
+                single_file,
+            )
+            peft_config, single_file_tensors = convert_single_file_lora(
+                load_file(single_file),
+                self._expected_lora_modules,
+            )
+            peft_helper = PEFTHelper.from_dict(peft_config)
+        else:
+            peft_helper = PEFTHelper.from_local_dir(
+                lora_path,
+                max_position_embeddings=None,  # no need in diffusion
+                tensorizer_config_dict=lora_request.tensorizer_config_dict,
+            )
 
         logger.info(
             "Loaded PEFT config: r=%d, lora_alpha=%d, target_modules=%s",
@@ -297,17 +317,28 @@ class DiffusionLoRAManager:
             peft_helper.target_modules,
         )
 
-        lora_model = LoRAModel.from_local_checkpoint(
-            lora_path,
-            expected_lora_modules=self._expected_lora_modules,
-            peft_helper=peft_helper,
-            lora_model_id=lora_request.lora_int_id,
-            device="cpu",  # consistent w/ vllm's behavior
-            dtype=self.dtype,
-            model_vocab_size=None,
-            tensorizer_config_dict=lora_request.tensorizer_config_dict,
-            weights_mapper=None,
-        )
+        if single_file_tensors is not None:
+            lora_model = LoRAModel.from_lora_tensors(
+                lora_model_id=lora_request.lora_int_id,
+                tensors=single_file_tensors,
+                peft_helper=peft_helper,
+                device="cpu",  # consistent w/ vllm's behavior
+                dtype=self.dtype,
+                model_vocab_size=None,
+                weights_mapper=None,
+            )
+        else:
+            lora_model = LoRAModel.from_local_checkpoint(
+                lora_path,
+                expected_lora_modules=self._expected_lora_modules,
+                peft_helper=peft_helper,
+                lora_model_id=lora_request.lora_int_id,
+                device="cpu",  # consistent w/ vllm's behavior
+                dtype=self.dtype,
+                model_vocab_size=None,
+                tensorizer_config_dict=lora_request.tensorizer_config_dict,
+                weights_mapper=None,
+            )
 
         logger.info(
             "Loaded LoRA model: id=%d, num_modules=%d, modules=%s",

--- a/vllm_omni/diffusion/lora/utils.py
+++ b/vllm_omni/diffusion/lora/utils.py
@@ -8,6 +8,7 @@ import os
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
+from vllm.logger import init_logger
 
 from vllm_omni.config.lora import LoRAConfig
 from vllm_omni.diffusion.lora.layers import (
@@ -18,6 +19,8 @@ from vllm_omni.diffusion.lora.layers import (
     DiffusionReplicatedLinearWithLoRA,
     DiffusionRowParallelLinearWithLoRA,
 )
+
+logger = init_logger(__name__)
 
 
 def _match_target_modules(module_name: str, target_modules: list[str]) -> bool:
@@ -78,12 +81,12 @@ def find_single_file_lora(lora_path: str) -> str | None:
     ``adapter_config.json`` (i.e. not a PEFT adapter directory).
     Returns None when the path should be handled by the PEFT loader.
     """
-    if os.path.isfile(lora_path) and lora_path.endswith(".safetensors"):
+    if os.path.isfile(lora_path) and lora_path.lower().endswith(".safetensors"):
         return lora_path
     if os.path.isdir(lora_path):
         if os.path.isfile(os.path.join(lora_path, "adapter_config.json")):
             return None
-        candidates = [f for f in os.listdir(lora_path) if f.endswith(".safetensors")]
+        candidates = [f for f in os.listdir(lora_path) if f.lower().endswith(".safetensors")]
         if len(candidates) == 1:
             return os.path.join(lora_path, candidates[0])
     return None
@@ -166,6 +169,7 @@ def convert_single_file_lora(
     converted: dict[str, torch.Tensor] = {}
     target_modules: set[str] = set()
     unmatched: list[str] = []
+    ranks: set[int] = set()
     max_rank = 0
     for path, parts in sorted(modules.items()):
         if "lora_A" not in parts or "lora_B" not in parts:
@@ -175,6 +179,7 @@ def convert_single_file_lora(
             unmatched.append(path)
             continue
         rank = parts["lora_A"].shape[0]
+        ranks.add(rank)
         max_rank = max(max_rank, rank)
         lora_b = parts["lora_B"]
         alpha = parts.get("alpha")
@@ -192,6 +197,13 @@ def convert_single_file_lora(
         )
     if not converted:
         raise ValueError("Single-file LoRA checkpoint contains no LoRA modules.")
+    if len(ranks) > 1:
+        logger.warning(
+            "Single-file LoRA has mixed ranks %s; using r=%d (max) in the synthesized "
+            "PEFT config. Per-module scaling stays exact because alpha is folded per module.",
+            sorted(ranks),
+            max_rank,
+        )
 
     peft_config = {
         "r": max_rank,

--- a/vllm_omni/diffusion/lora/utils.py
+++ b/vllm_omni/diffusion/lora/utils.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import os
+
+import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
@@ -53,6 +56,149 @@ def _expand_expected_modules_for_packed_layers(
             expanded.update(sub_names)
 
     return expanded
+
+
+# Key suffixes used by single-file LoRA checkpoints. Kohya-style exports
+# (used by e.g. lightx2v/Qwen-Image-Lightning and most community diffusion
+# LoRAs) use `lora_down`/`lora_up` plus per-module `alpha` scalars; some
+# exporters use PEFT-style `lora_A`/`lora_B` names but still ship a bare
+# safetensors file without an `adapter_config.json`.
+_LORA_A_SUFFIXES = (".lora_down.weight", ".lora_A.weight")
+_LORA_B_SUFFIXES = (".lora_up.weight", ".lora_B.weight")
+_ALPHA_SUFFIX = ".alpha"
+# Root prefixes some exporters prepend to module paths.
+_ROOT_PREFIXES = ("base_model.model.", "diffusion_model.", "transformer.")
+
+
+def find_single_file_lora(lora_path: str) -> str | None:
+    """Return the safetensors file if ``lora_path`` is a single-file LoRA.
+
+    Accepts either a direct path to a ``.safetensors`` file or a directory
+    that contains exactly one ``.safetensors`` file and no
+    ``adapter_config.json`` (i.e. not a PEFT adapter directory).
+    Returns None when the path should be handled by the PEFT loader.
+    """
+    if os.path.isfile(lora_path) and lora_path.endswith(".safetensors"):
+        return lora_path
+    if os.path.isdir(lora_path):
+        if os.path.isfile(os.path.join(lora_path, "adapter_config.json")):
+            return None
+        candidates = [f for f in os.listdir(lora_path) if f.endswith(".safetensors")]
+        if len(candidates) == 1:
+            return os.path.join(lora_path, candidates[0])
+    return None
+
+
+def _resolve_module_path(path: str, expected_lora_modules: set[str]) -> str | None:
+    """Map a checkpoint module path onto the pipeline's module tree.
+
+    diffusers wraps some projections in a ModuleList (e.g. ``attn.to_out.0``)
+    while vllm-omni implementations expose the projection directly
+    (``attn.to_out``), so a trailing index is folded into its parent when the
+    parent is a supported LoRA module. Returns None if the path cannot be
+    matched to any supported module.
+    """
+    leaf = path.rsplit(".", 1)[-1]
+    if leaf in expected_lora_modules:
+        return path
+    if leaf.isdigit():
+        parent = path.rsplit(".", 1)[0]
+        if parent.rsplit(".", 1)[-1] in expected_lora_modules:
+            return parent
+    return None
+
+
+def _target_module_suffix(path: str) -> str:
+    """Strip the leading block path (up to the first index) for readability,
+    e.g. ``transformer_blocks.31.attn.to_q`` -> ``attn.to_q``."""
+    parts = path.split(".")
+    for i, part in enumerate(parts):
+        if part.isdigit():
+            return ".".join(parts[i + 1 :]) or path
+    return path
+
+
+def convert_single_file_lora(
+    tensors: dict[str, torch.Tensor],
+    expected_lora_modules: set[str],
+) -> tuple[dict, dict[str, torch.Tensor]]:
+    """Convert a single-file (Kohya/diffusers) LoRA state dict to PEFT layout.
+
+    - renames ``{module}.lora_down/lora_up.weight`` (or ``lora_A/lora_B``) to
+      ``base_model.model.{module}.lora_A/lora_B.weight``
+    - folds per-module ``{module}.alpha`` scalars into ``lora_B`` and returns
+      a config with ``lora_alpha == r``, so vLLM's global scaling stays 1.0
+      and the effective per-module scale remains ``alpha / rank``
+    - strips root prefixes some exporters add (``transformer.`` etc.)
+    - folds diffusers ModuleList indirections (``attn.to_out.0`` ->
+      ``attn.to_out``) via :func:`_resolve_module_path`
+
+    Returns ``(peft_config_dict, converted_tensors)`` consumable by
+    ``PEFTHelper.from_dict`` and ``LoRAModel.from_lora_tensors``.
+    """
+    modules: dict[str, dict[str, torch.Tensor]] = {}
+    for key, tensor in tensors.items():
+        name = key
+        for prefix in _ROOT_PREFIXES:
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        matched = False
+        for suffix in _LORA_A_SUFFIXES:
+            if name.endswith(suffix):
+                modules.setdefault(name[: -len(suffix)], {})["lora_A"] = tensor
+                matched = True
+                break
+        if matched:
+            continue
+        for suffix in _LORA_B_SUFFIXES:
+            if name.endswith(suffix):
+                modules.setdefault(name[: -len(suffix)], {})["lora_B"] = tensor
+                matched = True
+                break
+        if matched:
+            continue
+        if name.endswith(_ALPHA_SUFFIX):
+            modules.setdefault(name[: -len(_ALPHA_SUFFIX)], {})["alpha"] = tensor
+        else:
+            raise ValueError(f"Unrecognized key in single-file LoRA checkpoint: {key}")
+
+    converted: dict[str, torch.Tensor] = {}
+    target_modules: set[str] = set()
+    unmatched: list[str] = []
+    max_rank = 0
+    for path, parts in sorted(modules.items()):
+        if "lora_A" not in parts or "lora_B" not in parts:
+            raise ValueError(f"LoRA module {path} is missing its lora_down/lora_up weights")
+        resolved = _resolve_module_path(path, expected_lora_modules)
+        if resolved is None:
+            unmatched.append(path)
+            continue
+        rank = parts["lora_A"].shape[0]
+        max_rank = max(max_rank, rank)
+        lora_b = parts["lora_B"]
+        alpha = parts.get("alpha")
+        if alpha is not None:
+            lora_b = lora_b * (float(alpha) / rank)
+        converted[f"base_model.model.{resolved}.lora_A.weight"] = parts["lora_A"].contiguous()
+        converted[f"base_model.model.{resolved}.lora_B.weight"] = lora_b.contiguous()
+        target_modules.add(_target_module_suffix(resolved))
+
+    if unmatched:
+        raise ValueError(
+            f"While converting a single-file LoRA, {len(unmatched)} module(s) do not match "
+            f"any supported LoRA module of this pipeline (supported: "
+            f"{sorted(expected_lora_modules)}): {unmatched[:8]}"
+        )
+    if not converted:
+        raise ValueError("Single-file LoRA checkpoint contains no LoRA modules.")
+
+    peft_config = {
+        "r": max_rank,
+        "lora_alpha": max_rank,
+        "target_modules": sorted(target_modules),
+    }
+    return peft_config, converted
 
 
 def from_layer_diffusion(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Closes #425.

The diffusion LoRA path only accepts PEFT directories: `PEFTHelper.from_local_dir` requires an `adapter_config.json`. But `lightx2v/Qwen-Image-Lightning` (480k+ downloads) — like virtually every published diffusion LoRA on the Hub — ships as a single Kohya-style safetensors file (`{module}.lora_down/lora_up.weight` + per-module `alpha` scalars, no config). Loading it fails twice over:

1. `NotADirectoryError`/`FileNotFoundError: ... adapter_config.json` (the loader expects a PEFT directory; there is none), and
2. even with a hand-written config, `ValueError: transformer_blocks.0.attn.add_k_proj.alpha is unsupported LoRA weight` (Kohya key layout).

Closing #425 therefore takes two things: the loader must accept the format these adapters are actually published in, and Lightning's **usage contract** — as a step-distillation adapter it must run at 4/8 steps with CFG disabled, which is not inferable from the checkpoint — must be documented. This PR does both, through the **existing runtime PEFT adapter path**:

- `vllm_omni/diffusion/lora/utils.py`: `find_single_file_lora()` (a bare `.safetensors` path, or a directory holding exactly one and no `adapter_config.json`) and `convert_single_file_lora()` — in-memory conversion to the PEFT layout: `lora_down/lora_up` (or `lora_A/lora_B`) key remap, per-module `alpha` folded into `lora_B` with `lora_alpha == r` (global scale stays 1.0, effective per-module scale stays `alpha/rank`), exporter root-prefix stripping, and folding of diffusers `ModuleList` indirection (`attn.to_out.0` -> `attn.to_out`) validated against the pipeline's supported LoRA modules with a clear error on mismatch.
- `vllm_omni/diffusion/lora/manager.py`: `_load_adapter()` branches to `PEFTHelper.from_dict` + `LoRAModel.from_lora_tensors` for the single-file case; PEFT directories take exactly the same path as before.
- `recipes/Qwen/Qwen-Image-Lightning.md`: the Lightning usage contract as a validated configuration — 4-step online request with `true_cfg_scale=1.0`, offline snippet, and how to verify the adapter is actually applied. (The loader change above is format-level and benefits any single-file adapter; this recipe covers what remains Lightning-specific.)
- `docs/user_guide/diffusion/lora.md`: document the second accepted format.
- `tests/diffusion/lora/test_single_file_lora.py`: unit tests for detection, key/config conversion, alpha folding, ModuleList folding, and error paths.

This change keeps the runtime adapter semantics of the existing PEFT path — per-request activation, `lora_scale`, LRU cache, and the server's per-request `lora` field keep working — and adds no new backend, flag, or API surface: the existing `lora_path` usage simply starts accepting the files users actually download.

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 0798b0b

Unit:

```bash
pytest tests/diffusion/lora/test_single_file_lora.py -v
pytest tests/diffusion/lora/test_lora_manager.py tests/diffusion/lora/test_base_linear.py -q  # regression
```

E2E (1x A800-80G), following the commands in the added recipe — serve `Qwen/Qwen-Image` and request 4-step generations with the **as-downloaded** adapter file:

```bash
huggingface-cli download lightx2v/Qwen-Image-Lightning \
  Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors --local-dir ./lightning

vllm serve Qwen/Qwen-Image --omni --port 8091

curl http://localhost:8091/v1/images/generations -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen-Image",
  "prompt": "a corgi wearing sunglasses on a beach, golden hour, photo",
  "num_inference_steps": 4, "true_cfg_scale": 1.0, "seed": 42,
  "lora": {"name": "lightning-4steps",
           "path": "./lightning/Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors",
           "scale": 1.0}
}'
# and the same request without the "lora" field as the control
```

## Test Result

**Before (upstream main): the exact same request fails with HTTP 500.** The loader treats the checkpoint file as a PEFT directory and looks for `adapter_config.json` inside it:

```
INFO  [manager.py:246] Loading new adapter: id=..., name=lightning-4steps
ERROR [diffusion_worker.py:1250] Error executing method 'execute_model_batch'. ...
  File "vllm_omni/diffusion/lora/manager.py", line 287, in _load_adapter
    peft_helper = PEFTHelper.from_local_dir(
  File "vllm/lora/peft_helper.py", line 110, in from_local_dir
    with open(lora_config_path) as f:
NotADirectoryError: [Errno 20] Not a directory:
  '.../Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors/adapter_config.json'
INFO: "POST /v1/images/generations HTTP/1.1" 500 Internal Server Error
```

(Pointing `lora_path` at a directory containing the file fails the same way with `FileNotFoundError: ... adapter_config.json`.)

**After (this PR): the identical request succeeds** (1x A800-80G):

- The as-downloaded single file loads through the new path — server log shows `Detected single-file (non-PEFT) LoRA ...` and `Loaded LoRA model: ... num_modules=720` — and the 4-step request returns 200 with a clean, fully-formed image.
- The same request without the `lora` field returns a blurry, washed-out image, as expected from the undistilled base at 4 steps — confirming the adapter is actually applied.
- A PEFT-format adapter directory loads through the unchanged original path (regression tests below).
- Usage-contract spot checks backing the recipe's guidance: with true CFG actually engaged (negative prompt + `true_cfg_scale=4.0`), the 4-step output is visibly oversaturated/color-shifted and takes ~2x per step; a 50-step run yields a comparable image at >10x the latency of the 4-step configuration.
- Unit: 6 new tests pass; regression (`test_lora_manager.py` + `test_base_linear.py`) 20 tests pass; `ruff check` / `ruff format` clean (v0.14.10, matching pre-commit).

<details>
<summary>Unit tests + lint</summary>

```
$ python -m pytest tests/diffusion/lora/test_single_file_lora.py -v
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
collected 6 items

tests/diffusion/lora/test_single_file_lora.py::test_convert_kohya_names_and_config PASSED       [ 16%]
tests/diffusion/lora/test_single_file_lora.py::test_convert_folds_alpha_into_lora_b PASSED      [ 33%]
tests/diffusion/lora/test_single_file_lora.py::test_convert_accepts_peft_style_names_and_prefixes PASSED [ 50%]
tests/diffusion/lora/test_single_file_lora.py::test_convert_rejects_unsupported_modules PASSED  [ 66%]
tests/diffusion/lora/test_single_file_lora.py::test_convert_rejects_unknown_keys PASSED         [ 83%]
tests/diffusion/lora/test_single_file_lora.py::test_find_single_file_lora PASSED                [100%]
====== 6 passed, 16 warnings in 0.12s ======

$ python -m pytest tests/diffusion/lora/test_lora_manager.py tests/diffusion/lora/test_base_linear.py -q
....................                                                                            [100%]
20 passed, 16 warnings in 0.13s

(warnings are pre-existing third-party DeprecationWarnings — SWIG bindings and
torch.jit.script_method from dependencies — identical on main, none introduced
by this diff)

$ ruff check vllm_omni/diffusion/lora/utils.py vllm_omni/diffusion/lora/manager.py tests/diffusion/lora/test_single_file_lora.py
All checks passed!
$ ruff format --check vllm_omni/diffusion/lora/utils.py vllm_omni/diffusion/lora/manager.py tests/diffusion/lora/test_single_file_lora.py
3 files already formatted
```

</details>

<details>
<summary>E2E: full reproducible before/after (identical request, as-downloaded Lightning file)</summary>

Setup (once):

```bash
huggingface-cli download lightx2v/Qwen-Image-Lightning \
  Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors --local-dir ./lightning

vllm serve Qwen/Qwen-Image --omni --port 8091
```

Identical client request for both runs (decodes and saves the returned image):

```bash
curl -s http://localhost:8091/v1/images/generations -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen-Image",
  "prompt": "a corgi wearing sunglasses on a beach, golden hour, photo",
  "num_inference_steps": 4, "true_cfg_scale": 1.0, "seed": 42,
  "lora": {"name": "lightning-4steps",
           "path": "./lightning/Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors",
           "scale": 1.0}
}' | python -c 'import sys,json,base64;d=json.load(sys.stdin);open("with_lora.png","wb").write(base64.b64decode(d["data"][0]["b64_json"]))'
```

**On upstream main:** HTTP 500 — no image in the response (the decode step fails with `KeyError: 'data'`), and the server logs the `NotADirectoryError` traceback shown above.

**On this PR:** `with_lora.png` is written — a clean, fully-formed 4-step image — and the server logs:

```
INFO [manager.py:249] Loading new adapter: id=181663504601837319, name=lightning-4steps
INFO [manager.py:297] Detected single-file (non-PEFT) LoRA at .../Qwen-Image-Lightning-4steps-V1.0-bf16.safetensors; converting to PEFT layout in memory
INFO [manager.py:313] Loaded PEFT config: r=64, lora_alpha=64, target_modules=['attn.add_k_proj', 'attn.add_q_proj', 'attn.add_v_proj', 'attn.to_add_out', 'attn.to_k', 'attn.to_out', 'attn.to_q', 'attn.to_v', 'img_mlp.net.0.proj', 'img_mlp.net.2', 'txt_mlp.net.0.proj', 'txt_mlp.net.2']
INFO [manager.py:343] Loaded LoRA model: id=181663504601837319, num_modules=720, modules=['transformer_blocks.0.attn.add_k_proj', ...]
INFO [manager.py:481] Increasing max LoRA rank: 0 -> 64
INFO [manager.py:554] Activating adapter: id=181663504601837319
```

Control: the same command minus the `"lora"` field (saved as `no_lora.png`) returns a blurry, washed-out image, and cleanly deactivates the adapter in the same server session (`INFO [manager.py:669] Deactivating all adapters: 480 layers`) — per-request switching works.

```
$ md5sum with_lora.png no_lora.png
20067fbf38ff8649b543658d96f6772b  with_lora.png   # clean image
f5834ee070d89f4e171a8b2dd9aa1882  no_lora.png     # blurry at 4 steps
```

</details>

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
