### PR TITLE
[CI] Add tests for Qwen3 Omni Thinker variant

### DIFF
--- a/tests/e2e/offline_inference/test_qwen3_omni.py
+++ b/tests/e2e/offline_inference/test_qwen3_omni.py
@@ -14,7 +14,7 @@ from tests.helpers.stage_config import get_deploy_config_path, modify_stage_conf
 from vllm_omni.platforms import current_omni_platform
 
 models = ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]
-thinker_only_models = ["Qwen/Qwen3-Omni-30B-A3B-Captioner"]
+thinker_only_models = ["Qwen/Qwen3-Omni-30B-A3B-Captioner", "Qwen/Qwen3-Omni-30B-A3B-Thinking"]
 
 # Single CI deploy YAML; rocm/xpu deltas are picked automatically via the
 # platforms: section. Only CUDA needs an extra enforce_eager tweak.

--- a/tests/e2e/offline_inference/test_qwen3_omni.py
+++ b/tests/e2e/offline_inference/test_qwen3_omni.py
@@ -20,7 +20,7 @@ from tests.helpers.stage_config import get_deploy_config_path, modify_stage_conf
 from vllm_omni.platforms import current_omni_platform
 
 models = ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]
-thinker_only_models = ["Qwen/Qwen3-Omni-30B-A3B-Captioner"]
+thinker_only_models = ["Qwen/Qwen3-Omni-30B-A3B-Captioner", "Qwen/Qwen3-Omni-30B-A3B-Thinking"]
 
 # Single CI deploy YAML; rocm/xpu deltas are picked automatically via the
 # platforms: section. Only CUDA needs an extra enforce_eager tweak.

--- a/tests/e2e/online_serving/test_qwen3_omni_thinking.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_thinking.py
@@ -24,14 +24,8 @@ LONG_VIDEO_HEIGHT = 224
 LONG_VIDEO_NUM_FRAMES = 3600
 LONG_AUDIO_DURATION = 120
 
-test_params = [
-    pytest.param(
-        OmniServerParams(
-            model=MODEL,
-            stage_config_path=STAGE_CONFIG_PATH
-        )
-    )
-]
+test_params = [pytest.param(OmniServerParams(model=MODEL, stage_config_path=STAGE_CONFIG_PATH))]
+
 
 def get_system_prompt():
     return {
@@ -48,11 +42,14 @@ def get_system_prompt():
         ],
     }
 
+
 def get_text_only_prompt():
     return "What is the capital of China?"
 
+
 def get_prompt():
     return "Analyse the audio, image or video provided"
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -71,6 +68,7 @@ def test_analyse_text_input(omni_server, openai_client):
 
     openai_client.send_omni_request(request_config)
 
+
 @pytest.mark.omni
 @pytest.mark.slow
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
@@ -88,6 +86,7 @@ def test_analyse_prompt_without_attached_media(omni_server, openai_client):
 
     openai_client.send_omni_request(request_config)
 
+
 @pytest.mark.omni
 @pytest.mark.slow
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
@@ -97,7 +96,9 @@ def test_analyse_audio_input(omni_server, openai_client):
     Input Modal: audio
     """
     audio_data_url = f"data:audio/wav;base64,{generate_synthetic_audio(5, 1)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url)
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -105,6 +106,7 @@ def test_analyse_audio_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -115,7 +117,9 @@ def test_analyse_long_audio_input(omni_server, openai_client):
     Input Modal: long audio
     """
     audio_data_url = f"data:audio/wav;base64,{generate_synthetic_audio(LONG_AUDIO_DURATION, 1)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url)
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -123,6 +127,7 @@ def test_analyse_long_audio_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -133,7 +138,9 @@ def test_analyse_image_input(omni_server, openai_client):
     Input Modal: image
     """
     image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(IMAGE_WIDTH, IMAGE_HEIGHT)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -141,6 +148,7 @@ def test_analyse_image_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -150,8 +158,12 @@ def test_analyse_large_image_input(omni_server, openai_client):
     """
     Input Modal: large image
     """
-    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(LARGE_IMAGE_WIDTH, LARGE_IMAGE_HEIGHT)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
+    image_data_url = (
+        f"data:image/jpeg;base64,{generate_synthetic_image(LARGE_IMAGE_WIDTH, LARGE_IMAGE_HEIGHT)['base64']}"
+    )
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -159,6 +171,7 @@ def test_analyse_large_image_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -168,8 +181,12 @@ def test_analyse_video_input(omni_server, openai_client):
     """
     Input Modal: video
     """
-    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+    video_data_url = (
+        f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES)['base64']}"
+    )
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -177,6 +194,7 @@ def test_analyse_video_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -187,7 +205,9 @@ def test_analyse_long_video_input(omni_server, openai_client):
     Input Modal: long video
     """
     video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(LONG_VIDEO_WIDTH, LONG_VIDEO_HEIGHT, LONG_VIDEO_NUM_FRAMES)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url
+    )
 
     request_config = {
         "model": omni_server.model,
@@ -195,6 +215,7 @@ def test_analyse_long_video_input(omni_server, openai_client):
     }
 
     openai_client.send_omni_request(request_config)
+
 
 @pytest.mark.omni
 @pytest.mark.slow
@@ -205,7 +226,9 @@ def test_analyse_video_with_audio_input(omni_server, openai_client):
     Input Modal: video with audio
     """
     video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES, embed_audio=True)['base64']}"
-    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url
+    )
 
     request_config = {
         "model": omni_server.model,

--- a/tests/e2e/online_serving/test_qwen3_omni_thinking.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_thinking.py
@@ -75,6 +75,23 @@ def test_analyse_text_input(omni_server, openai_client):
 @pytest.mark.slow
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_prompt_without_attached_media(omni_server, openai_client):
+    """
+    Input Modal: text asking to describe media provided but it is absent
+    """
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt())
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_audio_input(omni_server, openai_client):
     """
     Input Modal: audio
@@ -112,6 +129,9 @@ def test_analyse_long_audio_input(omni_server, openai_client):
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_image_input(omni_server, openai_client):
+    """
+    Input Modal: image
+    """
     image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(IMAGE_WIDTH, IMAGE_HEIGHT)['base64']}"
     messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
 
@@ -127,6 +147,9 @@ def test_analyse_image_input(omni_server, openai_client):
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_large_image_input(omni_server, openai_client):
+    """
+    Input Modal: large image
+    """
     image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(LARGE_IMAGE_WIDTH, LARGE_IMAGE_HEIGHT)['base64']}"
     messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
 
@@ -142,6 +165,9 @@ def test_analyse_large_image_input(omni_server, openai_client):
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_video_input(omni_server, openai_client):
+    """
+    Input Modal: video
+    """
     video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES)['base64']}"
     messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
 
@@ -157,6 +183,9 @@ def test_analyse_video_input(omni_server, openai_client):
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_long_video_input(omni_server, openai_client):
+    """
+    Input Modal: long video
+    """
     video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(LONG_VIDEO_WIDTH, LONG_VIDEO_HEIGHT, LONG_VIDEO_NUM_FRAMES)['base64']}"
     messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
 
@@ -172,6 +201,9 @@ def test_analyse_long_video_input(omni_server, openai_client):
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 def test_analyse_video_with_audio_input(omni_server, openai_client):
+    """
+    Input Modal: video with audio
+    """
     video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES, embed_audio=True)['base64']}"
     messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
 

--- a/tests/e2e/online_serving/test_qwen3_omni_thinking.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_thinking.py
@@ -1,0 +1,183 @@
+"""
+E2E Online tests for Qwen3-Omni model thinking variant
+"""
+
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
+from tests.helpers.runtime import OmniServerParams, dummy_messages_from_mix_data
+from tests.helpers.stage_config import get_deploy_config_path
+
+MODEL = "Qwen/Qwen3-Omni-30B-A3B-Thinking"
+STAGE_CONFIG_PATH = get_deploy_config_path("qwen3_omni_moe.yaml")
+
+IMAGE_WIDTH = 224
+IMAGE_HEIGHT = 224
+LARGE_IMAGE_WIDTH = 1920
+LARGE_IMAGE_HEIGHT = 1080
+VIDEO_WIDTH = 1280
+VIDEO_HEIGHT = 720
+NUM_VIDEO_FRAMES = 300
+LONG_VIDEO_WIDTH = 224
+LONG_VIDEO_HEIGHT = 224
+LONG_VIDEO_NUM_FRAMES = 3600
+LONG_AUDIO_DURATION = 120
+
+test_params = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            stage_config_path=STAGE_CONFIG_PATH
+        )
+    )
+]
+
+def get_system_prompt():
+    return {
+        "role": "system",
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "You are Qwen, a virtual human developed by the Qwen Team, "
+                    "Alibaba Group, capable of perceiving text, image, audio or video inputs, "
+                    "as well as generating text and speech."
+                ),
+            }
+        ],
+    }
+
+def get_text_only_prompt():
+    return "What is the capital of China?"
+
+def get_prompt():
+    return "Analyse the audio, image or video provided"
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_text_input(omni_server, openai_client):
+    """
+    Input Modal: text
+    """
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_text_only_prompt())
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_audio_input(omni_server, openai_client):
+    """
+    Input Modal: audio
+    """
+    audio_data_url = f"data:audio/wav;base64,{generate_synthetic_audio(5, 1)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_long_audio_input(omni_server, openai_client):
+    """
+    Input Modal: long audio
+    """
+    audio_data_url = f"data:audio/wav;base64,{generate_synthetic_audio(LONG_AUDIO_DURATION, 1)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), audio_data_url=audio_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_image_input(omni_server, openai_client):
+    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(IMAGE_WIDTH, IMAGE_HEIGHT)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_large_image_input(omni_server, openai_client):
+    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(LARGE_IMAGE_WIDTH, LARGE_IMAGE_HEIGHT)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), image_data_url=image_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_video_input(omni_server, openai_client):
+    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_long_video_input(omni_server, openai_client):
+    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(LONG_VIDEO_WIDTH, LONG_VIDEO_HEIGHT, LONG_VIDEO_NUM_FRAMES)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)
+
+@pytest.mark.omni
+@pytest.mark.slow
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+def test_analyse_video_with_audio_input(omni_server, openai_client):
+    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(VIDEO_WIDTH, VIDEO_HEIGHT, NUM_VIDEO_FRAMES, embed_audio=True)['base64']}"
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt(), video_data_url=video_data_url)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+    }
+
+    openai_client.send_omni_request(request_config)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Add online and offline tests for the Qwen3 Omni Thinker variant (Qwen/Qwen3-Omni-30B-A3B-Thinking)

## Test Plan

-  ```pytest -sv tests/e2e/online_serving/test_qwen3_omni_thinking.py```
-  ```pytest -sv tests/e2e/offline_inference/test_qwen3_omni.py::test_thinker_only_model_request```

**vLLM Version:**
0.24

**vLLM-Omni Commit:**
d4a869fe (0.1.dev2155+gd4a869fe5)

## Test Result

- Test 1: ``` 9 passed, 17 warnings in 162.61s (0:02:42) ```
-  Test 2: ```2 passed, 27 warnings in 555.23s (0:09:15)```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
