### PR TITLE
[Model] Add Boundless-World-Model (BWM) action-conditioned robot world model

### DIFF
--- a/examples/offline_inference/bwm/README.md
+++ b/examples/offline_inference/bwm/README.md
@@ -62,3 +62,7 @@ omni.generate(
 
 Actions are one-per-pixel-frame, `1 + 4 * (latent_frames - 1)` per chunk,
 normalized to [-1, 1] with the dataset's p01/p99 bounds client-side.
+If `num_frames` is omitted, the chunk length is derived from the action
+trajectory length. History frames are resized to `height`/`width` when
+they differ. The pipeline is single-device (no CFG by design; parallel
+configs are rejected at startup).

--- a/examples/offline_inference/bwm/README.md
+++ b/examples/offline_inference/bwm/README.md
@@ -1,0 +1,64 @@
+# Boundless-World-Model (BWM)
+
+Action-conditioned video world model for robotic manipulation, built on
+Wan2.2-TI2V-5B. Given history frames and a normalized 14-dim end-effector
+action trajectory, BWM generates the resulting manipulation video.
+
+See the recipe for full context: [`recipes/BLM/Boundless-World-Model.md`](../../../recipes/BLM/Boundless-World-Model.md).
+
+## 1. Assemble the model directory (once)
+
+```bash
+python download_bwm.py --output-dir models/BWM
+```
+
+Downloads the diffusers-format Wan2.2-TI2V-5B base and the BWM checkpoint,
+converts the fine-tuned DiT weights to diffusers naming, splits out the
+action encoder, and writes `model_index.json`.
+
+## 2. Get demo data (once)
+
+```bash
+git clone https://github.com/boundless-large-model/boundless-world-model /tmp/bwm-repo
+```
+
+The `demo/` folder ships three RoboTwin episodes in lerobot layout
+(mp4 + parquet actions + `stat.json` normalization statistics).
+
+## 3. Autoregressive rollout
+
+```bash
+python bwm_world_model.py \
+    --model models/BWM \
+    --episode-dir /tmp/bwm-repo/demo \
+    --episode 0 \
+    --output bwm_rollout.mp4
+```
+
+The script mirrors the reference rollout: each window conditions on 9
+history frames (first frame + 8 most recent) and the next 48 future
+actions, generating 57-frame chunks until the episode's action trajectory
+is exhausted.
+
+## Request contract
+
+The pipeline is request-level (like Cosmos3 `forward_dynamics`):
+
+```python
+omni.generate(
+    {
+        "prompt": "",  # unused: BWM runs with the text pathway disabled
+        "multi_modal_data": {
+            "video": history_frames,   # (T, H, W, C) uint8, T = 9
+            "action": action_window,   # (57, 14) float in [-1, 1]
+        },
+    },
+    OmniDiffusionSamplingParams(
+        height=672, width=896, num_frames=57,
+        num_inference_steps=50, guidance_scale=1.0, seed=42,
+    ),
+)
+```
+
+Actions are one-per-pixel-frame, `1 + 4 * (latent_frames - 1)` per chunk,
+normalized to [-1, 1] with the dataset's p01/p99 bounds client-side.

--- a/examples/offline_inference/bwm/bwm_world_model.py
+++ b/examples/offline_inference/bwm/bwm_world_model.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Boundless-World-Model (BWM) offline example: action-conditioned rollout.
+
+Given a robot manipulation episode (lerobot layout: mp4 + parquet actions,
+as shipped in the BWM repo's ``demo/`` folder), autoregressively generates
+the manipulation video from the first frame and the action trajectory,
+mirroring the reference ``scripts/infer.py`` rollout: each window feeds 9
+history frames (generated so far) plus the next 48 future actions.
+
+Usage:
+    # 1. Assemble the model directory (once):
+    python examples/offline_inference/bwm/download_bwm.py --output-dir models/BWM
+
+    # 2. Get demo data (once):
+    git clone https://github.com/boundless-large-model/boundless-world-model /tmp/bwm-repo
+
+    # 3. Roll out:
+    python examples/offline_inference/bwm/bwm_world_model.py \
+        --model models/BWM --episode-dir /tmp/bwm-repo/demo \
+        --episode 0 --output bwm_rollout.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import imageio.v2 as imageio
+import numpy as np
+
+# Column layout of lerobot "observation.state" (26 dims) and the 14-dim
+# end-effector subset ("eef_abs") the released BWM checkpoint is trained on.
+# Mirrors LoadCobotAction in the reference repo.
+EEF_INDICES = [7, 8, 9, 10, 11, 12, 6, 20, 21, 22, 23, 24, 25, 19]
+
+NUM_FRAMES = 57  # chunk length (pixel frames), release default
+NUM_HISTORY_FRAMES = 9  # history frames carried between windows
+
+
+def load_episode(episode_dir: Path, episode_index: int):
+    meta = None
+    with open(episode_dir / "demo.jsonl") as f:
+        for line in f:
+            entry = json.loads(line)
+            if entry["episode_index"] == episode_index:
+                meta = entry
+                break
+    if meta is None:
+        raise ValueError(f"Episode {episode_index} not found in {episode_dir}/demo.jsonl")
+
+    reader = imageio.get_reader(str(episode_dir / meta["video"]))
+    first_frame = reader.get_data(meta["start_frame"])
+    reader.close()
+
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(str(episode_dir / meta["action"]), columns=["observation.state"])
+    state = np.asarray(table.to_pydict()["observation.state"], dtype=np.float32)
+    start, end = int(meta["start_frame"]), int(meta["end_frame"])
+    state = state[start : end + 1]
+    if state.shape[1] == 26:
+        state = state[:, EEF_INDICES]
+
+    stat = json.loads((episode_dir / "stat.json").read_text())["state_pose"]
+    lo = np.asarray(stat.get("p01", stat["min"]), dtype=np.float32)
+    hi = np.asarray(stat.get("p99", stat["max"]), dtype=np.float32)
+    action = np.clip(2 * (state - lo) / (hi - lo + 1e-8) - 1.0, -1.0, 1.0)
+    return first_frame, action, meta
+
+
+def history_indices(num_generated: int, history: int) -> list[int]:
+    """Reference `_build_autoregressive_history_indices`: first frame plus
+    the most recent frames, padded with frame 0 early in the rollout."""
+    if num_generated < history:
+        return [0] * (history - num_generated) + list(range(num_generated))
+    if history == 1:
+        return [num_generated - 1]
+    return [0] + list(range(num_generated - (history - 1), num_generated))
+
+
+def extract_video(outputs) -> np.ndarray:
+    """Pull the video array out of Omni generate() results.
+
+    The post-process function returns ``{"video": <np array>}``; depending on
+    the entrypoint version it surfaces via ``images`` or nested request
+    outputs.
+    """
+    out = outputs[0]
+    if getattr(out, "is_pipeline_output", False) and getattr(out, "request_output", None) is not None:
+        out = out.request_output
+    candidates = getattr(out, "images", None) or []
+    for item in candidates:
+        if isinstance(item, dict) and "video" in item:
+            return np.asarray(item["video"])
+        if isinstance(item, np.ndarray):
+            return item
+    if isinstance(out, dict) and "video" in out:
+        return np.asarray(out["video"])
+    raise ValueError(f"Could not find video frames in output (type {type(out)})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Assembled BWM directory (see download_bwm.py)")
+    parser.add_argument("--episode-dir", type=Path, required=True, help="BWM demo folder (demo.jsonl layout)")
+    parser.add_argument("--episode", type=int, default=0)
+    parser.add_argument("--output", default="bwm_rollout.mp4")
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fps", type=int, default=24)
+    parser.add_argument("--max-windows", type=int, default=0, help="0 = full episode")
+    parser.add_argument("--enforce-eager", action="store_true", help="Disable torch.compile")
+    args = parser.parse_args()
+
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    first_frame, action, meta = load_episode(args.episode_dir, args.episode)
+    total_frames = action.shape[0]
+    height, width = first_frame.shape[:2]
+    print(f"Episode {args.episode}: {total_frames} action frames, {height}x{width}, task={meta['task']}")
+
+    omni = Omni(
+        model=args.model,
+        model_class_name="BoundlessWorldModelPipeline",
+        enforce_eager=args.enforce_eager,
+    )
+
+    generated: list[np.ndarray] = [first_frame]
+    future_per_window = NUM_FRAMES - NUM_HISTORY_FRAMES
+    window = 0
+    while len(generated) < total_frames:
+        if args.max_windows and window >= args.max_windows:
+            break
+        hist_idx = history_indices(len(generated), NUM_HISTORY_FRAMES)
+        future_start = len(generated)
+        future_count = min(future_per_window, total_frames - future_start)
+        if future_count < 4:
+            break  # remainder too short for a latent frame
+        # Window action condition: actions at the history frames + future
+        # actions, padded with the last action up to the chunk length.
+        cond = np.concatenate([action[hist_idx], action[future_start : future_start + future_count]], axis=0)
+        # Chunk length: history + future, rounded UP to the 4n+1 frame grid
+        # (rounding down would produce zero new frames on short tail windows).
+        num_frames = 1 + ((cond.shape[0] - 1 + 3) // 4) * 4
+        if cond.shape[0] < num_frames:
+            cond = np.concatenate([cond, np.repeat(cond[-1:], num_frames - cond.shape[0], axis=0)], axis=0)
+
+        history_frames = np.stack([generated[i] for i in hist_idx], axis=0)
+        print(
+            f"[window {window}] history={hist_idx[0]}..{hist_idx[-1]} "
+            f"future=[{future_start}, {future_start + future_count}) chunk={num_frames}"
+        )
+
+        outputs = omni.generate(
+            {
+                "prompt": meta.get("prompt", ""),
+                "multi_modal_data": {"video": history_frames, "action": cond},
+            },
+            OmniDiffusionSamplingParams(
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=args.num_inference_steps,
+                guidance_scale=1.0,
+                seed=args.seed + window,
+                output_type="np",
+            ),
+        )
+        video = extract_video(outputs)
+        frames = (np.asarray(video[0] if video.ndim == 5 else video) * 255).clip(0, 255).astype(np.uint8)
+        # Drop the history prefix; keep newly generated future frames.
+        new_frames = frames[NUM_HISTORY_FRAMES : NUM_HISTORY_FRAMES + future_count]
+        generated.extend(list(new_frames))
+        window += 1
+
+    writer = imageio.get_writer(args.output, fps=args.fps, quality=5)
+    for frame in generated:
+        writer.append_data(frame)
+    writer.close()
+    print(f"Wrote {len(generated)} frames -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/bwm/download_bwm.py
+++ b/examples/offline_inference/bwm/download_bwm.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Assemble a servable Boundless-World-Model (BWM) directory.
+
+BWM (https://huggingface.co/BLM-Lab/Boundless-World-Model) releases a single
+Wan-native-format checkpoint (fine-tuned Wan2.2-TI2V-5B DiT + action
+encoder). vLLM-Omni's Wan transformer loads diffusers-format weights, so this
+script:
+
+1. downloads the diffusers-format Wan2.2-TI2V-5B base
+   (``Wan-AI/Wan2.2-TI2V-5B-Diffusers``: transformer config + weights, VAE);
+2. downloads the BWM checkpoint (``step-12000.safetensors``);
+3. converts the fine-tuned DiT weights to diffusers naming and overlays them
+   on the base transformer state (the text pathway keeps base weights; BWM
+   runs with text conditioning disabled);
+4. splits the action-encoder weights into an ``action_encoder/`` component;
+5. writes a ``model_index.json`` with ``_class_name:
+   BoundlessWorldModelPipeline``.
+
+Usage:
+    python examples/offline_inference/bwm/download_bwm.py \
+        --output-dir models/BWM [--base-dir <existing diffusers base>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import torch
+from safetensors.torch import load_file, save_file
+
+# Wan-native -> diffusers weight-name fragments (the standard Wan conversion
+# map used by diffusers' convert_wan_to_diffusers.py, restricted to keys that
+# appear in the BWM checkpoint).
+TOP_LEVEL_RENAMES = {
+    "time_embedding.0.": "condition_embedder.time_embedder.linear_1.",
+    "time_embedding.2.": "condition_embedder.time_embedder.linear_2.",
+    "time_projection.1.": "condition_embedder.time_proj.",
+    "head.head.": "proj_out.",
+    "head.modulation": "scale_shift_table",
+}
+BLOCK_RENAMES = {
+    ".self_attn.q.": ".attn1.to_q.",
+    ".self_attn.k.": ".attn1.to_k.",
+    ".self_attn.v.": ".attn1.to_v.",
+    ".self_attn.o.": ".attn1.to_out.0.",
+    ".self_attn.norm_q.": ".attn1.norm_q.",
+    ".self_attn.norm_k.": ".attn1.norm_k.",
+    ".cross_attn.q.": ".attn2.to_q.",
+    ".cross_attn.k.": ".attn2.to_k.",
+    ".cross_attn.v.": ".attn2.to_v.",
+    ".cross_attn.o.": ".attn2.to_out.0.",
+    ".cross_attn.norm_q.": ".attn2.norm_q.",
+    ".cross_attn.norm_k.": ".attn2.norm_k.",
+    ".ffn.0.": ".ffn.net.0.proj.",
+    ".ffn.2.": ".ffn.net.2.",
+    ".norm3.": ".norm2.",
+    ".modulation": ".scale_shift_table",
+}
+ACTION_PREFIX = "pipe.action_encoder."
+
+
+def convert_dit_key(key: str) -> str:
+    for old, new in TOP_LEVEL_RENAMES.items():
+        if key.startswith(old) or key == old:
+            return key.replace(old, new, 1)
+    if key.startswith("blocks."):
+        for old, new in BLOCK_RENAMES.items():
+            if old in key:
+                return key.replace(old, new, 1)
+    return key  # e.g. patch_embedding.*
+
+
+def load_base_transformer_state(transformer_dir: Path) -> dict[str, torch.Tensor]:
+    index_file = transformer_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if index_file.exists():
+        index = json.loads(index_file.read_text())
+        shards = sorted(set(index["weight_map"].values()))
+        state: dict[str, torch.Tensor] = {}
+        for shard in shards:
+            state.update(load_file(str(transformer_dir / shard)))
+        return state
+    return load_file(str(transformer_dir / "diffusion_pytorch_model.safetensors"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--base-repo",
+        default="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        help="Diffusers-format Wan2.2-TI2V-5B repo (transformer + vae)",
+    )
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=None,
+        help="Existing local diffusers-format base (skips base download)",
+    )
+    parser.add_argument("--bwm-repo", default="BLM-Lab/Boundless-World-Model")
+    parser.add_argument("--bwm-file", default="step-12000.safetensors")
+    args = parser.parse_args()
+
+    from huggingface_hub import hf_hub_download, snapshot_download
+
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.base_dir is not None:
+        base = args.base_dir
+    else:
+        base = Path(
+            snapshot_download(
+                args.base_repo,
+                allow_patterns=["transformer/*", "vae/*", "model_index.json"],
+            )
+        )
+
+    print(f"[1/4] Copying VAE from {base}")
+    if not (out / "vae").exists():
+        shutil.copytree(base / "vae", out / "vae")
+
+    print(f"[2/4] Downloading BWM checkpoint {args.bwm_repo}/{args.bwm_file}")
+    ckpt_path = hf_hub_download(args.bwm_repo, args.bwm_file)
+    bwm_state = load_file(ckpt_path)
+
+    print("[3/4] Converting DiT weights to diffusers naming")
+    base_state = load_base_transformer_state(base / "transformer")
+    converted, action_state, unmatched = {}, {}, []
+    for key, tensor in bwm_state.items():
+        if key.startswith(ACTION_PREFIX):
+            action_state[key[len(ACTION_PREFIX) :]] = tensor
+            continue
+        new_key = convert_dit_key(key)
+        if new_key not in base_state:
+            unmatched.append((key, new_key))
+            continue
+        converted[new_key] = tensor
+    if unmatched:
+        raise RuntimeError(f"Unmapped checkpoint keys (conversion map incomplete): {unmatched[:10]}")
+
+    merged = dict(base_state)
+    merged.update(converted)
+    print(
+        f"  transformer: {len(converted)} fine-tuned keys over {len(base_state)} base keys; "
+        f"action encoder: {len(action_state)} keys"
+    )
+
+    tdir = out / "transformer"
+    tdir.mkdir(exist_ok=True)
+    shutil.copy(base / "transformer" / "config.json", tdir / "config.json")
+    save_file(merged, str(tdir / "diffusion_pytorch_model.safetensors"))
+
+    adir = out / "action_encoder"
+    adir.mkdir(exist_ok=True)
+    save_file(action_state, str(adir / "diffusion_pytorch_model.safetensors"))
+
+    print("[4/4] Writing model_index.json")
+    (out / "model_index.json").write_text(
+        json.dumps(
+            {
+                "_class_name": "BoundlessWorldModelPipeline",
+                "transformer": ["diffusers", "WanTransformer3DModel"],
+                "vae": ["diffusers", "AutoencoderKLWan"],
+                "action_encoder": ["vllm_omni", "BWMActionEncoder"],
+                "bwm": {"action_dim": 14, "action_type": "eef_abs"},
+            },
+            indent=2,
+        )
+    )
+    print(f"Done -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/BLM/Boundless-World-Model.md
+++ b/recipes/BLM/Boundless-World-Model.md
@@ -1,0 +1,89 @@
+# Boundless-World-Model (BWM)
+
+> Action-conditioned video world model for robotic manipulation (Wan2.2-TI2V-5B)
+
+## Summary
+
+- Vendor: BLM-Lab
+- Model: `BLM-Lab/Boundless-World-Model`
+- Task: Action-conditioned video generation (robot world model / forward dynamics): history frames + normalized end-effector action trajectory in, manipulation video out
+- Mode: Offline generation via the `Omni` API (request-level, one chunk per request; autoregressive rollouts loop client-side)
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe to run BWM as a learned simulator for robotic manipulation:
+given the first frame (or the last 9 frames of a running rollout) and a
+14-dim end-effector action trajectory, BWM generates the physically
+consistent resulting video. BWM ranks first among open-source models on the
+WorldArena Track 1 / Track 2 Data Engine leaderboards (May 2026).
+
+This is a concrete model integration under the world-model track
+([RFC #1987](https://github.com/vllm-project/vllm-omni/issues/1987)),
+request-level like Cosmos3 `forward_dynamics`.
+
+## References
+
+- Model weights: <https://huggingface.co/BLM-Lab/Boundless-World-Model>
+- Reference implementation: <https://github.com/boundless-large-model/boundless-world-model>
+- Base model: <https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers>
+- Related example: [`examples/offline_inference/bwm/`](../../examples/offline_inference/bwm/)
+- Pipeline: [`vllm_omni/diffusion/models/bwm/pipeline_bwm.py`](../../vllm_omni/diffusion/models/bwm/pipeline_bwm.py)
+
+## Model assembly
+
+The upstream release ships a single Wan-native-format checkpoint
+(fine-tuned DiT + action encoder). Assemble a servable diffusers-layout
+directory once:
+
+```bash
+python examples/offline_inference/bwm/download_bwm.py --output-dir models/BWM
+```
+
+This downloads the diffusers-format Wan2.2-TI2V-5B base (transformer
+config/weights + VAE, ~11 GB), the BWM checkpoint (~9.4 GB), converts the
+fine-tuned DiT weights to diffusers naming, and writes `model_index.json`
+with `_class_name: BoundlessWorldModelPipeline`. No text encoder is needed:
+BWM runs with the text pathway disabled (the cross-attention context is the
+action embedding).
+
+## Hardware Support
+
+## GPU
+
+### 1x H200 141GB (offline inference)
+
+#### Environment
+
+- OS: Ubuntu 22.04+
+- Python: 3.12
+- Driver / runtime: NVIDIA CUDA environment
+- vLLM version: match the repository requirements from your current checkout
+- vLLM-Omni version or commit: use the commit you are deploying from
+
+#### Command
+
+```bash
+# Demo data (lerobot layout: mp4 + parquet actions + normalization stats)
+git clone https://github.com/boundless-large-model/boundless-world-model /tmp/bwm-repo
+
+python examples/offline_inference/bwm/bwm_world_model.py \
+    --model models/BWM \
+    --episode-dir /tmp/bwm-repo/demo \
+    --episode 0 \
+    --output bwm_rollout.mp4
+```
+
+#### Verification
+
+The script prints one line per autoregressive window and writes
+`bwm_rollout.mp4` (~140 frames at 672x896). Compare against the reference
+implementation's output for the same episode
+(`bash scripts/infer_example.sh` in the BWM repo).
+
+#### Notes
+
+- Memory usage: ~30 GB peak (bf16 DiT ~10 GB + VAE + activations at 672x896x57 frames)
+- Release defaults: 57-frame chunks, 9 history frames, 50 denoise steps, flow shift 5.0, no CFG (`guidance_scale=1.0`)
+- Actions must be normalized to [-1, 1] with the dataset statistics client-side (`stat.json`, p01/p99 bounds); the example handles this
+- Known limitations: request-level serving only (interactive/session serving would build on the AR-diffusion engine, RFC #4366/#4480); single view; `eef_abs` (14-dim end-effector) action space as released

--- a/tests/diffusion/models/bwm/test_bwm_components.py
+++ b/tests/diffusion/models/bwm/test_bwm_components.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""L1 unit tests for Boundless-World-Model components (CPU).
+
+Covers the action encoder's shape contracts and frame grouping, the
+checkpoint weight-name conversion map, and the condition embedder's action
+modulation and text-pathway bypass.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.bwm.bwm_action_encoder import BWMActionEncoder
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+ACTION_DIM = 14
+DIM = 64  # small stand-in for the 3072 DiT dim
+
+
+def _load_download_module():
+    path = Path(__file__).resolve().parents[4] / "examples" / "offline_inference" / "bwm" / "download_bwm.py"
+    spec = importlib.util.spec_from_file_location("download_bwm", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["download_bwm"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestActionEncoder:
+    def test_output_shapes(self):
+        enc = BWMActionEncoder(action_dim=ACTION_DIM, dim=DIM)
+        num_latent_frames = 15
+        frames = 1 + 4 * (num_latent_frames - 1)  # 57
+        action = torch.randn(1, frames, ACTION_DIM)
+        context_emb, mod_emb = enc(action)
+        assert context_emb.shape == (1, frames, DIM)
+        assert mod_emb.shape == (1, num_latent_frames, DIM)
+
+    def test_leading_group_replicates_first_frame(self):
+        """The first latent frame's group is [a0, a0, a0, a0] (frame layout
+        1 + 4*(T-1)): a trajectory with distinct first action must produce a
+        first modulation equal to encoding that action alone repeated."""
+        enc = BWMActionEncoder(action_dim=ACTION_DIM, dim=DIM)
+        action = torch.randn(1, 5, ACTION_DIM)  # 2 latent frames
+        _, mod = enc(action)
+        first_group = action[:, 0:1].repeat(1, 4, 1).reshape(1, 1, ACTION_DIM * 4)
+        expected_first = enc.action_mlp2(first_group)
+        assert torch.allclose(mod[:, 0], expected_first[:, 0], atol=1e-6)
+
+
+class TestWeightConversion:
+    def test_all_bwm_checkpoint_key_families_map(self):
+        m = _load_download_module()
+        # Representative keys from the released step-12000.safetensors.
+        cases = {
+            "patch_embedding.weight": "patch_embedding.weight",
+            "time_embedding.0.weight": "condition_embedder.time_embedder.linear_1.weight",
+            "time_embedding.2.bias": "condition_embedder.time_embedder.linear_2.bias",
+            "time_projection.1.weight": "condition_embedder.time_proj.weight",
+            "head.head.weight": "proj_out.weight",
+            "head.modulation": "scale_shift_table",
+            "blocks.0.self_attn.q.weight": "blocks.0.attn1.to_q.weight",
+            "blocks.0.self_attn.o.bias": "blocks.0.attn1.to_out.0.bias",
+            "blocks.0.self_attn.norm_q.weight": "blocks.0.attn1.norm_q.weight",
+            "blocks.29.cross_attn.v.weight": "blocks.29.attn2.to_v.weight",
+            "blocks.3.ffn.0.weight": "blocks.3.ffn.net.0.proj.weight",
+            "blocks.3.ffn.2.bias": "blocks.3.ffn.net.2.bias",
+            "blocks.7.norm3.weight": "blocks.7.norm2.weight",
+            "blocks.7.modulation": "blocks.7.scale_shift_table",
+        }
+        for src, expected in cases.items():
+            assert m.convert_dit_key(src) == expected, src
+
+
+class TestConditionEmbedder:
+    def _make_embedder(self):
+        from vllm_omni.diffusion.models.bwm.bwm_condition_embedder import BWMConditionEmbedder
+        from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTimeTextImageEmbedding
+
+        inner = WanTimeTextImageEmbedding(
+            dim=DIM,
+            time_freq_dim=32,
+            time_proj_dim=DIM * 6,
+            text_embed_dim=DIM,
+        )
+        inner.__class__ = BWMConditionEmbedder
+        inner.action_mod_emb = None
+        return inner
+
+    def test_text_projection_bypassed(self):
+        emb = self._make_embedder()
+        context = torch.randn(1, 57, DIM)
+        timestep = torch.tensor([500.0])
+        _, _, out_context, out_img = emb(timestep, context)
+        # Action context must pass through unchanged (no text projection).
+        assert torch.equal(out_context, context)
+        assert out_img is None
+
+    def test_action_modulation_changes_temb_per_latent_frame(self):
+        emb = self._make_embedder()
+        num_latent_frames, spatial_tokens = 3, 4
+        seq_len = num_latent_frames * spatial_tokens
+        context = torch.randn(1, 10, DIM)
+        # Per-token timesteps (expand_timesteps mode).
+        timestep = torch.full((seq_len,), 500.0)
+
+        temb_base, proj_base, _, _ = emb(timestep, context, timestep_seq_len=seq_len)
+
+        emb.action_mod_emb = torch.zeros(1, num_latent_frames, DIM)
+        emb.action_mod_emb[:, 1] = 1.0  # perturb only the middle latent frame
+        temb_mod, proj_mod, _, _ = emb(timestep, context, timestep_seq_len=seq_len)
+        emb.action_mod_emb = None
+
+        delta = (temb_mod - temb_base).abs().sum(dim=-1)[0]  # (seq_len,)
+        frame0 = delta[:spatial_tokens]
+        frame1 = delta[spatial_tokens : 2 * spatial_tokens]
+        frame2 = delta[2 * spatial_tokens :]
+        assert torch.all(frame0 == 0) and torch.all(frame2 == 0)
+        assert torch.all(frame1 > 0)
+        assert not torch.allclose(proj_mod, proj_base)

--- a/tests/diffusion/models/bwm/test_bwm_components.py
+++ b/tests/diffusion/models/bwm/test_bwm_components.py
@@ -12,10 +12,12 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
 from vllm_omni.diffusion.models.bwm.bwm_action_encoder import BWMActionEncoder
+from vllm_omni.diffusion.models.bwm.pipeline_bwm import BoundlessWorldModelPipeline, resolve_num_frames
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -76,6 +78,48 @@ class TestWeightConversion:
         }
         for src, expected in cases.items():
             assert m.convert_dit_key(src) == expected, src
+
+
+class TestResolveNumFrames:
+    def test_derives_from_action_length_when_unset(self):
+        # OmniDiffusionSamplingParams.num_frames defaults to 1 (image-model
+        # default); both None and 1 must fall back to the action trajectory.
+        assert resolve_num_frames(57, None) == 57
+        assert resolve_num_frames(57, 1) == 57
+        assert resolve_num_frames(59, None) == 57  # snapped to the 4n+1 grid
+
+    def test_honors_explicit_request(self):
+        assert resolve_num_frames(100, 57) == 57
+        assert resolve_num_frames(100, 58) == 57  # snapped down
+
+    def test_rejects_empty_action(self):
+        with pytest.raises(ValueError):
+            resolve_num_frames(0, None)
+
+
+class TestHistoryFrames:
+    to_tensor = staticmethod(BoundlessWorldModelPipeline._history_frames_to_tensor)
+
+    def test_uint8_scaled_to_minus_one_one(self):
+        frames = np.full((2, 32, 48, 3), 255, dtype=np.uint8)
+        video = self.to_tensor(frames)
+        assert video.shape == (1, 3, 2, 32, 48)
+        assert torch.allclose(video, torch.ones_like(video))
+
+    def test_unit_float_rescaled(self):
+        frames = np.zeros((1, 32, 48, 3), dtype=np.float32)  # [0, 1] range
+        video = self.to_tensor(frames)
+        assert torch.allclose(video, -torch.ones_like(video))
+
+    def test_signed_float_passthrough(self):
+        frames = -np.ones((1, 32, 48, 3), dtype=np.float32)  # already [-1, 1]
+        video = self.to_tensor(frames)
+        assert torch.allclose(video, -torch.ones_like(video))
+
+    def test_resize_to_requested_resolution(self):
+        frames = np.random.randint(0, 255, (2, 32, 48, 3), dtype=np.uint8)
+        video = self.to_tensor(frames, height=64, width=96)
+        assert video.shape == (1, 3, 2, 64, 96)
 
 
 class TestConditionEmbedder:

--- a/vllm_omni/diffusion/models/bwm/__init__.py
+++ b/vllm_omni/diffusion/models/bwm/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.diffusion.models.bwm.pipeline_bwm import (
+    BoundlessWorldModelPipeline,
+    get_bwm_post_process_func,
+)
+
+__all__ = [
+    "BoundlessWorldModelPipeline",
+    "get_bwm_post_process_func",
+]

--- a/vllm_omni/diffusion/models/bwm/bwm_action_encoder.py
+++ b/vllm_omni/diffusion/models/bwm/bwm_action_encoder.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Action encoder for Boundless-World-Model (BWM).
+
+Ported from the reference implementation
+(https://github.com/boundless-large-model/boundless-world-model,
+``wan_video_action/models/wan_video_action_encoder.py``), keeping only the
+two branches the released ``adaln`` checkpoint uses:
+
+* ``action_mlp1``: per-frame action embeddings appended to the
+  cross-attention context (the DiT runs with the text pathway disabled, so
+  these tokens are the *entire* conditioning context);
+* ``action_mlp2``: actions grouped 4 pixel frames per latent frame and
+  projected to a per-latent-frame modulation added to the timestep
+  embedding (adaLN injection).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class BWMActionEncoder(nn.Module):
+    """Encode robot action trajectories for the BWM Wan2.2-TI2V-5B DiT."""
+
+    def __init__(self, action_dim: int = 14, dim: int = 3072):
+        super().__init__()
+        self.action_dim = action_dim
+        self.dim = dim
+        self.action_mlp1 = nn.Sequential(
+            nn.Linear(action_dim, dim),
+            nn.GELU(),
+            nn.Linear(dim, dim),
+        )
+        self.action_mlp2 = nn.Sequential(
+            nn.Linear(action_dim * 4, 4 * dim),
+            nn.SiLU(),
+            nn.Linear(4 * dim, dim),
+        )
+
+    def forward(self, action: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode an action trajectory.
+
+        Args:
+            action: ``(batch, frames, action_dim)`` normalized actions, where
+                ``frames = 1 + 4 * (num_latent_frames - 1)`` (one action per
+                pixel frame, aligned to the VAE temporal compression).
+
+        Returns:
+            ``(action_context_emb, action_mod_emb)``:
+            per-frame context tokens ``(batch, frames, dim)`` and grouped
+            per-latent-frame modulation ``(batch, num_latent_frames, dim)``.
+        """
+        action_context_emb = self.action_mlp1(action)
+        # Group actions 4-per-latent-frame; the first frame is replicated to
+        # complete the leading group (frame layout: 1 + 4 * (T_latent - 1)).
+        grouped = torch.cat([action[:, 0:1].repeat(1, 3, 1), action], dim=1)
+        grouped = grouped.reshape(action.shape[0], (action.shape[1] + 3) // 4, action.shape[2] * 4)
+        action_mod_emb = self.action_mlp2(grouped)
+        return action_context_emb, action_mod_emb

--- a/vllm_omni/diffusion/models/bwm/bwm_condition_embedder.py
+++ b/vllm_omni/diffusion/models/bwm/bwm_condition_embedder.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""BWM condition embedder: action-modulated timesteps, no text projection.
+
+BWM fine-tunes the Wan2.2-TI2V-5B DiT with two conditioning changes relative
+to the stock model (reference: ``model_fn_wan_video_action`` in the BWM repo):
+
+1. A per-latent-frame action modulation is added to the time embedding
+   *before* ``time_proj`` (adaLN injection), so it also flows into the
+   final output scale/shift through ``temb``.
+2. The text pathway is disabled. The cross-attention context is the action
+   encoder's per-frame tokens, which are already in DiT dimension, so the
+   text projection must be skipped.
+
+``BWMConditionEmbedder`` subclasses the stock embedder overriding only
+``forward``; the pipeline swaps the instance class in place
+(``__class__`` assignment) so parameter names, and therefore checkpoint
+loading, are unchanged.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTimeTextImageEmbedding
+
+
+class BWMConditionEmbedder(WanTimeTextImageEmbedding):
+    """WanTimeTextImageEmbedding with action adaLN and the text pathway off."""
+
+    # Set per forward by the pipeline: (batch, num_latent_frames, dim).
+    action_mod_emb: torch.Tensor | None = None
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None = None,
+        timestep_seq_len: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        timestep = self.timesteps_proj(timestep)
+        if timestep_seq_len is not None:
+            timestep = timestep.unflatten(0, (-1, timestep_seq_len))
+
+        time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
+        if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
+            timestep = timestep.to(time_embedder_dtype)
+        temb = self.time_embedder(timestep).type_as(encoder_hidden_states)
+
+        if self.action_mod_emb is not None:
+            mod = self.action_mod_emb
+            if temb.ndim == 3:
+                # Per-token timesteps (expand_timesteps mode): repeat each
+                # latent frame's modulation over its spatial tokens.
+                num_spatial_tokens = temb.shape[1] // mod.shape[1]
+                mod = mod.unsqueeze(2).repeat(1, 1, num_spatial_tokens, 1).flatten(1, 2)
+            temb = temb + mod.type_as(temb)
+
+        timestep_proj = self.time_proj(self.act_fn(temb))
+
+        # Text pathway disabled: encoder_hidden_states are pre-embedded action
+        # tokens in DiT dimension; do NOT apply the text projection.
+        return temb, timestep_proj, encoder_hidden_states, None

--- a/vllm_omni/diffusion/models/bwm/pipeline_bwm.py
+++ b/vllm_omni/diffusion/models/bwm/pipeline_bwm.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Boundless-World-Model (BWM) pipeline.
+
+BWM (https://github.com/boundless-large-model/boundless-world-model,
+weights: https://huggingface.co/BLM-Lab/Boundless-World-Model) is an
+action-conditioned video world model for robotic manipulation built on
+Wan2.2-TI2V-5B: given history frames and a normalized robot action
+trajectory, it generates the resulting manipulation video. Concrete model
+integration under the world-model track (RFC #1987), request-level like
+Cosmos3 ``forward_dynamics``: one chunk per request, autoregressive rollouts
+loop client-side (see ``examples/offline_inference/bwm/``).
+
+Differences from the stock Wan2.2 TI2V path:
+
+* no text/CLIP encoders: the cross-attention context is the action
+  encoder's per-frame tokens (see ``BWMConditionEmbedder``);
+* multi-frame history conditioning: the first ``num_history_frames`` pixel
+  frames are VAE-encoded and pinned at timestep 0 via the expand-timesteps
+  mask (the stock I2V pipeline pins only the first frame);
+* per-latent-frame action modulation added to the time embedding (adaLN).
+
+Request contract (all under ``multi_modal_data``):
+
+* ``video``: history frames as a ``(T, H, W, C)`` uint8 array, list of PIL
+  images, or a single PIL image (T=1);
+* ``action``: ``(frames, action_dim)`` float array, normalized with the
+  dataset statistics client-side, ``frames >= 1 + 4 * (T_latent - 1)``.
+
+Weights layout (assembled by ``examples/offline_inference/bwm/download_bwm.py``):
+``transformer/`` (fine-tuned DiT converted to diffusers naming), ``vae/``
+(stock Wan2.2 VAE), ``action_encoder/`` (BWM action encoder), and a
+``model_index.json`` with ``_class_name: BoundlessWorldModelPipeline``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, ClassVar
+
+import numpy as np
+import PIL.Image
+import torch
+from diffusers.utils.torch_utils import randn_tensor
+from torch import nn
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
+from vllm_omni.diffusion.models.bwm.bwm_action_encoder import BWMActionEncoder
+from vllm_omni.diffusion.models.bwm.bwm_condition_embedder import BWMConditionEmbedder
+from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
+    build_wan_scheduler,
+    create_transformer_from_config,
+    load_transformer_config,
+    retrieve_latents,
+)
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+logger = logging.getLogger(__name__)
+
+# BWM release defaults (configs/infer/infer.yaml in the reference repo).
+DEFAULT_NUM_FRAMES = 57
+DEFAULT_NUM_HISTORY_FRAMES = 9
+DEFAULT_NUM_INFERENCE_STEPS = 50
+DEFAULT_FLOW_SHIFT = 5.0
+DEFAULT_ACTION_DIM = 14
+
+
+def get_bwm_post_process_func(od_config: OmniDiffusionConfig):
+    from diffusers.video_processor import VideoProcessor
+
+    video_processor = VideoProcessor(vae_scale_factor=16)
+
+    def post_process_func(video: torch.Tensor, output_type: str = "np", sampling_params=None):
+        if output_type == "latent":
+            return video
+        return {"video": video_processor.postprocess_video(video, output_type=output_type)}
+
+    return post_process_func
+
+
+class BoundlessWorldModelPipeline(
+    nn.Module,
+    SupportImageInput,
+    ProgressBarMixin,
+    SupportsComponentDiscovery,
+):
+    """Action-conditioned world-model pipeline for BWM (Wan2.2-TI2V-5B)."""
+
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = []
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+    _resident_modules: ClassVar[list[str]] = ["action_encoder"]
+
+    # Skip the generic text-prompt warmup: BWM requires history frames and an
+    # action trajectory, which the dummy request cannot provide.
+    dummy_run_num_frames: ClassVar[int] = 0
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__()
+        self.od_config = od_config
+        self.device = get_local_device()
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=model,
+                subfolder="action_encoder",
+                revision=None,
+                prefix="action_encoder.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        subfolders = ["vae"]
+        prefetch_subfolders(model, subfolders, local_files_only=local_files_only)
+        self.vae = from_pretrained_with_prefetch(
+            DistributedAutoencoderKLWan.from_pretrained,
+            model,
+            subfolder="vae",
+            prefetch_list=subfolders,
+            local_files_only=local_files_only,
+            torch_dtype=dtype,
+        ).to(self.device)
+
+        transformer_config = load_transformer_config(model, "transformer", local_files_only)
+        self.transformer = create_transformer_from_config(
+            transformer_config,
+            quant_config=od_config.quantization_config,
+        )
+        # Swap the condition embedder's class in place: identical parameters
+        # (checkpoint loading unchanged), BWM forward semantics.
+        self.transformer.condition_embedder.__class__ = BWMConditionEmbedder
+        self.transformer.condition_embedder.action_mod_emb = None
+
+        model_config = getattr(od_config, "model_config", None) or {}
+        action_dim = int(model_config.get("action_dim", DEFAULT_ACTION_DIM))
+        self.action_encoder = BWMActionEncoder(
+            action_dim=action_dim,
+            dim=int(
+                transformer_config.get("num_attention_heads", 24) * transformer_config.get("attention_head_dim", 128)
+            ),
+        )
+
+        self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else DEFAULT_FLOW_SHIFT
+        self.scheduler = build_wan_scheduler("euler", self._flow_shift)
+
+        self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if hasattr(self.vae, "config") else 4
+        self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if hasattr(self.vae, "config") else 16
+
+        self._num_timesteps = None
+        self._current_timestep = None
+
+    # ------------------------------------------------------------ inputs
+
+    @staticmethod
+    def _history_frames_to_tensor(raw: Any) -> torch.Tensor:
+        """Return ``(1, C, T, H, W)`` float tensor in [-1, 1]."""
+        if isinstance(raw, PIL.Image.Image):
+            raw = [raw]
+        if isinstance(raw, (list, tuple)):
+            frames = [np.asarray(f.convert("RGB") if isinstance(f, PIL.Image.Image) else f) for f in raw]
+            raw = np.stack(frames, axis=0)
+        if isinstance(raw, np.ndarray):
+            raw = torch.from_numpy(raw)
+        if not isinstance(raw, torch.Tensor):
+            raise TypeError(f"Unsupported history video type {type(raw)}")
+        if raw.ndim != 4:
+            raise ValueError(f"History video must be (T, H, W, C), got shape {tuple(raw.shape)}")
+        video = raw.permute(3, 0, 1, 2).unsqueeze(0).float()  # (1, C, T, H, W)
+        if video.max() > 1.5:
+            video = video / 127.5 - 1.0
+        return video
+
+    # ------------------------------------------------------------ latents
+
+    def prepare_latents(
+        self,
+        history_video: torch.Tensor,
+        num_frames: int,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Noise latents, zero-padded history condition, and denoise mask.
+
+        The mask is 0 on the history latent frames (pinned at timestep 0,
+        expand-timesteps style) and 1 on frames to denoise.
+        """
+        num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
+        latent_height = height // self.vae_scale_factor_spatial
+        latent_width = width // self.vae_scale_factor_spatial
+        num_channels_latents = self.transformer.config.out_channels
+
+        shape = (1, num_channels_latents, num_latent_frames, latent_height, latent_width)
+        latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+
+        history_video = history_video.to(device=device, dtype=self.vae.dtype)
+        latent_condition = retrieve_latents(self.vae.encode(history_video), sample_mode="argmax")
+
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latent_condition.device, latent_condition.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latent_condition.device, latent_condition.dtype
+        )
+        latent_condition = ((latent_condition - latents_mean) * latents_std).to(dtype)
+
+        history_t = min(int(latent_condition.shape[2]), num_latent_frames)
+        condition = torch.zeros_like(latents)
+        condition[:, :, :history_t] = latent_condition[:, :, :history_t]
+
+        mask = torch.ones(1, 1, num_latent_frames, latent_height, latent_width, dtype=dtype, device=device)
+        mask[:, :, :history_t] = 0
+        return latents, condition, mask
+
+    # ------------------------------------------------------------ forward
+
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        if len(req.prompts) != 1:
+            raise ValueError("BWM supports a single request at a time.")
+        prompt = req.prompts[0]
+        multi_modal_data = prompt.get("multi_modal_data", {}) if not isinstance(prompt, str) else {}
+
+        raw_video = multi_modal_data.get("video", multi_modal_data.get("image"))
+        if raw_video is None:
+            raise ValueError(
+                "BWM requires history frames: "
+                '`"multi_modal_data": {"video": <(T,H,W,C) array or list of PIL images>, ...}`'
+            )
+        raw_action = multi_modal_data.get("action")
+        if raw_action is None:
+            extra_args = getattr(req.sampling_params, "extra_args", None) or {}
+            raw_action = extra_args.get("action")
+        if raw_action is None:
+            raise ValueError(
+                "BWM requires a normalized action trajectory: "
+                '`"multi_modal_data": {"action": <(frames, action_dim) array>, ...}`'
+            )
+
+        history_video = self._history_frames_to_tensor(raw_video)
+        action = torch.as_tensor(np.asarray(raw_action), dtype=torch.float32)
+        if action.ndim == 2:
+            action = action.unsqueeze(0)  # (1, frames, action_dim)
+        if action.ndim != 3 or action.shape[-1] != self.action_encoder.action_dim:
+            raise ValueError(
+                f"Action must be (frames, {self.action_encoder.action_dim}), got shape {tuple(action.shape)}"
+            )
+
+        height = req.sampling_params.height or history_video.shape[-2]
+        width = req.sampling_params.width or history_video.shape[-1]
+        num_frames = req.sampling_params.num_frames or DEFAULT_NUM_FRAMES
+        num_steps = req.sampling_params.num_inference_steps or DEFAULT_NUM_INFERENCE_STEPS
+        output_type = req.sampling_params.output_type or "np"
+
+        mod_value = self.vae_scale_factor_spatial * 2  # spatial compression x patch size
+        if height % mod_value != 0 or width % mod_value != 0:
+            raise ValueError(f"height/width must be divisible by {mod_value}, got {height}x{width}")
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
+
+        # One action per pixel frame, aligned to the latent grouping.
+        target_action_frames = 1 + 4 * (num_latent_frames - 1)
+        if action.shape[1] > target_action_frames:
+            action = action[:, :target_action_frames]
+        elif action.shape[1] < target_action_frames:
+            raise ValueError(
+                f"Action sequence too short: got {action.shape[1]} frames, need {target_action_frames} "
+                f"for {num_frames} video frames"
+            )
+
+        device = self.device
+        dtype = self.transformer.dtype
+
+        generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        action = action.to(device=device, dtype=dtype)
+        action_context_emb, action_mod_emb = self.action_encoder(action)
+
+        self.scheduler.set_timesteps(num_steps, device=device)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        latents, condition, mask = self.prepare_latents(
+            history_video=history_video,
+            num_frames=num_frames,
+            height=height,
+            width=width,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+        )
+
+        self.transformer.condition_embedder.action_mod_emb = action_mod_emb
+        try:
+            with self.progress_bar(total=len(timesteps)) as pbar:
+                for step_idx, t in enumerate(timesteps):
+                    self._current_timestep = t
+                    set_forward_context_denoise_step_idx(step_idx)
+
+                    latent_model_input = ((1 - mask) * condition + mask * latents).to(dtype)
+                    # Per-token timesteps: 0 on history tokens (2x2 spatial patch).
+                    temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
+                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
+
+                    noise_pred = self.transformer(
+                        hidden_states=latent_model_input,
+                        timestep=timestep,
+                        encoder_hidden_states=action_context_emb,
+                        return_dict=False,
+                    )[0]
+
+                    latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+                    pbar.update()
+        finally:
+            self.transformer.condition_embedder.action_mod_emb = None
+        self._current_timestep = None
+
+        latents = (1 - mask) * condition + mask * latents
+
+        if output_type == "latent":
+            return DiffusionOutput(output=latents)
+
+        latents = latents.to(self.vae.dtype)
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latents.device, latents.dtype
+        )
+        latents = latents / latents_std + latents_mean
+        output = self.vae.decode(latents, return_dict=False)[0]
+        return DiffusionOutput(output=output)
+
+    def load_weights(self, weights):
+        from vllm.model_executor.models.utils import AutoWeightsLoader
+
+        return AutoWeightsLoader(self).load_weights(weights)

--- a/vllm_omni/diffusion/models/bwm/pipeline_bwm.py
+++ b/vllm_omni/diffusion/models/bwm/pipeline_bwm.py
@@ -67,11 +67,45 @@ from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 logger = logging.getLogger(__name__)
 
 # BWM release defaults (configs/infer/infer.yaml in the reference repo).
-DEFAULT_NUM_FRAMES = 57
-DEFAULT_NUM_HISTORY_FRAMES = 9
+# Release defaults are 57-frame chunks with 9 history frames; the chunk
+# length is derived from the action trajectory (see resolve_num_frames).
 DEFAULT_NUM_INFERENCE_STEPS = 50
 DEFAULT_FLOW_SHIFT = 5.0
 DEFAULT_ACTION_DIM = 14
+
+
+def resolve_num_frames(action_frames: int, requested: int | None) -> int:
+    """Resolve the chunk length in pixel frames.
+
+    ``OmniDiffusionSamplingParams.num_frames`` defaults to 1 (an image-model
+    default), so a value of ``None`` or ``<= 1`` means the caller did not ask
+    for a specific length; in that case derive it from the action trajectory
+    (one action per pixel frame, ``1 + 4 * (T_latent - 1)`` alignment).
+    Explicit requests are snapped down to the 4n+1 frame grid.
+    """
+    if requested is None or requested <= 1:
+        if action_frames < 1:
+            raise ValueError("Action trajectory must contain at least one frame")
+        return 1 + 4 * ((action_frames - 1) // 4)
+    return 1 + 4 * ((requested - 1) // 4)
+
+
+def _reject_parallel_config(od_config: OmniDiffusionConfig) -> None:
+    """BWM runs single-device only.
+
+    CFG parallel is inapplicable (the model runs without classifier-free
+    guidance), and pipeline/sequence/tensor parallel are unsupported because
+    the action modulation reaches the condition embedder through module
+    state rather than a forward argument, which does not propagate across
+    stages the way real inputs do.
+    """
+    parallel = getattr(od_config, "parallel_config", None)
+    if parallel is None:
+        return
+    for field in ("tensor_parallel_size", "sequence_parallel_size", "pipeline_parallel_size", "cfg_parallel_size"):
+        size = int(getattr(parallel, field, 1) or 1)
+        if size > 1:
+            raise ValueError(f"BoundlessWorldModelPipeline is single-device only; got {field}={size}")
 
 
 def get_bwm_post_process_func(od_config: OmniDiffusionConfig):
@@ -109,6 +143,7 @@ class BoundlessWorldModelPipeline(
         self.od_config = od_config
         self.device = get_local_device()
         dtype = getattr(od_config, "dtype", torch.bfloat16)
+        _reject_parallel_config(od_config)
 
         model = od_config.model
         local_files_only = os.path.exists(model)
@@ -153,12 +188,15 @@ class BoundlessWorldModelPipeline(
 
         model_config = getattr(od_config, "model_config", None) or {}
         action_dim = int(model_config.get("action_dim", DEFAULT_ACTION_DIM))
+        # Explicit dtype cast (mirrors the VAE): the loader constructs the
+        # pipeline under set_default_torch_dtype(od_config.dtype), but the
+        # encoder must match the transformer even without that context.
         self.action_encoder = BWMActionEncoder(
             action_dim=action_dim,
             dim=int(
                 transformer_config.get("num_attention_heads", 24) * transformer_config.get("attention_head_dim", 128)
             ),
-        )
+        ).to(dtype)
 
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else DEFAULT_FLOW_SHIFT
         self.scheduler = build_wan_scheduler("euler", self._flow_shift)
@@ -172,8 +210,16 @@ class BoundlessWorldModelPipeline(
     # ------------------------------------------------------------ inputs
 
     @staticmethod
-    def _history_frames_to_tensor(raw: Any) -> torch.Tensor:
-        """Return ``(1, C, T, H, W)`` float tensor in [-1, 1]."""
+    def _history_frames_to_tensor(raw: Any, height: int | None = None, width: int | None = None) -> torch.Tensor:
+        """Return ``(1, C, T, H, W)`` float tensor in [-1, 1].
+
+        Value contract by input dtype: integer arrays are treated as
+        [0, 255]; float arrays with values in [0, 1] are rescaled to
+        [-1, 1]; other float arrays are assumed to already be in [-1, 1].
+        When ``height``/``width`` differ from the frame size, frames are
+        resized (bilinear, antialiased), mirroring the reference repo's
+        resize-to-render-resolution step.
+        """
         if isinstance(raw, PIL.Image.Image):
             raw = [raw]
         if isinstance(raw, (list, tuple)):
@@ -185,9 +231,20 @@ class BoundlessWorldModelPipeline(
             raise TypeError(f"Unsupported history video type {type(raw)}")
         if raw.ndim != 4:
             raise ValueError(f"History video must be (T, H, W, C), got shape {tuple(raw.shape)}")
+
+        is_integer = not raw.is_floating_point()
         video = raw.permute(3, 0, 1, 2).unsqueeze(0).float()  # (1, C, T, H, W)
-        if video.max() > 1.5:
+        if is_integer:
             video = video / 127.5 - 1.0
+        elif video.min() >= 0.0 and video.max() <= 1.0:
+            video = video * 2.0 - 1.0
+
+        if height is not None and width is not None and video.shape[-2:] != (height, width):
+            frames_2d = video.squeeze(0).permute(1, 0, 2, 3)  # (T, C, H, W)
+            frames_2d = torch.nn.functional.interpolate(
+                frames_2d, size=(height, width), mode="bilinear", align_corners=False, antialias=True
+            )
+            video = frames_2d.permute(1, 0, 2, 3).unsqueeze(0)
         return video
 
     # ------------------------------------------------------------ latents
@@ -223,10 +280,10 @@ class BoundlessWorldModelPipeline(
             .view(1, self.vae.config.z_dim, 1, 1, 1)
             .to(latent_condition.device, latent_condition.dtype)
         )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+        latents_std_inv = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
             latent_condition.device, latent_condition.dtype
         )
-        latent_condition = ((latent_condition - latents_mean) * latents_std).to(dtype)
+        latent_condition = ((latent_condition - latents_mean) * latents_std_inv).to(dtype)
 
         history_t = min(int(latent_condition.shape[2]), num_latent_frames)
         condition = torch.zeros_like(latents)
@@ -260,7 +317,6 @@ class BoundlessWorldModelPipeline(
                 '`"multi_modal_data": {"action": <(frames, action_dim) array>, ...}`'
             )
 
-        history_video = self._history_frames_to_tensor(raw_video)
         action = torch.as_tensor(np.asarray(raw_action), dtype=torch.float32)
         if action.ndim == 2:
             action = action.unsqueeze(0)  # (1, frames, action_dim)
@@ -269,17 +325,19 @@ class BoundlessWorldModelPipeline(
                 f"Action must be (frames, {self.action_encoder.action_dim}), got shape {tuple(action.shape)}"
             )
 
+        history_video = self._history_frames_to_tensor(raw_video)
         height = req.sampling_params.height or history_video.shape[-2]
         width = req.sampling_params.width or history_video.shape[-1]
-        num_frames = req.sampling_params.num_frames or DEFAULT_NUM_FRAMES
         num_steps = req.sampling_params.num_inference_steps or DEFAULT_NUM_INFERENCE_STEPS
         output_type = req.sampling_params.output_type or "np"
 
         mod_value = self.vae_scale_factor_spatial * 2  # spatial compression x patch size
         if height % mod_value != 0 or width % mod_value != 0:
             raise ValueError(f"height/width must be divisible by {mod_value}, got {height}x{width}")
-        if num_frames % self.vae_scale_factor_temporal != 1:
-            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        if history_video.shape[-2:] != (height, width):
+            history_video = self._history_frames_to_tensor(raw_video, height=height, width=width)
+
+        num_frames = resolve_num_frames(int(action.shape[1]), req.sampling_params.num_frames)
         num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
 
         # One action per pixel frame, aligned to the latent grouping.
@@ -352,10 +410,10 @@ class BoundlessWorldModelPipeline(
             .view(1, self.vae.config.z_dim, 1, 1, 1)
             .to(latents.device, latents.dtype)
         )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+        latents_std_inv = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
             latents.device, latents.dtype
         )
-        latents = latents / latents_std + latents_mean
+        latents = latents / latents_std_inv + latents_mean
         output = self.vae.decode(latents, return_dict=False)[0]
         return DiffusionOutput(output=output)
 

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -116,6 +116,11 @@ _DIFFUSION_MODELS = {
         "pipeline_wan2_2_i2v",
         "Wan22I2VPipeline",
     ),
+    "BoundlessWorldModelPipeline": (
+        "bwm",
+        "pipeline_bwm",
+        "BoundlessWorldModelPipeline",
+    ),
     "WanS2VPipeline": (
         "wan2_2",
         "pipeline_wan2_2_s2v",
@@ -503,6 +508,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "SoulXSingerSVCPipeline": "get_soulxsinger_post_process_func",
     "AudioXPipeline": "get_audiox_post_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_post_process_func",
+    "BoundlessWorldModelPipeline": "get_bwm_post_process_func",
     "WanS2VPipeline": "get_wan22_s2v_post_process_func",
     "WanT2VDMD2Pipeline": "get_wan22_post_process_func",
     "WanI2VDMD2Pipeline": "get_wan22_i2v_post_process_func",


### PR DESCRIPTION
## Purpose

Add support for Boundless-World-Model (BWM, https://huggingface.co/BLM-Lab/Boundless-World-Model), an action-conditioned video world model for robotic manipulation built on Wan2.2-TI2V-5B. Given history frames and a normalized 14-dim end-effector action trajectory, BWM generates the resulting manipulation video. It ranks 1st among open-source models on WorldArena Track 1 and Track 2 Data Engine (May 2026).

This is a concrete model integration under the world-model track (RFC #1987, Stage 1 robotics), request-level like Cosmos3 forward_dynamics: one chunk per request, autoregressive rollouts loop client-side.

Closes #4903

## Implementation

- `vllm_omni/diffusion/models/bwm/`: pipeline, action encoder, and a condition-embedder subclass. BWM disables the text pathway entirely, so no text encoder or CLIP is loaded. The cross-attention context is the action encoder's per-frame tokens, and a per-latent-frame action modulation is added to the time embedding (adaLN) before time_proj. The embedder subclass is swapped in place so parameter names and checkpoint loading stay unchanged.
- Multi-frame history conditioning generalizes the existing TI2V expand-timesteps mask from 1 pinned frame to N (release default: 9 history frames, 57-frame chunks).
- The released checkpoint is a single Wan-native-format safetensors. `examples/offline_inference/bwm/download_bwm.py` converts the fine-tuned DiT weights to diffusers naming, splits out the action encoder, and assembles a servable directory with `model_index.json`.
- Recipe under `recipes/BLM/`, offline autoregressive rollout example mirroring the reference `infer.py` (history indices, action windowing, p01/p99 normalization), and L1 unit tests (`core_model` + `cpu`) covering the action encoder shape contracts, the checkpoint weight-name conversion map, and the condition embedder's modulation and text-pathway bypass.

## Test Plan

- `pytest tests/diffusion/models/bwm/` (CPU, 5 tests)
- End-to-end on 1x H200: assemble the model dir, then run the offline example on the demo RoboTwin episode from the reference repo

## Test Result

- 5/5 unit tests pass, pre-commit clean
- Full 143-frame autoregressive rollout (3 windows, 9-frame history carry-over) completes; 50-step denoise runs at about 8 it/s eager on H200
- Side-by-side comparison against the reference implementation's output on the same episode shows matching task execution frame by frame (same grasp, lift, and hold of the correct bottle); differences are consistent with different noise seeds and the resolution setting (reference config renders 672x896, the example uses the native 480x640 of the demo video)

Happy to add online serving docs or an L3 e2e test if maintainers want them in this PR rather than a follow-up.