### PR TITLE
[Doc] Add MiMo-Audio serving recipe for 1x A100 80GB

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -69,6 +69,7 @@ recipes/
 | [`zai-org/GLM-TTS.md`](./zai-org/GLM-TTS.md) | Online serving for Chinese/English zero-shot voice-cloned TTS | 1x A40 48GB |
 | [`GLM/GLM-Image.md`](./GLM/GLM-Image.md) | Online serving for image generation | 1x A800 80GB / 2x A800 80GB |
 | [`JD/JoyAI-VL-Interaction.md`](./JD/JoyAI-VL-Interaction.md) | Real-time streaming video-language interaction (proactive speak/silence/delegate) | 1x GPU 24GB+ |
+| [`XiaomiMiMo/MiMo-Audio.md`](./XiaomiMiMo/MiMo-Audio.md) | Online serving for multimodal audio chat, speech understanding, and audio generation | 1x A100 80GB |
 
 Within a single recipe file, include different hardware support sections such
 as `GPU`, `ROCm`, and `NPU`, and add concrete tested configurations like

--- a/recipes/XiaomiMiMo/MiMo-Audio.md
+++ b/recipes/XiaomiMiMo/MiMo-Audio.md
@@ -1,0 +1,151 @@
+# MiMo-Audio
+
+> Online serving for multimodal audio chat, speech understanding, and audio generation
+
+## Summary
+
+- Vendor: XiaomiMiMo
+- Model: `XiaomiMiMo/MiMo-Audio-7B-Instruct`
+- Task: Multimodal chat with text and audio input; text and/or audio output; TTS-style audio generation
+- Mode: Online serving with the OpenAI-compatible `/v1/chat/completions` API
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe when you want to serve MiMo-Audio for audio understanding,
+text-only chat, or generated speech responses. The bundled deployment runs
+MiMo-Audio as a two-stage pipeline: Stage 0 is the fused thinker/talker that
+produces text and RVQ audio codes, and Stage 1 is the Code2Wav decoder that
+turns those codes into 24 kHz waveform audio.
+
+## References
+
+- Upstream model:
+  [`XiaomiMiMo/MiMo-Audio-7B-Instruct`](https://huggingface.co/XiaomiMiMo/MiMo-Audio-7B-Instruct)
+- Audio tokenizer:
+  [`XiaomiMiMo/MiMo-Audio-Tokenizer`](https://huggingface.co/XiaomiMiMo/MiMo-Audio-Tokenizer)
+- Online serving example:
+  [`examples/online_serving/mimo_audio/README.md`](../../examples/online_serving/mimo_audio/README.md)
+- Offline inference example:
+  [`examples/offline_inference/mimo_audio/README.md`](../../examples/offline_inference/mimo_audio/README.md)
+- Deploy config:
+  [`vllm_omni/deploy/mimo_audio.yaml`](../../vllm_omni/deploy/mimo_audio.yaml)
+- Chat template:
+  [`examples/online_serving/mimo_audio/chat_template.jinja`](../../examples/online_serving/mimo_audio/chat_template.jinja)
+- Related issue or discussion:
+  [vllm-project/vllm-omni#2645](https://github.com/vllm-project/vllm-omni/issues/2645)
+
+## Hardware Support
+
+This recipe records MiMo-Audio configurations that were personally validated.
+Additional GPU, ROCm, NPU, and XPU sections can be added as community
+validation lands.
+
+## GPU
+
+### 1x A100 80GB PCIe
+
+#### Environment
+
+- OS: Linux 6.8.0-124-generic with glibc 2.39
+- Python: 3.12.13
+- GPU: NVIDIA A100 80GB PCIe
+- Driver / runtime: NVIDIA driver 580.126.20, CUDA runtime 13.0.88
+- PyTorch: 2.11.0+cu130
+- vLLM version: 0.24.0
+- vLLM-Omni version or commit: 0.24.0 source checkout
+- Transformers: 5.12.1
+
+#### Command
+
+Start the server from the repository root:
+
+```bash
+hf download XiaomiMiMo/MiMo-Audio-Tokenizer \
+  --local-dir /workspace/models/MiMo-Audio-Tokenizer
+
+export MIMO_AUDIO_TOKENIZER_PATH=/workspace/models/MiMo-Audio-Tokenizer
+
+vllm serve XiaomiMiMo/MiMo-Audio-7B-Instruct \
+  --omni \
+  --served-model-name MiMo-Audio-7B-Instruct \
+  --deploy-config vllm_omni/deploy/mimo_audio.yaml \
+  --chat-template examples/online_serving/mimo_audio/chat_template.jinja \
+  --port 8091 \
+  --log-stats
+```
+
+The bundled `mimo_audio.yaml` places both stages on GPU 0 with async-chunk
+streaming through the shared-memory connector.
+
+#### Verification
+
+Text-only chat smoke test:
+
+```bash
+curl http://localhost:8091/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiMo-Audio-7B-Instruct",
+    "messages": [
+      {"role": "user", "content": "Reply with the phrase: MiMo-Audio text smoke test passed."}
+    ],
+    "modalities": ["text"],
+    "stream": false
+  }'
+```
+
+Observed output:
+
+```text
+choices[0].message.content: MiMo-Audio text smoke test passed.
+finish_reason: stop
+usage: prompt_tokens=34, completion_tokens=29, total_tokens=63
+```
+
+Audio-generation smoke test using the bundled client:
+
+```bash
+cd examples/online_serving/mimo_audio
+
+OPENAI_BASE_URL=http://localhost:8091/v1 \
+python openai_chat_completion_client_for_multimodal_generation.py \
+  --query-type text \
+  --prompt "Read this sentence in a calm and friendly voice."
+```
+
+Observed output:
+
+```text
+[req 0_chatcmpl-9141929dee9dd90a] Chat completion output from text: Read this sentence in a calm and friendly voice.
+[req 0_chatcmpl-9141929dee9dd90a] Audio saved to .//text/audio_0.wav
+WAV: 24 kHz, mono, 16-bit PCM, 7.36 s
+```
+
+Multi-round audio input smoke test using the bundled base64 message fixture:
+
+```bash
+cd examples/online_serving/mimo_audio
+
+OPENAI_BASE_URL=http://localhost:8091/v1 \
+python openai_chat_completion_client_for_multimodal_generation.py \
+  --query-type multi_audios \
+  --message-json ../../offline_inference/mimo_audio/message_base64_wav.json
+```
+
+Observed output:
+
+```text
+[req 0_chatcmpl-a6297fc07f0f497d] Chat completion output from text: <non-empty Chinese response>
+[req 0_chatcmpl-a6297fc07f0f497d] Audio saved to .//multi_audios/audio_0.wav
+WAV: 24 kHz, mono, 16-bit PCM, 57.12 s
+```
+
+#### Notes
+- Install `flash-attn` for your CUDA and PyTorch stack before validating audio
+generation. On CUDA GPUs, missing or incompatible FlashAttention can make
+generated audio noise-only even when the server appears healthy.
+- `MIMO_AUDIO_TOKENIZER_PATH` is required and must point to a local snapshot of the tokenizer weights. In vLLM-Omni 0.24.0, MiMo checks this value with
+  `os.path.exists()`, so a Hugging Face repo id is not sufficient.
+- MiMo-Audio is not compatible with the default chat template. Always pass
+  `--chat-template examples/online_serving/mimo_audio/chat_template.jinja`.


### PR DESCRIPTION
## Purpose

Add a community recipe for serving `XiaomiMiMo/MiMo-Audio-7B-Instruct` with
vLLM-Omni online serving.

This contributes to #2645 by adding:

- `recipes/XiaomiMiMo/MiMo-Audio.md`
- an index entry in `recipes/README.md`

The recipe documents a personally validated `1x NVIDIA A100 80GB PCIe`
configuration for MiMo-Audio multimodal chat, speech understanding, and audio
generation through the OpenAI-compatible `/v1/chat/completions` API.

No model code, runtime behavior, dependencies, or unit tests are changed.

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Source Checkout:** 0.24.0 source checkout

Validated online serving on `1x NVIDIA A100 80GB PCIe`.

Environment:

- OS: Ubuntu 24.04.4 LTS, Linux 6.8.0-124-generic, glibc 2.39
- GPU: 1x NVIDIA A100 80GB PCIe
- Driver / runtime: NVIDIA driver 580.126.20, CUDA runtime 13.0.88
- Python: 3.12.13
- PyTorch: 2.11.0+cu130
- Transformers: 5.12.1

Started MiMo-Audio online serving with the documented command shape:

```bash
hf download XiaomiMiMo/MiMo-Audio-Tokenizer \
  --local-dir /workspace/models/MiMo-Audio-Tokenizer

export MIMO_AUDIO_TOKENIZER_PATH=/workspace/models/MiMo-Audio-Tokenizer

vllm serve XiaomiMiMo/MiMo-Audio-7B-Instruct \
  --omni \
  --served-model-name MiMo-Audio-7B-Instruct \
  --deploy-config vllm_omni/deploy/mimo_audio.yaml \
  --chat-template examples/online_serving/mimo_audio/chat_template.jinja \
  --port 8091 \
  --log-stats
```

After the server started, I ran:

- a text-only `/v1/chat/completions` smoke test with `modalities: ["text"]`
- the bundled MiMo-Audio text-to-audio client
- the bundled MiMo-Audio multi-audio fixture client
- local WAV metadata checks for the generated audio files

Client commands:

```bash
curl http://localhost:8091/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "MiMo-Audio-7B-Instruct",
    "messages": [
      {"role": "user", "content": "Reply with the phrase: MiMo-Audio text smoke test passed."}
    ],
    "modalities": ["text"],
    "stream": false
  }'

cd examples/online_serving/mimo_audio

OPENAI_BASE_URL=http://localhost:8091/v1 \
python openai_chat_completion_client_for_multimodal_generation.py \
  --query-type text \
  --prompt "Read this sentence in a calm and friendly voice."

OPENAI_BASE_URL=http://localhost:8091/v1 \
python openai_chat_completion_client_for_multimodal_generation.py \
  --query-type multi_audios \
  --message-json ../../offline_inference/mimo_audio/message_base64_wav.json
```

No unit tests were run because this PR adds a community recipe and a small
example-client configuration convenience. The online smoke tests above validate
the documented serving path and generated audio outputs.

## Test Result

Server startup:

```text
vLLM server version 0.24.0, serving model XiaomiMiMo/MiMo-Audio-7B-Instruct
non-default args: {'model_tag': 'XiaomiMiMo/MiMo-Audio-7B-Instruct', 'chat_template': 'examples/online_serving/mimo_audio/chat_template.jinja', 'port': 8091, 'model': 'XiaomiMiMo/MiMo-Audio-7B-Instruct', 'served_model_name': ['MiMo-Audio-7B-Instruct']}
Model loading took 16.56 GiB memory
GPU KV cache size: 126,480 tokens
Application startup complete.
```

Text-only chat smoke test:

```text
HTTP 200 chat completion returned for model MiMo-Audio-7B-Instruct.
choices[0].message.content: MiMo-Audio text smoke test passed.
finish_reason: stop
usage: prompt_tokens=34, completion_tokens=29, total_tokens=63
```

Text-to-audio client:

```text
Chat completion output from text: Read this sentence in a calm and friendly voice.
Audio saved to .//text/audio_0.wav
```
[mimo_audio_text_generation.wav](https://github.com/user-attachments/files/29709615/mimo_audio_text_generation.wav)

Multi-audio fixture client:

```text
Chat completion output from text: <non-empty Chinese response>
Audio saved to .//multi_audios/audio_0.wav
```
[mimo_audio_multi_audios.wav](https://github.com/user-attachments/files/29709629/mimo_audio_multi_audios.wav)


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
