### PR TITLE
[Diffusion] Improve HuggingFace hub kernel loading in flash_attn_hub

### DIFF
--- a/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from functools import partial
+from functools import cache, partial
 
 import torch
 from vllm.logger import init_logger
@@ -16,6 +16,22 @@ from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
 )
 
 logger = init_logger(__name__)
+
+
+@cache
+def _get_hub_module(repo_id: str):
+    from kernels import get_kernel
+
+    last_error = None
+    for version in (1, 2, None):
+        try:
+            kwargs = {"trust_remote_code": True}
+            if version is not None:
+                kwargs["version"] = version
+            return get_kernel(repo_id, **kwargs)
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"Failed to load HuggingFace Hub kernel {repo_id!r}") from last_error
 
 
 def _run_varlen_dense(
@@ -88,23 +104,9 @@ class FlashAttentionHubImpl(AttentionImpl):
         if backend_kwargs:
             logger.warning("FlashAttentionHubImpl ignoring backend_kwargs: %s", list(backend_kwargs.keys()))
 
-        # Lazily get the kernel from the Hub to avoid network/disk overhead on import
-        from kernels import get_kernel
-
-        logger.info("Loading flash-attn2 kernel from HuggingFace Hub...")
-        try:
-            hub_module = get_kernel("kernels-community/flash-attn2", version=1)
-        except Exception as e:
-            try:
-                logger.info("Failed to load version 1, attempting version 2: %s", e)
-                hub_module = get_kernel("kernels-community/flash-attn2", version=2)
-            except Exception as e2:
-                logger.info("Failed to load version 2, attempting default: %s", e2)
-                hub_module = get_kernel("kernels-community/flash-attn2")
-
+        hub_module = _get_hub_module("kernels-community/flash-attn2")
         self.flash_attn_func = getattr(hub_module, "flash_attn_func", None)
         self.flash_attn_varlen_func = getattr(hub_module, "flash_attn_varlen_func", None)
-
         if self.flash_attn_func is None and self.flash_attn_varlen_func is None:
             raise RuntimeError("Failed to load flash-attn2 kernel from HuggingFace Hub: no functions found")
 
@@ -267,23 +269,9 @@ class FlashAttention3HubImpl(AttentionImpl):
         if backend_kwargs:
             logger.warning("FlashAttention3HubImpl ignoring backend_kwargs: %s", list(backend_kwargs.keys()))
 
-        # Lazily get the kernel from the Hub to avoid network/disk overhead on import
-        from kernels import get_kernel
-
-        logger.info("Loading flash-attn3 kernel from HuggingFace Hub...")
-        try:
-            hub_module = get_kernel("kernels-community/flash-attn3", version=1)
-        except Exception as e:
-            try:
-                logger.info("Failed to load version 1, attempting version 2: %s", e)
-                hub_module = get_kernel("kernels-community/flash-attn3", version=2)
-            except Exception as e2:
-                logger.info("Failed to load version 2, attempting default: %s", e2)
-                hub_module = get_kernel("kernels-community/flash-attn3")
-
+        hub_module = _get_hub_module("kernels-community/flash-attn3")
         self.flash_attn_func = getattr(hub_module, "flash_attn_func", None)
         self.flash_attn_varlen_func = getattr(hub_module, "flash_attn_varlen_func", None)
-
         if self.flash_attn_func is None and self.flash_attn_varlen_func is None:
             raise RuntimeError("Failed to load flash-attn3 kernel from HuggingFace Hub: no functions found")
 

--- a/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
@@ -30,10 +30,9 @@ def _load_hub_module(repo_id: str):
     last_error = None
     for version in (1, 2, None):
         try:
-            kwargs = {"trust_remote_code": True}
             if version is not None:
-                kwargs["version"] = version
-            return get_kernel(repo_id, **kwargs)
+                return get_kernel(repo_id, version=version)
+            return get_kernel(repo_id)
         except Exception as exc:
             logger.info("Failed to load %s version %s: %s", repo_id, version, exc)
             last_error = exc

--- a/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn_hub.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from functools import cache, partial
+import threading
+from functools import partial
 
 import torch
 from vllm.logger import init_logger
@@ -18,10 +19,14 @@ from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
 logger = init_logger(__name__)
 
 
-@cache
-def _get_hub_module(repo_id: str):
+_hub_modules: dict[str, object] = {}
+_hub_lock = threading.Lock()
+
+
+def _load_hub_module(repo_id: str):
     from kernels import get_kernel
 
+    logger.info("Loading %s kernel from HuggingFace Hub...", repo_id)
     last_error = None
     for version in (1, 2, None):
         try:
@@ -30,8 +35,16 @@ def _get_hub_module(repo_id: str):
                 kwargs["version"] = version
             return get_kernel(repo_id, **kwargs)
         except Exception as exc:
+            logger.info("Failed to load %s version %s: %s", repo_id, version, exc)
             last_error = exc
     raise RuntimeError(f"Failed to load HuggingFace Hub kernel {repo_id!r}") from last_error
+
+
+def _get_hub_module(repo_id: str):
+    with _hub_lock:
+        if repo_id not in _hub_modules:
+            _hub_modules[repo_id] = _load_hub_module(repo_id)
+        return _hub_modules[repo_id]
 
 
 def _run_varlen_dense(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

This PR refines the `FLASH_ATTN_HUB` / `FLASH_ATTN_3_HUB` backends by introducing a cached `_get_hub_module()` helper so each `kernels-community/flash-attn2` / `flash-attn3` repo is loaded once per process instead of on every `FlashAttention*HubImpl` construction. Diffusion models create one attention backend per layer, so this aligns rollout startup with diffusers' single-load hub kernel registry pattern, **reduces redundant HuggingFace Hub traffic**, and speeds up worker initialization while preserving the existing version fallback behavior (`v1` → `v2` → default) and adding `trust_remote_code=True` for more reliable Hub access. Attention forward behavior and backend selection are unchanged.

## Test Plan

- [x] `python3 -m pytest tests/diffusion/attention/test_kernels_hub.py::test_kernels_hub_platform_fallback -q`

- E2E test with verl-omni

<img width="962" height="824" alt="image" src="https://github.com/user-attachments/assets/1aa3f9fd-d037-4dba-8d87-bd5c0acbf6ee" />


## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
