### PR TITLE
[BugFix] Preserve diffusion extra_body params for out-of-process CFG Parallel

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -208,9 +208,12 @@ class AsyncOmni(EngineClient, OmniBase):
 
     def get_diffusion_od_config(self) -> Any | None:
         """Return the diffusion-stage config when the pipeline has one."""
+        saw_diffusion_stage = False
         for stage_client in self.engine.stage_clients:
             if getattr(stage_client, "stage_type", None) != "diffusion":
                 continue
+
+            saw_diffusion_stage = True
 
             od_config = getattr(stage_client, "od_config", None)
             if od_config is not None:
@@ -220,6 +223,11 @@ class AsyncOmni(EngineClient, OmniBase):
             od_config = getattr(inner_engine, "od_config", None)
             if od_config is not None:
                 return od_config
+
+        # Out-of-process diffusion clients don't carry od_config (it lives in the
+        # worker); fall back to the engine's model_class_name resolution.
+        if saw_diffusion_stage:
+            return self.engine.get_diffusion_od_config()
 
         return None
 


### PR DESCRIPTION
## Purpose

Fix #4882

Real chat/diffusion requests reached the Bagel pipeline with an empty `extra_args`, so `cfg_img_scale` fell back to its 1.5 default. With `cfg_parallel_size=2` that default requires a 3-branch (image-CFG) layout and raised: "Image CFG (cfg_img_scale=1.5) requires cfg_parallel_size=3" — the CI CFG-parallel Bagel failure.

Root cause: `AsyncOmni.get_diffusion_od_config()` only read `od_config` off the stage clients. In multi-process / CFG-parallel deployments the diffusion stage client is a thin RPC `StageDiffusionClient` that does not carry `od_config` (it lives in the worker), so resolution returned None. The empty od_config made `serving_chat._get_diffusion_extra_body_params()` yield an empty allowlist, and `apply_declared_extra_args` then dropped every model-specific extra_body param (cfg_img_scale, cfg_text_scale, ...). Single-card runs used an in-process (inline) client that does expose od_config, which is why only the CFG-parallel path failed.

Fix: fall back to the orchestrator engine's client-side `model_class_name` resolution (already implemented on `AsyncOmniEngine.get_diffusion_od_config`) when a diffusion stage exists but its client does not expose `od_config`.

## Test Plan

```
pytest -sv tests/e2e/online_serving/test_bagel_expansion.py::test_bagel[parallel_cfg_2] -m "full_model and diffusion and H100 and distributed_cuda" --run-level "full_model"
```

## Test Result

```
INFO 07-05 15:27:35 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:27:36 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:27:36 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
=========================================== test session starts ============================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /proj-tango-pvc/users/zhipeng.wang/vllm-omni/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /proj-tango-pvc/users/zhipeng.wang/vllm-omni
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.1, mock-3.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                           

tests/e2e/online_serving/test_bagel_expansion.py::test_bagel[parallel_cfg_2] INFO 07-05 15:27:36 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 07-05 15:27:36 [vllm.py:1006] Asynchronous scheduling is enabled.
INFO 07-05 15:27:36 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
Pre-test GPU status:
[GPU Memory Monitor] Waiting for GPU 0, 1, 2, 3, 4, 5, 6, 7 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 0: 0.9GiB/268.6GiB (0.3%)
  GPU 1: 0.9GiB/268.6GiB (0.3%)
  GPU 2: 0.9GiB/268.6GiB (0.3%)
  GPU 3: 0.9GiB/268.6GiB (0.3%)
  GPU 4: 0.9GiB/268.6GiB (0.3%)
  GPU 5: 0.9GiB/268.6GiB (0.3%)
  GPU 6: 0.9GiB/268.6GiB (0.3%)
  GPU 7: 0.9GiB/268.6GiB (0.3%)
[GPU Memory Freed] Devices 0, 1, 2, 3, 4, 5, 6, 7 meet memory condition
   Condition: Memory usage ratio ≤ 5.0%
   Wait time: 0.0 seconds (0.0 minutes)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
Sun Jul  5 15:27:37 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.20             Driver Version: 580.126.20     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA B300 SXM6 AC            On  |   00000000:1A:00.0 Off |                    0 |
| N/A   32C    P0            178W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA B300 SXM6 AC            On  |   00000000:69:00.0 Off |                    0 |
| N/A   38C    P0            180W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA B300 SXM6 AC            On  |   00000000:B5:00.0 Off |                    0 |
| N/A   33C    P0            177W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
... (showing first 20 of 48 lines)

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0          -     -      -      -      -      -      -      -    -              
    1          -     -      -      -      -      -      -      -    -              
    2          -     -      -      -      -      -      -      -    -              
    3          -     -      -      -      -      -      -      -    -              
    4          -     -      -      -      -      -      -      -    -              
    5          -     -      -      -      -      -      -      -    -              
    6          -     -      -      -      -      -      -      -    -              
    7          -     -      -      -      -      -      -      -    -

================================================================================
System Processes with GPU keywords
================================================================================
Launching OmniServer with: /proj-tango-pvc/users/zhipeng.wang/vllm-omni/.venv/bin/python3 -m vllm_omni.entrypoints.cli.main serve ByteDance-Seed/BAGEL-7B-MoT --host 127.0.0.1 --port 50669 --omni --cache-backend tea_cache --cfg-parallel-size 2 --stage-init-timeout 600 --init-timeout 900 --log-stats --stage-configs-path /tmp/bagel_j7_3aluf.yaml
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2142+g29dcdec66
 --> vLLM version 0.24.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
INFO 07-05 15:27:52 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:27:55 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:27:55 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:205: UserWarning: The `local_dir_use_symlinks` argument is deprecated and ignored in `hf_hub_download`. Downloading to a local directory does not use symlinks anymore.
  warnings.warn(
INFO 07-05 15:27:58 [serve.py:174] Detected diffusion model: ByteDance-Seed/BAGEL-7B-MoT
INFO 07-05 15:27:58 [logo.py:52]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 07-05 15:27:58 [logo.py:52]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 07-05 15:27:58 [logo.py:52]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 07-05 15:27:58 [logo.py:52]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 07-05 15:27:58 [logo.py:52] 
(APIServer pid=183862) INFO 07-05 15:27:58 [api_utils.py:339] vLLM server version 0.24.0, serving model ByteDance-Seed/BAGEL-7B-MoT
(APIServer pid=183862) INFO 07-05 15:27:58 [api_utils.py:273] non-default args: {'model_tag': 'ByteDance-Seed/BAGEL-7B-MoT', 'host': '127.0.0.1', 'port': 50669, 'model': 'ByteDance-Seed/BAGEL-7B-MoT'}
(APIServer pid=183862) INFO 07-05 15:27:58 [weight_utils.py:50] Using model weights format ['*']
(APIServer pid=183862) INFO 07-05 15:27:58 [omni_base.py:167] [AsyncOmni] Initializing with model ByteDance-Seed/BAGEL-7B-MoT
(APIServer pid=183862) INFO 07-05 15:27:58 [async_omni_engine.py:239] [AsyncOmniEngine] Initializing with model ByteDance-Seed/BAGEL-7B-MoT
(APIServer pid=183862) INFO 07-05 15:27:59 [async_omni_engine.py:301] [AsyncOmniEngine] Launching Orchestrator thread with 2 stages
(APIServer pid=183862) INFO 07-05 15:27:59 [initialization.py:364] Loaded OmniTransferConfig with 1 connector configurations
(APIServer pid=183862) WARNING 07-05 15:27:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_URL
(APIServer pid=183862) WARNING 07-05 15:27:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_IMAGE_TAG
(APIServer pid=183862) WARNING 07-05 15:27:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_PIPELINE
(APIServer pid=183862) WARNING 07-05 15:27:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_COMMIT
(APIServer pid=183862) INFO 07-05 15:28:00 [model.py:598] Resolved architecture: OmniBagelForConditionalGeneration
(APIServer pid=183862) INFO 07-05 15:28:00 [model.py:1725] Using max model len 32768
(APIServer pid=183862) INFO 07-05 15:28:00 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=32768.
(APIServer pid=183862) INFO 07-05 15:28:00 [vllm.py:1006] Asynchronous scheduling is enabled.
(APIServer pid=183862) INFO 07-05 15:28:00 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=183862) WARNING 07-05 15:28:00 [cuda.py:322] Forcing --disable_chunked_mm_input for models with multimodal-bidirectional attention.
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2142+g29dcdec66
 --> vLLM version 0.24.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
INFO 07-05 15:28:16 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:28:17 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:28:17 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
INFO 07-05 15:28:21 [multiproc_executor.py:188] Starting server...
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2142+g29dcdec66
 --> vLLM version 0.24.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2142+g29dcdec66
 --> vLLM version 0.24.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
INFO 07-05 15:28:34 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:28:35 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:28:36 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:28:36 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
INFO 07-05 15:28:36 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:28:36 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
INFO 07-05 15:28:39 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 07-05 15:28:39 [vllm.py:1006] Asynchronous scheduling is enabled.
INFO 07-05 15:28:39 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 07-05 15:28:39 [diffusion_worker.py:267] Final IR op priority after setting vLLM-Omni overrides: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 07-05 15:28:40 [diffusion_worker.py:752] Worker 0 created result MessageQueue
INFO 07-05 15:28:40 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 07-05 15:28:40 [vllm.py:1006] Asynchronous scheduling is enabled.
INFO 07-05 15:28:40 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 07-05 15:28:40 [diffusion_worker.py:267] Final IR op priority after setting vLLM-Omni overrides: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 07-05 15:28:40 [diffusion_worker.py:279] Worker 0: Initialized device and distributed environment.
INFO 07-05 15:28:40 [diffusion_worker.py:279] Worker 1: Initialized device and distributed environment.
INFO 07-05 15:28:40 [parallel_state.py:588] Building SP subgroups from explicit sp_group_ranks (sp_size=1, ulysses=1, ring=1, use_ulysses_low=True).
INFO 07-05 15:28:40 [parallel_state.py:588] Building SP subgroups from explicit sp_group_ranks (sp_size=1, ulysses=1, ring=1, use_ulysses_low=True).
INFO 07-05 15:28:40 [parallel_state.py:630] SP group details for rank 0: sp_group=[0], ulysses_group=[0], ring_group=[0]
INFO 07-05 15:28:40 [parallel_state.py:630] SP group details for rank 1: sp_group=[1], ulysses_group=[1], ring_group=[1]
INFO 07-05 15:28:41 [weight_utils.py:50] Using model weights format ['*']
INFO 07-05 15:28:41 [weight_utils.py:50] Using model weights format ['*']
[transformers] You are using a model of type `bagel` to instantiate a model of type ``. This may be expected if you are loading a checkpoint that shares a subset of the architecture (e.g., loading a `sam2_video` checkpoint into `Sam2Model`), but is otherwise not supported and can yield errors. Please verify that the checkpoint is compatible with the model you are instantiating.
[transformers] You are using a model of type `bagel` to instantiate a model of type ``. This may be expected if you are loading a checkpoint that shares a subset of the architecture (e.g., loading a `sam2_video` checkpoint into `Sam2Model`), but is otherwise not supported and can yield errors. Please verify that the checkpoint is compatible with the model you are instantiating.
INFO 07-05 15:28:41 [platform.py:155] Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_103, cuDNN 91900)
INFO 07-05 15:28:41 [selector.py:87] Resolved diffusion attention backend 'CUDNN_ATTN' for role='self' via platform default
INFO 07-05 15:28:42 [platform.py:155] Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_103, cuDNN 91900)
INFO 07-05 15:28:42 [selector.py:87] Resolved diffusion attention backend 'CUDNN_ATTN' for role='self' via platform default
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Multi-thread loading shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Multi-thread loading shards:  50% Completed | 1/2 [00:02<00:02,  2.54s/it]
Multi-thread loading shards: 100% Completed | 2/2 [00:15<00:00,  8.92s/it]
Multi-thread loading shards: 100% Completed | 2/2 [00:15<00:00,  7.96s/it]

INFO 07-05 15:28:59 [pipeline_bagel.py:1004] BagelPipeline weight filter kept 1467/1467 tensors (shape mismatches seen: 0)
INFO 07-05 15:29:00 [diffusion_model_runner.py:209] Model loading took 27.4895 GiB and 20.317248 seconds
INFO 07-05 15:29:00 [diffusion_model_runner.py:214] Model runner: Model loaded successfully.
INFO 07-05 15:29:00 [backend.py:140] Using custom TeaCache enabler for model: BagelPipeline
INFO 07-05 15:29:00 [backend.py:54] TeaCache applied with rel_l1_thresh=0.2, transformer_class=Bagel
INFO 07-05 15:29:00 [diffusion_model_runner.py:288] Model runner: Initialization complete.
INFO 07-05 15:29:00 [diffusion_worker.py:337] Worker 1: Process-scoped GPU memory after model loading: 28.30 GiB.
INFO 07-05 15:29:00 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:1, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 07-05 15:29:00 [diffusion_worker.py:228] Worker 1: Initialization complete.
INFO 07-05 15:29:00 [diffusion_worker.py:988] Worker 1: Scheduler loop started.
INFO 07-05 15:29:00 [diffusion_worker.py:880] Worker 1 ready to receive requests via shared memory
INFO 07-05 15:29:02 [diffusers_loader.py:428] Loading weights took 19.00 seconds
INFO 07-05 15:29:03 [diffusion_model_runner.py:209] Model loading took 27.4895 GiB and 22.903391 seconds
INFO 07-05 15:29:03 [diffusion_model_runner.py:214] Model runner: Model loaded successfully.
INFO 07-05 15:29:03 [backend.py:140] Using custom TeaCache enabler for model: BagelPipeline
INFO 07-05 15:29:03 [backend.py:54] TeaCache applied with rel_l1_thresh=0.2, transformer_class=Bagel
INFO 07-05 15:29:03 [diffusion_model_runner.py:288] Model runner: Initialization complete.
INFO 07-05 15:29:03 [diffusion_worker.py:337] Worker 0: Process-scoped GPU memory after model loading: 28.30 GiB.
INFO 07-05 15:29:03 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 07-05 15:29:03 [diffusion_worker.py:228] Worker 0: Initialization complete.
INFO 07-05 15:29:03 [diffusion_worker.py:988] Worker 0: Scheduler loop started.
INFO 07-05 15:29:03 [diffusion_worker.py:880] Worker 0 ready to receive requests via shared memory
INFO 07-05 15:29:03 [diffusion_engine.py:797] dummy run to warm up the model
INFO 07-05 15:29:03 [kv_transfer_manager.py:554] Initializing OmniConnector type=SharedMemoryConnector role=receiver
INFO 07-05 15:29:03 [factory.py:46] Created connector: SharedMemoryConnector
INFO 07-05 15:29:03 [kv_transfer_manager.py:1354] Skip receiving KV cache for dummy warmup request
INFO 07-05 15:29:07 [stage_diffusion_proc.py:130] StageDiffusionProc initialized with model: ByteDance-Seed/BAGEL-7B-MoT
(APIServer pid=183862) INFO 07-05 15:29:07 [stage_diffusion_client.py:142] [StageDiffusionClient] stage-1 [rep-0] initialized (owns_process=True, batch_size=1)
(APIServer pid=183862) INFO 07-05 15:29:07 [stage_runtime.py:656] [StageRuntime] Stage 1 replica 0 initialized (diffusion, batch_size=1)
(APIServer pid=183862) INFO 07-05 15:29:07 [stage_runtime.py:550] [stage_init] Stage-0 set runtime devices: 0
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2142+g29dcdec66
 --> vLLM version 0.24.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
INFO 07-05 15:30:04 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-05 15:30:06 [quack_fp8.py:76] Quack FP8 fused-bias GEMM enabled (CuteDSL).
INFO 07-05 15:30:06 [quack_fp8.py:128] Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:09 [core.py:114] Initializing a V1 LLM engine (v0.24.0) with config: model='ByteDance-Seed/BAGEL-7B-MoT', speculative_config=None, tokenizer='ByteDance-Seed/BAGEL-7B-MoT', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_verbose=False), seed=0, served_model_name=ByteDance-Seed/BAGEL-7B-MoT, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 4, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
(StageEngineCoreProc_stage0_replica0 pid=187820) Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:12 [parallel_state.py:1588] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.0.68.32:53053 backend=nccl
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:12 [parallel_state.py:1923] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:30:13 [memory_utils.py:39] Free memory on device cuda:0 (87.59/267.69 GiB) on startup is less than desired GPU memory utilization (0.45, 120.46 GiB). Capping requested memory to available free memory (87.59 GiB). This is expected when multiple Omni stages share a GPU; the per-process NVML accounting in determine_available_memory() will compute the correct KV cache budget.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:13 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(StageEngineCoreProc_stage0_replica0 pid=187820) [transformers] `OmniBagelProcessor` defines `image_processor_class = 'SiglipImageProcessor'`, which is deprecated. Register the correct mapping in `AutoImageProcessor` instead.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:26 [kv_transfer_manager.py:554] Initializing OmniConnector type=SharedMemoryConnector role=sender
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:26 [factory.py:46] Created connector: SharedMemoryConnector
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:26 [kv_transfer_manager.py:413] Sender connector eagerly initialized
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:30:26 [base.py:188] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:30:26 [base.py:188] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:26 [gpu_model_runner.py:5160] Starting to load model ByteDance-Seed/BAGEL-7B-MoT...
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:27 [vllm.py:1006] Asynchronous scheduling is enabled.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:27 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:27 [cuda.py:420] Using AttentionBackendEnum.TRITON_ATTN backend.
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:30:28 [bagel.py:391] Overriding vit_config.num_hidden_layers from 27 to 26 to match the Bagel model checkpoint.
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:30:28 [bagel.py:397] Setting vit_config.vision_use_head to False as it is not present in the Bagel model checkpoint.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:28 [cuda.py:521] Using backend AttentionBackendEnum.TORCH_SDPA for vit attention
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:28 [mm_encoder_attention.py:373] Using AttentionBackendEnum.TORCH_SDPA for MMEncoderAttention.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:31 [weight_utils.py:849] Filesystem type for checkpoints: EPC. Checkpoint size: 27.52 GiB. Available RAM: 2935.99 GiB.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:31 [weight_utils.py:872] Auto-prefetch is disabled because the filesystem (EPC) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  3.81it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:02<00:00,  1.48s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:02<00:00,  1.30s/it]
(StageEngineCoreProc_stage0_replica0 pid=187820) 
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:47 [default_loader.py:430] Loading weights took 16.25 seconds
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:48 [gpu_model_runner.py:5255] Model loading took 27.45 GiB memory and 20.466955 seconds
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:30:49 [gpu_model_runner.py:6271] Encoder cache will be initialized with a budget of 32768 tokens, and profiled with 3 img2img items of the maximum feature size.
(StageEngineCoreProc_stage0_replica0 pid=187820) /proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/diffusion/models/bagel/bagel_transformer.py:1239: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /pytorch/torch/csrc/autograd/python_variable_indexing.cpp:347.)
(StageEngineCoreProc_stage0_replica0 pid=187820)   return self.pos_embed[position_ids]
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:04 [base.py:142] Available KV cache memory: 59.03 GiB (process-scoped)
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:04 [kv_cache_utils.py:2146] GPU KV cache size: 1,105,248 tokens
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:04 [kv_cache_utils.py:2147] Maximum concurrency for 32,768 tokens per request: 33.73x
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:31:04 [base.py:188] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:05 [deep_gemm.py:175] deep_gemm not found in site-packages, trying vendored vllm.third_party.deep_gemm
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:05 [deep_gemm.py:202] DeepGEMM PDL enabled on vllm.third_party.deep_gemm.
(StageEngineCoreProc_stage0_replica0 pid=187820) 2026-07-05 15:31:05,093 - INFO - autotuner.py:622 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(StageEngineCoreProc_stage0_replica0 pid=187820) 2026-07-05 15:31:05,742 - INFO - autotuner.py:641 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|                       | 0/3 [00:00<?, ?it/s](StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:07 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/38eac66ed7/rank_0_0/backbone for vLLM's torch.compile
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:07 [backends.py:1148] Dynamo bytecode transform time: 1.67 s
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:09 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 32768) from the cache, took 1.177 s
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:09 [decorators.py:311] Directly load AOT compilation from path /root/.cache/vllm/torch_compile_cache/torch_aot_compile/e48d576296b1a6155598b6e0178965efa610b9355bd28ed682ef255dac85bb6c/rank_0_0/model
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:09 [monitor.py:53] torch.compile took 3.13 s in total
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:09 [monitor.py:81] Initial profiling/warmup run took 0.07 s
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|███████████████| 3/3 [00:03<00:00,  1.12s/it]
Capturing CUDA graphs (decode, FULL): 100%|██████████████████████████████████| 2/2 [00:00<00:00, 19.48it/s]
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:10 [gpu_model_runner.py:6656] Graph capturing finished in 4 secs, took -30.43 GiB
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:10 [jit_monitor.py:60] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:10 [core.py:337] init engine (profile, create kv cache, warmup model) took 21.54 s (compilation: 3.13 s)
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:31:10 [scheduler.py:192] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARAsyncScheduler. This scheduler interface is not public and compatibility may not be maintained. If you have subclassed Scheduler instead of AsyncScheduler, you will see degraded performance due to async scheduling being disabled.
(APIServer pid=183862) INFO 07-05 15:31:10 [stage_runtime.py:586] [StageRuntime] Stage 0 engine startup completed
(APIServer pid=183862) INFO 07-05 15:31:10 [stage_engine_core_client.py:157] [StageEngineCoreClient] stage-0 [rep-0] initializing EngineCore
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:31:10 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=183862) INFO 07-05 15:31:11 [stage_engine_core_client.py:213] [StageEngineCoreClient] stage-0 [rep-0] EngineCore running
(APIServer pid=183862) INFO 07-05 15:31:11 [stage_runtime.py:600] [StageRuntime] Stage 0 initialized
(APIServer pid=183862) [transformers] `OmniBagelProcessor` defines `image_processor_class = 'SiglipImageProcessor'`, which is deprecated. Register the correct mapping in `AutoImageProcessor` instead.
(APIServer pid=183862) INFO 07-05 15:31:31 [orchestrator.py:332] [Orchestrator] Starting event loop
(APIServer pid=183862) INFO 07-05 15:31:31 [async_omni_engine.py:328] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=183862) INFO 07-05 15:31:31 [omni_base.py:185] [AsyncOmni] AsyncOmniEngine initialized in 212.26 seconds
(APIServer pid=183862) INFO 07-05 15:31:31 [omni_base.py:205] [AsyncOmni] Initialized with 2 stages for model ByteDance-Seed/BAGEL-7B-MoT
(APIServer pid=183862) INFO 07-05 15:31:31 [api_server.py:814] Supported tasks: {'generate'}
(APIServer pid=183862) WARNING 07-05 15:31:31 [model.py:1477] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.05, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=183862) [transformers] `BagelProcessor` defines `image_processor_class = 'SiglipImageProcessor'`, which is deprecated. Register the correct mapping in `AutoImageProcessor` instead.
(APIServer pid=183862) INFO 07-05 15:31:34 [hf.py:548] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=183862) INFO 07-05 15:31:56 [base.py:223] Multi-modal warmup completed in 21.849s
(APIServer pid=183862) INFO 07-05 15:31:56 [base.py:223] Readonly multi-modal warmup completed in 0.199s
(APIServer pid=183862) INFO 07-05 15:31:57 [speaker_cache.py:242] Speaker cache ready (max_bytes=536870912)
(APIServer pid=183862) INFO 07-05 15:31:57 [serving_speech.py:335] Speaker storage: dir=/root/.cache/vllm-omni/speakers, max_speakers=1000, restored=0
(APIServer pid=183862) WARNING 07-05 15:31:57 [serving_speech.py:820] Could not load speakers from model config: 'BagelConfig' object has no attribute 'talker_config'
(APIServer pid=183862) INFO 07-05 15:31:57 [serving_speech.py:495] Loaded 0 supported speakers: []
(APIServer pid=183862) WARNING 07-05 15:31:57 [serving_speech.py:650] Failed to load codec frame rate from speech tokenizer config: ByteDance-Seed/BAGEL-7B-MoT does not appear to have a file named speech_tokenizer/config.json. Checkout 'https://huggingface.co/ByteDance-Seed/BAGEL-7B-MoT/tree/main' for available files.
(APIServer pid=183862) INFO 07-05 15:31:57 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=183862) INFO 07-05 15:31:57 [api_server.py:531] Starting vLLM API server 0 on http://127.0.0.1:50669
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:37] Available routes are:
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/chat/completions/derender, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/completions/derender, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/generate, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos/sync, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/omni/sleep, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:46] Route: /v1/omni/wakeup, Methods: POST
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:57] Route: /v1/video/chat/stream, Endpoint: streaming_video_chat
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:57] Route: /v1/realtime/video, Endpoint: streaming_video_output
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:57] Route: /v1/realtime, Endpoint: realtime_websocket
(APIServer pid=183862) INFO 07-05 15:31:57 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=183862) INFO:     Started server process [183862]
(APIServer pid=183862) INFO:     Waiting for application startup.
(APIServer pid=183862) INFO:     Application startup complete.
Server ready on 127.0.0.1:50669 (OmniServer startup took 260.020s)
OmniServer started successfully
--- Running test: test_bagel[parallel_cfg_2]
(APIServer pid=183862) WARNING 07-05 15:31:59 [input_processor.py:282] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
(APIServer pid=183862) [transformers] Keyword argument `target_h` is not a valid argument for this processor and will be ignored.
(APIServer pid=183862) [transformers] Keyword argument `target_w` is not a valid argument for this processor and will be ignored.
(APIServer pid=183862) [transformers] Keyword argument `modalities` is not a valid argument for this processor and will be ignored.
(APIServer pid=183862) INFO 07-05 15:32:21 [stage_engine_core_client.py:233] [StageEngineCoreClient] stage-0 [rep-0] add request: chatcmpl-8e8f0512f75e1b04-9fc78dc2
(APIServer pid=183862) INFO 07-05 15:32:21 [async_omni_engine.py:818] [AsyncOmniEngine] CFG expansion for req chatcmpl-8e8f0512f75e1b04-9fc78dc2: 1 companions
(APIServer pid=183862) INFO 07-05 15:32:21 [stage_engine_core_client.py:233] [StageEngineCoreClient] stage-0 [rep-0] add request: chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text
(APIServer pid=183862) INFO 07-05 15:32:21 [orchestrator.py:570] [Orchestrator] CFG companion submitted: chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text (role=cfg_text, parent=chatcmpl-8e8f0512f75e1b04-9fc78dc2, stage-0 replica-0)
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:32:21 [gpu_model_runner.py:604] additional_information on request data is deprecated, use model_intermediate_buffer
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:32:21 [jit_monitor.py:106] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
(StageEngineCoreProc_stage0_replica0 pid=187820) WARNING 07-05 15:32:21 [jit_monitor.py:106] Triton kernel JIT compilation during inference: kernel_unified_attention. This causes a latency spike; consider extending warmup to cover this shape/config.
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:32:21 [kv_transfer_manager.py:1101] KV cache serialized for chatcmpl-8e8f0512f75e1b04-9fc78dc2 in 2.7 ms
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:32:21 [kv_transfer_manager.py:1115] KV transfer OK: chatcmpl-8e8f0512f75e1b04-9fc78dc2, 1036773 bytes across 1 key(s), 0.002s, 603.8 MB/s
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:32:21 [kv_transfer_manager.py:1101] KV cache serialized for chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text in 1.8 ms
(StageEngineCoreProc_stage0_replica0 pid=187820) INFO 07-05 15:32:21 [kv_transfer_manager.py:1115] KV transfer OK: chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text, 635369 bytes across 1 key(s), 0.001s, 904.6 MB/s
(APIServer pid=183862) WARNING 07-05 15:32:21 [orchestrator.py:1204] [Orchestrator] req=chatcmpl-8e8f0512f75e1b04-9fc78dc2: only 0/1 CFG companion outputs arrived; downstream CFG conditioning may degrade
(APIServer pid=183862) INFO 07-05 15:32:21 [stage_diffusion_client.py:340] [StageDiffusionClient] stage-1 [rep-0] add request: chatcmpl-8e8f0512f75e1b04-9fc78dc2
INFO 07-05 15:32:21 [kv_transfer_manager.py:908] Sender info updated: host=10.0.68.32, base_port=50151, adjusted_port=50151 (local_rank=0)
INFO 07-05 15:32:21 [kv_transfer_manager.py:1376] Wait for KV cache for request chatcmpl-8e8f0512f75e1b04-9fc78dc2 from stage 0 to 1 via 1 key(s)...
/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py:319: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1586.)
  return torch.frombuffer(tensor_data_mv, dtype=torch.uint8, offset=offset, count=nbytes)
INFO 07-05 15:32:21 [kv_transfer_manager.py:1475] Successfully received KV cache for chatcmpl-8e8f0512f75e1b04-9fc78dc2, 1036773 bytes across 1 key(s), wait=0.002s, link=2.2ms
INFO 07-05 15:32:21 [kv_transfer_manager.py:1376] Wait for KV cache for request chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text from stage 0 to 1 via 1 key(s)...
INFO 07-05 15:32:21 [kv_transfer_manager.py:1475] Successfully received KV cache for chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text, 635369 bytes across 1 key(s), wait=0.001s, link=0.9ms
INFO 07-05 15:32:21 [bagel.py:265] Collected CFG KV cache for role=cfg_text, rid=chatcmpl-8e8f0512f75e1b04-9fc78dc2__cfg_text, size=635369 bytes
INFO 07-05 15:32:21 [kv_transfer_manager.py:1594] Applied CFG KV caches: ['cfg_text_past_key_values', 'cfg_text_kv_metadata']
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643] D2D: failed to serialize side-payload; falling back to object transport
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643] Traceback (most recent call last):
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]   File "/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py", line 1641, in _pack_kv_payload
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]     side_bytes = OmniSerializer.serialize(side)
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]   File "/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/distributed/omni_connectors/utils/serialization.py", line 344, in serialize
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]     return self.encoder.encode(obj)
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]            ^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]   File "/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/distributed/omni_connectors/utils/serialization.py", line 46, in encode
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]     return self.encoder.encode(obj)
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]            ^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]   File "/proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/distributed/omni_connectors/utils/serialization.py", line 78, in _enc_hook
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643]     raise TypeError(
ERROR 07-05 15:32:21 [kv_transfer_manager.py:1643] TypeError: Object of type SimpleNamespace is not serializable. Supported types: torch.Tensor, np.ndarray, PIL.Image, dataclass, RequestOutput, and standard Python types (dict, list, str, int, float, bool, None, bytes).
INFO 07-05 15:32:21 [pipeline_bagel.py:397] Using injected KV Cache (direct)
INFO 07-05 15:32:21 [pipeline_bagel.py:428] CFG enabled with injected branch KV context roles=[] active=None
INFO 07-05 15:32:21 [pipeline_bagel.py:397] Using injected KV Cache (direct)
INFO 07-05 15:32:21 [pipeline_bagel.py:428] CFG enabled with injected branch KV context roles=[] active=None
WARNING 07-05 15:32:23 [mot_gemm.py:86] 
WARNING 07-05 15:32:23 [mot_gemm.py:86] ================================================================================
WARNING 07-05 15:32:23 [mot_gemm.py:86]  ⚠️  [WARNING] No tuned MoT config found.
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Searched paths: /proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/diffusion/layers/mot/configs/device_name=B300SXM6AC,dtype=w16a16.json
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Using conservative default configs which are NOT optimal.
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Run `python benchmarks/kernels/mot_linear_benchmarks.py --tune` 
WARNING 07-05 15:32:23 [mot_gemm.py:86]  to generate hardware-specific optimal configs.
WARNING 07-05 15:32:23 [mot_gemm.py:86] ================================================================================
WARNING 07-05 15:32:23 [mot_gemm.py:86] 
WARNING 07-05 15:32:23 [mot_gemm.py:86] 
WARNING 07-05 15:32:23 [mot_gemm.py:86] ================================================================================
WARNING 07-05 15:32:23 [mot_gemm.py:86]  ⚠️  [WARNING] No tuned MoT config found.
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Searched paths: /proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/diffusion/layers/mot/configs/device_name=B300SXM6AC,dtype=w16a16.json
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Using conservative default configs which are NOT optimal.
WARNING 07-05 15:32:23 [mot_gemm.py:86]  Run `python benchmarks/kernels/mot_linear_benchmarks.py --tune` 
WARNING 07-05 15:32:23 [mot_gemm.py:86]  to generate hardware-specific optimal configs.
WARNING 07-05 15:32:23 [mot_gemm.py:86] ================================================================================
WARNING 07-05 15:32:23 [mot_gemm.py:86] 
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] 
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] [Overall Summary]
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] +-----------------------------+------------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | Field                       |      Value |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] +-----------------------------+------------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_requests                |          1 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_wall_time_ms            | 25,390.247 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_total_tokens            |         19 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_avg_time_per_request_ms | 25,390.247 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_avg_tokens_per_s        |      0.748 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | input_preprocess_time_ms    | 22,149.940 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_stage_0_wall_time_ms    |    153.688 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] | e2e_stage_1_wall_time_ms    |  2,875.796 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:752] +-----------------------------+------------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] 
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] [RequestE2EStats [request_id=chatcmpl-8e8f0512f75e1b04-9fc78dc2]]
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] +------------------+-----------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] | Field            |     Value |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] +------------------+-----------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] | e2e_total_ms     | 3,057.802 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] | e2e_total_tokens |        19 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:778] +------------------+-----------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:819] [OmniTiming] req=chatcmpl-8e8f0512f75e1b04-9fc78dc2 total=3.06s preprocess=22.15s engine=-19.09s stages=[0:0.15s,1:2.88s] transfers=[0->1=0.00ms]
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] 
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] [StageRequestStats [request_id=chatcmpl-8e8f0512f75e1b04-9fc78dc2]]
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] +---------------------------------+------------+------------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | Field                           |          0 |          1 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] +---------------------------------+------------+------------+
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | batch_id                        |          1 |          1 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | batch_size                      |          1 |          1 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | denoise_step_latency_ms         |      0.000 |  1,437.667 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | image_pixels                    |          0 |    262,144 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | inter_output_latencies_ms       |            |            |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | num_tokens_in                   |         18 |          0 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | num_tokens_out                  |          1 |          0 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | output_unit_count               |          1 |          1 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | output_unit_type                |       text |      image |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | serving_time_to_first_output_ms |      0.000 | 25,389.758 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | stage_gen_time_ms               |    154.331 |  2,875.334 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | vllm_itls_ms                    |            |            |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] | vllm_ttft_ms                    | 22,485.406 |      0.000 |
(APIServer pid=183862) INFO 07-05 15:32:24 [stats.py:861] +---------------------------------+------------+------------+
(APIServer pid=183862) INFO:     127.0.0.1:58256 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[diffusion] request#1 success in 25.959s
PASSEDOmniServer stopping...
(APIServer pid=183862) INFO 07-05 15:32:24 [launcher.py:100] [shutdown] API server: shutdown triggered
(APIServer pid=183862) INFO 07-05 15:32:24 [launcher.py:116] [shutdown] API server: stopping engine client mode=abort timeout=0s
(APIServer pid=183862) INFO 07-05 15:32:24 [omni_base.py:623] [AsyncOmni] Shutting down
(APIServer pid=183862) INFO 07-05 15:32:24 [async_omni_engine.py:1502] [AsyncOmniEngine] Shutting down Orchestrator
(APIServer pid=183862) INFO 07-05 15:32:24 [orchestrator.py:420] [Orchestrator] Received shutdown signal
(APIServer pid=183862) INFO 07-05 15:32:24 [orchestrator.py:1638] [Orchestrator] Shutting down all 2 client(s)
(APIServer pid=183862) INFO 07-05 15:32:24 [core_client.py:655] [shutdown] MPClient: start timeout=default
(APIServer pid=183862) INFO 07-05 15:32:24 [core_client.py:657] [shutdown] MPClient: stopping engine manager
(APIServer pid=183862) INFO:     Shutting down
(APIServer pid=183862) INFO:     Waiting for application shutdown.
(APIServer pid=183862) INFO:     Application shutdown complete.
(APIServer pid=183862) INFO:     Finished server process [183862]
(APIServer pid=183862) INFO 07-05 15:32:24 [omni_base.py:623] [AsyncOmni] Shutting down
(APIServer pid=183862) INFO 07-05 15:32:27 [core_client.py:659] [shutdown] MPClient: engine manager stopped
(APIServer pid=183862) INFO 07-05 15:32:27 [core_client.py:660] [shutdown] MPClient: cleaning up background resources
(APIServer pid=183862) INFO 07-05 15:32:27 [core_client.py:662] [shutdown] MPClient: complete
(APIServer pid=183862) INFO 07-05 15:32:27 [stage_pool.py:1204] [StagePool] Stage 0 replica 0 shut down
INFO 07-05 15:32:27 [diffusion_worker.py:920] Worker 1: Received shutdown message
INFO 07-05 15:32:27 [diffusion_worker.py:941] event loop terminated.
INFO 07-05 15:32:27 [diffusion_worker.py:920] Worker 0: Received shutdown message
INFO 07-05 15:32:27 [diffusion_worker.py:941] event loop terminated.
INFO 07-05 15:32:28 [diffusion_worker.py:1011] Worker 1: Shutdown complete.
INFO 07-05 15:32:28 [diffusion_worker.py:1011] Worker 0: Shutdown complete.
(APIServer pid=183862) INFO 07-05 15:32:32 [stage_pool.py:1204] [StagePool] Stage 1 replica 0 shut down
(APIServer pid=183862) INFO 07-05 15:32:32 [cumem.py:206] CuMemAllocator: sleep freed 0.00 GiB memory in total, of which 0.00 GiB is backed up in CPU and the rest 0.00 GiB is discarded directly.
Pre-test GPU status:
  Removing stale device lock /tmp/vllm_omni_device_0_init.lock (PID 183862 is dead)
[GPU Memory Monitor] Waiting for GPU 0, 1, 2, 3, 4, 5, 6, 7 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 0: 0.9GiB/268.6GiB (0.3%)
  GPU 1: 0.9GiB/268.6GiB (0.3%)
  GPU 2: 0.9GiB/268.6GiB (0.3%)
  GPU 3: 0.9GiB/268.6GiB (0.3%)
  GPU 4: 0.9GiB/268.6GiB (0.3%)
  GPU 5: 0.9GiB/268.6GiB (0.3%)
  GPU 6: 0.9GiB/268.6GiB (0.3%)
  GPU 7: 0.9GiB/268.6GiB (0.3%)
[GPU Memory Freed] Devices 0, 1, 2, 3, 4, 5, 6, 7 meet memory condition
   Condition: Memory usage ratio ≤ 5.0%
   Wait time: 0.0 seconds (0.0 minutes)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
Sun Jul  5 15:32:35 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.20             Driver Version: 580.126.20     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA B300 SXM6 AC            On  |   00000000:1A:00.0 Off |                    0 |
| N/A   33C    P0            181W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA B300 SXM6 AC            On  |   00000000:69:00.0 Off |                    0 |
| N/A   40C    P0            183W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA B300 SXM6 AC            On  |   00000000:B5:00.0 Off |                    0 |
| N/A   33C    P0            177W / 1100W |       4MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
... (showing first 20 of 48 lines)

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0          -     -      -      -      -      -      -      -    -              
    1          -     -      -      -      -      -      -      -    -              
    2          -     -      -      -      -      -      -      -    -              
    3          -     -      -      -      -      -      -      -    -              
    4          -     -      -      -      -      -      -      -    -              
    5          -     -      -      -      -      -      -      -    -              
    6          -     -      -      -      -      -      -      -    -              
    7          -     -      -      -      -      -      -      -    -

================================================================================
System Processes with GPU keywords
================================================================================
OmniServer stopped


============================================= warnings summary =============================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /proj-tango-pvc/users/zhipeng.wang/vllm-omni/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

vllm_omni/version.py:55
  /proj-tango-pvc/users/zhipeng.wang/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.1.dev2142+g29dcdec66
   --> vLLM version 0.24.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
================================ 1 passed, 17 warnings in 299.63s (0:04:59) ================================
```
