### PR TITLE
[Bugfix] text_to_image example: LoRA request is silently dropped (pass it via sampling params fields)

### DIFF
--- a/examples/offline_inference/text_to_image/text_to_image.py
+++ b/examples/offline_inference/text_to_image/text_to_image.py
@@ -522,8 +522,8 @@ def main():
         diffusion_params.extra_args.update({k: v for k, v in user_extra.items() if v is not None})
 
     if lora_request:
-        diffusion_params.extra_args["lora_request"] = lora_request
-        diffusion_params.extra_args["lora_scale"] = args.lora_scale
+        diffusion_params.lora_request = lora_request
+        diffusion_params.lora_scale = args.lora_scale
 
     # Build per-stage sampling params for multi-stage models (e.g. BAGEL),
     # or wrap single diffusion params for single-stage models.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Running the text-to-image example with `--lora-path` prints `Using LoRA from: ...` and `LoRA: scale=1.0`, but the generated image is **bit-identical** to a run without any LoRA — the adapter is silently ignored.

Root cause: the example stores the LoRA request in `extra_args`:

```python
diffusion_params.extra_args["lora_request"] = lora_request
diffusion_params.extra_args["lora_scale"] = args.lora_scale
```

but nothing consumes `extra_args["lora_request"]`. (The LoRA flags were added to this example in #4354 as part of the example consolidation; the init-time `lora_path` preload half is wired correctly, but the per-request half went to `extra_args` instead of the sampling-params fields.) The diffusion worker reads the **fields** `OmniDiffusionSamplingParams.lora_request` / `.lora_scale` (`vllm_omni/inputs/data.py`, `diffusion_worker.py`). Since the field arrives as `None`, the worker calls `lora_manager.set_active_adapter(None, ...)`, which also **deactivates** the adapter that was statically loaded at engine init — so the run degrades to base-model output while logging that LoRA is in use. The OpenAI serving path already sets the fields directly (e.g. `serving_video.py`: `gen_params.lora_request = lora_request`); this fix makes the example do the same (2 lines).

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 0798b0b

With a PEFT-format LoRA adapter (any PEFT adapter reproduces this; ours was a step-distillation adapter, which makes the effect visible at a glance) — the same command run three ways, only the checkout differs. Replace `/path/to/peft_adapter` with your local adapter directory:

```bash
# (a) before the fix (on main), with LoRA
python examples/offline_inference/text_to_image/text_to_image.py \
  --model Qwen/Qwen-Image \
  --prompt "a corgi wearing sunglasses on a beach, golden hour, photo" \
  --seed 42 --num-inference-steps 4 --cfg-scale 1.0 \
  --lora-path /path/to/peft_adapter --lora-scale 1.0 \
  --output before.png

# (b) control: same command without the two LoRA flags
python examples/offline_inference/text_to_image/text_to_image.py \
  --model Qwen/Qwen-Image \
  --prompt "a corgi wearing sunglasses on a beach, golden hour, photo" \
  --seed 42 --num-inference-steps 4 --cfg-scale 1.0 \
  --output nolora.png

# (c) after the fix (on this branch): identical command to (a)
python examples/offline_inference/text_to_image/text_to_image.py \
  --model Qwen/Qwen-Image \
  --prompt "a corgi wearing sunglasses on a beach, golden hour, photo" \
  --seed 42 --num-inference-steps 4 --cfg-scale 1.0 \
  --lora-path /path/to/peft_adapter --lora-scale 1.0 \
  --output after.png

md5sum before.png nolora.png after.png
```

## Test Result

| run | md5 of output |
|---|---|
| (a) `--lora-path`, on `main` (before fix) | `ae4fe3a8fb3d77f497aade2e446c8ba5` |
| (b) no LoRA at all | `ae4fe3a8fb3d77f497aade2e446c8ba5` (**identical to (a)** -> the LoRA was a no-op) |
| (c) `--lora-path`, on this branch (after fix) | `7d39439867cec99bba681c0a6d8ff30a` — the 4-step output is a clean, fully-formed image, as expected from a step-distillation adapter actually being applied |

The same adapter passed through `OmniDiffusionSamplingParams(lora_request=..., lora_scale=...)` directly produces the same post-fix behavior, confirming the fields are the correct wiring.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
