### PR TITLE
[Quantization] Add FP8 dynamic quantization support for MagiHuman

### DIFF
--- a/benchmarks/diffusion/quantization_quality.py
+++ b/benchmarks/diffusion/quantization_quality.py
@@ -192,6 +192,23 @@ def _output_fps(args) -> int:
     return 24
 
 
+def _prepare_video_frames_for_export(frames):
+    """Normalize integer NumPy video frames for diffusers' float-only exporter."""
+    array = np.asarray(frames)
+    if array.ndim == 4 and np.issubdtype(array.dtype, np.integer):
+        return list(array.astype(np.float32) / np.iinfo(array.dtype).max)
+    return list(array) if isinstance(frames, np.ndarray) and array.ndim == 4 else frames
+
+
+def _save_video(frames, output_path: Path, fps: int) -> None:
+    try:
+        from diffusers.utils import export_to_video
+
+        export_to_video(_prepare_video_frames_for_export(frames), str(output_path), fps=fps)
+    except ImportError:
+        np.save(output_path.with_suffix(".npy"), frames)
+
+
 def _generate_image(omni, args, prompt, seed):
     """Generate a single image and return (PIL.Image, time_seconds, memory_gib)."""
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
@@ -348,13 +365,7 @@ def run_benchmark(args):
     for i, prompt in enumerate(prompts):
         out = baseline_outputs[prompt][0]
         if is_video:
-            try:
-                from diffusers.utils import export_to_video
-
-                frames_list = list(out) if isinstance(out, np.ndarray) and out.ndim == 4 else out
-                export_to_video(frames_list, str(bl_dir / f"prompt_{i}.mp4"), fps=_output_fps(args))
-            except ImportError:
-                np.save(bl_dir / f"prompt_{i}.npy", out)
+            _save_video(out, bl_dir / f"prompt_{i}.mp4", fps=_output_fps(args))
         else:
             out.save(bl_dir / f"prompt_{i}.png")
 
@@ -395,13 +406,7 @@ def run_benchmark(args):
             qt_out = qt_outputs[prompt][0]
             if is_video:
                 lpips_score = compute_lpips_video(bl_out, qt_out, net=args.lpips_net)
-                try:
-                    from diffusers.utils import export_to_video
-
-                    frames_list = list(qt_out) if isinstance(qt_out, np.ndarray) and qt_out.ndim == 4 else qt_out
-                    export_to_video(frames_list, str(qt_dir / f"prompt_{i}.mp4"), fps=_output_fps(args))
-                except ImportError:
-                    np.save(qt_dir / f"prompt_{i}.npy", qt_out)
+                _save_video(qt_out, qt_dir / f"prompt_{i}.mp4", fps=_output_fps(args))
             else:
                 lpips_score = compute_lpips_images([bl_out], [qt_out], net=args.lpips_net)[0]
                 qt_out.save(qt_dir / f"prompt_{i}.png")

--- a/benchmarks/diffusion/quantization_quality.py
+++ b/benchmarks/diffusion/quantization_quality.py
@@ -44,6 +44,16 @@ LTX-2 example (text-to-video; audio output is generated but not scored by LPIPS)
         --height 704 --width 1216 \
         --num-frames 121 --num-inference-steps 40 --seed 42
 
+MagiHuman example (text-to-video+audio; LPIPS scores video frames only):
+    python benchmarks/diffusion/quantization_quality.py \
+        --model SII-GAIR/daVinci-MagiHuman-Base-1080p \
+        --model-type magi-human \
+        --task t2v \
+        --quantization fp8 \
+        --prompts "A woman speaks to the camera in a sunlit garden." \
+        --height 256 --width 448 \
+        --seconds 5 --num-inference-steps 8 --seed 52
+
 Multiple quantization methods:
     python benchmarks/diffusion/quantization_quality.py \
         --model Tongyi-MAI/Z-Image-Turbo \
@@ -67,6 +77,22 @@ from pathlib import Path
 
 import numpy as np
 import torch
+
+
+def _extract_peak_memory_gib(output, fallback_gib: float) -> float:
+    """Return worker-reported peak memory when the engine runs out of process."""
+    candidates = [output]
+    request_output = getattr(output, "request_output", None)
+    if isinstance(request_output, list):
+        candidates.extend(request_output)
+    elif request_output is not None:
+        candidates.append(request_output)
+
+    for candidate in candidates:
+        peak_memory_mb = getattr(candidate, "peak_memory_mb", None)
+        if peak_memory_mb:
+            return float(peak_memory_mb) / 1024.0
+    return fallback_gib
 
 
 def compute_lpips_images(
@@ -150,9 +176,20 @@ def _build_omni_kwargs(args, quantization=None):
         "parallel_config": parallel_config,
         "enforce_eager": args.enforce_eager,
     }
+    if args.model_type is not None:
+        kwargs["model_type"] = args.model_type
     if quantization:
-        kwargs["quantization_config"] = quantization
+        kwargs["quantization"] = quantization
     return kwargs
+
+
+def _output_fps(args) -> int:
+    """Return the native FPS when the model type provides one."""
+    if args.fps is not None:
+        return args.fps
+    if args.model_type == "magi-human":
+        return 25
+    return 24
 
 
 def _generate_image(omni, args, prompt, seed):
@@ -192,15 +229,27 @@ def _generate_video(omni, args, prompt, seed):
     generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(seed)
     torch.accelerator.reset_peak_memory_stats()
     start = time.perf_counter()
+    extra_args = {}
+    if args.seconds is not None:
+        extra_args["seconds"] = args.seconds
+    if args.sr_height is not None:
+        extra_args["sr_height"] = args.sr_height
+    if args.sr_width is not None:
+        extra_args["sr_width"] = args.sr_width
+    if args.sr_num_inference_steps is not None:
+        extra_args["sr_num_inference_steps"] = args.sr_num_inference_steps
+
     outputs = omni.generate(
         {"prompt": prompt, "negative_prompt": ""},
         OmniDiffusionSamplingParams(
             height=args.height,
             width=args.width,
+            seed=seed,
             generator=generator,
             guidance_scale=args.guidance_scale,
             num_inference_steps=args.num_inference_steps,
             num_frames=args.num_frames,
+            extra_args=extra_args,
         ),
     )
     elapsed = time.perf_counter() - start
@@ -241,7 +290,7 @@ def _generate_video(omni, args, prompt, seed):
         if frames_array.ndim == 5:
             frames_array = frames_array[0]
 
-    return frames_array, elapsed, peak_mem
+    return frames_array, elapsed, _extract_peak_memory_gib(first, peak_mem)
 
 
 def _free_gpu_memory():
@@ -288,6 +337,7 @@ def run_benchmark(args):
 
     bl_avg_time = np.mean([v[1] for v in baseline_outputs.values()])
     bl_mem = baseline_outputs[prompts[0]][2]  # use first prompt's memory
+    video_frame_count = len(baseline_outputs[prompts[0]][0]) if is_video else None
     omni_bl.shutdown()
     del omni_bl
     _free_gpu_memory()
@@ -302,7 +352,7 @@ def run_benchmark(args):
                 from diffusers.utils import export_to_video
 
                 frames_list = list(out) if isinstance(out, np.ndarray) and out.ndim == 4 else out
-                export_to_video(frames_list, str(bl_dir / f"prompt_{i}.mp4"), fps=args.fps)
+                export_to_video(frames_list, str(bl_dir / f"prompt_{i}.mp4"), fps=_output_fps(args))
             except ImportError:
                 np.save(bl_dir / f"prompt_{i}.npy", out)
         else:
@@ -349,7 +399,7 @@ def run_benchmark(args):
                     from diffusers.utils import export_to_video
 
                     frames_list = list(qt_out) if isinstance(qt_out, np.ndarray) and qt_out.ndim == 4 else qt_out
-                    export_to_video(frames_list, str(qt_dir / f"prompt_{i}.mp4"), fps=args.fps)
+                    export_to_video(frames_list, str(qt_dir / f"prompt_{i}.mp4"), fps=_output_fps(args))
                 except ImportError:
                     np.save(qt_dir / f"prompt_{i}.npy", qt_out)
             else:
@@ -387,7 +437,7 @@ def run_benchmark(args):
         f"seed={args.seed}, LPIPS ({args.lpips_net})"
     )
     if is_video:
-        lines.append(f"Video: {args.num_frames} frames")
+        lines.append(f"Video: {video_frame_count} frames")
     lines.append("")
     lines.append("### Summary")
     lines.append("")
@@ -443,6 +493,11 @@ def parse_args():
     )
     parser.add_argument("--model", required=True, help="Model name or local path.")
     parser.add_argument(
+        "--model-type",
+        default=None,
+        help="Optional vLLM-Omni model type override, for example magi-human.",
+    )
+    parser.add_argument(
         "--task",
         default="t2i",
         choices=["t2i", "t2v"],
@@ -465,7 +520,21 @@ def parse_args():
     parser.add_argument("--width", type=int, default=1024)
     parser.add_argument("--num-inference-steps", type=int, default=50)
     parser.add_argument("--num-frames", type=int, default=81, help="Number of video frames (t2v only).")
-    parser.add_argument("--fps", type=int, default=24, help="Video FPS for saving (t2v only).")
+    parser.add_argument("--seconds", type=int, default=None, help="MagiHuman output duration in seconds.")
+    parser.add_argument("--sr-height", type=int, default=None, help="MagiHuman SR output height.")
+    parser.add_argument("--sr-width", type=int, default=None, help="MagiHuman SR output width.")
+    parser.add_argument(
+        "--sr-num-inference-steps",
+        type=int,
+        default=None,
+        help="MagiHuman SR denoising steps.",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=None,
+        help="Video FPS for saving (defaults to 25 for MagiHuman and 24 otherwise).",
+    )
     parser.add_argument("--guidance-scale", type=float, default=4.0, help="CFG scale (used for video).")
     parser.add_argument("--output-dir", type=str, default="./quant_bench_output", help="Directory to save outputs.")
     parser.add_argument(

--- a/tests/diffusion/models/magi_human/test_magi_human_quantization.py
+++ b/tests/diffusion/models/magi_human/test_magi_human_quantization.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MagiHuman quantization config propagation."""
+
+import torch.nn as nn
+from pytest_mock import MockerFixture
+
+import vllm_omni.diffusion.models.magi_human.magi_human_dit as magi_human_dit
+from vllm_omni.diffusion.models.magi_human.magi_human_dit import (
+    DiTModel,
+    MagiHumanDiTConfig,
+    MoEColumnParallelLinear,
+    MoEQKVParallelLinear,
+    MoERowParallelLinear,
+)
+
+
+class _FakeParallelLinear(nn.Module):
+    def __init__(self, *args, quant_config=None, **kwargs):
+        super().__init__()
+        self.quant_config = quant_config
+        self.num_heads = kwargs.get("total_num_heads", 1)
+        self.num_kv_heads = kwargs.get("total_num_kv_heads", 1)
+
+
+def _tiny_magi_human_config() -> MagiHumanDiTConfig:
+    return MagiHumanDiTConfig(
+        num_layers=2,
+        hidden_size=128,
+        head_dim=16,
+        num_query_groups=2,
+        video_in_channels=16,
+        audio_in_channels=8,
+        text_in_channels=32,
+        mm_layers=[0],
+        gelu7_layers=[0],
+        enable_attn_gating=True,
+    )
+
+
+class TestMagiHumanDiTQuantization:
+    def _patch_parallel_linears(self, mocker: MockerFixture):
+        mocker.patch.object(magi_human_dit, "get_tensor_model_parallel_world_size", return_value=1)
+        mocker.patch.object(magi_human_dit, "QKVParallelLinear", _FakeParallelLinear)
+        mocker.patch.object(magi_human_dit, "ColumnParallelLinear", _FakeParallelLinear)
+        mocker.patch.object(magi_human_dit, "RowParallelLinear", _FakeParallelLinear)
+
+    def test_quant_config_propagates_to_shared_and_moe_parallel_linears(self, mocker: MockerFixture):
+        self._patch_parallel_linears(mocker)
+        mock_quant_config = mocker.MagicMock()
+
+        model = DiTModel(_tiny_magi_human_config(), quant_config=mock_quant_config)
+
+        moe_layer = model.block.layers[0]
+        assert isinstance(moe_layer.attention.linear_qkv, MoEQKVParallelLinear)
+        assert isinstance(moe_layer.attention.linear_proj, MoERowParallelLinear)
+        assert isinstance(moe_layer.attention.linear_gating, MoEColumnParallelLinear)
+        assert isinstance(moe_layer.mlp.up_gate_proj, MoEColumnParallelLinear)
+        assert isinstance(moe_layer.mlp.down_proj, MoERowParallelLinear)
+
+        for expert in moe_layer.attention.linear_qkv.experts:
+            assert expert.quant_config is mock_quant_config
+        for expert in moe_layer.attention.linear_proj.experts:
+            assert expert.quant_config is mock_quant_config
+        for expert in moe_layer.attention.linear_gating.experts:
+            assert expert.quant_config is mock_quant_config
+        for expert in moe_layer.mlp.up_gate_proj.experts:
+            assert expert.quant_config is mock_quant_config
+        for expert in moe_layer.mlp.down_proj.experts:
+            assert expert.quant_config is mock_quant_config
+
+        shared_layer = model.block.layers[1]
+        assert shared_layer.attention.linear_qkv.quant_config is mock_quant_config
+        assert shared_layer.attention.linear_proj.quant_config is mock_quant_config
+        assert shared_layer.attention.linear_gating.quant_config is mock_quant_config
+        assert shared_layer.mlp.up_gate_proj.quant_config is mock_quant_config
+        assert shared_layer.mlp.down_proj.quant_config is mock_quant_config
+
+    def test_none_quant_config_is_accepted(self, mocker: MockerFixture):
+        self._patch_parallel_linears(mocker)
+        model = DiTModel(_tiny_magi_human_config(), quant_config=None)
+
+        moe_layer = model.block.layers[0]
+        assert moe_layer.attention.linear_qkv.experts[0].quant_config is None
+        assert moe_layer.attention.linear_proj.experts[0].quant_config is None
+        assert moe_layer.attention.linear_gating.experts[0].quant_config is None
+        assert moe_layer.mlp.up_gate_proj.experts[0].quant_config is None
+        assert moe_layer.mlp.down_proj.experts[0].quant_config is None
+
+        shared_layer = model.block.layers[1]
+        assert shared_layer.attention.linear_qkv.quant_config is None
+        assert shared_layer.attention.linear_proj.quant_config is None
+        assert shared_layer.attention.linear_gating.quant_config is None
+        assert shared_layer.mlp.up_gate_proj.quant_config is None
+        assert shared_layer.mlp.down_proj.quant_config is None

--- a/tests/diffusion/quantization/test_quantization_fp8.py
+++ b/tests/diffusion/quantization/test_quantization_fp8.py
@@ -188,6 +188,38 @@ def _generate_single_stage_video(
         return num_frames_produced, peak_mem
 
 
+def _generate_magi_human_video(quantization: str | None = None) -> tuple[int, float]:
+    """Generate MagiHuman video+audio and return video frame count and worker peak memory."""
+    omni_kwargs: dict[str, Any] = {"model_type": "magi-human"}
+    if quantization:
+        omni_kwargs["quantization"] = quantization
+
+    with OmniRunner("SII-GAIR/daVinci-MagiHuman-Base-1080p", **omni_kwargs) as runner:
+        outputs = runner.omni.generate(
+            "A woman speaks calmly to the camera in a sunlit garden.",
+            OmniDiffusionSamplingParams(
+                height=256,
+                width=448,
+                num_inference_steps=8,
+                seed=42,
+                extra_args={"seconds": 1},
+            ),
+        )
+
+        first = outputs[0]
+        assert first.images, "MagiHuman did not return generated video frames"
+        frames = first.images[0]
+        assert getattr(frames, "ndim", 0) == 4
+        assert frames.shape[0] > 0
+
+        peak_memory_mb = getattr(first, "peak_memory_mb", None)
+        if peak_memory_mb:
+            peak_mem = float(peak_memory_mb) / 1024.0
+        else:
+            peak_mem = torch.accelerator.max_memory_allocated() / (1024**3)
+        return int(frames.shape[0]), peak_mem
+
+
 def _generate_bagel_image(
     quantization_config: str | None = None,
     num_inference_steps: int = 15,
@@ -372,6 +404,20 @@ def test_single_stage_ltx2_fp8_uses_less_memory():
 
     print(f"LTX-2 BF16 peak memory: {mem_bf16:.2f} GiB")
     print(f"LTX-2 FP8 peak memory:  {mem_fp8:.2f} GiB")
+    assert mem_fp8 < mem_bf16, f"FP8 ({mem_fp8:.2f} GiB) should use less memory than BF16 ({mem_bf16:.2f} GiB)"
+
+
+@hardware_test(res={"cuda": "H100"})
+def test_magi_human_fp8_uses_less_memory():
+    """MagiHuman online FP8 should generate video and use less memory than BF16."""
+    frames_bf16, mem_bf16 = _generate_magi_human_video()
+    torch.accelerator.empty_cache()
+
+    frames_fp8, mem_fp8 = _generate_magi_human_video(quantization="fp8")
+
+    assert frames_bf16 == frames_fp8
+    print(f"MagiHuman BF16 peak memory: {mem_bf16:.2f} GiB")
+    print(f"MagiHuman FP8 peak memory:  {mem_fp8:.2f} GiB")
     assert mem_fp8 < mem_bf16, f"FP8 ({mem_fp8:.2f} GiB) should use less memory than BF16 ({mem_bf16:.2f} GiB)"
 
 

--- a/tests/diffusion/quantization/test_quantization_quality.py
+++ b/tests/diffusion/quantization/test_quantization_quality.py
@@ -36,7 +36,7 @@ import importlib.util
 import json
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -82,6 +82,9 @@ class QualityTestConfig:
     gpu: str = "H100"  # minimum GPU requirement
     negative_prompt: str = ""
     guidance_scale: float | None = None
+    model_type: str | None = None
+    extra_args: dict[str, object] = field(default_factory=dict)
+    require_memory_reduction: bool = False
 
     def baseline_ref(self) -> str:
         return self.baseline_model or self.model or ""
@@ -203,6 +206,23 @@ QUALITY_CONFIGS = [
         num_frames=25,
         num_inference_steps=8,
     ),
+    QualityTestConfig(
+        id="fp8_magi_human",
+        model="SII-GAIR/daVinci-MagiHuman-Base-1080p",
+        model_type="magi-human",
+        quantization="fp8",
+        task="t2v",
+        prompt=(
+            "A cinematic close-up of a woman speaking calmly to the camera in a sunlit garden. "
+            "A gentle breeze moves her hair and soft birdsong is audible in the background."
+        ),
+        max_lpips=0.10,
+        height=256,
+        width=448,
+        num_inference_steps=8,
+        extra_args={"seconds": 5},
+        require_memory_reduction=True,
+    ),
 ]
 
 
@@ -305,15 +325,17 @@ def _generate_video(omni, config: QualityTestConfig):
         OmniDiffusionSamplingParams(
             height=config.height,
             width=config.width,
+            seed=config.seed,
             generator=generator,
             num_inference_steps=config.num_inference_steps,
             num_frames=config.num_frames,
             guidance_scale=config.guidance_scale,
+            extra_args=config.extra_args,
         ),
     )
 
-    peak_mem = torch.accelerator.max_memory_allocated() / (1024**3)
     first = outputs[0]
+    peak_mem = _extract_peak_memory_gib(first)
     if hasattr(first, "request_output") and isinstance(first.request_output, list):
         inner = first.request_output[0]
         if isinstance(inner, OmniRequestOutput) and hasattr(inner, "images"):
@@ -349,6 +371,31 @@ def _generate_video(omni, config: QualityTestConfig):
         # strip the leading batch dim
         frames_array = frames_array[0]
     return frames_array, peak_mem
+
+
+def _extract_peak_memory_gib(output) -> float:
+    fallback = torch.accelerator.max_memory_allocated() / (1024**3)
+    candidates = [output]
+    request_output = getattr(output, "request_output", None)
+    if isinstance(request_output, list):
+        candidates.extend(request_output)
+    elif request_output is not None:
+        candidates.append(request_output)
+
+    for candidate in candidates:
+        peak_memory_mb = getattr(candidate, "peak_memory_mb", None)
+        if peak_memory_mb:
+            return float(peak_memory_mb) / 1024.0
+    return fallback
+
+
+def _build_omni(config: QualityTestConfig, quantization=None):
+    kwargs = {"model": config.quantized_ref()}
+    if config.model_type is not None:
+        kwargs["model_type"] = config.model_type
+    if quantization is not None:
+        kwargs["quantization"] = quantization
+    return kwargs
 
 
 def _compute_lpips(baseline, quantized, task: str) -> float:
@@ -433,6 +480,14 @@ def test_benchmark_generate_image_unwraps_nested_omni_request_output(monkeypatch
     assert peak_mem == 0.0
 
 
+def test_benchmark_output_fps_uses_magi_human_native_rate():
+    from benchmarks.diffusion.quantization_quality import _output_fps
+
+    assert _output_fps(SimpleNamespace(fps=None, model_type="magi-human")) == 25
+    assert _output_fps(SimpleNamespace(fps=None, model_type=None)) == 24
+    assert _output_fps(SimpleNamespace(fps=30, model_type="magi-human")) == 30
+
+
 _marks = hardware_marks(res={"cuda": "H100"})
 _OUTPUT_DIR = Path(os.environ["VLLM_OMNI_QUALITY_OUTPUT_DIR"]) if "VLLM_OMNI_QUALITY_OUTPUT_DIR" in os.environ else None
 
@@ -459,7 +514,10 @@ def test_quantization_quality(config: QualityTestConfig):
     generate_fn = _generate_video if config.task == "t2v" else _generate_image
 
     # --- BF16 baseline ---
-    omni_bl = Omni(model=config.baseline_ref())
+    baseline_kwargs = {"model": config.baseline_ref()}
+    if config.model_type is not None:
+        baseline_kwargs["model_type"] = config.model_type
+    omni_bl = Omni(**baseline_kwargs)
     baseline_out, bl_mem = generate_fn(omni_bl, config)
     omni_bl.shutdown()
     del omni_bl
@@ -469,9 +527,12 @@ def test_quantization_quality(config: QualityTestConfig):
     # --- Quantized ---
     quantization = config.quantization_ref()
     if quantization is None:
-        omni_qt = Omni(model=config.quantized_ref())
+        quantized_kwargs = {"model": config.quantized_ref()}
+        if config.model_type is not None:
+            quantized_kwargs["model_type"] = config.model_type
+        omni_qt = Omni(**quantized_kwargs)
     else:
-        omni_qt = Omni(model=config.quantized_ref(), quantization_config=quantization)
+        omni_qt = Omni(**_build_omni(config, quantization))
     quant_out, qt_mem = generate_fn(omni_qt, config)
     omni_qt.shutdown()
     del omni_qt
@@ -481,6 +542,10 @@ def test_quantization_quality(config: QualityTestConfig):
     # --- Similarity metrics ---
     lpips_score = _compute_lpips(baseline_out, quant_out, config.task)
     psnr_score, mae_score = _compute_psnr_and_mae(baseline_out, quant_out, config.task)
+    if config.require_memory_reduction:
+        assert qt_mem < bl_mem, (
+            f"Quantized memory ({qt_mem:.2f} GiB) should be lower than BF16 ({bl_mem:.2f} GiB) for {config.id}"
+        )
     assert lpips_score <= config.max_lpips, (
         f"LPIPS {lpips_score:.4f} exceeds threshold {config.max_lpips} "
         f"for {config.quantization_ref() or 'pre-quantized checkpoint'} on {config.quantized_ref()}"

--- a/tests/diffusion/quantization/test_quantization_quality.py
+++ b/tests/diffusion/quantization/test_quantization_quality.py
@@ -488,6 +488,18 @@ def test_benchmark_output_fps_uses_magi_human_native_rate():
     assert _output_fps(SimpleNamespace(fps=30, model_type="magi-human")) == 30
 
 
+def test_benchmark_video_export_normalizes_uint8_frames():
+    from benchmarks.diffusion.quantization_quality import _prepare_video_frames_for_export
+
+    frames = np.array([[[[0, 127, 255]]]], dtype=np.uint8)
+
+    prepared = _prepare_video_frames_for_export(frames)
+
+    assert len(prepared) == 1
+    assert prepared[0].dtype == np.float32
+    np.testing.assert_allclose(prepared[0], [[[0.0, 127 / 255, 1.0]]])
+
+
 _marks = hardware_marks(res={"cuda": "H100"})
 _OUTPUT_DIR = Path(os.environ["VLLM_OMNI_QUALITY_OUTPUT_DIR"]) if "VLLM_OMNI_QUALITY_OUTPUT_DIR" in os.environ else None
 

--- a/vllm_omni/diffusion/models/magi_human/magi_human_dit.py
+++ b/vllm_omni/diffusion/models/magi_human/magi_human_dit.py
@@ -26,6 +26,11 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.vllm_flash_attn import flash_attn_varlen_func as _vllm_fa_varlen
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import (
+        QuantizationConfig,
+    )
+
 try:
     from magi_compiler.api import magi_register_custom_op
     from magi_compiler.config import CompileConfig
@@ -385,6 +390,7 @@ class MoEQKVParallelLinear(nn.Module):
         total_num_kv_heads: int,
         num_experts: int,
         bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.num_experts = num_experts
@@ -397,6 +403,7 @@ class MoEQKVParallelLinear(nn.Module):
                     total_num_kv_heads=total_num_kv_heads,
                     bias=bias,
                     return_bias=False,
+                    quant_config=quant_config,
                 )
                 for _ in range(num_experts)
             ]
@@ -432,6 +439,7 @@ class MoEColumnParallelLinear(nn.Module):
         output_size: int,
         num_experts: int,
         bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.num_experts = num_experts
@@ -443,6 +451,7 @@ class MoEColumnParallelLinear(nn.Module):
                     bias=bias,
                     gather_output=False,
                     return_bias=False,
+                    quant_config=quant_config,
                 )
                 for _ in range(num_experts)
             ]
@@ -474,6 +483,7 @@ class MoERowParallelLinear(nn.Module):
         output_size: int,
         num_experts: int,
         bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.num_experts = num_experts
@@ -485,6 +495,7 @@ class MoERowParallelLinear(nn.Module):
                     bias=bias,
                     input_is_parallel=True,
                     return_bias=False,
+                    quant_config=quant_config,
                 )
                 for _ in range(num_experts)
             ]
@@ -702,7 +713,11 @@ class AttentionConfig:
 class Attention(torch.nn.Module):
     config: AttentionConfig
 
-    def __init__(self, config: AttentionConfig):
+    def __init__(
+        self,
+        config: AttentionConfig,
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.config = config
         self.pre_norm = MultiModalityRMSNorm(config.hidden_size, eps=1e-6, num_modality=config.num_modality)
@@ -722,6 +737,7 @@ class Attention(torch.nn.Module):
                 total_num_kv_heads=config.num_heads_kv,
                 bias=False,
                 return_bias=False,
+                quant_config=quant_config,
             )
             self.linear_proj = RowParallelLinear(
                 input_size=config.num_heads_q * config.head_dim,
@@ -729,6 +745,7 @@ class Attention(torch.nn.Module):
                 bias=False,
                 input_is_parallel=True,
                 return_bias=False,
+                quant_config=quant_config,
             )
             if config.enable_attn_gating:
                 self.linear_gating = ColumnParallelLinear(
@@ -737,6 +754,7 @@ class Attention(torch.nn.Module):
                     bias=False,
                     gather_output=False,
                     return_bias=False,
+                    quant_config=quant_config,
                 )
             else:
                 self.linear_gating = None
@@ -749,12 +767,14 @@ class Attention(torch.nn.Module):
                 total_num_kv_heads=config.num_heads_kv,
                 num_experts=config.num_modality,
                 bias=False,
+                quant_config=quant_config,
             )
             self.linear_proj = MoERowParallelLinear(
                 input_size=config.num_heads_q * config.head_dim,
                 output_size=config.hidden_size,
                 num_experts=config.num_modality,
                 bias=False,
+                quant_config=quant_config,
             )
             if config.enable_attn_gating:
                 self.linear_gating = MoEColumnParallelLinear(
@@ -762,6 +782,7 @@ class Attention(torch.nn.Module):
                     output_size=config.num_heads_q,
                     num_experts=config.num_modality,
                     bias=False,
+                    quant_config=quant_config,
                 )
             else:
                 self.linear_gating = None
@@ -859,7 +880,11 @@ class MLPConfig:
 class MLP(torch.nn.Module):
     config: MLPConfig
 
-    def __init__(self, config: MLPConfig):
+    def __init__(
+        self,
+        config: MLPConfig,
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         num_experts = config.num_modality
         self.pre_norm = MultiModalityRMSNorm(config.hidden_size, num_modality=config.num_modality)
@@ -878,6 +903,7 @@ class MLP(torch.nn.Module):
                 bias=False,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
             )
             self.down_proj = RowParallelLinear(
                 input_size=config.intermediate_size,
@@ -885,6 +911,7 @@ class MLP(torch.nn.Module):
                 bias=False,
                 input_is_parallel=True,
                 return_bias=False,
+                quant_config=quant_config,
             )
         else:
             # MoE blocks: per-expert TP-sharded parallel layers.
@@ -893,12 +920,14 @@ class MLP(torch.nn.Module):
                 output_size=intermediate_size_up,
                 num_experts=num_experts,
                 bias=False,
+                quant_config=quant_config,
             )
             self.down_proj = MoERowParallelLinear(
                 input_size=config.intermediate_size,
                 output_size=config.hidden_size,
                 num_experts=num_experts,
                 bias=False,
+                quant_config=quant_config,
             )
         self.activation_func = create_activation_func(config.activation_type)
 
@@ -963,7 +992,12 @@ class Adapter(torch.nn.Module):
 # Transformer layer (no CP)
 # ---------------------------------------------------------------------------
 class TransFormerLayer(torch.nn.Module):
-    def __init__(self, config: Any, layer_idx: int):
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         num_modality = 3 if layer_idx in config.mm_layers else 1
         use_local_attn = layer_idx in config.local_attn_layers
@@ -980,7 +1014,7 @@ class TransFormerLayer(torch.nn.Module):
             use_local_attn=use_local_attn,
             enable_attn_gating=config.enable_attn_gating,
         )
-        self.attention: Attention = Attention(attention_config)
+        self.attention: Attention = Attention(attention_config, quant_config=quant_config)
 
         activation_type = MLPActivationType.GELU7 if layer_idx in config.gelu7_layers else MLPActivationType.SWIGLU7
         if activation_type == MLPActivationType.SWIGLU7:
@@ -998,7 +1032,7 @@ class TransFormerLayer(torch.nn.Module):
             num_layers=config.num_layers,
             gated_act=gated_act,
         )
-        self.mlp: MLP = MLP(mlp_config)
+        self.mlp: MLP = MLP(mlp_config, quant_config=quant_config)
         if self.post_norm:
             self.attn_post_norm = MultiModalityRMSNorm(config.hidden_size, num_modality=num_modality)
             self.mlp_post_norm = MultiModalityRMSNorm(config.hidden_size, num_modality=num_modality)
@@ -1052,11 +1086,15 @@ def config_patch(compile_config: CompileConfig) -> CompileConfig:
     config_patch=config_patch, dynamic_arg_dims={"x": 0, "rope": 0, "permute_mapping": 0, "inv_permute_mapping": 0}
 )
 class TransformerBlock(torch.nn.Module):
-    def __init__(self, model_config: Any):
+    def __init__(
+        self,
+        model_config: Any,
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.layers: list[TransFormerLayer] = nn.ModuleList()
         for layer_idx in range(model_config.num_layers):
-            self.layers.append(TransFormerLayer(model_config, layer_idx))
+            self.layers.append(TransFormerLayer(model_config, layer_idx, quant_config=quant_config))
 
     def forward(
         self,
@@ -1099,7 +1137,11 @@ class DiTModel(torch.nn.Module):
     def blocks(self) -> nn.ModuleList:
         return self.block.layers
 
-    def __init__(self, model_config: Any):
+    def __init__(
+        self,
+        model_config: Any,
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         validate_magi_human_tp_constraints(
             hidden_size=model_config.hidden_size,
@@ -1124,7 +1166,7 @@ class DiTModel(torch.nn.Module):
             params_dtype=torch.float32,
         )
         self.adapter: Adapter = Adapter(adapter_config)
-        self.block: TransformerBlock = TransformerBlock(model_config=model_config)
+        self.block: TransformerBlock = TransformerBlock(model_config=model_config, quant_config=quant_config)
         self.final_norm_video = MultiModalityRMSNorm(self.config.hidden_size)
         self.final_norm_audio = MultiModalityRMSNorm(self.config.hidden_size)
         self.final_linear_video = nn.Linear(

--- a/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
+++ b/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
@@ -12,7 +12,7 @@ import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import numpy as np
 import torch
@@ -62,6 +62,11 @@ from .magi_human_dit import (
     Modality,
     VarlenHandler,
 )
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import (
+        QuantizationConfig,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -1702,8 +1707,9 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
 
         dit_json = _load_json(model_path, f"{dit_subfolder}/config.json", local_files_only)
         dit_model_config = MagiHumanDiTConfig(**dit_json)
+        quant_config: QuantizationConfig | None = od_config.quantization_config
 
-        self.dit = DiTModel(dit_model_config)
+        self.dit = DiTModel(dit_model_config, quant_config=quant_config)
         self.dit.eval()
 
         self.vae = DistributedAutoencoderKLWan.from_pretrained(model_path, subfolder="vae")
@@ -1791,7 +1797,7 @@ class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery,
         sr_dit_subfolder = "sr"
         sr_dit_json = _load_json(model_path, f"{sr_dit_subfolder}/config.json", local_files_only)
         sr_dit_model_config = MagiHumanDiTConfig(**sr_dit_json)
-        self.sr_dit = DiTModel(sr_dit_model_config)
+        self.sr_dit = DiTModel(sr_dit_model_config, quant_config=quant_config)
         self.sr_dit.eval()
 
         self.weights_sources = [


### PR DESCRIPTION
## Summary

Adds FP8 dynamic online quantization support for MagiHuman by propagating
`quant_config` from `MagiHumanPipeline` into both the base DiT and SR DiT,
then through the DiT transformer stack into vLLM parallel linear layers.

This covers:

- base `dit` and `sr_dit`
- shared attention QKV, projection, and gating linears
- shared MLP up/down linears
- MagiHuman modality expert wrappers:
  - `MoEQKVParallelLinear`
  - `MoEColumnParallelLinear`
  - `MoERowParallelLinear`

This PR does not implement a new FP8 algorithm or kernel. It wires MagiHuman
into the existing vLLM FP8 dynamic online quantization path.

Part of #1854.

## Implementation

The pipeline reads `od_config.quantization_config` once and passes the same
configuration to both MagiHuman transformer instances:

- `MagiHumanPipeline.dit`
- `MagiHumanPipeline.sr_dit`

Within each DiT, the configuration is propagated through the transformer block
and layers into all vLLM parallel linear layers, including the per-modality
expert wrappers.

The BF16 path remains unchanged when `quant_config` is `None`.

## Full-Model Evaluation

Following the evaluation approach used in #3700, I ran BF16 and FP8 dynamic
online quantization end-to-end with the real
`SII-GAIR/daVinci-MagiHuman-Base-1080p` checkpoint.

Environment:

- NVIDIA RTX PRO 6000 Blackwell Server Edition, 96 GB
- vLLM 0.24.0
- PyTorch 2.11.0+cu130
- same checkpoint, prompt, seed, resolution, duration, and sampling steps for
  BF16 and FP8

### Quantization Quality Test

Configuration:

- height: 256
- width: 448
- duration: 5 seconds
- output: 125 frames
- denoising steps: 8
- seed: 42
- LPIPS network: AlexNet

| Config | Peak GPU memory | Memory reduction | LPIPS | PSNR | MAE |
|---|---:|---:|---:|---:|---:|
| BF16 | 79.68 GiB | - | ref | ref | ref |
| FP8 dynamic online | 51.98 GiB | 35% | 0.0143 | 28.6009 dB | 0.027912 |

The configured LPIPS threshold is `0.10`; the test passed with `0.0143`.

Test result:

```text
Quantization Quality: fp8_magi_human
Baseline:      SII-GAIR/daVinci-MagiHuman-Base-1080p
Quantized:     SII-GAIR/daVinci-MagiHuman-Base-1080p
Method:        fp8
LPIPS:         0.0143  (threshold: 0.1)
PSNR:          28.6009 dB
MAE:           0.027912
BF16 memory:   79.68 GiB
Quant memory:  51.98 GiB  (35% reduction)
Result:        PASS

1 passed, 5 deselected
```

### GPU Memory Regression Test

The dedicated full-model GPU test runs real BF16 and FP8 generation and asserts
that both produce video frames and that FP8 uses less peak GPU memory.

```text
MagiHuman BF16 peak memory: 78.95 GiB
MagiHuman FP8 peak memory:  51.18 GiB

1 passed, 11 deselected
```

### 540p SR Visual Comparison

I also ran the complete MagiHuman SR path to cover both the base `dit` and
`sr_dit`.

Configuration:

- base stage: height 256, width 448, 8/8 steps
- SR stage: height 512, width 896, 5/5 steps
- duration: 4 seconds
- output: 101 frames at 25 FPS
- seed: 42
- prompt: official `example/assets/prompt.txt` from daVinci-MagiHuman

| Config | Generation time | Peak GPU memory | Memory reduction | LPIPS |
|---|---:|---:|---:|---:|
| BF16 SR 540p | 27.41s | 89.68 GiB | - | ref |
| FP8 SR 540p | 24.13s | 61.92 GiB | 31% | 0.0489 |

The FP8 run logs confirm that online quantization was enabled and the Cutlass
FP8 kernel was selected:

```text
Building quantization config: fp8
Selected CutlassFP8ScaledMMLinearKernel for Fp8PerTensorOnlineLinearMethod
```

The BF16/FP8 540p side-by-side output is attached in
[this PR comment](https://github.com/vllm-project/vllm-omni/pull/4961#issuecomment-4951547430).
BF16 is shown on the left and FP8 dynamic online quantization on the right.

Generation time is a single-run measurement. The primary validation is output
similarity and peak GPU memory reduction.

## Tests

Static checks:

```bash
ruff check \
  benchmarks/diffusion/quantization_quality.py \
  tests/diffusion/models/magi_human/test_magi_human_quantization.py \
  tests/diffusion/quantization/test_quantization_fp8.py \
  tests/diffusion/quantization/test_quantization_quality.py \
  vllm_omni/diffusion/models/magi_human/magi_human_dit.py \
  vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py

ruff format --check \
  benchmarks/diffusion/quantization_quality.py \
  tests/diffusion/models/magi_human/test_magi_human_quantization.py \
  tests/diffusion/quantization/test_quantization_fp8.py \
  tests/diffusion/quantization/test_quantization_quality.py \
  vllm_omni/diffusion/models/magi_human/magi_human_dit.py \
  vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py

python -m py_compile \
  benchmarks/diffusion/quantization_quality.py \
  tests/diffusion/models/magi_human/test_magi_human_quantization.py \
  tests/diffusion/quantization/test_quantization_fp8.py \
  tests/diffusion/quantization/test_quantization_quality.py \
  vllm_omni/diffusion/models/magi_human/magi_human_dit.py \
  vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py

git diff --check
```

Unit and full-model tests:

```bash
python -m pytest \
  tests/diffusion/models/magi_human/test_magi_human_quantization.py -q

python -m pytest \
  tests/diffusion/quantization/test_quantization_fp8.py \
  -s -q -k magi_human \
  --override-ini="addopts="

python -m pytest \
  tests/diffusion/quantization/test_quantization_quality.py \
  -s -q -k fp8_magi_human \
  --override-ini="addopts="
```

Results:

- MagiHuman quantization propagation: `2 passed`
- benchmark CPU regression coverage: `3 passed`
- full-model FP8 memory regression: `1 passed`
- full-model FP8 quality test: `1 passed`
- pre-commit: passed
- Python 3.11 build: passed
- Python 3.12 build: passed
- DCO: passed
- Read the Docs: passed