### PR TITLE
[Bugfix][Model] Fix Qwen3-Omni video metadata handling for use_audio_in_video

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -412,6 +412,44 @@ def test_audio_in_video_002(omni_server, openai_client) -> None:
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
+def test_audio_in_video_default_loader_sampling_regression(omni_server, openai_client) -> None:
+    """
+    Regression: ``use_audio_in_video`` with default video loader sampling (no
+    ``media_io_kwargs.video.fps``) after a prior request that pinned fps.
+
+    Before the fix the second request could partial-hit mm-cache (audio cached,
+    video re-processed without audio) and fail with ``StopIteration`` in
+    ``replace_multimodal_special_tokens``.
+    """
+    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(224, 224, 128, embed_audio=True)['base64']}"
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        video_data_url=video_data_url,
+        content_text="Reply with one word: OK.",
+    )
+
+    base_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "stream": False,
+        "use_audio_in_video": True,
+        "modalities": ["text"],
+    }
+
+    # Prime mm-cache with explicit loader fps (historical failure mode).
+    openai_client.send_omni_request(
+        {
+            **base_config,
+            "extra_body": {"media_io_kwargs": {"video": {"fps": 1, "num_frames": 128}}},
+        }
+    )
+
+    # Default loader sampling: must succeed without explicit media_io fps.
+    openai_client.send_omni_request(dict(base_config))
+
+
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_one_word_prompt_001(omni_server, openai_client) -> None:
     """
     Input Modal: text only (one-word answer constraint).

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -17,7 +17,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsMultiModal, SupportsPP
 from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniConditionalGenerationMixin,
-    Qwen2_5OmniThinkerProcessingInfo,
 )
 from vllm.model_executor.models.utils import init_vllm_registered_model, maybe_prefix
 from vllm.model_executor.models.vision import (
@@ -39,6 +38,7 @@ from vllm_omni.model_executor.models.output_templates import OmniOutput
 from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
     Qwen2_5OmniThinkerDummyInputsBuilder,
     Qwen2_5OmniThinkerMultiModalProcessor,
+    Qwen2_5OmniThinkerProcessingInfo,
 )
 from vllm_omni.model_executor.models.utils import add_prefix_to_loaded_weights, split_list_into_ranges
 from vllm_omni.platforms import current_omni_platform

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -112,9 +112,17 @@ def _presampled_videos_hf_kwargs(
     # An explicit user-provided fps takes precedence.
     if "fps" not in videos_kwargs:
         fps_values = [_compute_sampled_video_fps(m) for m in video_metadata]
-        # The HF processor accepts a single fps per call.
-        if None not in fps_values and len(set(fps_values)) == 1:
-            videos_kwargs["fps"] = fps_values[0]
+        # HF accepts a single fps per call and uses it for every video's
+        # video_second_per_grid.
+        known_fps = [fps for fps in fps_values if fps is not None]
+        unique_fps = set(known_fps)
+        if len(unique_fps) == 1:
+            videos_kwargs["fps"] = known_fps[0]
+        elif len(unique_fps) > 1:
+            logger.warning(
+                f"Mixed sampled FPS {sorted(unique_fps)} in one request; HF accepts a single fps, using {known_fps[0]}."
+            )
+            videos_kwargs["fps"] = known_fps[0]
 
     mm_kwargs["videos_kwargs"] = videos_kwargs
     return mm_kwargs

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Iterator, Mapping
 from typing import Any
 
 import numpy as np
+import PIL.Image as PILImage
 import torch
 from torch import nn
 from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
@@ -26,7 +27,6 @@ from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniAudioFeatureInputs,
     Qwen2_5OmniThinkerDummyInputsBuilder,
-    Qwen2_5OmniThinkerProcessingInfo,
     check_interleaved_audio_video,
     merge_interleaved_embeddings,
 )
@@ -34,7 +34,13 @@ from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniConditionalGenerationMixin as Qwen2_5OmniConditionalGenerationMixinBase,
 )
 from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniThinkerMultiModalDataParser as _Qwen2_5OmniThinkerMultiModalDataParserBase,
+)
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniThinkerMultiModalProcessor as _Qwen2_5OmniThinkerMultiModalProcessorBase,
+)
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniThinkerProcessingInfo as _Qwen2_5OmniThinkerProcessingInfoBase,
 )
 from vllm.model_executor.models.qwen2_5_vl import (
     Qwen2_5_VisionTransformer,
@@ -56,12 +62,13 @@ from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItems,
 )
-from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.parse import MultiModalDataItems, VideoProcessorItems
 from vllm.multimodal.processing.processor import (
     MultiModalPromptUpdates,
     PlaceholderFeaturesInfo,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.utils.collection_utils import is_list_of
 
 from vllm_omni.quantization.component_config import (
     resolve_encoder_quant_config,
@@ -74,10 +81,126 @@ except (ImportError, ModuleNotFoundError):
 logger = init_logger(__name__)
 
 
+def _presampled_videos_hf_kwargs(
+    mm_data: Mapping[str, object],
+    mm_kwargs: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Adjust HF video kwargs for videos pre-sampled by vLLM's video loader.
+
+    When ``video_metadata`` is present (emitted by
+    ``Qwen2_5OmniVideoProcessorItems``), the frames were already sampled
+    according to ``media_io_kwargs``, so the HF processor must not re-sample
+    them, and it needs the sampled fps (instead of its default) to compute
+    ``video_second_per_grid`` correctly. Otherwise the audio/video temporal
+    alignment breaks under ``use_audio_in_video=True``.
+    """
+    video_metadata = mm_data.get("video_metadata")
+    if not video_metadata:
+        return mm_kwargs
+
+    mm_kwargs = dict(mm_kwargs)
+    videos_kwargs = dict(mm_kwargs.get("videos_kwargs") or {})
+    videos_kwargs["do_sample_frames"] = False
+
+    def _compute_sampled_video_fps(metadata) -> float | None:
+        duration = getattr(metadata, "duration", None)
+        indices = getattr(metadata, "frames_indices", None)
+        if not duration or not indices or duration <= 0:
+            return None
+        return len(indices) / float(duration)
+
+    # An explicit user-provided fps takes precedence.
+    if "fps" not in videos_kwargs:
+        fps_values = [_compute_sampled_video_fps(m) for m in video_metadata]
+        # The HF processor accepts a single fps per call.
+        if None not in fps_values and len(set(fps_values)) == 1:
+            videos_kwargs["fps"] = fps_values[0]
+
+    mm_kwargs["videos_kwargs"] = videos_kwargs
+    return mm_kwargs
+
+
+class Qwen2_5OmniVideoProcessorItems(VideoProcessorItems):
+    """Video items that carry the loader's ``(frames, metadata)`` tuples.
+
+    The tuples are kept in ``data`` so that mm hashing and cache-miss
+    re-parsing retain the metadata; ``get_processor_data`` unpacks them into
+    the ``videos`` + ``video_metadata`` arguments of the HF processor.
+    """
+
+    def get_processor_data(self) -> Mapping[str, object]:
+        from transformers.video_utils import VideoMetadata
+
+        videos = [frames for frames, _ in self.data]
+        video_metadata = [
+            VideoMetadata(**{k: v for k, v in metadata.items() if k != "do_sample_frames"}) for _, metadata in self.data
+        ]
+        return {"videos": videos, "video_metadata": video_metadata}
+
+
+class Qwen2_5OmniThinkerMultiModalDataParser(_Qwen2_5OmniThinkerMultiModalDataParserBase):
+    def _parse_video_data(self, data):
+        if data is None or isinstance(data, dict) or self.is_embeddings(data):
+            return super()._parse_video_data(data)
+
+        # Normalize to a list of per-video items (same as the base parser).
+        if (is_list_of(data, PILImage.Image) and len(data) > 0) or (
+            isinstance(data, (np.ndarray, torch.Tensor)) and data.ndim == 4
+        ):
+            data_items = [data]
+        elif isinstance(data, (np.ndarray, torch.Tensor)):
+            data_items = [elem for elem in data]
+        elif isinstance(data, tuple) and len(data) == 2:
+            data_items = [data]
+        else:
+            data_items = data
+
+        videos_with_metadata = [self._get_video_with_metadata(item) for item in data_items]
+
+        # Metadata is optional: videos fetched by vLLM's media connector
+        # arrive as (frames, metadata) tuples, while plain arrays (e.g.
+        # offline `multi_modal_data` or dummy profiling inputs) carry no
+        # metadata and parse as before.
+        if any(metadata is None for _, metadata in videos_with_metadata):
+            return super()._parse_video_data(data)
+
+        return Qwen2_5OmniVideoProcessorItems(
+            videos_with_metadata,
+            metadata=[metadata for _, metadata in videos_with_metadata],
+        )
+
+
+class Qwen2_5OmniThinkerProcessingInfo(_Qwen2_5OmniThinkerProcessingInfoBase):
+    def get_data_parser(self):
+        feature_extractor = self.get_feature_extractor()
+
+        return Qwen2_5OmniThinkerMultiModalDataParser(
+            spatial_merge_size=self.get_hf_config().vision_config.spatial_merge_size,
+            target_sr=feature_extractor.sampling_rate,
+            target_channels=self.get_target_channels(),
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
+
 class Qwen2_5OmniThinkerMultiModalProcessor(
     _Qwen2_5OmniThinkerMultiModalProcessorBase,
 ):
     """Override to fix use_audio_in_video detection when mm cache returns None."""
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ):
+        mm_kwargs = _presampled_videos_hf_kwargs(mm_data, mm_kwargs)
+        return super()._call_hf_processor(
+            prompt=prompt,
+            mm_data=mm_data,
+            mm_kwargs=mm_kwargs,
+            tok_kwargs=tok_kwargs,
+        )
 
     def _maybe_apply_prompt_updates(
         self,

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -187,6 +187,14 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
 ):
     """Override to fix use_audio_in_video detection when mm cache returns None."""
 
+    def _cached_apply_hf_processor(self, inputs, timing_ctx):
+        # If use_audio_in_video, process video and audio together; otherwise,
+        # skip cache to avoid errors.
+        # Prevents partial cache hits from causing processing failures.
+        if inputs.hf_processor_mm_kwargs.get("use_audio_in_video"):
+            return self._apply_hf_processor(inputs, timing_ctx)
+        return super()._cached_apply_hf_processor(inputs, timing_ctx)
+
     def _call_hf_processor(
         self,
         prompt: str,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -120,6 +120,8 @@ from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
     Qwen2_5OmniConditionalGenerationMixin,
+    Qwen2_5OmniThinkerMultiModalDataParser,
+    _presampled_videos_hf_kwargs,
 )
 from vllm_omni.quantization.component_config import (
     PRE_QUANTIZED_METHODS,
@@ -621,6 +623,19 @@ class Qwen3OmniMoeThinkerProcessingInfo(Qwen2AudioProcessingInfo, Qwen2_5_VLProc
         assert isinstance(feature_extractor, WhisperFeatureExtractor)
         return feature_extractor
 
+    def get_data_parser(self):
+        feature_extractor = self.get_feature_extractor()
+
+        # Install the Omni parser, which keeps video metadata from vLLM's
+        # video loader (see Qwen2_5OmniVideoProcessorItems); the parser
+        # inherited from Qwen2AudioProcessingInfo would drop it.
+        return Qwen2_5OmniThinkerMultiModalDataParser(
+            spatial_merge_size=self.get_hf_config().vision_config.spatial_merge_size,
+            target_sr=feature_extractor.sampling_rate,
+            target_channels=1,
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"audio": None, "image": None, "video": None}
 
@@ -671,7 +686,10 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
         mm_data = dict(mm_data)
+        mm_kwargs = dict(mm_kwargs)
         audios = mm_data.pop("audios", [])
+
+        mm_kwargs = dict(_presampled_videos_hf_kwargs(mm_data, mm_kwargs))
 
         def pad_to_hop_length(x: np.ndarray, hop_length: int) -> np.ndarray:
             length = x.shape[-1]
@@ -927,9 +945,13 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
 
             audio_in_video_item_idx += 1
 
-            second_per_grid_ts = hf_processor_mm_kwargs.get("second_per_grid_ts", None)
-            if second_per_grid_ts:
-                video_second_per_grid_t = second_per_grid_ts[item_idx]
+            # Prefer the HF-computed value (temporal_patch_size / sampled fps)
+            # over request kwargs;
+            second_per_grid_ts = out_mm_data.get("second_per_grid_ts")
+            if second_per_grid_ts is None:
+                second_per_grid_ts = hf_processor_mm_kwargs.get("second_per_grid_ts", None)
+            if second_per_grid_ts is not None:
+                video_second_per_grid_t = float(second_per_grid_ts[item_idx])
             else:
                 video_second_per_grid_t = 2.0
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -74,7 +74,6 @@ from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniAudioFeatureInputs,
     Qwen2_5OmniThinkerDummyInputsBuilder,
-    Qwen2_5OmniThinkerMultiModalProcessor,
     check_interleaved_audio_video,
     merge_interleaved_embeddings,
 )
@@ -121,6 +120,7 @@ from vllm.transformers_utils.processor import cached_processor_from_config
 from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
     Qwen2_5OmniConditionalGenerationMixin,
     Qwen2_5OmniThinkerMultiModalDataParser,
+    Qwen2_5OmniThinkerMultiModalProcessor,
     _presampled_videos_hf_kwargs,
 )
 from vllm_omni.quantization.component_config import (


### PR DESCRIPTION

## Purpose

Fix Qwen3-Omni failures when serving video with use_audio_in_video=True, especially when media_io_kwargs.video.fps is not explicitly set.

Root cause: vLLM's video loader pre-samples frames and attaches metadata (duration, frames_indices, etc.), but the default multimodal parser drops this metadata before the HF processor runs. Without it, the HF processor assumes its default fps, `video_second_per_grid` is wrong, and audio/video temporal interleaving breaks (e.g. Failed to apply `Qwen3OmniMoeProcessor` or `StopIteration` in `replace_multimodal_special_tokens`).

Error log:
```bash
[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] The above exception was the direct cause of the following exception:^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] ^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] Traceback (most recent call last):^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 382, in _create_chat_completion^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     conversation, engine_prompts = await self._preprocess_chat(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 667, in _preprocess_chat^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     (conversation,), (engine_prompt,) = await renderer.render_chat_async(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py", line 244, in replace_multimodal_special_tokens^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     audio_token_indices = np.arange(next(audio_lengths))^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                                     ^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] StopIteration^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] ^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] The above exception was the direct cause of the following exception:^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] ^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] Traceback (most recent call last):^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 382, in _create_chat_completion^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     conversation, engine_prompts = await self._preprocess_chat(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 667, in _preprocess_chat^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     (conversation,), (engine_prompt,) = await renderer.render_chat_async(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/base.py", line 1043, in render_chat_async^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     eng_prompts = await asyncio.gather(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                   ^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/base.py", line 919, in process_for_engine_async^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     engine_input = await self._process_singleton_async(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/base.py", line 831, in _process_singleton_async^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     return await self._process_tokens_async(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/hf.py", line 1138, in _process_tokens_async^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     engine_input = await super()._process_tokens_async(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/base.py", line 793, in _process_tokens_async^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     engine_input = await self._process_multimodal_async(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     result = self.fn(*self.args, **self.kwargs)^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/renderers/base.py", line 716, in _process_multimodal^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/multimodal/processing/processor.py", line 1685, in apply^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     ) = self._cached_apply_hf_processor(inputs, timing_ctx)^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/multimodal/processing/processor.py", line 1474, in _cached_apply_hf_processor^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     ) = self._apply_hf_processor_main(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen2_5_omni_thinker.py", line 846, in _apply_hf_processor_main^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     mm_processed_data = self._apply_hf_processor_mm_only(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen2_5_omni_thinker.py", line 870, in _apply_hf_processor_mm_only^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     _, mm_processed_data, _ = self._apply_hf_processor_text_mm(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/multimodal/processing/processor.py", line 1153, in _apply_hf_processor_text_mm^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     processed_data = self._call_hf_processor(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                      ^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py", line 751, in _call_hf_processor^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     hf_inputs = super()._call_hf_processor(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen2_5_omni_thinker.py", line 482, in _call_hf_processor^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     hf_inputs = super()._call_hf_processor(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/multimodal/processing/processor.py", line 1110, in _call_hf_processor^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     return self.info.ctx.call_hf_processor(^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]   File "/usr/local/lib/python3.12/dist-packages/vllm/multimodal/processing/context.py", line 277, in call_hf_processor^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]     raise ValueError(msg) from exc^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404] ValueError: Failed to apply Qwen3OmniMoeProcessor on data={'text': '<|video_pad|>', 'videos': [array([[[[177, 168, 157],^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          [177, 168, 157],^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          [177, 168, 157],^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          ...,^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          [159, 142, 123],^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          [159, 142, 123],^M
^[[0;36m(APIServer pid=462282)^[[0;0m ERROR 07-08 16:21:06 [serving_chat.py:404]          [159, 142, 123]],^M
```

## Test Plan

**vLLM Version:** v0.24.0

**vLLM-Omni Commit:** a97f6c3097a39a6702bd1a88916355537ee41026

serve script:
```bash
vllm serve /home/admin/model --omni --async-chunk \
        --deploy-config vllm_omni/deploy/qwen3_omni_moe.yaml \
        --port 8090
```

example request:
```bash
curl -X POST http://localhost:8090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/home/admin/model/",
    "mm_processor_kwargs": {"use_audio_in_video": true},
    "media_io_kwargs": {
      "video": {"fps": 1, "num_frames": 128}
    },
    "messages": [
      {"role": "user", "content": [
        {"type": "video_url", "video_url": {"url": "https://mass.alipay.com/afts/file/A*tyAwRKm5UsUAAAAAckAAAAgAevV3AQ"}},
        {"type": "text", "text": "Please Describe the video and audio."}
      ]}
    ]
  }' | jq '{id, choices: [.choices[] | {content: .message.content}]}'
```

UT:

```bash
# Only test the added ut
pytest  tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_audio_in_video_default_loader_sampling_regression[default] -v -s --run-level=full_model
```

## Test Result

```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4095k  100 4095k  100   439   508k     54  0:00:08  0:00:08 --:--:-- 1064k
{
  "id": "chatcmpl-964ca29dc93c5ba0",
  "choices": [
    {
      "content": "The video opens with a close-up shot of a large, round button resting on a light-colored wooden surface. The button has a bright yellow base and a flat, circular blue top. The camera remains mostly still, with slight movements and adjustments in framing.\n\nAt approximately the 4-second mark, a person's finger enters the frame from the right and presses down on the blue top of the button. As the button is pressed, a loud, rapid, and continuous rattling or chattering sound is heard. This sound is high-pitched and mechanical in nature, resembling the noise of a small, fast-moving object or a toy.\n\nSimultaneously, a voice in Mandarin Chinese asks, \"Listen to this bird call, what kind of bird is it? Put one of these birds on the table.\" The rattling sound continues for several seconds after the button is pressed, then stops abruptly. The button is then released, and the camera remains focused on it for the rest of the clip."
    },
    {
      "content": null
    }
  ]
}
```

UT result：
```bash
==================================================== warnings summary ====================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

vllm_omni/version.py:55
  /vllm-workspace/vllm-omni/scripts/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.20.1.dev175+gce4d0f9a5.d20260523
   --> vLLM version 0.24.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
======================================= 1 passed, 17 warnings in 144.10s (0:02:24) =======================================
```

## Follow-up / TODO

- [ ] Migrate to upstream vLLM — Land the equivalent fix in `vllm/vllm/model_executor/models/qwen2_5_omni_thinker.py` and `qwen3_omni_moe_thinker.py `. After upstream merge, remove the vllm-omni overrides and import from vLLM again.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
