### PR TITLE
[recipe] Add cosmos3-nano recipe for npu (1xA3)

### DIFF
--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -300,27 +300,6 @@ vllm serve nvidia/Cosmos3-Nano-Policy-DROID \
 #   ws://localhost:8000/v1/realtime/robot/openpi
 # The first server message is policy_server_config. Each infer request sends a
 # msgpack-numpy observation dict and receives a writable float32 action array.
-# Text-to-video-with-sound
-curl -sS -X POST http://localhost:8000/v1/videos/sync \
-  -H "Accept: video/mp4" \
-  -F "model=nvidia/Cosmos3-Nano" \
-  -F "prompt=Ocean waves at sunset with gentle ambient sounds." \
-  -F "size=1280x720" -F "num_frames=49" -F "fps=24" \
-  -F "num_inference_steps=20" -F "guidance_scale=6.0" -F "seed=42" \
-  -F "generate_sound=true" \
-  -o cosmos3_t2vs.mp4
-
-# Image-to-video-with-sound
-curl -sS -X POST http://localhost:8000/v1/videos/sync \
-  -H "Accept: video/mp4" \
-  -F "model=nvidia/Cosmos3-Nano" \
-  -F "prompt=The scene comes to life with natural ambient sounds." \
-  -F "size=1280x720" -F "num_frames=25" -F "fps=8" \
-  -F "num_inference_steps=10" -F "guidance_scale=6.0" -F "seed=42" \
-  -F "generate_sound=true" \
-  -F "input_reference=@/path/to/reference.jpg;type=image/jpeg" \
-  -o cosmos3_i2vs.mp4
-
 ```
 
 #### Notes
@@ -447,22 +426,21 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 
 ## NPU
 
-### 1x Ascend 910C (Atlas A3) — Online serving
+### 1x Ascend 910C / Atlas A3 (Online serving)
 
 #### Environment
 
 - OS: Linux (aarch64)
 - Python: 3.12+
-- Driver / runtime: CANN 8.5.1 + NNAL 8.5.1 + Ascend 910C
+- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910C
 - vLLM version: match the repository requirements from your current checkout
 - vLLM-Ascend version: match the repository requirements from your current checkout
 - vLLM-Omni version or commit: use the commit you are deploying from
-- Docker image: quay.io/atlas-ci/vllm-ascend (A3 variant)
 
 #### Command
 
 Requires the `vllm-omni` package (or the `quay.io/atlas-ci/vllm-ascend` A3 container),
-which provides the `vllm serve ... --omni` entrypoint used below.
+which provides the `vllm serve … --omni` entrypoint used below.
 
 Safety guardrails are **not supported** on NPU. Use `--no-guardrails`
 (required). The pipeline auto-resolves from `model_index.json`.
@@ -536,24 +514,84 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
 #### Notes
 
 - **Measured latency (1x Ascend 910C, bf16, guardrails off):**
-  - T2I 1024^2 — 10 steps → ~8 s
-  - T2V 1280x720 @ 20 steps — 49 frames → ~55 s
-  - I2V 1280x720 @ 10 steps — 25 frames → ~25 s
-  - V2V 480x320 @ 10 steps — 17 frames → ~12 s
-- **Memory:** transformer ~17 GiB (bf16); peak ~46 GiB for 720p video on 1 NPU.
-- **Disk:** full repo (transformer + Wan VAE + Qwen3-VL vision encoder + audio
-  tokenizer) ~33 GB.
+  - T2I 1024² — 10 steps → ~8 s
+  - T2V 1280×720 @ 20 steps — 49 frames → ~55 s
+  - I2V 1280×720 @ 10 steps — 25 frames → ~25 s
+  - V2V 480×320 @ 10 steps — 17 frames → ~12 s
+- **Memory:** transformer ~17 GiB (bf16); peak ~46 GiB for 720p video on 1 NPU;
+  full repo (transformer + Wan VAE + Qwen3-VL vision encoder + audio tokenizer)
+  ~33 GB on disk.
 - **Determinism:** identical seed reproduces identical output on the same
   hardware; outputs are not bit-identical across different GPU/NPU types.
 - **Supported sizes (per model card):** 256p / 480p / 720p at 16:9, 4:3, 1:1,
-  3:4, 9:16. Defaults: T2I 1024^2, 50 steps, guidance 7.0; T2V/I2V/V2V
-  1280x720, 35 steps, guidance 6.0, `flow_shift=10.0`.
-- **Key flags / params:** `--no-guardrails` (required on NPU). `--init-timeout 1800`
-  (for model loading). `--tensor-parallel-size 8` for multi-NPU.
-- **NPU-specific notes:**
-  - Guardrails (`cosmos-guardrail`) not available on Ascend NPU.
-  - Transfer V2V with `extra_params` (edge/blur/depth/seg/wsm) hits a
-    resolution-parsing bug. Basic V2V without transfer hints works.
-  - Audio generation (T2VS, I2VS) works but output quality is noticeably lower
-    than GPU; use at your own discretion.
-  - FP8 online quantization and layerwise offload not supported on NPU.
+  3:4, 9:16. Defaults: T2I 1024², 50 steps, guidance 7.0; T2V/I2V/V2V
+  1280×720, 35 steps, guidance 6.0, `flow_shift=10.0`.
+- **Key flags / params:** `--no-guardrails` (required on NPU), `--init-timeout 1800`
+  (for model loading), and `--tensor-parallel-size 8` for multi-NPU.
+- **Known limitations:**
+  - Guardrails (`cosmos-guardrail`) are not available on Ascend NPU.
+  - Transfer V2V with `extra_params` (`edge`/`blur`/`depth`/`seg`/`wsm`) hits a
+    resolution-parsing bug; basic V2V without transfer hints works.
+  - Audio generation (T2VS, I2VS) works but output quality is noticeably bad.
+  - FP8 online quantization and layerwise offload are not supported on NPU.
+
+### 1x Ascend 910C / Atlas A3 (Offline generation)
+
+#### Environment
+
+- OS: Linux (aarch64)
+- Python: 3.12+
+- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910C
+- vLLM-Omni version or commit: use the commit you are deploying from
+
+#### Command
+
+The same offline task examples run on NPU; pass model-specific knobs via
+`--extra-body`. Guardrails are not supported on NPU — pass `"guardrails": false`.
+
+```bash
+# Text-to-image -> examples/offline_inference/text_to_image
+python examples/offline_inference/text_to_image/text_to_image.py \
+  --model nvidia/Cosmos3-Nano \
+  --prompt "A photorealistic red sports car at golden hour, cinematic lighting." \
+  --negative-prompt "blurry, distorted, low quality" \
+  --height 1024 --width 1024 --num-inference-steps 50 --guidance-scale 7.0 \
+  --extra-body '{"flow_shift": 3.0, "guardrails": false}' \
+  --output cosmos3_t2i.png
+
+# Text-to-video -> examples/offline_inference/text_to_video
+python examples/offline_inference/text_to_video/text_to_video.py \
+  --model nvidia/Cosmos3-Nano \
+  --prompt "A robot arm is cleaning a plate in the kitchen." \
+  --negative-prompt "blurry, distorted, low quality, jittery, deformed" \
+  --height 720 --width 1280 --num-frames 189 --fps 24 \
+  --num-inference-steps 35 --guidance-scale 6.0 \
+  --extra-body '{"flow_shift": 10.0, "max_sequence_length": 4096, "guardrails": false,
+                 "use_resolution_template": false, "use_duration_template": false}' \
+  --output cosmos3_t2v.mp4
+
+# Image-to-video -> examples/offline_inference/image_to_video
+# (Cosmos3 bundles example frames under assets/; any RGB image works too.)
+python examples/offline_inference/image_to_video/image_to_video.py \
+  --model nvidia/Cosmos3-Nano \
+  --image /path/to/Cosmos3-Nano/assets/example_i2v_input.jpg \
+  --prompt "The scene comes to life with smooth, natural motion." \
+  --height 720 --width 1280 --num-frames 189 --fps 24 \
+  --num-inference-steps 35 --guidance-scale 6.0 \
+  --extra-body '{"flow_shift": 10.0, "max_sequence_length": 4096, "guardrails": false}' \
+  --output cosmos3_i2v.mp4
+```
+
+#### Verification
+
+```bash
+python -c "from PIL import Image; im=Image.open('cosmos3_t2i.png'); print('image', im.size, im.mode)"
+ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_t2v.mp4
+```
+
+#### Notes
+
+- Guardrails are not supported on NPU; `"guardrails": false` is required in
+  `--extra-body` (there is no `--no-guardrails` flag for the offline scripts).
+- Video at the 189-frame default takes ~15 min/clip on 1 NPU; reduce
+  `--num-frames` for faster iteration.

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -425,20 +425,20 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 
 ## NPU
 
-### 1x Ascend 910C / Atlas A3 (Online serving)
+### 1x Ascend 910B / 910C (Atlas A2 / A3) — Online serving
 
 #### Environment
 
 - OS: Linux (aarch64)
 - Python: 3.12+
-- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910C
+- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910B / 910C
 - vLLM version: match the repository requirements from your current checkout
 - vLLM-Ascend version: match the repository requirements from your current checkout
 - vLLM-Omni version or commit: use the commit you are deploying from
 
 #### Command
 
-Requires the `vllm-omni` package (or the `quay.io/atlas-ci/vllm-ascend` A3 container),
+Requires the `vllm-omni` package (or the `quay.io/atlas-ci/vllm-ascend` A2 / A3 container),
 which provides the `vllm serve … --omni` entrypoint used below.
 
 Safety guardrails are **on by default** (NVIDIA Open Model License). They load
@@ -521,7 +521,7 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
 
 #### Notes
 
-- **Measured latency (1x Ascend 910C, bf16, guardrails off):**
+- **Measured latency (1x Ascend 910B / 910C, bf16, guardrails off):**
   - T2I 1024² — 10 steps → ~8 s
   - T2V 1280×720 @ 20 steps — 49 frames → ~55 s
   - I2V 1280×720 @ 10 steps — 25 frames → ~25 s
@@ -542,13 +542,13 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
     resolution-parsing bug; basic V2V without transfer hints works.
   - FP8 online quantization and layerwise offload are not supported on NPU.
 
-### 1x Ascend 910C / Atlas A3 (Offline generation)
+### 1x Ascend 910B / 910C (Atlas A2 / A3) — Offline generation
 
 #### Environment
 
 - OS: Linux (aarch64)
 - Python: 3.12+
-- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910C
+- Driver / runtime: CANN 8.5.1 + NNAL + Ascend 910B / 910C
 - vLLM-Omni version or commit: use the commit you are deploying from
 
 #### Command

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -421,8 +421,7 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 - Model-specific knobs (`flow_shift`, `max_sequence_length`, `condition_*`,
   `generate_sound`/`sound_duration`, `guardrails`, `action_*`, ...) are declared
   once in `vllm_omni/model_extras/cosmos3.py` and forwarded through `--extra-body`;
-
-
+  unknown keys for the model are dropped.
 
 ## NPU
 

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -531,7 +531,6 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
   - Guardrails (`cosmos-guardrail`) are not available on Ascend NPU.
   - Transfer V2V with `extra_params` (`edge`/`blur`/`depth`/`seg`/`wsm`) hits a
     resolution-parsing bug; basic V2V without transfer hints works.
-  - Audio generation (T2VS, I2VS) works but output quality is noticeably bad.
   - FP8 online quantization and layerwise offload are not supported on NPU.
 
 ### 1x Ascend 910C / Atlas A3 (Offline generation)

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -441,19 +441,28 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 Requires the `vllm-omni` package (or the `quay.io/atlas-ci/vllm-ascend` A3 container),
 which provides the `vllm serve … --omni` entrypoint used below.
 
-Safety guardrails are **not supported** on NPU. Use `--no-guardrails`
-(required). The pipeline auto-resolves from `model_index.json`.
+Safety guardrails are **on by default** (NVIDIA Open Model License). They load
+the **gated** `nvidia/Cosmos-1.0-Guardrail` model, so to keep them on you must:
+
+1. `pip install cosmos-guardrail`
+2. Accept the license at <https://huggingface.co/nvidia/Cosmos-1.0-Guardrail>
+3. Export a token with access: `export HF_TOKEN=hf_...`
+
+Then launch the recommended server:
 
 ```bash
 vllm serve nvidia/Cosmos3-Nano \
   --omni \
   --host 0.0.0.0 --port 8000 \
-  --no-guardrails \
   --init-timeout 1800
 ```
 
-For tensor parallel add `--tensor-parallel-size 8`.
-`--quantization fp8` and `--enable-layerwise-offload` are not supported on NPU.
+To run **without** guardrails (you are responsible for license compliance),
+add `--no-guardrails` (no token/`cosmos-guardrail` needed). For tensor parallel
+add `--tensor-parallel-size 8`. `--quantization fp8` and
+`--enable-layerwise-offload` are not supported on NPU.
+The pipeline auto-resolves from `model_index.json`; pass
+`--model-class-name Cosmos3OmniDiffusersPipeline` to force it explicitly.
 
 #### Verification
 
@@ -525,10 +534,10 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
 - **Supported sizes (per model card):** 256p / 480p / 720p at 16:9, 4:3, 1:1,
   3:4, 9:16. Defaults: T2I 1024², 50 steps, guidance 7.0; T2V/I2V/V2V
   1280×720, 35 steps, guidance 6.0, `flow_shift=10.0`.
-- **Key flags / params:** `--no-guardrails` (required on NPU), `--init-timeout 1800`
-  (for model loading), and `--tensor-parallel-size 8` for multi-NPU.
+- **Key flags / params:** `--no-guardrails` (optional, to disable guardrails), `--init-timeout 1800`
+  (for model loading), `--tensor-parallel-size 8` for multi-NPU, and
+  `--model-class-name Cosmos3OmniDiffusersPipeline` to force the pipeline class.
 - **Known limitations:**
-  - Guardrails (`cosmos-guardrail`) are not available on Ascend NPU.
   - Transfer V2V with `extra_params` (`edge`/`blur`/`depth`/`seg`/`wsm`) hits a
     resolution-parsing bug; basic V2V without transfer hints works.
   - FP8 online quantization and layerwise offload are not supported on NPU.
@@ -545,7 +554,8 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
 #### Command
 
 The same offline task examples run on NPU; pass model-specific knobs via
-`--extra-body`. Guardrails are not supported on NPU — pass `"guardrails": false`.
+`--extra-body`. Guardrails are on by default — pass `"guardrails": false` for a
+quick local run (install `cosmos-guardrail` + accept the gated repo to enable them).
 
 ```bash
 # Text-to-image -> examples/offline_inference/text_to_image
@@ -589,7 +599,8 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 
 #### Notes
 
-- Guardrails are not supported on NPU; `"guardrails": false` is required in
-  `--extra-body` (there is no `--no-guardrails` flag for the offline scripts).
+- Guardrails are on by default on NPU with `cosmos-guardrail` installed. Pass
+  `"guardrails": false` in `--extra-body` to disable them (there is no
+  `--no-guardrails` flag for the offline scripts).
 - Video at the 189-frame default takes ~15 min/clip on 1 NPU; reduce
   `--num-frames` for faster iteration.

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -300,6 +300,27 @@ vllm serve nvidia/Cosmos3-Nano-Policy-DROID \
 #   ws://localhost:8000/v1/realtime/robot/openpi
 # The first server message is policy_server_config. Each infer request sends a
 # msgpack-numpy observation dict and receives a writable float32 action array.
+# Text-to-video-with-sound
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Nano" \
+  -F "prompt=Ocean waves at sunset with gentle ambient sounds." \
+  -F "size=1280x720" -F "num_frames=49" -F "fps=24" \
+  -F "num_inference_steps=20" -F "guidance_scale=6.0" -F "seed=42" \
+  -F "generate_sound=true" \
+  -o cosmos3_t2vs.mp4
+
+# Image-to-video-with-sound
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Nano" \
+  -F "prompt=The scene comes to life with natural ambient sounds." \
+  -F "size=1280x720" -F "num_frames=25" -F "fps=8" \
+  -F "num_inference_steps=10" -F "guidance_scale=6.0" -F "seed=42" \
+  -F "generate_sound=true" \
+  -F "input_reference=@/path/to/reference.jpg;type=image/jpeg" \
+  -o cosmos3_i2vs.mp4
+
 ```
 
 #### Notes
@@ -421,4 +442,118 @@ ffprobe -v error -show_entries stream=codec_type,nb_frames,width,height cosmos3_
 - Model-specific knobs (`flow_shift`, `max_sequence_length`, `condition_*`,
   `generate_sound`/`sound_duration`, `guardrails`, `action_*`, ...) are declared
   once in `vllm_omni/model_extras/cosmos3.py` and forwarded through `--extra-body`;
-  unknown keys for the model are dropped.
+
+
+
+## NPU
+
+### 1x Ascend 910C (Atlas A3) — Online serving
+
+#### Environment
+
+- OS: Linux (aarch64)
+- Python: 3.12+
+- Driver / runtime: CANN 8.5.1 + NNAL 8.5.1 + Ascend 910C
+- vLLM version: match the repository requirements from your current checkout
+- vLLM-Ascend version: match the repository requirements from your current checkout
+- vLLM-Omni version or commit: use the commit you are deploying from
+- Docker image: quay.io/atlas-ci/vllm-ascend (A3 variant)
+
+#### Command
+
+Requires the `vllm-omni` package (or the `quay.io/atlas-ci/vllm-ascend` A3 container),
+which provides the `vllm serve ... --omni` entrypoint used below.
+
+Safety guardrails are **not supported** on NPU. Use `--no-guardrails`
+(required). The pipeline auto-resolves from `model_index.json`.
+
+```bash
+vllm serve nvidia/Cosmos3-Nano \
+  --omni \
+  --host 0.0.0.0 --port 8000 \
+  --no-guardrails \
+  --init-timeout 1800
+```
+
+For tensor parallel add `--tensor-parallel-size 8`.
+`--quantization fp8` and `--enable-layerwise-offload` are not supported on NPU.
+
+#### Verification
+
+Best quality uses the JSON-upsampled prompts from `assets/` (download with
+`hf download nvidia/Cosmos3-Nano assets/ --local-dir Cosmos3-Nano`). Minimal
+self-contained examples:
+
+```bash
+curl http://localhost:8000/v1/models
+
+# Text-to-image -> /v1/images/generations  (1024x1024, 10 steps; base64 PNG)
+curl -sS -X POST http://localhost:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/Cosmos3-Nano",
+    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
+    "negative_prompt": "blurry, distorted, low quality",
+    "size": "1024x1024", "n": 1, "response_format": "b64_json",
+    "num_inference_steps": 10, "guidance_scale": 7.0, "seed": 42
+  }' | python -c "import sys,json,base64; open('cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
+
+# Text-to-video -> /v1/videos/sync  (720p, 49 frames @ 24fps)
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Nano" \
+  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
+  -F "negative_prompt=blurry, distorted, low quality, jittery, deformed" \
+  -F "size=1280x720" -F "num_frames=49" -F "fps=24" \
+  -F "num_inference_steps=20" -F "guidance_scale=6.0" \
+  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F "seed=123" \
+  -o cosmos3_t2v.mp4
+
+# Image-to-video -> /v1/videos/sync with an uploaded reference image
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Nano" \
+  -F "prompt=The scene comes to life with smooth, natural motion." \
+  -F "size=1280x720" -F "num_frames=25" -F "fps=8" \
+  -F "num_inference_steps=10" -F "guidance_scale=6.0" \
+  -F "seed=42" \
+  -F "input_reference=@reference.jpg;type=image/jpeg" \
+  -o cosmos3_i2v.mp4
+
+# Video-to-video -> /v1/videos/sync with an uploaded reference video
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Nano" \
+  -F "prompt=Continue the same scene with smooth natural motion and consistent subjects." \
+  -F "size=1280x720" -F "num_frames=17" -F "fps=5" \
+  -F "num_inference_steps=10" -F "guidance_scale=6.0" \
+  -F "seed=42" \
+  -F "input_reference=@reference.mp4;type=video/mp4" \
+  -o cosmos3_v2v.mp4
+```
+
+#### Notes
+
+- **Measured latency (1x Ascend 910C, bf16, guardrails off):**
+  - T2I 1024^2 — 10 steps → ~8 s
+  - T2V 1280x720 @ 20 steps — 49 frames → ~55 s
+  - I2V 1280x720 @ 10 steps — 25 frames → ~25 s
+  - V2V 480x320 @ 10 steps — 17 frames → ~12 s
+- **Memory:** transformer ~17 GiB (bf16); peak ~46 GiB for 720p video on 1 NPU.
+- **Disk:** full repo (transformer + Wan VAE + Qwen3-VL vision encoder + audio
+  tokenizer) ~33 GB.
+- **Determinism:** identical seed reproduces identical output on the same
+  hardware; outputs are not bit-identical across different GPU/NPU types.
+- **Supported sizes (per model card):** 256p / 480p / 720p at 16:9, 4:3, 1:1,
+  3:4, 9:16. Defaults: T2I 1024^2, 50 steps, guidance 7.0; T2V/I2V/V2V
+  1280x720, 35 steps, guidance 6.0, `flow_shift=10.0`.
+- **Key flags / params:** `--no-guardrails` (required on NPU). `--init-timeout 1800`
+  (for model loading). `--tensor-parallel-size 8` for multi-NPU.
+- **NPU-specific notes:**
+  - Guardrails (`cosmos-guardrail`) not available on Ascend NPU.
+  - Transfer V2V with `extra_params` (edge/blur/depth/seg/wsm) hits a
+    resolution-parsing bug. Basic V2V without transfer hints works.
+  - Audio generation (T2VS, I2VS) works but output quality is noticeably lower
+    than GPU; use at your own discretion.
+  - FP8 online quantization and layerwise offload not supported on NPU.

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -21,6 +21,7 @@ from vllm.logger import init_logger
 
 from vllm_omni.diffusion.models.progress_bar import _is_rank_zero
 from vllm_omni.errors import GuardrailViolationError
+from vllm_omni.platforms import current_omni_platform
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.data import OmniDiffusionConfig
@@ -28,6 +29,28 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# NPU compatibility: cosmos_guardrail.cosmos_utils.load_model calls
+# ``torch.load(path, weights_only=True)`` without ``map_location``.
+# On NPU, ``torch.cuda.is_available()`` is False, so deserializing a
+# CUDA checkpoint with ``weights_only=True`` raises an UnpicklingError.
+# Work around by patching ``torch.load`` to default ``map_location="cpu"``
+# when CUDA is unavailable and no explicit map_location was given.
+# ---------------------------------------------------------------------------
+_original_torch_load = torch.load
+
+
+def _patched_torch_load(*args, **kwargs):
+    if (
+        "map_location" not in kwargs
+        and not torch.cuda.is_available()
+        and current_omni_platform.is_npu()
+    ):
+        kwargs["map_location"] = "cpu"
+    return _original_torch_load(*args, **kwargs)
+
+
+torch.load = _patched_torch_load  # type: ignore[assignment]
 
 try:
     from cosmos_guardrail import CosmosSafetyChecker
@@ -75,7 +98,7 @@ def _build_text_guardrail(checker: Any) -> TextGuardrailFn:
 
 def _build_video_guardrail(checker: Any, offload_to_cpu: bool) -> VideoGuardrailFn:
     video_models = _nn_models(checker.video_guardrail)
-    compute_device = "cuda"
+    compute_device = current_omni_platform.device_type
 
     def video_guardrail(frames: np.ndarray) -> np.ndarray:
         if offload_to_cpu:
@@ -112,9 +135,9 @@ def _init_default_guardrails(offload_to_cpu: bool = False) -> None:
     checker = CosmosSafetyChecker()
 
     # Place text models on their resting device permanently. Video models
-    # idle on CPU when offload is on and move to GPU per-call (handled in
+    # idle on CPU when offload is on and move to compute device per-call (handled in
     # the video guardrail closure).
-    idle_device = "cpu" if offload_to_cpu else "cuda"
+    idle_device = "cpu" if offload_to_cpu else current_omni_platform.device_type
     for m in _nn_models(checker.text_guardrail):
         m.to(idle_device)
     for m in _nn_models(checker.video_guardrail):

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -41,8 +41,10 @@ _original_torch_load = torch.load
 
 
 def _patched_torch_load(*args, **kwargs):
-    if "map_location" not in kwargs and not torch.cuda.is_available() and (
-        current_omni_platform.is_npu() or current_omni_platform.is_xpu()
+    if (
+        "map_location" not in kwargs
+        and not torch.cuda.is_available()
+        and (current_omni_platform.is_npu() or current_omni_platform.is_xpu())
     ):
         kwargs["map_location"] = "cpu"
     return _original_torch_load(*args, **kwargs)

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -41,11 +41,7 @@ _original_torch_load = torch.load
 
 
 def _patched_torch_load(*args, **kwargs):
-    if (
-        "map_location" not in kwargs
-        and not torch.cuda.is_available()
-        and current_omni_platform.is_npu()
-    ):
+    if "map_location" not in kwargs and not torch.cuda.is_available() and current_omni_platform.is_npu():
         kwargs["map_location"] = "cpu"
     return _original_torch_load(*args, **kwargs)
 

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# NPU compatibility: cosmos_guardrail.cosmos_utils.load_model calls
+# NPU/XPU compatibility: cosmos_guardrail.cosmos_utils.load_model calls
 # ``torch.load(path, weights_only=True)`` without ``map_location``.
-# On NPU, ``torch.cuda.is_available()`` is False, so deserializing a
+# On NPU/XPU, ``torch.cuda.is_available()`` is False, so deserializing a
 # CUDA checkpoint with ``weights_only=True`` raises an UnpicklingError.
 # Work around by patching ``torch.load`` to default ``map_location="cpu"``
 # when CUDA is unavailable and no explicit map_location was given.
@@ -41,7 +41,9 @@ _original_torch_load = torch.load
 
 
 def _patched_torch_load(*args, **kwargs):
-    if "map_location" not in kwargs and not torch.cuda.is_available() and current_omni_platform.is_npu():
+    if "map_location" not in kwargs and not torch.cuda.is_available() and (
+        current_omni_platform.is_npu() or current_omni_platform.is_xpu()
+    ):
         kwargs["map_location"] = "cpu"
     return _original_torch_load(*args, **kwargs)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Add a model recipe for Cosmos3-Nano as requested by #4340. 

cc: @bjf-frz @gcanlin 

## Test Plan

We used the official vllm-omni 0.24.0 docker to run all the offline and online examples as described by the newly added model recipe, and then paste the results below. 

We also run the corresponding pytests using the command below.

```
python -m pytest \
  tests/diffusion/models/cosmos3/ \
  tests/model_extras/test_model_extras.py \
  -v \
  -k "cosmos3 or guardrail or Cosmos3 or guardrail" \
  --tb=short
```

**Environment:** Ascend 910C (Atlas A3), aarch64, Kunpeng 920 7285Z, CANN 9.0.0 + NNAL ATB (latest),
Python 3.12.13, PyTorch 2.10.0+torch_npu, guardrails off, bf16.

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 9ceca4ec8

<details><summary> output of collect_env.py </summary>

```
====================================
           System Info
====================================
OS                           : Ubuntu 22.04.5 LTS (aarch64)
GCC version                  : (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
Clang version                : 15.0.7
CMake version                : version 4.3.4
Libc version                 : glibc-2.35

====================================
         PyTorch Info
====================================
PyTorch version              : 2.10.0+cpu
Is debug build               : False
CUDA used to build PyTorch   : None

====================================
        Python Environment
====================================
Python version               : 3.12.13 (main, May 19 2026, 08:33:02) [GCC 11.4.0]
Python platform              : Linux-5.10.0-182.0.0.95.r2220_157.hce2.aarch64

====================================
         CUDA / GPU Info
====================================
Is CUDA available            : False
CUDA runtime version         : No CUDA
GPU models and configuration : No CUDA (Ascend NPU platform)

====================================
            CPU Info
====================================
Architecture                 : aarch64
CPU(s)                       : 320
Vendor ID                    : HiSilicon
Model name                   : Kunpeng 920 7285Z
Core(s) per socket           : 80
Socket(s)                    : 4
NUMA node(s)                 : 8

====================================
  Versions of relevant libraries
====================================
[pip3] numpy                 : 1.26.4
[pip3] onnxruntime           : 1.27.0
[pip3] torch                 : 2.10.0+cpu
[pip3] torch_npu             : 2.10.0
[pip3] torchaudio            : 2.10.0+cpu
[pip3] torchvision           : 0.25.0+cpu
[pip3] transformers          : 5.5.4
[pip3] triton                : 3.5.0
[pip3] triton_ascend         : 3.2.1
[pip3] x-transformers        : 2.23.3

====================================
           vLLM Info
====================================
vLLM Version                 : 0.24.0
vLLM-Omni Version            : 0.1.dev1+g9ceca4ec8 (git sha: 9ceca4ec8)
Platform plugin              : ascend -> vllm_ascend:register
```

</details>

## Test Result

### Online serving — OpenAI-compatible API (`curl`)

| # | Mode | Prompt | Input reference | Resolution / frames / steps | Guidance / seed | Output | Latency | 
|---|------|--------|-----------------|-----------------------------|-----------------|-----------------|---------|
| 1 | **T2I** — `/v1/images/generations` | "A photorealistic red sports car on a city street at golden hour, cinematic lighting." (neg: "blurry, distorted, low quality") | — | 1024×1024 · 1 frame · 10 steps | 7.0 / 42 |<img width="512" height="512" alt="cosmos3_nano_t2i" src="https://github.com/user-attachments/assets/5cf96d72-efa6-46aa-8f6d-9f86e5e4310a" /> | ~8 s | 
| 2 | **T2V** — `/v1/videos/sync` | "A robot arm is cleaning a plate in the kitchen" (neg: "blurry, distorted, low quality, jittery, deformed") | — | 1280×720 · 49 frames @ 24 fps · 20 steps (`max_sequence_length=4096`, `flow_shift=10.0`) | 6.0 / 123 |[ `cosmos3_t2v.mp4`](https://github.com/user-attachments/assets/e9bc29f2-d33b-4544-a899-8758aedc553d) | ~55 s | 
| 3 | **I2V** — `/v1/videos/sync` | "The scene comes to life with smooth, natural motion." | <img width="3034" height="1754" alt="example_i2v_input" src="https://github.com/user-attachments/assets/e645cdd4-75b3-459d-b5af-3b568eeac899" /> | 1280×720 · 25 frames @ 8 fps · 10 steps | 6.0 / 42 | [`cosmos3_i2v.mp4`](https://github.com/user-attachments/assets/3fcf289b-4507-419b-8134-6571c5391286) | ~19 s | 
| 4 | **V2V** — `/v1/videos/sync` | "Continue the same scene with smooth natural motion and consistent subjects." |[ `reference.mp4` (video)](https://github.com/user-attachments/assets/acecc631-ca4a-4bf1-8b6b-3abd27e415d2) | 1280×720 · 17 frames @ 5 fps · 10 steps | 6.0 / 42 | [`cosmos3_v2v.mp4`](https://github.com/user-attachments/assets/60e755d5-31b4-409e-ad90-d7ce35f466f5) | ~13 s | 
| 5 | **T2VS** — `/v1/videos/sync` (`generate_sound=true`) | "Ocean waves at sunset with gentle ambient sounds." | — | 1280×720 · 49 frames @ 24 fps · 20 steps | 6.0 / 42 | [`cosmos3_t2vs.mp4` (mp4 + AAC)](https://github.com/user-attachments/assets/3453143f-db8f-4ae7-b3ac-a844d145644f) | ~75 s | 
| 6 | **I2VS** — `/v1/videos/sync` (`generate_sound=true`) | "The scene comes to life with natural ambient sounds." | <img width="3034" height="1754" alt="example_i2v_input" src="https://github.com/user-attachments/assets/e645cdd4-75b3-459d-b5af-3b568eeac899" /> | 1280×720 · 25 frames @ 8 fps · 10 steps | 6.0 / 42 | [`cosmos3_i2vs.mp4` (mp4 + AAC)](https://github.com/user-attachments/assets/88176054-3b51-4047-9345-bf96355fa9f8) | ~19 s | 




### Offline generation — `examples/offline_inference/*` (1x Ascend 910C, bf16, guardrails off)

| # | Mode | Script | Prompt | Input image | Resolution / frames / steps | Output  | Latency |
|---|------|--------|--------|-------------|-----------------------------|------------------------------|---------|
| 1 | **T2I** | `text_to_image.py` | "A photorealistic red sports car at golden hour, cinematic lighting." | - | 1024×1024 · 1 frame · 50 steps (`flow_shift=3.0`) | <img width="1024" height="1024" alt="cosmos3_nano_t2i_offline" src="https://github.com/user-attachments/assets/67481901-68b7-491b-a849-088167ef3cab" /> — 1024×1024 RGB | **~11 s** (~4.9 it/s), peak ~38 GiB |
| 2 | **T2V** | `text_to_video.py` | "A robot arm is cleaning a plate in the kitchen." | — | 1280×720 · 189 frames @ 24 fps · 35 steps (`flow_shift=10.0`, `max_sequence_length=4096`) | [`cosmos3_nano_t2v_offline.mp4`](https://github.com/user-attachments/assets/49cbdf33-1f1e-4b78-bb4e-884c34656e8b) — 189f, 1280×720, 24 fps | **~885 s** (~24 s/step + ~21 s VAE decode) |
| 3 | **I2V** | `image_to_video.py` | "The scene comes to life with smooth, natural motion." | <img width="3034" height="1754" alt="cosmos3_nano_i2v_input" src="https://github.com/user-attachments/assets/0d43683d-97d7-48d2-bb2f-c412cc85c781" /> | 1280×720 · 189 frames @ 24 fps · 35 steps | [`cosmos3_nano_i2v_offline.mp4`](https://github.com/user-attachments/assets/acffb95e-376b-4877-b75f-83744f7d8d19) — 189f, 1280×720, 24 fps | **~886 s** |

## PyTest Result: 60 passed, 5 failed, 27 deselected

The 5 failures are due to a seprate issue in #4992, not related to this PR. 

<details> <summary> raw output in terminal </summary>


```
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_registered_and_exported PASSED [  1%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_skips_tokenizer_when_sound_disabled PASSED [  3%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_rebuilds_scheduler_with_cosmos3_defaults PASSED [  4%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_set_flow_shift_restores_checkpoint_scheduler_mode PASSED [  6%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_passes_tokenizer_attrs_into_transformer PASSED [  7%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_preprocess_i2v_image_and_action_video_inputs PASSED [  9%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_config_media_helpers_and_preprocess_budget PASSED [ 10%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_fps_matches_resolved_frame_rate_precedence PASSED [ 12%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_edge_uses_rgb_canny PASSED [ 13%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_blur_uses_scaled_bilateral PASSED [ 15%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_postprocess_handles_image_video_audio_and_validation PASSED [ 16%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_action_postprocess_handles_robolab_policy_outputs PASSED [ 18%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_ir_op_priority_hook_preserves_platform_fields PASSED [ 20%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prompt_formatting_and_checkpoint_key_remap PASSED [ 21%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_latents_for_video_image_sound_and_action PASSED [ 23%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_latents_i2v_encodes_only_conditioning_frame PASSED [ 24%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_action_video_latents_encodes_only_conditioning_frame[policy] PASSED [ 26%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_action_video_latents_encodes_only_conditioning_frame[forward_dynamics] PASSED [ 27%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_inverse_dynamics_latents_encodes_full_video PASSED [ 29%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_covers_cfg_i2v_and_multimodal_steps PASSED [ 30%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_applies_control_cfg PASSED [ 32%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_skips_idle_cfg_branches PASSED [ 33%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_interval_switches_branch_counts PASSED [ 35%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_uses_source_fps_except_wsm[edge-8.0] PASSED [ 36%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_uses_source_fps_except_wsm[wsm-10.0] PASSED [ 38%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_runs_multichunk_overlap_path PASSED [ 40%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_keeps_paired_cfg_when_cache_dit_active PASSED [ 41%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_defaults_and_mode_selection[prompt0-sampling_params0-expected0] PASSED [ 43%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_defaults_and_mode_selection[A warehouse robot-sampling_params1-expected1] PASSED [ 44%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_i2v_sound_and_action_routes PASSED [ 46%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_dispatches_robolab_policy_flow PASSED [ 47%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt0-sampling_params0-single prompt] PASSED [ 49%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt1-sampling_params1-both image and video] PASSED [ 50%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt2-sampling_params2-only for video] PASSED [ 52%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt3-sampling_params3-transfer inference is supported only for video outputs] PASSED [ 53%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt4-sampling_params4-cannot be combined with sound generation] PASSED [ 55%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt5-sampling_params5-cannot be combined with action generation] PASSED [ 56%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_from_config_loads_local_diffusers_component PASSED [ 58%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_from_config_downloads_component_from_hf_repo PASSED [ 60%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_default_component_requires_diffusers_checkpoint_name[None-no AVAE sound tokenizer checkpoint] PASSED [ 61%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_default_component_requires_diffusers_checkpoint_name[model.safetensors-diffusion_pytorch_model.safetensors] PASSED [ 63%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_component_config_precedence_and_conflict_detection PASSED [ 64%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_avae_uses_diffusers_decoder_state_dict_layout PASSED [ 66%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_mrope_position_ids_cover_text_video_sound_and_action PASSED [ 67%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[qk_norm_for_diffusion-False] PASSED [ 69%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[qk_norm_for_text-False] PASSED [ 70%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[position_embedding_type-rotary] PASSED [ 72%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[unified_3d_mrope_reset_spatial_ids-False] PASSED [ 73%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[joint_attn_implementation-one_way] PASSED [ 75%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_sharding_offload_and_patch_round_trip_contracts PASSED [ 76%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_prediction FAILED [ 78%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_accepts_transfer_control_latents FAILED [ 80%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_gathers_gen_tokens_before_unpatchify FAILED [ 81%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_and_action_modules_follow_config PASSED [ 83%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs0] PASSED [ 84%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs1] PASSED [ 86%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs2] PASSED [ 87%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_and_action_pack_unpack_validate_shapes PASSED [ 89%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config0-transformer_kwargs0-extra_kwargs0-expected_shapes0] FAILED [ 90%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config1-transformer_kwargs1-extra_kwargs1-expected_shapes1] FAILED [ 92%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_with_sound_ulysses_error_mentions_combined_sequence PASSED [ 93%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_latent_frames_padded_for_sequence_parallel PASSED [ 95%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_compute_rope_freqs_places_text_video_action_and_sound_positions PASSED [ 96%]
tests/model_extras/test_model_extras.py::test_cosmos3_extra_registry_declares_request_and_response_params PASSED [ 98%]
tests/model_extras/test_model_extras.py::test_cosmos3_text_to_image_prompt_builder_selects_image_modality PASSED [100%]

=================================== FAILURES ===================================
FAILED tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_prediction
FAILED tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_accepts_transfer_control_latents
FAILED tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_gathers_gen_tokens_before_unpatchify
FAILED tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config0-transformer_kwargs0-extra_kwargs0-expected_shapes0]
FAILED tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config1-transformer_kwargs1-extra_kwargs1-expected_shapes1]
=========== 5 failed, 60 passed, 27 deselected, 20 warnings in 3.64s ===========
```

</details>




**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
