### PR TITLE
[feat] Sampling and CUDA Graph for MOSS-TTS Local Stage-0+sampling optimization

### DIFF
--- a/tests/model_executor/models/moss_tts/test_local_stage0_opt.py
+++ b/tests/model_executor/models/moss_tts/test_local_stage0_opt.py
@@ -19,6 +19,14 @@ def _local_talker_cls():
     return MossTTSLocalTalkerForGeneration
 
 
+def _sample_token_stable():
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_local_depth import (
+        _sample_token_stable,
+    )
+
+    return _sample_token_stable
+
+
 class _DummyBackbone(nn.Module):
     def __init__(self, vocab_size: int, hidden_size: int) -> None:
         super().__init__()
@@ -56,6 +64,33 @@ class _DeterministicLocalTransformer:
         codes = base + offsets
         return torch.ones(batch, dtype=torch.bool, device=backbone_last_hidden.device), codes
 
+    def generate_frame_graphable(
+        self,
+        backbone_last_hidden,
+        audio_lm_heads,
+        audio_embeddings,
+        local_text_lm_head,
+        *,
+        n_vq,
+        seed,
+        frame_step,
+        do_sample=True,
+        temperature=1.0,
+        top_k=50,
+        top_p=1.0,
+        text_temperature=1.0,
+        text_top_k=50,
+        text_top_p=1.0,
+    ):
+        batch = int(backbone_last_hidden.shape[0])
+        self.calls.append(batch)
+        seed_base = seed.reshape(-1, 1).to(torch.long).remainder(1000)
+        offsets = torch.arange(n_vq, device=backbone_last_hidden.device, dtype=torch.long).reshape(1, n_vq)
+        codes = seed_base + frame_step.reshape(-1, 1).to(torch.long) + offsets
+        audio_embed = torch.zeros(batch, backbone_last_hidden.shape[-1], device=backbone_last_hidden.device)
+        audio_embed[:, 0] = codes[:, 0].to(audio_embed.dtype)
+        return torch.ones(batch, dtype=torch.bool, device=backbone_last_hidden.device), codes, audio_embed
+
 
 def _make_bare_local_talker(hidden_size: int = 4, n_vq: int = 3):
     cls = _local_talker_cls()
@@ -78,10 +113,20 @@ def _make_bare_local_talker(hidden_size: int = 4, n_vq: int = 3):
     talker._batch_state_spans = None
     talker._stage0_frame_graphs = {}
     talker._stage0_frame_graph_input = None
+    talker._stage0_frame_graph_seed = None
+    talker._stage0_frame_graph_frame_step = None
     talker._stage0_frame_graph_continue = None
     talker._stage0_frame_graph_codes = None
+    talker._stage0_frame_graph_audio_embed = None
     talker._stage0_frame_graph_max_batch = 0
     talker._stage0_frame_graph_bucket_sizes = (1, 2, 4)
+    talker._stage0_frame_graph_stats = {
+        "capture_count": 0,
+        "replay_count": 0,
+        "eager_fallback_count": 0,
+        "fallback_by_reason": {},
+        "bucket_usage": {},
+    }
     return talker
 
 
@@ -118,13 +163,94 @@ def test_preprocess_decode_batch_returns_shape_and_updates():
     assert updates == [{}, {}]
 
 
-def test_batched_local_frame_matches_scalar_greedy(monkeypatch):
+def test_stable_sampler_is_batch_order_independent():
+    sample_token = _sample_token_stable()
+    logits_ab = torch.tensor([[0.1, 0.4, 0.8, 1.2], [1.2, 0.8, 0.4, 0.1]], dtype=torch.float32)
+    seed_ab = torch.tensor([11, 22], dtype=torch.long)
+    step_ab = torch.tensor([3, 5], dtype=torch.long)
+
+    out_ab = sample_token(
+        logits_ab,
+        seed_ab,
+        step_ab,
+        codebook_index=0,
+        sample_kind=1,
+        temperature=1.7,
+        top_k=4,
+        top_p=1.0,
+        do_sample=True,
+    )
+    out_ba = sample_token(
+        logits_ab.flip(0),
+        seed_ab.flip(0),
+        step_ab.flip(0),
+        codebook_index=0,
+        sample_kind=1,
+        temperature=1.7,
+        top_k=4,
+        top_p=1.0,
+        do_sample=True,
+    )
+
+    assert torch.equal(out_ab, out_ba.flip(0))
+
+
+def test_stable_sampler_greedy_and_mask_edges():
+    sample_token = _sample_token_stable()
+    seed = torch.tensor([1, 2], dtype=torch.long)
+    step = torch.tensor([0, 0], dtype=torch.long)
+    logits = torch.tensor([[0.1, 3.0, 2.0], [4.0, 1.0, 0.5]], dtype=torch.float32)
+
+    greedy = sample_token(
+        logits,
+        seed,
+        step,
+        codebook_index=1,
+        sample_kind=2,
+        temperature=1.0,
+        top_k=3,
+        top_p=1.0,
+        do_sample=False,
+    )
+    top_k_one = sample_token(
+        logits,
+        seed,
+        step,
+        codebook_index=1,
+        sample_kind=2,
+        temperature=1.0,
+        top_k=1,
+        top_p=1.0,
+        do_sample=True,
+    )
+    all_masked = sample_token(
+        torch.full((2, 3), float("-inf")),
+        seed,
+        step,
+        codebook_index=1,
+        sample_kind=2,
+        temperature=1.0,
+        top_k=3,
+        top_p=0.5,
+        do_sample=True,
+    )
+
+    assert greedy.tolist() == [1, 0]
+    assert top_k_one.tolist() == [1, 0]
+    assert all_masked.shape == (2,)
+    assert torch.isfinite(all_masked.float()).all()
+    assert all_masked.min().item() >= 0
+    assert all_masked.max().item() < 3
+
+
+def test_unseeded_graph_enabled_path_keeps_scalar_eager(monkeypatch):
     monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", "1")
-    talker_batch = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    talker = _make_bare_local_talker(hidden_size=4, n_vq=3)
     talker_scalar = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    talker_scalar.audio_embeddings.load_state_dict(talker.audio_embeddings.state_dict())
     hidden = torch.tensor([[1.0, 0, 0, 0], [4.0, 0, 0, 0]])
     input_embeds = torch.zeros((2, 4))
-    infos_batch = [
+    infos = [
         {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
         {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
     ]
@@ -133,13 +259,13 @@ def test_batched_local_frame_matches_scalar_greedy(monkeypatch):
         {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
     ]
 
-    out_batch, _ = talker_batch.talker_mtp(
+    out, _ = talker.talker_mtp(
         torch.tensor([7, 7]),
         input_embeds,
         hidden,
         torch.zeros_like(hidden),
         do_sample=False,
-        req_infos=infos_batch,
+        req_infos=infos,
     )
     monkeypatch.delenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", raising=False)
     out_scalar, _ = talker_scalar.talker_mtp(
@@ -151,11 +277,50 @@ def test_batched_local_frame_matches_scalar_greedy(monkeypatch):
         req_infos=infos_scalar,
     )
 
-    assert torch.allclose(out_batch, out_scalar)
-    assert talker_batch.local_transformer.calls == [2]
+    assert torch.allclose(out, out_scalar)
+    assert talker.local_transformer.calls == [1, 1]
     assert talker_scalar.local_transformer.calls == [1, 1]
-    for info_b, info_s in zip(infos_batch, infos_scalar, strict=True):
+    assert talker.get_stage0_frame_graph_stats()["fallback_by_reason"]["no_seed"] == 2
+    for info_b, info_s in zip(infos, infos_scalar, strict=True):
         assert torch.equal(info_b["audio_codes"]["current"], info_s["audio_codes"]["current"])
+
+
+def test_seeded_graphable_batch_is_stable_under_row_reordering(monkeypatch):
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", "1")
+    talker_ab = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    talker_ba = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    hidden_ab = torch.tensor([[1.0, 0, 0, 0], [4.0, 0, 0, 0]])
+    hidden_ba = hidden_ab.flip(0)
+    input_embeds = torch.zeros((2, 4))
+    infos_ab = [
+        {"tts_local_seed": 11, "audio_state": {"is_stopping": False, "step": 2, "max_new_frames": -1}},
+        {"tts_local_seed": 22, "audio_state": {"is_stopping": False, "step": 5, "max_new_frames": -1}},
+    ]
+    infos_ba = [
+        {"tts_local_seed": 22, "audio_state": {"is_stopping": False, "step": 5, "max_new_frames": -1}},
+        {"tts_local_seed": 11, "audio_state": {"is_stopping": False, "step": 2, "max_new_frames": -1}},
+    ]
+
+    talker_ab.talker_mtp(
+        torch.tensor([7, 7]),
+        input_embeds,
+        hidden_ab,
+        torch.zeros_like(hidden_ab),
+        req_infos=infos_ab,
+    )
+    talker_ba.talker_mtp(
+        torch.tensor([7, 7]),
+        input_embeds,
+        hidden_ba,
+        torch.zeros_like(hidden_ba),
+        req_infos=infos_ba,
+    )
+
+    assert talker_ab.local_transformer.calls == [2]
+    assert talker_ba.local_transformer.calls == [2]
+    assert torch.equal(infos_ab[0]["audio_codes"]["current"], infos_ba[1]["audio_codes"]["current"])
+    assert torch.equal(infos_ab[1]["audio_codes"]["current"], infos_ba[0]["audio_codes"]["current"])
+    assert talker_ab.get_stage0_frame_graph_stats()["fallback_by_reason"]["cpu_device"] == 2
 
 
 def test_frame_graph_failure_falls_back_to_eager(monkeypatch):
@@ -167,8 +332,10 @@ def test_frame_graph_failure_falls_back_to_eager(monkeypatch):
 
     monkeypatch.setattr(talker, "_decode_stage0_local_frames_graph", fail_graph)
 
-    should_continue, codes = talker._decode_stage0_local_frames(
+    should_continue, codes, audio_embed = talker._decode_stage0_local_frames(
         torch.tensor([[2.0, 0, 0, 0]]),
+        seed=torch.tensor([123], dtype=torch.long),
+        frame_step=torch.tensor([0], dtype=torch.long),
         do_sample=False,
         temperature=1.7,
         top_k=25,
@@ -178,7 +345,9 @@ def test_frame_graph_failure_falls_back_to_eager(monkeypatch):
 
     assert should_continue.tolist() == [True]
     assert codes.tolist() == [[2, 3, 4]]
+    assert audio_embed is not None
     assert talker.local_transformer.calls == [1]
+    assert talker.get_stage0_frame_graph_stats()["fallback_by_reason"]["capture_failed"] == 1
 
 
 def test_make_omni_output_emits_batch_aligned_finished_meta():

--- a/tests/model_executor/models/moss_tts/test_local_stage0_opt.py
+++ b/tests/model_executor/models/moss_tts/test_local_stage0_opt.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for opt-in MOSS-TTS Local Stage-0 helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("vllm")
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
+
+
+def _local_talker_cls():
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    return MossTTSLocalTalkerForGeneration
+
+
+class _DummyBackbone(nn.Module):
+    def __init__(self, vocab_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_size)
+
+    def embed_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embedding(input_ids)
+
+
+class _DeterministicLocalTransformer:
+    def __init__(self, n_vq: int) -> None:
+        self.n_vq = n_vq
+        self.calls: list[int] = []
+
+    def generate_frame(
+        self,
+        backbone_last_hidden,
+        audio_lm_heads,
+        audio_embeddings,
+        local_text_lm_head,
+        *,
+        n_vq,
+        do_sample=True,
+        temperature=1.0,
+        top_k=50,
+        top_p=1.0,
+        repetition_penalty=1.0,
+        history_per_codebook=None,
+        generator=None,
+    ):
+        batch = int(backbone_last_hidden.shape[0])
+        self.calls.append(batch)
+        base = backbone_last_hidden[:, :1].round().to(torch.long).clamp_min(0)
+        offsets = torch.arange(n_vq, device=backbone_last_hidden.device, dtype=torch.long).reshape(1, n_vq)
+        codes = base + offsets
+        return torch.ones(batch, dtype=torch.bool, device=backbone_last_hidden.device), codes
+
+
+def _make_bare_local_talker(hidden_size: int = 4, n_vq: int = 3):
+    cls = _local_talker_cls()
+    talker = cls.__new__(cls)
+    nn.Module.__init__(talker)
+    talker.hidden_size = hidden_size
+    talker.n_vq = n_vq
+    talker.audio_vocab_size = 32
+    talker.audio_pad_token_id = 32
+    talker.text_vocab_size = 128
+    talker.audio_assistant_slot_token_id = 7
+    talker.im_end_token_id = 8
+    talker.model = _DummyBackbone(talker.text_vocab_size, hidden_size)
+    talker.audio_embeddings = nn.ModuleList([nn.Embedding(talker.audio_vocab_size, hidden_size) for _ in range(n_vq)])
+    talker.audio_lm_heads = nn.ModuleList([nn.Linear(hidden_size, talker.audio_vocab_size) for _ in range(n_vq)])
+    talker.local_text_lm_head = nn.Linear(hidden_size, 2)
+    talker.local_transformer = _DeterministicLocalTransformer(n_vq)
+    talker._stacked_audio_emb_w = None
+    talker._batch_state = None
+    talker._batch_state_spans = None
+    talker._stage0_frame_graphs = {}
+    talker._stage0_frame_graph_input = None
+    talker._stage0_frame_graph_continue = None
+    talker._stage0_frame_graph_codes = None
+    talker._stage0_frame_graph_max_batch = 0
+    talker._stage0_frame_graph_bucket_sizes = (1, 2, 4)
+    return talker
+
+
+def test_local_stage0_env_switches_default_off(monkeypatch):
+    monkeypatch.delenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_BATCH_PREPROCESS", raising=False)
+    monkeypatch.delenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", raising=False)
+
+    talker = _make_bare_local_talker()
+
+    assert talker.should_enable_stage0_decode_batch_preprocess()
+    assert not talker._decode_stage0_local_frames.__globals__["_env_enabled"](
+        "MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH"
+    )
+
+
+def test_preprocess_decode_batch_returns_shape_and_updates():
+    talker = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    req_infos = [
+        {"hidden_states": {"last": torch.ones(4)}},
+        {"hidden_states": {"last": torch.full((4,), 2.0)}},
+    ]
+
+    input_ids, embeds, last_hidden, text_step, updates = talker.preprocess_decode_batch(
+        input_ids=torch.tensor([11, 12], dtype=torch.long),
+        req_infos=req_infos,
+    )
+
+    assert input_ids.tolist() == [11, 12]
+    assert embeds.shape == (2, 4)
+    assert last_hidden.shape == (2, 4)
+    assert torch.allclose(last_hidden[0], torch.ones(4))
+    assert torch.allclose(last_hidden[1], torch.full((4,), 2.0))
+    assert torch.equal(text_step, torch.zeros_like(last_hidden))
+    assert updates == [{}, {}]
+
+
+def test_batched_local_frame_matches_scalar_greedy(monkeypatch):
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", "1")
+    talker_batch = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    talker_scalar = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    hidden = torch.tensor([[1.0, 0, 0, 0], [4.0, 0, 0, 0]])
+    input_embeds = torch.zeros((2, 4))
+    infos_batch = [
+        {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
+        {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
+    ]
+    infos_scalar = [
+        {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
+        {"audio_state": {"is_stopping": False, "step": 0, "max_new_frames": -1}},
+    ]
+
+    out_batch, _ = talker_batch.talker_mtp(
+        torch.tensor([7, 7]),
+        input_embeds,
+        hidden,
+        torch.zeros_like(hidden),
+        do_sample=False,
+        req_infos=infos_batch,
+    )
+    monkeypatch.delenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", raising=False)
+    out_scalar, _ = talker_scalar.talker_mtp(
+        torch.tensor([7, 7]),
+        input_embeds,
+        hidden,
+        torch.zeros_like(hidden),
+        do_sample=False,
+        req_infos=infos_scalar,
+    )
+
+    assert torch.allclose(out_batch, out_scalar)
+    assert talker_batch.local_transformer.calls == [2]
+    assert talker_scalar.local_transformer.calls == [1, 1]
+    for info_b, info_s in zip(infos_batch, infos_scalar, strict=True):
+        assert torch.equal(info_b["audio_codes"]["current"], info_s["audio_codes"]["current"])
+
+
+def test_frame_graph_failure_falls_back_to_eager(monkeypatch):
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", "1")
+    talker = _make_bare_local_talker(hidden_size=4, n_vq=3)
+
+    def fail_graph(*args, **kwargs):
+        raise RuntimeError("capture failed")
+
+    monkeypatch.setattr(talker, "_decode_stage0_local_frames_graph", fail_graph)
+
+    should_continue, codes = talker._decode_stage0_local_frames(
+        torch.tensor([[2.0, 0, 0, 0]]),
+        do_sample=False,
+        temperature=1.7,
+        top_k=25,
+        top_p=0.8,
+        generator=None,
+    )
+
+    assert should_continue.tolist() == [True]
+    assert codes.tolist() == [[2, 3, 4]]
+    assert talker.local_transformer.calls == [1]
+
+
+def test_make_omni_output_emits_batch_aligned_finished_meta():
+    talker = _make_bare_local_talker(hidden_size=4, n_vq=3)
+    info_dicts = [
+        {
+            "audio_state": {"is_stopping": False},
+            "audio_codes": {"current": torch.tensor([[1, 2, 3]]), "emit": True},
+        },
+        {
+            "audio_state": {"is_stopping": True},
+            "audio_codes": {"current": torch.empty((0, 3), dtype=torch.long), "emit": False},
+        },
+    ]
+
+    output = talker.make_omni_output(
+        torch.zeros((2, 4)),
+        runtime_additional_information=info_dicts,
+        request_token_spans=[(0, 1), (1, 2)],
+    )
+
+    assert len(output.multimodal_outputs["codes"]["audio"]) == 2
+    assert torch.equal(output.multimodal_outputs["codes"]["audio"][0], torch.tensor([[1, 2, 3]]))
+    assert output.multimodal_outputs["codes"]["audio"][1].numel() == 0
+    finished = output.multimodal_outputs["meta"]["finished"]
+    assert [bool(flag.item()) for flag in finished] == [False, True]

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -81,6 +81,8 @@ class CaptureTalkerMTP(torch.nn.Module):
         top_k=None,
         top_p=None,
         generator=None,
+        req_ids=None,
+        req_infos=None,
     ):
         self.calls.append(
             {
@@ -90,6 +92,8 @@ class CaptureTalkerMTP(torch.nn.Module):
                 "top_k": top_k,
                 "top_p": top_p,
                 "generator": generator,
+                "req_ids": req_ids,
+                "req_infos": req_infos,
             }
         )
         codes = torch.zeros((req_embeds.shape[0], 1), dtype=torch.int64)
@@ -306,6 +310,8 @@ def test_talker_mtp_forward_passes_qwen3_tts_subtalker_sampling_params_to_talker
             "top_k": 9,
             "top_p": 0.55,
             "generator": runner.talker_mtp.calls[0]["generator"],
+            "req_ids": None,
+            "req_infos": None,
         }
     ]
     assert runner.talker_mtp.calls[0]["generator"] is not None
@@ -348,6 +354,46 @@ def test_talker_mtp_forward_keeps_explicit_seeded_requests_scalar(monkeypatch):
     assert runner.talker_mtp.calls[0]["generator"] is not runner.talker_mtp.calls[1]["generator"]
     assert torch.equal(runner.talker_mtp_input_ids.gpu, saved_input_ids)
     assert torch.equal(runner.talker_mtp_inputs_embeds.gpu, saved_embeds)
+
+
+def test_talker_mtp_forward_batches_explicit_seeds_for_stable_seeded_model(monkeypatch):
+    import vllm_omni.worker.gpu_model_runner as mod
+
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH", "1")
+    monkeypatch.setattr(mod.current_omni_platform, "set_forward_context", _noop_forward_context)
+
+    runner = _make_runner(req_ids=("r1", "r2"), hidden_size=4)
+    runner.requests["r1"].sampling_params = SimpleNamespace(
+        seed=11,
+        extra_args={"tts_local_seed": 11},
+    )
+    runner.requests["r2"].sampling_params = SimpleNamespace(
+        seed=22,
+        extra_args={"tts_local_seed": 22},
+    )
+    runner.talker_mtp = CaptureTalkerMTP()
+    runner.model = SimpleNamespace(
+        talker_mtp_output_key=("codes", "audio"),
+        talker_mtp_accepts_req_infos=True,
+        supports_talker_mtp_stable_seeded_batch=True,
+    )
+    runner.vllm_config = SimpleNamespace(model_config=SimpleNamespace(subtalker_sampling_params={}))
+
+    def fake_determine(self, num_tokens, num_reqs, num_scheduled_tokens_np, max_num_scheduled_tokens, use_cascade_attn):
+        batch_desc = SimpleNamespace(num_tokens=int(num_tokens))
+        return (False, batch_desc, None, None, None)
+
+    monkeypatch.setattr(runner, "_determine_batch_execution_and_padding", fake_determine.__get__(runner, type(runner)))
+
+    inputs_embeds = torch.zeros((6, 4), dtype=torch.float32)
+    OmniGPUModelRunner._talker_mtp_forward(runner, ["r1", "r2"], inputs_embeds)
+
+    assert [call["batch_size"] for call in runner.talker_mtp.calls] == [2]
+    assert runner.talker_mtp.calls[0]["generator"] is None
+    assert runner.talker_mtp.calls[0]["req_ids"] == ["r1", "r2"]
+    assert [info["tts_local_seed"] for info in runner.talker_mtp.calls[0]["req_infos"]] == [11, 22]
+    assert runner.model_intermediate_buffer["r1"]["tts_local_seed"] == 11
+    assert runner.model_intermediate_buffer["r2"]["tts_local_seed"] == 22
 
 
 def test_update_intermediate_buffer_writes_to_buffer_and_setattr(monkeypatch):

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -429,6 +429,55 @@ def test_maybe_run_batch_preprocess_skips_missing_hook():
     OmniGPUModelRunner._maybe_run_batch_preprocess(runner, ["r1"], torch.device("cpu"))
 
 
+def test_stage0_decode_batch_preprocess_gate_requires_env(monkeypatch):
+    monkeypatch.delenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_BATCH_PREPROCESS", raising=False)
+    runner = object.__new__(OmniGPUModelRunner)
+
+    class DummyModel:
+        has_preprocess = True
+        enable_stage0_decode_batch_preprocess = True
+
+        def preprocess_decode_batch(self, *, input_ids, req_infos):
+            raise AssertionError("not called")
+
+    runner.model = DummyModel()
+
+    assert not OmniGPUModelRunner._should_enable_stage0_decode_batch_preprocess(runner)
+
+
+def test_stage0_decode_batch_preprocess_gate_requires_model_capability(monkeypatch):
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_BATCH_PREPROCESS", "1")
+    runner = object.__new__(OmniGPUModelRunner)
+
+    class DummyModel:
+        has_preprocess = True
+
+        def preprocess_decode_batch(self, *, input_ids, req_infos):
+            raise AssertionError("not called")
+
+    runner.model = DummyModel()
+
+    assert not OmniGPUModelRunner._should_enable_stage0_decode_batch_preprocess(runner)
+
+
+def test_stage0_decode_batch_preprocess_gate_accepts_capability_method(monkeypatch):
+    monkeypatch.setenv("MOSS_TTS_LOCAL_ENABLE_STAGE0_BATCH_PREPROCESS", "1")
+    runner = object.__new__(OmniGPUModelRunner)
+
+    class DummyModel:
+        has_preprocess = True
+
+        def should_enable_stage0_decode_batch_preprocess(self):
+            return True
+
+        def preprocess_decode_batch(self, *, input_ids, req_infos):
+            raise AssertionError("not called")
+
+    runner.model = DummyModel()
+
+    assert OmniGPUModelRunner._should_enable_stage0_decode_batch_preprocess(runner)
+
+
 def _make_full_payload_accumulation_runner(
     model_arch="Qwen3OmniMoeForConditionalGeneration",
     model_stage="talker",

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
@@ -27,6 +27,82 @@ from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_local import (
     _sample_token,
 )
 
+_RNG_MODULUS = 2_147_483_647
+
+
+def _stable_uniform01(
+    seed: torch.Tensor,
+    frame_step: torch.Tensor,
+    codebook_index: int,
+    sample_kind: int,
+) -> torch.Tensor:
+    """Deterministic per-row uniform random value in [0, 1).
+
+    The row position is intentionally not part of the mix, so a request gets
+    the same random stream regardless of which other requests share the batch.
+    The arithmetic stays below int64 overflow before the modulo.
+    """
+    seed_i64 = torch.remainder(seed.to(dtype=torch.long), _RNG_MODULUS)
+    step_i64 = torch.remainder(frame_step.to(dtype=torch.long), _RNG_MODULUS)
+    x = torch.remainder(
+        seed_i64
+        + step_i64 * 1_103_515_245
+        + int(codebook_index + 1) * 97_531
+        + int(sample_kind + 1) * 2_654_435_761,
+        _RNG_MODULUS,
+    )
+    x = torch.remainder(x * 48_271 + 12_820_163, _RNG_MODULUS)
+    x = torch.remainder(x * 40_692 + 7_253_089, _RNG_MODULUS)
+    return (x.to(dtype=torch.float32) + 0.5) / float(_RNG_MODULUS)
+
+
+def _sample_token_stable(
+    logits: torch.Tensor,
+    seed: torch.Tensor,
+    frame_step: torch.Tensor,
+    *,
+    codebook_index: int,
+    sample_kind: int,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    do_sample: bool,
+) -> torch.Tensor:
+    """Graph-friendly top-k/top-p sampler with deterministic tensor RNG."""
+    if not do_sample or temperature <= 0:
+        return logits.argmax(dim=-1)
+
+    logits = logits.float() / max(float(temperature), 1e-6)
+    vocab_size = int(logits.shape[-1])
+    if top_k and top_k > 0 and top_k < vocab_size:
+        top_vals, _ = torch.topk(logits, int(top_k), dim=-1)
+        thresh = top_vals[..., -1:].expand_as(logits)
+        logits = torch.where(logits < thresh, torch.full_like(logits, float("-inf")), logits)
+
+    if 0.0 < float(top_p) < 1.0:
+        sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
+        sorted_finite = torch.isfinite(sorted_logits)
+        safe_sorted_logits = torch.where(
+            sorted_finite.any(dim=-1, keepdim=True),
+            sorted_logits,
+            torch.zeros_like(sorted_logits),
+        )
+        probs = F.softmax(safe_sorted_logits, dim=-1)
+        cum = probs.cumsum(dim=-1)
+        drop = cum > float(top_p)
+        drop[..., 1:] = drop[..., :-1].clone()
+        drop[..., 0] = False
+        sorted_logits = sorted_logits.masked_fill(drop, float("-inf"))
+        logits = torch.full_like(logits, float("-inf")).scatter_(-1, sorted_idx, sorted_logits)
+
+    finite = torch.isfinite(logits)
+    safe_logits = torch.where(finite.any(dim=-1, keepdim=True), logits, torch.zeros_like(logits))
+    probs = F.softmax(safe_logits, dim=-1)
+    cdf = probs.cumsum(dim=-1)
+    u = _stable_uniform01(seed, frame_step, codebook_index, sample_kind).to(device=logits.device)
+    sampled = (cdf < u.unsqueeze(-1)).sum(dim=-1)
+    return sampled.clamp_max(vocab_size - 1).to(dtype=torch.long)
+
 
 class _MossTTSLocalAttention(nn.Module):
     """GPT2-style fused-QKV self-attention with interleaved RoPE.
@@ -235,6 +311,82 @@ class MossTTSLocalDepthTransformer(nn.Module):
                 local_hidden = hidden[:, channel_index + 1, :]
 
         return should_continue, codes
+
+    @torch.no_grad()
+    def generate_frame_graphable(
+        self,
+        backbone_last_hidden: torch.Tensor,  # (B, H)
+        audio_lm_heads: nn.ModuleList,  # n_vq x Linear(H -> audio_vocab_size)
+        audio_embeddings: nn.ModuleList,  # n_vq x Embedding(audio_vocab_size, H)
+        local_text_lm_head: nn.Module,  # Linear(H -> 2): [continue, stop]
+        *,
+        n_vq: int,
+        seed: torch.Tensor,
+        frame_step: torch.Tensor,
+        do_sample: bool = True,
+        temperature: float = 1.0,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        text_temperature: float = 1.0,
+        text_top_k: int = 50,
+        text_top_p: float = 1.0,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Generate one frame using only tensor RNG/state.
+
+        Returns ``(should_continue, codes, audio_embed)``. ``audio_embed`` is
+        the additive embedding for the sampled code frame, ready to overlay on
+        the next text-token embedding.
+        """
+        batch_size = backbone_last_hidden.shape[0]
+        dtype = self.ln_f.weight.dtype
+        seed = seed.to(device=backbone_last_hidden.device, dtype=torch.long).reshape(batch_size)
+        frame_step = frame_step.to(device=backbone_last_hidden.device, dtype=torch.long).reshape(batch_size)
+
+        embeds = backbone_last_hidden.new_zeros((batch_size, n_vq, self.hidden_size), dtype=dtype)
+        embeds[:, 0, :] = backbone_last_hidden.to(dtype)
+
+        hidden = self._forward_prefix(embeds[:, :1, :])
+        local_hidden = hidden[:, 0, :]
+
+        binary_logits = local_text_lm_head(local_hidden).float()
+        binary_choice = _sample_token_stable(
+            binary_logits,
+            seed,
+            frame_step,
+            codebook_index=-1,
+            sample_kind=0,
+            temperature=text_temperature,
+            top_k=text_top_k,
+            top_p=text_top_p,
+            do_sample=do_sample,
+        )
+        should_continue = binary_choice.eq(0)
+
+        codes = backbone_last_hidden.new_zeros((batch_size, n_vq), dtype=torch.long)
+        audio_embed = backbone_last_hidden.new_zeros((batch_size, self.hidden_size), dtype=dtype)
+        for channel_index in range(n_vq):
+            channel_logits = audio_lm_heads[channel_index](local_hidden).float()
+            channel_token = _sample_token_stable(
+                channel_logits,
+                seed,
+                frame_step,
+                codebook_index=channel_index,
+                sample_kind=channel_index + 1,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                do_sample=do_sample,
+            )
+            codes[:, channel_index] = channel_token
+            channel_embed = audio_embeddings[channel_index](channel_token).to(dtype)
+            audio_embed = audio_embed + channel_embed
+
+            if channel_index + 1 < n_vq:
+                embeds[:, channel_index + 1, :] = channel_embed
+                hidden = self._forward_prefix(embeds[:, : channel_index + 2, :])
+                local_hidden = hidden[:, channel_index + 1, :]
+
+        return should_continue, codes, audio_embed
 
 
 __all__ = ["MossTTSLocalDepthTransformer"]

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import copy
+import os
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -34,6 +35,16 @@ from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_local_depth impo
 from vllm_omni.model_executor.models.output_templates import OmniOutput
 
 logger = init_logger(__name__)
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _first_scalar(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else None
+    return value
 
 
 def _maybe_prefix(prefix: str, name: str) -> str:
@@ -1267,6 +1278,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     have_multimodal_outputs: bool = True
     has_preprocess: bool = True
     has_postprocess: bool = True
+    enable_stage0_decode_batch_preprocess: bool = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
@@ -1322,6 +1334,12 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         self._stacked_audio_emb_w: torch.Tensor | None = None
         self.mtp_hidden_size = hidden_size
         self.talker_mtp_accepts_req_infos = True
+        self._stage0_frame_graphs: dict[tuple[int, tuple[bool, float, int, float]], torch.cuda.CUDAGraph] = {}
+        self._stage0_frame_graph_input: torch.Tensor | None = None
+        self._stage0_frame_graph_continue: torch.Tensor | None = None
+        self._stage0_frame_graph_codes: torch.Tensor | None = None
+        self._stage0_frame_graph_max_batch = 0
+        self._stage0_frame_graph_bucket_sizes = self._parse_stage0_frame_graph_batch_buckets()
 
         self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
             ("audio_codes", "current"),
@@ -1332,6 +1350,25 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     # ------------------------------------------------------------------
     # vLLM hooks
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_stage0_frame_graph_batch_buckets() -> tuple[int, ...]:
+        raw = os.environ.get("MOSS_TTS_LOCAL_STAGE0_FRAME_GRAPH_BATCH_BUCKETS", "").strip()
+        if not raw:
+            return (1, 2, 4, 8, 16, 32, 64)
+        buckets: list[int] = []
+        for part in raw.split(","):
+            try:
+                value = int(part.strip())
+            except ValueError:
+                logger.warning("Ignoring invalid MOSS_TTS_LOCAL_STAGE0_FRAME_GRAPH_BATCH_BUCKETS entry: %s", part)
+                continue
+            if value > 0:
+                buckets.append(value)
+        return tuple(sorted(set(buckets))) or (1, 2, 4, 8, 16, 32, 64)
+
+    def should_enable_stage0_decode_batch_preprocess(self) -> bool:
+        return True
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_tokens(input_ids)
@@ -1459,7 +1496,11 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                 else torch.full((self.n_vq,), self.audio_pad_token_id, dtype=torch.long, device=device)
             )
 
-            max_new_frames = info_dict.get("max_new_frames", [-1])[0]
+            max_new_frames_raw = _first_scalar(info_dict.get("max_new_frames"))
+            try:
+                max_new_frames = int(max_new_frames_raw) if max_new_frames_raw is not None else -1
+            except (TypeError, ValueError):
+                max_new_frames = -1
 
             info_update: dict[str, Any] = {
                 "audio_state": {
@@ -1485,10 +1526,317 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             mtp_hidden = torch.zeros((1, self.hidden_size), device=device, dtype=text_embed.dtype)
         return input_ids, text_embed, {"mtp_inputs": (mtp_hidden, torch.zeros_like(mtp_hidden))}
 
+    def preprocess_decode_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Batch the Local decode-row embedding overlay.
+
+        This is the decode-only equivalent of calling ``preprocess`` for each
+        one-token row. It deliberately does not alter Qwen3 cache semantics or
+        pass a custom slot id; the runner only overlays ``inputs_embeds`` and
+        prepares the existing local-frame MTP buffers.
+        """
+        text_ids = input_ids.reshape(-1)
+        text_embed = self.model.embed_tokens(text_ids)
+        mtp_hidden_rows: list[torch.Tensor] = []
+        for info in req_infos:
+            hs = (info.get("hidden_states", {}) or {}) if isinstance(info, dict) else {}
+            last_hidden = hs.get("last")
+            if isinstance(last_hidden, torch.Tensor) and last_hidden.numel() > 0:
+                row = last_hidden.to(device=text_embed.device, dtype=text_embed.dtype).reshape(1, -1)
+                if row.shape[-1] != self.hidden_size:
+                    row = text_embed.new_zeros((1, self.hidden_size))
+            else:
+                row = text_embed.new_zeros((1, self.hidden_size))
+            mtp_hidden_rows.append(row)
+        if mtp_hidden_rows:
+            mtp_hidden = torch.cat(mtp_hidden_rows, dim=0)
+        else:
+            mtp_hidden = text_embed.new_empty((0, self.hidden_size))
+        text_step = torch.zeros_like(mtp_hidden)
+        updates = [{} for _ in req_infos]
+        return text_ids, text_embed, mtp_hidden, text_step, updates
+
     def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
         if hidden_states.numel() == 0:
             return {}
         return {"hidden_states": {"last": hidden_states[-1].detach()}}
+
+    def _stage0_frame_graph_bucket(self, batch_size: int) -> int:
+        for bucket in self._stage0_frame_graph_bucket_sizes:
+            if batch_size <= bucket:
+                return int(bucket)
+        return int(batch_size)
+
+    def _ensure_stage0_frame_graph_buffers(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if (
+            self._stage0_frame_graph_input is not None
+            and self._stage0_frame_graph_input.device == device
+            and self._stage0_frame_graph_input.dtype == dtype
+            and self._stage0_frame_graph_max_batch >= batch_size
+        ):
+            return
+        cap = max(int(batch_size), self._stage0_frame_graph_max_batch, 1)
+        self._stage0_frame_graph_input = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
+        self._stage0_frame_graph_continue = torch.zeros(cap, device=device, dtype=torch.bool)
+        self._stage0_frame_graph_codes = torch.zeros(cap, self.n_vq, device=device, dtype=torch.long)
+        self._stage0_frame_graph_max_batch = cap
+        self._stage0_frame_graphs.clear()
+
+    def _stage0_frame_graph_kernel(
+        self,
+        batch_size: int,
+        *,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+    ) -> None:
+        assert self._stage0_frame_graph_input is not None
+        assert self._stage0_frame_graph_continue is not None
+        assert self._stage0_frame_graph_codes is not None
+        should_continue, codes = self.local_transformer.generate_frame(
+            self._stage0_frame_graph_input[:batch_size],
+            self.audio_lm_heads,
+            self.audio_embeddings,
+            self.local_text_lm_head,
+            n_vq=self.n_vq,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=1.0,
+            history_per_codebook=None,
+            generator=None,
+        )
+        self._stage0_frame_graph_continue[:batch_size].copy_(should_continue)
+        self._stage0_frame_graph_codes[:batch_size].copy_(codes)
+
+    def _decode_stage0_local_frames_eager(
+        self,
+        hidden_batch: torch.Tensor,
+        *,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generator: torch.Generator | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.local_transformer.generate_frame(
+            hidden_batch,
+            self.audio_lm_heads,
+            self.audio_embeddings,
+            self.local_text_lm_head,
+            n_vq=self.n_vq,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=1.0,
+            history_per_codebook=None,
+            generator=generator,
+        )
+
+    def _decode_stage0_local_frames_graph(
+        self,
+        hidden_batch: torch.Tensor,
+        *,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """CUDA graph wrapper for the local frame transformer.
+
+        The graph is deliberately limited to deterministic/greedy frame decode.
+        Sampling and unsupported devices fall back to eager batching without
+        changing correctness.
+        """
+        if hidden_batch.device.type != "cuda" or do_sample:
+            return self._decode_stage0_local_frames_eager(
+                hidden_batch,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=None,
+            )
+        batch_size = int(hidden_batch.shape[0])
+        bucket = self._stage0_frame_graph_bucket(batch_size)
+        dtype = hidden_batch.dtype
+        self._ensure_stage0_frame_graph_buffers(batch_size=bucket, device=hidden_batch.device, dtype=dtype)
+        assert self._stage0_frame_graph_input is not None
+        assert self._stage0_frame_graph_continue is not None
+        assert self._stage0_frame_graph_codes is not None
+
+        self._stage0_frame_graph_input[:bucket].zero_()
+        self._stage0_frame_graph_input[:batch_size].copy_(hidden_batch)
+        graph_key = (bucket, (bool(do_sample), float(temperature), int(top_k), float(top_p)))
+        graph = self._stage0_frame_graphs.get(graph_key)
+        if graph is None:
+            self._stage0_frame_graph_kernel(
+                bucket,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+            )
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                self._stage0_frame_graph_kernel(
+                    bucket,
+                    do_sample=do_sample,
+                    temperature=temperature,
+                    top_k=top_k,
+                    top_p=top_p,
+                )
+            self._stage0_frame_graphs[graph_key] = graph
+            return (
+                self._stage0_frame_graph_continue[:batch_size].clone(),
+                self._stage0_frame_graph_codes[:batch_size].clone(),
+            )
+
+        graph.replay()
+        return (
+            self._stage0_frame_graph_continue[:batch_size].clone(),
+            self._stage0_frame_graph_codes[:batch_size].clone(),
+        )
+
+    def _decode_stage0_local_frames(
+        self,
+        hidden_batch: torch.Tensor,
+        *,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generator: torch.Generator | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if generator is not None or not _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH"):
+            return self._decode_stage0_local_frames_eager(
+                hidden_batch,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=generator,
+            )
+        try:
+            return self._decode_stage0_local_frames_graph(
+                hidden_batch,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+            )
+        except Exception:
+            logger.exception("MOSS-TTS Local Stage-0 frame graph failed; falling back to eager local decode")
+            self._stage0_frame_graphs.clear()
+            return self._decode_stage0_local_frames_eager(
+                hidden_batch,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=generator,
+            )
+
+    def _talker_mtp_stage0_batch(
+        self,
+        input_embeds: torch.Tensor,
+        last_talker_hidden: torch.Tensor,
+        req_infos: list[dict[str, Any]],
+        *,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generator: torch.Generator | None,
+    ) -> tuple[torch.Tensor, None]:
+        bsz = int(input_embeds.shape[0])
+        dev = input_embeds.device
+        input_embeds_out = input_embeds.reshape(bsz, -1).clone()
+
+        active_rows: list[int] = []
+        states: list[dict[str, Any]] = []
+        accs: list[torch.Tensor | None] = []
+        for i in range(bsz):
+            info = req_infos[i] if i < len(req_infos) and isinstance(req_infos[i], dict) else {}
+            state = dict(info.get("audio_state", {}) or {})
+            if state.get("is_stopping"):
+                info.setdefault("audio_codes", {}).update(
+                    {
+                        "current": input_embeds.new_empty((0, self.n_vq), dtype=torch.long),
+                        "emit": False,
+                    }
+                )
+                info["audio_state"] = state
+                continue
+            active_rows.append(i)
+            states.append(state)
+            acc = (info.get("audio_codes", {}) or {}).get("accumulated")
+            accs.append(acc if isinstance(acc, torch.Tensor) else None)
+
+        if not active_rows:
+            return input_embeds_out, None
+
+        active_idx = torch.tensor(active_rows, device=dev, dtype=torch.long)
+        hidden_batch = last_talker_hidden.index_select(0, active_idx).to(dtype=input_embeds_out.dtype)
+        should_continue_t, codes_b = self._decode_stage0_local_frames(
+            hidden_batch,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            generator=generator,
+        )
+        for local_i, row_i in enumerate(active_rows):
+            info = req_infos[row_i] if row_i < len(req_infos) and isinstance(req_infos[row_i], dict) else {}
+            state = states[local_i]
+            step = int(state.get("step", 0))
+            max_new_frames = int(state.get("max_new_frames", -1))
+            should_continue = bool(should_continue_t[local_i].item())
+            new_codes = codes_b[local_i].to(device=dev, dtype=torch.long)
+            acc = accs[local_i]
+
+            if not should_continue or (0 <= max_new_frames <= step):
+                state["is_stopping"] = True
+                state["step"] = step + 1
+                info["audio_state"] = state
+                info["audio_codes"] = {
+                    "current": input_embeds.new_empty((0, self.n_vq), dtype=torch.long),
+                    "accumulated": acc,
+                    "emit": False,
+                }
+                continue
+
+            updated_acc = (
+                torch.cat([acc.to(dev), new_codes.unsqueeze(0)], dim=0)
+                if acc is not None
+                else new_codes.unsqueeze(0)
+            )
+            state["step"] = step + 1
+            current = new_codes.unsqueeze(0)
+            input_embeds_out[row_i : row_i + 1] = input_embeds_out[row_i : row_i + 1] + self._audio_embed(
+                current
+            ).to(dtype=input_embeds_out.dtype)
+            info["audio_state"] = state
+            info["audio_codes"] = {
+                "current": current,
+                "accumulated": updated_acc,
+                "emit": True,
+            }
+
+        return input_embeds_out, None
 
     @torch.inference_mode()
     def talker_mtp(
@@ -1525,6 +1873,18 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         audio_top_k = 25
         audio_top_p = 0.8
         do_sample_val = True if do_sample is None else bool(do_sample)
+
+        if _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH") and generator is None:
+            return self._talker_mtp_stage0_batch(
+                input_embeds,
+                last_talker_hidden,
+                req_infos,
+                do_sample=do_sample_val,
+                temperature=audio_temperature,
+                top_k=audio_top_k,
+                top_p=audio_top_p,
+                generator=generator,
+            )
 
         for i in range(bsz):
             info = req_infos[i] if i < len(req_infos) and isinstance(req_infos[i], dict) else {}
@@ -1637,8 +1997,13 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         self._batch_state_spans = kwargs.get("request_token_spans")
 
         per_req_codes: list[torch.Tensor] = []
+        per_req_finished: list[torch.Tensor] = []
         have_codes = False
         for info in info_dicts:
+            state = (info.get("audio_state", {}) or {}) if isinstance(info, dict) else {}
+            per_req_finished.append(
+                torch.tensor(bool(state.get("is_stopping")), device=hidden.device, dtype=torch.bool)
+            )
             current = (info.get("audio_codes", {}) or {}).get("current") if isinstance(info, dict) else None
             emit = bool((info.get("audio_codes", {}) or {}).get("emit")) if isinstance(info, dict) else False
             if emit and isinstance(current, torch.Tensor) and current.numel() > 0:
@@ -1671,6 +2036,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             text_hidden_states=hidden,
             multimodal_outputs={
                 "codes": {"audio": per_req_codes, "ref": per_req_ref_codes},
+                "meta": {"finished": per_req_finished},
             },
         )
 

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
@@ -1279,6 +1279,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     has_preprocess: bool = True
     has_postprocess: bool = True
     enable_stage0_decode_batch_preprocess: bool = True
+    supports_talker_mtp_stable_seeded_batch: bool = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
@@ -1334,12 +1335,22 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         self._stacked_audio_emb_w: torch.Tensor | None = None
         self.mtp_hidden_size = hidden_size
         self.talker_mtp_accepts_req_infos = True
-        self._stage0_frame_graphs: dict[tuple[int, tuple[bool, float, int, float]], torch.cuda.CUDAGraph] = {}
+        self._stage0_frame_graphs: dict[tuple[Any, ...], torch.cuda.CUDAGraph] = {}
         self._stage0_frame_graph_input: torch.Tensor | None = None
+        self._stage0_frame_graph_seed: torch.Tensor | None = None
+        self._stage0_frame_graph_frame_step: torch.Tensor | None = None
         self._stage0_frame_graph_continue: torch.Tensor | None = None
         self._stage0_frame_graph_codes: torch.Tensor | None = None
+        self._stage0_frame_graph_audio_embed: torch.Tensor | None = None
         self._stage0_frame_graph_max_batch = 0
         self._stage0_frame_graph_bucket_sizes = self._parse_stage0_frame_graph_batch_buckets()
+        self._stage0_frame_graph_stats: dict[str, Any] = {
+            "capture_count": 0,
+            "replay_count": 0,
+            "eager_fallback_count": 0,
+            "fallback_by_reason": {},
+            "bucket_usage": {},
+        }
 
         self.gpu_resident_buffer_keys: set[tuple[str, str]] = {
             ("audio_codes", "current"),
@@ -1369,6 +1380,24 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
 
     def should_enable_stage0_decode_batch_preprocess(self) -> bool:
         return True
+
+    def _record_stage0_frame_graph_fallback(self, reason: str, count: int = 1) -> None:
+        stats = self._stage0_frame_graph_stats
+        stats["eager_fallback_count"] = int(stats.get("eager_fallback_count", 0)) + int(count)
+        by_reason = stats.setdefault("fallback_by_reason", {})
+        by_reason[reason] = int(by_reason.get(reason, 0)) + int(count)
+
+    def _record_stage0_frame_graph_bucket(self, bucket: int, count: int = 1) -> None:
+        usage = self._stage0_frame_graph_stats.setdefault("bucket_usage", {})
+        usage[int(bucket)] = int(usage.get(int(bucket), 0)) + int(count)
+
+    def get_stage0_frame_graph_stats(self) -> dict[str, Any]:
+        stats = copy.deepcopy(self._stage0_frame_graph_stats)
+        graph_hits = int(stats.get("replay_count", 0))
+        eager = int(stats.get("eager_fallback_count", 0))
+        denom = graph_hits + eager
+        stats["graph_hit_rate"] = (float(graph_hits) / float(denom)) if denom else 0.0
+        return stats
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_tokens(input_ids)
@@ -1580,6 +1609,8 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     ) -> None:
         if (
             self._stage0_frame_graph_input is not None
+            and self._stage0_frame_graph_seed is not None
+            and self._stage0_frame_graph_frame_step is not None
             and self._stage0_frame_graph_input.device == device
             and self._stage0_frame_graph_input.dtype == dtype
             and self._stage0_frame_graph_max_batch >= batch_size
@@ -1587,8 +1618,11 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             return
         cap = max(int(batch_size), self._stage0_frame_graph_max_batch, 1)
         self._stage0_frame_graph_input = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
+        self._stage0_frame_graph_seed = torch.zeros(cap, device=device, dtype=torch.long)
+        self._stage0_frame_graph_frame_step = torch.zeros(cap, device=device, dtype=torch.long)
         self._stage0_frame_graph_continue = torch.zeros(cap, device=device, dtype=torch.bool)
         self._stage0_frame_graph_codes = torch.zeros(cap, self.n_vq, device=device, dtype=torch.long)
+        self._stage0_frame_graph_audio_embed = torch.zeros(cap, self.hidden_size, device=device, dtype=dtype)
         self._stage0_frame_graph_max_batch = cap
         self._stage0_frame_graphs.clear()
 
@@ -1602,24 +1636,27 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         top_p: float,
     ) -> None:
         assert self._stage0_frame_graph_input is not None
+        assert self._stage0_frame_graph_seed is not None
+        assert self._stage0_frame_graph_frame_step is not None
         assert self._stage0_frame_graph_continue is not None
         assert self._stage0_frame_graph_codes is not None
-        should_continue, codes = self.local_transformer.generate_frame(
+        assert self._stage0_frame_graph_audio_embed is not None
+        should_continue, codes, audio_embed = self.local_transformer.generate_frame_graphable(
             self._stage0_frame_graph_input[:batch_size],
             self.audio_lm_heads,
             self.audio_embeddings,
             self.local_text_lm_head,
             n_vq=self.n_vq,
+            seed=self._stage0_frame_graph_seed[:batch_size],
+            frame_step=self._stage0_frame_graph_frame_step[:batch_size],
             do_sample=do_sample,
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
-            repetition_penalty=1.0,
-            history_per_codebook=None,
-            generator=None,
         )
         self._stage0_frame_graph_continue[:batch_size].copy_(should_continue)
         self._stage0_frame_graph_codes[:batch_size].copy_(codes)
+        self._stage0_frame_graph_audio_embed[:batch_size].copy_(audio_embed)
 
     def _decode_stage0_local_frames_eager(
         self,
@@ -1630,6 +1667,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         top_k: int,
         top_p: float,
         generator: torch.Generator | None,
+        repetition_penalty: float = 1.0,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return self.local_transformer.generate_frame(
             hidden_batch,
@@ -1641,57 +1679,104 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
-            repetition_penalty=1.0,
+            repetition_penalty=repetition_penalty,
             history_per_codebook=None,
             generator=generator,
+        )
+
+    def _decode_stage0_local_frames_seeded_eager(
+        self,
+        hidden_batch: torch.Tensor,
+        *,
+        seed: torch.Tensor,
+        frame_step: torch.Tensor,
+        do_sample: bool,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.local_transformer.generate_frame_graphable(
+            hidden_batch,
+            self.audio_lm_heads,
+            self.audio_embeddings,
+            self.local_text_lm_head,
+            n_vq=self.n_vq,
+            seed=seed,
+            frame_step=frame_step,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
         )
 
     def _decode_stage0_local_frames_graph(
         self,
         hidden_batch: torch.Tensor,
         *,
+        seed: torch.Tensor,
+        frame_step: torch.Tensor,
         do_sample: bool,
         temperature: float,
         top_k: int,
         top_p: float,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """CUDA graph wrapper for the local frame transformer.
-
-        The graph is deliberately limited to deterministic/greedy frame decode.
-        Sampling and unsupported devices fall back to eager batching without
-        changing correctness.
-        """
-        if hidden_batch.device.type != "cuda" or do_sample:
-            return self._decode_stage0_local_frames_eager(
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """CUDA graph wrapper for seeded local frame decode."""
+        if hidden_batch.device.type != "cuda":
+            self._record_stage0_frame_graph_fallback("cpu_device", int(hidden_batch.shape[0]))
+            return self._decode_stage0_local_frames_seeded_eager(
                 hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
                 do_sample=do_sample,
                 temperature=temperature,
                 top_k=top_k,
                 top_p=top_p,
-                generator=None,
             )
         batch_size = int(hidden_batch.shape[0])
+        if hidden_batch.dim() != 2 or hidden_batch.shape[-1] != self.hidden_size or batch_size <= 0:
+            self._record_stage0_frame_graph_fallback("unsupported_shape", max(batch_size, 1))
+            return self._decode_stage0_local_frames_seeded_eager(
+                hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+            )
         bucket = self._stage0_frame_graph_bucket(batch_size)
         dtype = hidden_batch.dtype
         self._ensure_stage0_frame_graph_buffers(batch_size=bucket, device=hidden_batch.device, dtype=dtype)
         assert self._stage0_frame_graph_input is not None
+        assert self._stage0_frame_graph_seed is not None
+        assert self._stage0_frame_graph_frame_step is not None
         assert self._stage0_frame_graph_continue is not None
         assert self._stage0_frame_graph_codes is not None
+        assert self._stage0_frame_graph_audio_embed is not None
 
         self._stage0_frame_graph_input[:bucket].zero_()
+        self._stage0_frame_graph_seed[:bucket].zero_()
+        self._stage0_frame_graph_frame_step[:bucket].zero_()
         self._stage0_frame_graph_input[:batch_size].copy_(hidden_batch)
-        graph_key = (bucket, (bool(do_sample), float(temperature), int(top_k), float(top_p)))
+        self._stage0_frame_graph_seed[:batch_size].copy_(seed.to(device=hidden_batch.device, dtype=torch.long))
+        self._stage0_frame_graph_frame_step[:batch_size].copy_(
+            frame_step.to(device=hidden_batch.device, dtype=torch.long)
+        )
+        self._record_stage0_frame_graph_bucket(bucket)
+        graph_key = (
+            int(bucket),
+            str(dtype),
+            str(hidden_batch.device),
+            bool(do_sample),
+            float(temperature),
+            int(top_k),
+            float(top_p),
+            int(self.n_vq),
+            int(self.audio_vocab_size),
+        )
         graph = self._stage0_frame_graphs.get(graph_key)
         if graph is None:
-            self._stage0_frame_graph_kernel(
-                bucket,
-                do_sample=do_sample,
-                temperature=temperature,
-                top_k=top_k,
-                top_p=top_p,
-            )
-            graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph):
+            try:
                 self._stage0_frame_graph_kernel(
                     bucket,
                     do_sample=do_sample,
@@ -1699,29 +1784,75 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                     top_k=top_k,
                     top_p=top_p,
                 )
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    self._stage0_frame_graph_kernel(
+                        bucket,
+                        do_sample=do_sample,
+                        temperature=temperature,
+                        top_k=top_k,
+                        top_p=top_p,
+                    )
+            except Exception:
+                self._record_stage0_frame_graph_fallback("capture_failed", batch_size)
+                logger.exception("MOSS-TTS Local Stage-0 frame graph capture failed; falling back to eager")
+                self._stage0_frame_graphs.pop(graph_key, None)
+                return self._decode_stage0_local_frames_seeded_eager(
+                    hidden_batch,
+                    seed=seed,
+                    frame_step=frame_step,
+                    do_sample=do_sample,
+                    temperature=temperature,
+                    top_k=top_k,
+                    top_p=top_p,
+                )
             self._stage0_frame_graphs[graph_key] = graph
+            self._stage0_frame_graph_stats["capture_count"] = int(
+                self._stage0_frame_graph_stats.get("capture_count", 0)
+            ) + 1
             return (
                 self._stage0_frame_graph_continue[:batch_size].clone(),
                 self._stage0_frame_graph_codes[:batch_size].clone(),
+                self._stage0_frame_graph_audio_embed[:batch_size].clone(),
             )
 
-        graph.replay()
+        try:
+            graph.replay()
+        except Exception:
+            self._record_stage0_frame_graph_fallback("replay_failed", batch_size)
+            logger.exception("MOSS-TTS Local Stage-0 frame graph replay failed; falling back to eager")
+            self._stage0_frame_graphs.pop(graph_key, None)
+            return self._decode_stage0_local_frames_seeded_eager(
+                hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+            )
+        self._stage0_frame_graph_stats["replay_count"] = int(self._stage0_frame_graph_stats.get("replay_count", 0)) + 1
         return (
             self._stage0_frame_graph_continue[:batch_size].clone(),
             self._stage0_frame_graph_codes[:batch_size].clone(),
+            self._stage0_frame_graph_audio_embed[:batch_size].clone(),
         )
 
     def _decode_stage0_local_frames(
         self,
         hidden_batch: torch.Tensor,
         *,
+        seed: torch.Tensor | None = None,
+        frame_step: torch.Tensor | None = None,
         do_sample: bool,
         temperature: float,
         top_k: int,
         top_p: float,
         generator: torch.Generator | None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if generator is not None or not _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH"):
+        repetition_penalty: float = 1.0,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if repetition_penalty != 1.0:
+            self._record_stage0_frame_graph_fallback("repetition_penalty", int(hidden_batch.shape[0]))
             return self._decode_stage0_local_frames_eager(
                 hidden_batch,
                 do_sample=do_sample,
@@ -1729,25 +1860,50 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                 top_k=top_k,
                 top_p=top_p,
                 generator=generator,
+                repetition_penalty=repetition_penalty,
+            ) + (None,)
+        if seed is None or frame_step is None:
+            self._record_stage0_frame_graph_fallback("no_seed", int(hidden_batch.shape[0]))
+            return self._decode_stage0_local_frames_eager(
+                hidden_batch,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=generator,
+            ) + (None,)
+        if not _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH"):
+            return self._decode_stage0_local_frames_seeded_eager(
+                hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
             )
         try:
             return self._decode_stage0_local_frames_graph(
                 hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
                 do_sample=do_sample,
                 temperature=temperature,
                 top_k=top_k,
                 top_p=top_p,
             )
         except Exception:
+            self._record_stage0_frame_graph_fallback("capture_failed", int(hidden_batch.shape[0]))
             logger.exception("MOSS-TTS Local Stage-0 frame graph failed; falling back to eager local decode")
             self._stage0_frame_graphs.clear()
-            return self._decode_stage0_local_frames_eager(
+            return self._decode_stage0_local_frames_seeded_eager(
                 hidden_batch,
+                seed=seed,
+                frame_step=frame_step,
                 do_sample=do_sample,
                 temperature=temperature,
                 top_k=top_k,
                 top_p=top_p,
-                generator=generator,
             )
 
     def _talker_mtp_stage0_batch(
@@ -1769,6 +1925,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         active_rows: list[int] = []
         states: list[dict[str, Any]] = []
         accs: list[torch.Tensor | None] = []
+        seeds: list[int | None] = []
         for i in range(bsz):
             info = req_infos[i] if i < len(req_infos) and isinstance(req_infos[i], dict) else {}
             state = dict(info.get("audio_state", {}) or {})
@@ -1785,20 +1942,63 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             states.append(state)
             acc = (info.get("audio_codes", {}) or {}).get("accumulated")
             accs.append(acc if isinstance(acc, torch.Tensor) else None)
+            seed_raw = info.get("tts_local_seed", state.get("tts_local_seed"))
+            try:
+                seed = int(seed_raw) if seed_raw is not None else None
+            except (TypeError, ValueError):
+                seed = None
+            seeds.append(seed)
 
         if not active_rows:
             return input_embeds_out, None
 
         active_idx = torch.tensor(active_rows, device=dev, dtype=torch.long)
         hidden_batch = last_talker_hidden.index_select(0, active_idx).to(dtype=input_embeds_out.dtype)
-        should_continue_t, codes_b = self._decode_stage0_local_frames(
-            hidden_batch,
-            do_sample=do_sample,
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            generator=generator,
-        )
+        num_active = len(active_rows)
+        should_continue_t = torch.empty(num_active, dtype=torch.bool, device=dev)
+        codes_b = torch.empty(num_active, self.n_vq, dtype=torch.long, device=dev)
+        audio_embed_b = torch.empty(num_active, self.hidden_size, dtype=input_embeds_out.dtype, device=dev)
+        have_audio_embed = torch.zeros(num_active, dtype=torch.bool, device=dev)
+
+        seeded_local_rows = [i for i, seed in enumerate(seeds) if seed is not None]
+        if seeded_local_rows:
+            seeded_idx = torch.tensor(seeded_local_rows, device=dev, dtype=torch.long)
+            seed_t = torch.tensor([int(seeds[i]) for i in seeded_local_rows], device=dev, dtype=torch.long)
+            step_t = torch.tensor(
+                [int(states[i].get("step", 0)) for i in seeded_local_rows],
+                device=dev,
+                dtype=torch.long,
+            )
+            should_continue_s, codes_s, audio_embed_s = self._decode_stage0_local_frames(
+                hidden_batch.index_select(0, seeded_idx),
+                seed=seed_t,
+                frame_step=step_t,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=None,
+            )
+            should_continue_t.index_copy_(0, seeded_idx, should_continue_s)
+            codes_b.index_copy_(0, seeded_idx, codes_s)
+            if audio_embed_s is not None:
+                audio_embed_b.index_copy_(0, seeded_idx, audio_embed_s.to(dtype=input_embeds_out.dtype))
+                have_audio_embed.index_fill_(0, seeded_idx, True)
+
+        for local_i, seed in enumerate(seeds):
+            if seed is not None:
+                continue
+            should_continue_u, codes_u, _ = self._decode_stage0_local_frames(
+                hidden_batch[local_i : local_i + 1],
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                generator=generator,
+            )
+            should_continue_t[local_i : local_i + 1] = should_continue_u
+            codes_b[local_i : local_i + 1] = codes_u
+
         for local_i, row_i in enumerate(active_rows):
             info = req_infos[row_i] if row_i < len(req_infos) and isinstance(req_infos[row_i], dict) else {}
             state = states[local_i]
@@ -1826,9 +2026,11 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             )
             state["step"] = step + 1
             current = new_codes.unsqueeze(0)
-            input_embeds_out[row_i : row_i + 1] = input_embeds_out[row_i : row_i + 1] + self._audio_embed(
-                current
-            ).to(dtype=input_embeds_out.dtype)
+            if bool(have_audio_embed[local_i].item()):
+                audio_embed = audio_embed_b[local_i : local_i + 1]
+            else:
+                audio_embed = self._audio_embed(current).to(dtype=input_embeds_out.dtype)
+            input_embeds_out[row_i : row_i + 1] = input_embeds_out[row_i : row_i + 1] + audio_embed
             info["audio_state"] = state
             info["audio_codes"] = {
                 "current": current,

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1867,7 +1867,16 @@ class OmniGPUModelRunner(GPUModelRunner):
                 seed = extra_args.get("tts_local_seed")
             return int(seed) if seed is not None else None
 
-        if decode_batch_size > 1 and any(_explicit_talker_seed(req_id) is not None for req_id in decode_req_ids):
+        supports_stable_seeded_batch = bool(
+            getattr(self.model, "supports_talker_mtp_stable_seeded_batch", False)
+            and getattr(self.model, "talker_mtp_accepts_req_infos", False)
+            and _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_FRAME_GRAPH")
+        )
+        if (
+            not supports_stable_seeded_batch
+            and decode_batch_size > 1
+            and any(_explicit_talker_seed(req_id) is not None for req_id in decode_req_ids)
+        ):
             # A torch.Generator is a single stream. Using one generator for a
             # multi-row batch would make explicitly-seeded requests depend on
             # other rows in the same scheduler step, so keep that path scalar.
@@ -1891,7 +1900,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             return
 
         generator = None
-        if decode_req_ids:
+        if decode_req_ids and not supports_stable_seeded_batch:
             first_req_id = decode_req_ids[0]
             seed = _explicit_talker_seed(first_req_id)
             if seed is not None:
@@ -1914,9 +1923,15 @@ class OmniGPUModelRunner(GPUModelRunner):
             talker_kwargs["generator"] = generator
         if getattr(self.model, "talker_mtp_accepts_req_infos", False):
             talker_kwargs["req_ids"] = decode_req_ids
-            talker_kwargs["req_infos"] = [
-                self.model_intermediate_buffer.setdefault(req_id, {}) for req_id in decode_req_ids
-            ]
+            req_infos = [self.model_intermediate_buffer.setdefault(req_id, {}) for req_id in decode_req_ids]
+            if supports_stable_seeded_batch:
+                for req_id, req_info in zip(decode_req_ids, req_infos, strict=True):
+                    seed = _explicit_talker_seed(req_id)
+                    if seed is not None:
+                        req_info["tts_local_seed"] = int(seed)
+                    else:
+                        req_info.pop("tts_local_seed", None)
+            talker_kwargs["req_infos"] = req_infos
         with current_omni_platform.set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1,5 +1,6 @@
 import contextlib
 import inspect
+import os
 from collections.abc import Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
@@ -47,6 +48,10 @@ else:
     )
 
 logger = init_logger(__name__)
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -1524,6 +1529,25 @@ class OmniGPUModelRunner(GPUModelRunner):
             device=device,
         )
 
+    def _should_enable_stage0_decode_batch_preprocess(self) -> bool:
+        """Return whether the model opted into the Stage-0 decode batch hook.
+
+        The hook is intentionally double gated: models must explicitly declare
+        support, and the deployment must enable it with an environment flag.
+        This keeps existing preprocess semantics unchanged by default.
+        """
+        if not _env_enabled("MOSS_TTS_LOCAL_ENABLE_STAGE0_BATCH_PREPROCESS"):
+            return False
+        model = getattr(self, "model", None)
+        if model is None or not getattr(model, "has_preprocess", False):
+            return False
+        if not callable(getattr(model, "preprocess_decode_batch", None)):
+            return False
+        should_enable = getattr(model, "should_enable_stage0_decode_batch_preprocess", None)
+        if callable(should_enable):
+            return bool(should_enable())
+        return bool(getattr(model, "enable_stage0_decode_batch_preprocess", False))
+
     def _preprocess(
         self,
         scheduler_output: "SchedulerOutput",
@@ -1674,7 +1698,11 @@ class OmniGPUModelRunner(GPUModelRunner):
             decode_req_ids = []
             decode_start_offsets = []
             decode_batch_items = []
-            batch_decode_preprocess = getattr(self.model, "preprocess_decode_batch", None)
+            batch_decode_preprocess = (
+                getattr(self.model, "preprocess_decode_batch", None)
+                if self._should_enable_stage0_decode_batch_preprocess()
+                else None
+            )
 
             def flush_decode_batch() -> None:
                 nonlocal inputs_embeds
@@ -1685,10 +1713,22 @@ class OmniGPUModelRunner(GPUModelRunner):
                 start_offsets_b = [item[1] for item in decode_batch_items]
                 req_infos_b = [item[2] for item in decode_batch_items]
                 ids_b = torch.stack([input_ids[offset : offset + 1].reshape(-1)[0] for offset in start_offsets_b])
-                req_input_ids, req_embeds, last_talker_hidden, text_step, updates = batch_decode_preprocess(
+                batch_result = batch_decode_preprocess(
                     input_ids=ids_b,
                     req_infos=req_infos_b,
                 )
+                if len(batch_result) == 3:
+                    req_input_ids, req_embeds, updates = batch_result
+                    last_talker_hidden = None
+                    text_step = None
+                elif len(batch_result) == 5:
+                    req_input_ids, req_embeds, last_talker_hidden, text_step, updates = batch_result
+                else:
+                    raise RuntimeError(
+                        "preprocess_decode_batch must return either "
+                        "(input_ids, embeds, updates) or "
+                        "(input_ids, embeds, last_talker_hidden, text_step, updates)"
+                    )
                 if inputs_embeds is None:
                     inputs_embeds = torch.empty(
                         (input_ids.shape[0], req_embeds.shape[-1]),
@@ -1700,17 +1740,18 @@ class OmniGPUModelRunner(GPUModelRunner):
                 inputs_embeds.index_copy_(0, offsets_t, req_embeds)
                 input_ids.index_copy_(0, offsets_t, req_input_ids.reshape(-1).to(dtype=input_ids.dtype))
 
-                dst = slice(len(decode_req_ids), len(decode_req_ids) + len(req_ids_b))
-                self.talker_mtp_input_ids.gpu[dst].copy_(req_input_ids.reshape(-1))
-                self.talker_mtp_inputs_embeds.gpu[dst].copy_(req_embeds)
-                self.last_talker_hidden.gpu[dst].copy_(last_talker_hidden)
-                self.text_step.gpu[dst].copy_(text_step)
+                if self.has_talker_mtp and last_talker_hidden is not None and text_step is not None:
+                    dst = slice(len(decode_req_ids), len(decode_req_ids) + len(req_ids_b))
+                    self.talker_mtp_input_ids.gpu[dst].copy_(req_input_ids.reshape(-1))
+                    self.talker_mtp_inputs_embeds.gpu[dst].copy_(req_embeds)
+                    self.last_talker_hidden.gpu[dst].copy_(last_talker_hidden)
+                    self.text_step.gpu[dst].copy_(text_step)
+                    decode_req_ids.extend(req_ids_b)
+                    decode_start_offsets.extend(start_offsets_b)
 
                 for req_id_b, update_dict_b in zip(req_ids_b, updates, strict=True):
                     self._merge_additional_information_update(req_id_b, update_dict_b)
 
-                decode_req_ids.extend(req_ids_b)
-                decode_start_offsets.extend(start_offsets_b)
                 decode_batch_items.clear()
 
             for req_index, req_id in enumerate(self.input_batch.req_ids):
@@ -1734,7 +1775,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_infos["_omni_prompt_len"] = prompt_len
                 req_infos["_omni_num_computed_tokens"] = num_computed_tokens
                 req_infos["_omni_is_prefill"] = is_prefill
-                if callable(batch_decode_preprocess) and self.has_talker_mtp and span_len == 1 and not is_prefill:
+                if callable(batch_decode_preprocess) and span_len == 1 and not is_prefill:
                     decode_batch_items.append((req_id, s, req_infos))
                     continue
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

#4676

## Test Plan

Validated MOSS-TTS Local Stage-0 CUDA Graph optimization with the local transformer checkpoint:

- Ran CPU-only unit tests for Stage-0 optimization gates, batch preprocessing, CUDA Graph fallback, and runner integration.
- Downloaded and verified local availability of:
  - `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
  - `OpenMOSS-Team/MOSS-Audio-Tokenizer-v2`
- Ran GPU smoke tests for baseline and Stage-0 frame graph modes using `/v1/audio/speech`.
- Ran `vllm-omni bench serve --omni` performance comparison with the existing TTS benchmark path on a small Seed-TTS-style voice clone dataset.

**vLLM Version:** `0.23.0`

**vLLM-Omni Commit:** `c4ee63e2836de869f7ac0464942cd22b04067109`

## Test Result

CPU-only tests:

```text
29 passed, 17 warnings in 0.22s
```

GPU smoke tests:

- Baseline `/v1/audio/speech`: HTTP 200, generated valid non-empty WAV.
- Stage-0 frame graph `/v1/audio/speech`: HTTP 200, generated valid non-empty WAV.
- Output audio: 48 kHz, stereo, finite samples, not all-zero.
- Server logs showed no `Stage-0 frame graph failed`, no eager fallback error, and no engine error.

Benchmark command path:

```text
vllm-omni bench serve --omni
```

Benchmark setup:

- Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- Task: `voice_clone`
- Concurrency: `1`
- Num prompts: `3`
- Warmups: `2`
- Output length: `64`
- Dataset: local Seed-TTS-style smoke dataset under `results/moss_local_stage0_cg/bench_dataset`

Benchmark results:

| Config | Mean E2EL | Median E2EL | Request throughput | Audio throughput | Mean audio RTF | Mean audio TTFP |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Greedy eager | `1387.68 ms` | `1442.25 ms` | `0.720 req/s` | `14.14 audio-s/s` | `0.0707` | `144.03 ms` |
| Stage-0 frame graph | `1208.67 ms` | `1248.19 ms` | `0.827 req/s` | `16.23 audio-s/s` | `0.0616` | `142.32 ms` |

Stage-0 frame graph compared with greedy eager:

- Mean E2E latency improved by `12.90%`.
- Median E2E latency improved by `13.46%`.
- Request throughput improved by `14.80%`.
- Audio throughput improved by `14.80%`.
- Mean audio RTF improved by `12.89%`.
