### PR TITLE
[Feature] Enable FP8 online quantization for GLM-Image text encoder

### DIFF
--- a/tests/diffusion/models/glm_image/test_glm_image_quantization.py
+++ b/tests/diffusion/models/glm_image/test_glm_image_quantization.py
@@ -569,6 +569,43 @@ class TestGlmImageTransformer2DModelQuantization:
             assert block.attn1.to_qkv.quant_config is mock_quant_config
             assert block.ff.net[0].proj.quant_config is mock_quant_config
 
+    def test_component_prefix_propagates_to_quantized_linears(self, mocker: MockerFixture):
+        """Verify component quantization can match transformer-scoped linears."""
+        from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+        mock_quant_config = mocker.MagicMock()
+        parallel_config = DiffusionParallelConfig(
+            tensor_parallel_size=1,
+            sequence_parallel_size=1,
+        )
+
+        mock_tf_config = mocker.MagicMock()
+        mock_tf_config.patch_size = 2
+        mock_tf_config.in_channels = 16
+        mock_tf_config.out_channels = 16
+        mock_tf_config.num_attention_heads = 64
+        mock_tf_config.attention_head_dim = 40
+        mock_tf_config.time_embed_dim = 512
+        mock_tf_config.condition_dim = 256
+        mock_tf_config.prior_vq_quantizer_codebook_size = 16384
+        mock_tf_config.text_embed_dim = 1024
+        mock_tf_config.num_layers = 1
+
+        mock_od_config = mocker.MagicMock(spec=OmniDiffusionConfig)
+        mock_od_config.tf_model_config = mock_tf_config
+        mock_od_config.parallel_config = parallel_config
+
+        GlmImageTransformer2DModel(
+            od_config=mock_od_config,
+            quant_config=mock_quant_config,
+            prefix="transformer",
+        )
+
+        prefixes = {call.kwargs["prefix"] for call in mock_quant_config.get_quant_method.call_args_list}
+        assert "transformer.glyph_projector.net.0.proj" in prefixes
+        assert "transformer.prior_projector.net.0.proj" in prefixes
+        assert "transformer.transformer_blocks.0.attn1.to_qkv" in prefixes
+
     def test_accepts_none_quant_config(self, mocker: MockerFixture):
         """Verify quant_config=None is accepted."""
         from vllm_omni.diffusion.data import OmniDiffusionConfig

--- a/tests/diffusion/models/t5_encoder/test_t5_encoder_prefix.py
+++ b/tests/diffusion/models/t5_encoder/test_t5_encoder_prefix.py
@@ -6,8 +6,10 @@ import pytest
 import torch
 from transformers import T5Config
 from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 
 from vllm_omni.diffusion.models.t5_encoder.t5_encoder import T5EncoderModel
+from vllm_omni.diffusion.models.utils import init_parameters
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -63,6 +65,32 @@ def setup_vllm_config(monkeypatch, mocker):
         yield
 
 
+class TestInitParameters:
+    def test_materializes_meta_parameter_without_dropping_parameter_subclass(self):
+        class CustomParameter(torch.nn.Parameter):
+            @property
+            def weight_loader(self):
+                return self._weight_loader
+
+        module = torch.nn.Module()
+
+        def weight_loader(*args):
+            return None
+
+        param = CustomParameter(torch.empty((2, 3), device="meta"), requires_grad=False)
+        param._weight_loader = weight_loader
+        param.tp_rank = 0
+        module.register_parameter("weight", param)
+
+        init_parameters(module, dtype=torch.float16, device=torch.device("cpu"))
+
+        assert isinstance(module.weight, CustomParameter)
+        assert module.weight.device == torch.device("cpu")
+        assert module.weight.dtype == torch.float16
+        assert module.weight.weight_loader is weight_loader
+        assert module.weight.tp_rank == 0
+
+
 class TestT5EncoderModelPrefixHandling:
     """Test that T5EncoderModel correctly handles prefix attribute."""
 
@@ -78,6 +106,22 @@ class TestT5EncoderModelPrefixHandling:
         model = T5EncoderModel(t5_config)
         assert hasattr(model, "prefix")
         assert model.prefix == ""
+
+    def test_quant_config_receives_component_prefixed_linears(self, mocker):
+        """Test that quantized T5 linears receive fully qualified prefixes."""
+        config = T5Config(**{**_SMALL_T5_CONFIG, "num_layers": 1})
+        quant_config = mocker.MagicMock()
+        quant_config.get_quant_method.side_effect = lambda layer, prefix: UnquantizedLinearMethod()
+
+        T5EncoderModel(config, prefix="text_encoder", quant_config=quant_config)
+
+        prefixes = {call.kwargs["prefix"] for call in quant_config.get_quant_method.call_args_list}
+        assert {
+            "text_encoder.encoder.block.0.layer.0.SelfAttention.qkv_proj",
+            "text_encoder.encoder.block.0.layer.0.SelfAttention.o",
+            "text_encoder.encoder.block.0.layer.1.DenseReluDense.wi",
+            "text_encoder.encoder.block.0.layer.1.DenseReluDense.wo",
+        }.issubset(prefixes)
 
 
 class TestT5EncoderModelWeightLoadingWithPrefix:

--- a/vllm_omni/diffusion/models/glm_image/glm_image_transformer.py
+++ b/vllm_omni/diffusion/models/glm_image/glm_image_transformer.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.utils import maybe_prefix
 
 from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTAdapterConfig
 
@@ -973,6 +974,7 @@ class GlmImageTransformer2DModel(CachedTransformer):
         self,
         od_config: OmniDiffusionConfig,
         quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -1031,7 +1033,7 @@ class GlmImageTransformer2DModel(CachedTransformer):
             inner_dim=inner_dim,
             activation_fn="gelu",
             quant_config=quant_config,
-            prefix="glyph_projector",
+            prefix=maybe_prefix(prefix, "glyph_projector"),
         )
         self.prior_token_embedding = nn.Embedding(prior_vq_quantizer_codebook_size, inner_dim)
         self.prior_projector = GlmImageFeedForward(
@@ -1040,7 +1042,7 @@ class GlmImageTransformer2DModel(CachedTransformer):
             inner_dim=inner_dim,
             activation_fn="linear-silu",
             quant_config=quant_config,
-            prefix="prior_projector",
+            prefix=maybe_prefix(prefix, "prior_projector"),
         )
 
         # Prepare module for SP (encapsulates patch embedding and RoPE for _sp_plan)
@@ -1064,7 +1066,7 @@ class GlmImageTransformer2DModel(CachedTransformer):
                     ffn_hidden_dim=ffn_hidden_dim,
                     parallel_config=self.parallel_config,
                     quant_config=quant_config,
-                    prefix=f"transformer_blocks.{i}",
+                    prefix=maybe_prefix(prefix, f"transformer_blocks.{i}"),
                 )
                 for i in range(num_layers)
             ]
@@ -1074,7 +1076,11 @@ class GlmImageTransformer2DModel(CachedTransformer):
         # Final modulation feeds proj_out; quant_config is NOT applied here
         # to avoid precision degradation in the final projection layer.
         self.norm_out = GlmImageAdaLayerNormContinuous(
-            inner_dim, time_embed_dim, elementwise_affine=False, quant_config=None, prefix="norm_out"
+            inner_dim,
+            time_embed_dim,
+            elementwise_affine=False,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "norm_out"),
         )
         self.proj_out = nn.Linear(inner_dim, patch_size * patch_size * out_channels, bias=True)
 

--- a/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
+++ b/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
@@ -29,10 +29,8 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
 )
 from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
-from transformers import (
-    ByT5Tokenizer,
-    T5EncoderModel,
-)
+from transformers import AutoConfig, ByT5Tokenizer
+from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.parallel_state import (
@@ -47,6 +45,8 @@ from vllm_omni.diffusion.models.glm_image.glm_image_transformer import (
     GlmImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
+from vllm_omni.diffusion.models.utils import init_parameters
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -283,12 +283,14 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsCompon
 
         # Load text encoder (T5 for glyph embeddings)
         logger.info("Loading T5EncoderModel (glyph encoder)...")
-        self.text_encoder = T5EncoderModel.from_pretrained(
-            model_path,
-            subfolder="text_encoder",
-            local_files_only=True,
-            torch_dtype=torch.bfloat16,
-        ).to(self.device)
+        text_encoder_config = AutoConfig.from_pretrained(model_path, subfolder="text_encoder", local_files_only=True)
+        self.text_encoder = T5EncoderModel(
+            text_encoder_config,
+            prefix="text_encoder",
+            quant_config=od_config.quantization_config,
+        )
+        init_parameters(self.text_encoder, dtype=torch.bfloat16, device=self.device)
+        self.text_encoder = self.text_encoder.to(dtype=torch.bfloat16, device=self.device)
         self.text_encoder.eval()
 
         # Load tokenizer for glyph encoding
@@ -303,17 +305,28 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsCompon
 
         # Load transformer (DiT)
         logger.info("Loading GlmImageTransformer2DModel (DiT)...")
-        self.transformer = GlmImageTransformer2DModel(od_config=od_config, quant_config=od_config.quantization_config)
+        self.transformer = GlmImageTransformer2DModel(
+            od_config=od_config,
+            quant_config=od_config.quantization_config,
+            prefix="transformer",
+        )
 
-        # Weight sources for DiT loading
+        # Weight sources for native loader-backed components.
         self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="text_encoder",
+                revision=od_config.revision,
+                prefix="text_encoder.",
+                fall_back_to_pt=True,
+            ),
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
                 subfolder="transformer",
                 revision=od_config.revision,
                 prefix="transformer.",
                 fall_back_to_pt=True,
-            )
+            ),
         ]
 
         # Configure scale factors
@@ -407,7 +420,8 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsCompon
         )
 
         outputs = self.text_encoder(input_ids, attention_mask=attention_mask)
-        glyph_embeds = outputs.last_hidden_state[attention_mask.bool()].unsqueeze(0)
+        last_hidden_state = outputs.last_hidden_state if hasattr(outputs, "last_hidden_state") else outputs[0]
+        glyph_embeds = last_hidden_state[attention_mask.bool()].unsqueeze(0)
 
         return glyph_embeds.to(device=device, dtype=dtype)
 
@@ -905,9 +919,5 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsCompon
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load transformer weights."""
-        transformer_weights = (
-            (name.replace("transformer.", "", 1), weight) for name, weight in weights if name.startswith("transformer.")
-        )
-        loaded = self.transformer.load_weights(transformer_weights)
-        return {f"transformer.{name}" for name in loaded}
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -20,6 +21,10 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.utils import maybe_prefix
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 
 class T5SelfAttention(nn.Module):
@@ -27,6 +32,7 @@ class T5SelfAttention(nn.Module):
         self,
         config: T5Config,
         has_relative_attention_bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -51,6 +57,8 @@ class T5SelfAttention(nn.Module):
             total_num_heads=self.n_heads,
             total_num_kv_heads=self.n_heads,  # T5 uses MHA
             bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "qkv_proj"),
         )
 
         # Output projection: all-reduce back to full d_model
@@ -61,6 +69,8 @@ class T5SelfAttention(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "o"),
         )
 
         if has_relative_attention_bias:
@@ -166,13 +176,20 @@ class T5SelfAttention(nn.Module):
 
 
 class T5DenseGatedActDense(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.wi = MergedColumnParallelLinear(
             config.d_model,
             [config.d_ff, config.d_ff],
             bias=False,
             gather_output=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "wi"),
         )
         self.wo = RowParallelLinear(
             config.d_ff,
@@ -180,6 +197,8 @@ class T5DenseGatedActDense(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "wo"),
         )
         self.act = get_act_fn(config.dense_act_fn)
 
@@ -193,7 +212,12 @@ class T5DenseGatedActDense(nn.Module):
 
 
 class T5DenseActDense(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.wi = ColumnParallelLinear(
             config.d_model,
@@ -201,6 +225,8 @@ class T5DenseActDense(nn.Module):
             bias=False,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "wi"),
         )
         self.wo = RowParallelLinear(
             config.d_ff,
@@ -208,6 +234,8 @@ class T5DenseActDense(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "wo"),
         )
         self.act = get_act_fn(config.dense_act_fn)
 
@@ -219,9 +247,20 @@ class T5DenseActDense(nn.Module):
 
 
 class T5LayerSelfAttention(nn.Module):
-    def __init__(self, config: T5Config, has_relative_attention_bias: bool = False, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
-        self.SelfAttention = T5SelfAttention(config, has_relative_attention_bias, prefix=f"{prefix}.SelfAttention")
+        self.SelfAttention = T5SelfAttention(
+            config,
+            has_relative_attention_bias,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "SelfAttention"),
+        )
         self.layer_norm = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
 
     def forward(
@@ -243,12 +282,25 @@ class T5LayerSelfAttention(nn.Module):
 
 
 class T5LayerFF(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         if config.is_gated_act:
-            self.DenseReluDense = T5DenseGatedActDense(config, prefix=f"{prefix}.DenseReluDense")
+            self.DenseReluDense = T5DenseGatedActDense(
+                config,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "DenseReluDense"),
+            )
         else:
-            self.DenseReluDense = T5DenseActDense(config, prefix=f"{prefix}.DenseReluDense")
+            self.DenseReluDense = T5DenseActDense(
+                config,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "DenseReluDense"),
+            )
         self.layer_norm = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -264,12 +316,23 @@ class T5LayerFF(nn.Module):
 
 
 class T5Block(nn.Module):
-    def __init__(self, config: T5Config, has_relative_attention_bias: bool = False, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.layer = nn.ModuleList(
             [
-                T5LayerSelfAttention(config, has_relative_attention_bias, prefix=f"{prefix}.layer.0"),
-                T5LayerFF(config, prefix=f"{prefix}.layer.1"),
+                T5LayerSelfAttention(
+                    config,
+                    has_relative_attention_bias,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "layer.0"),
+                ),
+                T5LayerFF(config, quant_config=quant_config, prefix=maybe_prefix(prefix, "layer.1")),
             ]
         )
 
@@ -285,12 +348,23 @@ class T5Block(nn.Module):
 
 
 class T5Stack(nn.Module):
-    def __init__(self, config: T5Config, shared: nn.Embedding, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        shared: nn.Embedding,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.embed_tokens = shared
         self.block = nn.ModuleList(
             [
-                T5Block(config, has_relative_attention_bias=(i == 0), prefix=f"{prefix}.block.{i}")
+                T5Block(
+                    config,
+                    has_relative_attention_bias=(i == 0),
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, f"block.{i}"),
+                )
                 for i in range(config.num_layers)
             ]
         )
@@ -325,12 +399,22 @@ class T5Stack(nn.Module):
 class T5EncoderModel(nn.Module):
     """T5 encoder model applying upstream vLLM layers"""
 
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.config = config
         self.prefix = prefix
         self.shared = VocabParallelEmbedding(config.vocab_size, config.d_model)
-        self.encoder = T5Stack(config, self.shared, prefix=f"{prefix}.encoder")
+        self.encoder = T5Stack(
+            config,
+            self.shared,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "encoder"),
+        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -380,8 +464,11 @@ class T5EncoderModel(nn.Module):
                 lookup_name = name.replace(f".{weight_name}.", f".{param_name}.", 1)
                 if lookup_name in params_dict:
                     param = params_dict[lookup_name]
-                    weight_loader = param.weight_loader
-                    weight_loader(param, loaded_weight, shard_id)
+                    weight_loader = getattr(param, "weight_loader", None)
+                    if weight_loader is None:
+                        default_weight_loader(param, loaded_weight)
+                    else:
+                        weight_loader(param, loaded_weight, shard_id)
                     matched = True
                     break
 

--- a/vllm_omni/diffusion/models/utils.py
+++ b/vllm_omni/diffusion/models/utils.py
@@ -103,19 +103,29 @@ def init_parameters(
 ):
     for name, param in module.named_parameters(recurse=False):
         if param.device == torch.device("meta"):
-            new_param = torch.empty_strided(
-                size=tuple(param.size()),
-                stride=tuple(param.stride()),
-                dtype=dtype or param.dtype,
-                device=device,
-                requires_grad=param.requires_grad,
-            )
-            # Preserve vLLM Parameter subclasses that provide custom weight loaders.
-            new_param.__class__ = param.__class__
-            new_param.__dict__ = getattr(param, "__dict__", {}).copy()
-            setattr(module, name, new_param)
+            setattr(module, name, _materialize_meta_parameter(param, dtype=dtype, device=device))
     for child in module.children():
         init_parameters(child, dtype, device)
+
+
+def _materialize_meta_parameter(
+    param: nn.Parameter,
+    dtype: torch.dtype | None,
+    device: torch.device | None,
+) -> nn.Parameter:
+    new_param = nn.Parameter(
+        torch.empty_like(
+            param.data,
+            dtype=dtype,
+            device=device,
+        ),
+        requires_grad=param.requires_grad,
+    )
+    if param.__class__ is not nn.Parameter:
+        # Preserve vLLM Parameter metadata used by fused weight loaders.
+        new_param.__class__ = param.__class__
+        new_param.__dict__ = getattr(param, "__dict__", {}).copy()
+    return new_param
 
 
 def create_transformers_model(

--- a/vllm_omni/diffusion/models/utils.py
+++ b/vllm_omni/diffusion/models/utils.py
@@ -103,14 +103,16 @@ def init_parameters(
 ):
     for name, param in module.named_parameters(recurse=False):
         if param.device == torch.device("meta"):
-            new_param = nn.Parameter(
-                torch.empty_like(
-                    param.data,
-                    dtype=dtype,
-                    device=device,
-                ),
+            new_param = torch.empty_strided(
+                size=tuple(param.size()),
+                stride=tuple(param.stride()),
+                dtype=dtype or param.dtype,
+                device=device,
                 requires_grad=param.requires_grad,
             )
+            # Preserve vLLM Parameter subclasses that provide custom weight loaders.
+            new_param.__class__ = param.__class__
+            new_param.__dict__ = getattr(param, "__dict__", {}).copy()
             setattr(module, name, new_param)
     for child in module.children():
         init_parameters(child, dtype, device)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This PR enables FP8 online quantization for the GLM-Image T5 text encoder.

GLM-Image already supports FP8 quantization for the DiT/transformer path, but the T5 text encoder was previously loaded through the HuggingFace module path and could not participate in vLLM's quantization framework. This PR wires the GLM-Image T5 encoder into vLLM-compatible linear layers so that per-component quantization can cover both `text_encoder` and `transformer`, while keeping the VAE in BF16.

Main changes:

- Propagate `quant_config` through GLM-Image T5 encoder linear layers.
- Route quantization by component prefix:
  - `text_encoder.*` -> FP8
  - `transformer.*` -> FP8
  - `vae` -> BF16 / not quantized
- Load GLM-Image text encoder weights through the native vLLM loader path alongside transformer weights.
- Handle T5-specific fused weight loading:
  - HF `q`, `k`, `v` -> `QKVParallelLinear`
  - HF `wi_0`, `wi_1` -> `MergedColumnParallelLinear`
  - shared/token embedding synchronization
- Preserve vLLM `Parameter` subclass metadata when materializing meta parameters so fused layer `weight_loader` / sharding metadata is not lost.
- Add regression tests for text encoder quantization prefixes, GLM transformer prefixes, TP constraints, and meta parameter subclass preservation.

This follows the same roadmap direction as Z-Image text encoder FP8 online quantization, but GLM-Image needs a T5-specific implementation because its text encoder uses fused QKV and gated MLP loading semantics.

## Test Plan

Environment:

- vLLM version: `0.24.0`
- vLLM-Omni commit: `b1d4e432`
- Model: `zai-org/GLM-Image`
- Hardware: 2x RTX 5090 32GB, CUDA visible devices `0,1`

Validation performed:

- `ruff check`: passed
- `ruff format --check`: passed
- targeted pytest suite: `63 passed, 20 warnings in 27.25s`
- real GLM-Image BF16 / FP8 generation on the downloaded local model snapshot
- FP8 TP=2 follow-up run for diffusion-stage memory sharding

FP8 routing was confirmed from runtime logs:

```text
Per-component quantization: {'text_encoder': 'fp8', 'transformer': 'fp8', 'vae': None}
Selected CutlassFP8ScaledMMLinearKernel for Fp8PerTensorOnlineLinearMethod
```

## Results

### BF16 vs FP8, TP=1

Benchmark setting: `256x256`, `2 steps`, `warmup=1`, `runs=3`, same prompt/seed. The diffusion stage uses TP=1.

| Metric | BF16 | FP8 online | Delta |
|---|---:|---:|---:|
| diffusion model loading memory | 14.0743 GiB | 7.5182 GiB | -46.6% |
| stage1 process GPU memory after loading | 14.71 GiB | 8.58 GiB | -41.7% |
| `nvidia-smi` GPU1 after init | 17384 MiB | 11004 MiB | -6380 MiB / -36.7% |
| `nvidia-smi` GPU1 after runs | 18001 MiB | 11621 MiB | -6380 MiB / -35.4% |
| measured median latency | 4.9640 s | 5.0725 s | +2.19% |
| init time | 56.50 s | 58.46 s | +1.96 s |

The primary benefit is diffusion-stage memory reduction. In the small 256x256 2-step benchmark, FP8 online is slightly slower because the workload is too small to amortize online scale/quant/dequant overhead. The slowdown is localized to stage1 diffusion; stage0 AR is effectively unchanged and VAE decode is flat.

Benchmark JSONs:

- `/data/vllm-omni/outputs/glm_image_smoke/final_bench/glm_image_bf16_256x256_2step_benchmark.json`
- `/data/vllm-omni/outputs/glm_image_smoke/final_bench/glm_image_fp8_256x256_2step_benchmark.json`

### 512x512 16-Step Generation, TP=1

Same prompt, same seed (`123`), same image size and step count.

| Metric | BF16 | FP8 online |
|---|---:|---:|
| diffusion model loading memory | 14.0743 GiB | 7.5182 GiB |
| stage1 process GPU memory after loading | 14.71 GiB | 8.58 GiB |
| generation time | 10.58 s | 9.62 s |
| image std | 87.4941 | 86.7926 |

Generated images:

- BF16: `/data/vllm-omni/outputs/glm_image_smoke/final_bench_images/bf16_512x512_16step/bf16_00_512x512_16step.png`
- FP8: `/data/vllm-omni/outputs/glm_image_smoke/final_bench_images/fp8_512x512_16step/fp8_00_512x512_16step.png`
- Side-by-side: `/data/vllm-omni/outputs/glm_image_smoke/final_bench_images/glm_image_bf16_vs_fp8_demo_512x512_16step.png`

### FP8 TP=2 Follow-up

The main BF16 / FP8 comparison above uses TP=1 for the diffusion stage. I also ran FP8 with diffusion-stage TP=2 to validate sharding across both GPUs.

| Setting | FP8 TP=1 | FP8 TP=2 | Notes |
|---|---:|---:|---|
| 256x256, 2 steps median latency | 5.0725 s | 5.0120 s | end-to-end slightly lower due to stage0 variance |
| 256x256 stage1 generation | 269.6 ms | 310.7 ms | diffusion stage is slower with TP=2 |
| 512x512, 16 steps latency | 9.6232 s | 9.8340 s | end-to-end slightly slower |
| 512x512 stage1 generation | 1818.4 ms | 2155.7 ms | TP communication/sync overhead exceeds compute gain |
| diffusion model loading memory | 7.5182 GiB | 4.5753 GiB / GPU | memory is sharded |

TP=2 mainly provides memory sharding for FP8 diffusion in this single-request benchmark. It does not improve latency here because batch size is 1 and NCCL communication/synchronization overhead offsets the reduced per-GPU matmul work.

BF16 TP=2 was also attempted, but the full GLM-Image pipeline does not fit on 2x RTX 5090 32GB in this deployment because stage0 AR and one BF16 diffusion rank share GPU0. FP8 TP=2 fits and completes successfully.

TP=2 JSONs:

- `/data/vllm-omni/outputs/glm_image_smoke/final_bench_tp2/glm_image_fp8_tp2_256x256_2step_benchmark.json`
- `/data/vllm-omni/outputs/glm_image_smoke/final_bench_tp2/glm_image_fp8_tp2_512x512_16step_demo.json`

## Notes

- VAE is intentionally kept in BF16 because it is precision-sensitive.
- Stage0 AR / vision-language encoder is not quantized by this PR.
- The default GLM-Image deploy config may need higher stage0 `gpu_memory_utilization` on 32GB GPUs so the AR engine can reserve KV cache after loading the 9B model.
