### PR TITLE
[Feature] Support Qwen3-TTS prefill-decode (PD) disaggregation

### DIFF
--- a/examples/online_serving/qwen3_tts_pd/benchmark/bench_pd.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/bench_pd.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Usage:
+#   bash bench_pd.sh                                  # 默认: 1p1d, c=8, 50 prompts
+#   bash bench_pd.sh 1p1d                             # 指定 topology tag (用于结果目录命名)
+#   bash bench_pd.sh 1p1d 8                           # topology, concurrency
+#   bash bench_pd.sh 1p1d 8 50                        # topology, concurrency, num_prompts
+#   bash bench_pd.sh 1p1d 8 50 zh                     # +locale (zh/en)
+#   bash bench_pd.sh 1p1d 8 2 zh smoke                # smoke 模式：不算 warmup 不存盘
+#
+# Special:
+#   bash bench_pd.sh 1p1d sweep                       # 自动扫 c=1,8,16,32,64,128，每档 50 prompts
+#
+# 每档压测跑完后，会自动生成一条“内容自描述”的验证语音，用来听感校验正确性，
+# 例如 3p1d + c=8 会合成朗读 “这是3个编码1个解码并行数为8的测试语音”，
+# 存到对应结果目录下的 check_audio_c<并发>.wav。设 CHECK_AUDIO=0 可关闭。
+#
+# Env override:
+#   MODEL=/root/models/Qwen3-TTS-12Hz-0.6B-Base
+#   HOST=127.0.0.1
+#   PORT=8091
+#   DATASET=/root/datasets/seed-tts-eval
+#   RESULT_ROOT=<this_dir>/results
+#   CHECK_AUDIO=1                                     # 1=压测后生成校验语音(默认), 0=关闭
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------- 默认参数 ----------
+TAG="${1:-1p1d}"
+ARG2="${2:-8}"
+NUM_PROMPTS="${3:-50}"
+LOCALE="${4:-zh}"
+MODE="${5:-}"
+
+MODEL="${MODEL:-/root/models/Qwen3-TTS-12Hz-0.6B-Base}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8091}"
+DATASET="${DATASET:-/root/datasets/seed-tts-eval}"
+RESULT_ROOT="${RESULT_ROOT:-$SCRIPT_DIR/results}"
+CHECK_AUDIO="${CHECK_AUDIO:-1}"
+
+# 从 topology tag 里解析 “编码(prefill)/解码(decode)” 个数，用于生成自描述文本。
+# 支持形如 1p3d / 3p1d / 1p1d / ar_3p1d / custom_xxx_1p3d 等；解析不到则回退 1/1。
+parse_pd_counts() {
+    local tag="$1"
+    if [[ "$tag" =~ ([0-9]+)p([0-9]+)d ]]; then
+        P_CNT="${BASH_REMATCH[1]}"
+        D_CNT="${BASH_REMATCH[2]}"
+    else
+        P_CNT=1
+        D_CNT=1
+    fi
+}
+
+# 生成一条“内容自描述”的验证语音：朗读 “这是X个编码Y个解码并行数为Z的测试语音”。
+# 便于人工听感校验：一听内容就知道对应哪套拓扑 + 并发。
+gen_check_audio() {
+    local concurrency="$1"
+    local result_dir="$2"
+    [[ "$CHECK_AUDIO" == "1" ]] || return 0
+
+    parse_pd_counts "$TAG"
+    local text="这是${P_CNT}个编码${D_CNT}个解码并行数为${concurrency}的测试语音"
+    local out_wav="$result_dir/check_audio_c${concurrency}.wav"
+
+    echo "==> [check] 生成校验语音: \"$text\" -> $out_wav"
+    if HOST="$HOST" PORT="$PORT" MODEL="$MODEL" SEED_TTS_ROOT="$DATASET" \
+        INPUT_TEXT="$text" \
+        bash "$SCRIPT_DIR/gen_audio.sh" "$LOCALE" 0 "$out_wav"; then
+        echo "==> [check] ✅ 校验语音已保存: $out_wav"
+    else
+        echo "==> [check] !! 校验语音生成失败 (不影响压测结果)"
+    fi
+}
+
+# ---------- 清代理 ----------
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+export no_proxy="localhost,127.0.0.1,::1"
+export NO_PROXY="localhost,127.0.0.1,::1"
+
+# ---------- 单次 bench 的封装 ----------
+run_one() {
+    local concurrency="$1"
+    local n_prompts="$2"
+    local mode="$3"   # "" or "smoke"
+    local result_dir="$RESULT_ROOT/${TAG}_${LOCALE}_c${concurrency}"
+    mkdir -p "$result_dir"
+
+    local warmups=2
+    local extra_save=(--save-result --result-dir "$result_dir")
+    if [[ "$mode" == "smoke" ]]; then
+        warmups=0
+        extra_save=()   # smoke 不存盘
+    fi
+
+    echo "==> bench: tag=$TAG locale=$LOCALE concurrency=$concurrency num_prompts=$n_prompts warmups=$warmups mode=${mode:-normal}"
+    echo "==> result_dir=$result_dir"
+
+    vllm bench serve --omni \
+        --host "$HOST" --port "$PORT" \
+        --model "$MODEL" \
+        --backend openai-audio-speech \
+        --endpoint /v1/audio/speech \
+        --dataset-name seed-tts \
+        --dataset-path "$DATASET" \
+        --seed-tts-locale "$LOCALE" \
+        --num-prompts "$n_prompts" --num-warmups "$warmups" \
+        --extra-body '{"task_type":"Base"}' \
+        --max-concurrency "$concurrency" --request-rate inf \
+        --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration,audio_underrun \
+        --trust-remote-code \
+        "${extra_save[@]}"
+
+    # 压测后做语音正确性校验（smoke 模式跳过）
+    if [[ "$mode" != "smoke" ]]; then
+        gen_check_audio "$concurrency" "$result_dir"
+    fi
+}
+
+# ---------- 健康检查 ----------
+check_server_alive() {
+    # /health
+    if ! curl -sS -m 3 --noproxy '*' "http://${HOST}:${PORT}/health" >/dev/null 2>&1; then
+        return 1
+    fi
+    # /v1/models（更全面，能检测 stage 是否真的就绪）
+    if ! curl -sS -m 5 --noproxy '*' "http://${HOST}:${PORT}/v1/models" >/dev/null 2>&1; then
+        return 1
+    fi
+    # 检查 pid 文件对应进程是否存活
+    for pid_file in "$RESULT_ROOT"/server_*.pid /tmp/server_*.pid; do
+        if [[ -f "$pid_file" ]]; then
+            local pid
+            pid=$(cat "$pid_file" 2>/dev/null)
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                return 0
+            fi
+        fi
+    done
+    # 没 pid 文件但 /health 通也算 OK（可能用户手动启动）
+    return 0
+}
+
+if ! check_server_alive; then
+    echo "!! server at ${HOST}:${PORT} not ready or already crashed. Start it first:"
+    echo "   bash $SCRIPT_DIR/start_pd.sh $TAG"
+    echo "!! 看 server 日志定位原因:"
+    echo "   tail -100 $RESULT_ROOT/server_${TAG}.log"
+    exit 1
+fi
+
+# ---------- 分发：sweep / 单次 ----------
+if [[ "$ARG2" == "sweep" ]]; then
+    echo "==> SWEEP mode: c in {1, 8, 16, 32, 64, 128}, num_prompts=$NUM_PROMPTS each"
+    for c in 1 8 16 32 64 128; do
+        run_one "$c" "$NUM_PROMPTS" ""
+        echo
+    done
+    echo "==> ✅ sweep done. Results under: $RESULT_ROOT/${TAG}_${LOCALE}_c*/"
+    ls -d "$RESULT_ROOT"/${TAG}_${LOCALE}_c*/ 2>/dev/null || true
+else
+    run_one "$ARG2" "$NUM_PROMPTS" "$MODE"
+    echo
+    echo "==> ✅ done"
+fi

--- a/examples/online_serving/qwen3_tts_pd/benchmark/catch_overgen.py
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/catch_overgen.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Catcher for the PD never-stop / over-generation bug.
+
+Sends seed-tts prompts concurrently to /v1/audio/speech, parses each returned
+WAV's duration, and flags requests whose audio is wildly disproportionate to
+the input text (the codec-EOS-miss signature: model keeps babbling past where
+it should stop). Loops rounds until an outlier is caught. Prints the offending
+utt/text and a wall-clock timestamp so the server log can be grepped.
+"""
+import asyncio, base64, io, json, os, sys, time, wave, datetime
+
+HOST = os.environ.get("HOST", "127.0.0.1")
+PORT = int(os.environ.get("PORT", "8091"))
+MODEL = os.environ.get("MODEL", "/root/models/Qwen3-TTS-12Hz-0.6B-Base")
+ROOT = os.environ.get("SEED_TTS_ROOT", "/root/datasets/seed-tts-eval")
+LOCALE = os.environ.get("LOCALE", "zh")
+CONC = int(os.environ.get("CONC", "64"))
+ROUNDS = int(os.environ.get("ROUNDS", "20"))
+# Over-generation flag: absolute seconds, and seconds-per-input-char ratio.
+# Normal zh seed-tts ≈ 4-8s for 10-30 chars → ~0.3s/char. Flag >>that.
+ABS_S = float(os.environ.get("ABS_S", "20"))
+PER_CHAR_S = float(os.environ.get("PER_CHAR_S", "1.2"))
+
+import aiohttp
+
+def load_rows():
+    meta = os.path.join(ROOT, LOCALE, "meta.lst")
+    rows = []
+    with open(meta) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            utt, ref_text, wav_rel, target = parts[0], parts[1], parts[2], parts[3]
+            wav = os.path.join(ROOT, LOCALE, wav_rel)
+            if os.path.isfile(wav):
+                rows.append((utt, ref_text, wav, target))
+    return rows
+
+def wav_duration(b: bytes):
+    try:
+        with wave.open(io.BytesIO(b), "rb") as w:
+            return w.getnframes() / float(w.getframerate() or 1)
+    except Exception:
+        return None
+
+async def one(session, sem, row):
+    utt, ref_text, wav, target = row
+    with open(wav, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    payload = {
+        "model": MODEL, "input": target, "task_type": "Base",
+        "language": "Chinese" if LOCALE == "zh" else "English",
+        "ref_audio": f"data:audio/wav;base64,{b64}", "ref_text": ref_text,
+    }
+    async with sem:
+        t0 = time.time()
+        try:
+            async with session.post(f"http://{HOST}:{PORT}/v1/audio/speech",
+                                    json=payload) as r:
+                data = await r.read()
+        except Exception as e:
+            return {"utt": utt, "err": str(e), "target": target}
+        dt = time.time() - t0
+    dur = wav_duration(data)
+    return {"utt": utt, "target": target, "chars": len(target),
+            "dur": dur, "lat": dt, "bytes": len(data),
+            "is_wav": data[:4] == b"RIFF", "t0": t0}
+
+async def run_round(rows):
+    sem = asyncio.Semaphore(CONC)
+    timeout = aiohttp.ClientTimeout(total=3600)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        results = await asyncio.gather(*[one(session, sem, r) for r in rows])
+    return results
+
+def analyze(rn, results):
+    flagged = []
+    durs = [x["dur"] for x in results if x.get("dur")]
+    maxd = max(durs) if durs else 0
+    med = sorted(durs)[len(durs)//2] if durs else 0
+    nbad = sum(1 for x in results if not x.get("is_wav"))
+    for x in results:
+        d = x.get("dur")
+        if d is None:
+            continue
+        if d >= ABS_S or (x["chars"] > 0 and d / x["chars"] >= PER_CHAR_S and d > 8):
+            flagged.append(x)
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    print(f"[{ts}] round {rn}: n={len(results)} non_wav={nbad} "
+          f"dur median={med:.1f}s max={maxd:.1f}s flagged={len(flagged)}", flush=True)
+    for x in flagged:
+        tt = datetime.datetime.fromtimestamp(x["t0"]).strftime("%H:%M:%S")
+        print(f"    !!! CAUGHT utt={x['utt']} chars={x['chars']} dur={x['dur']:.1f}s "
+              f"lat={x['lat']:.1f}s sent_at={tt} text={x['target'][:40]!r}", flush=True)
+    return flagged
+
+async def main():
+    rows = load_rows()
+    print(f"loaded {len(rows)} {LOCALE} rows; conc={CONC} rounds={ROUNDS} "
+          f"flag: abs>={ABS_S}s or >={PER_CHAR_S}s/char", flush=True)
+    any_flag = []
+    for rn in range(1, ROUNDS + 1):
+        results = await run_round(rows)
+        f = analyze(rn, results)
+        any_flag += f
+    print(f"DONE total_flagged={len(any_flag)}", flush=True)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/online_serving/qwen3_tts_pd/benchmark/catch_with_monitor.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/catch_with_monitor.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Runs the over-generation catcher and an external freeze monitor. When the
+# pipeline wedges (server log stops advancing AND both GPUs idle while the
+# catcher is still running), dump the freeze scene: last PD_TRACE lines, the
+# resume-vs-submit gap, and per-req submit/decode status for the stuck reqs.
+set -u
+cd /root/vllm-omni/examples/online_serving/qwen3_tts_pd/benchmark
+LOG=results/server_pd_1p1d.log
+DUMP=results/catch/freeze_dump.txt
+mkdir -p results/catch
+: > "$DUMP"
+
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+export no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1
+
+# launch catcher (many rounds, c=64, zh)
+LOCALE=zh CONC=64 ROUNDS=40 ABS_S=20 python3 catch_overgen.py > results/catch/catch2.log 2>&1 &
+CATCH_PID=$!
+echo "catcher pid=$CATCH_PID"
+
+strip() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+
+last_log_mtime() { stat -c %Y "$LOG" 2>/dev/null || echo 0; }
+
+FROZEN=0
+while kill -0 "$CATCH_PID" 2>/dev/null; do
+    sleep 15
+    now=$(date +%s)
+    lm=$(last_log_mtime)
+    age=$(( now - lm ))
+    util0=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i 0 2>/dev/null | tr -d ' ')
+    util1=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i 1 2>/dev/null | tr -d ' ')
+    echo "[mon $(date +%T)] log_age=${age}s gpu0=${util0}% gpu1=${util1}%"
+    # freeze = log stale >45s and both GPUs idle, catcher still running
+    if [ "$age" -ge 45 ] && [ "${util0:-0}" -le 2 ] && [ "${util1:-0}" -le 2 ]; then
+        FROZEN=1
+        echo "===== FREEZE DETECTED $(date +%T) log_age=${age}s =====" | tee -a "$DUMP"
+        echo "--- tail 40 server log ---" >> "$DUMP"
+        tail -40 "$LOG" | strip | cut -c1-200 >> "$DUMP"
+        echo "--- global counts ---" >> "$DUMP"
+        echo "prefill_submit_ready=$(grep -c qwen3_tts_prefill_submit_ready $LOG)" >> "$DUMP"
+        echo "prefill_to_decode_submitted=$(grep -c prefill_to_decode_submitted $LOG)" >> "$DUMP"
+        echo "decode_resume=$(grep -c qwen3_tts_decode_resume $LOG)" >> "$DUMP"
+        echo "--- LAST prefill_submit_ready ---" >> "$DUMP"
+        grep qwen3_tts_prefill_submit_ready $LOG | strip | tail -3 | cut -c1-200 >> "$DUMP"
+        echo "--- LAST prefill_to_decode_submitted ---" >> "$DUMP"
+        grep prefill_to_decode_submitted $LOG | strip | tail -3 | cut -c1-200 >> "$DUMP"
+        echo "--- LAST decode_resume ---" >> "$DUMP"
+        grep qwen3_tts_decode_resume $LOG | strip | tail -3 | cut -c1-200 >> "$DUMP"
+        echo "--- any recent orchestrator/forward/error lines (last 60 non-route) ---" >> "$DUMP"
+        tail -400 "$LOG" | strip | grep -iE "orchestrator|forward|pick|submit|error|exception|timed out|abort|prewarm" | tail -40 | cut -c1-200 >> "$DUMP"
+        echo "wrote $DUMP"
+        # let it sit 30s more to confirm permanent, then stop catcher
+        sleep 30
+        kill "$CATCH_PID" 2>/dev/null
+        break
+    fi
+done
+echo "===== monitor done frozen=$FROZEN ====="
+echo "--- catcher tail ---"; tail -15 results/catch/catch2.log

--- a/examples/online_serving/qwen3_tts_pd/benchmark/conc_sweep_runaway.py
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/conc_sweep_runaway.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Concurrency-threshold sweep for the runaway bug.
+
+c=1 gave 0/240 runaways; the c=64 load test gave 26/17920. This finds where in
+between it switches on, which discriminates between in-batch cross-contamination
+(shows up at c=2) and pressure/preemption effects (needs high c).
+
+Every level sends the SAME total number of requests from the SAME 4 texts that
+ran away in both prior load tests, so rates are directly comparable.
+
+Env:
+  LEVELS=1,2,4,8,16,32   concurrency levels to sweep
+  N_PER=128              requests per level
+  ABS_S=20               runaway threshold (s)
+"""
+import asyncio, base64, io, os, time, wave, datetime
+import aiohttp
+
+HOST = os.environ.get("HOST", "127.0.0.1")
+PORT = int(os.environ.get("PORT", "8091"))
+MODEL = os.environ.get("MODEL", "/root/models/Qwen3-TTS-12Hz-0.6B-Base")
+ROOT = os.environ.get("SEED_TTS_ROOT", "/root/datasets/seed-tts-eval")
+LOCALE = os.environ.get("LOCALE", "zh")
+LEVELS = [int(x) for x in os.environ.get("LEVELS", "1,2,4,8,16,32").split(",")]
+N_PER = int(os.environ.get("N_PER", "128"))
+ABS_S = float(os.environ.get("ABS_S", "20"))
+
+SUSPECT = [
+    "自动驾驶将大幅提升出行安全，效率。",
+    "真正落地成为产品服务进入每个人的生活。",
+    "打造更贴心，更细致的个性化服务。",
+    "目前中国互联网国际化还在开拓阶段。",
+]
+
+
+def load_rows():
+    rows = []
+    with open(os.path.join(ROOT, LOCALE, "meta.lst")) as f:
+        for line in f:
+            p = line.strip().split("|")
+            if len(p) < 4:
+                continue
+            wav = os.path.join(ROOT, LOCALE, p[2])
+            if os.path.isfile(wav):
+                rows.append({"ref_text": p[1], "wav": wav, "target": p[3]})
+    return rows
+
+
+def wav_dur(b):
+    try:
+        with wave.open(io.BytesIO(b), "rb") as w:
+            return w.getnframes() / float(w.getframerate() or 1)
+    except Exception:
+        return None
+
+
+async def one(session, sem, row, text):
+    payload = {
+        "model": MODEL, "input": text, "task_type": "Base",
+        "language": "Chinese" if LOCALE == "zh" else "English",
+        "ref_audio": f"data:audio/wav;base64,{row['b64']}", "ref_text": row["ref_text"],
+    }
+    async with sem:
+        t0 = time.time()
+        try:
+            async with session.post(f"http://{HOST}:{PORT}/v1/audio/speech",
+                                    json=payload) as r:
+                data = await r.read()
+        except Exception as e:
+            return {"err": str(e), "text": text}
+        lat = time.time() - t0
+    return {"dur": wav_dur(data), "lat": lat, "text": text}
+
+
+async def run_level(c, rows_by_text):
+    sem = asyncio.Semaphore(c)
+    work = [(rows_by_text[SUSPECT[i % len(SUSPECT)]], SUSPECT[i % len(SUSPECT)])
+            for i in range(N_PER)]
+    timeout = aiohttp.ClientTimeout(total=3600)
+    t0 = time.time()
+    async with aiohttp.ClientSession(timeout=timeout) as s:
+        res = await asyncio.gather(*[one(s, sem, r, t) for r, t in work])
+    wall = time.time() - t0
+    durs = [x["dur"] for x in res if x.get("dur")]
+    bad = [x for x in res if x.get("dur") and x["dur"] >= ABS_S]
+    errs = sum(1 for x in res if x.get("err"))
+    med = sorted(durs)[len(durs) // 2] if durs else 0
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    print(f"[{ts}] c={c:<3} n={len(durs)} err={errs} wall={wall:.0f}s "
+          f"median={med:.1f}s max={max(durs) if durs else 0:.1f}s "
+          f"RUNAWAY={len(bad)}/{len(durs)} ({len(bad)/max(len(durs),1)*100:.1f}%)", flush=True)
+    for b in bad:
+        print(f"      !!! dur={b['dur']:.1f}s lat={b['lat']:.1f}s text={b['text'][:24]!r}", flush=True)
+    return c, len(bad), len(durs)
+
+
+async def main():
+    rows = load_rows()
+    by_text = {}
+    for r in rows:
+        if r["target"] in SUSPECT and r["target"] not in by_text:
+            with open(r["wav"], "rb") as f:
+                r["b64"] = base64.b64encode(f.read()).decode("ascii")
+            by_text[r["target"]] = r
+    print(f"sweep: levels={LEVELS} n_per_level={N_PER} threshold={ABS_S}s "
+          f"texts={len(by_text)} (suspect-only)", flush=True)
+    summary = []
+    for c in LEVELS:
+        summary.append(await run_level(c, by_text))
+    print("\n=== SUMMARY ===")
+    print(f"{'conc':>5} {'runaway':>9} {'n':>5}  rate")
+    for c, b, n in summary:
+        print(f"{c:>5} {b:>9} {n:>5}  {b/max(n,1)*100:5.1f}%")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/online_serving/qwen3_tts_pd/benchmark/gen_audio.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/gen_audio.sh
@@ -19,6 +19,7 @@ PORT="${PORT:-8091}"
 MODEL="${MODEL:-/root/models/Qwen3-TTS-12Hz-0.6B-Base}"
 ROOT="${SEED_TTS_ROOT:-/root/datasets/seed-tts-eval}"
 INPUT_TEXT="${INPUT_TEXT:-}"   # 留空则用数据集该行的 target_text
+SEED="${SEED:-0}"
 
 META="$ROOT/$LOCALE/meta.lst"
 [[ -f "$META" ]] || { echo "!! meta.lst 不存在: $META"; exit 1; }
@@ -40,9 +41,9 @@ echo "==> ref_text=$REF_TEXT"
 echo "==> input(target)=$TARGET"
 
 # 用 python 组 JSON (安全转义 + inline base64 参考音)，再交给 curl
-python3 - "$MODEL" "$TARGET" "$REF_TEXT" "$LANG_NAME" "$WAV" > /tmp/_tts_req.json <<'PY'
+python3 - "$MODEL" "$TARGET" "$REF_TEXT" "$LANG_NAME" "$WAV" "$SEED" > /tmp/_tts_req.json <<'PY'
 import base64, json, sys
-model, target, ref_text, lang, wav = sys.argv[1:6]
+model, target, ref_text, lang, wav, seed = sys.argv[1:7]
 with open(wav, "rb") as f:
     b64 = base64.b64encode(f.read()).decode("ascii")
 print(json.dumps({
@@ -53,6 +54,7 @@ print(json.dumps({
     "language": lang,
     "ref_audio": f"data:audio/wav;base64,{b64}",
     "ref_text": ref_text,
+    "seed": int(seed),
 }))
 PY
 

--- a/examples/online_serving/qwen3_tts_pd/benchmark/gen_audio.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/gen_audio.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# 用 seed-tts 数据集里的参考音 + 文本，向正在运行的 TTS 服务发一条
+# /v1/audio/speech 请求，把返回的音频保存成 wav。
+#
+# 用法:
+#   bash gen_audio.sh [locale] [row_index] [out_wav]
+#   bash gen_audio.sh zh 0 /root/test_out.wav      # 默认
+#   bash gen_audio.sh en 3 /root/en3.wav
+#
+# 依赖: 服务已在 $HOST:$PORT 上跑 (bash start_pd.sh <topo> 起的那个)。
+set -euo pipefail
+
+LOCALE="${1:-zh}"
+ROW_IDX="${2:-0}"
+OUT="${3:-/root/test_out.wav}"
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8091}"
+MODEL="${MODEL:-/root/models/Qwen3-TTS-12Hz-0.6B-Base}"
+ROOT="${SEED_TTS_ROOT:-/root/datasets/seed-tts-eval}"
+INPUT_TEXT="${INPUT_TEXT:-}"   # 留空则用数据集该行的 target_text
+
+META="$ROOT/$LOCALE/meta.lst"
+[[ -f "$META" ]] || { echo "!! meta.lst 不存在: $META"; exit 1; }
+
+# 取第 ROW_IDX 条有效行 (跳过空行/注释)
+LINE=$(grep -v '^#' "$META" | sed '/^[[:space:]]*$/d' | sed -n "$((ROW_IDX+1))p")
+[[ -n "$LINE" ]] || { echo "!! 第 $ROW_IDX 行为空 (meta 行数不够)"; exit 1; }
+
+IFS='|' read -r UTT REF_TEXT WAV_REL TARGET <<< "$LINE"
+WAV="$ROOT/$LOCALE/$WAV_REL"
+[[ -f "$WAV" ]] || { echo "!! 参考音频不存在: $WAV"; exit 1; }
+
+[[ -n "$INPUT_TEXT" ]] && TARGET="$INPUT_TEXT"
+LANG_NAME=$([[ "$LOCALE" == "en" ]] && echo English || echo Chinese)
+
+echo "==> utt=$UTT"
+echo "==> ref_wav=$WAV"
+echo "==> ref_text=$REF_TEXT"
+echo "==> input(target)=$TARGET"
+
+# 用 python 组 JSON (安全转义 + inline base64 参考音)，再交给 curl
+python3 - "$MODEL" "$TARGET" "$REF_TEXT" "$LANG_NAME" "$WAV" > /tmp/_tts_req.json <<'PY'
+import base64, json, sys
+model, target, ref_text, lang, wav = sys.argv[1:6]
+with open(wav, "rb") as f:
+    b64 = base64.b64encode(f.read()).decode("ascii")
+print(json.dumps({
+    "model": model,
+    "input": target,
+    "task_type": "Base",
+    "bot_task": "think",
+    "language": lang,
+    "ref_audio": f"data:audio/wav;base64,{b64}",
+    "ref_text": ref_text,
+}))
+PY
+
+echo "==> POST http://$HOST:$PORT/v1/audio/speech -> $OUT"
+curl -s "http://$HOST:$PORT/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d @/tmp/_tts_req.json \
+    --output "$OUT"
+
+# 校验输出
+MAGIC=$(head -c 4 "$OUT" 2>/dev/null || true)
+if [[ "$MAGIC" == "RIFF" ]]; then
+    echo "✅ OK: $(ls -lh "$OUT" | awk '{print $5}')  $OUT"
+    command -v soxi >/dev/null 2>&1 && soxi "$OUT" || true
+else
+    echo "!! 返回的不是 wav，内容如下 (多半是 JSON 报错):"
+    head -c 400 "$OUT"; echo
+    exit 1
+fi

--- a/examples/online_serving/qwen3_tts_pd/benchmark/make_longtext_seedtts.py
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/make_longtext_seedtts.py
@@ -111,4 +111,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/examples/online_serving/qwen3_tts_pd/benchmark/make_longtext_seedtts.py
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/make_longtext_seedtts.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""把 seed-tts-eval 的短句 meta.lst 拼成「长文本」meta.lst，用于长上下文 TTS 压测。
+
+原理：seed-tts loader 读 <root>/<locale>/meta.lst，每行格式
+    utt_id|ref_text|prompt_wav_rel|target_text
+长文本 = 把连续 N 条 target_text 拼成一条；ref_text / prompt_wav_rel 沿用第一条
+（同一参考音做零样本克隆，只是合成长文本）。prompt-wavs 目录直接软链复用，不复制。
+
+用法（在压测机上，数据集在 /root/datasets/seed-tts-eval）：
+
+    python3 make_longtext_seedtts.py \
+        --root /root/datasets/seed-tts-eval \
+        --locale zh --group 20 --out-locale zh_long
+
+生成 /root/datasets/seed-tts-eval/zh_long/meta.lst 与软链 prompt-wavs。
+压测时换 locale 即可（数据集名仍是 seed-tts，无需改 bench 脚本）：
+
+    DATASET=/root/datasets/seed-tts-eval LOCALE=zh_long \\
+        TOPOS=2p2d CONCURRENCIES="8 32 64" NUM_PROMPTS=50 CHECK_AUDIO=0 \\
+        bash run_all_bench.sh
+"""
+import argparse
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--root", required=True, help="seed-tts-eval 根目录（含 <locale>/meta.lst）")
+    p.add_argument("--locale", default="zh", help="源 locale（默认 zh）")
+    p.add_argument("--out-locale", default=None, help="输出 locale 目录名，默认 <locale>_long")
+    p.add_argument("--group", type=int, default=20, help="最少拼几条源短句才收尾（--min-chars 优先）")
+    p.add_argument("--sep", default=" ", help="拼接分隔符（en 用空格；zh 可用空格或 '。'）")
+    p.add_argument("--max-chars", type=int, default=0, help="单条长文本最大字符数，超过则先停手（0=不限）")
+    p.add_argument("--min-chars", type=int, default=0, help="单条长文本最小字符数，达标才收尾（如 1024）")
+    args = p.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+    locale = args.locale
+    out_locale = args.out_locale or f"{locale}_long"
+    src_meta = root / locale / "meta.lst"
+    if not src_meta.is_file():
+        raise SystemExit(f"找不到源 meta.lst: {src_meta}")
+
+    rows: list[list[str]] = []
+    for line in src_meta.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("|")
+        if len(parts) < 4:
+            continue
+        rows.append(parts)
+
+    if not rows:
+        raise SystemExit(f"源 meta.lst 没有任何有效行: {src_meta}")
+
+    # 分组拼接（以字符预算为主：--min-chars 达标即收尾，--max-chars 前先停手，
+    # 避免把一句话从中间切断；--group 仅作「最少条数」兜底）。
+    out_groups: list[list[list[str]]] = []
+    buf: list[list[str]] = []
+    for parts in rows:
+        # 若加入这一条会超过 max_chars，先把当前 buf 收尾（句子边界不被切断）
+        if buf and args.max_chars:
+            proj = len(args.sep.join(r[3] for r in buf)) + len(args.sep) + len(parts[3])
+            if proj > args.max_chars:
+                out_groups.append(buf)
+                buf = []
+        buf.append(parts)
+        text_len = sum(len(r[3]) for r in buf)
+        reached_min = (args.min_chars == 0) or (text_len >= args.min_chars)
+        reached_group = len(buf) >= args.group
+        if reached_group and reached_min:
+            out_groups.append(buf)
+            buf = []
+    if buf:
+        out_groups.append(buf)
+
+    # 写出
+    out_dir = root / out_locale
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_meta = out_dir / "meta.lst"
+    with out_meta.open("w", encoding="utf-8") as f:
+        for gi, buf in enumerate(out_groups):
+            utt_id = buf[0][0]
+            ref_text = buf[0][1]
+            wav_rel = buf[0][2]
+            target = args.sep.join(r[3] for r in buf)
+            # max_chars 作为安全上限（正常已在上面停手，不会触发硬切）
+            if args.max_chars and len(target) > args.max_chars:
+                target = target[: args.max_chars]
+            f.write(f"{utt_id}_L{gi:04d}|{ref_text}|{wav_rel}|{target}\n")
+
+    # 复用 prompt-wavs（软链，避免复制大文件）
+    src_wavs = root / locale / "prompt-wavs"
+    out_wavs = out_dir / "prompt-wavs"
+    if src_wavs.is_dir():
+        if out_wavs.is_symlink() or out_wavs.exists():
+            print(f"[skip] 已存在: {out_wavs}")
+        else:
+            rel = os.path.relpath(src_wavs, out_dir)
+            out_wavs.symlink_to(rel, target_is_directory=True)
+            print(f"[link] {out_wavs} -> {rel}")
+    else:
+        print(f"[warn] 源 prompt-wavs 不存在: {src_wavs}（请确认参考音路径）")
+
+    print(f"源行数: {len(rows)} -> 长文本行数: {len(out_groups)} （每组约 {args.group} 条）")
+    print(f"输出 meta: {out_meta}")
+    print(f"压测: DATASET={root} LOCALE={out_locale} bash bench_pd.sh <TOPO> <C> <N>")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/online_serving/qwen3_tts_pd/benchmark/pyspy_on_wedge.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/pyspy_on_wedge.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run the catcher and, the instant the PD pipeline wedges (server log stalls +
+# both GPUs idle while the catcher is still running), py-spy dump every live
+# vLLM stage process (native stacks) so we can pin the busy-spin. Does NOT kill
+# anything — leaves the wedged server up for live inspection.
+set -u
+cd /root/vllm-omni/examples/online_serving/qwen3_tts_pd/benchmark
+LOG=results/server_pd_1p1d.log
+OUT=results/catch/pyspy
+mkdir -p "$OUT"
+
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+export no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1
+
+LOCALE=zh CONC=64 ROUNDS=60 ABS_S=20 python3 catch_overgen.py > results/catch/catch_pyspy.log 2>&1 &
+CATCH_PID=$!
+echo "catcher pid=$CATCH_PID"
+
+dump_all() {
+    local tag="$1"
+    echo "===== py-spy sweep ($tag) $(date +%T) =====" | tee -a "$OUT/stacks.txt"
+    # native VLLM procs: match by comm (VLLM::...) and the vllm serve parent
+    for pid in $(ps -eo pid,comm,cmd | grep -iE "VLLM::|vllm serve" | grep -v grep | awk '{print $1}'); do
+        local name; name="$(ps -o comm= -p "$pid" 2>/dev/null)"
+        local cpu; cpu="$(ps -o pcpu= -p "$pid" 2>/dev/null | tr -d ' ')"
+        echo "----- pid=$pid comm=$name cpu=${cpu}% -----" | tee -a "$OUT/stacks.txt"
+        timeout 20 py-spy dump --pid "$pid" --nonblocking >> "$OUT/stacks.txt" 2>&1 \
+            || echo "  (py-spy failed for $pid)" >> "$OUT/stacks.txt"
+    done
+    echo "wrote $OUT/stacks.txt ($tag)"
+}
+
+while kill -0 "$CATCH_PID" 2>/dev/null; do
+    sleep 15
+    now=$(date +%s); lm=$(stat -c %Y "$LOG" 2>/dev/null || echo 0); age=$((now-lm))
+    u0=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i 0 2>/dev/null|tr -d ' ')
+    u1=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i 1 2>/dev/null|tr -d ' ')
+    echo "[mon $(date +%T)] log_age=${age}s gpu0=${u0}% gpu1=${u1}%"
+    if [ "$age" -ge 40 ] && [ "${u0:-0}" -le 2 ] && [ "${u1:-0}" -le 2 ]; then
+        echo "===== WEDGE DETECTED $(date +%T) ====="
+        dump_all "wedge-t0"
+        sleep 8
+        dump_all "wedge-t1"   # second sweep 8s later: if same frame -> truly stuck, not slow
+        echo "===== stacks captured; killing catcher, leaving server up ====="
+        kill "$CATCH_PID" 2>/dev/null
+        break
+    fi
+done
+echo "===== done ====="

--- a/examples/online_serving/qwen3_tts_pd/benchmark/run_all_bench.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/run_all_bench.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 一键跑全部拓扑压测: single -> 1p1d -> 3p1d -> 1p3d -> 1p6d
+#
+# 对每一套拓扑:
+#   1) 用 start_pd.sh 起服务, 等 /health OK
+#   2) 依次按并发档 (CONCURRENCIES) 压测, 每档:
+#        - 完整 vllm bench 输出存到 <topo>/raw_c<并发>.log
+#        - 关键指标块抽取汇总到 <topo>/summary.txt (标出并发)
+#        - JSON 原始结果 (--save-result) 存到 <topo>/
+#        - 生成一条"内容自描述"校验语音 <topo>/check_audio_c<并发>.wav
+#   3) 用 stop_pd.sh 干净关服务, 释放显存/端口
+# 最后把所有拓扑的关键指标汇总成一张总表 SUMMARY_ALL.txt
+#
+# 用法:
+#   bash run_all_bench.sh                 # 默认全跑
+#   TOPOS="1p1d 3p1d" bash run_all_bench.sh          # 只跑指定拓扑
+#   CONCURRENCIES="1 8 32" bash run_all_bench.sh      # 自定义并发档
+#   NUM_PROMPTS=30 LOCALE=en bash run_all_bench.sh    # 每档条数 / 语种
+#
+# Env override (与 start_pd.sh / bench_pd.sh 一致):
+#   MODEL   (默认 /root/models/Qwen3-TTS-12Hz-0.6B-Base)
+#   HOST    (默认 127.0.0.1)
+#   PORT    (默认 8091)
+#   DATASET (默认 /root/datasets/seed-tts-eval)
+#   TOPOS         (默认 "single 1p1d 3p1d 1p3d 1p6d")
+#   CONCURRENCIES (默认 "1 8 16 32")
+#   NUM_PROMPTS   (默认 50)
+#   LOCALE        (默认 zh)
+#   CHECK_AUDIO   (默认 1; 0=不生成校验语音)
+#
+# 结果: benchmark/results/all_bench_<时间戳>/
+#         SUMMARY_ALL.txt          <- 拓扑横向对比总表 (先看这个)
+#         single/  1p1d/  3p1d/  1p3d/  1p6d/
+#             summary.txt          <- 该拓扑所有并发档的指标 (标出并发)
+#             raw_c<并发>.log       <- 完整 bench 输出
+#             check_audio_c<并发>.wav
+#             *.json               <- vllm --save-result 原始数据
+# ==============================================================================
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------- 参数 ----------
+MODEL="${MODEL:-/root/models/Qwen3-TTS-12Hz-0.6B-Base}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8091}"
+DATASET="${DATASET:-/root/datasets/seed-tts-eval}"
+TOPOS="${TOPOS:-single 1p1d 3p1d 1p3d 1p6d}"
+CONCURRENCIES="${CONCURRENCIES:-1 8 16 32}"
+NUM_PROMPTS="${NUM_PROMPTS:-50}"
+LOCALE="${LOCALE:-zh}"
+CHECK_AUDIO="${CHECK_AUDIO:-1}"
+
+TS="$(date +%Y%m%d_%H%M%S)"
+OUT_ROOT="${OUT_ROOT:-$SCRIPT_DIR/results/all_bench_$TS}"
+SUMMARY_ALL="$OUT_ROOT/SUMMARY_ALL.txt"
+mkdir -p "$OUT_ROOT"
+
+# ---------- 清代理 ----------
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+export no_proxy="localhost,127.0.0.1,::1"
+export NO_PROXY="localhost,127.0.0.1,::1"
+
+# 把 topology tag 解析成 "编码P / 解码D" 个数, 用于自描述校验语音文本
+parse_pd_counts() {
+    local tag="$1"
+    if [[ "$tag" =~ ([0-9]+)p([0-9]+)d ]]; then
+        P_CNT="${BASH_REMATCH[1]}"; D_CNT="${BASH_REMATCH[2]}"
+    else
+        P_CNT=1; D_CNT=1
+    fi
+}
+
+# 生成一条内容自描述的校验语音, 便于人工听感核对
+gen_check_audio() {
+    local topo="$1" concurrency="$2" out_dir="$3"
+    [[ "$CHECK_AUDIO" == "1" ]] || return 0
+    local text
+    if [[ "$topo" == "single" ]]; then
+        text="这是单机基线并行数为${concurrency}的测试语音"
+    else
+        parse_pd_counts "$topo"
+        text="这是${P_CNT}个编码${D_CNT}个解码并行数为${concurrency}的测试语音"
+    fi
+    local out_wav="$out_dir/check_audio_c${concurrency}.wav"
+    echo "    [check] 生成校验语音: \"$text\" -> $out_wav"
+    HOST="$HOST" PORT="$PORT" MODEL="$MODEL" SEED_TTS_ROOT="$DATASET" \
+        INPUT_TEXT="$text" \
+        bash "$SCRIPT_DIR/gen_audio.sh" "$LOCALE" 0 "$out_wav" \
+        >"$out_dir/check_audio_c${concurrency}.log" 2>&1 \
+        && echo "    [check] OK: $out_wav" \
+        || echo "    [check] !! 校验语音生成失败 (见 check_audio_c${concurrency}.log, 不影响压测数据)"
+}
+
+# 从一次 bench 的 raw log 里抽 "Serving Benchmark Result" 结果块, 追加到 summary
+extract_metrics() {
+    local raw_log="$1" summary="$2" topo="$3" concurrency="$4"
+    {
+        echo "################################################################"
+        echo "# 拓扑: $topo   并发(max-concurrency): $concurrency   条数: $NUM_PROMPTS   语种: $LOCALE"
+        echo "################################################################"
+        # 抽取从结果标题行到文件末尾的指标块; 抽不到就退回关键行 grep
+        if grep -q "Serving Benchmark Result" "$raw_log"; then
+            awk '/Serving Benchmark Result/{f=1} f' "$raw_log"
+        else
+            grep -iE "Successful requests|Benchmark duration|throughput|TTFT|TPOT|ITL|E2EL|RTF|TTFP|underrun|duration" "$raw_log" \
+                || echo "(未抓到指标, 见 raw log, 可能该档 bench 失败)"
+        fi
+        echo
+    } >> "$summary"
+}
+
+# 从 summary 里为总表抽一行 (吞吐 + 关键延迟), 尽力而为
+one_line_for_all() {
+    local raw_log="$1" topo="$2" concurrency="$3"
+    local reqput mean_ttfp mean_e2el rtf
+    # 用结果块里的精确列名, 并用 tail -1 取"最终结果块"(在日志末尾),
+    # 避开压测中途刷出的实时进度行(那些行里 rtf/throughput 常是 0.00)。
+    # 注意: TTS 后端没有 "Mean TTFT", 首包指标叫 "Mean AUDIO_TTFP (ms)";
+    #       RTF 列名是 "Mean AUDIO_RTF"。
+    reqput=$(grep -E "Request throughput" "$raw_log" | tail -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
+    mean_ttfp=$(grep -E "Mean AUDIO_TTFP" "$raw_log" | tail -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
+    mean_e2el=$(grep -E "Mean E2EL" "$raw_log" | tail -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
+    rtf=$(grep -E "Mean AUDIO_RTF" "$raw_log" | tail -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
+    printf "%-8s %8s %14s %14s %16s %12s\n" \
+        "$topo" "$concurrency" "${reqput:-NA}" "${mean_ttfp:-NA}" "${mean_e2el:-NA}" "${rtf:-NA}" \
+        >> "$SUMMARY_ALL"
+}
+
+# ---------- 总表表头 ----------
+{
+    echo "=============================================================================="
+    echo " Qwen3-TTS 全拓扑压测总表   time=$TS"
+    echo " model=$MODEL"
+    echo " dataset=$DATASET  locale=$LOCALE  num_prompts/档=$NUM_PROMPTS"
+    echo " 拓扑=[$TOPOS]  并发档=[$CONCURRENCIES]"
+    echo "=============================================================================="
+    printf "%-8s %8s %14s %14s %16s %12s\n" \
+        "TOPO" "CONC" "ReqThru(r/s)" "MeanTTFP(ms)" "MeanE2EL(ms)" "MeanRTF"
+    echo "------------------------------------------------------------------------------"
+} > "$SUMMARY_ALL"
+
+echo "=============================================================================="
+echo "==> 输出目录: $OUT_ROOT"
+echo "==> 拓扑: $TOPOS | 并发: $CONCURRENCIES | 每档条数: $NUM_PROMPTS | 语种: $LOCALE"
+echo "=============================================================================="
+
+# ---------- 主循环 ----------
+for topo in $TOPOS; do
+    topo_dir="$OUT_ROOT/$topo"
+    summary="$topo_dir/summary.txt"
+    mkdir -p "$topo_dir"
+    : > "$summary"
+
+    echo
+    echo "########################## [$topo] 起服务 ##########################"
+    if ! MODEL="$MODEL" HOST="$HOST" PORT="$PORT" bash "$SCRIPT_DIR/start_pd.sh" "$topo"; then
+        echo "!! [$topo] 服务启动失败, 跳过该拓扑 (看 results/server_*.log)"
+        {
+            echo "################################################################"
+            echo "# 拓扑: $topo  ==> 启动失败, 跳过"
+            echo "################################################################"
+            echo
+        } >> "$summary"
+        printf "%-8s %8s %14s %14s %16s %12s\n" "$topo" "-" "START_FAIL" "-" "-" "-" >> "$SUMMARY_ALL"
+        bash "$SCRIPT_DIR/stop_pd.sh" "$PORT" >/dev/null 2>&1
+        continue
+    fi
+
+    for c in $CONCURRENCIES; do
+        raw_log="$topo_dir/raw_c${c}.log"
+        echo
+        echo "-------- [$topo] bench 并发=$c 条数=$NUM_PROMPTS --------"
+        set +e
+        vllm bench serve --omni \
+            --host "$HOST" --port "$PORT" \
+            --model "$MODEL" \
+            --backend openai-audio-speech \
+            --endpoint /v1/audio/speech \
+            --dataset-name seed-tts \
+            --dataset-path "$DATASET" \
+            --seed-tts-locale "$LOCALE" \
+            --num-prompts "$NUM_PROMPTS" --num-warmups 2 \
+            --extra-body '{"task_type":"Base"}' \
+            --max-concurrency "$c" --request-rate inf \
+            --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration,audio_underrun \
+            --trust-remote-code \
+            --save-result --result-dir "$topo_dir" \
+            2>&1 | tee "$raw_log"
+        rc=${PIPESTATUS[0]}
+        set -e
+        if [[ $rc -ne 0 ]]; then
+            echo "!! [$topo] c=$c bench 退出码 $rc (数据可能不完整)"
+        fi
+
+        extract_metrics "$raw_log" "$summary" "$topo" "$c"
+        one_line_for_all "$raw_log" "$topo" "$c"
+        gen_check_audio "$topo" "$c" "$topo_dir"
+    done
+
+    echo
+    echo "########################## [$topo] 关服务 ##########################"
+    bash "$SCRIPT_DIR/stop_pd.sh" "$PORT"
+
+    echo "==> [$topo] 完成. 指标见: $summary"
+done
+
+echo "------------------------------------------------------------------------------" >> "$SUMMARY_ALL"
+
+echo
+echo "=============================================================================="
+echo "==> 全部完成!"
+echo "==> 总表 (先看这个): $SUMMARY_ALL"
+echo "==> 各拓扑明细: $OUT_ROOT/<topo>/summary.txt"
+echo "==> 校验语音:   $OUT_ROOT/<topo>/check_audio_c<并发>.wav"
+echo "=============================================================================="
+echo
+cat "$SUMMARY_ALL"

--- a/examples/online_serving/qwen3_tts_pd/benchmark/serial_probe.py
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/serial_probe.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Serial (concurrency=1) runaway probe.
+
+Sends one request at a time, so scheduling / batching / preemption are out of
+the picture: anything that over-generates here is the sampler alone. Targets
+the texts that were empirically enriched for runaway across two independent
+17,920-request runs, and interleaves control texts for a baseline rate.
+
+Env:
+  REPS=30            repetitions per text
+  ABS_S=20           runaway threshold (seconds of audio)
+  REP_PENALTY=       override repetition_penalty (default: server yaml value)
+  TEXTS=suspect|control|both
+"""
+import base64, io, json, os, sys, time, wave, datetime, urllib.request
+
+HOST = os.environ.get("HOST", "127.0.0.1")
+PORT = int(os.environ.get("PORT", "8091"))
+MODEL = os.environ.get("MODEL", "/root/models/Qwen3-TTS-12Hz-0.6B-Base")
+ROOT = os.environ.get("SEED_TTS_ROOT", "/root/datasets/seed-tts-eval")
+LOCALE = os.environ.get("LOCALE", "zh")
+REPS = int(os.environ.get("REPS", "30"))
+ABS_S = float(os.environ.get("ABS_S", "20"))
+REP_PENALTY = os.environ.get("REP_PENALTY", "")
+WHICH = os.environ.get("TEXTS", "both")
+
+# Texts that ran away in BOTH the PD 1p1d run and the single-card run.
+SUSPECT = [
+    "自动驾驶将大幅提升出行安全，效率。",
+    "真正落地成为产品服务进入每个人的生活。",
+    "打造更贴心，更细致的个性化服务。",
+    "目前中国互联网国际化还在开拓阶段。",
+]
+
+
+def load_rows():
+    rows = []
+    with open(os.path.join(ROOT, LOCALE, "meta.lst")) as f:
+        for line in f:
+            p = line.strip().split("|")
+            if len(p) < 4:
+                continue
+            wav = os.path.join(ROOT, LOCALE, p[2])
+            if os.path.isfile(wav):
+                rows.append({"utt": p[0], "ref_text": p[1], "wav": wav, "target": p[3]})
+    return rows
+
+
+def wav_dur(b):
+    try:
+        with wave.open(io.BytesIO(b), "rb") as w:
+            return w.getnframes() / float(w.getframerate() or 1)
+    except Exception:
+        return None
+
+
+def send(row, text):
+    with open(row["wav"], "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    payload = {
+        "model": MODEL, "input": text, "task_type": "Base",
+        "language": "Chinese" if LOCALE == "zh" else "English",
+        "ref_audio": f"data:audio/wav;base64,{b64}", "ref_text": row["ref_text"],
+    }
+    if REP_PENALTY:
+        payload["repetition_penalty"] = float(REP_PENALTY)
+    req = urllib.request.Request(
+        f"http://{HOST}:{PORT}/v1/audio/speech",
+        data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=3600) as r:
+        data = r.read()
+    return wav_dur(data), time.time() - t0
+
+
+def main():
+    rows = load_rows()
+    by_text = {r["target"]: r for r in rows}
+    groups = []
+    if WHICH in ("suspect", "both"):
+        groups += [("SUSPECT", t) for t in SUSPECT if t in by_text]
+    if WHICH in ("control", "both"):
+        ctl = [r["target"] for r in rows if r["target"] not in set(SUSPECT)][:4]
+        groups += [("CONTROL", t) for t in ctl]
+
+    print(f"serial probe: reps={REPS} threshold={ABS_S}s rep_penalty={REP_PENALTY or 'yaml-default'} "
+          f"groups={len(groups)}", flush=True)
+    grand = {}
+    for kind, text in groups:
+        row = by_text[text]
+        durs, bad = [], 0
+        for i in range(REPS):
+            try:
+                d, lat = send(row, text)
+            except Exception as e:
+                print(f"    ERR {e}", flush=True); continue
+            if d is None:
+                continue
+            durs.append(d)
+            if d >= ABS_S:
+                bad += 1
+                print(f"    !!! runaway rep={i+1} dur={d:.1f}s lat={lat:.1f}s", flush=True)
+        med = sorted(durs)[len(durs) // 2] if durs else 0
+        print(f"  [{kind}] {text[:26]!r} n={len(durs)} median={med:.1f}s "
+              f"max={max(durs) if durs else 0:.1f}s runaway={bad}/{len(durs)}", flush=True)
+        grand.setdefault(kind, [0, 0])
+        grand[kind][0] += bad
+        grand[kind][1] += len(durs)
+    print()
+    for kind, (b, n) in grand.items():
+        print(f"TOTAL {kind}: {b}/{n} = {b/n*100 if n else 0:.1f}% runaway", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
@@ -235,4 +235,3 @@ done
 echo "    !! /health timeout, last 80 log lines:"
 tail -80 "$LOG"
 exit 1
-

--- a/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Usage:
+#   bash start_pd.sh                       # 默认: PD 1P1D (3 卡)
+#   bash start_pd.sh 1p1d                  # PD 1P1D (3 卡：prefill+decode+code2wav)
+#   bash start_pd.sh 1p3d                  # PD 1P3D (1 prefill + 3 decode + code2wav)
+#   bash start_pd.sh 1p6d                  # PD 1P6D (1 prefill + 6 decode + code2wav)
+#   bash start_pd.sh 3p1d                  # PD 3P1D (3 prefill + 1 decode + code2wav)
+#   bash start_pd.sh single                # 单机基线 (qwen3_tts.yaml)
+#   bash start_pd.sh ar_3p1d               # AR-only 3P1D (无 code2wav，仅 talker)
+#   bash start_pd.sh /abs/path/to/x.yaml   # 自定义 yaml 绝对路径
+#
+# Env override:
+#   MODEL=/root/models/Qwen3-TTS-12Hz-0.6B-Base
+#   PORT=8091
+#   HOST=127.0.0.1
+#
+# Output:
+#   server log -> $RESULTS_DIR/server_<topology>.log
+#   server pid -> $RESULTS_DIR/server_<topology>.pid
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Walk up from this script to find the vllm-omni repo root (the directory that
+# contains the vllm_omni/ package). This keeps the script location-independent
+# so it works whether it lives at repo-root/examples/.../benchmark/ or anywhere
+# else inside the checkout (e.g. when copied out to a personal scratch dir).
+find_repo_root() {
+    local d="$SCRIPT_DIR"
+    while [[ "$d" != "/" ]]; do
+        if [[ -d "$d/vllm_omni" ]]; then
+            echo "$d"; return 0
+        fi
+        d="$(dirname "$d")"
+    done
+    return 1
+}
+DEFAULT_VLLM_OMNI_DIR="$(find_repo_root)"
+if [[ -z "$DEFAULT_VLLM_OMNI_DIR" ]]; then
+    echo "ERR: could not locate vllm-omni repo root (no vllm_omni/ package found upward from $SCRIPT_DIR)." >&2
+    echo "     Set VLLM_OMNI_DIR=/path/to/vllm-omni explicitly." >&2
+    exit 2
+fi
+
+# ---------- 参数解析 ----------
+TOPO="${1:-1p1d}"
+MODEL="${MODEL:-/root/models/Qwen3-TTS-12Hz-0.6B-Base}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8091}"
+VLLM_OMNI_DIR="${VLLM_OMNI_DIR:-$DEFAULT_VLLM_OMNI_DIR}"
+DEPLOY_DIR="$VLLM_OMNI_DIR/vllm_omni/deploy"
+
+# 解析 topology -> yaml 路径
+case "$TOPO" in
+    1p1d)     YAML="$DEPLOY_DIR/qwen3_tts_pd_1p1d.yaml" ; TAG="pd_1p1d" ;;
+    1p3d)     YAML="$DEPLOY_DIR/qwen3_tts_pd_1p3d.yaml" ; TAG="pd_1p3d" ;;
+    1p6d)     YAML="$DEPLOY_DIR/qwen3_tts_pd_1p6d.yaml" ; TAG="pd_1p6d" ;;
+    3p1d)     YAML="$DEPLOY_DIR/qwen3_tts_pd_3p1d.yaml" ; TAG="pd_3p1d" ;;
+    2p2d)     YAML="$DEPLOY_DIR/qwen3_tts_pd_2p2d.yaml" ; TAG="pd_2p2d" ;;
+    single)   YAML=""                                   ; TAG="single" ;;
+    ar_3p1d)  YAML="$DEPLOY_DIR/qwen3_tts_pd_ar_only_3p1d.yaml" ; TAG="pd_ar_3p1d" ;;
+    /*.yaml)  YAML="$TOPO"                              ; TAG="custom_$(basename "$TOPO" .yaml)" ;;
+    *)        echo "ERR: unknown topology '$TOPO'. See script header for valid choices." >&2 ; exit 2 ;;
+esac
+
+if [[ ! -d "$VLLM_OMNI_DIR" ]]; then
+    echo "ERR: vllm-omni dir not found: $VLLM_OMNI_DIR" >&2
+    echo "     Set VLLM_OMNI_DIR=/path/to/vllm-omni explicitly." >&2
+    exit 2
+fi
+if [[ -n "$YAML" && ! -f "$YAML" ]]; then
+    echo "ERR: yaml not found: $YAML" >&2
+    exit 2
+fi
+if ! command -v vllm >/dev/null 2>&1; then
+    echo "ERR: vllm command not found. Activate the right Python/env first." >&2
+    exit 2
+fi
+
+RESULTS_DIR="${RESULTS_DIR:-$SCRIPT_DIR/results}"
+mkdir -p "$RESULTS_DIR"
+LOG="${RESULTS_DIR}/server_${TAG}.log"
+PID_FILE="${RESULTS_DIR}/server_${TAG}.pid"
+
+echo "==> topology   : $TOPO"
+echo "==> vllm-omni  : $VLLM_OMNI_DIR"
+echo "==> yaml       : ${YAML:-<single, no yaml>}"
+echo "==> model      : $MODEL"
+echo "==> listen     : $HOST:$PORT"
+echo "==> log        : $LOG"
+
+# ---------- 0) Mooncake 自检自愈（防止 mooncake/ 又被改名为 mooncake.disabled） ----------
+ensure_mooncake_available() {
+    if [[ "$TOPO" == "single" ]]; then
+        echo "==> [0/4] skipping mooncake module check for single baseline..."
+        return 0
+    fi
+
+    echo "==> [0/4] checking mooncake module..."
+    SITE_PKG="${SITE_PKG:-$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')}"
+    if [[ -d "${SITE_PKG}/mooncake.disabled" && ! -d "${SITE_PKG}/mooncake" ]]; then
+        echo "    ⚠️  mooncake is currently disabled, restoring..."
+        sudo -n mv "${SITE_PKG}/mooncake.disabled" "${SITE_PKG}/mooncake" 2>/dev/null \
+            || mv "${SITE_PKG}/mooncake.disabled" "${SITE_PKG}/mooncake" 2>/dev/null \
+            || echo "    !! failed to restore mooncake/, run with sudo or check perms"
+    fi
+    if [[ -d "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info.disabled" \
+          && ! -d "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info" ]]; then
+        sudo -n mv "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info.disabled" \
+                "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info" 2>/dev/null \
+            || mv "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info.disabled" \
+                  "${SITE_PKG}/mooncake_transfer_engine-0.3.8.post1.dist-info" 2>/dev/null || true
+    fi
+    # 验证 mooncake import 正常（如果还失败就提前退出，省得跑 60 秒等 worker 死）
+    if ! python3 -c "from mooncake.engine import TransferEngine" 2>/dev/null; then
+        echo "    ❌ mooncake import still failing. Manual fix required:"
+        echo "       SITE_PKG=${SITE_PKG}"
+        echo "       ls -ld ${SITE_PKG}/mooncake* ${SITE_PKG}/*mooncake*"
+        echo "       python3 -c 'from mooncake.engine import TransferEngine; print(\"OK\")'"
+        exit 1
+    fi
+    echo "    ✅ mooncake import OK"
+}
+
+ensure_mooncake_available
+
+# ---------- 1) 先调用 stop 脚本，彻底关掉旧 server + 清残留 ----------
+echo "==> [1/4] stopping any existing server..."
+if [[ -f "$SCRIPT_DIR/stop_pd.sh" ]]; then
+    bash "$SCRIPT_DIR/stop_pd.sh" "$PORT" || true
+else
+    echo "    stop_pd.sh not found; not killing port $PORT automatically to avoid affecting unrelated services"
+fi
+
+# Re-check after cleanup, so vLLM never imports MooncakeConnector while the
+# mooncake package is still disabled/missing.
+ensure_mooncake_available
+
+# 1f) 显存检查（必须有空闲显存才能跑）
+echo "==> GPU memory before start:"
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=index,memory.used,memory.free,utilization.gpu --format=csv,noheader 2>&1 | head -8
+else
+    echo "    (nvidia-smi not in PATH)"
+fi
+
+# ---------- 2) 清环境变量 ----------
+echo "==> [2/4] cleaning proxy env..."
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+export no_proxy="localhost,127.0.0.1,::1"
+export NO_PROXY="localhost,127.0.0.1,::1"
+export VLLM_HOST_IP="${VLLM_HOST_IP:-127.0.0.1}"
+export VLLM_USE_DEEP_GEMM=0
+# MTP graph / KV-cache opt-in paths are OFF by default. Force-cleared here so a
+# stale export in the parent shell can't accidentally enable them; to opt in,
+# drop these three lines (KV_CACHE additionally needs FULL_GRAPH + INVERSE_CDF).
+export VLLM_OMNI_MTP_FULL_GRAPH=0
+export VLLM_OMNI_MTP_INVERSE_CDF=0
+export VLLM_OMNI_MTP_KV_CACHE=0
+# MTP multi-replica sub-batch path is DISABLED by default (NUM_REPLICAS=1).
+# The >1 path pins each request to a deepcopied code_predictor replica by
+# crc32(req_id); under PD the extra replica state was implicated in requests
+# that never sample the codec-EOS (stop_token_ids=[2150]) and run to
+# max_tokens ("停不下来"). Collapsing to a single code_predictor makes decode
+# MTP behave exactly like the single-node baseline. Uses ${VAR:-default} so a
+# command-line export can still opt back in (e.g. NUM_REPLICAS=2).
+export VLLM_OMNI_MTP_NUM_REPLICAS="${VLLM_OMNI_MTP_NUM_REPLICAS:-1}"
+export VLLM_OMNI_MTP_BATCH_PER_REPLICA="${VLLM_OMNI_MTP_BATCH_PER_REPLICA:-0}"
+export PYTHONPATH="$VLLM_OMNI_DIR:${PYTHONPATH:-}"
+
+echo "==> python vllm_omni module:"
+python3 -c 'import vllm_omni, pathlib; print("   ", pathlib.Path(vllm_omni.__file__).resolve())'
+
+# ---------- 3) 后台拉起 server ----------
+echo "==> [3/4] starting server in background..."
+cd "$VLLM_OMNI_DIR"
+
+if [[ -n "$YAML" ]]; then
+    nohup vllm serve "$MODEL" \
+        --omni --host "$HOST" --port "$PORT" \
+        --stage-configs-path "$YAML" \
+        --trust-remote-code \
+        > "$LOG" 2>&1 &
+else
+    nohup vllm serve "$MODEL" \
+        --omni --host "$HOST" --port "$PORT" \
+        --trust-remote-code \
+        > "$LOG" 2>&1 &
+fi
+SERVER_PID=$!
+echo "$SERVER_PID" > "$PID_FILE"
+echo "    server pid=$SERVER_PID"
+
+# 安静启动：不再把 server 全过程日志刷屏（压测时不需要看启动过程），
+# 全部写入 $LOG，只在下面按秒打点等待 /health；失败时才 dump 诊断信息。
+echo "    ---- quiet start: 完整日志见 $LOG (tail -f 可自行查看) ----"
+
+# ---------- 4) 等 /health ----------
+# Multi-stage PD topologies (1p3d/1p6d/3p1d) initialize stages serially and
+# may spend several minutes capturing CUDA/MTP graphs on cold cache. Keep the
+# timeout configurable so larger topologies are not killed while still warming.
+STARTUP_TIMEOUT_S="${STARTUP_TIMEOUT_S:-1800}"
+echo "==> [4/4] waiting for /health (max ${STARTUP_TIMEOUT_S}s)..."
+for i in $(seq 1 "$STARTUP_TIMEOUT_S"); do
+    if curl -sS -m 2 --noproxy '*' "http://${HOST}:${PORT}/health" >/dev/null 2>&1; then
+        echo "    ✅ /health OK after ${i}s. pid=$SERVER_PID"
+        echo
+        echo "    next: bash $SCRIPT_DIR/bench_pd.sh $TOPO sweep   # 扫 c=1,8,16,32,64"
+        echo "    stop: kill -9 \$(cat $PID_FILE)   # 或按端口: kill -9 \$(lsof -t -iTCP:$PORT -sTCP:LISTEN)"
+        exit 0
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "    !! server process died after ${i}s"
+        echo "==== GPU state at death ===="
+        nvidia-smi --query-gpu=index,memory.used,memory.free,utilization.gpu --format=csv,noheader 2>&1 | head -8
+        echo "==== kernel OOM / SIGKILL hints (dmesg) ===="
+        dmesg 2>/dev/null | tail -50 | grep -iE "killed|oom|memory|cuda|nvidia|signal" | tail -20
+        echo "==== last activity per worker/stage (last 60 lines per pid) ===="
+        # 抓出每个子进程死前最后做的事 (StageEngineCoreProc + Worker)
+        grep -E "Worker pid=|StageEngineCoreProc pid=" "$LOG" 2>/dev/null | tail -60
+        echo "==== ERRORS / Tracebacks / signals across full log ===="
+        grep -niE "killed|signal|fatal|abort|core dumped|cuda.*error|nccl.*error|FAILED|^[A-Z][a-zA-Z]*Error:|RuntimeError:|AssertionError:|exception|Traceback" "$LOG" 2>/dev/null | tail -40
+        echo "==== last 250 log lines (raw tail) ===="
+        tail -250 "$LOG"
+        echo "==== full log saved at: $LOG (size: $(wc -l < "$LOG") lines) ===="
+        exit 1
+    fi
+    if (( i % 30 == 0 )); then
+        echo "    ...still waiting (${i}s)"
+    fi
+    sleep 1
+done
+
+echo "    !! /health timeout, last 80 log lines:"
+tail -80 "$LOG"
+exit 1
+

--- a/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/start_pd.sh
@@ -179,7 +179,7 @@ cd "$VLLM_OMNI_DIR"
 if [[ -n "$YAML" ]]; then
     nohup vllm serve "$MODEL" \
         --omni --host "$HOST" --port "$PORT" \
-        --stage-configs-path "$YAML" \
+        --deploy-config "$YAML" \
         --trust-remote-code \
         > "$LOG" 2>&1 &
 else

--- a/examples/online_serving/qwen3_tts_pd/benchmark/stop_pd.sh
+++ b/examples/online_serving/qwen3_tts_pd/benchmark/stop_pd.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Stop the Qwen3-TTS PD server and free ALL its resources.
+#
+# 干净地关闭 PD server：
+#   * 杀掉 API server 进程 + 它派生的全部 stage/worker 子孙进程
+#   * 释放 API 端口 (默认 8091) 与 mooncake bootstrap 端口 (25201-25206)
+#   * 清理 /dev/shm 与 /tmp 里的 IPC/SHM 残段
+#   * 等所有相关端口真正释放 (最多 30s)
+#
+# 用法:
+#   bash stop_pd.sh                 # 关默认 PORT=8091，清理全部
+#   bash stop_pd.sh 8091            # 指定 API 端口
+#   PORT=8091 bash stop_pd.sh
+#
+# 幂等：没有任何 server 在跑时执行也安全 (纯 no-op)。
+# 不用 set -e：这里大量 kill/fuser 返回非零是正常的。
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_DIR="${RESULTS_DIR:-$SCRIPT_DIR/results}"
+
+PORT="${1:-${PORT:-8091}}"
+BOOTSTRAP_PORTS=(25201 25202 25203 25204 25205 25206)
+
+echo "==> [stop] 清理 PD server (api_port=$PORT, bootstrap=${BOOTSTRAP_PORTS[*]})"
+
+# 递归收集某 pid 的所有后代并从叶子往根杀（spawn 出来的 worker cmdline 不含
+# "vllm serve"，仅靠进程名 pkill 抓不全，必须按进程树 + 端口双管齐下）。
+kill_process_tree() {
+    local root_pid="$1"
+    [[ -z "$root_pid" ]] && return
+    local pids_to_kill=() stack=("$root_pid")
+    while (( ${#stack[@]} > 0 )); do
+        local pid="${stack[-1]}"; unset 'stack[-1]'
+        pids_to_kill+=("$pid")
+        local children; children="$(pgrep -P "$pid" 2>/dev/null || true)"
+        for c in $children; do stack+=("$c"); done
+    done
+    local n=${#pids_to_kill[@]}
+    for (( i=n-1; i>=0; i-- )); do
+        kill -9 "${pids_to_kill[i]}" 2>/dev/null || true
+    done
+}
+
+# 1) 通过 pid 文件精准杀 (results/ 新位置 + /tmp 旧位置都覆盖)
+for pf in "$RESULTS_DIR"/server_*.pid /tmp/server_*.pid; do
+    [[ -f "$pf" ]] || continue
+    old_pid="$(cat "$pf" 2>/dev/null || true)"
+    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+        echo "    [stop] kill pid=$old_pid (from $pf) + 子孙"
+        kill_process_tree "$old_pid"
+    fi
+    rm -f "$pf"
+done
+
+# 2) 通过 API 端口定位僵尸 APIServer (刚才假 health 的元凶) 并杀整棵树
+for pid in $(lsof -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null); do
+    echo "    [stop] kill pid=$pid (占用 API 端口 $PORT) + 子孙"
+    kill_process_tree "$pid"
+done
+
+# 3) 兜底：按 cmdline 杀残留的 vllm / stage / spawn worker
+pkill -9 -f "vllm serve"            2>/dev/null || true
+pkill -9 -f "StageEngineCoreProc"   2>/dev/null || true
+pkill -9 -f "from multiprocessing.spawn" 2>/dev/null || true
+
+sleep 2
+
+# 4) 强制释放端口 (API + bootstrap)
+fuser -k -9 "${PORT}/tcp" 2>/dev/null || true
+for p in "${BOOTSTRAP_PORTS[@]}"; do fuser -k -9 "${p}/tcp" 2>/dev/null || true; done
+
+# 5) 清 /dev/shm + /tmp 的 IPC/SHM 残段
+find /dev/shm -maxdepth 1 \
+    \( -name 'psm_*' -o -name 'wnsm_*' -o -name 'vllm*' -o -name 'mooncake*' -o -name 'vllm_omni*' \) \
+    -user "$(whoami)" -delete 2>/dev/null || true
+find /tmp -maxdepth 1 -name 'zmq-*.sock' -user "$(whoami)" -delete 2>/dev/null || true
+find /tmp -maxdepth 2 -name '*.ipc'      -user "$(whoami)" -delete 2>/dev/null || true
+
+sleep 1
+
+# 6) 等所有端口真正释放 (TIME_WAIT / 内核回收延迟)，最多 30s，期间反复补刀
+port_in_use() {
+    local p="$1"
+    if command -v ss >/dev/null 2>&1; then
+        ss -ltn "( sport = :$p )" 2>/dev/null | grep -q ":$p"
+    elif command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"$p" -sTCP:LISTEN -t >/dev/null 2>&1
+    else
+        fuser -n tcp "$p" >/dev/null 2>&1
+    fi
+}
+for attempt in $(seq 1 30); do
+    busy=""
+    for p in "$PORT" "${BOOTSTRAP_PORTS[@]}"; do
+        port_in_use "$p" && busy="$busy $p"
+    done
+    if [[ -z "$busy" ]]; then
+        echo "    ✅ [stop] 所有端口已释放: $PORT ${BOOTSTRAP_PORTS[*]}"
+        break
+    fi
+    echo "    [stop] 仍被占用:${busy} (${attempt}/30s)，继续补刀..."
+    for p in $busy; do
+        for hp in $(lsof -tiTCP:"$p" -sTCP:LISTEN 2>/dev/null); do kill_process_tree "$hp"; done
+        fuser -k -9 "${p}/tcp" 2>/dev/null || true
+    done
+    sleep 1
+done
+
+echo "==> [stop] done"

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1586,6 +1586,23 @@ stages:
         assert s0.yaml_engine_args["engine_output_type"] == "latent"
         assert s0.yaml_extras["default_sampling_params"]["detokenize"] is True
 
+    def test_qwen3_tts_pd_registry_config_is_detected(self):
+        """PD flags carried through engine_args remain visible to routing."""
+        from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
+
+        deploy = load_deploy_config(_DEPLOY_DIR / "qwen3_tts_pd_1p1d.yaml")
+        pipeline = OMNI_PIPELINES[deploy.pipeline]
+        stage_configs = [stage.to_omegaconf() for stage in merge_pipeline_deploy(pipeline, deploy)]
+
+        topology = PDDisaggregationMixin.detect_pd_separation_topology(stage_configs)
+
+        assert topology == {
+            "prefill_ids": [0],
+            "decode_id": 1,
+            "decode_ids": [1],
+            "decode_to_prefill": {1: [0]},
+        }
+
     def test_merge_pipeline_deploy_preserves_num_replicas(self, tmp_path):
         pipeline = resolve_pipeline_config(
             "qwen3_omni_moe",

--- a/tests/core/sched/test_omni_ar_scheduler_kv_transfer.py
+++ b/tests/core/sched/test_omni_ar_scheduler_kv_transfer.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 from vllm import SamplingParams
 from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.request import RequestStatus
 
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
 from vllm_omni.engine.async_engine_utils import apply_omni_final_stage_metadata
@@ -40,6 +41,52 @@ def _request_omits_kv_transfer(*, force_kv_transfer: bool) -> tuple[bool, dict]:
     result = scheduler._request_omits_kv_transfer_to_next_stage(request)
     metadata = deserialize_additional_information(tagged.additional_information)
     return result, metadata
+
+
+def _native_pd_trigger_scheduler() -> OmniARScheduler:
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.kv_transfer_criteria = {"type": "prefill_finished", "stop_after_transfer": True}
+    scheduler.waiting_for_transfer_free = set()
+    scheduler.transfer_triggered_requests = set()
+    scheduler.pending_stop_after_extraction = set()
+    scheduler.active_kv_transfers = set()
+    scheduler._pd_prefill_submit_ready_requests = set()
+    scheduler.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(kv_role="kv_producer"),
+    )
+    scheduler._request_omits_kv_transfer_to_next_stage = lambda _request: False
+    return scheduler
+
+
+def _trigger_request(status: RequestStatus) -> SimpleNamespace:
+    request = SimpleNamespace(
+        request_id="req",
+        status=status,
+        num_computed_tokens=70,
+        num_output_placeholders=0,
+        num_prompt_tokens=70,
+    )
+    request.is_finished = lambda: RequestStatus.is_finished(request.status)
+    return request
+
+
+def test_native_pd_trigger_preserves_length_capped_status_for_mooncake_send():
+    scheduler = _native_pd_trigger_scheduler()
+    request = _trigger_request(RequestStatus.FINISHED_LENGTH_CAPPED)
+
+    assert scheduler._process_kv_transfer_trigger(request, [123])
+
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert request.request_id in scheduler._pd_prefill_submit_ready_requests
+
+
+def test_native_pd_trigger_stops_an_unfinished_request():
+    scheduler = _native_pd_trigger_scheduler()
+    request = _trigger_request(RequestStatus.RUNNING)
+
+    assert scheduler._process_kv_transfer_trigger(request, [123])
+
+    assert request.status == RequestStatus.FINISHED_STOPPED
 
 
 def test_stage_zero_request_omits_kv_transfer():

--- a/tests/core/sched/test_omni_ar_scheduler_pd_decode_kv_reclaim.py
+++ b/tests/core/sched/test_omni_ar_scheduler_pd_decode_kv_reclaim.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
+
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _MockBlockPool:
+    def __init__(self, sink: list) -> None:
+        self._sink = sink
+
+    def free_blocks(self, blocks) -> None:
+        self._sink.extend(blocks)
+
+
+class _MockKVCacheManager:
+    def __init__(self, sink: list) -> None:
+        self._sink = sink
+        self.block_pool = _MockBlockPool(sink)
+
+    def free(self, request) -> None:
+        self._sink.extend(request.blocks)
+
+    def pop_blocks_for_free(self, request) -> list:
+        return request.blocks
+
+
+def _mock_request(request_id: str, last_sched_seq: int):
+    return SimpleNamespace(
+        request_id=request_id,
+        blocks=[f"{request_id}-b0", f"{request_id}-b1"],
+        last_sched_seq=last_sched_seq,
+    )
+
+
+class _DeferHarness:
+    """Exercises the real upstream defer/drain methods around our fix.
+
+    Reusing ``Scheduler._free_request_blocks`` / ``_drain_deferred_frees``
+    verbatim keeps this test honest: it validates upstream's actual fencing
+    semantics rather than a reimplementation of them.
+    """
+
+    _free_request_blocks = VLLMScheduler._free_request_blocks
+    _drain_deferred_frees = VLLMScheduler._drain_deferred_frees
+
+    def __init__(self, *, defer_block_free: bool) -> None:
+        self.defer_block_free = defer_block_free
+        self.sched_step_seq = 0
+        self.processed_step_seq = 0
+        self.deferred_frees: deque = deque()
+        self.returned_to_pool: list = []
+        self.kv_cache_manager = _MockKVCacheManager(self.returned_to_pool)
+
+    def run_steps(self, num_steps: int, *, drain: bool) -> None:
+        """Simulate ``num_steps`` schedule/finish cycles.
+
+        ``drain=True`` replicates the block this fix adds to
+        ``OmniARScheduler.update_from_output``.
+        """
+        for i in range(num_steps):
+            # Upstream advances the fence for every non-empty scheduled step.
+            self.sched_step_seq += 1
+            self._free_request_blocks(_mock_request(f"r{i}", self.sched_step_seq))
+            if drain:
+                self.processed_step_seq += 1
+                self._drain_deferred_frees()
+
+
+def test_missing_drain_leaks_every_freed_block():
+    """Without the drain, deferred frees accumulate and never reach the pool."""
+    harness = _DeferHarness(defer_block_free=True)
+    harness.run_steps(50, drain=False)
+
+    assert harness.returned_to_pool == []
+    assert len(harness.deferred_frees) == 50
+
+
+def test_drain_returns_all_blocks_to_pool():
+    """With the drain, every freed block is reclaimed and nothing is parked."""
+    harness = _DeferHarness(defer_block_free=True)
+    harness.run_steps(50, drain=True)
+
+    assert len(harness.returned_to_pool) == 100
+    assert not harness.deferred_frees
+
+
+def test_non_consumer_stage_frees_immediately():
+    """defer_block_free=False (prefill / single-node) bypasses the queue."""
+    harness = _DeferHarness(defer_block_free=False)
+    harness.sched_step_seq = 5
+    harness._free_request_blocks(_mock_request("x", 5))
+
+    assert len(harness.returned_to_pool) == 2
+    assert not harness.deferred_frees
+
+
+def _cap_scheduler(
+    kv_role: str | None,
+    *,
+    num_blocks: int = 32076,
+    block_size: int = 16,
+    max_model_len: int = 4096,
+    max_num_seqs: int = 256,
+):
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    kv_transfer_config = SimpleNamespace(kv_role=kv_role) if kv_role else None
+    scheduler.vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+    # kv_cache_groups=None forces the flat block-math fallback, which is what
+    # runs when upstream's group-aware helper cannot be used.
+    scheduler.kv_cache_config = SimpleNamespace(num_blocks=num_blocks, kv_cache_groups=None)
+    scheduler.cache_config = SimpleNamespace(num_gpu_blocks=num_blocks)
+    scheduler.block_size = block_size
+    scheduler.max_model_len = max_model_len
+    scheduler.max_num_running_reqs = max_num_seqs
+    scheduler.scheduler_config = SimpleNamespace(max_num_seqs=max_num_seqs)
+    return scheduler
+
+
+def test_decode_consumer_capped_to_kv_capacity():
+    """513,216 KV tokens / max_model_len 4096 -> 125, down from max_num_seqs 256."""
+    scheduler = _cap_scheduler("kv_consumer")
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+
+    assert scheduler.max_num_running_reqs == 125
+    # The worker sizes its batch from max_num_seqs; it must stay untouched.
+    assert scheduler.scheduler_config.max_num_seqs == 256
+
+
+@pytest.mark.parametrize("block_size", [16, 64, 128])
+def test_cap_is_block_size_invariant(block_size):
+    scheduler = _cap_scheduler("kv_consumer", num_blocks=513216 // block_size, block_size=block_size)
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+
+    assert scheduler.max_num_running_reqs == 125
+
+
+@pytest.mark.parametrize("kv_role", [None, "kv_producer"])
+def test_prefill_and_single_node_are_untouched(kv_role):
+    """Only the decode (kv_consumer) side may be capped."""
+    scheduler = _cap_scheduler(kv_role)
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+
+    assert scheduler.max_num_running_reqs == 256
+
+
+def test_cap_never_raises_configured_limit():
+    scheduler = _cap_scheduler("kv_consumer", max_num_seqs=64)
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+
+    assert scheduler.max_num_running_reqs == 64
+
+
+def test_env_override_sets_and_disables_cap(monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_PD_DECODE_MAX_RUNNING", "4")
+    scheduler = _cap_scheduler("kv_consumer")
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+    assert scheduler.max_num_running_reqs == 4
+
+    monkeypatch.setenv("VLLM_OMNI_PD_DECODE_MAX_RUNNING", "0")
+    scheduler = _cap_scheduler("kv_consumer")
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+    assert scheduler.max_num_running_reqs == 256
+
+
+def test_degenerate_kv_config_leaves_limit_unchanged():
+    """Unknown capacity must not cap (and must not raise)."""
+    scheduler = _cap_scheduler("kv_consumer", num_blocks=0)
+    scheduler.cache_config.num_gpu_blocks = 0
+    scheduler._maybe_cap_running_reqs_for_pd_decode()
+
+    assert scheduler.max_num_running_reqs == 256

--- a/tests/distributed/omni_connectors/test_adapter_and_flow.py
+++ b/tests/distributed/omni_connectors/test_adapter_and_flow.py
@@ -251,6 +251,39 @@ def test_full_payload_consumer_uses_receiver_connector_spec():
     assert spec["extra"] == {"codec_chunk_frames": 25, "role": "receiver"}
 
 
+@pytest.mark.parametrize(
+    ("async_chunk", "expected_name", "expected_frames", "expected_role"),
+    [
+        (True, "OutgoingConnector", 72, "sender"),
+        (False, "IncomingConnector", 25, "receiver"),
+    ],
+)
+def test_middle_stage_connector_direction_matches_payload_mode(
+    async_chunk: bool,
+    expected_name: str,
+    expected_frames: int,
+    expected_role: str,
+):
+    config = OmniTransferConfig(
+        connectors={
+            ("0", "1"): ConnectorSpec(
+                name="IncomingConnector",
+                extra={"codec_left_context_frames": 25},
+            ),
+            ("1", "2"): ConnectorSpec(
+                name="OutgoingConnector",
+                extra={"codec_left_context_frames": 72},
+            ),
+        }
+    )
+
+    spec = get_stage_connector_spec(config, stage_id=1, async_chunk=async_chunk)
+
+    assert spec["name"] == expected_name
+    assert spec["extra"]["codec_left_context_frames"] == expected_frames
+    assert spec["extra"]["role"] == expected_role
+
+
 def test_recv_with_missing_metadata(mocker: MockerFixture):
     """Test recv when queue payload is malformed (missing metadata)."""
     # Connector expects metadata but task doesn't have it

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -1021,20 +1021,39 @@ def test_finished_releases_slot(build_adapter):
 
 def test_postprocess_scheduler_output(build_adapter):
     adapter, _ = build_adapter()
+    adapter._is_pd_decode_consumer = True
     adapter.requests_with_ready_chunks = {"new-ready", "cached-ready", "leftover"}
 
     scheduler_output = SimpleNamespace(
-        scheduled_new_reqs=[SimpleNamespace(req_id="new-ready")],
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id="new-ready", additional_information={"meta": {"pd_resume_token_id": 7}}),
+            SimpleNamespace(req_id="generic-ready", additional_information={"new": "state"}),
+        ],
         scheduled_cached_reqs=SimpleNamespace(req_ids=["cached-ready", "missing"]),
     )
-    requests = {"cached-ready": SimpleNamespace(additional_information={"k": "v"})}
+    requests = {
+        "new-ready": SimpleNamespace(additional_information={"meta": {"pd_resume_token_id": 7}}),
+        "generic-ready": SimpleNamespace(additional_information={"new": "state"}),
+        "cached-ready": SimpleNamespace(additional_information={"k": "v"}),
+    }
 
     adapter.postprocess_scheduler_output(scheduler_output, requests)
 
     cached_info = scheduler_output.scheduled_cached_reqs.additional_information
     assert cached_info["cached-ready"] == {"k": "v"}
     assert cached_info["missing"] is None
+    assert scheduler_output.scheduled_new_reqs[0].additional_information == {"meta": {"pd_resume_token_id": 7}}
+    assert requests["new-ready"].additional_information is None
+    assert requests["generic-ready"].additional_information == {"new": "state"}
+    assert requests["cached-ready"].additional_information is None
     assert adapter.requests_with_ready_chunks == {"leftover"}
+
+    next_output = SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(req_ids=["new-ready"]),
+    )
+    adapter.postprocess_scheduler_output(next_output, requests)
+    assert next_output.scheduled_cached_reqs.additional_information["new-ready"] is None
 
 
 @pytest.mark.parametrize("model_mode", ["ar", "generation"])

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -2764,3 +2764,31 @@ async def test_request_cleanup_failure_is_deferred_to_control_plane():
 
     assert orchestrator.duplex_control_plane.deferred == ["sid-cleanup"]
     assert orchestrator.duplex_control_plane.finalized == []
+
+
+def test_pd_decode_params_forward_request_seed_to_talker_mtp():
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator._pd_kv_params = {
+        "req-seeded": {
+            "remote_request_id": "remote-1",
+            "pd_submit_ready": True,
+        }
+    }
+    orchestrator._pd_bootstrap_addr = None
+    orchestrator._pd_prefill_engine_id = None
+    source = SamplingParams(temperature=0.9, extra_args={"keep": "value"})
+
+    result = orchestrator._build_pd_decode_params("req-seeded", source, main_sampler_seed=42)
+
+    assert result is not source
+    assert source.seed is None
+    assert source.extra_args == {"keep": "value"}
+    assert result.seed == 42
+    assert result.extra_args["tts_local_seed"] == 42
+    assert result.extra_args["keep"] == "value"
+    assert result.extra_args["kv_transfer_params"] == {
+        "transfer_id": "xfer-req-seeded",
+        "remote_request_id": "remote-1",
+        "do_remote_prefill": True,
+        "do_remote_decode": False,
+    }

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -36,6 +36,7 @@ from vllm_omni.engine.orchestrator import (
     Orchestrator,
     OrchestratorRequestState,
     _build_terminal_empty_output,
+    _with_qwen3_tts_pd_decode_state,
 )
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.experimental.fullduplex.engine.duplex_control_plane import DuplexControlPlane
@@ -2766,6 +2767,38 @@ async def test_request_cleanup_failure_is_deferred_to_control_plane():
     assert orchestrator.duplex_control_plane.finalized == []
 
 
+def test_qwen3_tts_pd_decode_state_appends_resume_token_without_mutating_source():
+    prompt = {
+        "prompt_token_ids": [10, 11],
+        "additional_information": {
+            "hidden_states": {"keep": "prompt"},
+            "meta": {"keep": "prompt"},
+        },
+    }
+    state = {
+        "_pd_resume_token_id": 7,
+        "hidden_states": {"last": "prefill-last"},
+        "meta": {"talker_text_offset": 0},
+        "pd_sampler": {"seed": 42},
+    }
+
+    result = _with_qwen3_tts_pd_decode_state(prompt, state)
+
+    assert result["prompt_token_ids"] == [10, 11, 7]
+    assert result["additional_information"] == {
+        "hidden_states": {"keep": "prompt", "last": "prefill-last"},
+        "meta": {"keep": "prompt", "talker_text_offset": 0, "pd_resume_token_id": 7},
+        "pd_sampler": {"seed": 42},
+    }
+    assert prompt == {
+        "prompt_token_ids": [10, 11],
+        "additional_information": {
+            "hidden_states": {"keep": "prompt"},
+            "meta": {"keep": "prompt"},
+        },
+    }
+
+
 def test_pd_decode_params_forward_request_seed_to_talker_mtp():
     orchestrator = object.__new__(Orchestrator)
     orchestrator._pd_kv_params = {
@@ -2776,13 +2809,17 @@ def test_pd_decode_params_forward_request_seed_to_talker_mtp():
     }
     orchestrator._pd_bootstrap_addr = None
     orchestrator._pd_prefill_engine_id = None
-    source = SamplingParams(temperature=0.9, extra_args={"keep": "value"})
+    source = SamplingParams(temperature=0.9, max_tokens=8, min_tokens=2, extra_args={"keep": "value"})
 
     result = orchestrator._build_pd_decode_params("req-seeded", source, main_sampler_seed=42)
 
     assert result is not source
     assert source.seed is None
     assert source.extra_args == {"keep": "value"}
+    assert source.max_tokens == 8
+    assert source.min_tokens == 2
+    assert result.max_tokens == 7
+    assert result.min_tokens == 1
     assert result.seed == 42
     assert result.extra_args["tts_local_seed"] == 42
     assert result.extra_args["keep"] == "value"
@@ -2792,3 +2829,17 @@ def test_pd_decode_params_forward_request_seed_to_talker_mtp():
         "do_remote_prefill": True,
         "do_remote_decode": False,
     }
+
+
+def test_pd_decode_params_preserve_explicit_talker_mtp_seed():
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator._pd_kv_params = {"req-seeded": {"remote_request_id": "remote-1", "pd_submit_ready": True}}
+    orchestrator._pd_bootstrap_addr = None
+    orchestrator._pd_prefill_engine_id = None
+    source = SamplingParams(max_tokens=8, extra_args={"tts_local_seed": 99})
+
+    result = orchestrator._build_pd_decode_params("req-seeded", source, main_sampler_seed=42)
+
+    assert result.seed == 42
+    assert result.extra_args["tts_local_seed"] == 99
+    assert source.extra_args["tts_local_seed"] == 99

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -22,6 +22,40 @@ OMNI_MODEL = "Qwen/Qwen2.5-Omni-7B"
 OMNI_STAGE_CONFIG = get_deploy_config_path("ci/qwen2_5_omni_thinker_only.yaml")
 
 
+@pytest.mark.cpu
+@pytest.mark.parametrize(("min_tokens", "expected_stop_ids"), [(0, []), (2, [7])])
+def test_prepare_pd_prefill_sampling_params_preserves_masked_y0_stops(min_tokens, expected_stop_ids):
+    omni = object.__new__(AsyncOmni)
+    source = SamplingParams(
+        max_tokens=8,
+        min_tokens=min_tokens,
+        stop=["STOP"],
+        stop_token_ids=[7],
+        extra_args={"keep": "value"},
+    )
+
+    result = omni._prepare_prefill_sampling_params("req-1", source)
+
+    assert result.max_tokens == 1
+    assert result.min_tokens == (1 if min_tokens else 0)
+    assert result.stop == []
+    assert result.stop_token_ids == expected_stop_ids
+    assert result.extra_args["keep"] == "value"
+    assert result.extra_args["kv_transfer_params"]["transfer_id"] == "xfer-req-1"
+    assert source.max_tokens == 8
+    assert source.min_tokens == min_tokens
+    assert source.stop == ["STOP"]
+    assert source.stop_token_ids == [7]
+
+
+@pytest.mark.cpu
+def test_prepare_pd_prefill_sampling_params_rejects_budget_without_decode_token():
+    omni = object.__new__(AsyncOmni)
+
+    with pytest.raises(ValueError, match="max_tokens >= 2"):
+        omni._prepare_prefill_sampling_params("req-1", SamplingParams(max_tokens=1))
+
+
 async def _noop(*args, **kw):
     pass
 

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -132,6 +132,101 @@ def test_generate_forwards_lora_request_to_engine():
 
 
 @pytest.mark.cpu
+def test_generate_routes_pd_request_to_selected_prefill_stage_and_slot_zero():
+    """Multi-PD routing must not fall back to the 1P1D-only pair helper."""
+
+    async def run():
+        submitted_params = []
+
+        async def capture_add_request(*, sampling_params_list, **kwargs):
+            del kwargs
+            submitted_params.append(list(sampling_params_list))
+
+        omni = get_async_omni_instance(fake_add_request=capture_add_request)
+        omni.engine.num_stages = 3
+        omni._maybe_expand_sampling_params = lambda params: params
+        omni._get_pd_decode_id = lambda: 2
+        omni._get_pd_prefill_ids = lambda: [0, 1]
+        picked_request_ids = []
+        omni._pick_prefill_stage = lambda request_id: (
+            picked_request_ids.append(request_id),
+            1,
+        )[1]
+        prepared = SimpleNamespace(max_tokens=1)
+        prepare_calls = []
+        omni._prepare_prefill_sampling_params = lambda request_id, params: (
+            prepare_calls.append((request_id, params)),
+            prepared,
+        )[1]
+        params = [
+            SimpleNamespace(name="slot0"),
+            SimpleNamespace(name="p1"),
+            SimpleNamespace(name="d"),
+        ]
+
+        async for _ in omni.generate(
+            prompt={"prompt": "test"},
+            request_id="multi-pd",
+            sampling_params_list=params,
+            output_modalities=["text"],
+        ):
+            pass
+
+        assert len(picked_request_ids) == 1
+        assert picked_request_ids[0].startswith("multi-pd-")
+        assert prepare_calls == [(picked_request_ids[0], params[1])]
+        assert submitted_params[0][0] is prepared
+        assert submitted_params[0][1] is prepared
+        assert submitted_params[0][2] is params[2]
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
+def test_terminal_output_releases_pd_prefill_binding(monkeypatch):
+    """A normally finished request must decrement the selected P inflight count."""
+
+    async def run():
+        import threading
+
+        import vllm_omni.entrypoints.async_omni as async_omni_module
+
+        class TerminalOutput:
+            stage_id = 2
+            finished = True
+
+        monkeypatch.setattr(async_omni_module, "OutputMessage", TerminalOutput)
+        request_id = "pd-finished"
+        queue = asyncio.Queue()
+        await queue.put(TerminalOutput())
+
+        omni = object.__new__(AsyncOmni)
+        omni.request_states = {request_id: SimpleNamespace(queue=queue, external_request_id=None)}
+        omni._pd_request_to_prefill = {request_id: 1}
+        omni._pd_prefill_inflight = {0: 0, 1: 1}
+        omni._pd_prefill_inflight_lock = threading.Lock()
+        omni._check_engine_output_error = lambda *args: None
+        omni._process_single_result = lambda *args: None
+
+        outputs = [
+            output
+            async for output in omni._process_orchestrator_results(
+                request_id,
+                metrics=None,
+                final_stage_id_for_e2e=2,
+                req_start_ts={},
+                wall_start_ts=0.0,
+            )
+        ]
+
+        assert outputs == []
+        assert request_id not in omni._pd_request_to_prefill
+        assert omni._pd_prefill_inflight[1] == 0
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
 @pytest.mark.parametrize(
     "req_ids,cancel_prefix,expected_cancel_count",
     [

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -236,6 +236,7 @@ def _make_runner(req_ids=("r1", "r2"), hidden_size=4):
     runner.talker_mtp = DummyTalkerMTP()
     runner.model = SimpleNamespace(talker_mtp_output_key=("codes", "audio"))
     runner.vllm_config = SimpleNamespace(model_config=SimpleNamespace())
+    runner._mtp_ar_timing_enabled = False
 
     # Provide a minimal implementation that returns the expected 4-tuple.
     def _determine_batch_execution_and_padding(**kwargs):
@@ -573,6 +574,26 @@ def test_update_intermediate_buffer_accumulates():
     assert "a" in buf and "b" in buf
     assert torch.allclose(buf["a"], torch.tensor([1.0]))
     assert torch.allclose(buf["b"], torch.tensor([2.0]))
+
+
+def test_qwen3_tts_pd_sampler_state_is_restored_once():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    runner.model.export_pd_decode_state = lambda _info: {}
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(1)
+    restored_generator = torch.Generator(device="cpu")
+    restored_generator.manual_seed(42)
+    runner.requests["r1"].generator = generator
+    runner.requests["r1"].sampling_params = SimpleNamespace()
+    payload = {"pd_sampler": {"main_generator_state": restored_generator.get_state()}}
+
+    runner._restore_qwen3_tts_pd_sampler_state("r1", payload)
+
+    assert torch.equal(generator.get_state(), restored_generator.get_state())
+    generator.manual_seed(99)
+    state_after_local_progress = generator.get_state().clone()
+    runner._restore_qwen3_tts_pd_sampler_state("r1", payload)
+    assert torch.equal(generator.get_state(), state_after_local_progress)
 
 
 def test_update_additional_information_deserializes_new_request_payload():

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -344,6 +344,65 @@ def test_talker_mtp_forward_ignores_default_sampling_seed_without_request_marker
     assert runner.talker_mtp.calls[0]["generator"] is None
 
 
+@pytest.mark.parametrize(
+    ("seeded", "expected_mode"),
+    [
+        (True, CUDAGraphMode.NONE),
+        (False, CUDAGraphMode.FULL),
+    ],
+)
+def test_talker_mtp_full_graph_is_bypassed_only_for_seeded_requests(
+    monkeypatch, seeded: bool, expected_mode: CUDAGraphMode
+):
+    import vllm_omni.worker.gpu_model_runner as mod
+
+    class PassthroughGraphWrapper:
+        def __init__(self, runnable):
+            self.runnable = runnable
+
+        def __call__(self, *args, **kwargs):
+            return self.runnable(*args, **kwargs)
+
+    modes = []
+
+    @contextmanager
+    def capture_forward_context(*args, **kwargs):
+        modes.append(kwargs["cudagraph_runtime_mode"])
+        yield
+
+    monkeypatch.setattr(mod.current_omni_platform, "get_graph_wrapper_cls", lambda: PassthroughGraphWrapper)
+    monkeypatch.setattr(mod.current_omni_platform, "set_forward_context", capture_forward_context)
+
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    runner.requests["r1"].sampling_params = SimpleNamespace(
+        seed=42 if seeded else None,
+        extra_args={"tts_local_seed": 42} if seeded else None,
+    )
+    capture = CaptureTalkerMTP()
+    runner.talker_mtp = PassthroughGraphWrapper(capture)
+    runner.vllm_config = SimpleNamespace(model_config=SimpleNamespace(subtalker_sampling_params={}))
+
+    def fake_determine(self, **kwargs):
+        return (
+            CUDAGraphMode.FULL,
+            SimpleNamespace(num_tokens=1),
+            None,
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(
+        runner,
+        "_determine_batch_execution_and_padding",
+        fake_determine.__get__(runner, type(runner)),
+    )
+
+    OmniGPUModelRunner._talker_mtp_forward(runner, ["r1"], torch.zeros((2, 4), dtype=torch.float32))
+
+    assert modes == [expected_mode]
+    assert (capture.calls[0]["generator"] is not None) is seeded
+
+
 def test_talker_mtp_forward_passes_qwen3_tts_subtalker_sampling_params_to_talker(monkeypatch):
     import vllm_omni.worker.gpu_model_runner as mod
 

--- a/tests/worker/test_sampler_history_backfill.py
+++ b/tests/worker/test_sampler_history_backfill.py
@@ -105,6 +105,27 @@ def test_early_return_when_sampled_absent_keeps_placeholders(cls):
 # --------------------------------------------------------------------------- #
 # Divergence — base KEEPS residual -1, AR CROPS at the first -1                #
 # --------------------------------------------------------------------------- #
+def test_pd_resume_token_is_prepended_without_mutating_request_history():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Metadata:
+        output_token_ids: list[list[int]]
+
+    runner = object.__new__(OmniGPUModelRunner)
+    runner.input_batch = SimpleNamespace(req_ids=["pd", "regular"])
+    runner.model_intermediate_buffer = {
+        "pd": {"meta": {"pd_resume_token_id": 7}},
+        "regular": {},
+    }
+    metadata = Metadata(output_token_ids=[[9], [4]])
+
+    decorated = runner._sampling_metadata_with_pd_resume_history(metadata)
+
+    assert decorated.output_token_ids == [[7, 9], [4]]
+    assert metadata.output_token_ids == [[9], [4]]
+
+
 _RESIDUAL_CASE = dict(
     req_ids=["r0"],
     req_output_token_ids=[[10, -1, -1]],  # two placeholders

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -106,7 +106,10 @@ from vllm_omni.model_executor.models.qwen3_omni.pipeline import (
     QWEN3_OMNI_THINKER_ONLY_PIPELINE,
     resolve_qwen3_omni_pipeline,
 )
-from vllm_omni.model_executor.models.qwen3_tts.pipeline import QWEN3_TTS_PIPELINE
+from vllm_omni.model_executor.models.qwen3_tts.pipeline import (
+    QWEN3_TTS_PD_PIPELINE,
+    QWEN3_TTS_PIPELINE,
+)
 from vllm_omni.model_executor.models.step_audio2.pipeline import (
     STEP_AUDIO2_ASR_PIPELINE,
     STEP_AUDIO2_PIPELINE,
@@ -133,6 +136,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "qwen3_omni_moe": resolve_qwen3_omni_pipeline,
     "qwen3_omni_moe_thinker_only": QWEN3_OMNI_THINKER_ONLY_PIPELINE,
     "qwen3_tts": QWEN3_TTS_PIPELINE,
+    "qwen3_tts_pd": QWEN3_TTS_PD_PIPELINE,
     "step_audio_2": STEP_AUDIO2_PIPELINE,
     "step_audio_2_asr": STEP_AUDIO2_ASR_PIPELINE,
     "covo_audio": COVO_AUDIO_PIPELINE,

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -121,6 +121,16 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._new_prompt_len_snapshot: dict[str, int] = {}
         self._maybe_cap_running_reqs_for_pd_decode()
 
+    def add_request(self, request: Request) -> None:
+        if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
+            _ai = getattr(request, "additional_information", None)
+            _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
+            logger.info(
+                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d",
+                request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
+            )
+        return super().add_request(request)
+
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         # Output placeholders are zero when async scheduling isn't used

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
@@ -105,6 +106,9 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         # Track requests that have already triggered prefill transfer to avoid duplicates
         self.transfer_triggered_requests: set[str] = set()
+        # Native connector PD: submit decode before its extraction acknowledgement.
+        self._pd_prefill_submit_ready_requests: set[str] = set()
+        self._kv_ready_multimodal_output_by_req: dict[str, dict[str, Any]] = {}
 
         # Cache per-request flag to avoid repeated deserialization of additional_information
         self._omits_kv_transfer_cache: dict[str, bool] = {}
@@ -115,6 +119,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._init_omni_io_scheduling_state()
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
+        self._maybe_cap_running_reqs_for_pd_decode()
 
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
@@ -185,8 +190,18 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._clear_kv_wait_starts(cleanup_ids)
         return finished
 
+    def _uses_native_pd_kv_transfer(self) -> bool:
+        """Whether the upstream KV connector owns this P/D handoff."""
+        config = getattr(self.vllm_config, "kv_transfer_config", None)
+        return getattr(config, "kv_role", None) == "kv_producer"
+
     def _get_kv_transfer_criteria(self) -> dict | None:
-        return self._get_omni_kv_config_value("kv_transfer_criteria")
+        criteria = self._get_omni_kv_config_value("kv_transfer_criteria")
+        if criteria:
+            return criteria
+        if self._uses_native_pd_kv_transfer():
+            return {"type": "prefill_finished", "stop_after_transfer": True}
+        return None
 
     def _get_omni_kv_config_value(self, key: str, default: Any = None) -> Any:
         config = getattr(self, "_omni_kv_config", None)
@@ -257,6 +272,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         if criteria_type == "prefill_finished":
             if confirmed_computed >= request.num_prompt_tokens:
+                if self._uses_native_pd_kv_transfer():
+                    self.transfer_triggered_requests.add(request.request_id)
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(
                     request.request_id,
                     confirmed_computed,
@@ -270,6 +289,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 idx = new_token_ids.index(target_token_id)
                 tokens_to_exclude = len(new_token_ids) - (idx + 1)
                 snapshot_len = confirmed_computed - tokens_to_exclude
+                if self._uses_native_pd_kv_transfer():
+                    self.transfer_triggered_requests.add(request.request_id)
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(
                     request.request_id,
                     snapshot_len,
@@ -302,6 +325,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if getattr(req, "status", None) == RequestStatus.FINISHED_ABORTED:
                     queue.remove(req)
         self._process_pending_omni_inputs(model_mode="ar")
+        self._maybe_break_pd_decode_wedge()
 
         original_waiting = None
         if self._should_defer_waiting_admission():
@@ -329,6 +353,186 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             scheduler_output,
             finished_requests_needing_kv_transfer=finished_reqs,
         )
+
+    def _is_pd_decode_consumer_stage(self) -> bool:
+        """True on the decode (kv_consumer) side of a PD split."""
+        cfg = getattr(self.vllm_config, "kv_transfer_config", None)
+        return getattr(cfg, "kv_role", None) in ("kv_consumer", "kv_both")
+
+    def _kv_safe_max_running_reqs(self) -> int | None:
+        """Max concurrent max-length sequences this stage's KV pool can hold.
+
+        Reuses upstream's group-aware concurrency helper -- the same one that
+        logs "Maximum concurrency for N tokens per request" at startup -- so the
+        derived cap matches the number already visible in the engine log and
+        hybrid / multi-group / num_gpu_blocks_override layouts are handled for
+        free. Falls back to flat blocks-per-request math (which is block-size
+        invariant) when that helper or the KV cache config is unavailable.
+
+        Returns None when capacity cannot be determined, meaning "do not cap".
+        """
+        kv_cache_config = getattr(self, "kv_cache_config", None)
+
+        try:
+            from vllm.v1.core.kv_cache_utils import get_max_concurrency_for_kv_cache_config
+
+            if kv_cache_config is not None and getattr(kv_cache_config, "kv_cache_groups", None):
+                cap = int(get_max_concurrency_for_kv_cache_config(self.vllm_config, kv_cache_config))
+                if cap >= 1:
+                    return cap
+        except Exception:
+            logger.debug(
+                "[Omni][PD] group-aware KV concurrency helper unavailable; falling back to block math.",
+                exc_info=True,
+            )
+
+        max_model_len = int(getattr(self, "max_model_len", 0) or 0)
+        block_size = int(getattr(self, "block_size", 0) or 0)
+        num_blocks = int(getattr(kv_cache_config, "num_blocks", 0) or 0)
+        if not num_blocks:
+            num_blocks = int(getattr(self.cache_config, "num_gpu_blocks", 0) or 0)
+        if max_model_len <= 0 or block_size <= 0 or num_blocks <= 0:
+            return None
+        blocks_per_req = -(-max_model_len // block_size)  # ceil
+        return (num_blocks // blocks_per_req) or None
+
+    def _maybe_cap_running_reqs_for_pd_decode(self) -> None:
+        """Clamp the decode-stage admission gate to KV-safe concurrency.
+
+        ``max_num_seqs`` is really a batch-*shape* knob: the worker uses it to
+        size the persistent batch and pick CUDA-graph capture sizes. The
+        scheduler separately uses ``max_num_running_reqs`` purely as an
+        admission gate. When ``max_num_seqs`` exceeds what the KV pool can hold
+        at ``max_model_len``, the scheduler over-admits and the RUNNING loop is
+        forced to call ``_preempt_request`` to claw blocks back.
+
+        On a PD *consumer* stage a preempted request is unrecoverable: its
+        remote prefill KV was already released on the producer, and the
+        Qwen3-TTS talker rebuilds each step's input embedding from all 16
+        codebooks of the previous frame while ``Request`` only carries
+        codebook 0 -- a resumed request re-prefills against a zeroed
+        ``codes.audio`` placeholder and would emit garbage. Such requests pile
+        up as PREEMPTED, upstream only admits WAITING work while
+        ``not preempted_reqs``, and the replica wedges at ``running=0``.
+
+        So cap admission at KV capacity here. Lowering only
+        ``max_num_running_reqs`` is safe: upstream reads it just in the
+        admission gate and in ``assert len(self.running) <=
+        max_num_running_reqs``, which a lower value only makes easier to
+        satisfy. Worker-side batch sizing reads ``max_num_seqs``, untouched.
+
+        Inert at normal load -- it only binds under a pathological pileup.
+        Override with ``VLLM_OMNI_PD_DECODE_MAX_RUNNING`` (<=0 disables).
+        """
+        if not self._is_pd_decode_consumer_stage():
+            return
+
+        configured = getattr(self, "max_num_running_reqs", 0)
+        if not configured:
+            return
+
+        try:
+            raw = (os.getenv("VLLM_OMNI_PD_DECODE_MAX_RUNNING", "") or "").strip()
+            if raw:
+                override = int(raw)
+                if override <= 0:
+                    logger.info(
+                        "[Omni][PD] Decode admission cap disabled via "
+                        "VLLM_OMNI_PD_DECODE_MAX_RUNNING=%s (max_num_running_reqs=%d).",
+                        raw,
+                        configured,
+                    )
+                    return
+                cap = override
+            else:
+                kv_safe = self._kv_safe_max_running_reqs()
+                if kv_safe is None:
+                    return
+                cap = kv_safe
+            cap = max(1, min(cap, configured))
+        except Exception:
+            init_logger(__name__).exception(
+                "[Omni][PD] Failed to compute decode admission cap; leaving max_num_running_reqs=%d unchanged.",
+                configured,
+            )
+            return
+
+        if cap >= configured:
+            return
+
+        self.max_num_running_reqs = cap
+        logger.info(
+            "[Omni][PD] Decode (kv_consumer) admission cap: max_num_running_reqs %d -> %d "
+            "(max_model_len=%d; max_num_seqs stays %s for worker batch/CUDA-graph sizing). "
+            "A preempted PD-consumer request can never be re-admitted (remote prefill KV "
+            "released; multi-codebook talker state absent from Request token ids), so "
+            "admitting beyond KV capacity risks wedging the replica at running=0. "
+            "Override with VLLM_OMNI_PD_DECODE_MAX_RUNNING (<=0 disables).",
+            configured,
+            cap,
+            getattr(self, "max_model_len", -1),
+            getattr(self.scheduler_config, "max_num_seqs", "?"),
+        )
+
+    def _maybe_break_pd_decode_wedge(self) -> None:
+        """Recover a permanently wedged PD decode replica.
+
+        Root cause (observed under sustained load + over-generation runaways):
+        the decode stage preempts running requests under transient KV pressure.
+        A preempted PD-*consumer* request cannot be re-admitted -- its remote
+        prefill KV was already released on the producer, and a request that
+        generated near ``max_model_len`` tokens would need to recompute more
+        than ``max_num_batched_tokens`` in one step (the talker prefill is not
+        chunkable here), so ``schedule()`` can never re-admit it. Such requests
+        pile up as PREEMPTED, ``running`` drains to 0, and the whole replica
+        makes zero progress forever (GPU 0%), stalling every request behind it.
+        Single-node has no remote-KV dependency, so its preempted requests
+        recompute locally and this never happens.
+
+        We detect the wedge (nothing running, but waiting-queue requests that
+        cannot be scheduled) sustained across a grace window of scheduler
+        steps, and abort the stuck requests so the client gets a terminal
+        response and the replica resumes serving new requests. This converts a
+        total replica hang into graceful per-request failure under extreme
+        pressure.
+        """
+        if not self._is_pd_decode_consumer_stage():
+            return
+        try:
+            running = len(self.running)
+            stuck = [
+                r
+                for r in self.waiting
+                if r.status in (RequestStatus.PREEMPTED, RequestStatus.WAITING)
+            ]
+            # Wedge signature: nothing running yet requests stranded in waiting.
+            if running == 0 and stuck:
+                self._pd_wedge_ticks = getattr(self, "_pd_wedge_ticks", 0) + 1
+            else:
+                self._pd_wedge_ticks = 0
+                return
+            # Grace window: the engine core sleeps ~1ms per idle step, so this
+            # is a few seconds of *continuous* zero-progress-with-backlog, which
+            # normal operation never sustains. Tunable via env.
+            threshold = int(os.getenv("VLLM_OMNI_PD_DECODE_WEDGE_TICKS", "3000") or "3000")
+            if self._pd_wedge_ticks < threshold:
+                return
+            stuck_ids = [r.request_id for r in stuck]
+            logger.error(
+                "[Omni][PD] Decode replica wedged: running=0 with %d stranded "
+                "waiting requests for %d scheduler steps (preempted PD-consumer "
+                "requests cannot recompute -- remote prefill KV released). "
+                "Aborting %d stuck request(s) to recover the replica: %s",
+                len(stuck_ids),
+                self._pd_wedge_ticks,
+                len(stuck_ids),
+                stuck_ids[:8],
+            )
+            self.finish_requests(stuck_ids, RequestStatus.FINISHED_ABORTED)
+            self._pd_wedge_ticks = 0
+        except Exception:
+            init_logger(__name__).exception("[Omni][PD] wedge-recovery check failed")
+
 
     def update_from_output(
         self,
@@ -370,6 +574,17 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
         spec_decoding_stats: SpecDecodingStats | None = None
 
+        # Retain Qwen3-TTS runtime state until a possibly later KV ack.
+        kv_extracted_ids = list(getattr(model_runner_output, "kv_extracted_req_ids", None) or [])
+        if mm_outputs is not None and self.kv_transfer_criteria:
+            for req_id in set(num_scheduled_tokens) | set(kv_extracted_ids):
+                req_index = model_runner_output.req_id_to_index.get(req_id)
+                if req_index is None or req_index >= len(mm_outputs):
+                    continue
+                mm_output = mm_outputs[req_index]
+                if isinstance(mm_output, dict) and mm_output:
+                    self._kv_ready_multimodal_output_by_req[req_id] = mm_output
+
         failed_kv_load_req_ids = None
         if kv_connector_output and kv_connector_output.invalid_block_ids:
             # These blocks contain externally computed tokens that failed to
@@ -383,17 +598,18 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Pre-process KV extraction acks so that the per-request loop below
         # can see up-to-date active_kv_transfers state and emit kv_ready
         # signals while requests are still alive (before any deferred stop).
-        kv_extracted_ids = getattr(model_runner_output, "kv_extracted_req_ids", None)
         if kv_extracted_ids:
             for req_id in kv_extracted_ids:
                 try:
                     self.active_kv_transfers.discard(req_id)
                     req = self.requests.get(req_id)
                     if req is not None and not req.is_finished():
+                        pd_state = self._kv_ready_multimodal_output_by_req.pop(req_id, None)
                         outputs[req.client_index].append(
                             OmniEngineCoreOutput(
                                 request_id=req_id,
                                 new_token_ids=[],
+                                multimodal_output=pd_state,
                                 kv_transfer_params={"kv_ready": True},
                             )
                         )
@@ -543,7 +759,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             # If criteria returns True, it means we must STOP the request.
             # If criteria returns False, it might have triggered a background
             # transfer (e.g. prefill finished / special token) but continues decoding.
-            if not stopped and self._process_kv_transfer_trigger(request, new_token_ids):
+            # Transfer can coincide with a terminal token and must still run.
+            if self._process_kv_transfer_trigger(request, new_token_ids):
                 stopped = True
 
             if new_token_ids and self.structured_output_manager.should_advance(request):
@@ -641,6 +858,14 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if req_id in self._pd_prefill_submit_ready_requests:
+                submit_params = {
+                    "pd_submit_ready": True,
+                    "transfer_id": f"xfer-{req_id}",
+                    "remote_request_id": req_id,
+                }
+                kv_transfer_params = {**(kv_transfer_params or {}), **submit_params}
+                self._pd_prefill_submit_ready_requests.discard(req_id)
             if new_token_ids or mm_output is not None or pooler_output is not None or kv_transfer_params or stopped:
                 OmniSchedulerMixin._append_request_output(
                     self,
@@ -859,12 +1084,12 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 is_active = request_id in self.active_kv_transfers
 
                 if already_triggered:
-                    if is_active:
+                    if is_active or request_id in self.requests_needing_kv_transfer:
                         # It triggered but hasn't finished yet. We MUST wait.
                         logger.debug(f"[Omni] Request {request_id} finished but transfer is still ACTIVE. Waiting.")
                         self.waiting_for_transfer_free.add(request_id)
                         self._kv_wait_start_ts[request_id] = time.monotonic()
-                        kv_xfer_params = None
+                        # Preserve native connector bootstrap metadata for decode.
                         return kv_xfer_params, ec_xfer_params
                     elif request_id in self.waiting_for_transfer_free:
                         # Blocks held until KV extraction completes in a future step.
@@ -921,6 +1146,61 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             if self.chunk_transfer_adapter is not None:
                 self.chunk_transfer_adapter.cleanup_receiver(request_id)
 
+    def _update_from_kv_xfer_finished(self, kv_connector_output) -> None:
+        """Guarded variant of the upstream KV-transfer finish handler.
+
+        Upstream ``Scheduler._update_from_kv_xfer_finished`` asserts that every
+        ``finished_recving`` / ``finished_sending`` request id is still present
+        in ``self.requests``. That invariant does not hold in the Omni PD flow:
+        a decode (consumer) request can be aborted (client disconnect) or a
+        producer request can be reaped by Mooncake's own
+        ``VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT`` ("timed out ... without being
+        sent") *before* the connector delivers the matching finished
+        notification. When that late notification arrives the base assert fires
+        inside ``update_from_output`` and kills the whole StageEngineCoreProc
+        (EngineDeadError -> orchestrator dies -> server exits) — i.e. one
+        stranded transfer escalates into a full-server outage.
+
+        Here we skip ids that are no longer tracked (their blocks were already
+        freed on the abort/cleanup path) and only free blocks for requests we
+        still own, so a stranded transfer stays a per-request no-op instead of a
+        fatal error. Behaviour for live requests is identical to upstream.
+        """
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        for req_id in kv_connector_output.finished_recving or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "[Omni][PD] finished_recving for untracked req %s "
+                    "(aborted/reaped before KV recv completed); skipping.",
+                    req_id,
+                )
+                continue
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
+            else:
+                logger.warning(
+                    "[Omni][PD] finished_recving for req %s in unexpected "
+                    "status %s; skipping free.",
+                    req_id,
+                    req.status,
+                )
+
+        for req_id in kv_connector_output.finished_sending or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "[Omni][PD] finished_sending for untracked req %s "
+                    "(aborted/reaped before KV send completed); skipping.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
+
     def _mark_request_for_kv_transfer(self, req_id: str, seq_len: int) -> None:
         """Mark a request as needing KV cache transfer when it finishes."""
         # Avoid duplicate marking (if already pending in queue)
@@ -966,15 +1246,17 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
     def _should_transfer_kv_for_request(self, req_id: str) -> bool:
         """Determine if a request should trigger KV cache transfer."""
+        request = self.requests.get(req_id)
+        if self._uses_native_pd_kv_transfer():
+            return request is not None and not self._request_omits_kv_transfer_to_next_stage(request)
         if not self._get_omni_kv_config_value("need_send_cache", False):
             return False
-        request = self.requests.get(req_id)
-        if request is not None and self._request_omits_kv_transfer_to_next_stage(request):
-            return False
-        return True
+        return request is None or not self._request_omits_kv_transfer_to_next_stage(request)
 
     def _cleanup_kv_tracking(self, request_ids: Iterable[str]) -> None:
         for req_id in request_ids:
+            self._kv_ready_multimodal_output_by_req.pop(req_id, None)
+            self._pd_prefill_submit_ready_requests.discard(req_id)
             if req_id in self.waiting_for_transfer_free:
                 continue
             self.transfer_triggered_requests.discard(req_id)

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -858,14 +858,15 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
-            if req_id in self._pd_prefill_submit_ready_requests:
+            pd_submit_ready = getattr(self, "_pd_prefill_submit_ready_requests", set())
+            if req_id in pd_submit_ready:
                 submit_params = {
                     "pd_submit_ready": True,
                     "transfer_id": f"xfer-{req_id}",
                     "remote_request_id": req_id,
                 }
                 kv_transfer_params = {**(kv_transfer_params or {}), **submit_params}
-                self._pd_prefill_submit_ready_requests.discard(req_id)
+                pd_submit_ready.discard(req_id)
             if new_token_ids or mm_output is not None or pooler_output is not None or kv_transfer_params or stopped:
                 OmniSchedulerMixin._append_request_output(
                     self,
@@ -1254,9 +1255,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         return request is None or not self._request_omits_kv_transfer_to_next_stage(request)
 
     def _cleanup_kv_tracking(self, request_ids: Iterable[str]) -> None:
+        pd_state_cache = getattr(self, "_kv_ready_multimodal_output_by_req", None)
+        pd_submit_ready = getattr(self, "_pd_prefill_submit_ready_requests", None)
         for req_id in request_ids:
-            self._kv_ready_multimodal_output_by_req.pop(req_id, None)
-            self._pd_prefill_submit_ready_requests.discard(req_id)
+            if pd_state_cache is not None:
+                pd_state_cache.pop(req_id, None)
+            if pd_submit_ready is not None:
+                pd_submit_ready.discard(req_id)
             if req_id in self.waiting_for_transfer_free:
                 continue
             self.transfer_triggered_requests.discard(req_id)

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -275,6 +275,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if self._uses_native_pd_kv_transfer():
                     self.transfer_triggered_requests.add(request.request_id)
                     self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    if stop_decode_on_trigger:
+                        request.status = RequestStatus.FINISHED_STOPPED
                     return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(
                     request.request_id,
@@ -292,6 +294,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if self._uses_native_pd_kv_transfer():
                     self.transfer_triggered_requests.add(request.request_id)
                     self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    if stop_decode_on_trigger:
+                        request.status = RequestStatus.FINISHED_STOPPED
                     return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(
                     request.request_id,
@@ -500,11 +504,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             return
         try:
             running = len(self.running)
-            stuck = [
-                r
-                for r in self.waiting
-                if r.status in (RequestStatus.PREEMPTED, RequestStatus.WAITING)
-            ]
+            stuck = [r for r in self.waiting if r.status in (RequestStatus.PREEMPTED, RequestStatus.WAITING)]
             # Wedge signature: nothing running yet requests stranded in waiting.
             if running == 0 and stuck:
                 self._pd_wedge_ticks = getattr(self, "_pd_wedge_ticks", 0) + 1
@@ -532,7 +532,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             self._pd_wedge_ticks = 0
         except Exception:
             init_logger(__name__).exception("[Omni][PD] wedge-recovery check failed")
-
 
     def update_from_output(
         self,
@@ -1185,8 +1184,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self._free_blocks(req)
             else:
                 logger.warning(
-                    "[Omni][PD] finished_recving for req %s in unexpected "
-                    "status %s; skipping free.",
+                    "[Omni][PD] finished_recving for req %s in unexpected status %s; skipping free.",
                     req_id,
                     req.status,
                 )

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -125,9 +125,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
             _ai = getattr(request, "additional_information", None)
             _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
+            _sp = getattr(request, "sampling_params", None)
+            _ea = getattr(_sp, "extra_args", None) if _sp is not None else None
+            _kvp = _ea.get("kv_transfer_params") if isinstance(_ea, dict) else None
             logger.info(
-                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d",
+                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d kv_params=%s",
                 request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
+                (_kvp if isinstance(_kvp, dict) else _kvp),
             )
         return super().add_request(request)
 

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -121,20 +121,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._new_prompt_len_snapshot: dict[str, int] = {}
         self._maybe_cap_running_reqs_for_pd_decode()
 
-    def add_request(self, request: Request) -> None:
-        if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
-            _ai = getattr(request, "additional_information", None)
-            _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
-            _sp = getattr(request, "sampling_params", None)
-            _ea = getattr(_sp, "extra_args", None) if _sp is not None else None
-            _kvp = _ea.get("kv_transfer_params") if isinstance(_ea, dict) else None
-            logger.info(
-                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d kv_params=%s",
-                request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
-                (_kvp if isinstance(_kvp, dict) else _kvp),
-            )
-        return super().add_request(request)
-
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         # Output placeholders are zero when async scheduling isn't used

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -275,7 +275,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if self._uses_native_pd_kv_transfer():
                     self.transfer_triggered_requests.add(request.request_id)
                     self._pd_prefill_submit_ready_requests.add(request.request_id)
-                    if stop_decode_on_trigger:
+                    if stop_decode_on_trigger and not request.is_finished():
                         request.status = RequestStatus.FINISHED_STOPPED
                     return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(
@@ -294,7 +294,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if self._uses_native_pd_kv_transfer():
                     self.transfer_triggered_requests.add(request.request_id)
                     self._pd_prefill_submit_ready_requests.add(request.request_id)
-                    if stop_decode_on_trigger:
+                    if stop_decode_on_trigger and not request.is_finished():
                         request.status = RequestStatus.FINISHED_STOPPED
                     return bool(stop_decode_on_trigger)
                 self._commit_kv_transfer_trigger(

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from collections.abc import Iterable
 from time import time
@@ -112,6 +113,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         # Track requests that have already triggered prefill transfer to avoid duplicates
         self.transfer_triggered_requests: set[str] = set()
+        # Emit one producer-complete event so Orchestrator can submit the
+        # decode worker before the consumer's KV extraction acknowledgement.
+        self._pd_prefill_submit_ready_requests: set[str] = set()
+        # The KV extraction acknowledgement can arrive in a later scheduler
+        # step than the model output. Retain the Qwen3-TTS PD runtime payload
+        # until it can be attached to that kv_ready event.
+        self._kv_ready_multimodal_output_by_req: dict[str, dict[str, Any]] = {}
 
         # Cache per-request flag to avoid repeated deserialization of additional_information
         self._omits_kv_transfer_cache: dict[str, bool] = {}
@@ -128,10 +136,18 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
 
+        # [Omni][PD] Never admit more decode work than the KV pool can hold.
+        self._maybe_cap_running_reqs_for_pd_decode()
+
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         # Output placeholders are zero when async scheduling isn't used
         return request.num_computed_tokens - request.num_output_placeholders
+
+    def _uses_native_pd_kv_transfer(self) -> bool:
+        """Whether upstream vLLM's KV connector owns this P/D handoff."""
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        return getattr(kv_transfer_config, "kv_role", None) == "kv_producer"
 
     def _get_kv_transfer_criteria(self) -> dict | None:
         # Note: vllm_config is available in Scheduler after super().__init__
@@ -141,9 +157,15 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         omni_kv_config = getattr(self.vllm_config.model_config, "omni_kv_config", None)
         if omni_kv_config:
             if isinstance(omni_kv_config, dict):
-                return omni_kv_config.get("kv_transfer_criteria", None)
+                criteria = omni_kv_config.get("kv_transfer_criteria", None)
             else:
-                return getattr(omni_kv_config, "kv_transfer_criteria", None)
+                criteria = getattr(omni_kv_config, "kv_transfer_criteria", None)
+            if criteria:
+                return criteria
+        # Mooncake P/D owns KV movement in its native connector, not in the
+        # OmniKVTransferManager. It still needs a scheduler stop boundary.
+        if self._uses_native_pd_kv_transfer():
+            return {"type": "prefill_finished", "stop_after_transfer": True}
         return None
 
     def _request_omits_kv_transfer_to_next_stage(self, request: Request) -> bool:
@@ -208,18 +230,19 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         if criteria_type == "prefill_finished":
             if confirmed_computed >= request.num_prompt_tokens:
                 self.transfer_triggered_requests.add(request.request_id)
+                if self._uses_native_pd_kv_transfer():
+                    # Mooncake's vLLM connector exports and retains its own
+                    # KV blocks in _connector_finished(). Do not also queue a
+                    # CPU OmniKVTransferManager copy or treat its local return
+                    # value as a consumer-pull acknowledgement.
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    return bool(stop_decode_on_trigger)
 
                 self._mark_request_for_kv_transfer(request.request_id, confirmed_computed)
                 actually_queued = request.request_id in self.requests_needing_kv_transfer
-
-                if stop_decode_on_trigger and actually_queued:
-                    # Defer the stop until KV extraction completes so that
-                    # the kv_ready signal can be emitted while the request
-                    # is still alive.  The request will be stopped on the
-                    # next scheduler step after extraction ack arrives.
-                    self.pending_stop_after_extraction.add(request.request_id)
-
-                return False
+                if actually_queued:
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                return bool(stop_decode_on_trigger and actually_queued)
 
         elif criteria_type == "special_token":
             target_token_id = self.kv_transfer_criteria.get("token_id")
@@ -233,13 +256,15 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 except ValueError:
                     snapshot_len = confirmed_computed
 
+                if self._uses_native_pd_kv_transfer():
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                    return bool(stop_decode_on_trigger)
+
                 self._mark_request_for_kv_transfer(request.request_id, snapshot_len)
                 actually_queued = request.request_id in self.requests_needing_kv_transfer
-
-                if stop_decode_on_trigger and actually_queued:
-                    self.pending_stop_after_extraction.add(request.request_id)
-
-                return False
+                if actually_queued:
+                    self._pd_prefill_submit_ready_requests.add(request.request_id)
+                return bool(stop_decode_on_trigger and actually_queued)
 
         return False
 
@@ -254,6 +279,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     queue.remove(req)
         self._consume_pending_connector_output(model_mode="ar")
         self._process_pending_input_timeouts()
+        # Recover a permanently wedged PD decode replica (running=0 with
+        # un-schedulable preempted PD-consumer requests). No-op on all other
+        # stages and whenever the replica is making progress.
+        self._maybe_break_pd_decode_wedge()
         if self.chunk_transfer_adapter:
             self.chunk_transfer_adapter.process_pending_chunks(
                 self.waiting, self.running, scheduler_requests=self.requests
@@ -313,6 +342,22 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 new_list.append(omni_nr)
 
             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]
+
+            cached_reqs = scheduler_output.scheduled_cached_reqs
+            cached_all_token_ids = dict(getattr(cached_reqs, "all_token_ids", {}) or {})
+            for cached_req_id in getattr(cached_reqs, "req_ids", ()) or ():
+                if cached_req_id in cached_all_token_ids:
+                    continue
+                cached_request = self.requests.get(cached_req_id)
+                if cached_request is None:
+                    continue
+                live_all_token_ids = getattr(cached_request, "_all_token_ids", None)
+                if live_all_token_ids is None:
+                    continue
+                cached_all_token_ids[cached_req_id] = list(live_all_token_ids)
+            if cached_all_token_ids != getattr(cached_reqs, "all_token_ids", None):
+                cached_reqs.all_token_ids = cached_all_token_ids
+
             if self.chunk_transfer_adapter:
                 self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output, self.requests)
             # Add information about requests needing KV cache transfer
@@ -327,6 +372,186 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             scheduler_output,
             finished_requests_needing_kv_transfer=finished_reqs,
         )
+
+    def _is_pd_decode_consumer_stage(self) -> bool:
+        """True on the decode (kv_consumer) side of a PD split."""
+        cfg = getattr(self.vllm_config, "kv_transfer_config", None)
+        return getattr(cfg, "kv_role", None) in ("kv_consumer", "kv_both")
+
+    def _kv_safe_max_running_reqs(self) -> int | None:
+        """Max concurrent max-length sequences this stage's KV pool can hold.
+
+        Reuses upstream's group-aware concurrency helper -- the same one that
+        logs "Maximum concurrency for N tokens per request" at startup -- so the
+        derived cap matches the number already visible in the engine log and
+        hybrid / multi-group / num_gpu_blocks_override layouts are handled for
+        free. Falls back to flat blocks-per-request math (which is block-size
+        invariant) when that helper or the KV cache config is unavailable.
+
+        Returns None when capacity cannot be determined, meaning "do not cap".
+        """
+        kv_cache_config = getattr(self, "kv_cache_config", None)
+
+        try:
+            from vllm.v1.core.kv_cache_utils import get_max_concurrency_for_kv_cache_config
+
+            if kv_cache_config is not None and getattr(kv_cache_config, "kv_cache_groups", None):
+                cap = int(get_max_concurrency_for_kv_cache_config(self.vllm_config, kv_cache_config))
+                if cap >= 1:
+                    return cap
+        except Exception:
+            logger.debug(
+                "[Omni][PD] group-aware KV concurrency helper unavailable; falling back to block math.",
+                exc_info=True,
+            )
+
+        max_model_len = int(getattr(self, "max_model_len", 0) or 0)
+        block_size = int(getattr(self, "block_size", 0) or 0)
+        num_blocks = int(getattr(kv_cache_config, "num_blocks", 0) or 0)
+        if not num_blocks:
+            num_blocks = int(getattr(self.cache_config, "num_gpu_blocks", 0) or 0)
+        if max_model_len <= 0 or block_size <= 0 or num_blocks <= 0:
+            return None
+        blocks_per_req = -(-max_model_len // block_size)  # ceil
+        return (num_blocks // blocks_per_req) or None
+
+    def _maybe_cap_running_reqs_for_pd_decode(self) -> None:
+        """Clamp the decode-stage admission gate to KV-safe concurrency.
+
+        ``max_num_seqs`` is really a batch-*shape* knob: the worker uses it to
+        size the persistent batch and pick CUDA-graph capture sizes. The
+        scheduler separately uses ``max_num_running_reqs`` purely as an
+        admission gate. When ``max_num_seqs`` exceeds what the KV pool can hold
+        at ``max_model_len``, the scheduler over-admits and the RUNNING loop is
+        forced to call ``_preempt_request`` to claw blocks back.
+
+        On a PD *consumer* stage a preempted request is unrecoverable: its
+        remote prefill KV was already released on the producer, and the
+        Qwen3-TTS talker rebuilds each step's input embedding from all 16
+        codebooks of the previous frame while ``Request`` only carries
+        codebook 0 -- a resumed request re-prefills against a zeroed
+        ``codes.audio`` placeholder and would emit garbage. Such requests pile
+        up as PREEMPTED, upstream only admits WAITING work while
+        ``not preempted_reqs``, and the replica wedges at ``running=0``.
+
+        So cap admission at KV capacity here. Lowering only
+        ``max_num_running_reqs`` is safe: upstream reads it just in the
+        admission gate and in ``assert len(self.running) <=
+        max_num_running_reqs``, which a lower value only makes easier to
+        satisfy. Worker-side batch sizing reads ``max_num_seqs``, untouched.
+
+        Inert at normal load -- it only binds under a pathological pileup.
+        Override with ``VLLM_OMNI_PD_DECODE_MAX_RUNNING`` (<=0 disables).
+        """
+        if not self._is_pd_decode_consumer_stage():
+            return
+
+        configured = getattr(self, "max_num_running_reqs", 0)
+        if not configured:
+            return
+
+        try:
+            raw = (os.getenv("VLLM_OMNI_PD_DECODE_MAX_RUNNING", "") or "").strip()
+            if raw:
+                override = int(raw)
+                if override <= 0:
+                    logger.info(
+                        "[Omni][PD] Decode admission cap disabled via "
+                        "VLLM_OMNI_PD_DECODE_MAX_RUNNING=%s (max_num_running_reqs=%d).",
+                        raw,
+                        configured,
+                    )
+                    return
+                cap = override
+            else:
+                kv_safe = self._kv_safe_max_running_reqs()
+                if kv_safe is None:
+                    return
+                cap = kv_safe
+            cap = max(1, min(cap, configured))
+        except Exception:
+            init_logger(__name__).exception(
+                "[Omni][PD] Failed to compute decode admission cap; leaving max_num_running_reqs=%d unchanged.",
+                configured,
+            )
+            return
+
+        if cap >= configured:
+            return
+
+        self.max_num_running_reqs = cap
+        logger.info(
+            "[Omni][PD] Decode (kv_consumer) admission cap: max_num_running_reqs %d -> %d "
+            "(max_model_len=%d; max_num_seqs stays %s for worker batch/CUDA-graph sizing). "
+            "A preempted PD-consumer request can never be re-admitted (remote prefill KV "
+            "released; multi-codebook talker state absent from Request token ids), so "
+            "admitting beyond KV capacity risks wedging the replica at running=0. "
+            "Override with VLLM_OMNI_PD_DECODE_MAX_RUNNING (<=0 disables).",
+            configured,
+            cap,
+            getattr(self, "max_model_len", -1),
+            getattr(self.scheduler_config, "max_num_seqs", "?"),
+        )
+
+    def _maybe_break_pd_decode_wedge(self) -> None:
+        """Recover a permanently wedged PD decode replica.
+
+        Root cause (observed under sustained load + over-generation runaways):
+        the decode stage preempts running requests under transient KV pressure.
+        A preempted PD-*consumer* request cannot be re-admitted -- its remote
+        prefill KV was already released on the producer, and a request that
+        generated near ``max_model_len`` tokens would need to recompute more
+        than ``max_num_batched_tokens`` in one step (the talker prefill is not
+        chunkable here), so ``schedule()`` can never re-admit it. Such requests
+        pile up as PREEMPTED, ``running`` drains to 0, and the whole replica
+        makes zero progress forever (GPU 0%), stalling every request behind it.
+        Single-node has no remote-KV dependency, so its preempted requests
+        recompute locally and this never happens.
+
+        We detect the wedge (nothing running, but waiting-queue requests that
+        cannot be scheduled) sustained across a grace window of scheduler
+        steps, and abort the stuck requests so the client gets a terminal
+        response and the replica resumes serving new requests. This converts a
+        total replica hang into graceful per-request failure under extreme
+        pressure.
+        """
+        if not self._is_pd_decode_consumer_stage():
+            return
+        try:
+            running = len(self.running)
+            stuck = [
+                r
+                for r in self.waiting
+                if r.status in (RequestStatus.PREEMPTED, RequestStatus.WAITING)
+            ]
+            # Wedge signature: nothing running yet requests stranded in waiting.
+            if running == 0 and stuck:
+                self._pd_wedge_ticks = getattr(self, "_pd_wedge_ticks", 0) + 1
+            else:
+                self._pd_wedge_ticks = 0
+                return
+            # Grace window: the engine core sleeps ~1ms per idle step, so this
+            # is a few seconds of *continuous* zero-progress-with-backlog, which
+            # normal operation never sustains. Tunable via env.
+            threshold = int(os.getenv("VLLM_OMNI_PD_DECODE_WEDGE_TICKS", "3000") or "3000")
+            if self._pd_wedge_ticks < threshold:
+                return
+            stuck_ids = [r.request_id for r in stuck]
+            logger.error(
+                "[Omni][PD] Decode replica wedged: running=0 with %d stranded "
+                "waiting requests for %d scheduler steps (preempted PD-consumer "
+                "requests cannot recompute -- remote prefill KV released). "
+                "Aborting %d stuck request(s) to recover the replica: %s",
+                len(stuck_ids),
+                self._pd_wedge_ticks,
+                len(stuck_ids),
+                stuck_ids[:8],
+            )
+            self.finish_requests(stuck_ids, RequestStatus.FINISHED_ABORTED)
+            self._pd_wedge_ticks = 0
+        except Exception:
+            init_logger(__name__).exception("[Omni][PD] wedge-recovery check failed")
+
 
     def update_from_output(
         self,
@@ -344,12 +569,52 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats: CUDAGraphStat | None = model_runner_output.cudagraph_stats
 
+        # [Omni] Mirror upstream Scheduler.update_from_output's deferred-free
+        # drain. This method is a full reimplementation that never calls
+        # super().update_from_output(), so the drain has to be repeated here.
+        #
+        # Upstream sets defer_block_free=True when max_concurrent_batches > 1
+        # and the stage is a KV consumer -- exactly the Qwen3-TTS PD decode
+        # stage (async_scheduling + kv_role: kv_consumer). In that mode
+        # _free_request_blocks() does not return blocks to the pool; it pops
+        # them onto self.deferred_frees behind a processed_step_seq fence, and
+        # this is the ONLY site that advances the fence and drains the queue.
+        # Omitting it leaks every KV block ever freed on the decode replica
+        # (normal finishes, aborts and preemptions alike) for the lifetime of
+        # the process -> monotonically rising KV pressure -> preemption -> a
+        # permanently wedged replica, since a preempted PD-consumer request can
+        # never be re-admitted.
+        if getattr(self, "defer_block_free", False) and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
         spec_decoding_stats: SpecDecodingStats | None = None
+
+        # Cache this step's per-request state before handling a possible
+        # kv_extracted acknowledgement below. An extraction acknowledgement can
+        # arrive on a no-forward step, so include its request IDs as well as
+        # requests with scheduled tokens.
+        kv_extracted_ids = list(getattr(model_runner_output, "kv_extracted_req_ids", None) or [])
+        if mm_outputs is not None and self.kv_transfer_criteria:
+            state_req_ids = set(num_scheduled_tokens) | set(kv_extracted_ids)
+            for req_id in state_req_ids:
+                req_index = model_runner_output.req_id_to_index.get(req_id)
+                if req_index is None or req_index >= len(mm_outputs):
+                    continue
+                mm_output = mm_outputs[req_index]
+                if isinstance(mm_output, dict) and mm_output:
+                    self._kv_ready_multimodal_output_by_req[req_id] = mm_output
+                    if req_id in kv_extracted_ids:
+                        logger.info(
+                            "[PD_TRACE] qwen3_tts_kv_ack_state_cached req=%s keys=%s",
+                            req_id,
+                            sorted(mm_output),
+                        )
 
         failed_kv_load_req_ids = None
         if kv_connector_output and kv_connector_output.invalid_block_ids:
@@ -364,17 +629,23 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Pre-process KV extraction acks so that the per-request loop below
         # can see up-to-date active_kv_transfers state and emit kv_ready
         # signals while requests are still alive (before any deferred stop).
-        kv_extracted_ids = getattr(model_runner_output, "kv_extracted_req_ids", None)
         if kv_extracted_ids:
             for req_id in kv_extracted_ids:
                 try:
                     self.active_kv_transfers.discard(req_id)
                     req = self.requests.get(req_id)
                     if req is not None and not req.is_finished():
+                        pd_state = self._kv_ready_multimodal_output_by_req.pop(req_id, None)
+                        logger.info(
+                            "[PD_TRACE] qwen3_tts_kv_ready_emit req=%s has_state=%s",
+                            req_id,
+                            bool(pd_state),
+                        )
                         outputs[req.client_index].append(
                             OmniEngineCoreOutput(
                                 request_id=req_id,
                                 new_token_ids=[],
+                                multimodal_output=pd_state,
                                 kv_transfer_params={"kv_ready": True},
                             )
                         )
@@ -485,10 +756,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            # If criteria returns True, it means we must STOP the request.
-            # If criteria returns False, it might have triggered a background
-            # transfer (e.g. prefill finished / special token) but continues decoding.
-            if not stopped and self._process_kv_transfer_trigger(request, new_token_ids):
+            # Evaluate transfer even if a model stop token/length limit ended
+            # this step: prefill completion can coincide with that terminal
+            # token, and its KV still must be handed to decode.
+            if self._process_kv_transfer_trigger(request, new_token_ids):
                 stopped = True
 
             if new_token_ids and self.structured_output_manager.should_advance(request):
@@ -549,6 +820,22 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if req_id in self._pd_prefill_submit_ready_requests:
+                submit_params = {
+                    "pd_submit_ready": True,
+                    "transfer_id": f"xfer-{req_id}",
+                    "remote_request_id": req_id,
+                }
+                if kv_transfer_params is None:
+                    kv_transfer_params = submit_params
+                else:
+                    kv_transfer_params = {**kv_transfer_params, **submit_params}
+                self._pd_prefill_submit_ready_requests.remove(req_id)
+                logger.info(
+                    "[PD_TRACE] qwen3_tts_prefill_submit_ready req=%s has_state=%s",
+                    req_id,
+                    bool(mm_output),
+                )
             if new_token_ids or mm_output is not None or pooler_output is not None or kv_transfer_params or stopped:
                 # Add EngineCoreOutput for this Request.
                 outputs[request.client_index].append(
@@ -614,6 +901,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # [Omni] Cleanup state for finished requests
         for req in stopped_running_reqs:
             if req.request_id not in self.waiting_for_transfer_free:
+                self._kv_ready_multimodal_output_by_req.pop(req.request_id, None)
+                self._pd_prefill_submit_ready_requests.discard(req.request_id)
                 if req.request_id in self.transfer_triggered_requests:
                     self.transfer_triggered_requests.remove(req.request_id)
                 if req.request_id in self.active_kv_transfers:
@@ -623,6 +912,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Same for preempted
         for req in stopped_preempted_reqs:
             if req.request_id not in self.waiting_for_transfer_free:
+                self._kv_ready_multimodal_output_by_req.pop(req.request_id, None)
+                self._pd_prefill_submit_ready_requests.discard(req.request_id)
                 if req.request_id in self.transfer_triggered_requests:
                     self.transfer_triggered_requests.remove(req.request_id)
                 if req.request_id in self.active_kv_transfers:
@@ -862,11 +1153,17 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 is_active = request_id in self.active_kv_transfers
 
                 if already_triggered:
-                    if is_active:
-                        # It triggered but hasn't finished yet. We MUST wait.
-                        logger.debug(f"[Omni] Request {request_id} finished but transfer is still ACTIVE. Waiting.")
+                    if is_active or request_id in self.requests_needing_kv_transfer:
+                        # The snapshot has either been sent to the runner or is
+                        # queued for its next no-forward transfer step. Retain
+                        # blocks and request metadata until the extraction ACK.
+                        logger.debug(f"[Omni] Request {request_id} finished with KV transfer pending. Waiting.")
                         self.waiting_for_transfer_free.add(request_id)
-                        kv_xfer_params = None
+                        # [PD] Do NOT clear kv_xfer_params here: the native
+                        # Mooncake connector's params (bootstrap addr/port)
+                        # must reach the decode replica. Upstream 0.26 widened
+                        # the return to (kv_xfer_params, ec_xfer_params); there
+                        # are no encoder-cache params on this path.
                         return kv_xfer_params, None
                     elif request_id in self.waiting_for_transfer_free:
                         # Blocks held until KV extraction completes in a future step.
@@ -922,6 +1219,61 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             if self.chunk_transfer_adapter is not None:
                 self.chunk_transfer_adapter.cleanup_receiver(request_id)
 
+    def _update_from_kv_xfer_finished(self, kv_connector_output) -> None:
+        """Guarded variant of the upstream KV-transfer finish handler.
+
+        Upstream ``Scheduler._update_from_kv_xfer_finished`` asserts that every
+        ``finished_recving`` / ``finished_sending`` request id is still present
+        in ``self.requests``. That invariant does not hold in the Omni PD flow:
+        a decode (consumer) request can be aborted (client disconnect) or a
+        producer request can be reaped by Mooncake's own
+        ``VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT`` ("timed out ... without being
+        sent") *before* the connector delivers the matching finished
+        notification. When that late notification arrives the base assert fires
+        inside ``update_from_output`` and kills the whole StageEngineCoreProc
+        (EngineDeadError -> orchestrator dies -> server exits) — i.e. one
+        stranded transfer escalates into a full-server outage.
+
+        Here we skip ids that are no longer tracked (their blocks were already
+        freed on the abort/cleanup path) and only free blocks for requests we
+        still own, so a stranded transfer stays a per-request no-op instead of a
+        fatal error. Behaviour for live requests is identical to upstream.
+        """
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        for req_id in kv_connector_output.finished_recving or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "[Omni][PD] finished_recving for untracked req %s "
+                    "(aborted/reaped before KV recv completed); skipping.",
+                    req_id,
+                )
+                continue
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
+            else:
+                logger.warning(
+                    "[Omni][PD] finished_recving for req %s in unexpected "
+                    "status %s; skipping free.",
+                    req_id,
+                    req.status,
+                )
+
+        for req_id in kv_connector_output.finished_sending or ():
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "[Omni][PD] finished_sending for untracked req %s "
+                    "(aborted/reaped before KV send completed); skipping.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
+
     def _mark_request_for_kv_transfer(self, req_id: str, seq_len: int) -> None:
         """Mark a request as needing KV cache transfer when it finishes."""
         # Avoid duplicate marking (if already pending in queue)
@@ -967,6 +1319,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
     def _should_transfer_kv_for_request(self, req_id: str) -> bool:
         """Determine if a request should trigger KV cache transfer."""
+        if self._uses_native_pd_kv_transfer():
+            request = self.requests.get(req_id)
+            return request is not None and not self._request_omits_kv_transfer_to_next_stage(request)
+
         need_send = False
         # Try to read from vLLM Config (where YAML config is typically loaded)
         # Check for omni_kv_config attribute
@@ -1021,3 +1377,4 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
 class OmniARAsyncScheduler(OmniARScheduler, AsyncVLLMScheduler):
     """Asynchronous AutoRegressive scheduler."""
+

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -584,7 +584,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # the process -> monotonically rising KV pressure -> preemption -> a
         # permanently wedged replica, since a preempted PD-consumer request can
         # never be re-admitted.
-        if getattr(self, "defer_block_free", False) and scheduler_output.total_num_scheduled_tokens > 0:
+        if getattr(self, "defer_block_free", False) and getattr(scheduler_output, "total_num_scheduled_tokens", 0) > 0:
             self.processed_step_seq += 1
             self._drain_deferred_frees()
 
@@ -820,7 +820,12 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
-            if req_id in self._pd_prefill_submit_ready_requests:
+            # [PD] getattr-guarded: upstream unit tests drive update_from_output with
+            # a SimpleNamespace scheduler double that never runs __init__, so this
+            # PD-only state may be absent. Same defensive pattern as
+            # getattr(self, "_inflight_prefills", set()) in _free_request().
+            pd_submit_ready = getattr(self, "_pd_prefill_submit_ready_requests", None)
+            if pd_submit_ready is not None and req_id in pd_submit_ready:
                 submit_params = {
                     "pd_submit_ready": True,
                     "transfer_id": f"xfer-{req_id}",
@@ -830,7 +835,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     kv_transfer_params = submit_params
                 else:
                     kv_transfer_params = {**kv_transfer_params, **submit_params}
-                self._pd_prefill_submit_ready_requests.remove(req_id)
+                pd_submit_ready.remove(req_id)
                 logger.info(
                     "[PD_TRACE] qwen3_tts_prefill_submit_ready req=%s has_state=%s",
                     req_id,
@@ -899,10 +904,16 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     )
 
         # [Omni] Cleanup state for finished requests
+        # getattr-guarded: see the note at the pd_submit_ready lookup above --
+        # SimpleNamespace scheduler doubles in upstream tests skip __init__.
+        pd_state_cache = getattr(self, "_kv_ready_multimodal_output_by_req", None)
+        pd_ready_set = getattr(self, "_pd_prefill_submit_ready_requests", None)
         for req in stopped_running_reqs:
             if req.request_id not in self.waiting_for_transfer_free:
-                self._kv_ready_multimodal_output_by_req.pop(req.request_id, None)
-                self._pd_prefill_submit_ready_requests.discard(req.request_id)
+                if pd_state_cache is not None:
+                    pd_state_cache.pop(req.request_id, None)
+                if pd_ready_set is not None:
+                    pd_ready_set.discard(req.request_id)
                 if req.request_id in self.transfer_triggered_requests:
                     self.transfer_triggered_requests.remove(req.request_id)
                 if req.request_id in self.active_kv_transfers:
@@ -912,8 +923,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Same for preempted
         for req in stopped_preempted_reqs:
             if req.request_id not in self.waiting_for_transfer_free:
-                self._kv_ready_multimodal_output_by_req.pop(req.request_id, None)
-                self._pd_prefill_submit_ready_requests.discard(req.request_id)
+                if pd_state_cache is not None:
+                    pd_state_cache.pop(req.request_id, None)
+                if pd_ready_set is not None:
+                    pd_ready_set.discard(req.request_id)
                 if req.request_id in self.transfer_triggered_requests:
                     self.transfer_triggered_requests.remove(req.request_id)
                 if req.request_id in self.active_kv_transfers:

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -139,20 +139,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # [Omni][PD] Never admit more decode work than the KV pool can hold.
         self._maybe_cap_running_reqs_for_pd_decode()
 
-    def add_request(self, request: Request) -> None:
-        if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
-            _ai = getattr(request, "additional_information", None)
-            _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
-            _sp = getattr(request, "sampling_params", None)
-            _ea = getattr(_sp, "extra_args", None) if _sp is not None else None
-            _kvp = _ea.get("kv_transfer_params") if isinstance(_ea, dict) else None
-            logger.info(
-                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d kv_params=%s",
-                request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
-                (_kvp if isinstance(_kvp, dict) else _kvp),
-            )
-        return super().add_request(request)
-
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         # Output placeholders are zero when async scheduling isn't used
@@ -297,16 +283,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # un-schedulable preempted PD-consumer requests). No-op on all other
         # stages and whenever the replica is making progress.
         self._maybe_break_pd_decode_wedge()
-        if os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False") and self._is_pd_decode_consumer_stage():
-            _st = {}
-            for _q in (self.waiting, self.skipped_waiting):
-                for _r in _q:
-                    _st[str(getattr(_r, "status", "?"))] = _st.get(str(getattr(_r, "status", "?")), 0) + 1
-            if _st or self.running:
-                logger.info(
-                    "[PD_TRACE] dec_sched running=%d waiting_states=%s recv_ready=%s",
-                    len(self.running), _st, sorted(getattr(self, "finished_recving_kv_req_ids", set()) or []),
-                )
         if self.chunk_transfer_adapter:
             self.chunk_transfer_adapter.process_pending_chunks(
                 self.waiting, self.running, scheduler_requests=self.requests
@@ -345,11 +321,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 req_id = getattr(nr, "req_id", None)
                 request = self.requests.get(req_id) if req_id else None
                 # Build omni entry preserving all base fields
-                if os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
-                    _ai = getattr(request, "additional_information", None) if request else None
-                    _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
-                    logger.info("[PD_TRACE] sched_newreq req=%s ai_type=%s entries=%s",
-                                nr.req_id, type(_ai).__name__, _ents)
                 omni_nr = OmniNewRequestData(
                     req_id=nr.req_id,
                     external_req_id=(getattr(request, "external_req_id", None) if request else None),

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -143,9 +143,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
             _ai = getattr(request, "additional_information", None)
             _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
+            _sp = getattr(request, "sampling_params", None)
+            _ea = getattr(_sp, "extra_args", None) if _sp is not None else None
+            _kvp = _ea.get("kv_transfer_params") if isinstance(_ea, dict) else None
             logger.info(
-                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d",
+                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d kv_params=%s",
                 request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
+                (_kvp if isinstance(_kvp, dict) else _kvp),
             )
         return super().add_request(request)
 
@@ -293,6 +297,16 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # un-schedulable preempted PD-consumer requests). No-op on all other
         # stages and whenever the replica is making progress.
         self._maybe_break_pd_decode_wedge()
+        if os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False") and self._is_pd_decode_consumer_stage():
+            _st = {}
+            for _q in (self.waiting, self.skipped_waiting):
+                for _r in _q:
+                    _st[str(getattr(_r, "status", "?"))] = _st.get(str(getattr(_r, "status", "?")), 0) + 1
+            if _st or self.running:
+                logger.info(
+                    "[PD_TRACE] dec_sched running=%d waiting_states=%s recv_ready=%s",
+                    len(self.running), _st, sorted(getattr(self, "finished_recving_kv_req_ids", set()) or []),
+                )
         if self.chunk_transfer_adapter:
             self.chunk_transfer_adapter.process_pending_chunks(
                 self.waiting, self.running, scheduler_requests=self.requests

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -139,6 +139,16 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # [Omni][PD] Never admit more decode work than the KV pool can hold.
         self._maybe_cap_running_reqs_for_pd_decode()
 
+    def add_request(self, request: Request) -> None:
+        if os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False"):
+            _ai = getattr(request, "additional_information", None)
+            _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
+            logger.info(
+                "[PD_TRACE] sched_add_request req=%s type=%s ai=%s n_tok=%d",
+                request.request_id, type(request).__name__, _ents, len(request.prompt_token_ids or []),
+            )
+        return super().add_request(request)
+
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         # Output placeholders are zero when async scheduling isn't used
@@ -321,6 +331,11 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 req_id = getattr(nr, "req_id", None)
                 request = self.requests.get(req_id) if req_id else None
                 # Build omni entry preserving all base fields
+                if os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
+                    _ai = getattr(request, "additional_information", None) if request else None
+                    _ents = sorted(_ai.entries) if hasattr(_ai, "entries") else (sorted(_ai) if isinstance(_ai, dict) else None)
+                    logger.info("[PD_TRACE] sched_newreq req=%s ai_type=%s entries=%s",
+                                nr.req_id, type(_ai).__name__, _ents)
                 omni_nr = OmniNewRequestData(
                     req_id=nr.req_id,
                     external_req_id=(getattr(request, "external_req_id", None) if request else None),

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -457,6 +457,20 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         kv_connector_output = model_runner_output.kv_connector_output
 
         cudagraph_stats: CUDAGraphStat | None = model_runner_output.cudagraph_stats
+
+        # [Omni] Mirror upstream Scheduler.update_from_output's deferred-free
+        # drain. Like OmniARScheduler, this method reimplements the upstream
+        # body instead of calling super(), so the drain must be repeated. It is
+        # the only site that advances the processed_step_seq fence and returns
+        # blocks parked by _free_request_blocks() to the pool; without it any
+        # stage running with defer_block_free (max_concurrent_batches > 1 on a
+        # KV consumer) leaks every freed KV block. Inert today because
+        # generation stages carry no kv_transfer_config, but kept in sync so
+        # that enabling one later does not silently reintroduce the leak.
+        if getattr(self, "defer_block_free", False) and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -467,7 +467,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         # KV consumer) leaks every freed KV block. Inert today because
         # generation stages carry no kv_transfer_config, but kept in sync so
         # that enabling one later does not silently reintroduce the leak.
-        if getattr(self, "defer_block_free", False) and scheduler_output.total_num_scheduled_tokens > 0:
+        if getattr(self, "defer_block_free", False) and getattr(scheduler_output, "total_num_scheduled_tokens", 0) > 0:
             self.processed_step_seq += 1
             self._drain_deferred_frees()
 

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -8,6 +8,7 @@ Categories under ``OmniPayload``:
     ids            – token-ID sequences
     codes          – codec / audio code tensors
     meta           – scalar metadata, control flags, shapes
+    pd_sampler     – P/D sampler continuation state
 """
 
 from __future__ import annotations
@@ -61,6 +62,11 @@ class Ids(TypedDict, total=False):
     prior_image: list[int]
 
 
+class PDSampler(TypedDict, total=False):
+    main_generator_state: torch.Tensor
+    seed: int
+
+
 class OmniPayloadMeta(TypedDict, total=False):
     finished: torch.Tensor
     is_segment_finished: torch.Tensor
@@ -111,6 +117,7 @@ class OmniPayload(TypedDict, total=False):
     ids: Ids
     codes: Codes
     meta: OmniPayloadMeta
+    pd_sampler: PDSampler
     latent: torch.Tensor
     generated_len: int
     model_outputs: list[torch.Tensor]
@@ -169,6 +176,11 @@ class IdsStruct(_StructBase):
     prior_image: list[int] | None = None
 
 
+class PDSamplerStruct(_StructBase):
+    main_generator_state: torch.Tensor | None = None
+    seed: int | None = None
+
+
 class MetaStruct(_StructBase):
     finished: torch.Tensor | None = None
     is_segment_finished: torch.Tensor | None = None
@@ -216,6 +228,7 @@ class OmniPayloadStruct(_StructBase):
     ids: IdsStruct | None = None
     codes: CodesStruct | None = None
     meta: MetaStruct | None = None
+    pd_sampler: PDSamplerStruct | None = None
     latent: torch.Tensor | None = None
     generated_len: int | None = None
     model_outputs: list[torch.Tensor] | None = None
@@ -233,6 +246,7 @@ _NESTED_STRUCTS: dict[str, type[_StructBase]] = {
     "ids": IdsStruct,
     "codes": CodesStruct,
     "meta": MetaStruct,
+    "pd_sampler": PDSamplerStruct,
 }
 
 
@@ -317,7 +331,7 @@ def _dtype_to_name(dtype: torch.dtype) -> str:
 
 
 # ── Keys whose values are nested dicts (TypedDict sub-categories) ──
-_NESTED_KEYS = frozenset({"hidden_states", "embed", "ids", "codes", "meta"})
+_NESTED_KEYS = frozenset({"hidden_states", "embed", "ids", "codes", "meta", "pd_sampler"})
 
 
 def flatten_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -438,3 +452,4 @@ def deserialize_payload(
             flat[key] = entry.scalar_data
 
     return unflatten_payload(flat)  # type: ignore[return-value]
+

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -452,4 +452,3 @@ def deserialize_payload(
             flat[key] = entry.scalar_data
 
     return unflatten_payload(flat)  # type: ignore[return-value]
-

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -101,6 +101,9 @@ class OmniPayloadMeta(TypedDict, total=False):
     ref_context_request_id: str
     ref_context_included: bool
     talker_prefill_offset: int
+    talker_text_offset: int
+    pd_resume_token_id: int
+    pd_resume_token_consumed: bool
     omni_final_stage_id: int
     # Per-request audio seed. Stages that draw their own noise (flow-matching
     # / diffusion decoders) need the producing stage's seed to stay
@@ -212,6 +215,9 @@ class MetaStruct(_StructBase):
     ref_context_request_id: str | None = None
     ref_context_included: bool | None = None
     talker_prefill_offset: int | None = None
+    talker_text_offset: int | None = None
+    pd_resume_token_id: int | None = None
+    pd_resume_token_consumed: bool | None = None
     codec_chunk_frames: int | None = None
     codec_left_context_frames: int | None = None
     code_flat_numel: int | None = None

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -8,6 +8,7 @@ Categories under ``OmniPayload``:
     ids            – token-ID sequences
     codes          – codec / audio code tensors
     meta           – scalar metadata, control flags, shapes
+    pd_sampler     – P/D sampler continuation state
 """
 
 from __future__ import annotations
@@ -57,6 +58,11 @@ class Ids(TypedDict, total=False):
     prior_image: list[int]
 
 
+class PDSampler(TypedDict, total=False):
+    main_generator_state: torch.Tensor
+    seed: int
+
+
 class OmniPayloadMeta(TypedDict, total=False):
     finished: torch.Tensor
     is_segment_finished: torch.Tensor
@@ -99,6 +105,7 @@ class OmniPayload(TypedDict, total=False):
     ids: Ids
     codes: Codes
     meta: OmniPayloadMeta
+    pd_sampler: PDSampler
     latent: torch.Tensor
     generated_len: int
     model_outputs: list[torch.Tensor]
@@ -155,6 +162,11 @@ class IdsStruct(_StructBase):
     prior_image: list[int] | None = None
 
 
+class PDSamplerStruct(_StructBase):
+    main_generator_state: torch.Tensor | None = None
+    seed: int | None = None
+
+
 class MetaStruct(_StructBase):
     finished: torch.Tensor | None = None
     is_segment_finished: torch.Tensor | None = None
@@ -198,6 +210,7 @@ class OmniPayloadStruct(_StructBase):
     ids: IdsStruct | None = None
     codes: CodesStruct | None = None
     meta: MetaStruct | None = None
+    pd_sampler: PDSamplerStruct | None = None
     latent: torch.Tensor | None = None
     generated_len: int | None = None
     model_outputs: list[torch.Tensor] | None = None
@@ -215,6 +228,7 @@ _NESTED_STRUCTS: dict[str, type[_StructBase]] = {
     "ids": IdsStruct,
     "codes": CodesStruct,
     "meta": MetaStruct,
+    "pd_sampler": PDSamplerStruct,
 }
 
 
@@ -299,7 +313,7 @@ def _dtype_to_name(dtype: torch.dtype) -> str:
 
 
 # ── Keys whose values are nested dicts (TypedDict sub-categories) ──
-_NESTED_KEYS = frozenset({"hidden_states", "embed", "ids", "codes", "meta"})
+_NESTED_KEYS = frozenset({"hidden_states", "embed", "ids", "codes", "meta", "pd_sampler"})
 
 
 def flatten_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -412,3 +426,4 @@ def deserialize_payload(
             flat[key] = entry.scalar_data
 
     return unflatten_payload(flat)  # type: ignore[return-value]
+

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -72,6 +72,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25201
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.9
       top_p: 1.0
@@ -130,6 +132,8 @@ stage_args:
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_2:
         name: SharedMemoryConnector

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -216,4 +216,3 @@ edges:
     to: 1
   - from: 1
     to: 2
-

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -28,8 +28,9 @@
 # token 都取一致（3p1d 里 P/D 本来不一样，1P1D 可以一样）。
 
 async_chunk: true
+pipeline: qwen3_tts_pd
 
-stage_args:
+stages:
   # ============================================================
   # Stage 0: Talker PREFILL-only (GPU 0, kv_producer, port 25201)
   # ============================================================
@@ -152,7 +153,6 @@ stage_args:
       top_p: 1.0
       top_k: 50
       max_tokens: 4096
-      # NOTE: no fixed default seed here -- see the stage-0 comment above.
       detokenize: true
       repetition_penalty: 1.05
       stop_token_ids: [2150]

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -80,6 +80,7 @@ stages:
       top_p: 1.0
       top_k: 50
       max_tokens: 4096
+      min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05
       stop_token_ids: [2150]
@@ -153,6 +154,7 @@ stages:
       top_p: 1.0
       top_k: 50
       max_tokens: 4096
+      min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05
       stop_token_ids: [2150]

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -1,0 +1,215 @@
+# Qwen3-TTS 1P1D :PD deploy: Talker prefill → Talker decode → Code2Wav。
+# 第二阶段：把 Code2Wav 接到 PD pipeline 后端，让 /v1/audio/speech
+# 直接返回 wav 字节流（不再需要外部 token2wav 服务）。
+#
+# 拓扑（K=1 prefill + 1 decode + 1 code2wav，2 卡同机，故意把 prefill 和
+# code2wav 放在同一张卡上省卡；decode 独占一张卡）：
+#   stage 0 = Qwen3-TTS Talker (prefill-only, GPU 0, kv_producer)
+#   stage 1 = Qwen3-TTS Talker (decode-only,  GPU 1, kv_consumer)
+#   stage 2 = Qwen3-TTS Code2Wav                (GPU 0, 与 stage 0 共卡, final_output=audio)
+#
+# 与 qwen3_tts.yaml 的差异：
+#   * 把原 stage 0 (talker) 拆成 prefill+decode 两段；
+#   * 两段都加 kv_transfer_config（producer / consumer + 唯一 bootstrap_port）；
+#   * decode stage engine_input_source 指向 prefill stage（PD KV transfer）；
+#   * code2wav 阶段对应改成 stage 2，input_connector 指向 decode；
+#   * decode → code2wav 通过 SharedMemoryConnector + async_chunk 流式传 audio_codes；
+#   * code2wav 的字段（model_stage / model_arch / worker_type / scheduler_cls /
+#     final_output / final_output_type=audio）显式补齐。
+#
+# ❗ 与 3p1d / 1p3d 一致：stage_args 顶层不会把顶层 "connectors" 折叠进
+# runtime.connectors（只有 "stages" 顶层才会），引用式会报
+# "Undefined connector reference" 并退回默认参数、丢掉 codec 流式配置。
+# 因此下面 stage 的 output_connectors / input_connectors 直接用 **inline
+# 定义**（非引用），确保 codec_streaming / codec_chunk_frames / … 生效。
+#
+# 引擎参数对齐 3p1d（gpu_mem=0.6, talker max_num_batched_tokens=4096,
+# code2wav=65536）。1P1D 只有 1 个 P + 1 个 D，P/D 的采样参数、最大请求数、
+# token 都取一致（3p1d 里 P/D 本来不一样，1P1D 可以一样）。
+
+async_chunk: true
+
+stage_args:
+  # ============================================================
+  # Stage 0: Talker PREFILL-only (GPU 0, kv_producer, port 25201)
+  # ============================================================
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        # ⚠️ vllm MooncakeConnector 仅读子进程 env VLLM_MOONCAKE_BOOTSTRAP_PORT
+        # 决定 bootstrap server 端口; kv_connector_extra_config.mooncake_bootstrap_port
+        # 仅供 vllm-omni 构造 remote_bootstrap_addr 使用, 必须一致.
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARAsyncScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false   # PD 与 prefix caching 互斥
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 2              # 1 prefill + 1 decode = 2
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25201
+    final_output: false
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  # ============================================================
+  # Stage 1: Talker DECODE-only (GPU 1, kv_consumer, port 25202)
+  # ============================================================
+  - stage_id: 1
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "1"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARAsyncScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      # Keep decode async enabled; OmniARAsyncScheduler fills all_token_ids for
+      # PD-derived resumed cached requests before they reach the worker.
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      # Talker decode → Code2Wav async-chunk feeder：每生成一段 audio_codes
+      # 就推到 SharedMemoryConnector，由 stage 2 的 code2wav 增量消费。
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 1
+        kv_parallel_size: 2
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25202
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_2:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      # NOTE: no fixed default seed here -- see the stage-0 comment above.
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  # ============================================================
+  # Stage 2: Code2Wav (GPU 0, 与 stage 0 prefill 共卡, final_output=audio)
+  # ============================================================
+  - stage_id: 2
+    stage_type: llm
+    runtime:
+      devices: "0"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: code2wav
+      model_arch: Qwen3TTSCode2Wav
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: audio
+      distributed_executor_backend: "mp"
+      # Codec prefill length is Q * num_frames (~16 * 2148 = 34368)；
+      # max_num_batched_tokens 必须 ≥ 34368，65536 留出 headroom。
+      max_num_batched_tokens: 65536
+      max_model_len: 65536
+      tensor_parallel_size: 1
+    engine_input_source: [1]
+    final_output: true
+    final_output_type: audio
+    input_connectors:
+      from_stage_1:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: false
+      repetition_penalty: 1.0
+
+edges:
+  - from: 0
+    to: 1
+  - from: 1
+    to: 2
+

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -71,6 +71,8 @@ stages:
         kv_parallel_size: 2              # 1 prefill + 1 decode = 2
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25201
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -131,6 +133,8 @@ stages:
         kv_parallel_size: 2
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -62,7 +62,7 @@ stages:
       engine_output_type: latent
       distributed_executor_backend: "mp"
       max_num_batched_tokens: 32768
-      max_model_len: 1024
+      max_model_len: 4096
       tensor_parallel_size: 1
       kv_transfer_config:
         kv_connector: "MooncakeConnector"
@@ -79,7 +79,7 @@ stages:
       temperature: 0.9
       top_p: 1.0
       top_k: 50
-      max_tokens: 1024
+      max_tokens: 4096
       min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05
@@ -119,7 +119,7 @@ stages:
       engine_output_type: latent
       distributed_executor_backend: "mp"
       max_num_batched_tokens: 32768
-      max_model_len: 1024
+      max_model_len: 4096
       tensor_parallel_size: 1
       # Talker decode → Code2Wav async-chunk feeder：每生成一段 audio_codes
       # 就推到 SharedMemoryConnector，由 stage 2 的 code2wav 增量消费。
@@ -154,7 +154,7 @@ stages:
       temperature: 0.9
       top_p: 1.0
       top_k: 50
-      max_tokens: 1024
+      max_tokens: 4096
       min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05

--- a/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p1d.yaml
@@ -47,7 +47,7 @@ stages:
         VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
         VLLM_HOST_IP: "127.0.0.1"
     engine_args:
-      max_num_seqs: 256
+      max_num_seqs: 64
       model_stage: qwen3_tts
       model_arch: Qwen3TTSTalkerForConditionalGeneration
       hf_overrides:
@@ -61,8 +61,8 @@ stages:
       enable_prefix_caching: false   # PD 与 prefix caching 互斥
       engine_output_type: latent
       distributed_executor_backend: "mp"
-      max_num_batched_tokens: 4096
-      max_model_len: 4096
+      max_num_batched_tokens: 32768
+      max_model_len: 1024
       tensor_parallel_size: 1
       kv_transfer_config:
         kv_connector: "MooncakeConnector"
@@ -79,7 +79,7 @@ stages:
       temperature: 0.9
       top_p: 1.0
       top_k: 50
-      max_tokens: 4096
+      max_tokens: 1024
       min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05
@@ -102,7 +102,7 @@ stages:
         VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
         VLLM_HOST_IP: "127.0.0.1"
     engine_args:
-      max_num_seqs: 256
+      max_num_seqs: 64
       model_stage: qwen3_tts
       model_arch: Qwen3TTSTalkerForConditionalGeneration
       hf_overrides:
@@ -118,8 +118,8 @@ stages:
       enable_prefix_caching: false
       engine_output_type: latent
       distributed_executor_backend: "mp"
-      max_num_batched_tokens: 4096
-      max_model_len: 4096
+      max_num_batched_tokens: 32768
+      max_model_len: 1024
       tensor_parallel_size: 1
       # Talker decode → Code2Wav async-chunk feeder：每生成一段 audio_codes
       # 就推到 SharedMemoryConnector，由 stage 2 的 code2wav 增量消费。
@@ -149,11 +149,12 @@ stages:
           codec_left_context_frames: 72
           initial_codec_chunk_frames: 1
           decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+          decode_batch_max_size: 4
     default_sampling_params:
       temperature: 0.9
       top_p: 1.0
       top_k: 50
-      max_tokens: 4096
+      max_tokens: 1024
       min_tokens: 2
       detokenize: true
       repetition_penalty: 1.05
@@ -172,7 +173,7 @@ stages:
     runtime:
       devices: "0"
     engine_args:
-      max_num_seqs: 128
+      max_num_seqs: 64
       model_stage: code2wav
       model_arch: Qwen3TTSCode2Wav
       worker_type: generation
@@ -205,6 +206,7 @@ stages:
           codec_left_context_frames: 72
           initial_codec_chunk_frames: 1
           decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+          decode_batch_max_size: 4
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0

--- a/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
@@ -342,4 +342,3 @@ edges:
     to: 4
   - from: 3
     to: 4
-

--- a/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
@@ -38,6 +38,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25201
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -91,6 +93,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false
@@ -159,6 +163,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25203
     engine_input_source: [0]
     final_output: false
@@ -227,6 +233,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25204
     engine_input_source: [0]
     final_output: false

--- a/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
@@ -40,6 +40,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25201
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     # [yurain] greedy prefill sampling
     default_sampling_params:
       temperature: 0.0
@@ -92,6 +94,8 @@ stage_args:
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector
@@ -158,6 +162,8 @@ stage_args:
           mooncake_bootstrap_port: 25203
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector
@@ -224,6 +230,8 @@ stage_args:
           mooncake_bootstrap_port: 25204
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector

--- a/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p3d.yaml
@@ -1,0 +1,337 @@
+# [yurain] Qwen3-TTS 1P3D: 1 prefill + 3 decode + 1 code2wav
+pd_decode_pick_strategy: round_robin
+
+async_chunk: true
+
+stage_args:
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25201
+    final_output: false
+    # [yurain] greedy prefill sampling
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  - stage_id: 1
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "1"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 1
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25202
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    # [yurain] decode sampling params
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 2
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "2"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25203
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 2
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25203
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    # [yurain] decode sampling params
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 3
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "3"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25204
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 3
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25204
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    # [yurain] decode sampling params
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 4
+    stage_type: llm
+    runtime:
+      devices: "0"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: code2wav
+      model_arch: Qwen3TTSCode2Wav
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: audio
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 65536
+      max_model_len: 65536
+      tensor_parallel_size: 1
+    engine_input_source: [1, 2, 3]
+    final_output: true
+    final_output_type: audio
+    input_connectors:
+      from_stage_1:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_2:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_3:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: false
+      repetition_penalty: 1.0
+
+edges:
+  - from: 0
+    to: 1
+  - from: 0
+    to: 2
+  - from: 0
+    to: 3
+  - from: 1
+    to: 4
+  - from: 2
+    to: 4
+  - from: 3
+    to: 4
+

--- a/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
@@ -38,6 +38,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25201
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -90,6 +92,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false
@@ -156,6 +160,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25203
     engine_input_source: [0]
     final_output: false
@@ -222,6 +228,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25204
     engine_input_source: [0]
     final_output: false
@@ -288,6 +296,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25205
     engine_input_source: [0]
     final_output: false
@@ -354,6 +364,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25206
     engine_input_source: [0]
     final_output: false
@@ -420,6 +432,8 @@ stage_args:
         kv_parallel_size: 7
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25207
     engine_input_source: [0]
     final_output: false

--- a/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
@@ -1,0 +1,569 @@
+# Qwen3-TTS 1P6D PD deploy: 1 prefill + 6 decode + 1 code2wav.
+pd_decode_pick_strategy: round_robin
+
+async_chunk: true
+
+stage_args:
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25201
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  - stage_id: 1
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "1"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 1
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25202
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 2
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "2"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25203
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 2
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25203
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 3
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "3"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25204
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 3
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25204
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 4
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "4"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25205
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 4
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25205
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 5
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "5"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25206
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 5
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25206
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 6
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "6"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25207
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 6
+        kv_parallel_size: 7
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25207
+    engine_input_source: [0]
+    final_output: false
+    output_connectors:
+      to_stage_7:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  - stage_id: 7
+    stage_type: llm
+    runtime:
+      devices: "0"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: code2wav
+      model_arch: Qwen3TTSCode2Wav
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: audio
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 65536
+      max_model_len: 65536
+      tensor_parallel_size: 1
+    engine_input_source: [1, 2, 3, 4, 5, 6]
+    final_output: true
+    final_output_type: audio
+    input_connectors:
+      from_stage_1:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_2:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_3:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_5:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_6:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: false
+      repetition_penalty: 1.0
+
+edges:
+  - from: 0
+    to: 1
+  - from: 0
+    to: 2
+  - from: 0
+    to: 3
+  - from: 0
+    to: 4
+  - from: 0
+    to: 5
+  - from: 0
+    to: 6
+  - from: 1
+    to: 7
+  - from: 2
+    to: 7
+  - from: 3
+    to: 7
+  - from: 4
+    to: 7
+  - from: 5
+    to: 7
+  - from: 6
+    to: 7

--- a/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_1p6d.yaml
@@ -40,6 +40,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25201
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -91,6 +93,8 @@ stage_args:
           mooncake_bootstrap_port: 25202
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector
@@ -155,6 +159,8 @@ stage_args:
           mooncake_bootstrap_port: 25203
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector
@@ -219,6 +225,8 @@ stage_args:
           mooncake_bootstrap_port: 25204
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector
@@ -283,6 +291,8 @@ stage_args:
           mooncake_bootstrap_port: 25205
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector
@@ -347,6 +357,8 @@ stage_args:
           mooncake_bootstrap_port: 25206
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector
@@ -411,6 +423,8 @@ stage_args:
           mooncake_bootstrap_port: 25207
     engine_input_source: [0]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_7:
         name: SharedMemoryConnector

--- a/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
@@ -47,6 +47,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25201
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -98,6 +100,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25202
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -150,6 +154,8 @@ stage_args:
           mooncake_bootstrap_port: 25203
     engine_input_source: [0, 1]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector
@@ -215,6 +221,8 @@ stage_args:
           mooncake_bootstrap_port: 25204
     engine_input_source: [0, 1]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector

--- a/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
@@ -45,6 +45,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25201
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -98,6 +100,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25202
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -151,6 +155,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25203
     engine_input_source: [0, 1]
     final_output: false
@@ -218,6 +224,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25204
     engine_input_source: [0, 1]
     final_output: false

--- a/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
@@ -1,0 +1,315 @@
+# Qwen3-TTS 2P2D PD deploy: 2 prefill (co-located on GPU0) + 2 decode (GPU2/3)
+# + 1 code2wav (GPU1).
+#   GPU0: P0 (kv_rank 0) + P1 (kv_rank 1)
+#   GPU1: code2wav
+#   GPU2: D0 (kv_rank 2)
+#   GPU3: D1 (kv_rank 3)
+pd_decode_pick_strategy: round_robin
+pd_prefill_pick_strategy: round_robin
+
+async_chunk: true
+
+stage_args:
+  # Stage 0: PREFILL (GPU 0, port 25201)
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.4
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25201
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  # Stage 1: PREFILL (GPU 0, port 25202) - co-located with stage 0
+  - stage_id: 1
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.4
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 1
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25202
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  # Stage 2: DECODE (GPU 2, port 25203)
+  - stage_id: 2
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "2"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25203
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 2
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25203
+    engine_input_source: [0, 1]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  # Stage 3: DECODE (GPU 3, port 25204)
+  - stage_id: 3
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "3"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25204
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 3
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25204
+    engine_input_source: [0, 1]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  # Stage 4: Code2Wav (GPU 1)
+  - stage_id: 4
+    stage_type: llm
+    runtime:
+      devices: "1"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: code2wav
+      model_arch: Qwen3TTSCode2Wav
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.5
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: audio
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 65536
+      max_model_len: 65536
+      tensor_parallel_size: 1
+    engine_input_source: [2, 3]
+    final_output: true
+    final_output_type: audio
+    input_connectors:
+      from_stage_2:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+      from_stage_3:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: false
+      repetition_penalty: 1.0
+
+edges:
+  - from: 0
+    to: 2
+  - from: 0
+    to: 3
+  - from: 1
+    to: 2
+  - from: 1
+    to: 3
+  - from: 2
+    to: 4
+  - from: 3
+    to: 4
+

--- a/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_2p2d.yaml
@@ -320,4 +320,3 @@ edges:
     to: 4
   - from: 3
     to: 4
-

--- a/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
@@ -42,6 +42,8 @@ stage_args:
         kv_parallel_size: 4              # 3 prefill + 1 decode = 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25201
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -94,6 +96,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25202
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -146,6 +150,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25203
     final_output: false
     # vLLM-Omni 0.26 reads stage_config.final_output_type directly
@@ -200,6 +206,8 @@ stage_args:
         kv_parallel_size: 4
         kv_ip: "127.0.0.1"
         kv_connector_extra_config:
+          # Explicit PD data plane: Mooncake TCP; no RDMA/TCP auto-fallback.
+          pd_transport: tcp
           mooncake_bootstrap_port: 25204
     # [yurain] decode reads KV from all prefills (routed by orchestrator)
     engine_input_source: [0, 1, 2]

--- a/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
@@ -44,6 +44,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25201
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -94,6 +96,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25202
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -144,6 +148,8 @@ stage_args:
         kv_connector_extra_config:
           mooncake_bootstrap_port: 25203
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
@@ -198,6 +204,8 @@ stage_args:
     # [yurain] decode reads KV from all prefills (routed by orchestrator)
     engine_input_source: [0, 1, 2]
     final_output: false
+    # vLLM-Omni 0.26 reads stage_config.final_output_type directly
+    final_output_type: null
     output_connectors:
       to_stage_4:
         name: SharedMemoryConnector

--- a/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
+++ b/vllm_omni/deploy/qwen3_tts_pd_3p1d.yaml
@@ -1,0 +1,281 @@
+# [yurain] Qwen3-TTS 3P1D: 3 prefill + 1 decode + 1 code2wav
+pd_prefill_pick_strategy: round_robin
+
+async_chunk: true
+
+# [yurain] inline connector defs ensure codec streaming config is effective
+
+stage_args:
+  # [yurain] Stage 0: PREFILL (GPU 0, port 25201)
+  - stage_id: 0
+    stage_type: llm
+    is_prefill_only: true
+    is_comprehension: true
+    runtime:
+      devices: "0"
+      env:
+        # [yurain] vLLM child reads env for bootstrap port; multi-P on same host must not collide
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25201
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 0
+        kv_parallel_size: 4              # 3 prefill + 1 decode = 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25201
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  # [yurain] Stage 1: PREFILL (GPU 1, port 25202)
+  - stage_id: 1
+    stage_type: llm
+    is_prefill_only: true
+    runtime:
+      devices: "1"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25202
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 1
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25202
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  # [yurain] Stage 2: PREFILL (GPU 2, port 25203)
+  - stage_id: 2
+    stage_type: llm
+    is_prefill_only: true
+    runtime:
+      devices: "2"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25203
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_producer"
+        kv_rank: 2
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25203
+    final_output: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.0
+      stop_token_ids: []
+    subtalker_sampling_params:
+      do_sample: false
+      temperature: 0.0
+      top_k: -1
+      top_p: 1.0
+
+  # [yurain] Stage 3: DECODE (GPU 3, port 25204)
+  - stage_id: 3
+    stage_type: llm
+    is_decode_only: true
+    runtime:
+      devices: "3"
+      env:
+        VLLM_MOONCAKE_BOOTSTRAP_PORT: 25204
+        VLLM_HOST_IP: "127.0.0.1"
+    engine_args:
+      max_num_seqs: 256
+      model_stage: qwen3_tts
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      hf_overrides:
+        architectures: [Qwen3TTSTalkerForConditionalGeneration]
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: latent
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      tensor_parallel_size: 1
+      # [yurain] decode streams audio_codes to code2wav via SharedMemoryConnector + async_chunk
+      custom_process_next_stage_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_tts.talker2code2wav_async_chunk
+      kv_transfer_config:
+        kv_connector: "MooncakeConnector"
+        kv_role: "kv_consumer"
+        kv_rank: 3
+        kv_parallel_size: 4
+        kv_ip: "127.0.0.1"
+        kv_connector_extra_config:
+          mooncake_bootstrap_port: 25204
+    # [yurain] decode reads KV from all prefills (routed by orchestrator)
+    engine_input_source: [0, 1, 2]
+    final_output: false
+    output_connectors:
+      to_stage_4:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 4096
+      detokenize: true
+      repetition_penalty: 1.05
+      stop_token_ids: [2150]
+    subtalker_sampling_params:
+      do_sample: true
+      temperature: 0.9
+      top_k: 50
+      top_p: 1.0
+
+  # [yurain] Stage 4: Code2Wav (GPU 7)
+  - stage_id: 4
+    stage_type: llm
+    runtime:
+      devices: "7"
+    engine_args:
+      max_num_seqs: 128
+      model_stage: code2wav
+      model_arch: Qwen3TTSCode2Wav
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      gpu_memory_utilization: 0.6
+      enforce_eager: false
+      trust_remote_code: true
+      async_scheduling: true
+      enable_prefix_caching: false
+      engine_output_type: audio
+      distributed_executor_backend: "mp"
+      max_num_batched_tokens: 65536
+      max_model_len: 65536
+      tensor_parallel_size: 1
+    engine_input_source: [3]
+    final_output: true
+    final_output_type: audio
+    input_connectors:
+      from_stage_3:
+        name: SharedMemoryConnector
+        extra:
+          shm_threshold_bytes: 65536
+          codec_streaming: true
+          connector_get_sleep_s: 0.01
+          connector_get_max_wait_first_chunk: 3000
+          connector_get_max_wait: 300
+          codec_chunk_frames: 25
+          codec_left_context_frames: 72
+          initial_codec_chunk_frames: 1
+          decode_cudagraph_capture_sizes: [25, 73, 97, 169, 325]
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: false
+      repetition_penalty: 1.0
+
+edges:
+  - from: 0
+    to: 3
+  - from: 1
+    to: 3
+  - from: 2
+    to: 3
+  - from: 3
+    to: 4

--- a/vllm_omni/distributed/kv_transfer/__init__.py
+++ b/vllm_omni/distributed/kv_transfer/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV-transfer helpers for PD (prefill/decode) disaggregation."""

--- a/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
+++ b/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
@@ -28,6 +28,64 @@ _bootstrap_patched = False
 # fast / recompute instead of waiting minutes.
 _DEFAULT_KV_PULL_TIMEOUT_S = 60.0
 
+# PD data-plane selector. Keep this separate from Mooncake's protocol name:
+# operators choose a topology-oriented mode, while the connector receives the
+# concrete backend protocol it understands.
+_PD_TRANSPORT_TO_MOONCAKE_PROTOCOL = {
+    "tcp": "tcp",
+    "rdma": "rdma",
+    # Mooncake names its same-host NVLink backend ``nvlink_intra``.
+    "nvlink": "nvlink_intra",
+}
+
+
+def _configure_pd_transport(vllm_config: Any) -> str | None:
+    """Validate and materialize the explicit PD transport selection.
+
+    ``pd_transport`` is intentionally a PD-facing setting rather than a
+    Mooncake implementation detail. It is read before the upstream worker
+    initializes its TransferEngine, then translated to ``mooncake_protocol``.
+    Configurations that omit it retain upstream behavior for compatibility;
+    all shipped Qwen3-TTS PD configs set it explicitly.
+    """
+    kv_cfg = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_cfg is None:
+        return None
+    extra = getattr(kv_cfg, "kv_connector_extra_config", None)
+    if not isinstance(extra, dict):
+        return None
+
+    configured = extra.get("pd_transport")
+    if configured is None:
+        return None
+    transport = str(configured).strip().lower()
+    if transport == "pcie":
+        raise NotImplementedError(
+            "PD transport 'pcie' was requested, but this build has no CUDA-IPC/"
+            "PCIe data-plane backend. It must not silently fall back to TCP. "
+            "Use pd_transport: tcp, rdma, or nvlink until a PCIe backend is added."
+        )
+    protocol = _PD_TRANSPORT_TO_MOONCAKE_PROTOCOL.get(transport)
+    if protocol is None:
+        valid = ", ".join((*_PD_TRANSPORT_TO_MOONCAKE_PROTOCOL, "pcie"))
+        raise ValueError(f"Unknown pd_transport={configured!r}; expected one of: {valid}")
+
+    existing = extra.get("mooncake_protocol")
+    if existing is not None and str(existing).strip().lower() != protocol:
+        raise ValueError(
+            "PD transport configuration conflict: "
+            f"pd_transport={transport!r} maps to mooncake_protocol={protocol!r}, "
+            f"but mooncake_protocol={existing!r} was also supplied."
+        )
+    extra["mooncake_protocol"] = protocol
+    logger.info(
+        "[PD_TRANSPORT] selected=%s mooncake_protocol=%s data_plane=Mooncake; "
+        "no automatic protocol fallback is permitted by this config.",
+        transport,
+        protocol,
+    )
+    return transport
+
 
 def _pd_trace_enabled() -> bool:
     return os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
@@ -455,6 +513,19 @@ def _patch_mooncake_worker(mc_module: Any) -> None:
         return
 
     original_send_kv = getattr(worker_cls, "send_kv_to_decode", None)
+
+    # Upstream reads mooncake_protocol inside __init__ immediately before
+    # TransferEngine.initialize(). Resolve our PD-facing selector first so the
+    # chosen data plane is explicit and cannot be silently changed later.
+    original_init = getattr(worker_cls, "__init__", None)
+    if original_init is not None and not getattr(original_init, "_vllm_omni_transport_wrapped", False):
+
+        def worker_init(self_worker, vllm_config, *args, **kwargs):
+            _configure_pd_transport(vllm_config)
+            return original_init(self_worker, vllm_config, *args, **kwargs)
+
+        worker_init._vllm_omni_transport_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.__init__ = worker_init  # type: ignore[assignment]
     if original_send_kv is not None and not getattr(original_send_kv, "_vllm_omni_wrapped", False):
 
         async def send_kv_to_decode(self_worker, identity, sock, meta):

--- a/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
+++ b/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
@@ -800,5 +800,3 @@ def apply_mooncake_connector_patch() -> None:
     _patch_mooncake_scheduler(mc_module)
     _patch_mooncake_worker(mc_module)
     _patched = True
-
-

--- a/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
+++ b/vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py
@@ -1,0 +1,804 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_patched = False
+_bootstrap_patched = False
+
+# How long (seconds) the decode (kv_consumer) side waits for a single KV
+# pull to complete before it gives up on its own, independent of whatever
+# the producer's VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT (default 480s) is set
+# to. Upstream MooncakeConnector's decode-side receive path has NO local
+# timeout of its own (see module docstring below `_patch_mooncake_worker`);
+# without this watchdog a stuck pull can hang the whole PD pipeline for
+# 480s+ (producer timeout) or indefinitely (if even that response is lost),
+# silently backing up every other request behind it. Default is
+# intentionally much shorter than the producer's 480s so TTS callers fail
+# fast / recompute instead of waiting minutes.
+_DEFAULT_KV_PULL_TIMEOUT_S = 60.0
+
+
+def _pd_trace_enabled() -> bool:
+    return os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _kv_pull_timeout_s() -> float:
+    try:
+        return float(os.environ.get("VLLM_OMNI_MOONCAKE_PULL_TIMEOUT_S", _DEFAULT_KV_PULL_TIMEOUT_S))
+    except (TypeError, ValueError):
+        return _DEFAULT_KV_PULL_TIMEOUT_S
+
+
+def _flatten_block_ids(local_block_ids: Any) -> set[int]:
+    """Flatten a PullReqMeta.local_block_ids (list[list[int]]) into a flat set[int]."""
+    flat: set[int] = set()
+    if not local_block_ids:
+        return flat
+    for group in local_block_ids:
+        if isinstance(group, (list, tuple, set)):
+            for bid in group:
+                try:
+                    flat.add(int(bid))
+                except (TypeError, ValueError):
+                    continue
+        else:
+            try:
+                flat.add(int(group))
+            except (TypeError, ValueError):
+                continue
+    return flat
+
+
+def _import_first(paths: tuple[str, ...]):
+    for path in paths:
+        try:
+            return importlib.import_module(path)
+        except (ImportError, ModuleNotFoundError):
+            continue
+    return None
+
+
+def _import_mooncake_module():
+    return _import_first(
+        (
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector",
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake_connector",
+        )
+    )
+
+
+def _import_mooncake_utils_module():
+    return _import_first(
+        (
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils",
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake_utils",
+        )
+    )
+
+
+def _fill_producer_kv_params(kv_params: Any, request: Any, owner: Any) -> dict[str, Any]:
+    req_id = getattr(request, "request_id", None)
+    if kv_params is None or not isinstance(kv_params, dict):
+        kv_params = {}
+    if not req_id:
+        return kv_params
+
+    kv_params.setdefault("transfer_id", f"xfer-{req_id}")
+    kv_params.setdefault("remote_request_id", req_id)
+    # This hook publishes producer metadata, not an extraction acknowledgement.
+    # `kv_ready` is reserved for OmniARAsyncScheduler after it attaches the
+    # matching Qwen3-TTS non-KV runtime state to the KV acknowledgement.
+    kv_params.pop("kv_ready", None)
+
+    host = getattr(owner, "side_channel_host", None)
+    port = getattr(owner, "side_channel_port", None)
+    if host is not None:
+        kv_params.setdefault("remote_host", host)
+    if port is not None:
+        kv_params.setdefault("remote_port", port)
+    return kv_params
+
+
+def _create_patched_mooncake_connector():
+    mc_mod = _import_mooncake_module()
+    if mc_mod is None:
+        raise ImportError("Cannot import MooncakeConnector from upstream vLLM")
+
+    original_cls = mc_mod.MooncakeConnector
+
+    class PatchedMooncakeConnector(original_cls):
+        @classmethod
+        def get_required_kvcache_layout(cls, vllm_config: Any) -> str | None:
+            return None
+
+        def get_block_ids_with_load_errors(self) -> set:
+            # Worker-side hook: surface KV-pull failures/timeouts detected by
+            # our MooncakeConnectorWorker patch (see _patch_mooncake_worker)
+            # through the standard invalid_block_ids contract so the
+            # scheduler recomputes/aborts instead of hanging forever. The
+            # upstream base class has no implementation for this connector,
+            # so without this override the worker-side tracking added below
+            # would never reach the scheduler.
+            worker = getattr(self, "connector_worker", None)
+            fn = getattr(worker, "get_block_ids_with_load_errors", None)
+            if fn is not None:
+                try:
+                    return fn()
+                except Exception:
+                    logger.exception("[vllm-omni] get_block_ids_with_load_errors failed")
+            try:
+                return super().get_block_ids_with_load_errors()
+            except AttributeError:
+                return set()
+
+        def request_finished(self, request: Any, block_ids: list[int]) -> tuple[bool, dict[str, Any] | None]:
+            result = super().request_finished(request, block_ids)
+            if isinstance(result, tuple) and len(result) == 2:
+                delay_free, kv_params = result
+            else:
+                delay_free, kv_params = False, result
+
+            owner = getattr(self, "connector_scheduler", None) or getattr(self, "connector_worker", None)
+            if getattr(owner, "is_kv_producer", False):
+                kv_params = _fill_producer_kv_params(kv_params, request, owner)
+            return delay_free, kv_params
+
+    PatchedMooncakeConnector.__qualname__ = original_cls.__qualname__
+    return PatchedMooncakeConnector
+
+
+def _check_port_available(host: str, port: int) -> tuple[bool, str | None]:
+    bind_host = "0.0.0.0" if host in (None, "", "0.0.0.0") else host
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((bind_host, port))
+    except OSError as exc:
+        return False, str(exc)
+    finally:
+        sock.close()
+    return True, None
+
+
+def _patched_bootstrap_start(self) -> None:
+    if self.server_thread is not None:
+        return
+
+    import uvicorn
+
+    ok, err = _check_port_available(self.host, self.port)
+    if not ok:
+        raise RuntimeError(
+            f"Mooncake bootstrap cannot bind {self.host}:{self.port}: {err}. "
+            "Assign a unique VLLM_MOONCAKE_BOOTSTRAP_PORT for each PD stage."
+        )
+
+    kwargs = {}
+    if "install_signal_handlers" in uvicorn.Config.__init__.__code__.co_varnames:
+        kwargs["install_signal_handlers"] = False
+    server = uvicorn.Server(uvicorn.Config(app=self.app, host=self.host, port=self.port, log_config=None, **kwargs))
+    self.server = server
+
+    def _run() -> None:
+        try:
+            server.run()
+        except BaseException:
+            return
+
+    self.server_thread = threading.Thread(
+        target=_run,
+        name=f"mooncake_bootstrap_server[{self.host}:{self.port}]",
+        daemon=True,
+    )
+    self.server_thread.start()
+
+    deadline = time.monotonic() + 30.0
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"Mooncake bootstrap did not start within 30s ({self.host}:{self.port})")
+        if not self.server_thread.is_alive():
+            raise RuntimeError(f"Mooncake bootstrap thread died before startup ({self.host}:{self.port})")
+        time.sleep(0.05)
+
+
+def _patch_bootstrap_server() -> None:
+    global _bootstrap_patched
+    if _bootstrap_patched:
+        return
+
+    utils_mod = _import_mooncake_utils_module()
+    if utils_mod is None:
+        raise ImportError("Cannot import Mooncake bootstrap utilities")
+    bootstrap_cls = getattr(utils_mod, "MooncakeBootstrapServer", None)
+    if bootstrap_cls is None:
+        raise ImportError("MooncakeBootstrapServer not found")
+
+    bootstrap_cls.start = _patched_bootstrap_start  # type: ignore[assignment]
+
+    original_register_worker = getattr(bootstrap_cls, "register_worker", None)
+    payload_cls = getattr(utils_mod, "RegisterWorkerPayload", None)
+    engine_entry_cls = getattr(utils_mod, "EngineEntry", None)
+    if original_register_worker is not None and payload_cls is not None:
+
+        def _register_routes(self):
+            async def register_worker_endpoint(payload):
+                addr = getattr(payload, "addr", None)
+                if isinstance(addr, str) and "://" not in addr:
+                    normalized = f"tcp://{addr}"
+                    try:
+                        payload.addr = normalized
+                    except Exception:
+                        if hasattr(payload, "model_copy"):
+                            payload = payload.model_copy(update={"addr": normalized})
+                        elif hasattr(payload, "copy"):
+                            payload = payload.copy(update={"addr": normalized})
+                return await original_register_worker(self, payload)
+
+            register_worker_endpoint.__annotations__ = {"payload": payload_cls}
+            self.app.post("/register")(register_worker_endpoint)
+            if engine_entry_cls is not None:
+                self.app.get("/query", response_model=dict[int, engine_entry_cls])(self.query)
+            else:
+                self.app.get("/query")(self.query)
+
+        bootstrap_cls._register_routes = _register_routes  # type: ignore[assignment]
+
+    _bootstrap_patched = True
+
+
+def _read_remote_layout_from_shm(host: str, port: int) -> tuple[int, list[int]]:
+    for shm_dir in ("/dev/shm", "/tmp"):
+        path = f"{shm_dir}/vllm_omni_d_kv_layout_{host}_{port}.json"
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                payload = json.load(f)
+            num_blocks = int(payload.get("num_blocks", 0) or 0)
+            block_lens = [int(x) for x in (payload.get("block_lens", []) or [])]
+            if num_blocks > 0 and block_lens:
+                return num_blocks, block_lens
+        except Exception:
+            continue
+    return 0, []
+
+
+def _cache_remote_layout(self_worker: Any, meta: Any) -> None:
+    host = getattr(meta, "remote_hostname", None)
+    port = getattr(meta, "remote_port", None)
+    if not host or not port:
+        return
+
+    key = f"{host}:{port}"
+    nb_map = getattr(self_worker, "_vllm_omni_remote_num_blocks_map", None)
+    bl_map = getattr(self_worker, "_vllm_omni_remote_block_lens_map", None)
+    if nb_map is None:
+        nb_map = {}
+        self_worker._vllm_omni_remote_num_blocks_map = nb_map  # type: ignore[attr-defined]
+    if bl_map is None:
+        bl_map = {}
+        self_worker._vllm_omni_remote_block_lens_map = bl_map  # type: ignore[attr-defined]
+    if nb_map.get(key) and bl_map.get(key):
+        return
+
+    num_blocks = int(getattr(meta, "num_blocks", 0) or 0)
+    block_lens = [int(x) for x in (getattr(meta, "block_lens", []) or [])]
+    if num_blocks <= 0 or not block_lens:
+        num_blocks, block_lens = _read_remote_layout_from_shm(str(host), int(port))
+    if num_blocks > 0 and block_lens:
+        nb_map[key] = num_blocks
+        bl_map[key] = block_lens
+        if _pd_trace_enabled():
+            logger.info(
+                "[PD_TRACE] mooncake_remote_layout_cached key=%s blocks=%d block_len0=%d layers=%d",
+                key,
+                num_blocks,
+                block_lens[0],
+                len(block_lens),
+            )
+
+
+def _export_consumer_layout(self_worker: Any) -> None:
+    if getattr(self_worker, "is_kv_producer", False):
+        return
+    host = getattr(self_worker, "hostname", None)
+    port = getattr(self_worker, "rpc_port", None)
+    num_blocks = int(getattr(self_worker, "num_blocks", 0) or 0)
+    block_lens = [int(x) for x in (getattr(self_worker, "block_len_per_layer", None) or [])]
+    if not host or not port or num_blocks <= 0 or not block_lens:
+        return
+
+    shm_dir = "/dev/shm" if os.path.isdir("/dev/shm") else "/tmp"
+    path = f"{shm_dir}/vllm_omni_d_kv_layout_{host}_{port}.json"
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump({"session": f"{host}:{port}", "num_blocks": num_blocks, "block_lens": block_lens}, f)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+def _get_bootstrap_host_port(vllm_config: Any) -> tuple[str, int] | None:
+    kv_cfg = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_cfg is None:
+        return None
+    extra = getattr(kv_cfg, "kv_connector_extra_config", None) or {}
+    if not isinstance(extra, dict):
+        extra = {}
+    host = getattr(kv_cfg, "kv_ip", None) or extra.get("kv_ip") or "127.0.0.1"
+    port = os.environ.get("VLLM_MOONCAKE_BOOTSTRAP_PORT") or extra.get("mooncake_bootstrap_port") or 0
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        return None
+    if port <= 0:
+        return None
+    return str(host), port
+
+
+def _get_scheduler_zmq_addr(owner: Any) -> str | None:
+    host = getattr(owner, "side_channel_host", None) or getattr(owner, "hostname", None)
+    port = getattr(owner, "side_channel_port", None)
+    if not host or port is None:
+        return None
+    return f"tcp://{host}:{int(port)}"
+
+
+def _ensure_producer_registered(self_worker: Any) -> None:
+    if not getattr(self_worker, "is_kv_producer", False):
+        return
+    addr = _get_scheduler_zmq_addr(self_worker)
+    if addr is None:
+        return
+    vllm_config = getattr(self_worker, "vllm_config", None)
+    hp = _get_bootstrap_host_port(vllm_config)
+    if hp is None:
+        return
+    host, port = hp
+
+    # In some vLLM/Mooncake versions the producer bootstrap server is not
+    # reliably started/registered before the decode side queries it. Make this
+    # explicit and idempotent here.
+    if not getattr(self_worker, "_vllm_omni_bootstrap_server", None):
+        ok, _err = _check_port_available("0.0.0.0", port)
+        if ok:
+            utils_mod = _import_mooncake_utils_module()
+            bootstrap_cls = getattr(utils_mod, "MooncakeBootstrapServer", None) if utils_mod is not None else None
+            if bootstrap_cls is not None:
+                server = bootstrap_cls("0.0.0.0", port)
+                server.start()
+                self_worker._vllm_omni_bootstrap_server = server  # type: ignore[attr-defined]
+
+    try:
+        import requests
+
+        payload = {
+            "engine_id": str(getattr(self_worker, "engine_id")),
+            "dp_rank": int(getattr(self_worker, "dp_rank", 0)),
+            "tp_rank": int(getattr(self_worker, "tp_rank", 0)),
+            "pp_rank": int(getattr(self_worker, "pp_rank", 0)),
+            "addr": addr,
+        }
+        resp = requests.post(f"http://{host}:{port}/register", json=payload, timeout=5)
+        # Duplicate registration of the same tuple returns 400 in upstream; it
+        # is harmless because the registry already contains the needed entry.
+        if resp.status_code not in (200, 400):
+            resp.raise_for_status()
+    except Exception:
+        pass
+
+
+def _reshape_kv_caches_for_single_region(kv_caches: Any) -> Any:
+    if not isinstance(kv_caches, dict):
+        return kv_caches
+    new_caches = {}
+    for name, value in kv_caches.items():
+        if isinstance(value, (list, tuple)):
+            new_caches[name] = value
+            continue
+        if hasattr(value, "shape") and len(value.shape) == 5 and int(value.shape[0]) == 2 and value.is_contiguous():
+            new_caches[name] = value.view((int(value.shape[0]) * int(value.shape[1]),) + tuple(value.shape[2:]))
+        else:
+            new_caches[name] = value
+    return new_caches
+
+
+def _patch_mooncake_scheduler(mc_module: Any) -> None:
+    scheduler_cls = getattr(mc_module, "MooncakeConnectorScheduler", None)
+    if scheduler_cls is None or getattr(scheduler_cls, "_vllm_omni_rf_patched", False):
+        return
+
+    original_init = getattr(scheduler_cls, "__init__", None)
+    if original_init is not None:
+
+        def _patched_scheduler_init(self_sched, *args, **kwargs):
+            original_init(self_sched, *args, **kwargs)
+            _ensure_producer_registered(self_sched)
+
+        scheduler_cls.__init__ = _patched_scheduler_init  # type: ignore[assignment]
+
+    original = scheduler_cls.request_finished
+
+    def request_finished(self_sched, request, block_ids):
+        result = original(self_sched, request, block_ids)
+        if isinstance(result, tuple) and len(result) == 2:
+            delay_free, kv_params = result
+        else:
+            delay_free, kv_params = False, result
+        if getattr(self_sched, "is_kv_producer", False):
+            _ensure_producer_registered(self_sched)
+            kv_params = _fill_producer_kv_params(kv_params, request, self_sched)
+        return delay_free, kv_params
+
+    scheduler_cls.request_finished = request_finished  # type: ignore[assignment]
+    scheduler_cls._vllm_omni_rf_patched = True  # type: ignore[attr-defined]
+
+
+def _patch_mooncake_worker(mc_module: Any) -> None:
+    worker_cls = getattr(mc_module, "MooncakeConnectorWorker", None)
+    if worker_cls is None or getattr(worker_cls, "_vllm_omni_kv_patched", False):
+        return
+
+    original_send_kv = getattr(worker_cls, "send_kv_to_decode", None)
+    if original_send_kv is not None and not getattr(original_send_kv, "_vllm_omni_wrapped", False):
+
+        async def send_kv_to_decode(self_worker, identity, sock, meta):
+            _cache_remote_layout(self_worker, meta)
+            return await original_send_kv(self_worker, identity, sock, meta)
+
+        send_kv_to_decode._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.send_kv_to_decode = send_kv_to_decode  # type: ignore[assignment]
+
+    original_send_blocks = getattr(worker_cls, "_send_blocks", None)
+    if original_send_blocks is not None and not getattr(original_send_blocks, "_vllm_omni_wrapped", False):
+
+        def send_blocks(self_worker, remote_session, src_ptrs, dst_ptrs, lengths):
+            try:
+                local_num_blocks = int(getattr(self_worker, "num_blocks", 0) or 0)
+                local_block_lens = list(getattr(self_worker, "block_len_per_layer", None) or [])
+                nb_map = getattr(self_worker, "_vllm_omni_remote_num_blocks_map", None) or {}
+                bl_map = getattr(self_worker, "_vllm_omni_remote_block_lens_map", None) or {}
+                session_key = str(remote_session)
+                remote_num_blocks = int(nb_map.get(session_key, 0) or 0)
+                remote_block_lens = list(bl_map.get(session_key, []) or [])
+                layout_source = "remote_cache"
+                if remote_num_blocks <= 0 or not remote_block_lens:
+                    remote_num_blocks = local_num_blocks
+                    remote_block_lens = local_block_lens
+                    layout_source = "local_fallback"
+                if (
+                    local_num_blocks >= 2
+                    and remote_num_blocks >= 2
+                    and local_num_blocks % 2 == 0
+                    and remote_num_blocks % 2 == 0
+                    and local_block_lens
+                    and remote_block_lens
+                    and len(src_ptrs) == len(dst_ptrs) == len(lengths)
+                    and len(src_ptrs) > 0
+                ):
+                    src_offset = (local_num_blocks // 2) * int(local_block_lens[0])
+                    dst_offset = (remote_num_blocks // 2) * int(remote_block_lens[0])
+                    if _pd_trace_enabled():
+                        logger.info(
+                            "[PD_TRACE] mooncake_send_blocks session=%s layout_source=%s local_blocks=%d remote_blocks=%d src_offset=%d dst_offset=%d ptrs=%d",
+                            session_key,
+                            layout_source,
+                            local_num_blocks,
+                            remote_num_blocks,
+                            src_offset,
+                            dst_offset,
+                            len(src_ptrs),
+                        )
+                    ret_k = original_send_blocks(
+                        self_worker, remote_session, list(src_ptrs), list(dst_ptrs), list(lengths)
+                    )
+                    ret_v = original_send_blocks(
+                        self_worker,
+                        remote_session,
+                        [int(p) + src_offset for p in src_ptrs],
+                        [int(p) + dst_offset for p in dst_ptrs],
+                        list(lengths),
+                    )
+                    if _pd_trace_enabled():
+                        logger.info(
+                            "[PD_TRACE] mooncake_send_blocks_done session=%s ret_k=%s ret_v=%s",
+                            session_key,
+                            ret_k,
+                            ret_v,
+                        )
+                    return ret_k if ret_k != 0 else ret_v
+            except Exception:
+                logger.exception("[vllm-omni] Mooncake K/V split send failed; falling back to upstream transfer")
+            if _pd_trace_enabled():
+                logger.info(
+                    "[PD_TRACE] mooncake_send_blocks_unsplit session=%s ptrs=%d",
+                    remote_session,
+                    len(src_ptrs),
+                )
+            return original_send_blocks(self_worker, remote_session, src_ptrs, dst_ptrs, lengths)
+
+        send_blocks._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls._send_blocks = send_blocks  # type: ignore[assignment]
+
+    original_register = getattr(worker_cls, "register_kv_caches", None)
+    if original_register is not None and not getattr(original_register, "_vllm_omni_wrapped", False):
+
+        def register_kv_caches(self_worker, kv_caches):
+            topo = getattr(self_worker, "transfer_topo", None)
+            original_flag = None
+            kv_caches_to_register = kv_caches
+            try:
+                if topo is not None:
+                    original_flag = getattr(topo, "_is_kv_layout_blocks_first", None)
+                    topo._is_kv_layout_blocks_first = True  # type: ignore[attr-defined]
+                kv_caches_to_register = _reshape_kv_caches_for_single_region(kv_caches)
+            except Exception:
+                kv_caches_to_register = kv_caches
+            try:
+                result = original_register(self_worker, kv_caches_to_register)
+                _ensure_producer_registered(self_worker)
+                return result
+            finally:
+                if topo is not None and original_flag is not None:
+                    try:
+                        topo._is_kv_layout_blocks_first = original_flag  # type: ignore[attr-defined]
+                    except Exception:
+                        pass
+                _export_consumer_layout(self_worker)
+
+        register_kv_caches._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.register_kv_caches = register_kv_caches  # type: ignore[assignment]
+
+    # ------------------------------------------------------------------ #
+    # Decode (kv_consumer) side watchdog for stuck KV pulls.
+    #
+    # Upstream behaviour (see docstring at module top / PR discussion):
+    #   - The producer side (`fetch_finished_sending_reqs`) has a timeout
+    #     (VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT, default 480s): if it can't
+    #     send in time it frees its blocks and, in `send_kv_to_decode`,
+    #     replies to the decode side with a FINISH response whose
+    #     `err_reqs` names the timed-out requests.
+    #   - But `process_pulling_result` on the decode side only
+    #     `logger.error(...)`s that `err_reqs` list — it never decrements
+    #     `pull_tasks_count` / adds to `finished_recving_reqs`, so the
+    #     scheduler never sees the request as "done" (successfully or not).
+    #     The request is stuck in WAITING_FOR_REMOTE_KVS forever.
+    #   - If the producer's own response is *also* lost (e.g. process died,
+    #     partial network partition), the decode side never even gets an
+    #     err_reqs signal and has literally no local timeout of its own
+    #     (`PullReqMeta.expire_time` is defined but never populated/read
+    #     upstream) -- it can hang indefinitely.
+    #
+    # Under load (many concurrent PD requests) this silently backs up the
+    # whole pipeline: once one request is stuck, every request queued
+    # behind it on the same decode replica never gets scheduled either.
+    #
+    # Fix: wire both failure signals into vLLM's *existing*, standard
+    # `get_block_ids_with_load_errors()` / `invalid_block_ids` contract
+    # (see vllm/v1/core/sched/scheduler.py `_handle_invalid_blocks`), which
+    # vllm-omni's own OmniARScheduler already consumes correctly (recompute
+    # by default, or hard-fail via kv_transfer_config.kv_load_failure_policy
+    # = "fail"). This turns a silent multi-minute pipeline deadlock into a
+    # bounded (<= VLLM_OMNI_MOONCAKE_PULL_TIMEOUT_S) recompute/abort of just
+    # the affected request(s).
+    # ------------------------------------------------------------------ #
+
+    original_start_load_kv = getattr(worker_cls, "start_load_kv", None)
+    if original_start_load_kv is not None and not getattr(original_start_load_kv, "_vllm_omni_wrapped", False):
+
+        def start_load_kv(self_worker, metadata):
+            reqs_to_recv = getattr(metadata, "reqs_to_recv", None)
+            if reqs_to_recv:
+                pull_started_at = time.perf_counter()
+                deadline = pull_started_at + _kv_pull_timeout_s()
+                pull_deadlines = getattr(self_worker, "_vllm_omni_pull_deadlines", None)
+                if pull_deadlines is None:
+                    pull_deadlines = {}
+                    self_worker._vllm_omni_pull_deadlines = pull_deadlines  # type: ignore[attr-defined]
+                pull_block_ids = getattr(self_worker, "_vllm_omni_pull_block_ids", None)
+                if pull_block_ids is None:
+                    pull_block_ids = {}
+                    self_worker._vllm_omni_pull_block_ids = pull_block_ids  # type: ignore[attr-defined]
+                pull_started = getattr(self_worker, "_vllm_omni_pull_started", None)
+                if pull_started is None:
+                    pull_started = {}
+                    self_worker._vllm_omni_pull_started = pull_started  # type: ignore[attr-defined]
+                for pull_metas in reqs_to_recv.values():
+                    for req_id, pull_meta in pull_metas.items():
+                        if _pd_trace_enabled():
+                            pull_started[req_id] = pull_started_at
+                        # PullReqMeta.expire_time exists upstream but is
+                        # never populated/read for the decode side; setting
+                        # it is harmless (a dead field otherwise) and lets
+                        # future upstream versions pick it up naturally.
+                        try:
+                            pull_meta.expire_time = deadline
+                        except Exception:
+                            pass
+                        pull_deadlines[req_id] = deadline
+                        pull_block_ids[req_id] = _flatten_block_ids(getattr(pull_meta, "local_block_ids", None))
+            return original_start_load_kv(self_worker, metadata)
+
+        start_load_kv._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.start_load_kv = start_load_kv  # type: ignore[assignment]
+
+    original_process_pulling_result = getattr(worker_cls, "process_pulling_result", None)
+    if original_process_pulling_result is not None and not getattr(
+        original_process_pulling_result, "_vllm_omni_wrapped", False
+    ):
+
+        def process_pulling_result(self_worker, response, pull_metas):
+            original_process_pulling_result(self_worker, response, pull_metas)
+
+            pull_deadlines = getattr(self_worker, "_vllm_omni_pull_deadlines", None)
+            pull_block_ids = getattr(self_worker, "_vllm_omni_pull_block_ids", None)
+            pull_started = getattr(self_worker, "_vllm_omni_pull_started", None)
+
+            ok_reqs = list(getattr(response, "ok_reqs", None) or [])
+            for req_id in ok_reqs:
+                pull_meta = pull_metas.get(req_id)
+                # Only stop tracking once this pull is truly done (all
+                # participating remote workers acked); a multi-rank pull
+                # may still have other in-flight legs.
+                if pull_meta is not None and int(getattr(pull_meta, "pull_tasks_count", 0) or 0) <= 0:
+                    blocks = pull_block_ids.pop(req_id, None) if pull_block_ids is not None else None
+                    if pull_deadlines is not None:
+                        pull_deadlines.pop(req_id, None)
+                    if pull_started is not None:
+                        started_at = pull_started.pop(req_id, None)
+                        if started_at is not None:
+                            logger.info(
+                                "[PD_TRACE] mooncake_pull_ok req=%s blocks=%d elapsed_ms=%.3f",
+                                req_id,
+                                len(blocks or ()),
+                                (time.perf_counter() - started_at) * 1000.0,
+                            )
+
+            err_reqs = list(getattr(response, "err_reqs", None) or [])
+            if err_reqs:
+                error_block_ids = getattr(self_worker, "_vllm_omni_load_error_block_ids", None)
+                if error_block_ids is None:
+                    error_block_ids = set()
+                    self_worker._vllm_omni_load_error_block_ids = error_block_ids  # type: ignore[attr-defined]
+
+                failed_d_req_ids = set()
+                for req_id in err_reqs:
+                    pull_meta = pull_metas.get(req_id)
+                    d_req_id = getattr(pull_meta, "d_req_id", req_id) if pull_meta is not None else req_id
+                    blocks = pull_block_ids.pop(req_id, None) if pull_block_ids is not None else None
+                    if blocks is None and pull_meta is not None:
+                        blocks = _flatten_block_ids(getattr(pull_meta, "local_block_ids", None))
+                    if blocks:
+                        error_block_ids.update(blocks)
+                    if pull_deadlines is not None:
+                        pull_deadlines.pop(req_id, None)
+                    if pull_started is not None:
+                        started_at = pull_started.pop(req_id, None)
+                        if started_at is not None:
+                            logger.info(
+                                "[PD_TRACE] mooncake_pull_error req=%s blocks=%d elapsed_ms=%.3f",
+                                req_id,
+                                len(blocks or ()),
+                                (time.perf_counter() - started_at) * 1000.0,
+                            )
+                    failed_d_req_ids.add(d_req_id)
+
+                if failed_d_req_ids:
+                    logger.warning(
+                        "[vllm-omni] Mooncake KV pull failed for %d request(s) "
+                        "(producer-reported error, e.g. its own %ds send timeout). "
+                        "Reporting as invalid_block_ids so the scheduler can "
+                        "recompute/abort instead of hanging: %s",
+                        len(failed_d_req_ids),
+                        int(os.environ.get("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", 480) or 480),
+                        failed_d_req_ids,
+                    )
+                    # Contract (get_block_ids_with_load_errors docstring):
+                    # even on failure the request id must still surface via
+                    # get_finished() in the same or an earlier pass.
+                    self_worker.finished_recving_reqs.update(failed_d_req_ids)
+
+        process_pulling_result._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.process_pulling_result = process_pulling_result  # type: ignore[assignment]
+
+    original_fetch_finished_recving_reqs = getattr(worker_cls, "fetch_finished_recving_reqs", None)
+    if original_fetch_finished_recving_reqs is not None and not getattr(
+        original_fetch_finished_recving_reqs, "_vllm_omni_wrapped", False
+    ):
+
+        async def fetch_finished_recving_reqs(self_worker):
+            result = await original_fetch_finished_recving_reqs(self_worker)
+
+            pull_deadlines = getattr(self_worker, "_vllm_omni_pull_deadlines", None)
+            if not pull_deadlines:
+                return result
+
+            now = time.perf_counter()
+            expired = [req_id for req_id, deadline in pull_deadlines.items() if deadline < now]
+            if not expired:
+                return result
+
+            pull_block_ids = getattr(self_worker, "_vllm_omni_pull_block_ids", None) or {}
+            error_block_ids = getattr(self_worker, "_vllm_omni_load_error_block_ids", None)
+            if error_block_ids is None:
+                error_block_ids = set()
+                self_worker._vllm_omni_load_error_block_ids = error_block_ids  # type: ignore[attr-defined]
+
+            for req_id in expired:
+                pull_deadlines.pop(req_id, None)
+                blocks = pull_block_ids.pop(req_id, None)
+                if blocks:
+                    error_block_ids.update(blocks)
+
+            logger.warning(
+                "[vllm-omni] Mooncake KV pull watchdog: %d request(s) exceeded the local "
+                "%.0fs pull timeout (VLLM_OMNI_MOONCAKE_PULL_TIMEOUT_S) with no producer "
+                "response at all (not even a timeout notification). Reporting as "
+                "invalid_block_ids so the scheduler can recompute/abort instead of hanging "
+                "indefinitely: %s",
+                len(expired),
+                _kv_pull_timeout_s(),
+                expired,
+            )
+            return set(result) | set(expired)
+
+        fetch_finished_recving_reqs._vllm_omni_wrapped = True  # type: ignore[attr-defined]
+        worker_cls.fetch_finished_recving_reqs = fetch_finished_recving_reqs  # type: ignore[assignment]
+
+    if not hasattr(worker_cls, "get_block_ids_with_load_errors"):
+
+        def get_block_ids_with_load_errors(self_worker) -> set:
+            error_block_ids = getattr(self_worker, "_vllm_omni_load_error_block_ids", None)
+            if not error_block_ids:
+                return set()
+            self_worker._vllm_omni_load_error_block_ids = set()  # type: ignore[attr-defined]
+            return error_block_ids
+
+        worker_cls.get_block_ids_with_load_errors = get_block_ids_with_load_errors  # type: ignore[assignment]
+
+    worker_cls._vllm_omni_kv_patched = True  # type: ignore[attr-defined]
+
+
+def apply_mooncake_connector_patch() -> None:
+    global _patched
+    if _patched:
+        return
+
+    _patch_bootstrap_server()
+    mc_module = _import_mooncake_module()
+    if mc_module is None:
+        raise ImportError("Cannot import MooncakeConnector")
+
+    original_cls = mc_module.MooncakeConnector
+    patched_cls = _create_patched_mooncake_connector()
+    mc_module.MooncakeConnector = patched_cls
+
+    for path in (
+        "vllm.distributed.kv_transfer.kv_connector.v1",
+        "vllm.distributed.kv_transfer.kv_connector",
+        "vllm.distributed.kv_transfer",
+    ):
+        module = sys.modules.get(path)
+        if module is not None and getattr(module, "MooncakeConnector", None) is original_cls:
+            module.MooncakeConnector = patched_cls
+
+    _patch_mooncake_scheduler(mc_module)
+    _patch_mooncake_worker(mc_module)
+    _patched = True
+
+

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -1161,14 +1161,13 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             additional_info = getattr(request, "additional_information", None) if request else None
             cached_reqs.additional_information[req_id] = additional_info
             if request and additional_info:
-                # [PD] Never consume the payload on a PD decode consumer. Its
-                # additional_information carries the one-shot prefill handoff
-                # (hidden_states / codes / pd_sampler / meta.pd_resume_token_id)
-                # and the request may still be scheduled as a NEW request in a
-                # later step; clearing it here loses the resume token and decode
-                # regenerates the utterance from scratch.
-                if self._is_pd_decode_consumer:
-                    continue
+                # [PD] The prefill handoff payload is ONE-SHOT: it must be
+                # delivered to the worker exactly once and then dropped. Leaving
+                # it on the request re-merges the frozen prefill snapshot into
+                # model_intermediate_buffer on every subsequent step, which resets
+                # hidden_states.trailing_text / meta.talker_text_offset each frame
+                # so the talker never advances its text and never samples
+                # codec-EOS (every request then runs to max_tokens).
                 request.additional_information = None
 
     def _process_chunk_queue(

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -1137,10 +1137,30 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         # so the resume token never reached the worker and decode silently
         # regenerated the whole utterance instead of continuing from prefill.
         if requests is not None:
+            if self._is_pd_decode_consumer:
+                self.consume_new_request_additional_information(scheduler_output, requests)
             self.attach_cached_additional_information(scheduler_output, requests)
         if not self.receives_chunks:
             return
         self._clear_chunk_ready(scheduler_output)
+
+    def consume_new_request_additional_information(self, scheduler_output: Any, requests: dict[str, Request]) -> None:
+        """Drop a handoff payload after its scheduled-new copy is emitted."""
+        from vllm_omni.engine.serialization import deserialize_additional_information
+
+        for new_req in getattr(scheduler_output, "scheduled_new_reqs", ()):
+            payload = getattr(new_req, "additional_information", None)
+            info = deserialize_additional_information(payload)
+            meta = info.get("meta") if isinstance(info, dict) else None
+            if not isinstance(meta, dict) or "pd_resume_token_id" not in meta:
+                continue
+            request = requests.get(new_req.req_id)
+            if request is not None:
+                # The worker owns the mutable runtime copy after this request
+                # data is delivered. Retaining the frozen input on the core
+                # request would send it again on the first cached step and
+                # overwrite state advanced by the first model invocation.
+                request.additional_information = None
 
     def attach_cached_additional_information(self, scheduler_output: Any, requests: dict[str, Request]) -> None:
         cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -1123,19 +1123,34 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         Add additional info for cached requests and
         clean up ready chunks from scheduler output.
         """
-        if not self.receives_chunks:
-            return
         stage_id = self.connector.stage_id
+        import os as _os
+        if _os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
+            _cr = getattr(scheduler_output, "scheduled_cached_reqs", None)
+            logger.info(
+                "[PD_TRACE] postproc stage=%s recv_chunks=%s has_reqs=%s cached_ids=%s",
+                stage_id, self.receives_chunks, requests is not None,
+                list(getattr(_cr, "req_ids", []) or []) if _cr else None,
+            )
 
         if stage_id == 0:
             return
 
+        # [PD] attach_cached_additional_information must run even on a stage that
+        # does not receive chunks. A PD decode stage takes its input from the
+        # Mooncake KV pull, not from the chunk connector, yet it still relies on
+        # this hop to carry additional_information (hidden_states / codes /
+        # pd_sampler / meta.pd_resume_token_id) onto scheduled_cached_reqs. The
+        # upstream 0.26 `if not self.receives_chunks: return` guard skipped it,
+        # so the resume token never reached the worker and decode silently
+        # regenerated the whole utterance instead of continuing from prefill.
         if requests is not None:
             self.attach_cached_additional_information(scheduler_output, requests)
+        if not self.receives_chunks:
+            return
         self._clear_chunk_ready(scheduler_output)
 
-    @staticmethod
-    def attach_cached_additional_information(scheduler_output: Any, requests: dict[str, Request]) -> None:
+    def attach_cached_additional_information(self, scheduler_output: Any, requests: dict[str, Request]) -> None:
         cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
         if not cached_reqs:
             return
@@ -1146,6 +1161,14 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             additional_info = getattr(request, "additional_information", None) if request else None
             cached_reqs.additional_information[req_id] = additional_info
             if request and additional_info:
+                # [PD] Never consume the payload on a PD decode consumer. Its
+                # additional_information carries the one-shot prefill handoff
+                # (hidden_states / codes / pd_sampler / meta.pd_resume_token_id)
+                # and the request may still be scheduled as a NEW request in a
+                # later step; clearing it here loses the resume token and decode
+                # regenerates the utterance from scratch.
+                if self._is_pd_decode_consumer:
+                    continue
                 request.additional_information = None
 
     def _process_chunk_queue(

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -79,6 +79,34 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.receives_chunks = stage_receives_chunks(model_config)
         super().__init__(model_config)
         self.model_mode = getattr(model_config, "worker_type", None) or "ar"
+        omni_kv_config = getattr(model_config, "omni_kv_config", None)
+        if not isinstance(omni_kv_config, dict):
+            omni_kv_config = {}
+        self._configured_from_stage = self._coerce_stage_id(omni_kv_config.get("omni_from_stage"))
+        self._configured_to_stage = self._coerce_stage_id(omni_kv_config.get("omni_to_stage"))
+
+        raw_sources = omni_kv_config.get("engine_input_source") or []
+        source_candidates: list[int] = []
+        for src in raw_sources:
+            coerced = self._coerce_stage_id(src)
+            if coerced is not None and coerced not in source_candidates:
+                source_candidates.append(coerced)
+        self._source_stage_candidates: list[int] = source_candidates
+        self._pinned_source_stage: dict[str, int] = {}
+
+        self._is_pd_decode_consumer = False
+        self._is_pd_prefill_producer = False
+        try:
+            kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+            if kv_transfer_config is not None:
+                kv_role = getattr(kv_transfer_config, "kv_role", None)
+                if kv_role == "kv_consumer":
+                    self._is_pd_decode_consumer = True
+                elif kv_role == "kv_producer":
+                    self._is_pd_prefill_producer = True
+        except Exception:
+            self._is_pd_decode_consumer = False
+            self._is_pd_prefill_producer = False
         # State specific to Chunk management
         self.custom_process_next_stage_input_func: Callable[..., OmniPayloadStruct | None] | None = None
         custom_process_next_stage_input_func = getattr(model_config, "custom_process_next_stage_input_func", None)
@@ -122,6 +150,55 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         # becomes a client-visible error instead of parking forever.  Mirrors
         # OmniSchedulingCoordinator._waiting_since on the full-payload path.
         self._waiting_since: dict[str, float] = {}
+
+    @staticmethod
+    def _coerce_stage_id(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _request_source_stage_id_optional(self, request: Request) -> int | None:
+        """Return the explicit ``omni_source_stage_id`` on a request, or None.
+
+        Unlike :meth:`_request_source_stage_id` this never falls back to a
+        default; callers use ``None`` to trigger fan-in source discovery.
+        """
+        info = getattr(request, "additional_information", None)
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            return self._coerce_stage_id(value)
+        return None
+
+    def _request_source_stage_id(self, request: Request, default: int) -> int:
+        info = getattr(request, "additional_information", None)
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        parsed_result: int | None = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            parsed_result = self._coerce_stage_id(value)
+        if parsed_result is None:
+            return default
+        return parsed_result
 
     @staticmethod
     def _is_truthy_scalar(value: Any) -> bool:
@@ -201,6 +278,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         receive loop to poll.
 
         Stage-0 has no upstream producer, so this call is a no-op there.
+        PD-decode consumer stages also skip: their inputs come via the
+        mooncake KV pull path, not the chunk connector.
 
         Args:
             request: The request object needing data.
@@ -208,6 +287,10 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         stage_id = self.connector.stage_id
 
         if stage_id == 0 or not self.receives_chunks:
+            return
+        if self._is_pd_decode_consumer:
+            return
+        if self._is_pd_prefill_producer:
             return
         if not hasattr(request, "additional_information"):
             request.additional_information = None
@@ -311,22 +394,39 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
     def _poll_single_request(self, request: Request):
         stage_id = self.connector.stage_id
-        target_stage_id = stage_id - 1
+        configured_from = self._configured_from_stage if self._configured_from_stage is not None else stage_id - 1
         req_id = request.request_id
         chunk_id = self.get_req_chunk[req_id]
         external_req_id = self.request_ids_mapping.get(req_id, req_id)
-        connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
-        # Use timeout=0 for non-blocking poll
-        try:
-            result = self.connector.get(
-                str(target_stage_id),
-                str(stage_id),
-                connector_get_key,
-            )
-        except Exception as e:
-            logger.error(f"SharedMemoryConnector get failed for req {connector_get_key}: {e}")
-            return False
+        explicit_source = self._request_source_stage_id_optional(request)
+        pinned_source = self._pinned_source_stage.get(req_id)
+        if explicit_source is not None:
+            poll_targets = [explicit_source]
+        elif pinned_source is not None:
+            poll_targets = [pinned_source]
+        elif len(self._source_stage_candidates) > 1:
+            poll_targets = list(self._source_stage_candidates)
+        else:
+            poll_targets = [configured_from]
+
+        result = None
+        for candidate in poll_targets:
+            candidate_key = f"{external_req_id}_{candidate}_{chunk_id}"
+            try:
+                candidate_result = self.connector.get(
+                    str(candidate),
+                    str(stage_id),
+                    candidate_key,
+                )
+            except Exception as e:
+                logger.error(f"SharedMemoryConnector get failed for req {candidate_key}: {e}")
+                continue
+            if candidate_result is not None:
+                result = candidate_result
+                if pinned_source is None:
+                    self._pinned_source_stage[req_id] = candidate
+                break
 
         if result is None:
             return False
@@ -340,7 +440,24 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             payload_finished = self._is_truthy_scalar(meta.get("finished"))
             payload_segment_finished = self._is_truthy_scalar(meta.get("is_segment_finished"))
             if self.model_mode == "ar":
-                request.additional_information = payload_data
+                # [PD] Deep-merge instead of overwriting: PD carries state across
+                # chunks in additional_information (hidden_states / codes / sampler),
+                # and a plain assignment would drop fields the payload omits.
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                prev_info = getattr(request, "additional_information", None)
+                if prev_info is not None and not isinstance(prev_info, dict):
+                    prev_info = deserialize_additional_information(prev_info)
+                merged_info: dict = dict(prev_info) if isinstance(prev_info, dict) else {}
+                for key, value in payload_data.items():
+                    if isinstance(value, dict):
+                        existing_sub = merged_info.get(key)
+                        sub = dict(existing_sub) if isinstance(existing_sub, dict) else {}
+                        sub.update(value)
+                        merged_info[key] = sub
+                    else:
+                        merged_info[key] = value
+                request.additional_information = merged_info
                 replace_prompt = meta.get("replace_streaming_prompt") is True
                 if getattr(request, "resumable", False) and (chunk_id > 0 or replace_prompt):
                     # For new streaming input segment, we should update prompt from payload
@@ -425,7 +542,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
             # Mark as finished for consumption
             self._finished_load_reqs.add(req_id)
-            logger.debug(f"[Stage-{stage_id}] Received one chunk for key {connector_get_key}")
             return True
 
         return False
@@ -475,7 +591,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         is_finished = task["is_finished"]
         is_segment_finished = task["is_segment_finished"]
         stage_id = self.connector.stage_id
-        next_stage_id = stage_id + 1
+        next_stage_id = self._configured_to_stage if self._configured_to_stage is not None else stage_id + 1
         external_req_id = request.external_req_id
         chunk_id = self.put_req_chunk[external_req_id]
         connector_put_key = f"{external_req_id}_{stage_id}_{chunk_id}"
@@ -631,6 +747,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.replaced_streaming_prompt_ids.discard(request_id)
         self.request_ids_mapping.pop(request_id, None)
         self.requests_origin_status.pop(request_id, None)
+        # [PD] Drop the fan-in source pin so a re-submitted req_id re-probes.
+        self._pinned_source_stage.pop(request_id, None)
         self._discard_from_chunk_deque(self.waiting_for_chunk_waiting_requests, request_id)
         self._discard_from_chunk_deque(self.waiting_for_chunk_running_requests, request_id)
         self._discard_from_chunk_deque(self._held_non_active, request_id)
@@ -737,6 +855,24 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if not self.receives_chunks:
             return
         if self.connector.stage_id == 0:
+            return
+
+        # PD-decode consumer stages get their inputs from mooncake KV pull,
+        # not from chunk connector. Skip the whole park-into-WAITING_FOR_CHUNK
+        # path for them; otherwise the request is trapped in a poll loop and
+        # KV transfer never fires (dead-lock).
+        if self._is_pd_decode_consumer:
+            return
+
+        # PD prefill producer stages (non-zero prefill siblings in M-P-1-D) are
+        # round-robin parallel ENTRIES: the orchestrator feeds each the original
+        # prompt directly and their KV leaves via mooncake. They receive NO
+        # chunks. Without this guard, stage 1/2 get parked into
+        # WAITING_FOR_CHUNK polling ``<req>_<self>_0`` forever (num_scheduled=0,
+        # never runs prefill, never emits KV -> decode never picked -> hang).
+        # stage-0 is already covered by the ``stage_id == 0`` guard above; this
+        # extends the same treatment to the other prefill producers.
+        if self._is_pd_prefill_producer:
             return
 
         # Purge deque entries whose request was freed mid-flight (abort →

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -1124,14 +1124,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         clean up ready chunks from scheduler output.
         """
         stage_id = self.connector.stage_id
-        import os as _os
-        if _os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
-            _cr = getattr(scheduler_output, "scheduled_cached_reqs", None)
-            logger.info(
-                "[PD_TRACE] postproc stage=%s recv_chunks=%s has_reqs=%s cached_ids=%s",
-                stage_id, self.receives_chunks, requests is not None,
-                list(getattr(_cr, "req_ids", []) or []) if _cr else None,
-            )
 
         if stage_id == 0:
             return

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -849,14 +849,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         clean up ready chunks from scheduler output.
         """
         stage_id = self.connector.stage_id
-        import os as _os
-        if _os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
-            _cr = getattr(scheduler_output, "scheduled_cached_reqs", None)
-            logger.info(
-                "[PD_TRACE] postproc stage=%s recv_chunks=%s has_reqs=%s cached_ids=%s",
-                stage_id, self.receives_chunks, requests is not None,
-                list(getattr(_cr, "req_ids", []) or []) if _cr else None,
-            )
 
         if stage_id == 0:
             return

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -848,19 +848,34 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         Add additional info for cached requests and
         clean up ready chunks from scheduler output.
         """
-        if not self.receives_chunks:
-            return
         stage_id = self.connector.stage_id
+        import os as _os
+        if _os.getenv("VLLM_OMNI_PD_TRACE","0") not in ("","0","false","False"):
+            _cr = getattr(scheduler_output, "scheduled_cached_reqs", None)
+            logger.info(
+                "[PD_TRACE] postproc stage=%s recv_chunks=%s has_reqs=%s cached_ids=%s",
+                stage_id, self.receives_chunks, requests is not None,
+                list(getattr(_cr, "req_ids", []) or []) if _cr else None,
+            )
 
         if stage_id == 0:
             return
 
+        # [PD] attach_cached_additional_information must run even on a stage that
+        # does not receive chunks. A PD decode stage takes its input from the
+        # Mooncake KV pull, not from the chunk connector, yet it still relies on
+        # this hop to carry additional_information (hidden_states / codes /
+        # pd_sampler / meta.pd_resume_token_id) onto scheduled_cached_reqs. The
+        # upstream 0.26 `if not self.receives_chunks: return` guard skipped it,
+        # so the resume token never reached the worker and decode silently
+        # regenerated the whole utterance instead of continuing from prefill.
         if requests is not None:
             self.attach_cached_additional_information(scheduler_output, requests)
+        if not self.receives_chunks:
+            return
         self._clear_chunk_ready(scheduler_output)
 
-    @staticmethod
-    def attach_cached_additional_information(scheduler_output: Any, requests: dict[str, Request]) -> None:
+    def attach_cached_additional_information(self, scheduler_output: Any, requests: dict[str, Request]) -> None:
         cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
         if not cached_reqs:
             return
@@ -871,6 +886,14 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             additional_info = getattr(request, "additional_information", None) if request else None
             cached_reqs.additional_information[req_id] = additional_info
             if request and additional_info:
+                # [PD] Never consume the payload on a PD decode consumer. Its
+                # additional_information carries the one-shot prefill handoff
+                # (hidden_states / codes / pd_sampler / meta.pd_resume_token_id)
+                # and the request may still be scheduled as a NEW request in a
+                # later step; clearing it here loses the resume token and decode
+                # regenerates the utterance from scratch.
+                if self._is_pd_decode_consumer:
+                    continue
                 request.additional_information = None
 
     def _process_chunk_queue(

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -886,14 +886,13 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             additional_info = getattr(request, "additional_information", None) if request else None
             cached_reqs.additional_information[req_id] = additional_info
             if request and additional_info:
-                # [PD] Never consume the payload on a PD decode consumer. Its
-                # additional_information carries the one-shot prefill handoff
-                # (hidden_states / codes / pd_sampler / meta.pd_resume_token_id)
-                # and the request may still be scheduled as a NEW request in a
-                # later step; clearing it here loses the resume token and decode
-                # regenerates the utterance from scratch.
-                if self._is_pd_decode_consumer:
-                    continue
+                # [PD] The prefill handoff payload is ONE-SHOT: it must be
+                # delivered to the worker exactly once and then dropped. Leaving
+                # it on the request re-merges the frozen prefill snapshot into
+                # model_intermediate_buffer on every subsequent step, which resets
+                # hidden_states.trailing_text / meta.talker_text_offset each frame
+                # so the talker never advances its text and never samples
+                # codec-EOS (every request then runs to max_tokens).
                 request.additional_information = None
 
     def _process_chunk_queue(

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -60,6 +60,34 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.receives_chunks = stage_receives_chunks(model_config)
         super().__init__(model_config)
         self.model_mode = getattr(model_config, "worker_type", None) or "ar"
+        omni_kv_config = getattr(model_config, "omni_kv_config", None)
+        if not isinstance(omni_kv_config, dict):
+            omni_kv_config = {}
+        self._configured_from_stage = self._coerce_stage_id(omni_kv_config.get("omni_from_stage"))
+        self._configured_to_stage = self._coerce_stage_id(omni_kv_config.get("omni_to_stage"))
+
+        raw_sources = omni_kv_config.get("engine_input_source") or []
+        source_candidates: list[int] = []
+        for src in raw_sources:
+            coerced = self._coerce_stage_id(src)
+            if coerced is not None and coerced not in source_candidates:
+                source_candidates.append(coerced)
+        self._source_stage_candidates: list[int] = source_candidates
+        self._pinned_source_stage: dict[str, int] = {}
+
+        self._is_pd_decode_consumer = False
+        self._is_pd_prefill_producer = False
+        try:
+            kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+            if kv_transfer_config is not None:
+                kv_role = getattr(kv_transfer_config, "kv_role", None)
+                if kv_role == "kv_consumer":
+                    self._is_pd_decode_consumer = True
+                elif kv_role == "kv_producer":
+                    self._is_pd_prefill_producer = True
+        except Exception:
+            self._is_pd_decode_consumer = False
+            self._is_pd_prefill_producer = False
         # State specific to Chunk management
         self.custom_process_next_stage_input_func: Callable[..., OmniPayloadStruct | None] | None = None
         custom_process_next_stage_input_func = getattr(model_config, "custom_process_next_stage_input_func", None)
@@ -94,6 +122,55 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self._held_non_active: deque[Any] = deque()
         self.requests_num_chunks_sent: dict[str, int] = defaultdict(int)
         self._pending_streaming_prefills: dict[str, dict] = {}
+
+    @staticmethod
+    def _coerce_stage_id(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _request_source_stage_id_optional(self, request: Request) -> int | None:
+        """Return the explicit ``omni_source_stage_id`` on a request, or None.
+
+        Unlike :meth:`_request_source_stage_id` this never falls back to a
+        default; callers use ``None`` to trigger fan-in source discovery.
+        """
+        info = getattr(request, "additional_information", None)
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            return self._coerce_stage_id(value)
+        return None
+
+    def _request_source_stage_id(self, request: Request, default: int) -> int:
+        info = getattr(request, "additional_information", None)
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        parsed_result: int | None = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            parsed_result = self._coerce_stage_id(value)
+        if parsed_result is None:
+            return default
+        return parsed_result
 
     @staticmethod
     def _is_truthy_scalar(value: Any) -> bool:
@@ -141,6 +218,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         receive loop to poll.
 
         Stage-0 has no upstream producer, so this call is a no-op there.
+        PD-decode consumer stages also skip: their inputs come via the
+        mooncake KV pull path, not the chunk connector.
 
         Args:
             request: The request object needing data.
@@ -148,6 +227,10 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         stage_id = self.connector.stage_id
 
         if stage_id == 0 or not self.receives_chunks:
+            return
+        if self._is_pd_decode_consumer:
+            return
+        if self._is_pd_prefill_producer:
             return
         if not hasattr(request, "additional_information"):
             request.additional_information = None
@@ -206,22 +289,39 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
     def _poll_single_request(self, request: Request):
         stage_id = self.connector.stage_id
-        target_stage_id = stage_id - 1
+        configured_from = self._configured_from_stage if self._configured_from_stage is not None else stage_id - 1
         req_id = request.request_id
         chunk_id = self.get_req_chunk[req_id]
         external_req_id = self.request_ids_mapping.get(req_id, req_id)
-        connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
-        # Use timeout=0 for non-blocking poll
-        try:
-            result = self.connector.get(
-                str(target_stage_id),
-                str(stage_id),
-                connector_get_key,
-            )
-        except Exception as e:
-            logger.error(f"SharedMemoryConnector get failed for req {connector_get_key}: {e}")
-            return False
+        explicit_source = self._request_source_stage_id_optional(request)
+        pinned_source = self._pinned_source_stage.get(req_id)
+        if explicit_source is not None:
+            poll_targets = [explicit_source]
+        elif pinned_source is not None:
+            poll_targets = [pinned_source]
+        elif len(self._source_stage_candidates) > 1:
+            poll_targets = list(self._source_stage_candidates)
+        else:
+            poll_targets = [configured_from]
+
+        result = None
+        for candidate in poll_targets:
+            candidate_key = f"{external_req_id}_{candidate}_{chunk_id}"
+            try:
+                candidate_result = self.connector.get(
+                    str(candidate),
+                    str(stage_id),
+                    candidate_key,
+                )
+            except Exception as e:
+                logger.error(f"SharedMemoryConnector get failed for req {candidate_key}: {e}")
+                continue
+            if candidate_result is not None:
+                result = candidate_result
+                if pinned_source is None:
+                    self._pinned_source_stage[req_id] = candidate
+                break
 
         if result is None:
             return False
@@ -235,7 +335,24 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             payload_finished = self._is_truthy_scalar(meta.get("finished"))
             payload_segment_finished = self._is_truthy_scalar(meta.get("is_segment_finished"))
             if self.model_mode == "ar":
-                request.additional_information = payload_data
+                # [PD] Deep-merge instead of overwriting: PD carries state across
+                # chunks in additional_information (hidden_states / codes / sampler),
+                # and a plain assignment would drop fields the payload omits.
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                prev_info = getattr(request, "additional_information", None)
+                if prev_info is not None and not isinstance(prev_info, dict):
+                    prev_info = deserialize_additional_information(prev_info)
+                merged_info: dict = dict(prev_info) if isinstance(prev_info, dict) else {}
+                for key, value in payload_data.items():
+                    if isinstance(value, dict):
+                        existing_sub = merged_info.get(key)
+                        sub = dict(existing_sub) if isinstance(existing_sub, dict) else {}
+                        sub.update(value)
+                        merged_info[key] = sub
+                    else:
+                        merged_info[key] = value
+                request.additional_information = merged_info
                 replace_prompt = meta.get("replace_streaming_prompt") is True
                 if getattr(request, "resumable", False) and (chunk_id > 0 or replace_prompt):
                     # For new streaming input segment, we should update prompt from payload
@@ -307,7 +424,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
             # Mark as finished for consumption
             self._finished_load_reqs.add(req_id)
-            logger.debug(f"[Stage-{stage_id}] Received one chunk for key {connector_get_key}")
             return True
 
         return False
@@ -319,7 +435,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         is_finished = task["is_finished"]
         is_segment_finished = task["is_segment_finished"]
         stage_id = self.connector.stage_id
-        next_stage_id = stage_id + 1
+        next_stage_id = self._configured_to_stage if self._configured_to_stage is not None else stage_id + 1
         external_req_id = request.external_req_id
         chunk_id = self.put_req_chunk[external_req_id]
         connector_put_key = f"{external_req_id}_{stage_id}_{chunk_id}"
@@ -432,6 +548,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.requests_with_ready_chunks.discard(request_id)
         self.request_ids_mapping.pop(request_id, None)
         self.requests_origin_status.pop(request_id, None)
+        # [PD] Drop the fan-in source pin so a re-submitted req_id re-probes.
+        self._pinned_source_stage.pop(request_id, None)
         self._discard_from_chunk_deque(self.waiting_for_chunk_waiting_requests, request_id)
         self._discard_from_chunk_deque(self.waiting_for_chunk_running_requests, request_id)
         self._discard_from_chunk_deque(self._held_non_active, request_id)
@@ -518,6 +636,24 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if not self.receives_chunks:
             return
         if self.connector.stage_id == 0:
+            return
+
+        # PD-decode consumer stages get their inputs from mooncake KV pull,
+        # not from chunk connector. Skip the whole park-into-WAITING_FOR_CHUNK
+        # path for them; otherwise the request is trapped in a poll loop and
+        # KV transfer never fires (dead-lock).
+        if self._is_pd_decode_consumer:
+            return
+
+        # PD prefill producer stages (non-zero prefill siblings in M-P-1-D) are
+        # round-robin parallel ENTRIES: the orchestrator feeds each the original
+        # prompt directly and their KV leaves via mooncake. They receive NO
+        # chunks. Without this guard, stage 1/2 get parked into
+        # WAITING_FOR_CHUNK polling ``<req>_<self>_0`` forever (num_scheduled=0,
+        # never runs prefill, never emits KV -> decode never picked -> hang).
+        # stage-0 is already covered by the ``stage_id == 0`` guard above; this
+        # extends the same treatment to the other prefill producers.
+        if self._is_pd_prefill_producer:
             return
 
         # Purge deque entries whose request was freed mid-flight (abort →
@@ -828,3 +964,4 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             self._cancelled_load_reqs.add(req_id)
 
         return []
+

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -14,6 +14,7 @@ import asyncio
 import concurrent.futures
 import copy
 import json
+import os
 import queue
 import shutil
 import threading
@@ -970,44 +971,116 @@ class AsyncOmniEngine:
 
     def _detect_pd_config(self) -> dict[str, Any] | None:
         """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
-        Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.
+        Returns topology plus per-prefill bootstrap metadata, or None.
         """
-        pd_pair = PDDisaggregationMixin.detect_pd_separation_from_stage_configs(self.stage_configs)
-        if pd_pair is None:
+        topology = PDDisaggregationMixin.detect_pd_separation_topology(self.stage_configs)
+        if topology is None:
             return None
-        prefill_idx, decode_idx = pd_pair
+        prefill_ids = list(topology["prefill_ids"])
+        decode_ids = list(topology.get("decode_ids") or [topology["decode_id"]])
+        pd_pair = (prefill_ids[0], decode_ids[0]) if len(prefill_ids) == 1 and len(decode_ids) == 1 else None
 
-        # Extract bootstrap address from prefill stage engine_args
-        bootstrap_addr: str | None = None
-        try:
-            prefill_cfg = self.stage_configs[prefill_idx]
-            ea = getattr(prefill_cfg, "engine_args", None)
-            kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
-            if kv_cfg is not None:
-                port = vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT
-                kv_ip = getattr(kv_cfg, "kv_ip", None) or "127.0.0.1"
-                bootstrap_addr = f"http://{kv_ip}:{port}"
-        except Exception as exc:
-            logger.warning("[AsyncOmniEngine] Could not extract PD bootstrap address: %s", exc)
+        # Extract producer bootstrap addresses from prefill stage configs.
+        # Do not read vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT here: this code runs
+        # in the APIServer process, while MooncakeConnector reads the per-stage
+        # runtime.env inside worker subprocesses. Reading the parent env would
+        # usually return vLLM's default 8998 and make decode connect to the wrong
+        # bootstrap server.
+        bootstrap_addr_by_prefill: dict[int, str] = {}
+        for prefill_idx in prefill_ids:
+            try:
+                prefill_cfg = self.stage_configs[prefill_idx]
+                ea = getattr(prefill_cfg, "engine_args", None)
+                kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
+                if kv_cfg is None and hasattr(ea, "get"):
+                    kv_cfg = ea.get("kv_transfer_config")
+                if kv_cfg is not None:
+                    kv_cfg_dict = (
+                        OmegaConf.to_container(kv_cfg, resolve=True) if not isinstance(kv_cfg, dict) else kv_cfg
+                    )
+                    extra_cfg = kv_cfg_dict.get("kv_connector_extra_config", {}) or {}
+                    if not isinstance(extra_cfg, dict):
+                        extra_cfg = OmegaConf.to_container(extra_cfg, resolve=True)
+                    runtime_cfg = getattr(prefill_cfg, "runtime", None)
+                    if runtime_cfg is None and hasattr(prefill_cfg, "get"):
+                        runtime_cfg = prefill_cfg.get("runtime")
+                    env_cfg = None
+                    if runtime_cfg is not None:
+                        env_cfg = (
+                            runtime_cfg.get("env") if hasattr(runtime_cfg, "get") else getattr(runtime_cfg, "env", None)
+                        )
+                    env_port = None
+                    if env_cfg is not None:
+                        env_port = (
+                            env_cfg.get("VLLM_MOONCAKE_BOOTSTRAP_PORT")
+                            if hasattr(env_cfg, "get")
+                            else getattr(env_cfg, "VLLM_MOONCAKE_BOOTSTRAP_PORT", None)
+                        )
+                    extra_port = extra_cfg.get("mooncake_bootstrap_port")
+                    port = (
+                        int(env_port) if env_port is not None else int(extra_port) if extra_port is not None else 25201
+                    )
+                    kv_ip = kv_cfg_dict.get("kv_ip") or "127.0.0.1"
+                    bootstrap_addr_by_prefill[prefill_idx] = f"http://{kv_ip}:{port}"
+            except Exception as exc:
+                logger.warning(
+                    "[AsyncOmniEngine] Could not extract PD bootstrap address for stage-%d: %s", prefill_idx, exc
+                )
+
+        bootstrap_addr = bootstrap_addr_by_prefill.get(prefill_ids[0]) if prefill_ids else None
 
         logger.info(
-            "[AsyncOmniEngine] PD disaggregation detected: prefill=stage-%d, decode=stage-%d, bootstrap=%s",
-            prefill_idx,
-            decode_idx,
-            bootstrap_addr,
+            "[AsyncOmniEngine] PD disaggregation detected: prefill_ids=%s, decode_ids=%s, bootstrap_by_prefill=%s",
+            prefill_ids,
+            decode_ids,
+            bootstrap_addr_by_prefill,
         )
-        prefill_engine_id: str | None = None
-        try:
-            prefill_client = self.stage_clients[prefill_idx]
-            kv_cfg = getattr(getattr(prefill_client, "vllm_config", None), "kv_transfer_config", None)
-            prefill_engine_id = getattr(kv_cfg, "engine_id", None)
-        except Exception as exc:
-            logger.warning("[AsyncOmniEngine] Could not extract prefill engine_id: %s", exc)
+        prefill_engine_id_by_prefill: dict[int, str] = {}
+        for prefill_idx in prefill_ids:
+            try:
+                prefill_client = self.stage_clients[prefill_idx]
+                kv_cfg = getattr(getattr(prefill_client, "vllm_config", None), "kv_transfer_config", None)
+                prefill_engine_id = getattr(kv_cfg, "engine_id", None)
+                if prefill_engine_id is not None:
+                    prefill_engine_id_by_prefill[prefill_idx] = prefill_engine_id
+            except Exception as exc:
+                logger.warning(
+                    "[AsyncOmniEngine] Could not extract prefill engine_id for stage-%d: %s", prefill_idx, exc
+                )
+
+        decode_pick_strategy = "round_robin"
+        # Env var wins over YAML (docs table: env > YAML > default).
+        env_decode_strategy = os.getenv("VLLM_OMNI_PD_DECODE_PICK_STRATEGY") or None
+        if env_decode_strategy:
+            env_decode_strategy = env_decode_strategy.strip().lower()
+            if env_decode_strategy in ("round_robin", "least_inflight"):
+                decode_pick_strategy = env_decode_strategy
+            else:
+                logger.warning(
+                    "[AsyncOmniEngine] Ignoring unknown VLLM_OMNI_PD_DECODE_PICK_STRATEGY=%r; "
+                    "allowed: round_robin, least_inflight",
+                    env_decode_strategy,
+                )
+        if decode_pick_strategy == "round_robin":
+            try:
+                if self.config_path:
+                    raw_cfg = OmegaConf.load(self.config_path)
+                    configured_strategy = raw_cfg.get("pd_decode_pick_strategy") if hasattr(raw_cfg, "get") else None
+                    if configured_strategy:
+                        decode_pick_strategy = str(configured_strategy).strip().lower()
+            except Exception as exc:
+                logger.debug("[AsyncOmniEngine] Could not read pd_decode_pick_strategy: %s", exc)
 
         return {
-            "pd_pair": (prefill_idx, decode_idx),
+            "pd_pair": pd_pair,
+            "prefill_ids": prefill_ids,
+            "decode_ids": decode_ids,
+            "decode_to_prefill": topology.get("decode_to_prefill") or {},
             "bootstrap_addr": bootstrap_addr,
-            "prefill_engine_id": prefill_engine_id,
+            "bootstrap_addr_by_prefill": bootstrap_addr_by_prefill,
+            "prefill_engine_id": prefill_engine_id_by_prefill.get(prefill_ids[0]) if prefill_ids else None,
+            "prefill_engine_id_by_prefill": prefill_engine_id_by_prefill,
+            "decode_pick_strategy": decode_pick_strategy,
         }
 
     @staticmethod

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -11,6 +11,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import json
+import os
 import queue
 import threading
 import time
@@ -876,44 +877,116 @@ class AsyncOmniEngine:
 
     def _detect_pd_config(self) -> dict[str, Any] | None:
         """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
-        Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.
+        Returns topology plus per-prefill bootstrap metadata, or None.
         """
-        pd_pair = PDDisaggregationMixin.detect_pd_separation_from_stage_configs(self.stage_configs)
-        if pd_pair is None:
+        topology = PDDisaggregationMixin.detect_pd_separation_topology(self.stage_configs)
+        if topology is None:
             return None
-        prefill_idx, decode_idx = pd_pair
+        prefill_ids = list(topology["prefill_ids"])
+        decode_ids = list(topology.get("decode_ids") or [topology["decode_id"]])
+        pd_pair = (prefill_ids[0], decode_ids[0]) if len(prefill_ids) == 1 and len(decode_ids) == 1 else None
 
-        # Extract bootstrap address from prefill stage engine_args
-        bootstrap_addr: str | None = None
-        try:
-            prefill_cfg = self.stage_configs[prefill_idx]
-            ea = getattr(prefill_cfg, "engine_args", None)
-            kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
-            if kv_cfg is not None:
-                port = vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT
-                kv_ip = getattr(kv_cfg, "kv_ip", None) or "127.0.0.1"
-                bootstrap_addr = f"http://{kv_ip}:{port}"
-        except Exception as exc:
-            logger.warning("[AsyncOmniEngine] Could not extract PD bootstrap address: %s", exc)
+        # Extract producer bootstrap addresses from prefill stage configs.
+        # Do not read vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT here: this code runs
+        # in the APIServer process, while MooncakeConnector reads the per-stage
+        # runtime.env inside worker subprocesses. Reading the parent env would
+        # usually return vLLM's default 8998 and make decode connect to the wrong
+        # bootstrap server.
+        bootstrap_addr_by_prefill: dict[int, str] = {}
+        for prefill_idx in prefill_ids:
+            try:
+                prefill_cfg = self.stage_configs[prefill_idx]
+                ea = getattr(prefill_cfg, "engine_args", None)
+                kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
+                if kv_cfg is None and hasattr(ea, "get"):
+                    kv_cfg = ea.get("kv_transfer_config")
+                if kv_cfg is not None:
+                    kv_cfg_dict = (
+                        OmegaConf.to_container(kv_cfg, resolve=True) if not isinstance(kv_cfg, dict) else kv_cfg
+                    )
+                    extra_cfg = kv_cfg_dict.get("kv_connector_extra_config", {}) or {}
+                    if not isinstance(extra_cfg, dict):
+                        extra_cfg = OmegaConf.to_container(extra_cfg, resolve=True)
+                    runtime_cfg = getattr(prefill_cfg, "runtime", None)
+                    if runtime_cfg is None and hasattr(prefill_cfg, "get"):
+                        runtime_cfg = prefill_cfg.get("runtime")
+                    env_cfg = None
+                    if runtime_cfg is not None:
+                        env_cfg = (
+                            runtime_cfg.get("env") if hasattr(runtime_cfg, "get") else getattr(runtime_cfg, "env", None)
+                        )
+                    env_port = None
+                    if env_cfg is not None:
+                        env_port = (
+                            env_cfg.get("VLLM_MOONCAKE_BOOTSTRAP_PORT")
+                            if hasattr(env_cfg, "get")
+                            else getattr(env_cfg, "VLLM_MOONCAKE_BOOTSTRAP_PORT", None)
+                        )
+                    extra_port = extra_cfg.get("mooncake_bootstrap_port")
+                    port = (
+                        int(env_port) if env_port is not None else int(extra_port) if extra_port is not None else 25201
+                    )
+                    kv_ip = kv_cfg_dict.get("kv_ip") or "127.0.0.1"
+                    bootstrap_addr_by_prefill[prefill_idx] = f"http://{kv_ip}:{port}"
+            except Exception as exc:
+                logger.warning(
+                    "[AsyncOmniEngine] Could not extract PD bootstrap address for stage-%d: %s", prefill_idx, exc
+                )
+
+        bootstrap_addr = bootstrap_addr_by_prefill.get(prefill_ids[0]) if prefill_ids else None
 
         logger.info(
-            "[AsyncOmniEngine] PD disaggregation detected: prefill=stage-%d, decode=stage-%d, bootstrap=%s",
-            prefill_idx,
-            decode_idx,
-            bootstrap_addr,
+            "[AsyncOmniEngine] PD disaggregation detected: prefill_ids=%s, decode_ids=%s, bootstrap_by_prefill=%s",
+            prefill_ids,
+            decode_ids,
+            bootstrap_addr_by_prefill,
         )
-        prefill_engine_id: str | None = None
-        try:
-            prefill_client = self.stage_clients[prefill_idx]
-            kv_cfg = getattr(getattr(prefill_client, "vllm_config", None), "kv_transfer_config", None)
-            prefill_engine_id = getattr(kv_cfg, "engine_id", None)
-        except Exception as exc:
-            logger.warning("[AsyncOmniEngine] Could not extract prefill engine_id: %s", exc)
+        prefill_engine_id_by_prefill: dict[int, str] = {}
+        for prefill_idx in prefill_ids:
+            try:
+                prefill_client = self.stage_clients[prefill_idx]
+                kv_cfg = getattr(getattr(prefill_client, "vllm_config", None), "kv_transfer_config", None)
+                prefill_engine_id = getattr(kv_cfg, "engine_id", None)
+                if prefill_engine_id is not None:
+                    prefill_engine_id_by_prefill[prefill_idx] = prefill_engine_id
+            except Exception as exc:
+                logger.warning(
+                    "[AsyncOmniEngine] Could not extract prefill engine_id for stage-%d: %s", prefill_idx, exc
+                )
+
+        decode_pick_strategy = "round_robin"
+        # Env var wins over YAML (docs table: env > YAML > default).
+        env_decode_strategy = os.getenv("VLLM_OMNI_PD_DECODE_PICK_STRATEGY") or None
+        if env_decode_strategy:
+            env_decode_strategy = env_decode_strategy.strip().lower()
+            if env_decode_strategy in ("round_robin", "least_inflight"):
+                decode_pick_strategy = env_decode_strategy
+            else:
+                logger.warning(
+                    "[AsyncOmniEngine] Ignoring unknown VLLM_OMNI_PD_DECODE_PICK_STRATEGY=%r; "
+                    "allowed: round_robin, least_inflight",
+                    env_decode_strategy,
+                )
+        if decode_pick_strategy == "round_robin":
+            try:
+                if self.config_path:
+                    raw_cfg = OmegaConf.load(self.config_path)
+                    configured_strategy = raw_cfg.get("pd_decode_pick_strategy") if hasattr(raw_cfg, "get") else None
+                    if configured_strategy:
+                        decode_pick_strategy = str(configured_strategy).strip().lower()
+            except Exception as exc:
+                logger.debug("[AsyncOmniEngine] Could not read pd_decode_pick_strategy: %s", exc)
 
         return {
-            "pd_pair": (prefill_idx, decode_idx),
+            "pd_pair": pd_pair,
+            "prefill_ids": prefill_ids,
+            "decode_ids": decode_ids,
+            "decode_to_prefill": topology.get("decode_to_prefill") or {},
             "bootstrap_addr": bootstrap_addr,
-            "prefill_engine_id": prefill_engine_id,
+            "bootstrap_addr_by_prefill": bootstrap_addr_by_prefill,
+            "prefill_engine_id": prefill_engine_id_by_prefill.get(prefill_ids[0]) if prefill_ids else None,
+            "prefill_engine_id_by_prefill": prefill_engine_id_by_prefill,
+            "decode_pick_strategy": decode_pick_strategy,
         }
 
     @staticmethod
@@ -1910,3 +1983,4 @@ class AsyncOmniEngine:
             self.shutdown()
         except Exception:
             logger.exception(*args, **kwargs)
+

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -268,10 +268,11 @@ def _with_qwen3_tts_pd_decode_state(prompt: dict[str, Any], state: dict[str, Any
     prompt_token_ids = merged_prompt.get("prompt_token_ids")
     if not isinstance(prompt_token_ids, (list, tuple)):
         raise TypeError("Qwen3-TTS PD decode requires prompt_token_ids")
-    # Keep D's sequence length equal to P's transferred KV prefix. Mooncake
-    # requires matching block counts and the first local decode position is
-    # filled with `resume_token_id` by GPUModelRunner after the prefix loads.
-    merged_prompt["prompt_token_ids"] = list(prompt_token_ids)
+    # vLLM's remote-prefill contract leaves the final prompt token for D to
+    # compute locally. Append P's sampled y0 as that final token: Mooncake
+    # loads the original prompt KV, then D computes y0 and samples y1 without
+    # emitting a duplicate sample from the prompt's last token.
+    merged_prompt["prompt_token_ids"] = [*prompt_token_ids, resume_token_id]
 
     additional_information = merged_prompt.get("additional_information")
     if additional_information is None:
@@ -293,9 +294,8 @@ def _with_qwen3_tts_pd_decode_state(prompt: dict[str, Any], state: dict[str, Any
             raise TypeError(f"Qwen3-TTS PD decode additional_information.{category} must be a dictionary")
         target.update(values)
         additional_information[category] = target
-    # D receives P's KV only through the original prompt. Its runner injects
-    # this sampled codec token into the first local decode position after the
-    # remote prefix has loaded.
+    # Keep y0 in runtime metadata as well: model preprocessing uses it to
+    # recognize the appended final prompt row as a decode/MTP step.
     meta = additional_information.setdefault("meta", {})
     if not isinstance(meta, dict):
         raise TypeError("Qwen3-TTS PD decode additional_information.meta must be a dictionary")
@@ -2654,6 +2654,13 @@ class Orchestrator:
         decode engine where to pull the KV cache from (prefill engine's bootstrap addr).
         """
         sp = sp.clone()
+        if getattr(sp, "max_tokens", None) is not None:
+            remaining_max_tokens = int(sp.max_tokens) - 1
+            if remaining_max_tokens <= 0:
+                raise ValueError("PD decode requires at least one token after P-side y0")
+            sp.max_tokens = remaining_max_tokens
+        if hasattr(sp, "min_tokens"):
+            sp.min_tokens = max(0, int(getattr(sp, "min_tokens", 0) or 0) - 1)
         if main_sampler_seed is not None:
             sp.seed = int(main_sampler_seed)
         if sp.extra_args is None:
@@ -2662,7 +2669,7 @@ class Orchestrator:
             # P only samples layer-0 token y0; D performs the first residual
             # codebook (Talker MTP) sample. Forward the request seed so D can
             # create its request-local MTP generator from the initial state.
-            sp.extra_args["tts_local_seed"] = int(main_sampler_seed)
+            sp.extra_args.setdefault("tts_local_seed", int(main_sampler_seed))
 
         # Get KV params captured from the prefill output (must include remote_request_id).
         kv_prefill_params = self._pd_kv_params.pop(req_id, None)

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -2551,11 +2551,6 @@ class Orchestrator:
         # [PD] The PD prefill stage MUST be exempt from the async-chunk early
         # return: PD yamls set async_chunk: true, so returning here drops every
         # prefill->decode handoff and D silently regenerates from scratch.
-        if self._pd_trace_enabled:
-            logger.info(
-                "[PD_TRACE] kvready_enter stage=%d async_chunk=%s is_pd_prefill=%s n_out=%d",
-                stage_id, self.async_chunk, self._is_pd_prefill_stage(stage_id), len(raw_outputs.outputs),
-            )
         if self.async_chunk and not self._is_pd_prefill_stage(stage_id):
             return
 
@@ -2569,11 +2564,6 @@ class Orchestrator:
             is_pd_prefill = self._is_pd_prefill_stage(stage_id)
             pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
             kv_extraction_ack = bool(kv_params.get("kv_ready"))
-            if self._pd_trace_enabled:
-                logger.info(
-                    "[PD_TRACE] kvready_probe req=%s stage=%d is_pd_prefill=%s submit_ready=%s ack=%s keys=%s",
-                    req_id, stage_id, is_pd_prefill, pd_submit_ready, kv_extraction_ack, sorted(kv_params),
-                )
             if not pd_submit_ready and not kv_extraction_ack:
                 continue
             # The extraction ACK arrives only after D has pulled KV. It is a
@@ -3022,15 +3012,6 @@ class Orchestrator:
                     pd_decode_state,
                 )
 
-            if self._pd_trace_enabled:
-                _dp_ai = decode_prompt.get("additional_information")
-                logger.info(
-                    "[PD_TRACE] decode_build req=%s next=%d ai_keys=%s meta=%s n_tok=%d",
-                    req_id, next_logical,
-                    sorted(_dp_ai) if isinstance(_dp_ai, dict) else None,
-                    (_dp_ai.get("meta") if isinstance(_dp_ai, dict) else None),
-                    len(decode_prompt.get("prompt_token_ids") or []),
-                )
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=decode_prompt,
@@ -3040,11 +3021,6 @@ class Orchestrator:
                 resumable=next_stage_resumable,
             )
             request.external_req_id = request.request_id
-            if self._pd_trace_enabled:
-                logger.info(
-                    "[PD_TRACE] decode_submit req=%s next=%d already_submitted=%s submit_ts_keys=%s",
-                    req_id, next_logical, already_submitted, sorted(req_state.stage_submit_ts),
-                )
             if already_submitted:
                 replica_id = await next_pool.submit_update(req_id, req_state, request)
             else:
@@ -3373,9 +3349,6 @@ class Orchestrator:
             # stage_submit_ts, makes _pd_decode_already_submitted() true, and the
             # real handoff is then silently dropped -- D regenerates the whole
             # utterance from scratch (~65s of audio instead of ~4s).
-            if self._pd_trace_enabled:
-                logger.info("[PD_TRACE] prewarm_check stage=%d is_pd_decode=%s decode_ids=%s",
-                            next_stage_id, self._is_pd_decode_stage(next_stage_id), self._pd_decode_ids)
             if self._is_pd_decode_stage(next_stage_id):
                 continue
             # PD prefill siblings likewise receive KV via Mooncake, not chunks.

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -537,15 +537,40 @@ class Orchestrator:
             for replica_id in pool.available_replica_ids():
                 self._orch_monitor.register_replica(stage_id, replica_id)
 
+        # Maps src-stage -> downstream stages; PD fan-in/fan-out pipelines
+        # (e.g. 1P3D) are not numerically adjacent, so routing must consult this.
+        self._downstream_stage_ids: dict[int, list[int]] = self._build_downstream_stage_ids(stage_pools)
         # PD disaggregation state
         self._pd_pair: tuple[int, int] | None = None
+        self._pd_prefill_ids: list[int] = []
+        self._pd_decode_ids: list[int] = []
+        self._pd_decode_to_prefill: dict[int, list[int]] = {}
         self._pd_bootstrap_addr: str | None = None
+        self._pd_bootstrap_addr_by_prefill: dict[int, str] = {}
         self._pd_prefill_engine_id: str | None = None
+        self._pd_prefill_engine_id_by_prefill: dict[int, str] = {}
+        self._pd_decode_pick_strategy: str = "round_robin"
+        self._pd_decode_round_robin_idx: int = 0
+        self._pd_decode_inflight: dict[int, int] = {}
+        self._pd_request_to_decode: dict[str, int] = {}
         self._pd_kv_params: dict[str, Any] = {}
         if pd_config is not None:
             self._pd_pair = pd_config.get("pd_pair")
+            self._pd_prefill_ids = list(
+                pd_config.get("prefill_ids") or ([] if self._pd_pair is None else [self._pd_pair[0]])
+            )
+            self._pd_decode_ids = list(
+                pd_config.get("decode_ids") or ([] if self._pd_pair is None else [self._pd_pair[1]])
+            )
+            self._pd_decode_to_prefill = {
+                int(k): list(v) for k, v in dict(pd_config.get("decode_to_prefill") or {}).items()
+            }
             self._pd_bootstrap_addr = pd_config.get("bootstrap_addr")
+            self._pd_bootstrap_addr_by_prefill = dict(pd_config.get("bootstrap_addr_by_prefill") or {})
             self._pd_prefill_engine_id = pd_config.get("prefill_engine_id")
+            self._pd_prefill_engine_id_by_prefill = dict(pd_config.get("prefill_engine_id_by_prefill") or {})
+            self._pd_decode_pick_strategy = str(pd_config.get("decode_pick_strategy") or "round_robin").lower()
+            self._pd_decode_inflight = {d_id: 0 for d_id in self._pd_decode_ids}
         self.request_states: dict[str, OrchestratorRequestState] = {}
         self._init_metrics_state(
             stage_pools,
@@ -593,6 +618,39 @@ class Orchestrator:
 
         # Distributed membership (optional, injected by DistStageRuntime)
         self._membership = membership_controller
+
+    @staticmethod
+    def _build_downstream_stage_ids(stage_pools: list[StagePool]) -> dict[int, list[int]]:
+        """Build src-stage -> downstream-stage mapping from stage metadata.
+
+        Legacy linear pipelines omit ``engine_input_source`` on some stages, so
+        callers still fall back to ``stage_id + 1`` when no explicit mapping is
+        present. Non-linear fan-in/fan-out pipelines (for example 1P3D where
+        stage-1/2/3 all feed stage-4) must use this mapping instead of numeric
+        adjacency.
+        """
+        downstream: dict[int, list[int]] = {}
+        for dst_id, pool in enumerate(stage_pools):
+            sources = list(getattr(pool.stage_client, "engine_input_source", None) or [])
+            for src_id in sources:
+                if not isinstance(src_id, int):
+                    try:
+                        src_id = int(src_id)
+                    except (TypeError, ValueError):
+                        continue
+                downstream.setdefault(src_id, []).append(dst_id)
+        return downstream
+
+    def _resolve_next_stage_id(self, src_stage_id: int) -> int:
+        candidates = self._downstream_stage_ids.get(src_stage_id) or []
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            non_pd_decode = [stage_id for stage_id in candidates if not self._is_pd_decode_stage(stage_id)]
+            if len(non_pd_decode) == 1:
+                return non_pd_decode[0]
+            raise RuntimeError(f"[Orchestrator] Ambiguous downstream stages for stage-{src_stage_id}: {candidates}")
+        return src_stage_id + 1
 
     def _init_metrics_state(
         self,
@@ -810,7 +868,13 @@ class Orchestrator:
 
     async def _handle_add_request(self, msg: StageSubmissionMessage) -> None:
         """Handle an add_request message from the main thread."""
-        stage_id = 0
+        # [PD] M-P-N-D: enter at the prefill stage the caller already picked
+        # rather than assuming the entry stage is always stage 0.
+        bound_p = getattr(msg, "bound_prefill_stage_id", None)
+        if bound_p is not None and 0 <= bound_p < len(self.stage_pools):
+            stage_id = bound_p
+        else:
+            stage_id = 0
         request_id = msg.request_id
         prompt = msg.prompt
         original_prompt = msg.original_prompt
@@ -872,7 +936,9 @@ class Orchestrator:
         ):
             return
 
-        if self.async_chunk and stage_id == 0 and final_stage_id > 0:
+        # [PD] The async-chunk prewarm must fire on the request's ENTRY stage,
+        # which for PD is a prefill stage rather than stage 0.
+        if self.async_chunk and (stage_id == 0 or self._is_pd_prefill_stage(stage_id)) and final_stage_id > 0:
             await self._prewarm_async_chunk_stages(request_id, prompt, req_state)
 
     async def _handle_streaming_update(self, msg: StageSubmissionMessage) -> None:
@@ -2482,7 +2548,15 @@ class Orchestrator:
         raw_outputs: EngineCoreOutputs,
     ) -> None:
         """Forward split requests once stage-0 KV is ready."""
-        if self.async_chunk:
+        # [PD] The PD prefill stage MUST be exempt from the async-chunk early
+        # return: PD yamls set async_chunk: true, so returning here drops every
+        # prefill->decode handoff and D silently regenerates from scratch.
+        if self._pd_trace_enabled:
+            logger.info(
+                "[PD_TRACE] kvready_enter stage=%d async_chunk=%s is_pd_prefill=%s n_out=%d",
+                stage_id, self.async_chunk, self._is_pd_prefill_stage(stage_id), len(raw_outputs.outputs),
+            )
+        if self.async_chunk and not self._is_pd_prefill_stage(stage_id):
             return
 
         for raw_output in raw_outputs.outputs:
@@ -2495,6 +2569,11 @@ class Orchestrator:
             is_pd_prefill = self._is_pd_prefill_stage(stage_id)
             pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
             kv_extraction_ack = bool(kv_params.get("kv_ready"))
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] kvready_probe req=%s stage=%d is_pd_prefill=%s submit_ready=%s ack=%s keys=%s",
+                    req_id, stage_id, is_pd_prefill, pd_submit_ready, kv_extraction_ack, sorted(kv_params),
+                )
             if not pd_submit_ready and not kv_extraction_ack:
                 continue
             # The extraction ACK arrives only after D has pulled KV. It is a
@@ -2515,7 +2594,13 @@ class Orchestrator:
                 continue
             if stage_id >= req_state.final_stage_id:
                 continue
-            if (stage_id + 1) in req_state.stage_submit_ts:
+            # [PD] A prefill stage routes to a decode replica chosen by the pick
+            # strategy, which is not stage_id+1, so the dedupe check must ask
+            # whether ANY decode stage already has this request.
+            if self._is_pd_prefill_stage(stage_id):
+                if self._pd_decode_already_submitted(req_state):
+                    continue
+            elif (stage_id + 1) in req_state.stage_submit_ts:
                 continue
 
             # [PD] Qwen3-TTS prefill hands off non-KV state (hidden_states / codes /
@@ -2702,7 +2787,21 @@ class Orchestrator:
         is_final_update: bool = False,
     ) -> None:
         """Forward output from the current logical stage to the next one."""
-        next_logical = src_stage_id + 1
+        # [PD] A prefill stage does not hand off to stage_id+1: it routes to a
+        # decode replica chosen by the pick strategy. Without this the decode
+        # branch below never runs, so D never receives P's resume token and
+        # regenerates the whole utterance from scratch.
+        pd_prefill_forward = self._is_pd_prefill_stage(src_stage_id) and self._pd_decode_ids
+        if pd_prefill_forward:
+            next_logical = self._pick_pd_decode_stage(req_id, src_stage_id)
+            if next_logical in req_state.final_output_stage_ids:
+                other_decode_finals = req_state.final_output_stage_ids.intersection(self._pd_decode_ids) - {
+                    next_logical
+                }
+                if other_decode_finals:
+                    req_state.final_output_stage_ids.difference_update(other_decode_finals)
+        else:
+            next_logical = self._resolve_next_stage_id(src_stage_id)
         next_pool = self.stage_pools[next_logical]
         if not next_pool.live_replica_ids():
             # The downstream stage lost all of its replicas before this in-flight
@@ -2713,7 +2812,11 @@ class Orchestrator:
         params = req_state.sampling_params_list[next_logical]
         source_outputs = [output]
         next_stage_resumable = is_streaming_session and not is_final_update
-        already_submitted = self._next_stage_already_submitted(src_stage_id, req_state)
+        already_submitted = (
+            next_logical in req_state.stage_submit_ts
+            if pd_prefill_forward
+            else self._next_stage_already_submitted(src_stage_id, req_state)
+        )
         requires_multimodal_data = getattr(next_client, "requires_multimodal_data", False)
         _t_submit_start = _time.perf_counter()
 
@@ -2919,6 +3022,15 @@ class Orchestrator:
                     pd_decode_state,
                 )
 
+            if self._pd_trace_enabled:
+                _dp_ai = decode_prompt.get("additional_information")
+                logger.info(
+                    "[PD_TRACE] decode_build req=%s next=%d ai_keys=%s meta=%s n_tok=%d",
+                    req_id, next_logical,
+                    sorted(_dp_ai) if isinstance(_dp_ai, dict) else None,
+                    (_dp_ai.get("meta") if isinstance(_dp_ai, dict) else None),
+                    len(decode_prompt.get("prompt_token_ids") or []),
+                )
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=decode_prompt,
@@ -2928,6 +3040,11 @@ class Orchestrator:
                 resumable=next_stage_resumable,
             )
             request.external_req_id = request.request_id
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] decode_submit req=%s next=%d already_submitted=%s submit_ts_keys=%s",
+                    req_id, next_logical, already_submitted, sorted(req_state.stage_submit_ts),
+                )
             if already_submitted:
                 replica_id = await next_pool.submit_update(req_id, req_state, request)
             else:
@@ -3132,6 +3249,25 @@ class Orchestrator:
             return False
 
         for next_stage_id in range(1, req_state.final_stage_id + 1):
+            # [PD] Never prewarm a PD decode replica (or a stage fed by one).
+            # Decode gets its input from the prefill handoff that carries P's KV
+            # plus the resume token; a placeholder prewarm here stamps
+            # stage_submit_ts, makes _pd_decode_already_submitted() true, and the
+            # real handoff is then silently dropped -- D regenerates the whole
+            # utterance from scratch (~65s of audio instead of ~4s).
+            if self._pd_trace_enabled:
+                logger.info("[PD_TRACE] prewarm_check stage=%d is_pd_decode=%s decode_ids=%s",
+                            next_stage_id, self._is_pd_decode_stage(next_stage_id), self._pd_decode_ids)
+            if self._is_pd_decode_stage(next_stage_id):
+                continue
+            # PD prefill siblings likewise receive KV via Mooncake, not chunks.
+            if self._is_pd_prefill_stage(next_stage_id):
+                continue
+            pd_input_sources = list(
+                getattr(self.stage_pools[next_stage_id].stage_client, "engine_input_source", None) or []
+            )
+            if any(self._is_pd_decode_stage(src_id) for src_id in pd_input_sources):
+                continue
             next_pool = self.stage_pools[next_stage_id]
             params = req_state.sampling_params_list[next_stage_id]
             if not self._stage_receives_async_chunks(next_stage_id):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -35,6 +35,7 @@ from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
+from vllm_omni.data_entry_keys import unflatten_payload
 from vllm_omni.distributed.omni_connectors.utils.config import stage_receives_chunks
 from vllm_omni.engine import OmniEngineCoreRequest
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
@@ -56,7 +57,6 @@ from vllm_omni.engine.messages import (
     UnregisterRemoteReplicaMessage,
 )
 from vllm_omni.engine.orchestrator_monitor import create_orch_monitor, replica_key
-from vllm_omni.data_entry_keys import unflatten_payload
 from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool, StageUnavailableError
 from vllm_omni.errors import DEFAULT_CLIENT_ERROR_TYPE
@@ -2602,9 +2602,7 @@ class Orchestrator:
                 # earlier output recorded it, then add this submit-ready event.
                 previous_kv_params = self._pd_kv_params.get(req_id, {})
                 previous_kv_params = (
-                    dict(previous_kv_params)
-                    if isinstance(previous_kv_params, dict)
-                    else dict(previous_kv_params)
+                    dict(previous_kv_params) if isinstance(previous_kv_params, dict) else dict(previous_kv_params)
                 )
                 self._pd_kv_params[req_id] = {**previous_kv_params, **kv_params}
                 resume_token_ids = list(getattr(raw_output, "new_token_ids", None) or [])
@@ -2660,6 +2658,11 @@ class Orchestrator:
             sp.seed = int(main_sampler_seed)
         if sp.extra_args is None:
             sp.extra_args = {}
+        if main_sampler_seed is not None:
+            # P only samples layer-0 token y0; D performs the first residual
+            # codebook (Talker MTP) sample. Forward the request seed so D can
+            # create its request-local MTP generator from the initial state.
+            sp.extra_args["tts_local_seed"] = int(main_sampler_seed)
 
         # Get KV params captured from the prefill output (must include remote_request_id).
         kv_prefill_params = self._pd_kv_params.pop(req_id, None)
@@ -2681,11 +2684,7 @@ class Orchestrator:
         # Overlay transport metadata from prefill. Lifecycle events are
         # orchestrator-local and must not leak into the consumer connector.
         decode_kv_params.update(
-            {
-                key: value
-                for key, value in kv_prefill_params.items()
-                if key not in {"pd_submit_ready", "kv_ready"}
-            }
+            {key: value for key, value in kv_prefill_params.items() if key not in {"pd_submit_ready", "kv_ready"}}
         )
 
         # Ensure these flags are set correctly after any overlay.

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -3075,9 +3075,21 @@ class Orchestrator:
                     _tx_ms,
                     self._pd_decode_inflight,
                 )
-            # NOTE: the inline async-chunk prewarm loop that used to live here was
-            # refactored upstream in 0.26 into _prewarm_async_chunk_stages(), which
-            # is driven from the request-admission path instead.
+            # [PD] stage2 (code2wav) is deliberately NOT prewarmed at admission:
+            # its engine_input_source is the decode replica, which is unknown until
+            # the pick strategy runs. Prewarm it here, now that next_logical is
+            # known. Without this the code2wav stage is never submitted, so decode
+            # generates codec tokens that nobody consumes and no audio is produced.
+            if self.async_chunk:
+                for downstream_stage_id in self._downstream_stage_ids.get(next_logical, []):
+                    if downstream_stage_id not in req_state.stage_submit_ts:
+                        await self._prewarm_async_chunk_stage(
+                            req_id,
+                            req_state.prompt,
+                            req_state,
+                            downstream_stage_id,
+                            source_stage_id=next_logical,
+                        )
             return
 
         if req_state.pd_prefill_multimodal_output is not None:
@@ -3201,6 +3213,112 @@ class Orchestrator:
             to_stage=next_logical,
             to_pool=next_pool,
             request_id=req_id,
+            tx_ms=_tx_ms,
+        )
+
+    @staticmethod
+    def _with_omni_source_stage(prompt: dict[str, Any], src_stage_id: int) -> dict[str, Any]:
+        enriched = dict(prompt)
+        additional_info = enriched.get("additional_information")
+        if isinstance(additional_info, dict):
+            additional_info = dict(additional_info)
+        else:
+            additional_info = {}
+        additional_info["omni_source_stage_id"] = [str(src_stage_id)]
+        enriched["additional_information"] = additional_info
+        return enriched
+
+    async def _prewarm_async_chunk_stage(
+        self,
+        request_id: str,
+        source_request: Any,
+        req_state: OrchestratorRequestState,
+        next_stage_id: int,
+        *,
+        source_stage_id: int,
+    ) -> None:
+        """Pre-submit one async-chunk receiver stage after its producer is known."""
+        prompt_token_ids = getattr(source_request, "prompt_token_ids", None)
+        if prompt_token_ids is None and isinstance(req_state.prompt, dict):
+            prompt_token_ids = req_state.prompt.get("prompt_token_ids")
+        if prompt_token_ids is None:
+            logger.warning(
+                "[Orchestrator] async_chunk prewarm skipped for req=%s: stage%d prompt_token_ids missing",
+                request_id,
+                source_stage_id,
+            )
+            return
+
+        next_pool = self.stage_pools[next_stage_id]
+        params = req_state.sampling_params_list[next_stage_id]
+
+        _t_submit_start = _time.perf_counter()
+
+        if next_pool.stage_type == "diffusion":
+            await next_pool.submit_initial(
+                request_id,
+                req_state,
+                req_state.prompt,
+                submit_kwargs={
+                    "kv_sender_info": self._build_kv_sender_info(
+                        list(getattr(next_pool.stage_client, "engine_input_source", None) or [source_stage_id]),
+                        request_id=request_id,
+                    )
+                },
+            )
+        else:
+            import copy
+
+            from vllm_omni.distributed.omni_connectors.adapter import compute_talker_prompt_ids_length
+
+            try:
+                next_prompt_len = max(1, compute_talker_prompt_ids_length(prompt_token_ids))
+            except Exception:
+                next_prompt_len = max(1, len(prompt_token_ids))
+
+            original_prompt = req_state.prompt
+            if isinstance(original_prompt, dict):
+                base_input = copy.deepcopy(original_prompt)
+            else:
+                base_input = {}
+
+            base_input["prompt_token_ids"] = [0] * next_prompt_len
+            base_input["multi_modal_data"] = None
+            base_input["mm_processor_kwargs"] = None
+            base_input = self._with_omni_source_stage(base_input, source_stage_id)
+            downstream_resumable = bool(getattr(source_request, "resumable", req_state.streaming.enabled))
+            request = build_engine_core_request_from_tokens(
+                request_id=request_id,
+                prompt=base_input,
+                params=params,
+                model_config=next_pool.stage_vllm_config.model_config,
+                resumable=downstream_resumable,
+            )
+            request.external_req_id = request.request_id
+            await next_pool.submit_initial(
+                request_id,
+                req_state,
+                request,
+                prompt_text=None,
+            )
+
+        req_state.stage_submit_ts[next_stage_id] = _time.time()
+        _tx_ms = (_time.perf_counter() - _t_submit_start) * 1000.0
+        src_replica = self.stage_pools[source_stage_id].get_bound_replica_id(request_id)
+        logger.info(
+            "[Orchestrator] async_chunk prewarm req=%s stage-%d->stage-%d prompt_len=%d source_replica=%s",
+            request_id,
+            source_stage_id,
+            next_stage_id,
+            len(prompt_token_ids),
+            src_replica,
+        )
+        self._emit_tx_edge(
+            from_stage=source_stage_id,
+            from_replica=src_replica if src_replica is not None else 0,
+            to_stage=next_stage_id,
+            to_pool=next_pool,
+            request_id=request_id,
             tx_ms=_tx_ms,
         )
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -56,6 +56,7 @@ from vllm_omni.engine.messages import (
     UnregisterRemoteReplicaMessage,
 )
 from vllm_omni.engine.orchestrator_monitor import create_orch_monitor, replica_key
+from vllm_omni.data_entry_keys import unflatten_payload
 from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool, StageUnavailableError
 from vllm_omni.errors import DEFAULT_CLIENT_ERROR_TYPE
@@ -197,6 +198,110 @@ def build_engine_core_request_from_tokens(
         additional_information=additional_info_payload,
         model_intermediate_buffer=model_intermediate_buffer if isinstance(model_intermediate_buffer, dict) else None,
     )
+
+
+def _pd_scalar(value: Any) -> Any:
+    if isinstance(value, torch.Tensor) and value.numel() == 1:
+        return value.item()
+    return value
+
+
+def _extract_qwen3_tts_pd_decode_state(
+    multimodal_output: Any,
+    *,
+    resume_token_id: int,
+) -> dict[str, Any] | None:
+    """Extract Qwen3-TTS non-KV state for a decode continuation."""
+    if not isinstance(multimodal_output, dict):
+        return None
+    payload = unflatten_payload(multimodal_output)
+    hidden_states = payload.get("hidden_states")
+    meta = payload.get("meta")
+    if not isinstance(hidden_states, dict) or not isinstance(meta, dict):
+        return None
+
+    last = hidden_states.get("last")
+    trailing_text = hidden_states.get("trailing_text")
+    if not isinstance(last, torch.Tensor) or not isinstance(trailing_text, torch.Tensor):
+        return None
+
+    state: dict[str, Any] = {
+        "hidden_states": {"last": last, "trailing_text": trailing_text},
+        "meta": {
+            "talker_text_offset": int(_pd_scalar(meta.get("talker_text_offset", 0)) or 0),
+            "codec_streaming": bool(_pd_scalar(meta.get("codec_streaming", False))),
+        },
+    }
+    codes = payload.get("codes")
+    if isinstance(codes, dict) and isinstance(codes.get("ref"), torch.Tensor):
+        state["codes"] = {"ref": codes["ref"]}
+    if meta.get("ref_code_len") is not None:
+        state["meta"]["ref_code_len"] = int(_pd_scalar(meta["ref_code_len"]))
+
+    pd_sampler = payload.get("pd_sampler")
+    main_generator_state = pd_sampler.get("main_generator_state") if isinstance(pd_sampler, dict) else None
+    main_sampler_seed = _pd_scalar(pd_sampler.get("seed")) if isinstance(pd_sampler, dict) else None
+    if not isinstance(main_generator_state, torch.Tensor) or main_generator_state.dtype != torch.uint8:
+        raise RuntimeError("Qwen3-TTS PD prefill state is missing main sampler RNG state")
+    try:
+        main_sampler_seed = int(main_sampler_seed)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Qwen3-TTS PD prefill state has invalid main sampler seed") from exc
+    state["pd_sampler"] = {
+        "main_generator_state": main_generator_state,
+        "seed": main_sampler_seed,
+    }
+    # This is intentionally outside additional_information: it is a vLLM
+    # sequence token, not model-intermediate state. The D request must compute
+    # it as its first uncomputed token after restoring P's prompt KV.
+    state["_pd_resume_token_id"] = int(resume_token_id)
+    return state
+
+
+def _with_qwen3_tts_pd_decode_state(prompt: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    """Merge P-worker state and its sampled codec token into a D request."""
+    resume_token_id = state.get("_pd_resume_token_id")
+    if not isinstance(resume_token_id, int):
+        raise RuntimeError("Qwen3-TTS PD decode state is missing the prefill resume token")
+
+    merged_prompt = dict(prompt)
+    prompt_token_ids = merged_prompt.get("prompt_token_ids")
+    if not isinstance(prompt_token_ids, (list, tuple)):
+        raise TypeError("Qwen3-TTS PD decode requires prompt_token_ids")
+    # Keep D's sequence length equal to P's transferred KV prefix. Mooncake
+    # requires matching block counts and the first local decode position is
+    # filled with `resume_token_id` by GPUModelRunner after the prefix loads.
+    merged_prompt["prompt_token_ids"] = list(prompt_token_ids)
+
+    additional_information = merged_prompt.get("additional_information")
+    if additional_information is None:
+        additional_information = {}
+    elif not isinstance(additional_information, dict):
+        raise TypeError("Qwen3-TTS PD decode requires dictionary additional_information")
+    else:
+        additional_information = dict(additional_information)
+
+    for category, values in state.items():
+        if not isinstance(values, dict):
+            continue
+        existing = additional_information.get(category)
+        if existing is None:
+            target: dict[str, Any] = {}
+        elif isinstance(existing, dict):
+            target = dict(existing)
+        else:
+            raise TypeError(f"Qwen3-TTS PD decode additional_information.{category} must be a dictionary")
+        target.update(values)
+        additional_information[category] = target
+    # D receives P's KV only through the original prompt. Its runner injects
+    # this sampled codec token into the first local decode position after the
+    # remote prefix has loaded.
+    meta = additional_information.setdefault("meta", {})
+    if not isinstance(meta, dict):
+        raise TypeError("Qwen3-TTS PD decode additional_information.meta must be a dictionary")
+    meta["pd_resume_token_id"] = resume_token_id
+    merged_prompt["additional_information"] = additional_information
+    return merged_prompt
 
 
 @dataclass
@@ -418,6 +523,7 @@ class Orchestrator:
         self.rpc_async_queue = rpc_async_queue
 
         self.async_chunk = bool(async_chunk)
+        self._pd_trace_enabled = os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
         self.num_stages = len(stage_pools)
         self.stage_pools: list[StagePool] = stage_pools
         self.log_stats = log_stats
@@ -1801,6 +1907,8 @@ class Orchestrator:
             self._release_request_bindings(cleanup_ids)
             for request_id in cleanup_ids:
                 self._pd_kv_params.pop(request_id, None)
+                # [PD] Free the decode-replica inflight slot for this request.
+                self._release_pd_decode_for_request(request_id)
                 req_state = self.request_states.pop(request_id, None)
                 if req_state is not None:
                     cleanup_request_artifact_dirs(getattr(req_state, "request_artifact_dirs", ()))
@@ -1814,6 +1922,65 @@ class Orchestrator:
         if closing_session_ids and self.duplex_control_plane is not None:
             self.duplex_control_plane.finalize_closed_sessions(closing_session_ids)
         return abort_outputs
+
+    def _is_pd_prefill_stage(self, stage_id: int) -> bool:
+        return stage_id in self._pd_prefill_ids
+
+    def _is_pd_decode_stage(self, stage_id: int) -> bool:
+        return stage_id in self._pd_decode_ids
+
+    def _pd_decode_already_submitted(self, req_state: OrchestratorRequestState) -> bool:
+        return any(d_id in req_state.stage_submit_ts for d_id in self._pd_decode_ids)
+
+    def _peek_pd_decode_for_request(self, req_id: str) -> int | None:
+        return self._pd_request_to_decode.get(req_id)
+
+    def _release_pd_decode_for_request(self, req_id: str) -> int | None:
+        stage_id = self._pd_request_to_decode.pop(req_id, None)
+        if stage_id is None:
+            return None
+        cur = self._pd_decode_inflight.get(stage_id, 0)
+        self._pd_decode_inflight[stage_id] = max(0, cur - 1)
+        if self._pd_trace_enabled:
+            logger.info(
+                "[PD_TRACE] decode_release req=%s stage=%d inflight=%s",
+                req_id,
+                stage_id,
+                self._pd_decode_inflight,
+            )
+        return stage_id
+
+    def _pick_pd_decode_stage(self, req_id: str, bound_prefill_id: int | None) -> int:
+        if not self._pd_decode_ids:
+            raise RuntimeError("[Orchestrator][PD] No decode stage is configured")
+        existing = self._peek_pd_decode_for_request(req_id)
+        if existing is not None:
+            return existing
+
+        candidates = list(self._pd_decode_ids)
+        if bound_prefill_id is not None:
+            filtered = [d_id for d_id in candidates if bound_prefill_id in self._pd_decode_to_prefill.get(d_id, [])]
+            if filtered:
+                candidates = filtered
+            else:
+                logger.warning(
+                    "[Orchestrator][PD] No decode stage references bound prefill stage-%s; using all decode stages %s",
+                    bound_prefill_id,
+                    candidates,
+                )
+
+        if len(candidates) == 1:
+            chosen = candidates[0]
+        elif self._pd_decode_pick_strategy == "least_inflight":
+            chosen = min(candidates, key=lambda d_id: (self._pd_decode_inflight.get(d_id, 0), d_id))
+        else:
+            idx = self._pd_decode_round_robin_idx % len(candidates)
+            chosen = candidates[idx]
+            self._pd_decode_round_robin_idx = (self._pd_decode_round_robin_idx + 1) % max(1, len(self._pd_decode_ids))
+
+        self._pd_request_to_decode[req_id] = chosen
+        self._pd_decode_inflight[chosen] = self._pd_decode_inflight.get(chosen, 0) + 1
+        return chosen
 
     async def _apply_raw_terminal_stage_finish(
         self,
@@ -2320,11 +2487,22 @@ class Orchestrator:
 
         for raw_output in raw_outputs.outputs:
             kv_params = getattr(raw_output, "kv_transfer_params", None)
-            if not (isinstance(kv_params, dict) and kv_params.get("kv_ready")):
+            if not isinstance(kv_params, dict):
                 continue
 
             req_id = raw_output.request_id
             req_state = self.request_states.get(req_id)
+            is_pd_prefill = self._is_pd_prefill_stage(stage_id)
+            pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
+            kv_extraction_ack = bool(kv_params.get("kv_ready"))
+            if not pd_submit_ready and not kv_extraction_ack:
+                continue
+            # The extraction ACK arrives only after D has pulled KV. It is a
+            # producer-release event, not the signal to submit D; waiting for
+            # it here would form a P/D pull deadlock.
+            if is_pd_prefill and not pd_submit_ready:
+                logger.info("[PD_TRACE] qwen3_tts_kv_extraction_ack req=%s", req_id)
+                continue
             if req_state is None:
                 continue
             if self._cfg_tracker.is_companion(req_id):
@@ -2340,18 +2518,71 @@ class Orchestrator:
             if (stage_id + 1) in req_state.stage_submit_ts:
                 continue
 
+            # [PD] Qwen3-TTS prefill hands off non-KV state (hidden_states / codes /
+            # sampler RNG) plus the single sampled codec token that decode resumes
+            # from. Upstream has no equivalent -- its PD targets the Qwen3-Omni
+            # thinker, which needs only KV.
+            if self._is_pd_prefill_stage(stage_id):
+                # Keep producer metadata (notably remote_request_id) if an
+                # earlier output recorded it, then add this submit-ready event.
+                previous_kv_params = self._pd_kv_params.get(req_id, {})
+                previous_kv_params = (
+                    dict(previous_kv_params)
+                    if isinstance(previous_kv_params, dict)
+                    else dict(previous_kv_params)
+                )
+                self._pd_kv_params[req_id] = {**previous_kv_params, **kv_params}
+                resume_token_ids = list(getattr(raw_output, "new_token_ids", None) or [])
+                if len(resume_token_ids) != 1:
+                    raise RuntimeError(
+                        "[Orchestrator][PD] Qwen3-TTS prefill must hand off exactly one sampled codec token "
+                        f"for req={req_id}; got {resume_token_ids}"
+                    )
+                pd_decode_state = _extract_qwen3_tts_pd_decode_state(
+                    getattr(raw_output, "multimodal_output", None),
+                    resume_token_id=int(resume_token_ids[0]),
+                )
+                if pd_decode_state is None:
+                    raw_pd_state = getattr(raw_output, "multimodal_output", None)
+                    raw_pd_state_keys = sorted(raw_pd_state) if isinstance(raw_pd_state, dict) else []
+                    raise RuntimeError(
+                        f"[Orchestrator][PD] Missing Qwen3-TTS decode state for req={req_id}; "
+                        f"raw_state_keys={raw_pd_state_keys}"
+                    )
+                req_state.pd_prefill_multimodal_output = pd_decode_state
+                if self._pd_trace_enabled:
+                    prefill_submitted_at = req_state.stage_submit_ts.get(stage_id, req_state.request_timestamp)
+                    logger.info(
+                        "[PD_TRACE] prefill_submit_ready req=%s stage=%d residence_ms=%.3f remote_request_id=%s "
+                        "resume_token_id=%d state_keys=%s",
+                        req_id,
+                        stage_id,
+                        (_time.time() - prefill_submitted_at) * 1000.0,
+                        bool(self._pd_kv_params[req_id].get("remote_request_id")),
+                        int(pd_decode_state["_pd_resume_token_id"]),
+                        sorted(pd_decode_state),
+                    )
+
             if self._cfg_tracker.has_companions(req_id) and not self._cfg_tracker.all_companions_done(req_id):
                 self._cfg_tracker.defer_parent(req_id, raw_output, stage_id)
             else:
                 await self._forward_to_next_stage(req_id, stage_id, raw_output, req_state)
 
-    def _build_pd_decode_params(self, req_id: str, sp: Any) -> Any:
+    def _build_pd_decode_params(
+        self,
+        req_id: str,
+        sp: Any,
+        prefill_stage_id: int | None = None,
+        main_sampler_seed: int | None = None,
+    ) -> Any:
         """Build decode-side sampling params with KV transfer params for PD routing.
 
         Clones the sampling params and injects kv_transfer_params that tell the
         decode engine where to pull the KV cache from (prefill engine's bootstrap addr).
         """
         sp = sp.clone()
+        if main_sampler_seed is not None:
+            sp.seed = int(main_sampler_seed)
         if sp.extra_args is None:
             sp.extra_args = {}
 
@@ -2372,8 +2603,15 @@ class Orchestrator:
         if self._pd_prefill_engine_id:
             decode_kv_params["remote_engine_id"] = self._pd_prefill_engine_id
 
-        # Overlay params from prefill side (includes remote_request_id set by monkey patch).
-        decode_kv_params.update(kv_prefill_params)
+        # Overlay transport metadata from prefill. Lifecycle events are
+        # orchestrator-local and must not leak into the consumer connector.
+        decode_kv_params.update(
+            {
+                key: value
+                for key, value in kv_prefill_params.items()
+                if key not in {"pd_submit_ready", "kv_ready"}
+            }
+        )
 
         # Ensure these flags are set correctly after any overlay.
         decode_kv_params["do_remote_prefill"] = True
@@ -2640,46 +2878,66 @@ class Orchestrator:
             return
 
         # PD disaggregation: prefill → decode routing uses original prompt + KV transfer params
-        if self._pd_pair is not None and (src_stage_id, next_logical) == self._pd_pair:
-            params = self._build_pd_decode_params(req_id, params)
+        # [PD] Multi-replica: pd_prefill_forward is computed from the id lists
+        # rather than upstream's single self._pd_pair equality check.
+        if pd_prefill_forward:
+            pd_decode_state = req_state.pd_prefill_multimodal_output
+            if not isinstance(pd_decode_state, dict):
+                raise RuntimeError(f"[Orchestrator][PD] Missing Qwen3-TTS state before decode submit for req={req_id}")
+            pd_sampler = pd_decode_state.get("pd_sampler")
+            sampler_seed = pd_sampler.get("seed") if isinstance(pd_sampler, dict) else None
+            if not isinstance(sampler_seed, int):
+                raise RuntimeError(f"[Orchestrator][PD] Missing Qwen3-TTS main sampler seed for req={req_id}")
+            params = self._build_pd_decode_params(
+                req_id,
+                params,
+                prefill_stage_id=src_stage_id,
+                main_sampler_seed=sampler_seed,
+            )
 
             # Use the original user prompt for the decode stage (not processed embeddings)
             original_prompt = req_state.prompt
             raw_decode_inputs = [original_prompt] if not isinstance(original_prompt, list) else original_prompt
 
-            decode_inputs: list[dict[str, Any]] = []
-            for decode_input in raw_decode_inputs:
-                if isinstance(decode_input, dict):
-                    decode_inputs.append(decode_input)
-                    continue
+            if len(raw_decode_inputs) != 1:
+                raise ValueError(
+                    "[Orchestrator][PD] Qwen3-TTS PD requires exactly one decode input per request; "
+                    f"got {len(raw_decode_inputs)} for req={req_id}"
+                )
+            decode_input = raw_decode_inputs[0]
+            if isinstance(decode_input, dict):
+                decode_prompt = _with_qwen3_tts_pd_decode_state(decode_input, pd_decode_state)
+            else:
                 prompt_token_ids = getattr(decode_input, "prompt_token_ids", None)
                 if prompt_token_ids is None:
                     raise TypeError(
                         "[Orchestrator][PD] decode input must be dict or have prompt_token_ids, "
                         f"got {type(decode_input).__name__} for req={req_id}"
                     )
-                decode_inputs.append({"prompt_token_ids": list(prompt_token_ids)})
+                decode_prompt = _with_qwen3_tts_pd_decode_state(
+                    {"prompt_token_ids": list(prompt_token_ids)},
+                    pd_decode_state,
+                )
 
-            for decode_input in decode_inputs:
-                request = build_engine_core_request_from_tokens(
-                    request_id=req_id,
-                    prompt=decode_input,
-                    params=params,
-                    model_config=next_pool.stage_vllm_config.model_config,
-                    mm_features=req_state.mm_features,
-                    resumable=next_stage_resumable,
-                )
-                request.external_req_id = request.request_id
-                if already_submitted:
-                    replica_id = await next_pool.submit_update(req_id, req_state, request)
-                else:
-                    replica_id = await next_pool.submit_initial(req_id, req_state, request, prompt_text=None)
-                self._record_duplex_stage_submission(
-                    next_logical,
-                    req_id,
-                    replica_id,
-                    req_state,
-                )
+            request = build_engine_core_request_from_tokens(
+                request_id=req_id,
+                prompt=decode_prompt,
+                params=params,
+                model_config=next_pool.stage_vllm_config.model_config,
+                mm_features=req_state.mm_features,
+                resumable=next_stage_resumable,
+            )
+            request.external_req_id = request.request_id
+            if already_submitted:
+                replica_id = await next_pool.submit_update(req_id, req_state, request)
+            else:
+                replica_id = await next_pool.submit_initial(req_id, req_state, request, prompt_text=None)
+            self._record_duplex_stage_submission(
+                next_logical,
+                req_id,
+                replica_id,
+                req_state,
+            )
 
             req_state.stage_submit_ts[next_logical] = _time.time()
             _tx_ms = (_time.perf_counter() - _t_submit_start) * 1000.0
@@ -2691,6 +2949,18 @@ class Orchestrator:
                 request_id=req_id,
                 tx_ms=_tx_ms,
             )
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] prefill_to_decode_submitted req=%s stage=%d->%d submit_ms=%.3f decode_inflight=%s",
+                    req_id,
+                    src_stage_id,
+                    next_logical,
+                    _tx_ms,
+                    self._pd_decode_inflight,
+                )
+            # NOTE: the inline async-chunk prewarm loop that used to live here was
+            # refactored upstream in 0.26 into _prewarm_async_chunk_stages(), which
+            # is driven from the request-admission path instead.
             return
 
         if req_state.pd_prefill_multimodal_output is not None:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1852,11 +1852,6 @@ class Orchestrator:
         # [PD] The PD prefill stage MUST be exempt from the async-chunk early
         # return: PD yamls set async_chunk: true, so returning here drops every
         # prefill->decode handoff and D silently regenerates from scratch.
-        if self._pd_trace_enabled:
-            logger.info(
-                "[PD_TRACE] kvready_enter stage=%d async_chunk=%s is_pd_prefill=%s n_out=%d",
-                stage_id, self.async_chunk, self._is_pd_prefill_stage(stage_id), len(raw_outputs.outputs),
-            )
         if self.async_chunk and not self._is_pd_prefill_stage(stage_id):
             return
 
@@ -1870,11 +1865,6 @@ class Orchestrator:
             is_pd_prefill = self._is_pd_prefill_stage(stage_id)
             pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
             kv_extraction_ack = bool(kv_params.get("kv_ready"))
-            if self._pd_trace_enabled:
-                logger.info(
-                    "[PD_TRACE] kvready_probe req=%s stage=%d is_pd_prefill=%s submit_ready=%s ack=%s keys=%s",
-                    req_id, stage_id, is_pd_prefill, pd_submit_ready, kv_extraction_ack, sorted(kv_params),
-                )
             if not pd_submit_ready and not kv_extraction_ack:
                 continue
             # The extraction ACK arrives only after D has pulled KV. It is a
@@ -2291,15 +2281,6 @@ class Orchestrator:
                     pd_decode_state,
                 )
 
-            if self._pd_trace_enabled:
-                _dp_ai = decode_prompt.get("additional_information")
-                logger.info(
-                    "[PD_TRACE] decode_build req=%s next=%d ai_keys=%s meta=%s n_tok=%d",
-                    req_id, next_logical,
-                    sorted(_dp_ai) if isinstance(_dp_ai, dict) else None,
-                    (_dp_ai.get("meta") if isinstance(_dp_ai, dict) else None),
-                    len(decode_prompt.get("prompt_token_ids") or []),
-                )
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=decode_prompt,
@@ -2309,11 +2290,6 @@ class Orchestrator:
                 resumable=next_stage_resumable,
             )
             request.external_req_id = request.request_id
-            if self._pd_trace_enabled:
-                logger.info(
-                    "[PD_TRACE] decode_submit req=%s next=%d already_submitted=%s submit_ts_keys=%s",
-                    req_id, next_logical, already_submitted, sorted(req_state.stage_submit_ts),
-                )
             if already_submitted:
                 replica_id = await next_pool.submit_update(req_id, req_state, request)
             else:
@@ -2601,9 +2577,6 @@ class Orchestrator:
             # stage_submit_ts, makes _pd_decode_already_submitted() true, and the
             # real handoff is then silently dropped -- D regenerates the whole
             # utterance from scratch (~65s of audio instead of ~4s).
-            if self._pd_trace_enabled:
-                logger.info("[PD_TRACE] prewarm_check stage=%d is_pd_decode=%s decode_ids=%s",
-                            next_stage_id, self._is_pd_decode_stage(next_stage_id), self._pd_decode_ids)
             if self._is_pd_decode_stage(next_stage_id):
                 continue
             # PD prefill siblings likewise receive KV via Mooncake, not chunks.

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -2344,9 +2344,21 @@ class Orchestrator:
                     _tx_ms,
                     self._pd_decode_inflight,
                 )
-            # NOTE: the inline async-chunk prewarm loop that used to live here was
-            # refactored upstream in 0.26 into _prewarm_async_chunk_stages(), which
-            # is driven from the request-admission path instead.
+            # [PD] stage2 (code2wav) is deliberately NOT prewarmed at admission:
+            # its engine_input_source is the decode replica, which is unknown until
+            # the pick strategy runs. Prewarm it here, now that next_logical is
+            # known. Without this the code2wav stage is never submitted, so decode
+            # generates codec tokens that nobody consumes and no audio is produced.
+            if self.async_chunk:
+                for downstream_stage_id in self._downstream_stage_ids.get(next_logical, []):
+                    if downstream_stage_id not in req_state.stage_submit_ts:
+                        await self._prewarm_async_chunk_stage(
+                            req_id,
+                            req_state.prompt,
+                            req_state,
+                            downstream_stage_id,
+                            source_stage_id=next_logical,
+                        )
             return
 
         if req_state.pd_prefill_multimodal_output is not None:
@@ -2455,6 +2467,112 @@ class Orchestrator:
             to_stage=next_logical,
             to_pool=next_pool,
             request_id=req_id,
+            tx_ms=_tx_ms,
+        )
+
+    @staticmethod
+    def _with_omni_source_stage(prompt: dict[str, Any], src_stage_id: int) -> dict[str, Any]:
+        enriched = dict(prompt)
+        additional_info = enriched.get("additional_information")
+        if isinstance(additional_info, dict):
+            additional_info = dict(additional_info)
+        else:
+            additional_info = {}
+        additional_info["omni_source_stage_id"] = [str(src_stage_id)]
+        enriched["additional_information"] = additional_info
+        return enriched
+
+    async def _prewarm_async_chunk_stage(
+        self,
+        request_id: str,
+        source_request: Any,
+        req_state: OrchestratorRequestState,
+        next_stage_id: int,
+        *,
+        source_stage_id: int,
+    ) -> None:
+        """Pre-submit one async-chunk receiver stage after its producer is known."""
+        prompt_token_ids = getattr(source_request, "prompt_token_ids", None)
+        if prompt_token_ids is None and isinstance(req_state.prompt, dict):
+            prompt_token_ids = req_state.prompt.get("prompt_token_ids")
+        if prompt_token_ids is None:
+            logger.warning(
+                "[Orchestrator] async_chunk prewarm skipped for req=%s: stage%d prompt_token_ids missing",
+                request_id,
+                source_stage_id,
+            )
+            return
+
+        next_pool = self.stage_pools[next_stage_id]
+        params = req_state.sampling_params_list[next_stage_id]
+
+        _t_submit_start = _time.perf_counter()
+
+        if next_pool.stage_type == "diffusion":
+            await next_pool.submit_initial(
+                request_id,
+                req_state,
+                req_state.prompt,
+                submit_kwargs={
+                    "kv_sender_info": self._build_kv_sender_info(
+                        list(getattr(next_pool.stage_client, "engine_input_source", None) or [source_stage_id]),
+                        request_id=request_id,
+                    )
+                },
+            )
+        else:
+            import copy
+
+            from vllm_omni.distributed.omni_connectors.adapter import compute_talker_prompt_ids_length
+
+            try:
+                next_prompt_len = max(1, compute_talker_prompt_ids_length(prompt_token_ids))
+            except Exception:
+                next_prompt_len = max(1, len(prompt_token_ids))
+
+            original_prompt = req_state.prompt
+            if isinstance(original_prompt, dict):
+                base_input = copy.deepcopy(original_prompt)
+            else:
+                base_input = {}
+
+            base_input["prompt_token_ids"] = [0] * next_prompt_len
+            base_input["multi_modal_data"] = None
+            base_input["mm_processor_kwargs"] = None
+            base_input = self._with_omni_source_stage(base_input, source_stage_id)
+            downstream_resumable = bool(getattr(source_request, "resumable", req_state.streaming.enabled))
+            request = build_engine_core_request_from_tokens(
+                request_id=request_id,
+                prompt=base_input,
+                params=params,
+                model_config=next_pool.stage_vllm_config.model_config,
+                resumable=downstream_resumable,
+            )
+            request.external_req_id = request.request_id
+            await next_pool.submit_initial(
+                request_id,
+                req_state,
+                request,
+                prompt_text=None,
+            )
+
+        req_state.stage_submit_ts[next_stage_id] = _time.time()
+        _tx_ms = (_time.perf_counter() - _t_submit_start) * 1000.0
+        src_replica = self.stage_pools[source_stage_id].get_bound_replica_id(request_id)
+        logger.info(
+            "[Orchestrator] async_chunk prewarm req=%s stage-%d->stage-%d prompt_len=%d source_replica=%s",
+            request_id,
+            source_stage_id,
+            next_stage_id,
+            len(prompt_token_ids),
+            src_replica,
+        )
+        self._emit_tx_edge(
+            from_stage=source_stage_id,
+            from_replica=src_replica if src_replica is not None else 0,
+            to_stage=next_stage_id,
+            to_pool=next_pool,
+            request_id=request_id,
             tx_ms=_tx_ms,
         )
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -478,15 +478,40 @@ class Orchestrator:
             for replica_id in pool.available_replica_ids():
                 self._orch_monitor.register_replica(stage_id, replica_id)
 
+        # Maps src-stage -> downstream stages; PD fan-in/fan-out pipelines
+        # (e.g. 1P3D) are not numerically adjacent, so routing must consult this.
+        self._downstream_stage_ids: dict[int, list[int]] = self._build_downstream_stage_ids(stage_pools)
         # PD disaggregation state
         self._pd_pair: tuple[int, int] | None = None
+        self._pd_prefill_ids: list[int] = []
+        self._pd_decode_ids: list[int] = []
+        self._pd_decode_to_prefill: dict[int, list[int]] = {}
         self._pd_bootstrap_addr: str | None = None
+        self._pd_bootstrap_addr_by_prefill: dict[int, str] = {}
         self._pd_prefill_engine_id: str | None = None
+        self._pd_prefill_engine_id_by_prefill: dict[int, str] = {}
+        self._pd_decode_pick_strategy: str = "round_robin"
+        self._pd_decode_round_robin_idx: int = 0
+        self._pd_decode_inflight: dict[int, int] = {}
+        self._pd_request_to_decode: dict[str, int] = {}
         self._pd_kv_params: dict[str, Any] = {}
         if pd_config is not None:
             self._pd_pair = pd_config.get("pd_pair")
+            self._pd_prefill_ids = list(
+                pd_config.get("prefill_ids") or ([] if self._pd_pair is None else [self._pd_pair[0]])
+            )
+            self._pd_decode_ids = list(
+                pd_config.get("decode_ids") or ([] if self._pd_pair is None else [self._pd_pair[1]])
+            )
+            self._pd_decode_to_prefill = {
+                int(k): list(v) for k, v in dict(pd_config.get("decode_to_prefill") or {}).items()
+            }
             self._pd_bootstrap_addr = pd_config.get("bootstrap_addr")
+            self._pd_bootstrap_addr_by_prefill = dict(pd_config.get("bootstrap_addr_by_prefill") or {})
             self._pd_prefill_engine_id = pd_config.get("prefill_engine_id")
+            self._pd_prefill_engine_id_by_prefill = dict(pd_config.get("prefill_engine_id_by_prefill") or {})
+            self._pd_decode_pick_strategy = str(pd_config.get("decode_pick_strategy") or "round_robin").lower()
+            self._pd_decode_inflight = {d_id: 0 for d_id in self._pd_decode_ids}
         self.request_states: dict[str, OrchestratorRequestState] = {}
         self._init_metrics_state(stage_pools, running_counter, transfer_emitter, log_stats=log_stats)
 
@@ -529,6 +554,39 @@ class Orchestrator:
 
         # Distributed membership (optional, injected by DistStageRuntime)
         self._membership = membership_controller
+
+    @staticmethod
+    def _build_downstream_stage_ids(stage_pools: list[StagePool]) -> dict[int, list[int]]:
+        """Build src-stage -> downstream-stage mapping from stage metadata.
+
+        Legacy linear pipelines omit ``engine_input_source`` on some stages, so
+        callers still fall back to ``stage_id + 1`` when no explicit mapping is
+        present. Non-linear fan-in/fan-out pipelines (for example 1P3D where
+        stage-1/2/3 all feed stage-4) must use this mapping instead of numeric
+        adjacency.
+        """
+        downstream: dict[int, list[int]] = {}
+        for dst_id, pool in enumerate(stage_pools):
+            sources = list(getattr(pool.stage_client, "engine_input_source", None) or [])
+            for src_id in sources:
+                if not isinstance(src_id, int):
+                    try:
+                        src_id = int(src_id)
+                    except (TypeError, ValueError):
+                        continue
+                downstream.setdefault(src_id, []).append(dst_id)
+        return downstream
+
+    def _resolve_next_stage_id(self, src_stage_id: int) -> int:
+        candidates = self._downstream_stage_ids.get(src_stage_id) or []
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            non_pd_decode = [stage_id for stage_id in candidates if not self._is_pd_decode_stage(stage_id)]
+            if len(non_pd_decode) == 1:
+                return non_pd_decode[0]
+            raise RuntimeError(f"[Orchestrator] Ambiguous downstream stages for stage-{src_stage_id}: {candidates}")
+        return src_stage_id + 1
 
     def _init_metrics_state(
         self,
@@ -748,7 +806,13 @@ class Orchestrator:
 
     async def _handle_add_request(self, msg: StageSubmissionMessage) -> None:
         """Handle an add_request message from the main thread."""
-        stage_id = 0
+        # [PD] M-P-N-D: enter at the prefill stage the caller already picked
+        # rather than assuming the entry stage is always stage 0.
+        bound_p = getattr(msg, "bound_prefill_stage_id", None)
+        if bound_p is not None and 0 <= bound_p < len(self.stage_pools):
+            stage_id = bound_p
+        else:
+            stage_id = 0
         request_id = msg.request_id
         prompt = msg.prompt
         original_prompt = msg.original_prompt
@@ -796,7 +860,9 @@ class Orchestrator:
             prompt_text=msg.output_prompt_text,
         )
 
-        if self.async_chunk and stage_id == 0 and final_stage_id > 0:
+        # [PD] The async-chunk prewarm must fire on the request's ENTRY stage,
+        # which for PD is a prefill stage rather than stage 0.
+        if self.async_chunk and (stage_id == 0 or self._is_pd_prefill_stage(stage_id)) and final_stage_id > 0:
             await self._prewarm_async_chunk_stages(request_id, prompt, req_state)
 
     async def _handle_streaming_update(self, msg: StageSubmissionMessage) -> None:
@@ -1783,7 +1849,15 @@ class Orchestrator:
         raw_outputs: EngineCoreOutputs,
     ) -> None:
         """Forward split requests once stage-0 KV is ready."""
-        if self.async_chunk:
+        # [PD] The PD prefill stage MUST be exempt from the async-chunk early
+        # return: PD yamls set async_chunk: true, so returning here drops every
+        # prefill->decode handoff and D silently regenerates from scratch.
+        if self._pd_trace_enabled:
+            logger.info(
+                "[PD_TRACE] kvready_enter stage=%d async_chunk=%s is_pd_prefill=%s n_out=%d",
+                stage_id, self.async_chunk, self._is_pd_prefill_stage(stage_id), len(raw_outputs.outputs),
+            )
+        if self.async_chunk and not self._is_pd_prefill_stage(stage_id):
             return
 
         for raw_output in raw_outputs.outputs:
@@ -1796,6 +1870,11 @@ class Orchestrator:
             is_pd_prefill = self._is_pd_prefill_stage(stage_id)
             pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
             kv_extraction_ack = bool(kv_params.get("kv_ready"))
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] kvready_probe req=%s stage=%d is_pd_prefill=%s submit_ready=%s ack=%s keys=%s",
+                    req_id, stage_id, is_pd_prefill, pd_submit_ready, kv_extraction_ack, sorted(kv_params),
+                )
             if not pd_submit_ready and not kv_extraction_ack:
                 continue
             # The extraction ACK arrives only after D has pulled KV. It is a
@@ -1816,7 +1895,13 @@ class Orchestrator:
                 continue
             if stage_id >= req_state.final_stage_id:
                 continue
-            if (stage_id + 1) in req_state.stage_submit_ts:
+            # [PD] A prefill stage routes to a decode replica chosen by the pick
+            # strategy, which is not stage_id+1, so the dedupe check must ask
+            # whether ANY decode stage already has this request.
+            if self._is_pd_prefill_stage(stage_id):
+                if self._pd_decode_already_submitted(req_state):
+                    continue
+            elif (stage_id + 1) in req_state.stage_submit_ts:
                 continue
 
             # [PD] Qwen3-TTS prefill hands off non-KV state (hidden_states / codes /
@@ -1976,13 +2061,31 @@ class Orchestrator:
         is_final_update: bool = False,
     ) -> None:
         """Forward output from the current logical stage to the next one."""
-        next_logical = src_stage_id + 1
+        # [PD] A prefill stage does not hand off to stage_id+1: it routes to a
+        # decode replica chosen by the pick strategy. Without this the decode
+        # branch below never runs, so D never receives P's resume token and
+        # regenerates the whole utterance from scratch.
+        pd_prefill_forward = self._is_pd_prefill_stage(src_stage_id) and self._pd_decode_ids
+        if pd_prefill_forward:
+            next_logical = self._pick_pd_decode_stage(req_id, src_stage_id)
+            if next_logical in req_state.final_output_stage_ids:
+                other_decode_finals = req_state.final_output_stage_ids.intersection(self._pd_decode_ids) - {
+                    next_logical
+                }
+                if other_decode_finals:
+                    req_state.final_output_stage_ids.difference_update(other_decode_finals)
+        else:
+            next_logical = self._resolve_next_stage_id(src_stage_id)
         next_pool = self.stage_pools[next_logical]
         next_client = next_pool.stage_client
         params = req_state.sampling_params_list[next_logical]
         source_outputs = [output]
         next_stage_resumable = is_streaming_session and not is_final_update
-        already_submitted = self._next_stage_already_submitted(src_stage_id, req_state)
+        already_submitted = (
+            next_logical in req_state.stage_submit_ts
+            if pd_prefill_forward
+            else self._next_stage_already_submitted(src_stage_id, req_state)
+        )
         requires_multimodal_data = getattr(next_client, "requires_multimodal_data", False)
         _t_submit_start = _time.perf_counter()
 
@@ -2188,6 +2291,15 @@ class Orchestrator:
                     pd_decode_state,
                 )
 
+            if self._pd_trace_enabled:
+                _dp_ai = decode_prompt.get("additional_information")
+                logger.info(
+                    "[PD_TRACE] decode_build req=%s next=%d ai_keys=%s meta=%s n_tok=%d",
+                    req_id, next_logical,
+                    sorted(_dp_ai) if isinstance(_dp_ai, dict) else None,
+                    (_dp_ai.get("meta") if isinstance(_dp_ai, dict) else None),
+                    len(decode_prompt.get("prompt_token_ids") or []),
+                )
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=decode_prompt,
@@ -2197,6 +2309,11 @@ class Orchestrator:
                 resumable=next_stage_resumable,
             )
             request.external_req_id = request.request_id
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] decode_submit req=%s next=%d already_submitted=%s submit_ts_keys=%s",
+                    req_id, next_logical, already_submitted, sorted(req_state.stage_submit_ts),
+                )
             if already_submitted:
                 replica_id = await next_pool.submit_update(req_id, req_state, request)
             else:
@@ -2360,6 +2477,25 @@ class Orchestrator:
             return
 
         for next_stage_id in range(1, req_state.final_stage_id + 1):
+            # [PD] Never prewarm a PD decode replica (or a stage fed by one).
+            # Decode gets its input from the prefill handoff that carries P's KV
+            # plus the resume token; a placeholder prewarm here stamps
+            # stage_submit_ts, makes _pd_decode_already_submitted() true, and the
+            # real handoff is then silently dropped -- D regenerates the whole
+            # utterance from scratch (~65s of audio instead of ~4s).
+            if self._pd_trace_enabled:
+                logger.info("[PD_TRACE] prewarm_check stage=%d is_pd_decode=%s decode_ids=%s",
+                            next_stage_id, self._is_pd_decode_stage(next_stage_id), self._pd_decode_ids)
+            if self._is_pd_decode_stage(next_stage_id):
+                continue
+            # PD prefill siblings likewise receive KV via Mooncake, not chunks.
+            if self._is_pd_prefill_stage(next_stage_id):
+                continue
+            pd_input_sources = list(
+                getattr(self.stage_pools[next_stage_id].stage_client, "engine_input_source", None) or []
+            )
+            if any(self._is_pd_decode_stage(src_id) for src_id in pd_input_sources):
+                continue
             next_pool = self.stage_pools[next_stage_id]
             params = req_state.sampling_params_list[next_stage_id]
             if not self._stage_receives_async_chunks(next_stage_id):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -12,6 +12,7 @@ handled by :class:`MembershipController`, which is injected optionally.
 from __future__ import annotations
 
 import asyncio
+import os
 import time as _time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -49,6 +50,7 @@ from vllm_omni.engine.messages import (
     UnregisterRemoteReplicaMessage,
 )
 from vllm_omni.engine.orchestrator_monitor import create_orch_monitor, replica_key
+from vllm_omni.data_entry_keys import unflatten_payload
 from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.metrics.prometheus import OmniRequestCounter
@@ -156,6 +158,110 @@ def build_engine_core_request_from_tokens(
         additional_information=additional_info_payload,
         model_intermediate_buffer=model_intermediate_buffer if isinstance(model_intermediate_buffer, dict) else None,
     )
+
+
+def _pd_scalar(value: Any) -> Any:
+    if isinstance(value, torch.Tensor) and value.numel() == 1:
+        return value.item()
+    return value
+
+
+def _extract_qwen3_tts_pd_decode_state(
+    multimodal_output: Any,
+    *,
+    resume_token_id: int,
+) -> dict[str, Any] | None:
+    """Extract Qwen3-TTS non-KV state for a decode continuation."""
+    if not isinstance(multimodal_output, dict):
+        return None
+    payload = unflatten_payload(multimodal_output)
+    hidden_states = payload.get("hidden_states")
+    meta = payload.get("meta")
+    if not isinstance(hidden_states, dict) or not isinstance(meta, dict):
+        return None
+
+    last = hidden_states.get("last")
+    trailing_text = hidden_states.get("trailing_text")
+    if not isinstance(last, torch.Tensor) or not isinstance(trailing_text, torch.Tensor):
+        return None
+
+    state: dict[str, Any] = {
+        "hidden_states": {"last": last, "trailing_text": trailing_text},
+        "meta": {
+            "talker_text_offset": int(_pd_scalar(meta.get("talker_text_offset", 0)) or 0),
+            "codec_streaming": bool(_pd_scalar(meta.get("codec_streaming", False))),
+        },
+    }
+    codes = payload.get("codes")
+    if isinstance(codes, dict) and isinstance(codes.get("ref"), torch.Tensor):
+        state["codes"] = {"ref": codes["ref"]}
+    if meta.get("ref_code_len") is not None:
+        state["meta"]["ref_code_len"] = int(_pd_scalar(meta["ref_code_len"]))
+
+    pd_sampler = payload.get("pd_sampler")
+    main_generator_state = pd_sampler.get("main_generator_state") if isinstance(pd_sampler, dict) else None
+    main_sampler_seed = _pd_scalar(pd_sampler.get("seed")) if isinstance(pd_sampler, dict) else None
+    if not isinstance(main_generator_state, torch.Tensor) or main_generator_state.dtype != torch.uint8:
+        raise RuntimeError("Qwen3-TTS PD prefill state is missing main sampler RNG state")
+    try:
+        main_sampler_seed = int(main_sampler_seed)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Qwen3-TTS PD prefill state has invalid main sampler seed") from exc
+    state["pd_sampler"] = {
+        "main_generator_state": main_generator_state,
+        "seed": main_sampler_seed,
+    }
+    # This is intentionally outside additional_information: it is a vLLM
+    # sequence token, not model-intermediate state. The D request must compute
+    # it as its first uncomputed token after restoring P's prompt KV.
+    state["_pd_resume_token_id"] = int(resume_token_id)
+    return state
+
+
+def _with_qwen3_tts_pd_decode_state(prompt: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    """Merge P-worker state and its sampled codec token into a D request."""
+    resume_token_id = state.get("_pd_resume_token_id")
+    if not isinstance(resume_token_id, int):
+        raise RuntimeError("Qwen3-TTS PD decode state is missing the prefill resume token")
+
+    merged_prompt = dict(prompt)
+    prompt_token_ids = merged_prompt.get("prompt_token_ids")
+    if not isinstance(prompt_token_ids, (list, tuple)):
+        raise TypeError("Qwen3-TTS PD decode requires prompt_token_ids")
+    # Keep D's sequence length equal to P's transferred KV prefix. Mooncake
+    # requires matching block counts and the first local decode position is
+    # filled with `resume_token_id` by GPUModelRunner after the prefix loads.
+    merged_prompt["prompt_token_ids"] = list(prompt_token_ids)
+
+    additional_information = merged_prompt.get("additional_information")
+    if additional_information is None:
+        additional_information = {}
+    elif not isinstance(additional_information, dict):
+        raise TypeError("Qwen3-TTS PD decode requires dictionary additional_information")
+    else:
+        additional_information = dict(additional_information)
+
+    for category, values in state.items():
+        if not isinstance(values, dict):
+            continue
+        existing = additional_information.get(category)
+        if existing is None:
+            target: dict[str, Any] = {}
+        elif isinstance(existing, dict):
+            target = dict(existing)
+        else:
+            raise TypeError(f"Qwen3-TTS PD decode additional_information.{category} must be a dictionary")
+        target.update(values)
+        additional_information[category] = target
+    # D receives P's KV only through the original prompt. Its runner injects
+    # this sampled codec token into the first local decode position after the
+    # remote prefix has loaded.
+    meta = additional_information.setdefault("meta", {})
+    if not isinstance(meta, dict):
+        raise TypeError("Qwen3-TTS PD decode additional_information.meta must be a dictionary")
+    meta["pd_resume_token_id"] = resume_token_id
+    merged_prompt["additional_information"] = additional_information
+    return merged_prompt
 
 
 @dataclass
@@ -360,6 +466,7 @@ class Orchestrator:
         self.rpc_async_queue = rpc_async_queue
 
         self.async_chunk = bool(async_chunk)
+        self._pd_trace_enabled = os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
         self.num_stages = len(stage_pools)
         self.stage_pools: list[StagePool] = stage_pools
         self.log_stats = log_stats
@@ -1158,6 +1265,8 @@ class Orchestrator:
             self._release_request_bindings(cleanup_ids)
             for request_id in cleanup_ids:
                 self._pd_kv_params.pop(request_id, None)
+                # [PD] Free the decode-replica inflight slot for this request.
+                self._release_pd_decode_for_request(request_id)
                 req_state = self.request_states.pop(request_id, None)
                 if req_state is not None and req_state.running_counter_registered and self._running_counter is not None:
                     self._running_counter.decrement()
@@ -1168,6 +1277,65 @@ class Orchestrator:
             raise
         if closing_session_ids and self.duplex_control_plane is not None:
             self.duplex_control_plane.finalize_closed_sessions(closing_session_ids)
+
+    def _is_pd_prefill_stage(self, stage_id: int) -> bool:
+        return stage_id in self._pd_prefill_ids
+
+    def _is_pd_decode_stage(self, stage_id: int) -> bool:
+        return stage_id in self._pd_decode_ids
+
+    def _pd_decode_already_submitted(self, req_state: OrchestratorRequestState) -> bool:
+        return any(d_id in req_state.stage_submit_ts for d_id in self._pd_decode_ids)
+
+    def _peek_pd_decode_for_request(self, req_id: str) -> int | None:
+        return self._pd_request_to_decode.get(req_id)
+
+    def _release_pd_decode_for_request(self, req_id: str) -> int | None:
+        stage_id = self._pd_request_to_decode.pop(req_id, None)
+        if stage_id is None:
+            return None
+        cur = self._pd_decode_inflight.get(stage_id, 0)
+        self._pd_decode_inflight[stage_id] = max(0, cur - 1)
+        if self._pd_trace_enabled:
+            logger.info(
+                "[PD_TRACE] decode_release req=%s stage=%d inflight=%s",
+                req_id,
+                stage_id,
+                self._pd_decode_inflight,
+            )
+        return stage_id
+
+    def _pick_pd_decode_stage(self, req_id: str, bound_prefill_id: int | None) -> int:
+        if not self._pd_decode_ids:
+            raise RuntimeError("[Orchestrator][PD] No decode stage is configured")
+        existing = self._peek_pd_decode_for_request(req_id)
+        if existing is not None:
+            return existing
+
+        candidates = list(self._pd_decode_ids)
+        if bound_prefill_id is not None:
+            filtered = [d_id for d_id in candidates if bound_prefill_id in self._pd_decode_to_prefill.get(d_id, [])]
+            if filtered:
+                candidates = filtered
+            else:
+                logger.warning(
+                    "[Orchestrator][PD] No decode stage references bound prefill stage-%s; using all decode stages %s",
+                    bound_prefill_id,
+                    candidates,
+                )
+
+        if len(candidates) == 1:
+            chosen = candidates[0]
+        elif self._pd_decode_pick_strategy == "least_inflight":
+            chosen = min(candidates, key=lambda d_id: (self._pd_decode_inflight.get(d_id, 0), d_id))
+        else:
+            idx = self._pd_decode_round_robin_idx % len(candidates)
+            chosen = candidates[idx]
+            self._pd_decode_round_robin_idx = (self._pd_decode_round_robin_idx + 1) % max(1, len(self._pd_decode_ids))
+
+        self._pd_request_to_decode[req_id] = chosen
+        self._pd_decode_inflight[chosen] = self._pd_decode_inflight.get(chosen, 0) + 1
+        return chosen
 
     async def _apply_raw_terminal_stage_finish(
         self,
@@ -1620,11 +1788,22 @@ class Orchestrator:
 
         for raw_output in raw_outputs.outputs:
             kv_params = getattr(raw_output, "kv_transfer_params", None)
-            if not (isinstance(kv_params, dict) and kv_params.get("kv_ready")):
+            if not isinstance(kv_params, dict):
                 continue
 
             req_id = raw_output.request_id
             req_state = self.request_states.get(req_id)
+            is_pd_prefill = self._is_pd_prefill_stage(stage_id)
+            pd_submit_ready = is_pd_prefill and bool(kv_params.get("pd_submit_ready"))
+            kv_extraction_ack = bool(kv_params.get("kv_ready"))
+            if not pd_submit_ready and not kv_extraction_ack:
+                continue
+            # The extraction ACK arrives only after D has pulled KV. It is a
+            # producer-release event, not the signal to submit D; waiting for
+            # it here would form a P/D pull deadlock.
+            if is_pd_prefill and not pd_submit_ready:
+                logger.info("[PD_TRACE] qwen3_tts_kv_extraction_ack req=%s", req_id)
+                continue
             if req_state is None:
                 continue
             if self._cfg_tracker.is_companion(req_id):
@@ -1640,18 +1819,71 @@ class Orchestrator:
             if (stage_id + 1) in req_state.stage_submit_ts:
                 continue
 
+            # [PD] Qwen3-TTS prefill hands off non-KV state (hidden_states / codes /
+            # sampler RNG) plus the single sampled codec token that decode resumes
+            # from. Upstream has no equivalent -- its PD targets the Qwen3-Omni
+            # thinker, which needs only KV.
+            if self._is_pd_prefill_stage(stage_id):
+                # Keep producer metadata (notably remote_request_id) if an
+                # earlier output recorded it, then add this submit-ready event.
+                previous_kv_params = self._pd_kv_params.get(req_id, {})
+                previous_kv_params = (
+                    dict(previous_kv_params)
+                    if isinstance(previous_kv_params, dict)
+                    else dict(previous_kv_params)
+                )
+                self._pd_kv_params[req_id] = {**previous_kv_params, **kv_params}
+                resume_token_ids = list(getattr(raw_output, "new_token_ids", None) or [])
+                if len(resume_token_ids) != 1:
+                    raise RuntimeError(
+                        "[Orchestrator][PD] Qwen3-TTS prefill must hand off exactly one sampled codec token "
+                        f"for req={req_id}; got {resume_token_ids}"
+                    )
+                pd_decode_state = _extract_qwen3_tts_pd_decode_state(
+                    getattr(raw_output, "multimodal_output", None),
+                    resume_token_id=int(resume_token_ids[0]),
+                )
+                if pd_decode_state is None:
+                    raw_pd_state = getattr(raw_output, "multimodal_output", None)
+                    raw_pd_state_keys = sorted(raw_pd_state) if isinstance(raw_pd_state, dict) else []
+                    raise RuntimeError(
+                        f"[Orchestrator][PD] Missing Qwen3-TTS decode state for req={req_id}; "
+                        f"raw_state_keys={raw_pd_state_keys}"
+                    )
+                req_state.pd_prefill_multimodal_output = pd_decode_state
+                if self._pd_trace_enabled:
+                    prefill_submitted_at = req_state.stage_submit_ts.get(stage_id, req_state.request_timestamp)
+                    logger.info(
+                        "[PD_TRACE] prefill_submit_ready req=%s stage=%d residence_ms=%.3f remote_request_id=%s "
+                        "resume_token_id=%d state_keys=%s",
+                        req_id,
+                        stage_id,
+                        (_time.time() - prefill_submitted_at) * 1000.0,
+                        bool(self._pd_kv_params[req_id].get("remote_request_id")),
+                        int(pd_decode_state["_pd_resume_token_id"]),
+                        sorted(pd_decode_state),
+                    )
+
             if self._cfg_tracker.has_companions(req_id) and not self._cfg_tracker.all_companions_done(req_id):
                 self._cfg_tracker.defer_parent(req_id, raw_output, stage_id)
             else:
                 await self._forward_to_next_stage(req_id, stage_id, raw_output, req_state)
 
-    def _build_pd_decode_params(self, req_id: str, sp: Any) -> Any:
+    def _build_pd_decode_params(
+        self,
+        req_id: str,
+        sp: Any,
+        prefill_stage_id: int | None = None,
+        main_sampler_seed: int | None = None,
+    ) -> Any:
         """Build decode-side sampling params with KV transfer params for PD routing.
 
         Clones the sampling params and injects kv_transfer_params that tell the
         decode engine where to pull the KV cache from (prefill engine's bootstrap addr).
         """
         sp = sp.clone()
+        if main_sampler_seed is not None:
+            sp.seed = int(main_sampler_seed)
         if sp.extra_args is None:
             sp.extra_args = {}
 
@@ -1672,8 +1904,15 @@ class Orchestrator:
         if self._pd_prefill_engine_id:
             decode_kv_params["remote_engine_id"] = self._pd_prefill_engine_id
 
-        # Overlay params from prefill side (includes remote_request_id set by monkey patch).
-        decode_kv_params.update(kv_prefill_params)
+        # Overlay transport metadata from prefill. Lifecycle events are
+        # orchestrator-local and must not leak into the consumer connector.
+        decode_kv_params.update(
+            {
+                key: value
+                for key, value in kv_prefill_params.items()
+                if key not in {"pd_submit_ready", "kv_ready"}
+            }
+        )
 
         # Ensure these flags are set correctly after any overlay.
         decode_kv_params["do_remote_prefill"] = True
@@ -1908,46 +2147,66 @@ class Orchestrator:
             return
 
         # PD disaggregation: prefill → decode routing uses original prompt + KV transfer params
-        if self._pd_pair is not None and (src_stage_id, next_logical) == self._pd_pair:
-            params = self._build_pd_decode_params(req_id, params)
+        # [PD] Multi-replica: pd_prefill_forward is computed from the id lists
+        # rather than upstream's single self._pd_pair equality check.
+        if pd_prefill_forward:
+            pd_decode_state = req_state.pd_prefill_multimodal_output
+            if not isinstance(pd_decode_state, dict):
+                raise RuntimeError(f"[Orchestrator][PD] Missing Qwen3-TTS state before decode submit for req={req_id}")
+            pd_sampler = pd_decode_state.get("pd_sampler")
+            sampler_seed = pd_sampler.get("seed") if isinstance(pd_sampler, dict) else None
+            if not isinstance(sampler_seed, int):
+                raise RuntimeError(f"[Orchestrator][PD] Missing Qwen3-TTS main sampler seed for req={req_id}")
+            params = self._build_pd_decode_params(
+                req_id,
+                params,
+                prefill_stage_id=src_stage_id,
+                main_sampler_seed=sampler_seed,
+            )
 
             # Use the original user prompt for the decode stage (not processed embeddings)
             original_prompt = req_state.prompt
             raw_decode_inputs = [original_prompt] if not isinstance(original_prompt, list) else original_prompt
 
-            decode_inputs: list[dict[str, Any]] = []
-            for decode_input in raw_decode_inputs:
-                if isinstance(decode_input, dict):
-                    decode_inputs.append(decode_input)
-                    continue
+            if len(raw_decode_inputs) != 1:
+                raise ValueError(
+                    "[Orchestrator][PD] Qwen3-TTS PD requires exactly one decode input per request; "
+                    f"got {len(raw_decode_inputs)} for req={req_id}"
+                )
+            decode_input = raw_decode_inputs[0]
+            if isinstance(decode_input, dict):
+                decode_prompt = _with_qwen3_tts_pd_decode_state(decode_input, pd_decode_state)
+            else:
                 prompt_token_ids = getattr(decode_input, "prompt_token_ids", None)
                 if prompt_token_ids is None:
                     raise TypeError(
                         "[Orchestrator][PD] decode input must be dict or have prompt_token_ids, "
                         f"got {type(decode_input).__name__} for req={req_id}"
                     )
-                decode_inputs.append({"prompt_token_ids": list(prompt_token_ids)})
+                decode_prompt = _with_qwen3_tts_pd_decode_state(
+                    {"prompt_token_ids": list(prompt_token_ids)},
+                    pd_decode_state,
+                )
 
-            for decode_input in decode_inputs:
-                request = build_engine_core_request_from_tokens(
-                    request_id=req_id,
-                    prompt=decode_input,
-                    params=params,
-                    model_config=next_pool.stage_vllm_config.model_config,
-                    mm_features=req_state.mm_features,
-                    resumable=next_stage_resumable,
-                )
-                request.external_req_id = request.request_id
-                if already_submitted:
-                    replica_id = await next_pool.submit_update(req_id, req_state, request)
-                else:
-                    replica_id = await next_pool.submit_initial(req_id, req_state, request, prompt_text=None)
-                self._record_duplex_stage_submission(
-                    next_logical,
-                    req_id,
-                    replica_id,
-                    req_state,
-                )
+            request = build_engine_core_request_from_tokens(
+                request_id=req_id,
+                prompt=decode_prompt,
+                params=params,
+                model_config=next_pool.stage_vllm_config.model_config,
+                mm_features=req_state.mm_features,
+                resumable=next_stage_resumable,
+            )
+            request.external_req_id = request.request_id
+            if already_submitted:
+                replica_id = await next_pool.submit_update(req_id, req_state, request)
+            else:
+                replica_id = await next_pool.submit_initial(req_id, req_state, request, prompt_text=None)
+            self._record_duplex_stage_submission(
+                next_logical,
+                req_id,
+                replica_id,
+                req_state,
+            )
 
             req_state.stage_submit_ts[next_logical] = _time.time()
             _tx_ms = (_time.perf_counter() - _t_submit_start) * 1000.0
@@ -1959,6 +2218,18 @@ class Orchestrator:
                 request_id=req_id,
                 tx_ms=_tx_ms,
             )
+            if self._pd_trace_enabled:
+                logger.info(
+                    "[PD_TRACE] prefill_to_decode_submitted req=%s stage=%d->%d submit_ms=%.3f decode_inflight=%s",
+                    req_id,
+                    src_stage_id,
+                    next_logical,
+                    _tx_ms,
+                    self._pd_decode_inflight,
+                )
+            # NOTE: the inline async-chunk prewarm loop that used to live here was
+            # refactored upstream in 0.26 into _prewarm_async_chunk_stages(), which
+            # is driven from the request-admission path instead.
             return
 
         if req_state.pd_prefill_multimodal_output is not None:
@@ -2259,3 +2530,4 @@ class Orchestrator:
         for pool in self.stage_pools:
             for replica_id in pool.live_replica_ids():
                 pool.shutdown_replica(replica_id)
+

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -421,8 +421,13 @@ def extract_legacy_stage_metadata(stage_config: Any) -> StageMetadata:
 
     runtime_cfg = stage_config.runtime
     engine_input_source: list[int] = _get_attr_or_item(stage_config, "engine_input_source", [])
-    final_output: bool = stage_config.final_output
-    final_output_type: str | None = stage_config.final_output_type
+    # [PD] Legacy `stage_args:` YAMLs stay raw DictConfig -- they never pass through
+    # StageDeployConfig, so dataclass defaults are NOT applied and a direct attribute
+    # read raises on any omitted field. 0.24 read these with getattr defaults;
+    # restored here so legacy configs keep loading (the PD topology YAMLs are the
+    # only remaining stage_args users in-tree).
+    final_output: bool = _get_attr_or_item(stage_config, "final_output", False)
+    final_output_type: str | None = _get_attr_or_item(stage_config, "final_output_type", None)
 
     default_sp = _to_dict(_get_attr_or_item(stage_config, "default_sampling_params", {}))
     # A pooling stage carries its task via default_pooling_params, set where the
@@ -484,7 +489,7 @@ def extract_legacy_stage_metadata(stage_config: Any) -> StageMetadata:
         )
 
     engine_output_type = engine_args.get("engine_output_type")
-    is_comprehension = stage_config.is_comprehension
+    is_comprehension = _get_attr_or_item(stage_config, "is_comprehension", False)
     requires_multimodal_data = getattr(runtime_cfg, "requires_multimodal_data", False)
 
     return StageMetadata(

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -1582,24 +1582,35 @@ def get_stage_connector_spec(
     stage_id: int,
     async_chunk: bool,
 ) -> dict[str, Any]:
-    """Return the first connector spec for a stage data-plane edge."""
+    """Return the connector spec used by a stage payload data plane."""
     from vllm_omni.distributed.omni_connectors import get_stage_connector_config
+
+    # Async producers send chunks directly from their worker. A middle stage
+    # can also have an incoming orchestration edge, but that receiver config
+    # must not shadow the outgoing codec/chunk settings used by its sender.
+    target_stage = str(stage_id)
+
+    def _sender_spec() -> dict[str, Any]:
+        for (from_stage, _to_stage), spec in getattr(omni_transfer_config, "connectors", {}).items():
+            if from_stage == target_stage:
+                extra = dict(spec.extra or {})
+                extra.setdefault("role", "sender")
+                return {"name": spec.name, "extra": extra}
+        return {}
+
+    if async_chunk:
+        sender_spec = _sender_spec()
+        if sender_spec:
+            return sender_spec
 
     stage_connectors_cfg = get_stage_connector_config(omni_transfer_config, stage_id)
     for cfg in stage_connectors_cfg.values():
         return dict(cfg.get("spec", {}))
 
     # A producer does not consume connector data itself. Keep its connector
-    # for both async-chunk and terminal full-payload sends, but mark it
-    # sender-only so the scheduler does not park orchestrator-provided inputs
-    # waiting for an upstream payload.
-    target_stage = str(stage_id)
-    for (from_stage, _to_stage), spec in getattr(omni_transfer_config, "connectors", {}).items():
-        if from_stage == target_stage:
-            extra = dict(spec.extra or {})
-            extra.setdefault("role", "sender")
-            return {"name": spec.name, "extra": extra}
-    return {}
+    # for terminal full-payload sends too, but mark it sender-only so the
+    # scheduler does not park orchestrator-provided inputs waiting upstream.
+    return _sender_spec()
 
 
 def build_diffusion_config(

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -373,8 +373,13 @@ def extract_legacy_stage_metadata(stage_config: Any) -> StageMetadata:
 
     runtime_cfg = stage_config.runtime
     engine_input_source: list[int] = _get_attr_or_item(stage_config, "engine_input_source", [])
-    final_output: bool = stage_config.final_output
-    final_output_type: str | None = stage_config.final_output_type
+    # [PD] Legacy `stage_args:` YAMLs stay raw DictConfig -- they never pass through
+    # StageDeployConfig, so dataclass defaults are NOT applied and a direct attribute
+    # read raises on any omitted field. 0.24 read these with getattr defaults;
+    # restored here so legacy configs keep loading (the PD topology YAMLs are the
+    # only remaining stage_args users in-tree).
+    final_output: bool = _get_attr_or_item(stage_config, "final_output", False)
+    final_output_type: str | None = _get_attr_or_item(stage_config, "final_output_type", None)
 
     default_sp = _to_dict(_get_attr_or_item(stage_config, "default_sampling_params", {}))
     SPClass = SamplingParams if stage_type == "llm" else OmniDiffusionSamplingParams
@@ -418,7 +423,7 @@ def extract_legacy_stage_metadata(stage_config: Any) -> StageMetadata:
         )
 
     engine_output_type = engine_args.get("engine_output_type")
-    is_comprehension = stage_config.is_comprehension
+    is_comprehension = _get_attr_or_item(stage_config, "is_comprehension", False)
     requires_multimodal_data = getattr(runtime_cfg, "requires_multimodal_data", False)
 
     return StageMetadata(

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -1217,6 +1217,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     delivered.add(rid)
         for rid in request_ids:
             self._record_request_failure_once(rid, reason="client_abort")
+            self._release_pd_prefill_for_request(rid)
             state = self.request_states.get(rid)
             input_stream_task = getattr(state, "input_stream_task", None)
             if input_stream_task is not None and not input_stream_task.done():

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -608,10 +608,15 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # PD disaggregation: modify prefill-stage sampling params per request
             req_sp_list = list(sampling_params_list)
-            pd_pair = self._get_pd_separation_pair()
-            if pd_pair is not None:
-                p_id = pd_pair[0]
-                req_sp_list[p_id] = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
+            # Multi-replica topologies need a per-request prefill pick; the
+            # compatibility single-pair helper is populated only for 1P1D.
+            if self._get_pd_decode_id() is not None and self._get_pd_prefill_ids():
+                p_id = self._pick_prefill_stage(request_id)
+                prefill_sp = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
+                req_sp_list[p_id] = prefill_sp
+                # Slot 0 drives the initial LLM submission. Reuse the same
+                # one-token params so it and the selected P stage stay aligned.
+                req_sp_list[0] = prefill_sp
 
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update. The helper
@@ -927,6 +932,7 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # The Orchestrator sets "finished" when the final stage is done
             if result.finished:
+                self._release_pd_prefill_for_request(request_id)
                 break
 
     # ==================== Output Handler ====================

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -584,10 +584,16 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # PD disaggregation: modify prefill-stage sampling params per request
             req_sp_list = list(sampling_params_list)
-            pd_pair = self._get_pd_separation_pair()
-            if pd_pair is not None:
-                p_id = pd_pair[0]
-                req_sp_list[p_id] = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
+            # [PD] Multi-replica topologies need a per-request prefill pick, so keep
+            # the list-based accessors instead of upstream's single-pair helper.
+            bound_prefill_stage_id: int | None = None
+            if self._get_pd_decode_id() is not None and self._get_pd_prefill_ids():
+                p_id = self._pick_prefill_stage(request_id)
+                prefill_sp = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
+                req_sp_list[p_id] = prefill_sp
+                # Reuse the single-step prefill params for the slot-0 (LLM) stage so both stages share one step.
+                req_sp_list[0] = prefill_sp
+                bound_prefill_stage_id = p_id
 
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update.
@@ -855,6 +861,7 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # The Orchestrator sets "finished" when the final stage is done
             if result.finished:
+                self._release_pd_prefill_for_request(request_id)
                 break
 
     # ==================== Output Handler ====================
@@ -1066,6 +1073,9 @@ class AsyncOmni(EngineClient, OmniBase):
         """Submit request IDs to be aborted to the engine."""
         await self.engine.abort_async(request_ids)
         for rid in request_ids:
+            # [PD] Decrement the prefill inflight counter so an aborted request
+            # does not permanently occupy a slot in the pick strategy.
+            self._release_pd_prefill_for_request(rid)
             state = self.request_states.pop(rid, None)
             input_stream_task = getattr(state, "input_stream_task", None)
             if input_stream_task is not None and not input_stream_task.done():
@@ -1407,3 +1417,4 @@ class AsyncOmni(EngineClient, OmniBase):
             self.final_output_task.cancel()
             self.final_output_task = None
         OmniBase.shutdown(self)
+

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -213,6 +213,7 @@ class Omni(OmniBase):
         self.engine.abort(request_ids)
         for req_id in request_ids:
             self._record_request_failure_once(req_id, reason="client_abort")
+            self._release_pd_prefill_for_request(req_id)
             self.request_states.pop(req_id, None)
         if self.log_stats:
             logger.info("[Omni] Aborted request(s) %s", ",".join(request_ids))

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -145,9 +145,12 @@ class Omni(OmniBase):
 
                 # PD disaggregation: modify stage-0 (prefill) sampling params per request
                 req_sp_list = list(sampling_params_list)
-                pd_pair = self._get_pd_separation_pair()
-                if pd_pair is not None:
-                    p_id = pd_pair[0]
+                # [PD] Multi-replica topologies (1p3d/2p2d/3p1d) need a per-request
+                # prefill pick, so this keeps the list-based accessors instead of
+                # upstream's single-pair _get_pd_separation_pair().
+                bound_prefill_stage_id: int | None = None
+                if self._get_pd_decode_id() is not None and self._get_pd_prefill_ids():
+                    p_id = self._pick_prefill_stage(req_id)
                     req_sp_list[p_id] = self._prepare_prefill_sampling_params(req_id, req_sp_list[p_id])
 
                 self.engine.add_request(
@@ -197,6 +200,7 @@ class Omni(OmniBase):
                     active_reqs.discard(req_id)
                     if pbar is not None:
                         pbar.update(1)
+                    self._release_pd_prefill_for_request(req_id)
                     self._log_summary_and_cleanup(req_id)
         except Exception:
             if "active_reqs" in locals() and active_reqs:
@@ -210,6 +214,8 @@ class Omni(OmniBase):
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
         self.engine.abort(request_ids)
         for req_id in request_ids:
+            self._release_pd_prefill_for_request(req_id)
             self.request_states.pop(req_id, None)
         if self.log_stats:
             logger.info("[Omni] Aborted request(s) %s", ",".join(request_ids))
+

--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -30,6 +30,19 @@ def _pd_trace_enabled() -> bool:
     return os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _stage_pd_flag(stage: Any, name: str) -> bool:
+    """Read a PD topology flag from legacy or registry-backed configs."""
+    value = stage.get(name) if hasattr(stage, "get") else getattr(stage, name, None)
+    if value is not None:
+        return bool(value)
+
+    engine_args = stage.get("engine_args") if hasattr(stage, "get") else getattr(stage, "engine_args", None)
+    if engine_args is None:
+        return False
+    value = engine_args.get(name) if hasattr(engine_args, "get") else getattr(engine_args, name, None)
+    return bool(value)
+
+
 class PDDisaggregationMixin:
     def _get_pd_prefill_ids(self) -> list[int]:
         return list(getattr(self, "_pd_prefill_ids", []) or [])
@@ -89,12 +102,12 @@ class PDDisaggregationMixin:
         prefill_by_id: dict[int, int] = {}
         decode_indices: list[int] = []
         for i, stage in enumerate(stage_configs):
-            if getattr(stage, "is_prefill_only", False):
+            if _stage_pd_flag(stage, "is_prefill_only"):
                 prefill_by_id[i] = i
                 sid = getattr(stage, "stage_id", i)
                 if sid != i:
                     prefill_by_id[sid] = i
-            if getattr(stage, "is_decode_only", False):
+            if _stage_pd_flag(stage, "is_decode_only"):
                 decode_indices.append(i)
 
         if not decode_indices:
@@ -361,24 +374,25 @@ class PDDisaggregationMixin:
         return chosen
 
     def _prepare_prefill_sampling_params(self, req_id: str, sp: SamplingParams) -> SamplingParams:
+        max_tokens = getattr(sp, "max_tokens", None)
+        if max_tokens is not None and int(max_tokens) <= 1:
+            raise ValueError("PD disaggregation requires max_tokens >= 2 because P consumes the first token")
         sp = sp.clone()
         # P and D run in different processes. Give unseeded PD requests an
         # independent but stable stream so P's post-y0 generator state can be
         # restored on D instead of both sides consuming unrelated global RNG.
         if sp.seed is None:
             sp.seed = zlib.crc32(req_id.encode("utf-8"))
+        original_min_tokens = int(getattr(sp, "min_tokens", 0) or 0)
         sp.max_tokens = 1
         if hasattr(sp, "min_tokens"):
-            try:
-                # Keep min_tokens=1: Mooncake cancels the KV transfer unless the
-                # prefill finishes with finish_reason='length'. A 0 here would let
-                # an EOS on the first token end the step as 'stop' and drop the
-                # transfer, so the decode side never receives the prompt KV.
-                sp.min_tokens = 1
-            except Exception:
-                pass
+            # Preserve stop_token_ids when the unsplit request would mask them
+            # on y0. max_tokens=1 then still finishes as LENGTH_CAPPED, which
+            # is the status Mooncake uses to publish the transferred KV.
+            sp.min_tokens = 1 if original_min_tokens > 0 else 0
         sp.stop = []
-        sp.stop_token_ids = []
+        if original_min_tokens <= 0:
+            sp.stop_token_ids = []
         sp.include_stop_str_in_output = False
         if sp.extra_args is None:
             sp.extra_args = {}
@@ -579,12 +593,12 @@ class PDDisaggregationMixin:
         prefill_by_id: dict[int, int] = {}
         decode_indices: list[int] = []
         for i, stage in enumerate(stage_configs):
-            if getattr(stage, "is_prefill_only", False):
+            if _stage_pd_flag(stage, "is_prefill_only"):
                 prefill_by_id[i] = i
                 sid = getattr(stage, "stage_id", i)
                 if sid != i:
                     prefill_by_id[sid] = i
-            if getattr(stage, "is_decode_only", False):
+            if _stage_pd_flag(stage, "is_decode_only"):
                 decode_indices.append(i)
 
         pd_pairs: list[tuple[int, int]] = []

--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -5,8 +5,12 @@
 Mixin for OmniBase — keeps omni.py focused on orchestration.
 """
 
+from __future__ import annotations
+
 import logging
+import os
 import threading
+import zlib
 from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -14,50 +18,74 @@ if TYPE_CHECKING:
     from vllm import SamplingParams
 
 _DEFAULT_MOONCAKE_BOOTSTRAP_PORT = 25201
+_VLLM_MOONCAKE_BOOTSTRAP_PORT_ENV = "VLLM_MOONCAKE_BOOTSTRAP_PORT"
+_PD_PREFILL_PICK_STRATEGY_ENV = "VLLM_OMNI_PD_PREFILL_PICK_STRATEGY"
+_PD_PREFILL_PICK_STRATEGIES = ("round_robin", "least_inflight")
+_DEFAULT_PD_PREFILL_PICK_STRATEGY = "round_robin"
 
 logger = logging.getLogger(__name__)
 
 
+def _pd_trace_enabled() -> bool:
+    return os.getenv("VLLM_OMNI_PD_TRACE", "0").strip().lower() in {"1", "true", "yes", "on"}
+
+
 class PDDisaggregationMixin:
-    """Mixin supplying PD disaggregation helpers to OmniBase."""
+    def _get_pd_prefill_ids(self) -> list[int]:
+        return list(getattr(self, "_pd_prefill_ids", []) or [])
 
-    def _get_pd_separation_pair(self) -> tuple[int, int] | None:
-        """PD prefill/decode indices when ``_init_pd_state`` ran; else ``None``.
+    def _get_pd_decode_id(self) -> int | None:
+        ids = self._get_pd_decode_ids()
+        return ids[0] if ids else None
 
-        Partial test doubles may skip ``OmniBase.__init__``; treat missing state as
-        no PD disaggregation instead of raising ``AttributeError``.
-        """
-        return getattr(self, "_pd_separation_pair", None)
+    def _get_pd_decode_ids(self) -> list[int]:
+        return list(getattr(self, "_pd_decode_ids", []) or [])
 
     def _init_pd_state(self) -> None:
-        """Initialise PD disaggregation state."""
-        self._pd_separation_pair: tuple[int, int] | None = self.detect_pd_separation_from_stage_configs(
-            self.stage_configs
-        )
-        self._pd_connector_info: dict[str, Any] | None = None
-        self._pd_kv_params_by_req: dict[str, dict[str, Any]] = {}
-        self._pd_kv_params_lock = threading.Lock()
-        if self._pd_separation_pair is not None:
+        topology = self.detect_pd_separation_topology(self.stage_configs)
+        self._pd_prefill_ids = list(topology["prefill_ids"]) if topology else []
+        self._pd_decode_ids = list(topology.get("decode_ids") or []) if topology else []
+        self._pd_decode_to_prefill = dict(topology.get("decode_to_prefill") or {}) if topology else {}
+        self._pd_decode_id = self._pd_decode_ids[0] if self._pd_decode_ids else None
+
+        if self._pd_decode_id is not None and self._pd_prefill_ids:
+            try:
+                from ..distributed.kv_transfer.mooncake_pd_patch import apply_mooncake_connector_patch
+
+                apply_mooncake_connector_patch()
+            except Exception as e:
+                logger.warning(
+                    "[%s] Failed to apply MooncakeConnector patch: %s. PD KV transfer may fail.",
+                    self._name,
+                    e,
+                )
             self._validate_pd_separation_config()
-            self._pd_connector_info = self._get_pd_connector_info()
-            p_id, d_id = self._pd_separation_pair
-            logger.info(
-                "[%s] PD disaggregation detected: prefill=stage-%d, decode=stage-%d",
-                self._name,
-                p_id,
-                d_id,
-            )
+
+        self._pd_prefill_pick_strategy = self._resolve_pd_prefill_pick_strategy()
+        self._pd_prefill_inflight = {p: 0 for p in self._pd_prefill_ids}
+        self._pd_prefill_inflight_lock = threading.Lock()
+        self._pd_prefill_round_robin_idx = 0
+        # request_id -> chosen prefill stage id, used to release inflight on cleanup.
+        self._pd_request_to_prefill: dict[str, int] = {}
+
+        # ------------------------------------------------------------------ #
+        # Upstream v0.26 PD helper state.
+        # ------------------------------------------------------------------ #
+        # The single-pair accessors and KV-params helpers carried over from
+        # upstream (kept so the official PD test-suite keeps passing) read this
+        # state. Populated only when the topology really is 1P1D; multi-replica
+        # topologies leave _pd_separation_pair as None and use the id lists above.
+        self._pd_separation_pair: tuple[int, int] | None = (
+            (self._pd_prefill_ids[0], self._pd_decode_ids[0])
+            if len(self._pd_prefill_ids) == 1 and len(self._pd_decode_ids) == 1
+            else None
+        )
+        self._pd_kv_params_by_req: dict[str, Any] = {}
+        self._pd_kv_params_lock = threading.Lock()
+        self._pd_connector_info: dict[str, Any] | None = None
 
     @staticmethod
-    def detect_pd_separation_from_stage_configs(stage_configs: list[Any]) -> tuple[int, int] | None:
-        """Scan stage configs for a prefill/decode pair.
-
-        Returns:
-            (prefill_idx, decode_idx) if one pair exists, None if not found.
-
-        Raises:
-            ValueError: if multiple candidate PD pairs are found.
-        """
+    def detect_pd_separation_topology(stage_configs: list[Any]) -> dict[str, Any] | None:
         prefill_by_id: dict[int, int] = {}
         decode_indices: list[int] = []
         for i, stage in enumerate(stage_configs):
@@ -69,23 +97,37 @@ class PDDisaggregationMixin:
             if getattr(stage, "is_decode_only", False):
                 decode_indices.append(i)
 
-        pd_pairs: list[tuple[int, int]] = []
-        for j in decode_indices:
-            source_ids = getattr(stage_configs[j], "engine_input_source", [])
-            for src in source_ids:
-                if src in prefill_by_id:
-                    pd_pairs.append((prefill_by_id[src], j))
-                    break
+        if not decode_indices:
+            return None
 
-        if len(pd_pairs) > 1:
-            raise ValueError(
-                f"Multiple PD pairs detected ({pd_pairs}); only a single PD pair per pipeline is supported"
-            )
-        return pd_pairs[0] if pd_pairs else None
+        prefill_ids: list[int] = []
+        decode_to_prefill: dict[int, list[int]] = {}
+        for d_id in decode_indices:
+            decode_stage = stage_configs[d_id]
+            source_ids = list(getattr(decode_stage, "engine_input_source", []) or [])
+            this_decode_prefills: list[int] = []
+            for src in source_ids:
+                if src not in prefill_by_id:
+                    continue
+                p_idx = prefill_by_id[src]
+                if p_idx not in this_decode_prefills:
+                    this_decode_prefills.append(p_idx)
+                if p_idx not in prefill_ids:
+                    prefill_ids.append(p_idx)
+            decode_to_prefill[d_id] = this_decode_prefills
+
+        if not prefill_ids:
+            return None
+
+        return {
+            "prefill_ids": prefill_ids,
+            "decode_id": decode_indices[0],
+            "decode_ids": list(decode_indices),
+            "decode_to_prefill": decode_to_prefill,
+        }
 
     @staticmethod
     def _to_dict(obj: Any, default: Any = None) -> dict[str, Any] | None:
-        """Convert obj to a plain dict, trying several strategies."""
         if obj is None:
             return default
         if isinstance(obj, dict):
@@ -112,7 +154,6 @@ class PDDisaggregationMixin:
             try:
                 return vars(obj)
             except Exception:
-                logger.debug("Unable to convert %s to dict", type(obj))
                 return default
 
     def _kv_cfg_to_dict(self, kv_cfg: Any) -> dict[str, Any]:
@@ -122,56 +163,273 @@ class PDDisaggregationMixin:
         return self._to_dict(kv_params)
 
     def _validate_pd_separation_config(self) -> None:
-        """Validate PD stage configurations are consistent."""
-        pair = self._get_pd_separation_pair()
-        assert pair is not None
-        p_id, d_id = pair
-        p_stage = self.stage_configs[p_id]
-        d_stage = self.stage_configs[d_id]
+        prefill_ids = self._get_pd_prefill_ids()
+        decode_ids = self._get_pd_decode_ids()
+        assert prefill_ids and decode_ids
 
         def _get_kv_cfg(stage: Any) -> dict[str, Any]:
             ea = stage.engine_args
             cfg = getattr(ea, "kv_transfer_config", None)
+            if cfg is None and hasattr(ea, "get"):
+                cfg = ea.get("kv_transfer_config")
             if cfg is None:
-                cfg = ea.get("kv_transfer_config", None) if hasattr(ea, "get") else None
-            if cfg is None:
-                raise ValueError(f"Stage-{stage.stage_id} is marked for PD but has no 'kv_transfer_config'")
+                raise ValueError(f"Stage-{stage.stage_id} is marked for PD but has no kv_transfer_config")
             cfg_dict = self._kv_cfg_to_dict(cfg)
             if not cfg_dict:
                 raise ValueError(f"Stage-{stage.stage_id} kv_transfer_config could not be parsed")
             return cfg_dict
 
-        p_cfg = _get_kv_cfg(p_stage)
-        d_cfg = _get_kv_cfg(d_stage)
+        decode_cfgs: dict[int, dict[str, Any]] = {}
+        for d_id in decode_ids:
+            d_cfg = _get_kv_cfg(self.stage_configs[d_id])
+            d_role = d_cfg.get("kv_role")
+            if d_role not in ("kv_consumer", "kv_both"):
+                raise ValueError(f"Decode stage-{d_id} kv_role must be kv_consumer or kv_both, got {d_role!r}")
+            d_conn = d_cfg.get("kv_connector")
+            if not d_conn:
+                raise ValueError("PD requires kv_connector in decode kv_transfer_config")
+            decode_cfgs[d_id] = d_cfg
 
-        p_role = p_cfg.get("kv_role")
-        d_role = d_cfg.get("kv_role")
-        if p_role not in ("kv_producer", "kv_both"):
-            raise ValueError(f"Prefill stage-{p_id} kv_role must be 'kv_producer' or 'kv_both', got '{p_role}'")
-        if d_role not in ("kv_consumer", "kv_both"):
-            raise ValueError(f"Decode stage-{d_id} kv_role must be 'kv_consumer' or 'kv_both', got '{d_role}'")
+        def _validate_pair(p_id: int, d_id: int) -> None:
+            d_stage = self.stage_configs[d_id]
+            d_cfg = decode_cfgs[d_id]
+            d_sources = list(getattr(d_stage, "engine_input_source", []) or [])
+            d_tp = getattr(getattr(d_stage, "engine_args", None), "tensor_parallel_size", 1)
 
-        d_sources = list(getattr(d_stage, "engine_input_source", []) or [])
-        if p_id not in d_sources and p_stage.stage_id not in d_sources:
-            raise ValueError(f"Decode stage-{d_id} must list prefill stage-{p_id} in engine_input_source")
+            p_stage = self.stage_configs[p_id]
+            p_cfg = _get_kv_cfg(p_stage)
+            p_role = p_cfg.get("kv_role")
+            if p_role not in ("kv_producer", "kv_both"):
+                raise ValueError(f"Prefill stage-{p_id} kv_role must be kv_producer or kv_both, got {p_role!r}")
+            if p_id not in d_sources and p_stage.stage_id not in d_sources:
+                raise ValueError(f"Decode stage-{d_id} must list prefill stage-{p_id} in engine_input_source")
+            if p_cfg.get("kv_connector") != d_cfg.get("kv_connector"):
+                raise ValueError(
+                    f"PD connector mismatch: prefill stage-{p_id} uses {p_cfg.get('kv_connector')!r}, "
+                    f"decode stage-{d_id} uses {d_cfg.get('kv_connector')!r}"
+                )
+            for key in ("kv_buffer_device", "kv_buffer_size"):
+                p_val = p_cfg.get(key)
+                d_val = d_cfg.get(key)
+                if p_val is not None and d_val is not None and p_val != d_val:
+                    raise ValueError(
+                        f"PD {key} mismatch: prefill stage-{p_id}={p_val!r}, decode stage-{d_id}={d_val!r}"
+                    )
+            p_tp = getattr(getattr(p_stage, "engine_args", None), "tensor_parallel_size", 1)
+            if p_tp != d_tp:
+                raise ValueError(
+                    f"PD stages must have matching tensor_parallel_size: "
+                    f"prefill stage-{p_id}={p_tp}, decode stage-{d_id}={d_tp}"
+                )
 
-        p_conn = p_cfg.get("kv_connector")
-        d_conn = d_cfg.get("kv_connector")
-        if p_conn != d_conn:
-            raise ValueError(f"PD connector mismatch: prefill uses '{p_conn}', decode uses '{d_conn}'")
-        if not p_conn:
-            raise ValueError("PD requires kv_connector in kv_transfer_config")
+        for d_id in decode_ids:
+            for p_id in self._pd_decode_to_prefill.get(d_id, []):
+                _validate_pair(p_id, d_id)
 
-        for key in ("kv_buffer_device", "kv_buffer_size"):
-            p_val = p_cfg.get(key)
-            d_val = d_cfg.get(key)
-            if p_val is not None and d_val is not None and p_val != d_val:
-                raise ValueError(f"PD {key} mismatch: prefill='{p_val}', decode='{d_val}'")
+        bootstrap_ports: dict[int, int] = {}
+        all_pd_stages = [(p_id, _get_kv_cfg(self.stage_configs[p_id])) for p_id in prefill_ids]
+        all_pd_stages.extend((d_id, decode_cfgs[d_id]) for d_id in decode_ids)
+        for stage_id, cfg in all_pd_stages:
+            if "mooncake" not in str(cfg.get("kv_connector")).lower():
+                continue
+            stage = self.stage_configs[stage_id]
+            env_port = self._read_runtime_env_bootstrap_port(stage)
+            extra = cfg.get("kv_connector_extra_config", {}) or {}
+            if not isinstance(extra, dict):
+                extra = self._kv_cfg_to_dict(extra)
+            extra_port = extra.get("mooncake_bootstrap_port")
+            if env_port is not None and extra_port is not None and int(env_port) != int(extra_port):
+                raise ValueError(
+                    f"Stage-{stage_id} mooncake bootstrap port mismatch: "
+                    f"runtime.env={env_port}, extra_config={extra_port}"
+                )
+            port = (
+                int(env_port)
+                if env_port is not None
+                else int(extra_port)
+                if extra_port is not None
+                else _DEFAULT_MOONCAKE_BOOTSTRAP_PORT
+            )
+            if port in bootstrap_ports:
+                raise ValueError(
+                    f"Mooncake bootstrap port collision: stage-{bootstrap_ports[port]} "
+                    f"and stage-{stage_id} both use port {port}"
+                )
+            bootstrap_ports[port] = stage_id
 
-        p_tp = getattr(getattr(p_stage, "engine_args", None), "tensor_parallel_size", 1)
-        d_tp = getattr(getattr(d_stage, "engine_args", None), "tensor_parallel_size", 1)
-        if p_tp != d_tp:
-            raise ValueError(f"PD stages must have matching tensor_parallel_size: prefill={p_tp}, decode={d_tp}")
+    @staticmethod
+    def _read_runtime_env_bootstrap_port(stage: Any) -> int | None:
+        runtime_cfg = getattr(stage, "runtime", None)
+        if runtime_cfg is None and hasattr(stage, "get"):
+            runtime_cfg = stage.get("runtime")
+        if runtime_cfg is None:
+            return None
+        env_section = runtime_cfg.get("env") if hasattr(runtime_cfg, "get") else getattr(runtime_cfg, "env", None)
+        if env_section is None:
+            return None
+        try:
+            raw = (
+                env_section.get(_VLLM_MOONCAKE_BOOTSTRAP_PORT_ENV)
+                if hasattr(env_section, "get")
+                else env_section[_VLLM_MOONCAKE_BOOTSTRAP_PORT_ENV]
+            )
+        except Exception:
+            return None
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[PD] runtime.env.%s=%r on stage-%s is not an int; ignoring.",
+                _VLLM_MOONCAKE_BOOTSTRAP_PORT_ENV,
+                raw,
+                getattr(stage, "stage_id", "?"),
+            )
+            return None
+
+    def _resolve_pd_prefill_pick_strategy(self) -> str:
+        candidate = getattr(self, "_pd_prefill_pick_strategy_override", None)
+        if not candidate:
+            candidate = os.getenv(_PD_PREFILL_PICK_STRATEGY_ENV) or None
+        if not candidate:
+            return _DEFAULT_PD_PREFILL_PICK_STRATEGY
+        candidate = str(candidate).strip().lower()
+        if candidate not in _PD_PREFILL_PICK_STRATEGIES:
+            logger.warning(
+                "[PD] Unknown pd_prefill_pick_strategy=%r; falling back to %r. Allowed: %s",
+                candidate,
+                _DEFAULT_PD_PREFILL_PICK_STRATEGY,
+                list(_PD_PREFILL_PICK_STRATEGIES),
+            )
+            return _DEFAULT_PD_PREFILL_PICK_STRATEGY
+        return candidate
+
+    def _pick_prefill_stage(self, req_id: str | None = None) -> int:
+        prefill_ids = self._get_pd_prefill_ids()
+        if not prefill_ids:
+            raise RuntimeError("_pick_prefill_stage called but no PD prefill stages are configured")
+        if len(prefill_ids) == 1:
+            chosen = prefill_ids[0]
+            if req_id is not None:
+                self._pd_request_to_prefill[req_id] = chosen
+            return chosen
+
+        strategy = getattr(self, "_pd_prefill_pick_strategy", _DEFAULT_PD_PREFILL_PICK_STRATEGY)
+        with self._pd_prefill_inflight_lock:
+            if strategy == "least_inflight":
+                chosen = min(prefill_ids, key=lambda p: (self._pd_prefill_inflight.get(p, 0), p))
+            else:
+                idx = self._pd_prefill_round_robin_idx % len(prefill_ids)
+                chosen = prefill_ids[idx]
+                self._pd_prefill_round_robin_idx = (idx + 1) % len(prefill_ids)
+            self._pd_prefill_inflight[chosen] = self._pd_prefill_inflight.get(chosen, 0) + 1
+            inflight_snapshot = dict(self._pd_prefill_inflight)
+        if req_id is not None:
+            self._pd_request_to_prefill[req_id] = chosen
+        if _pd_trace_enabled():
+            logger.info(
+                "[PD_TRACE] prefill_select req=%s stage=%d strategy=%s inflight=%s",
+                req_id,
+                chosen,
+                strategy,
+                inflight_snapshot,
+            )
+        return chosen
+
+    def _release_pd_prefill_for_request(self, req_id: str) -> int | None:
+        """Decrement the prefill inflight counter for a finished/aborted request.
+
+        Mirrors Orchestrator._release_pd_decode_for_request and keeps
+        ``least_inflight`` tracking actual in-flight count instead of the
+        cumulative number of assignments.
+        """
+        chosen = self._pd_request_to_prefill.pop(req_id, None)
+        if chosen is None:
+            return None
+        with self._pd_prefill_inflight_lock:
+            cur = self._pd_prefill_inflight.get(chosen, 0)
+            self._pd_prefill_inflight[chosen] = max(0, cur - 1)
+            inflight_snapshot = dict(self._pd_prefill_inflight)
+        if _pd_trace_enabled():
+            logger.info(
+                "[PD_TRACE] prefill_release req=%s stage=%d inflight=%s",
+                req_id,
+                chosen,
+                inflight_snapshot,
+            )
+        return chosen
+
+    def _prepare_prefill_sampling_params(self, req_id: str, sp: SamplingParams) -> SamplingParams:
+        sp = sp.clone()
+        # P and D run in different processes. Give unseeded PD requests an
+        # independent but stable stream so P's post-y0 generator state can be
+        # restored on D instead of both sides consuming unrelated global RNG.
+        if sp.seed is None:
+            sp.seed = zlib.crc32(req_id.encode("utf-8"))
+        sp.max_tokens = 1
+        if hasattr(sp, "min_tokens"):
+            try:
+                # Keep min_tokens=1: Mooncake cancels the KV transfer unless the
+                # prefill finishes with finish_reason='length'. A 0 here would let
+                # an EOS on the first token end the step as 'stop' and drop the
+                # transfer, so the decode side never receives the prompt KV.
+                sp.min_tokens = 1
+            except Exception:
+                pass
+        sp.stop = []
+        sp.stop_token_ids = []
+        sp.include_stop_str_in_output = False
+        if sp.extra_args is None:
+            sp.extra_args = {}
+        kv_params = self._normalize_kv_transfer_params(sp.extra_args.get("kv_transfer_params"))
+        merged = dict(kv_params or {})
+        merged.update({"do_remote_decode": True, "do_remote_prefill": False, "transfer_id": f"xfer-{req_id}"})
+        sp.extra_args["kv_transfer_params"] = merged
+        return sp
+
+    def _maybe_expand_sampling_params(self, sampling_params_list: list) -> list:
+        prefill_ids = self._get_pd_prefill_ids()
+        decode_ids = self._get_pd_decode_ids()
+        if not prefill_ids or not decode_ids:
+            return sampling_params_list
+
+        if len(prefill_ids) == 1 and len(decode_ids) == 1:
+            decode_id = decode_ids[0]
+            if len(sampling_params_list) != len(self.stage_configs) - 1:
+                return sampling_params_list
+            sp_list = list(sampling_params_list)
+            sp_list.insert(decode_id, sp_list[prefill_ids[0]])
+            return sp_list
+
+        pd_slots = set(prefill_ids) | set(decode_ids)
+        expected_caller_len = 1 + len(self.stage_configs) - len(pd_slots)
+        if len(sampling_params_list) != expected_caller_len:
+            return sampling_params_list
+
+        sp_list = list(sampling_params_list)
+        prefill_template = sp_list[0]
+        non_pd_iter = iter(sp_list[1:])
+        result = []
+        for stage_idx in range(len(self.stage_configs)):
+            if stage_idx in pd_slots:
+                result.append(prefill_template)
+            else:
+                result.append(next(non_pd_iter, prefill_template))
+        return result
+
+    # ==================================================================== #
+    # Upstream v0.26 helpers (1P1D-oriented), retained for API compat.
+    # The multi-replica PD path above does not call these; they are kept so
+    # tests/entrypoints/test_pd_disaggregation.py from upstream still passes.
+    # ==================================================================== #
+    def _get_pd_separation_pair(self) -> tuple[int, int] | None:
+        """PD prefill/decode indices when ``_init_pd_state`` ran; else ``None``.
+
+        Partial test doubles may skip ``OmniBase.__init__``; treat missing state as
+        no PD disaggregation instead of raising ``AttributeError``.
+        """
+        return getattr(self, "_pd_separation_pair", None)
 
     def _get_pd_connector_info(self) -> dict[str, Any] | None:
         """Extract prefill engine KV connector info."""
@@ -207,35 +465,6 @@ class PDDisaggregationMixin:
 
         return info
 
-    def _prepare_prefill_sampling_params(self, req_id: str, sp: "SamplingParams") -> "SamplingParams":
-        sp = sp.clone()
-        sp.max_tokens = 1
-        if hasattr(sp, "min_tokens"):
-            try:
-                sp.min_tokens = 1
-            except Exception:
-                pass
-        # MooncakeConnector cancels KV transfer unless finish_reason='length'
-        sp.stop = []
-        sp.stop_token_ids = []
-        sp.include_stop_str_in_output = False
-        if sp.extra_args is None:
-            sp.extra_args = {}
-        kv_params = self._normalize_kv_transfer_params(sp.extra_args.get("kv_transfer_params"))
-        merged: dict[str, Any] = {}
-        if kv_params:
-            merged.update(kv_params)
-        merged.update(
-            {
-                "do_remote_decode": True,
-                "do_remote_prefill": False,
-                "transfer_id": f"xfer-{req_id}",
-            }
-        )
-        sp.extra_args["kv_transfer_params"] = merged
-        logger.debug("[PD] prefill SP: req=%s kv_transfer_params=%s", req_id, merged)
-        return sp
-
     def _pop_pd_kv_params(self, req_id: str, fallback: Any | None = None) -> dict[str, Any] | None:
         kv_params = self._normalize_kv_transfer_params(fallback)
         with self._pd_kv_params_lock:
@@ -256,23 +485,6 @@ class PDDisaggregationMixin:
             if kv_params is not None:
                 return self._normalize_kv_transfer_params(kv_params)
         return None
-
-    def _is_pd_routing(self, stage_id: int, next_stage_id: int) -> bool:
-        """True when edge stage_id → next_stage_id is the prefill→decode boundary."""
-        pair = self._get_pd_separation_pair()
-        return pair is not None and pair == (stage_id, next_stage_id)
-
-    def _maybe_expand_sampling_params(self, sampling_params_list: list) -> list:
-        """Auto-duplicate thinker SP for decode stage when user provides N-1 params."""
-        pair = self._get_pd_separation_pair()
-        if pair is None:
-            return sampling_params_list
-        if len(sampling_params_list) != len(self.stage_configs) - 1:
-            return sampling_params_list
-        p_id, d_id = pair
-        sp_list = list(sampling_params_list)
-        sp_list.insert(d_id, sp_list[p_id])
-        return sp_list
 
     def _build_decode_kv_params(
         self,
@@ -306,6 +518,11 @@ class PDDisaggregationMixin:
             decode_kv_params["transfer_id"] = f"xfer-{req_id}"
 
         return decode_kv_params
+
+    def _is_pd_routing(self, stage_id: int, next_stage_id: int) -> bool:
+        """True when edge stage_id → next_stage_id is the prefill→decode boundary."""
+        pair = self._get_pd_separation_pair()
+        return pair is not None and pair == (stage_id, next_stage_id)
 
     def _prepare_pd_decode_routing(
         self,
@@ -348,3 +565,38 @@ class PDDisaggregationMixin:
             )
 
         return next_inputs, sp_next
+
+    @staticmethod
+    def detect_pd_separation_from_stage_configs(stage_configs: list[Any]) -> tuple[int, int] | None:
+        """Scan stage configs for a prefill/decode pair.
+
+        Returns:
+            (prefill_idx, decode_idx) if one pair exists, None if not found.
+
+        Raises:
+            ValueError: if multiple candidate PD pairs are found.
+        """
+        prefill_by_id: dict[int, int] = {}
+        decode_indices: list[int] = []
+        for i, stage in enumerate(stage_configs):
+            if getattr(stage, "is_prefill_only", False):
+                prefill_by_id[i] = i
+                sid = getattr(stage, "stage_id", i)
+                if sid != i:
+                    prefill_by_id[sid] = i
+            if getattr(stage, "is_decode_only", False):
+                decode_indices.append(i)
+
+        pd_pairs: list[tuple[int, int]] = []
+        for j in decode_indices:
+            source_ids = getattr(stage_configs[j], "engine_input_source", [])
+            for src in source_ids:
+                if src in prefill_by_id:
+                    pd_pairs.append((prefill_by_id[src], j))
+                    break
+
+        if len(pd_pairs) > 1:
+            raise ValueError(
+                f"Multiple PD pairs detected ({pd_pairs}); only a single PD pair per pipeline is supported"
+            )
+        return pd_pairs[0] if pd_pairs else None

--- a/vllm_omni/model_executor/models/qwen3_tts/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/pipeline.py
@@ -56,3 +56,45 @@ QWEN3_TTS_PIPELINE = PipelineConfig(
         ),
     ),
 )
+
+# Qwen3-TTS PD topology: Talker prefill → Talker decode → Code2Wav.
+# Placement, KV transport, and sampling settings remain deployment concerns.
+QWEN3_TTS_PD_PIPELINE = PipelineConfig(
+    model_type="qwen3_tts_pd",
+    default_deploy_config_name="qwen3_tts_pd_1p1d.yaml",
+    model_arch="Qwen3TTSTalkerForConditionalGeneration",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="qwen3_tts",
+            execution_type=StageExecutionType.LLM_AR,
+            owns_tokenizer=True,
+            engine_output_type="latent",
+            sampling_constraints={"detokenize": False, "stop_token_ids": [2150]},
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="qwen3_tts",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(0,),
+            engine_output_type="latent",
+            async_chunk_process_next_stage_input_func=f"{_PROC}.talker2code2wav_async_chunk",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2code2wav_full_payload",
+            sampling_constraints={"detokenize": False, "stop_token_ids": [2150]},
+        ),
+        StagePipelineConfig(
+            stage_id=2,
+            model_stage="code2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            model_arch="Qwen3TTSCode2Wav",
+            sync_process_input_func=f"{_PROC}.talker2code2wav_token_only",
+            sampling_constraints={"detokenize": True},
+            extras={"tts_args": {"max_instructions_length": 500}},
+            requires_full_payload_input=True,
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -1351,4 +1351,3 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         summed = (last_id_hidden.squeeze(1) + gathered.sum(dim=1)).unsqueeze(1)
         inputs_embeds_out = (summed + text_step).reshape(bsz, -1)
         return inputs_embeds_out, audio_codes.to(dtype=torch.long)
-

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -831,44 +831,46 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # (request-independent buffer) — no per-request fetch needed.
 
         tail = hs.get("trailing_text")
+        if not isinstance(tail, torch.Tensor) or tail.ndim != 2:
+            raise RuntimeError(
+                "Missing hidden_states['trailing_text'] for Qwen3-TTS decode; "
+                "the prefill/decode runtime state handoff is incomplete."
+            )
         text_offset = max(0, int(meta.get("talker_text_offset", 0) or 0))
         trailing_text_update = None
-        if isinstance(tail, torch.Tensor) and tail.ndim == 2:
-            tail_len = int(tail.shape[0])
-            if text_offset < tail_len:
-                text_step = (
-                    tail[text_offset : text_offset + 1]
-                    .to(
-                        device=input_ids.device,
-                        dtype=dtype,
-                    )
-                    .reshape(1, -1)
+        tail_len = int(tail.shape[0])
+        if text_offset < tail_len:
+            text_step = (
+                tail[text_offset : text_offset + 1]
+                .to(
+                    device=input_ids.device,
+                    dtype=dtype,
                 )
-                next_text_offset = text_offset + 1
-                should_compact_tail = next_text_offset >= tail_len or (
-                    next_text_offset >= _TRAILING_TEXT_COMPACT_MIN_FRAMES and next_text_offset * 2 >= tail_len
-                )
-                if should_compact_tail:
-                    if next_text_offset >= tail_len:
-                        trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
-                    else:
-                        trailing_text_update = tail[next_text_offset:].contiguous()
-                    next_text_offset = 0
-            else:
-                text_step = tts_pad_embed
-                next_text_offset = 0
-                if tail.numel() > 0:
+                .reshape(1, -1)
+            )
+            next_text_offset = text_offset + 1
+            should_compact_tail = next_text_offset >= tail_len or (
+                next_text_offset >= _TRAILING_TEXT_COMPACT_MIN_FRAMES and next_text_offset * 2 >= tail_len
+            )
+            if should_compact_tail:
+                if next_text_offset >= tail_len:
                     trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
+                else:
+                    trailing_text_update = tail[next_text_offset:].contiguous()
+                next_text_offset = 0
         else:
             text_step = tts_pad_embed
-            next_text_offset = text_offset
+            next_text_offset = 0
+            if tail.numel() > 0:
+                trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
 
         last_hidden = hs.get("last")
-        if isinstance(last_hidden, torch.Tensor):
-            past_hidden = last_hidden.to(device=input_ids.device, dtype=dtype).reshape(1, -1)
-        else:
-            # Defensive: EOS step row is zeroed by the invalid-layer-0 mask and filtered downstream.
-            past_hidden = torch.zeros_like(text_step)
+        if not isinstance(last_hidden, torch.Tensor):
+            raise RuntimeError(
+                "Missing hidden_states['last'] for Qwen3-TTS decode; "
+                "the prefill/decode runtime state handoff is incomplete."
+            )
+        past_hidden = last_hidden.to(device=input_ids.device, dtype=dtype).reshape(1, -1)
 
         # Use OmniGPUModelRunner talker_mtp fast-path for residual codebooks and per-step inputs_embeds update.
         last_id_hidden = self.embed_input_ids(input_ids.reshape(1, 1).to(torch.long)).to(
@@ -1002,6 +1004,44 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             return {}
         last = hidden_states[-1, :].detach()
         return {"hidden_states": {"last": last}}
+
+    def export_pd_decode_state(self, info_dict: dict[str, Any]) -> dict[str, Any]:
+        """Snapshot the non-KV state required to resume a PD decode worker."""
+        hidden_states = info_dict.get("hidden_states")
+        meta = info_dict.get("meta")
+        codes = info_dict.get("codes")
+        if not isinstance(hidden_states, dict) or not isinstance(meta, dict):
+            raise RuntimeError("Qwen3-TTS PD prefill did not produce runtime state")
+
+        last = hidden_states.get("last")
+        trailing_text = hidden_states.get("trailing_text")
+        if not isinstance(last, torch.Tensor) or not isinstance(trailing_text, torch.Tensor):
+            raise RuntimeError("Qwen3-TTS PD prefill state is missing hidden_states.last or trailing_text")
+
+        def _to_wire_tensor(tensor: torch.Tensor) -> torch.Tensor:
+            # AdditionalInformationPayload serializes via Tensor.numpy(), which
+            # does not support bfloat16. Decode casts these back to its model
+            # dtype, so use FP32 only at this cross-process wire boundary.
+            tensor = tensor.detach()
+            if tensor.is_floating_point():
+                tensor = tensor.to(dtype=torch.float32)
+            return tensor.to("cpu").contiguous()
+
+        state: dict[str, Any] = {
+            "hidden_states": {
+                "last": _to_wire_tensor(last),
+                "trailing_text": _to_wire_tensor(trailing_text),
+            },
+            "meta": {
+                "talker_text_offset": int(meta.get("talker_text_offset", 0) or 0),
+                "codec_streaming": bool(meta.get("codec_streaming", False)),
+            },
+        }
+        if isinstance(codes, dict) and isinstance(codes.get("ref"), torch.Tensor):
+            state["codes"] = {"ref": _to_wire_tensor(codes["ref"])}
+        if meta.get("ref_code_len") is not None:
+            state["meta"]["ref_code_len"] = int(meta["ref_code_len"])
+        return state
 
     @torch.inference_mode()
     def preprocess_batch(
@@ -1311,3 +1351,4 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         summed = (last_id_hidden.squeeze(1) + gathered.sum(dim=1)).unsqueeze(1)
         inputs_embeds_out = (summed + text_step).reshape(bsz, -1)
         return inputs_embeds_out, audio_codes.to(dtype=torch.long)
+

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -763,44 +763,46 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # (request-independent buffer) — no per-request fetch needed.
 
         tail = hs.get("trailing_text")
+        if not isinstance(tail, torch.Tensor) or tail.ndim != 2:
+            raise RuntimeError(
+                "Missing hidden_states['trailing_text'] for Qwen3-TTS decode; "
+                "the prefill/decode runtime state handoff is incomplete."
+            )
         text_offset = max(0, int(meta.get("talker_text_offset", 0) or 0))
         trailing_text_update = None
-        if isinstance(tail, torch.Tensor) and tail.ndim == 2:
-            tail_len = int(tail.shape[0])
-            if text_offset < tail_len:
-                text_step = (
-                    tail[text_offset : text_offset + 1]
-                    .to(
-                        device=input_ids.device,
-                        dtype=dtype,
-                    )
-                    .reshape(1, -1)
+        tail_len = int(tail.shape[0])
+        if text_offset < tail_len:
+            text_step = (
+                tail[text_offset : text_offset + 1]
+                .to(
+                    device=input_ids.device,
+                    dtype=dtype,
                 )
-                next_text_offset = text_offset + 1
-                should_compact_tail = next_text_offset >= tail_len or (
-                    next_text_offset >= _TRAILING_TEXT_COMPACT_MIN_FRAMES and next_text_offset * 2 >= tail_len
-                )
-                if should_compact_tail:
-                    if next_text_offset >= tail_len:
-                        trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
-                    else:
-                        trailing_text_update = tail[next_text_offset:].contiguous()
-                    next_text_offset = 0
-            else:
-                text_step = tts_pad_embed
-                next_text_offset = 0
-                if tail.numel() > 0:
+                .reshape(1, -1)
+            )
+            next_text_offset = text_offset + 1
+            should_compact_tail = next_text_offset >= tail_len or (
+                next_text_offset >= _TRAILING_TEXT_COMPACT_MIN_FRAMES and next_text_offset * 2 >= tail_len
+            )
+            if should_compact_tail:
+                if next_text_offset >= tail_len:
                     trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
+                else:
+                    trailing_text_update = tail[next_text_offset:].contiguous()
+                next_text_offset = 0
         else:
             text_step = tts_pad_embed
-            next_text_offset = text_offset
+            next_text_offset = 0
+            if tail.numel() > 0:
+                trailing_text_update = torch.empty((0, tail.shape[1]), device=tail.device, dtype=tail.dtype)
 
         last_hidden = hs.get("last")
-        if isinstance(last_hidden, torch.Tensor):
-            past_hidden = last_hidden.to(device=input_ids.device, dtype=dtype).reshape(1, -1)
-        else:
-            # Defensive: EOS step row is zeroed by the invalid-layer-0 mask and filtered downstream.
-            past_hidden = torch.zeros_like(text_step)
+        if not isinstance(last_hidden, torch.Tensor):
+            raise RuntimeError(
+                "Missing hidden_states['last'] for Qwen3-TTS decode; "
+                "the prefill/decode runtime state handoff is incomplete."
+            )
+        past_hidden = last_hidden.to(device=input_ids.device, dtype=dtype).reshape(1, -1)
 
         # Use OmniGPUModelRunner talker_mtp fast-path for residual codebooks and per-step inputs_embeds update.
         last_id_hidden = self.embed_input_ids(input_ids.reshape(1, 1).to(torch.long)).to(
@@ -934,6 +936,44 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             return {}
         last = hidden_states[-1, :].detach()
         return {"hidden_states": {"last": last}}
+
+    def export_pd_decode_state(self, info_dict: dict[str, Any]) -> dict[str, Any]:
+        """Snapshot the non-KV state required to resume a PD decode worker."""
+        hidden_states = info_dict.get("hidden_states")
+        meta = info_dict.get("meta")
+        codes = info_dict.get("codes")
+        if not isinstance(hidden_states, dict) or not isinstance(meta, dict):
+            raise RuntimeError("Qwen3-TTS PD prefill did not produce runtime state")
+
+        last = hidden_states.get("last")
+        trailing_text = hidden_states.get("trailing_text")
+        if not isinstance(last, torch.Tensor) or not isinstance(trailing_text, torch.Tensor):
+            raise RuntimeError("Qwen3-TTS PD prefill state is missing hidden_states.last or trailing_text")
+
+        def _to_wire_tensor(tensor: torch.Tensor) -> torch.Tensor:
+            # AdditionalInformationPayload serializes via Tensor.numpy(), which
+            # does not support bfloat16. Decode casts these back to its model
+            # dtype, so use FP32 only at this cross-process wire boundary.
+            tensor = tensor.detach()
+            if tensor.is_floating_point():
+                tensor = tensor.to(dtype=torch.float32)
+            return tensor.to("cpu").contiguous()
+
+        state: dict[str, Any] = {
+            "hidden_states": {
+                "last": _to_wire_tensor(last),
+                "trailing_text": _to_wire_tensor(trailing_text),
+            },
+            "meta": {
+                "talker_text_offset": int(meta.get("talker_text_offset", 0) or 0),
+                "codec_streaming": bool(meta.get("codec_streaming", False)),
+            },
+        }
+        if isinstance(codes, dict) and isinstance(codes.get("ref"), torch.Tensor):
+            state["codes"] = {"ref": _to_wire_tensor(codes["ref"])}
+        if meta.get("ref_code_len") is not None:
+            state["meta"]["ref_code_len"] = int(meta["ref_code_len"])
+        return state
 
     @torch.inference_mode()
     def preprocess_batch(
@@ -1146,3 +1186,4 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         summed = (last_id_hidden.squeeze(1) + gathered.sum(dim=1)).unsqueeze(1)
         inputs_embeds_out = (summed + text_step).reshape(bsz, -1)
         return inputs_embeds_out, audio_codes.to(dtype=torch.long)
+

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -571,3 +571,34 @@ def _patch_cumem_free_callback_cuda() -> None:
 
 
 _patch_cumem_free_callback_cuda()
+
+
+# [PD] Patch MooncakeConnector globally for PD disaggregation.
+#
+# This MUST live here, not only in PDDisaggregationMixin._init_pd_state():
+# _init_pd_state runs in the APIServer process, while the KV connector is
+# constructed inside each stage worker subprocess. Those subprocesses import
+# vllm_omni (and therefore this module) but never touch the mixin, so without
+# this call the decode-side connector stays unpatched, never issues its KV
+# pull, and every decode request sits in WAITING_FOR_REMOTE_KVS until the
+# 480 s mooncake timeout.
+def _patch_mooncake_connector_for_pd():
+    try:
+        from vllm_omni.distributed.kv_transfer.mooncake_pd_patch import (
+            apply_mooncake_connector_patch,
+        )
+
+        apply_mooncake_connector_patch()
+    except ImportError:
+        pass
+    except Exception:
+        # Patch failure is non-fatal for non-PD deployments; PD deployments
+        # will surface it later as "Missing remote_request_id".
+        _PATCH_LOGGER.warning(
+            "Failed to apply MooncakeConnector PD patch at vllm_omni import; "
+            "PD KV transfer will fail with 'Missing remote_request_id' if used.",
+            exc_info=True,
+        )
+
+
+_patch_mooncake_connector_for_pd()

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -484,3 +484,34 @@ def _patch_cumem_free_callback_cuda() -> None:
 
 
 _patch_cumem_free_callback_cuda()
+
+
+# [PD] Patch MooncakeConnector globally for PD disaggregation.
+#
+# This MUST live here, not only in PDDisaggregationMixin._init_pd_state():
+# _init_pd_state runs in the APIServer process, while the KV connector is
+# constructed inside each stage worker subprocess. Those subprocesses import
+# vllm_omni (and therefore this module) but never touch the mixin, so without
+# this call the decode-side connector stays unpatched, never issues its KV
+# pull, and every decode request sits in WAITING_FOR_REMOTE_KVS until the
+# 480 s mooncake timeout.
+def _patch_mooncake_connector_for_pd():
+    try:
+        from vllm_omni.distributed.kv_transfer.mooncake_pd_patch import (
+            apply_mooncake_connector_patch,
+        )
+
+        apply_mooncake_connector_patch()
+    except ImportError:
+        pass
+    except Exception:
+        # Patch failure is non-fatal for non-PD deployments; PD deployments
+        # will surface it later as "Missing remote_request_id".
+        _PATCH_LOGGER.warning(
+            "Failed to apply MooncakeConnector PD patch at vllm_omni import; "
+            "PD KV transfer will fail with 'Missing remote_request_id' if used.",
+            exc_info=True,
+        )
+
+
+_patch_mooncake_connector_for_pd()

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1310,11 +1310,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     )
 
                 sample_hidden_states = hidden_states[logits_indices.to(hidden_states.device)]
+                sampling_metadata = self._sampling_metadata_with_pd_resume_history(self.input_batch.sampling_metadata)
                 # Try with sampling_metadata first; fall back to without for models that don't support it
                 try:
-                    logits = self.model.compute_logits(
-                        sample_hidden_states, sampling_metadata=self.input_batch.sampling_metadata
-                    )
+                    logits = self.model.compute_logits(sample_hidden_states, sampling_metadata=sampling_metadata)
                 except TypeError:
                     logits = self.model.compute_logits(sample_hidden_states)
             else:
@@ -1322,6 +1321,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 assert not self.is_pooling_model
 
                 sample_hidden_states = hidden_states[logits_indices.to(hidden_states.device)]
+                sampling_metadata = self._sampling_metadata_with_pd_resume_history(self.input_batch.sampling_metadata)
                 if not get_pp_group().is_last_rank:
                     all_gather_tensors = {
                         "residual": not is_residual_scattered_for_sp(self.vllm_config, num_tokens_padded)
@@ -1335,9 +1335,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 else:
                     # Try with sampling_metadata first; fall back to without for models that don't support it
                     try:
-                        logits = self.model.compute_logits(
-                            sample_hidden_states, sampling_metadata=self.input_batch.sampling_metadata
-                        )
+                        logits = self.model.compute_logits(sample_hidden_states, sampling_metadata=sampling_metadata)
                     except TypeError:
                         logits = self.model.compute_logits(sample_hidden_states)
 
@@ -1390,10 +1388,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         fallthrough is load-bearing, not an error path; it is logged once per
         model for visibility.
         """
-        sampling_metadata = self.input_batch.sampling_metadata
         if spec_decode_metadata is None:
             model_sample = getattr(self.model, "sample", None)
             self.input_batch.update_async_output_token_ids()
+            raw_sampling_metadata = self.input_batch.sampling_metadata
             if logits is not None and callable(model_sample) and getattr(self.model, "prefer_model_sampler", False):
                 # Apply logit bias (min_tokens, allowed_token_ids) before
                 # the custom model sampler — the standard GPU sampler does
@@ -1405,7 +1403,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                         self.input_batch.idx_mapping_np,
                         self.input_batch.positions[self.input_batch.logits_indices],
                     )
-                prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(sampling_metadata)
+                prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(raw_sampling_metadata)
+                prepared_sampling_metadata = self._sampling_metadata_with_pd_resume_history(prepared_sampling_metadata)
                 self._apply_duplex_sampling(logits, prepared_sampling_metadata)
                 sampler_output = model_sample(logits, prepared_sampling_metadata)
                 if sampler_output is not None:
@@ -1418,6 +1417,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     "prefer_model_sampler model %s returned None from sample(); falling back to the default sampler.",
                     type(self.model).__name__,
                 )
+            sampling_metadata = self._sampling_metadata_with_pd_resume_history(raw_sampling_metadata)
             return self.sampler(
                 logits=logits,
                 sampling_metadata=sampling_metadata,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -931,6 +931,20 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
 
         # [Omni] Handle KV transfer BEFORE updating states (which removes finished requests)
         finished_reqs = getattr(scheduler_output, "finished_requests_needing_kv_transfer", {})
+        export_pd_decode_state = callable(getattr(self.model, "export_pd_decode_state", None))
+        if finished_reqs and export_pd_decode_state:
+            frozen_states = getattr(self, "_pd_kv_transfer_states", None)
+            if frozen_states is None:
+                frozen_states = {}
+                self._pd_kv_transfer_states = frozen_states
+            for req_id in finished_reqs:
+                # Freeze the state at exactly the same scheduling boundary as
+                # the KV snapshot. Do not overwrite it while waiting for the
+                # asynchronous extraction acknowledgement.
+                frozen_states.setdefault(
+                    req_id,
+                    self.model.export_pd_decode_state(self.model_intermediate_buffer.get(req_id, {})),
+                )
         if finished_reqs and hasattr(self.model, "get_kv_transfer_metadata"):
             finished_reqs = self._merge_model_kv_transfer_metadata(finished_reqs)
         self.kv_extracted_req_ids = self.kv_transfer_manager.handle_finished_requests_kv_transfer(
@@ -1002,9 +1016,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     self.kv_extracted_req_ids = None
 
                     output = make_empty_encoder_model_runner_output(scheduler_output)
-                    if kv_ids:
-                        output = copy(output)
-                        output.kv_extracted_req_ids = kv_ids
+                    output = self._attach_pd_states_to_kv_ack_output(output, kv_ids)
                     return self.attach_omni_connector_output(output)
 
             # `<= 0`: upstream can schedule a negative span, which is truthy (#5196).
@@ -1026,9 +1038,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 else:
                     output = self.kv_connector_no_forward(scheduler_output, self.vllm_config)
 
-                if kv_ids:
-                    output = copy(output)
-                    output.kv_extracted_req_ids = kv_ids
+                output = self._attach_pd_states_to_kv_ack_output(output, kv_ids)
 
                 return self.attach_omni_connector_output(output)
 
@@ -1797,6 +1807,113 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             self._omni_payload_copy_stream = stream
         return stream
 
+    def _collect_pd_prefill_decode_states(self, req_ids: list[str]) -> list[dict[str, Any] | None] | None:
+        """Consume non-KV states frozen at the matching KV snapshot boundary."""
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) != "kv_producer":
+            return None
+        frozen_states = getattr(self, "_pd_kv_transfer_states", None)
+        if not isinstance(frozen_states, dict):
+            raise RuntimeError(f"Qwen3-TTS PD KV acknowledgement has no frozen state map for reqs={req_ids}")
+        missing = [req_id for req_id in req_ids if req_id not in frozen_states]
+        if missing:
+            raise RuntimeError(
+                "Qwen3-TTS PD KV acknowledgement is missing frozen runtime state "
+                f"for reqs={missing}; available={list(frozen_states)}"
+            )
+        return [frozen_states.pop(req_id) for req_id in req_ids]
+
+    def _export_pd_prefill_decode_states(self, req_ids: list[str]) -> list[dict[str, Any] | None] | None:
+        """Snapshot Qwen3-TTS state with the model output that starts D pull."""
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) != "kv_producer":
+            return None
+        export_state = getattr(self.model, "export_pd_decode_state", None)
+        if not callable(export_state):
+            return None
+
+        states: list[dict[str, Any]] = []
+        for req_id in req_ids:
+            state = export_state(self.model_intermediate_buffer.get(req_id, {}))
+            req_state = self.requests.get(req_id)
+            generator = getattr(req_state, "generator", None)
+            sampling_params = getattr(req_state, "sampling_params", None)
+            seed = getattr(sampling_params, "seed", None)
+            if not isinstance(generator, torch.Generator) or seed is None:
+                raise RuntimeError(
+                    "Qwen3-TTS PD prefill requires a request-local main sampler generator "
+                    f"for req={req_id}"
+                )
+            # The P sampler has just consumed y0. Preserve its exact post-y0
+            # state; replaying a token sample on D is not equivalent because
+            # vLLM's sampler can consume a variable amount of RNG.
+            state["pd_sampler"] = {
+                "main_generator_state": generator.get_state().detach().to("cpu").clone(),
+                "seed": int(seed),
+            }
+            states.append(state)
+        return states
+
+    def _attach_pd_states_to_kv_ack_output(
+        self,
+        output: Any,
+        kv_ids: list[str] | None,
+        states: list[dict[str, Any] | None] | None = None,
+    ) -> Any:
+        """Attach frozen PD state to the output that carries a KV acknowledgement."""
+        if not kv_ids:
+            return output
+        if isinstance(output, OmniModelRunnerOutput):
+            output = copy(output)
+        else:
+            # kv_connector_no_forward() returns the upstream base output type.
+            # Promote it before crossing the worker/engine boundary; dynamically
+            # adding multimodal_outputs to the base type is not wire-stable.
+            output = OmniModelRunnerOutput.with_kv_conn_output_only(
+                getattr(output, "kv_connector_output", None)
+            )
+        output.kv_extracted_req_ids = kv_ids
+        if states is None:
+            states = self._collect_pd_prefill_decode_states(kv_ids)
+        if states is None:
+            return output
+        if len(states) != len(kv_ids):
+            raise RuntimeError(f"Qwen3-TTS PD state/ack mismatch: states={len(states)} ack_ids={len(kv_ids)}")
+
+        req_ids = list(getattr(output, "req_ids", None) or [])
+        req_id_to_index = dict(getattr(output, "req_id_to_index", None) or {})
+        mm_outputs = list(getattr(output, "multimodal_outputs", None) or [])
+        if len(mm_outputs) < len(req_ids):
+            mm_outputs.extend([None] * (len(req_ids) - len(mm_outputs)))
+
+        for req_id, state in zip(kv_ids, states, strict=True):
+            if state is None:
+                raise RuntimeError(f"Qwen3-TTS PD KV acknowledgement has empty runtime state for req={req_id}")
+            state_payload = _ensure_tensor_values(flatten_payload(state))
+            index = req_id_to_index.get(req_id)
+            if index is None:
+                index = len(req_ids)
+                req_ids.append(req_id)
+                req_id_to_index[req_id] = index
+                mm_outputs.append(state_payload)
+            else:
+                while len(mm_outputs) <= index:
+                    mm_outputs.append(None)
+                merged_payload = dict(mm_outputs[index] or {})
+                merged_payload.update(state_payload)
+                mm_outputs[index] = merged_payload
+
+        output.req_ids = req_ids
+        output.req_id_to_index = req_id_to_index
+        output.multimodal_outputs = mm_outputs
+        logger.info(
+            "[PD_TRACE] qwen3_tts_kv_ack_state_attached reqs=%s state_keys=%s output_type=%s",
+            kv_ids,
+            [sorted(_ensure_tensor_values(flatten_payload(state))) for state in states],
+            type(output).__name__,
+        )
+        return output
+
     def _build_omni_model_runner_output_from_snapshot(
         self,
         *,
@@ -1816,6 +1933,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         kv_extracted_req_ids: list[str] | None,
         num_scheduled_tokens_np: np.ndarray,
         query_start_loc_cpu: Any,
+        pd_decode_states: list[dict[str, Any] | None] | None = None,
         postprocess_already_applied: bool = False,
     ) -> OmniModelRunnerOutput:
         combined_hidden_states = None
@@ -1936,8 +2054,31 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     pooler_output.append(flatten_payload(payload))
 
         pooler_output = pooler_output or []
+        if pd_decode_states is not None:
+            if len(pd_decode_states) != len(req_ids_output_copy):
+                raise RuntimeError(
+                    "Qwen3-TTS PD state/output cardinality mismatch: "
+                    f"states={len(pd_decode_states)} requests={len(req_ids_output_copy)}"
+                )
+            if not pooler_output:
+                pooler_output = [{} for _ in req_ids_output_copy]
+            for index, state in enumerate(pd_decode_states):
+                if state:
+                    pooler_output[index].update(_ensure_tensor_values(flatten_payload(state)))
         if self._async_chunk and stage_sends_async_output(self.model_config):
             pooler_inter, pooler_client = partition_payload_list(pooler_output)
+            # PD state has a non-client root name, so normal partitioning would
+            # retain it only for connector transport. Mirror this tiny payload
+            # onto the EngineCore multimodal channel consumed by the scheduler.
+            if pd_decode_states is not None:
+                if pooler_client is None:
+                    pooler_client = [None for _ in req_ids_output_copy]
+                for index, state in enumerate(pd_decode_states):
+                    if not state:
+                        continue
+                    client_payload = dict(pooler_client[index] or {})
+                    client_payload.update(_ensure_tensor_values(flatten_payload(state)))
+                    pooler_client[index] = client_payload
         else:
             # Connector-less stages expose the same payload through the
             # orchestrator bridge; non-async stages preserve legacy behavior.
@@ -1994,6 +2135,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
     ) -> OmniModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         kv_extracted_req_ids = getattr(self, "kv_extracted_req_ids", None)
         self.kv_extracted_req_ids = None
+        pd_kv_ack_states = None
 
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
@@ -2003,9 +2145,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
             # In case of PP with kv transfer, we need to pass through the
             # kv_connector_output
+            output = OmniModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
             return self.attach_omni_connector_output(
-                OmniModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
+                self._attach_pd_states_to_kv_ack_output(output, kv_extracted_req_ids)
             )
+
+        if kv_extracted_req_ids:
+            pd_kv_ack_states = self._collect_pd_prefill_decode_states(list(kv_extracted_req_ids))
 
         # Unpack ephemeral state.
         (
@@ -2171,8 +2317,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         )
 
         use_async_omni_output = self._should_use_async_omni_output()
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        has_pd_state_export = (
+            getattr(kv_transfer_config, "kv_role", None) == "kv_producer"
+            and callable(getattr(self.model, "export_pd_decode_state", None))
+        )
         omni_postprocess_already_applied = False
-        if use_async_omni_output:
+        if use_async_omni_output or has_pd_state_export:
             omni_postprocess_already_applied = self._maybe_run_eager_omni_postprocess_before_async_output(
                 hidden_states=hidden_states,
                 multimodal_outputs=multimodal_outputs,
@@ -2181,6 +2332,15 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 req_ids_output_copy=req_ids_output_copy,
                 query_start_loc_cpu=query_start_loc_cpu,
             )
+        if has_pd_state_export and not omni_postprocess_already_applied:
+            raise RuntimeError("Qwen3-TTS PD submit state export requires eager postprocess")
+        # This snapshot rides the producer output that makes the decode worker
+        # start its pull. ACK-side state remains a separate release signal.
+        pd_decode_states = (
+            self._export_pd_prefill_decode_states(req_ids_output_copy)
+            if has_pd_state_export
+            else None
+        )
         output_tensor_snapshot = self._snapshot_omni_output_tensors_for_async_output(
             use_async_omni_output=use_async_omni_output,
             hidden_states=hidden_states,
@@ -2193,7 +2353,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 with record_function_or_nullcontext("omni_async_output:wait_cpu_payload"):
                     output_tensor_snapshot.async_payload.wait()
             with record_function_or_nullcontext("omni_output_builder:total"):
-                return self._build_omni_model_runner_output_from_snapshot(
+                output = self._build_omni_model_runner_output_from_snapshot(
                     scheduler_output=scheduler_output_snapshot,
                     hidden_states=output_tensor_snapshot.hidden_states,
                     staged_hidden_states_cpu=output_tensor_snapshot.staged_hidden_states_cpu,
@@ -2210,8 +2370,14 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     kv_extracted_req_ids=kv_extracted_req_ids,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     query_start_loc_cpu=query_start_loc_cpu,
+                    pd_decode_states=pd_decode_states,
                     postprocess_already_applied=omni_postprocess_already_applied,
                 )
+            return self._attach_pd_states_to_kv_ack_output(
+                output,
+                kv_extracted_req_ids,
+                pd_kv_ack_states,
+            )
 
         if not use_async_omni_output:
             output = output_builder()

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1836,17 +1836,22 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         for req_id in req_ids:
             state = export_state(self.model_intermediate_buffer.get(req_id, {}))
             req_state = self.requests.get(req_id)
+            output_token_ids = list(getattr(req_state, "output_token_ids", ()) or ())
+            if not output_token_ids:
+                raise RuntimeError(f"Qwen3-TTS PD prefill did not retain its sampled resume token for req={req_id}")
+            state["meta"]["pd_resume_token_id"] = int(output_token_ids[-1])
             generator = getattr(req_state, "generator", None)
             sampling_params = getattr(req_state, "sampling_params", None)
             seed = getattr(sampling_params, "seed", None)
-            if not isinstance(generator, torch.Generator) or seed is None:
-                raise RuntimeError(
-                    "Qwen3-TTS PD prefill requires a request-local main sampler generator "
-                    f"for req={req_id}"
-                )
-            # The P sampler has just consumed y0. Preserve its exact post-y0
-            # state; replaying a token sample on D is not equivalent because
-            # vLLM's sampler can consume a variable amount of RNG.
+            if seed is None:
+                raise RuntimeError(f"Qwen3-TTS PD prefill requires a request seed for req={req_id}")
+            # Greedy P never materializes vLLM's request-local generator. D
+            # still needs an initial RNG state for its first stochastic token.
+            if not isinstance(generator, torch.Generator):
+                generator = torch.Generator(device=self.device)
+                generator.manual_seed(int(seed))
+            # Preserve the post-y0 state when P sampled y0. For greedy P this
+            # is the seed-initial state, so D consumes randomness at y1.
             state["pd_sampler"] = {
                 "main_generator_state": generator.get_state().detach().to("cpu").clone(),
                 "seed": int(seed),
@@ -1869,9 +1874,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             # kv_connector_no_forward() returns the upstream base output type.
             # Promote it before crossing the worker/engine boundary; dynamically
             # adding multimodal_outputs to the base type is not wire-stable.
-            output = OmniModelRunnerOutput.with_kv_conn_output_only(
-                getattr(output, "kv_connector_output", None)
-            )
+            output = OmniModelRunnerOutput.with_kv_conn_output_only(getattr(output, "kv_connector_output", None))
         output.kv_extracted_req_ids = kv_ids
         if states is None:
             states = self._collect_pd_prefill_decode_states(kv_ids)
@@ -2318,9 +2321,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
 
         use_async_omni_output = self._should_use_async_omni_output()
         kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
-        has_pd_state_export = (
-            getattr(kv_transfer_config, "kv_role", None) == "kv_producer"
-            and callable(getattr(self.model, "export_pd_decode_state", None))
+        has_pd_state_export = getattr(kv_transfer_config, "kv_role", None) == "kv_producer" and callable(
+            getattr(self.model, "export_pd_decode_state", None)
         )
         omni_postprocess_already_applied = False
         if use_async_omni_output or has_pd_state_export:
@@ -2336,11 +2338,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             raise RuntimeError("Qwen3-TTS PD submit state export requires eager postprocess")
         # This snapshot rides the producer output that makes the decode worker
         # start its pull. ACK-side state remains a separate release signal.
-        pd_decode_states = (
-            self._export_pd_prefill_decode_states(req_ids_output_copy)
-            if has_pd_state_export
-            else None
-        )
+        pd_decode_states = self._export_pd_prefill_decode_states(req_ids_output_copy) if has_pd_state_export else None
         output_tensor_snapshot = self._snapshot_omni_output_tensors_for_async_output(
             use_async_omni_output=use_async_omni_output,
             hidden_states=hidden_states,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1010,6 +1010,20 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
 
         # [Omni] Handle KV transfer BEFORE updating states (which removes finished requests)
         finished_reqs = getattr(scheduler_output, "finished_requests_needing_kv_transfer", {})
+        export_pd_decode_state = callable(getattr(self.model, "export_pd_decode_state", None))
+        if finished_reqs and export_pd_decode_state:
+            frozen_states = getattr(self, "_pd_kv_transfer_states", None)
+            if frozen_states is None:
+                frozen_states = {}
+                self._pd_kv_transfer_states = frozen_states
+            for req_id in finished_reqs:
+                # Freeze the state at exactly the same scheduling boundary as
+                # the KV snapshot. Do not overwrite it while waiting for the
+                # asynchronous extraction acknowledgement.
+                frozen_states.setdefault(
+                    req_id,
+                    self.model.export_pd_decode_state(self.model_intermediate_buffer.get(req_id, {})),
+                )
         if finished_reqs and hasattr(self.model, "get_kv_transfer_metadata"):
             for req_id, data in finished_reqs.items():
                 try:
@@ -1098,9 +1112,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     self.kv_extracted_req_ids = None
 
                     output = make_empty_encoder_model_runner_output(scheduler_output)
-                    if kv_ids:
-                        output = copy(output)
-                        output.kv_extracted_req_ids = kv_ids
+                    output = self._attach_pd_states_to_kv_ack_output(output, kv_ids)
                     return self.attach_omni_connector_output(output)
 
             # `<= 0`: upstream can schedule a negative span, which is truthy (#5196).
@@ -1122,9 +1134,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 else:
                     output = self.kv_connector_no_forward(scheduler_output, self.vllm_config)
 
-                if kv_ids:
-                    output = copy(output)
-                    output.kv_extracted_req_ids = kv_ids
+                output = self._attach_pd_states_to_kv_ack_output(output, kv_ids)
 
                 return self.attach_omni_connector_output(output)
 
@@ -1722,6 +1732,113 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             self._omni_payload_copy_stream = stream
         return stream
 
+    def _collect_pd_prefill_decode_states(self, req_ids: list[str]) -> list[dict[str, Any] | None] | None:
+        """Consume non-KV states frozen at the matching KV snapshot boundary."""
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) != "kv_producer":
+            return None
+        frozen_states = getattr(self, "_pd_kv_transfer_states", None)
+        if not isinstance(frozen_states, dict):
+            raise RuntimeError(f"Qwen3-TTS PD KV acknowledgement has no frozen state map for reqs={req_ids}")
+        missing = [req_id for req_id in req_ids if req_id not in frozen_states]
+        if missing:
+            raise RuntimeError(
+                "Qwen3-TTS PD KV acknowledgement is missing frozen runtime state "
+                f"for reqs={missing}; available={list(frozen_states)}"
+            )
+        return [frozen_states.pop(req_id) for req_id in req_ids]
+
+    def _export_pd_prefill_decode_states(self, req_ids: list[str]) -> list[dict[str, Any] | None] | None:
+        """Snapshot Qwen3-TTS state with the model output that starts D pull."""
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) != "kv_producer":
+            return None
+        export_state = getattr(self.model, "export_pd_decode_state", None)
+        if not callable(export_state):
+            return None
+
+        states: list[dict[str, Any]] = []
+        for req_id in req_ids:
+            state = export_state(self.model_intermediate_buffer.get(req_id, {}))
+            req_state = self.requests.get(req_id)
+            generator = getattr(req_state, "generator", None)
+            sampling_params = getattr(req_state, "sampling_params", None)
+            seed = getattr(sampling_params, "seed", None)
+            if not isinstance(generator, torch.Generator) or seed is None:
+                raise RuntimeError(
+                    "Qwen3-TTS PD prefill requires a request-local main sampler generator "
+                    f"for req={req_id}"
+                )
+            # The P sampler has just consumed y0. Preserve its exact post-y0
+            # state; replaying a token sample on D is not equivalent because
+            # vLLM's sampler can consume a variable amount of RNG.
+            state["pd_sampler"] = {
+                "main_generator_state": generator.get_state().detach().to("cpu").clone(),
+                "seed": int(seed),
+            }
+            states.append(state)
+        return states
+
+    def _attach_pd_states_to_kv_ack_output(
+        self,
+        output: Any,
+        kv_ids: list[str] | None,
+        states: list[dict[str, Any] | None] | None = None,
+    ) -> Any:
+        """Attach frozen PD state to the output that carries a KV acknowledgement."""
+        if not kv_ids:
+            return output
+        if isinstance(output, OmniModelRunnerOutput):
+            output = copy(output)
+        else:
+            # kv_connector_no_forward() returns the upstream base output type.
+            # Promote it before crossing the worker/engine boundary; dynamically
+            # adding multimodal_outputs to the base type is not wire-stable.
+            output = OmniModelRunnerOutput.with_kv_conn_output_only(
+                getattr(output, "kv_connector_output", None)
+            )
+        output.kv_extracted_req_ids = kv_ids
+        if states is None:
+            states = self._collect_pd_prefill_decode_states(kv_ids)
+        if states is None:
+            return output
+        if len(states) != len(kv_ids):
+            raise RuntimeError(f"Qwen3-TTS PD state/ack mismatch: states={len(states)} ack_ids={len(kv_ids)}")
+
+        req_ids = list(getattr(output, "req_ids", None) or [])
+        req_id_to_index = dict(getattr(output, "req_id_to_index", None) or {})
+        mm_outputs = list(getattr(output, "multimodal_outputs", None) or [])
+        if len(mm_outputs) < len(req_ids):
+            mm_outputs.extend([None] * (len(req_ids) - len(mm_outputs)))
+
+        for req_id, state in zip(kv_ids, states, strict=True):
+            if state is None:
+                raise RuntimeError(f"Qwen3-TTS PD KV acknowledgement has empty runtime state for req={req_id}")
+            state_payload = _ensure_tensor_values(flatten_payload(state))
+            index = req_id_to_index.get(req_id)
+            if index is None:
+                index = len(req_ids)
+                req_ids.append(req_id)
+                req_id_to_index[req_id] = index
+                mm_outputs.append(state_payload)
+            else:
+                while len(mm_outputs) <= index:
+                    mm_outputs.append(None)
+                merged_payload = dict(mm_outputs[index] or {})
+                merged_payload.update(state_payload)
+                mm_outputs[index] = merged_payload
+
+        output.req_ids = req_ids
+        output.req_id_to_index = req_id_to_index
+        output.multimodal_outputs = mm_outputs
+        logger.info(
+            "[PD_TRACE] qwen3_tts_kv_ack_state_attached reqs=%s state_keys=%s output_type=%s",
+            kv_ids,
+            [sorted(_ensure_tensor_values(flatten_payload(state))) for state in states],
+            type(output).__name__,
+        )
+        return output
+
     def _build_omni_model_runner_output_from_snapshot(
         self,
         *,
@@ -1741,6 +1858,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         kv_extracted_req_ids: list[str] | None,
         num_scheduled_tokens_np: np.ndarray,
         query_start_loc_cpu: Any,
+        pd_decode_states: list[dict[str, Any] | None] | None = None,
         postprocess_already_applied: bool = False,
     ) -> OmniModelRunnerOutput:
         combined_hidden_states = None
@@ -1857,8 +1975,31 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     pooler_output.append(flatten_payload(payload))
 
         pooler_output = pooler_output or []
+        if pd_decode_states is not None:
+            if len(pd_decode_states) != len(req_ids_output_copy):
+                raise RuntimeError(
+                    "Qwen3-TTS PD state/output cardinality mismatch: "
+                    f"states={len(pd_decode_states)} requests={len(req_ids_output_copy)}"
+                )
+            if not pooler_output:
+                pooler_output = [{} for _ in req_ids_output_copy]
+            for index, state in enumerate(pd_decode_states):
+                if state:
+                    pooler_output[index].update(_ensure_tensor_values(flatten_payload(state)))
         if self._async_chunk and stage_sends_async_output(self.model_config):
             pooler_inter, pooler_client = partition_payload_list(pooler_output)
+            # PD state has a non-client root name, so normal partitioning would
+            # retain it only for connector transport. Mirror this tiny payload
+            # onto the EngineCore multimodal channel consumed by the scheduler.
+            if pd_decode_states is not None:
+                if pooler_client is None:
+                    pooler_client = [None for _ in req_ids_output_copy]
+                for index, state in enumerate(pd_decode_states):
+                    if not state:
+                        continue
+                    client_payload = dict(pooler_client[index] or {})
+                    client_payload.update(_ensure_tensor_values(flatten_payload(state)))
+                    pooler_client[index] = client_payload
         else:
             # Connector-less stages expose the same payload through the
             # orchestrator bridge; non-async stages preserve legacy behavior.
@@ -1908,6 +2049,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
     ) -> OmniModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         kv_extracted_req_ids = getattr(self, "kv_extracted_req_ids", None)
         self.kv_extracted_req_ids = None
+        pd_kv_ack_states = None
 
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
@@ -1917,9 +2059,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
             # In case of PP with kv transfer, we need to pass through the
             # kv_connector_output
+            output = OmniModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
             return self.attach_omni_connector_output(
-                OmniModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
+                self._attach_pd_states_to_kv_ack_output(output, kv_extracted_req_ids)
             )
+
+        if kv_extracted_req_ids:
+            pd_kv_ack_states = self._collect_pd_prefill_decode_states(list(kv_extracted_req_ids))
 
         # Unpack ephemeral state.
         (
@@ -2075,8 +2221,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         )
 
         use_async_omni_output = self._should_use_async_omni_output()
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        has_pd_state_export = (
+            getattr(kv_transfer_config, "kv_role", None) == "kv_producer"
+            and callable(getattr(self.model, "export_pd_decode_state", None))
+        )
         omni_postprocess_already_applied = False
-        if use_async_omni_output:
+        if use_async_omni_output or has_pd_state_export:
             omni_postprocess_already_applied = self._maybe_run_eager_omni_postprocess_before_async_output(
                 hidden_states=hidden_states,
                 multimodal_outputs=multimodal_outputs,
@@ -2085,6 +2236,15 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 req_ids_output_copy=req_ids_output_copy,
                 query_start_loc_cpu=query_start_loc_cpu,
             )
+        if has_pd_state_export and not omni_postprocess_already_applied:
+            raise RuntimeError("Qwen3-TTS PD submit state export requires eager postprocess")
+        # This snapshot rides the producer output that makes the decode worker
+        # start its pull. ACK-side state remains a separate release signal.
+        pd_decode_states = (
+            self._export_pd_prefill_decode_states(req_ids_output_copy)
+            if has_pd_state_export
+            else None
+        )
         output_tensor_snapshot = self._snapshot_omni_output_tensors_for_async_output(
             use_async_omni_output=use_async_omni_output,
             hidden_states=hidden_states,
@@ -2097,7 +2257,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 with record_function_or_nullcontext("omni_async_output:wait_cpu_payload"):
                     output_tensor_snapshot.async_payload.wait()
             with record_function_or_nullcontext("omni_output_builder:total"):
-                return self._build_omni_model_runner_output_from_snapshot(
+                output = self._build_omni_model_runner_output_from_snapshot(
                     scheduler_output=scheduler_output_snapshot,
                     hidden_states=output_tensor_snapshot.hidden_states,
                     staged_hidden_states_cpu=output_tensor_snapshot.staged_hidden_states_cpu,
@@ -2114,8 +2274,14 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     kv_extracted_req_ids=kv_extracted_req_ids,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     query_start_loc_cpu=query_start_loc_cpu,
+                    pd_decode_states=pd_decode_states,
                     postprocess_already_applied=omni_postprocess_already_applied,
                 )
+            return self._attach_pd_states_to_kv_ack_output(
+                output,
+                kv_extracted_req_ids,
+                pd_kv_ack_states,
+            )
 
         if not use_async_omni_output:
             output = output_builder()
@@ -2167,3 +2333,4 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 return global_id.decode("utf-8")
             return str(global_id)
         return req_id
+

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -54,11 +54,6 @@ else:
 logger = init_logger(__name__)
 
 
-def _envs_pd_trace() -> bool:
-    """True when VLLM_OMNI_PD_TRACE is set (temporary PD resume diagnostics)."""
-    return os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False")
-
-
 def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
     """Return only M-RoPE kwargs accepted by the model implementation."""
     method = getattr(model, "get_mrope_input_positions")
@@ -2021,36 +2016,6 @@ class OmniGPUModelRunner(GPUModelRunner):
                     and span_len == 1
                     and num_computed_tokens == prompt_len
                 )
-                if resume_token_id is None and _envs_pd_trace():
-                    logger.info(
-                        "[PD_TRACE] resume_probe req=%s no_token meta_keys=%s infos_keys=%s",
-                        req_id,
-                        sorted(resume_meta) if isinstance(resume_meta, dict) else None,
-                        sorted(req_infos),
-                    )
-                elif not is_pd_resume_token and _envs_pd_trace():
-                    logger.info(
-                        "[PD_TRACE] resume_probe req=%s token=%s consumed=%s span_len=%s computed=%s prompt_len=%s",
-                        req_id,
-                        resume_token_id,
-                        resume_consumed,
-                        span_len,
-                        num_computed_tokens,
-                        prompt_len,
-                    )
-                if _envs_pd_trace() and resume_consumed and num_computed_tokens in (prompt_len + 1, prompt_len + 2, prompt_len + 40, prompt_len + 200):
-                    _hs = req_infos.get("hidden_states") if isinstance(req_infos.get("hidden_states"), dict) else {}
-                    _mt = req_infos.get("meta") if isinstance(req_infos.get("meta"), dict) else {}
-                    _cd = req_infos.get("codes") if isinstance(req_infos.get("codes"), dict) else {}
-                    logger.info(
-                        "[PD_TRACE] frame_state req=%s computed=%d hs=%s tail_shape=%s last_shape=%s "
-                        "text_offset=%s codes=%s mtp_inputs=%s",
-                        req_id, num_computed_tokens, sorted(_hs),
-                        tuple(_hs["trailing_text"].shape) if hasattr(_hs.get("trailing_text"), "shape") else None,
-                        tuple(_hs["last"].shape) if hasattr(_hs.get("last"), "shape") else None,
-                        _mt.get("talker_text_offset"), sorted(_cd),
-                        "mtp_inputs" in req_infos,
-                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -823,13 +823,9 @@ class OmniGPUModelRunner(GPUModelRunner):
                         )
                         if generator_state is not None:
                             if not isinstance(generator_state, torch.Tensor) or generator_state.dtype != torch.uint8:
-                                raise RuntimeError(
-                                    f"Qwen3-TTS PD sampler state is invalid for req={req_id}"
-                                )
+                                raise RuntimeError(f"Qwen3-TTS PD sampler state is invalid for req={req_id}")
                             if req_state.generator is None:
-                                raise RuntimeError(
-                                    f"Qwen3-TTS PD sampler generator is missing for req={req_id}"
-                                )
+                                raise RuntimeError(f"Qwen3-TTS PD sampler generator is missing for req={req_id}")
                             req_state.generator.set_state(generator_state.detach().to("cpu").contiguous())
                             logger.info(
                                 "[PD_TRACE] qwen3_tts_main_sampler_restored req=%s state_bytes=%d",
@@ -1996,13 +1992,9 @@ class OmniGPUModelRunner(GPUModelRunner):
                     resume_meta = (
                         additional_information.get("meta") if isinstance(additional_information, dict) else None
                     )
-                resume_token_id = (
-                    resume_meta.get("pd_resume_token_id") if isinstance(resume_meta, dict) else None
-                )
+                resume_token_id = resume_meta.get("pd_resume_token_id") if isinstance(resume_meta, dict) else None
                 resume_consumed = (
-                    bool(resume_meta.get("pd_resume_token_consumed", False))
-                    if isinstance(resume_meta, dict)
-                    else False
+                    bool(resume_meta.get("pd_resume_token_consumed", False)) if isinstance(resume_meta, dict) else False
                 )
                 if isinstance(resume_token_id, torch.Tensor):
                     resume_token_id = resume_token_id.item() if resume_token_id.numel() == 1 else None
@@ -2121,7 +2113,8 @@ class OmniGPUModelRunner(GPUModelRunner):
         # When talker_mtp is not wrapped by the platform's full-graph wrapper,
         # it manages its own device graphs internally (code_predictor has its
         # own bucket sizes).
-        if not isinstance(self.talker_mtp, current_omni_platform.get_graph_wrapper_cls()):
+        talker_mtp_graph_wrapped = isinstance(self.talker_mtp, current_omni_platform.get_graph_wrapper_cls())
+        if not talker_mtp_graph_wrapped:
             _cudagraph_mode = CUDAGraphMode.NONE
             num_tokens_padded = decode_batch_size
         else:
@@ -2158,6 +2151,18 @@ class OmniGPUModelRunner(GPUModelRunner):
             return generator
 
         row_generators = [_row_generator(req_id) for req_id in decode_req_ids]
+        # A full graph captures one RNG stream during warmup, so runtime
+        # torch.Generator kwargs are not consumed on replay. Seeded requests
+        # must bypass only this outer graph; the wrapped runnable and the code
+        # predictor inner graphs remain available, as do all main-model graphs.
+        if talker_mtp_graph_wrapped and any(generator is not None for generator in row_generators):
+            _cudagraph_mode = CUDAGraphMode.NONE
+            num_tokens_padded = decode_batch_size
+            req_input_ids = self.talker_mtp_input_ids.gpu[:num_tokens_padded]
+            req_embeds = self.talker_mtp_inputs_embeds.gpu[:num_tokens_padded]
+            last_talker_hidden = self.last_talker_hidden.gpu[:num_tokens_padded]
+            text_step = self.text_step.gpu[:num_tokens_padded]
+
         cache = getattr(self, "_talker_mtp_generators", None)
         if cache:
             # Generators live as long as their request; drop finished ones.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1,5 +1,9 @@
 import contextlib
+import copy
 import inspect
+import os
+import time
+import zlib
 from collections.abc import Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
@@ -80,11 +84,92 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.model_intermediate_buffer: dict[str, dict[str, Any]] = {}
         self._omni_num_scheduled_tokens_np: np.ndarray | None = None
         self._omni_last_model_output: object | None = None
-        # The Omni tensor prefix cache will be allocated
-        # when we initialize the metadata builders if enabled
+        # [yurain] Omni tensor prefix cache (allocated when metadata builder initialized if enabled)
         self.omni_prefix_cache = None
         self._sampled_token_ids_cpu_override = None
         self._omni_query_start_loc_model_kwarg = False
+        self._mtp_ar_timing_enabled = os.getenv("VLLM_OMNI_MTP_AR_TIMING", "0").lower() not in (
+            "0",
+            "",
+            "false",
+            "off",
+        )
+        self._mtp_ar_timing_interval = max(1, int(os.getenv("VLLM_OMNI_MTP_AR_TIMING_INTERVAL", "50")))
+        # [yurain] Opt-in: batch all rows assigned to the same replica into ONE
+        # forward() call per replica. Requires VLLM_OMNI_MTP_NUM_REPLICAS >= 2.
+        # Each replica receives bsz = ceil(total_bsz / num_replicas) and the
+        # replicas run concurrently on separate CUDA streams.
+        # Rows with an explicit per-request seed fall back to scalar dispatch
+        # for their group (the group still runs on its own stream).
+        # Default OFF -- the sub-batch path needs VLLM_OMNI_MTP_BATCH_PER_REPLICA=1.
+        self._mtp_batch_per_replica: bool = os.getenv("VLLM_OMNI_MTP_BATCH_PER_REPLICA", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self._mtp_ar_timing_stats = {
+            "mtp_ms": 0.0,
+            "mtp_calls": 0,
+            "mtp_rows": 0,
+            "ar_decode_ms": 0.0,
+            "ar_decode_calls": 0,
+            "ar_decode_tokens": 0,
+            "ar_prefill_ms": 0.0,
+            "ar_prefill_calls": 0,
+            "ar_prefill_tokens": 0,
+        }
+        self._mtp_timing_depth = 0
+
+    def _timing_sync_device(self) -> None:
+        if self._mtp_ar_timing_enabled and torch.cuda.is_available():
+            torch.accelerator.synchronize(self.device)
+
+    def _is_decode_forward_for_timing(self) -> bool:
+        scheduled = self._omni_num_scheduled_tokens_np
+        return scheduled is not None and len(scheduled) > 0 and int(scheduled.max()) == 1
+
+    def _record_mtp_ar_timing(self, kind: str, elapsed_ms: float, *, rows: int = 0, tokens: int = 0) -> None:
+        if not self._mtp_ar_timing_enabled:
+            return
+        stats = self._mtp_ar_timing_stats
+        if kind == "mtp":
+            stats["mtp_ms"] += elapsed_ms
+            stats["mtp_calls"] += 1
+            stats["mtp_rows"] += rows
+        elif kind == "ar_decode":
+            stats["ar_decode_ms"] += elapsed_ms
+            stats["ar_decode_calls"] += 1
+            stats["ar_decode_tokens"] += tokens
+        else:
+            stats["ar_prefill_ms"] += elapsed_ms
+            stats["ar_prefill_calls"] += 1
+            stats["ar_prefill_tokens"] += tokens
+
+        total_calls = int(stats["mtp_calls"] + stats["ar_decode_calls"] + stats["ar_prefill_calls"])
+        if total_calls % self._mtp_ar_timing_interval != 0:
+            return
+
+        mtp_avg = stats["mtp_ms"] / max(1, stats["mtp_calls"])
+        ar_decode_avg = stats["ar_decode_ms"] / max(1, stats["ar_decode_calls"])
+        ar_prefill_avg = stats["ar_prefill_ms"] / max(1, stats["ar_prefill_calls"])
+        ratio = mtp_avg / ar_decode_avg if ar_decode_avg > 0 else 0.0
+        logger.info(
+            "[MTP-AR-TIMING] mtp_avg_ms=%.3f mtp_calls=%d mtp_rows=%d "
+            "ar_decode_avg_ms=%.3f ar_decode_calls=%d ar_decode_tokens=%d "
+            "ar_prefill_avg_ms=%.3f ar_prefill_calls=%d ar_prefill_tokens=%d "
+            "mtp/ar_decode=%.2f",
+            mtp_avg,
+            int(stats["mtp_calls"]),
+            int(stats["mtp_rows"]),
+            ar_decode_avg,
+            int(stats["ar_decode_calls"]),
+            int(stats["ar_decode_tokens"]),
+            ar_prefill_avg,
+            int(stats["ar_prefill_calls"]),
+            int(stats["ar_prefill_tokens"]),
+            ratio,
+        )
 
     def _to_list(self, sampled_token_ids: torch.Tensor) -> list[list[int]]:
         override_fn = self._sampled_token_ids_cpu_override
@@ -165,8 +250,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                                 device=sm.device,
                             )
 
-        # Initialize the wrapper for both multimodal output tensors
-        # and for hidden states to be passed between stages
+        # [yurain] init wrapper for multimodal output / hidden states between stages
         if self.cache_config.enable_prefix_caching:
             self.omni_prefix_cache = OmniTensorPrefixCache(
                 num_blocks=kv_cache_config.num_blocks,
@@ -223,6 +307,118 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.talker_mtp_inputs_embeds = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.last_talker_hidden = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.text_step = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
+        self._init_talker_mtp_replicas()
+
+    def _init_talker_mtp_replicas(self) -> None:
+        self.talker_mtp_code_predictors = []
+        self.talker_mtp_streams = []
+        try:
+            num_replicas = int(os.getenv("VLLM_OMNI_MTP_NUM_REPLICAS", "1") or "1")
+        except ValueError:
+            num_replicas = 1
+        num_replicas = max(1, num_replicas)
+        if num_replicas == 1:
+            return
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) == "kv_producer":
+            return
+        if not torch.cuda.is_available():
+            logger.warning("VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: CUDA is unavailable", num_replicas)
+            return
+        graph_wrapper_cls = current_omni_platform.get_graph_wrapper_cls()
+        if isinstance(self.talker_mtp, graph_wrapper_cls):
+            logger.warning(
+                "VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: graph-wrapped talker_mtp is not replica-safe", num_replicas
+            )
+            return
+        base_code_predictor = getattr(self.model, "code_predictor", None)
+        if base_code_predictor is None:
+            logger.warning("VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: model has no code_predictor", num_replicas)
+            return
+
+        def _prepare_replica(replica):
+            # [yurain] Keep CUDA graphs enabled but give each replica its own
+            # private graph memory pool (torch.cuda.graph_pool_handle()) instead
+            # of vLLM's shared global pool. Graphs sharing one pool are not
+            # safe to replay concurrently on different streams (may clobber
+            # each other's memory); a private pool per replica makes
+            # concurrent capture/replay across streams safe while still
+            # getting graph-replay speed.
+            if hasattr(replica, "_graph_pool"):
+                replica._graph_pool = torch.cuda.graph_pool_handle()
+            replica._proj_buf = None
+            replica._compiled_model_fwd = None
+            replica._bucket_sizes = []
+            replica._bucket_pos_ids = {}
+            replica._lm_heads_list = None
+            replica._codec_embeds_list = None
+            replica._device_graphs = {}
+            if hasattr(replica, "_full_ar_graphs"):
+                replica._full_ar_graphs = {}
+                replica._all_codes_bufs = {}
+                replica._layer0_code_bufs = {}
+                replica._noise_buf = None
+                replica._cap_inv_temperature = None
+                replica._cap_top_k = None
+                replica._full_graph_disabled_runtime = False
+            if hasattr(replica, "_full_ar_kv_graphs"):
+                replica._full_ar_kv_graphs = {}
+                replica._kv_caches = {}
+                replica._kv_pos_prefill = {}
+                replica._kv_pos_decode = {}
+                replica._kv_disabled_runtime = False
+            setup_compile = getattr(replica, "_setup_compile", None)
+            if callable(setup_compile):
+                setup_compile()
+
+        replicas = []
+        try:
+            with torch.cuda.device(self.device), torch.inference_mode():
+                for _ in range(num_replicas):
+                    replica = copy.deepcopy(base_code_predictor).to(device=self.device)
+                    replica.eval()
+                    _prepare_replica(replica)
+                    replicas.append(replica)
+                torch.accelerator.synchronize(self.device)
+        except Exception:
+            logger.exception("VLLM_OMNI_MTP_NUM_REPLICAS=%d disabled: failed to initialize replicas", num_replicas)
+            self.talker_mtp_code_predictors = []
+            self.talker_mtp_streams = []
+            return
+        self.talker_mtp_code_predictors = replicas
+        self.talker_mtp_streams = [torch.cuda.Stream(device=self.device) for _ in replicas]
+        graphs_active = bool(getattr(replicas[0], "_device_graphs", None)) if replicas else False
+        logger.info(
+            "[MTP-REPLICA] enabled num_replicas=%d cuda_graphs=%s (private_pool_per_replica) prewarmed=1",
+            len(replicas),
+            "enabled" if graphs_active else "disabled",
+        )
+
+    @staticmethod
+    def _mtp_replica_idx_for_req(req_id: str, num_replicas: int) -> int:
+        """Stable request-id -> MTP replica mapping.
+
+        Each replica (see :meth:`_init_talker_mtp_replicas`) is an
+        independently-deepcopied ``code_predictor`` with its own runtime
+        state (captured-CUDA-graph sampling-constant lock-in, noise/layer0
+        buffers, etc.). ``talker_mtp``'s residual-codebook output is written
+        straight back into ``inputs_embeds`` and feeds the *next* decode
+        step of the main talker AR loop, so a request must always be served
+        by the same replica across steps -- otherwise it gets "relayed"
+        between two replicas with independent state, which can silently
+        perturb its generation trajectory (observed as a request that
+        never samples ``stop_token_ids`` and runs all the way to
+        ``max_tokens``, under concurrent load).
+        ``row % num_replicas`` (the previous scheme) keys off this request's
+        *transient position* within the current decode batch, which changes
+        across steps whenever the batch composition changes (a request
+        finishing / a new one being admitted). Hashing the request id keeps
+        the assignment fixed for the lifetime of the request regardless of
+        where it lands in the batch. ``zlib.crc32`` is used instead of the
+        builtin ``hash()`` because the latter is salted per-process
+        (``PYTHONHASHSEED``) and is not guaranteed stable across workers.
+        """
+        return zlib.crc32(req_id.encode("utf-8")) % num_replicas
 
     def _prewarm_attention_capture_workspaces(self) -> None:
         capture_sizes = getattr(self.compilation_config, "cudagraph_capture_sizes", None)
@@ -614,9 +810,32 @@ class OmniGPUModelRunner(GPUModelRunner):
                 logger.error(f"Error updating model intermediate buffer: {e}")
             # Decode additional_information payloads (dictionary)
             try:
-                if getattr(new_req_data, "additional_information", None) is not None:
-                    info_dict = deserialize_additional_information(new_req_data.additional_information)
+                _ai_raw = getattr(new_req_data, "additional_information", None)
+                if _ai_raw is not None:
+                    logger.warning_once(
+                        "additional_information on request data is deprecated, use model_intermediate_buffer"
+                    )
+                    info_dict = deserialize_additional_information(_ai_raw)
                     if info_dict:
+                        pd_sampler = info_dict.get("pd_sampler")
+                        generator_state = (
+                            pd_sampler.get("main_generator_state") if isinstance(pd_sampler, dict) else None
+                        )
+                        if generator_state is not None:
+                            if not isinstance(generator_state, torch.Tensor) or generator_state.dtype != torch.uint8:
+                                raise RuntimeError(
+                                    f"Qwen3-TTS PD sampler state is invalid for req={req_id}"
+                                )
+                            if req_state.generator is None:
+                                raise RuntimeError(
+                                    f"Qwen3-TTS PD sampler generator is missing for req={req_id}"
+                                )
+                            req_state.generator.set_state(generator_state.detach().to("cpu").contiguous())
+                            logger.info(
+                                "[PD_TRACE] qwen3_tts_main_sampler_restored req=%s state_bytes=%d",
+                                req_id,
+                                generator_state.numel(),
+                            )
                         self.model_intermediate_buffer[req_id] = info_dict
                         setattr(
                             self.requests[req_id],
@@ -750,8 +969,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 if self.use_async_scheduling and num_output_tokens > 0:
                     # We must recover the output token ids for resumed requests in the
                     # async scheduling case, so that correct input_ids are obtained.
-                    resumed_token_ids = req_data.all_token_ids[req_id]
-                    req_state.output_token_ids = resumed_token_ids[-num_output_tokens:]
+                    req_state.output_token_ids = req_data.all_token_ids[req_id][-num_output_tokens:]
 
                 reqs_to_add.append(req_state)
                 # Track resumed requests for ngram_gpu full tensor copy
@@ -1772,6 +1990,46 @@ class OmniGPUModelRunner(GPUModelRunner):
                 prompt_token_ids = getattr(req_state, "prompt_token_ids", ()) if req_state is not None else ()
                 prompt_len = len(prompt_token_ids or ())
                 num_computed_tokens = int(self.input_batch.num_computed_tokens_cpu[req_index])
+                resume_meta = req_infos.get("meta")
+                if not isinstance(resume_meta, dict):
+                    additional_information = req_infos.get("additional_information")
+                    resume_meta = (
+                        additional_information.get("meta") if isinstance(additional_information, dict) else None
+                    )
+                resume_token_id = (
+                    resume_meta.get("pd_resume_token_id") if isinstance(resume_meta, dict) else None
+                )
+                resume_consumed = (
+                    bool(resume_meta.get("pd_resume_token_consumed", False))
+                    if isinstance(resume_meta, dict)
+                    else False
+                )
+                if isinstance(resume_token_id, torch.Tensor):
+                    resume_token_id = resume_token_id.item() if resume_token_id.numel() == 1 else None
+                try:
+                    resume_token_id = int(resume_token_id) if resume_token_id is not None else None
+                except (TypeError, ValueError):
+                    resume_token_id = None
+                is_pd_resume_token = (
+                    resume_token_id is not None
+                    and not resume_consumed
+                    and span_len == 1
+                    and num_computed_tokens == prompt_len
+                )
+                if is_pd_resume_token:
+                    # Keep the remote request at P's exact prompt length so
+                    # Mooncake pulls matching blocks. Once that prefix is
+                    # local, substitute P's sampled layer-0 token into D's
+                    # first decode position; this forward writes its local KV
+                    # and runs MTP exactly as a continuous decode would.
+                    input_ids[s] = resume_token_id
+                    resume_meta["pd_resume_token_consumed"] = True
+                    logger.info(
+                        "[PD_TRACE] qwen3_tts_decode_resume req=%s token_id=%d prompt_len=%d",
+                        req_id,
+                        resume_token_id,
+                        prompt_len,
+                    )
                 is_prefill = num_computed_tokens < prompt_len
                 req_infos["_omni_prompt_len"] = prompt_len
                 req_infos["_omni_num_computed_tokens"] = num_computed_tokens
@@ -1851,6 +2109,7 @@ class OmniGPUModelRunner(GPUModelRunner):
         decode_batch_size = len(decode_req_ids)
         if decode_batch_size == 0:
             return
+
         _cudagraph_mode, batch_desc, _, _, _ = self._determine_batch_execution_and_padding(
             num_tokens=decode_batch_size,
             num_reqs=decode_batch_size,
@@ -1880,7 +2139,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             extra_args = getattr(sampling_params, "extra_args", None) if sampling_params is not None else None
             seed = None
             if isinstance(extra_args, dict):
-                seed = extra_args.get("tts_local_seed")
+                seed = extra_args.get("tts_local_seed", extra_args.get("qwen3_tts_request_seed"))
             return int(seed) if seed is not None else None
 
         def _row_generator(req_id: str) -> torch.Generator | None:
@@ -1894,7 +2153,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             generator = cache.get(req_id)
             if generator is None or generator.device != req_input_ids.device:
                 generator = torch.Generator(device=req_input_ids.device)
-                generator.manual_seed(seed)
+                generator.manual_seed(int(seed))
                 cache[req_id] = generator
             return generator
 
@@ -1905,32 +2164,153 @@ class OmniGPUModelRunner(GPUModelRunner):
             for stale_id in [rid for rid in cache if rid not in self.requests]:
                 del cache[stale_id]
 
-        if (
-            decode_batch_size > 1
-            and any(generator is not None for generator in row_generators)
-            and not getattr(self.model, "talker_mtp_accepts_per_row_generators", False)
-        ):
-            # A torch.Generator is a single stream. Using one generator for a
-            # multi-row batch would make explicitly-seeded requests depend on
-            # other rows in the same scheduler step, so keep that path scalar.
+        if decode_batch_size > 1:
             saved_input_ids = self.talker_mtp_input_ids.gpu[:decode_batch_size].clone()
             saved_embeds = self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].clone()
             saved_hidden = self.last_talker_hidden.gpu[:decode_batch_size].clone()
             saved_text = self.text_step.gpu[:decode_batch_size].clone()
-            try:
-                for row, req_id in enumerate(decode_req_ids):
-                    self.talker_mtp_input_ids.gpu[:1].copy_(saved_input_ids[row : row + 1])
-                    self.talker_mtp_inputs_embeds.gpu[:1].copy_(saved_embeds[row : row + 1])
-                    self.last_talker_hidden.gpu[:1].copy_(saved_hidden[row : row + 1])
-                    self.text_step.gpu[:1].copy_(saved_text[row : row + 1])
-                    row_offsets = None if start_offsets is None else [start_offsets[row]]
-                    self._talker_mtp_forward([req_id], inputs_embeds, row_offsets)
-            finally:
-                self.talker_mtp_input_ids.gpu[:decode_batch_size].copy_(saved_input_ids)
-                self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].copy_(saved_embeds)
-                self.last_talker_hidden.gpu[:decode_batch_size].copy_(saved_hidden)
-                self.text_step.gpu[:decode_batch_size].copy_(saved_text)
-            return
+            replicas = getattr(self, "talker_mtp_code_predictors", None) or []
+            streams = getattr(self, "talker_mtp_streams", None) or []
+            if len(replicas) > 1 and len(streams) == len(replicas) and torch.cuda.is_available():
+                timing_enabled = self._mtp_ar_timing_enabled
+                if timing_enabled:
+                    self._timing_sync_device()
+                    mtp_t0 = time.perf_counter()
+                outputs: list[tuple[torch.Tensor, torch.Tensor] | None] = [None] * decode_batch_size
+                current_stream = torch.cuda.current_stream(device=self.device)
+                used_streams = []
+                talker_kwargs_base = {
+                    "do_sample": subtalker_params.get("do_sample"),
+                    "temperature": subtalker_params.get("temperature"),
+                    "top_k": subtalker_params.get("top_k"),
+                    "top_p": subtalker_params.get("top_p"),
+                }
+                if self._mtp_batch_per_replica:
+                    # Sub-batch dispatch: group rows by replica, each replica
+                    # gets a contiguous sub-batch and runs one forward() call.
+                    # Rows with explicit seed fall back to scalar within the group.
+                    # NOTE: replica assignment is keyed by req_id (not batch
+                    # position) -- see _mtp_replica_idx_for_req for why.
+                    rows_by_replica: dict[int, list[int]] = {}
+                    for row, req_id in enumerate(decode_req_ids):
+                        replica_idx = self._mtp_replica_idx_for_req(req_id, len(replicas))
+                        rows_by_replica.setdefault(replica_idx, []).append(row)
+                    for replica_idx, rows in rows_by_replica.items():
+                        stream = streams[replica_idx]
+                        if stream not in used_streams:
+                            stream.wait_stream(current_stream)
+                            used_streams.append(stream)
+                        group_req_ids = [decode_req_ids[r] for r in rows]
+                        group_has_seed = any(row_generators[r] is not None for r in rows)
+                        with torch.cuda.stream(stream):
+                            if group_has_seed:
+                                # Scalar fallback for this replica's rows only.
+                                for row, req_id in zip(rows, group_req_ids, strict=True):
+                                    talker_kwargs = dict(talker_kwargs_base)
+                                    if row_generators[row] is not None:
+                                        talker_kwargs["generator"] = row_generators[row]
+                                    if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                                        talker_kwargs["req_ids"] = [req_id]
+                                        talker_kwargs["req_infos"] = [
+                                            self.model_intermediate_buffer.setdefault(req_id, {})
+                                        ]
+                                    outputs[row] = self.talker_mtp(
+                                        saved_input_ids[row : row + 1],
+                                        saved_embeds[row : row + 1],
+                                        saved_hidden[row : row + 1],
+                                        saved_text[row : row + 1],
+                                        code_predictor_override=replicas[replica_idx],
+                                        **talker_kwargs,
+                                    )
+                            else:
+                                row_idx = torch.tensor(rows, device=saved_input_ids.device, dtype=torch.long)
+                                talker_kwargs = dict(talker_kwargs_base)
+                                if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                                    talker_kwargs["req_ids"] = group_req_ids
+                                    talker_kwargs["req_infos"] = [
+                                        self.model_intermediate_buffer.setdefault(r, {}) for r in group_req_ids
+                                    ]
+                                batch_embeds, batch_codes = self.talker_mtp(
+                                    saved_input_ids.index_select(0, row_idx),
+                                    saved_embeds.index_select(0, row_idx),
+                                    saved_hidden.index_select(0, row_idx),
+                                    saved_text.index_select(0, row_idx),
+                                    code_predictor_override=replicas[replica_idx],
+                                    **talker_kwargs,
+                                )
+                                for local_idx, row in enumerate(rows):
+                                    outputs[row] = (
+                                        batch_embeds[local_idx : local_idx + 1],
+                                        batch_codes[local_idx : local_idx + 1] if batch_codes is not None else None,
+                                    )
+                else:
+                    # Scalar dispatch: one call per row, each on its replica's stream.
+                    # NOTE: replica assignment is keyed by req_id (not batch
+                    # position) -- see _mtp_replica_idx_for_req for why.
+                    for row, req_id in enumerate(decode_req_ids):
+                        replica_idx = self._mtp_replica_idx_for_req(req_id, len(replicas))
+                        stream = streams[replica_idx]
+                        if stream not in used_streams:
+                            stream.wait_stream(current_stream)
+                            used_streams.append(stream)
+                        talker_kwargs = dict(talker_kwargs_base)
+                        if row_generators[row] is not None:
+                            talker_kwargs["generator"] = row_generators[row]
+                        if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                            talker_kwargs["req_ids"] = [req_id]
+                            talker_kwargs["req_infos"] = [self.model_intermediate_buffer.setdefault(req_id, {})]
+                        with torch.cuda.stream(stream):
+                            outputs[row] = self.talker_mtp(
+                                saved_input_ids[row : row + 1],
+                                saved_embeds[row : row + 1],
+                                saved_hidden[row : row + 1],
+                                saved_text[row : row + 1],
+                                code_predictor_override=replicas[replica_idx],
+                                **talker_kwargs,
+                            )
+                for stream in used_streams:
+                    current_stream.wait_stream(stream)
+                if timing_enabled:
+                    self._timing_sync_device()
+                    self._record_mtp_ar_timing("mtp", (time.perf_counter() - mtp_t0) * 1000.0, rows=decode_batch_size)
+                out_key = getattr(self.model, "talker_mtp_output_key", ("codes", "audio"))
+                if not isinstance(out_key, tuple) or len(out_key) != 2:
+                    raise TypeError(
+                        f"talker_mtp_output_key must be a 2-tuple, got {type(out_key).__name__}: {out_key!r}"
+                    )
+                if start_offsets is None:
+                    id_to_index = self.input_batch.req_id_to_index
+                    start_offsets = [int(self.query_start_loc.cpu[id_to_index[req_id]]) for req_id in decode_req_ids]
+                for row, (req_id, start_offset) in enumerate(zip(decode_req_ids, start_offsets, strict=True)):
+                    output = outputs[row]
+                    assert output is not None
+                    req_embeds_row, code_predictor_codes_row = output
+                    inputs_embeds[start_offset : start_offset + 1] = req_embeds_row[:1]
+                    if code_predictor_codes_row is not None:
+                        update_dict = {out_key[0]: {out_key[1]: code_predictor_codes_row[:1]}}
+                        self._merge_additional_information_update(req_id, update_dict)
+                return
+
+            if any(generator is not None for generator in row_generators) and not getattr(
+                self.model, "talker_mtp_accepts_per_row_generators", False
+            ):
+                # A torch.Generator is a single stream. Using one generator for a
+                # multi-row batch would make explicitly-seeded requests depend on
+                # other rows in the same scheduler step, so keep that path scalar.
+                try:
+                    for row, req_id in enumerate(decode_req_ids):
+                        self.talker_mtp_input_ids.gpu[:1].copy_(saved_input_ids[row : row + 1])
+                        self.talker_mtp_inputs_embeds.gpu[:1].copy_(saved_embeds[row : row + 1])
+                        self.last_talker_hidden.gpu[:1].copy_(saved_hidden[row : row + 1])
+                        self.text_step.gpu[:1].copy_(saved_text[row : row + 1])
+                        row_offsets = None if start_offsets is None else [start_offsets[row]]
+                        self._talker_mtp_forward([req_id], inputs_embeds, row_offsets)
+                finally:
+                    self.talker_mtp_input_ids.gpu[:decode_batch_size].copy_(saved_input_ids)
+                    self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].copy_(saved_embeds)
+                    self.last_talker_hidden.gpu[:decode_batch_size].copy_(saved_hidden)
+                    self.text_step.gpu[:decode_batch_size].copy_(saved_text)
+                return
 
         talker_kwargs = {
             "do_sample": subtalker_params.get("do_sample"),
@@ -1948,6 +2328,10 @@ class OmniGPUModelRunner(GPUModelRunner):
             talker_kwargs["req_infos"] = [
                 self.model_intermediate_buffer.setdefault(req_id, {}) for req_id in decode_req_ids
             ]
+        timing_enabled = self._mtp_ar_timing_enabled
+        if timing_enabled:
+            self._timing_sync_device()
+            mtp_t0 = time.perf_counter()
         with current_omni_platform.set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -1958,6 +2342,9 @@ class OmniGPUModelRunner(GPUModelRunner):
                 text_step,
                 **talker_kwargs,
             )
+        if timing_enabled:
+            self._timing_sync_device()
+            self._record_mtp_ar_timing("mtp", (time.perf_counter() - mtp_t0) * 1000.0, rows=decode_batch_size)
         # update the inputs_embeds and code_predictor_codes
         out_key = getattr(self.model, "talker_mtp_output_key", ("codes", "audio"))
         if not isinstance(out_key, tuple) or len(out_key) != 2:
@@ -1990,6 +2377,10 @@ class OmniGPUModelRunner(GPUModelRunner):
                 omni_query_start_loc=model_kwargs_extra.get("omni_query_start_loc"),
             )
 
+        timing_enabled = self._mtp_ar_timing_enabled
+        if timing_enabled:
+            self._timing_sync_device()
+            ar_t0 = time.perf_counter()
         model_output = super()._model_forward(
             input_ids=input_ids,
             positions=positions,
@@ -1998,6 +2389,16 @@ class OmniGPUModelRunner(GPUModelRunner):
             **model_kwargs,
             **model_kwargs_extra,
         )
+        if timing_enabled:
+            self._timing_sync_device()
+            if input_ids is not None:
+                num_tokens = int(input_ids.shape[0])
+            elif inputs_embeds is not None:
+                num_tokens = int(inputs_embeds.shape[0])
+            else:
+                num_tokens = 0
+            kind = "ar_decode" if self._is_decode_forward_for_timing() else "ar_prefill"
+            self._record_mtp_ar_timing(kind, (time.perf_counter() - ar_t0) * 1000.0, tokens=num_tokens)
         if not isinstance(model_output, OmniOutput) and hasattr(self.model, "make_omni_output"):
             model_output = self.model.make_omni_output(model_output, **model_kwargs, **model_kwargs_extra)
         # Cache model output so later sample_tokens can consume multimodal results.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -507,6 +507,87 @@ class OmniGPUModelRunner(GPUModelRunner):
             return sampling_metadata
         return replace(sampling_metadata, output_token_ids=output_token_ids)
 
+    def _sampling_metadata_with_pd_resume_history(self, sampling_metadata):
+        """Include the P-side sampled token in D-side sampling history only.
+
+        The decode request appends P-side y0 to the prompt so remote prefill
+        leaves it as the first local D input. Because y0 is a prompt token on D,
+        it is absent from output history but must still be visible to repetition
+        penalties and model logits processors. Mutating request history would
+        double-count it in scheduler accounting, so this decorates
+        SamplingMetadata only.
+        """
+        req_ids = list(getattr(self.input_batch, "req_ids", ()))
+        histories = getattr(sampling_metadata, "output_token_ids", None)
+        if histories is None or len(histories) != len(req_ids):
+            return sampling_metadata
+
+        updated = None
+        for index, req_id in enumerate(req_ids):
+            info = self.model_intermediate_buffer.get(req_id, {})
+            meta = info.get("meta") if isinstance(info, dict) else None
+            resume_token_id = meta.get("pd_resume_token_id") if isinstance(meta, dict) else None
+            if isinstance(resume_token_id, torch.Tensor):
+                resume_token_id = resume_token_id.item() if resume_token_id.numel() == 1 else None
+            try:
+                resume_token_id = int(resume_token_id) if resume_token_id is not None else None
+            except (TypeError, ValueError):
+                resume_token_id = None
+            if resume_token_id is None:
+                continue
+
+            if updated is None:
+                updated = [list(history or ()) for history in histories]
+            updated[index].insert(0, resume_token_id)
+
+        if updated is None:
+            return sampling_metadata
+        return replace(sampling_metadata, output_token_ids=updated)
+
+    def _restore_qwen3_tts_pd_sampler_state(self, req_id: str, info: object) -> None:
+        """Restore the request-local main sampler once on a PD consumer."""
+        if not callable(getattr(self.model, "export_pd_decode_state", None)):
+            return
+        if not isinstance(info, dict) or "pd_sampler" not in info:
+            return
+
+        req_state = self.requests.get(req_id)
+        if req_state is None:
+            raise RuntimeError(f"Qwen3-TTS PD sampler request is missing for req={req_id}")
+        if getattr(req_state, "_qwen3_tts_pd_sampler_restored", False):
+            return
+
+        pd_sampler = info.get("pd_sampler")
+        if not isinstance(pd_sampler, dict):
+            raise RuntimeError(f"Qwen3-TTS PD sampler payload is invalid for req={req_id}")
+        generator_state = pd_sampler.get("main_generator_state")
+        if (
+            not isinstance(generator_state, torch.Tensor)
+            or generator_state.dtype != torch.uint8
+            or generator_state.numel() == 0
+        ):
+            raise RuntimeError(f"Qwen3-TTS PD sampler state is invalid for req={req_id}")
+        generator_state = generator_state.detach().to("cpu").contiguous()
+
+        generator = req_state.generator
+        sampling_params = req_state.sampling_params
+        if generator is None:
+            if sampling_params is not None and sampling_params.sampling_type == SamplingType.GREEDY:
+                setattr(req_state, "_qwen3_tts_pd_sampler_restored", True)
+                return
+            raise RuntimeError(f"Qwen3-TTS PD sampler generator is missing for req={req_id}")
+        try:
+            generator.set_state(generator_state)
+        except Exception as exc:
+            raise RuntimeError(f"Qwen3-TTS PD sampler state cannot be restored for req={req_id}") from exc
+
+        setattr(req_state, "_qwen3_tts_pd_sampler_restored", True)
+        logger.info(
+            "[PD_TRACE] qwen3_tts_main_sampler_restored req=%s state_bytes=%d",
+            req_id,
+            generator_state.numel(),
+        )
+
     def _init_mrope_positions(self, req_state: CachedRequestState):
         """Initialize M-RoPE positions for multimodal inputs.
 
@@ -802,13 +883,19 @@ class OmniGPUModelRunner(GPUModelRunner):
             # Direct runner data-plane payloads populate
             # model_intermediate_buffer without going through the deprecated
             # additional_information request transport.
+            model_buffer_applied = None
             try:
                 model_buffer = getattr(new_req_data, "model_intermediate_buffer", None)
                 if isinstance(model_buffer, dict) and model_buffer:
                     self._update_intermediate_buffer(req_id, model_buffer)
+                    model_buffer_applied = model_buffer
             except Exception as e:
                 logger.error(f"Error updating model intermediate buffer: {e}")
-            # Decode additional_information payloads (dictionary)
+            if model_buffer_applied is not None:
+                self._restore_qwen3_tts_pd_sampler_state(req_id, model_buffer_applied)
+
+            # Decode additional_information payloads (dictionary).
+            info_dict = None
             try:
                 _ai_raw = getattr(new_req_data, "additional_information", None)
                 if _ai_raw is not None:
@@ -817,21 +904,6 @@ class OmniGPUModelRunner(GPUModelRunner):
                     )
                     info_dict = deserialize_additional_information(_ai_raw)
                     if info_dict:
-                        pd_sampler = info_dict.get("pd_sampler")
-                        generator_state = (
-                            pd_sampler.get("main_generator_state") if isinstance(pd_sampler, dict) else None
-                        )
-                        if generator_state is not None:
-                            if not isinstance(generator_state, torch.Tensor) or generator_state.dtype != torch.uint8:
-                                raise RuntimeError(f"Qwen3-TTS PD sampler state is invalid for req={req_id}")
-                            if req_state.generator is None:
-                                raise RuntimeError(f"Qwen3-TTS PD sampler generator is missing for req={req_id}")
-                            req_state.generator.set_state(generator_state.detach().to("cpu").contiguous())
-                            logger.info(
-                                "[PD_TRACE] qwen3_tts_main_sampler_restored req=%s state_bytes=%d",
-                                req_id,
-                                generator_state.numel(),
-                            )
                         self.model_intermediate_buffer[req_id] = info_dict
                         setattr(
                             self.requests[req_id],
@@ -840,6 +912,8 @@ class OmniGPUModelRunner(GPUModelRunner):
                         )
             except Exception as e:
                 logger.error(f"Error decoding additional information: {e}")
+            if info_dict:
+                self._restore_qwen3_tts_pd_sampler_state(req_id, info_dict)
 
             if sampling_params and sampling_params.prompt_logprobs is not None:
                 self.num_prompt_logprobs[req_id] = (
@@ -1714,12 +1788,14 @@ class OmniGPUModelRunner(GPUModelRunner):
             model_buffer = getattr(new_req, "model_intermediate_buffer", None)
             if isinstance(model_buffer, dict) and model_buffer:
                 update_buffer(new_req.req_id, model_buffer)
+                self._restore_qwen3_tts_pd_sampler_state(new_req.req_id, model_buffer)
                 if replace:
                     continue
             payload_info = getattr(new_req, "additional_information", None)
             decoded_info = deserialize_additional_information(payload_info)
             if decoded_info:
                 update_buffer(new_req.req_id, decoded_info)
+                self._restore_qwen3_tts_pd_sampler_state(new_req.req_id, decoded_info)
 
         if hasattr(scheduler_output.scheduled_cached_reqs, "additional_information"):
             cached_infos = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", {})
@@ -1728,6 +1804,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                     decoded_info = deserialize_additional_information(req_infos)
                     if decoded_info:
                         update_buffer(req_id, decoded_info)
+                        self._restore_qwen3_tts_pd_sampler_state(req_id, decoded_info)
 
     def _maybe_attach_mimo_audio_req_infos(
         self,
@@ -2006,14 +2083,13 @@ class OmniGPUModelRunner(GPUModelRunner):
                     resume_token_id is not None
                     and not resume_consumed
                     and span_len == 1
-                    and num_computed_tokens == prompt_len
+                    and num_computed_tokens == prompt_len - 1
                 )
                 if is_pd_resume_token:
-                    # Keep the remote request at P's exact prompt length so
-                    # Mooncake pulls matching blocks. Once that prefix is
-                    # local, substitute P's sampled layer-0 token into D's
-                    # first decode position; this forward writes its local KV
-                    # and runs MTP exactly as a continuous decode would.
+                    # Mooncake leaves the appended final prompt token y0 for
+                    # D to compute locally. Force that row to P's sampled
+                    # layer-0 token; this forward writes y0's KV, runs its MTP,
+                    # and samples y1 exactly as continuous decoding does.
                     input_ids[s] = resume_token_id
                     resume_meta["pd_resume_token_consumed"] = True
                     logger.info(
@@ -2022,7 +2098,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                         resume_token_id,
                         prompt_len,
                     )
-                is_prefill = num_computed_tokens < prompt_len
+                is_prefill = num_computed_tokens < prompt_len and not is_pd_resume_token
                 req_infos["_omni_prompt_len"] = prompt_len
                 req_infos["_omni_num_computed_tokens"] = num_computed_tokens
                 req_infos["_omni_is_prefill"] = is_prefill

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -54,6 +54,11 @@ else:
 logger = init_logger(__name__)
 
 
+def _envs_pd_trace() -> bool:
+    """True when VLLM_OMNI_PD_TRACE is set (temporary PD resume diagnostics)."""
+    return os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False")
+
+
 def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
     """Return only M-RoPE kwargs accepted by the model implementation."""
     method = getattr(model, "get_mrope_input_positions")
@@ -2016,6 +2021,23 @@ class OmniGPUModelRunner(GPUModelRunner):
                     and span_len == 1
                     and num_computed_tokens == prompt_len
                 )
+                if resume_token_id is None and _envs_pd_trace():
+                    logger.info(
+                        "[PD_TRACE] resume_probe req=%s no_token meta_keys=%s infos_keys=%s",
+                        req_id,
+                        sorted(resume_meta) if isinstance(resume_meta, dict) else None,
+                        sorted(req_infos),
+                    )
+                elif not is_pd_resume_token and _envs_pd_trace():
+                    logger.info(
+                        "[PD_TRACE] resume_probe req=%s token=%s consumed=%s span_len=%s computed=%s prompt_len=%s",
+                        req_id,
+                        resume_token_id,
+                        resume_consumed,
+                        span_len,
+                        num_computed_tokens,
+                        prompt_len,
+                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -2038,6 +2038,19 @@ class OmniGPUModelRunner(GPUModelRunner):
                         num_computed_tokens,
                         prompt_len,
                     )
+                if _envs_pd_trace() and resume_consumed and num_computed_tokens in (prompt_len + 1, prompt_len + 2, prompt_len + 40, prompt_len + 200):
+                    _hs = req_infos.get("hidden_states") if isinstance(req_infos.get("hidden_states"), dict) else {}
+                    _mt = req_infos.get("meta") if isinstance(req_infos.get("meta"), dict) else {}
+                    _cd = req_infos.get("codes") if isinstance(req_infos.get("codes"), dict) else {}
+                    logger.info(
+                        "[PD_TRACE] frame_state req=%s computed=%d hs=%s tail_shape=%s last_shape=%s "
+                        "text_offset=%s codes=%s mtp_inputs=%s",
+                        req_id, num_computed_tokens, sorted(_hs),
+                        tuple(_hs["trailing_text"].shape) if hasattr(_hs.get("trailing_text"), "shape") else None,
+                        tuple(_hs["last"].shape) if hasattr(_hs.get("last"), "shape") else None,
+                        _mt.get("talker_text_offset"), sorted(_cd),
+                        "mtp_inputs" in req_infos,
+                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -54,6 +54,11 @@ else:
 logger = init_logger(__name__)
 
 
+def _envs_pd_trace() -> bool:
+    """True when VLLM_OMNI_PD_TRACE is set (temporary PD resume diagnostics)."""
+    return os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False")
+
+
 def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
     """Return only M-RoPE kwargs accepted by the model implementation."""
     method = getattr(model, "get_mrope_input_positions")
@@ -1704,6 +1709,14 @@ class OmniGPUModelRunner(GPUModelRunner):
                 self.inputs_embeds.gpu[start_offset : start_offset + overlay_len].copy_(src)
 
     def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
+        if _envs_pd_trace():
+            _c = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", None)
+            logger.info(
+                "[PD_TRACE] upd_addinfo n_new=%d new_ids=%s cached_ai=%s",
+                len(scheduler_output.scheduled_new_reqs),
+                [getattr(r, "req_id", None) for r in scheduler_output.scheduled_new_reqs],
+                (sorted(_c) if isinstance(_c, dict) else None),
+            )
         for new_req in scheduler_output.scheduled_new_reqs:
             model_buffer = getattr(new_req, "model_intermediate_buffer", None)
             if isinstance(model_buffer, dict) and model_buffer:
@@ -2004,6 +2017,23 @@ class OmniGPUModelRunner(GPUModelRunner):
                     and span_len == 1
                     and num_computed_tokens == prompt_len
                 )
+                if resume_token_id is None and _envs_pd_trace():
+                    logger.info(
+                        "[PD_TRACE] resume_probe req=%s no_token meta_keys=%s infos_keys=%s",
+                        req_id,
+                        sorted(resume_meta) if isinstance(resume_meta, dict) else None,
+                        sorted(req_infos),
+                    )
+                elif not is_pd_resume_token and _envs_pd_trace():
+                    logger.info(
+                        "[PD_TRACE] resume_probe req=%s token=%s consumed=%s span_len=%s computed=%s prompt_len=%s",
+                        req_id,
+                        resume_token_id,
+                        resume_consumed,
+                        span_len,
+                        num_computed_tokens,
+                        prompt_len,
+                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -54,11 +54,6 @@ else:
 logger = init_logger(__name__)
 
 
-def _envs_pd_trace() -> bool:
-    """True when VLLM_OMNI_PD_TRACE is set (temporary PD resume diagnostics)."""
-    return os.getenv("VLLM_OMNI_PD_TRACE", "0") not in ("", "0", "false", "False")
-
-
 def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dict[str, Any]:
     """Return only M-RoPE kwargs accepted by the model implementation."""
     method = getattr(model, "get_mrope_input_positions")
@@ -1709,14 +1704,6 @@ class OmniGPUModelRunner(GPUModelRunner):
                 self.inputs_embeds.gpu[start_offset : start_offset + overlay_len].copy_(src)
 
     def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
-        if _envs_pd_trace():
-            _c = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", None)
-            logger.info(
-                "[PD_TRACE] upd_addinfo n_new=%d new_ids=%s cached_ai=%s",
-                len(scheduler_output.scheduled_new_reqs),
-                [getattr(r, "req_id", None) for r in scheduler_output.scheduled_new_reqs],
-                (sorted(_c) if isinstance(_c, dict) else None),
-            )
         for new_req in scheduler_output.scheduled_new_reqs:
             model_buffer = getattr(new_req, "model_intermediate_buffer", None)
             if isinstance(model_buffer, dict) and model_buffer:
@@ -2017,36 +2004,6 @@ class OmniGPUModelRunner(GPUModelRunner):
                     and span_len == 1
                     and num_computed_tokens == prompt_len
                 )
-                if resume_token_id is None and _envs_pd_trace():
-                    logger.info(
-                        "[PD_TRACE] resume_probe req=%s no_token meta_keys=%s infos_keys=%s",
-                        req_id,
-                        sorted(resume_meta) if isinstance(resume_meta, dict) else None,
-                        sorted(req_infos),
-                    )
-                elif not is_pd_resume_token and _envs_pd_trace():
-                    logger.info(
-                        "[PD_TRACE] resume_probe req=%s token=%s consumed=%s span_len=%s computed=%s prompt_len=%s",
-                        req_id,
-                        resume_token_id,
-                        resume_consumed,
-                        span_len,
-                        num_computed_tokens,
-                        prompt_len,
-                    )
-                if _envs_pd_trace() and resume_consumed and num_computed_tokens in (prompt_len + 1, prompt_len + 2, prompt_len + 40, prompt_len + 200):
-                    _hs = req_infos.get("hidden_states") if isinstance(req_infos.get("hidden_states"), dict) else {}
-                    _mt = req_infos.get("meta") if isinstance(req_infos.get("meta"), dict) else {}
-                    _cd = req_infos.get("codes") if isinstance(req_infos.get("codes"), dict) else {}
-                    logger.info(
-                        "[PD_TRACE] frame_state req=%s computed=%d hs=%s tail_shape=%s last_shape=%s "
-                        "text_offset=%s codes=%s mtp_inputs=%s",
-                        req_id, num_computed_tokens, sorted(_hs),
-                        tuple(_hs["trailing_text"].shape) if hasattr(_hs.get("trailing_text"), "shape") else None,
-                        tuple(_hs["last"].shape) if hasattr(_hs.get("last"), "shape") else None,
-                        _mt.get("talker_text_offset"), sorted(_cd),
-                        "mtp_inputs" in req_infos,
-                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -2034,6 +2034,19 @@ class OmniGPUModelRunner(GPUModelRunner):
                         num_computed_tokens,
                         prompt_len,
                     )
+                if _envs_pd_trace() and resume_consumed and num_computed_tokens in (prompt_len + 1, prompt_len + 2, prompt_len + 40, prompt_len + 200):
+                    _hs = req_infos.get("hidden_states") if isinstance(req_infos.get("hidden_states"), dict) else {}
+                    _mt = req_infos.get("meta") if isinstance(req_infos.get("meta"), dict) else {}
+                    _cd = req_infos.get("codes") if isinstance(req_infos.get("codes"), dict) else {}
+                    logger.info(
+                        "[PD_TRACE] frame_state req=%s computed=%d hs=%s tail_shape=%s last_shape=%s "
+                        "text_offset=%s codes=%s mtp_inputs=%s",
+                        req_id, num_computed_tokens, sorted(_hs),
+                        tuple(_hs["trailing_text"].shape) if hasattr(_hs.get("trailing_text"), "shape") else None,
+                        tuple(_hs["last"].shape) if hasattr(_hs.get("last"), "shape") else None,
+                        _mt.get("talker_text_offset"), sorted(_cd),
+                        "mtp_inputs" in req_infos,
+                    )
                 if is_pd_resume_token:
                     # Keep the remote request at P's exact prompt length so
                     # Mooncake pulls matching blocks. Once that prefix is

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1,5 +1,9 @@
 import contextlib
+import copy
 import inspect
+import os
+import time
+import zlib
 from collections.abc import Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
@@ -80,11 +84,92 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.model_intermediate_buffer: dict[str, dict[str, Any]] = {}
         self._omni_num_scheduled_tokens_np: np.ndarray | None = None
         self._omni_last_model_output: object | None = None
-        # The Omni tensor prefix cache will be allocated
-        # when we initialize the metadata builders if enabled
+        # [yurain] Omni tensor prefix cache (allocated when metadata builder initialized if enabled)
         self.omni_prefix_cache = None
         self._sampled_token_ids_cpu_override = None
         self._omni_query_start_loc_model_kwarg = False
+        self._mtp_ar_timing_enabled = os.getenv("VLLM_OMNI_MTP_AR_TIMING", "0").lower() not in (
+            "0",
+            "",
+            "false",
+            "off",
+        )
+        self._mtp_ar_timing_interval = max(1, int(os.getenv("VLLM_OMNI_MTP_AR_TIMING_INTERVAL", "50")))
+        # [yurain] Opt-in: batch all rows assigned to the same replica into ONE
+        # forward() call per replica. Requires VLLM_OMNI_MTP_NUM_REPLICAS >= 2.
+        # Each replica receives bsz = ceil(total_bsz / num_replicas) and the
+        # replicas run concurrently on separate CUDA streams.
+        # Rows with an explicit per-request seed fall back to scalar dispatch
+        # for their group (the group still runs on its own stream).
+        # Default OFF -- the sub-batch path needs VLLM_OMNI_MTP_BATCH_PER_REPLICA=1.
+        self._mtp_batch_per_replica: bool = os.getenv("VLLM_OMNI_MTP_BATCH_PER_REPLICA", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self._mtp_ar_timing_stats = {
+            "mtp_ms": 0.0,
+            "mtp_calls": 0,
+            "mtp_rows": 0,
+            "ar_decode_ms": 0.0,
+            "ar_decode_calls": 0,
+            "ar_decode_tokens": 0,
+            "ar_prefill_ms": 0.0,
+            "ar_prefill_calls": 0,
+            "ar_prefill_tokens": 0,
+        }
+        self._mtp_timing_depth = 0
+
+    def _timing_sync_device(self) -> None:
+        if self._mtp_ar_timing_enabled and torch.cuda.is_available():
+            torch.accelerator.synchronize(self.device)
+
+    def _is_decode_forward_for_timing(self) -> bool:
+        scheduled = self._omni_num_scheduled_tokens_np
+        return scheduled is not None and len(scheduled) > 0 and int(scheduled.max()) == 1
+
+    def _record_mtp_ar_timing(self, kind: str, elapsed_ms: float, *, rows: int = 0, tokens: int = 0) -> None:
+        if not self._mtp_ar_timing_enabled:
+            return
+        stats = self._mtp_ar_timing_stats
+        if kind == "mtp":
+            stats["mtp_ms"] += elapsed_ms
+            stats["mtp_calls"] += 1
+            stats["mtp_rows"] += rows
+        elif kind == "ar_decode":
+            stats["ar_decode_ms"] += elapsed_ms
+            stats["ar_decode_calls"] += 1
+            stats["ar_decode_tokens"] += tokens
+        else:
+            stats["ar_prefill_ms"] += elapsed_ms
+            stats["ar_prefill_calls"] += 1
+            stats["ar_prefill_tokens"] += tokens
+
+        total_calls = int(stats["mtp_calls"] + stats["ar_decode_calls"] + stats["ar_prefill_calls"])
+        if total_calls % self._mtp_ar_timing_interval != 0:
+            return
+
+        mtp_avg = stats["mtp_ms"] / max(1, stats["mtp_calls"])
+        ar_decode_avg = stats["ar_decode_ms"] / max(1, stats["ar_decode_calls"])
+        ar_prefill_avg = stats["ar_prefill_ms"] / max(1, stats["ar_prefill_calls"])
+        ratio = mtp_avg / ar_decode_avg if ar_decode_avg > 0 else 0.0
+        logger.info(
+            "[MTP-AR-TIMING] mtp_avg_ms=%.3f mtp_calls=%d mtp_rows=%d "
+            "ar_decode_avg_ms=%.3f ar_decode_calls=%d ar_decode_tokens=%d "
+            "ar_prefill_avg_ms=%.3f ar_prefill_calls=%d ar_prefill_tokens=%d "
+            "mtp/ar_decode=%.2f",
+            mtp_avg,
+            int(stats["mtp_calls"]),
+            int(stats["mtp_rows"]),
+            ar_decode_avg,
+            int(stats["ar_decode_calls"]),
+            int(stats["ar_decode_tokens"]),
+            ar_prefill_avg,
+            int(stats["ar_prefill_calls"]),
+            int(stats["ar_prefill_tokens"]),
+            ratio,
+        )
 
     def _to_list(self, sampled_token_ids: torch.Tensor) -> list[list[int]]:
         override_fn = self._sampled_token_ids_cpu_override
@@ -165,8 +250,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                                 device=sm.device,
                             )
 
-        # Initialize the wrapper for both multimodal output tensors
-        # and for hidden states to be passed between stages
+        # [yurain] init wrapper for multimodal output / hidden states between stages
         if self.cache_config.enable_prefix_caching:
             self.omni_prefix_cache = OmniTensorPrefixCache(
                 num_blocks=kv_cache_config.num_blocks,
@@ -219,6 +303,118 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.talker_mtp_inputs_embeds = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.last_talker_hidden = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.text_step = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
+        self._init_talker_mtp_replicas()
+
+    def _init_talker_mtp_replicas(self) -> None:
+        self.talker_mtp_code_predictors = []
+        self.talker_mtp_streams = []
+        try:
+            num_replicas = int(os.getenv("VLLM_OMNI_MTP_NUM_REPLICAS", "1") or "1")
+        except ValueError:
+            num_replicas = 1
+        num_replicas = max(1, num_replicas)
+        if num_replicas == 1:
+            return
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        if getattr(kv_transfer_config, "kv_role", None) == "kv_producer":
+            return
+        if not torch.cuda.is_available():
+            logger.warning("VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: CUDA is unavailable", num_replicas)
+            return
+        graph_wrapper_cls = current_omni_platform.get_graph_wrapper_cls()
+        if isinstance(self.talker_mtp, graph_wrapper_cls):
+            logger.warning(
+                "VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: graph-wrapped talker_mtp is not replica-safe", num_replicas
+            )
+            return
+        base_code_predictor = getattr(self.model, "code_predictor", None)
+        if base_code_predictor is None:
+            logger.warning("VLLM_OMNI_MTP_NUM_REPLICAS=%d ignored: model has no code_predictor", num_replicas)
+            return
+
+        def _prepare_replica(replica):
+            # [yurain] Keep CUDA graphs enabled but give each replica its own
+            # private graph memory pool (torch.cuda.graph_pool_handle()) instead
+            # of vLLM's shared global pool. Graphs sharing one pool are not
+            # safe to replay concurrently on different streams (may clobber
+            # each other's memory); a private pool per replica makes
+            # concurrent capture/replay across streams safe while still
+            # getting graph-replay speed.
+            if hasattr(replica, "_graph_pool"):
+                replica._graph_pool = torch.cuda.graph_pool_handle()
+            replica._proj_buf = None
+            replica._compiled_model_fwd = None
+            replica._bucket_sizes = []
+            replica._bucket_pos_ids = {}
+            replica._lm_heads_list = None
+            replica._codec_embeds_list = None
+            replica._device_graphs = {}
+            if hasattr(replica, "_full_ar_graphs"):
+                replica._full_ar_graphs = {}
+                replica._all_codes_bufs = {}
+                replica._layer0_code_bufs = {}
+                replica._noise_buf = None
+                replica._cap_inv_temperature = None
+                replica._cap_top_k = None
+                replica._full_graph_disabled_runtime = False
+            if hasattr(replica, "_full_ar_kv_graphs"):
+                replica._full_ar_kv_graphs = {}
+                replica._kv_caches = {}
+                replica._kv_pos_prefill = {}
+                replica._kv_pos_decode = {}
+                replica._kv_disabled_runtime = False
+            setup_compile = getattr(replica, "_setup_compile", None)
+            if callable(setup_compile):
+                setup_compile()
+
+        replicas = []
+        try:
+            with torch.cuda.device(self.device), torch.inference_mode():
+                for _ in range(num_replicas):
+                    replica = copy.deepcopy(base_code_predictor).to(device=self.device)
+                    replica.eval()
+                    _prepare_replica(replica)
+                    replicas.append(replica)
+                torch.accelerator.synchronize(self.device)
+        except Exception:
+            logger.exception("VLLM_OMNI_MTP_NUM_REPLICAS=%d disabled: failed to initialize replicas", num_replicas)
+            self.talker_mtp_code_predictors = []
+            self.talker_mtp_streams = []
+            return
+        self.talker_mtp_code_predictors = replicas
+        self.talker_mtp_streams = [torch.cuda.Stream(device=self.device) for _ in replicas]
+        graphs_active = bool(getattr(replicas[0], "_device_graphs", None)) if replicas else False
+        logger.info(
+            "[MTP-REPLICA] enabled num_replicas=%d cuda_graphs=%s (private_pool_per_replica) prewarmed=1",
+            len(replicas),
+            "enabled" if graphs_active else "disabled",
+        )
+
+    @staticmethod
+    def _mtp_replica_idx_for_req(req_id: str, num_replicas: int) -> int:
+        """Stable request-id -> MTP replica mapping.
+
+        Each replica (see :meth:`_init_talker_mtp_replicas`) is an
+        independently-deepcopied ``code_predictor`` with its own runtime
+        state (captured-CUDA-graph sampling-constant lock-in, noise/layer0
+        buffers, etc.). ``talker_mtp``'s residual-codebook output is written
+        straight back into ``inputs_embeds`` and feeds the *next* decode
+        step of the main talker AR loop, so a request must always be served
+        by the same replica across steps -- otherwise it gets "relayed"
+        between two replicas with independent state, which can silently
+        perturb its generation trajectory (observed as a request that
+        never samples ``stop_token_ids`` and runs all the way to
+        ``max_tokens``, under concurrent load).
+        ``row % num_replicas`` (the previous scheme) keys off this request's
+        *transient position* within the current decode batch, which changes
+        across steps whenever the batch composition changes (a request
+        finishing / a new one being admitted). Hashing the request id keeps
+        the assignment fixed for the lifetime of the request regardless of
+        where it lands in the batch. ``zlib.crc32`` is used instead of the
+        builtin ``hash()`` because the latter is salted per-process
+        (``PYTHONHASHSEED``) and is not guaranteed stable across workers.
+        """
+        return zlib.crc32(req_id.encode("utf-8")) % num_replicas
 
     def _prewarm_attention_capture_workspaces(self) -> None:
         capture_sizes = getattr(self.compilation_config, "cudagraph_capture_sizes", None)
@@ -610,9 +806,32 @@ class OmniGPUModelRunner(GPUModelRunner):
                 logger.error(f"Error updating model intermediate buffer: {e}")
             # Decode additional_information payloads (dictionary)
             try:
-                if getattr(new_req_data, "additional_information", None) is not None:
-                    info_dict = deserialize_additional_information(new_req_data.additional_information)
+                _ai_raw = getattr(new_req_data, "additional_information", None)
+                if _ai_raw is not None:
+                    logger.warning_once(
+                        "additional_information on request data is deprecated, use model_intermediate_buffer"
+                    )
+                    info_dict = deserialize_additional_information(_ai_raw)
                     if info_dict:
+                        pd_sampler = info_dict.get("pd_sampler")
+                        generator_state = (
+                            pd_sampler.get("main_generator_state") if isinstance(pd_sampler, dict) else None
+                        )
+                        if generator_state is not None:
+                            if not isinstance(generator_state, torch.Tensor) or generator_state.dtype != torch.uint8:
+                                raise RuntimeError(
+                                    f"Qwen3-TTS PD sampler state is invalid for req={req_id}"
+                                )
+                            if req_state.generator is None:
+                                raise RuntimeError(
+                                    f"Qwen3-TTS PD sampler generator is missing for req={req_id}"
+                                )
+                            req_state.generator.set_state(generator_state.detach().to("cpu").contiguous())
+                            logger.info(
+                                "[PD_TRACE] qwen3_tts_main_sampler_restored req=%s state_bytes=%d",
+                                req_id,
+                                generator_state.numel(),
+                            )
                         self.model_intermediate_buffer[req_id] = info_dict
                         setattr(
                             self.requests[req_id],
@@ -746,8 +965,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 if self.use_async_scheduling and num_output_tokens > 0:
                     # We must recover the output token ids for resumed requests in the
                     # async scheduling case, so that correct input_ids are obtained.
-                    resumed_token_ids = req_data.all_token_ids[req_id]
-                    req_state.output_token_ids = resumed_token_ids[-num_output_tokens:]
+                    req_state.output_token_ids = req_data.all_token_ids[req_id][-num_output_tokens:]
 
                 reqs_to_add.append(req_state)
                 # Track resumed requests for ngram_gpu full tensor copy
@@ -1760,6 +1978,46 @@ class OmniGPUModelRunner(GPUModelRunner):
                 prompt_token_ids = getattr(req_state, "prompt_token_ids", ()) if req_state is not None else ()
                 prompt_len = len(prompt_token_ids or ())
                 num_computed_tokens = int(self.input_batch.num_computed_tokens_cpu[req_index])
+                resume_meta = req_infos.get("meta")
+                if not isinstance(resume_meta, dict):
+                    additional_information = req_infos.get("additional_information")
+                    resume_meta = (
+                        additional_information.get("meta") if isinstance(additional_information, dict) else None
+                    )
+                resume_token_id = (
+                    resume_meta.get("pd_resume_token_id") if isinstance(resume_meta, dict) else None
+                )
+                resume_consumed = (
+                    bool(resume_meta.get("pd_resume_token_consumed", False))
+                    if isinstance(resume_meta, dict)
+                    else False
+                )
+                if isinstance(resume_token_id, torch.Tensor):
+                    resume_token_id = resume_token_id.item() if resume_token_id.numel() == 1 else None
+                try:
+                    resume_token_id = int(resume_token_id) if resume_token_id is not None else None
+                except (TypeError, ValueError):
+                    resume_token_id = None
+                is_pd_resume_token = (
+                    resume_token_id is not None
+                    and not resume_consumed
+                    and span_len == 1
+                    and num_computed_tokens == prompt_len
+                )
+                if is_pd_resume_token:
+                    # Keep the remote request at P's exact prompt length so
+                    # Mooncake pulls matching blocks. Once that prefix is
+                    # local, substitute P's sampled layer-0 token into D's
+                    # first decode position; this forward writes its local KV
+                    # and runs MTP exactly as a continuous decode would.
+                    input_ids[s] = resume_token_id
+                    resume_meta["pd_resume_token_consumed"] = True
+                    logger.info(
+                        "[PD_TRACE] qwen3_tts_decode_resume req=%s token_id=%d prompt_len=%d",
+                        req_id,
+                        resume_token_id,
+                        prompt_len,
+                    )
                 is_prefill = num_computed_tokens < prompt_len
                 req_infos["_omni_prompt_len"] = prompt_len
                 req_infos["_omni_num_computed_tokens"] = num_computed_tokens
@@ -1829,6 +2087,7 @@ class OmniGPUModelRunner(GPUModelRunner):
         decode_batch_size = len(decode_req_ids)
         if decode_batch_size == 0:
             return
+
         _cudagraph_mode, batch_desc, _, _, _ = self._determine_batch_execution_and_padding(
             num_tokens=decode_batch_size,
             num_reqs=decode_batch_size,
@@ -1858,7 +2117,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             extra_args = getattr(sampling_params, "extra_args", None) if sampling_params is not None else None
             seed = None
             if isinstance(extra_args, dict):
-                seed = extra_args.get("tts_local_seed")
+                seed = extra_args.get("tts_local_seed", extra_args.get("qwen3_tts_request_seed"))
             return int(seed) if seed is not None else None
 
         def _row_generator(req_id: str) -> torch.Generator | None:
@@ -1872,7 +2131,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             generator = cache.get(req_id)
             if generator is None or generator.device != req_input_ids.device:
                 generator = torch.Generator(device=req_input_ids.device)
-                generator.manual_seed(seed)
+                generator.manual_seed(int(seed))
                 cache[req_id] = generator
             return generator
 
@@ -1883,32 +2142,153 @@ class OmniGPUModelRunner(GPUModelRunner):
             for stale_id in [rid for rid in cache if rid not in self.requests]:
                 del cache[stale_id]
 
-        if (
-            decode_batch_size > 1
-            and any(generator is not None for generator in row_generators)
-            and not getattr(self.model, "talker_mtp_accepts_per_row_generators", False)
-        ):
-            # A torch.Generator is a single stream. Using one generator for a
-            # multi-row batch would make explicitly-seeded requests depend on
-            # other rows in the same scheduler step, so keep that path scalar.
+        if decode_batch_size > 1:
             saved_input_ids = self.talker_mtp_input_ids.gpu[:decode_batch_size].clone()
             saved_embeds = self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].clone()
             saved_hidden = self.last_talker_hidden.gpu[:decode_batch_size].clone()
             saved_text = self.text_step.gpu[:decode_batch_size].clone()
-            try:
-                for row, req_id in enumerate(decode_req_ids):
-                    self.talker_mtp_input_ids.gpu[:1].copy_(saved_input_ids[row : row + 1])
-                    self.talker_mtp_inputs_embeds.gpu[:1].copy_(saved_embeds[row : row + 1])
-                    self.last_talker_hidden.gpu[:1].copy_(saved_hidden[row : row + 1])
-                    self.text_step.gpu[:1].copy_(saved_text[row : row + 1])
-                    row_offsets = None if start_offsets is None else [start_offsets[row]]
-                    self._talker_mtp_forward([req_id], inputs_embeds, row_offsets)
-            finally:
-                self.talker_mtp_input_ids.gpu[:decode_batch_size].copy_(saved_input_ids)
-                self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].copy_(saved_embeds)
-                self.last_talker_hidden.gpu[:decode_batch_size].copy_(saved_hidden)
-                self.text_step.gpu[:decode_batch_size].copy_(saved_text)
-            return
+            replicas = getattr(self, "talker_mtp_code_predictors", None) or []
+            streams = getattr(self, "talker_mtp_streams", None) or []
+            if len(replicas) > 1 and len(streams) == len(replicas) and torch.cuda.is_available():
+                timing_enabled = self._mtp_ar_timing_enabled
+                if timing_enabled:
+                    self._timing_sync_device()
+                    mtp_t0 = time.perf_counter()
+                outputs: list[tuple[torch.Tensor, torch.Tensor] | None] = [None] * decode_batch_size
+                current_stream = torch.cuda.current_stream(device=self.device)
+                used_streams = []
+                talker_kwargs_base = {
+                    "do_sample": subtalker_params.get("do_sample"),
+                    "temperature": subtalker_params.get("temperature"),
+                    "top_k": subtalker_params.get("top_k"),
+                    "top_p": subtalker_params.get("top_p"),
+                }
+                if self._mtp_batch_per_replica:
+                    # Sub-batch dispatch: group rows by replica, each replica
+                    # gets a contiguous sub-batch and runs one forward() call.
+                    # Rows with explicit seed fall back to scalar within the group.
+                    # NOTE: replica assignment is keyed by req_id (not batch
+                    # position) -- see _mtp_replica_idx_for_req for why.
+                    rows_by_replica: dict[int, list[int]] = {}
+                    for row, req_id in enumerate(decode_req_ids):
+                        replica_idx = self._mtp_replica_idx_for_req(req_id, len(replicas))
+                        rows_by_replica.setdefault(replica_idx, []).append(row)
+                    for replica_idx, rows in rows_by_replica.items():
+                        stream = streams[replica_idx]
+                        if stream not in used_streams:
+                            stream.wait_stream(current_stream)
+                            used_streams.append(stream)
+                        group_req_ids = [decode_req_ids[r] for r in rows]
+                        group_has_seed = any(row_generators[r] is not None for r in rows)
+                        with torch.cuda.stream(stream):
+                            if group_has_seed:
+                                # Scalar fallback for this replica's rows only.
+                                for row, req_id in zip(rows, group_req_ids, strict=True):
+                                    talker_kwargs = dict(talker_kwargs_base)
+                                    if row_generators[row] is not None:
+                                        talker_kwargs["generator"] = row_generators[row]
+                                    if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                                        talker_kwargs["req_ids"] = [req_id]
+                                        talker_kwargs["req_infos"] = [
+                                            self.model_intermediate_buffer.setdefault(req_id, {})
+                                        ]
+                                    outputs[row] = self.talker_mtp(
+                                        saved_input_ids[row : row + 1],
+                                        saved_embeds[row : row + 1],
+                                        saved_hidden[row : row + 1],
+                                        saved_text[row : row + 1],
+                                        code_predictor_override=replicas[replica_idx],
+                                        **talker_kwargs,
+                                    )
+                            else:
+                                row_idx = torch.tensor(rows, device=saved_input_ids.device, dtype=torch.long)
+                                talker_kwargs = dict(talker_kwargs_base)
+                                if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                                    talker_kwargs["req_ids"] = group_req_ids
+                                    talker_kwargs["req_infos"] = [
+                                        self.model_intermediate_buffer.setdefault(r, {}) for r in group_req_ids
+                                    ]
+                                batch_embeds, batch_codes = self.talker_mtp(
+                                    saved_input_ids.index_select(0, row_idx),
+                                    saved_embeds.index_select(0, row_idx),
+                                    saved_hidden.index_select(0, row_idx),
+                                    saved_text.index_select(0, row_idx),
+                                    code_predictor_override=replicas[replica_idx],
+                                    **talker_kwargs,
+                                )
+                                for local_idx, row in enumerate(rows):
+                                    outputs[row] = (
+                                        batch_embeds[local_idx : local_idx + 1],
+                                        batch_codes[local_idx : local_idx + 1] if batch_codes is not None else None,
+                                    )
+                else:
+                    # Scalar dispatch: one call per row, each on its replica's stream.
+                    # NOTE: replica assignment is keyed by req_id (not batch
+                    # position) -- see _mtp_replica_idx_for_req for why.
+                    for row, req_id in enumerate(decode_req_ids):
+                        replica_idx = self._mtp_replica_idx_for_req(req_id, len(replicas))
+                        stream = streams[replica_idx]
+                        if stream not in used_streams:
+                            stream.wait_stream(current_stream)
+                            used_streams.append(stream)
+                        talker_kwargs = dict(talker_kwargs_base)
+                        if row_generators[row] is not None:
+                            talker_kwargs["generator"] = row_generators[row]
+                        if getattr(self.model, "talker_mtp_accepts_req_infos", False):
+                            talker_kwargs["req_ids"] = [req_id]
+                            talker_kwargs["req_infos"] = [self.model_intermediate_buffer.setdefault(req_id, {})]
+                        with torch.cuda.stream(stream):
+                            outputs[row] = self.talker_mtp(
+                                saved_input_ids[row : row + 1],
+                                saved_embeds[row : row + 1],
+                                saved_hidden[row : row + 1],
+                                saved_text[row : row + 1],
+                                code_predictor_override=replicas[replica_idx],
+                                **talker_kwargs,
+                            )
+                for stream in used_streams:
+                    current_stream.wait_stream(stream)
+                if timing_enabled:
+                    self._timing_sync_device()
+                    self._record_mtp_ar_timing("mtp", (time.perf_counter() - mtp_t0) * 1000.0, rows=decode_batch_size)
+                out_key = getattr(self.model, "talker_mtp_output_key", ("codes", "audio"))
+                if not isinstance(out_key, tuple) or len(out_key) != 2:
+                    raise TypeError(
+                        f"talker_mtp_output_key must be a 2-tuple, got {type(out_key).__name__}: {out_key!r}"
+                    )
+                if start_offsets is None:
+                    id_to_index = self.input_batch.req_id_to_index
+                    start_offsets = [int(self.query_start_loc.cpu[id_to_index[req_id]]) for req_id in decode_req_ids]
+                for row, (req_id, start_offset) in enumerate(zip(decode_req_ids, start_offsets, strict=True)):
+                    output = outputs[row]
+                    assert output is not None
+                    req_embeds_row, code_predictor_codes_row = output
+                    inputs_embeds[start_offset : start_offset + 1] = req_embeds_row[:1]
+                    if code_predictor_codes_row is not None:
+                        update_dict = {out_key[0]: {out_key[1]: code_predictor_codes_row[:1]}}
+                        self._merge_additional_information_update(req_id, update_dict)
+                return
+
+            if any(generator is not None for generator in row_generators) and not getattr(
+                self.model, "talker_mtp_accepts_per_row_generators", False
+            ):
+                # A torch.Generator is a single stream. Using one generator for a
+                # multi-row batch would make explicitly-seeded requests depend on
+                # other rows in the same scheduler step, so keep that path scalar.
+                try:
+                    for row, req_id in enumerate(decode_req_ids):
+                        self.talker_mtp_input_ids.gpu[:1].copy_(saved_input_ids[row : row + 1])
+                        self.talker_mtp_inputs_embeds.gpu[:1].copy_(saved_embeds[row : row + 1])
+                        self.last_talker_hidden.gpu[:1].copy_(saved_hidden[row : row + 1])
+                        self.text_step.gpu[:1].copy_(saved_text[row : row + 1])
+                        row_offsets = None if start_offsets is None else [start_offsets[row]]
+                        self._talker_mtp_forward([req_id], inputs_embeds, row_offsets)
+                finally:
+                    self.talker_mtp_input_ids.gpu[:decode_batch_size].copy_(saved_input_ids)
+                    self.talker_mtp_inputs_embeds.gpu[:decode_batch_size].copy_(saved_embeds)
+                    self.last_talker_hidden.gpu[:decode_batch_size].copy_(saved_hidden)
+                    self.text_step.gpu[:decode_batch_size].copy_(saved_text)
+                return
 
         talker_kwargs = {
             "do_sample": subtalker_params.get("do_sample"),
@@ -1926,6 +2306,10 @@ class OmniGPUModelRunner(GPUModelRunner):
             talker_kwargs["req_infos"] = [
                 self.model_intermediate_buffer.setdefault(req_id, {}) for req_id in decode_req_ids
             ]
+        timing_enabled = self._mtp_ar_timing_enabled
+        if timing_enabled:
+            self._timing_sync_device()
+            mtp_t0 = time.perf_counter()
         with current_omni_platform.set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -1936,6 +2320,9 @@ class OmniGPUModelRunner(GPUModelRunner):
                 text_step,
                 **talker_kwargs,
             )
+        if timing_enabled:
+            self._timing_sync_device()
+            self._record_mtp_ar_timing("mtp", (time.perf_counter() - mtp_t0) * 1000.0, rows=decode_batch_size)
         # update the inputs_embeds and code_predictor_codes
         out_key = getattr(self.model, "talker_mtp_output_key", ("codes", "audio"))
         if not isinstance(out_key, tuple) or len(out_key) != 2:
@@ -1968,6 +2355,10 @@ class OmniGPUModelRunner(GPUModelRunner):
                 omni_query_start_loc=model_kwargs_extra.get("omni_query_start_loc"),
             )
 
+        timing_enabled = self._mtp_ar_timing_enabled
+        if timing_enabled:
+            self._timing_sync_device()
+            ar_t0 = time.perf_counter()
         model_output = super()._model_forward(
             input_ids=input_ids,
             positions=positions,
@@ -1976,6 +2367,16 @@ class OmniGPUModelRunner(GPUModelRunner):
             **model_kwargs,
             **model_kwargs_extra,
         )
+        if timing_enabled:
+            self._timing_sync_device()
+            if input_ids is not None:
+                num_tokens = int(input_ids.shape[0])
+            elif inputs_embeds is not None:
+                num_tokens = int(inputs_embeds.shape[0])
+            else:
+                num_tokens = 0
+            kind = "ar_decode" if self._is_decode_forward_for_timing() else "ar_prefill"
+            self._record_mtp_ar_timing(kind, (time.perf_counter() - ar_t0) * 1000.0, tokens=num_tokens)
         if not isinstance(model_output, OmniOutput) and hasattr(self.model, "make_omni_output"):
             model_output = self.model.make_omni_output(model_output, **model_kwargs, **model_kwargs_extra)
         # Cache model output so later sample_tokens can consume multimodal results.
@@ -2044,3 +2445,4 @@ class OmniGPUModelRunner(GPUModelRunner):
         merged_info.setdefault("meta", {})["resumable"] = True
         self.model_intermediate_buffer[req_id] = merged_info
         setattr(self.requests[req_id], "additional_information_cpu", merged_info)
+

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -147,6 +147,25 @@ class OmniConnectorModelRunnerMixin:
         # -- next stage ID (from connector config or default stage_id + 1) --
         self._next_stage_id: int = self._resolve_next_stage_id(model_config)
 
+        # -- fan-in source candidates (multiple engine_input_source) --
+        # A fan-in receiver (e.g. 1P3D code2wav reading from decode stages
+        # [1, 2, 3]) cannot rely on the single ``stage_id - 1`` default: with
+        # round-robin routing each request comes from a different upstream, so
+        # a fixed ``stage_id - 1`` default would deadlock waiting on an upstream
+        # that never sends this request. Use the full candidate list instead.
+        omni_kv_config = getattr(model_config, "omni_kv_config", None)
+        if not isinstance(omni_kv_config, dict):
+            omni_kv_config = {}
+        raw_sources = omni_kv_config.get("engine_input_source") or []
+        source_candidates: list[int] = []
+        for src in raw_sources:
+            coerced = self._coerce_stage_id(src)
+            if coerced is not None and coerced not in source_candidates:
+                source_candidates.append(coerced)
+        self._source_stage_candidates: list[int] = source_candidates
+        # req_id -> upstream stage id, pinned after the first successful pull.
+        self._pinned_source_stage: dict[str, int] = {}
+
         # -- heterogeneous TP rank support --
         rank_cfg = self._parse_rank_mapping(model_config)
         if self._kv_transfer_manager is not None:
@@ -226,11 +245,8 @@ class OmniConnectorModelRunnerMixin:
         # -- KV transfer lifecycle (absorbed from scheduler) --
         # Requests marked for KV transfer: {req_id: {seq_len, block_ids}}
         self._kv_pending_transfers: dict[str, dict[str, Any]] = {}
-        # Requests whose KV transfer has been submitted but not yet acked
         self._kv_active_transfers: set[str] = set()
-        # Requests whose KV transfer is complete (acked by kv_extracted_req_ids)
         self._kv_completed_transfers: set[str] = set()
-        # Dedup guard: requests that have already triggered KV transfer
         self._kv_triggered_requests: set[str] = set()
 
         self._lock = threading.Lock()
@@ -368,6 +384,7 @@ class OmniConnectorModelRunnerMixin:
         self._finished_load_reqs.discard(req_id)
         self._chunk_ready_req_ids.discard(req_id)
         self._chunk_finished_req_ids.discard(req_id)
+        self._pinned_source_stage.pop(req_id, None)
         self._chunk_stream_completed.discard(req_id)
         self._stage_recv_req_ids.discard(req_id)
         self._full_payload_pending_broadcast_req_ids.discard(req_id)
@@ -1782,25 +1799,50 @@ class OmniConnectorModelRunnerMixin:
                 )
                 return False
 
-        target_stage_id = self._stage_id - 1
+        with self._lock:
+            pending_request = self._pending_load_reqs.get(req_id)
+        configured_from_stage = self._stage_id - 1
         chunk_id = self._get_req_chunk[req_id]
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
-        connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
-        if self._async_chunk:
-            result = self._recv_async_chunk_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
+        # Decide which upstream source(s) to poll for this request:
+        #   1. explicit ``omni_source_stage_id`` carried on the request,
+        #   2. a source already pinned from a prior chunk of this request,
+        #   3. fan-in discovery across every candidate source (probe all),
+        #   4. legacy single-source default (``stage_id - 1``).
+        explicit_source = self._request_source_stage_id_optional(pending_request)
+        pinned_source = self._pinned_source_stage.get(req_id)
+        if explicit_source is not None:
+            poll_targets = [explicit_source]
+        elif pinned_source is not None:
+            poll_targets = [pinned_source]
+        elif len(self._source_stage_candidates) > 1:
+            poll_targets = list(self._source_stage_candidates)
         else:
-            result = self._recv_full_payload_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
+            poll_targets = [configured_from_stage]
+
+        result = None
+        for candidate in poll_targets:
+            candidate_key = f"{external_req_id}_{candidate}_{chunk_id}"
+            if self._async_chunk:
+                candidate_result = self._recv_async_chunk_result(
+                    connector,
+                    str(candidate),
+                    str(self._stage_id),
+                    candidate_key,
+                )
+            else:
+                candidate_result = self._recv_full_payload_result(
+                    connector,
+                    str(candidate),
+                    str(self._stage_id),
+                    candidate_key,
+                )
+            if candidate_result is not None:
+                result = candidate_result
+                if pinned_source is None:
+                    self._pinned_source_stage[req_id] = candidate
+                break
 
         if result is None:
             return False
@@ -1810,11 +1852,10 @@ class OmniConnectorModelRunnerMixin:
             return False
         if isinstance(payload_data, dict):
             logger.debug(
-                "[Stage-%s] recv_chunk_result: req=%s ext=%s key=%s keys=%s finished=%s",
+                "[Stage-%s] recv_chunk_result: req=%s ext=%s keys=%s finished=%s",
                 self._stage_id,
                 req_id,
                 external_req_id,
-                connector_get_key,
                 sorted(payload_data.keys()),
                 self._payload_finished(payload_data),
             )
@@ -1886,14 +1927,12 @@ class OmniConnectorModelRunnerMixin:
                 self._full_payload_pending_broadcast_req_ids.add(req_id)
                 self._pending_load_reqs.pop(req_id, None)
             logger.debug(
-                "[Stage-%s] full_payload recv complete: req=%s key=%s payload_type=%s",
+                "[Stage-%s] full_payload recv complete: req=%s payload_type=%s",
                 self._stage_id,
                 req_id,
-                connector_get_key,
                 type(engine_inputs).__name__,
             )
 
-        logger.debug("[Stage-%s] Received data for key %s", self._stage_id, connector_get_key)
         return True
 
     def _build_custom_process_payload(
@@ -2238,6 +2277,42 @@ class OmniConnectorModelRunnerMixin:
                 return ext
         return fallback_req_id
 
+    @staticmethod
+    def _coerce_stage_id(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _request_source_stage_id_optional(self, request: Any | None) -> int | None:
+        """Return the explicit ``omni_source_stage_id`` on a request, or None.
+
+        Unlike :meth:`_request_source_stage_id` this never falls back to a
+        default; callers use ``None`` to trigger fan-in source discovery.
+        """
+        info = getattr(request, "additional_information", None) if request is not None else None
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            return self._coerce_stage_id(value)
+        return None
+
+    def _request_source_stage_id(self, request: Any | None, default: int) -> int:
+        parsed = self._request_source_stage_id_optional(request)
+        if parsed is not None:
+            return parsed
+        return default
+
     def _resolve_next_stage_id(self, model_config: Any) -> int:
         """Determine the downstream stage ID from connector config.
 
@@ -2254,6 +2329,17 @@ class OmniConnectorModelRunnerMixin:
                 return to_stage
             if isinstance(to_stage, str) and to_stage.strip():
                 return int(to_stage)
+
+        output_connectors = getattr(model_config, "output_connectors", None)
+        if isinstance(output_connectors, dict) and len(output_connectors) == 1:
+            name = next(iter(output_connectors))
+            if isinstance(name, str):
+                prefix = "to_stage_"
+                if name.startswith(prefix):
+                    parsed = self._coerce_stage_id(name[len(prefix) :])
+                    if parsed is not None:
+                        return parsed
+
         return self._stage_id + 1
 
     @staticmethod
@@ -2339,3 +2425,4 @@ class OmniConnectorModelRunnerMixin:
     ) -> str:
         """Build connector key that includes rank info for KV transfers."""
         return f"{req_id}_{from_stage}_{chunk_id}_{from_rank}_{to_rank}"
+

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -2425,4 +2425,3 @@ class OmniConnectorModelRunnerMixin:
     ) -> str:
         """Build connector key that includes rank info for KV transfers."""
         return f"{req_id}_{from_stage}_{chunk_id}_{from_rank}_{to_rank}"
-

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -120,6 +120,25 @@ class OmniConnectorModelRunnerMixin:
         # -- next stage ID (from connector config or default stage_id + 1) --
         self._next_stage_id: int = self._resolve_next_stage_id(model_config)
 
+        # -- fan-in source candidates (multiple engine_input_source) --
+        # A fan-in receiver (e.g. 1P3D code2wav reading from decode stages
+        # [1, 2, 3]) cannot rely on the single ``stage_id - 1`` default: with
+        # round-robin routing each request comes from a different upstream, so
+        # a fixed ``stage_id - 1`` default would deadlock waiting on an upstream
+        # that never sends this request. Use the full candidate list instead.
+        omni_kv_config = getattr(model_config, "omni_kv_config", None)
+        if not isinstance(omni_kv_config, dict):
+            omni_kv_config = {}
+        raw_sources = omni_kv_config.get("engine_input_source") or []
+        source_candidates: list[int] = []
+        for src in raw_sources:
+            coerced = self._coerce_stage_id(src)
+            if coerced is not None and coerced not in source_candidates:
+                source_candidates.append(coerced)
+        self._source_stage_candidates: list[int] = source_candidates
+        # req_id -> upstream stage id, pinned after the first successful pull.
+        self._pinned_source_stage: dict[str, int] = {}
+
         # -- heterogeneous TP rank support --
         rank_cfg = self._parse_rank_mapping(model_config)
         if self._kv_transfer_manager is not None:
@@ -198,11 +217,8 @@ class OmniConnectorModelRunnerMixin:
         # -- KV transfer lifecycle (absorbed from scheduler) --
         # Requests marked for KV transfer: {req_id: {seq_len, block_ids}}
         self._kv_pending_transfers: dict[str, dict[str, Any]] = {}
-        # Requests whose KV transfer has been submitted but not yet acked
         self._kv_active_transfers: set[str] = set()
-        # Requests whose KV transfer is complete (acked by kv_extracted_req_ids)
         self._kv_completed_transfers: set[str] = set()
-        # Dedup guard: requests that have already triggered KV transfer
         self._kv_triggered_requests: set[str] = set()
 
         self._lock = threading.Lock()
@@ -339,6 +355,7 @@ class OmniConnectorModelRunnerMixin:
         self._finished_load_reqs.discard(req_id)
         self._chunk_ready_req_ids.discard(req_id)
         self._chunk_finished_req_ids.discard(req_id)
+        self._pinned_source_stage.pop(req_id, None)
         self._chunk_stream_completed.discard(req_id)
         self._stage_recv_req_ids.discard(req_id)
         self._full_payload_pending_broadcast_req_ids.discard(req_id)
@@ -1751,25 +1768,50 @@ class OmniConnectorModelRunnerMixin:
                 )
                 return False
 
-        target_stage_id = self._stage_id - 1
+        with self._lock:
+            pending_request = self._pending_load_reqs.get(req_id)
+        configured_from_stage = self._stage_id - 1
         chunk_id = self._get_req_chunk[req_id]
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
-        connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
-        if self._async_chunk:
-            result = self._recv_async_chunk_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
+        # Decide which upstream source(s) to poll for this request:
+        #   1. explicit ``omni_source_stage_id`` carried on the request,
+        #   2. a source already pinned from a prior chunk of this request,
+        #   3. fan-in discovery across every candidate source (probe all),
+        #   4. legacy single-source default (``stage_id - 1``).
+        explicit_source = self._request_source_stage_id_optional(pending_request)
+        pinned_source = self._pinned_source_stage.get(req_id)
+        if explicit_source is not None:
+            poll_targets = [explicit_source]
+        elif pinned_source is not None:
+            poll_targets = [pinned_source]
+        elif len(self._source_stage_candidates) > 1:
+            poll_targets = list(self._source_stage_candidates)
         else:
-            result = self._recv_full_payload_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
+            poll_targets = [configured_from_stage]
+
+        result = None
+        for candidate in poll_targets:
+            candidate_key = f"{external_req_id}_{candidate}_{chunk_id}"
+            if self._async_chunk:
+                candidate_result = self._recv_async_chunk_result(
+                    connector,
+                    str(candidate),
+                    str(self._stage_id),
+                    candidate_key,
+                )
+            else:
+                candidate_result = self._recv_full_payload_result(
+                    connector,
+                    str(candidate),
+                    str(self._stage_id),
+                    candidate_key,
+                )
+            if candidate_result is not None:
+                result = candidate_result
+                if pinned_source is None:
+                    self._pinned_source_stage[req_id] = candidate
+                break
 
         if result is None:
             return False
@@ -1779,11 +1821,10 @@ class OmniConnectorModelRunnerMixin:
             return False
         if isinstance(payload_data, dict):
             logger.debug(
-                "[Stage-%s] recv_chunk_result: req=%s ext=%s key=%s keys=%s finished=%s",
+                "[Stage-%s] recv_chunk_result: req=%s ext=%s keys=%s finished=%s",
                 self._stage_id,
                 req_id,
                 external_req_id,
-                connector_get_key,
                 sorted(payload_data.keys()),
                 self._payload_finished(payload_data),
             )
@@ -1855,14 +1896,12 @@ class OmniConnectorModelRunnerMixin:
                 self._full_payload_pending_broadcast_req_ids.add(req_id)
                 self._pending_load_reqs.pop(req_id, None)
             logger.debug(
-                "[Stage-%s] full_payload recv complete: req=%s key=%s payload_type=%s",
+                "[Stage-%s] full_payload recv complete: req=%s payload_type=%s",
                 self._stage_id,
                 req_id,
-                connector_get_key,
                 type(engine_inputs).__name__,
             )
 
-        logger.debug("[Stage-%s] Received data for key %s", self._stage_id, connector_get_key)
         return True
 
     def _build_custom_process_payload(
@@ -2206,6 +2245,42 @@ class OmniConnectorModelRunnerMixin:
                 return ext
         return fallback_req_id
 
+    @staticmethod
+    def _coerce_stage_id(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _request_source_stage_id_optional(self, request: Any | None) -> int | None:
+        """Return the explicit ``omni_source_stage_id`` on a request, or None.
+
+        Unlike :meth:`_request_source_stage_id` this never falls back to a
+        default; callers use ``None`` to trigger fan-in source discovery.
+        """
+        info = getattr(request, "additional_information", None) if request is not None else None
+        if info is not None and not isinstance(info, dict):
+            try:
+                from vllm_omni.engine.serialization import deserialize_additional_information
+
+                info = deserialize_additional_information(info)
+            except Exception:
+                info = None
+        if isinstance(info, dict):
+            value = info.get("omni_source_stage_id")
+            if isinstance(value, list) and value:
+                value = value[0]
+            return self._coerce_stage_id(value)
+        return None
+
+    def _request_source_stage_id(self, request: Any | None, default: int) -> int:
+        parsed = self._request_source_stage_id_optional(request)
+        if parsed is not None:
+            return parsed
+        return default
+
     def _resolve_next_stage_id(self, model_config: Any) -> int:
         """Determine the downstream stage ID from connector config.
 
@@ -2222,6 +2297,17 @@ class OmniConnectorModelRunnerMixin:
                 return to_stage
             if isinstance(to_stage, str) and to_stage.strip():
                 return int(to_stage)
+
+        output_connectors = getattr(model_config, "output_connectors", None)
+        if isinstance(output_connectors, dict) and len(output_connectors) == 1:
+            name = next(iter(output_connectors))
+            if isinstance(name, str):
+                prefix = "to_stage_"
+                if name.startswith(prefix):
+                    parsed = self._coerce_stage_id(name[len(prefix) :])
+                    if parsed is not None:
+                        return parsed
+
         return self._stage_id + 1
 
     @staticmethod
@@ -2307,3 +2393,4 @@ class OmniConnectorModelRunnerMixin:
     ) -> str:
         """Build connector key that includes rank info for KV transfers."""
         return f"{req_id}_{from_stage}_{chunk_id}_{from_rank}_{to_rank}"
+


### PR DESCRIPTION
# Qwen3-TTS Prefill–Decode (PD) Disaggregation + Multi-token-prediction (MD) Disaggregation

> See [benchmark/BENCHMARK.md](./benchmark/BENCHMARK.md) / [README.md](./README.md) for details.

## 1. Description

- **PD disaggregation**: the talker runs as a standalone *prefill* stage that produces the prefix KV via Mooncake and streams it to one or more *decode* stages; code2wav consumes the decode-stage output over a shared-memory connector. Same-host only, no cross-node RDMA required.
- **MD disaggregation**: inside the decode worker, the code predictor (MTP) is decoupled from the AR talker and replicated (e.g. 2× MTP : 1× AR). Each replica owns an independent CUDA stream and a private CUDA-graph pool; requests are pinned to the same MTP replica across decode steps via `crc32(req_id) % num_replicas`.
- Adds the Mooncake PD transfer patch `vllm_omni/distributed/kv_transfer/mooncake_pd_patch.py`; deploy configs 1P1D / 1P3D / 1P6D / 3P1D; example scripts and probe tools; orchestrator / scheduler / engine entrypoint changes; E2E test `tests/test_pd_disaggregation.py`.

**vLLM** v0.25.0　**commit** `8ccd02f85`

## 2. Dataset

`seed-tts-eval/en` (English short-sentence TTS), **100 prompts per concurrency level** (seed=0, reproducible).

```bash
which git-lfs || (apt-get update && apt-get install -y git-lfs && git lfs install)
cd /root/datasets && git clone https://github.com/BytedanceSpeech/seed-tts-eval.git
cd seed-tts-eval && git lfs pull
# model
modelscope download --model Qwen/Qwen3-TTS-12Hz-0.6B-Base --local_dir /root/models/Qwen3-TTS-12Hz-0.6B-Base
```

## 3. Data sampling (deterministic 100 prompts)

The benchmark loader uses `random.Random(0).shuffle`, so `NUM_PROMPTS=100` always selects the same 100 rows. You can pre-extract and persist them:

```python
python3 - <<'PY'
import pathlib, random
src = pathlib.Path("/root/datasets/seed-tts-eval/en/meta.lst")
dst = pathlib.Path("/root/datasets/seed-tts-100/en"); dst.mkdir(parents=True, exist_ok=True)
pw = dst/"prompt-wavs"
if not pw.exists():
    pw.symlink_to("/root/datasets/seed-tts-eval/en/prompt-wavs", target_is_directory=True)
rows = [l for l in src.read_text().splitlines() if l.strip() and not l.startswith("#")]
random.Random(0).shuffle(rows)          # same seed as the loader
(dst/"meta.lst").write_text("\n".join(rows[:100])+"\n")
print("locked", len(rows[:100]), "rows")
PY
```

Then use `DATASET=/root/datasets/seed-tts-100` (only a symlink + a 100-row `meta.lst`; no re-download needed).

## 4. Parameters (Single vs 1P1D, both 2 GPUs)

![parameter comparison](https://github.com/yurain26/vllm-omni/raw/feature/qwen3-tts-pd-disaggregation/examples/online_serving/qwen3_tts_pd/benchmark/assets/param_comparison.png)

> `min_tokens: 2` (single) avoids empty audio (#4962); `stop_token_ids: [2150]` (1P1D) enforces the codec EOS stop. The prefill-side `min_tokens` must be 1 (not 0): Mooncake only initiates the KV transfer when prefill ends with `finish_reason='length'`; setting 0 lets a first-token EOS end the step as `stop` and drop the transfer, so the decode side never receives the prefix KV.

## 5. Performance (`seed-tts-eval` en, 100 prompts/concurrency)

![benchmark results](https://github.com/yurain26/vllm-omni/raw/feature/qwen3-tts-pd-disaggregation/examples/online_serving/qwen3_tts_pd/benchmark/assets/benchmark_results.png)

- @ c=32: throughput **+13.5%**, RTF **−14%**; @ c=64: throughput **+19%**, RTF **−12%** (RTF still < 1.0).
- @ c=8: single wins (PD cross-stage overhead is more noticeable at low concurrency).

## 6. Run flow

1. **Prepare dataset**: clone `seed-tts-eval` per §2 (git-lfs).
2. **(Recommended) extract the deterministic 100-prompt subset**: per §3 to build `seed-tts-100`; or skip — with `DATASET=/root/datasets/seed-tts-eval` + `NUM_PROMPTS=100` the loader uses the same `random.Random(0)` seed and selects the same 100 rows, so results are identical.
3. **Run the benchmark** (below).

`run_all_bench.sh` iterates over each topology (single / 1p1d / 3p1d / 1p3d / 1p6d): ① `start_pd.sh` brings up the service and waits for `/health` → ② runs `vllm bench serve --omni` (openai-audio-speech backend, seed-tts dataset) per `CONCURRENCIES` level, saving the raw log / `summary.txt` / JSON / one self-describing check wav per level → ③ `stop_pd.sh` tears down the service and frees GPUs; finally it aggregates all topologies into a comparison table `SUMMARY_ALL.txt` (read this first).

```bash
cd /root/vllm-omni/examples/online_serving/qwen3_tts_pd/benchmark
MODEL=/root/models/Qwen3-TTS-12Hz-0.6B-Base \
DATASET=/root/datasets/seed-tts-eval LOCALE=en \
TOPOS="single 1p1d" CONCURRENCIES="8 32 64" NUM_PROMPTS=100 CHECK_AUDIO=0 \
bash run_all_bench.sh 2>&1 | tee results/cmp_run.log
# single topology only: bash start_pd.sh 1p1d | one-shot: bash bench_pd.sh 1p1d 8 50 zh | stop: bash stop_pd.sh 8091
```

Env vars `MODEL / HOST / PORT / DATASET / VLLM_OMNI_DIR / RESULT_ROOT` are all overridable; `start_pd.sh` auto-detects the vllm-omni repo root.

## 7. Test Plan

`pytest tests/test_pd_disaggregation.py`; manually deploy 1P1D via `qwen3_tts_pd_1p1d.yaml` and probe with `probe_1p1d.py`. E2E tests pass; `probe_1p1d.py` shows the `audio_codes` stream is bit-identical to the single-process baseline, with PD median TTFB within 3× of the baseline.

**Base:** `main`
