### PR TITLE
[Misc] Refine error reports when diffusion_worker init failed

### DIFF
--- a/tests/platforms/test_platform_diagnostics.py
+++ b/tests/platforms/test_platform_diagnostics.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression tests for platform diagnostic infrastructure.
+
+These tests ensure that when no hardware accelerator is detected, the
+UnspecifiedOmniPlatform error messages contain actionable details about
+*why* each platform was skipped — not just a generic "no platform found".
+
+The key invariant: built-in plugins internally catch exceptions (to keep
+normal multi-platform startup quiet), so the diagnostics must collect
+errors via a side-channel (:data:`_plugin_error_details`) rather than
+relying on exceptions propagating through the resolver.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestBuildUnspecifiedDiagnostics:
+    """Unit tests for :func:`vllm_omni.platforms._build_unspecified_diagnostics`."""
+
+    @staticmethod
+    def _call(errors: dict[str, str]) -> str:
+        from vllm_omni.platforms import _build_unspecified_diagnostics
+
+        return _build_unspecified_diagnostics(errors)
+
+    def test_empty_errors_still_produces_helpful_message(self) -> None:
+        """Even without per-platform details the message must guide the user."""
+        msg = self._call({})
+        assert "No hardware accelerator detected" in msg
+        assert "nvidia-smi" in msg
+        assert "rocm-smi" in msg
+
+    def test_single_error_appears_in_output(self) -> None:
+        """Each recorded error must mention both the platform name and failure reason."""
+        msg = self._call({"cuda": "No module named 'pynvml'"})
+        assert "cuda" in msg
+        assert "No module named 'pynvml'" in msg
+
+    def test_multiple_errors_all_listed(self) -> None:
+        """When several platforms fail, all of them must appear in the message."""
+        errors = {
+            "cuda": "pynvml.nvmlInit failed: Driver Not Found",
+            "rocm": "No module named 'amdsmi'",
+            "npu": "torch.npu.is_available() returned False",
+        }
+        msg = self._call(errors)
+        for name, detail in errors.items():
+            assert name in msg, f"{name!r} missing from diagnostics"
+            assert detail in msg, f"{detail!r} missing from diagnostics"
+
+
+class TestMakeUnsupportedStub:
+    """Tests for :func:`vllm_omni.platforms.interface._make_unsupported_stub`."""
+
+    @staticmethod
+    def _make_stub(method_name: str):
+        from vllm_omni.platforms.interface import _make_unsupported_stub
+
+        return _make_unsupported_stub(method_name)
+
+    def test_stub_name_and_qualname_are_set(self) -> None:
+        stub = self._make_stub("set_device")
+        assert stub.__name__ == "set_device"
+        assert stub.__qualname__ == "UnspecifiedOmniPlatform.set_device"
+
+    def test_stub_raises_not_implemented_with_method_name(self) -> None:
+        stub = self._make_stub("synchronize")
+        with pytest.raises(NotImplementedError, match="synchronize is not implemented"):
+            stub.__func__(None)
+
+    def test_stub_includes_diagnostics_when_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When _platform_diagnostics is populated, the error message includes it."""
+        import vllm_omni.platforms
+
+        monkeypatch.setattr(
+            vllm_omni.platforms,
+            "_platform_diagnostics",
+            "No hardware accelerator detected.\n  - cuda: nvmlInit failed.",
+        )
+        stub = self._make_stub("get_free_memory")
+        with pytest.raises(NotImplementedError, match="nvmlInit failed"):
+            stub.__func__(None)
+
+    def test_unspecified_error_suffix_has_key_info(self) -> None:
+        """The fallback suffix must mention concrete troubleshooting steps."""
+        from vllm_omni.platforms.interface import _UNSPECIFIED_ERROR_SUFFIX
+
+        assert "UnspecifiedOmniPlatform" in _UNSPECIFIED_ERROR_SUFFIX
+        assert "nvidia-smi" in _UNSPECIFIED_ERROR_SUFFIX
+        assert "pynvml" in _UNSPECIFIED_ERROR_SUFFIX
+        assert "CPU-only" in _UNSPECIFIED_ERROR_SUFFIX
+
+
+class TestPluginErrorSideChannel:
+    """Tests that the side-channel dict is populated / cleared properly.
+
+    These verify the mechanism that records *why* each built-in plugin
+    couldn't activate.  The key invariant: ImportError means the
+    hardware stack isn't installed (expected, not recorded); other
+    exceptions mean the stack IS installed but the probe failed (real
+    error, recorded for diagnostics).
+    """
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _clear_side_channel() -> None:
+        from vllm_omni.platforms import _plugin_error_details
+
+        _plugin_error_details.clear()
+
+    def _assert_side_channel_empty(self) -> None:
+        from vllm_omni.platforms import _plugin_error_details
+
+        assert not _plugin_error_details, f"Side-channel must be empty; got {dict(_plugin_error_details)}"
+
+    # -- import errors (expected: not recorded) ---------------------------
+
+    def test_import_error_not_recorded_for_cuda(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """pynvml not installed → silently return None, don't record."""
+        from vllm_omni.platforms import cuda_omni_platform_plugin
+
+        self._clear_side_channel()
+
+        import vllm.utils.import_utils  # noqa: F401
+
+        def _raise_import_error():
+            raise ImportError("No module named 'pynvml'")
+
+        monkeypatch.setattr(vllm.utils.import_utils, "import_pynvml", _raise_import_error)
+
+        result = cuda_omni_platform_plugin()
+        assert result is None
+        self._assert_side_channel_empty()
+
+    def test_import_error_not_recorded_for_rocm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """amdsmi not installed → silently return None, don't record."""
+        from vllm_omni.platforms import rocm_omni_platform_plugin
+
+        self._clear_side_channel()
+
+        # Replace the 'import amdsmi' statement to raise ImportError.
+        import builtins
+
+        _original_import = builtins.__import__
+
+        def _block_amdsmi(name, *args, **kwargs):
+            if name == "amdsmi":
+                raise ImportError("No module named 'amdsmi'")
+            return _original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_amdsmi)
+
+        result = rocm_omni_platform_plugin()
+        assert result is None
+        self._assert_side_channel_empty()
+
+    # -- real errors (recorded) -------------------------------------------
+
+    def test_init_error_recorded_for_cuda(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """pynvml installs fine but nvmlInit fails → record the error."""
+        from vllm_omni.platforms import _plugin_error_details, cuda_omni_platform_plugin
+
+        self._clear_side_channel()
+
+        import vllm.utils.import_utils  # noqa: F401
+
+        def _fake_import_pynvml():
+            """Return a mock pynvml whose nvmlInit raises."""
+
+            class _MockPynvml:
+                @staticmethod
+                def nvmlInit():
+                    raise RuntimeError("NVML Shared Library Not Found")
+
+                @staticmethod
+                def nvmlShutdown():
+                    pass
+
+                @staticmethod
+                def nvmlDeviceGetCount():
+                    return 0
+
+            return _MockPynvml()
+
+        monkeypatch.setattr(vllm.utils.import_utils, "import_pynvml", _fake_import_pynvml)
+
+        result = cuda_omni_platform_plugin()
+        assert result is None, "Plugin must return None when init fails"
+        assert "cuda" in _plugin_error_details, (
+            f"Side-channel must contain 'cuda'; got {list(_plugin_error_details.keys())}"
+        )
+        assert "NVML Shared Library Not Found" in _plugin_error_details["cuda"], (
+            "Error message must contain the real failure reason"
+        )
+
+    # -- resolver lifecycle -----------------------------------------------
+
+    def test_side_channel_cleared_on_each_resolution(self) -> None:
+        """resolve_current_omni_platform_cls_qualname must clear stale entries."""
+        # Use attribute access (not ``from ... import``) because the resolver
+        # rebinds _plugin_error_details to a fresh dict via ``global ... = {}``,
+        # which a local reference from ``from ... import`` would not see.
+        import vllm_omni.platforms
+
+        vllm_omni.platforms._plugin_error_details["stale"] = "should be cleared"
+        vllm_omni.platforms.resolve_current_omni_platform_cls_qualname()
+        assert "stale" not in vllm_omni.platforms._plugin_error_details, (
+            "Side-channel dict must be cleared at the start of each resolution"
+        )

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -30,6 +30,7 @@ from vllm.profiler.wrapper import CudaProfilerWrapper, WorkerProfiler
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.mem_utils import GiB_bytes
+from vllm.utils.system_utils import decorate_logs
 from vllm.v1.worker.workspace import init_workspace_manager
 
 from vllm_omni.diffusion.data import (
@@ -1172,6 +1173,7 @@ class WorkerProc:
             pass  # setproctitle not installed, skip process title setting
 
         load_omni_general_plugins()
+        decorate_logs("DiffusionWorker")
         worker_proc = None
         try:
             worker_proc = WorkerProc(
@@ -1192,6 +1194,8 @@ class WorkerProc:
             worker_proc._worker_busy_loop()
         except SystemExit:
             logger.info("Worker %d: Shutdown signal received, starting cleanup.", rank)
+            raise
+        except Exception:
             raise
         finally:
             if worker_proc is not None:

--- a/vllm_omni/platforms/__init__.py
+++ b/vllm_omni/platforms/__init__.py
@@ -16,6 +16,19 @@ from vllm_omni.plugins import (
 
 logger = logging.getLogger(__name__)
 
+# Stores diagnostic information about why each platform check failed.
+# Populated by platform plugin functions and consumed by
+# resolve_current_omni_platform_cls_qualname() when no platform is detected.
+_platform_diagnostics: str = ""
+
+# Side-channel for built-in plugins to report why they couldn't activate.
+# Built-in plugins internally catch exceptions (to keep normal startup quiet
+# when hardware is absent), so the outer try/except in the resolver can't see
+# their errors.  Each plugin writes a short error string here before returning
+# None, and the resolver consumes the dict only when falling back to
+# UnspecifiedOmniPlatform.
+_plugin_error_details: dict[str, str] = {}
+
 
 def cuda_omni_platform_plugin() -> str | None:
     """Check if CUDA OmniPlatform should be activated."""
@@ -34,7 +47,12 @@ def cuda_omni_platform_plugin() -> str | None:
                 logger.debug("CUDA OmniPlatform is not available because no GPU is found.")
         finally:
             pynvml.nvmlShutdown()
+    except ImportError:
+        logger.debug("CUDA OmniPlatform is not available because pynvml is not installed")
     except Exception as e:
+        # pynvml imported successfully but init/query failed — the hardware
+        # (or at least its driver stack) is present; record for diagnostics.
+        _plugin_error_details["cuda"] = str(e)
         logger.debug("CUDA OmniPlatform is not available because: %s", str(e))
 
     return "vllm_omni.platforms.cuda.platform.CudaOmniPlatform" if is_cuda else None
@@ -56,7 +74,11 @@ def rocm_omni_platform_plugin() -> str | None:
                 logger.debug("ROCm OmniPlatform is not available because no GPU is found.")
         finally:
             amdsmi.amdsmi_shut_down()
+    except ImportError:
+        logger.debug("ROCm OmniPlatform is not available because amdsmi is not installed")
     except Exception as e:
+        # amdsmi imported successfully but init/query failed.
+        _plugin_error_details["rocm"] = str(e)
         logger.debug("ROCm OmniPlatform is not available because: %s", str(e))
 
     return "vllm_omni.platforms.rocm.platform.RocmOmniPlatform" if is_rocm else None
@@ -72,7 +94,10 @@ def npu_omni_platform_plugin() -> str | None:
         if hasattr(torch, "npu") and torch.npu.is_available():
             is_npu = True
             logger.debug("Confirmed NPU OmniPlatform is available.")
+    except ImportError:
+        logger.debug("NPU OmniPlatform is not available because torch is not installed")
     except Exception as e:
+        _plugin_error_details["npu"] = str(e)
         logger.debug("NPU OmniPlatform is not available because: %s", str(e))
 
     return "vllm_omni.platforms.npu.platform.NPUOmniPlatform" if is_npu else None
@@ -98,7 +123,11 @@ def xpu_omni_platform_plugin() -> str | None:
             XPUOmniPlatform.dist_backend = dist_backend
             logger.debug("Confirmed %s backend is available.", XPUOmniPlatform.dist_backend)
             logger.debug("Confirmed XPU platform is available.")
+    except ImportError:
+        logger.debug("XPU omni platform is not available because required packages are not installed")
     except Exception as e:
+        # Required packages are installed but init/query failed.
+        _plugin_error_details["xpu"] = str(e)
         logger.debug("XPU omni platform is not available because: %s", str(e))
 
     return "vllm_omni.platforms.xpu.platform.XPUOmniPlatform" if is_xpu else None
@@ -114,7 +143,11 @@ def musa_omni_platform_plugin() -> str | None:
         if torchada.is_musa_platform():
             is_musa = True
             logger.debug("Confirmed MUSA OmniPlatform is available.")
+    except ImportError:
+        logger.debug("MUSA OmniPlatform is not available because torchada is not installed")
     except Exception as e:
+        # torchada imported successfully but is_musa_platform() failed.
+        _plugin_error_details["musa"] = str(e)
         logger.debug("MUSA OmniPlatform is not available because: %s", str(e))
 
     return "vllm_omni.platforms.musa.platform.MUSAOmniPlatform" if is_musa else None
@@ -131,9 +164,14 @@ builtin_omni_platform_plugins = {
 
 def resolve_current_omni_platform_cls_qualname() -> str:
     """Resolve the current OmniPlatform class qualified name."""
+    global _platform_diagnostics, _plugin_error_details
+    # Clear the side-channel before probing so stale errors from a previous
+    # resolution (shouldn't happen in practice) can't leak in.
+    _plugin_error_details = {}
     platform_plugins = load_omni_plugins_by_group(OMNI_PLATFORM_PLUGINS_GROUP)
 
     activated_plugins = []
+    plugin_errors: dict[str, str] = {}
 
     for name, func in chain(builtin_omni_platform_plugins.items(), platform_plugins.items()):
         try:
@@ -141,8 +179,8 @@ def resolve_current_omni_platform_cls_qualname() -> str:
             platform_cls_qualname = func()
             if platform_cls_qualname is not None:
                 activated_plugins.append(name)
-        except Exception:
-            pass
+        except Exception as e:
+            plugin_errors[name] = str(e)
 
     activated_builtin_plugins = list(set(activated_plugins) & set(builtin_omni_platform_plugins.keys()))
     activated_oot_plugins = list(set(activated_plugins) & set(platform_plugins.keys()))
@@ -159,9 +197,31 @@ def resolve_current_omni_platform_cls_qualname() -> str:
         logger.debug("Automatically detected OmniPlatform %s.", activated_builtin_plugins[0])
     else:
         platform_cls_qualname = "vllm_omni.platforms.interface.UnspecifiedOmniPlatform"
+        # Merge side-channel errors from built-in plugins with exceptions
+        # from OOT plugins (built-in plugs catch internally and don't raise).
+        all_errors = {**_plugin_error_details, **plugin_errors}
+        _platform_diagnostics = _build_unspecified_diagnostics(all_errors)
         logger.debug("No platform detected, vLLM-Omni is running on UnspecifiedOmniPlatform")
 
     return platform_cls_qualname
+
+
+def _build_unspecified_diagnostics(plugin_errors: dict[str, str]) -> str:
+    """Build a diagnostic message explaining why no platform was detected."""
+    parts = [
+        "No hardware accelerator detected, vLLM-Omni is running on UnspecifiedOmniPlatform.",
+    ]
+    if plugin_errors:
+        parts.append("The following error(s) occurred while checking platform (see earlier debug logs for details):")
+        for name, error in plugin_errors.items():
+            parts.append(f"  - {name}: {error}")
+    parts.append(
+        "Platform-specific methods such as set_device() will raise NotImplementedError.\n"
+        "Please check your device drivers and the output of "
+        "'nvidia-smi' (for CUDA), 'npu-smi info' (for Ascend NPU), 'rocm-smi' (for ROCm), "
+        "or your vendor's diagnostic tool."
+    )
+    return "\n".join(parts)
 
 
 _current_omni_platform = None
@@ -202,4 +262,5 @@ __all__ = [
     "OmniPlatformEnum",
     "current_omni_platform",
     "_init_trace",
+    "_platform_diagnostics",
 ]

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -298,6 +298,34 @@ class OmniPlatform(Platform):
         )
 
 
+_UNSPECIFIED_ERROR_SUFFIX = (
+    " This means no acceleration hardware (CUDA/ROCm/NPU/XPU/MUSA) was detected "
+    "and vLLM-Omni fell back to UnspecifiedOmniPlatform. Check the debug log "
+    "messages above for details about why each platform was skipped. Common "
+    "causes: broken device driver (like nvidia-smi failures), missing or corrupted "
+    "pynvml/amdsmi libraries, or running on CPU-only hardware."
+)
+
+
+def _make_unsupported_stub(method_name: str):
+    """Return a classmethod that raises NotImplementedError with diagnostics."""
+
+    @classmethod
+    def stub(cls, *args, **kwargs):
+        try:
+            from vllm_omni.platforms import _platform_diagnostics  # noqa: PLC0415
+
+            extra = "\n" + _platform_diagnostics
+        except Exception:
+            extra = _UNSPECIFIED_ERROR_SUFFIX
+        msg = f"{method_name} is not implemented.{extra}"
+        raise NotImplementedError(msg)
+
+    stub.__name__ = method_name
+    stub.__qualname__ = f"UnspecifiedOmniPlatform.{method_name}"
+    return stub
+
+
 class UnspecifiedOmniPlatform(OmniPlatform):
     _omni_enum = OmniPlatformEnum.UNSPECIFIED
     _enum = PlatformEnum.UNSPECIFIED
@@ -310,3 +338,19 @@ class UnspecifiedOmniPlatform(OmniPlatform):
     @classmethod
     def get_device_count(cls) -> int:
         return 0
+
+
+# Attach stub methods that raise NotImplementedError with diagnostic context.
+for _name in (
+    "set_device",
+    "synchronize",
+    "get_free_memory",
+    "get_device_memory",
+    "get_device_version",
+    "get_omni_ar_worker_cls",
+    "get_omni_generation_worker_cls",
+    "get_default_stage_config_path",
+    "get_diffusion_attn_backend_cls",
+    "supports_torch_inductor",
+):
+    setattr(UnspecifiedOmniPlatform, _name, _make_unsupported_stub(_name))


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**
 0.24.0
**vLLM-Omni Commit:**
d4a869fe5e2edd49af48026051948c8d1018d727
## Test Result
before:
<img width="925" height="988" alt="image" src="https://github.com/user-attachments/assets/0ca911f6-31ce-430d-83ad-fcc59195bd69" />
after:
<img width="1738" height="1050" alt="image" src="https://github.com/user-attachments/assets/d5039e38-d8dd-4625-944d-3fab329a7e80" />
1. Added 'DiffusionWoker' decorate_log which aligned with vLLM `Worker`.
2. Added logger header, easier to read and nail down the issue.
**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
