### PR TITLE
[Bugfix] Skip empty audio chunks in streaming _create_audio_choice

### DIFF
--- a/tests/e2e/online_serving/test_mimo_audio_expansion.py
+++ b/tests/e2e/online_serving/test_mimo_audio_expansion.py
@@ -100,7 +100,6 @@ def test_text_to_text_001(omni_server, openai_client) -> None:
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
-@pytest.mark.skip(reason="CI failed 8571")
 def test_audio_to_text_audio_001(omni_server, openai_client) -> None:
     """
     Test audio and text input processing and text/audio output generation via OpenAI API.

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1856,6 +1856,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         yield f"data: {data}\n\n"
 
                 elif final_output_type == "audio":
+                    if not omni_res.multimodal_output:
+                        continue
                     # Observe audio_ttfp_s on first audio packet for this request_id
                     # (once-per-request guard via first_audio_ts). The same hook
                     # also captures (stage, replica) for the streaming-continuity


### PR DESCRIPTION
## Purpose

When an audio generation stage produces no audio (e.g. the model responded with text only, despite that `"modalities": ["text", "audio"]` is set, due to various reasons, e.g. a too low max_tokens), the stage emits a completion signal with finished=True but no multimodal data. The orchestrator tags it with final_output_type="audio" based on stage metadata, so the streaming generator calls _create_audio_choice which crashes accessing multimodal_output on a bare CompletionOutput.

Skip audio outputs that carry no multimodal data in the streaming path.


## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 93be93f30ed646ea8e97bc4370be6c9b305a4b90

```
pytest -s -v tests/e2e/online_serving/test_mimo_audio_expansion.py::test_audio_to_text_audio_001 --run-level full_model
```

Another test:

run mimo audio following the guide at: https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/examples/online_serving/mimo_audio/#run-examples-mimo-audio, then send this request for multiple times

```
curl -X POST http://127.0.0.1:18091/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "MiMo-Audio-7B-Instruct",
    "messages": [{"role": "user", "content": "Say hello"}],
    "stream": true,
    "modalities": ["text", "audio"],
    "sampling_params_list": [{"max_tokens": 64}, {"max_tokens": 64}]
  }'
```

## Test Result

Without the fix: both the first test and the second test occasionally fails with `data: {"error": {"message": "'CompletionOutput' object has no attribute 'multimodal_output'", "type": "InternalServerError", "param": null, "code": 500}}`

With the fix: request always succeeds.