### PR TITLE
[NPU][Qwen3-TTS] Code predictor prefix npu-graph

### DIFF
--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -473,13 +473,11 @@ class CodePredictorWrapper(nn.Module):
         self._device_graphs: dict[int | tuple[int, int], tuple] = {}  # (graph, static_output) per bucket
         prefix_graph_cfg = self._stage_connector_extra_config(vllm_config)
         prefix_graphs_requested = self._parse_bool_config(prefix_graph_cfg.get("code_predictor_prefix_graphs"))
-        is_npu = current_omni_platform.is_npu()
-        self._prefix_graphs_enabled = prefix_graphs_requested and wrapper_config.use_cuda_graphs and not is_npu
+        self._prefix_graphs_enabled = prefix_graphs_requested and wrapper_config.use_cuda_graphs
         if prefix_graphs_requested and not self._prefix_graphs_enabled:
             logger.info_once(
-                "code_predictor: prefix CUDA graphs requested but disabled because use_cuda_graphs=%s is_npu=%s",
+                "code_predictor: prefix graphs requested but disabled because use_cuda_graphs=%s",
                 wrapper_config.use_cuda_graphs,
-                is_npu,
             )
         self._prefix_graph_buckets = self._parse_positive_int_set(
             prefix_graph_cfg.get("code_predictor_prefix_graph_buckets")
@@ -725,6 +723,37 @@ class CodePredictorWrapper(nn.Module):
         max_seq = self._num_groups + 1
         proj_buf = self._proj_buf
         pool = torch.npu.graph_pool_handle()
+
+        if self._prefix_graphs_enabled:
+            prefix_seq_lens = self._prefix_seq_lens(max_seq)
+            needs_full_graph = set(prefix_seq_lens) != set(range(2, max_seq))
+            for bsz in self._bucket_sizes:
+                capture_prefixes = not self._prefix_graph_buckets or bsz in self._prefix_graph_buckets
+
+                if not capture_prefixes or needs_full_graph:
+                    static_input = proj_buf[:bsz, :max_seq, :]
+                    pos_ids = self._bucket_pos_ids[bsz]
+                    g = torch.npu.NPUGraph()
+                    with torch.npu.graph(g, pool=pool):
+                        static_output = self._compiled_model_fwd(static_input, pos_ids)
+                    self._device_graphs[bsz] = (g, static_output)
+
+                if capture_prefixes:
+                    for seq_len in prefix_seq_lens:
+                        static_input = proj_buf[:bsz, :seq_len, :]
+                        pos_ids = self._bucket_pos_ids[(bsz, seq_len)]
+                        g = torch.npu.NPUGraph()
+                        with torch.npu.graph(g, pool=pool):
+                            static_output = self._compiled_model_fwd(static_input, pos_ids)
+                        self._device_graphs[(bsz, seq_len)] = (g, static_output)
+
+            logger.info(
+                "code_predictor: captured prefix NPU graphs for buckets %s prefix_buckets=%s seq_lens=%s",
+                self._bucket_sizes,
+                sorted(self._prefix_graph_buckets) if self._prefix_graph_buckets else "all",
+                prefix_seq_lens,
+            )
+            return
 
         for bsz in self._bucket_sizes:
             static_input = proj_buf[:bsz, :max_seq, :]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Support code predictor prefix NPU graph.

Implemented prefix NPU graph support in `_capture_npu_graphs`, following the prefix CUDA graph pattern. When enabled by configuration, it reduces the autoregressive sequence length for the code predictor.

## Test Plan

**vLLM Version:** v0.23.0

**vLLM-Ascend Commit:** 4885d8e7b7f4bf03a0b6c895428fc4fdcdfd6f23

**vLLM-Omni Commit:** 65bc737fd4375aca26c890941a02cdf88dcc3e14 

On A2 NPU environment, Qwen3-TTS was served with the following configuration and command. Using a fixed test input, performance metrics were compared between configurations with prefix graph disabled and enabled.

- Service startup

```bash
vllm serve /home/x50058110/tts-aclg/Qwen3-TTS-12Hz-1.7B-Base \
  --omni \
  --port 18091 \
  --allowed-local-media-path / \
  --deploy-config /home/x50058110/tts-aclg/tts.yaml \
```

- deploy-config

```yaml
async_chunk: true

connectors:
  connector_of_shared_memory:
    name: SharedMemoryConnector
    extra:
      shm_threshold_bytes: 65536
      codec_streaming: true
      connector_get_sleep_s: 0.01
      connector_get_max_wait_first_chunk: 3000
      connector_get_max_wait: 300
      codec_chunk_frames: 25
      codec_left_context_frames: 72
      code_predictor_prefix_graphs: true
      code_predictor_prefix_graph_buckets: [1, 2, 4, 8, 16, 32, 64]
      code_predictor_prefix_graph_seq_lens: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
      ref_code_context_frames: 72
      initial_codec_chunk_frames: 1
      decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
      decode_cudagraph_batch_sizes: [1]
      decode_compile_shapes: []
      decode_batch_max_size: 8
      decode_batch_bucket_frames: []
      decode_enable_tf32: false

stages:
  - stage_id: 0
    max_num_seqs: 8
    gpu_memory_utilization: 0.3
    trust_remote_code: true
    enable_prefix_caching: false
    async_scheduling: false
    max_num_batched_tokens: 512
    max_model_len: 4096
    devices: "0"
    output_connectors:
      to_stage_1: connector_of_shared_memory
    default_sampling_params:
      temperature: 0.9
      top_k: 50
      max_tokens: 4096
      seed: 42
      repetition_penalty: 1.05
    subtalker_sampling_params:
      do_sample: true
      temperature: 0.9
      top_k: 50
      top_p: 1.0

  - stage_id: 1
    max_num_seqs: 8
    gpu_memory_utilization: 0.3
    enforce_eager: false
    trust_remote_code: true
    enable_prefix_caching: false
    async_scheduling: false
    max_num_batched_tokens: 65536
    max_model_len: 65536
    devices: "0"
    input_connectors:
      from_stage_0: connector_of_shared_memory
    default_sampling_params:
      temperature: 0.0
      top_p: 1.0
      top_k: -1
      max_tokens: 65536
      seed: 42
      repetition_penalty: 1.0

platforms:
  npu:
    stages:
      - stage_id: 0
        enforce_eager: false

```

- Test setup
  - ref_audio: 4s wav
  - prompt: "Hello, welcome to the voice synthesis benchmark test.Hello, welcome to the voice synthesis benchmark test.Hello, welcome to the voice synthesis benchmark test."
  - num_warmups: 1
  - concurrency: 1
  - num_requests: 5

## Test Result

- enable prefix graph (as deploy-config):

```
==================================================
             Serving Benchmark Result             
==================================================
Successful requests:                    5         
Failed requests:                        0         
Maximum request concurrency:            1         
Benchmark duration (s):                 36.38     
Request throughput (req/s):             0.14      
--------------------------------------------------
                End-to-end Latency                
--------------------------------------------------
Mean E2EL (ms):                         7276.39   
Median E2EL (ms):                       7077.90   
P99 E2EL (ms):                          8069.97   
==================================================
                   Audio Result                   
==================================================
Total audio duration generated (s):     63.20     
Audio throughput (audio duration/s):    1.74      
--------------------------------------------------
               Time to First Packet               
--------------------------------------------------
Mean AUDIO_TTFP (ms):                   188.01    
Median AUDIO_TTFP (ms):                 187.48    
P99 AUDIO_TTFP (ms):                    195.13    
--------------------------------------------------
                 Real Time Factor                 
--------------------------------------------------
Mean AUDIO_RTF:                         0.576     
Median AUDIO_RTF:                       0.577     
P99 AUDIO_RTF:                          0.580     
==================================================
```

- disable prefix graph (set code_predictor_prefix_graphs to false):

```
==================================================
             Serving Benchmark Result             
==================================================
Successful requests:                    5         
Failed requests:                        0         
Maximum request concurrency:            1         
Benchmark duration (s):                 40.92     
Request throughput (req/s):             0.12      
--------------------------------------------------
                End-to-end Latency                
--------------------------------------------------
Mean E2EL (ms):                         8183.28   
Median E2EL (ms):                       8115.61   
P99 E2EL (ms):                          8661.09   
==================================================
                   Audio Result                   
==================================================
Total audio duration generated (s):     65.28     
Audio throughput (audio duration/s):    1.60      
--------------------------------------------------
               Time to First Packet               
--------------------------------------------------
Mean AUDIO_TTFP (ms):                   195.30    
Median AUDIO_TTFP (ms):                 196.26    
P99 AUDIO_TTFP (ms):                    199.08    
--------------------------------------------------
                 Real Time Factor                 
--------------------------------------------------
Mean AUDIO_RTF:                         0.627     
Median AUDIO_RTF:                       0.627     
P99 AUDIO_RTF:                          0.629     
==================================================
```

- Summarize

| Config               | Mean E2EL (s) | Mean TTFP (ms) |
| -------------------- | ------------- | -------------- |
| disable prefix graph | 8.183         | 195.30         |
| enable prefix graph  | 7.276         | 188.01         |
| diff                 | -11.08%       | -3.73%         |

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)