### PR TITLE
[Recipe] Tongyi/Z-Image-Turbo (RTX 5090 32GB)

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -62,6 +62,7 @@ recipes/
 | [`StabilityAI/Stable-Audio-Open.md`](./StabilityAI/Stable-Audio-Open.md) | Offline + online text-to-audio generation (Stable Audio Open) | 1x RTX 4090 24GB |
 | [`Tencent/Covo-Audio-Chat.md`](./Tencent/Covo-Audio-Chat.md) | Online serving for audio chat | 1x A100 80GB |
 | [`Tencent/HunyuanImage-3.0-Instruct.md`](./Tencent/HunyuanImage-3.0-Instruct.md) | DiT-only text-to-image serving and benchmark, including ModelOpt mixed FP8/NVFP4 | 4x H100/H800 80GB / 2x B200 |
+| [`Tongyi/Z-Image-Turbo.md`](./Tongyi/Z-Image-Turbo.md) | Text-to-image serving | 1x RTX 5090 32GB |
 | [`Wan-AI/Wan2.2-I2V.md`](./Wan-AI/Wan2.2-I2V.md) | Image-to-video serving (Wan2.2 14B) | 8x Ascend NPU (A2/A3) |
 | [`Wan-AI/Wan2.2-S2V.md`](./Wan-AI/Wan2.2-S2V.md) | Speech-to-video serving (Wan2.2 14B) | 2x A100/H100 80GB |
 | [`Wan-AI/Wan2.1-VACE.md`](./Wan-AI/Wan2.1-VACE.md) | Unified T2V, I2V, V2LF, FLF2V, inpaint, and R2V | 1x RTX 5090 (1.3B) / 1x L40S 48GB with layerwise offload (14B) |

--- a/recipes/Tongyi/Z-Image-Turbo.md
+++ b/recipes/Tongyi/Z-Image-Turbo.md
@@ -1,0 +1,109 @@
+# Z-Image-Turbo for text-to-image
+
+## Summary
+
+- Vendor: Tongyi
+- Model: `Tongyi-MAI/Z-Image-Turbo`
+- Task: Text-to-image generation
+- Mode: Online serving with the OpenAI-compatible image generation API
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe when you want a known-good starting point for serving
+`Tongyi-MAI/Z-Image-Turbo` with vLLM-Omni on a single NVIDIA GeForce RTX 5090
+32 GB GPU and validate the deployment with both the online image-generation API
+and the shared offline text-to-image example.
+
+## References
+
+- Upstream model card: <https://huggingface.co/Tongyi-MAI/Z-Image-Turbo>
+- Supported models:
+  [`docs/models/supported_models.md`](../../docs/models/supported_models.md)
+- Image generation API:
+  [`docs/serving/image_generation_api.md`](../../docs/serving/image_generation_api.md)
+- Related example under `examples/`:
+  [`examples/offline_inference/text_to_image/text_to_image.py`](../../examples/offline_inference/text_to_image/text_to_image.py)
+- Related docs:
+  [`docs/user_guide/examples/offline_inference/text_to_image.md`](../../docs/user_guide/examples/offline_inference/text_to_image.md)
+- Related issue or discussion:
+  [#2645](https://github.com/vllm-project/vllm-omni/issues/2645)
+
+## Hardware Support
+
+## GPU
+
+### 1x NVIDIA GeForce RTX 5090 32GB
+
+#### Environment
+
+- OS: Linux (AutoDL container)
+- Python: `3.12.3`
+- PyTorch: `2.7.0+cu128`
+- Driver / runtime: NVIDIA driver `580.105.08`, CUDA runtime `13.0`
+- GPU: NVIDIA GeForce RTX 5090 32 GB (`32607 MiB`)
+- vLLM version: `0.24.0`
+- vLLM-Omni version or commit: `0.1.dev2146+g86bdcaf3d` (`86bdcaf3`)
+
+#### Command
+
+```bash
+CUDA_VISIBLE_DEVICES=0 vllm serve Tongyi-MAI/Z-Image-Turbo \
+  --omni \
+  --port 8000
+```
+
+#### Verification
+
+Health check and image generation:
+
+```bash
+curl -s -o /tmp/zimage_health.txt -w '%{http_code}' \
+  http://127.0.0.1:8000/health
+curl -o /tmp/z_image_turbo_5090.png \
+  -X POST http://127.0.0.1:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "a cup of coffee on the table",
+    "size": "1024x1024",
+    "num_inference_steps": 9,
+    "guidance_scale": 0.0,
+    "seed": 42,
+    "response_format": "file"
+  }'
+ls -lh /tmp/z_image_turbo_5090.png
+file /tmp/z_image_turbo_5090.png
+```
+```
+
+Offline smoke test:
+
+```bash
+python examples/offline_inference/text_to_image/text_to_image.py \
+  --model Tongyi-MAI/Z-Image-Turbo \
+  --prompt "a cup of coffee on the table" \
+  --seed 42 \
+  --guidance-scale 0.0 \
+  --num-images-per-prompt 1 \
+  --num-inference-steps 9 \
+  --height 1024 \
+  --width 1024 \
+  --output /root/autodl-tmp/outputs/z_image_coffee.png
+```
+
+#### Notes
+
+- Output: online serving returned `HTTP 200 OK`; the request saved a `3.1M`
+  PNG at `/tmp/z_image_turbo_5090.png`, and `file(1)` identified it as a valid
+  `1024x1024` RGB PNG. The offline example also completed successfully and saved
+  `/root/autodl-tmp/outputs/z_image_coffee.png`.
+- Performance: the validated online request completed in `5125.196 ms`
+  end-to-end (`num_inference_steps=9`, `guidance_scale=0.0`, `1024x1024`).
+  The offline example completed in `5.3693 s`.
+- Memory usage: observed model loading used `19.1941 GiB`; process-scoped GPU
+  memory after loading was `19.96 GiB`; offline peak memory was `24230 MB`
+  (~`23.66 GiB`). This is consistent with the user-guide baseline of `24.8 GiB`
+  peak VRAM for `1024x1024`.
+- Key flags: `--omni` is required. `Tongyi-MAI/Z-Image-Turbo` is a distilled
+  model, so start from `4-9` denoising steps with `guidance_scale=0.0` rather
+  than using large CFG values or 50-step diffusion defaults.


### PR DESCRIPTION
## Summary

Add a new community recipe for serving `Tongyi-MAI/Z-Image-Turbo` on `1x NVIDIA GeForce RTX 5090 32GB`.

This recipe documents:
- environment details for an AutoDL-based CUDA setup
- online serving with the OpenAI-compatible image generation API
- a no-`jq` verification path using `response_format: "file"`
- validated server-side and client-side output checks

## Related Issue

- related to #2645

## Environment

- OS: Linux (AutoDL container)
- Python: `3.12.3`
- PyTorch: `2.7.0+cu128`
- Driver: `580.105.08`
- CUDA runtime: `13.0`
- GPU: `NVIDIA GeForce RTX 5090 32GB`
- vLLM-Omni commit: `86bdcaf3`

## Test Plan

1. Start the server:

```bash
export HF_HOME=/root/autodl-tmp/hf
export HUGGINGFACE_HUB_CACHE=/root/autodl-tmp/hf/hub
export TRANSFORMERS_CACHE=/root/autodl-tmp/hf/transformers
export TORCH_HOME=/root/autodl-tmp/torch
export TRITON_CACHE_DIR=/root/autodl-tmp/triton
export TMPDIR=/root/autodl-tmp/tmp

CUDA_VISIBLE_DEVICES=0 vllm serve Tongyi-MAI/Z-Image-Turbo \
  --omni \
  --port 8000
```

2. Check health:

```bash
curl -s -o /tmp/zimage_health.txt -w '%{http_code}' \
  http://127.0.0.1:8000/health
```

3. Send an online generation request without `jq`:

```bash
curl -o /tmp/z_image_turbo_5090.png \
  -X POST http://127.0.0.1:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "a cup of coffee on the table",
    "size": "1024x1024",
    "num_inference_steps": 9,
    "guidance_scale": 0.0,
    "seed": 42,
    "response_format": "file"
  }'
```

4. Verify the saved file:

```bash
ls -lh /tmp/z_image_turbo_5090.png
file /tmp/z_image_turbo_5090.png
```

## Test Results

- Server returned `HTTP 200 OK` for `/v1/images/generations`
- Request parameters:
  - resolution: `1024x1024`
  - batch size: `1`
  - `num_inference_steps=9`
  - `guidance_scale=0.0`
  - `seed=42`
- Server-side observed metrics:
  - `e2e_wall_time_ms = 5125.196`
  - `e2e_avg_time_per_request_ms = 5125.196`
  - `e2e_stage_0_wall_time_ms = 5120.172`
  - `denoise_step_latency_ms = 568.803`
  - `serving_time_to_first_output_ms = 5124.620`
- Client-side observed output:
  - file path: `/tmp/z_image_turbo_5090.png`
  - file size: `3.1M`
  - file type: `PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced`
- Observed GPU memory footprint during model load / serving: about `24.8 GiB`

## Notes

- `Tongyi-MAI/Z-Image-Turbo` is a distilled diffusion model, so this recipe uses `4-9` steps and `guidance_scale=0.0` instead of a Qwen-Image-style 50-step CFG setup.
- The verification path intentionally avoids `jq`, since `response_format: "file"` works better in minimal environments.