### PR TITLE
refactor: diffusion mixin and atoms on disaggregate and batching

### DIFF
--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
@@ -112,7 +112,7 @@ def test_hunyuan_step_group_key_ignores_step_index_for_later_steps():
         ),
     ],
 )
-def test_prepare_encode_preserves_normal_hunyuan_bot_task_semantics(
+def test_encode_preserves_normal_hunyuan_bot_task_semantics(
     monkeypatch,
     sampling,
     prompt_item,
@@ -140,7 +140,7 @@ def test_prepare_encode_preserves_normal_hunyuan_bot_task_semantics(
     )
 
     with pytest.raises(RuntimeError, match="stop after prepare_model_inputs"):
-        pipeline.prepare_encode(state)
+        pipeline.encode(state)
 
     assert captured["bot_task"] == expected_model_bot_task
     assert captured["system_prompt_bot_task"] == expected_system_bot_task
@@ -167,6 +167,7 @@ def test_forward_uses_same_hunyuan_bot_task_semantics(monkeypatch):
                 request_id="req-forward-bot-task",
                 sampling_params=_sampling_params(bot_task="think_recaption", use_system_prompt="dynamic"),
                 prompt={"prompt": "prompt", "bot_task": "vanilla"},
+                kv_sender_info=None,
             )
         ]
     )

--- a/tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch import nn
 
+from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import (
     QwenImagePipeline,
 )
@@ -17,6 +18,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_layered import (
     QwenImageLayeredPipeline,
 )
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -57,14 +59,6 @@ class _FakeTokenizer:
 
 class _FakeProcessor(_FakeTokenizer):
     pass
-
-
-class _FakeScheduler:
-    def __init__(self):
-        self.begin_index = None
-
-    def set_begin_index(self, begin_index: int):
-        self.begin_index = begin_index
 
 
 PIPELINE_CASES = [
@@ -129,37 +123,25 @@ def test_encode_prompt_rejects_prompt_longer_than_explicit_max_sequence_length(
         pipeline.encode_prompt(prompt="prompt", max_sequence_length=16)
 
 
-def test_prepare_encode_defaults_to_tokenizer_max_length():
+def test_encode_defaults_to_tokenizer_max_length():
     pipeline = object.__new__(QwenImagePipeline)
     nn.Module.__init__(pipeline)
     pipeline.tokenizer_max_length = 1024
     pipeline.vae_scale_factor = 8
     pipeline.default_sample_size = 128
-    pipeline.scheduler = _FakeScheduler()
-    pipeline._extract_prompts = lambda prompts: (["prompt"], None)
+    pipeline.check_cfg_parallel_validity = lambda true_cfg_scale, has_neg_prompt: None
 
     captured = {}
 
-    def _fake_prepare_generation_context(**kwargs):
+    def _fake_encode_prompt(**kwargs):
         captured["max_sequence_length"] = kwargs["max_sequence_length"]
         embeds = torch.ones((1, 1, 1))
         mask = torch.ones((1, 1), dtype=torch.long)
-        return {
-            "prompt_embeds": embeds,
-            "prompt_embeds_mask": mask,
-            "negative_prompt_embeds": None,
-            "negative_prompt_embeds_mask": None,
-            "latents": embeds,
-            "timesteps": torch.tensor([1]),
-            "do_true_cfg": False,
-            "guidance": None,
-            "img_shapes": [[(1, 1, 1)]],
-            "txt_seq_lens": [1],
-            "negative_txt_seq_lens": None,
-        }
+        return embeds, mask
 
-    pipeline._prepare_generation_context = _fake_prepare_generation_context
-    state = SimpleNamespace(
+    pipeline.encode_prompt = _fake_encode_prompt
+    state = DiffusionRequestState(
+        request_id="qwen-prompt",
         prompt="prompt",
         sampling=SimpleNamespace(
             height=None,
@@ -169,12 +151,14 @@ def test_prepare_encode_defaults_to_tokenizer_max_length():
             guidance_scale_provided=False,
             num_outputs_per_prompt=0,
             generator=None,
+            latents=None,
             true_cfg_scale=None,
             max_sequence_length=None,
+            output_type=None,
         ),
     )
 
-    pipeline.prepare_encode(state)
+    pipeline.encode(state)
 
     assert captured["max_sequence_length"] == 1024
 
@@ -198,84 +182,132 @@ def _make_request_batch_prompt_sampling(**overrides):
     return SimpleNamespace(**values)
 
 
-def test_forward_collates_request_prompt_tensors_for_qwen_image():
+@pytest.mark.parametrize("use_additional_information", [False, True])
+def test_state_generation_context_uses_request_prompt_tensors(use_additional_information: bool):
     pipeline = object.__new__(QwenImagePipeline)
     nn.Module.__init__(pipeline)
     pipeline.vae_scale_factor = 8
     pipeline.default_sample_size = 128
-
-    class StopAfterPrepareContextError(Exception):
-        pass
-
-    captured = {}
-
-    def _fake_prepare_generation_context(**kwargs):
-        captured.update(kwargs)
-        raise StopAfterPrepareContextError
-
-    pipeline._prepare_generation_context = _fake_prepare_generation_context
+    pipeline.tokenizer_max_length = 1024
 
     prompt_embeds_a = torch.zeros(2, 3)
-    prompt_embeds_b = torch.ones(2, 3)
     prompt_embeds_mask_a = torch.tensor([True, True])
-    prompt_embeds_mask_b = torch.tensor([True, False])
     negative_prompt_embeds_a = torch.full((2, 3), 2.0)
-    negative_prompt_embeds_b = torch.full((2, 3), 3.0)
     negative_prompt_embeds_mask_a = torch.tensor([False, True])
-    negative_prompt_embeds_mask_b = torch.tensor([False, False])
+    prompt_fields = {
+        "prompt_embeds": prompt_embeds_a,
+        "prompt_embeds_mask": prompt_embeds_mask_a,
+        "negative_prompt_embeds": negative_prompt_embeds_a,
+        "negative_prompt_embeds_mask": negative_prompt_embeds_mask_a,
+    }
+    if use_additional_information:
+        prompt_fields = {key: [value] for key, value in prompt_fields.items()}
+        prompt = {
+            "prompt": "prompt-a",
+            "negative_prompt": "negative-a",
+            "additional_information": prompt_fields,
+        }
+    else:
+        prompt = {
+            "prompt": "prompt-a",
+            "negative_prompt": "negative-a",
+            **prompt_fields,
+        }
+
+    state = DiffusionRequestState(
+        request_id="qwen-prompt-a",
+        prompt=prompt,
+        sampling=_make_request_batch_prompt_sampling(),
+    )
+
+    context = pipeline._state_generation_context(state)
+
+    assert context["prompt"] is None
+    assert context["negative_prompt"] is None
+    torch.testing.assert_close(context["prompt_embeds"], prompt_embeds_a.unsqueeze(0))
+    torch.testing.assert_close(context["prompt_embeds_mask"], prompt_embeds_mask_a.unsqueeze(0))
+    torch.testing.assert_close(context["negative_prompt_embeds"], negative_prompt_embeds_a.unsqueeze(0))
+    torch.testing.assert_close(context["negative_prompt_embeds_mask"], negative_prompt_embeds_mask_a.unsqueeze(0))
+
+
+def test_forward_uses_atoms_and_batches_denoise_for_qwen_image():
+    pipeline = object.__new__(QwenImagePipeline)
+    nn.Module.__init__(pipeline)
+    pipeline._interrupt = False
+
+    def _request(request_id: str, prompt: str):
+        return SimpleNamespace(
+            request_id=request_id,
+            prompt=prompt,
+            sampling_params=_make_request_batch_prompt_sampling(),
+            kv_sender_info=None,
+        )
 
     batch = DiffusionRequestBatch(
         requests=[
-            SimpleNamespace(
-                request_id="qwen-prompt-a",
-                prompt={
-                    "prompt": "prompt-a",
-                    "negative_prompt": "negative-a",
-                    "prompt_embeds": prompt_embeds_a,
-                    "prompt_embeds_mask": prompt_embeds_mask_a,
-                    "negative_prompt_embeds": negative_prompt_embeds_a,
-                    "negative_prompt_embeds_mask": negative_prompt_embeds_mask_a,
-                },
-                sampling_params=_make_request_batch_prompt_sampling(),
-            ),
-            SimpleNamespace(
-                request_id="qwen-prompt-b",
-                prompt={
-                    "prompt": "prompt-b",
-                    "negative_prompt": "negative-b",
-                    "additional_information": {
-                        "prompt_embeds": [prompt_embeds_b],
-                        "prompt_embeds_mask": [prompt_embeds_mask_b],
-                        "negative_prompt_embeds": [negative_prompt_embeds_b],
-                        "negative_prompt_embeds_mask": [negative_prompt_embeds_mask_b],
-                    },
-                },
-                sampling_params=_make_request_batch_prompt_sampling(),
-            ),
+            _request("qwen-prompt-a", "prompt-a"),
+            _request("qwen-prompt-b", "prompt-b"),
         ]
     )
 
-    with pytest.raises(StopAfterPrepareContextError):
-        pipeline.forward(batch)
+    events = []
+    build_calls = []
 
-    assert captured["prompt"] is None
-    assert captured["negative_prompt"] is None
-    torch.testing.assert_close(
-        captured["prompt_embeds"],
-        torch.stack([prompt_embeds_a, prompt_embeds_b], dim=0),
-    )
-    torch.testing.assert_close(
-        captured["prompt_embeds_mask"],
-        torch.stack([prompt_embeds_mask_a, prompt_embeds_mask_b], dim=0),
-    )
-    torch.testing.assert_close(
-        captured["negative_prompt_embeds"],
-        torch.stack([negative_prompt_embeds_a, negative_prompt_embeds_b], dim=0),
-    )
-    torch.testing.assert_close(
-        captured["negative_prompt_embeds_mask"],
-        torch.stack([negative_prompt_embeds_mask_a, negative_prompt_embeds_mask_b], dim=0),
-    )
+    def _record(stage: str, state: DiffusionRequestState):
+        events.append((stage, state.request_id))
+        return state
+
+    def _fake_prepare(state):
+        _record("prepare", state)
+        offset = 0.0 if state.request_id.endswith("a") else 10.0
+        state.latents = torch.tensor([[offset, offset + 1]])
+        state.timesteps = torch.tensor([1])
+        state.step_index = 0
+        return state
+
+    def _fake_build_step_batch(states, *, cached_batch=None):
+        build_calls.append(([state.request_id for state in states], cached_batch is not None))
+        return SimpleNamespace(states=states)
+
+    def _fake_denoise_step(input_batch):
+        events.append(("denoise", tuple(state.request_id for state in input_batch.states)))
+        return torch.cat([state.latents + 1 for state in input_batch.states], dim=0)
+
+    def _fake_step_scheduler(state, noise_pred):
+        events.append(("step", state.request_id))
+        state.latents = noise_pred
+        state.step_index += 1
+        return state
+
+    def _fake_decode(state):
+        _record("decode", state)
+        state.extra["decoded_output"] = DiffusionOutput(output=state.latents)
+        return state
+
+    pipeline.init_state = lambda state: _record("init", state)
+    pipeline.check_inputs = lambda state: _record("check", state)
+    pipeline.encode = lambda state: _record("encode", state)
+    pipeline.prepare = _fake_prepare
+    pipeline.build_step_batch = _fake_build_step_batch
+    pipeline.denoise_step = _fake_denoise_step
+    pipeline.step_scheduler = _fake_step_scheduler
+    pipeline.decode = _fake_decode
+
+    outputs = pipeline.forward(batch)
+
+    assert build_calls == [(["qwen-prompt-a", "qwen-prompt-b"], False)]
+    assert [event for event in events[:8]] == [
+        ("init", "qwen-prompt-a"),
+        ("check", "qwen-prompt-a"),
+        ("encode", "qwen-prompt-a"),
+        ("prepare", "qwen-prompt-a"),
+        ("init", "qwen-prompt-b"),
+        ("check", "qwen-prompt-b"),
+        ("encode", "qwen-prompt-b"),
+        ("prepare", "qwen-prompt-b"),
+    ]
+    assert ("denoise", ("qwen-prompt-a", "qwen-prompt-b")) in events
+    assert [output.output.tolist() for output in outputs] == [[[1.0, 2.0]], [[11.0, 12.0]]]
 
 
 @pytest.mark.parametrize(

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -8,10 +8,15 @@ import pytest
 import torch
 
 import vllm_omni.diffusion.worker.diffusion_model_runner as model_runner_module
+import vllm_omni.diffusion.worker.diffusion_model_runner_v2 as model_runner_v2_module
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.models.interface import StagePayload
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
+from vllm_omni.diffusion.worker.input_batch import InputBatch
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.diffusion]
 
@@ -67,9 +72,18 @@ class _ChunkStepPipeline:
         self.prepare_calls = 0
         self.decode_calls = 0
 
-    def prepare_encode(self, state):
-        self.prepare_calls += 1
+    def init_state(self, state):
+        return state
+
+    def check_inputs(self, state):
+        return state
+
+    def encode(self, state):
         state.prompt_embeds = torch.zeros(1, 1, 1)
+        return state
+
+    def prepare(self, state):
+        self.prepare_calls += 1
         state.latents = torch.zeros(1, 1)
         state.timesteps = torch.tensor([1.0, 0.0])
         state.step_index = 0
@@ -78,16 +92,42 @@ class _ChunkStepPipeline:
         state.total_chunks = len(self._outputs)
         return state
 
-    def denoise_step(self, input_batch, states):
-        del states
+    def diffuse(self, state):
+        while not state.denoise_completed:
+            state.step_index += 1
+        return state
+
+    def pack_stage_state(self, state, boundary):
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields={},
+            tensor_fields={},
+            private_scalar_fields={},
+            private_tensor_fields={},
+        )
+
+    def unpack_stage_state(self, payload, state):
+        del payload
+        return state
+
+    def build_step_attention_metadata(self, input_batch):
+        del input_batch
+        return {}
+
+    def build_step_batch(self, states, *, cached_batch=None):
+        return InputBatch.make_batch(states, cached_batch=cached_batch)
+
+    def denoise_step(self, input_batch):
         return torch.ones_like(input_batch.latents)
 
     def step_scheduler(self, state, noise_pred):
         state.latents = noise_pred
         state.step_index += 1
         state.step_in_chunk += 1
+        return state
 
-    def post_decode(self, state):
+    def decode(self, state):
         output = self._outputs[self.decode_calls]
         self.decode_calls += 1
         state.chunk_index += 1
@@ -95,16 +135,15 @@ class _ChunkStepPipeline:
         state.step_in_chunk = 0
         if not state.request_denoise_completed:
             state.latents = torch.zeros(1, 1)
-        return output
+        state.extra["decoded_output"] = output
+        return state
+
+    def postprocess(self, state):
+        return state.extra["decoded_output"]
 
 
 def _make_request(skip_cache_refresh: bool = True):
-    sampling_params = SimpleNamespace(
-        generator=None,
-        seed=None,
-        generator_device=None,
-        num_inference_steps=4,
-    )
+    sampling_params = OmniDiffusionSamplingParams(num_inference_steps=4)
     return SimpleNamespace(
         request_id="req-test",
         prompt="a prompt",
@@ -126,10 +165,29 @@ def _make_request_with_params(req_id: str, sampling_params):
 
 def _fake_platform_for_peak_memory():
     return SimpleNamespace(
+        is_available=lambda: True,
         reset_peak_memory_stats=lambda: None,
         max_memory_reserved=lambda: 0,
         max_memory_allocated=lambda: 0,
     )
+
+
+class _StepParallelConfig:
+    use_hsdp = False
+
+
+class _StepRunnerConfig:
+    cache_backend = None
+    enable_cache_dit_summary = True
+    parallel_config = _StepParallelConfig()
+    streaming_output = True
+    step_execution = True
+    cfg_kv_collect_func = None
+
+
+class _NoopKVTransferManager:
+    def receive_multi_kv_cache_distributed(self, req, cfg_kv_collect_func=None, target_device=None):
+        del req, cfg_kv_collect_func, target_device
 
 
 def _make_runner(cache_backend, cache_backend_name: str, enable_cache_dit_summary: bool = True):
@@ -195,24 +253,31 @@ def test_execute_stepwise_streaming_returns_chunks_at_boundaries(monkeypatch):
         DiffusionOutput(output="chunk-0", finished=False, chunk_index=0, total_chunks=2),
         DiffusionOutput(output="chunk-1", finished=True, chunk_index=1, total_chunks=2),
     ]
-    runner = _make_runner(cache_backend=None, cache_backend_name=None)
+    runner = object.__new__(DiffusionModelRunnerV2)
+    runner.vllm_config = object()
+    runner.device = torch.device("cpu")
     runner.pipeline = _ChunkStepPipeline(chunks)
-    runner.od_config.streaming_output = True
-    runner.od_config.step_execution = True
+    runner.cache_backend = None
+    runner.offload_backend = None
+    runner.state_cache = {}
+    runner.prompt_embed_cache = None
+    runner.od_config = _StepRunnerConfig()
+    runner.kv_transfer_manager = _NoopKVTransferManager()
+    runner._kv_prefetch_enabled = False
     req = _make_request(skip_cache_refresh=True)
     req.request_id = "req"
 
-    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "reset_peak_memory_stats", lambda: None)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_reserved", lambda: 0)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_allocated", lambda: 0)
+    fake_platform = _fake_platform_for_peak_memory()
+    monkeypatch.setattr(model_runner_v2_module, "set_forward_context", _noop_forward_context)
+    monkeypatch.setattr(model_runner_module, "current_omni_platform", fake_platform)
+    monkeypatch.setattr(model_runner_v2_module, "current_omni_platform", fake_platform)
     scheduler_output = SimpleNamespace(
         finished_req_ids=set(),
         scheduled_new_reqs=[SimpleNamespace(request_id="req", req=req)],
         scheduled_cached_reqs=SimpleNamespace(request_ids=[]),
     )
 
-    first = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+    first = DiffusionModelRunnerV2.execute_stepwise(runner, scheduler_output)
     assert first.get_request_output("req").result is None
 
     scheduler_output = SimpleNamespace(
@@ -220,12 +285,12 @@ def test_execute_stepwise_streaming_returns_chunks_at_boundaries(monkeypatch):
         scheduled_new_reqs=[],
         scheduled_cached_reqs=SimpleNamespace(request_ids=["req"]),
     )
-    second = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+    second = DiffusionModelRunnerV2.execute_stepwise(runner, scheduler_output)
     assert second.get_request_output("req").result == chunks[0]
     assert second.get_request_output("req").finished is False
 
-    DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
-    fourth = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+    DiffusionModelRunnerV2.execute_stepwise(runner, scheduler_output)
+    fourth = DiffusionModelRunnerV2.execute_stepwise(runner, scheduler_output)
     assert fourth.get_request_output("req").result == chunks[1]
     assert fourth.get_request_output("req").finished is True
 
@@ -291,6 +356,7 @@ def test_execute_model_passes_single_request_batch_to_non_admission_pipeline(mon
     req = _make_request(skip_cache_refresh=True)
 
     monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    monkeypatch.setattr(model_runner_module, "current_omni_platform", _fake_platform_for_peak_memory())
 
     output = DiffusionModelRunner.execute_model(runner, req)
 
@@ -307,6 +373,7 @@ def test_execute_model_accepts_bare_diffusion_output_from_single_request_pipelin
     req = _make_request(skip_cache_refresh=True)
 
     monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    monkeypatch.setattr(model_runner_module, "current_omni_platform", _fake_platform_for_peak_memory())
 
     output = DiffusionModelRunner.execute_model(runner, req)
 

--- a/tests/diffusion/test_diffusion_plugin_hooks.py
+++ b/tests/diffusion/test_diffusion_plugin_hooks.py
@@ -122,6 +122,36 @@ class TestWorkerUsesHook:
         mock_platform.get_diffusion_model_runner_cls.assert_called_once()
         mock_resolve.assert_called_once_with("custom.path")
 
+    @patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
+    def test_streaming_output_uses_v2_runner_with_default_runner(self, mock_platform):
+        """Streaming output needs the stepwise runner even before load_model."""
+        from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
+        import vllm_omni.diffusion.worker.diffusion_worker as worker_module
+
+        class _SelectedRunner:
+            def __init__(self, vllm_config, od_config, device):
+                self.vllm_config = vllm_config
+                self.od_config = od_config
+                self.device = device
+
+        class _StreamingOutputConfig:
+            step_execution = False
+            streaming_output = True
+            stage_id = 0
+
+        mock_platform.get_diffusion_model_runner_cls.return_value = (
+            "vllm_omni.diffusion.worker.diffusion_model_runner.DiffusionModelRunner"
+        )
+        od_config = _StreamingOutputConfig()
+
+        with (
+            patch.object(DiffusionWorker, "init_device"),
+            patch.object(worker_module, "DiffusionModelRunnerV2", _SelectedRunner),
+        ):
+            worker = DiffusionWorker(local_rank=0, rank=0, od_config=od_config, skip_load_model=True)
+
+        assert isinstance(worker.model_runner, _SelectedRunner)
+
     @patch("vllm_omni.diffusion.worker.diffusion_worker.get_diffusion_ir_op_priority_func")
     @patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
     def test_ir_op_priority_hook_receives_platform_default(self, mock_platform, mock_get_hook):

--- a/tests/diffusion/test_diffusion_plugin_hooks.py
+++ b/tests/diffusion/test_diffusion_plugin_hooks.py
@@ -125,8 +125,8 @@ class TestWorkerUsesHook:
     @patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
     def test_streaming_output_uses_v2_runner_with_default_runner(self, mock_platform):
         """Streaming output needs the stepwise runner even before load_model."""
-        from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
         import vllm_omni.diffusion.worker.diffusion_worker as worker_module
+        from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
 
         class _SelectedRunner:
             def __init__(self, vllm_config, od_config, device):

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -31,12 +31,12 @@ from vllm_omni.diffusion.ipc import (
     pack_diffusion_output_shm,
     unpack_diffusion_output_shm,
 )
+from vllm_omni.diffusion.models.interface import StagePayload
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
     DiffusionPipelineProfilerMixin,
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched import StepScheduler
-from vllm_omni.diffusion.models.interface import StagePayload
 from vllm_omni.diffusion.sched.interface import (
     CachedRequestData,
     DiffusionSchedulerOutput,

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -14,6 +14,7 @@ import torch
 from pytest_mock import MockerFixture
 
 import vllm_omni.diffusion.worker.diffusion_model_runner as model_runner_module
+import vllm_omni.diffusion.worker.diffusion_model_runner_v2 as model_runner_v2_module
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
@@ -35,12 +36,14 @@ from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched import StepScheduler
+from vllm_omni.diffusion.models.interface import StagePayload
 from vllm_omni.diffusion.sched.interface import (
     CachedRequestData,
     DiffusionSchedulerOutput,
     NewRequestData,
 )
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
 from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
 from vllm_omni.diffusion.worker.input_batch import InputBatch
 from vllm_omni.diffusion.worker.utils import DiffusionRequestState, RunnerOutput
@@ -77,27 +80,65 @@ class _StepPipeline:
         self.scheduler_calls = 0
         self.decode_calls = 0
 
-    def prepare_encode(self, state, **kwargs):
-        del kwargs
-        self.prepare_calls += 1
-        state.timesteps = [torch.tensor(10), torch.tensor(5)]
-        state.latents = torch.tensor([0.0])
+    def init_state(self, state):
+        return state
+
+    def check_inputs(self, state):
+        return state
+
+    def encode(self, state):
         state.prompt_embeds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
         return state
 
-    def denoise_step(self, input_batch, **kwargs):
-        self.denoise_calls += 1
-        return torch.full_like(input_batch.prompt_embeds, fill_value=0.5)
+    def prepare(self, state):
+        self.prepare_calls += 1
+        state.latents = torch.tensor([0.0])
+        state.timesteps = [torch.tensor(10), torch.tensor(5)]
+        return state
 
-    def step_scheduler(self, state, noise_pred, **kwargs):
-        del noise_pred, kwargs
+    def diffuse(self, state):
+        while not state.denoise_completed:
+            state.step_index += 1
+        return state
+
+    def pack_stage_state(self, state, boundary):
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields={},
+            tensor_fields={},
+            private_scalar_fields={},
+            private_tensor_fields={},
+        )
+
+    def unpack_stage_state(self, payload, state):
+        del payload
+        return state
+
+    def build_step_attention_metadata(self, input_batch):
+        del input_batch
+        return {}
+
+    def build_step_batch(self, states, *, cached_batch=None):
+        return InputBatch.make_batch(states, cached_batch=cached_batch)
+
+    def denoise_step(self, input_batch):
+        self.denoise_calls += 1
+        return torch.full_like(input_batch.latents, fill_value=0.5)
+
+    def step_scheduler(self, state, noise_pred):
+        del noise_pred
         self.scheduler_calls += 1
         state.step_index += 1
+        return state
 
-    def post_decode(self, state, **kwargs):
-        del kwargs
+    def decode(self, state):
         self.decode_calls += 1
-        return DiffusionOutput(output=torch.tensor([state.step_index], dtype=torch.float32))
+        state.extra["decoded_output"] = DiffusionOutput(output=torch.tensor([state.step_index], dtype=torch.float32))
+        return state
+
+    def postprocess(self, state):
+        return state.extra["decoded_output"]
 
 
 class _ProfilingStepPipeline(_StepPipeline):
@@ -114,18 +155,18 @@ class _ProfilingStepPipeline(_StepPipeline):
     def clear_profiler_records(self) -> None:
         self._stage_durations.clear()
 
-    def prepare_encode(self, state, **kwargs):
-        result = super().prepare_encode(state, **kwargs)
+    def encode(self, state):
+        result = super().encode(state)
         self._stage_durations["QwenImagePipeline.text_encoder.forward"] = 1.0
         return result
 
-    def denoise_step(self, input_batch, **kwargs):
-        result = super().denoise_step(input_batch, **kwargs)
+    def denoise_step(self, input_batch):
+        result = super().denoise_step(input_batch)
         self._stage_durations["QwenImagePipeline.diffuse"] = 2.0
         return result
 
-    def post_decode(self, state, **kwargs):
-        result = super().post_decode(state, **kwargs)
+    def decode(self, state):
+        result = super().decode(state)
         self._stage_durations["QwenImagePipeline.vae.decode"] = 3.0
         return result
 
@@ -148,18 +189,18 @@ class _AutoDenoiseProfilerPipeline(DiffusionPipelineProfilerMixin):
 class _InterruptingStepPipeline(_StepPipeline):
     interrupt = True
 
-    def denoise_step(self, state, **kwargs):
-        del state, kwargs
+    def denoise_step(self, input_batch):
+        del input_batch
         self.denoise_calls += 1
         return None
 
-    def step_scheduler(self, state, noise_pred, **kwargs):
-        del state, noise_pred, kwargs
+    def step_scheduler(self, state, noise_pred):
+        del state, noise_pred
         raise AssertionError("step_scheduler should not run after interrupt")
 
-    def post_decode(self, state, **kwargs):
-        del state, kwargs
-        raise AssertionError("post_decode should not run after interrupt")
+    def decode(self, state):
+        del state
+        raise AssertionError("decode should not run after interrupt")
 
 
 class _FakePeakMemoryPlatform:
@@ -180,6 +221,14 @@ class _FakePeakMemoryPlatform:
 
     def is_available(self) -> bool:
         return True
+
+
+def _patch_stepwise_runtime(monkeypatch, platform=None):
+    platform = platform or _FakePeakMemoryPlatform([0.0])
+    monkeypatch.setattr(model_runner_v2_module, "set_forward_context", _noop_forward_context)
+    monkeypatch.setattr(model_runner_module, "current_omni_platform", platform)
+    monkeypatch.setattr(model_runner_v2_module, "current_omni_platform", platform)
+    return platform
 
 
 class _IdentityNoiseTransformer(torch.nn.Module):
@@ -208,18 +257,51 @@ class _DistributedStepPipeline(CFGParallelMixin):
     def interrupt(self):
         return self._interrupt
 
-    def prepare_encode(self, state, **kwargs):
-        del kwargs
-        state.timesteps = [torch.tensor(1.0, device=self.device)]
-        state.latents = torch.ones((1, 1), device=self.device)
-        state.step_index = 0
-        state.scheduler = self.scheduler
-        state.do_true_cfg = self.mode == "cfg"
+    def init_state(self, state):
+        return state
+
+    def check_inputs(self, state):
+        return state
+
+    def encode(self, state):
         state.prompt_embeds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
         return state
 
-    def denoise_step(self, state, **kwargs):
-        del kwargs
+    def prepare(self, state):
+        state.latents = torch.ones((1, 1), device=self.device)
+        state.timesteps = [torch.tensor(1.0, device=self.device)]
+        state.step_index = 0
+        state.scheduler = self.scheduler
+        state.do_true_cfg = self.mode == "cfg"
+        return state
+
+    def diffuse(self, state):
+        while not state.denoise_completed:
+            state.step_index += 1
+        return state
+
+    def pack_stage_state(self, state, boundary):
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields={},
+            tensor_fields={},
+            private_scalar_fields={},
+            private_tensor_fields={},
+        )
+
+    def unpack_stage_state(self, payload, state):
+        del payload
+        return state
+
+    def build_step_attention_metadata(self, input_batch):
+        del input_batch
+        return {}
+
+    def build_step_batch(self, states, *, cached_batch=None):
+        return InputBatch.make_batch(states, cached_batch=cached_batch)
+
+    def denoise_step(self, input_batch):
         if self.mode == "ulysses":
             sp_group = get_sp_group().ulysses_group
             seq_world_size = torch.distributed.get_world_size(sp_group)
@@ -228,7 +310,7 @@ class _DistributedStepPipeline(CFGParallelMixin):
             intermediate = SeqAllToAll4D.apply(sp_group, input_tensor, 2, 1, False)
             output = SeqAllToAll4D.apply(sp_group, intermediate, 1, 2, False)
             torch.testing.assert_close(output, original, rtol=1e-5, atol=1e-5)
-            return torch.ones_like(state.latents)
+            return torch.ones_like(input_batch.latents)
 
         if self.mode == "ring":
             ring_group = get_sp_group().ring_group
@@ -241,10 +323,10 @@ class _DistributedStepPipeline(CFGParallelMixin):
             comm.wait()
             expected = torch.full_like(recv_tensor, float(((rank - 1) % world_size) + 1))
             torch.testing.assert_close(recv_tensor, expected, rtol=1e-5, atol=1e-5)
-            return torch.ones_like(state.latents)
+            return torch.ones_like(input_batch.latents)
 
-        positive_kwargs = {"x": state.latents + 1}
-        negative_kwargs = {"x": state.latents - 1}
+        positive_kwargs = {"x": input_batch.latents + 1}
+        negative_kwargs = {"x": input_batch.latents - 1}
         return self.predict_noise_maybe_with_cfg(
             do_true_cfg=True,
             true_cfg_scale=1.0,
@@ -253,8 +335,7 @@ class _DistributedStepPipeline(CFGParallelMixin):
             cfg_normalize=False,
         )
 
-    def step_scheduler(self, state, noise_pred, **kwargs):
-        del kwargs
+    def step_scheduler(self, state, noise_pred):
         if self.mode == "cfg":
             state.latents = self.scheduler_step_maybe_with_cfg(
                 noise_pred,
@@ -266,10 +347,14 @@ class _DistributedStepPipeline(CFGParallelMixin):
         else:
             state.latents = state.latents + noise_pred
         state.step_index += 1
+        return state
 
-    def post_decode(self, state, **kwargs):
-        del kwargs
-        return DiffusionOutput(output=state.latents.detach().cpu())
+    def decode(self, state):
+        state.extra["decoded_output"] = DiffusionOutput(output=state.latents.detach().cpu())
+        return state
+
+    def postprocess(self, state):
+        return state.extra["decoded_output"]
 
 
 def _make_step_request(num_inference_steps: int = 2):
@@ -307,7 +392,7 @@ def _make_vllm_config():
 
 
 def _make_runner():
-    runner = object.__new__(DiffusionModelRunner)
+    runner = object.__new__(DiffusionModelRunnerV2)
     runner.vllm_config = _make_vllm_config()
     runner.od_config = SimpleNamespace(
         cache_backend=None,
@@ -326,7 +411,7 @@ def _make_runner():
 
 
 def _make_distributed_runner(mode: str, device: torch.device):
-    runner = object.__new__(DiffusionModelRunner)
+    runner = object.__new__(DiffusionModelRunnerV2)
     runner.vllm_config = _make_vllm_config()
     runner.od_config = SimpleNamespace(
         cache_backend=None,
@@ -423,7 +508,7 @@ def _distributed_step_worker(local_rank: int, world_size: int, mode: str, master
             "MASTER_PORT": master_port,
         }
     )
-    model_runner_module.set_forward_context = _noop_forward_context
+    model_runner_v2_module.set_forward_context = _noop_forward_context
 
     try:
         init_distributed_environment()
@@ -437,7 +522,7 @@ def _distributed_step_worker(local_rank: int, world_size: int, mode: str, master
             raise ValueError(f"Unsupported distributed test mode: {mode}")
 
         runner = _make_distributed_runner(mode, device)
-        result = DiffusionModelRunner.execute_stepwise(
+        result = DiffusionModelRunnerV2.execute_stepwise(
             runner,
             _make_scheduler_output(_make_step_request(num_inference_steps=1), step_id=0),
         )
@@ -500,14 +585,14 @@ def test_step_profiler_reports_denoise_step_as_diffuse():
 
 @pytest.mark.cpu
 class TestRunner:
-    """DiffusionModelRunner.execute_stepwise"""
+    """DiffusionModelRunnerV2.execute_stepwise"""
 
     def test_completes_request_and_clears_state(self, monkeypatch):
         runner = _make_runner()
         req = _make_step_request()
-        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+        _patch_stepwise_runtime(monkeypatch)
 
-        result = DiffusionModelRunner.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
+        result = DiffusionModelRunnerV2.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
         first = result.get_request_output("req-1")
         assert first.request_id == "req-1"
         assert first.step_index == 1
@@ -515,7 +600,7 @@ class TestRunner:
         assert first.result is None
         assert "req-1" in runner.state_cache
 
-        result = DiffusionModelRunner.execute_stepwise(runner, _make_cached_scheduler_output(step_id=1))
+        result = DiffusionModelRunnerV2.execute_stepwise(runner, _make_cached_scheduler_output(step_id=1))
         second = result.get_request_output("req-1")
         assert second.request_id == "req-1"
         assert second.step_index == 2
@@ -535,33 +620,33 @@ class TestRunner:
         runner.pipeline = _ProfilingStepPipeline()
         req = _make_step_request()
         reset_calls = []
-        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+        monkeypatch.setattr(model_runner_v2_module, "set_forward_context", _noop_forward_context)
         monkeypatch.setattr(
-            model_runner_module.current_omni_platform,
+            model_runner_v2_module.current_omni_platform,
             "is_available",
             lambda: True,
         )
         monkeypatch.setattr(
-            model_runner_module.current_omni_platform,
+            model_runner_v2_module.current_omni_platform,
             "reset_peak_memory_stats",
             lambda: reset_calls.append(True),
         )
         monkeypatch.setattr(
-            model_runner_module.current_omni_platform,
+            model_runner_v2_module.current_omni_platform,
             "max_memory_reserved",
             lambda: 2 * 1024**2,
         )
         monkeypatch.setattr(
-            model_runner_module.current_omni_platform,
+            model_runner_v2_module.current_omni_platform,
             "max_memory_allocated",
             lambda: 1024**2,
         )
 
-        DiffusionModelRunner.execute_stepwise(
+        DiffusionModelRunnerV2.execute_stepwise(
             runner,
             _make_scheduler_output(req, step_id=0),
         )
-        result = DiffusionModelRunner.execute_stepwise(
+        result = DiffusionModelRunnerV2.execute_stepwise(
             runner,
             _make_cached_scheduler_output(step_id=1),
         )
@@ -581,21 +666,20 @@ class TestRunner:
         runner = _make_runner()
         req = _make_step_request()
         fake_platform = _FakePeakMemoryPlatform([1500.0, 1200.0])
-        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
-        monkeypatch.setattr(model_runner_module, "current_omni_platform", fake_platform)
+        _patch_stepwise_runtime(monkeypatch, fake_platform)
 
-        first = DiffusionModelRunner.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
+        first = DiffusionModelRunnerV2.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
         first_output = first.get_request_output("req-1")
         assert first_output.finished is False
         assert first_output.result is None
 
-        second = DiffusionModelRunner.execute_stepwise(runner, _make_cached_scheduler_output(step_id=1))
+        second = DiffusionModelRunnerV2.execute_stepwise(runner, _make_cached_scheduler_output(step_id=1))
         second_output = second.get_request_output("req-1")
         assert second_output.finished is True
         assert second_output.result is not None
         assert second_output.result.peak_memory_mb == pytest.approx(1500.0)
 
-    def test_rejects_multi_request_step_batch(self):
+    def test_handles_multi_request_step_batch(self, monkeypatch):
         runner = _make_runner()
         req_1 = _make_step_request()
         req_2 = _make_step_request()
@@ -613,18 +697,19 @@ class TestRunner:
             num_waiting_reqs=0,
         )
 
-        result = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+        _patch_stepwise_runtime(monkeypatch)
+        result = DiffusionModelRunnerV2.execute_stepwise(runner, scheduler_output)
         assert len(result) == 2
 
-    def test_receives_kv_payload_before_prepare_encode(self, monkeypatch):
+    def test_receives_kv_payload_before_step_inputs(self, monkeypatch):
         runner = _make_runner()
         captured: dict[str, object] = {}
         kv_payload = object()
 
         class _CapturingStepPipeline(_StepPipeline):
-            def prepare_encode(self, state, **kwargs):
+            def check_inputs(self, state):
                 captured["past_key_values"] = getattr(state.sampling, "past_key_values", None)
-                return super().prepare_encode(state, **kwargs)
+                return super().check_inputs(state)
 
         class _KVTransferManager:
             def receive_multi_kv_cache_distributed(self, req, cfg_kv_collect_func=None, target_device=None):
@@ -636,10 +721,10 @@ class TestRunner:
         runner.pipeline.device = torch.device("cpu")
         runner.od_config.cfg_kv_collect_func = "collect-cfg"
         runner.kv_transfer_manager = _KVTransferManager()
-        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+        _patch_stepwise_runtime(monkeypatch)
         req = _make_step_request()
 
-        DiffusionModelRunner.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
+        DiffusionModelRunnerV2.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
 
         assert captured["past_key_values"] is kv_payload
         assert captured["cfg_kv_collect_func"] == "collect-cfg"
@@ -650,15 +735,15 @@ class TestRunner:
         runner = _make_runner()
 
         with pytest.raises(ValueError, match="Missing cached state"):
-            DiffusionModelRunner.execute_stepwise(runner, _make_cached_scheduler_output(request_id="req-missing"))
+            DiffusionModelRunnerV2.execute_stepwise(runner, _make_cached_scheduler_output(request_id="req-missing"))
 
     def test_interrupt_marks_request_finished_and_clears_state(self, monkeypatch):
         runner = _make_runner()
         runner.pipeline = _InterruptingStepPipeline()
         req = _make_step_request()
-        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+        _patch_stepwise_runtime(monkeypatch)
 
-        result = DiffusionModelRunner.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
+        result = DiffusionModelRunnerV2.execute_stepwise(runner, _make_scheduler_output(req, step_id=0))
         output = result.get_request_output("req-1")
         assert output.request_id == "req-1"
         assert output.step_index == 0
@@ -1022,16 +1107,70 @@ class TestSupportedPipelines:
 
         assert stage_cfg["engine_args"]["step_execution"] is True
 
-    def test_qwen_image_supports_step_execution(self):
-        from vllm_omni.diffusion.models.interface import SupportsStepExecution, supports_step_execution
-        from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
+    def test_qwen_image_edit_supports_v2_step_execution(self):
+        from vllm_omni.diffusion.models.interface import (
+            DiffusionV2Atoms,
+            supports_step_execution,
+        )
+        from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import QwenImageEditPipeline
 
         # Avoid loading model weights; protocol membership depends on the class contract.
-        pipeline = object.__new__(QwenImagePipeline)
+        pipeline = object.__new__(QwenImageEditPipeline)
 
         assert pipeline.supports_step_execution is True
         assert supports_step_execution(pipeline) is True
-        assert isinstance(pipeline, SupportsStepExecution) is True
+        assert isinstance(pipeline, DiffusionV2Atoms) is True
+
+    def test_qwen_image_edit_stage_payload_codec_keeps_model_private_fields(self):
+        from vllm_omni.diffusion.models.interface import StageBoundary
+        from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import QwenImageEditPipeline
+
+        pipeline = object.__new__(QwenImageEditPipeline)
+        sampling = OmniDiffusionSamplingParams()
+        state = DiffusionRequestState(request_id="req-1", sampling=sampling)
+        state.prompt_embeds = torch.ones((1, 2, 3))
+        state.prompt_embeds_mask = torch.ones((1, 2), dtype=torch.bool)
+        state.latents = torch.ones((1, 4, 8))
+        state.img_shapes = [[(1, 2, 2), (1, 4, 4)]]
+        state.txt_seq_lens = [2]
+        state.extra.update(
+            {
+                "image_latents": torch.zeros((1, 4, 8)),
+                "calculated_height": 64,
+                "calculated_width": 64,
+                "cfg_normalize": True,
+                "decode_height": 32,
+                "decode_width": 32,
+                "num_inference_steps": 2,
+                "output_type": "pil",
+                "sigmas": [1.0, 0.5],
+                "true_cfg_scale": 4.0,
+            }
+        )
+
+        payload = pipeline.pack_stage_state(state, StageBoundary.ENCODE_TO_DIT)
+
+        assert payload.request_id == "req-1"
+        assert payload.boundary is StageBoundary.ENCODE_TO_DIT
+        assert "latents" not in payload.tensor_fields
+        assert "prompt_embeds" in payload.tensor_fields
+        assert "image_latents" not in payload.tensor_fields
+        assert "image_latents" in payload.private_tensor_fields
+        assert payload.scalar_fields["img_shapes"] == [[(1, 2, 2), (1, 4, 4)]]
+        assert payload.private_scalar_fields["num_inference_steps"] == 2
+
+        restored = DiffusionRequestState(request_id="req-1", sampling=OmniDiffusionSamplingParams())
+        pipeline.unpack_stage_state(payload, restored)
+
+        assert restored.latents is None
+        torch.testing.assert_close(restored.extra["image_latents"], state.extra["image_latents"])
+        assert restored.img_shapes == state.img_shapes
+        assert restored.extra["decode_height"] == 32
+
+        decode_payload = pipeline.pack_stage_state(state, StageBoundary.DIT_TO_DECODE)
+
+        assert decode_payload.tensor_fields == {"latents": state.latents}
+        assert decode_payload.private_tensor_fields == {}
 
 
 @hardware_test(

--- a/tests/diffusion/test_diffusion_streaming_output.py
+++ b/tests/diffusion/test_diffusion_streaming_output.py
@@ -469,14 +469,14 @@ class TestSupportedPipelines:
 
     def test_helios_supports_step_execution_for_streaming_output(self) -> None:
         from vllm_omni.diffusion.models.helios.pipeline_helios import HeliosPipeline
-        from vllm_omni.diffusion.models.interface import SupportsStepExecution, supports_step_execution
+        from vllm_omni.diffusion.models.interface import DiffusionV2Atoms, supports_step_execution
 
         # Avoid loading model weights; protocol membership depends on the class contract.
         pipeline = object.__new__(HeliosPipeline)
 
         assert pipeline.supports_step_execution is True
         assert supports_step_execution(pipeline) is True
-        assert isinstance(pipeline, SupportsStepExecution) is True
+        assert isinstance(pipeline, DiffusionV2Atoms) is True
 
     def test_load_model_rejects_streaming_output_without_step_execution(self, monkeypatch) -> None:
         class _NoStepPipeline:

--- a/vllm_omni/diffusion/models/helios/pipeline_helios.py
+++ b/vllm_omni/diffusion/models/helios/pipeline_helios.py
@@ -8,7 +8,7 @@ import json
 import logging
 import math
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -26,11 +26,13 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.helios.helios_transformer import HeliosTransformer3DModel
 from vllm_omni.diffusion.models.helios.scheduling_helios import HeliosScheduler
-from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import StageBoundary, StagePayload, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.step_mixin import DiffusionV2CFGStepMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 from vllm_omni.platforms import current_omni_platform
 
 if TYPE_CHECKING:
@@ -155,7 +157,12 @@ def get_helios_pre_process_func(
 
 
 class HeliosPipeline(
-    nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    DiffusionV2CFGStepMixin,
+    CFGParallelMixin,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     """Helios text-to-video / image-to-video / video-to-video pipeline for vllm-omni.
 
@@ -167,6 +174,175 @@ class HeliosPipeline(
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+    stage_payload_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: ("prompt_embeds", "negative_prompt_embeds"),
+        StageBoundary.DIT_TO_DECODE: ("latents",),
+    }
+    stage_payload_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "do_true_cfg",
+            "chunk_index",
+            "step_in_chunk",
+            "total_chunks",
+            "chunk_num_steps",
+        ),
+        StageBoundary.DIT_TO_DECODE: (
+            "do_true_cfg",
+            "chunk_index",
+            "step_in_chunk",
+            "total_chunks",
+            "chunk_num_steps",
+        ),
+    }
+    stage_payload_private_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "history_latents",
+            "image_latents",
+            "indices_hidden_states",
+            "indices_latents_history_long",
+            "indices_latents_history_mid",
+            "indices_latents_history_short",
+            "latents_mean",
+            "latents_std",
+        ),
+        StageBoundary.DIT_TO_DECODE: (
+            "history_latents",
+            "history_video",
+            "image_latents",
+            "indices_hidden_states",
+            "indices_latents_history_long",
+            "indices_latents_history_mid",
+            "indices_latents_history_short",
+            "latents_history_long",
+            "latents_history_mid",
+            "latents_history_short",
+            "latents_mean",
+            "latents_std",
+            "stage1_start_latents",
+        ),
+    }
+    stage_payload_private_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "attention_kwargs",
+            "batch_size",
+            "dtype",
+            "generator",
+            "guidance_scale",
+            "height",
+            "history_sizes",
+            "is_amplify_first_chunk",
+            "is_enable_stage2",
+            "is_skip_first_chunk",
+            "keep_first_frame",
+            "num_channels_latents",
+            "num_history_latent_frames",
+            "num_latent_frames_per_chunk",
+            "num_steps",
+            "output_type",
+            "pyramid_num_inference_steps_list",
+            "pyramid_num_stages",
+            "total_generated_latent_frames",
+            "use_cfg_zero_star",
+            "use_zero_init",
+            "vae_dtype",
+            "width",
+            "window_num_frames",
+            "zero_steps",
+        ),
+        StageBoundary.DIT_TO_DECODE: (
+            "attention_kwargs",
+            "batch_size",
+            "dtype",
+            "generator",
+            "guidance_scale",
+            "height",
+            "history_sizes",
+            "is_amplify_first_chunk",
+            "is_enable_stage2",
+            "is_first_chunk",
+            "is_second_chunk",
+            "is_skip_first_chunk",
+            "keep_first_frame",
+            "num_channels_latents",
+            "num_history_latent_frames",
+            "num_latent_frames_per_chunk",
+            "num_steps",
+            "output_type",
+            "pyramid_num_inference_steps_list",
+            "pyramid_num_stages",
+            "stage2_height",
+            "stage2_start_point_list",
+            "stage2_width",
+            "stage_index",
+            "stage_step_index",
+            "total_generated_latent_frames",
+            "use_cfg_zero_star",
+            "use_zero_init",
+            "vae_dtype",
+            "width",
+            "window_num_frames",
+            "zero_steps",
+        ),
+    }
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        def state_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: getattr(state, name) for name in field_names if getattr(state, name, None) is not None}
+
+        def extra_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: state.extra[name] for name in field_names if name in state.extra}
+
+        def extra_tensor_fields(field_names: tuple[str, ...]) -> dict[str, torch.Tensor]:
+            tensors: dict[str, torch.Tensor] = {}
+            for name in field_names:
+                if name not in state.extra:
+                    continue
+                value = state.extra[name]
+                if value is None:
+                    continue
+                if not torch.is_tensor(value):
+                    raise TypeError(f"Helios private tensor field {name!r} must be a torch.Tensor.")
+                tensors[name] = value
+            return tensors
+
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields=state_fields(self.stage_payload_scalar_fields.get(boundary, ())),
+            tensor_fields=state_fields(self.stage_payload_tensor_fields.get(boundary, ())),
+            private_scalar_fields=extra_fields(self.stage_payload_private_scalar_fields.get(boundary, ())),
+            private_tensor_fields=extra_tensor_fields(self.stage_payload_private_tensor_fields.get(boundary, ())),
+        )
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if payload.request_id != state.request_id:
+            raise ValueError(
+                f"StagePayload request_id {payload.request_id!r} does not match state {state.request_id!r}."
+            )
+        if payload.boundary not in (StageBoundary.ENCODE_TO_DIT, StageBoundary.DIT_TO_DECODE):
+            raise ValueError(f"Unsupported stage payload boundary: {payload.boundary!r}.")
+        for name, value in payload.scalar_fields.items():
+            setattr(state, name, value)
+        for name, value in payload.tensor_fields.items():
+            setattr(state, name, value)
+        state.extra.update(payload.private_scalar_fields)
+        state.extra.update(payload.private_tensor_fields)
+        if payload.boundary is StageBoundary.ENCODE_TO_DIT:
+            state.extra.setdefault("image_latents", None)
+        if payload.boundary is StageBoundary.DIT_TO_DECODE:
+            state.extra.setdefault("history_video", None)
+            state.extra.setdefault("image_latents", None)
+        if "output_type" in state.extra:
+            state.sampling.output_type = state.extra["output_type"]
+        return state
 
     def __init__(
         self,
@@ -175,6 +351,7 @@ class HeliosPipeline(
         prefix: str = "",
     ):
         super().__init__()
+        del prefix
         self.od_config = od_config
 
         self.device = get_local_device()
@@ -270,6 +447,10 @@ class HeliosPipeline(
     def current_timestep(self):
         return self._current_timestep
 
+    @property
+    def interrupt(self) -> bool:
+        return getattr(self, "_interrupt", False)
+
     def _stage1_sigmas(self, num_steps: int) -> np.ndarray:
         # DMD drops the last timestep in set_timesteps(). Only compensate for
         # the one-step dummy-run edge case; otherwise preserve the historical
@@ -277,13 +458,38 @@ class HeliosPipeline(
         sigma_count = num_steps + 2 if self.is_distilled and num_steps == 1 else num_steps + 1
         return np.linspace(0.999, 0.0, sigma_count)[:-1]
 
-    def prepare_encode(
+    def check_inputs(
         self,
         state: DiffusionRequestState,
-        **kwargs: Any,
     ) -> DiffusionRequestState:
-        """Initialize Helios request state for chunk-wise step execution."""
-        del kwargs
+        req = DiffusionRequestBatch(
+            requests=[
+                OmniDiffusionRequest(
+                    prompt=state.prompt,
+                    sampling_params=state.sampling,
+                    request_id=state.request_id,
+                )
+            ]
+        )
+        extra = getattr(state.sampling, "extra_args", {}) or {}
+        image = extra.get("image")
+        video = extra.get("video")
+        if image is not None and video is not None:
+            raise ValueError("image and video cannot be provided simultaneously")
+        if len(req.prompts) > 1:
+            raise ValueError("Helios step execution supports a single prompt, not a batched request.")
+        prompt = None
+        if len(req.prompts) == 1:
+            prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
+        if prompt is None:
+            raise ValueError("Prompt is required for Helios generation.")
+        return state
+
+    def encode(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        """Encode prompt/media inputs and initialize chunk-independent state."""
         # Wrap the single request in a DiffusionRequestBatch so the batch
         # compatibility properties (`prompts`, etc.) used below are available;
         # OmniDiffusionRequest itself only exposes a singular `prompt`.
@@ -527,6 +733,14 @@ class HeliosPipeline(
                 "zero_steps": int(extra.get("zero_steps", 1)),
             }
         )
+        return state
+
+    def prepare(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if "history_latents" not in state.extra:
+            raise ValueError(f"Request {state.request_id} has no Helios history latents after encode/unpack.")
         self._prepare_next_chunk(state)
         return state
 
@@ -655,10 +869,10 @@ class HeliosPipeline(
     def denoise_step(
         self,
         input_batch: InputBatch,
-        states: Sequence[DiffusionRequestState],
         **kwargs: Any,
     ) -> torch.Tensor | None:
         del kwargs
+        states = list(input_batch.states)
         if len(states) != 1:
             raise ValueError("Helios step execution supports a single request, not a batched request.")
         state = states[0]
@@ -776,7 +990,7 @@ class HeliosPipeline(
         state: DiffusionRequestState,
         noise_pred: torch.Tensor,
         **kwargs: Any,
-    ) -> None:
+    ) -> DiffusionRequestState:
         del kwargs
         if state.extra["is_enable_stage2"]:
             self._step_scheduler_stage2(state, noise_pred)
@@ -799,6 +1013,7 @@ class HeliosPipeline(
                 state.latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, state.latents, state.do_true_cfg)
             state.step_in_chunk += 1
             state.step_index = state.step_in_chunk
+        return state
 
     def _step_scheduler_stage2(self, state: DiffusionRequestState, noise_pred: torch.Tensor) -> None:
         extra = state.extra
@@ -864,12 +1079,10 @@ class HeliosPipeline(
             extra["stage2_start_point_list"].append(state.latents)
         self._set_stage2_timesteps(state)
 
-    def post_decode(
+    def decode(
         self,
         state: DiffusionRequestState,
-        **kwargs: Any,
-    ) -> DiffusionOutput:
-        del kwargs
+    ) -> DiffusionRequestState:
         extra = state.extra
         is_first_chunk = extra["is_first_chunk"]
         is_second_chunk = extra["is_second_chunk"]
@@ -892,10 +1105,13 @@ class HeliosPipeline(
         else:
             extra["history_video"] = torch.cat([extra["history_video"], current_video], dim=2)
 
-        output = current_latents if extra["output_type"] == "latent" else current_video
         completed_chunk_index = state.chunk_index
         state.chunk_index += 1
         finished = state.request_denoise_completed
+        if getattr(self.od_config, "streaming_output", False):
+            output = current_latents if extra["output_type"] == "latent" else current_video
+        else:
+            output = real_history_latents if extra["output_type"] == "latent" else extra["history_video"]
         if not finished:
             self._prepare_next_chunk(state)
         else:
@@ -903,656 +1119,43 @@ class HeliosPipeline(
             if current_omni_platform.is_available():
                 current_omni_platform.empty_cache()
 
-        return DiffusionOutput(
+        state.extra["decoded_output"] = DiffusionOutput(
             output=output,
             stage_durations=self.stage_durations if hasattr(self, "stage_durations") else {},
             chunk_index=completed_chunk_index,
             total_chunks=state.total_chunks,
             finished=finished,
         )
+        return state
 
-    def forward(
+    def postprocess(
         self,
-        req: DiffusionRequestBatch,
-        prompt: str | None = None,
-        negative_prompt: str | None = None,
-        height: int = 384,
-        width: int = 640,
-        num_inference_steps: int = 50,
-        guidance_scale: float = 5.0,
-        frame_num: int = 132,
-        output_type: str | None = "np",
-        generator: torch.Generator | list[torch.Generator] | None = None,
-        prompt_embeds: torch.Tensor | None = None,
-        negative_prompt_embeds: torch.Tensor | None = None,
-        attention_kwargs: dict | None = None,
-        # Helios-specific
-        history_sizes: list | None = None,
-        num_latent_frames_per_chunk: int = 9,
-        keep_first_frame: bool = True,
-        # I2V
-        image: torch.Tensor | None = None,
-        add_noise_to_image_latents: bool = True,
-        image_noise_sigma_min: float = 0.111,
-        image_noise_sigma_max: float = 0.135,
-        # V2V
-        video: torch.Tensor | None = None,
-        add_noise_to_video_latents: bool = True,
-        video_noise_sigma_min: float = 0.111,
-        video_noise_sigma_max: float = 0.135,
-        # Stage 2 (pyramid multi-stage denoising)
-        is_enable_stage2: bool = False,
-        pyramid_num_stages: int = 3,
-        pyramid_num_inference_steps_list: list | None = None,
-        is_skip_first_chunk: bool = False,
-        # DMD
-        is_amplify_first_chunk: bool = False,
-        # CFG Zero Star
-        use_cfg_zero_star: bool = False,
-        use_zero_init: bool = True,
-        zero_steps: int = 1,
-        **kwargs,
+        state: DiffusionRequestState,
     ) -> DiffusionOutput:
-        if pyramid_num_inference_steps_list is None:
-            pyramid_num_inference_steps_list = [10, 10, 10]
-        if history_sizes is None:
-            history_sizes = [16, 2, 1]
+        output = state.extra.get("decoded_output")
+        if output is None:
+            raise ValueError(f"Request {state.request_id} has not been decoded.")
+        if not isinstance(output, DiffusionOutput):
+            raise TypeError(f"Decoded output for request {state.request_id} must be a DiffusionOutput.")
+        return output
 
-        # Read Helios-specific params from extra_args
-        extra = getattr(req.sampling_params, "extra_args", {}) or {}
-        is_enable_stage2 = extra.get("is_enable_stage2", is_enable_stage2)
-        pyramid_num_stages = extra.get("pyramid_num_stages", pyramid_num_stages)
-        pyramid_num_inference_steps_list = extra.get(
-            "pyramid_num_inference_steps_list", pyramid_num_inference_steps_list
-        )
-        is_amplify_first_chunk = extra.get("is_amplify_first_chunk", is_amplify_first_chunk)
-        use_cfg_zero_star = extra.get("use_cfg_zero_star", use_cfg_zero_star)
-        use_zero_init = extra.get("use_zero_init", use_zero_init)
-        zero_steps = extra.get("zero_steps", zero_steps)
-        is_skip_first_chunk = extra.get("is_skip_first_chunk", is_skip_first_chunk)
-
-        image = extra.get("image", image)
-        video = extra.get("video", video)
-        add_noise_to_image_latents = extra.get("add_noise_to_image_latents", add_noise_to_image_latents)
-        image_noise_sigma_min = extra.get("image_noise_sigma_min", image_noise_sigma_min)
-        image_noise_sigma_max = extra.get("image_noise_sigma_max", image_noise_sigma_max)
-        add_noise_to_video_latents = extra.get("add_noise_to_video_latents", add_noise_to_video_latents)
-        video_noise_sigma_min = extra.get("video_noise_sigma_min", video_noise_sigma_min)
-        video_noise_sigma_max = extra.get("video_noise_sigma_max", video_noise_sigma_max)
-
-        if image is not None and video is not None:
-            raise ValueError("image and video cannot be provided simultaneously")
-
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
         if len(req.prompts) > 1:
             raise ValueError("This model only supports a single prompt, not a batched request.")
-        if len(req.prompts) == 1:
-            prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
-            negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
-
-        if prompt is None and prompt_embeds is None:
-            raise ValueError("Prompt or prompt_embeds is required for Helios generation.")
-
-        height = req.sampling_params.height or height
-        width = req.sampling_params.width or width
-        num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
-
-        if req.sampling_params.guidance_scale_provided:
-            guidance_scale = req.sampling_params.guidance_scale
-
-        self._guidance_scale = guidance_scale
-
-        height = (height // 16) * 16
-        width = (width // 16) * 16
-        num_frames = max(num_frames, 1)
-
-        device = self.device
-        dtype = self.transformer.dtype
-
-        if generator is None:
-            generator = req.sampling_params.generator
-        if generator is None and req.sampling_params.seed is not None:
-            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
-
-        # Encode prompts
-        if prompt_embeds is None:
-            prompt_embeds, negative_prompt_embeds = self.encode_prompt(
-                prompt=prompt,
-                negative_prompt=negative_prompt,
-                do_classifier_free_guidance=self.do_classifier_free_guidance,
-                num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
-                max_sequence_length=req.sampling_params.max_sequence_length or 226,
-                device=device,
-                dtype=dtype,
-            )
-        else:
-            prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
-            if negative_prompt_embeds is not None:
-                negative_prompt_embeds = negative_prompt_embeds.to(device=device, dtype=dtype)
-
-        batch_size = prompt_embeds.shape[0]
-
-        history_sizes = sorted(history_sizes, reverse=True)
-
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean)
-            .view(1, self.vae.config.z_dim, 1, 1, 1)
-            .to(self.vae.device, self.vae.dtype)
+        state = DiffusionRequestState(
+            request_id=req.request_id,
+            sampling=req.sampling_params,
+            prompt=req.prompts[0] if req.prompts else None,
+            kv_sender_info=req.kv_sender_info,
         )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
-            self.vae.device, self.vae.dtype
-        )
-
-        # Prepare I2V image latents
-        fake_image_latents = None
-        image_latents = None
-        if image is not None:
-            image_latents, fake_image_latents = self.prepare_image_latents(
-                image,
-                latents_mean=latents_mean,
-                latents_std=latents_std,
-                num_latent_frames_per_chunk=num_latent_frames_per_chunk,
-                dtype=torch.float32,
-                device=device,
-                generator=generator,
-            )
-
-        if image_latents is not None and add_noise_to_image_latents:
-            image_noise_sigma = (
-                torch.rand(1, device=device, generator=generator) * (image_noise_sigma_max - image_noise_sigma_min)
-                + image_noise_sigma_min
-            )
-            image_latents = (
-                image_noise_sigma * randn_tensor(image_latents.shape, generator=generator, device=device)
-                + (1 - image_noise_sigma) * image_latents
-            )
-            fake_image_noise_sigma = (
-                torch.rand(1, device=device, generator=generator) * (video_noise_sigma_max - video_noise_sigma_min)
-                + video_noise_sigma_min
-            )
-            fake_image_latents = (
-                fake_image_noise_sigma * randn_tensor(fake_image_latents.shape, generator=generator, device=device)
-                + (1 - fake_image_noise_sigma) * fake_image_latents
-            )
-
-        # Prepare V2V video latents
-        video_latents = None
-        if video is not None:
-            image_latents, video_latents = self.prepare_video_latents(
-                video,
-                latents_mean=latents_mean,
-                latents_std=latents_std,
-                num_latent_frames_per_chunk=num_latent_frames_per_chunk,
-                dtype=torch.float32,
-                device=device,
-                generator=generator,
-            )
-
-        if video_latents is not None and add_noise_to_video_latents:
-            image_noise_sigma = (
-                torch.rand(1, device=device, generator=generator) * (image_noise_sigma_max - image_noise_sigma_min)
-                + image_noise_sigma_min
-            )
-            image_latents = (
-                image_noise_sigma * randn_tensor(image_latents.shape, generator=generator, device=device)
-                + (1 - image_noise_sigma) * image_latents
-            )
-
-            noisy_latents_chunks = []
-            num_latent_chunks = video_latents.shape[2] // num_latent_frames_per_chunk
-            for i in range(num_latent_chunks):
-                chunk_start = i * num_latent_frames_per_chunk
-                chunk_end = chunk_start + num_latent_frames_per_chunk
-                latent_chunk = video_latents[:, :, chunk_start:chunk_end, :, :]
-                chunk_frames = latent_chunk.shape[2]
-                frame_sigmas = (
-                    torch.rand(chunk_frames, device=device, generator=generator)
-                    * (video_noise_sigma_max - video_noise_sigma_min)
-                    + video_noise_sigma_min
-                )
-                frame_sigmas = frame_sigmas.view(1, 1, chunk_frames, 1, 1)
-                noisy_chunk = (
-                    frame_sigmas * randn_tensor(latent_chunk.shape, generator=generator, device=device)
-                    + (1 - frame_sigmas) * latent_chunk
-                )
-                noisy_latents_chunks.append(noisy_chunk)
-            video_latents = torch.cat(noisy_latents_chunks, dim=2)
-
-        # Prepare latent variables
-        num_channels_latents = self.transformer.config.in_channels
-        window_num_frames = (num_latent_frames_per_chunk - 1) * self.vae_scale_factor_temporal + 1
-        num_latent_chunk = max(1, (num_frames + window_num_frames - 1) // window_num_frames)
-        num_history_latent_frames = sum(history_sizes)
-        history_video = None
-        total_generated_latent_frames = 0
-
-        if not keep_first_frame:
-            history_sizes[-1] = history_sizes[-1] + 1
-
-        history_latents = torch.zeros(
-            batch_size,
-            num_channels_latents,
-            num_history_latent_frames,
-            height // self.vae_scale_factor_spatial,
-            width // self.vae_scale_factor_spatial,
-            device=device,
-            dtype=torch.float32,
-        )
-
-        if fake_image_latents is not None:
-            history_latents = torch.cat([history_latents[:, :, :-1, :, :], fake_image_latents], dim=2)
-            total_generated_latent_frames += 1
-
-        if video_latents is not None:
-            history_frames = history_latents.shape[2]
-            video_frames = video_latents.shape[2]
-            if video_frames < history_frames:
-                keep_frames = history_frames - video_frames
-                history_latents = torch.cat([history_latents[:, :, :keep_frames, :, :], video_latents], dim=2)
-            else:
-                history_latents = video_latents
-            total_generated_latent_frames += video_latents.shape[2]
-
-        # Prepare frame indices
-        if keep_first_frame:
-            indices = torch.arange(0, sum([1, *history_sizes, num_latent_frames_per_chunk]))
-            (
-                indices_prefix,
-                indices_latents_history_long,
-                indices_latents_history_mid,
-                indices_latents_history_1x,
-                indices_hidden_states,
-            ) = indices.split([1, *history_sizes, num_latent_frames_per_chunk], dim=0)
-            indices_latents_history_short = torch.cat([indices_prefix, indices_latents_history_1x], dim=0)
-        else:
-            indices = torch.arange(0, sum([*history_sizes, num_latent_frames_per_chunk]))
-            (
-                indices_latents_history_long,
-                indices_latents_history_mid,
-                indices_latents_history_short,
-                indices_hidden_states,
-            ) = indices.split([*history_sizes, num_latent_frames_per_chunk], dim=0)
-
-        indices_hidden_states = indices_hidden_states.unsqueeze(0)
-        indices_latents_history_short = indices_latents_history_short.unsqueeze(0)
-        indices_latents_history_mid = indices_latents_history_mid.unsqueeze(0)
-        indices_latents_history_long = indices_latents_history_long.unsqueeze(0)
-
-        if attention_kwargs is None:
-            attention_kwargs = {}
-
-        vae_dtype = self.vae.dtype
-
-        # Chunked denoising loop
-        for k in range(num_latent_chunk):
-            is_first_chunk = k == 0
-            is_second_chunk = k == 1
-
-            if keep_first_frame:
-                latents_history_long, latents_history_mid, latents_history_1x = history_latents[
-                    :, :, -num_history_latent_frames:
-                ].split(history_sizes, dim=2)
-                if image_latents is None and is_first_chunk:
-                    latents_prefix = torch.zeros(
-                        (
-                            batch_size,
-                            num_channels_latents,
-                            1,
-                            latents_history_1x.shape[-2],
-                            latents_history_1x.shape[-1],
-                        ),
-                        device=latents_history_1x.device,
-                        dtype=latents_history_1x.dtype,
-                    )
-                else:
-                    latents_prefix = image_latents
-                latents_history_short = torch.cat([latents_prefix, latents_history_1x], dim=2)
-            else:
-                latents_history_long, latents_history_mid, latents_history_short = history_latents[
-                    :, :, -num_history_latent_frames:
-                ].split(history_sizes, dim=2)
-
-            # Prepare noise for this chunk
-            latents = self.prepare_latents(
-                batch_size,
-                num_channels_latents,
-                height,
-                width,
-                window_num_frames,
-                dtype=torch.float32,
-                device=device,
-                generator=generator,
-                latents=None,
-            )
-
-            if not is_enable_stage2:
-                # Stage 1 only: single-stage denoising
-                patch_size = self.transformer.config.patch_size
-                image_seq_len = (latents.shape[-1] * latents.shape[-2] * latents.shape[-3]) // (
-                    patch_size[0] * patch_size[1] * patch_size[2]
-                )
-                sigmas = np.linspace(0.999, 0.0, num_steps + 1)[:-1]
-                mu = calculate_shift(image_seq_len)
-                self.scheduler.set_timesteps(num_steps, device=device, sigmas=sigmas, mu=mu)
-                timesteps = self.scheduler.timesteps
-                self._num_timesteps = len(timesteps)
-
-                latents = self._stage1_sample(
-                    latents=latents,
-                    prompt_embeds=prompt_embeds,
-                    negative_prompt_embeds=negative_prompt_embeds,
-                    timesteps=timesteps,
-                    guidance_scale=guidance_scale,
-                    indices_hidden_states=indices_hidden_states,
-                    indices_latents_history_short=indices_latents_history_short,
-                    indices_latents_history_mid=indices_latents_history_mid,
-                    indices_latents_history_long=indices_latents_history_long,
-                    latents_history_short=latents_history_short,
-                    latents_history_mid=latents_history_mid,
-                    latents_history_long=latents_history_long,
-                    attention_kwargs=attention_kwargs,
-                    transformer_dtype=dtype,
-                    use_cfg_zero_star=use_cfg_zero_star,
-                    use_zero_init=use_zero_init,
-                    zero_steps=zero_steps,
-                )
-            else:
-                # Stage 2: pyramid multi-stage denoising
-                latents = self._stage2_sample(
-                    latents=latents,
-                    pyramid_num_stages=pyramid_num_stages,
-                    pyramid_num_inference_steps_list=pyramid_num_inference_steps_list,
-                    prompt_embeds=prompt_embeds,
-                    negative_prompt_embeds=negative_prompt_embeds,
-                    guidance_scale=guidance_scale,
-                    indices_hidden_states=indices_hidden_states,
-                    indices_latents_history_short=indices_latents_history_short,
-                    indices_latents_history_mid=indices_latents_history_mid,
-                    indices_latents_history_long=indices_latents_history_long,
-                    latents_history_short=latents_history_short,
-                    latents_history_mid=latents_history_mid,
-                    latents_history_long=latents_history_long,
-                    attention_kwargs=attention_kwargs,
-                    transformer_dtype=dtype,
-                    is_amplify_first_chunk=is_amplify_first_chunk and is_first_chunk,
-                    use_cfg_zero_star=use_cfg_zero_star,
-                    use_zero_init=use_zero_init,
-                    zero_steps=zero_steps,
-                    device=device,
-                    generator=generator,
-                )
-
-            if keep_first_frame and (
-                (is_first_chunk and image_latents is None) or (is_skip_first_chunk and is_second_chunk)
-            ):
-                image_latents = latents[:, :, 0:1, :, :]
-
-            total_generated_latent_frames += latents.shape[2]
-            history_latents = torch.cat([history_latents, latents], dim=2)
-            real_history_latents = history_latents[:, :, -total_generated_latent_frames:]
-            index_slice = (
-                slice(None),
-                slice(None),
-                slice(-num_latent_frames_per_chunk, None),
-            )
-
-            current_latents = real_history_latents[index_slice].to(vae_dtype) / latents_std + latents_mean
-            current_video = self.vae.decode(current_latents, return_dict=False)[0]
-
-            if history_video is None:
-                history_video = current_video
-            else:
-                history_video = torch.cat([history_video, current_video], dim=2)
-
-        if current_omni_platform.is_available():
-            current_omni_platform.empty_cache()
-        self._current_timestep = None
-
-        if output_type == "latent":
-            output = real_history_latents
-        else:
-            output = history_video
-
-        return DiffusionOutput(
-            output=output, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
-        )
-
-    def _stage1_sample(
-        self,
-        latents: torch.Tensor,
-        prompt_embeds: torch.Tensor,
-        negative_prompt_embeds: torch.Tensor | None,
-        timesteps: torch.Tensor,
-        guidance_scale: float,
-        indices_hidden_states: torch.Tensor,
-        indices_latents_history_short: torch.Tensor,
-        indices_latents_history_mid: torch.Tensor,
-        indices_latents_history_long: torch.Tensor,
-        latents_history_short: torch.Tensor,
-        latents_history_mid: torch.Tensor,
-        latents_history_long: torch.Tensor,
-        attention_kwargs: dict,
-        transformer_dtype: torch.dtype,
-        use_cfg_zero_star: bool = False,
-        use_zero_init: bool = True,
-        zero_steps: int = 1,
-    ) -> torch.Tensor:
-        """Single-stage denoising loop for one chunk."""
-        batch_size = latents.shape[0]
-        do_true_cfg = guidance_scale > 1.0 and negative_prompt_embeds is not None
-
-        with self.progress_bar(total=len(timesteps)) as pbar:
-            for i, t in enumerate(timesteps):
-                self._current_timestep = t
-                timestep = t.expand(batch_size)
-
-                transformer_kwargs = {
-                    "hidden_states": latents.to(transformer_dtype),
-                    "timestep": timestep,
-                    "indices_hidden_states": indices_hidden_states,
-                    "indices_latents_history_short": indices_latents_history_short,
-                    "indices_latents_history_mid": indices_latents_history_mid,
-                    "indices_latents_history_long": indices_latents_history_long,
-                    "latents_history_short": latents_history_short.to(transformer_dtype),
-                    "latents_history_mid": latents_history_mid.to(transformer_dtype),
-                    "latents_history_long": latents_history_long.to(transformer_dtype),
-                    "attention_kwargs": attention_kwargs,
-                    "return_dict": False,
-                }
-
-                if use_cfg_zero_star and do_true_cfg:
-                    noise_pred = self.transformer(
-                        encoder_hidden_states=prompt_embeds,
-                        **transformer_kwargs,
-                    )[0]
-
-                    noise_uncond = self.transformer(
-                        encoder_hidden_states=negative_prompt_embeds,
-                        **transformer_kwargs,
-                    )[0]
-
-                    positive_flat = noise_pred.view(batch_size, -1)
-                    negative_flat = noise_uncond.view(batch_size, -1)
-                    alpha_cfg = optimized_scale(positive_flat, negative_flat)
-                    alpha_cfg = alpha_cfg.view(batch_size, *([1] * (len(noise_pred.shape) - 1)))
-                    alpha_cfg = alpha_cfg.to(noise_pred.dtype)
-
-                    if (i <= zero_steps) and use_zero_init:
-                        noise_pred = noise_pred * 0.0
-                    else:
-                        noise_pred = noise_uncond * alpha_cfg + guidance_scale * (noise_pred - noise_uncond * alpha_cfg)
-                else:
-                    positive_kwargs = {
-                        "encoder_hidden_states": prompt_embeds,
-                        **transformer_kwargs,
-                    }
-                    if do_true_cfg:
-                        negative_kwargs = {
-                            "encoder_hidden_states": negative_prompt_embeds,
-                            **transformer_kwargs,
-                        }
-                    else:
-                        negative_kwargs = None
-
-                    noise_pred = self.predict_noise_maybe_with_cfg(
-                        do_true_cfg=do_true_cfg,
-                        true_cfg_scale=guidance_scale,
-                        positive_kwargs=positive_kwargs,
-                        negative_kwargs=negative_kwargs,
-                        cfg_normalize=False,
-                    )
-
-                latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
-
-                pbar.update()
-
-        return latents
-
-    def _stage2_sample(
-        self,
-        latents: torch.Tensor,
-        pyramid_num_stages: int,
-        pyramid_num_inference_steps_list: list[int],
-        prompt_embeds: torch.Tensor,
-        negative_prompt_embeds: torch.Tensor | None,
-        guidance_scale: float,
-        indices_hidden_states: torch.Tensor,
-        indices_latents_history_short: torch.Tensor,
-        indices_latents_history_mid: torch.Tensor,
-        indices_latents_history_long: torch.Tensor,
-        latents_history_short: torch.Tensor,
-        latents_history_mid: torch.Tensor,
-        latents_history_long: torch.Tensor,
-        attention_kwargs: dict,
-        transformer_dtype: torch.dtype,
-        is_amplify_first_chunk: bool = False,
-        use_cfg_zero_star: bool = False,
-        use_zero_init: bool = True,
-        zero_steps: int = 1,
-        device: torch.device | None = None,
-        generator: torch.Generator | list[torch.Generator] | None = None,
-    ) -> torch.Tensor:
-        """Pyramid multi-stage denoising for one chunk."""
-        batch_size, num_channel, num_frames_lat, height, width = latents.shape
-
-        # Downsample latents to the smallest pyramid level
-        latents_flat = latents.permute(0, 2, 1, 3, 4).reshape(batch_size * num_frames_lat, num_channel, height, width)
-        for _ in range(pyramid_num_stages - 1):
-            height //= 2
-            width //= 2
-            latents_flat = F.interpolate(latents_flat, size=(height, width), mode="bilinear") * 2
-        latents = latents_flat.reshape(batch_size, num_frames_lat, num_channel, height, width).permute(0, 2, 1, 3, 4)
-
-        start_point_list = None
-        if self.is_distilled:
-            start_point_list = [latents]
-
-        do_true_cfg = guidance_scale > 1.0 and negative_prompt_embeds is not None
-
-        for i_s in range(pyramid_num_stages):
-            patch_size = self.transformer.config.patch_size
-            image_seq_len = (latents.shape[-1] * latents.shape[-2] * latents.shape[-3]) // (
-                patch_size[0] * patch_size[1] * patch_size[2]
-            )
-            mu = calculate_shift(image_seq_len)
-            self.scheduler.set_timesteps(
-                pyramid_num_inference_steps_list[i_s],
-                stage_index=i_s,
-                device=device,
-                mu=mu,
-                is_amplify_first_chunk=is_amplify_first_chunk,
-            )
-            timesteps = self.scheduler.timesteps
-
-            if i_s > 0:
-                # Upsample latents to next pyramid level
-                height *= 2
-                width *= 2
-                num_frames_cur = latents.shape[2]
-                latents_flat = latents.permute(0, 2, 1, 3, 4).reshape(
-                    batch_size * num_frames_cur, num_channel, height // 2, width // 2
-                )
-                latents_flat = F.interpolate(latents_flat, size=(height, width), mode="nearest")
-                latents = latents_flat.reshape(batch_size, num_frames_cur, num_channel, height, width).permute(
-                    0, 2, 1, 3, 4
-                )
-
-                # Add block noise to fix artifacts between stages
-                ori_sigma = 1 - self.scheduler.ori_start_sigmas[i_s]
-                gamma = self.scheduler.config.gamma
-                alpha = 1 / (math.sqrt(1 + (1 / gamma)) * (1 - ori_sigma) + ori_sigma)
-                beta = alpha * (1 - ori_sigma) / math.sqrt(gamma)
-
-                noise = self.sample_block_noise(
-                    batch_size, num_channel, latents.shape[2], height, width, patch_size, generator=generator
-                )
-                noise = noise.to(device=device, dtype=transformer_dtype)
-                latents = alpha * latents + beta * noise
-
-                if self.is_distilled and start_point_list is not None:
-                    start_point_list.append(latents)
-
-            with self.progress_bar(total=len(timesteps)) as pbar:
-                for idx, t in enumerate(timesteps):
-                    self._current_timestep = t
-                    timestep = t.expand(latents.shape[0]).to(torch.int64)
-
-                    transformer_kwargs = {
-                        "hidden_states": latents.to(transformer_dtype),
-                        "timestep": timestep,
-                        "indices_hidden_states": indices_hidden_states,
-                        "indices_latents_history_short": indices_latents_history_short,
-                        "indices_latents_history_mid": indices_latents_history_mid,
-                        "indices_latents_history_long": indices_latents_history_long,
-                        "latents_history_short": latents_history_short.to(transformer_dtype),
-                        "latents_history_mid": latents_history_mid.to(transformer_dtype),
-                        "latents_history_long": latents_history_long.to(transformer_dtype),
-                        "attention_kwargs": attention_kwargs,
-                        "return_dict": False,
-                    }
-
-                    noise_pred = self.transformer(
-                        encoder_hidden_states=prompt_embeds,
-                        **transformer_kwargs,
-                    )[0]
-
-                    if do_true_cfg:
-                        noise_uncond = self.transformer(
-                            encoder_hidden_states=negative_prompt_embeds,
-                            **transformer_kwargs,
-                        )[0]
-
-                        if use_cfg_zero_star:
-                            positive_flat = noise_pred.view(batch_size, -1)
-                            negative_flat = noise_uncond.view(batch_size, -1)
-                            alpha_cfg = optimized_scale(positive_flat, negative_flat)
-                            alpha_cfg = alpha_cfg.view(batch_size, *([1] * (len(noise_pred.shape) - 1)))
-                            alpha_cfg = alpha_cfg.to(noise_pred.dtype)
-
-                            if (i_s == 0 and idx <= zero_steps) and use_zero_init:
-                                noise_pred = noise_pred * 0.0
-                            else:
-                                noise_pred = noise_uncond * alpha_cfg + guidance_scale * (
-                                    noise_pred - noise_uncond * alpha_cfg
-                                )
-                        else:
-                            noise_pred = noise_uncond + guidance_scale * (noise_pred - noise_uncond)
-
-                    latents = self.scheduler.step(
-                        noise_pred,
-                        t,
-                        latents,
-                        return_dict=False,
-                        cur_sampling_step=idx,
-                        dmd_noisy_tensor=start_point_list[i_s] if start_point_list is not None else None,
-                        dmd_sigmas=self.scheduler.sigmas,
-                        dmd_timesteps=self.scheduler.timesteps,
-                        all_timesteps=timesteps,
-                    )[0]
-
-                    pbar.update()
-
-        return latents
+        state = self.init_state(state)
+        state = self.check_inputs(state)
+        state = self.encode(state)
+        state = self.prepare(state)
+        while not state.request_denoise_completed:
+            state = self.diffuse(state)
+            state = self.decode(state)
+        return self.postprocess(state)
 
     def sample_block_noise(self, batch_size, channel, num_frames, height, width, patch_size=(1, 2, 2), generator=None):
         gamma = self.scheduler.config.gamma

--- a/vllm_omni/diffusion/models/helios/pipeline_helios.py
+++ b/vllm_omni/diffusion/models/helios/pipeline_helios.py
@@ -1139,23 +1139,648 @@ class HeliosPipeline(
             raise TypeError(f"Decoded output for request {state.request_id} must be a DiffusionOutput.")
         return output
 
-    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+    def forward(
+        self,
+        req: DiffusionRequestBatch,
+        prompt: str | None = None,
+        negative_prompt: str | None = None,
+        height: int = 384,
+        width: int = 640,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        frame_num: int = 132,
+        output_type: str | None = "np",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        prompt_embeds: torch.Tensor | None = None,
+        negative_prompt_embeds: torch.Tensor | None = None,
+        attention_kwargs: dict | None = None,
+        # Helios-specific
+        history_sizes: list | None = None,
+        num_latent_frames_per_chunk: int = 9,
+        keep_first_frame: bool = True,
+        # I2V
+        image: torch.Tensor | None = None,
+        add_noise_to_image_latents: bool = True,
+        image_noise_sigma_min: float = 0.111,
+        image_noise_sigma_max: float = 0.135,
+        # V2V
+        video: torch.Tensor | None = None,
+        add_noise_to_video_latents: bool = True,
+        video_noise_sigma_min: float = 0.111,
+        video_noise_sigma_max: float = 0.135,
+        # Stage 2 (pyramid multi-stage denoising)
+        is_enable_stage2: bool = False,
+        pyramid_num_stages: int = 3,
+        pyramid_num_inference_steps_list: list | None = None,
+        is_skip_first_chunk: bool = False,
+        # DMD
+        is_amplify_first_chunk: bool = False,
+        # CFG Zero Star
+        use_cfg_zero_star: bool = False,
+        use_zero_init: bool = True,
+        zero_steps: int = 1,
+        **kwargs,
+    ) -> DiffusionOutput:
+        if pyramid_num_inference_steps_list is None:
+            pyramid_num_inference_steps_list = [10, 10, 10]
+        if history_sizes is None:
+            history_sizes = [16, 2, 1]
+
+        # Read Helios-specific params from extra_args
+        extra = getattr(req.sampling_params, "extra_args", {}) or {}
+        is_enable_stage2 = extra.get("is_enable_stage2", is_enable_stage2)
+        pyramid_num_stages = extra.get("pyramid_num_stages", pyramid_num_stages)
+        pyramid_num_inference_steps_list = extra.get(
+            "pyramid_num_inference_steps_list", pyramid_num_inference_steps_list
+        )
+        is_amplify_first_chunk = extra.get("is_amplify_first_chunk", is_amplify_first_chunk)
+        use_cfg_zero_star = extra.get("use_cfg_zero_star", use_cfg_zero_star)
+        use_zero_init = extra.get("use_zero_init", use_zero_init)
+        zero_steps = extra.get("zero_steps", zero_steps)
+        is_skip_first_chunk = extra.get("is_skip_first_chunk", is_skip_first_chunk)
+
+        image = extra.get("image", image)
+        video = extra.get("video", video)
+        add_noise_to_image_latents = extra.get("add_noise_to_image_latents", add_noise_to_image_latents)
+        image_noise_sigma_min = extra.get("image_noise_sigma_min", image_noise_sigma_min)
+        image_noise_sigma_max = extra.get("image_noise_sigma_max", image_noise_sigma_max)
+        add_noise_to_video_latents = extra.get("add_noise_to_video_latents", add_noise_to_video_latents)
+        video_noise_sigma_min = extra.get("video_noise_sigma_min", video_noise_sigma_min)
+        video_noise_sigma_max = extra.get("video_noise_sigma_max", video_noise_sigma_max)
+
+        if image is not None and video is not None:
+            raise ValueError("image and video cannot be provided simultaneously")
+
         if len(req.prompts) > 1:
             raise ValueError("This model only supports a single prompt, not a batched request.")
-        state = DiffusionRequestState(
-            request_id=req.request_id,
-            sampling=req.sampling_params,
-            prompt=req.prompts[0] if req.prompts else None,
-            kv_sender_info=req.kv_sender_info,
+        if len(req.prompts) == 1:
+            prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
+            negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
+
+        if prompt is None and prompt_embeds is None:
+            raise ValueError("Prompt or prompt_embeds is required for Helios generation.")
+
+        height = req.sampling_params.height or height
+        width = req.sampling_params.width or width
+        num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
+        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+
+        if req.sampling_params.guidance_scale_provided:
+            guidance_scale = req.sampling_params.guidance_scale
+
+        self._guidance_scale = guidance_scale
+
+        height = (height // 16) * 16
+        width = (width // 16) * 16
+        num_frames = max(num_frames, 1)
+
+        device = self.device
+        dtype = self.transformer.dtype
+
+        if generator is None:
+            generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        # Encode prompts
+        if prompt_embeds is None:
+            prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=self.do_classifier_free_guidance,
+                num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
+                max_sequence_length=req.sampling_params.max_sequence_length or 226,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
+            if negative_prompt_embeds is not None:
+                negative_prompt_embeds = negative_prompt_embeds.to(device=device, dtype=dtype)
+
+        batch_size = prompt_embeds.shape[0]
+
+        history_sizes = sorted(history_sizes, reverse=True)
+
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(self.vae.device, self.vae.dtype)
         )
-        state = self.init_state(state)
-        state = self.check_inputs(state)
-        state = self.encode(state)
-        state = self.prepare(state)
-        while not state.request_denoise_completed:
-            state = self.diffuse(state)
-            state = self.decode(state)
-        return self.postprocess(state)
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            self.vae.device, self.vae.dtype
+        )
+
+        # Prepare I2V image latents
+        fake_image_latents = None
+        image_latents = None
+        if image is not None:
+            image_latents, fake_image_latents = self.prepare_image_latents(
+                image,
+                latents_mean=latents_mean,
+                latents_std=latents_std,
+                num_latent_frames_per_chunk=num_latent_frames_per_chunk,
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+            )
+
+        if image_latents is not None and add_noise_to_image_latents:
+            image_noise_sigma = (
+                torch.rand(1, device=device, generator=generator) * (image_noise_sigma_max - image_noise_sigma_min)
+                + image_noise_sigma_min
+            )
+            image_latents = (
+                image_noise_sigma * randn_tensor(image_latents.shape, generator=generator, device=device)
+                + (1 - image_noise_sigma) * image_latents
+            )
+            fake_image_noise_sigma = (
+                torch.rand(1, device=device, generator=generator) * (video_noise_sigma_max - video_noise_sigma_min)
+                + video_noise_sigma_min
+            )
+            fake_image_latents = (
+                fake_image_noise_sigma * randn_tensor(fake_image_latents.shape, generator=generator, device=device)
+                + (1 - fake_image_noise_sigma) * fake_image_latents
+            )
+
+        # Prepare V2V video latents
+        video_latents = None
+        if video is not None:
+            image_latents, video_latents = self.prepare_video_latents(
+                video,
+                latents_mean=latents_mean,
+                latents_std=latents_std,
+                num_latent_frames_per_chunk=num_latent_frames_per_chunk,
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+            )
+
+        if video_latents is not None and add_noise_to_video_latents:
+            image_noise_sigma = (
+                torch.rand(1, device=device, generator=generator) * (image_noise_sigma_max - image_noise_sigma_min)
+                + image_noise_sigma_min
+            )
+            image_latents = (
+                image_noise_sigma * randn_tensor(image_latents.shape, generator=generator, device=device)
+                + (1 - image_noise_sigma) * image_latents
+            )
+
+            noisy_latents_chunks = []
+            num_latent_chunks = video_latents.shape[2] // num_latent_frames_per_chunk
+            for i in range(num_latent_chunks):
+                chunk_start = i * num_latent_frames_per_chunk
+                chunk_end = chunk_start + num_latent_frames_per_chunk
+                latent_chunk = video_latents[:, :, chunk_start:chunk_end, :, :]
+                chunk_frames = latent_chunk.shape[2]
+                frame_sigmas = (
+                    torch.rand(chunk_frames, device=device, generator=generator)
+                    * (video_noise_sigma_max - video_noise_sigma_min)
+                    + video_noise_sigma_min
+                )
+                frame_sigmas = frame_sigmas.view(1, 1, chunk_frames, 1, 1)
+                noisy_chunk = (
+                    frame_sigmas * randn_tensor(latent_chunk.shape, generator=generator, device=device)
+                    + (1 - frame_sigmas) * latent_chunk
+                )
+                noisy_latents_chunks.append(noisy_chunk)
+            video_latents = torch.cat(noisy_latents_chunks, dim=2)
+
+        # Prepare latent variables
+        num_channels_latents = self.transformer.config.in_channels
+        window_num_frames = (num_latent_frames_per_chunk - 1) * self.vae_scale_factor_temporal + 1
+        num_latent_chunk = max(1, (num_frames + window_num_frames - 1) // window_num_frames)
+        num_history_latent_frames = sum(history_sizes)
+        history_video = None
+        total_generated_latent_frames = 0
+
+        if not keep_first_frame:
+            history_sizes[-1] = history_sizes[-1] + 1
+
+        history_latents = torch.zeros(
+            batch_size,
+            num_channels_latents,
+            num_history_latent_frames,
+            height // self.vae_scale_factor_spatial,
+            width // self.vae_scale_factor_spatial,
+            device=device,
+            dtype=torch.float32,
+        )
+
+        if fake_image_latents is not None:
+            history_latents = torch.cat([history_latents[:, :, :-1, :, :], fake_image_latents], dim=2)
+            total_generated_latent_frames += 1
+
+        if video_latents is not None:
+            history_frames = history_latents.shape[2]
+            video_frames = video_latents.shape[2]
+            if video_frames < history_frames:
+                keep_frames = history_frames - video_frames
+                history_latents = torch.cat([history_latents[:, :, :keep_frames, :, :], video_latents], dim=2)
+            else:
+                history_latents = video_latents
+            total_generated_latent_frames += video_latents.shape[2]
+
+        # Prepare frame indices
+        if keep_first_frame:
+            indices = torch.arange(0, sum([1, *history_sizes, num_latent_frames_per_chunk]))
+            (
+                indices_prefix,
+                indices_latents_history_long,
+                indices_latents_history_mid,
+                indices_latents_history_1x,
+                indices_hidden_states,
+            ) = indices.split([1, *history_sizes, num_latent_frames_per_chunk], dim=0)
+            indices_latents_history_short = torch.cat([indices_prefix, indices_latents_history_1x], dim=0)
+        else:
+            indices = torch.arange(0, sum([*history_sizes, num_latent_frames_per_chunk]))
+            (
+                indices_latents_history_long,
+                indices_latents_history_mid,
+                indices_latents_history_short,
+                indices_hidden_states,
+            ) = indices.split([*history_sizes, num_latent_frames_per_chunk], dim=0)
+
+        indices_hidden_states = indices_hidden_states.unsqueeze(0)
+        indices_latents_history_short = indices_latents_history_short.unsqueeze(0)
+        indices_latents_history_mid = indices_latents_history_mid.unsqueeze(0)
+        indices_latents_history_long = indices_latents_history_long.unsqueeze(0)
+
+        if attention_kwargs is None:
+            attention_kwargs = {}
+
+        vae_dtype = self.vae.dtype
+
+        # Chunked denoising loop
+        for k in range(num_latent_chunk):
+            is_first_chunk = k == 0
+            is_second_chunk = k == 1
+
+            if keep_first_frame:
+                latents_history_long, latents_history_mid, latents_history_1x = history_latents[
+                    :, :, -num_history_latent_frames:
+                ].split(history_sizes, dim=2)
+                if image_latents is None and is_first_chunk:
+                    latents_prefix = torch.zeros(
+                        (
+                            batch_size,
+                            num_channels_latents,
+                            1,
+                            latents_history_1x.shape[-2],
+                            latents_history_1x.shape[-1],
+                        ),
+                        device=latents_history_1x.device,
+                        dtype=latents_history_1x.dtype,
+                    )
+                else:
+                    latents_prefix = image_latents
+                latents_history_short = torch.cat([latents_prefix, latents_history_1x], dim=2)
+            else:
+                latents_history_long, latents_history_mid, latents_history_short = history_latents[
+                    :, :, -num_history_latent_frames:
+                ].split(history_sizes, dim=2)
+
+            # Prepare noise for this chunk
+            latents = self.prepare_latents(
+                batch_size,
+                num_channels_latents,
+                height,
+                width,
+                window_num_frames,
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+                latents=None,
+            )
+
+            if not is_enable_stage2:
+                # Stage 1 only: single-stage denoising
+                patch_size = self.transformer.config.patch_size
+                image_seq_len = (latents.shape[-1] * latents.shape[-2] * latents.shape[-3]) // (
+                    patch_size[0] * patch_size[1] * patch_size[2]
+                )
+                sigmas = np.linspace(0.999, 0.0, num_steps + 1)[:-1]
+                mu = calculate_shift(image_seq_len)
+                self.scheduler.set_timesteps(num_steps, device=device, sigmas=sigmas, mu=mu)
+                timesteps = self.scheduler.timesteps
+                self._num_timesteps = len(timesteps)
+
+                latents = self._stage1_sample(
+                    latents=latents,
+                    prompt_embeds=prompt_embeds,
+                    negative_prompt_embeds=negative_prompt_embeds,
+                    timesteps=timesteps,
+                    guidance_scale=guidance_scale,
+                    indices_hidden_states=indices_hidden_states,
+                    indices_latents_history_short=indices_latents_history_short,
+                    indices_latents_history_mid=indices_latents_history_mid,
+                    indices_latents_history_long=indices_latents_history_long,
+                    latents_history_short=latents_history_short,
+                    latents_history_mid=latents_history_mid,
+                    latents_history_long=latents_history_long,
+                    attention_kwargs=attention_kwargs,
+                    transformer_dtype=dtype,
+                    use_cfg_zero_star=use_cfg_zero_star,
+                    use_zero_init=use_zero_init,
+                    zero_steps=zero_steps,
+                )
+            else:
+                # Stage 2: pyramid multi-stage denoising
+                latents = self._stage2_sample(
+                    latents=latents,
+                    pyramid_num_stages=pyramid_num_stages,
+                    pyramid_num_inference_steps_list=pyramid_num_inference_steps_list,
+                    prompt_embeds=prompt_embeds,
+                    negative_prompt_embeds=negative_prompt_embeds,
+                    guidance_scale=guidance_scale,
+                    indices_hidden_states=indices_hidden_states,
+                    indices_latents_history_short=indices_latents_history_short,
+                    indices_latents_history_mid=indices_latents_history_mid,
+                    indices_latents_history_long=indices_latents_history_long,
+                    latents_history_short=latents_history_short,
+                    latents_history_mid=latents_history_mid,
+                    latents_history_long=latents_history_long,
+                    attention_kwargs=attention_kwargs,
+                    transformer_dtype=dtype,
+                    is_amplify_first_chunk=is_amplify_first_chunk and is_first_chunk,
+                    use_cfg_zero_star=use_cfg_zero_star,
+                    use_zero_init=use_zero_init,
+                    zero_steps=zero_steps,
+                    device=device,
+                    generator=generator,
+                )
+
+            if keep_first_frame and (
+                (is_first_chunk and image_latents is None) or (is_skip_first_chunk and is_second_chunk)
+            ):
+                image_latents = latents[:, :, 0:1, :, :]
+
+            total_generated_latent_frames += latents.shape[2]
+            history_latents = torch.cat([history_latents, latents], dim=2)
+            real_history_latents = history_latents[:, :, -total_generated_latent_frames:]
+            index_slice = (
+                slice(None),
+                slice(None),
+                slice(-num_latent_frames_per_chunk, None),
+            )
+
+            current_latents = real_history_latents[index_slice].to(vae_dtype) / latents_std + latents_mean
+            current_video = self.vae.decode(current_latents, return_dict=False)[0]
+
+            if history_video is None:
+                history_video = current_video
+            else:
+                history_video = torch.cat([history_video, current_video], dim=2)
+
+        if current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+        self._current_timestep = None
+
+        if output_type == "latent":
+            output = real_history_latents
+        else:
+            output = history_video
+
+        return DiffusionOutput(
+            output=output, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
+        )
+
+    def _stage1_sample(
+        self,
+        latents: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        timesteps: torch.Tensor,
+        guidance_scale: float,
+        indices_hidden_states: torch.Tensor,
+        indices_latents_history_short: torch.Tensor,
+        indices_latents_history_mid: torch.Tensor,
+        indices_latents_history_long: torch.Tensor,
+        latents_history_short: torch.Tensor,
+        latents_history_mid: torch.Tensor,
+        latents_history_long: torch.Tensor,
+        attention_kwargs: dict,
+        transformer_dtype: torch.dtype,
+        use_cfg_zero_star: bool = False,
+        use_zero_init: bool = True,
+        zero_steps: int = 1,
+    ) -> torch.Tensor:
+        """Single-stage denoising loop for one chunk."""
+        batch_size = latents.shape[0]
+        do_true_cfg = guidance_scale > 1.0 and negative_prompt_embeds is not None
+
+        with self.progress_bar(total=len(timesteps)) as pbar:
+            for i, t in enumerate(timesteps):
+                self._current_timestep = t
+                timestep = t.expand(batch_size)
+
+                transformer_kwargs = {
+                    "hidden_states": latents.to(transformer_dtype),
+                    "timestep": timestep,
+                    "indices_hidden_states": indices_hidden_states,
+                    "indices_latents_history_short": indices_latents_history_short,
+                    "indices_latents_history_mid": indices_latents_history_mid,
+                    "indices_latents_history_long": indices_latents_history_long,
+                    "latents_history_short": latents_history_short.to(transformer_dtype),
+                    "latents_history_mid": latents_history_mid.to(transformer_dtype),
+                    "latents_history_long": latents_history_long.to(transformer_dtype),
+                    "attention_kwargs": attention_kwargs,
+                    "return_dict": False,
+                }
+
+                if use_cfg_zero_star and do_true_cfg:
+                    noise_pred = self.transformer(
+                        encoder_hidden_states=prompt_embeds,
+                        **transformer_kwargs,
+                    )[0]
+
+                    noise_uncond = self.transformer(
+                        encoder_hidden_states=negative_prompt_embeds,
+                        **transformer_kwargs,
+                    )[0]
+
+                    positive_flat = noise_pred.view(batch_size, -1)
+                    negative_flat = noise_uncond.view(batch_size, -1)
+                    alpha_cfg = optimized_scale(positive_flat, negative_flat)
+                    alpha_cfg = alpha_cfg.view(batch_size, *([1] * (len(noise_pred.shape) - 1)))
+                    alpha_cfg = alpha_cfg.to(noise_pred.dtype)
+
+                    if (i <= zero_steps) and use_zero_init:
+                        noise_pred = noise_pred * 0.0
+                    else:
+                        noise_pred = noise_uncond * alpha_cfg + guidance_scale * (noise_pred - noise_uncond * alpha_cfg)
+                else:
+                    positive_kwargs = {
+                        "encoder_hidden_states": prompt_embeds,
+                        **transformer_kwargs,
+                    }
+                    if do_true_cfg:
+                        negative_kwargs = {
+                            "encoder_hidden_states": negative_prompt_embeds,
+                            **transformer_kwargs,
+                        }
+                    else:
+                        negative_kwargs = None
+
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_true_cfg,
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=False,
+                    )
+
+                latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+
+                pbar.update()
+
+        return latents
+
+    def _stage2_sample(
+        self,
+        latents: torch.Tensor,
+        pyramid_num_stages: int,
+        pyramid_num_inference_steps_list: list[int],
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        guidance_scale: float,
+        indices_hidden_states: torch.Tensor,
+        indices_latents_history_short: torch.Tensor,
+        indices_latents_history_mid: torch.Tensor,
+        indices_latents_history_long: torch.Tensor,
+        latents_history_short: torch.Tensor,
+        latents_history_mid: torch.Tensor,
+        latents_history_long: torch.Tensor,
+        attention_kwargs: dict,
+        transformer_dtype: torch.dtype,
+        is_amplify_first_chunk: bool = False,
+        use_cfg_zero_star: bool = False,
+        use_zero_init: bool = True,
+        zero_steps: int = 1,
+        device: torch.device | None = None,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+    ) -> torch.Tensor:
+        """Pyramid multi-stage denoising for one chunk."""
+        batch_size, num_channel, num_frames_lat, height, width = latents.shape
+
+        # Downsample latents to the smallest pyramid level
+        latents_flat = latents.permute(0, 2, 1, 3, 4).reshape(batch_size * num_frames_lat, num_channel, height, width)
+        for _ in range(pyramid_num_stages - 1):
+            height //= 2
+            width //= 2
+            latents_flat = F.interpolate(latents_flat, size=(height, width), mode="bilinear") * 2
+        latents = latents_flat.reshape(batch_size, num_frames_lat, num_channel, height, width).permute(0, 2, 1, 3, 4)
+
+        start_point_list = None
+        if self.is_distilled:
+            start_point_list = [latents]
+
+        do_true_cfg = guidance_scale > 1.0 and negative_prompt_embeds is not None
+
+        for i_s in range(pyramid_num_stages):
+            patch_size = self.transformer.config.patch_size
+            image_seq_len = (latents.shape[-1] * latents.shape[-2] * latents.shape[-3]) // (
+                patch_size[0] * patch_size[1] * patch_size[2]
+            )
+            mu = calculate_shift(image_seq_len)
+            self.scheduler.set_timesteps(
+                pyramid_num_inference_steps_list[i_s],
+                stage_index=i_s,
+                device=device,
+                mu=mu,
+                is_amplify_first_chunk=is_amplify_first_chunk,
+            )
+            timesteps = self.scheduler.timesteps
+
+            if i_s > 0:
+                # Upsample latents to next pyramid level
+                height *= 2
+                width *= 2
+                num_frames_cur = latents.shape[2]
+                latents_flat = latents.permute(0, 2, 1, 3, 4).reshape(
+                    batch_size * num_frames_cur, num_channel, height // 2, width // 2
+                )
+                latents_flat = F.interpolate(latents_flat, size=(height, width), mode="nearest")
+                latents = latents_flat.reshape(batch_size, num_frames_cur, num_channel, height, width).permute(
+                    0, 2, 1, 3, 4
+                )
+
+                # Add block noise to fix artifacts between stages
+                ori_sigma = 1 - self.scheduler.ori_start_sigmas[i_s]
+                gamma = self.scheduler.config.gamma
+                alpha = 1 / (math.sqrt(1 + (1 / gamma)) * (1 - ori_sigma) + ori_sigma)
+                beta = alpha * (1 - ori_sigma) / math.sqrt(gamma)
+
+                noise = self.sample_block_noise(
+                    batch_size, num_channel, latents.shape[2], height, width, patch_size, generator=generator
+                )
+                noise = noise.to(device=device, dtype=transformer_dtype)
+                latents = alpha * latents + beta * noise
+
+                if self.is_distilled and start_point_list is not None:
+                    start_point_list.append(latents)
+
+            with self.progress_bar(total=len(timesteps)) as pbar:
+                for idx, t in enumerate(timesteps):
+                    self._current_timestep = t
+                    timestep = t.expand(latents.shape[0]).to(torch.int64)
+
+                    transformer_kwargs = {
+                        "hidden_states": latents.to(transformer_dtype),
+                        "timestep": timestep,
+                        "indices_hidden_states": indices_hidden_states,
+                        "indices_latents_history_short": indices_latents_history_short,
+                        "indices_latents_history_mid": indices_latents_history_mid,
+                        "indices_latents_history_long": indices_latents_history_long,
+                        "latents_history_short": latents_history_short.to(transformer_dtype),
+                        "latents_history_mid": latents_history_mid.to(transformer_dtype),
+                        "latents_history_long": latents_history_long.to(transformer_dtype),
+                        "attention_kwargs": attention_kwargs,
+                        "return_dict": False,
+                    }
+
+                    noise_pred = self.transformer(
+                        encoder_hidden_states=prompt_embeds,
+                        **transformer_kwargs,
+                    )[0]
+
+                    if do_true_cfg:
+                        noise_uncond = self.transformer(
+                            encoder_hidden_states=negative_prompt_embeds,
+                            **transformer_kwargs,
+                        )[0]
+
+                        if use_cfg_zero_star:
+                            positive_flat = noise_pred.view(batch_size, -1)
+                            negative_flat = noise_uncond.view(batch_size, -1)
+                            alpha_cfg = optimized_scale(positive_flat, negative_flat)
+                            alpha_cfg = alpha_cfg.view(batch_size, *([1] * (len(noise_pred.shape) - 1)))
+                            alpha_cfg = alpha_cfg.to(noise_pred.dtype)
+
+                            if (i_s == 0 and idx <= zero_steps) and use_zero_init:
+                                noise_pred = noise_pred * 0.0
+                            else:
+                                noise_pred = noise_uncond * alpha_cfg + guidance_scale * (
+                                    noise_pred - noise_uncond * alpha_cfg
+                                )
+                        else:
+                            noise_pred = noise_uncond + guidance_scale * (noise_pred - noise_uncond)
+
+                    latents = self.scheduler.step(
+                        noise_pred,
+                        t,
+                        latents,
+                        return_dict=False,
+                        cur_sampling_step=idx,
+                        dmd_noisy_tensor=start_point_list[i_s] if start_point_list is not None else None,
+                        dmd_sigmas=self.scheduler.sigmas,
+                        dmd_timesteps=self.scheduler.timesteps,
+                        all_timesteps=timesteps,
+                    )[0]
+
+                    pbar.update()
+
+        return latents
 
     def sample_block_noise(self, batch_size, channel, num_frames, height, width, patch_size=(1, 2, 2), generator=None):
         gamma = self.scheduler.config.gamma

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -24,14 +24,23 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import (
+    StageBoundary,
+    StagePayload,
+    SupportImageInput,
+    SupportsComponentDiscovery,
+)
+from vllm_omni.diffusion.models.step_mixin import DiffusionV2CFGStepMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
     DiffusionPipelineProfilerMixin,
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 from vllm_omni.inputs.data import OmniTextPrompt
-from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import Siglip2VisionTransformer
+from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import (
+    Siglip2VisionTransformer,
+)
 
 from .hunyuan_image3_tokenizer import TokenizerEncodeOutput, TokenizerWrapper
 from .hunyuan_image3_transformer import (
@@ -54,7 +63,6 @@ from .system_prompt import get_system_prompt
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.worker.input_batch import InputBatch
-    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 logger = logging.getLogger(__name__)
 
@@ -62,14 +70,46 @@ BatchRaggedImages = torch.Tensor | list[torch.Tensor | list[torch.Tensor]]
 BatchRaggedTensor = torch.Tensor | list[torch.Tensor]
 
 _STEP_MODEL_KWARGS = "hunyuan_model_kwargs"
+_STEP_MODEL_KWARGS_STRUCTURE = "hunyuan_model_kwargs_structure"
 _STEP_INPUT_IDS = "hunyuan_input_ids"
 _STEP_GENERATOR = "hunyuan_generator"
 _STEP_GUIDANCE_SCALE = "hunyuan_guidance_scale"
 _STEP_CFG_FACTOR = "hunyuan_cfg_factor"
 _STEP_OUTPUT_SIZE = "hunyuan_output_size"
+_STEP_OUTPUT_TYPE = "hunyuan_output_type"
+_STEP_NUM_INFERENCE_STEPS = "hunyuan_num_inference_steps"
 _STEP_COT_TEXT_LIST = "hunyuan_cot_text_list"
 _STEP_AR_KV = "hunyuan_ar_kv"
+_STEP_AR_KV_STRUCTURE = "hunyuan_ar_kv_structure"
 _STEP_PROMPT_KV = "hunyuan_prompt_kv"
+_STEP_TENSOR_TREE_PREFIX = "hunyuan_tensor_tree:"
+_STEP_TENSOR_TREE_REF = "__hunyuan_tensor_ref__"
+_STEP_TENSOR_TREE_TUPLE = "__hunyuan_tuple__"
+_STEP_MODEL_KWARGS_PAYLOAD_KEYS = (
+    "ar_kv_data",
+    "ar_kv_reuse_len",
+    "ar_kv_reuse_offset",
+    "attention_mask",
+    "cond_timestep",
+    "cond_timestep_scatter_index",
+    "cond_vae_image_mask",
+    "cond_vae_images",
+    "cond_vit_image_mask",
+    "cond_vit_images",
+    "custom_pos_emb",
+    "full_attn_spans",
+    "gen_timestep_scatter_index",
+    "image_mask",
+    "mode",
+    "num_image_tokens",
+    "past_key_values",
+    "position_ids",
+    "prefill_step",
+    "query_lens",
+    "seq_lens",
+    "use_cache",
+    "vit_kwargs",
+)
 
 
 def default(val, d):
@@ -337,6 +377,7 @@ class HunyuanImage3Pipeline(
     HunyuanImage3PreTrainedModel,
     GenerationMixin,
     SupportImageInput,
+    DiffusionV2CFGStepMixin,
     SupportsComponentDiscovery,
     DiffusionPipelineProfilerMixin,
 ):
@@ -346,6 +387,207 @@ class HunyuanImage3Pipeline(
     _dit_modules: ClassVar[list[str]] = ["model"]
     _encoder_modules: ClassVar[list[str]] = ["vision_model"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+    stage_payload_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.DIT_TO_DECODE: ("latents",),
+    }
+    stage_payload_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: ("do_true_cfg",),
+    }
+    stage_payload_private_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (_STEP_INPUT_IDS,),
+    }
+    stage_payload_private_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            _STEP_GENERATOR,
+            _STEP_GUIDANCE_SCALE,
+            _STEP_CFG_FACTOR,
+            _STEP_OUTPUT_SIZE,
+            _STEP_OUTPUT_TYPE,
+            _STEP_NUM_INFERENCE_STEPS,
+            _STEP_COT_TEXT_LIST,
+        ),
+        StageBoundary.DIT_TO_DECODE: (
+            _STEP_GENERATOR,
+            _STEP_OUTPUT_TYPE,
+            _STEP_COT_TEXT_LIST,
+        ),
+    }
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        def state_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: getattr(state, name) for name in field_names if getattr(state, name, None) is not None}
+
+        def extra_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: state.extra[name] for name in field_names if name in state.extra}
+
+        def extra_tensor_fields(
+            field_names: tuple[str, ...],
+        ) -> dict[str, torch.Tensor]:
+            tensors: dict[str, torch.Tensor] = {}
+            for name in field_names:
+                if name not in state.extra:
+                    continue
+                value = state.extra[name]
+                if value is None:
+                    continue
+                if not torch.is_tensor(value):
+                    raise TypeError(f"Hunyuan private tensor field {name!r} must be a torch.Tensor.")
+                tensors[name] = value
+            return tensors
+
+        private_scalar_fields = extra_fields(self.stage_payload_private_scalar_fields.get(boundary, ()))
+        private_tensor_fields = extra_tensor_fields(self.stage_payload_private_tensor_fields.get(boundary, ()))
+        if boundary is StageBoundary.ENCODE_TO_DIT:
+            if _STEP_MODEL_KWARGS in state.extra:
+                private_scalar_fields[_STEP_MODEL_KWARGS_STRUCTURE] = self._pack_model_kwargs_structure(
+                    state,
+                    private_tensor_fields,
+                )
+            if _STEP_AR_KV in state.extra and state.extra[_STEP_AR_KV] is not None:
+                private_scalar_fields[_STEP_AR_KV_STRUCTURE] = self._flatten_tensor_tree(
+                    _STEP_AR_KV,
+                    state.extra[_STEP_AR_KV],
+                    private_tensor_fields,
+                )
+
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields=state_fields(self.stage_payload_scalar_fields.get(boundary, ())),
+            tensor_fields=state_fields(self.stage_payload_tensor_fields.get(boundary, ())),
+            private_scalar_fields=private_scalar_fields,
+            private_tensor_fields=private_tensor_fields,
+        )
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if payload.request_id != state.request_id:
+            raise ValueError(
+                f"StagePayload request_id {payload.request_id!r} does not match state {state.request_id!r}."
+            )
+        if payload.boundary not in (
+            StageBoundary.ENCODE_TO_DIT,
+            StageBoundary.DIT_TO_DECODE,
+        ):
+            raise ValueError(f"Unsupported stage payload boundary: {payload.boundary!r}.")
+        for name, value in payload.scalar_fields.items():
+            setattr(state, name, value)
+        for name, value in payload.tensor_fields.items():
+            setattr(state, name, value)
+        tensor_tree_fields = {
+            name: value
+            for name, value in payload.private_tensor_fields.items()
+            if name.startswith(_STEP_TENSOR_TREE_PREFIX)
+        }
+        private_tensor_fields = {
+            name: value
+            for name, value in payload.private_tensor_fields.items()
+            if not name.startswith(_STEP_TENSOR_TREE_PREFIX)
+        }
+        state.extra.update(payload.private_scalar_fields)
+        state.extra.update(private_tensor_fields)
+        if _STEP_MODEL_KWARGS_STRUCTURE in state.extra:
+            state.extra[_STEP_MODEL_KWARGS] = self._restore_tensor_tree(
+                state.extra.pop(_STEP_MODEL_KWARGS_STRUCTURE),
+                tensor_tree_fields,
+            )
+            if _STEP_GENERATOR in state.extra:
+                state.extra[_STEP_MODEL_KWARGS]["generator"] = state.extra[_STEP_GENERATOR]
+        if _STEP_AR_KV_STRUCTURE in state.extra:
+            state.extra[_STEP_AR_KV] = self._restore_tensor_tree(
+                state.extra.pop(_STEP_AR_KV_STRUCTURE),
+                tensor_tree_fields,
+            )
+        if _STEP_OUTPUT_TYPE in state.extra:
+            state.sampling.output_type = state.extra[_STEP_OUTPUT_TYPE]
+        return state
+
+    def _flatten_tensor_tree(
+        self,
+        path: str,
+        value: Any,
+        tensor_fields: dict[str, torch.Tensor],
+    ) -> Any:
+        if torch.is_tensor(value):
+            key = f"{_STEP_TENSOR_TREE_PREFIX}{path}"
+            tensor_fields[key] = value
+            return {_STEP_TENSOR_TREE_REF: key}
+        if isinstance(value, tuple):
+            return {
+                _STEP_TENSOR_TREE_TUPLE: [
+                    self._flatten_tensor_tree(f"{path}.{i}", item, tensor_fields) for i, item in enumerate(value)
+                ]
+            }
+        if isinstance(value, list):
+            return [self._flatten_tensor_tree(f"{path}.{i}", item, tensor_fields) for i, item in enumerate(value)]
+        if isinstance(value, dict):
+            return {key: self._flatten_tensor_tree(f"{path}.{key}", item, tensor_fields) for key, item in value.items()}
+        return value
+
+    def _restore_tensor_tree(
+        self,
+        structure: Any,
+        tensor_fields: dict[str, torch.Tensor],
+    ) -> Any:
+        if isinstance(structure, dict):
+            if set(structure) == {_STEP_TENSOR_TREE_REF}:
+                key = structure[_STEP_TENSOR_TREE_REF]
+                if key not in tensor_fields:
+                    raise ValueError(f"Missing Hunyuan tensor payload field {key!r}.")
+                return tensor_fields[key]
+            if set(structure) == {_STEP_TENSOR_TREE_TUPLE}:
+                return tuple(
+                    self._restore_tensor_tree(item, tensor_fields) for item in structure[_STEP_TENSOR_TREE_TUPLE]
+                )
+            return {key: self._restore_tensor_tree(item, tensor_fields) for key, item in structure.items()}
+        if isinstance(structure, list):
+            return [self._restore_tensor_tree(item, tensor_fields) for item in structure]
+        return structure
+
+    def _full_attn_spans_from_tokenizer_output(
+        self,
+        input_ids: torch.Tensor,
+        tokenizer_output: TokenizerEncodeOutput,
+    ) -> list[list[tuple[int, int]]]:
+        seq_len = input_ids.shape[1]
+        batch_image_slices = [
+            tokenizer_output.joint_image_slices[i] + tokenizer_output.gen_image_slices[i]
+            for i in range(input_ids.shape[0])
+        ]
+        full_attn_spans: list[list[tuple[int, int]]] = [[] for _ in range(input_ids.shape[0])]
+        for i, image_slices in enumerate(batch_image_slices):
+            for image_slice in image_slices:
+                start = image_slice.start if image_slice.start is not None else 0
+                stop = image_slice.stop if image_slice.stop is not None else seq_len
+                assert start < stop, f"Invalid image slice: {image_slice}"
+                full_attn_spans[i].append((int(start), int(stop)))
+            if full_attn_spans[i]:
+                full_attn_spans[i].sort(key=lambda x: x[0])
+        return full_attn_spans
+
+    def _pack_model_kwargs_structure(
+        self,
+        state: DiffusionRequestState,
+        tensor_fields: dict[str, torch.Tensor],
+    ) -> Any:
+        model_kwargs = state.extra[_STEP_MODEL_KWARGS]
+        payload_kwargs = {key: model_kwargs[key] for key in _STEP_MODEL_KWARGS_PAYLOAD_KEYS if key in model_kwargs}
+        if "full_attn_spans" not in payload_kwargs and "tokenizer_output" in model_kwargs:
+            input_ids = state.extra[_STEP_INPUT_IDS]
+            payload_kwargs["full_attn_spans"] = self._full_attn_spans_from_tokenizer_output(
+                input_ids,
+                model_kwargs["tokenizer_output"],
+            )
+        if "tokenizer_output" in model_kwargs:
+            payload_kwargs["prefill_step"] = True
+        return self._flatten_tensor_tree(_STEP_MODEL_KWARGS, payload_kwargs, tensor_fields)
 
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
@@ -486,6 +728,10 @@ class HunyuanImage3Pipeline(
             self._pipeline = HunyuanImage3Text2ImagePipeline(model=self, scheduler=self.scheduler, vae=self.vae)
         return self._pipeline
 
+    @property
+    def interrupt(self) -> bool:
+        return getattr(self, "_interrupt", False)
+
     def _validate_step_request(self, state: "DiffusionRequestState") -> None:
         prompt = state.prompt
         sampling = state.sampling
@@ -580,7 +826,13 @@ class HunyuanImage3Pipeline(
             if not allow_cond_image or not any(has_cond_image):
                 batch_cond_image_info = None
 
-        return prompt, cot_text_list, system_prompt, batch_cond_image_info, tokenizer_bot_task
+        return (
+            prompt,
+            cot_text_list,
+            system_prompt,
+            batch_cond_image_info,
+            tokenizer_bot_task,
+        )
 
     def _extract_step_prompt_inputs(
         self,
@@ -591,10 +843,12 @@ class HunyuanImage3Pipeline(
             [state.prompt] if state.prompt is not None else [],
             getattr(sampling, "extra_args", {}) or {},
             request_id=state.request_id,
-            allow_cond_image=False,
+            allow_cond_image=True,
         )
 
-    def _snapshot_injected_ar_kv(self) -> list[list[tuple[torch.Tensor, torch.Tensor]] | None] | None:
+    def _snapshot_injected_ar_kv(
+        self,
+    ) -> list[list[tuple[torch.Tensor, torch.Tensor]] | None] | None:
         snapshot: list[list[tuple[torch.Tensor, torch.Tensor]] | None] = []
         found = False
         for layer in self.model.layers:
@@ -1151,7 +1405,7 @@ class HunyuanImage3Pipeline(
         return cond_vae_images, cond_t, batch_cond_vit_images
 
     @staticmethod
-    def check_inputs(prompt=None, message_list=None):
+    def _check_prompt_inputs(prompt=None, message_list=None):
         if prompt is None and message_list is None:
             raise ValueError("Either `prompt` or `message_list` should be provided.")
         if prompt is not None and message_list is not None:
@@ -1208,7 +1462,7 @@ class HunyuanImage3Pipeline(
         **kwargs,
     ):
         # 1. Sanity check
-        self.check_inputs(prompt, message_list)
+        self._check_prompt_inputs(prompt, message_list)
         device = default(device, self.device)
 
         # 2. Format inputs
@@ -1410,23 +1664,16 @@ class HunyuanImage3Pipeline(
         # attention and image tokens use full attention.
         bsz, seq_len = inputs_tensor.shape
         device = inputs_tensor.device
-        tokenizer_output = model_kwargs["tokenizer_output"]
-        batch_image_slices = [
-            tokenizer_output.joint_image_slices[i] + tokenizer_output.gen_image_slices[i] for i in range(bsz)
-        ]
+        full_attn_spans = model_kwargs.get("full_attn_spans")
+        if full_attn_spans is None:
+            tokenizer_output = model_kwargs["tokenizer_output"]
+            full_attn_spans = self._full_attn_spans_from_tokenizer_output(inputs_tensor, tokenizer_output)
         attention_mask = (
             torch.ones(seq_len, seq_len, dtype=torch.bool, device=device).tril(diagonal=0).repeat(bsz, 1, 1)
         )
-        full_attn_spans: list[list[tuple[int, int]]] = [[] for _ in range(bsz)]
         for i in range(bsz):
-            for j, image_slice in enumerate(batch_image_slices[i]):
-                attention_mask[i, image_slice, image_slice] = True
-                start = image_slice.start if image_slice.start is not None else 0
-                stop = image_slice.stop if image_slice.stop is not None else seq_len
-                assert start < stop, f"Invalid image slice: {image_slice}"
-                full_attn_spans[i].append((int(start), int(stop)))
-            if full_attn_spans[i]:
-                full_attn_spans[i].sort(key=lambda x: x[0])
+            for start, stop in full_attn_spans[i]:
+                attention_mask[i, start:stop, start:stop] = True
         attention_mask = attention_mask.unsqueeze(1)
         model_kwargs["full_attn_spans"] = full_attn_spans
         return attention_mask
@@ -1485,6 +1732,7 @@ class HunyuanImage3Pipeline(
         is_encoder_decoder: bool = False,
         num_new_tokens: int = 1,
     ) -> dict[str, Any]:
+        del is_encoder_decoder, num_new_tokens
         mode = model_kwargs["mode"]
 
         updated_model_kwargs = {
@@ -1506,8 +1754,11 @@ class HunyuanImage3Pipeline(
                 updated_model_kwargs[cache_name] = getattr(outputs, possible_cache_name)
                 break
 
-        if "tokenizer_output" in model_kwargs:
+        is_prefill_step = "tokenizer_output" in model_kwargs or bool(model_kwargs.get("prefill_step"))
+        if is_prefill_step:
             if mode == "gen_text":
+                if "tokenizer_output" not in model_kwargs:
+                    raise ValueError("Hunyuan gen_text prefill requires tokenizer_output.")
                 # When enable batching, we use right padding, which requires a real_pos to index the valid
                 # end position of the sequence. If tokenizer_output in model_kwargs, it means we are in the
                 # prefill step of generation.
@@ -1530,9 +1781,15 @@ class HunyuanImage3Pipeline(
                 current_starts = timestep_position_ids.reshape(-1)
                 max_current_start = int(current_starts.max().item())
                 for attention_mask_i, position_ids_i, current_start_i in zip(
-                    model_kwargs["attention_mask"], updated_model_kwargs["position_ids"], current_starts
+                    model_kwargs["attention_mask"],
+                    updated_model_kwargs["position_ids"],
+                    current_starts,
                 ):
-                    query_mask = torch.index_select(attention_mask_i, dim=1, index=position_ids_i.reshape(-1) - offset)
+                    query_mask = torch.index_select(
+                        attention_mask_i,
+                        dim=1,
+                        index=position_ids_i.reshape(-1) - offset,
+                    )
                     current_start = int(current_start_i.item())
                     prefix_mask = torch.index_select(
                         query_mask,
@@ -1562,46 +1819,6 @@ class HunyuanImage3Pipeline(
                 updated_model_kwargs["gen_timestep_scatter_index"] = model_kwargs["gen_timestep_scatter_index"]
 
         return updated_model_kwargs
-
-    def _generate(
-        self,
-        generator: list[torch.Generator] | None = None,
-        **kwargs,
-    ):
-        mode = kwargs.get("mode", "gen_text")
-        # verbose > 1 not support
-        if mode == "gen_text":
-            raise NotImplementedError("Not support gen text for hunyuan image")
-
-        elif mode == "gen_image":
-            batch_gen_image_info: list[ImageInfo] = kwargs.get("batch_gen_image_info")
-            if batch_gen_image_info is None:
-                raise ValueError("`batch_gen_image_info` should be provided when `mode` is `gen_image`.")
-
-            image_info: ImageInfo = batch_gen_image_info[0]
-            num_image_tokens = (
-                image_info.image_token_length
-                + (1 if image_info.add_timestep_token else 0)
-                + (1 if image_info.add_guidance_token else 0)
-            )
-            kwargs["num_image_tokens"] = num_image_tokens
-            # 50 and 5.0 hard code
-            results = self.pipeline(
-                batch_size=len(batch_gen_image_info),
-                image_size=[
-                    batch_gen_image_info[0].image_height,
-                    batch_gen_image_info[0].image_width,
-                ],
-                num_inference_steps=kwargs.get("num_inference_steps", 50),
-                guidance_scale=kwargs.get("guidance_scale", 5.0),
-                generator=generator,
-                model_kwargs=kwargs,
-            )
-            samples = results[0]
-            return samples
-
-        else:
-            raise ValueError(f"Unknown mode {mode}, only `gen_text` and `gen_image` are supported.")
 
     @staticmethod
     def _check_inputs(cond, target, check_list):
@@ -1800,27 +2017,6 @@ class HunyuanImage3Pipeline(
             k, v = kv["key"], kv["value"]
             cache_mgr._injected_ar_kv = [(k[:positive_reuse_len], v[:positive_reuse_len])]
 
-    def _extract_ar_kv_from_request(self, req) -> dict[str, Any]:
-        kv = getattr(getattr(req, "sampling_params", None), "past_key_values", None)
-        if kv is None:
-            return {}
-        key_cache = getattr(kv, "key_cache", None)
-        value_cache = getattr(kv, "value_cache", None)
-        if not key_cache or not value_cache:
-            return {}
-        ar_kv_data = {
-            i: {"key": k, "value": v}
-            for i, (k, v) in enumerate(zip(key_cache, value_cache))
-            if k is not None and v is not None
-        }
-        if not ar_kv_data:
-            return {}
-        logger.info(
-            f"[AR KV Reuse] Extracted {len(ar_kv_data)} layers of AR KV, "
-            f"each with length: {next(iter(ar_kv_data.values()))['key'].shape}"
-        )
-        return {"ar_kv_data": ar_kv_data}
-
     def _extract_ar_kv_from_sampling(self, sampling: Any) -> dict[str, Any]:
         kv = getattr(sampling, "past_key_values", None)
         if kv is None:
@@ -1836,12 +2032,18 @@ class HunyuanImage3Pipeline(
         }
         return {"ar_kv_data": ar_kv_data} if ar_kv_data else {}
 
-    def prepare_encode(
+    def check_inputs(
         self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> "DiffusionRequestState":
-        del kwargs
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        self._validate_step_request(state)
+        self._extract_step_prompt_inputs(state)
+        return state
+
+    def encode(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
         self._validate_step_request(state)
         pipe = self.pipeline
         sampling = state.sampling
@@ -1894,6 +2096,39 @@ class HunyuanImage3Pipeline(
             + (1 if image_info.add_guidance_token else 0)
         )
         model_kwargs["num_image_tokens"] = num_image_tokens
+        state.do_true_cfg = guidance_scale > 1.0
+        state.extra.update(
+            {
+                _STEP_MODEL_KWARGS: model_kwargs,
+                _STEP_INPUT_IDS: input_ids,
+                _STEP_GENERATOR: model_kwargs["generator"],
+                _STEP_GUIDANCE_SCALE: guidance_scale,
+                _STEP_CFG_FACTOR: 1 + int(guidance_scale > 1.0),
+                _STEP_OUTPUT_SIZE: (target_height, target_width),
+                _STEP_OUTPUT_TYPE: sampling.output_type or "pil",
+                _STEP_NUM_INFERENCE_STEPS: num_inference_steps,
+                _STEP_COT_TEXT_LIST: cot_text_list,
+            }
+        )
+        return state
+
+    def prepare(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if _STEP_MODEL_KWARGS not in state.extra:
+            raise ValueError(f"Missing Hunyuan model kwargs for request {state.request_id}.")
+        if _STEP_INPUT_IDS not in state.extra:
+            raise ValueError(f"Missing Hunyuan input ids for request {state.request_id}.")
+        if _STEP_OUTPUT_SIZE not in state.extra:
+            raise ValueError(f"Missing Hunyuan output size for request {state.request_id}.")
+
+        pipe = self.pipeline
+        model_kwargs = state.extra[_STEP_MODEL_KWARGS]
+        input_ids = state.extra[_STEP_INPUT_IDS]
+        target_height, target_width = state.extra[_STEP_OUTPUT_SIZE]
+        num_inference_steps = state.extra[_STEP_NUM_INFERENCE_STEPS]
+        guidance_scale = state.extra[_STEP_GUIDANCE_SCALE]
 
         timesteps, _ = retrieve_timesteps(
             self.scheduler,
@@ -1937,22 +2172,15 @@ class HunyuanImage3Pipeline(
             device=self.device,
         )
         model_kwargs["ar_kv_reuse_len"] = ar_kv_reuse_len
+        state.extra[_STEP_AR_KV] = self._snapshot_injected_ar_kv()
 
         state.latents = latents
         state.timesteps = timesteps
         state.step_index = 0
         state.scheduler = req_scheduler
-        state.do_true_cfg = guidance_scale > 1.0
-        state.extra = {
-            _STEP_MODEL_KWARGS: model_kwargs,
-            _STEP_INPUT_IDS: input_ids,
-            _STEP_GENERATOR: model_kwargs["generator"],
-            _STEP_GUIDANCE_SCALE: guidance_scale,
-            _STEP_CFG_FACTOR: 1 + int(guidance_scale > 1.0),
-            _STEP_OUTPUT_SIZE: (target_height, target_width),
-            _STEP_COT_TEXT_LIST: cot_text_list,
-            _STEP_AR_KV: self._snapshot_injected_ar_kv(),
-        }
+        state.extra[_STEP_MODEL_KWARGS] = model_kwargs
+        state.extra[_STEP_INPUT_IDS] = input_ids
+        state.extra[_STEP_GENERATOR] = model_kwargs["generator"]
         return state
 
     def _step_group_key(self, state: "DiffusionRequestState") -> tuple[Any, ...]:
@@ -2006,7 +2234,9 @@ class HunyuanImage3Pipeline(
         return row_state_indexes, row_branches
 
     @staticmethod
-    def _validate_step_group_states(states: list["DiffusionRequestState"]) -> tuple[bool, int]:
+    def _validate_step_group_states(
+        states: list["DiffusionRequestState"],
+    ) -> tuple[bool, int]:
         if not states:
             raise ValueError("HunyuanImage3 denoise_step received an empty group.")
 
@@ -2182,10 +2412,10 @@ class HunyuanImage3Pipeline(
         state: "DiffusionRequestState",
         noise_pred: torch.Tensor,
         **kwargs: Any,
-    ) -> None:
+    ) -> DiffusionRequestState:
         del kwargs
         if getattr(self, "interrupt", False):
-            return
+            return state
         generator = state.extra.get(_STEP_GENERATOR)
         step_kwargs = self.pipeline.prepare_extra_func_kwargs(state.scheduler.step, {"generator": generator})
         latent_dtype = state.latents.dtype
@@ -2197,21 +2427,22 @@ class HunyuanImage3Pipeline(
             return_dict=False,
         )[0].to(dtype=latent_dtype)
         state.step_index += 1
+        return state
 
-    def post_decode(
+    def decode(
         self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> DiffusionOutput:
-        output_type = kwargs.get("output_type", "pil")
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        output_type = state.extra.get(_STEP_OUTPUT_TYPE, state.sampling.output_type or "pil")
         generator = state.extra.get(_STEP_GENERATOR)
         latents = state.latents
         if output_type == "latent":
-            return DiffusionOutput(
+            state.extra["decoded_output"] = DiffusionOutput(
                 output=latents,
                 custom_output={},
                 stage_durations=getattr(self, "stage_durations", None),
             )
+            return state
 
         if hasattr(self.vae.config, "scaling_factor") and self.vae.config.scaling_factor:
             latents = latents / self.vae.config.scaling_factor
@@ -2235,79 +2466,39 @@ class HunyuanImage3Pipeline(
         custom_output = {}
         if any(text is not None for text in cot_text_list):
             custom_output["ar_generated_text"] = cot_text_list[0]
-        return DiffusionOutput(
+        state.extra["decoded_output"] = DiffusionOutput(
             output=image[0],
             custom_output=custom_output,
             stage_durations=getattr(self, "stage_durations", None),
         )
+        return state
 
-    def forward(
+    def postprocess(
         self,
-        req: DiffusionRequestBatch,
-        prompt: str | list[str] = "",
-        image_size="auto",
-        height: int = 1024,
-        width: int = 1024,
-        num_inference_steps: int = 50,
-        guidance_scale: float = 5.0,
-        generator: torch.Generator | list[torch.Generator] | None = None,
-        **kwargs,
+        state: DiffusionRequestState,
     ) -> DiffusionOutput:
-        extra_args = getattr(getattr(req, "sampling_params", None), "extra_args", {}) or {}
-        (
-            prompt_from_req,
-            cot_text_list,
-            system_prompt,
-            batch_cond_image_info,
-            tokenizer_bot_task,
-        ) = self._extract_prompt_inputs(
-            req.prompts,
-            extra_args,
+        output = state.extra.get("decoded_output")
+        if output is None:
+            raise ValueError(f"Request {state.request_id} has not been decoded.")
+        if not isinstance(output, DiffusionOutput):
+            raise TypeError(f"Decoded output for request {state.request_id} must be a DiffusionOutput.")
+        return output
+
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        if len(req.prompts) > 1:
+            logger.warning(
+                "This model only supports a single prompt, not a batched request. Taking only the first prompt for now."
+            )
+        state = DiffusionRequestState(
             request_id=req.request_id,
-            allow_cond_image=True,
+            sampling=req.sampling_params,
+            prompt=req.prompts[0],
+            kv_sender_info=req.kv_sender_info,
         )
-        prompt = prompt_from_req or prompt
-        cot_text = (
-            [self._normalize_cot_text(t) for t in cot_text_list] if any(t is not None for t in cot_text_list) else None
-        )
-
-        generator = req.sampling_params.generator or generator
-        height = req.sampling_params.height or height
-        width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-        if req.sampling_params.guidance_scale_provided:
-            guidance_scale = req.sampling_params.guidance_scale
-        if guidance_scale <= 1.0:
-            logger.info("HunyuanImage3.0 runs without classifier-free guidance when guidance_scale <= 1.0.")
-        image_size = (height, width)
-
-        # ---- AR KV Reuse: extract injected KV from request ----
-        ar_kv_kwargs = self._extract_ar_kv_from_request(req)
-
-        model_inputs = self.prepare_model_inputs(
-            prompt=prompt,
-            cot_text=cot_text,
-            system_prompt=system_prompt,
-            mode="gen_image",
-            generator=generator,
-            image_size=image_size,
-            num_inference_steps=num_inference_steps,
-            guidance_scale=guidance_scale,
-            batch_cond_image_info=batch_cond_image_info,
-            bot_task=tokenizer_bot_task,
-            **ar_kv_kwargs,
-        )
-
-        model_inputs.update(ar_kv_kwargs)
-
-        outputs = self._generate(**model_inputs, **kwargs)
-        image = outputs[0]
-        custom_output = {}
-        if any(t is not None for t in cot_text_list):
-            custom_output["ar_generated_text"] = cot_text_list[0] if len(cot_text_list) == 1 else cot_text_list
-        stage_durations = self.stage_durations if hasattr(self, "stage_durations") else None
-        return DiffusionOutput(
-            output=image,
-            custom_output=custom_output,
-            stage_durations=stage_durations,
-        )
+        state = self.init_state(state)
+        state = self.check_inputs(state)
+        state = self.encode(state)
+        state = self.prepare(state)
+        state = self.diffuse(state)
+        state = self.decode(state)
+        return self.postprocess(state)

--- a/vllm_omni/diffusion/models/interface.py
+++ b/vllm_omni/diffusion/models/interface.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     Literal,
     Protocol,
@@ -42,32 +42,101 @@ class SupportAudioOutput(Protocol):
     support_audio_output: ClassVar[bool] = True
 
 
-@runtime_checkable
-class SupportsStepExecution(Protocol):
-    """State-driven step-level execution protocol for diffusion pipelines.
+class StageBoundary(str, Enum):
+    ENCODE_TO_DIT = "encode_to_dit"
+    DIT_TO_DECODE = "dit_to_decode"
 
-    Pipelines should split request-level ``forward()`` into:
-    ``prepare_encode()`` (one-time request setup), ``denoise_step()``
-    (one denoise forward), ``step_scheduler()`` (one scheduler update),
-    and ``post_decode()`` (final decode).
-    """
+
+@dataclass
+class StagePayload:
+    request_id: str
+    boundary: StageBoundary
+    scalar_fields: dict[str, object]
+    tensor_fields: dict[str, "torch.Tensor"]
+    private_scalar_fields: dict[str, object]
+    private_tensor_fields: dict[str, "torch.Tensor"]
+    payload_version: int = 1
+
+
+@runtime_checkable
+class DiffusionV2Atoms(Protocol):
+    """State-based diffusion atoms shared by request mode and step mode."""
 
     supports_step_execution: ClassVar[bool] = True
 
-    def prepare_encode(self, state: DiffusionRequestState, **kwargs: Any) -> DiffusionRequestState:
-        """Prepare request-level inputs and return initialized state."""
+    def init_state(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Initialize pipeline-private fields on a newly created request state."""
         ...
 
-    def denoise_step(self, input_batch: InputBatch, **kwargs: Any) -> torch.Tensor | None:
-        """Run one denoise forward on the runner-assembled batch."""
+    def check_inputs(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Validate request inputs before model work begins."""
         ...
 
-    def step_scheduler(self, state: DiffusionRequestState, noise_pred: torch.Tensor, **kwargs: Any) -> None:
-        """Run one scheduler step."""
+    def encode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Run text/input encoders and populate encoded prompt fields."""
         ...
 
-    def post_decode(self, state: DiffusionRequestState, **kwargs: Any) -> DiffusionOutput:
-        """Decode output after denoise loop or at a partial chunk boundary."""
+    def prepare(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Prepare model-specific denoise state after encode."""
+        ...
+
+    def diffuse(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Run the full diffusion loop for request-mode/golden-path execution."""
+        ...
+
+    def decode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Decode raw latent state into the model output representation."""
+        ...
+
+    def postprocess(self, state: DiffusionRequestState) -> DiffusionOutput:
+        """Apply model-specific output post-processing and return final output."""
+        ...
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        """Pack state for a stage boundary without exposing model-private schema to the runner."""
+        ...
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        """Apply a received stage payload to an existing request state."""
+        ...
+
+    def build_step_batch(
+        self,
+        states: list[DiffusionRequestState],
+        *,
+        cached_batch: InputBatch | None = None,
+    ) -> InputBatch:
+        """Build the runner-visible step batch for one scheduler tick."""
+        ...
+
+    def build_step_attention_metadata(
+        self,
+        input_batch: InputBatch,
+    ) -> object | None:
+        """Build optional forward-context attention metadata for the step batch."""
+        ...
+
+    def denoise_step(
+        self,
+        input_batch: InputBatch,
+    ) -> torch.Tensor | None:
+        """Run one DiT denoise step on the runner-assembled batch."""
+        ...
+
+    def step_scheduler(
+        self,
+        state: DiffusionRequestState,
+        noise_pred: torch.Tensor,
+    ) -> DiffusionRequestState:
+        """Apply one scheduler step to a request-local state."""
         ...
 
 
@@ -97,6 +166,9 @@ class SupportsComponentDiscovery(Protocol):
 
 
 def supports_step_execution(pipeline: object) -> bool:
-    """Return whether `pipeline` implements :class:`SupportsStepExecution`."""
+    """Return whether `pipeline` implements the v2 step atom contract."""
 
-    return isinstance(pipeline, SupportsStepExecution)
+    return getattr(pipeline, "supports_step_execution", False) is True and isinstance(
+        pipeline,
+        DiffusionV2Atoms,
+    )

--- a/vllm_omni/diffusion/models/interface.py
+++ b/vllm_omni/diffusion/models/interface.py
@@ -52,9 +52,9 @@ class StagePayload:
     request_id: str
     boundary: StageBoundary
     scalar_fields: dict[str, object]
-    tensor_fields: dict[str, "torch.Tensor"]
+    tensor_fields: dict[str, torch.Tensor]
     private_scalar_fields: dict[str, object]
-    private_tensor_fields: dict[str, "torch.Tensor"]
+    private_tensor_fields: dict[str, torch.Tensor]
     payload_version: int = 1
 
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -50,7 +50,6 @@ from vllm_omni.diffusion.utils.size_utils import (
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.diffusion.worker.utils import DiffusionRequestState
-
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -727,9 +726,7 @@ class QwenImagePipeline(
             return value.unsqueeze(0)
         if value.ndim == target_ndim:
             return value
-        raise ValueError(
-            f"Expected prompt tensor with ndim {target_ndim - 1} or {target_ndim}, got {value.ndim}."
-        )
+        raise ValueError(f"Expected prompt tensor with ndim {target_ndim - 1} or {target_ndim}, got {value.ndim}.")
 
     def _state_generation_context(self, state: DiffusionRequestState) -> dict[str, Any]:
         sampling = state.sampling

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import copy
 import inspect
 import json
 import logging
 import math
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -28,7 +27,11 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
-from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import (
+    StageBoundary,
+    StagePayload,
+    SupportsComponentDiscovery,
+)
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -36,6 +39,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.step_mixin import DiffusionV2CFGStepMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
@@ -44,11 +48,8 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
-from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
-
-if TYPE_CHECKING:
-    from vllm_omni.diffusion.worker.input_batch import InputBatch
-    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -253,7 +254,11 @@ def apply_rotary_emb_qwen(
 
 
 class QwenImagePipeline(
-    nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    DiffusionV2CFGStepMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     supports_request_batch = True
     _dit_modules: ClassVar[list[str]] = ["transformer"]
@@ -261,6 +266,84 @@ class QwenImagePipeline(
     _vae_modules: ClassVar[list[str]] = ["vae"]
 
     supports_step_execution: ClassVar[bool] = True
+    stage_payload_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "prompt_embeds",
+            "prompt_embeds_mask",
+            "negative_prompt_embeds",
+            "negative_prompt_embeds_mask",
+        ),
+        StageBoundary.DIT_TO_DECODE: ("latents",),
+    }
+    stage_payload_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "do_true_cfg",
+            "img_shapes",
+            "txt_seq_lens",
+            "negative_txt_seq_lens",
+        ),
+    }
+    stage_payload_private_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {}
+    stage_payload_private_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "cfg_normalize",
+            "decode_height",
+            "decode_width",
+            "guidance_scale",
+            "num_inference_steps",
+            "output_type",
+            "sigmas",
+            "true_cfg_scale",
+        ),
+        StageBoundary.DIT_TO_DECODE: ("decode_height", "decode_width", "output_type"),
+    }
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        def state_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: getattr(state, name) for name in field_names if getattr(state, name, None) is not None}
+
+        def extra_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: state.extra[name] for name in field_names if name in state.extra}
+
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields=state_fields(self.stage_payload_scalar_fields.get(boundary, ())),
+            tensor_fields=state_fields(self.stage_payload_tensor_fields.get(boundary, ())),
+            private_scalar_fields=extra_fields(self.stage_payload_private_scalar_fields.get(boundary, ())),
+            private_tensor_fields=extra_fields(self.stage_payload_private_tensor_fields.get(boundary, ())),
+        )
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if payload.request_id != state.request_id:
+            raise ValueError(
+                f"StagePayload request_id {payload.request_id!r} does not match state {state.request_id!r}."
+            )
+        if payload.boundary not in (StageBoundary.ENCODE_TO_DIT, StageBoundary.DIT_TO_DECODE):
+            raise ValueError(f"Unsupported stage payload boundary: {payload.boundary!r}.")
+        for name, value in payload.scalar_fields.items():
+            setattr(state, name, value)
+        for name, value in payload.tensor_fields.items():
+            setattr(state, name, value)
+        state.extra.update(payload.private_scalar_fields)
+        state.extra.update(payload.private_tensor_fields)
+        if "cfg_normalize" in state.extra:
+            state.sampling.cfg_normalize = bool(state.extra["cfg_normalize"])
+        if "true_cfg_scale" in state.extra:
+            state.sampling.true_cfg_scale = state.extra["true_cfg_scale"]
+        if "output_type" in state.extra:
+            state.sampling.output_type = state.extra["output_type"]
+        if "sigmas" in state.extra:
+            state.sampling.sigmas = state.extra["sigmas"]
+        return state
 
     def __init__(
         self,
@@ -357,7 +440,7 @@ class QwenImagePipeline(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
 
-    def check_inputs(
+    def _check_generation_inputs(
         self,
         prompt,
         height,
@@ -634,51 +717,98 @@ class QwenImagePipeline(
             negative_prompt = None
         return prompt, negative_prompt
 
-    def _prepare_generation_context(
-        self,
-        *,
-        prompt,
-        negative_prompt,
-        height,
-        width,
-        num_inference_steps,
-        sigmas,
-        guidance_scale,
-        num_images_per_prompt,
-        generator,
-        true_cfg_scale,
-        max_sequence_length,
-        prompt_embeds=None,
-        prompt_embeds_mask=None,
-        negative_prompt_embeds=None,
-        negative_prompt_embeds_mask=None,
-        latents=None,
-        attention_kwargs=None,
-        callback_on_step_end_tensor_inputs=None,
-    ):
-        """Shared preparation logic for forward() and prepare_encode().
-
-        Validates inputs, encodes prompts, prepares latents, computes timesteps,
-        and returns all intermediate values as a dict.
-        """
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            negative_prompt,
-            prompt_embeds,
-            negative_prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds_mask,
-            callback_on_step_end_tensor_inputs,
-            max_sequence_length,
+    @staticmethod
+    def _normalize_single_prompt_tensor(value: object | None, *, target_ndim: int) -> torch.Tensor | None:
+        if value is None:
+            return None
+        if not torch.is_tensor(value):
+            raise TypeError(f"Expected prompt tensor with ndim {target_ndim}, got {type(value)!r}.")
+        if value.ndim == target_ndim - 1:
+            return value.unsqueeze(0)
+        if value.ndim == target_ndim:
+            return value
+        raise ValueError(
+            f"Expected prompt tensor with ndim {target_ndim - 1} or {target_ndim}, got {value.ndim}."
         )
 
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = attention_kwargs or {}
-        self._current_timestep = None
-        self._interrupt = False
+    def _state_generation_context(self, state: DiffusionRequestState) -> dict[str, Any]:
+        sampling = state.sampling
+        prompt, negative_prompt = self._extract_prompts([state.prompt] if state.prompt is not None else [])
+        prompt_embeds = None
+        prompt_embeds_mask = None
+        negative_prompt_embeds = None
+        negative_prompt_embeds_mask = None
+        if state.prompt is not None:
+            prompt_embeds = DiffusionRequestBatch.get_prompt_field(state.prompt, "prompt_embeds")
+            prompt_embeds_mask = DiffusionRequestBatch.get_prompt_field(state.prompt, "prompt_embeds_mask")
+            negative_prompt_embeds = DiffusionRequestBatch.get_prompt_field(state.prompt, "negative_prompt_embeds")
+            negative_prompt_embeds_mask = DiffusionRequestBatch.get_prompt_field(
+                state.prompt,
+                "negative_prompt_embeds_mask",
+            )
+        prompt_embeds = self._normalize_single_prompt_tensor(prompt_embeds, target_ndim=3)
+        prompt_embeds_mask = self._normalize_single_prompt_tensor(prompt_embeds_mask, target_ndim=2)
+        negative_prompt_embeds = self._normalize_single_prompt_tensor(negative_prompt_embeds, target_ndim=3)
+        negative_prompt_embeds_mask = self._normalize_single_prompt_tensor(negative_prompt_embeds_mask, target_ndim=2)
+        if prompt_embeds is not None:
+            prompt = None
+        if negative_prompt_embeds is not None:
+            negative_prompt = None
 
+        height = sampling.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling.width or self.default_sample_size * self.vae_scale_factor
+        height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
+        return {
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "height": height,
+            "width": width,
+            "num_inference_steps": sampling.num_inference_steps or 50,
+            "sigmas": sampling.sigmas,
+            "guidance_scale": sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
+            "num_images_per_prompt": sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
+            "generator": sampling.generator,
+            "true_cfg_scale": sampling.true_cfg_scale or 4.0,
+            "max_sequence_length": sampling.max_sequence_length or self.tokenizer_max_length,
+            "prompt_embeds": prompt_embeds,
+            "prompt_embeds_mask": prompt_embeds_mask,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
+            "latents": sampling.latents,
+            "attention_kwargs": {},
+            "callback_on_step_end_tensor_inputs": ["latents"],
+            "output_type": sampling.output_type or "pil",
+        }
+
+    def check_inputs(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        context = self._state_generation_context(state)
+        self._check_generation_inputs(
+            context["prompt"],
+            context["height"],
+            context["width"],
+            context["negative_prompt"],
+            context["prompt_embeds"],
+            context["negative_prompt_embeds"],
+            context["prompt_embeds_mask"],
+            context["negative_prompt_embeds_mask"],
+            context["callback_on_step_end_tensor_inputs"],
+            context["max_sequence_length"],
+        )
+        return state
+
+    def encode(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        context = self._state_generation_context(state)
+        self._guidance_scale = context["guidance_scale"]
+        self._attention_kwargs = context["attention_kwargs"]
+
+        prompt = context["prompt"]
+        prompt_embeds = context["prompt_embeds"]
         if prompt is not None and isinstance(prompt, str):
             batch_size = 1
         elif prompt is not None and isinstance(prompt, list):
@@ -688,124 +818,101 @@ class QwenImagePipeline(
         else:
             batch_size = 1
 
-        has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+        has_neg_prompt = context["negative_prompt"] is not None or (
+            context["negative_prompt_embeds"] is not None and context["negative_prompt_embeds_mask"] is not None
         )
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+        do_true_cfg = context["true_cfg_scale"] > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(context["true_cfg_scale"], has_neg_prompt)
 
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
-            prompt=prompt,
-            prompt_embeds=prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
+        state.prompt_embeds, state.prompt_embeds_mask = self.encode_prompt(
+            prompt=context["prompt"],
+            prompt_embeds=context["prompt_embeds"],
+            prompt_embeds_mask=context["prompt_embeds_mask"],
+            num_images_per_prompt=context["num_images_per_prompt"],
+            max_sequence_length=context["max_sequence_length"],
         )
         if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
-                num_images_per_prompt=num_images_per_prompt,
-                max_sequence_length=max_sequence_length,
+            state.negative_prompt_embeds, state.negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=context["negative_prompt"],
+                prompt_embeds=context["negative_prompt_embeds"],
+                prompt_embeds_mask=context["negative_prompt_embeds_mask"],
+                num_images_per_prompt=context["num_images_per_prompt"],
+                max_sequence_length=context["max_sequence_length"],
                 prompt_name="negative_prompt",
             )
         else:
-            negative_prompt_embeds = None
-            negative_prompt_embeds_mask = None
+            state.negative_prompt_embeds = None
+            state.negative_prompt_embeds_mask = None
 
+        state.do_true_cfg = do_true_cfg
+        state.img_shapes = [
+            [
+                (
+                    1,
+                    context["height"] // self.vae_scale_factor // 2,
+                    context["width"] // self.vae_scale_factor // 2,
+                )
+            ]
+        ] * batch_size
+        state.txt_seq_lens = txt_seq_lens_from_embeds(state.prompt_embeds)
+        state.negative_txt_seq_lens = txt_seq_lens_from_embeds(state.negative_prompt_embeds)
+        state.extra["cfg_normalize"] = True
+        state.extra["decode_height"] = context["height"]
+        state.extra["decode_width"] = context["width"]
+        state.extra["guidance_scale"] = context["guidance_scale"]
+        state.extra["num_inference_steps"] = context["num_inference_steps"]
+        state.extra["output_type"] = context["output_type"]
+        state.extra["sigmas"] = context["sigmas"]
+        state.extra["true_cfg_scale"] = context["true_cfg_scale"]
+        return state
+
+    def prepare(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if state.prompt_embeds is None:
+            raise ValueError(f"Request {state.request_id} has no prompt_embeds after encode().")
+        if state.img_shapes is None:
+            raise ValueError(f"Request {state.request_id} has no img_shapes after encode/unpack.")
+        decode_height = state.extra.get("decode_height")
+        decode_width = state.extra.get("decode_width")
+        if decode_height is None or decode_width is None:
+            raise ValueError(f"Request {state.request_id} has no decode size after encode/unpack.")
+
+        num_images_per_prompt = (
+            state.sampling.num_outputs_per_prompt if state.sampling.num_outputs_per_prompt > 0 else 1
+        )
+        batch_size = max(state.prompt_embeds.shape[0] // num_images_per_prompt, 1)
         num_channels_latents = self.transformer.in_channels // 4
-        latents = self.prepare_latents(
+        state.latents = self.prepare_latents(
             batch_size * num_images_per_prompt,
             num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
+            int(decode_height),
+            int(decode_width),
+            state.prompt_embeds.dtype,
             self.device,
-            generator,
-            latents,
+            state.sampling.generator,
+            state.sampling.latents,
         )
-
-        img_shapes = [[(1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)]] * batch_size
-
-        timesteps, num_inference_steps = self.prepare_timesteps(
-            num_inference_steps,
-            sigmas,
-            latents.shape[1],
+        timesteps, _ = self.prepare_timesteps(
+            state.extra["num_inference_steps"],
+            state.extra["sigmas"],
+            state.latents.shape[1],
         )
         self._num_timesteps = len(timesteps)
+        state.timesteps = timesteps
 
+        guidance_scale = state.extra["guidance_scale"]
+        self._guidance_scale = guidance_scale
         if self.transformer.guidance_embeds:
             guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
+            state.guidance = guidance.expand(state.latents.shape[0])
         else:
-            guidance = None
+            state.guidance = None
 
-        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
-        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
-
-        return {
-            "prompt_embeds": prompt_embeds,
-            "prompt_embeds_mask": prompt_embeds_mask,
-            "negative_prompt_embeds": negative_prompt_embeds,
-            "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
-            "latents": latents,
-            "img_shapes": img_shapes,
-            "timesteps": timesteps,
-            "do_true_cfg": do_true_cfg,
-            "guidance": guidance,
-            "txt_seq_lens": txt_seq_lens,
-            "negative_txt_seq_lens": negative_txt_seq_lens,
-        }
-
-    def prepare_encode(
-        self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> "DiffusionRequestState":
-        """Populate *state* with encoded prompts, latents, timesteps, and CFG config."""
-        sampling = state.sampling
-        prompt, negative_prompt = self._extract_prompts([state.prompt] if state.prompt is not None else [])
-
-        ctx = self._prepare_generation_context(
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            height=sampling.height or self.default_sample_size * self.vae_scale_factor,
-            width=sampling.width or self.default_sample_size * self.vae_scale_factor,
-            num_inference_steps=sampling.num_inference_steps or 50,
-            sigmas=sampling.sigmas,
-            guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
-            num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
-            generator=sampling.generator,
-            true_cfg_scale=sampling.true_cfg_scale or 4.0,
-            max_sequence_length=sampling.max_sequence_length or self.tokenizer_max_length,
-            attention_kwargs=kwargs.get("attention_kwargs"),
-        )
-
-        # prepare_timesteps() has already materialized request-specific timestep
-        # state on self.scheduler, so deepcopy preserves dynamic-shifting state
-        # without replaying set_timesteps() on the per-request scheduler.
-        # Per-request scheduler (must not share state with self.scheduler)
-        req_scheduler = copy.deepcopy(self.scheduler)
-        req_scheduler.set_begin_index(0)
-
-        # Populate state from generation context
-        state.prompt_embeds = ctx["prompt_embeds"]
-        state.prompt_embeds_mask = ctx["prompt_embeds_mask"]
-        state.negative_prompt_embeds = ctx["negative_prompt_embeds"]
-        state.negative_prompt_embeds_mask = ctx["negative_prompt_embeds_mask"]
-        state.latents = ctx["latents"]
-        state.timesteps = ctx["timesteps"]
+        state.scheduler = self._new_request_scheduler()
         state.step_index = 0
-        state.scheduler = req_scheduler
-        state.do_true_cfg = ctx["do_true_cfg"]
-        state.guidance = ctx["guidance"]
-        state.img_shapes = ctx["img_shapes"]
-        state.txt_seq_lens = ctx["txt_seq_lens"]
-        state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
-        # QwenImage always normalizes CFG output (matching forward())
-        state.sampling.cfg_normalize = True
-
+        state.sampling.cfg_normalize = bool(state.extra["cfg_normalize"])
         return state
 
     def _build_denoise_kwargs(
@@ -822,15 +929,12 @@ class QwenImagePipeline(
         negative_prompt_embeds_mask: torch.Tensor | None,
         negative_txt_seq_lens: list[int] | None,
         image_latents: torch.Tensor | None = None,
-        extra_transformer_kwargs: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any] | None, int | None]:
         """Build positive/negative kwargs and output_slice for one denoise step.
 
         Returns:
             (positive_kwargs, negative_kwargs, output_slice)
         """
-        extra_transformer_kwargs = extra_transformer_kwargs or {}
-
         # Broadcast timestep to match batch size
         t_for_model = timestep.expand(latents.shape[0]).to(
             device=latents.device,
@@ -850,7 +954,8 @@ class QwenImagePipeline(
             "encoder_hidden_states": prompt_embeds,
             "img_shapes": img_shapes,
             "txt_seq_lens": txt_seq_lens,
-            **extra_transformer_kwargs,
+            "return_dict": False,
+            "attention_kwargs": self.attention_kwargs,
         }
         if do_true_cfg:
             negative_kwargs = {
@@ -861,7 +966,8 @@ class QwenImagePipeline(
                 "encoder_hidden_states": negative_prompt_embeds,
                 "img_shapes": img_shapes,
                 "txt_seq_lens": negative_txt_seq_lens,
-                **extra_transformer_kwargs,
+                "return_dict": False,
+                "attention_kwargs": self.attention_kwargs,
             }
         else:
             negative_kwargs = None
@@ -900,183 +1006,86 @@ class QwenImagePipeline(
             stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )
 
-    def denoise_step(
+    def decode(
         self,
-        input_batch: "InputBatch",
-        **kwargs: Any,
-    ) -> torch.Tensor | None:
-        """One denoise step: read from *input_batch*, delegate to CFGParallelMixin.
-
-        Reuses ``predict_noise_maybe_with_cfg`` so that CFG-parallel,
-        sequential-CFG, and no-CFG paths are handled identically to
-        ``diffuse()``.
-        """
-        del kwargs
-        if self.interrupt:
-            return None
-
-        t = input_batch.timesteps
-        self._current_timestep = t
-        self.transformer.do_true_cfg = input_batch.do_true_cfg
-
-        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
-            latents=input_batch.latents,
-            timestep=t,
-            guidance=input_batch.guidance,
-            prompt_embeds=input_batch.prompt_embeds,
-            prompt_embeds_mask=input_batch.prompt_embeds_mask,
-            img_shapes=input_batch.img_shapes,
-            txt_seq_lens=input_batch.txt_seq_lens,
-            do_true_cfg=input_batch.do_true_cfg,
-            negative_prompt_embeds=input_batch.negative_prompt_embeds,
-            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
-            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
-            image_latents=input_batch.image_latents,
-            extra_transformer_kwargs={
-                "attention_kwargs": self.attention_kwargs,
-                "return_dict": False,
-            },
-        )
-
-        return self.predict_noise_maybe_with_cfg(
-            input_batch.do_true_cfg,
-            input_batch.true_cfg_scale,
-            positive_kwargs,
-            negative_kwargs,
-            input_batch.cfg_normalize,
-            output_slice,
-        )
-
-    def step_scheduler(
-        self,
-        state: "DiffusionRequestState",
-        noise_pred: torch.Tensor,
-        **kwargs: Any,
-    ) -> None:
-        """One scheduler step: update ``state.latents`` and advance ``step_index``."""
-        if self.interrupt:
-            return
-
-        t = state.current_timestep
-        state.latents = self.scheduler_step_maybe_with_cfg(
-            noise_pred,
-            t,
-            state.latents,
-            state.do_true_cfg,
-            per_request_scheduler=state.scheduler,
-        )
-
-        state.step_index += 1
-
-    def post_decode(
-        self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> DiffusionOutput:
-        """Decode final latents from *state*."""
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
         self._current_timestep = None
+        try:
+            height = state.extra["decode_height"]
+            width = state.extra["decode_width"]
+            output_type = state.extra["output_type"]
+        except KeyError as exc:
+            raise ValueError(f"Request {state.request_id} is missing decode metadata.") from exc
+        if state.latents is None:
+            raise ValueError(f"Request {state.request_id} has no latents to decode.")
+        state.extra["decoded_output"] = self._decode_latents(
+            state.latents,
+            int(height),
+            int(width),
+            str(output_type),
+        )
+        return state
 
-        height = state.sampling.height or self.default_sample_size * self.vae_scale_factor
-        width = state.sampling.width or self.default_sample_size * self.vae_scale_factor
-        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
-
-        return self._decode_latents(state.latents, height, width, output_type)
+    def postprocess(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionOutput:
+        output = state.extra.get("decoded_output")
+        if output is None:
+            raise ValueError(f"Request {state.request_id} has not been decoded.")
+        if not isinstance(output, DiffusionOutput):
+            raise TypeError(f"Decoded output for request {state.request_id} must be a DiffusionOutput.")
+        return output
 
     def forward(self, req: DiffusionRequestBatch) -> list[DiffusionOutput]:
-        sampling_params_list = req.sampling_params_list
-        common_sampling_params = sampling_params_list[0]
-        extracted_prompt, negative_prompt = self._extract_prompts(req.prompts)
-        prompt = extracted_prompt
+        states: list[DiffusionRequestState] = []
+        for request in req.requests:
+            state = DiffusionRequestState(
+                request_id=request.request_id,
+                sampling=request.sampling_params,
+                prompt=request.prompt,
+                kv_sender_info=request.kv_sender_info,
+            )
+            state = self.init_state(state)
+            state = self.check_inputs(state)
+            state = self.encode(state)
+            state = self.prepare(state)
+            states.append(state)
 
-        height = common_sampling_params.height or self.default_sample_size * self.vae_scale_factor
-        width = common_sampling_params.width or self.default_sample_size * self.vae_scale_factor
-        height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
-        num_inference_steps = common_sampling_params.num_inference_steps or 50
-        sigmas = common_sampling_params.sigmas
-        max_sequence_length = common_sampling_params.max_sequence_length or 1024
-        num_images_per_prompt = (
-            common_sampling_params.num_outputs_per_prompt if common_sampling_params.num_outputs_per_prompt > 0 else 1
-        )
-        generator = req.collate_request_generators(num_images_per_prompt, None)
-        latents = req.collate_request_tensors("latents", None)
-        prompt_fields = DiffusionRequestBatch.collate_prompt_field_map(
-            req.prompts,
-            {
-                "prompt_embeds": None,
-                "prompt_embeds_mask": None,
-                "negative_prompt_embeds": None,
-                "negative_prompt_embeds_mask": None,
-            },
-        )
-        prompt_embeds = prompt_fields["prompt_embeds"]
-        prompt_embeds_mask = prompt_fields["prompt_embeds_mask"]
-        negative_prompt_embeds = prompt_fields["negative_prompt_embeds"]
-        negative_prompt_embeds_mask = prompt_fields["negative_prompt_embeds_mask"]
-        if prompt_embeds is not None:
-            prompt = None
-        if negative_prompt_embeds is not None:
-            negative_prompt = None
-        true_cfg_scale = common_sampling_params.true_cfg_scale or 4.0
-        if common_sampling_params.guidance_scale_provided:
-            guidance_scale = common_sampling_params.guidance_scale
-        else:
-            guidance_scale = 1.0
+        cached_batch = None
+        while True:
+            active_states = [state for state in states if not state.denoise_completed]
+            if not active_states:
+                break
+            if self.interrupt:
+                break
 
-        latents = req.collate_request_tensors("latents", None)
-        output_type = common_sampling_params.output_type or "pil"
-        attention_kwargs = None
-        callback_on_step_end_tensor_inputs = ["latents"]
+            input_batch = self.build_step_batch(active_states, cached_batch=cached_batch)
+            cached_batch = input_batch
+            noise_pred = self.denoise_step(input_batch)
+            if noise_pred is None:
+                if self.interrupt:
+                    break
+                raise RuntimeError("denoise_step returned None without pipeline interrupt.")
 
-        ctx = self._prepare_generation_context(
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            height=height,
-            width=width,
-            num_inference_steps=num_inference_steps,
-            sigmas=sigmas,
-            guidance_scale=guidance_scale,
-            num_images_per_prompt=num_images_per_prompt,
-            generator=generator,
-            true_cfg_scale=true_cfg_scale,
-            max_sequence_length=max_sequence_length,
-            prompt_embeds=prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
-            negative_prompt_embeds=negative_prompt_embeds,
-            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
-            latents=latents,
-            attention_kwargs=attention_kwargs,
-            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
-        )
+            row_offset = 0
+            for state in active_states:
+                if state.latents is None:
+                    raise ValueError(f"Request {state.request_id} has no latents after denoise_step().")
+                next_row_offset = row_offset + int(state.latents.shape[0])
+                self.step_scheduler(state, noise_pred[row_offset:next_row_offset])
+                row_offset = next_row_offset
+            if row_offset != int(noise_pred.shape[0]):
+                raise ValueError(
+                    f"Consumed {row_offset} noise rows, but denoise_step returned {int(noise_pred.shape[0])}."
+                )
 
-        latents = self.diffuse(
-            ctx["prompt_embeds"],
-            ctx["prompt_embeds_mask"],
-            ctx["negative_prompt_embeds"],
-            ctx["negative_prompt_embeds_mask"],
-            ctx["latents"],
-            ctx["img_shapes"],
-            ctx["txt_seq_lens"],
-            ctx["negative_txt_seq_lens"],
-            ctx["timesteps"],
-            ctx["do_true_cfg"],
-            ctx["guidance"],
-            true_cfg_scale,
-            image_latents=None,
-            cfg_normalize=True,
-            additional_transformer_kwargs={
-                "return_dict": False,
-                "attention_kwargs": self.attention_kwargs,
-            },
-        )
-
-        self._current_timestep = None
-
-        result = self._decode_latents(latents, height, width, output_type)
-        return split_diffusion_output_by_request(
-            result,
-            req,
-            num_outputs_per_prompt=num_images_per_prompt,
-        )
+        outputs: list[DiffusionOutput] = []
+        for state in states:
+            state = self.decode(state)
+            outputs.append(self.postprocess(state))
+        return outputs
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
 
 import inspect
 import json
@@ -28,7 +29,12 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
-from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import (
+    StageBoundary,
+    StagePayload,
+    SupportImageInput,
+    SupportsComponentDiscovery,
+)
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -36,6 +42,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
+from vllm_omni.diffusion.models.step_mixin import DiffusionV2CFGStepMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -46,6 +53,7 @@ from vllm_omni.diffusion.utils.size_utils import (
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -221,11 +229,130 @@ def retrieve_latents(
 
 
 class QwenImageEditPipeline(
-    nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    SupportImageInput,
+    DiffusionV2CFGStepMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
+    supports_step_execution: ClassVar[bool] = True
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+    stage_payload_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "prompt_embeds",
+            "prompt_embeds_mask",
+            "negative_prompt_embeds",
+            "negative_prompt_embeds_mask",
+        ),
+        StageBoundary.DIT_TO_DECODE: ("latents",),
+    }
+    stage_payload_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "do_true_cfg",
+            "img_shapes",
+            "txt_seq_lens",
+            "negative_txt_seq_lens",
+        ),
+    }
+    stage_payload_private_tensor_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: ("image_latents",),
+    }
+    stage_payload_private_scalar_fields: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "cfg_normalize",
+            "decode_height",
+            "decode_width",
+            "guidance_scale",
+            "num_inference_steps",
+            "output_type",
+            "sigmas",
+            "true_cfg_scale",
+        ),
+        StageBoundary.DIT_TO_DECODE: ("decode_height", "decode_width", "output_type"),
+    }
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        def state_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: getattr(state, name) for name in field_names if getattr(state, name, None) is not None}
+
+        def extra_fields(field_names: tuple[str, ...]) -> dict[str, object]:
+            return {name: state.extra[name] for name in field_names if name in state.extra}
+
+        return StagePayload(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields=state_fields(self.stage_payload_scalar_fields.get(boundary, ())),
+            tensor_fields=state_fields(self.stage_payload_tensor_fields.get(boundary, ())),
+            private_scalar_fields=extra_fields(self.stage_payload_private_scalar_fields.get(boundary, ())),
+            private_tensor_fields=extra_fields(self.stage_payload_private_tensor_fields.get(boundary, ())),
+        )
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if payload.request_id != state.request_id:
+            raise ValueError(
+                f"StagePayload request_id {payload.request_id!r} does not match state {state.request_id!r}."
+            )
+        if payload.boundary not in (StageBoundary.ENCODE_TO_DIT, StageBoundary.DIT_TO_DECODE):
+            raise ValueError(f"Unsupported stage payload boundary: {payload.boundary!r}.")
+        for name, value in payload.scalar_fields.items():
+            setattr(state, name, value)
+        for name, value in payload.tensor_fields.items():
+            setattr(state, name, value)
+        state.extra.update(payload.private_scalar_fields)
+        state.extra.update(payload.private_tensor_fields)
+        if "cfg_normalize" in state.extra:
+            state.sampling.cfg_normalize = bool(state.extra["cfg_normalize"])
+        if "true_cfg_scale" in state.extra:
+            state.sampling.true_cfg_scale = state.extra["true_cfg_scale"]
+        if "output_type" in state.extra:
+            state.sampling.output_type = state.extra["output_type"]
+        if "sigmas" in state.extra:
+            state.sampling.sigmas = state.extra["sigmas"]
+        return state
+
+    def _prepare_image_latents(
+        self,
+        image: torch.Tensor,
+        batch_size: int,
+        num_channels_latents: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator,
+    ) -> torch.Tensor:
+        image = image.to(device=device, dtype=dtype)
+        if image.shape[1] != self.latent_channels:
+            image_latents = self._encode_vae_image(image=image, generator=generator)
+        else:
+            image_latents = image
+        if batch_size > image_latents.shape[0] and batch_size % image_latents.shape[0] == 0:
+            additional_image_per_prompt = batch_size // image_latents.shape[0]
+            image_latents = torch.cat([image_latents] * additional_image_per_prompt, dim=0)
+        elif batch_size > image_latents.shape[0] and batch_size % image_latents.shape[0] != 0:
+            raise ValueError(
+                f"Cannot duplicate `image` of batch size {image_latents.shape[0]} to {batch_size} text prompts."
+            )
+        else:
+            image_latents = torch.cat([image_latents], dim=0)
+
+        image_latent_height, image_latent_width = image_latents.shape[3:]
+        return self._pack_latents(
+            image_latents,
+            batch_size,
+            num_channels_latents,
+            image_latent_height,
+            image_latent_width,
+        )
 
     def __init__(
         self,
@@ -310,7 +437,7 @@ class QwenImageEditPipeline(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
 
-    def check_inputs(
+    def _check_generation_inputs(
         self,
         prompt,
         height,
@@ -373,51 +500,6 @@ class QwenImageEditPipeline(
         split_result = torch.split(selected, valid_lengths.tolist(), dim=0)
 
         return split_result
-
-    def _get_qwen_prompt_embeds(
-        self,
-        prompt: str | list[str] = None,
-        image: torch.Tensor | None = None,
-        dtype: torch.dtype | None = None,
-    ):
-        dtype = dtype or self.text_encoder.dtype
-
-        prompt = [prompt] if isinstance(prompt, str) else prompt
-
-        template = self.prompt_template_encode
-        drop_idx = self.prompt_template_encode_start_idx
-        txt = [template.format(e) for e in prompt]
-
-        model_inputs = self.processor(
-            text=txt,
-            images=image,
-            padding=True,
-            return_tensors="pt",
-        ).to(self.device)
-
-        outputs = self.text_encoder(
-            input_ids=model_inputs.input_ids,
-            attention_mask=model_inputs.attention_mask,
-            pixel_values=model_inputs.pixel_values,
-            image_grid_thw=model_inputs.image_grid_thw,
-            output_hidden_states=True,
-        )
-
-        hidden_states = outputs.hidden_states[-1]
-        split_hidden_states = self._extract_masked_hidden(hidden_states, model_inputs.attention_mask)
-        split_hidden_states = [e[drop_idx:] for e in split_hidden_states]
-        attn_mask_list = [torch.ones(e.size(0), dtype=torch.long, device=e.device) for e in split_hidden_states]
-        max_seq_len = max([e.size(0) for e in split_hidden_states])
-        prompt_embeds = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0), u.size(1))]) for u in split_hidden_states]
-        )
-        encoder_attention_mask = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
-        )
-
-        prompt_embeds = prompt_embeds.to(dtype=dtype, device=self.device)
-
-        return prompt_embeds, encoder_attention_mask
 
     def _get_qwen_prompt_embeds(
         self,
@@ -677,25 +759,15 @@ class QwenImageEditPipeline(
     def interrupt(self):
         return self._interrupt
 
-    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
-        """Forward pass for image editing."""
-        # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
-        # TODO: May be some data formatting operations on the API side. Hack for now.
-        if len(req.prompts) > 1:
-            logger.warning(
-                """This model only supports a single prompt, not a batched request.""",
-                """Taking only the first image for now.""",
-            )
-        first_prompt = req.prompts[0]
+    def _edit_request_context(
+        self,
+        state: DiffusionRequestState,
+    ) -> dict[str, object]:
+        first_prompt = state.prompt
+        if not isinstance(first_prompt, (str, dict)):
+            raise TypeError("QwenImageEditPipeline expects a string or dict prompt.")
         prompt = first_prompt if isinstance(first_prompt, str) else (first_prompt.get("prompt") or "")
         negative_prompt = None if isinstance(first_prompt, str) else first_prompt.get("negative_prompt")
-        if negative_prompt is None:
-            logger.warning(
-                "negative_prompt is not set. The official Qwen-Image-Edit model "
-                "may produce lower-quality results without a negative_prompt. "
-                "Qwen official repository recommends to use whitespace string as negative_prompt. "
-                "Note: some distilled variants may not be affected by this."
-            )
 
         # Get preprocessed image from request (pre-processing is done in DiffusionEngine)
         if not isinstance(first_prompt, str) and "preprocessed_image" in (
@@ -705,163 +777,313 @@ class QwenImageEditPipeline(
             image = additional_information.get("preprocessed_image")
             calculated_height = additional_information.get("calculated_height")
             calculated_width = additional_information.get("calculated_width")
-            height = req.sampling_params.height
-            width = req.sampling_params.width
+            height = state.sampling.height
+            width = state.sampling.width
         else:
             raise RuntimeError("Missing preprocess image that should have been created by the preprocess function.")
+        if prompt_image is None:
+            raise RuntimeError("Missing prompt_image that should have been created by the preprocess function.")
+        if image is None:
+            raise RuntimeError("Missing preprocessed_image that should have been created by the preprocess function.")
+        if not torch.is_tensor(image):
+            raise TypeError("QwenImageEditPipeline expects preprocessed_image to be a torch.Tensor.")
+        if height is None or width is None:
+            raise RuntimeError("QwenImageEditPipeline requires resolved height and width before prepare().")
+        if calculated_height is None or calculated_width is None:
+            raise RuntimeError("Missing calculated image size from Qwen-Image-Edit preprocess.")
+        return {
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "prompt_image": prompt_image,
+            "image": image,
+            "height": int(height),
+            "width": int(width),
+            "calculated_height": int(calculated_height),
+            "calculated_width": int(calculated_width),
+        }
 
-        num_inference_steps = req.sampling_params.num_inference_steps or 50
-        sigmas = req.sampling_params.sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or 1024
-        generator = req.sampling_params.generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or 4.0
-        if req.sampling_params.guidance_scale_provided:
-            guidance_scale = req.sampling_params.guidance_scale
+    def check_inputs(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        context = self._edit_request_context(state)
+        self._check_generation_inputs(
+            context["prompt"],
+            context["height"],
+            context["width"],
+            context["image"],
+            context["negative_prompt"],
+            None,
+            None,
+            None,
+            None,
+            ["latents"],
+            state.sampling.max_sequence_length or self.tokenizer_max_length,
+        )
+        if context["negative_prompt"] is None:
+            logger.warning(
+                "negative_prompt is not set. The official Qwen-Image-Edit model "
+                "may produce lower-quality results without a negative_prompt. "
+                "Qwen official repository recommends to use whitespace string as negative_prompt. "
+                "Note: some distilled variants may not be affected by this."
+            )
+        return state
+
+    def encode(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        context = self._edit_request_context(state)
+
+        max_sequence_length = state.sampling.max_sequence_length or self.tokenizer_max_length
+        true_cfg_scale = state.sampling.true_cfg_scale or 4.0
+        if state.sampling.guidance_scale_provided:
+            guidance_scale = state.sampling.guidance_scale
         else:
             guidance_scale = 1.0
         num_images_per_prompt = (
-            req.sampling_params.num_outputs_per_prompt if req.sampling_params.num_outputs_per_prompt > 0 else 1
-        )
-        latents = req.sampling_params.latents
-        prompt_embeds = None
-        negative_prompt_embeds = None
-        prompt_embeds_mask = None
-        negative_prompt_embeds_mask = None
-        output_type = req.sampling_params.output_type or "pil"
-        attention_kwargs = None
-        callback_on_step_end_tensor_inputs = ["latents"]
-
-        # 1. check inputs
-        # 2. encode prompts
-        # 3. prepare latents and timesteps
-        # 4. diffusion process
-        # 5. decode latents
-        # 6. post-process outputs
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            image,
-            negative_prompt,
-            prompt_embeds,
-            negative_prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds_mask,
-            callback_on_step_end_tensor_inputs,
-            max_sequence_length,
+            state.sampling.num_outputs_per_prompt if state.sampling.num_outputs_per_prompt > 0 else 1
         )
 
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = attention_kwargs
-        self._current_timestep = None
-        self._interrupt = False
-
-        batch_size = 1
-
-        has_neg_prompt = negative_prompt is not None
+        has_neg_prompt = context["negative_prompt"] is not None
 
         do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
 
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
-            prompt=prompt,
-            image=prompt_image,  # Use resized image for prompt encoding
-            prompt_embeds=prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
+        state.prompt_embeds, state.prompt_embeds_mask = self.encode_prompt(
+            prompt=context["prompt"],
+            image=context["prompt_image"],  # Use resized image for prompt encoding
+            prompt_embeds=None,
+            prompt_embeds_mask=None,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
         )
 
         if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=prompt_image,  # Use same resized image for negative prompt encoding
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
+            state.negative_prompt_embeds, state.negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=context["negative_prompt"],
+                image=context["prompt_image"],  # Use same resized image for negative prompt encoding
+                prompt_embeds=None,
+                prompt_embeds_mask=None,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
                 prompt_name="negative_prompt",
             )
-
+        else:
+            state.negative_prompt_embeds = None
+            state.negative_prompt_embeds_mask = None
+        state.do_true_cfg = do_true_cfg
+        batch_size = 1
         num_channels_latents = self.transformer.in_channels // 4
-        # random noise latents, and image latents encoded by vae
-        latents, image_latents = self.prepare_latents(
-            image,
+        state.extra["image_latents"] = self._prepare_image_latents(
+            context["image"],
             batch_size * num_images_per_prompt,
             num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
+            state.prompt_embeds.dtype,
             self.device,
-            generator,
-            latents,
+            state.sampling.generator,
         )
-        img_shapes = [
+        state.extra["cfg_normalize"] = True
+        state.extra["decode_height"] = context["height"]
+        state.extra["decode_width"] = context["width"]
+        state.extra["guidance_scale"] = guidance_scale
+        state.extra["num_inference_steps"] = state.sampling.num_inference_steps or 50
+        state.extra["output_type"] = state.sampling.output_type or "pil"
+        state.extra["sigmas"] = state.sampling.sigmas
+        state.extra["true_cfg_scale"] = true_cfg_scale
+        state.img_shapes = [
             [
-                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
-                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
+                (1, context["height"] // self.vae_scale_factor // 2, context["width"] // self.vae_scale_factor // 2),
+                (
+                    1,
+                    context["calculated_height"] // self.vae_scale_factor // 2,
+                    context["calculated_width"] // self.vae_scale_factor // 2,
+                ),
             ]
         ] * batch_size
+        state.txt_seq_lens = (
+            state.prompt_embeds_mask.sum(dim=1).tolist() if state.prompt_embeds_mask is not None else None
+        )
+        state.negative_txt_seq_lens = (
+            state.negative_prompt_embeds_mask.sum(dim=1).tolist()
+            if state.negative_prompt_embeds_mask is not None
+            else None
+        )
+        return state
 
-        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+    def prepare(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        if state.prompt_embeds is None:
+            raise ValueError(f"Request {state.request_id} has no prompt_embeds after encode().")
+        if state.img_shapes is None:
+            raise ValueError(f"Request {state.request_id} has no img_shapes after encode/unpack.")
+        if "image_latents" not in state.extra:
+            raise ValueError(f"Request {state.request_id} has no image_latents after encode/unpack.")
+        num_images_per_prompt = (
+            state.sampling.num_outputs_per_prompt if state.sampling.num_outputs_per_prompt > 0 else 1
+        )
+        batch_size = 1
+        num_channels_latents = self.transformer.in_channels // 4
+        decode_height = state.extra.get("decode_height")
+        decode_width = state.extra.get("decode_width")
+        if decode_height is None or decode_width is None:
+            raise ValueError(f"Request {state.request_id} has no decode size after encode/unpack.")
+
+        state.latents, _ = self.prepare_latents(
+            None,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            int(decode_height),
+            int(decode_width),
+            state.prompt_embeds.dtype,
+            self.device,
+            state.sampling.generator,
+            state.sampling.latents,
+        )
+        timesteps, _ = self.prepare_timesteps(
+            state.extra["num_inference_steps"],
+            state.extra["sigmas"],
+            state.latents.shape[1],
+        )
         self._num_timesteps = len(timesteps)
+        state.timesteps = timesteps
 
         # handle guidance
+        guidance_scale = state.extra["guidance_scale"]
+        self._guidance_scale = guidance_scale
         if self.transformer.guidance_embeds:
             guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
+            state.guidance = guidance.expand(state.latents.shape[0])
         else:
-            guidance = None
+            state.guidance = None
 
-        if self.attention_kwargs is None:
-            self._attention_kwargs = {}
+        state.scheduler = self._new_request_scheduler()
+        state.step_index = 0
+        state.sampling.cfg_normalize = bool(state.extra["cfg_normalize"])
+        return state
 
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
-        negative_txt_seq_lens = (
-            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
-        )
+    def _build_denoise_kwargs(
+        self,
+        latents: torch.Tensor,
+        timestep: torch.Tensor,
+        guidance: torch.Tensor | None,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        img_shapes: list,
+        txt_seq_lens: list[int] | None,
+        do_true_cfg: bool,
+        negative_prompt_embeds: torch.Tensor | None,
+        negative_prompt_embeds_mask: torch.Tensor | None,
+        negative_txt_seq_lens: list[int] | None,
+        image_latents: torch.Tensor | None,
+    ) -> tuple[dict[str, object], dict[str, object] | None, int]:
+        timestep = timestep.expand(latents.shape[0]).to(device=latents.device, dtype=latents.dtype)
+        latent_model_input = latents
+        if image_latents is not None:
+            latent_model_input = torch.cat([latents, image_latents], dim=1)
 
-        latents = self.diffuse(
-            prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds,
-            negative_prompt_embeds_mask,
-            latents,
-            img_shapes,
-            txt_seq_lens,
-            negative_txt_seq_lens,
-            timesteps,
-            do_true_cfg,
-            guidance,
-            true_cfg_scale,
-            image_latents=image_latents,
-            cfg_normalize=True,
-            additional_transformer_kwargs={
+        positive_kwargs = {
+            "hidden_states": latent_model_input,
+            "timestep": timestep / 1000,
+            "guidance": guidance,
+            "encoder_hidden_states_mask": prompt_embeds_mask,
+            "encoder_hidden_states": prompt_embeds,
+            "img_shapes": img_shapes,
+            "txt_seq_lens": txt_seq_lens,
+            "return_dict": False,
+            "attention_kwargs": self.attention_kwargs,
+        }
+        if do_true_cfg:
+            negative_kwargs = {
+                "hidden_states": latent_model_input,
+                "timestep": timestep / 1000,
+                "guidance": guidance,
+                "encoder_hidden_states_mask": negative_prompt_embeds_mask,
+                "encoder_hidden_states": negative_prompt_embeds,
+                "img_shapes": img_shapes,
+                "txt_seq_lens": negative_txt_seq_lens,
                 "return_dict": False,
                 "attention_kwargs": self.attention_kwargs,
-            },
-        )
-
-        self._current_timestep = None
-        if output_type == "latent":
-            image = latents
+            }
         else:
-            latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
-            latents = latents.to(self.vae.dtype)
-            latents_mean = (
-                torch.tensor(self.vae.config.latents_mean)
-                .view(1, self.vae.config.z_dim, 1, 1, 1)
-                .to(latents.device, latents.dtype)
-            )
-            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
-                latents.device, latents.dtype
-            )
-            latents = latents / latents_std + latents_mean
-            image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+            negative_kwargs = None
+        return positive_kwargs, negative_kwargs, latents.size(1)
 
-        return DiffusionOutput(
-            output=image, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
+    def _decode_latents(
+        self,
+        latents: torch.Tensor,
+        height: int,
+        width: int,
+        output_type: str,
+    ) -> torch.Tensor:
+        if output_type == "latent":
+            return latents
+        self._current_timestep = None
+        latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+        latents = latents.to(self.vae.dtype)
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
         )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latents.device, latents.dtype
+        )
+        latents = latents / latents_std + latents_mean
+        return self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+
+    def decode(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        self._current_timestep = None
+        try:
+            height = state.extra["decode_height"]
+            width = state.extra["decode_width"]
+            output_type = state.extra["output_type"]
+        except KeyError as exc:
+            raise ValueError(f"Request {state.request_id} is missing decode metadata.") from exc
+        if state.latents is None:
+            raise ValueError(f"Request {state.request_id} has no latents to decode.")
+        image = self._decode_latents(state.latents, int(height), int(width), output_type)
+        state.extra["decoded_output"] = DiffusionOutput(
+            output=image,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+        return state
+
+    def postprocess(
+        self,
+        state: DiffusionRequestState,
+    ) -> DiffusionOutput:
+        output = state.extra.get("decoded_output")
+        if output is None:
+            raise ValueError(f"Request {state.request_id} has not been decoded.")
+        if not isinstance(output, DiffusionOutput):
+            raise TypeError(f"Decoded output for request {state.request_id} must be a DiffusionOutput.")
+        return output
+
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        """Forward pass for image editing."""
+        if len(req.prompts) > 1:
+            logger.warning(
+                "This model only supports a single prompt, not a batched request. Taking only the first image for now."
+            )
+        state = DiffusionRequestState(
+            request_id=req.request_id,
+            sampling=req.sampling_params,
+            prompt=req.prompts[0],
+            kv_sender_info=req.kv_sender_info,
+        )
+        state = self.init_state(state)
+        state = self.check_inputs(state)
+        state = self.encode(state)
+        state = self.prepare(state)
+        state = self.diffuse(state)
+        state = self.decode(state)
+        return self.postprocess(state)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm_omni/diffusion/models/step_mixin.py
+++ b/vllm_omni/diffusion/models/step_mixin.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import torch
+
+    from vllm_omni.diffusion.worker.input_batch import InputBatch
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+
+class DiffusionV2AtomDefaultsMixin:
+    """Default hooks shared by step/disaggregated diffusion pipelines."""
+
+    supports_step_execution: ClassVar[bool] = True
+
+    def init_state(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        state.extra.pop("decoded_output", None)
+        self._guidance_scale = 1.0
+        self._attention_kwargs = {}
+        self._current_timestep = None
+        self._interrupt = False
+        return state
+
+    # TODO: build varlen attention metadata here when step batching
+    # starts using packed varlen attention.
+    def build_step_attention_metadata(
+        self,
+        input_batch: InputBatch,
+    ) -> object | None:
+        return None
+
+    # TODO: keep this hook for future varlen/cudagraph batching and
+    # disaggregated DiT batch layouts.
+    def build_step_batch(
+        self,
+        states: list[DiffusionRequestState],
+        *,
+        cached_batch: InputBatch | None = None,
+    ) -> InputBatch:
+        from vllm_omni.diffusion.worker.input_batch import InputBatch
+
+        return InputBatch.make_batch(states, cached_batch=cached_batch)
+
+    def diffuse(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        while not state.denoise_completed:
+            if self.interrupt:
+                break
+            input_batch = self.build_step_batch([state])
+            noise_pred = self.denoise_step(input_batch)
+            if noise_pred is None:
+                if self.interrupt:
+                    break
+                raise RuntimeError("denoise_step returned None without pipeline interrupt.")
+            self.step_scheduler(state, noise_pred)
+        return state
+
+    def _new_request_scheduler(self) -> object:
+        scheduler = deepcopy(getattr(self, "scheduler"))
+        scheduler.set_begin_index(0)
+        return scheduler
+
+
+class DiffusionV2CFGStepMixin(DiffusionV2AtomDefaultsMixin):
+    """Default one-step CFG denoise/scheduler hooks.
+
+    Pipelines using this mixin keep model-specific tensor schema in
+    ``_build_denoise_kwargs``.
+    """
+
+    def denoise_step(
+        self,
+        input_batch: InputBatch,
+    ) -> torch.Tensor | None:
+        if self.interrupt:
+            return None
+
+        t = input_batch.timesteps
+        self._current_timestep = t
+        self.transformer.do_true_cfg = input_batch.do_true_cfg
+        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
+            latents=input_batch.latents,
+            timestep=t,
+            guidance=input_batch.guidance,
+            prompt_embeds=input_batch.prompt_embeds,
+            prompt_embeds_mask=input_batch.prompt_embeds_mask,
+            img_shapes=input_batch.img_shapes,
+            txt_seq_lens=input_batch.txt_seq_lens,
+            do_true_cfg=input_batch.do_true_cfg,
+            negative_prompt_embeds=input_batch.negative_prompt_embeds,
+            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
+            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
+            image_latents=input_batch.image_latents,
+        )
+        return self.predict_noise_maybe_with_cfg(
+            input_batch.do_true_cfg,
+            input_batch.true_cfg_scale,
+            positive_kwargs,
+            negative_kwargs,
+            input_batch.cfg_normalize,
+            output_slice,
+        )
+
+    def step_scheduler(
+        self,
+        state: DiffusionRequestState,
+        noise_pred: torch.Tensor,
+    ) -> DiffusionRequestState:
+        if self.interrupt:
+            return state
+        t = state.current_timestep
+        state.latents = self.scheduler_step_maybe_with_cfg(
+            noise_pred,
+            t,
+            state.latents,
+            state.do_true_cfg,
+            per_request_scheduler=state.scheduler,
+        )
+        state.step_index += 1
+        return state

--- a/vllm_omni/diffusion/worker/__init__.py
+++ b/vllm_omni/diffusion/worker/__init__.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+    from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
     from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker, WorkerProc
 
 __all__ = [
     "DiffusionModelRunner",
+    "DiffusionModelRunnerV2",
     "DiffusionWorker",
     "WorkerProc",
 ]
@@ -22,6 +24,10 @@ def __getattr__(name: str) -> Any:
         from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
 
         return DiffusionModelRunner
+    if name == "DiffusionModelRunnerV2":
+        from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
+
+        return DiffusionModelRunnerV2
     if name in {"DiffusionWorker", "WorkerProc"}:
         from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker, WorkerProc
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import time
 from collections.abc import Iterable
 from contextlib import nullcontext
-from typing import Any
 
 import torch
 from torch.profiler import record_function

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -10,7 +10,6 @@ model-related operations.
 
 from __future__ import annotations
 
-import copy
 import time
 from collections.abc import Iterable
 from contextlib import nullcontext
@@ -37,16 +36,11 @@ from vllm_omni.diffusion.offloader import get_offload_backend
 from vllm_omni.diffusion.registry import _NO_CACHE_ACCELERATION
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
-from vllm_omni.diffusion.worker.input_batch import InputBatch, scatter_latents
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.diffusion.worker.utils import (
     BatchRunnerOutput,
     DiffusionRequestState,
     RunnerOutput,
-    attach_stage_durations,
-    clear_pipeline_stage_durations,
-    consume_pipeline_stage_durations,
-    merge_stage_durations,
 )
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.platforms import current_omni_platform
@@ -220,7 +214,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if getattr(self.od_config, "step_execution", False) and not self.supports_step_mode():
             raise ValueError(
                 "step_execution=True requires a pipeline implementing "
-                "prepare_encode(), denoise_step(), step_scheduler(), and post_decode(); "
+                "DiffusionV2Atoms; "
                 f"{self.od_config.model_class_name} does not support that contract."
             )
         if self.od_config.streaming_output and not self.supports_step_mode():
@@ -340,7 +334,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         use_prefetch: bool = False,
     ) -> None:
         # Receive AR KV. Single-request execution can use the prefetch path:
-        # consume prior-forward payload, sync-fallback on miss; request-batch
+        # consume prior-forward payload, synchronously receive on miss; request-batch
         # execution keeps the synchronous per-request receive path.
         kv_recv_t0 = time.perf_counter()
         if use_prefetch and self._kv_prefetch_enabled:
@@ -495,19 +489,6 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
 
         return self._runner_output_from_outputs(reqs, outputs)
 
-    def _attach_stepwise_metrics(
-        self,
-        state: DiffusionRequestState,
-        output: DiffusionOutput,
-        *,
-        is_primary: bool,
-    ) -> None:
-        merge_stage_durations(
-            state,
-            consume_pipeline_stage_durations(self.pipeline),
-        )
-        attach_stage_durations(state, output)
-
     def execute_model(self, req: OmniDiffusionRequest, kv_prefetch_jobs: dict | None = None) -> DiffusionOutput:
         """
         Execute a forward pass for the given requests.
@@ -563,240 +544,3 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
     def supports_step_mode(self) -> bool:
         """Return whether current pipeline supports step execution."""
         return self.pipeline is not None and supports_step_execution(self.pipeline)
-
-    def _update_states(
-        self, scheduler_output: DiffusionSchedulerOutput
-    ) -> tuple[list[DiffusionRequestState], list[str]]:
-        """Step-before update: cleanup finished requests and get/create one running state."""
-        for request_id in scheduler_output.finished_req_ids:
-            self.state_cache.pop(request_id, None)
-
-        resolved: list[DiffusionRequestState] = []
-        new_request_ids: list[str] = []
-        try:
-            # process new requests
-            for sched_new_req in scheduler_output.scheduled_new_reqs:
-                request_id = sched_new_req.request_id
-                new_request_ids.append(request_id)
-                if request_id in self.state_cache:
-                    raise ValueError(f"Received duplicate new-request payload for cached request {request_id}.")
-                new_state = DiffusionRequestState(
-                    request_id=request_id,
-                    sampling=copy.deepcopy(sched_new_req.req.sampling_params),
-                    prompt=sched_new_req.req.prompt,
-                    kv_sender_info=sched_new_req.req.kv_sender_info,
-                )
-                state_req = copy.copy(sched_new_req.req)
-                state_req.sampling_params = new_state.sampling
-                self.kv_transfer_manager.receive_multi_kv_cache_distributed(
-                    state_req,
-                    cfg_kv_collect_func=getattr(self.od_config, "cfg_kv_collect_func", None),
-                    target_device=self.target_device,
-                )
-                self.state_cache[request_id] = new_state
-                resolved.append(new_state)
-
-            # process cached requests
-            for request_id in scheduler_output.scheduled_cached_reqs.request_ids:
-                state = self.state_cache.get(request_id)
-                if state is None:
-                    raise ValueError(f"Missing cached state for request {request_id}.")
-                resolved.append(state)
-        except Exception:
-            for request_id in new_request_ids:
-                self.state_cache.pop(request_id, None)
-            raise
-
-        return resolved, new_request_ids
-
-    def _prepare_batch_inputs(self, states: list[DiffusionRequestState], new_request_ids: list[str]) -> InputBatch:
-        # process new reqs
-        for state in states:
-            if state.request_id in new_request_ids:
-                # set generator
-                if state.sampling.generator is None and state.sampling.seed is not None:
-                    if state.sampling.generator_device is not None:
-                        gen_device = state.sampling.generator_device
-                    elif self.device.type == "cpu":
-                        gen_device = "cpu"
-                    else:
-                        gen_device = self.device
-                    state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
-                clear_pipeline_stage_durations(self.pipeline)
-                # encode
-                self.pipeline.prepare_encode(state)
-                merge_stage_durations(
-                    state,
-                    consume_pipeline_stage_durations(self.pipeline),
-                )
-
-        input_batch = InputBatch.make_batch(
-            states,
-            cached_batch=getattr(self, "input_batch", None),
-        )
-        self.input_batch = input_batch
-        return input_batch
-
-    def _update_states_after(
-        self,
-        states: list[DiffusionRequestState],
-        input_batch: InputBatch,
-        interrupted: bool = False,
-    ):
-        """Step-after update: clear cached state for completed request."""
-        gathered_latents = torch.cat([state.latents for state in states], dim=0)
-        if (
-            input_batch.latents.size() == gathered_latents.size()
-            and input_batch.latents.dtype == gathered_latents.dtype
-            and input_batch.latents.device == gathered_latents.device
-        ):
-            input_batch.latents.copy_(gathered_latents)
-        else:
-            input_batch.latents = gathered_latents.clone()
-
-        self.input_batch = input_batch
-        scatter_latents(states, input_batch)
-
-        for state in states:
-            if interrupted or state.request_denoise_completed:
-                self.state_cache.pop(state.request_id, None)
-
-    def _prepare_attn_metadata(self, input_batch: InputBatch) -> Any:
-        model_state = getattr(self, "model_state", None)
-        if model_state is None:
-            return {}
-        prepare_attn = getattr(model_state, "prepare_attn", None)
-        if not callable(prepare_attn):
-            return {}
-        return prepare_attn(input_batch)
-
-    def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
-        """Execute one step for one scheduled request and return runner output."""
-        assert self.pipeline is not None, "Model not loaded. Call load_model() first."
-        if not self.supports_step_mode():
-            raise ValueError("Current pipeline does not support step execution.")
-        # Stepwise mode only supports the basic state-driven denoise path for now.
-        # Request-mode extras such as cache backends, editing inputs, and
-        # similar features are not supported here yet.
-        if self.od_config.cache_backend not in (None, "none"):
-            raise ValueError("Step mode does not support cache_backend yet.")
-
-        use_hsdp = self.od_config.parallel_config.use_hsdp
-        grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
-        with grad_context:
-            had_active_states = bool(self.state_cache)
-            states, new_request_ids = self._update_states(scheduler_output)
-            is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
-            if new_request_ids and not had_active_states and is_primary and current_omni_platform.is_available():
-                current_omni_platform.reset_peak_memory_stats()
-            input_batch = self._prepare_batch_inputs(states, new_request_ids)
-            attn_metadata = self._prepare_attn_metadata(input_batch)
-
-            with set_forward_context(
-                vllm_config=self.vllm_config,
-                omni_diffusion_config=self.od_config,
-                attn_metadata=attn_metadata,
-            ):
-                clear_pipeline_stage_durations(self.pipeline)
-                noise_pred = self.pipeline.denoise_step(input_batch, states=states)
-                denoise_stage_durations = consume_pipeline_stage_durations(self.pipeline)
-                for state in states:
-                    merge_stage_durations(
-                        state,
-                        denoise_stage_durations,
-                    )
-
-                runner_output_list = []
-                pipeline_interrupted = getattr(self.pipeline, "interrupt", False)
-                if noise_pred is None and pipeline_interrupted:
-                    for state in states:
-                        runner_output_list.append(
-                            RunnerOutput(
-                                request_id=state.request_id,
-                                step_index=state.step_index,
-                                finished=True,
-                                result=DiffusionOutput(error="stepwise denoise interrupted"),
-                            )
-                        )
-
-                else:
-                    offset = 0
-                    for req in states:
-                        row_num = req.latents.shape[0]
-                        try:
-                            self.pipeline.step_scheduler(
-                                req, noise_pred[offset : offset + row_num] if noise_pred is not None else None
-                            )
-                            if self.od_config.streaming_output:
-                                should_decode = req.chunk_denoise_completed
-                            else:
-                                should_decode = req.denoise_completed
-
-                            if should_decode:
-                                clear_pipeline_stage_durations(self.pipeline)
-                                result = self.pipeline.post_decode(req)
-                                if result is not None:
-                                    self._attach_stepwise_metrics(
-                                        req,
-                                        result,
-                                        is_primary=is_primary,
-                                    )
-                            else:
-                                result = None
-                            # finished should be computed after post_decode() advanced chunk_index
-                            finished = (
-                                req.request_denoise_completed
-                                if self.od_config.streaming_output
-                                else req.denoise_completed
-                            )
-                            runner_output_list.append(
-                                RunnerOutput(
-                                    request_id=req.request_id,
-                                    step_index=req.step_index,
-                                    finished=finished,
-                                    result=result,
-                                )
-                            )
-                            offset = offset + row_num
-                        except Exception as per_req_exc:
-                            offset = offset + row_num
-                            logger.error(
-                                "Stepwise per-request error for %s: %s",
-                                req.request_id,
-                                per_req_exc,
-                                exc_info=True,
-                            )
-                            runner_output_list.append(
-                                RunnerOutput(
-                                    request_id=req.request_id,
-                                    step_index=req.step_index,
-                                    finished=True,
-                                    result=DiffusionOutput(error=str(per_req_exc)),
-                                )
-                            )
-
-                    if noise_pred is not None and offset != noise_pred.shape[0]:
-                        raise ValueError(
-                            f"Stepwise noise_pred consumed {offset} rows, "
-                            f"but batched noise_pred has {noise_pred.shape[0]} rows."
-                        )
-
-                if is_primary:
-                    batch_peak_memory_mb = self._sample_peak_memory_mb()
-                    states_by_id = {state.request_id: state for state in states}
-                    for state in states:
-                        state.peak_memory_mb = max(state.peak_memory_mb, batch_peak_memory_mb)
-                    for runner_output in runner_output_list:
-                        if runner_output.result is None:
-                            continue
-                        state = states_by_id.get(runner_output.request_id)
-                        if state is None:
-                            continue
-                        runner_output.result.peak_memory_mb = max(
-                            runner_output.result.peak_memory_mb,
-                            state.peak_memory_mb,
-                        )
-
-                self._update_states_after(states, input_batch, pipeline_interrupted)
-
-                return BatchRunnerOutput.from_list(runner_output_list)

--- a/vllm_omni/diffusion/worker/diffusion_model_runner_v2.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner_v2.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Stepwise diffusion runner using state-based pipeline atoms."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from torch.profiler import record_function
+
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.forward_context import set_forward_context
+from vllm_omni.diffusion.models.interface import StagePayload, supports_step_execution
+from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
+from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.input_batch import InputBatch
+from vllm_omni.diffusion.worker.utils import (
+    BatchRunnerOutput,
+    DiffusionRequestState,
+    RunnerOutput,
+    attach_stage_durations,
+    clear_pipeline_stage_durations,
+    consume_pipeline_stage_durations,
+    merge_stage_durations,
+)
+from vllm_omni.platforms import current_omni_platform
+
+
+@dataclass
+class _StepRequestView:
+    request_id: str
+    prompt: object
+    sampling_params: object
+    kv_sender_info: dict | None
+
+
+class DiffusionModelRunnerV2(DiffusionModelRunner):
+    """Runner-side execution for diffusion v2 atoms.
+
+    The runner owns state cache, batching, step loop, scatter/gather, metrics,
+    and local stage execution. The pipeline owns model math and state atoms.
+    """
+
+    def supports_step_mode(self) -> bool:
+        return self.pipeline is not None and supports_step_execution(self.pipeline)
+
+    def run_encode_stage(
+        self,
+        state: DiffusionRequestState,
+        payload: StagePayload | None = None,
+    ) -> DiffusionRequestState:
+        """Build a DiT-ready state from local request data or a received payload."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_encode_stage"):
+            state = self.pipeline.init_state(state)
+            if payload is None:
+                state = self.pipeline.check_inputs(state)
+                state = self.pipeline.encode(state)
+            else:
+                state = self.pipeline.unpack_stage_state(payload, state)
+            state = self.pipeline.prepare(state)
+        merge_stage_durations(
+            state,
+            consume_pipeline_stage_durations(self.pipeline),
+        )
+        return state
+
+    def _update_states(
+        self, scheduler_output: DiffusionSchedulerOutput
+    ) -> tuple[list[DiffusionRequestState], list[str]]:
+        """Step-before update: cleanup finished requests and resolve running states."""
+        for request_id in scheduler_output.finished_req_ids:
+            self.state_cache.pop(request_id, None)
+
+        resolved: list[DiffusionRequestState] = []
+        new_request_ids: list[str] = []
+        for sched_new_req in scheduler_output.scheduled_new_reqs:
+            request_id = sched_new_req.request_id
+            new_request_ids.append(request_id)
+            if request_id in self.state_cache:
+                raise ValueError(f"Received duplicate new-request payload for cached request {request_id}.")
+            req = sched_new_req.req
+            sampling = deepcopy(req.sampling_params)
+            new_state = DiffusionRequestState(
+                request_id=request_id,
+                sampling=sampling,
+                prompt=getattr(req, "prompt", None),
+                kv_sender_info=getattr(req, "kv_sender_info", None),
+            )
+            state_req = _StepRequestView(
+                request_id=request_id,
+                prompt=new_state.prompt,
+                sampling_params=sampling,
+                kv_sender_info=new_state.kv_sender_info,
+            )
+            self.kv_transfer_manager.receive_multi_kv_cache_distributed(
+                state_req,
+                cfg_kv_collect_func=getattr(self.od_config, "cfg_kv_collect_func", None),
+                target_device=self.target_device,
+            )
+            self.state_cache[request_id] = new_state
+            resolved.append(new_state)
+
+        for request_id in scheduler_output.scheduled_cached_reqs.request_ids:
+            state = self.state_cache.get(request_id)
+            if state is None:
+                raise ValueError(f"Missing cached state for request {request_id}.")
+            resolved.append(state)
+
+        return resolved, new_request_ids
+
+    def _prepare_generator(self, state: DiffusionRequestState) -> None:
+        if state.sampling.generator is not None or state.sampling.seed is None:
+            return
+        if state.sampling.generator_device is not None:
+            gen_device = state.sampling.generator_device
+        elif self.device.type == "cpu":
+            gen_device = "cpu"
+        else:
+            gen_device = self.device
+        state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
+
+    def _prepare_batch_inputs(self, states: list[DiffusionRequestState], new_request_ids: list[str]) -> InputBatch:
+        for state_index, state in enumerate(states):
+            if state.request_id not in new_request_ids:
+                continue
+            self._prepare_generator(state)
+            prepared_state = self.run_encode_stage(state)
+            if prepared_state.request_id != state.request_id:
+                raise ValueError("Pipeline atom changed request_id during encode stage.")
+            states[state_index] = prepared_state
+            self.state_cache[prepared_state.request_id] = prepared_state
+
+        input_batch = self.pipeline.build_step_batch(
+            states,
+            cached_batch=getattr(self, "input_batch", None),
+        )
+        self.input_batch = input_batch
+        return input_batch
+
+    def _update_states_after(
+        self,
+        states: list[DiffusionRequestState],
+        input_batch: InputBatch,
+        interrupted: bool = False,
+    ) -> None:
+        self.input_batch = input_batch
+
+        for state in states:
+            if interrupted or state.request_denoise_completed:
+                self.state_cache.pop(state.request_id, None)
+
+    def run_denoise_stage(
+        self,
+        input_batch: InputBatch,
+    ) -> tuple[dict[str, RunnerOutput], bool]:
+        """Run one DiT denoise step and request-local scheduler updates."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_denoise_stage"):
+            noise_pred = self.pipeline.denoise_step(input_batch)
+
+        stage_results: dict[str, DiffusionOutput] = {}
+        if noise_pred is None and getattr(self.pipeline, "interrupt", False):
+            for state in input_batch.states:
+                stage_results[state.request_id] = DiffusionOutput(error="stepwise denoise interrupted")
+            pipeline_interrupted = True
+        elif noise_pred is None:
+            raise RuntimeError("denoise_step returned None without pipeline interrupt.")
+        else:
+            pipeline_interrupted = False
+            offset = 0
+            for state in input_batch.states:
+                if state.latents is None:
+                    raise ValueError(f"Request {state.request_id} has no latents for denoise scheduling.")
+                row_num = state.latents.shape[0]
+                step_noise_pred = noise_pred[offset : offset + row_num]
+                updated_state = self.pipeline.step_scheduler(state, step_noise_pred)
+                if updated_state is not state:
+                    raise RuntimeError("step_scheduler must update the existing DiffusionRequestState.")
+                offset += row_num
+
+            if offset != noise_pred.shape[0]:
+                raise ValueError(
+                    f"Stepwise noise_pred consumed {offset} rows, "
+                    f"but batched noise_pred has {noise_pred.shape[0]} rows."
+                )
+
+        denoise_stage_durations = consume_pipeline_stage_durations(self.pipeline)
+        for state in input_batch.states:
+            merge_stage_durations(state, denoise_stage_durations)
+
+        states_by_id = {state.request_id: state for state in input_batch.states}
+        stage_outputs: dict[str, RunnerOutput] = {}
+        for request_id, result in stage_results.items():
+            state = states_by_id.get(request_id)
+            if state is not None:
+                attach_stage_durations(state, result)
+            stage_outputs[request_id] = RunnerOutput(
+                request_id=request_id,
+                step_index=state.step_index if state is not None else 0,
+                finished=True,
+                result=result,
+            )
+        return stage_outputs, pipeline_interrupted
+
+    def run_decode_stage(
+        self,
+        state: DiffusionRequestState,
+        payload: StagePayload | None = None,
+    ) -> DiffusionOutput:
+        """Decode final/chunk latents through pipeline atoms."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_decode_stage"):
+            if payload is not None:
+                state = self.pipeline.unpack_stage_state(payload, state)
+            updated_state = self.pipeline.decode(state)
+            if updated_state is not state:
+                raise RuntimeError("decode must update the existing DiffusionRequestState.")
+            result = self.pipeline.postprocess(state)
+        merge_stage_durations(
+            state,
+            consume_pipeline_stage_durations(self.pipeline),
+        )
+        attach_stage_durations(state, result)
+        return result
+
+    def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
+        """Execute one scheduled diffusion step batch."""
+        assert self.pipeline is not None, "Model not loaded. Call load_model() first."
+        if not self.supports_step_mode():
+            raise ValueError("Current pipeline does not support step execution.")
+        if self.od_config.cache_backend not in (None, "none"):
+            raise ValueError("Step mode does not support cache_backend yet.")
+
+        use_hsdp = self.od_config.parallel_config.use_hsdp
+        grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
+        with grad_context:
+            had_active_states = bool(self.state_cache)
+            states, new_request_ids = self._update_states(scheduler_output)
+            if not states:
+                return BatchRunnerOutput.from_list([])
+            is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+            if new_request_ids and not had_active_states and is_primary and current_omni_platform.is_available():
+                current_omni_platform.reset_peak_memory_stats()
+            input_batch = self._prepare_batch_inputs(states, new_request_ids)
+            attn_metadata = self.pipeline.build_step_attention_metadata(input_batch)
+
+            with set_forward_context(
+                vllm_config=self.vllm_config,
+                omni_diffusion_config=self.od_config,
+                attn_metadata=attn_metadata,
+            ):
+                denoise_outputs, pipeline_interrupted = self.run_denoise_stage(input_batch)
+                runner_output_list: list[RunnerOutput] = []
+                for state in states:
+                    denoise_output = denoise_outputs.get(state.request_id)
+                    if denoise_output is not None:
+                        runner_output_list.append(denoise_output)
+                        continue
+
+                    should_decode = (
+                        state.chunk_denoise_completed if self.od_config.streaming_output else state.denoise_completed
+                    )
+
+                    result = self.run_decode_stage(state) if should_decode else None
+                    finished = (
+                        state.request_denoise_completed if self.od_config.streaming_output else state.denoise_completed
+                    )
+                    runner_output_list.append(
+                        RunnerOutput(
+                            request_id=state.request_id,
+                            step_index=state.step_index,
+                            finished=finished,
+                            result=result,
+                        )
+                    )
+
+                if is_primary:
+                    batch_peak_memory_mb = self._sample_peak_memory_mb()
+                    states_by_id = {state.request_id: state for state in states}
+                    for state in states:
+                        state.peak_memory_mb = max(state.peak_memory_mb, batch_peak_memory_mb)
+                    for runner_output in runner_output_list:
+                        if runner_output.result is None:
+                            continue
+                        state = states_by_id.get(runner_output.request_id)
+                        if state is None:
+                            continue
+                        runner_output.result.peak_memory_mb = max(
+                            runner_output.result.peak_memory_mb,
+                            state.peak_memory_mb,
+                        )
+
+                self._update_states_after(states, input_batch, pipeline_interrupted)
+                return BatchRunnerOutput.from_list(runner_output_list)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -48,6 +48,7 @@ from vllm_omni.diffusion.registry import get_diffusion_ir_op_priority_func
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
 from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput
 from vllm_omni.engine.stage_init_utils import set_death_signal
 from vllm_omni.lora.request import LoRARequest
@@ -240,6 +241,11 @@ class DiffusionWorker:
         else:
             model_runner_cls_path = current_omni_platform.get_diffusion_model_runner_cls()
         model_runner_cls = resolve_obj_by_qualname(model_runner_cls_path)
+        needs_step_runner = bool(
+            getattr(self.od_config, "step_execution", False) or getattr(self.od_config, "streaming_output", False)
+        )
+        if needs_step_runner and model_runner_cls is DiffusionModelRunner:
+            model_runner_cls = DiffusionModelRunnerV2
         self.model_runner = model_runner_cls(
             vllm_config=self.vllm_config,
             od_config=self.od_config,
@@ -318,7 +324,7 @@ class DiffusionWorker:
             init_workspace_manager(self.device)
 
     def _create_profiler(self) -> WorkerProfiler | None:
-        profiler_config = self.od_config.profiler_config
+        profiler_config = getattr(self.od_config, "profiler_config", None)
         profiler_type = getattr(profiler_config, "profiler", None)
         if profiler_type == "torch":
             return create_omni_profiler(

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -465,7 +465,9 @@ def _prepare_image_latents(
     *,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
-    image_latents = [getattr(state.sampling, "image_latent", None) for state in states]
+    image_latents = [
+        state.extra.get("image_latents", getattr(state.sampling, "image_latent", None)) for state in states
+    ]
     if all(image_latent is None for image_latent in image_latents):
         return None
     if any(image_latent is None for image_latent in image_latents):

--- a/vllm_omni/diffusion/worker/utils.py
+++ b/vllm_omni/diffusion/worker/utils.py
@@ -55,10 +55,10 @@ class DiffusionRequestState:
     """Per-request mutable state across all pipeline stages.
 
     Owned by Runner and passed through all step-execution stages:
-    ``prepare_encode()`` initializes/updates fields, ``denoise_step()`` and
-    ``step_scheduler()`` mutate per-step fields, and ``post_decode()``
-    consumes final latents. This state object is also the cache unit for
-    future continuous batching.
+    ``prepare`` initializes request state, ``denoise_step`` and
+    ``step_scheduler`` mutate per-step fields, and ``decode`` consumes
+    final/chunk latents. This state object is also the cache unit for future
+    continuous batching.
 
     This dataclass keeps only the minimal cross-model state required by the
     step-execution contract. Pipeline-specific state should be stored in
@@ -78,7 +78,7 @@ class DiffusionRequestState:
     prompt: OmniPromptType | None = None
     kv_sender_info: dict | None = None
 
-    # ── Encoded prompts (set once by prepare_encode) ──
+    # ── Encoded prompts (set once by encode) ──
     prompt_embeds: torch.Tensor | None = None
     prompt_embeds_mask: torch.Tensor | None = None
     negative_prompt_embeds: torch.Tensor | None = None
@@ -87,7 +87,7 @@ class DiffusionRequestState:
     # ── Latent state (mutated every step by step_scheduler) ──
     latents: torch.Tensor | None = None
 
-    # ── Timestep schedule (set once by prepare_encode) ──
+    # ── Timestep schedule (set once by prepare) ──
     timesteps: torch.Tensor | list[torch.Tensor] | None = None
     step_index: int = 0
 
@@ -97,14 +97,14 @@ class DiffusionRequestState:
     total_chunks: int = 1
     chunk_num_steps: int | None = None
 
-    # ── Per-request scheduler instance (set once by prepare_encode) ──
+    # ── Per-request scheduler instance (set once by prepare) ──
     scheduler: Any | None = None
 
-    # ── CFG config (set once by prepare_encode) ──
+    # ── CFG config (set once by prepare) ──
     do_true_cfg: bool = False
     guidance: torch.Tensor | None = None
 
-    # ── Spatial / sequence metadata (set once by prepare_encode) ──
+    # ── Spatial / sequence metadata (set once by prepare) ──
     img_shapes: list | None = None
     txt_seq_lens: list[int] | None = None
     negative_txt_seq_lens: list[int] | None = None


### PR DESCRIPTION
  <!-- markdownlint-disable -->

  ## Purpose

  Refactor diffusion pipeline stage execution to make pipeline logic easier to split by
  stage and reuse across batching flows.

  This PR introduces shared pipeline atoms/mixins and updates the diffusion runner/worker
  path to route stage execution through the new structure. The main goal is to prepare
  diffusion pipelines for future stage separation while keeping request batching support
  maintainable.
  
  
  ## Test Plan

  - Run ruff format/check on changed Python files.
  - Run pre-commit hooks for changed files.
  - Run focused diffusion model runner tests.

  **vLLM Version:**

  v0.24.0

  **vLLM-Omni Commit:**


  ## Test Result

  - `ruff format`: passed
  - `ruff check`: passed
  - `pre-commit`: passed
  - `pytest tests/diffusion/test_diffusion_model_runner.py`: passed