### PR TITLE
[Feature] Add per-stage KV cache efficiency metrics

### DIFF
--- a/tests/engine/test_output_processor.py
+++ b/tests/engine/test_output_processor.py
@@ -12,7 +12,7 @@ from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine import FinishReason
 
 from vllm_omni.engine.output_modality import OutputModalityNames
-from vllm_omni.engine.output_processor import OmniRequestState
+from vllm_omni.engine.output_processor import MultimodalOutputProcessor, OmniRequestState
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -268,6 +268,18 @@ def test_no_detokenizer_make_request_output_with_routed_experts():
     assert result is not None
     assert not isinstance(result, PoolingRequestOutput)
     assert result.outputs[0].routed_experts is routed_experts
+
+
+def test_request_output_can_carry_internal_kv_cache_metrics():
+    s = _make_no_detok_state(RequestOutputKind.CUMULATIVE)
+    s.add_multimodal_tensor(torch.randn(10), mm_type=AUDIO)
+    result = s.make_request_output([], None, FinishReason.STOP, None)
+    payload = {"seq_len": 32, "block_ids": [1, 2], "source": "kv_cache_manager"}
+
+    MultimodalOutputProcessor._attach_kv_cache_metrics(result, payload)
+
+    assert getattr(result, "_omni_kv_cache_metrics") == payload
+    assert getattr(result.outputs[0], "_omni_kv_cache_metrics", None) is None
 
 
 def test_no_detokenizer_stream_interval_skipped():

--- a/tests/metrics/test_kv.py
+++ b/tests/metrics/test_kv.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from prometheus_client import REGISTRY, generate_latest
+
+from vllm_omni.metrics import definitions as defs
+from vllm_omni.metrics import kv as kv_mod
+from vllm_omni.metrics.kv import (
+    OmniKVCacheMetrics,
+    compute_kv_efficiency,
+    estimate_kv_bytes_per_token,
+    resolve_kv_block_size,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+_MODEL = "test-kv-model"
+
+
+def _sample_value(output: str, line_prefix: str) -> float | None:
+    for line in output.splitlines():
+        if line.startswith(line_prefix):
+            return float(line.split()[-1])
+    return None
+
+
+class TestComputeKVEfficiency:
+    def test_full_blocks_have_no_tail_waste(self) -> None:
+        snap = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=32,
+            bytes_per_token=128,
+        )
+        assert snap.allocated_blocks == 2
+        assert snap.allocated_tokens == 32
+        assert snap.tail_waste_tokens == 0
+        assert snap.occupancy_ratio == 1.0
+        assert snap.fragmentation_ratio == 0.0
+        assert snap.footprint_tokens == 32
+        assert snap.footprint_bytes == 4096
+
+    def test_partial_tail_waste_is_capacity_minus_useful_tokens(self) -> None:
+        snap = compute_kv_efficiency(block_size=16, sequence_tokens=33)
+        assert snap.allocated_blocks == 3
+        assert snap.allocated_tokens == 48
+        assert snap.tail_waste_tokens == 15
+        assert snap.occupancy_ratio == pytest.approx(33 / 48)
+        assert snap.fragmentation_ratio == pytest.approx(15 / 48)
+
+    def test_prefix_hit_ratio_uses_prompt_tokens(self) -> None:
+        snap = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=33,
+            cached_tokens=11,
+            prompt_tokens=44,
+        )
+        assert snap.cached_tokens == 11
+        assert snap.prompt_tokens == 44
+        assert snap.prefix_hit_ratio == pytest.approx(0.25)
+
+    def test_explicit_overallocation_counts_as_fragmentation(self) -> None:
+        snap = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=17,
+            allocated_blocks=4,
+        )
+        assert snap.allocated_tokens == 64
+        assert snap.tail_waste_tokens == 47
+        assert snap.occupancy_ratio == pytest.approx(17 / 64)
+        assert snap.fragmentation_ratio == pytest.approx(47 / 64)
+
+    def test_empty_snapshot_is_zero_safe(self) -> None:
+        snap = compute_kv_efficiency(block_size=16, sequence_tokens=0)
+        assert snap.allocated_blocks == 0
+        assert snap.allocated_tokens == 0
+        assert snap.occupancy_ratio == 0.0
+        assert snap.fragmentation_ratio == 0.0
+
+
+class _ModelConfig:
+    dtype = "float16"
+
+    def get_num_layers(self, parallel_config=None):
+        return 24
+
+    def get_num_kv_heads(self, parallel_config=None):
+        return 8
+
+    def get_head_size(self):
+        return 64
+
+
+class TestConfigResolution:
+    def test_resolve_block_size_from_cache_config(self) -> None:
+        cfg = SimpleNamespace(cache_config=SimpleNamespace(block_size=32))
+        assert resolve_kv_block_size(cfg) == 32
+
+    def test_estimate_bytes_per_token_from_vllm_config(self) -> None:
+        cfg = SimpleNamespace(
+            model_config=_ModelConfig(),
+            cache_config=SimpleNamespace(cache_dtype="auto"),
+            parallel_config=SimpleNamespace(),
+        )
+        assert estimate_kv_bytes_per_token(cfg) == 24 * 2 * 8 * 64 * 2
+
+
+class TestPrometheusObserve:
+    def test_all_families_present_with_expected_labels(self) -> None:
+        metrics = OmniKVCacheMetrics(model_name=_MODEL)
+        snap = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=33,
+            bytes_per_token=128,
+            cached_tokens=3,
+            prompt_tokens=12,
+        )
+        metrics.observe_snapshot(
+            stage=1,
+            replica=0,
+            modality="text",
+            snapshot=snap,
+        )
+        out = generate_latest(REGISTRY).decode()
+        for family in (
+            defs.KV_FOOTPRINT_TOKENS,
+            defs.KV_FOOTPRINT_BYTES,
+            defs.KV_BLOCK_OCCUPANCY_RATIO,
+            defs.KV_TAIL_WASTE_TOKENS,
+            defs.KV_FRAGMENTATION_RATIO,
+            defs.KV_PREFIX_HIT_RATIO,
+        ):
+            assert f"# HELP {family}" in out
+        assert f"# HELP {defs.KV_CACHED_TOKENS}" in out
+
+        labels = 'modality="text",model_name="test-kv-model",replica="0",source="stage_tokens",stage="1"'
+        assert (
+            _sample_value(
+                out,
+                f"{defs.KV_FOOTPRINT_TOKENS}{{{labels}}}",
+            )
+            == 48.0
+        )
+        assert (
+            _sample_value(
+                out,
+                f"{defs.KV_FOOTPRINT_BYTES}{{{labels}}}",
+            )
+            == 6144.0
+        )
+        assert (
+            _sample_value(
+                out,
+                f"{defs.KV_TAIL_WASTE_TOKENS}_sum{{{labels}}}",
+            )
+            == 15.0
+        )
+        assert (
+            _sample_value(
+                out,
+                f"{defs.KV_CACHED_TOKENS}{{{labels}}}",
+            )
+            == 3.0
+        )
+
+    def test_cached_tokens_gauge_uses_latest_snapshot(self) -> None:
+        metrics = OmniKVCacheMetrics(model_name=_MODEL)
+        first = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=16,
+            cached_tokens=5,
+            prompt_tokens=10,
+        )
+        second = compute_kv_efficiency(
+            block_size=16,
+            sequence_tokens=16,
+            cached_tokens=2,
+            prompt_tokens=10,
+        )
+        metrics.observe_snapshot(stage=2, replica=0, modality="text", snapshot=first)
+        metrics.observe_snapshot(stage=2, replica=0, modality="text", snapshot=second)
+
+        out = generate_latest(REGISTRY).decode()
+        labels = 'modality="text",model_name="test-kv-model",replica="0",source="stage_tokens",stage="2"'
+        assert (
+            _sample_value(
+                out,
+                f"{defs.KV_CACHED_TOKENS}{{{labels}}}",
+            )
+            == 2.0
+        )
+
+    def test_families_recreated_after_registry_unregister(self) -> None:
+        metrics = OmniKVCacheMetrics(model_name=_MODEL)
+        snap = compute_kv_efficiency(block_size=16, sequence_tokens=16)
+        metrics.observe_snapshot(stage=3, replica=0, modality="text", snapshot=snap)
+
+        assert kv_mod._kv_families is not None
+        for family in kv_mod._kv_families.values():
+            REGISTRY.unregister(family)
+
+        metrics.observe_snapshot(stage=3, replica=0, modality="text", snapshot=snap)
+
+        out = generate_latest(REGISTRY).decode()
+        labels = 'modality="text",model_name="test-kv-model",replica="0",source="stage_tokens",stage="3"'
+        assert _sample_value(out, f"{defs.KV_FOOTPRINT_TOKENS}{{{labels}}}") == 16.0
+
+
+class TestStagePoolSnapshot:
+    def test_llm_stage_metrics_carries_kv_snapshot_without_changing_prompt_counter(self) -> None:
+        from vllm_omni.engine.stage_pool import StagePool, _ReplicaMetrics
+
+        pool = object.__new__(StagePool)
+        pool.stage_id = 1
+        pool.clients = [
+            SimpleNamespace(
+                stage_type="llm",
+                final_output_type="text",
+            )
+        ]
+        pool._output_processor = SimpleNamespace(pop_native_text_metrics=lambda request_id: {})
+        pool._stage_vllm_config = None
+        pool._kv_block_size = 16
+        pool._kv_bytes_per_token = 128
+        pool._replica_metrics = [_ReplicaMetrics()]
+        pool._output_timestamps_by_request = {}
+        pool._non_empty_first_output_timestamps_by_request = {}
+        pool._audio_frames_by_request = {}
+        pool._audio_sample_rate_by_request = {}
+
+        request_output = SimpleNamespace(
+            request_id="req-kv",
+            prompt_token_ids=list(range(21)),
+            outputs=[SimpleNamespace(token_ids=list(range(5)), cumulative_token_ids=None)],
+            final_output_type="text",
+            images=[],
+            video=None,
+            videos=None,
+            trajectory_latents=None,
+        )
+
+        stats = pool.build_stage_metrics(
+            [request_output],
+            submit_ts=10.0,
+            request_timestamp=10.0,
+            replica_id=0,
+        )
+
+        assert stats.num_tokens_in == 0
+        assert stats.num_tokens_out == 5
+        assert stats.kv_snapshot is not None
+        assert stats.kv_snapshot.sequence_tokens == 26
+        assert stats.kv_snapshot.allocated_tokens == 32
+        assert stats.kv_snapshot.tail_waste_tokens == 6
+        assert stats.kv_snapshot.footprint_bytes == 4096
+
+    def test_stage_metrics_prefers_real_block_ids_when_present(self) -> None:
+        from vllm_omni.engine.stage_pool import StagePool, _ReplicaMetrics
+
+        pool = object.__new__(StagePool)
+        pool.stage_id = 0
+        pool.clients = [
+            SimpleNamespace(
+                stage_type="llm",
+                final_output_type="text",
+            )
+        ]
+        pool._output_processor = SimpleNamespace(pop_native_text_metrics=lambda request_id: {})
+        pool._stage_vllm_config = None
+        pool._kv_block_size = 16
+        pool._kv_bytes_per_token = 128
+        pool._replica_metrics = [_ReplicaMetrics()]
+        pool._output_timestamps_by_request = {}
+        pool._non_empty_first_output_timestamps_by_request = {}
+        pool._audio_frames_by_request = {}
+        pool._audio_sample_rate_by_request = {}
+
+        request_output = SimpleNamespace(
+            request_id="req-kv-real-blocks",
+            prompt_token_ids=list(range(17)),
+            outputs=[SimpleNamespace(token_ids=[], cumulative_token_ids=None)],
+            final_output_type="text",
+            images=[],
+            video=None,
+            videos=None,
+            trajectory_latents=None,
+            kv_transfer_params={"metadata": {"block_ids": [11, 12, 13, 14]}},
+        )
+
+        stats = pool.build_stage_metrics(
+            [request_output],
+            submit_ts=10.0,
+            request_timestamp=10.0,
+            replica_id=0,
+        )
+
+        assert stats.kv_snapshot is not None
+        assert stats.kv_snapshot.source == "kv_transfer_params"
+        assert stats.kv_snapshot.allocated_blocks == 4
+        assert stats.kv_snapshot.allocated_tokens == 64
+        assert stats.kv_snapshot.tail_waste_tokens == 47
+
+    def test_stage_metrics_prefers_scheduler_kv_cache_payload(self) -> None:
+        from vllm_omni.engine.stage_pool import StagePool, _ReplicaMetrics
+
+        pool = object.__new__(StagePool)
+        pool.stage_id = 0
+        pool.clients = [
+            SimpleNamespace(
+                stage_type="llm",
+                final_output_type="text",
+            )
+        ]
+        pool._output_processor = SimpleNamespace(pop_native_text_metrics=lambda request_id: {})
+        pool._stage_vllm_config = None
+        pool._kv_block_size = 16
+        pool._kv_bytes_per_token = 128
+        pool._replica_metrics = [_ReplicaMetrics()]
+        pool._output_timestamps_by_request = {}
+        pool._non_empty_first_output_timestamps_by_request = {}
+        pool._audio_frames_by_request = {}
+        pool._audio_sample_rate_by_request = {}
+
+        request_output = SimpleNamespace(
+            request_id="req-kv-cache-manager",
+            prompt_token_ids=list(range(11)),
+            outputs=[SimpleNamespace(token_ids=list(range(4)), cumulative_token_ids=None)],
+            final_output_type="text",
+            images=[],
+            video=None,
+            videos=None,
+            trajectory_latents=None,
+            kv_transfer_params={"metadata": {"block_ids": [99]}},
+        )
+        request_output._omni_kv_cache_metrics = {
+            "seq_len": 35,
+            "block_ids": [11, 12, 13],
+            "source": "kv_cache_manager",
+        }
+
+        stats = pool.build_stage_metrics(
+            [request_output],
+            submit_ts=10.0,
+            request_timestamp=10.0,
+            replica_id=0,
+        )
+
+        assert stats.kv_snapshot is not None
+        assert stats.kv_snapshot.source == "kv_cache_manager"
+        assert stats.kv_snapshot.sequence_tokens == 35
+        assert stats.kv_snapshot.allocated_blocks == 3
+        assert stats.kv_snapshot.allocated_tokens == 48
+        assert stats.kv_snapshot.tail_waste_tokens == 13
+
+
+class TestSchedulerKVPayload:
+    def test_scheduler_payload_reads_allocator_block_ids(self) -> None:
+        from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
+
+        class _KVCacheManager:
+            def get_block_ids(self, request_id):
+                assert request_id == "req-kv"
+                return ([10, 11, 12],)
+
+        scheduler = object.__new__(OmniSchedulerMixin)
+        scheduler.kv_cache_manager = _KVCacheManager()
+        request = SimpleNamespace(
+            request_id="req-kv",
+            num_computed_tokens=35,
+            prompt_token_ids=list(range(11)),
+            output_token_ids=list(range(24)),
+        )
+
+        payload = scheduler._build_kv_cache_metrics_payload(request)
+
+        assert payload == {
+            "seq_len": 35,
+            "block_ids": [10, 11, 12],
+            "source": "kv_cache_manager",
+        }

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -411,6 +411,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             status_before_stop = request.status
             finish_reason = None
             routed_experts = None
+            kv_cache_metrics: dict[str, Any] | None = None
+            kv_cache_metrics_collected = False
 
             # Check for stop and update request status.
             if new_token_ids:
@@ -461,6 +463,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     request.spec_token_ids = []
                     request._output_token_ids.clear()
                 if finished:
+                    kv_cache_metrics = self._build_kv_cache_metrics_payload(request)
+                    kv_cache_metrics_collected = True
                     kv_transfer_params = self._free_request(request)
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -482,6 +486,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
             if new_token_ids or mm_output is not None or pooler_output is not None or kv_transfer_params or stopped:
+                if not kv_cache_metrics_collected:
+                    kv_cache_metrics = self._build_kv_cache_metrics_payload(request)
                 # Add EngineCoreOutput for this Request.
                 outputs[request.client_index].append(
                     OmniEngineCoreOutput(
@@ -501,6 +507,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         num_nans_in_logits=request.num_nans_in_logits,
                         is_segment_finished=is_segment_finished,
                         new_prompt_len_snapshot=self._new_prompt_len_snapshot.get(req_id, None),
+                        kv_cache_metrics=kv_cache_metrics,
                     )
                 )
             else:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -503,6 +503,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             status_before_stop = request.status
             finish_reason = None
             routed_experts = None
+            kv_cache_metrics: dict[str, Any] | None = None
+            kv_cache_metrics_collected = False
 
             # Diffusion request: completes in one step; mark finished and free resources
             if (
@@ -530,6 +532,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     if self.chunk_transfer_adapter:
                         self.chunk_transfer_adapter.segment_finished_requests.discard(req_id)
                 if finished:
+                    kv_cache_metrics = self._build_kv_cache_metrics_payload(request)
+                    kv_cache_metrics_collected = True
                     kv_transfer_params = self._free_request(request)
                     if self.chunk_transfer_adapter is not None:
                         self.chunk_transfer_adapter.cleanup(
@@ -561,6 +565,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
             if new_token_ids or mm_output is not None or pooler_output is not None or kv_transfer_params or stopped:
+                if not kv_cache_metrics_collected:
+                    kv_cache_metrics = self._build_kv_cache_metrics_payload(request)
                 # Add EngineCoreOutput for this Request.
                 outputs[request.client_index].append(
                     OmniEngineCoreOutput(
@@ -578,6 +584,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        kv_cache_metrics=kv_cache_metrics,
                     )
                 )
             else:
@@ -591,6 +598,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 continue
             request.status = RequestStatus.FINISHED_STOPPED
             finish_reason = request.get_finished_reason()
+            kv_cache_metrics = self._build_kv_cache_metrics_payload(request)
             finished = self._handle_stopped_request(request)
             kv_transfer_params = None
             if finished:
@@ -609,6 +617,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     events=request.take_events(),
                     kv_transfer_params=kv_transfer_params,
                     trace_headers=request.trace_headers,
+                    kv_cache_metrics=kv_cache_metrics,
                 )
             )
             stopped_running_reqs.add(request)

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -11,6 +11,7 @@ from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.request import RequestStatus
 
 from vllm_omni.core.sched.output import OmniChunkRecvHandle, OmniSchedulerOutput
+from vllm_omni.metrics.kv import normalize_kv_block_ids
 
 logger = init_logger(__name__)
 
@@ -49,6 +50,54 @@ class OmniSchedulerMixin:
     # ------------------------------------------------------------------ #
     #  Shared scheduler/output helpers (lift the AR / generation duplicates)
     # ------------------------------------------------------------------ #
+
+    def _kv_sequence_len_for_request(self, request: Request) -> int:
+        get_confirmed = getattr(self, "_get_confirmed_num_computed_tokens", None)
+        if callable(get_confirmed):
+            try:
+                seq_len = int(get_confirmed(request))
+                if seq_len > 0:
+                    return seq_len
+            except Exception:
+                pass
+        try:
+            seq_len = int(getattr(request, "num_computed_tokens", 0) or 0)
+            if seq_len > 0:
+                return seq_len
+        except Exception:
+            pass
+        try:
+            return len(getattr(request, "prompt_token_ids", None) or []) + len(
+                getattr(request, "output_token_ids", None) or []
+            )
+        except Exception:
+            return 0
+
+    def _build_kv_cache_metrics_payload(self, request: Request) -> dict[str, Any] | None:
+        """Best-effort allocator snapshot for per-stage KV efficiency metrics."""
+        try:
+            kv_cache_manager = getattr(self, "kv_cache_manager", None)
+            get_block_ids = getattr(kv_cache_manager, "get_block_ids", None)
+            if not callable(get_block_ids):
+                return None
+            block_ids = normalize_kv_block_ids(get_block_ids(request.request_id))
+            if not block_ids:
+                return None
+            seq_len = self._kv_sequence_len_for_request(request)
+            if seq_len <= 0:
+                return None
+            return {
+                "seq_len": seq_len,
+                "block_ids": block_ids,
+                "source": "kv_cache_manager",
+            }
+        except Exception:
+            logger.debug(
+                "Failed to collect KV cache metrics for request %s",
+                getattr(request, "request_id", "<unknown>"),
+                exc_info=True,
+            )
+            return None
 
     def _consume_pending_connector_output(self, model_mode: str) -> None:
         """Drain ``self._latest_omni_connector_output`` into the coordinator.

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -125,6 +125,8 @@ class OmniEngineCoreOutput(EngineCoreOutput):
     is_segment_finished: bool | None = False
     # Streaming update prompt length
     new_prompt_len_snapshot: int | None = None
+    # Internal KV efficiency payload consumed by StagePool metrics.
+    kv_cache_metrics: dict[str, Any] | None = None
 
 
 class OmniEngineCoreOutputs(EngineCoreOutputs):

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -512,6 +512,23 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
     def pop_native_text_metrics(self, request_id: str) -> dict[str, Any]:
         return self._native_text_metrics_by_request.pop(request_id, {})
 
+    @staticmethod
+    def _attach_kv_cache_metrics(request_output: Any, kv_cache_metrics: Any) -> None:
+        if request_output is None or not isinstance(kv_cache_metrics, dict):
+            return
+        setattr(request_output, "_omni_kv_cache_metrics", dict(kv_cache_metrics))
+
+    def _attach_kv_cache_metrics_to_outputs(
+        self,
+        processor_output: OutputProcessorOutput,
+        kv_metrics_by_external_req_id: dict[str, dict[str, Any]],
+    ) -> None:
+        if not kv_metrics_by_external_req_id:
+            return
+        for request_output in getattr(processor_output, "request_outputs", None) or []:
+            payload = kv_metrics_by_external_req_id.get(getattr(request_output, "request_id", None))
+            self._attach_kv_cache_metrics(request_output, payload)
+
     def abort_requests(self, request_ids, internal: bool) -> list[str]:
         request_ids = list(request_ids)
         for request_id in request_ids:
@@ -599,11 +616,15 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         # that would trigger upstream's `assert detokenizer is not None`.
         upstream_outputs: list[EngineCoreOutput] = []
         mm_only_outputs: list[EngineCoreOutput] = []
+        kv_metrics_by_external_req_id: dict[str, dict[str, Any]] = {}
 
         for eco in engine_core_outputs:
             req_state = self.request_states.get(eco.request_id)
             if req_state is None:
                 continue
+            kv_cache_metrics = getattr(eco, "kv_cache_metrics", None)
+            if isinstance(kv_cache_metrics, dict):
+                kv_metrics_by_external_req_id[req_state.external_req_id] = kv_cache_metrics
 
             # Accumulate multimodal tensors regardless of path.
             if isinstance(req_state, OmniRequestState):
@@ -623,11 +644,13 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         self._process_mm_only_outputs(mm_only_outputs)
 
         # Delegate text/pooling outputs to upstream.
-        return super().process_outputs(
+        processor_output = super().process_outputs(
             upstream_outputs,
             engine_core_timestamp=engine_core_timestamp,
             iteration_stats=iteration_stats,
         )
+        self._attach_kv_cache_metrics_to_outputs(processor_output, kv_metrics_by_external_req_id)
+        return processor_output
 
     def _process_mm_only_outputs(
         self,
@@ -647,6 +670,7 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             finish_reason = eco.finish_reason
             stop_reason = eco.stop_reason
             kv_transfer_params = eco.kv_transfer_params
+            kv_cache_metrics = getattr(eco, "kv_cache_metrics", None)
             routed_experts = eco.routed_experts
             req_state.num_cached_tokens = eco.num_cached_tokens
             req_state.is_prefilling = False
@@ -659,6 +683,7 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
                 kv_transfer_params,
                 routed_experts,
             ):
+                self._attach_kv_cache_metrics(request_output, kv_cache_metrics)
                 if req_state.queue is not None:
                     req_state.queue.put(request_output)
 

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -26,6 +26,12 @@ from vllm_omni.engine.stage_client import (
 )
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.metrics import definitions as defs
+from vllm_omni.metrics.kv import (
+    compute_kv_efficiency,
+    estimate_kv_bytes_per_token,
+    normalize_kv_block_ids,
+    resolve_kv_block_size,
+)
 from vllm_omni.metrics.stats import StageRequestStats as StageRequestMetrics
 from vllm_omni.metrics.stats import StageStats
 from vllm_omni.metrics.utils import count_tokens_from_outputs
@@ -95,6 +101,8 @@ class StagePool:
         self.clients: list[StagePoolClient | None] = list(normalized_clients)
         self._output_processor = output_processor
         self._stage_vllm_config = stage_vllm_config
+        self._kv_block_size = resolve_kv_block_size(stage_vllm_config)
+        self._kv_bytes_per_token = estimate_kv_bytes_per_token(stage_vllm_config)
         self._next_replica_id = 0
         self._request_bindings: dict[str, int] = {}
         self._replica_metrics: list[_ReplicaMetrics] = [_ReplicaMetrics() for _ in self.clients]
@@ -521,6 +529,84 @@ class StagePool:
 
     # ---- Metrics ----
 
+    def _kv_sequence_tokens(self, request_outputs: list[Any], num_tokens_out: int) -> int:
+        prompt_tokens = 0
+        for ro in request_outputs:
+            prompt_token_ids = getattr(ro, "prompt_token_ids", None)
+            if prompt_token_ids is not None:
+                try:
+                    prompt_tokens += len(prompt_token_ids)
+                except TypeError:
+                    pass
+        return prompt_tokens + max(int(num_tokens_out or 0), 0)
+
+    def _cached_prompt_tokens(self, request_outputs: list[Any]) -> tuple[int, int]:
+        cached_tokens = 0
+        prompt_tokens = 0
+        for ro in request_outputs:
+            cached_tokens += self._coerce_int_scalar(getattr(ro, "num_cached_tokens", None))
+            prompt_token_ids = getattr(ro, "prompt_token_ids", None)
+            if prompt_token_ids is not None:
+                try:
+                    prompt_tokens += len(prompt_token_ids)
+                except TypeError:
+                    pass
+        return cached_tokens, prompt_tokens
+
+    def _kv_payload_from_scheduler(self, request_outputs: list[Any]) -> dict[str, Any] | None:
+        for ro in request_outputs:
+            payload = getattr(ro, "_omni_kv_cache_metrics", None)
+            if isinstance(payload, Mapping):
+                return dict(payload)
+        return None
+
+    def _kv_payload_from_transfer_params(self, request_outputs: list[Any]) -> dict[str, Any] | None:
+        for ro in request_outputs:
+            params = getattr(ro, "kv_transfer_params", None)
+            if not isinstance(params, Mapping):
+                continue
+            metadata = params.get("kv_metadata") or params.get("metadata")
+            if isinstance(metadata, Mapping):
+                return {
+                    "seq_len": metadata.get("seq_len"),
+                    "block_ids": metadata.get("block_ids"),
+                    "source": "kv_transfer_params",
+                }
+        return None
+
+    def _build_kv_snapshot(self, request_outputs: list[Any], num_tokens_out: int) -> Any | None:
+        if self.stage_type != "llm":
+            return None
+
+        fallback_sequence_tokens = self._kv_sequence_tokens(request_outputs, num_tokens_out)
+        cached_tokens, prompt_tokens = self._cached_prompt_tokens(request_outputs)
+        payload = self._kv_payload_from_scheduler(request_outputs) or self._kv_payload_from_transfer_params(
+            request_outputs
+        )
+
+        source = "stage_tokens"
+        sequence_tokens = fallback_sequence_tokens
+        allocated_blocks = None
+        if payload is not None:
+            source = str(payload.get("source") or source)
+            sequence_tokens = self._coerce_int_scalar(payload.get("seq_len")) or fallback_sequence_tokens
+            block_ids = normalize_kv_block_ids(payload.get("block_ids"))
+            if block_ids:
+                allocated_blocks = len(block_ids)
+
+        if sequence_tokens <= 0 and not allocated_blocks:
+            return None
+
+        return compute_kv_efficiency(
+            block_size=getattr(self, "_kv_block_size", 16),
+            sequence_tokens=sequence_tokens,
+            allocated_blocks=allocated_blocks,
+            bytes_per_token=getattr(self, "_kv_bytes_per_token", 0),
+            cached_tokens=cached_tokens,
+            prompt_tokens=prompt_tokens,
+            source=source,
+        )
+
     def build_stage_metrics(
         self,
         request_outputs: list[Any],
@@ -598,6 +684,7 @@ class StagePool:
         batch_id = metrics.batch_seq
         metrics.agg_total_tokens += num_tokens_out
         metrics.agg_total_gen_time_ms += stage_gen_time_ms
+        kv_snapshot = self._build_kv_snapshot(request_outputs, num_tokens_out)
 
         return StageRequestMetrics(
             num_tokens_in=num_tokens_in,
@@ -628,6 +715,7 @@ class StagePool:
             vllm_tpot_ms=float(native_text_metrics.get("vllm_tpot_ms") or 0.0),
             vllm_itl_ms=float(native_text_metrics.get("vllm_itl_ms") or 0.0),
             vllm_itls_ms=list(native_text_metrics.get("vllm_itls_ms") or []),
+            kv_snapshot=kv_snapshot,
         )
 
     def _infer_output_unit_type(self, request_outputs: list[Any], *, token_count: int) -> str:

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -21,6 +21,7 @@ from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import coerce_param_message_types, get_final_stage_id_for_e2e
 from vllm_omni.errors import raise_client_error_or
+from vllm_omni.metrics.kv import OmniKVCacheMetrics, observe_kv_at_stage_metrics
 from vllm_omni.metrics.modality import OmniModalityMetrics, observe_modality_at_finalize
 from vllm_omni.metrics.prometheus import OmniPrometheusMetrics
 from vllm_omni.metrics.stats import OrchestratorAggregator
@@ -193,6 +194,7 @@ class OmniBase(PDDisaggregationMixin):
         self._consumed_metric_messages: dict[str, set[int]] = {}
         self.prom_metrics = OmniPrometheusMetrics(model_name=model, log_stats=log_stats)
         self.mod_metrics = OmniModalityMetrics(model_name=model, log_stats=log_stats)
+        self.kv_metrics = OmniKVCacheMetrics(model_name=model, log_stats=log_stats)
 
         self.default_sampling_params_list = self.engine.default_sampling_params_list
         if not self.output_modalities:
@@ -358,6 +360,13 @@ class OmniBase(PDDisaggregationMixin):
         stage_id = msg.stage_id
         stage_meta = self.engine.get_stage_metadata(stage_id)
         req_state.metrics.on_stage_metrics(stage_id, req_id, _m, stage_meta.final_output_type)
+        observe_kv_at_stage_metrics(
+            self.kv_metrics,
+            stage_id=stage_id,
+            replica_id=getattr(msg, "replica_id", None),
+            stage_metrics=_m,
+            modality=stage_meta.final_output_type,
+        )
         submit_ts = msg.stage_submit_ts
         now = time.time()
         if req_state.metrics.stage_first_ts[stage_id] is None:
@@ -409,6 +418,13 @@ class OmniBase(PDDisaggregationMixin):
             consumed = self._consumed_metric_message_ids(req_id)
             if msg_id not in consumed:
                 req_state.metrics.on_stage_metrics(stage_id, req_id, msg.metrics, output_type)
+                observe_kv_at_stage_metrics(
+                    self.kv_metrics,
+                    stage_id=stage_id,
+                    replica_id=msg.replica_id,
+                    stage_metrics=msg.metrics,
+                    modality=output_type,
+                )
                 submit_ts = msg.stage_submit_ts
                 now = time.time()
                 if req_state.metrics.stage_first_ts[stage_id] is None:
@@ -518,6 +534,13 @@ class OmniBase(PDDisaggregationMixin):
             consumed = self._consumed_metric_message_ids(req_id)
             if msg_id not in consumed:
                 metrics.on_stage_metrics(stage_id, req_id, _m, output_type)
+                observe_kv_at_stage_metrics(
+                    self.kv_metrics,
+                    stage_id=stage_id,
+                    replica_id=result.replica_id,
+                    stage_metrics=_m,
+                    modality=output_type,
+                )
                 consumed.add(msg_id)
 
         if not stage_meta.final_output:

--- a/vllm_omni/metrics/definitions.py
+++ b/vllm_omni/metrics/definitions.py
@@ -121,6 +121,18 @@ GENERATION_TOKENS = METRIC_PREFIX + "generation_tokens"
 
 
 # ============================================================================
+# KV cache efficiency family (per-stage + per-replica LLM stages)
+# ============================================================================
+KV_FOOTPRINT_TOKENS = METRIC_PREFIX + "kv_footprint_tokens"
+KV_FOOTPRINT_BYTES = METRIC_PREFIX + "kv_footprint_bytes"
+KV_BLOCK_OCCUPANCY_RATIO = METRIC_PREFIX + "kv_block_occupancy_ratio"
+KV_TAIL_WASTE_TOKENS = METRIC_PREFIX + "kv_tail_waste_tokens"
+KV_FRAGMENTATION_RATIO = METRIC_PREFIX + "kv_fragmentation_ratio"
+KV_CACHED_TOKENS = METRIC_PREFIX + "kv_cached_tokens"
+KV_PREFIX_HIT_RATIO = METRIC_PREFIX + "kv_prefix_hit_ratio"
+
+
+# ============================================================================
 # Audio family (per-stage + per-replica audio path metrics)
 # ============================================================================
 AUDIO_TTFP_S = METRIC_PREFIX + AUDIO_TTFP + "_s"
@@ -171,6 +183,11 @@ TRANSFER_LABELS = (
     "to_stage",
     "to_replica",
 )
+
+# KV cache efficiency label set. ``source`` distinguishes allocator-backed
+# observations from fallback estimates, and ``modality`` keeps text/audio/image
+# stage profiles separate without high-cardinality request labels.
+KV_LABELS = ("model_name", "stage", "replica", "modality", "source")
 
 
 # ============================================================================
@@ -226,6 +243,12 @@ RTF_BUCKETS = (
     5.0,
     10.0,
 )
+
+# Buckets for ratio histograms: occupancy, fragmentation, and prefix-hit.
+RATIO_BUCKETS = (0.0, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 1.0)
+
+# Buckets for per-stage KV tail-waste token histograms.
+TOKENS_BUCKETS = (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384)
 
 # Bytes bucket for transfer payload size.
 BYTES_BUCKETS = (

--- a/vllm_omni/metrics/kv.py
+++ b/vllm_omni/metrics/kv.py
@@ -1,0 +1,348 @@
+"""KV cache efficiency metrics for vLLM-Omni.
+
+This module owns both the pure formulas and the Prometheus observe API. Runtime
+hooks feed it with allocator-backed block IDs when available, and stage-token
+fallbacks otherwise.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from vllm_omni.metrics import definitions as defs
+
+_labelnames = list(defs.KV_LABELS)
+_kv_families: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class KVEfficiencySnapshot:
+    """One logical KV allocation snapshot for a stage request."""
+
+    block_size: int
+    sequence_tokens: int
+    allocated_blocks: int
+    allocated_tokens: int
+    occupied_tokens: int
+    tail_waste_tokens: int
+    occupancy_ratio: float
+    fragmentation_ratio: float
+    footprint_tokens: int
+    footprint_bytes: int
+    bytes_per_token: int
+    cached_tokens: int = 0
+    prompt_tokens: int = 0
+    prefix_hit_ratio: float = 0.0
+    source: str = "stage_tokens"
+
+
+def _coerce_positive_int(value: Any, default: int = 0) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    return coerced if coerced > 0 else default
+
+
+def normalize_kv_block_ids(raw_block_ids: Any) -> list[int]:
+    """Normalize vLLM KV block id shapes to the first cache group's flat list."""
+
+    if raw_block_ids is None:
+        return []
+    if isinstance(raw_block_ids, tuple) and raw_block_ids and isinstance(raw_block_ids[0], (list, tuple)):
+        raw_block_ids = raw_block_ids[0]
+    if isinstance(raw_block_ids, list) and raw_block_ids and isinstance(raw_block_ids[0], (list, tuple)):
+        raw_block_ids = raw_block_ids[0]
+    try:
+        return [int(block_id) for block_id in raw_block_ids]
+    except (TypeError, ValueError):
+        return []
+
+
+def _cache_dtype_nbytes(cache_dtype: Any, fallback_dtype: Any = None) -> int:
+    """Best-effort byte width for vLLM cache dtypes."""
+
+    if cache_dtype is not None and str(cache_dtype).lower() in {"auto", "none"}:
+        cache_dtype = None
+    value = str(cache_dtype or fallback_dtype or "").lower()
+    if not value:
+        return 0
+    if "fp8" in value or "float8" in value or "int8" in value:
+        return 1
+    if "bf16" in value or "bfloat16" in value or "fp16" in value or "float16" in value or "half" in value:
+        return 2
+    if "fp32" in value or "float32" in value:
+        return 4
+    return 0
+
+
+def _first_positive_attr(source: Any, names: tuple[str, ...]) -> int:
+    for name in names:
+        value = getattr(source, name, None)
+        coerced = _coerce_positive_int(value)
+        if coerced > 0:
+            return coerced
+    return 0
+
+
+def estimate_kv_bytes_per_token(vllm_config: Any | None) -> int:
+    """Estimate per-token KV bytes from a stage VllmConfig.
+
+    Formula: layers * 2(K+V) * num_kv_heads * head_dim * dtype_bytes.
+    Returns 0 when the required model/cache attributes are unavailable.
+    """
+
+    if vllm_config is None:
+        return 0
+    model_config = getattr(vllm_config, "model_config", None)
+    cache_config = getattr(vllm_config, "cache_config", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    if model_config is None:
+        return 0
+
+    get_num_layers = getattr(model_config, "get_num_layers", None)
+    get_num_kv_heads = getattr(model_config, "get_num_kv_heads", None)
+    get_head_size = getattr(model_config, "get_head_size", None)
+    try:
+        num_layers = int(get_num_layers(parallel_config) if callable(get_num_layers) else 0)
+    except TypeError:
+        try:
+            num_layers = int(get_num_layers() if callable(get_num_layers) else 0)
+        except Exception:
+            num_layers = 0
+    except Exception:
+        num_layers = 0
+
+    try:
+        num_kv_heads = int(get_num_kv_heads(parallel_config) if callable(get_num_kv_heads) else 0)
+    except TypeError:
+        try:
+            num_kv_heads = int(get_num_kv_heads() if callable(get_num_kv_heads) else 0)
+        except Exception:
+            num_kv_heads = 0
+    except Exception:
+        num_kv_heads = 0
+
+    try:
+        head_dim = int(get_head_size() if callable(get_head_size) else 0)
+    except Exception:
+        head_dim = 0
+
+    if num_layers <= 0:
+        num_layers = _first_positive_attr(model_config, ("num_hidden_layers", "num_layers", "n_layer"))
+    if num_kv_heads <= 0:
+        num_kv_heads = _first_positive_attr(
+            model_config,
+            ("num_key_value_heads", "num_kv_heads", "num_attention_heads", "n_head"),
+        )
+    if head_dim <= 0:
+        head_dim = _first_positive_attr(model_config, ("head_dim",))
+    if head_dim <= 0:
+        hidden_size = _first_positive_attr(model_config, ("hidden_size",))
+        num_attention_heads = _first_positive_attr(model_config, ("num_attention_heads", "n_head"))
+        if hidden_size > 0 and num_attention_heads > 0:
+            head_dim = hidden_size // num_attention_heads
+
+    cache_dtype = getattr(cache_config, "cache_dtype", None) if cache_config is not None else None
+    fallback_dtype = getattr(model_config, "dtype", None)
+    dtype_bytes = _cache_dtype_nbytes(cache_dtype, fallback_dtype)
+
+    if min(num_layers, num_kv_heads, head_dim, dtype_bytes) <= 0:
+        return 0
+    return int(num_layers * 2 * num_kv_heads * head_dim * dtype_bytes)
+
+
+def resolve_kv_block_size(vllm_config: Any | None, default: int = 16) -> int:
+    """Resolve stage KV block size from VllmConfig-like objects."""
+
+    if vllm_config is not None:
+        cache_config = getattr(vllm_config, "cache_config", None)
+        block_size = _coerce_positive_int(getattr(cache_config, "block_size", None))
+        if block_size > 0:
+            return block_size
+        block_size = _coerce_positive_int(getattr(vllm_config, "block_size", None))
+        if block_size > 0:
+            return block_size
+    return int(default)
+
+
+def compute_kv_efficiency(
+    *,
+    block_size: int,
+    sequence_tokens: int,
+    allocated_blocks: int | None = None,
+    bytes_per_token: int = 0,
+    cached_tokens: int = 0,
+    prompt_tokens: int | None = None,
+    source: str = "stage_tokens",
+) -> KVEfficiencySnapshot:
+    """Compute logical KV block occupancy and tail waste.
+
+    ``sequence_tokens`` is the number of useful tokens occupying KV blocks for
+    this snapshot. ``allocated_blocks`` may come from a real allocator; if it is
+    absent, the function uses ``ceil(sequence_tokens / block_size)``.
+    """
+
+    block_size = _coerce_positive_int(block_size, default=16)
+    sequence_tokens = max(int(sequence_tokens or 0), 0)
+    min_blocks = math.ceil(sequence_tokens / block_size) if sequence_tokens > 0 else 0
+    if allocated_blocks is None:
+        allocated_blocks = min_blocks
+    allocated_blocks = max(int(allocated_blocks or 0), min_blocks)
+    allocated_tokens = allocated_blocks * block_size
+    occupied_tokens = min(sequence_tokens, allocated_tokens)
+    tail_waste_tokens = max(allocated_tokens - occupied_tokens, 0)
+    occupancy_ratio = (occupied_tokens / allocated_tokens) if allocated_tokens > 0 else 0.0
+    fragmentation_ratio = (tail_waste_tokens / allocated_tokens) if allocated_tokens > 0 else 0.0
+    bytes_per_token = max(int(bytes_per_token or 0), 0)
+    footprint_bytes = allocated_tokens * bytes_per_token
+    cached_tokens = max(int(cached_tokens or 0), 0)
+    prompt_tokens = sequence_tokens if prompt_tokens is None else max(int(prompt_tokens or 0), 0)
+    prefix_hit_ratio = (cached_tokens / prompt_tokens) if prompt_tokens > 0 else 0.0
+
+    return KVEfficiencySnapshot(
+        block_size=block_size,
+        sequence_tokens=sequence_tokens,
+        allocated_blocks=allocated_blocks,
+        allocated_tokens=allocated_tokens,
+        occupied_tokens=occupied_tokens,
+        tail_waste_tokens=tail_waste_tokens,
+        occupancy_ratio=occupancy_ratio,
+        fragmentation_ratio=fragmentation_ratio,
+        footprint_tokens=allocated_tokens,
+        footprint_bytes=footprint_bytes,
+        bytes_per_token=bytes_per_token,
+        cached_tokens=cached_tokens,
+        prompt_tokens=prompt_tokens,
+        prefix_hit_ratio=prefix_hit_ratio,
+        source=source,
+    )
+
+
+def _families() -> dict[str, Any]:
+    """Return Prometheus families, creating them after vLLM metric reset.
+
+    vLLM's PrometheusStatLogger unregisters all collectors whose name contains
+    "vllm" during startup. Import-time custom collectors would be removed
+    before the first request, so vLLM-Omni families are initialized lazily when
+    a request actually observes a snapshot.
+    """
+
+    global _kv_families
+    if _kv_families is not None:
+        try:
+            from prometheus_client import REGISTRY
+
+            registered = getattr(REGISTRY, "_collector_to_names", {})
+            if all(family in registered for family in _kv_families.values()):
+                return _kv_families
+            for family in _kv_families.values():
+                if family in registered:
+                    REGISTRY.unregister(family)
+        except Exception:
+            return _kv_families
+        _kv_families = None
+
+    from prometheus_client import Gauge, Histogram
+
+    _kv_families = {
+        "footprint_tokens": Gauge(
+            defs.KV_FOOTPRINT_TOKENS,
+            "Logical allocated KV block capacity in tokens for the latest stage snapshot.",
+            labelnames=_labelnames,
+        ),
+        "footprint_bytes": Gauge(
+            defs.KV_FOOTPRINT_BYTES,
+            "Estimated allocated KV footprint in bytes for the latest stage snapshot.",
+            labelnames=_labelnames,
+        ),
+        "block_occupancy": Histogram(
+            defs.KV_BLOCK_OCCUPANCY_RATIO,
+            "Per-stage KV block occupancy ratio: useful tokens / allocated block capacity.",
+            labelnames=_labelnames,
+            buckets=defs.RATIO_BUCKETS,
+        ),
+        "tail_waste": Histogram(
+            defs.KV_TAIL_WASTE_TOKENS,
+            "Per-stage KV tail waste in tokens: allocated block capacity minus useful tokens.",
+            labelnames=_labelnames,
+            buckets=defs.TOKENS_BUCKETS,
+        ),
+        "fragmentation": Histogram(
+            defs.KV_FRAGMENTATION_RATIO,
+            "Per-stage logical KV fragmentation ratio: tail waste tokens / allocated block capacity.",
+            labelnames=_labelnames,
+            buckets=defs.RATIO_BUCKETS,
+        ),
+        "cached_tokens": Gauge(
+            defs.KV_CACHED_TOKENS,
+            "Tokens served from prefix cache in the latest stage snapshot.",
+            labelnames=_labelnames,
+        ),
+        "prefix_hit_ratio": Histogram(
+            defs.KV_PREFIX_HIT_RATIO,
+            "Per-stage prefix cache hit ratio: cached tokens / prompt tokens.",
+            labelnames=_labelnames,
+            buckets=defs.RATIO_BUCKETS,
+        ),
+    }
+    return _kv_families
+
+
+class OmniKVCacheMetrics:
+    """Observe API for KV cache efficiency families."""
+
+    def __init__(self, model_name: str, log_stats: bool = True) -> None:
+        self._model_name = model_name
+        self._log_stats = log_stats
+
+    def observe_snapshot(
+        self,
+        *,
+        stage: int | str,
+        replica: int | str | None,
+        modality: str | None,
+        snapshot: KVEfficiencySnapshot | None,
+    ) -> None:
+        if not self._log_stats or snapshot is None or replica is None:
+            return
+        labels = {
+            "model_name": self._model_name,
+            "stage": str(stage),
+            "replica": str(replica),
+            "modality": str(modality or "unknown"),
+            "source": str(snapshot.source or "unknown"),
+        }
+        families = _families()
+        families["footprint_tokens"].labels(**labels).set(snapshot.footprint_tokens)
+        if snapshot.footprint_bytes > 0:
+            families["footprint_bytes"].labels(**labels).set(snapshot.footprint_bytes)
+        families["block_occupancy"].labels(**labels).observe(snapshot.occupancy_ratio)
+        families["tail_waste"].labels(**labels).observe(snapshot.tail_waste_tokens)
+        families["fragmentation"].labels(**labels).observe(snapshot.fragmentation_ratio)
+        families["cached_tokens"].labels(**labels).set(snapshot.cached_tokens)
+        if snapshot.prompt_tokens > 0:
+            families["prefix_hit_ratio"].labels(**labels).observe(snapshot.prefix_hit_ratio)
+
+
+def observe_kv_at_stage_metrics(
+    kv_metrics: OmniKVCacheMetrics,
+    *,
+    stage_id: int,
+    replica_id: int | None,
+    stage_metrics: Any,
+    modality: str | None,
+) -> None:
+    """Emit a KV snapshot carried by ``StageRequestStats`` if present."""
+
+    snapshot = getattr(stage_metrics, "kv_snapshot", None)
+    if snapshot is None:
+        return
+    kv_metrics.observe_snapshot(
+        stage=stage_id,
+        replica=replica_id,
+        modality=modality,
+        snapshot=snapshot,
+    )

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -61,6 +61,7 @@ class StageRequestStats:
     vllm_tpot_ms: float = 0.0
     vllm_itl_ms: float = 0.0
     vllm_itls_ms: list[float] | None = None
+    kv_snapshot: Any | None = None
 
     @property
     def rx_mbps(self) -> float:
@@ -122,6 +123,7 @@ STAGE_EXCLUDE = {
     "rx_in_flight_time_ms",
     "final_output_type",
     "pipeline_timings",
+    "kv_snapshot",
 }
 TRANSFER_EXCLUDE = {"from_stage", "to_stage", "request_id", "used_shm"}
 E2E_EXCLUDE = {"request_id"}


### PR DESCRIPTION
## Summary

Related to #4802. 

Add per-stage KV cache efficiency metrics for vLLM-Omni LLM stages.

This PR focuses on `LLM_AR` and `LLM_GENERATION` execution stages. Diffusion stages are intentionally left out of scope because their scheduler abstraction is still separate.

New vLLM-Omni Prometheus metrics:

- `vllm_omni:kv_footprint_tokens`
- `vllm_omni:kv_footprint_bytes`
- `vllm_omni:kv_block_occupancy_ratio`
- `vllm_omni:kv_tail_waste_tokens`
- `vllm_omni:kv_fragmentation_ratio`
- `vllm_omni:kv_cached_tokens`
- `vllm_omni:kv_prefix_hit_ratio`

## What Changed

- Added KV efficiency calculation helpers and Prometheus collectors for per-stage LLM KV snapshots.
- Collected allocator-backed KV block IDs in the AR/generation schedulers and propagated them through the output path into `StagePool`.
- Emitted per-stage KV metrics from `OmniBase`, with `stage_tokens` fallback when allocator metadata is unavailable.
- Kept collection best-effort and low-risk: final-request snapshots are captured before KV free, and `kv_cached_tokens` is reported as a latest-value Gauge.

## Testing

GPU validation was run on an RTX 4090 server with Python 3.12.3, Torch 2.11.0+cu130, vLLM 0.23.0, and a tiny OPT CUDA smoke through Omni `LLM_AR`.

I also ran a 12-request workload through a single Omni `LLM_AR` stage with varied prompt lengths, varied `max_tokens`, and repeated-prefix prompts. The Prometheus scrape produced 12 allocator-backed KV observations with `source="kv_cache_manager"`:

- `kv_block_occupancy_ratio_count = 12`, `kv_block_occupancy_ratio_sum = 8.0`
- occupancy buckets: `<=0.5: 3`, `<=0.75: 6`, `<=0.9: 9`, `<=1.0: 12`
- `kv_tail_waste_tokens_count = 12`, `kv_tail_waste_tokens_sum = 123`
- tail waste buckets: `<=4: 3`, `<=8: 5`, `<=16: 12`
- `kv_fragmentation_ratio_count = 12`, `kv_fragmentation_ratio_sum = 4.0`
- fragmentation buckets: `<=0.1: 3`, `<=0.25: 6`, `<=0.5: 10`, `<=1.0: 12`
- `kv_prefix_hit_ratio_count = 12`, `kv_prefix_hit_ratio_sum = 3.0491803278688523`

Detailed workload table, raw Prometheus scrape, output JSON, run script, and run log are attached as 
[kv_metrics_result.zip](https://github.com/user-attachments/files/29746515/kv_metrics_result.zip)



