### PR TITLE
[Doc] Add Cosmos3-Nano RTX 5090 low-VRAM recipe

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -48,7 +48,7 @@ recipes/
 | [`LTX/LTX-2.3.md`](./LTX/LTX-2.3.md) | Text-to-video with audio generation (22B) | 1x GPU (96GB VRAM) |
 | [`MammothModa2/MammothModa2-Preview.md`](./MammothModa2/MammothModa2-Preview.md) | Text-to-image with the shared offline image example (AR → DiT) | 1x L40S 48GB / 1x ≥40GB GPU |
 | [`mistralai/Voxtral-TTS.md`](./mistralai/Voxtral-TTS.md) | Online serving for TTS | 1x RTX 4090 24GB |
-| [`cosmos3/Cosmos3-Nano.md`](./cosmos3/Cosmos3-Nano.md) | Text-to-image, text-to-video, image-to-video, video-to-video generation, text to video with sound, action policy | 1x H200 141GB / B300 |
+| [`cosmos3/Cosmos3-Nano.md`](./cosmos3/Cosmos3-Nano.md) | Text-to-image, text-to-video, image-to-video, video-to-video generation, text to video with sound, action policy | 1x H200 141GB / B300 / 1x RTX 5090 32GB low-VRAM |
 | [`cosmos3/Cosmos3-Super.md`](./cosmos3/Cosmos3-Super.md) | 64B T2I / T2V / I2V / V2V generation (+ optional audio) / Action policy | 8x H200/H100/A100 / 2x H200 / B300 |
 | [`OpenBMB/MiniCPM-o-4_5.md`](./OpenBMB/MiniCPM-o-4_5.md) | Online serving for omni multimodal chat (text / image / audio / video → text + 24 kHz speech) | 2x A100/H100 80GB / 3x mid-tier GPU / 8x RTX 4090 24GB |
 | [`OpenBMB/VoxCPM2.md`](./OpenBMB/VoxCPM2.md) | Online + offline TTS with native AR pipeline (48 kHz, 30+ languages) | 1x RTX 4090 24GB |

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -356,6 +356,96 @@ vllm serve nvidia/Cosmos3-Nano-Policy-DROID \
     action payload under the top-level `action` field; sync `/v1/videos/sync`
     returns raw MP4 bytes and does not expose action metadata in the response body.
 
+### 1x RTX 5090 32GB (low-VRAM online serving)
+
+#### Environment
+
+- OS: Ubuntu 22.04+
+- GPU: NVIDIA GeForce RTX 5090 32GB
+- Driver / runtime: NVIDIA driver 570.211.01, CUDA 12.9
+- Python: 3.12
+- torch: 2.11.0+cu129
+- vLLM version: 0.24.0
+- vLLM-Omni version or commit: v0.24.0 (`d4a869fe5e2e`)
+
+#### Command
+
+The BF16 single-GPU server needs layerwise offload on an RTX 5090 32GB. The same
+command **without** `--enable-layerwise-offload` loaded the model but failed the
+startup dummy run with CUDA OOM after using 31.09 GiB; only 33 MiB was free while
+allocating another 40 MiB.
+
+```bash
+MODEL=/path/to/Cosmos3-Nano
+
+CUDA_VISIBLE_DEVICES=0 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_ATTENTION_BACKEND=CUDNN_ATTN \
+vllm serve "$MODEL" \
+  --omni \
+  --host 0.0.0.0 --port 8000 \
+  --num-gpus 1 \
+  --model-class-name Cosmos3OmniDiffusersPipeline \
+  --no-guardrails \
+  --enable-layerwise-offload \
+  --init-timeout 1800
+```
+
+#### Verification
+
+The following reduced-size low-VRAM validation requests were run on the same
+server. They validate the 32GB consumer GPU deployment path, including API
+success, decoded outputs, latency, peak GPU memory, and visual output quality.
+They are **not** a full 720p / 189-frame quality validation.
+
+```bash
+# Text-to-image -> /v1/images/generations (512x512, 20 steps; base64 PNG)
+curl -sS -X POST http://localhost:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "/path/to/Cosmos3-Nano",
+    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
+    "negative_prompt": "blurry, distorted, low quality",
+    "size": "512x512", "n": 1, "response_format": "b64_json",
+    "num_inference_steps": 20, "guidance_scale": 7.0, "seed": 42
+  }' | python -c "import sys,json,base64; open('cosmos3_rtx5090_t2i_512.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
+
+# Text-to-video -> /v1/videos/sync (512x512, 33 frames @ 24fps, 20 steps)
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=/path/to/Cosmos3-Nano" \
+  -F "prompt=A red sports car drives through a rainy neon city at night, cinematic lighting, smooth camera motion." \
+  -F "negative_prompt=blurry, distorted, low quality" \
+  -F "size=512x512" -F "num_frames=33" -F "fps=24" \
+  -F "num_inference_steps=20" -F "guidance_scale=6.0" \
+  -F "max_sequence_length=4096" -F "flow_shift=3.0" \
+  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":false}' \
+  -F "seed=123" \
+  -o cosmos3_rtx5090_t2v_512_33f.mp4
+```
+
+#### Notes
+
+- **Validated profile:** 1x RTX 5090 32GB, BF16, guardrails off, layerwise
+  offload on, CUDNN attention.
+
+  | Scenario | Request profile | Client-side E2E latency | Peak GPU memory (`nvidia-smi`) | Output validation |
+  |---|---|---:|---:|---|
+  | T2I | 512x512, 20 steps, guidance 7.0 | 9.72 s | 19931 MiB (~19.5 GiB) | 512x512 RGB PNG; fixed-seed output visually matched the prompt |
+  | T2V | 512x512, 33 frames @ 24fps, 20 steps, guidance 6.0 | 11.74 s | 23241 MiB (~22.7 GiB) | H.264 MP4, 512x512, 33 frames; fixed-seed output was readable |
+
+- **Startup memory:** with layerwise offload enabled, GPU memory after warmup was
+  about 19.4 GiB by `nvidia-smi`; vLLM-Omni logged 17.58 GiB process-scoped GPU
+  memory after model loading, before the startup warmup request.
+- **Baseline boundary:** without `--enable-layerwise-offload`, the same BF16
+  single-GPU command loaded the model but failed the startup dummy run with CUDA
+  OOM. This is the tested reason the RTX 5090 32GB recipe enables layerwise
+  offload.
+- **Known limitations:** this setup depends on CPU offload bandwidth and was
+  validated at reduced resolution/frame count. I2V, V2V, T2V with sound, action,
+  and the full 720p / 189-frame parameters remain unvalidated for this GPU class;
+  use the H200/B300 recipe above for those full-size settings.
+
 ### 1x GPU (Offline generation)
 
 #### Environment


### PR DESCRIPTION
## Summary

- Add a Cosmos3-Nano low-VRAM online serving recipe validated on 1x RTX 5090 32GB.
- Document the BF16 launch command with `--enable-layerwise-offload`, `VLLM_WORKER_MULTIPROC_METHOD=spawn`, and CUDNN attention.
- Add reduced-size validation results for T2I and T2V, including latency, peak GPU memory, and output validation.

Related to #4340

## Duplicate-work check

This does not duplicate an existing open PR.

Checked:
- `gh api 'repos/vllm-project/vllm-omni/issues/4340/comments?per_page=100'`
- `gh pr list --repo vllm-project/vllm-omni --state open --search "4340 in:body"`
- `gh pr list --repo vllm-project/vllm-omni --state open --search "Cosmos3 Nano RTX 5090 low VRAM recipe"`

Existing open PRs mentioning #4340 are for Cosmos3 L2/L3 tests, pipeline parallel, and TeaCache, not this RTX 5090 low-VRAM recipe.

## Validation

Runtime validation was performed on 1x NVIDIA GeForce RTX 5090 32GB with Cosmos3-Nano.

- Without `--enable-layerwise-offload`, BF16 startup loaded the model but failed the startup dummy run with CUDA OOM after using 31.09 GiB.
- With `--enable-layerwise-offload`, T2I 512x512, 20 steps completed in 9.72s with peak GPU memory 19931 MiB.
- With `--enable-layerwise-offload`, T2V 512x512, 33 frames, 20 steps completed in 11.74s with peak GPU memory 23241 MiB.
- T2I output decoded as 512x512 RGB PNG.
- T2V output decoded as H.264 MP4, 512x512, 24 fps, 33 frames.

This validates the reduced-size low-VRAM deployment path. Full 720p / 189-frame validation and other modalities remain out of scope for this PR.

## Test Plan

- `git diff --check origin/main..HEAD`
- `file /tmp/cosmos3_rtx5090_validation/cosmos3_rtx5090_t2i_512.png /tmp/cosmos3_rtx5090_validation/cosmos3_rtx5090_t2v_512_33f.mp4`
- `ffprobe -v error -select_streams v:0 -show_entries stream=codec_name,width,height,r_frame_rate,nb_frames,duration -of default=nokey=0:noprint_wrappers=1 /tmp/cosmos3_rtx5090_validation/cosmos3_rtx5090_t2v_512_33f.mp4`

## AI assistance

This PR was prepared with AI assistance. The human submitter reviewed the changed documentation and validation results.
