### PR TITLE
[Bugfix] Fix full-payload mm splitting for dual hidden/scheduled batch axes (#4870 follow-up)

### DIFF
--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -480,6 +480,52 @@ def test_build_omni_output_splits_mm_by_scheduled_tokens_when_hidden_is_tail_onl
     assert torch.equal(output.inter_stage_outputs[2]["codes.audio"], codes[2:3])
 
 
+def test_build_omni_output_splits_mm_by_hidden_len_when_scheduled_is_padded(monkeypatch):
+    """Thinker mm rows align to hidden_states.shape[0], not padded scheduled count."""
+    runner = _make_async_output_runner(engine_output_type="latent")
+    runner.model.omni_pooler_payload_include_hidden = False
+    runner._async_chunk = False
+    runner.requests = {"r1": object(), "r2": object(), "r3": object()}
+
+    monkeypatch.setattr(
+        GPUARModelRunner,
+        "_resolve_pooler_payload_req_ids",
+        lambda self, req_ids: ("latent", req_ids),
+    )
+    monkeypatch.setattr(GPUARModelRunner, "_should_accumulate_full_payload_output", lambda self: False)
+    monkeypatch.setattr(GPUARModelRunner, "get_omni_connector_output", lambda self: None)
+    monkeypatch.setattr(GPUARModelRunner, "_process_additional_information_updates", lambda *args, **kwargs: None)
+
+    layers = torch.arange(96, dtype=torch.long).reshape(3, 32)
+    output = GPUARModelRunner._build_omni_model_runner_output_from_snapshot(
+        runner,
+        scheduler_output=SimpleNamespace(
+            total_num_scheduled_tokens=5,
+            num_scheduled_tokens={"r1": 1, "r2": 1, "r3": 1},
+        ),
+        hidden_states=torch.randn(3, 4),
+        staged_hidden_states_cpu=None,
+        multimodal_outputs={"hidden_states": {"layers": {0: layers}}},
+        req_ids_output_copy=["r1", "r2", "r3"],
+        req_id_to_index_output_copy={"r1": 0, "r2": 1, "r3": 2},
+        valid_sampled_token_ids=[[101], [102], [103]],
+        logprobs_lists=None,
+        prompt_logprobs_dict={},
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        ec_connector_output=None,
+        cudagraph_stats=None,
+        kv_extracted_req_ids=None,
+        num_scheduled_tokens_np=np.array([1, 1, 1], dtype=np.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.long),
+    )
+
+    assert output.inter_stage_outputs is not None
+    assert torch.equal(output.inter_stage_outputs[0]["hidden_states.layer_0"], layers[0:1])
+    assert torch.equal(output.inter_stage_outputs[1]["hidden_states.layer_0"], layers[1:2])
+    assert torch.equal(output.inter_stage_outputs[2]["hidden_states.layer_0"], layers[2:3])
+
+
 def test_async_snapshot_payload_omits_hidden_when_model_opts_out():
     runner = _make_async_output_runner()
     runner.model.omni_pooler_payload_include_hidden = False

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -902,7 +902,8 @@ class NPUARModelRunner(OmniNPUModelRunner):
         ) = self.execute_model_state
         # Clear ephemeral state.
         self.execute_model_state = None
-        seq_len = hidden_states.shape[0]
+        hidden_seq_len = int(hidden_states.shape[0])
+        scheduled_seq_len = int(scheduler_output.total_num_scheduled_tokens)
 
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
@@ -1141,7 +1142,8 @@ class NPUARModelRunner(OmniNPUModelRunner):
                                 start=start,
                                 end=end,
                                 pass_lists_through=False,
-                                seq_len=seq_len,
+                                seq_len=hidden_seq_len,
+                                scheduled_seq_len=scheduled_seq_len,
                             )
                     payload.update(mm_payload)
                 pooler_output.append(flatten_payload(payload))

--- a/vllm_omni/utils/mm_outputs.py
+++ b/vllm_omni/utils/mm_outputs.py
@@ -106,7 +106,13 @@ def _to_cpu(value):
 
 
 def to_payload_element(
-    element: object, idx: int, start: int, end: int, pass_lists_through: bool = False, seq_len: int | None = None
+    element: object,
+    idx: int,
+    start: int,
+    end: int,
+    pass_lists_through: bool = False,
+    seq_len: int | None = None,
+    scheduled_seq_len: int | None = None,
 ):
     """Build an mm payload element corresponding to one request index
     from an element containing 0 or more CPU tensors.
@@ -120,21 +126,39 @@ def to_payload_element(
             passthrough data; this should be False in normal cases, but True
             if we need to avoid splitting nonempty lists prior to calling
             postprocess, which is the case for prefix cache.
-        seq_len: Optional sequence length (i.e., dim 0 of hidden states).
-            When set, a tensor whose first dimension equals seq_len is
-            sliced per request. The prefix cache passthrough also passes
-            the total scheduled token count here so 1D (seq_len,) metadata
-            that is intentionally not cached is still split per request.
+        seq_len: Optional hidden-aligned batch length (``hidden_states.shape[0]``).
+            When a tensor's first dimension equals this value, it is sliced
+            per request using ``start:end``.
+        scheduled_seq_len: Optional scheduler-aligned batch length
+            (``scheduler_output.total_num_scheduled_tokens``). Some full-payload
+            mm tensors (e.g. batched ``codes.audio`` with tail-only hidden states)
+            are laid out by scheduled tokens instead of the hidden tail shape.
+            When omitted, ``seq_len`` is reused for backward compatibility.
     """
-    # Cached per-token tensors are merged elsewhere; here a first dim
-    # equal to seq_len means a per-request slice is required.
-    if seq_len is not None and isinstance(element, torch.Tensor) and element.shape[0] == seq_len:
+    if scheduled_seq_len is None:
+        scheduled_seq_len = seq_len
+
+    # Cached per-token tensors are merged elsewhere; here a first dim equal to
+    # either the hidden-aligned or scheduler-aligned batch length means a
+    # per-request slice is required.
+    if isinstance(element, torch.Tensor) and (
+        (seq_len is not None and element.shape[0] == seq_len)
+        or (scheduled_seq_len is not None and element.shape[0] == scheduled_seq_len)
+    ):
         return element[start:end].contiguous()
     # Every other case is shared between prefix cache (passthrough data)
     # and running a model without prefix caching.
     elif isinstance(element, dict):
         return {
-            sk: to_payload_element(sv, idx, start, end, pass_lists_through=pass_lists_through, seq_len=seq_len)
+            sk: to_payload_element(
+                sv,
+                idx,
+                start,
+                end,
+                pass_lists_through=pass_lists_through,
+                seq_len=seq_len,
+                scheduled_seq_len=scheduled_seq_len,
+            )
             for sk, sv in element.items()
         }
     elif isinstance(element, list):

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -839,7 +839,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         end: int,
         audio_sparse_output: bool,
         sparse_mm_index: dict[str, int],
-        seq_len: int,
+        hidden_seq_len: int,
+        scheduled_seq_len: int,
     ) -> dict[str, object]:
         if combined_multimodal_outputs:
             return self._build_combined_prefix_cache_mm_payload(
@@ -876,7 +877,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 start=start,
                 end=end,
                 pass_lists_through=False,
-                seq_len=seq_len,
+                seq_len=hidden_seq_len,
+                scheduled_seq_len=scheduled_seq_len,
             )
         return mm_payload
 
@@ -894,7 +896,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         mm_cpu: dict[str, object] | None,
         audio_sparse_output: bool,
         sparse_mm_index: dict[str, int],
-        seq_len: int,
+        hidden_seq_len: int,
+        scheduled_seq_len: int,
     ) -> dict[str, object]:
         payload: dict[str, object] = {}
         if not audio_sparse_output:
@@ -920,7 +923,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             end=end,
             audio_sparse_output=audio_sparse_output,
             sparse_mm_index=sparse_mm_index,
-            seq_len=seq_len,
+            hidden_seq_len=hidden_seq_len,
+            scheduled_seq_len=scheduled_seq_len,
         )
         payload.update(mm_payload)
         return payload
@@ -1731,7 +1735,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         # The actual multimodal wire transport uses multimodal_outputs instead.
         pooler_output: list[dict[str, object]] | None = None
         if needs_pooler_payload:
-            mm_seq_len = int(scheduler_output.total_num_scheduled_tokens)
+            hidden_seq_len = int(hidden_states.shape[0])
+            scheduled_seq_len = int(scheduler_output.total_num_scheduled_tokens)
             mm_cpu = None
             if self.omni_prefix_cache is not None:
                 (
@@ -1787,7 +1792,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         mm_cpu=mm_cpu,
                         audio_sparse_output=audio_sparse_output,
                         sparse_mm_index=sparse_mm_index,
-                        seq_len=mm_seq_len,
+                        hidden_seq_len=hidden_seq_len,
+                        scheduled_seq_len=scheduled_seq_len,
                     )
                     pooler_output.append(flatten_payload(payload))
 


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm-omni/issues/4906

PR #4870 fixed Qwen3-TTS CustomVoice concurrent `no_async_chunk` serving by slicing
full-payload multimodal tensors with `scheduler_output.total_num_scheduled_tokens`
instead of `hidden_states.shape[0]`. That unblocks batched `codes.audio` when async
output snapshots omit hidden states (tail-only hidden), but it regressed Qwen3-Omni
`no_async_chunk` E2E: thinker text stayed correct while talker/code2wav audio was
corrupted under concurrent batching.
This PR keeps the #4870 fix and restores Omni correctness by teaching
`to_payload_element` to slice against **either** batch axis, depending on each
tensor's actual dim-0 layout.
## Root Cause
Full-payload pooler output splitting uses `to_payload_element`, which only slices
when `element.shape[0] == seq_len`. Different mm tensors align to different axes:
| Tensor | Typical dim-0 alignment | Example |
|--------|-------------------------|---------|
| Thinker `hidden_states.layer_*` | `hidden_states.shape[0]` | Qwen3-Omni thinker handoff |
| Talker `codes.audio` | `total_num_scheduled_tokens` | Qwen3-TTS / talker batched codec rows |
These diverge when:
1. **Async output snapshots omit hidden** — talker stages set
   `hidden_states_snapshot = hidden_states[:0]` while `codes.audio` still has N
   scheduled rows (#4870 scenario).
2. **CUDA graph padding** — `total_num_scheduled_tokens` can exceed the valid mm
   row count while thinker layers remain hidden-aligned.
3. **Model-internal hidden trimming** — e.g. talker crops hidden to codec span.
#4870 switched the single `seq_len` to `total_num_scheduled_tokens` globally.
That fixed (1) but broke thinker tensors aligned to `hidden_states.shape[0]`: when
`element.shape[0] != total_num_scheduled_tokens`, slicing is skipped and each
request clones the whole batched tensor, causing cross-request contamination
(repetitive/garbled audio; text unaffected).
## Fix
Pass both axes into the pooler payload builder:
- `hidden_seq_len = hidden_states.shape[0]`
- `scheduled_seq_len = scheduler_output.total_num_scheduled_tokens`
`to_payload_element` slices when `element.shape[0]` matches **either** value.
When `scheduled_seq_len` is omitted, behavior falls back to the pre-#4870 path
(backward compatible for prefix-cache callers).
Changes are limited to:
- `vllm_omni/utils/mm_outputs.py`
- `vllm_omni/worker/gpu_ar_model_runner.py`
- `vllm_omni/platforms/npu/worker/npu_ar_model_runner.py` (parity)
- `tests/worker/test_gpu_ar_model_runner.py` (Omni regression)
No serving-layer changes; #4870's scoped Qwen3-TTS streaming coercion is unchanged.
## Test Plan
- [x] `test_build_omni_output_splits_mm_by_scheduled_tokens_when_hidden_is_tail_only`
      (TTS / talker tail-only hidden + batched `codes.audio`)
- [x] `test_build_omni_output_splits_mm_by_hidden_len_when_scheduled_is_padded`
      (Omni thinker layers aligned to hidden, scheduled count padded)
- [x] `tests/utils/test_mm_outputs_partition.py`
- [x] E2E: `test_text_to_text_audio_001[default]` — 5 concurrent requests,
      `--no-async-chunk`, text/audio cosine similarity 0.97–1.0
`nohup pytest -sv tests/e2e/online_serving/test_qwen3_tts_customvoice_expansion.py -m "full_model" --run-level "full_model" -k "no_async_chunk" &`

## Test Result
### Unit tests
```bash
python3 -m pytest -q \
  tests/worker/test_gpu_ar_model_runner.py::test_build_omni_output_splits_mm_by_scheduled_tokens_when_hidden_is_tail_only \
  tests/worker/test_gpu_ar_model_runner.py::test_build_omni_output_splits_mm_by_hidden_len_when_scheduled_is_padded \
  tests/utils/test_mm_outputs_partition.py \
  --tb=short
Result: 6 passed.

E2E (Qwen3-Omni)
pytest -sv tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_text_to_text_audio_001 \
  -m "full_model" --run-level "full_model" -k "default"
Result: 1 passed — 5 concurrent responses, ASR/text cosine similarity 0.971–1.000.
```

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=========== 4 passed, 4 deselected, 16 warnings in 468.72s (0:07:48) ===========
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=========== 38 passed, 3 skipped, 16 warnings in 5594.28s (1:33:14) ============
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
