### PR TITLE
[Perf][Qwen3-TTS] Drop default seed from qwen3_tts.yaml to restore batched MTP sampling

### DIFF
--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -54,7 +54,6 @@ stages:
       temperature: 0.9
       top_k: 50
       max_tokens: 4096
-      seed: 42
       repetition_penalty: 1.05
     subtalker_sampling_params:
       do_sample: true
@@ -85,7 +84,6 @@ stages:
       top_p: 1.0
       top_k: -1
       max_tokens: 65536
-      seed: 42
       repetition_penalty: 1.0
 
 platforms:


### PR DESCRIPTION
## Purpose

Mitigates the Qwen3-TTS side of #4963 (nightly perf regression, failing since the 2026-07-04 run).

Root cause chain:

1. `qwen3_tts.yaml` has carried `seed: 42` in both stages' default sampling params since #1161 (introduced for the disaggregated pipeline, carried into the deploy schema by #2383). It never influenced residual-MTP sampling.
2. #4869 started propagating the deploy-level default seed into every request's `extra_args["tts_local_seed"]`. That put **all** traffic on the explicitly-seeded talker-MTP path, whose multi-row fallback ran one scalar forward per row — the 2026-07-04 nightly collapsed to ~11 audio_throughput at every concurrency (also #4883's timeouts, build 12043 at `0798b0bf`).
3. #4889 kept seeded batches batched via per-row generators, but per-row `torch.multinomial` still costs ~40% audio_throughput and ~2x TTFP/RTF at c>=16 vs the unseeded batched multinomial. That residual gap is what #4963 flags (e.g. base c=16: TTFP 658ms -> 1134ms, RTF 0.365 -> 0.635, audio_throughput 40.3 -> 24.2 comparing the 07-03 and 07-07 nightlies).

## Changes

Remove `seed: 42` from both stages of `vllm_omni/deploy/qwen3_tts.yaml`, matching what #4869 already did for `qwen3_tts_high_concurrency.yaml`. With no default seed, no request carries `tts_local_seed`, so the code predictor returns to the single batched-multinomial fast path — the exact pre-07-04 hot path.

- The nightly perf job launches the server with only the model name (this default profile) and never sends a per-request seed; its WER/quality phase is `enabled: false`, so nothing in CI needs the default determinism.
- Deterministic sampling remains fully available per request via the `seed` field, which stays batched through #4889's per-row generator path.
- Making the *seeded* path itself cheap is complementary follow-up work: #4261 (Gumbel-max sampling) plus potential per-step noise pre-draw.

VoxCPM2's TTFP regression in #4963 starts the same night but is a separate mechanism (the seed propagation is qwen3_tts-gated); prime suspects there are #4606/#4878 and it needs its own bisect.

## Test Plan

**vLLM Version:** 0.24.0

- 2-line YAML deletion; verified the file parses and no test references the deploy-level seed.
- Nightly perf (qwen3_tts_base / qwen3_tts_customvoice cells) should return to the pre-07-04 baselines; happy to run an H20 smoke against this head on request.

## Test Result

Pending CI.