### PR TITLE
[BugFix] Force LTX2.3 RMSNorm IR ops to vllm_c

### DIFF
--- a/tests/diffusion/test_diffusion_plugin_hooks.py
+++ b/tests/diffusion/test_diffusion_plugin_hooks.py
@@ -140,3 +140,30 @@ class TestWorkerUsesHook:
         mock_platform.get_default_ir_op_priority.assert_called_once_with(vllm_config)
         mock_get_hook.assert_called_once_with(od_config)
         hook.assert_called_once_with(default_priority, vllm_config=vllm_config)
+
+    @pytest.mark.parametrize("model_class_name", ["LTX23Pipeline", "LTX23ImageToVideoPipeline"])
+    @patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
+    def test_ltx23_ir_op_priority_prefers_vllm_c_rms_norm(
+        self,
+        mock_platform: Mock,
+        model_class_name: str,
+    ) -> None:
+        """Test LTX-2.3 resolves native-only platform RMSNorm defaults back to vllm_c."""
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        from vllm_omni.diffusion.worker.diffusion_worker import _resolve_ir_op_priority
+
+        default_priority = IrOpPriorityConfig.with_default(
+            ["native"],
+            rms_norm=["native"],
+            fused_add_rms_norm=["native"],
+        )
+        mock_platform.get_default_ir_op_priority.return_value = default_priority
+
+        merged = _resolve_ir_op_priority(
+            SimpleNamespace(model_class_name=model_class_name),
+            SimpleNamespace(),
+        )
+
+        assert merged.rms_norm == ["vllm_c", "native"]
+        assert merged.fused_add_rms_norm == ["vllm_c", "native"]

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -19,7 +19,7 @@ import json
 import os
 from collections.abc import Iterable
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, ClassVar
 
 import numpy as np
@@ -61,6 +61,21 @@ from .pipeline_ltx2 import (
 )
 
 logger = init_logger(__name__)
+
+
+def get_ltx23_ir_op_priority_func(od_config: OmniDiffusionConfig):
+    del od_config
+
+    def ir_op_priority_func(ir_op_priority, vllm_config=None):
+        del vllm_config
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        priority_kwargs = {field.name: list(getattr(ir_op_priority, field.name)) for field in fields(ir_op_priority)}
+        priority_kwargs["rms_norm"] = ["vllm_c", "native"]
+        priority_kwargs["fused_add_rms_norm"] = ["vllm_c", "native"]
+        return IrOpPriorityConfig(**priority_kwargs)
+
+    return ir_op_priority_func
 
 
 def _get_audio_latents_from_sampling(sampling: Any) -> torch.Tensor | None:

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3_image2video.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3_image2video.py
@@ -23,6 +23,7 @@ from .pipeline_ltx2_3 import (
     _LTX23PromptContext,
     _LTX23RequestInputs,
     get_ltx2_post_process_func,
+    get_ltx23_ir_op_priority_func,
 )
 from .pipeline_ltx2_image2video import LTX2ImageToVideoPipeline, _I2VVideoAudioScheduler
 
@@ -450,5 +451,6 @@ class LTX23ImageToVideoPipeline(LTX23Pipeline):
 
 __all__ = [
     "LTX23ImageToVideoPipeline",
+    "get_ltx23_ir_op_priority_func",
     "get_ltx2_post_process_func",
 ]

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -547,6 +547,8 @@ _DIFFUSION_IR_OP_PRIORITY_FUNCS = {
     # `ir_op_priority_func` function must be placed in {mod_folder}/{mod_relname}.py,
     # where mod_folder and mod_relname are defined and mapped using `_DIFFUSION_MODELS` via the `arch` key.
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_ir_op_priority_func",
+    "LTX23Pipeline": "get_ltx23_ir_op_priority_func",
+    "LTX23ImageToVideoPipeline": "get_ltx23_ir_op_priority_func",
 }
 
 _DIFFUSION_PRE_PROCESS_FUNCS = {


### PR DESCRIPTION
## Purpose

vLLM 0.24 makes the CUDA platform default prefer native RMSNorm under inductor. LTX-2.3 regresses on that native-only RMSNorm path, while forcing the RMSNorm family back to `vllm_c,native` recovers the compile-path regression.

This patch keeps the upstream inductor-aware platform default intact and adds a model-specific LTX-2.3 override through the existing diffusion IR op priority hook. Both `LTX23Pipeline` and `LTX23ImageToVideoPipeline` now prefer `vllm_c` for `rms_norm` and `fused_add_rms_norm`, while preserving the rest of the platform priority fields.

## Test Plan

https://github.com/vllm-project/vllm-omni/pull/4464
- `python -m pytest -q tests/diffusion/test_diffusion_plugin_hooks.py -k ltx23_ir_op_priority`

## Test Result

0.24 ori compile：stage_0_gen_ms = 4710.10ms
0.23 compile：stage_0_gen_ms = 4215.94ms
0.24 compile used vllm_c：stage_0_gen_ms = 4169.64ms

0.24 ori eager :  stage_0_gen_ms =  6712.5ms
0.23 eager:  stage_0_gen_ms = 5014.2ms
0.24 eager used vllm_c : 5007.3ms