### PR TITLE
[Bugfix][Core] Fix deadlock between spawn-env lock and device flocks in stage init

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -537,7 +537,7 @@ def test_initialize_local_llm_replica_passes_stage_init_timeout_to_complete_stag
     prev_device_env = os.environ.get(device_env_var)
     os.environ[device_env_var] = "0"
 
-    def _capture_acquire_device_locks(*_args):
+    def _capture_acquire_device_locks(*_args, **_kwargs):
         nonlocal captured_timeout
         captured_timeout = _args[2]
         return []
@@ -569,6 +569,204 @@ def test_initialize_local_llm_replica_passes_stage_init_timeout_to_complete_stag
             os.environ[device_env_var] = prev_device_env
 
     assert captured_timeout == 302
+
+
+def test_acquire_device_locks_prefers_explicit_visible_devices(monkeypatch):
+    """acquire_device_locks(visible_devices=...) must not read the device env."""
+    import vllm_omni.engine.stage_init_utils as init_utils
+    from vllm_omni.platforms import current_omni_platform
+
+    device_env_var = current_omni_platform.device_control_env_var
+    # Poison the env: if the function reads it, it would lock device 7.
+    monkeypatch.setenv(device_env_var, "7")
+
+    locked: list[str] = []
+    real_open = os.open
+
+    def _capture_open(path, *args, **kwargs):
+        if isinstance(path, str) and "vllm_omni_device_" in path:
+            locked.append(path)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(init_utils.os, "open", _capture_open)
+
+    lock_fds = init_utils.acquire_device_locks(
+        0,
+        {"tensor_parallel_size": 1},
+        stage_init_timeout=5,
+        visible_devices="3",
+    )
+    try:
+        assert any("vllm_omni_device_3_init.lock" in p for p in locked)
+        assert not any("vllm_omni_device_7_init.lock" in p for p in locked)
+    finally:
+        init_utils.release_device_locks(lock_fds)
+
+
+def test_initialize_local_llm_replica_does_not_hold_spawn_lock_during_device_lock_wait(monkeypatch):
+    """Regression: the flock wait must run outside the spawn-env lock, or
+    colocated stages deadlock through lock-order inversion
+    (spawn-lock+flock vs flock+spawn-lock)."""
+    import vllm_omni.engine.stage_runtime as runtime_mod
+
+    runtime = StageRuntime(
+        stage_configs=[],
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=30,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+    fake_vllm_config = types.SimpleNamespace()
+    fake_addresses = types.SimpleNamespace(inputs=["in"], outputs=["out"], frontend_stats_publish_address=None)
+
+    plan = ReplicaInitPlan(
+        replica_id=0,
+        num_replicas=1,
+        launch_mode="local",
+        stage_cfg=types.SimpleNamespace(engine_args={}, runtime=types.SimpleNamespace(devices="1,3")),
+        metadata=types.SimpleNamespace(stage_id=1, runtime_cfg={"devices": "1,3"}),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_vllm_config=fake_vllm_config,
+        executor_class=object,
+        engine_args_dict={},
+    )
+
+    observed: dict[str, object] = {}
+
+    def _fake_acquire_device_locks(*_args, **_kwargs):
+        # The deadlock happened exactly here: the flock wait ran while the
+        # spawn-env lock was held. Assert it is free at this point.
+        observed["spawn_lock_held"] = runtime._spawn_device_lock.locked()
+        observed["visible_devices"] = _kwargs.get("visible_devices")
+        return []
+
+    monkeypatch.setattr(runtime_mod, "acquire_device_locks", _fake_acquire_device_locks)
+    monkeypatch.setattr(
+        runtime_mod,
+        "resolve_stage_physical_devices",
+        lambda *_a, **_k: "1,3",
+    )
+
+    from vllm_omni.engine.stage_engine_startup import StageReplicaResources
+
+    @contextlib.contextmanager
+    def _fake_launch_stage_replica(**_kwargs):
+        yield StageReplicaResources(
+            manager=types.SimpleNamespace(shutdown=lambda: None),
+            addresses=fake_addresses,
+        )
+
+    monkeypatch.setattr(runtime_mod, "launch_stage_replica", _fake_launch_stage_replica)
+    monkeypatch.setattr(
+        runtime_mod.StageEngineCoreClientBase,
+        "make_async_mp_client",
+        staticmethod(lambda **_: types.SimpleNamespace(shutdown=lambda: None)),
+    )
+
+    runtime._initialize_local_llm_replica(plan, 30)
+
+    assert observed["spawn_lock_held"] is False
+    assert observed["visible_devices"] == "1,3"
+
+
+def test_parallel_replica_init_with_shared_device_does_not_deadlock(monkeypatch):
+    """End-to-end deadlock reproducer: two replicas with overlapping devices
+    initializing in parallel must both complete. Uses real flocks (high device
+    ids) and a fake launch that takes the spawn-env lock like the real path;
+    before the fix this timed out.
+    """
+    import threading
+
+    import vllm_omni.engine.stage_runtime as runtime_mod
+
+    runtime = StageRuntime(
+        stage_configs=[],
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=30,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+    fake_addresses = types.SimpleNamespace(inputs=["in"], outputs=["out"], frontend_stats_publish_address=None)
+
+    def _make_plan(stage_id: int, devices: str, tp: int) -> ReplicaInitPlan:
+        return ReplicaInitPlan(
+            replica_id=0,
+            num_replicas=1,
+            launch_mode="local",
+            stage_cfg=types.SimpleNamespace(engine_args={}, runtime=types.SimpleNamespace(devices=devices)),
+            metadata=types.SimpleNamespace(stage_id=stage_id, runtime_cfg={"devices": devices}),
+            stage_connector_spec={},
+            omni_kv_connector=(None, None, None),
+            stage_vllm_config=types.SimpleNamespace(),
+            executor_class=object,
+            engine_args_dict={"tensor_parallel_size": tp},
+        )
+
+    # High device ids so the real /tmp flock files never clash with real GPUs.
+    plans = {
+        0: ("101,102", 2),  # "thinker": locks devices 101+102
+        1: ("102", 1),  # "talker": colocated on device 102
+    }
+    device_map = {0: "101,102", 1: "102"}
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "resolve_stage_physical_devices",
+        lambda stage_id, *_a, **_k: device_map[stage_id],
+    )
+
+    from vllm_omni.engine.stage_engine_startup import StageReplicaResources
+
+    @contextlib.contextmanager
+    def _fake_launch_stage_replica(**kwargs):
+        # Mimic the real launcher: it enters scoped_spawn_device_env, which
+        # takes the spawn-env lock while the subprocess spawns.
+        spawn_lock = kwargs.get("spawn_device_lock")
+        expected_lock = getattr(runtime, "_spawn_device_lock", None)
+        assert expected_lock is not None and spawn_lock is expected_lock, (
+            "launch_stage_replica must still receive the runtime's own spawn-env lock. "
+            "If the wiring changed, fix this fake instead of relaxing the check: with a "
+            "different lock the two threads below never contend and this reproducer "
+            "silently stops exercising the deadlock."
+        )
+        with spawn_lock:
+            time.sleep(0.2)
+            yield StageReplicaResources(
+                manager=types.SimpleNamespace(shutdown=lambda: None),
+                addresses=fake_addresses,
+            )
+
+    monkeypatch.setattr(runtime_mod, "launch_stage_replica", _fake_launch_stage_replica)
+    monkeypatch.setattr(
+        runtime_mod.StageEngineCoreClientBase,
+        "make_async_mp_client",
+        staticmethod(lambda **_: types.SimpleNamespace(shutdown=lambda: None)),
+    )
+
+    errors: list[BaseException] = []
+
+    def _init(stage_id: int) -> None:
+        devices, tp = plans[stage_id]
+        try:
+            runtime._initialize_local_llm_replica(_make_plan(stage_id, devices, tp), 30)
+        except BaseException as exc:  # pragma: no cover - surfaced via assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_init, args=(sid,), daemon=True) for sid in plans]
+    for t in threads:
+        t.start()
+    deadline = time.time() + 30
+    for t in threads:
+        t.join(timeout=max(0.1, deadline - time.time()))
+
+    stuck = [t for t in threads if t.is_alive()]
+    assert not stuck, "parallel replica init deadlocked (threads still waiting on locks after 30s)"
+    assert not errors, f"replica init raised: {errors!r}"
 
 
 def test_build_engine_args_cli_tokenizer_overrides_inferred_base_tokenizer(tmp_path):

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -893,10 +893,16 @@ def acquire_device_locks(
     stage_id: int,
     engine_args_dict: dict[str, Any],
     stage_init_timeout: int,
+    visible_devices: str | None = None,
 ) -> list[int]:
     """Acquire exclusive file locks on devices needed by this stage.
 
     Returns list of lock file descriptors that must be released after init.
+
+    ``visible_devices`` (comma-separated, CUDA_VISIBLE_DEVICES format) takes
+    precedence over the device-control env var. Pass it instead of scoping a
+    device env: the flock wait below must not run under the spawn-env lock, or
+    it deadlocks against replicas holding device locks (opposing lock ordering).
     """
     lock_fds: list[int] = []
     try:
@@ -926,9 +932,12 @@ def acquire_device_locks(
             * cfg_parallel_size
         )
 
-        # Get physical device IDs
-        device_control_env = current_omni_platform.device_control_env_var
-        visible_devices_str = os.environ.get(device_control_env)
+        # Physical device IDs: explicit list first, else the env var.
+        if visible_devices is not None:
+            visible_devices_str = visible_devices
+        else:
+            device_control_env = current_omni_platform.device_control_env_var
+            visible_devices_str = os.environ.get(device_control_env)
         physical_devices: list[int] = []
 
         if visible_devices_str:

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -560,12 +560,15 @@ class StageRuntime:
                 raise RuntimeError(f"LLM stage {plan.metadata.stage_id} is missing executor_class")
             if plan.engine_args_dict is None:
                 raise RuntimeError(f"LLM stage {plan.metadata.stage_id} is missing engine args")
-            with self._scoped_spawn_device_env(physical_devices):
-                lock_fds = acquire_device_locks(
-                    plan.metadata.stage_id,
-                    plan.engine_args_dict,
-                    stage_init_timeout,
-                )
+            # Pass devices explicitly rather than scoping the device env: the
+            # flock wait must stay outside the spawn-env lock, else it deadlocks
+            # against a replica holding device locks (opposing lock ordering).
+            lock_fds = acquire_device_locks(
+                plan.metadata.stage_id,
+                plan.engine_args_dict,
+                stage_init_timeout,
+                visible_devices=physical_devices,
+            )
             # Serialize engine-core spawning across all LLM replicas to avoid
             # ZMQ port-allocation races and simultaneous CUDA context init.
             with self._replica_launch_lock:


### PR DESCRIPTION
# Purpose
**(Updated on 9.10)**
Closes #4894 together with #7328.

#7328 (merged 2026-09-09) is the primary fix for the reported stall: it groups
serial local LLM replicas by the connected component of their physical-device
overlap, so two replicas that share a GPU no longer initialize in parallel
threads inside one orchestrator. This PR is the complementary, defense-in-depth
half: it removes the **inverted lock ordering** that made the stall possible in
the first place, so the invariant holds regardless of how replicas are grouped
or who else holds a device lock on the host.

### Lock-ordering inversion (still present on `main`)

Two locks are taken in opposite order on the LLM init path:

1. **spawn-env lock** — `StageRuntime._spawn_device_lock`, a process-wide
   `threading.Lock` held by `scoped_spawn_device_env` while it rewrites
   `CUDA_VISIBLE_DEVICES`.
2. **device flocks** — per-GPU file locks taken in `acquire_device_locks`.

`_initialize_local_llm_replica` wraps the flock acquisition in the spawn-env
lock, only so `acquire_device_locks` can read the stage's devices from the env:

```python
with self._scoped_spawn_device_env(physical_devices):   # holds spawn-env lock
    lock_fds = acquire_device_locks(...)                 # may wait on a flock
...
with launch_stage_replica(..., spawn_device_lock=self._spawn_device_lock):
    ...                                                  # re-takes spawn-env lock
```

Lock order is `spawn-lock -> flock` here and `flock -> spawn-lock` in every
replica that already holds its device locks and is about to spawn. Before
#7328 that produced the AB-BA deadlock captured via `faulthandler` on a 4xH20
Ming-flash-omni run (thinker on GPUs 0-3, talker colocated on GPU 3): both
threads wait until `stage_init_timeout`, then the waiter logs
`Timeout waiting for device N initialization lock, proceeding anyway` and
continues **without** the lock.

### Why it still matters after #7328 and #7292

- #7328 only reasons about replicas **inside this process**. The flock is
  host-wide. If any other process (a second orchestrator on the same node, a
  leftover engine core from a previous run) holds a device flock, the thread
  waiting for it still holds the spawn-env lock for up to `stage_init_timeout`.
- #7292 (merged the same day) releases the launch lock right after spawn so
  replicas on **disjoint** GPUs initialize concurrently. Every one of those
  replicas needs the spawn-env lock to spawn. With the inversion in place, one
  externally blocked flock wait stalls every unrelated GPU's replica behind the
  spawn-env lock, which is exactly the serialization #7292 set out to remove,
  and ends with the waiter proceeding unlocked.

Passing the device list explicitly keeps the flock wait outside any
process-wide lock, so the cycle cannot form no matter which layer schedules the
replicas.

### Changes

- `acquire_device_locks` gains `visible_devices: str | None = None`, which
  takes precedence over the device-control env var. The env-var fallback keeps
  every other call site unchanged.
- `_initialize_local_llm_replica` drops the `scoped_spawn_device_env` wrapper
  and calls `acquire_device_locks(..., visible_devices=physical_devices)`.
- Four regression tests in `tests/engine/test_async_omni_engine_stage_init.py`:
  explicit `visible_devices` precedence, the spawn-env lock is not held during
  the flock wait, the `parallel_stage_init` path still skips the parent-side
  lock, and two replicas on a shared device initialized from two threads (below
  #7328's grouping layer) complete without deadlock.

### Not covered here: the diffusion path

`_initialize_local_diffusion_replica` on current `main` holds the spawn-env
lock (`_stage_device_scope`) around the whole launch, and
`launch_diffusion_stage_replica` calls `acquire_device_locks` from the env
inside it (`stage_engine_startup.py:1597`). #7328 keeps local diffusion in its
own `inline:diffusion` group, so a diffusion stage and an LLM stage on the same
GPU still run in parallel threads with the same inversion. Fixing it means
threading `visible_devices` through `launch_diffusion_stage_replica` and moving
the flock wait outside `_stage_device_scope`, which is a larger change to the
diffusion launch sequence; it will go in a follow-up PR that reuses the
`visible_devices` parameter added here.

## Test Plan

**vLLM Version:** 0.28.0; PyTorch 2.13.0+cu130; Python 3.12

**vLLM-Omni Commit:** c0eb569fb (this branch, merged with `main` at 35a83a088,
which includes #7328 and #7292)

`tests/engine/` has no Buildkite lane for the `bug`/`core` labels, so these are
author-run.

```bash
# the four regression tests added by this PR
pytest tests/engine/test_async_omni_engine_stage_init.py \
  -k "prefers_explicit_visible_devices or does_not_hold_spawn_lock_during_device_lock_wait or parallel_path_skips_parent_device_lock or shared_device_does_not_deadlock"

# the stage-init module, including the concurrency test added by #7292
pytest tests/engine/test_async_omni_engine_stage_init.py \
       tests/engine/test_parallel_stage_init.py \
       tests/engine/test_single_stage_mode.py \
       tests/engine/test_stage_device_layout.py \
       tests/engine/test_stage_runtime_launch_concurrency.py
```

## Test Result

Single RTX PRO 6000 Blackwell node (the tests are CPU-side and mock the engine
core).

- Four regression tests: **4 passed**.
- Stage-init module (five files above): **187 passed, 1 skipped** in 24.5 s.
- Independent verification by @Kare0638 on 2x H100 with MammothModa2 TP=2
  (comment above, on the pre-merge branch): stage-0 engine start 600 s stall ->
  81.7 s.