### PR TITLE
[BugFix] Drop removed get_cache_scale call in HunyuanImage3 diffusion loader

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -2235,13 +2235,8 @@ class HunyuanImage3Model(nn.Module):
             # processed with quantization, LoRA, fine-tuning, etc.
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
-            if self.quant_config is not None and (scale_name := self.quant_config.get_cache_scale(name)):
-                # Loading kv cache scales for compressed-tensors quantization
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = loaded_weight[0]
-                weight_loader(param, loaded_weight)
-                continue
+            # KV-cache scales are renamed via maybe_remap_kv_scale_name below;
+            # quant_config.get_cache_scale was removed in vLLM v0.23.0 (see #4810).
 
             is_found = False
             for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Purpose

Fixes #4891.

vLLM removed `QuantizationConfig.get_cache_scale` in v0.23.0 (vllm#43167). #4810 migrated the AR-side custom loaders but missed the diffusion-side HunyuanImage3 loader, so quantized checkpoints crash during DiT weight loading:

```
AttributeError: 'ModelOptMixedPrecisionConfig' object has no attribute 'get_cache_scale'
```

Drop the dead call the same way #4810 did for the AR loader; KV-cache scale names are already handled by `maybe_remap_kv_scale_name` in this loader.

## Test Plan

Serve a ModelOpt mixed FP8/NVFP4 HunyuanImage-3.0-Instruct checkpoint with the AR+DiT deploy on 2x RTX PRO 6000 (sm_120), vLLM 0.24.0.

## Test Result

Without this change the DiT worker crashes at load; with it, both stages load, the orchestrator reaches ready, and text-to-image generation completes end to end.