### PR TITLE
[Model] Add Qwen-Image Edit Step Execution Support

### DIFF
--- a/docs/design/feature/diffusion_step_execution.md
+++ b/docs/design/feature/diffusion_step_execution.md
@@ -26,7 +26,10 @@ Current in-tree support:
 | Pipeline | Example models | Step execution |
 |----------|----------------|----------------|
 | `QwenImagePipeline` | `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512` | Yes |
-| All other diffusion pipelines | `QwenImageEditPipeline`, `QwenImageEditPlusPipeline`, `QwenImageLayeredPipeline`, GLM-Image, Wan, Flux, etc. | No |
+| `QwenImageEditPipeline` | `Qwen/Qwen-Image-Edit` | Yes |
+| `QwenImageEditPlusPipeline` | `Qwen/Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2511` | Yes |
+| `QwenImageLayeredPipeline` | Qwen-Image layered editing models | Yes |
+| All other diffusion pipelines | GLM-Image, Wan, Flux, etc. | No |
 
 Current engine/runtime limitations:
 

--- a/docs/user_guide/diffusion/step_execution.md
+++ b/docs/user_guide/diffusion/step_execution.md
@@ -44,7 +44,10 @@ batching only becomes relevant when `--max-num-seqs > 1`.
 | Pipeline | Example models | Step execution |
 |----------|----------------|----------------|
 | `QwenImagePipeline` | `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512` | Yes |
-| All other diffusion pipelines | `QwenImageEditPipeline`, `QwenImageEditPlusPipeline`, `QwenImageLayeredPipeline`, GLM-Image, Wan, Flux, etc. | No |
+| `QwenImageEditPipeline` | `Qwen/Qwen-Image-Edit` | Yes |
+| `QwenImageEditPlusPipeline` | `Qwen/Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2511` | Yes |
+| `QwenImageLayeredPipeline` | Qwen-Image layered editing models | Yes |
+| All other diffusion pipelines | GLM-Image, Wan, Flux, etc. | No |
 
 !!! warning "Experimental continuous batching"
     When `--step-execution` is enabled and `max_num_seqs > 1` is configured,

--- a/tests/dfx/perf/tests/test_qwen_image_step_execution_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_step_execution_vllm_omni.json
@@ -1,0 +1,289 @@
+[
+  {
+    "test_name": "test_qwen_image_step_execution_baseline_serial",
+    "description": "Qwen-Image request-level serial baseline",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Qwen/Qwen-Image",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "256x256_steps20_t2i_serial",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 256,
+        "height": 256,
+        "num-inference-steps": 20,
+        "num-prompts": 24,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "512x512_steps20_t2i_serial",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": 16,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_t2i_serial",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": 8,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      }
+    ]
+  },
+  {
+    "test_name": "test_qwen_image_step_execution_single",
+    "description": "Qwen-Image step execution without batching",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Qwen/Qwen-Image",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true,
+        "step-execution": true,
+        "max-num-seqs": 1
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "256x256_steps20_t2i_step_single",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 256,
+        "height": 256,
+        "num-inference-steps": 20,
+        "num-prompts": 24,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "512x512_steps20_t2i_step_single",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": 16,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_t2i_step_single",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": 8,
+        "max-concurrency": 1,
+        "enable-negative-prompt": true
+      }
+    ]
+  },
+  {
+    "test_name": "test_qwen_image_step_execution_batch2",
+    "description": "Qwen-Image step-wise batching sweep",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Qwen/Qwen-Image",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true,
+        "step-execution": true,
+        "max-num-seqs": 2
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "256x256_steps20_t2i_step_batch2",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 256,
+        "height": 256,
+        "num-inference-steps": 20,
+        "num-prompts": [24, 48],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "512x512_steps20_t2i_step_batch2",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": [16, 32],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_t2i_step_batch2",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": [8, 16],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "enable-negative-prompt": true
+      }
+    ]
+  },
+  {
+    "test_name": "test_qwen_image_edit_2511_step_execution_baseline_serial",
+    "description": "Qwen-Image-Edit-2511 request-level serial baseline",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Qwen/Qwen-Image-Edit-2511",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "512x512_steps20_i2i_1img_serial",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": 8,
+        "max-concurrency": 1,
+        "num-input-images": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_i2i_1img_serial",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": 4,
+        "max-concurrency": 1,
+        "num-input-images": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "512x512_steps20_i2i_2img_serial",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": 8,
+        "max-concurrency": 1,
+        "num-input-images": 2,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_i2i_2img_serial",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": 4,
+        "max-concurrency": 1,
+        "num-input-images": 2,
+        "enable-negative-prompt": true
+      }
+    ]
+  },
+  {
+    "test_name": "test_qwen_image_edit_2511_step_execution_batch2",
+    "description": "Qwen-Image-Edit-2511 step-wise batching sweep",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Qwen/Qwen-Image-Edit-2511",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true,
+        "step-execution": true,
+        "max-num-seqs": 2
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "512x512_steps20_i2i_1img_step_batch2",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": [8, 16],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "num-input-images": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_i2i_1img_step_batch2",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": [4, 8],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 2,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "num-input-images": 1,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "512x512_steps20_i2i_2img_step_batch2",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": [8, 16],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "num-input-images": 2,
+        "enable-negative-prompt": true
+      },
+      {
+        "name": "1024x1024_steps20_i2i_2img_step_batch2",
+        "dataset": "random",
+        "task": "i2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 20,
+        "num-prompts": [4, 8],
+        "max-concurrency": [1, 2],
+        "warmup-requests": 2,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 20,
+        "num-input-images": 2,
+        "enable-negative-prompt": true
+      }
+    ]
+  }
+]

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -65,9 +65,10 @@ def _make_step_request(
     num_inference_steps: int = 4,
     step_index: int | None = None,
     sampling_params: OmniDiffusionSamplingParams | None = None,
+    prompt=None,
 ) -> OmniDiffusionRequest:
     return OmniDiffusionRequest(
-        prompt=f"prompt_{req_id}",
+        prompt=prompt if prompt is not None else f"prompt_{req_id}",
         sampling_params=sampling_params
         or OmniDiffusionSamplingParams(
             num_inference_steps=num_inference_steps,
@@ -925,6 +926,81 @@ class TestStepScheduler:
         assert _new_ids(second) == [req_b]
         assert second.num_running_reqs == 1
         assert second.num_waiting_reqs == 1
+
+    def test_step_batch_co_schedules_matching_condition_image_signature(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        prompt_a = {
+            "prompt": "prompt_a",
+            "additional_information": {"preprocessed_image": torch.zeros(1, 16, 1, 64, 128)},
+        }
+        prompt_b = {
+            "prompt": "prompt_b",
+            "additional_information": {"preprocessed_image": torch.ones(1, 16, 1, 64, 128)},
+        }
+        sampling_a = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+        sampling_b = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+
+        req_a = scheduler.add_request(_make_step_request("a", sampling_params=sampling_a, prompt=prompt_a))
+        req_b = scheduler.add_request(_make_step_request("b", sampling_params=sampling_b, prompt=prompt_b))
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_a, req_b]
+        assert sched_output.num_waiting_reqs == 0
+
+    def test_step_batch_separates_different_condition_image_shapes(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        prompt_wide = {
+            "prompt": "prompt_wide",
+            "additional_information": {"preprocessed_image": torch.zeros(1, 16, 1, 64, 128)},
+        }
+        prompt_tall = {
+            "prompt": "prompt_tall",
+            "additional_information": {"preprocessed_image": torch.zeros(1, 16, 1, 128, 64)},
+        }
+        sampling_wide = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+        sampling_tall = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+
+        req_wide = scheduler.add_request(_make_step_request("wide", sampling_params=sampling_wide, prompt=prompt_wide))
+        req_tall = scheduler.add_request(_make_step_request("tall", sampling_params=sampling_tall, prompt=prompt_tall))
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_wide]
+        assert req_tall not in _new_ids(sched_output)
+        assert sched_output.num_waiting_reqs == 1
+
+    def test_step_batch_separates_different_condition_image_counts(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        prompt_one_image = {
+            "prompt": "prompt_one",
+            "additional_information": {"vae_image_sizes": [(1024, 1024)]},
+        }
+        prompt_two_images = {
+            "prompt": "prompt_two",
+            "additional_information": {"vae_image_sizes": [(1024, 1024), (1024, 1024)]},
+        }
+        sampling_one = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+        sampling_two = OmniDiffusionSamplingParams(height=512, width=512, num_inference_steps=4)
+
+        req_one = scheduler.add_request(
+            _make_step_request("one", sampling_params=sampling_one, prompt=prompt_one_image)
+        )
+        req_two = scheduler.add_request(
+            _make_step_request("two", sampling_params=sampling_two, prompt=prompt_two_images)
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_one]
+        assert req_two not in _new_ids(sched_output)
+        assert sched_output.num_waiting_reqs == 1
 
     def test_step_batch_co_schedules_requests_sharing_lora(self) -> None:
         """Multiple requests with the same LoRA (id + scale) co-batch."""

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -3,6 +3,7 @@
 """Tests for step-level diffusion execution across runner / worker / executor / engine."""
 
 import contextlib
+import importlib
 import os
 import queue
 import threading
@@ -1022,12 +1023,37 @@ class TestSupportedPipelines:
 
         assert stage_cfg["engine_args"]["step_execution"] is True
 
-    def test_qwen_image_supports_step_execution(self):
+    @pytest.mark.parametrize(
+        ("module_name", "class_name"),
+        [
+            pytest.param(
+                "vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image",
+                "QwenImagePipeline",
+                id="qwen-image",
+            ),
+            pytest.param(
+                "vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit",
+                "QwenImageEditPipeline",
+                id="qwen-image-edit",
+            ),
+            pytest.param(
+                "vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus",
+                "QwenImageEditPlusPipeline",
+                id="qwen-image-edit-plus",
+            ),
+            pytest.param(
+                "vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_layered",
+                "QwenImageLayeredPipeline",
+                id="qwen-image-layered",
+            ),
+        ],
+    )
+    def test_qwen_image_pipelines_support_step_execution(self, module_name, class_name):
         from vllm_omni.diffusion.models.interface import SupportsStepExecution, supports_step_execution
-        from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
 
+        pipeline_cls = getattr(importlib.import_module(module_name), class_name)
         # Avoid loading model weights; protocol membership depends on the class contract.
-        pipeline = object.__new__(QwenImagePipeline)
+        pipeline = object.__new__(pipeline_cls)
 
         assert pipeline.supports_step_execution is True
         assert supports_step_execution(pipeline) is True

--- a/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
@@ -33,6 +33,28 @@ def _get_diffusion_feature_cases(model: str):
             OmniServerParams(
                 model=model,
                 server_args=[
+                    "--step-execution",
+                ],
+            ),
+            id="step_execution",
+            marks=SINGLE_CARD_FEATURE_MARKS,
+        ),
+        pytest.param(
+            OmniServerParams(
+                model=model,
+                server_args=[
+                    "--step-execution",
+                    "--max-num-seqs",
+                    "2",
+                ],
+            ),
+            id="step_execution_batch2",
+            marks=SINGLE_CARD_FEATURE_MARKS,
+        ),
+        pytest.param(
+            OmniServerParams(
+                model=model,
+                server_args=[
                     "--enable-cpu-offload",
                 ],
             ),

--- a/tests/e2e/online_serving/test_qwen_image_layered_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_layered_expansion.py
@@ -35,6 +35,28 @@ FEATURE_CASES = [
     pytest.param(
         OmniServerParams(
             model=MODEL,
+            server_args=[
+                "--step-execution",
+            ],
+        ),
+        id="step_execution",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            server_args=[
+                "--step-execution",
+                "--max-num-seqs",
+                "2",
+            ],
+        ),
+        id="step_execution_batch2",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
             server_args=["--enable-cpu-offload"],
         ),
         id="cpu_offload",

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.qwen_image.stepwise_mixin import QwenImageStepwiseMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
@@ -47,7 +48,6 @@ from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
 
 if TYPE_CHECKING:
-    from vllm_omni.diffusion.worker.input_batch import InputBatch
     from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 from vllm_omni.model_executor.model_loader.weight_utils import (
@@ -253,7 +253,11 @@ def apply_rotary_emb_qwen(
 
 
 class QwenImagePipeline(
-    nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    QwenImageStepwiseMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     supports_request_batch = True
     _dit_modules: ClassVar[list[str]] = ["transformer"]
@@ -766,12 +770,15 @@ class QwenImagePipeline(
         """Populate *state* with encoded prompts, latents, timesteps, and CFG config."""
         sampling = state.sampling
         prompt, negative_prompt = self._extract_prompts([state.prompt] if state.prompt is not None else [])
+        height = sampling.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling.width or self.default_sample_size * self.vae_scale_factor
+        height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
 
         ctx = self._prepare_generation_context(
             prompt=prompt,
             negative_prompt=negative_prompt,
-            height=sampling.height or self.default_sample_size * self.vae_scale_factor,
-            width=sampling.width or self.default_sample_size * self.vae_scale_factor,
+            height=height,
+            width=width,
             num_inference_steps=sampling.num_inference_steps or 50,
             sigmas=sampling.sigmas,
             guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
@@ -803,184 +810,12 @@ class QwenImagePipeline(
         state.img_shapes = ctx["img_shapes"]
         state.txt_seq_lens = ctx["txt_seq_lens"]
         state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
+        state.extra["height"] = height
+        state.extra["width"] = width
         # QwenImage always normalizes CFG output (matching forward())
         state.sampling.cfg_normalize = True
 
         return state
-
-    def _build_denoise_kwargs(
-        self,
-        latents: torch.Tensor,
-        timestep: torch.Tensor,
-        guidance: torch.Tensor | None,
-        prompt_embeds: torch.Tensor,
-        prompt_embeds_mask: torch.Tensor,
-        img_shapes: list,
-        txt_seq_lens: list[int] | None,
-        do_true_cfg: bool,
-        negative_prompt_embeds: torch.Tensor | None,
-        negative_prompt_embeds_mask: torch.Tensor | None,
-        negative_txt_seq_lens: list[int] | None,
-        image_latents: torch.Tensor | None = None,
-        extra_transformer_kwargs: dict[str, Any] | None = None,
-    ) -> tuple[dict[str, Any], dict[str, Any] | None, int | None]:
-        """Build positive/negative kwargs and output_slice for one denoise step.
-
-        Returns:
-            (positive_kwargs, negative_kwargs, output_slice)
-        """
-        extra_transformer_kwargs = extra_transformer_kwargs or {}
-
-        # Broadcast timestep to match batch size
-        t_for_model = timestep.expand(latents.shape[0]).to(
-            device=latents.device,
-            dtype=latents.dtype,
-        )
-
-        # Concatenate image latents if available (editing pipelines)
-        latent_model_input = latents
-        if image_latents is not None:
-            latent_model_input = torch.cat([latents, image_latents], dim=1)
-
-        positive_kwargs = {
-            "hidden_states": latent_model_input,
-            "timestep": t_for_model / 1000,
-            "guidance": guidance,
-            "encoder_hidden_states_mask": prompt_embeds_mask,
-            "encoder_hidden_states": prompt_embeds,
-            "img_shapes": img_shapes,
-            "txt_seq_lens": txt_seq_lens,
-            **extra_transformer_kwargs,
-        }
-        if do_true_cfg:
-            negative_kwargs = {
-                "hidden_states": latent_model_input,
-                "timestep": t_for_model / 1000,
-                "guidance": guidance,
-                "encoder_hidden_states_mask": negative_prompt_embeds_mask,
-                "encoder_hidden_states": negative_prompt_embeds,
-                "img_shapes": img_shapes,
-                "txt_seq_lens": negative_txt_seq_lens,
-                **extra_transformer_kwargs,
-            }
-        else:
-            negative_kwargs = None
-
-        output_slice = latents.size(1) if image_latents is not None else None
-        return positive_kwargs, negative_kwargs, output_slice
-
-    def _decode_latents(
-        self,
-        latents: torch.Tensor,
-        height: int,
-        width: int,
-        output_type: str = "pil",
-    ) -> DiffusionOutput:
-        """Unpack, normalize, and VAE-decode latents into a DiffusionOutput."""
-        if output_type == "latent":
-            return DiffusionOutput(
-                output=latents,
-                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
-            )
-
-        latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
-        latents = latents.to(self.vae.dtype)
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean)
-            .view(1, self.vae.config.z_dim, 1, 1, 1)
-            .to(latents.device, latents.dtype)
-        )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
-            latents.device, latents.dtype
-        )
-        latents = latents / latents_std + latents_mean
-        image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
-        return DiffusionOutput(
-            output=image,
-            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
-        )
-
-    def denoise_step(
-        self,
-        input_batch: "InputBatch",
-        **kwargs: Any,
-    ) -> torch.Tensor | None:
-        """One denoise step: read from *input_batch*, delegate to CFGParallelMixin.
-
-        Reuses ``predict_noise_maybe_with_cfg`` so that CFG-parallel,
-        sequential-CFG, and no-CFG paths are handled identically to
-        ``diffuse()``.
-        """
-        del kwargs
-        if self.interrupt:
-            return None
-
-        t = input_batch.timesteps
-        self._current_timestep = t
-        self.transformer.do_true_cfg = input_batch.do_true_cfg
-
-        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
-            latents=input_batch.latents,
-            timestep=t,
-            guidance=input_batch.guidance,
-            prompt_embeds=input_batch.prompt_embeds,
-            prompt_embeds_mask=input_batch.prompt_embeds_mask,
-            img_shapes=input_batch.img_shapes,
-            txt_seq_lens=input_batch.txt_seq_lens,
-            do_true_cfg=input_batch.do_true_cfg,
-            negative_prompt_embeds=input_batch.negative_prompt_embeds,
-            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
-            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
-            image_latents=input_batch.image_latents,
-            extra_transformer_kwargs={
-                "attention_kwargs": self.attention_kwargs,
-                "return_dict": False,
-            },
-        )
-
-        return self.predict_noise_maybe_with_cfg(
-            input_batch.do_true_cfg,
-            input_batch.true_cfg_scale,
-            positive_kwargs,
-            negative_kwargs,
-            input_batch.cfg_normalize,
-            output_slice,
-        )
-
-    def step_scheduler(
-        self,
-        state: "DiffusionRequestState",
-        noise_pred: torch.Tensor,
-        **kwargs: Any,
-    ) -> None:
-        """One scheduler step: update ``state.latents`` and advance ``step_index``."""
-        if self.interrupt:
-            return
-
-        t = state.current_timestep
-        state.latents = self.scheduler_step_maybe_with_cfg(
-            noise_pred,
-            t,
-            state.latents,
-            state.do_true_cfg,
-            per_request_scheduler=state.scheduler,
-        )
-
-        state.step_index += 1
-
-    def post_decode(
-        self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> DiffusionOutput:
-        """Decode final latents from *state*."""
-        self._current_timestep = None
-
-        height = state.sampling.height or self.default_sample_size * self.vae_scale_factor
-        width = state.sampling.width or self.default_sample_size * self.vae_scale_factor
-        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
-
-        return self._decode_latents(state.latents, height, width, output_type)
 
     def forward(self, req: DiffusionRequestBatch) -> list[DiffusionOutput]:
         sampling_params_list = req.sampling_params_list

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -689,6 +689,133 @@ class QwenImageEditPipeline(
     def interrupt(self):
         return self._interrupt
 
+    def _prepare_generation_context(
+        self,
+        *,
+        prompt,
+        negative_prompt,
+        prompt_image,
+        image,
+        calculated_height,
+        calculated_width,
+        height,
+        width,
+        num_inference_steps,
+        sigmas,
+        guidance_scale,
+        num_images_per_prompt,
+        generator,
+        true_cfg_scale,
+        max_sequence_length,
+        prompt_embeds=None,
+        prompt_embeds_mask=None,
+        negative_prompt_embeds=None,
+        negative_prompt_embeds_mask=None,
+        latents=None,
+        attention_kwargs=None,
+        callback_on_step_end_tensor_inputs=None,
+    ):
+        """Shared request preparation for forward() and step-wise prepare_encode()."""
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            image,
+            negative_prompt,
+            prompt_embeds,
+            negative_prompt_embeds,
+            prompt_embeds_mask,
+            negative_prompt_embeds_mask,
+            callback_on_step_end_tensor_inputs,
+            max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        batch_size = 1
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            image=prompt_image,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                image=prompt_image,
+                prompt_embeds=negative_prompt_embeds,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+                prompt_name="negative_prompt",
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_latents = self.prepare_latents(
+            image,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            latents,
+        )
+        img_shapes = [
+            [
+                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
+                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
+            ]
+        ] * batch_size
+
+        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
+            guidance = guidance.expand(latents.shape[0])
+        else:
+            guidance = None
+
+        if self.attention_kwargs is None:
+            self._attention_kwargs = {}
+
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        negative_txt_seq_lens = (
+            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+        )
+
+        return {
+            "prompt_embeds": prompt_embeds,
+            "prompt_embeds_mask": prompt_embeds_mask,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
+            "latents": latents,
+            "image_latents": image_latents,
+            "img_shapes": img_shapes,
+            "timesteps": timesteps,
+            "do_true_cfg": do_true_cfg,
+            "guidance": guidance,
+            "txt_seq_lens": txt_seq_lens,
+            "negative_txt_seq_lens": negative_txt_seq_lens,
+        }
+
     def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
         """Forward pass for image editing."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
@@ -749,104 +876,45 @@ class QwenImageEditPipeline(
         # 4. diffusion process
         # 5. decode latents
         # 6. post-process outputs
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            image,
-            negative_prompt,
-            prompt_embeds,
-            negative_prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds_mask,
-            callback_on_step_end_tensor_inputs,
-            max_sequence_length,
-        )
-
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = attention_kwargs
-        self._current_timestep = None
-        self._interrupt = False
-
-        batch_size = 1
-
-        has_neg_prompt = negative_prompt is not None
-
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
-
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+        ctx = self._prepare_generation_context(
             prompt=prompt,
-            image=prompt_image,  # Use resized image for prompt encoding
+            negative_prompt=negative_prompt,
+            prompt_image=prompt_image,  # Use resized image for prompt encoding
+            image=image,
+            calculated_height=calculated_height,
+            calculated_width=calculated_width,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            sigmas=sigmas,
+            guidance_scale=guidance_scale,
+            num_images_per_prompt=num_images_per_prompt,
+            generator=generator,
+            true_cfg_scale=true_cfg_scale,
+            max_sequence_length=max_sequence_length,
             prompt_embeds=prompt_embeds,
             prompt_embeds_mask=prompt_embeds_mask,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
-        )
-
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=prompt_image,  # Use same resized image for negative prompt encoding
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
-                num_images_per_prompt=num_images_per_prompt,
-                max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
-            )
-
-        num_channels_latents = self.transformer.in_channels // 4
-        # random noise latents, and image latents encoded by vae
-        latents, image_latents = self.prepare_latents(
-            image,
-            batch_size * num_images_per_prompt,
-            num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
-            self.device,
-            generator,
-            latents,
-        )
-        img_shapes = [
-            [
-                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
-                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
-            ]
-        ] * batch_size
-
-        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
-        self._num_timesteps = len(timesteps)
-
-        # handle guidance
-        if self.transformer.guidance_embeds:
-            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
-        else:
-            guidance = None
-
-        if self.attention_kwargs is None:
-            self._attention_kwargs = {}
-
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
-        negative_txt_seq_lens = (
-            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            latents=latents,
+            attention_kwargs=attention_kwargs,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
         )
 
         latents = self.diffuse(
-            prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds,
-            negative_prompt_embeds_mask,
-            latents,
-            img_shapes,
-            txt_seq_lens,
-            negative_txt_seq_lens,
-            timesteps,
-            do_true_cfg,
-            guidance,
+            ctx["prompt_embeds"],
+            ctx["prompt_embeds_mask"],
+            ctx["negative_prompt_embeds"],
+            ctx["negative_prompt_embeds_mask"],
+            ctx["latents"],
+            ctx["img_shapes"],
+            ctx["txt_seq_lens"],
+            ctx["negative_txt_seq_lens"],
+            ctx["timesteps"],
+            ctx["do_true_cfg"],
+            ctx["guidance"],
             true_cfg_scale,
-            image_latents=image_latents,
+            image_latents=ctx["image_latents"],
             cfg_normalize=True,
             additional_transformer_kwargs={
                 "return_dict": False,
@@ -917,109 +985,46 @@ class QwenImageEditPipeline(
                 "height and width from sampling params or preprocessing."
             )
 
-        num_inference_steps = sampling.num_inference_steps or 50
-        sigmas = sampling.sigmas
-        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
-        generator = sampling.generator
-        true_cfg_scale = sampling.true_cfg_scale or 4.0
-        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
-        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
-        callback_on_step_end_tensor_inputs = ["latents"]
-
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            image,
-            negative_prompt,
-            None,
-            None,
-            None,
-            None,
-            callback_on_step_end_tensor_inputs,
-            max_sequence_length,
-        )
-
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
-        self._current_timestep = None
-        self._interrupt = False
-
-        batch_size = 1
-        has_neg_prompt = negative_prompt is not None
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
-
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+        ctx = self._prepare_generation_context(
             prompt=prompt,
-            image=prompt_image,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
-        )
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=prompt_image,
-                num_images_per_prompt=num_images_per_prompt,
-                max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
-            )
-        else:
-            negative_prompt_embeds = None
-            negative_prompt_embeds_mask = None
-
-        num_channels_latents = self.transformer.in_channels // 4
-        latents, image_latents = self.prepare_latents(
-            image,
-            batch_size * num_images_per_prompt,
-            num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
-            self.device,
-            generator,
-            sampling.latents,
-        )
-        img_shapes = [
-            [
-                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
-                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
-            ]
-        ] * batch_size
-
-        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
-        self._num_timesteps = len(timesteps)
-
-        if self.transformer.guidance_embeds:
-            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
-        else:
-            guidance = None
-
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
-        negative_txt_seq_lens = (
-            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+            negative_prompt=negative_prompt,
+            prompt_image=prompt_image,
+            image=image,
+            calculated_height=calculated_height,
+            calculated_width=calculated_width,
+            height=height,
+            width=width,
+            num_inference_steps=sampling.num_inference_steps or 50,
+            sigmas=sampling.sigmas,
+            guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
+            num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
+            generator=sampling.generator,
+            true_cfg_scale=sampling.true_cfg_scale or 4.0,
+            max_sequence_length=sampling.max_sequence_length or self.tokenizer_max_length,
+            latents=sampling.latents,
+            attention_kwargs=kwargs.get("attention_kwargs") or {},
+            callback_on_step_end_tensor_inputs=["latents"],
         )
 
         req_scheduler = copy.deepcopy(self.scheduler)
         req_scheduler.set_begin_index(0)
 
-        state.prompt_embeds = prompt_embeds
-        state.prompt_embeds_mask = prompt_embeds_mask
-        state.negative_prompt_embeds = negative_prompt_embeds
-        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
-        state.latents = latents
-        state.timesteps = timesteps
+        state.prompt_embeds = ctx["prompt_embeds"]
+        state.prompt_embeds_mask = ctx["prompt_embeds_mask"]
+        state.negative_prompt_embeds = ctx["negative_prompt_embeds"]
+        state.negative_prompt_embeds_mask = ctx["negative_prompt_embeds_mask"]
+        state.latents = ctx["latents"]
+        state.timesteps = ctx["timesteps"]
         state.step_index = 0
         state.scheduler = req_scheduler
-        state.do_true_cfg = do_true_cfg
-        state.guidance = guidance
-        state.img_shapes = img_shapes
-        state.txt_seq_lens = txt_seq_lens
-        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.do_true_cfg = ctx["do_true_cfg"]
+        state.guidance = ctx["guidance"]
+        state.img_shapes = ctx["img_shapes"]
+        state.txt_seq_lens = ctx["txt_seq_lens"]
+        state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
         state.extra["height"] = height
         state.extra["width"] = width
         state.sampling.cfg_normalize = True
-        state.sampling.image_latent = image_latents
+        state.sampling.image_latent = ctx["image_latents"]
 
         return state

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import inspect
 import json
 import logging
 import math
 import os
 from collections.abc import Iterable
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 import PIL.Image
@@ -36,6 +37,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
+from vllm_omni.diffusion.models.qwen_image.stepwise_mixin import QwenImageStepwiseMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -52,6 +54,9 @@ from vllm_omni.model_executor.model_loader.weight_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 
 def get_qwen_image_edit_pre_process_func(
@@ -221,11 +226,18 @@ def retrieve_latents(
 
 
 class QwenImageEditPipeline(
-    nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    SupportImageInput,
+    QwenImageStepwiseMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    supports_step_execution: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -866,3 +878,148 @@ class QwenImageEditPipeline(
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def prepare_encode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> "DiffusionRequestState":
+        """Populate per-request state for step-wise single-image editing."""
+        sampling = state.sampling
+        first_prompt = state.prompt
+        if first_prompt is None:
+            raise ValueError("QwenImageEditPipeline.prepare_encode requires a non-null state.prompt.")
+        if isinstance(first_prompt, str):
+            raise ValueError(
+                "QwenImageEditPipeline requires an image-bearing prompt. "
+                "A raw string prompt was passed to step-wise prepare_encode."
+            )
+
+        prompt = first_prompt.get("prompt") or ""
+        negative_prompt = first_prompt.get("negative_prompt")
+        additional_information = first_prompt.get("additional_information") or {}
+        prompt_image = additional_information.get("prompt_image")
+        image = additional_information.get("preprocessed_image")
+        calculated_height = additional_information.get("calculated_height")
+        calculated_width = additional_information.get("calculated_width")
+        if image is None or prompt_image is None:
+            raise ValueError(
+                "QwenImageEditPipeline step-wise prepare_encode expected the "
+                "pre-process function to populate preprocessed_image and "
+                "prompt_image on additional_information."
+            )
+
+        height = sampling.height or calculated_height
+        width = sampling.width or calculated_width
+        if height is None or width is None:
+            raise ValueError(
+                "QwenImageEditPipeline step-wise prepare_encode requires "
+                "height and width from sampling params or preprocessing."
+            )
+
+        num_inference_steps = sampling.num_inference_steps or 50
+        sigmas = sampling.sigmas
+        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
+        generator = sampling.generator
+        true_cfg_scale = sampling.true_cfg_scale or 4.0
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        callback_on_step_end_tensor_inputs = ["latents"]
+
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            image,
+            negative_prompt,
+            None,
+            None,
+            None,
+            None,
+            callback_on_step_end_tensor_inputs,
+            max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
+        self._current_timestep = None
+        self._interrupt = False
+
+        batch_size = 1
+        has_neg_prompt = negative_prompt is not None
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            image=prompt_image,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                image=prompt_image,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+                prompt_name="negative_prompt",
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_latents = self.prepare_latents(
+            image,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            sampling.latents,
+        )
+        img_shapes = [
+            [
+                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
+                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
+            ]
+        ] * batch_size
+
+        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
+            guidance = guidance.expand(latents.shape[0])
+        else:
+            guidance = None
+
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        negative_txt_seq_lens = (
+            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+        )
+
+        req_scheduler = copy.deepcopy(self.scheduler)
+        req_scheduler.set_begin_index(0)
+
+        state.prompt_embeds = prompt_embeds
+        state.prompt_embeds_mask = prompt_embeds_mask
+        state.negative_prompt_embeds = negative_prompt_embeds
+        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
+        state.latents = latents
+        state.timesteps = timesteps
+        state.step_index = 0
+        state.scheduler = req_scheduler
+        state.do_true_cfg = do_true_cfg
+        state.guidance = guidance
+        state.img_shapes = img_shapes
+        state.txt_seq_lens = txt_seq_lens
+        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.extra["height"] = height
+        state.extra["width"] = width
+        state.sampling.cfg_normalize = True
+        state.sampling.image_latent = image_latents
+
+        return state

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -640,6 +640,133 @@ class QwenImageEditPlusPipeline(
     def interrupt(self):
         return self._interrupt
 
+    def _prepare_generation_context(
+        self,
+        *,
+        prompt,
+        negative_prompt,
+        condition_images,
+        vae_images,
+        vae_image_sizes,
+        height,
+        width,
+        num_inference_steps,
+        sigmas,
+        guidance_scale,
+        num_images_per_prompt,
+        generator,
+        true_cfg_scale,
+        max_sequence_length,
+        prompt_embeds=None,
+        prompt_embeds_mask=None,
+        negative_prompt_embeds=None,
+        negative_prompt_embeds_mask=None,
+        latents=None,
+        attention_kwargs=None,
+        callback_on_step_end_tensor_inputs=None,
+    ):
+        """Shared request preparation for forward() and step-wise prepare_encode()."""
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            image=None,
+            negative_prompt=negative_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            max_sequence_length=max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        batch_size = 1
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            image=condition_images,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                image=condition_images,
+                prompt_embeds=negative_prompt_embeds,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+                prompt_name="negative_prompt",
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_latents = self.prepare_latents(
+            vae_images,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            latents,
+        )
+        img_shapes = [
+            [
+                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
+                *[
+                    (1, vae_height // self.vae_scale_factor // 2, vae_width // self.vae_scale_factor // 2)
+                    for vae_width, vae_height in vae_image_sizes
+                ],
+            ]
+        ] * batch_size
+
+        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
+            guidance = guidance.expand(latents.shape[0])
+        else:
+            guidance = None
+
+        if self.attention_kwargs is None:
+            self._attention_kwargs = {}
+
+        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
+        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
+
+        return {
+            "prompt_embeds": prompt_embeds,
+            "prompt_embeds_mask": prompt_embeds_mask,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
+            "latents": latents,
+            "image_latents": image_latents,
+            "img_shapes": img_shapes,
+            "timesteps": timesteps,
+            "do_true_cfg": do_true_cfg,
+            "guidance": guidance,
+            "txt_seq_lens": txt_seq_lens,
+            "negative_txt_seq_lens": negative_txt_seq_lens,
+        }
+
     def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
         """Forward pass for image editing with support for multiple images."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
@@ -704,106 +831,44 @@ class QwenImageEditPlusPipeline(
         # 4. diffusion process
         # 5. decode latents
         # 6. post-process outputs
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            image,
-            negative_prompt,
-            prompt_embeds,
-            negative_prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds_mask,
-            callback_on_step_end_tensor_inputs,
-            max_sequence_length,
-        )
-
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = attention_kwargs
-        self._current_timestep = None
-        self._interrupt = False
-
-        batch_size = 1
-
-        has_neg_prompt = negative_prompt is not None
-
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
-
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+        ctx = self._prepare_generation_context(
             prompt=prompt,
-            image=condition_images,  # Use condition images for prompt encoding
+            negative_prompt=negative_prompt,
+            condition_images=condition_images,  # Use condition images for prompt encoding
+            vae_images=vae_images,  # Use VAE images for latent preparation
+            vae_image_sizes=vae_image_sizes,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            sigmas=sigmas,
+            guidance_scale=guidance_scale,
+            num_images_per_prompt=num_images_per_prompt,
+            generator=generator,
+            true_cfg_scale=true_cfg_scale,
+            max_sequence_length=max_sequence_length,
             prompt_embeds=prompt_embeds,
             prompt_embeds_mask=prompt_embeds_mask,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            latents=latents,
+            attention_kwargs=attention_kwargs,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
         )
-
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=condition_images,  # Use same condition images for negative prompt encoding
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
-                num_images_per_prompt=num_images_per_prompt,
-                max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
-            )
-
-        num_channels_latents = self.transformer.in_channels // 4
-        # random noise latents, and image latents encoded by vae
-        latents, image_latents = self.prepare_latents(
-            vae_images,  # Use VAE images for latent preparation
-            batch_size * num_images_per_prompt,
-            num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
-            self.device,
-            generator,
-            latents,
-        )
-        # img_shapes includes shapes for output image and all input images
-        img_shapes = [
-            [
-                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
-                *[
-                    (1, vae_height // self.vae_scale_factor // 2, vae_width // self.vae_scale_factor // 2)
-                    for vae_width, vae_height in vae_image_sizes
-                ],
-            ]
-        ] * batch_size
-
-        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
-        self._num_timesteps = len(timesteps)
-
-        # handle guidance
-        if self.transformer.guidance_embeds:
-            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
-        else:
-            guidance = None
-
-        if self.attention_kwargs is None:
-            self._attention_kwargs = {}
-
-        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
-        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
 
         latents = self.diffuse(
-            prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds,
-            negative_prompt_embeds_mask,
-            latents,
-            img_shapes,
-            txt_seq_lens,
-            negative_txt_seq_lens,
-            timesteps,
-            do_true_cfg,
-            guidance,
+            ctx["prompt_embeds"],
+            ctx["prompt_embeds_mask"],
+            ctx["negative_prompt_embeds"],
+            ctx["negative_prompt_embeds_mask"],
+            ctx["latents"],
+            ctx["img_shapes"],
+            ctx["txt_seq_lens"],
+            ctx["negative_txt_seq_lens"],
+            ctx["timesteps"],
+            ctx["do_true_cfg"],
+            ctx["guidance"],
             true_cfg_scale,
-            image_latents=image_latents,
+            image_latents=ctx["image_latents"],
             cfg_normalize=True,
             additional_transformer_kwargs={
                 "return_dict": False,
@@ -856,9 +921,7 @@ class QwenImageEditPlusPipeline(
         sampling = state.sampling
         first_prompt = state.prompt
         if first_prompt is None:
-            raise ValueError(
-                "QwenImageEditPlusPipeline.prepare_encode requires a non-null state.prompt."
-            )
+            raise ValueError("QwenImageEditPlusPipeline.prepare_encode requires a non-null state.prompt.")
         if isinstance(first_prompt, str):
             raise ValueError(
                 "QwenImageEditPlusPipeline requires an image-bearing prompt. "
@@ -890,113 +953,47 @@ class QwenImageEditPlusPipeline(
             )
         height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
 
-        num_inference_steps = sampling.num_inference_steps or 50
-        sigmas = sampling.sigmas
-        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
-        generator = sampling.generator
-        true_cfg_scale = sampling.true_cfg_scale or 4.0
-        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
-        num_outputs_per_prompt = (
-            sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
-        )
-
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            image=None,
-            negative_prompt=negative_prompt,
-            max_sequence_length=max_sequence_length,
-        )
-
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
-        self._current_timestep = None
-        self._interrupt = False
-
-        batch_size = 1
-        has_neg_prompt = negative_prompt is not None
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
-
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+        ctx = self._prepare_generation_context(
             prompt=prompt,
-            image=condition_images,
-            num_images_per_prompt=num_outputs_per_prompt,
-            max_sequence_length=max_sequence_length,
+            negative_prompt=negative_prompt,
+            condition_images=condition_images,
+            vae_images=vae_images,
+            vae_image_sizes=vae_image_sizes,
+            height=height,
+            width=width,
+            num_inference_steps=sampling.num_inference_steps or 50,
+            sigmas=sampling.sigmas,
+            guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
+            num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
+            generator=sampling.generator,
+            true_cfg_scale=sampling.true_cfg_scale or 4.0,
+            max_sequence_length=sampling.max_sequence_length or self.tokenizer_max_length,
+            latents=sampling.latents,
+            attention_kwargs=kwargs.get("attention_kwargs") or {},
         )
-
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=condition_images,
-                num_images_per_prompt=num_outputs_per_prompt,
-                max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
-            )
-        else:
-            negative_prompt_embeds = None
-            negative_prompt_embeds_mask = None
-
-        num_channels_latents = self.transformer.in_channels // 4
-        latents, image_latents = self.prepare_latents(
-            vae_images,
-            batch_size * num_outputs_per_prompt,
-            num_channels_latents,
-            height,
-            width,
-            prompt_embeds.dtype,
-            self.device,
-            generator,
-            sampling.latents,
-        )
-
-        img_shapes = [
-            [
-                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
-                *[
-                    (1, vae_h // self.vae_scale_factor // 2, vae_w // self.vae_scale_factor // 2)
-                    for vae_w, vae_h in vae_image_sizes
-                ],
-            ]
-        ] * batch_size
-
-        timesteps, num_inference_steps = self.prepare_timesteps(
-            num_inference_steps, sigmas, latents.shape[1]
-        )
-        self._num_timesteps = len(timesteps)
-
-        if self.transformer.guidance_embeds:
-            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
-        else:
-            guidance = None
-
-        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
-        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
 
         req_scheduler = copy.deepcopy(self.scheduler)
         req_scheduler.set_begin_index(0)
 
-        state.prompt_embeds = prompt_embeds
-        state.prompt_embeds_mask = prompt_embeds_mask
-        state.negative_prompt_embeds = negative_prompt_embeds
-        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
-        state.latents = latents
-        state.timesteps = timesteps
+        state.prompt_embeds = ctx["prompt_embeds"]
+        state.prompt_embeds_mask = ctx["prompt_embeds_mask"]
+        state.negative_prompt_embeds = ctx["negative_prompt_embeds"]
+        state.negative_prompt_embeds_mask = ctx["negative_prompt_embeds_mask"]
+        state.latents = ctx["latents"]
+        state.timesteps = ctx["timesteps"]
         state.step_index = 0
         state.scheduler = req_scheduler
-        state.do_true_cfg = do_true_cfg
-        state.guidance = guidance
-        state.img_shapes = img_shapes
-        state.txt_seq_lens = txt_seq_lens
-        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.do_true_cfg = ctx["do_true_cfg"]
+        state.guidance = ctx["guidance"]
+        state.img_shapes = ctx["img_shapes"]
+        state.txt_seq_lens = ctx["txt_seq_lens"]
+        state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
         state.extra["height"] = height
         state.extra["width"] = width
         # Match forward(): QwenImage CFG output is always normalized
         state.sampling.cfg_normalize = True
         # InputBatch._prepare_image_latents (worker/input_batch.py) reads
         # this to gather the batched image_latents tensor each step.
-        state.sampling.image_latent = image_latents
+        state.sampling.image_latent = ctx["image_latents"]
 
         return state

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import json
 import logging
 import os
 from collections.abc import Iterable
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 import PIL.Image
@@ -41,6 +42,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.qwen_image.stepwise_mixin import QwenImageStepwiseMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -57,6 +59,9 @@ from vllm_omni.model_executor.model_loader.weight_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 CONDITION_IMAGE_SIZE = 384 * 384
 VAE_IMAGE_SIZE = 1024 * 1024
@@ -185,11 +190,23 @@ def get_qwen_image_edit_plus_post_process_func(
 
 
 class QwenImageEditPlusPipeline(
-    nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    SupportImageInput,
+    QwenImageStepwiseMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    # Step-wise continuous batching support. prepare_encode populates per-request
+    # state (encoded prompts, packed image_latents, timesteps) that the runner
+    # gathers into a batched InputBatch each step. The remaining hooks
+    # (denoise_step, step_scheduler, post_decode) are inherited from
+    # QwenImageStepwiseMixin and are identical across all QwenImage pipelines.
+    supports_step_execution: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -818,3 +835,168 @@ class QwenImageEditPlusPipeline(
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def prepare_encode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> "DiffusionRequestState":
+        """Populate pre-request state for step-wise multi-image edit denoising.
+
+        Mirrors ``forward()``'s preparation up to (but not including) the
+        denoise loop, then stores the packed ``image_latents`` on
+        ``state.sampling.image_latent`` so ``InputBatch._prepare_image_latents``
+        can gather it across the batch.
+
+        The pre-processed condition and VAE images (produced by
+        ``get_qwen_image_edit_plus_pre_process_func``) are read from
+        ``state.prompt["additional_information"]`` - the same sink
+        ``forward()`` uses on the request-mode path.
+        """
+        sampling = state.sampling
+        first_prompt = state.prompt
+        if first_prompt is None:
+            raise ValueError(
+                "QwenImageEditPlusPipeline.prepare_encode requires a non-null state.prompt."
+            )
+        if isinstance(first_prompt, str):
+            raise ValueError(
+                "QwenImageEditPlusPipeline requires an image-bearing prompt. "
+                "A raw string prompt was passed to step-wise prepare_encode."
+            )
+        prompt = first_prompt.get("prompt") or ""
+        negative_prompt = first_prompt.get("negative_prompt")
+
+        additional_information = first_prompt.get("additional_information") or {}
+        condition_images = additional_information.get("condition_images")
+        vae_images = additional_information.get("vae_images")
+        vae_image_sizes = additional_information.get("vae_image_sizes")
+        calculated_height = additional_information.get("calculated_height")
+        calculated_width = additional_information.get("calculated_width")
+        if not condition_images or not vae_images or not vae_image_sizes:
+            raise ValueError(
+                "EditPlus step-wise prepare_encode expected the pre-process "
+                "function to populate condition_images / vae_images / "
+                "vae_image_sizes on additional_information. Ensure the "
+                "QwenImageEditPlusPipeline pre-processor ran before scheduling"
+            )
+
+        height = sampling.height or calculated_height
+        width = sampling.width or calculated_width
+        if height is None or width is None:
+            raise ValueError(
+                "EditPlus step-wise prepare_encode: neither sampling.(height,width) "
+                "nor additional_information.(calculated_height, calculated_width) provided"
+            )
+        height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
+
+        num_inference_steps = sampling.num_inference_steps or 50
+        sigmas = sampling.sigmas
+        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
+        generator = sampling.generator
+        true_cfg_scale = sampling.true_cfg_scale or 4.0
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
+        num_outputs_per_prompt = (
+            sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        )
+
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            image=None,
+            negative_prompt=negative_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
+        self._current_timestep = None
+        self._interrupt = False
+
+        batch_size = 1
+        has_neg_prompt = negative_prompt is not None
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            image=condition_images,
+            num_images_per_prompt=num_outputs_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                image=condition_images,
+                num_images_per_prompt=num_outputs_per_prompt,
+                max_sequence_length=max_sequence_length,
+                prompt_name="negative_prompt",
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_latents = self.prepare_latents(
+            vae_images,
+            batch_size * num_outputs_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            sampling.latents,
+        )
+
+        img_shapes = [
+            [
+                (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2),
+                *[
+                    (1, vae_h // self.vae_scale_factor // 2, vae_w // self.vae_scale_factor // 2)
+                    for vae_w, vae_h in vae_image_sizes
+                ],
+            ]
+        ] * batch_size
+
+        timesteps, num_inference_steps = self.prepare_timesteps(
+            num_inference_steps, sigmas, latents.shape[1]
+        )
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, dtype=torch.float32)
+            guidance = guidance.expand(latents.shape[0])
+        else:
+            guidance = None
+
+        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
+        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
+
+        req_scheduler = copy.deepcopy(self.scheduler)
+        req_scheduler.set_begin_index(0)
+
+        state.prompt_embeds = prompt_embeds
+        state.prompt_embeds_mask = prompt_embeds_mask
+        state.negative_prompt_embeds = negative_prompt_embeds
+        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
+        state.latents = latents
+        state.timesteps = timesteps
+        state.step_index = 0
+        state.scheduler = req_scheduler
+        state.do_true_cfg = do_true_cfg
+        state.guidance = guidance
+        state.img_shapes = img_shapes
+        state.txt_seq_lens = txt_seq_lens
+        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.extra["height"] = height
+        state.extra["width"] = width
+        # Match forward(): QwenImage CFG output is always normalized
+        state.sampling.cfg_normalize = True
+        # InputBatch._prepare_image_latents (worker/input_batch.py) reads
+        # this to gather the batched image_latents tensor each step.
+        state.sampling.image_latent = image_latents
+
+        return state

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import inspect
 import json
 import logging
 import math
 import os
 from collections.abc import Iterable
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 import PIL.Image
@@ -36,6 +37,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.qwen_image.stepwise_mixin import QwenImageStepwiseMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -52,6 +54,10 @@ from vllm_omni.model_executor.model_loader.weight_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.input_batch import InputBatch
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 
 # Interface called in diffusion engine
@@ -203,11 +209,18 @@ def retrieve_latents(
 
 
 class QwenImageLayeredPipeline(
-    nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
+    nn.Module,
+    SupportImageInput,
+    QwenImageStepwiseMixin,
+    QwenImageCFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    supports_step_execution: ClassVar[bool] = True
 
     color_format = "RGBA"
 
@@ -647,6 +660,229 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
     @property
     def interrupt(self):
         return self._interrupt
+
+    def _get_stepwise_transformer_kwargs(
+        self,
+        input_batch: "InputBatch",
+    ) -> dict[str, torch.Tensor]:
+        is_rgb = torch.zeros(input_batch.latents.shape[0], device=self.device, dtype=torch.long)
+        return {"additional_t_cond": is_rgb}
+
+    def prepare_encode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> "DiffusionRequestState":
+        """Populate per-request state for step-wise layered image editing."""
+        sampling = state.sampling
+        first_prompt = state.prompt
+        if first_prompt is None:
+            raise ValueError("QwenImageLayeredPipeline.prepare_encode requires a non-null state.prompt.")
+        if isinstance(first_prompt, str):
+            raise ValueError(
+                "QwenImageLayeredPipeline requires an image-bearing prompt. "
+                "A raw string prompt was passed to step-wise prepare_encode."
+            )
+
+        prompt = first_prompt.get("prompt") or ""
+        negative_prompt = first_prompt.get("negative_prompt")
+        additional_information = first_prompt.get("additional_information") or {}
+        prompt_image = additional_information.get("prompt_image")
+        image = additional_information.get("preprocessed_image")
+        calculated_height = additional_information.get("calculated_height")
+        calculated_width = additional_information.get("calculated_width")
+        if image is None or prompt_image is None:
+            raise ValueError(
+                "QwenImageLayeredPipeline step-wise prepare_encode expected "
+                "the pre-process function to populate preprocessed_image and "
+                "prompt_image on additional_information."
+            )
+
+        image = image.to(dtype=self.text_encoder.dtype)
+        height = sampling.height or calculated_height
+        width = sampling.width or calculated_width
+        if height is None or width is None:
+            raise ValueError(
+                "QwenImageLayeredPipeline step-wise prepare_encode requires "
+                "height and width from sampling params or preprocessing."
+            )
+
+        layers = sampling.layers
+        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
+        cfg_normalize = sampling.cfg_normalize
+        use_en_prompt = sampling.use_en_prompt
+        num_inference_steps = sampling.num_inference_steps or 50
+        sigmas = sampling.sigmas
+        generator = sampling.generator
+        true_cfg_scale = sampling.true_cfg_scale or 4.0
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else None
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            negative_prompt=negative_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
+        self._current_timestep = None
+        self._interrupt = False
+
+        if prompt is None or prompt == "" or prompt == " ":
+            prompt = self.get_image_caption(prompt_image, use_en_prompt=use_en_prompt, device=self.device)
+
+        batch_size = 1
+        has_neg_prompt = negative_prompt is not None
+        if true_cfg_scale > 1 and not has_neg_prompt:
+            logger.warning(
+                f"true_cfg_scale is passed as {true_cfg_scale}, but classifier-free "
+                f"guidance is not enabled since no negative_prompt is provided."
+            )
+        elif true_cfg_scale <= 1 and has_neg_prompt:
+            logger.warning(
+                " negative_prompt is passed but classifier-free guidance is not enabled since true_cfg_scale <= 1"
+            )
+
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt=prompt,
+            device=self.device,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt=negative_prompt,
+                device=self.device,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+                prompt_name="negative_prompt",
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_latents = self.prepare_latents(
+            image,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            layers,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            sampling.latents,
+        )
+        img_shapes = [
+            [
+                *[
+                    (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)
+                    for _ in range(layers + 1)
+                ],
+                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
+            ]
+        ] * batch_size
+
+        sigmas = np.linspace(1.0, 0, num_inference_steps + 1)[:-1] if sigmas is None else sigmas
+        base_seqlen = 256 * 256 / 16 / 16
+        mu = (image_latents.shape[1] / base_seqlen) ** 0.5
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler,
+            num_inference_steps,
+            self.device,
+            sigmas=sigmas,
+            mu=mu,
+        )
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds and guidance_scale is None:
+            raise ValueError("guidance_scale is required for guidance-distilled model.")
+        elif self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, device=self.device, dtype=torch.float32)
+            guidance = guidance.expand(latents.shape[0])
+        elif not self.transformer.guidance_embeds and guidance_scale is not None:
+            logger.warning(
+                f"guidance_scale is passed as {guidance_scale}, but ignored since the model is not guidance-distilled."
+            )
+            guidance = None
+        else:
+            guidance = None
+
+        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
+        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
+
+        req_scheduler = copy.deepcopy(self.scheduler)
+        req_scheduler.set_begin_index(0)
+
+        state.prompt_embeds = prompt_embeds
+        state.prompt_embeds_mask = prompt_embeds_mask
+        state.negative_prompt_embeds = negative_prompt_embeds
+        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
+        state.latents = latents
+        state.timesteps = timesteps
+        state.step_index = 0
+        state.scheduler = req_scheduler
+        state.do_true_cfg = do_true_cfg
+        state.guidance = guidance
+        state.img_shapes = img_shapes
+        state.txt_seq_lens = txt_seq_lens
+        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.extra["height"] = height
+        state.extra["width"] = width
+        state.extra["layers"] = layers
+        state.sampling.cfg_normalize = cfg_normalize
+        state.sampling.image_latent = image_latents
+
+        return state
+
+    def post_decode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        """Decode final layered latents from *state*."""
+        self._current_timestep = None
+        height = state.extra.get("height") or state.sampling.height
+        width = state.extra.get("width") or state.sampling.width
+        layers = state.extra.get("layers", state.sampling.layers)
+        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
+        if state.latents is None:
+            raise ValueError(f"Request {state.request_id} has no latents to decode.")
+
+        if output_type == "latent":
+            image = state.latents
+        else:
+            latents = self._unpack_latents(state.latents, height, width, layers, self.vae_scale_factor)
+            latents = latents.to(self.vae.dtype)
+            latents_mean = (
+                torch.tensor(self.vae.config.latents_mean)
+                .view(1, self.vae.config.z_dim, 1, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
+                1, self.vae.config.z_dim, 1, 1, 1
+            ).to(latents.device, latents.dtype)
+            latents = latents / latents_std + latents_mean
+
+            b, c, f, h, w = latents.shape
+            latents = latents[:, :, 1:]
+            output_frames = f - 1
+            latents = latents.permute(0, 2, 1, 3, 4).view(-1, c, 1, h, w)
+            image = self.vae.decode(latents, return_dict=False)[0].squeeze(2)
+            image = self.image_processor.postprocess(image, output_type=output_type)
+            image = [image[bidx * output_frames : (bidx + 1) * output_frames] for bidx in range(b)]
+
+        return DiffusionOutput(
+            output=image,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
 
     def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
         """Forward pass for image layered."""

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -668,66 +668,49 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         is_rgb = torch.zeros(input_batch.latents.shape[0], device=self.device, dtype=torch.long)
         return {"additional_t_cond": is_rgb}
 
-    def prepare_encode(
+    def _prepare_generation_context(
         self,
-        state: "DiffusionRequestState",
-        **kwargs: Any,
-    ) -> "DiffusionRequestState":
-        """Populate per-request state for step-wise layered image editing."""
-        sampling = state.sampling
-        first_prompt = state.prompt
-        if first_prompt is None:
-            raise ValueError("QwenImageLayeredPipeline.prepare_encode requires a non-null state.prompt.")
-        if isinstance(first_prompt, str):
-            raise ValueError(
-                "QwenImageLayeredPipeline requires an image-bearing prompt. "
-                "A raw string prompt was passed to step-wise prepare_encode."
-            )
-
-        prompt = first_prompt.get("prompt") or ""
-        negative_prompt = first_prompt.get("negative_prompt")
-        additional_information = first_prompt.get("additional_information") or {}
-        prompt_image = additional_information.get("prompt_image")
-        image = additional_information.get("preprocessed_image")
-        calculated_height = additional_information.get("calculated_height")
-        calculated_width = additional_information.get("calculated_width")
-        if image is None or prompt_image is None:
-            raise ValueError(
-                "QwenImageLayeredPipeline step-wise prepare_encode expected "
-                "the pre-process function to populate preprocessed_image and "
-                "prompt_image on additional_information."
-            )
-
+        *,
+        prompt,
+        negative_prompt,
+        prompt_image,
+        image,
+        calculated_height,
+        calculated_width,
+        height,
+        width,
+        layers,
+        use_en_prompt,
+        num_inference_steps,
+        sigmas,
+        guidance_scale,
+        num_images_per_prompt,
+        generator,
+        true_cfg_scale,
+        max_sequence_length,
+        prompt_embeds=None,
+        prompt_embeds_mask=None,
+        negative_prompt_embeds=None,
+        negative_prompt_embeds_mask=None,
+        latents=None,
+        attention_kwargs=None,
+    ):
+        """Shared request preparation for forward() and step-wise prepare_encode()."""
         image = image.to(dtype=self.text_encoder.dtype)
-        height = sampling.height or calculated_height
-        width = sampling.width or calculated_width
-        if height is None or width is None:
-            raise ValueError(
-                "QwenImageLayeredPipeline step-wise prepare_encode requires "
-                "height and width from sampling params or preprocessing."
-            )
-
-        layers = sampling.layers
-        max_sequence_length = sampling.max_sequence_length or self.tokenizer_max_length
-        cfg_normalize = sampling.cfg_normalize
-        use_en_prompt = sampling.use_en_prompt
-        num_inference_steps = sampling.num_inference_steps or 50
-        sigmas = sampling.sigmas
-        generator = sampling.generator
-        true_cfg_scale = sampling.true_cfg_scale or 4.0
-        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else None
-        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
-
         self.check_inputs(
             prompt,
             height,
             width,
             negative_prompt=negative_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
             max_sequence_length=max_sequence_length,
         )
 
         self._guidance_scale = guidance_scale
-        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
+        self._attention_kwargs = attention_kwargs
         self._current_timestep = None
         self._interrupt = False
 
@@ -735,7 +718,10 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
             prompt = self.get_image_caption(prompt_image, use_en_prompt=use_en_prompt, device=self.device)
 
         batch_size = 1
-        has_neg_prompt = negative_prompt is not None
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+        )
+
         if true_cfg_scale > 1 and not has_neg_prompt:
             logger.warning(
                 f"true_cfg_scale is passed as {true_cfg_scale}, but classifier-free "
@@ -751,6 +737,8 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
 
         prompt_embeds, prompt_embeds_mask = self.encode_prompt(
             prompt=prompt,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
             device=self.device,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
@@ -758,6 +746,8 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         if do_true_cfg:
             negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
                 prompt=negative_prompt,
+                prompt_embeds=negative_prompt_embeds,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
                 device=self.device,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
@@ -778,7 +768,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
             prompt_embeds.dtype,
             self.device,
             generator,
-            sampling.latents,
+            latents,
         )
         img_shapes = [
             [
@@ -812,33 +802,115 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 f"guidance_scale is passed as {guidance_scale}, but ignored since the model is not guidance-distilled."
             )
             guidance = None
-        else:
+        elif not self.transformer.guidance_embeds and guidance_scale is None:
             guidance = None
+
+        if self.attention_kwargs is None:
+            self._attention_kwargs = {}
 
         txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
         negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
+        is_rgb = torch.tensor([0] * batch_size).to(device=self.device, dtype=torch.long)
+
+        return {
+            "prompt_embeds": prompt_embeds,
+            "prompt_embeds_mask": prompt_embeds_mask,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
+            "latents": latents,
+            "image_latents": image_latents,
+            "img_shapes": img_shapes,
+            "timesteps": timesteps,
+            "do_true_cfg": do_true_cfg,
+            "guidance": guidance,
+            "txt_seq_lens": txt_seq_lens,
+            "negative_txt_seq_lens": negative_txt_seq_lens,
+            "is_rgb": is_rgb,
+        }
+
+    def prepare_encode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> "DiffusionRequestState":
+        """Populate per-request state for step-wise layered image editing."""
+        sampling = state.sampling
+        first_prompt = state.prompt
+        if first_prompt is None:
+            raise ValueError("QwenImageLayeredPipeline.prepare_encode requires a non-null state.prompt.")
+        if isinstance(first_prompt, str):
+            raise ValueError(
+                "QwenImageLayeredPipeline requires an image-bearing prompt. "
+                "A raw string prompt was passed to step-wise prepare_encode."
+            )
+
+        prompt = first_prompt.get("prompt") or ""
+        negative_prompt = first_prompt.get("negative_prompt")
+        additional_information = first_prompt.get("additional_information") or {}
+        prompt_image = additional_information.get("prompt_image")
+        image = additional_information.get("preprocessed_image")
+        calculated_height = additional_information.get("calculated_height")
+        calculated_width = additional_information.get("calculated_width")
+        if image is None or prompt_image is None:
+            raise ValueError(
+                "QwenImageLayeredPipeline step-wise prepare_encode expected "
+                "the pre-process function to populate preprocessed_image and "
+                "prompt_image on additional_information."
+            )
+
+        height = sampling.height or calculated_height
+        width = sampling.width or calculated_width
+        if height is None or width is None:
+            raise ValueError(
+                "QwenImageLayeredPipeline step-wise prepare_encode requires "
+                "height and width from sampling params or preprocessing."
+            )
+
+        layers = sampling.layers
+        cfg_normalize = sampling.cfg_normalize
+        ctx = self._prepare_generation_context(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            prompt_image=prompt_image,
+            image=image,
+            calculated_height=calculated_height,
+            calculated_width=calculated_width,
+            height=height,
+            width=width,
+            layers=layers,
+            use_en_prompt=sampling.use_en_prompt,
+            num_inference_steps=sampling.num_inference_steps or 50,
+            sigmas=sampling.sigmas,
+            guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else None,
+            num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
+            generator=sampling.generator,
+            true_cfg_scale=sampling.true_cfg_scale or 4.0,
+            max_sequence_length=sampling.max_sequence_length or self.tokenizer_max_length,
+            latents=sampling.latents,
+            attention_kwargs=kwargs.get("attention_kwargs") or {},
+        )
 
         req_scheduler = copy.deepcopy(self.scheduler)
         req_scheduler.set_begin_index(0)
 
-        state.prompt_embeds = prompt_embeds
-        state.prompt_embeds_mask = prompt_embeds_mask
-        state.negative_prompt_embeds = negative_prompt_embeds
-        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
-        state.latents = latents
-        state.timesteps = timesteps
+        state.prompt_embeds = ctx["prompt_embeds"]
+        state.prompt_embeds_mask = ctx["prompt_embeds_mask"]
+        state.negative_prompt_embeds = ctx["negative_prompt_embeds"]
+        state.negative_prompt_embeds_mask = ctx["negative_prompt_embeds_mask"]
+        state.latents = ctx["latents"]
+        state.timesteps = ctx["timesteps"]
         state.step_index = 0
         state.scheduler = req_scheduler
-        state.do_true_cfg = do_true_cfg
-        state.guidance = guidance
-        state.img_shapes = img_shapes
-        state.txt_seq_lens = txt_seq_lens
-        state.negative_txt_seq_lens = negative_txt_seq_lens
+        state.do_true_cfg = ctx["do_true_cfg"]
+        state.guidance = ctx["guidance"]
+        state.img_shapes = ctx["img_shapes"]
+        state.txt_seq_lens = ctx["txt_seq_lens"]
+        state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
         state.extra["height"] = height
         state.extra["width"] = width
         state.extra["layers"] = layers
         state.sampling.cfg_normalize = cfg_normalize
-        state.sampling.image_latent = image_latents
+        state.sampling.image_latent = ctx["image_latents"]
 
         return state
 
@@ -866,9 +938,9 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 .view(1, self.vae.config.z_dim, 1, 1, 1)
                 .to(latents.device, latents.dtype)
             )
-            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
-                1, self.vae.config.z_dim, 1, 1, 1
-            ).to(latents.device, latents.dtype)
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+                latents.device, latents.dtype
+            )
             latents = latents / latents_std + latents_mean
 
             b, c, f, h, w = latents.shape
@@ -935,139 +1007,50 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         else:
             raise RuntimeError("Missing preprocess image that should have been created by the preprocess function.")
 
-        # 2. check inputs
-        self.check_inputs(
-            prompt,
-            height,
-            width,
-            negative_prompt=negative_prompt,
-            prompt_embeds=prompt_embeds,
-            negative_prompt_embeds=negative_prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
-            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
-            max_sequence_length=max_sequence_length,
-        )
-
-        self._guidance_scale = guidance_scale
-        self._attention_kwargs = attention_kwargs
-        self._current_timestep = None
-        self._interrupt = False
-
-        # 3. encode prompot & negative prompt
-        if prompt is None or prompt == "" or prompt == " ":
-            prompt = self.get_image_caption(prompt_image, use_en_prompt=use_en_prompt, device=self.device)
-        batch_size = 1
-
-        has_neg_prompt = negative_prompt is not None
-
-        if true_cfg_scale > 1 and not has_neg_prompt:
-            logger.warning(
-                f"true_cfg_scale is passed as {true_cfg_scale}, but classifier-free "
-                f"guidance is not enabled since no negative_prompt is provided."
-            )
-        elif true_cfg_scale <= 1 and has_neg_prompt:
-            logger.warning(
-                " negative_prompt is passed but classifier-free guidance is not enabled since true_cfg_scale <= 1"
-            )
-
-        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
-        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
-
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+        ctx = self._prepare_generation_context(
             prompt=prompt,
+            negative_prompt=negative_prompt,
+            prompt_image=prompt_image,
+            image=image,
+            calculated_height=calculated_height,
+            calculated_width=calculated_width,
+            height=height,
+            width=width,
+            layers=layers,
+            use_en_prompt=use_en_prompt,
+            num_inference_steps=num_inference_steps,
+            sigmas=sigmas,
+            guidance_scale=guidance_scale,
+            num_images_per_prompt=num_images_per_prompt,
+            generator=generator,
+            true_cfg_scale=true_cfg_scale,
+            max_sequence_length=max_sequence_length,
             prompt_embeds=prompt_embeds,
             prompt_embeds_mask=prompt_embeds_mask,
-            device=self.device,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            latents=latents,
+            attention_kwargs=attention_kwargs,
         )
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
-                device=self.device,
-                num_images_per_prompt=num_images_per_prompt,
-                max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
-            )
-
-        # 4. Prepare latent variables
-        num_channels_latents = self.transformer.in_channels // 4
-        latents, image_latents = self.prepare_latents(
-            image,
-            batch_size * num_images_per_prompt,
-            num_channels_latents,
-            height,
-            width,
-            layers,
-            prompt_embeds.dtype,
-            self.device,
-            generator,
-            latents,
-        )
-        img_shapes = [
-            [
-                *[
-                    (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)
-                    for _ in range(layers + 1)
-                ],
-                (1, calculated_height // self.vae_scale_factor // 2, calculated_width // self.vae_scale_factor // 2),
-            ]
-        ] * batch_size
-
-        # 5. Prepare timesteps
-        sigmas = np.linspace(1.0, 0, num_inference_steps + 1)[:-1] if sigmas is None else sigmas
-        base_seqlen = 256 * 256 / 16 / 16
-        mu = (image_latents.shape[1] / base_seqlen) ** 0.5
-        timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler,
-            num_inference_steps,
-            self.device,
-            sigmas=sigmas,
-            mu=mu,
-        )
-        self._num_timesteps = len(timesteps)
-
-        # handle guidance
-        if self.transformer.guidance_embeds and guidance_scale is None:
-            raise ValueError("guidance_scale is required for guidance-distilled model.")
-        elif self.transformer.guidance_embeds:
-            guidance = torch.full([1], guidance_scale, device=self.device, dtype=torch.float32)
-            guidance = guidance.expand(latents.shape[0])
-        elif not self.transformer.guidance_embeds and guidance_scale is not None:
-            logger.warning(
-                f"guidance_scale is passed as {guidance_scale}, but ignored since the model is not guidance-distilled."
-            )
-            guidance = None
-        elif not self.transformer.guidance_embeds and guidance_scale is None:
-            guidance = None
-
-        if self.attention_kwargs is None:
-            self._attention_kwargs = {}
-
-        txt_seq_lens = txt_seq_lens_from_embeds(prompt_embeds)
-        negative_txt_seq_lens = txt_seq_lens_from_embeds(negative_prompt_embeds)
-        is_rgb = torch.tensor([0] * batch_size).to(device=self.device, dtype=torch.long)
 
         latents = self.diffuse(
-            prompt_embeds,
-            prompt_embeds_mask,
-            negative_prompt_embeds,
-            negative_prompt_embeds_mask,
-            latents,
-            img_shapes,
-            txt_seq_lens,
-            negative_txt_seq_lens,
-            timesteps,
-            do_true_cfg,
-            guidance,
+            ctx["prompt_embeds"],
+            ctx["prompt_embeds_mask"],
+            ctx["negative_prompt_embeds"],
+            ctx["negative_prompt_embeds_mask"],
+            ctx["latents"],
+            ctx["img_shapes"],
+            ctx["txt_seq_lens"],
+            ctx["negative_txt_seq_lens"],
+            ctx["timesteps"],
+            ctx["do_true_cfg"],
+            ctx["guidance"],
             true_cfg_scale,
-            image_latents=image_latents,
+            image_latents=ctx["image_latents"],
             cfg_normalize=cfg_normalize,
             additional_transformer_kwargs={
                 "return_dict": False,
-                "additional_t_cond": is_rgb,
+                "additional_t_cond": ctx["is_rgb"],
                 "attention_kwargs": self.attention_kwargs,
             },
         )

--- a/vllm_omni/diffusion/models/qwen_image/stepwise_mixin.py
+++ b/vllm_omni/diffusion/models/qwen_image/stepwise_mixin.py
@@ -108,9 +108,9 @@ class QwenImageStepwiseMixin:
             .view(1, self.vae.config.z_dim, 1, 1, 1)
             .to(latents.device, latents.dtype)
         )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
-            1, self.vae.config.z_dim, 1, 1, 1
-        ).to(latents.device, latents.dtype)
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latents.device, latents.dtype
+        )
         latents = latents / latents_std + latents_mean
         image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
         return DiffusionOutput(

--- a/vllm_omni/diffusion/models/qwen_image/stepwise_mixin.py
+++ b/vllm_omni/diffusion/models/qwen_image/stepwise_mixin.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm_omni.diffusion.data import DiffusionOutput
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.input_batch import InputBatch
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+
+class QwenImageStepwiseMixin:
+    """Shared step-wise (continuous-batching) execution hooks for QwenImage pipelines.
+
+    Provides the four hooks the DiffusionRunner calls each step plus two shared
+    helpers.  Concrete classes must supply:
+      - ``self.vae_scale_factor``, ``self.vae``, ``self.transformer``
+      - ``self.interrupt``, ``self.attention_kwargs``, ``self._current_timestep``
+      - ``self.default_sample_size``
+      - ``predict_noise_maybe_with_cfg()`` / ``scheduler_step_maybe_with_cfg()``
+        (from ``QwenImageCFGParallelMixin``)
+      - ``_unpack_latents()`` (static method on the concrete class)
+      - ``self.stage_durations`` (optional, for profiling)
+
+    Only ``prepare_encode`` must be defined per-pipeline because it is the only
+    hook that differs between T2I, single-image edit, and multi-image edit.
+    """
+
+    def _build_denoise_kwargs(
+        self,
+        latents: torch.Tensor,
+        timestep: torch.Tensor,
+        guidance: torch.Tensor | None,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        img_shapes: list,
+        txt_seq_lens: list[int] | None,
+        do_true_cfg: bool,
+        negative_prompt_embeds: torch.Tensor | None,
+        negative_prompt_embeds_mask: torch.Tensor | None,
+        negative_txt_seq_lens: list[int] | None,
+        image_latents: torch.Tensor | None = None,
+        extra_transformer_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None, int | None]:
+        """Build positive/negative transformer kwargs and output_slice for one denoise step.
+
+        When *image_latents* is provided (edit pipelines), the output latents
+        are concatenated with image latents along the sequence dim and
+        ``output_slice = latents.size(1)`` tells the caller where the
+        output-only region ends so noise prediction can be cropped back.
+        """
+        extra_transformer_kwargs = extra_transformer_kwargs or {}
+        t_for_model = timestep.expand(latents.shape[0]).to(
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+        latent_model_input = latents
+        if image_latents is not None:
+            latent_model_input = torch.cat([latents, image_latents], dim=1)
+
+        positive_kwargs: dict[str, Any] = {
+            "hidden_states": latent_model_input,
+            "timestep": t_for_model / 1000,
+            "guidance": guidance,
+            "encoder_hidden_states_mask": prompt_embeds_mask,
+            "encoder_hidden_states": prompt_embeds,
+            "img_shapes": img_shapes,
+            "txt_seq_lens": txt_seq_lens,
+            **extra_transformer_kwargs,
+        }
+        if do_true_cfg:
+            negative_kwargs: dict[str, Any] | None = {
+                "hidden_states": latent_model_input,
+                "timestep": t_for_model / 1000,
+                "guidance": guidance,
+                "encoder_hidden_states_mask": negative_prompt_embeds_mask,
+                "encoder_hidden_states": negative_prompt_embeds,
+                "img_shapes": img_shapes,
+                "txt_seq_lens": negative_txt_seq_lens,
+                **extra_transformer_kwargs,
+            }
+        else:
+            negative_kwargs = None
+
+        output_slice = latents.size(1) if image_latents is not None else None
+        return positive_kwargs, negative_kwargs, output_slice
+
+    def _decode_latents(
+        self,
+        latents: torch.Tensor,
+        height: int,
+        width: int,
+        output_type: str = "pil",
+    ) -> DiffusionOutput:
+        """Unpack, normalize, and VAE-decode latents into a DiffusionOutput."""
+        if output_type == "latent":
+            return DiffusionOutput(
+                output=latents,
+                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+            )
+        latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+        latents = latents.to(self.vae.dtype)
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
+            1, self.vae.config.z_dim, 1, 1, 1
+        ).to(latents.device, latents.dtype)
+        latents = latents / latents_std + latents_mean
+        image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+        return DiffusionOutput(
+            output=image,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def denoise_step(
+        self,
+        input_batch: "InputBatch",
+        **kwargs: Any,
+    ) -> torch.Tensor | None:
+        """One denoise step: read from *input_batch*, delegate to CFGParallelMixin."""
+        del kwargs
+        if self.interrupt:
+            return None
+
+        t = input_batch.timesteps
+        self._current_timestep = t
+        self.transformer.do_true_cfg = input_batch.do_true_cfg
+
+        extra_transformer_kwargs = {
+            "attention_kwargs": self.attention_kwargs,
+            "return_dict": False,
+        }
+        get_extra_kwargs = getattr(self, "_get_stepwise_transformer_kwargs", None)
+        if callable(get_extra_kwargs):
+            extra_transformer_kwargs.update(get_extra_kwargs(input_batch))
+
+        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
+            latents=input_batch.latents,
+            timestep=t,
+            guidance=input_batch.guidance,
+            prompt_embeds=input_batch.prompt_embeds,
+            prompt_embeds_mask=input_batch.prompt_embeds_mask,
+            img_shapes=input_batch.img_shapes,
+            txt_seq_lens=input_batch.txt_seq_lens,
+            do_true_cfg=input_batch.do_true_cfg,
+            negative_prompt_embeds=input_batch.negative_prompt_embeds,
+            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
+            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
+            image_latents=input_batch.image_latents,
+            extra_transformer_kwargs=extra_transformer_kwargs,
+        )
+
+        return self.predict_noise_maybe_with_cfg(
+            input_batch.do_true_cfg,
+            input_batch.true_cfg_scale,
+            positive_kwargs,
+            negative_kwargs,
+            input_batch.cfg_normalize,
+            output_slice,
+        )
+
+    def step_scheduler(
+        self,
+        state: "DiffusionRequestState",
+        noise_pred: torch.Tensor,
+        **kwargs: Any,
+    ) -> None:
+        """One scheduler step: update ``state.latents`` and advance ``step_index``."""
+        del kwargs
+        if self.interrupt:
+            return
+        t = state.current_timestep
+        state.latents = self.scheduler_step_maybe_with_cfg(
+            noise_pred,
+            t,
+            state.latents,
+            state.do_true_cfg,
+            per_request_scheduler=state.scheduler,
+        )
+        state.step_index += 1
+
+    def post_decode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        """Decode final latents from *state*."""
+        self._current_timestep = None
+        default_size = self.default_sample_size * self.vae_scale_factor
+        height = state.extra.get("height") or state.sampling.height or default_size
+        width = state.extra.get("width") or state.sampling.width or default_size
+        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
+        if state.latents is None:
+            raise ValueError(f"Request {state.request_id} has no latents to decode.")
+        return self._decode_latents(state.latents, height, width, output_type)

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -25,7 +25,10 @@ logger = init_logger(__name__)
 
 # LoRA identity is derived from `sampling.lora_request`, not a same-named field
 # on sampling params, so it must be resolved separately from the bulk lookup.
-_SAMPLING_PARAMS_KEY_FIELD_NAMES = frozenset(f.name for f in fields(SamplingParamsKey)) - {"lora_int_id"}
+_SAMPLING_PARAMS_KEY_FIELD_NAMES = frozenset(f.name for f in fields(SamplingParamsKey)) - {
+    "condition_image_signature",
+    "lora_int_id",
+}
 _REQUEST_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES = frozenset(f.name for f in fields(RequestBatchSamplingParamsKey)) - {
     "lora_int_id"
 }
@@ -36,6 +39,7 @@ def get_sampling_params_key(request: OmniDiffusionRequest) -> SamplingParamsKey:
     sampling = request.sampling_params
     lora_request = getattr(sampling, "lora_request", None)
     return SamplingParamsKey(
+        condition_image_signature=_get_condition_image_signature(request),
         lora_int_id=lora_request.lora_int_id if lora_request is not None else None,
         **{name: getattr(sampling, name) for name in _SAMPLING_PARAMS_KEY_FIELD_NAMES},
     )
@@ -48,6 +52,73 @@ def get_request_batch_sampling_params_key(request: OmniDiffusionRequest) -> Requ
     key_kwargs = {name: getattr(sampling, name) for name in _REQUEST_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES}
     key_kwargs["lora_int_id"] = lora_request.lora_int_id if lora_request is not None else None
     return RequestBatchSamplingParamsKey(**key_kwargs)
+
+
+def _shape_signature(value: object) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return tuple(int(dim) for dim in shape)
+
+
+def _sizes_signature(value: object) -> tuple[tuple[int, ...], ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)):
+        return None
+    try:
+        return tuple(tuple(int(dim) for dim in item) for item in value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _tensor_sequence_shape_signature(value: object) -> tuple[tuple[int, ...], ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)):
+        return None
+    if isinstance(value, (list, tuple)):
+        shapes = [_shape_signature(item) for item in value]
+        if all(shape is not None for shape in shapes):
+            return tuple(shape for shape in shapes if shape is not None)
+        return None
+    shape = _shape_signature(value)
+    if shape is None:
+        return None
+    return (shape,)
+
+
+def _get_additional_information(request: OmniDiffusionRequest) -> dict:
+    prompt = request.prompt
+    if isinstance(prompt, dict):
+        additional_information = prompt.get("additional_information")
+        if isinstance(additional_information, dict):
+            return additional_information
+    return {}
+
+
+def _get_condition_image_signature(request: OmniDiffusionRequest) -> tuple | None:
+    sampling = request.sampling_params
+    image_latent = getattr(sampling, "image_latent", None)
+    image_latent_shape = _shape_signature(image_latent)
+    if image_latent_shape is not None:
+        return ("image_latent", image_latent_shape[1:])
+
+    additional_information = _get_additional_information(request)
+
+    vae_image_sizes = _sizes_signature(additional_information.get("vae_image_sizes"))
+    if vae_image_sizes is not None:
+        return ("vae_image_sizes", vae_image_sizes)
+
+    vae_image_shapes = _tensor_sequence_shape_signature(additional_information.get("vae_images"))
+    if vae_image_shapes is not None:
+        return ("vae_images", vae_image_shapes)
+
+    preprocessed_image_shape = _shape_signature(additional_information.get("preprocessed_image"))
+    if preprocessed_image_shape is not None:
+        return ("preprocessed_image", preprocessed_image_shape)
+
+    return None
 
 
 class _BaseScheduler(SchedulerInterface):

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -64,6 +64,11 @@ class SamplingParamsKey:
     # differently shaped outputs and cannot share a batch.
     num_outputs_per_prompt: int = 1
 
+    # Conditional-image layout. Step-wise edit pipelines currently gather
+    # image_latents without padding, so requests with different condition image
+    # latent shapes must not share a denoise-step batch.
+    condition_image_signature: tuple | None = None
+
     # LoRA identity. Requests with different adapters or scales must run in
     # separate batches so the worker can activate exactly one adapter per step.
     lora_int_id: int | None = None


### PR DESCRIPTION

## Purpose


This PR extends the diffusion step-wise execution path to the Qwen-Image editing family.


Step execution was already available for `QwenImagePipeline` (text-to-image). This change makes the same step-wise runner contract available to:


- `QwenImageEditPipeline` (`Qwen/Qwen-Image-Edit`)
- `QwenImageEditPlusPipeline` (`Qwen/Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2511`)
- `QwenImageLayeredPipeline` (`Qwen/Qwen-Image-Layered`)


The main goal is feature coverage and runtime compatibility: Qwen-Image edit pipelines can now run through the segmented `prepare_encode -> denoise_step -> step_scheduler -> post_decode` contract, so they can participate in the experimental step-wise batching runtime when `--step-execution` is enabled.


This PR focuses on enabling step-execution compatibility for Qwen-Image editing pipelines. It does not claim a universal throughput improvement for edit workloads, which can remain transformer compute-bound.


## Implementation


- Adds `QwenImageStepwiseMixin`, which shares the common Qwen-Image step-wise hooks:
  - transformer kwargs construction for positive / negative CFG branches
  - optional concatenation of edit `image_latents`
  - one-step denoising through the existing Qwen-Image CFG parallel helper
  - per-request scheduler stepping
  - final latent decode for normal Qwen-Image output
- Refactors `QwenImagePipeline` to reuse the shared mixin instead of keeping a T2I-only copy of the same step hooks.
- Adds pipeline-specific request-preparation helpers for Qwen-Image Edit, EditPlus, and Layered, and uses them from both `forward()` and step-wise `prepare_encode()`:
  - keeps the step-wise path aligned with the normal forward path for input validation, prompt / negative-prompt encoding, latent packing, timestep setup, guidance, CFG state, and model-specific conditioning
  - reuses each pipeline's existing prompt / image preprocessing outputs (`prompt_image` / `preprocessed_image` for Edit and Layered; `condition_images` / `vae_images` / `vae_image_sizes` for EditPlus)
  - initializes request-local latents, image latents, timesteps, scheduler copy, CFG state, text sequence lengths, and shape metadata
  - stores output `height` / `width` and model-specific extras on `DiffusionRequestState`
- Adds a layered-specific `post_decode()` because layered outputs unpack/decode differently from the regular image pipelines.
- Updates step execution docs, protocol tests, online-serving expansion tests, and the Qwen-Image step-execution benchmark config so the newly supported pipelines are listed and checked.


## Expected Behavior


With this PR, the following should work in online serving:


```bash
vllm serve Qwen/Qwen-Image-Edit-2509 --omni --step-execution --max-num-seqs 1
vllm serve Qwen/Qwen-Image-Edit-2511 --omni --step-execution --max-num-seqs 2
```


`--max-num-seqs 1` validates the step-wise path itself. `--max-num-seqs > 1` additionally exercises compatible-request step-wise batching.


## Test Plan


### 1. L1 protocol / documentation validation


Purpose: verify the supported-pipeline contract without loading model weights.


Expected result:


- `QwenImagePipeline`, `QwenImageEditPipeline`, `QwenImageEditPlusPipeline`, and `QwenImageLayeredPipeline` satisfy `SupportsStepExecution`.
- Default diffusion stage config propagates `step_execution=True`.


### 2. L4 functional serving validation


Purpose: verify step execution works through real online serving requests.


Run the existing Qwen-Image T2I expansion test and the Qwen-Image Edit / EditPlus step-execution cases.


Recommended functional matrix:


| Model | Scenario | Request shape | Server args | Expected |
| --- | --- | --- | --- | --- |
| `Qwen/Qwen-Image` | T2I | text prompt | `--step-execution` | image response succeeds |
| `Qwen/Qwen-Image-Edit-2511` | single-image edit | 1 input image + prompt | `--step-execution` | image response succeeds |
| `Qwen/Qwen-Image-Edit-2511` | multi-image edit | 2 input images + prompt | `--step-execution` | image response succeeds |
| `Qwen/Qwen-Image-Layered` | layered edit | RGBA image + prompt | `--step-execution` | layered image output succeeds |


Also repeat the Edit / EditPlus rows with `--step-execution --max-num-seqs 2` to exercise the batching path.


### 3. Performance benchmark plan


Purpose: compare request-level execution with step-wise batching under the same GPU count, driver, CUDA, PyTorch, vLLM, vLLM-Omni commit, prompt source, seed policy, resolution, and `num_inference_steps`.


The benchmark config lives at `tests/dfx/perf/tests/test_qwen_image_step_execution_vllm_omni.json`. It records completed requests, throughput QPS, mean latency, peak memory, and failed requests.


### 4. Commands


```bash
cd tests
python -m pytest -s -v diffusion/test_diffusion_step_pipeline.py::TestSupportedPipelines \
  -m "core_model and diffusion"
```


```bash
cd tests
python -m pytest -s -v e2e/online_serving/test_qwen_image_expansion.py \
  -m "full_model and diffusion and H100" \
  --run-level=full_model \
  -k "step_execution"
```


```bash
cd tests
python -m pytest -s -v e2e/online_serving/test_qwen_image_edit_expansion.py \
  -m "full_model and diffusion and H100" \
  --run-level=full_model \
  -k "step_execution"
```


```bash
cd tests
python -m pytest -s -v dfx/perf/scripts/run_diffusion_benchmark.py \
  --test-config-file dfx/perf/tests/test_qwen_image_step_execution_vllm_omni.json
```


## Test Result


**vLLM Version:** `0.24.0`


**vLLM-Omni Commit:** `todo`


### Functional


| Command | Result |
| --- | --- |
| `python -m pytest -s -v diffusion/test_diffusion_step_pipeline.py::TestSupportedPipelines -m "core_model and diffusion"` | Passed |
| `python -m pytest -s -v e2e/online_serving/test_qwen_image_expansion.py -m "full_model and diffusion and H100" --run-level=full_model -k "step_execution"` | Passed |
| `python -m pytest -s -v e2e/online_serving/test_qwen_image_edit_expansion.py -m "full_model and diffusion and H100" --run-level=full_model -k "step_execution"` | Passed |


### Performance


Hardware: 1x H800, NVIDIA driver 570.148.08, CUDA 13.0, PyTorch 2.11.0+cu130, Python 3.12.3


Benchmark command:


```bash
cd tests
python -m pytest -s -v dfx/perf/scripts/run_diffusion_benchmark.py \
  --test-config-file dfx/perf/tests/test_qwen_image_step_execution_vllm_omni.json
```



Summary: 27 benchmark records, 27 completed successfully, 0 failed requests.


| Model | Scenario | Resolution | Steps | Baseline QPS | Step-wise batched QPS | Delta | Notes |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| `Qwen/Qwen-Image` | T2I | `256x256` | `20` | 0.3541 | 0.6433 | +81.7% | latency_mean=3.1061s, peak_mem=55146MB |
| `Qwen/Qwen-Image` | T2I | `512x512` | `20` | 0.3349 | 0.5558 | +65.9% | latency_mean=3.5940s, peak_mem=55146MB |
| `Qwen/Qwen-Image` | T2I | `1024x1024` | `20` | 0.1443 | 0.1567 | +8.6% | latency_mean=12.7344s, peak_mem=58824MB |
| `Qwen/Qwen-Image-Edit-2511` | 1-image edit | `512x512` | `20` | 0.1197 | 0.1243 | +3.9% | latency_mean=16.0630s, peak_mem=57600MB; compute-bound |
| `Qwen/Qwen-Image-Edit-2511` | 1-image edit | `1024x1024` | `20` | 0.0712 | 0.0743 | +4.4% | latency_mean=26.8007s, peak_mem=59914MB; compute-bound |
| `Qwen/Qwen-Image-Edit-2511` | 2-image edit | `512x512` | `20` | 0.0616 | 0.0635 | +3.0% | latency_mean=31.4670s, peak_mem=57614MB; compute-bound |
| `Qwen/Qwen-Image-Edit-2511` | 2-image edit | `1024x1024` | `20` | 0.0430 | 0.0445 | +3.7% | latency_mean=44.7530s, peak_mem=59928MB; compute-bound |
