### PR TITLE
[Perf] Ming-TTS Stage-0 flow-head speedup: RoPE/QKV fusion, opt-in torch.compile, PIECEWISE cudagraph

### DIFF
--- a/vllm_omni/deploy/ming_tts_moe.yaml
+++ b/vllm_omni/deploy/ming_tts_moe.yaml
@@ -22,11 +22,7 @@ connectors:
   connector_of_shared_memory:
     name: SharedMemoryConnector
     extra:
-      # Chunk unit is patches (~80ms audio each); 25 => ~2s/chunk delays the
-      # first streamed packet to ~end of generation (TTFP~=E2EL). 3 => ~240ms
-      # first-chunk latency, ~-42% TTFP; stage-1 decodes per-patch so any >=1 is
-      # safe. Use 1 for lowest TTFP at the cost of more inter-stage transfers.
-      latent_chunk_size: 3
+      latent_chunk_size: 25
       latent_left_context: 0
 
 stages:
@@ -34,11 +30,6 @@ stages:
     max_num_seqs: 1
     tensor_parallel_size: 1
     gpu_memory_utilization: 0.60
-    # PIECEWISE decode cudagraph (not enforce_eager): graphs the non-attention
-    # backbone while keeping attention eager. FULL cudagraph (enforce_eager:false
-    # default) truncates output on this MoE (backbone attn metadata across a
-    # growing seq_len); PIECEWISE is correct and removes the eager MoE CPU
-    # dispatch overhead. ~-17% E2EL vs enforce_eager, audio-validated.
     enforce_eager: false
     compilation_config:
       cudagraph_mode: PIECEWISE

--- a/vllm_omni/deploy/ming_tts_moe.yaml
+++ b/vllm_omni/deploy/ming_tts_moe.yaml
@@ -22,7 +22,11 @@ connectors:
   connector_of_shared_memory:
     name: SharedMemoryConnector
     extra:
-      latent_chunk_size: 25
+      # Chunk unit is patches (~80ms audio each); 25 => ~2s/chunk delays the
+      # first streamed packet to ~end of generation (TTFP~=E2EL). 3 => ~240ms
+      # first-chunk latency, ~-42% TTFP; stage-1 decodes per-patch so any >=1 is
+      # safe. Use 1 for lowest TTFP at the cost of more inter-stage transfers.
+      latent_chunk_size: 3
       latent_left_context: 0
 
 stages:
@@ -30,7 +34,14 @@ stages:
     max_num_seqs: 1
     tensor_parallel_size: 1
     gpu_memory_utilization: 0.60
-    enforce_eager: true
+    # PIECEWISE decode cudagraph (not enforce_eager): graphs the non-attention
+    # backbone while keeping attention eager. FULL cudagraph (enforce_eager:false
+    # default) truncates output on this MoE (backbone attn metadata across a
+    # growing seq_len); PIECEWISE is correct and removes the eager MoE CPU
+    # dispatch overhead. ~-17% E2EL vs enforce_eager, audio-validated.
+    enforce_eager: false
+    compilation_config:
+      cudagraph_mode: PIECEWISE
     enable_prefix_caching: false
     async_scheduling: false
     max_num_batched_tokens: 8192

--- a/vllm_omni/model_executor/models/common/ming/dit.py
+++ b/vllm_omni/model_executor/models/common/ming/dit.py
@@ -7,13 +7,8 @@ from x_transformers.x_transformers import apply_rotary_pos_emb
 
 
 def _apply_rope_cached(t, cos, sin):
-    """Cat-free RoPE apply, bit-exact to x_transformers ``apply_rotary_pos_emb``
-    for the ``scale==1`` / interleaved-half case (validated max-abs-diff 0.0).
-
-    ``cos``/``sin`` are precomputed per seq_len (see ``Attention._rope_cos_sin``)
-    so ``freqs.cos()``/``freqs.sin()`` are not recomputed every block/ODE-step,
-    and the ``cat((t, t_unrotated))`` (empty when rot_dim==head_dim) is skipped.
-    """
+    """Bit-exact RoPE for ``scale==1`` / interleaved-half.
+    Uses precomputed ``cos``/``sin`` per seq_len to skip per-step trig and cat."""
     rot_dim = cos.shape[-1]
     tr = t[..., :rot_dim]
     x = tr.reshape(*tr.shape[:-1], -1, 2)
@@ -86,9 +81,7 @@ class Attention(nn.Module):
         self.attn_mask_enabled = attn_mask_enabled
         # cos/sin cache keyed by seq_len (freqs are deterministic in seq_len).
         self._rope_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        # Lazily-built fused QKV weight (bit-exact: concat of to_q/k/v). One GEMM
-        # + one HBM weight read instead of three — the win at tiny M is bytes,
-        # not FLOPs. Built on first forward (after weights load), reused after.
+        # Lazily-built fused QKV weight (concat of to_q/k/v).
         self._qkv_w: torch.Tensor | None = None
         self._qkv_b: torch.Tensor | None = None
 

--- a/vllm_omni/model_executor/models/common/ming/dit.py
+++ b/vllm_omni/model_executor/models/common/ming/dit.py
@@ -86,6 +86,19 @@ class Attention(nn.Module):
         self.attn_mask_enabled = attn_mask_enabled
         # cos/sin cache keyed by seq_len (freqs are deterministic in seq_len).
         self._rope_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+        # Lazily-built fused QKV weight (bit-exact: concat of to_q/k/v). One GEMM
+        # + one HBM weight read instead of three — the win at tiny M is bytes,
+        # not FLOPs. Built on first forward (after weights load), reused after.
+        self._qkv_w: torch.Tensor | None = None
+        self._qkv_b: torch.Tensor | None = None
+
+    def _qkv(self, x):
+        if self._qkv_w is None:
+            self._qkv_w = torch.cat([self.to_q.weight, self.to_k.weight, self.to_v.weight], dim=0)
+            if self.to_q.bias is not None:
+                self._qkv_b = torch.cat([self.to_q.bias, self.to_k.bias, self.to_v.bias], dim=0)
+        qkv = F.linear(x, self._qkv_w, self._qkv_b)
+        return qkv.split(self.inner_dim, dim=-1)
 
     def _rope_cos_sin(self, freqs):
         seq_len = freqs.shape[-2]
@@ -98,9 +111,7 @@ class Attention(nn.Module):
 
     def forward(self, x, mask=None, rope=None):
         batch_size = x.shape[0]
-        query = self.to_q(x)
-        key = self.to_k(x)
-        value = self.to_v(x)
+        query, key, value = self._qkv(x)
 
         inner_dim = key.shape[-1]
         head_dim = inner_dim // self.heads

--- a/vllm_omni/model_executor/models/common/ming/dit.py
+++ b/vllm_omni/model_executor/models/common/ming/dit.py
@@ -81,7 +81,8 @@ class Attention(nn.Module):
         self.attn_mask_enabled = attn_mask_enabled
         # cos/sin cache keyed by seq_len (freqs are deterministic in seq_len).
         self._rope_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        # Lazily-built fused QKV weight (concat of to_q/k/v).
+        # TODO: materialize fused weights eagerly outside any torch.compile
+        # scope (e.g. post-weight-load);
         self._qkv_w: torch.Tensor | None = None
         self._qkv_b: torch.Tensor | None = None
 

--- a/vllm_omni/model_executor/models/common/ming/dit.py
+++ b/vllm_omni/model_executor/models/common/ming/dit.py
@@ -6,6 +6,24 @@ from torch import nn
 from x_transformers.x_transformers import apply_rotary_pos_emb
 
 
+def _apply_rope_cached(t, cos, sin):
+    """Cat-free RoPE apply, bit-exact to x_transformers ``apply_rotary_pos_emb``
+    for the ``scale==1`` / interleaved-half case (validated max-abs-diff 0.0).
+
+    ``cos``/``sin`` are precomputed per seq_len (see ``Attention._rope_cos_sin``)
+    so ``freqs.cos()``/``freqs.sin()`` are not recomputed every block/ODE-step,
+    and the ``cat((t, t_unrotated))`` (empty when rot_dim==head_dim) is skipped.
+    """
+    rot_dim = cos.shape[-1]
+    tr = t[..., :rot_dim]
+    x = tr.reshape(*tr.shape[:-1], -1, 2)
+    rot_half = torch.stack((-x[..., 1], x[..., 0]), dim=-1).reshape_as(tr)
+    out = tr * cos + rot_half * sin
+    if rot_dim < t.shape[-1]:  # partial rotary (unused by ming heads); keep general
+        out = torch.cat((out, t[..., rot_dim:]), dim=-1)
+    return out.type(t.dtype)
+
+
 class RMSNorm(nn.Module):
     def __init__(self, dim, eps=1e-6):
         super().__init__()
@@ -66,6 +84,17 @@ class Attention(nn.Module):
         self.to_out.append(nn.Dropout(dropout))
         self.pe_attn_head = pe_attn_head
         self.attn_mask_enabled = attn_mask_enabled
+        # cos/sin cache keyed by seq_len (freqs are deterministic in seq_len).
+        self._rope_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _rope_cos_sin(self, freqs):
+        seq_len = freqs.shape[-2]
+        cached = self._rope_cache.get(seq_len)
+        if cached is None:
+            f = freqs.unsqueeze(1) if freqs.ndim == 3 else freqs  # b n d -> b 1 n d for 4D q/k
+            cached = (f.cos(), f.sin())
+            self._rope_cache[seq_len] = cached
+        return cached
 
     def forward(self, x, mask=None, rope=None):
         batch_size = x.shape[0]
@@ -86,14 +115,21 @@ class Attention(nn.Module):
 
         if rope is not None:
             freqs, xpos_scale = rope
-            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
-            if self.pe_attn_head is not None:
-                on = self.pe_attn_head
-                query[:, :on, :, :] = apply_rotary_pos_emb(query[:, :on, :, :], freqs, q_xpos_scale)
-                key[:, :on, :, :] = apply_rotary_pos_emb(key[:, :on, :, :], freqs, k_xpos_scale)
+            scale_is_one = xpos_scale is None or (not torch.is_tensor(xpos_scale) and xpos_scale == 1.0)
+            if scale_is_one and self.pe_attn_head is None:
+                # Fast path: cached, cat-free RoPE (bit-exact for scale==1, full rotary).
+                cos, sin = self._rope_cos_sin(freqs)
+                query = _apply_rope_cached(query, cos, sin)
+                key = _apply_rope_cached(key, cos, sin)
             else:
-                query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
-                key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+                q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+                if self.pe_attn_head is not None:
+                    on = self.pe_attn_head
+                    query[:, :on, :, :] = apply_rotary_pos_emb(query[:, :on, :, :], freqs, q_xpos_scale)
+                    key[:, :on, :, :] = apply_rotary_pos_emb(key[:, :on, :, :], freqs, k_xpos_scale)
+                else:
+                    query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+                    key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
 
         if self.attn_mask_enabled and mask is not None:
             valid_sample_indices = mask.any(dim=1)

--- a/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
+++ b/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
@@ -333,8 +333,16 @@ class MingLLMModel(nn.Module):
             dit_model = self.flowloss.cfm.model
             if not getattr(dit_model, "_ming_compiled", False):
                 try:
-                    torch._inductor.config.triton.cudagraphs = False
-                    dit_model.forward = torch.compile(dit_model.forward, fullgraph=False, dynamic=False)
+                    # Scoped options (avoid mutating global inductor config).
+                    dit_model.forward = torch.compile(
+                        dit_model.forward,
+                        fullgraph=False,
+                        dynamic=False,
+                        options={
+                            "triton.cudagraphs": False,
+                            "triton.cudagraph_trees": False,
+                        },
+                    )
                     dit_model._ming_compiled = True
                     logger.info("Ming CFM DiT torch.compile enabled (inductor cudagraphs off).")
                 except Exception as exc:

--- a/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
+++ b/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
@@ -326,18 +326,19 @@ class MingLLMModel(nn.Module):
         try:
             from .fm.cfm_cudagraph import CFMGraphExecutor, CFMSampler
 
-            # Optional (opt-in) inductor fusion of the DiT blocks, captured by the
-            # outer CFM CUDA graph. Inductor cudagraphs are disabled so they don't
-            # fight the hand-written graph. Compile is triggered by the executor's
-            # warmup passes before capture. Near-exact (bf16 fp reordering), so it
-            # is gated off by default; validate audio quality before enabling.
-            if os.environ.get("MING_CFM_COMPILE", "0") == "1":
-                dit_model = self.flowloss.cfm.model
-                if not getattr(dit_model, "_ming_compiled", False):
+            # TODO(perf):
+            #   (1) compile per-block (dit_model.blocks) instead of the
+            #   whole forward for tighter fusion / fewer graph breaks;
+            #   (2) move the compile + a synthetic warmup forward to a post-weight-load hook
+            dit_model = self.flowloss.cfm.model
+            if not getattr(dit_model, "_ming_compiled", False):
+                try:
                     torch._inductor.config.triton.cudagraphs = False
                     dit_model.forward = torch.compile(dit_model.forward, fullgraph=False, dynamic=False)
                     dit_model._ming_compiled = True
                     logger.info("Ming CFM DiT torch.compile enabled (inductor cudagraphs off).")
+                except Exception as exc:
+                    logger.warning("Ming CFM torch.compile failed (%s); using uncompiled DiT.", exc)
 
             sampler = CFMSampler(self.flowloss.cfm.model, steps=_CFM_STEPS)
             self._cfm_graph = CFMGraphExecutor(

--- a/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
+++ b/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
@@ -326,6 +326,19 @@ class MingLLMModel(nn.Module):
         try:
             from .fm.cfm_cudagraph import CFMGraphExecutor, CFMSampler
 
+            # Optional (opt-in) inductor fusion of the DiT blocks, captured by the
+            # outer CFM CUDA graph. Inductor cudagraphs are disabled so they don't
+            # fight the hand-written graph. Compile is triggered by the executor's
+            # warmup passes before capture. Near-exact (bf16 fp reordering), so it
+            # is gated off by default; validate audio quality before enabling.
+            if os.environ.get("MING_CFM_COMPILE", "0") == "1":
+                dit_model = self.flowloss.cfm.model
+                if not getattr(dit_model, "_ming_compiled", False):
+                    torch._inductor.config.triton.cudagraphs = False
+                    dit_model.forward = torch.compile(dit_model.forward, fullgraph=False, dynamic=False)
+                    dit_model._ming_compiled = True
+                    logger.info("Ming CFM DiT torch.compile enabled (inductor cudagraphs off).")
+
             sampler = CFMSampler(self.flowloss.cfm.model, steps=_CFM_STEPS)
             self._cfm_graph = CFMGraphExecutor(
                 sampler,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Perf for ming-tts model.

## Test Plan

**vLLM Version:** v0.24.0

**vLLM-Omni Commit:** 3e578178bd989e15e886027dc43173b8dd1359c0

## Test Result

serve script:
```bash
vllm serve "$MODEL" \
    --deploy-config "$DEPLOY_CONFIG" \
    --host "$HOST" \
    --port "$PORT" \
    --trust-remote-code \
    --omni
```

bench script:
```bash
vllm bench serve --omni \
    --host "$HOST" --port "$PORT" \
    --model "$MODEL" \
    --trust-remote-code \
    --backend openai-audio-speech \
    --endpoint /v1/audio/speech \
    --dataset-name seed-tts \
    --dataset-path BytedanceSpeech/seed-tts-eval \
    --seed-tts-locale en \
    --num-prompts 20 \
    --num-warmups 2 \
    --hf-output-len 200 \
    --max-concurrency 1 \
    --request-rate inf \
    --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration,audio_underrun \
    --save-result \
    --result-dir "$RESULT_DIR"
```

Test on `seed-tts-eval` dataset: 

```bash
vllm bench serve --omni \
    --host "$HOST" --port "$PORT" \
    --model "$MODEL" \
    --trust-remote-code \
    --backend openai-audio-speech \
    --endpoint /v1/audio/speech \
    --dataset-name seed-tts \
    --dataset-path "$DATASET_PATH" \
    --seed-tts-locale en \
    --num-prompts 1100 \
    --num-warmups 2 \
    --max-concurrency 16 \
    --request-rate inf \
    --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration,audio_underrun \
    --save-result \
    --result-dir "$RESULT_DIR"
```

bench result: 

| Feature              | E2EL mean | Step Δ | Cumulative Δ | TTFP mean | RTF  | Bench time |
|----------------------|-----------|--------|--------------|-----------|------|------------|
| baseline             | 1428.0 ms | —      | —            | 1424.0 ms | 0.19 | 28.57 s    |
| + RoPE cache         | 1422.5 ms | −0.4%  | −0.4%        | 1418.4 ms | 0.19 | 28.46 s    |
| + Fused-QKV          | 1387.9 ms | −2.4%  | −2.8%        | 1382.8 ms | 0.18 | 27.77 s    |
| + torch.compile      | 1300.3 ms | −6.3%  | −8.9%        | 1296.2 ms | 0.17 | 26.01 s    |
| + PIECEWISE (final)  | 1007.2 ms | −22.5% | −29.5%       | 1003.4 ms | 0.14 | 20.15 s    |


Seed-tts result on baseline:

```bash
============ Serving Benchmark Result ============
Successful requests:                     1100
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  781.15
Request throughput (req/s):              1.41
Peak concurrent requests:                18.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          11283.05
Median E2EL (ms):                        11219.47
P99 E2EL (ms):                           13075.90
================== Text Result ===================
Total input tokens:                      147573
Total generated tokens:                  0
Output token throughput (tok/s):         0.00
Peak output token throughput (tok/s):    16.00
Peak concurrent requests:                18.00
Total Token throughput (tok/s):          188.92
================== Audio Result ==================
Total audio duration generated(s):       9113.41
Total audio frames generated:            218721888
Audio throughput(audio duration/s):      11.67
Streaming continuity OK rate:            100.00%
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          1.47
Median AUDIO_RTF:                        1.37
P99 AUDIO_RTF:                           3.11
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    11280.24
Median AUDIO_TTFP (ms):                  11216.33
P99 AUDIO_TTFP (ms):                     13074.34
------------------Audio Duration------------------
Mean AUDIO_DURATION (s):                 8.28
Median AUDIO_DURATION (s):               8.23
P99 AUDIO_DURATION (s):                  14.11
-------------Streaming Audio Underrun-------------
Mean AUDIO_UNDERRUN (s):                 0.00
Median AUDIO_UNDERRUN (s):               0.00
P99 AUDIO_UNDERRUN (s):                  0.00
==================================================
```

Seed-tts result on the current PR:

```bash
============ Serving Benchmark Result ============
Successful requests:                     1100
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  606.98
Request throughput (req/s):              1.81
Peak concurrent requests:                25.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          8785.30
Median E2EL (ms):                        8767.27
P99 E2EL (ms):                           11279.72
================== Text Result ===================
Total input tokens:                      147573
Total generated tokens:                  0
Output token throughput (tok/s):         0.00
Peak output token throughput (tok/s):    16.00
Peak concurrent requests:                25.00
Total Token throughput (tok/s):          243.13
================== Audio Result ==================
Total audio duration generated(s):       9160.45
Total audio frames generated:            219850848
Audio throughput(audio duration/s):      15.09
Streaming continuity OK rate:            100.00%
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          1.15
Median AUDIO_RTF:                        1.06
P99 AUDIO_RTF:                           2.44
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    8779.47
Median AUDIO_TTFP (ms):                  8764.00
P99 AUDIO_TTFP (ms):                     11271.83
------------------Audio Duration------------------
Mean AUDIO_DURATION (s):                 8.33
Median AUDIO_DURATION (s):               8.23
P99 AUDIO_DURATION (s):                  14.11
-------------Streaming Audio Underrun-------------
Mean AUDIO_UNDERRUN (s):                 0.00
Median AUDIO_UNDERRUN (s):               0.00
P99 AUDIO_UNDERRUN (s):                  0.00
==================================================
```


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
