### PR TITLE
[Model] Add Qwen3-VL and JoyAI support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -20,6 +20,7 @@ th {
 | Architecture | Models | Example HF Models | NVIDIA GPU | AMD GPU | Ascend NPU | Intel GPU |
 |--------------|--------|-------------------|------------|---------|-----|-----------|
 | `Qwen3OmniMoeForConditionalGeneration` | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
+| `Qwen3VLForConditionalGeneration` | Qwen3-VL / JoyAI-VL-Interaction | `Qwen/Qwen3-VL-8B-Instruct`, `jdopensource/JoyAI-VL-Interaction-Preview` | ✅︎ |   |   |   |
 | `Qwen2_5OmniForConditionalGeneration` | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B`, `Qwen/Qwen2.5-Omni-3B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `MingFlashOmniForConditionalGeneration` + `MingImagePipeline` | Ming-flash-omni-2.0 (omni-speech + imagegen<sup>1</sup>) | `Jonathan1909/Ming-flash-omni-2.0` | ✅︎ |   |   |   |
 | `BagelForConditionalGeneration` | BAGEL (DiT-only) | `ByteDance-Seed/BAGEL-7B-MoT` | ✅︎ | ✅︎ | | ✅︎ |

--- a/examples/online_serving/joyvl_interaction/bench/bench_realtime.py
+++ b/examples/online_serving/joyvl_interaction/bench/bench_realtime.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import statistics
+import time
+from dataclasses import dataclass, field
+from urllib.parse import urlencode
+
+import websockets
+
+_JPEG_1X1 = (
+    b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    b"\xff\xdb\x00C\x00"
+    b"\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b"
+    b"\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $.' "
+    b"\",#\x1c\x1c(7),01444\x1f'9=82<.342\xff\xc0\x00\x0b\x08\x00\x01"
+    b"\x00\x01\x01\x01\x11\x00\xff\xc4\x00\x14\x00\x01\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\xff\xc4\x00\x14\x10"
+    b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"\xff\xda\x00\x08\x01\x01\x00\x00?\x00T\xdf\xff\xd9"
+)
+
+
+@dataclass
+class SessionStats:
+    latencies_ms: list[float] = field(default_factory=list)
+    errors: int = 0
+    completed: int = 0
+
+
+def _realtime_url(server: str, session_id: str) -> str:
+    base = server.rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://") :]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://") :]
+    return f"{base}/v1/realtime?{urlencode({'session_id': session_id})}"
+
+
+def _image_data_url() -> str:
+    return "data:image/jpeg;base64," + base64.b64encode(_JPEG_1X1).decode()
+
+
+async def _run_session(server: str, session_id: str, frames: int, query: str) -> SessionStats:
+    stats = SessionStats()
+    image = _image_data_url()
+    async with websockets.connect(_realtime_url(server, session_id), max_size=None) as ws:
+        await ws.recv()  # session.created
+        await ws.send(json.dumps({"type": "input.append", "modality": "text", "data": query}))
+        for frame_idx in range(frames):
+            started = time.perf_counter()
+            await ws.send(json.dumps({"type": "input.append", "modality": "video", "data": image}))
+            while True:
+                event = json.loads(await ws.recv())
+                if event.get("type") == "error":
+                    stats.errors += 1
+                if event.get("type") == "response.done":
+                    stats.completed += 1
+                    stats.latencies_ms.append((time.perf_counter() - started) * 1000)
+                    break
+                if event.get("type") == "response.cancelled":
+                    break
+        await ws.send(json.dumps({"type": "close"}))
+    return stats
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    rank = (len(values) - 1) * pct
+    lo = int(rank)
+    hi = min(lo + 1, len(values) - 1)
+    weight = rank - lo
+    ordered = sorted(values)
+    return ordered[lo] * (1 - weight) + ordered[hi] * weight
+
+
+async def run(server: str, sessions: int, frames: int, query: str) -> dict:
+    started = time.perf_counter()
+    results = await asyncio.gather(*[_run_session(server, f"bench-{idx}", frames, query) for idx in range(sessions)])
+    wall_time_s = time.perf_counter() - started
+    latencies = [latency for result in results for latency in result.latencies_ms]
+    completed = sum(result.completed for result in results)
+    errors = sum(result.errors for result in results)
+    return {
+        "sessions": sessions,
+        "frames_per_session": frames,
+        "completed": completed,
+        "errors": errors,
+        "wall_time_s": round(wall_time_s, 3),
+        "throughput_fps": round(completed / wall_time_s, 3) if wall_time_s else 0.0,
+        "latency_ms": {
+            "avg": round(statistics.fmean(latencies), 3) if latencies else 0.0,
+            "p50": round(_percentile(latencies, 0.50), 3),
+            "p95": round(_percentile(latencies, 0.95), 3),
+            "max": round(max(latencies), 3) if latencies else 0.0,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark JoyVL realtime websocket serving")
+    parser.add_argument("--server", default="http://127.0.0.1:8070")
+    parser.add_argument("--sessions", type=int, default=4)
+    parser.add_argument("--frames", type=int, default=20)
+    parser.add_argument("--query", default="Describe each frame briefly.")
+    args = parser.parse_args()
+
+    print(json.dumps(asyncio.run(run(args.server, args.sessions, args.frames, args.query)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py
+++ b/examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+from urllib.parse import urlencode
+
+import websockets
+from stream_client import iter_frames
+
+
+def _realtime_url(server: str, session_id: str) -> str:
+    base = server.rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://") :]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://") :]
+    query = urlencode({"session_id": session_id})
+    return f"{base}/v1/realtime?{query}"
+
+
+async def _receive(ws) -> None:
+    async for message in ws:
+        event = json.loads(message)
+        etype = event.get("type")
+        if etype == "response.delta":
+            print(event.get("data", ""), flush=True)
+        elif etype == "error":
+            print(f"error: {event.get('message', '')}", flush=True)
+
+
+async def run(video: str, server: str, session_id: str, query: str | None, fps: float) -> None:
+    async with websockets.connect(_realtime_url(server, session_id)) as ws:
+        recv_task = asyncio.create_task(_receive(ws))
+        if query:
+            await ws.send(json.dumps({"type": "input.append", "modality": "text", "data": query}))
+
+        delay = 1.0 / fps if fps > 0 else 0.0
+        for _, jpeg in iter_frames(video, fps):
+            data_url = "data:image/jpeg;base64," + base64.b64encode(jpeg).decode()
+            await ws.send(json.dumps({"type": "input.append", "modality": "video", "data": data_url}))
+            if delay:
+                await asyncio.sleep(delay)
+
+        await ws.send(json.dumps({"type": "close"}))
+        await recv_task
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="JoyVL realtime full-duplex websocket demo")
+    parser.add_argument("video")
+    parser.add_argument("--server", default="http://127.0.0.1:8070")
+    parser.add_argument("--query", default=None)
+    parser.add_argument("--fps", type=float, default=1.0)
+    parser.add_argument("--session-id", default="realtime-cli")
+    args = parser.parse_args()
+
+    asyncio.run(run(args.video, args.server, args.session_id, args.query, args.fps))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py
+++ b/examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py
@@ -7,10 +7,15 @@ import argparse
 import asyncio
 import base64
 import json
+import struct
+import wave
+from pathlib import Path
 from urllib.parse import urlencode
 
 import websockets
 from stream_client import iter_frames
+
+_ASR_HEADER = struct.Struct(">iii")
 
 
 def _realtime_url(server: str, session_id: str) -> str:
@@ -23,31 +28,121 @@ def _realtime_url(server: str, session_id: str) -> str:
     return f"{base}/v1/realtime?{query}"
 
 
-async def _receive(ws) -> None:
+def _read_wav_pcm(path: str) -> bytes:
+    with wave.open(path, "rb") as wav:
+        if wav.getnchannels() != 1 or wav.getsampwidth() != 2:
+            raise ValueError("query WAV must be mono 16-bit PCM")
+        return wav.readframes(wav.getnframes())
+
+
+def _asr_text(payload: dict) -> str:
+    response = payload.get("asr_response") or {}
+    result = response.get("recognition_result") or {}
+    hypotheses = result.get("hypothesis") or []
+    if not hypotheses:
+        return ""
+    return hypotheses[0].get("text") or ""
+
+
+async def _transcribe_query(asr_url: str, wav_path: str) -> str:
+    async with websockets.connect(asr_url, max_size=None) as ws:
+        await ws.send(_ASR_HEADER.pack(-1, 0, 0) + _read_wav_pcm(wav_path))
+        async for message in ws:
+            if not isinstance(message, str):
+                continue
+            text = _asr_text(json.loads(message))
+            if text:
+                return text
+    return ""
+
+
+async def _synthesize(tts_url: str, voice: str, text: str, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    async with websockets.connect(tts_url, max_size=None) as ws:
+        await ws.send(json.dumps({"config": {"voice": voice}}))
+        await ws.send(json.dumps({"type": "input_text.append", "text": text}))
+        await ws.send(json.dumps({"type": "input_text.commit"}))
+        async for message in ws:
+            if isinstance(message, bytes):
+                with output_path.open("ab") as out:
+                    out.write(message)
+                continue
+            event = json.loads(message)
+            if event.get("type") == "response.done":
+                return
+            if event.get("type") == "error":
+                print("tts error", flush=True)
+                return
+
+
+async def _tts_worker(tts_url: str, voice: str, output_path: Path, queue: asyncio.Queue[str | None]) -> None:
+    while True:
+        text = await queue.get()
+        if text is None:
+            return
+        await _synthesize(tts_url, voice, text, output_path)
+
+
+async def _receive(ws, tts_queue: asyncio.Queue[str | None] | None = None) -> None:
     async for message in ws:
         event = json.loads(message)
         etype = event.get("type")
         if etype == "response.delta":
-            print(event.get("data", ""), flush=True)
+            text = event.get("data", "")
+            print(text, flush=True)
+            if tts_queue is not None and text:
+                await tts_queue.put(text)
         elif etype == "error":
             print(f"error: {event.get('message', '')}", flush=True)
 
 
-async def run(video: str, server: str, session_id: str, query: str | None, fps: float) -> None:
-    async with websockets.connect(_realtime_url(server, session_id)) as ws:
-        recv_task = asyncio.create_task(_receive(ws))
-        if query:
-            await ws.send(json.dumps({"type": "input.append", "modality": "text", "data": query}))
+async def run(
+    video: str,
+    server: str,
+    session_id: str,
+    query: str | None,
+    fps: float,
+    *,
+    asr_url: str | None = None,
+    query_wav: str | None = None,
+    tts_url: str | None = None,
+    tts_out: str | None = None,
+    voice: str = "vivian",
+) -> None:
+    if query_wav:
+        if not asr_url:
+            raise ValueError("--query-wav requires --asr-url")
+        query = await _transcribe_query(asr_url, query_wav)
+        print(f"ASR query: {query}", flush=True)
 
-        delay = 1.0 / fps if fps > 0 else 0.0
-        for _, jpeg in iter_frames(video, fps):
-            data_url = "data:image/jpeg;base64," + base64.b64encode(jpeg).decode()
-            await ws.send(json.dumps({"type": "input.append", "modality": "video", "data": data_url}))
-            if delay:
-                await asyncio.sleep(delay)
+    tts_queue: asyncio.Queue[str | None] | None = None
+    tts_task: asyncio.Task | None = None
+    if tts_url:
+        if not tts_out:
+            raise ValueError("--tts-url requires --tts-out")
+        tts_queue = asyncio.Queue()
+        tts_task = asyncio.create_task(_tts_worker(tts_url, voice, Path(tts_out), tts_queue))
 
-        await ws.send(json.dumps({"type": "close"}))
-        await recv_task
+    try:
+        async with websockets.connect(_realtime_url(server, session_id)) as ws:
+            recv_task = asyncio.create_task(_receive(ws, tts_queue))
+            if query:
+                await ws.send(json.dumps({"type": "input.append", "modality": "text", "data": query}))
+
+            delay = 1.0 / fps if fps > 0 else 0.0
+            for _, jpeg in iter_frames(video, fps):
+                data_url = "data:image/jpeg;base64," + base64.b64encode(jpeg).decode()
+                await ws.send(json.dumps({"type": "input.append", "modality": "video", "data": data_url}))
+                if delay:
+                    await asyncio.sleep(delay)
+
+            await ws.send(json.dumps({"type": "close"}))
+            await recv_task
+    finally:
+        if tts_queue is not None:
+            await tts_queue.put(None)
+        if tts_task is not None:
+            await tts_task
 
 
 def main() -> None:
@@ -55,11 +150,29 @@ def main() -> None:
     parser.add_argument("video")
     parser.add_argument("--server", default="http://127.0.0.1:8070")
     parser.add_argument("--query", default=None)
+    parser.add_argument("--query-wav", default=None, help="mono 16-bit PCM WAV sent to the ASR bridge as the query")
+    parser.add_argument("--asr-url", default=None, help="ASR bridge websocket, e.g. ws://127.0.0.1:8093/v1/asr")
+    parser.add_argument("--tts-url", default=None, help="TTS bridge websocket, e.g. ws://127.0.0.1:8092/v1/tts")
+    parser.add_argument("--tts-out", default=None, help="append synthesized PCM bytes to this file")
+    parser.add_argument("--voice", default="vivian")
     parser.add_argument("--fps", type=float, default=1.0)
     parser.add_argument("--session-id", default="realtime-cli")
     args = parser.parse_args()
 
-    asyncio.run(run(args.video, args.server, args.session_id, args.query, args.fps))
+    asyncio.run(
+        run(
+            args.video,
+            args.server,
+            args.session_id,
+            args.query,
+            args.fps,
+            asr_url=args.asr_url,
+            query_wav=args.query_wav,
+            tts_url=args.tts_url,
+            tts_out=args.tts_out,
+            voice=args.voice,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/examples/online_serving/joyvl_interaction/scripts/start_all.sh
+++ b/examples/online_serving/joyvl_interaction/scripts/start_all.sh
@@ -24,6 +24,8 @@ MODEL="${MODEL:-jdopensource/JoyAI-VL-Interaction-Preview}"
 SERVED_NAME="${SERVED_NAME:-JoyAI-VL-Interaction-Preview}"
 GPU="${GPU:-0}"
 MODEL_PORT="${MODEL_PORT:-8061}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-131072}"
+IMAGE_LIMIT="${IMAGE_LIMIT:-256}"
 ORCH_PORT="${ORCH_PORT:-8070}"
 WEBUI_PORT="${WEBUI_PORT:-8999}"
 WEBUI_USERNAME="${WEBUI_USERNAME:-admin}"
@@ -65,9 +67,9 @@ spawn() { local log="$1"; shift; setsid "$@" > "$log" 2>&1 < /dev/null & }
 
 echo "[1/3] model on GPU ${GPU}…"
 spawn "$LOG/model.log" env HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CUDA_VISIBLE_DEVICES="$GPU" \
-  vllm serve "$MODEL" --served-model-name "$SERVED_NAME" --port "$MODEL_PORT" \
-  --gpu-memory-utilization 0.85 --max-model-len 131072 --enable-prefix-caching \
-  --limit-mm-per-prompt '{"image":256,"video":1}'
+  vllm serve "$MODEL" --omni --served-model-name "$SERVED_NAME" --port "$MODEL_PORT" \
+  --gpu-memory-utilization 0.85 --max-model-len "$MAX_MODEL_LEN" --enable-prefix-caching \
+  --limit-mm-per-prompt "{\"image\":${IMAGE_LIMIT},\"video\":1}"
 wait_http "http://127.0.0.1:${MODEL_PORT}/health" && echo "  up :${MODEL_PORT}"
 
 echo "[2/3] orchestrator (memory=${ENABLE_MEMORY})…"

--- a/examples/online_serving/joyvl_interaction/scripts/start_model.sh
+++ b/examples/online_serving/joyvl_interaction/scripts/start_model.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Serve the JoyVL interaction model as a plain VLM (NOT --omni: it is a
-# standard Qwen3-VL autoregressive model, not an omni/diffusion model).
+# Serve the JoyVL interaction model through vLLM-Omni's Qwen3-VL pipeline.
 set -euo pipefail
 
 MODEL="${MODEL:-jdopensource/JoyAI-VL-Interaction-Preview}"
@@ -13,6 +12,7 @@ MAX_MODEL_LEN="${MAX_MODEL_LEN:-131072}"
 IMAGE_LIMIT="${IMAGE_LIMIT:-256}"
 
 CUDA_VISIBLE_DEVICES="${GPU}" vllm serve "${MODEL}" \
+    --omni \
     --served-model-name "${SERVED_NAME}" \
     --port "${PORT}" \
     --max-model-len "${MAX_MODEL_LEN}" \

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -95,6 +95,17 @@ Send the standing instruction once (it persists for the session); subsequent tur
 just the frame. Ready-made headless client: `cli/run_cli_demo.py`. Reset a session with
 `POST /reset {"session_id": "..."}`.
 
+For a true full-duplex flow, connect to `/v1/realtime` over WebSocket. Send
+`input.append` events for text instructions and video/image frames; the server emits
+`response.created`, `response.delta`, and `response.done` while it keeps accepting more
+input on the same connection. New frame input can barge in and cancel stale output. A
+ready-made realtime client is available:
+
+```bash
+python examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py \
+  path/to/video.mp4 --query "Alert me if a fire breaks out"
+```
+
 **What to ask it** — give a standing task and let it act on its own each second:
 
 - **Proactive alerting** — "tell me when someone enters", "alert me if a fire breaks out"
@@ -167,6 +178,10 @@ the model + orchestrator + WebUI together — point `WEBUI_DIR` at your clone.
 # headless: stream a clip and print the per-tick decision timeline
 # (the CLI reads video frames via OpenCV: `uv pip install opencv-python`)
 python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
+  path/to/video.mp4 --query "Alert me if a fire breaks out"
+
+# full-duplex websocket: send frames and receive deltas on the same connection
+python examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py \
   path/to/video.mp4 --query "Alert me if a fire breaks out"
 
 pytest tests/fullduplex   # framework + JoyVL unit tests

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -9,15 +9,16 @@
 - Task: Per-tick proactive interaction over a live video stream — the model decides
   on its own each second to speak, stay silent, or delegate a hard question
 - Mode: Online serving — an OpenAI-compatible interaction orchestrator in front of
-  a plain `vllm serve` backend
+  a `vllm serve --omni` backend
 - Maintainer: Community
 
 ## When to use this recipe
 
 Use this to stand up the streaming-interaction serving layer (`vllm_omni/experimental/fullduplex/`).
-The model is served unchanged by `vllm serve`; this layer adds session state, 3-tier
-summary memory, the per-tick decision, and pluggable ASR / TTS / delegation. For the
-framework internals and how to add another full-duplex model, see
+The model is served unchanged by the Qwen3-VL stage in `vllm serve --omni`; this layer
+adds session state, 3-tier summary memory, the per-tick decision, and pluggable
+ASR / TTS / delegation. For the framework internals and how to add another
+full-duplex model, see
 [`vllm_omni/experimental/fullduplex/README.md`](../../vllm_omni/experimental/fullduplex/README.md).
 
 ## Environment
@@ -34,11 +35,11 @@ framework internals and how to add another full-duplex model, see
 From repository root:
 
 ```bash
-# 1. Serve the model (plain `vllm serve`, NOT --omni; it uses the Qwen3-VL architecture).
+# 1. Serve the model through vLLM-Omni's Qwen3-VL single-stage pipeline.
 #    The image limit must cover the short-term frame window (chunk_frames, default 100 = T_s);
 #    prefix caching keeps the accumulating window cheap. Lower both for smaller GPUs.
 vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
-  --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
+  --omni --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
   --max-model-len 131072 --enable-prefix-caching \
   --limit-mm-per-prompt '{"image":256,"video":1}'
 
@@ -55,7 +56,7 @@ fp8 path, since the model is a standard Qwen3-VL VLM):
 
 ```bash
 vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
-  --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
+  --omni --served-model-name JoyAI-VL-Interaction-Preview --port 8061 \
   --quantization fp8 --max-model-len 131072 --enable-prefix-caching \
   --limit-mm-per-prompt '{"image":256,"video":1}'
 ```
@@ -197,9 +198,9 @@ the audio-track caveat.
 
 ## Notes
 
-- `--omni` is **not** used: the model keeps the Qwen3-VL architecture (only the
-  weights are retrained), so stock `vllm serve` runs the forward pass; this recipe
-  only adds the interaction/serving layer.
+- `--omni` uses the single-stage Qwen3-VL pipeline. The model still keeps the
+  standard Qwen3-VL architecture; vLLM-Omni supplies the stage topology and deploy
+  defaults, while the interaction layer handles session state and proactive behavior.
 - On a host without `nvcc` / `ninja`, `vllm serve` of the 8B can crash engine-core in the
   FlashInfer sampler JIT (`FileNotFoundError: 'ninja'`) during `profile_run`. Set
   `VLLM_USE_FLASHINFER_SAMPLER=0` (or install `ninja`) to work around it.

--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -106,6 +106,22 @@ python examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py \
   path/to/video.mp4 --query "Alert me if a fire breaks out"
 ```
 
+For a reproducible audio/video demo, run the optional ASR/TTS bridge scripts and point
+the same realtime client at them. `--query-wav` sends a mono 16-bit PCM WAV to the ASR
+bridge as the standing instruction; `--tts-url` sends each `response.delta` to the TTS
+bridge and appends raw PCM bytes to `--tts-out`:
+
+```bash
+# optional terminals, if you want voice input/output in the demo
+bash examples/online_serving/joyvl_interaction/scripts/start_asr.sh
+bash examples/online_serving/joyvl_interaction/scripts/start_tts.sh
+
+python examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py \
+  path/to/video.mp4 \
+  --asr-url ws://127.0.0.1:8093/v1/asr --query-wav path/to/query.wav \
+  --tts-url ws://127.0.0.1:8092/v1/tts --tts-out /tmp/joyvl-demo.pcm
+```
+
 **What to ask it** — give a standing task and let it act on its own each second:
 
 - **Proactive alerting** — "tell me when someone enters", "alert me if a fire breaks out"
@@ -183,6 +199,10 @@ python examples/online_serving/joyvl_interaction/cli/run_cli_demo.py \
 # full-duplex websocket: send frames and receive deltas on the same connection
 python examples/online_serving/joyvl_interaction/cli/run_realtime_demo.py \
   path/to/video.mp4 --query "Alert me if a fire breaks out"
+
+# websocket benchmark: multiple realtime sessions, JSON latency/throughput summary
+python examples/online_serving/joyvl_interaction/bench/bench_realtime.py \
+  --server http://127.0.0.1:8070 --sessions 4 --frames 20
 
 pytest tests/fullduplex   # framework + JoyVL unit tests
 ```

--- a/tests/fullduplex/test_joyvl_examples.py
+++ b/tests/fullduplex/test_joyvl_examples.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "examples" / "online_serving" / "joyvl_interaction" / "scripts"
+
+
+def _read_script(name: str) -> str:
+    return (SCRIPTS_DIR / name).read_text(encoding="utf-8")
+
+
+def test_joyvl_model_launcher_uses_omni_pipeline():
+    script = _read_script("start_model.sh")
+
+    assert "NOT --omni" not in script
+    assert 'vllm serve "${MODEL}"' in script
+    assert "--omni" in script
+    assert "--limit-mm-per-prompt" in script
+    assert "IMAGE_LIMIT" in script
+
+
+def test_joyvl_one_shot_launcher_uses_reproducible_omni_args():
+    script = _read_script("start_all.sh")
+
+    assert 'vllm serve "$MODEL" --omni' in script
+    assert '--max-model-len "$MAX_MODEL_LEN"' in script
+    assert "--limit-mm-per-prompt" in script
+    assert "IMAGE_LIMIT" in script

--- a/tests/fullduplex/test_joyvl_serving_realtime.py
+++ b/tests/fullduplex/test_joyvl_serving_realtime.py
@@ -31,17 +31,45 @@ class _SlowBackend:
         pass
 
 
-def test_realtime_websocket_barge_in_cancels_stale_response(monkeypatch):
+class _CountingBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.active = 0
+        self.max_active = 0
+
+    async def generate(self, *args, **kwargs):
+        self.calls += 1
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            await asyncio.sleep(0.02)
+            return f"</response> reply {self.calls}", None
+        finally:
+            self.active -= 1
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _app_with_backend(monkeypatch, backend, **config_kwargs):
     from vllm_omni.experimental.fullduplex.joyvl.serving import server as server_mod
 
-    backend = _SlowBackend()
     monkeypatch.setattr(server_mod, "OpenAIBackend", lambda *args, **kwargs: backend)
-    app = server_mod.create_app(
-        InteractionConfig(enable_memory=False, enable_delegation=False, force_silence_before_query=False)
-    )
+    config = InteractionConfig(enable_memory=False, enable_delegation=False, **config_kwargs)
+    return server_mod.create_app(config)
+
+
+def test_realtime_websocket_barge_in_cancels_stale_response(monkeypatch):
+    backend = _SlowBackend()
+    app = _app_with_backend(monkeypatch, backend, force_silence_before_query=False)
 
     with TestClient(app) as client:
         with client.websocket_connect("/v1/realtime?session_id=ws-test") as ws:
+            session = ws.receive_json()
+            assert session["type"] == ev.SESSION_CREATED
+            assert session["session_id"] == "ws-test"
+            assert session["input_modalities"] == ["image", "video", "text"]
+
             ws.send_json({"type": ev.INPUT_APPEND, "modality": "text", "data": "watch the frame"})
             ws.send_json({"type": ev.INPUT_APPEND, "modality": "video", "data": "data:image/jpeg;base64,AAA"})
             first_created = ws.receive_json()
@@ -63,3 +91,71 @@ def test_realtime_websocket_barge_in_cancels_stale_response(monkeypatch):
             assert events[-1]["type"] == ev.RESPONSE_DONE
             assert events[-1]["response_index"] == 2
             assert "switch to fresh query" in json.dumps(backend.messages[-1])
+
+
+def test_realtime_websocket_rejects_unsupported_modality(monkeypatch):
+    app = _app_with_backend(monkeypatch, _CountingBackend(), force_silence_before_query=False)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/realtime?session_id=bad-input") as ws:
+            assert ws.receive_json()["type"] == ev.SESSION_CREATED
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "audio", "data": "..."})
+            event = ws.receive_json()
+            assert event["type"] == ev.ERROR
+            assert "unsupported input modality: audio" in event["message"]
+
+
+def test_realtime_websocket_cancel_interrupts_active_response(monkeypatch):
+    app = _app_with_backend(monkeypatch, _SlowBackend(), force_silence_before_query=False)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/realtime?session_id=cancel-test") as ws:
+            assert ws.receive_json()["type"] == ev.SESSION_CREATED
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "video", "data": "data:image/jpeg;base64,AAA"})
+            created = ws.receive_json()
+            assert created["type"] == ev.RESPONSE_CREATED
+
+            ws.send_json({"type": ev.RESPONSE_CANCEL})
+            cancelled = ws.receive_json()
+            assert cancelled["type"] == ev.RESPONSE_CANCELLED
+            assert cancelled["response_index"] == created["response_index"]
+
+
+def test_realtime_websocket_long_run_completes_repeated_frames(monkeypatch):
+    backend = _CountingBackend()
+    app = _app_with_backend(monkeypatch, backend, force_silence_before_query=False)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/realtime?session_id=long-run") as ws:
+            assert ws.receive_json()["type"] == ev.SESSION_CREATED
+            for idx in range(20):
+                ws.send_json({"type": ev.INPUT_APPEND, "modality": "video", "data": f"data:image/jpeg;base64,{idx}"})
+                events = []
+                for _ in range(4):
+                    event = ws.receive_json()
+                    events.append(event)
+                    if event["type"] == ev.RESPONSE_DONE:
+                        break
+                assert [e["type"] for e in events] == [
+                    ev.RESPONSE_CREATED,
+                    ev.RESPONSE_DELTA,
+                    ev.RESPONSE_DONE,
+                ]
+            assert backend.calls == 20
+
+
+@pytest.mark.asyncio
+async def test_session_manager_allows_concurrent_independent_sessions(monkeypatch):
+    from vllm_omni.experimental.fullduplex.joyvl.serving import server as server_mod
+
+    backend = _CountingBackend()
+    monkeypatch.setattr(server_mod, "OpenAIBackend", lambda *args, **kwargs: backend)
+    manager = server_mod.SessionManager(InteractionConfig(enable_memory=False, enable_delegation=False))
+    try:
+        await asyncio.gather(
+            manager.step("session-a", ["data:image/jpeg;base64,A"], "query"),
+            manager.step("session-b", ["data:image/jpeg;base64,B"], "query"),
+        )
+    finally:
+        await manager.aclose()
+    assert backend.max_active == 2

--- a/tests/fullduplex/test_joyvl_serving_realtime.py
+++ b/tests/fullduplex/test_joyvl_serving_realtime.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from vllm_omni.experimental.fullduplex.core import protocol as ev
+from vllm_omni.experimental.fullduplex.joyvl.serving.config import InteractionConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _SlowBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.messages: list[list[dict]] = []
+
+    async def generate(self, *args, **kwargs):
+        self.calls += 1
+        self.messages.append(args[0])
+        call = self.calls
+        if call == 1:
+            await asyncio.sleep(0.2)
+            return "</response> stale", None
+        return "</response> fresh", None
+
+    async def aclose(self) -> None:
+        pass
+
+
+def test_realtime_websocket_barge_in_cancels_stale_response(monkeypatch):
+    from vllm_omni.experimental.fullduplex.joyvl.serving import server as server_mod
+
+    backend = _SlowBackend()
+    monkeypatch.setattr(server_mod, "OpenAIBackend", lambda *args, **kwargs: backend)
+    app = server_mod.create_app(
+        InteractionConfig(enable_memory=False, enable_delegation=False, force_silence_before_query=False)
+    )
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/realtime?session_id=ws-test") as ws:
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "text", "data": "watch the frame"})
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "video", "data": "data:image/jpeg;base64,AAA"})
+            first_created = ws.receive_json()
+            assert first_created["type"] == ev.RESPONSE_CREATED
+            assert first_created["response_index"] == 1
+
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "text", "data": "switch to fresh query"})
+            ws.send_json({"type": ev.INPUT_APPEND, "modality": "video", "data": "data:image/jpeg;base64,BBB"})
+
+            events = [first_created]
+            for _ in range(8):
+                event = ws.receive_json()
+                events.append(event)
+                if event["type"] == ev.RESPONSE_DONE:
+                    break
+
+            assert [e["response_index"] for e in events if e["type"] == ev.RESPONSE_CREATED] == [1, 2]
+            assert [e["data"] for e in events if e["type"] == ev.RESPONSE_DELTA] == ["fresh"]
+            assert events[-1]["type"] == ev.RESPONSE_DONE
+            assert events[-1]["response_index"] == 2
+            assert "switch to fresh query" in json.dumps(backend.messages[-1])

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -521,6 +521,7 @@ class TestPipelineDiscovery:
         assert "qwen2_5_omni" in OMNI_PIPELINES
         assert "qwen3_omni_moe" in OMNI_PIPELINES
         assert "qwen3_tts" in OMNI_PIPELINES
+        assert "qwen3_vl" in OMNI_PIPELINES
 
     def test_registry_resolver_qwen3_omni_all_stages(self):
         """Test that providing the HF config for qwen3 omni with audio enabled uses all stages."""
@@ -1153,6 +1154,53 @@ class TestQwen2_5OmniPipeline:
         assert s.execution_type == StageExecutionType.LLM_GENERATION
         assert s.final_output_type == "audio"
         assert s.engine_output_type == "audio"
+
+
+class TestQwen3VLPipeline:
+    def test_registered(self):
+        p = StageConfigFactory.resolve_pipeline_config("qwen3_vl")
+        assert isinstance(p, PipelineConfig)
+        assert p.model_arch == "Qwen3VLForConditionalGeneration"
+        assert p.hf_architectures == ("Qwen3VLForConditionalGeneration",)
+        assert len(p.stages) == 1
+        assert p.validate() == []
+
+    def test_stage_shape(self):
+        p = StageConfigFactory.resolve_pipeline_config("qwen3_vl")
+        assert isinstance(p, PipelineConfig)
+
+        s = p.get_stage(0)
+        assert isinstance(s, StagePipelineConfig)
+        assert s.model_stage == "qwen3_vl"
+        assert s.execution_type == StageExecutionType.LLM_AR
+        assert s.final_output is True
+        assert s.final_output_type == "text"
+        assert s.owns_tokenizer is True
+        assert s.requires_multimodal_data is True
+        assert s.engine_output_type == "text"
+        assert s.model_arch == "Qwen3VLForConditionalGeneration"
+        assert s.sampling_constraints["detokenize"] is True
+
+    def test_create_from_joyai_qwen3_vl_config(self):
+        class JoyAIQwen3VLConfig(PretrainedConfig):
+            model_type = "qwen3_vl"
+
+            def __init__(self):
+                super().__init__(architectures=["Qwen3VLForConditionalGeneration"])
+
+        with patch("vllm_omni.config.config_factory.get_config", return_value=JoyAIQwen3VLConfig()):
+            stages = StageConfigFactory.create_from_model("JoyAI/JoyAI-VL-Interaction-Preview")
+
+        assert stages is not None
+        assert len(stages) == 1
+        stage = stages[0]
+        assert stage.stage_type == StageType.LLM
+        assert stage.worker_type == "ar"
+        assert stage.final_output is True
+        assert stage.final_output_type == "text"
+        assert stage.yaml_runtime["requires_multimodal_data"] is True
+        assert stage.yaml_engine_args["model_arch"] == "Qwen3VLForConditionalGeneration"
+        assert stage.yaml_engine_args["engine_output_type"] == "text"
 
 
 class TestQwen3TTSPipeline:

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -80,6 +80,7 @@ from vllm_omni.model_executor.models.qwen2_5_omni.pipeline import (
 )
 from vllm_omni.model_executor.models.qwen3_omni.pipeline import resolve_qwen3_omni_pipeline
 from vllm_omni.model_executor.models.qwen3_tts.pipeline import QWEN3_TTS_PIPELINE
+from vllm_omni.model_executor.models.qwen3_vl.pipeline import QWEN3_VL_PIPELINE
 from vllm_omni.model_executor.models.voxcpm2.pipeline import VOXCPM2_PIPELINE
 from vllm_omni.model_executor.models.voxtral_tts.pipeline import VOXTRAL_TTS_PIPELINE
 
@@ -94,6 +95,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "qwen2_5_omni_thinker_only": QWEN2_5_OMNI_THINKER_ONLY_PIPELINE,
     "qwen3_omni_moe": resolve_qwen3_omni_pipeline,
     "qwen3_tts": QWEN3_TTS_PIPELINE,
+    "qwen3_vl": QWEN3_VL_PIPELINE,
     "covo_audio": COVO_AUDIO_PIPELINE,
     "bagel": BAGEL_PIPELINE,
     "bagel_think": BAGEL_THINK_PIPELINE,

--- a/vllm_omni/deploy/qwen3_vl.yaml
+++ b/vllm_omni/deploy/qwen3_vl.yaml
@@ -1,0 +1,19 @@
+# Qwen3-VL deploy: single-stage multimodal understanding.
+async_chunk: false
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.9
+    enforce_eager: false
+    async_scheduling: true
+    enable_prefix_caching: false
+    max_num_batched_tokens: 8192
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 1024
+      detokenize: true

--- a/vllm_omni/experimental/fullduplex/README.md
+++ b/vllm_omni/experimental/fullduplex/README.md
@@ -24,13 +24,31 @@ vllm_omni/experimental/fullduplex/
 `core/` is the only part shared across models; data planes differ by model and are
 intentionally not shared.
 
-## Scope
+## Serving paths
 
-The runnable serving path is `joyvl/serving/` driving `decision/` + `memory/` directly.
-`joyvl/adapter.py` + `core/` are a **demonstration** of how a model plugs into the
-generic full-duplex framework (exercised by `tests/fullduplex/`), not the serving path
-the HTTP orchestrator currently uses — a fused-audio model (e.g. MiniCPM-o) is the case
-`core/` is built for.
+JoyVL has two serving paths:
+
+- `/v1/chat/completions` accepts one frame turn per request for OpenAI-compatible clients.
+- `/v1/realtime` (alias: `/v1/realtime/joyvl`) is a WebSocket endpoint backed by
+  `core.DuplexRuntime`. It accepts the event protocol below, keeps receiving input while
+  a response is in flight, and uses epoch barge-in so newer input cancels stale output.
+
+Example realtime events:
+
+```json
+{"type":"input.append","modality":"text","data":"Alert me if a fire breaks out"}
+{"type":"input.append","modality":"video","data":"data:image/jpeg;base64,..."}
+{"type":"response.cancel"}
+{"type":"close"}
+```
+
+Server output uses the same protocol:
+
+```json
+{"type":"response.created","response_index":1}
+{"type":"response.delta","response_index":1,"modality":"text","data":"Smoke is visible."}
+{"type":"response.done","response_index":1}
+```
 
 ## Adding a full-duplex model
 

--- a/vllm_omni/experimental/fullduplex/README.md
+++ b/vllm_omni/experimental/fullduplex/README.md
@@ -45,10 +45,16 @@ Example realtime events:
 Server output uses the same protocol:
 
 ```json
+{"type":"session.created","session_id":"demo","input_modalities":["image","video","text"],"output_modalities":["text"]}
 {"type":"response.created","response_index":1}
 {"type":"response.delta","response_index":1,"modality":"text","data":"Smoke is visible."}
 {"type":"response.done","response_index":1}
 ```
+
+Audio is pluggable rather than hard-wired into JoyVL: feed user speech through the ASR
+bridge to produce a text `input.append`, and send `response.delta` text through the TTS
+bridge for playback. `playback.ack` and `response.cancel` are part of the shared
+protocol; `response.cancel` immediately barge-ins and drops stale output.
 
 ## Adding a full-duplex model
 

--- a/vllm_omni/experimental/fullduplex/core/protocol.py
+++ b/vllm_omni/experimental/fullduplex/core/protocol.py
@@ -13,11 +13,25 @@ PLAYBACK_ACK = "playback.ack"
 CLOSE = "close"
 
 
+SESSION_CREATED = "session.created"
 RESPONSE_CREATED = "response.created"
 RESPONSE_DELTA = "response.delta"
 RESPONSE_DONE = "response.done"
 RESPONSE_CANCELLED = "response.cancelled"
 ERROR = "error"
+
+
+def session_created(
+    session_id: str,
+    input_modalities: tuple[str, ...] | list[str],
+    output_modalities: tuple[str, ...] | list[str],
+) -> dict[str, Any]:
+    return {
+        "type": SESSION_CREATED,
+        "session_id": session_id,
+        "input_modalities": list(input_modalities),
+        "output_modalities": list(output_modalities),
+    }
 
 
 def created(response_index: int) -> dict[str, Any]:

--- a/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
@@ -12,9 +12,13 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
+from vllm_omni.experimental.fullduplex.core import protocol as ev
+from vllm_omni.experimental.fullduplex.core.adapter import DuplexAdapter, DuplexCapability, OutputChunk
+from vllm_omni.experimental.fullduplex.core.runtime import DuplexRuntime
+from vllm_omni.experimental.fullduplex.core.session import DuplexSession, DuplexSessionConfig
 from vllm_omni.experimental.fullduplex.joyvl.bridges.backend import OpenAIBackend
 from vllm_omni.experimental.fullduplex.joyvl.bridges.delegation import (
     DelegationBridge,
@@ -28,6 +32,72 @@ from vllm_omni.experimental.fullduplex.joyvl.decision.output_parser import to_to
 from vllm_omni.experimental.fullduplex.joyvl.memory.memory import Summarizer
 from vllm_omni.experimental.fullduplex.joyvl.serving.config import InteractionConfig
 from vllm_omni.experimental.fullduplex.joyvl.serving.session import InteractionSession, StepResult
+
+
+class JoyVLRealtimeAdapter(DuplexAdapter):
+    """Connect the JoyVL serving session to the shared full-duplex runtime."""
+
+    def __init__(self, manager: SessionManager, session_id: str) -> None:
+        self._manager = manager
+        self._session_id = session_id
+        self._pending_frames: list[str] = []
+        self._pending_query: str | None = None
+        self._lock = asyncio.Lock()
+
+    def capabilities(self) -> DuplexCapability:
+        return DuplexCapability(frozenset({"image", "video", "text"}), frozenset({"text"}), proactive=True)
+
+    async def on_input(self, session: DuplexSession, modality: str, data: Any) -> None:
+        async with self._lock:
+            if modality in ("image", "video"):
+                frame = self._coerce_frame(data)
+                if frame:
+                    self._pending_frames.append(frame)
+            elif modality == "text":
+                text = self._coerce_text(data)
+                if text:
+                    self._pending_query = text
+
+    def should_respond(self, session: DuplexSession) -> bool:
+        return bool(self._pending_frames)
+
+    async def respond(self, session: DuplexSession) -> AsyncIterator[OutputChunk]:
+        async with self._lock:
+            frames = self._pending_frames
+            query = self._pending_query
+            self._pending_frames = []
+            self._pending_query = None
+        if not frames:
+            return
+
+        result = await self._manager.step(self._session_id, frames, query)
+        if result.action.spoke and result.action.text:
+            yield OutputChunk("text", result.action.text)
+
+    @staticmethod
+    def _coerce_frame(data: Any) -> str | None:
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict):
+            image_url = data.get("image_url")
+            if isinstance(image_url, dict):
+                return image_url.get("url")
+            if isinstance(image_url, str):
+                return image_url
+            url = data.get("url")
+            if isinstance(url, str):
+                return url
+        return None
+
+    @staticmethod
+    def _coerce_text(data: Any) -> str | None:
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict):
+            text = data.get("text")
+            if isinstance(text, str):
+                return text
+        return None
 
 
 class SessionManager:
@@ -203,6 +273,15 @@ def _session_id(request: Request, payload: dict[str, Any]) -> str:
     )
 
 
+def _websocket_session_id(websocket: WebSocket) -> str:
+    return (
+        websocket.headers.get("x-streaming-session")
+        or websocket.headers.get("x-session-id")
+        or websocket.query_params.get("session_id")
+        or "default"
+    )
+
+
 def _completion_response(model: str, result: StepResult) -> dict[str, Any]:
     action = result.action
     memory = {"long_term_memory": result.long_term_memory, "mid_term_summaries": result.mid_term_summaries}
@@ -263,6 +342,41 @@ def create_app(config: InteractionConfig) -> FastAPI:
             return JSONResponse({"error": "interaction server requires at least one image_url frame"}, status_code=400)
         result = await manager.step(_session_id(request, payload), frames, query)
         return JSONResponse(_completion_response(config.main_model, result))
+
+    @app.websocket("/v1/realtime")
+    @app.websocket("/v1/realtime/joyvl")
+    async def realtime(websocket: WebSocket) -> None:
+        await websocket.accept()
+        session_id = _websocket_session_id(websocket)
+        adapter = JoyVLRealtimeAdapter(manager, session_id)
+        session = DuplexSession(
+            session_id,
+            DuplexSessionConfig(
+                input_modalities=("image", "video", "text"),
+                output_modalities=("text",),
+                proactive=True,
+            ),
+        )
+        runtime = DuplexRuntime(session, adapter)
+
+        async def receive_events() -> AsyncIterator[dict[str, Any]]:
+            while True:
+                try:
+                    event = await websocket.receive_json()
+                except WebSocketDisconnect:
+                    yield {"type": ev.CLOSE}
+                    return
+                yield event
+                if event.get("type") == ev.CLOSE:
+                    return
+
+        async def emit(event: dict[str, Any]) -> None:
+            await websocket.send_json(event)
+
+        try:
+            await runtime.run(receive_events(), emit)
+        except WebSocketDisconnect:
+            return
 
     @app.post("/reset")
     @app.post("/v1/streaming/reset")

--- a/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/serving/server.py
@@ -358,6 +358,9 @@ def create_app(config: InteractionConfig) -> FastAPI:
             ),
         )
         runtime = DuplexRuntime(session, adapter)
+        await websocket.send_json(
+            ev.session_created(session_id, session.config.input_modalities, session.config.output_modalities)
+        )
 
         async def receive_events() -> AsyncIterator[dict[str, Any]]:
             while True:

--- a/vllm_omni/model_executor/models/qwen3_vl/__init__.py
+++ b/vllm_omni/model_executor/models/qwen3_vl/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_omni/model_executor/models/qwen3_vl/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen3_vl/pipeline.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen3-VL single-stage multimodal understanding topology."""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+QWEN3_VL_PIPELINE = PipelineConfig(
+    model_type="qwen3_vl",
+    model_arch="Qwen3VLForConditionalGeneration",
+    hf_architectures=("Qwen3VLForConditionalGeneration",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="qwen3_vl",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            engine_output_type="text",
+            model_arch="Qwen3VLForConditionalGeneration",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)


### PR DESCRIPTION
## Purpose

  Add vLLM-Omni `--omni` support for Qwen3-VL style models, including JoyAI-VL-Interaction-Preview.

  This PR adds a single-stage LLM AR pipeline for `model_type="qwen3_vl"` / `Qwen3VLForConditionalGeneration`, so
  checkpoints like `jdopensource/JoyAI-VL-Interaction-Preview` can be served through vLLM-Omni instead of falling back
  to the diffusion default path.

  Changes:
  - Add `QWEN3_VL_PIPELINE`
  - Register `qwen3_vl` in `OMNI_PIPELINES`
  - Add default `vllm_omni/deploy/qwen3_vl.yaml`
  - Add config factory tests for Qwen3-VL / JoyAI routing
  - Update supported models docs and JoyAI recipe to use `vllm serve --omni`

  ## Test Plan

  **vLLM Version:** 0.24.0

  **vLLM-Omni Commit:** f950e530

  Unit/config tests:
  ```bash
  .venv/bin/python -m pytest tests/test_config_factory.py -q

  Pre-submit checks:

  .venv/bin/pre-commit run --files \
    docs/models/supported_models.md \
    recipes/JD/JoyAI-VL-Interaction.md \
    tests/test_config_factory.py \
    vllm_omni/config/pipeline_registry.py \
    vllm_omni/deploy/qwen3_vl.yaml \
    vllm_omni/model_executor/models/qwen3_vl/__init__.py \
    vllm_omni/model_executor/models/qwen3_vl/pipeline.py

  Real serve smoke on NVIDIA H20:

  CUDA_VISIBLE_DEVICES=0 VLLM_USE_FLASHINFER_SAMPLER=0 \
  .venv/bin/vllm serve /mnt/data3/models/JoyAI/JoyAI-VL-Interaction-Preview \
    --omni \
    --served-model-name JoyAI-VL-Interaction-Preview \
    --host 127.0.0.1 \
    --port 18061 \
    --max-model-len 8192 \
    --gpu-memory-utilization 0.55 \
    --max-num-seqs 1 \
    --limit-mm-per-prompt '{"image":4,"video":1}'

  Requests tested:

  - GET /health
  - GET /v1/models
  - text-only /v1/chat/completions
  - image+text /v1/chat/completions with a base64 image_url

  ## Test Result

  Pre-commit:

  Passed

  Unit/config tests:

  118 passed, 17 warnings in 3.38s

  Real serve smoke:

  Resolved architecture: Qwen3VLForConditionalGeneration
  Model loading took 16.79 GiB memory
  /health -> 200 OK
  /v1/models -> returned JoyAI-VL-Interaction-Preview

  Text chat result:

  1+1等于2。

  Image chat result:

  HTTP 200
  prompt_tokens=467
  content="这是一张展示“LLM-Omni”品牌标识的图片，左侧为黄蓝渐变的抽象图形标志，右侧是黑色粗体"

  Notes:

  - The image response was intentionally capped with max_tokens=32, so it ended with finish_reason="length".
  - Local environment has http_proxy set; smoke requests were sent with proxy disabled / direct localhost connection.

