### PR TITLE
[Core] Copy-on-write session fork for the AR-diffusion KV cache

### DIFF
--- a/tests/ar_diffusion/test_kv_fork.py
+++ b/tests/ar_diffusion/test_kv_fork.py
@@ -210,7 +210,28 @@ class TestSessionFork:
         child = state.fork("pos.b0", "neg.b0")
         assert resident(kv, child.pos) == resident(kv, state.pos)
         assert resident(kv, child.neg) == resident(kv, state.neg)
+        # Text conditioning is prompt-derived and branch-invariant: inherited.
         assert child._cross_text_populated == state._cross_text_populated
+
+        child.close()
+        state.close()
+
+    def test_fork_invalidates_image_conditioning_on_both_branches(self):
+        # The image cross-attn pool is engine-wide, not per session. If a
+        # forked branch kept _cross_img_populated=True, it would skip
+        # repopulation and silently read whichever branch last wrote the
+        # shared pool. Fork must force BOTH branches to re-project image
+        # conditioning from their own next observation.
+        kv = make_cache()
+        state = ARDiffusionKVState(kv, kv.begin_request("pos"), kv.begin_request("neg"), num_layers=2)
+        run_chunks(kv, state.pos, 1)
+        run_chunks(kv, state.neg, 1)
+        state._cross_text_populated = {False: True, True: True}
+        state._cross_img_populated = {False: True, True: True}
+
+        child = state.fork("pos.b0", "neg.b0")
+        assert child._cross_img_populated == {False: False, True: False}
+        assert state._cross_img_populated == {False: False, True: False}
 
         child.close()
         state.close()

--- a/tests/ar_diffusion/test_kv_fork.py
+++ b/tests/ar_diffusion/test_kv_fork.py
@@ -152,9 +152,7 @@ class TestForkWriteIsolationGPU:
     def test_child_divergence_does_not_touch_parent_bytes(self):
         device = torch.device("cuda")
         cfg = ARDiffusionKVConfig(enable=True, chunk_size=16, window_chunks=4)
-        kv = ARDiffusionKVCache(
-            cfg, max_model_len=4096, available_bytes=1 << 24, device=device, **DIMS
-        )
+        kv = ARDiffusionKVCache(cfg, max_model_len=4096, available_bytes=1 << 24, device=device, **DIMS)
         chunk_kv_shape = (1, cfg.chunk_size, DIMS["num_kv_heads"], DIMS["head_size"])
 
         def write_chunk(adapter, fill):

--- a/tests/ar_diffusion/test_kv_fork.py
+++ b/tests/ar_diffusion/test_kv_fork.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for copy-on-write session fork over the AR-Diffusion KV cache.
+
+Exercised against the installed vLLM KV stack on CPU (block bookkeeping
+only, no GPU tensors), like the rest of the AR-Diffusion KV tests.
+"""
+
+import pytest
+import torch
+
+from vllm_omni.experimental.ar_diffusion.kv_cache import ARDiffusionKVCache, ARDiffusionKVConfig
+from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
+
+DIMS = dict(num_layers=2, num_kv_heads=4, head_size=64, dtype=torch.float16, block_size=16)
+
+
+def make_cache(*, chunk_size=16, window_chunks=4, available_bytes=1 << 24):
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=chunk_size, window_chunks=window_chunks)
+    return ARDiffusionKVCache(cfg, max_model_len=4096, available_bytes=available_bytes, **DIMS)
+
+
+def run_chunks(kv, adapter, n):
+    for _ in range(n):
+        kv.allocate_chunk(adapter)
+        kv.commit_chunk(adapter)
+
+
+def resident(kv, adapter):
+    return kv.window_block_ids(adapter)
+
+
+class TestForkAtLastCommit:
+    def test_fork_shares_blocks_without_allocation(self):
+        kv = make_cache()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 3)
+        free_before = kv.manager.block_pool.get_num_free_blocks()
+
+        child = kv.fork_at_last_commit(parent, "child")
+
+        # Zero new blocks consumed: the fork is a table copy plus refcounts.
+        assert kv.manager.block_pool.get_num_free_blocks() == free_before
+        assert resident(kv, child) == resident(kv, parent)
+        assert child.num_computed_tokens == parent.num_computed_tokens
+        assert child.completed_chunks == parent.completed_chunks
+
+    def test_post_fork_divergence_is_isolated(self):
+        kv = make_cache()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 2)
+        child = kv.fork_at_last_commit(parent, "child")
+
+        shared = set(resident(kv, parent))
+        run_chunks(kv, child, 1)
+        run_chunks(kv, parent, 1)
+
+        parent_new = set(resident(kv, parent)) - shared
+        child_new = set(resident(kv, child)) - shared
+        # Each branch appended fresh physical blocks, and they do not collide.
+        assert parent_new and child_new
+        assert parent_new.isdisjoint(child_new)
+
+    def test_shared_blocks_survive_parent_free(self):
+        kv = make_cache()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 2)
+        child = kv.fork_at_last_commit(parent, "child")
+        shared = resident(kv, child)
+
+        kv.end_request(parent)
+        # The child still resolves the shared history blocks.
+        assert resident(kv, child) == shared
+
+        # Allocating a fresh session must not hand out the child's blocks.
+        other = kv.begin_request("other")
+        run_chunks(kv, other, 2)
+        assert set(resident(kv, other)).isdisjoint(set(shared))
+
+    def test_refcounts_balance_after_both_free(self):
+        kv = make_cache()
+        free_at_start = kv.manager.block_pool.get_num_free_blocks()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 3)
+        child = kv.fork_at_last_commit(parent, "child")
+        run_chunks(kv, child, 1)
+
+        kv.end_request(parent)
+        kv.end_request(child)
+        assert kv.manager.block_pool.get_num_free_blocks() == free_at_start
+
+    def test_fork_mid_chunk_is_rejected(self):
+        kv = make_cache()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 1)
+        kv.allocate_chunk(parent)  # in-flight, not committed
+        with pytest.raises(RuntimeError, match="chunk-commit boundary"):
+            kv.fork_at_last_commit(parent, "child")
+
+    def test_fork_rejects_duplicate_and_unknown_ids(self):
+        kv = make_cache()
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 1)
+        kv.fork_at_last_commit(parent, "child")
+        with pytest.raises(ValueError, match="already exists"):
+            kv.fork_at_last_commit(parent, "child")
+        ghost = kv.begin_request("ghost")
+        kv._adapters.pop("ghost")
+        kv.manager.coordinator.single_type_managers[0].req_to_blocks.pop("ghost", None)
+        with pytest.raises(ValueError, match="unknown parent"):
+            kv.fork_at_last_commit(ghost, "child2")
+
+    def test_fork_after_window_eviction_shares_only_resident_blocks(self):
+        # Roll past the window so old blocks were evicted (null placeholders);
+        # the fork must share exactly the resident window, and rolling the
+        # child forward must not corrupt the parent's view.
+        kv = make_cache(window_chunks=2)
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 5)
+        child = kv.fork_at_last_commit(parent, "child")
+        assert resident(kv, child) == resident(kv, parent)
+
+        parent_view = list(resident(kv, parent))
+        run_chunks(kv, child, 2)  # child evicts shared blocks from ITS table
+        assert resident(kv, parent) == parent_view
+
+    def test_multi_branch_fanout(self):
+        # RL-style: N branches from one state, each rolled independently.
+        kv = make_cache(available_bytes=1 << 26)
+        parent = kv.begin_request("parent")
+        run_chunks(kv, parent, 2)
+        free_before = kv.manager.block_pool.get_num_free_blocks()
+        branches = [kv.fork_at_last_commit(parent, f"b{i}") for i in range(4)]
+        assert kv.manager.block_pool.get_num_free_blocks() == free_before
+
+        for branch in branches:
+            run_chunks(kv, branch, 1)
+        tails = [set(resident(kv, b)) - set(resident(kv, parent)) for b in branches]
+        for i in range(len(tails)):
+            for j in range(i + 1, len(tails)):
+                assert tails[i].isdisjoint(tails[j])
+
+
+class TestSessionFork:
+    def test_forks_both_cfg_streams(self):
+        kv = make_cache()
+        state = ARDiffusionKVState(kv, kv.begin_request("pos"), kv.begin_request("neg"), num_layers=2)
+        run_chunks(kv, state.pos, 2)
+        run_chunks(kv, state.neg, 2)
+        state._cross_text_populated = {False: True, True: True}
+
+        child = state.fork("pos.b0", "neg.b0")
+        assert resident(kv, child.pos) == resident(kv, state.pos)
+        assert resident(kv, child.neg) == resident(kv, state.neg)
+        assert child._cross_text_populated == state._cross_text_populated
+
+        child.close()
+        state.close()
+
+    def test_partial_fork_failure_rolls_back(self):
+        kv = make_cache()
+        state = ARDiffusionKVState(kv, kv.begin_request("pos"), kv.begin_request("neg"), num_layers=2)
+        run_chunks(kv, state.pos, 1)
+        run_chunks(kv, state.neg, 1)
+        kv.begin_request("neg.b0")  # occupy the neg child id to force failure
+        run_chunks(kv, kv._adapters["neg.b0"], 1)
+
+        free_before = kv.manager.block_pool.get_num_free_blocks()
+        with pytest.raises(ValueError):
+            state.fork("pos.b0", "neg.b0")
+        # The half-made pos fork was released; no leaked references.
+        assert kv.manager.block_pool.get_num_free_blocks() == free_before
+        assert "pos.b0" not in kv._adapters

--- a/tests/ar_diffusion/test_kv_fork.py
+++ b/tests/ar_diffusion/test_kv_fork.py
@@ -140,6 +140,67 @@ class TestForkAtLastCommit:
                 assert tails[i].isdisjoint(tails[j])
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="write-isolation test needs GPU-backed pools")
+class TestForkWriteIsolationGPU:
+    """Tensor-level check of the commit-once assumption the fork relies on.
+
+    The CPU tests verify the bookkeeping; this verifies the memory: after a
+    fork, the shared physical slots hold identical bytes for both sessions,
+    and a diverging child never rewrites the parent's committed K/V.
+    """
+
+    def test_child_divergence_does_not_touch_parent_bytes(self):
+        device = torch.device("cuda")
+        cfg = ARDiffusionKVConfig(enable=True, chunk_size=16, window_chunks=4)
+        kv = ARDiffusionKVCache(
+            cfg, max_model_len=4096, available_bytes=1 << 24, device=device, **DIMS
+        )
+        chunk_kv_shape = (1, cfg.chunk_size, DIMS["num_kv_heads"], DIMS["head_size"])
+
+        def write_chunk(adapter, fill):
+            kv.allocate_chunk(adapter)
+            slots = kv.chunk_write_slots(adapter)
+            for layer in range(DIMS["num_layers"]):
+                k = torch.full(chunk_kv_shape, fill, dtype=DIMS["dtype"], device=device)
+                v = torch.full(chunk_kv_shape, -fill, dtype=DIMS["dtype"], device=device)
+                kv.write_chunk_kv(layer, k, v, adapter)
+            kv.commit_chunk(adapter)
+            return slots
+
+        parent = kv.begin_request("parent")
+        parent_slots = [write_chunk(parent, fill=float(i + 1)) for i in range(2)]
+
+        def read_bytes(slot_list):
+            return [
+                (kv._k_pools[layer][slots].clone(), kv._v_pools[layer][slots].clone())
+                for layer in range(DIMS["num_layers"])
+                for slots in slot_list
+            ]
+
+        before = read_bytes(parent_slots)
+        child = kv.fork_at_last_commit(parent, "child")
+
+        # Shared prefix resolves to the same physical slots for the child.
+        assert kv.window_block_ids(child) == kv.window_block_ids(parent)
+
+        # The child diverges with different values; the parent's committed
+        # bytes must be bit-identical afterwards.
+        write_chunk(child, fill=99.0)
+        after = read_bytes(parent_slots)
+        for (k0, v0), (k1, v1) in zip(before, after):
+            assert torch.equal(k0, k1)
+            assert torch.equal(v0, v1)
+
+        # And symmetrically: the parent rolling forward does not disturb the
+        # child's shared view of the prefix.
+        child_prefix_before = read_bytes(parent_slots)
+        write_chunk(parent, fill=77.0)
+        child_prefix_after = read_bytes(parent_slots)
+        for (k0, v0), (k1, v1) in zip(child_prefix_before, child_prefix_after):
+            assert torch.equal(k0, k1)
+            assert torch.equal(v0, v1)
+
+
 class TestSessionFork:
     def test_forks_both_cfg_streams(self):
         kv = make_cache()

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -469,6 +469,76 @@ class ARDiffusionKVCache:
         adapter.on_chunk_committed()
         _log.debug("AR-Diffusion commit: req=%s after=%d", adapter.request_id, adapter.completed_chunks)
 
+    # -- session fork (copy-on-write) ----------------------------------------
+
+    def fork_at_last_commit(
+        self,
+        parent: ARDiffusionRequestAdapter,
+        child_request_id: str,
+    ) -> ARDiffusionRequestAdapter:
+        """Fork a session's KV state at its last committed chunk.
+
+        Copy-on-write over the paged pool: the child gets a copy of the
+        parent's block table with reference counts incremented
+        (``BlockPool.touch``), so both sessions read the same physical
+        blocks and zero KV bytes move. Divergence is automatic: committed
+        chunks are never rewritten (the commit-once discipline), and each
+        session's next ``allocate_chunk`` appends fresh blocks visible only
+        to that session. Window eviction stays per-request (null-block
+        placeholders in each table); a physical block returns to the free
+        queue only when the last holder releases it, exactly as in vLLM's
+        prefix-caching path.
+
+        Fork is only legal at a chunk-commit boundary: an in-flight chunk's
+        slots are still being written, and sharing them would let two
+        sessions write the same physical slots. Raises if the parent has
+        allocated-but-uncommitted blocks.
+
+        Scope notes (the completeness invariant is the caller's): the
+        cross-attention pools are conditioning state, not session history,
+        and are shared as-is (rewrite them if the branch changes prompt or
+        conditioning image); RNG streams live in the pipeline and must be
+        snapshotted alongside the fork for deterministic re-denoise.
+        """
+        if child_request_id in self._adapters:
+            raise ValueError(f"fork target request_id already exists: {child_request_id}")
+
+        st_manager = self.manager.coordinator.single_type_managers[0]
+        parent_blocks = st_manager.req_to_blocks.get(parent.request_id)
+        if parent_blocks is None:
+            raise ValueError(f"unknown parent request: {parent.request_id}")
+
+        committed_logical_blocks = (parent.num_computed_tokens + self.block_size - 1) // self.block_size
+        if len(parent_blocks) != committed_logical_blocks:
+            raise RuntimeError(
+                "fork_at_last_commit requires a chunk-commit boundary: "
+                f"parent has {len(parent_blocks)} allocated logical blocks but only "
+                f"{committed_logical_blocks} committed ones (in-flight chunk pending)"
+            )
+
+        child = ARDiffusionRequestAdapter(
+            child_request_id,
+            chunk_size=self.spec.chunk_size,
+            prefill_prefix_tokens=parent._prefill,
+        )
+        child._completed_chunks = parent.completed_chunks
+
+        shared = list(parent_blocks)
+        # Symmetric with free_blocks: touch every table entry (including null
+        # placeholders, whose refcount is unused but kept balanced).
+        self.manager.block_pool.touch(shared)
+        st_manager.req_to_blocks[child_request_id] = type(parent_blocks)(shared)
+        self._adapters[child_request_id] = child
+
+        _log.debug(
+            "AR-Diffusion fork: parent=%s child=%s shared_blocks=%d free=%d",
+            parent.request_id,
+            child_request_id,
+            len(shared),
+            self.manager.block_pool.get_num_free_blocks(),
+        )
+        return child
+
     # -- pool-backed K/V access --------------------------------------------
 
     def write_chunk_kv(

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
@@ -144,6 +144,32 @@ class ARDiffusionKVState:
             )
         return [self.kv_cache.read_cross_kv(i, is_negative) for i in range(self.num_layers)]
 
+    def fork(self, pos_request_id: str, neg_request_id: str) -> ARDiffusionKVState:
+        """Fork this session's KV state at its last committed chunk.
+
+        Forks BOTH classifier-free-guidance streams (each owns independent
+        pool blocks, so a session fork that captured only one would produce
+        a branch whose positive and negative passes disagree about history).
+        Copy-on-write at the block table: no KV bytes move. The cross-attn
+        pool state is conditioning, shared by construction; the populated
+        flags are inherited. Raises mid-chunk (uncommitted context pending).
+        """
+        for is_negative, ctx in self._paged_pending.items():
+            if ctx is not None and ctx.commit_current and ctx._allocated_video and not ctx._committed:
+                branch = "neg" if is_negative else "pos"
+                raise RuntimeError(f"cannot fork mid-chunk: uncommitted paged context pending on {branch}")
+        child_pos = self.kv_cache.fork_at_last_commit(self.pos, pos_request_id)
+        try:
+            child_neg = self.kv_cache.fork_at_last_commit(self.neg, neg_request_id)
+        except Exception:
+            self.kv_cache.end_request(child_pos)
+            raise
+        child = ARDiffusionKVState(self.kv_cache, child_pos, child_neg, self.num_layers)
+        child._committed = dict(self._committed)
+        child._cross_text_populated = dict(self._cross_text_populated)
+        child._cross_img_populated = dict(self._cross_img_populated)
+        return child
+
     def close(self) -> None:
         """Final teardown: free both branches' resident pool blocks."""
         self.kv_cache.end_request(self.pos)

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
@@ -150,9 +150,19 @@ class ARDiffusionKVState:
         Forks BOTH classifier-free-guidance streams (each owns independent
         pool blocks, so a session fork that captured only one would produce
         a branch whose positive and negative passes disagree about history).
-        Copy-on-write at the block table: no KV bytes move. The cross-attn
-        pool state is conditioning, shared by construction; the populated
-        flags are inherited. Raises mid-chunk (uncommitted context pending).
+        Copy-on-write at the block table: no KV bytes move. Raises mid-chunk
+        (uncommitted context pending).
+
+        Cross-attention handling: the cross-attn pool is a single engine-wide
+        buffer, not per session. The TEXT half is prompt-derived and identical
+        across a session's branches, so its populated flags are inherited.
+        The IMAGE half (I2V) is observation-derived and diverges after a
+        fork, so its flags are invalidated on BOTH the child and the parent:
+        each branch re-projects image conditioning from its own next
+        observation before reading. This makes fork safe under a
+        run-one-branch-at-a-time execution contract; INTERLEAVING sibling
+        forwards with I2V conditioning still contends on the shared pool and
+        needs per-session cross buffers (session-memory manager territory).
         """
         for is_negative, ctx in self._paged_pending.items():
             if ctx is not None and ctx.commit_current and ctx._allocated_video and not ctx._committed:
@@ -167,7 +177,8 @@ class ARDiffusionKVState:
         child = ARDiffusionKVState(self.kv_cache, child_pos, child_neg, self.num_layers)
         child._committed = dict(self._committed)
         child._cross_text_populated = dict(self._cross_text_populated)
-        child._cross_img_populated = dict(self._cross_img_populated)
+        child._cross_img_populated = {False: False, True: False}
+        self._cross_img_populated = {False: False, True: False}
         return child
 
     def close(self) -> None:


### PR DESCRIPTION
## Purpose

Narrow validation implementation for #4907: copy-on-write session fork over the AR-diffusion paged KV pool, for speculative action branches, RL imagined rollouts (#4770), and rollback.

This is deliberately scoped and I am not asking to finalize the public API before maintainer guidance. It validates the fork portion of the session-memory / WMMS discussions (#4480, #4497) on the allocator that is already in tree (#4366). If the RFC authors prefer this lands inside the #4480 session-memory manager instead, I am happy to rework it there.

## What it does

- `ARDiffusionKVCache.fork_at_last_commit(parent, child_request_id)`: copies the parent's block table and increments `BlockPool` refcounts (`touch`). Zero tensor bytes move. Only legal at chunk-commit boundaries, since an in-flight chunk's slots are still being written. Divergence is automatic under the commit-once discipline: each session's next `allocate_chunk` appends fresh blocks visible only to that session, and a physical block returns to the free queue when its last holder releases it, same as vLLM's prefix-caching refcount path.
- `ARDiffusionKVState.fork(pos_id, neg_id)`: forks both classifier-free-guidance streams atomically (each owns independent pool blocks), with rollback on partial failure.

Scope boundary: this is the KV-cache portion of a session fork. Full deterministic world-state fork additionally needs RNG/noise and any recurrent state captured at the session layer (the completeness invariant #4497 articulates); that stays out of this PR on purpose.

Cross-attention conditioning: the cross-attn pool is a single engine-wide buffer, not per session. Text conditioning is prompt-derived and branch-invariant, so its populated flags are inherited. Image conditioning (I2V) is observation-derived and diverges after a fork, so fork invalidates the image flags on both branches and each re-projects from its own next observation. This is safe under a run-one-branch-at-a-time execution contract; truly interleaved sibling forwards with I2V conditioning need per-session cross buffers (open question 5 below).

## Measurements

1x H200, timings after `torch.cuda.synchronize()`; the clone baseline includes allocation plus copy. Microbenchmark on `ARDiffusionKVCache` at DreamZero-like scale (30 layers, 20-chunk window, 5.36 GiB resident, bf16):

| approach | fork cost | memory per branch |
|---|---|---|
| branch by deep copy (status quo) | 43.8 ms | 5.36 GiB |
| `fork_at_last_commit`, 4-way fan-out | 0.01 ms per branch | 0 tensor bytes; O(block-table) metadata and refcounts only |

For scale context, a device-side full clone of a 37 GiB world-model KV cache measures 19.2 ms, so the full-copy problem is memory rather than latency: 37 GiB per branch caps fan-out at about two branches next to a loaded model.

## Test Plan

`tests/ar_diffusion/test_kv_fork.py`, CPU-only block bookkeeping in the style of the existing conformance tests:

- fork shares blocks without consuming pool blocks
- post-fork divergence is isolated (disjoint new blocks)
- shared blocks survive the parent's free, and a fresh session cannot be handed the child's blocks
- refcounts balance back to the starting free count after both sessions free
- mid-chunk fork is rejected (commit-boundary invariant)
- duplicate / unknown request ids are rejected
- fork after window eviction shares exactly the resident window, and the child rolling forward does not disturb the parent's view
- 4-branch fan-out with pairwise-disjoint tails
- session-level fork covers both CFG streams; text conditioning flags are inherited and image conditioning flags are invalidated on both branches (the pool is engine-wide, so a stale flag would read the sibling's conditioning)

Plus one GPU write-isolation test (skipped when CUDA is unavailable): after a fork, shared physical slots hold identical bytes for both sessions, a diverging child never rewrites the parent's committed K/V, and the parent rolling forward does not disturb the child's shared prefix.
- partial session-fork failure rolls back without leaking references

## Test Result

- 12/12 new tests pass on an H200 (11 CPU bookkeeping + 1 GPU write isolation); all 82 pre-existing `tests/ar_diffusion/` tests still pass (94 total)
- pre-commit clean

## Open questions (mirrors #4907)

1. Land here or inside the #4480 session-memory manager?
2. Eviction pinning policy for long-lived branches (quota vs LRU reclamation)?
3. RNG/noise state representation for a later deterministic session-layer fork?
4. `fork_batch` now or later?
5. Should cross-attn conditioning become a per-session memory object (under the #4480 manager) so sibling branches can interleave forwards? Today the pool is engine-wide; fork handles it by invalidating the image-conditioning flags on both branches, which covers sequential branch execution but not interleaving.
