### PR TITLE
[Skills] Add review-worker-runner skill for worker/model-runner audits

### DIFF
--- a/.claude/skills/readme.md
+++ b/.claude/skills/readme.md
@@ -37,6 +37,11 @@ include:
   local plus CI-like `pytest` commands; see `references/test-routing.md` for
   level-to-command mapping
 - `review-pr`: provides a structured workflow for reviewing pull requests
+- `review-worker-runner`: reviews/audits `vllm_omni/worker/*` (GPU worker + AR/generation
+  model runners) with a fixed set of lenses — upstream-vs-omni fork drift, dead/deprecated
+  code, base↔AR divergent duplicates, model-specific logic that belongs in `OmniModelState`,
+  wrapper-vs-raw model access, silent failures, async/threading correctness, rebase
+  fork-fragility; produces inline `# ISSUE(review):` marks and a type-first rollup audit
 - `vllm-omni-npu-model-runner-upgrade`: upgrades NPU model runners to align with the
   latest vllm-ascend NPUModelRunner
 

--- a/.claude/skills/review-worker-runner/SKILL.md
+++ b/.claude/skills/review-worker-runner/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: review-worker-runner
+description: Review or audit vLLM-Omni worker / model-runner code (vllm_omni/worker/*, platform runner variants). Applies a fixed set of review lenses distilled from prior audits — upstream-vs-omni fork drift, dead/deprecated code, base↔AR divergent duplicates, model-specific logic that belongs in OmniModelState, wrapper-vs-raw model access, silent failures, async/threading correctness, rebase fork-fragility. Use when the user says "review the model runner", "audit gpu_model_runner / gpu_ar_model_runner / the worker", "explain this runner function and flag issues", or asks to mark review findings inline or produce a runner audit.
+---
+
+# Worker / ModelRunner Code Review
+
+Structured review of `vllm_omni/worker/*` (the GPU worker + AR / generation model runners, shared
+`OmniGPUModelRunner` base, connector mixin, memory/payload helpers) and the platform runner variants.
+This skill encodes the recurring findings so every review applies the same lenses and produces a
+consistent, actionable output.
+
+**Three outputs the user typically wants:**
+1. **Inline marks** — annotate findings in-place as `# ISSUE(review): …` (and `# OMNI:` for unmarked
+   fork deltas), keeping the file `py_compile`-clean.
+2. **Rollup audit** — a single markdown file, **type-first**: Level 1 = error type (model-specific
+   issues listed individually), Level 2 = `file:line — description`.
+3. **Refactor design doc** — when a subsystem is tangled enough that the audit isn't the deliverable
+   (e.g. the async-omni-output path), a design that makes it maintainable. Principles that recur:
+   *one behavior, two execution modes* (same builder inline or on a thread); *the boundary is a type,
+   not a convention* (a frozen snapshot dataclass, not a closure); *models declare, the runner
+   decides* (a capability spec + one policy gate); *mechanical moves first, semantic fixes second*,
+   each step shippable and output-hash-verified.
+
+Confirm which (or both) before starting. Default to inline marks when reviewing one function, rollup
+when auditing a whole file/area, a design doc when asked to *fix/refactor* a tangled subsystem.
+
+**Prior-art artifacts** (sample outputs of this skill; keep in sync when re-auditing):
+`worker_runner_audit.md` (type-first rollup) and `async_omni_output_refactor_design.md` (refactor
+design) on branch `dev/worker-runner-audit-comments` of the `tzhouam/vllm-omni` fork.
+
+## Workflow
+
+1. **Read the whole file — do not keyword-grep.** Keyword filters miss inline reviewer comments and
+   real issues. First build the map:
+   - `grep -nE "^    def |^def "` → the function inventory.
+   - `grep -nE "^\s*#"` → the *complete* comment inventory (existing reviewer notes are findings).
+   - Then read each function body.
+2. **Per function, answer four things:** (a) what it does; (b) **upstream fork body or OMNI delta?**;
+   (c) **which model(s) require it?** (text-only pays nothing / it's for talker-MTP / Fish-KV / …);
+   (d) run the lenses below.
+3. **Verify empirically when cheap.** Don't assert "dead"/"over-provisioned"/"never fires" from
+   reading — confirm it: `grep` the field/flag/def across the repo (dead code, dead extension
+   points), or run a small probe (e.g. the FA3 `scheduler_metadata` size claim was proven with a real
+   run + kernel instrumentation). Cite the evidence.
+4. **Mark inline** as `# ISSUE(review): <what> — <why> — <fix>`. Use `# OMNI:` on unmarked fork
+   deltas. After edits, run `<venv>/bin/python -m py_compile <file>` — must stay clean.
+5. **Roll up** into the type-first audit (see `references/reference.md` for the template + the
+   suggested-order footer). Line numbers must match the branch you annotated.
+
+## Priority 0 — correctness bugs outrank cleanups
+
+Real bugs found by these lenses go **first** in any rollup (own section, severity-tagged, "fix + test
+before the cleanup passes"). Patterns that have produced confirmed bugs here:
+- **Off-by-one on a size used as an index**: `x.clamp(max=size)` permits index `size` — OOB for a
+  `size`-wide tensor (valid `0..size-1`). Almost always wants `size - 1`.
+- **Early return shadowing a careful guard**: an unconditional `if not tokens: return` above a
+  nuanced no-tokens block makes the latter unreachable — skipping the DP `_dummy_run(1)` that
+  prevents a `coordinate_batch_across_dp` out-of-sync **hang**, and the `kv_connector_no_forward` path.
+- **Silent wrong-data fallback**: on index-out-of-range return `v[0]` (request 0's payload) instead
+  of raising — ships the wrong request's output with no signal.
+- **In-place mutation of engine-shared state**: mutating `scheduler_output` (e.g.
+  `custom_metadata`) without the `replace()`-copy the ngram path uses — contaminates the
+  engine-core process's copy.
+- **`bool(value)` on a maybe-tensor**: raises "Boolean value of Tensor with more than one element is
+  ambiguous" when a marker is a multi-element tensor/ndarray.
+- **Jointly-constraining asserts**: `assert shape[0]==1` + `assert shape[0]==num_reqs` silently
+  forces `num_reqs==1` — batched requests unsupported on that path with no error; the sibling branch
+  asserting only `len(list)==1` silently **misaligns** payloads for batches.
+- **capture≠replay**: a `_dummy_run` copy missing the base's `has_preprocess` input branch —
+  captures on `input_ids` while runtime feeds `inputs_embeds`.
+
+## The review lenses
+
+Apply all of these to each function. Each = *the tell* → *why it matters* → *fix direction*.
+
+1. **Provenance — upstream fork vs OMNI delta.** Is this block upstream `GPUModelRunner` body or an
+   omni addition? Omni tells: `model_intermediate_buffer`, `make_omni_output`, `talker_mtp`,
+   connector calls, `additional_information`, per-request `model.preprocess`/`postprocess`, hardcoded
+   model names. Upstream tells: `query_start_loc`, `CpuGpuBuffer`, `num_scheduled_tokens`,
+   `cudagraph`, `spec_decode`. **Unmarked deltas are silent fork drift** → mark `# OMNI:` so rebases
+   notice; large fork bodies (`_update_states`, `_dummy_run`, `_preprocess`) need per-delta markers.
+
+2. **Dead code (verify with grep).** Write-only fields (assigned, never read — e.g.
+   `_omni_last_model_output`); uncalled helpers (only the `def` matches — e.g.
+   `_decode_and_store_request_payloads`); **dead extension points** — a `getattr(model, "supports_X",
+   False)` flag *no model declares* (grep the flag across `model_executor/models/` — if absent, the
+   branch is dead, e.g. `_sampled_token_ids_cpu_override`); dead defensive guards (`if callable(x)`
+   where `x` is always a tensor attr — `CpuGpuBuffer.cpu`); unused params.
+
+3. **Deprecated / legacy remnants.** Back-compat aliases (`runtime_additional_information`),
+   deprecated methods still called (`_update_additional_information`,
+   `_merge_additional_information_update`), no-longer-used wire fields (`pooler_output`). The
+   `additional_information` naming is the canonical case — 3 names for one concept; converge on
+   `model_intermediate_buffer` and retire aliases.
+
+4. **Divergent duplicates (base ↔ AR ↔ generation).** Match method names across the 3 runner files;
+   the dangerous copies **differ subtly** (AR's trailing `-1` truncation in
+   `_build_model_sampler_output_token_ids`; AR's `skips_...` short-circuit in
+   `_sampling_metadata_for_model_sampler`; `_dummy_run` ~90% dup). **NamedTuple forks**
+   (`ExecuteModelState`) can't be fixed by inheritance (you cannot extend a `typing.NamedTuple`) — a
+   full copy is unavoidable, so guard it with a field-parity test + `# OMNI:` on added fields, and
+   watch for silent field-order/type drift. Merge target: the `OmniModelState` hook (B-align).
+
+5. **Model-specific logic in the generic runner (the biggest theme — list each individually).**
+   Tells: hardcoded arch strings / allowlists (`_OMNI_CONNECTOR_INIT_ARCHS`); `__class__.__name__ ==
+   "…"` checks (MiMoAudio); model-name-keyed behavior (`qwen3_tts_request_seed`, MammothModa2
+   `generated_len`, `thinker_reply_part_per_request`); the ~30 `getattr(self.model, "<cap>", …)`
+   probes; "Only required by X" comments. Fix: move behind a **model-declared capability on
+   `OmniModelState`** (prefer `get_model_state_cls()` over any arch allowlist). See the model→feature
+   map in `references/reference.md`.
+
+6. **Wrapper vs raw model.** `self.model` may be a `CUDAGraphWrapper`/`UBatchWrapper`.
+   `isinstance` / `supports_X(...)` **must** use `self.get_model()` (unwraps); attr/method access
+   works via `__getattr__` delegation but is inconsistent. Rule: bind `model = self.get_model()` once
+   per function and use it for both the check and the calls.
+
+7. **Silent failures.** `try/except Exception` that logs + drops (prompt_embeds decode swallows a
+   native tensor); `traceback.print_exc()` to stdout (use `logger.exception`); `getattr` fallbacks
+   that silently skip real work. Ask: *does swallowing this hide a bug?* If yes → narrow the except /
+   raise.
+
+8. **Fork-fragility (rebase hazards).** Code that silently no-ops or breaks when upstream shifts:
+   `getattr` on `input_batch`/`model_config` internals (renamed attr → silent skip of backfill,
+   etc.); `dataclasses.replace` assuming a type stays a dataclass; `self.pin_memory` coupling
+   assuming base reads it; imports of upstream modules that may not exist
+   (`vllm.compilation.breakable_cudagraph`); **stale over-provisioning** from an old upstream formula
+   (FA3 `scheduler_metadata` resize) — verify empirically. Mark `# OMNI:`.
+
+9. **Async / threading correctness.** Event recorded but never waited
+   (`async_copy_ready_event.record()` with no reader `.synchronize()`); daemon thread started in
+   `__init__` (a background exception only surfaces if the result is awaited — dropped object
+   swallows it; at minimum `logger.exception` in the thread); `non_blocking=True` D2H copies read
+   before completion; `torch.Event()` vs `torch.cuda.Event()` device backing. Ask: *who
+   synchronizes, and does every reader wait first?*
+   **Deferred-builder anti-patterns** (the async-omni-output cluster; full treatment in the
+   `async_omni_output_refactor_design.md` prior-art doc):
+   - *Implicit snapshot boundary* — a closure capturing N locals encodes "everything the background
+     thread reads must be frozen" as convention; a missed copy compiles fine and races silently.
+     Fix: a frozen snapshot dataclass + one `capture()`.
+   - *Cross-thread live-state access* — trace the whole deferred call graph for reads/writes of
+     `self.requests` / `input_batch` / `model_intermediate_buffer` / connector state
+     (`accumulate_full_payload_output`). Verify per site whether it's main-thread-only (check actual
+     callers — don't assume) or a real race; resolve at capture time or assert unreachable.
+   - *Dual-mode function with an implicit contract* — same body runs inline (sync) and on a thread
+     (async) with mode differences as scattered `if`s; nothing enforces "async reads only frozen
+     args". One builder + typed snapshot + mode asserts (e.g. `async ⇒ no prefix cache`).
+   - *Clone-before-copy* — CUDA-graph output buffers are reused by step N+1; payloads must be
+     `clone()`d on the producing stream before the copy stream D2H-copies them.
+   - *Eager side-effects can't defer* — postprocess that writes cross-step state
+     (`hidden_states['last']`) must run on the hot path before snapshotting; only pure output
+     assembly may defer (`postprocess_already_applied` travels in the snapshot).
+
+10. **Implicit cross-phase state.** Instance attrs written in `_preprocess` and read later in
+    `sample_tokens`/`_build_model_kwargs_extra` (`_omni_num_scheduled_tokens_np`) → should be
+    `ExecuteModelState` fields, not mutable attrs. Base methods reaching **subclass-only** attrs via
+    `hasattr` (`_downstream_payload_cache`, "only appears on the AR runner") → layering smell; own the
+    lifecycle in one place (`OmniModelState.remove_request`).
+
+11. **Naming / docstring / type-hint drift.** Stale docstrings ("Align with v0.14.0"); wrong return
+    annotations (`-> dict` returns a tuple; `-> dict[str,dict]` returns `None`); `object` where
+    `torch.Tensor` is meant; misleading names (`_collect_additional_information_for_prefill` that only
+    overlays prompt_embeds).
+
+12. **Style / structure.** `*args/**kwargs` + `kwargs.pop(...)` + `if kwargs: raise` (make the
+    signature explicit — this also restores type-checking); imports-inside-functions — **distinguish**
+    a deliberate lazy-dep (keep: `fish_kvcache_backend`, `breakable_cudagraph`) from a hoistable
+    import-safe one (hoist: `ray_utils`, `RoutedExpertsLists`); over-long functions (`_update_states`,
+    `_dummy_run` — split); inner-helper closures ("no inner helper" — make a method); fragile
+    `**kwargs` unpack with key-exclusion hacks.
+
+13. **Test coverage.** Flag untested modules (`base.py`, `memory_utils.py`, `payload_span.py` have no
+    direct unit tests) — "add L1 CPU characterization tests before any refactor that moves them."
+    Otherwise everything in `tests/worker/` is CPU-only L1/L2.
+
+14. **CUDA-graph capture == replay contract.** The `has_preprocess` buffer path in `_dummy_run` must
+    mirror `_preprocess` (same fixed persistent buffers, sized to `max(max_num_reqs,
+    max_cudagraph_capture_size)`) — capture and replay must read the same addresses. A change to one
+    without the other is a silent capture≠runtime bug.
+
+15. **Subsystem-level redundancy.** Beyond dead functions, ask whether a *whole subsystem's premise*
+    still holds. Method: find the original justification (git log / PR / rebase notes) → check whether
+    upstream or the orchestrator has since absorbed it → if plausible, list the investigation steps
+    and the full removal cluster rather than keeping it by inertia. Known candidates: cross-stage
+    `prompt_embeds` decode+overlay (upstream `EngineCoreRequest` now carries `prompt_embeds`
+    natively); per-process NVML memory estimation (only earns its keep if stages still init in
+    parallel on one device — check orchestrator + measure init cost). File these as
+    "Possibly-redundant subsystem: <name>" with numbered investigation questions.
+
+16. **Misplaced code units.** Free functions and dataclasses defined inside a runner module
+    (payload helpers `_to_cpu_contiguous`/`_ensure_tensor_values`/…, `ExecuteModelState`,
+    `OmniAsyncGPUModelRunnerOutput`, snapshot types) → move to `utils` / a neutral data module.
+    This also fixes backwards imports (generation runner importing from the AR runner).
+
+## Output conventions
+
+- **Inline:** `# ISSUE(review): <defect> — <why it matters> — <fix direction>`. For fork deltas that
+  should survive rebases: `# OMNI: <what and why>`. One concern per comment; keep the file parsing.
+- **Rollup audit:** type-first (see `references/reference.md`). Level 1 = error type; **model-specific
+  types listed individually** (talker-MTP, Fish-KV, GLM-Image, Higgs, MammothModa2, MiMoAudio,
+  connector-allowlist, capability-probes — each its own `##`). Level 2 = `file:line — description`.
+  End with a suggested order (quick wins now → investigate → B-align structural).
+- **The B-align through-line:** most structural findings (duplicates + model-specific) converge on
+  extracting model logic into a v1 `OmniModelState` that mirrors `worker_v2/OmniModelState` — call
+  that out as the destination rather than proposing ad-hoc fixes.
+
+See `references/reference.md` for: the model→feature map, the capability-probe catalogue, the key-file
+roles, upstream-vs-omni tells, known gotchas, and the audit template.

--- a/.claude/skills/review-worker-runner/references/reference.md
+++ b/.claude/skills/review-worker-runner/references/reference.md
@@ -1,0 +1,187 @@
+# Worker / ModelRunner Review — reference
+
+Supporting material for the `review-worker-runner` skill.
+
+## Key files & roles
+
+| File | Role | Notes |
+| --- | --- | --- |
+| `worker/base.py` | `OmniGPUWorkerBase` — per-process NVML memory accounting, sleep/wake + CuMem, profiler | **no unit tests** |
+| `worker/mixins.py` | `OmniWorkerMixin` — loads omni plugins in worker processes | |
+| `worker/gpu_ar_worker.py`, `gpu_generation_worker.py` | worker `init_device` + `self.model_runner = …` | |
+| `worker/gpu_model_runner.py` | `OmniGPUModelRunner(GPUModelRunner)` — shared services (M-RoPE, prompt-embeds overlay, `model_intermediate_buffer`, pre/postprocess hooks, talker-MTP, Fish-KV, `_dummy_run`) | ~2145 L; the shared base — cleanups here propagate to NPU for free |
+| `worker/gpu_ar_model_runner.py` | `GPUARModelRunner` — two-phase execute/sample, output build, async output, prefix cache, KV-transfer. Also `ExecuteModelState`, `OmniAsyncGPUModelRunnerOutput`, `_ensure_tensor_values` | |
+| `worker/gpu_generation_model_runner.py` | `GPUGenerationModelRunner` — non-AR (code2wav) two-phase flow | **imports `ExecuteModelState` from the AR runner → backwards coupling** |
+| `worker/omni_connector_model_runner_mixin.py` | connector data plane (recv threads, payload cache, KV transfer, async chunk) | **OUT OF SCOPE** — OmniConnector owners |
+| `worker/gpu_memory_utils.py` | NVML per-process memory helpers | |
+| `worker/memory_utils.py`, `worker/payload_span.py` | `request_memory_tolerant`; span helpers | **no unit tests** |
+| `utils/mm_outputs.py` | `partition_payload_list`, `build_mm_cpu` | correctly shared GPU+NPU — keep single-source |
+| `platforms/xpu/worker/*` | 19-line clean subclasses of the GPU runners | |
+| `platforms/npu/worker/*` | diverged parallel hierarchy (~0.16 similarity) | OUT OF SCOPE (npu-upgrade skill) |
+
+Two-phase flow (both upstream **and** omni): `execute_model()` runs forward, returns `None`, stores
+an `ExecuteModelState`; `sample_tokens()` reads it, samples, builds output. Don't claim omni "added"
+two-phase — it didn't.
+
+## Model → feature map (which model needs the model-specific code)
+
+| Feature / code | Gating signal | Model(s) |
+| --- | --- | --- |
+| talker-MTP (`_init_talker_mtp`, `_talker_mtp_forward`, AR graph capture) | `talker_mtp` / `talker` / `talker_mtp_graph_safe` | fish_speech, qwen3_tts, qwen3_omni |
+| Fish-KV attention extensions (`_maybe_attach_attention_metadata_extensions`, `_prewarm_attention_capture_workspaces`) | Fish-KV attention backend | fish_speech (fish-kv) |
+| GLM-Image M-RoPE decode fixup (`_calc_mrope_positions`, `_fixup_precomputed_mrope_decode_positions`) | `precomputed_mrope_decode` | glm_image_ar |
+| Higgs `omni_query_start_loc` | `supports_omni_query_start_loc` | higgs_audio_v3_talker |
+| MammothModa2 `generated_len` (image-grid EOL constraint) | (injected for all; only it consumes) | mammoth_moda2 |
+| MiMoAudio req-infos | `__class__.__name__ == "MiMoAudioForConditionalGeneration"` | mimo_audio |
+| `qwen3_tts_request_seed` | `sampling_params.extra_args["qwen3_tts_request_seed"]` | qwen3_tts |
+| custom-sampler decode history (`_build_model_sampler_output_token_ids`, `_sampling_metadata_for_model_sampler`) | `prefer_model_sampler` | cosyvoice3, higgs_audio3, hunyuanimage3, glm_tts |
+| force `output_token_ids` tracking (`_maybe_enable_output_token_ids_for_model_sampler`) | `prefer_model_sampler` + `logitsprocs_need_output_token_ids` | hunyuan_image3 |
+| connector init allowlist (`_OMNI_CONNECTOR_INIT_ARCHS`) | `model_config.model_arch` ∈ set | Qwen3OmniMoe, Qwen2_5Omni, CovoAudio, MiMoAudioModel, Qwen3TTSTalker, Qwen3TTSCode2Wav, CosyVoice3, DyninOmni — **AR**: +IndexTTS2Talker; **generation**: +IndexTTS2S2MelDecoder (divergent!) |
+
+## Capability-probe catalogue (~30 `getattr/hasattr(self.model, …)`)
+
+These are the scattered probes that B-align consolidates into a declared capability object on
+`OmniModelState`. Inputs/preprocess: `has_preprocess`, `preprocess_batch`, `preprocess_decode_batch`,
+`prepare_runner_inputs`. Outputs/postprocess: `has_postprocess`, `postprocess_uses_hidden_states`,
+`postprocess_uses_multimodal_outputs`, `postprocess_uses_req_infos`, `make_omni_output`,
+`gpu_resident_buffer_keys`. Sampler: `prefer_model_sampler`, `sample`,
+`skips_model_sampler_output_token_history`, `logitsprocs_need_output_token_ids`. Positions:
+`supports_mrope`, `precomputed_mrope_decode`, `supports_omni_query_start_loc`,
+`supports_omni_decode_step_metadata`. Talker-MTP: `talker_mtp`, `talker`, `talker_mtp_graph_safe`,
+`mtp_hidden_size`. Connector/lifecycle: `flush_pending_metadata`, `on_requests_finished`,
+`get_kv_transfer_metadata`. **Dead:** `supports_sampled_token_ids_cpu_override` (no model declares it).
+
+Rule of thumb: if a probe reads a per-model flag → it's a capability that belongs on the model state;
+if the runner branches on the *result* to run model-specific code → that code belongs behind a hook.
+
+## Upstream-vs-omni tells
+
+- **Upstream vocabulary:** `query_start_loc`, `CpuGpuBuffer` (`.cpu`/`.gpu`/`.np` — `.cpu` is a tensor
+  *attribute*, never callable), `num_scheduled_tokens`, `slot_mappings`, `spec_decode_metadata`,
+  `cudagraph_mode`, `ExecuteModelState`, `inputs_embeds`, `_prepare_inputs`.
+- **Omni deltas:** `model_intermediate_buffer` / `additional_information` / `runtime_additional_information`
+  (same concept, 3 names), `make_omni_output`, `model.preprocess`/`postprocess`, `talker_mtp`,
+  connector (`init_omni_connectors`, `_local_stage_payload_cache`), `OmniKVTransferManager`,
+  `prompt_embeds` cross-stage overlay, hardcoded arch names, `request_token_spans`.
+
+## Async-omni-output pipeline map (PR #4476; qwen3_omni-only)
+
+Two async layers: upstream `AsyncGPUModelRunnerOutput` (sampled-token/logprobs non-blocking D2H) +
+omni's `OmniAsyncGPUModelRunnerOutput` (defers the whole `OmniModelRunnerOutput` build to a daemon
+thread). Flow in `sample_tokens`: ① CPU metadata snapshot (scheduler_output `replace()`-copy,
+req_ids, query_start_loc clone, …) → ② gate `_should_use_async_omni_output()` (async scheduling ∧
+no prefix cache ∧ no spec decode ∧ `async_chunk` ∧ no routed-experts ∧ model flags) → ③ **eager
+postprocess** on live GPU tensors (talker writes `hidden_states['last']` for next step's preprocess
+— cannot defer) → ④ GPU payload snapshot: clone-on-producing-stream → dedicated copy stream D2H →
+event (`_snapshot_tensor_payload_to_cpu_async`) → ⑤ construct async output (starts daemon builder
+thread) → ⑥ `input_batch.set_async_sampled_token_ids(...)` (next step's sampler-history consumer).
+Engine calls `get_output()` → join → re-raise background exception → `super().get_output()`.
+Perf rationale: moves omni output construction off the decode critical path (measured
+`next_cpu_start − prev_gpu_end` p50 from +0.8ms to −0.8ms). Refactor target:
+the `async_omni_output_refactor_design.md` prior-art doc (OmniStepSnapshot / one-builder-two-modes /
+AsyncOutputSpec / worker/output/ package).
+
+## Correctness-bug catalogue (confirmed instances — check for recurrences)
+
+| Pattern | Known instance |
+| --- | --- |
+| `clamp(max=size)` off-by-one (OOB index) | AR `sample_tokens` prompt_token_ids vocab correction |
+| Early return shadows careful no-tokens guard (DP hang + kv_connector_no_forward skipped) | generation `execute_model` |
+| OOB fallback returns `v[0]` (wrong request's payload, silent) | AR `_unwrap_lists` in combined prefix-cache mm payload |
+| In-place mutation of engine-shared `scheduler_output` | AR execute_model `custom_metadata` write (ngram path `replace()`-copies; this doesn't) |
+| `bool(value)` on maybe-tensor crash | AR `_is_sparse_audio_marker` |
+| Joint asserts force `num_reqs==1` / len-1 list misaligns batch | generation `sample_tokens` tensor + list branches |
+| capture≠replay: `_dummy_run` copy missing `has_preprocess` branch | generation `_dummy_run` |
+| Silent KV-transfer-metadata drop (bare `except Exception`) | AR execute_model `get_kv_transfer_metadata` |
+| `None`-fallthrough to default sampler (wrong tokens for custom sampler) | AR `_sample` `prefer_model_sampler` |
+| Stale memoization keyed before data arrives | AR `_request_needs_downstream_stage_payload` (`final_stage_id` None → caches True forever) |
+
+## Known gotchas (verify against these)
+
+- **`typing.NamedTuple` cannot be extended by inheritance** — this is why `ExecuteModelState` is a full
+  copy of upstream's, not a subclass. To reduce drift use composition (wrap upstream's tuple) or a
+  field-parity test; inheritance only works if both become `@dataclass` (upstream won't).
+- **`CpuGpuBuffer.cpu` is a tensor attribute, never callable** — so `if callable(query_start_loc_cpu)`
+  guards are dead.
+- **`get_model()` unwraps `CUDAGraphWrapper`/`UBatchWrapper`; `self.model` relies on `__getattr__`
+  delegation** — `isinstance`/`supports_X` must use `get_model()`.
+- **FA3 `scheduler_metadata` size = `1 + round_up(batch,4)*4`, split-count-independent** (verified by
+  real run) — omni's resize to `max_num_seqs*max_num_splits+1` is a stale v0.16 over-provision (~10×).
+- **`torch.Event()` may be CPU-backed**; upstream async output uses `torch.cuda.Event()` — verify
+  device backing before trusting `.record()`/`.synchronize()` to gate GPU copies.
+- **Async-output ↔ sampler-history coupling:** `OmniAsyncGPUModelRunnerOutput.__init__` writes
+  `sampled_token_ids_cpu` + `async_copy_ready_event` onto `input_batch`; next step
+  `_build_model_sampler_output_token_ids` reads + syncs them. Invisible, untested — move together.
+- **Two-places coupling:** `_OMNI_CONNECTOR_INIT_ARCHS` (runner) **and**
+  `omni_scheduling_coordinator._FULL_PAYLOAD_INPUT_STAGES` must be kept in lock-step — forgetting the
+  latter is a **silent Stage-1 consumer hang**.
+- **CUDA-graph capture == replay:** `_dummy_run` `has_preprocess` buffer path must mirror `_preprocess`.
+- **Deferred-builder thread boundary:** the async output builder runs `_build_omni_model_runner_output_from_snapshot`
+  on a daemon thread — any read of `self.requests`/`input_batch`/`model_intermediate_buffer` or write of
+  connector accumulation state inside its call graph is a potential race. Verify each site's actual
+  callers before claiming a race (e.g. `_resolve_global_request_id` turned out main-thread-only via
+  `execute_model`); the confirmed live access is the `accumulate_full_payload_output` block.
+- **Eager side-effects can't defer:** talker postprocess writes `hidden_states['last']` read by the
+  *next* step's preprocess — it must run before snapshotting; only pure output assembly may defer.
+- **Systemic docstring gap:** ~120 omni-added methods lack docstrings — report as ONE count-per-file
+  sweep item, not per-line findings; keep *wrong* (drifted) docstrings separate as bugs.
+- **Anchor hygiene:** inline comment insertions shift line numbers — after annotating, re-grep every
+  anchor cited in the rollup/design docs and refresh (`grep -oE "file\.py:[0-9]+"` over the doc,
+  verify each against the source).
+
+## Tests & CI
+
+- CPU-only L1/L2 suite in `tests/worker/` (`test_gpu_ar_model_runner.py`,
+  `test_gpu_generation_model_runner.py`, `test_omni_gpu_model_runner.py`, `test_omni_connector_mixin.py`,
+  `test_process_gpu_memory.py`). Markers: `core_model` = L1&L2, `advanced_model` = L3, `full_model` = L4;
+  `omni`/`tts`/`diffusion`. Use the `vllm-omni-test` skill to add coverage.
+- Untested (add characterization tests before refactor): `base.py`, `memory_utils.py`, `payload_span.py`.
+
+## Rollup audit template
+
+```markdown
+# Worker / ModelRunner Audit
+
+**Level 1 = error type** (model-specific issues listed individually). **Level 2 = `file:line` — description.**
+Branch `<branch>`; comments-only, no behaviour change.
+
+## Correctness — <bug class> (severity-tagged, FIRST)
+## Dead / unused code
+- `file:line` — <what> — <verified how> — <fix>.
+## Stale over-provisioned workaround (verified)
+## Deprecated / legacy remnant
+## Possibly-redundant subsystem: <name>
+## Divergent duplicate — needs merge (rfc8 A1)
+## Implicit cross-phase state
+## Base method reaching subclass-only attributes
+## Wrapper-vs-raw model (get_model())
+## Dead defensive guard
+## Silent failure / swallowed exception
+## Async / threading correctness
+## Fork-fragility (rebase hazard)
+## Redundant sync / D2H / perf
+---
+## Model-specific: talker-MTP baked into the generic runner
+## Model-specific: Fish-KV attention …
+## Model-specific: GLM-Image M-RoPE fixup …
+## Model-specific: Higgs omni_query_start_loc …
+## Model-specific: MammothModa2 generated_len …
+## Model-specific: MiMoAudio class-name check …
+## Model-specific: connector arch allowlist (divergent) …
+## Model-specific: scattered getattr(self.model,…) probes …
+---
+## Naming inconsistency (additional_information)
+## Stale / missing docstring
+## Wrong type annotation
+## Import inside function (hoist vs keep-lazy)
+## Unclear signature (*args/**kwargs)
+## Over-long / should-split function
+## Fragile hack
+## Missing tests (untested modules)
+---
+## Suggested order
+1. Now (low risk, CPU-testable): dead/stale, deprecated, dead guard, silent-failure, wrapper-vs-raw,
+   naming/docs/type-hints, non-lazy import hoists. Guard with tests/worker/; add missing char tests first.
+2. Investigate (may unlock large removals): prompt_embeds subsystem; process-level memory estimation.
+3. Structural (MR-V2 / B-align): merge duplicates + evict every Model-specific type into OmniModelState.
+```


### PR DESCRIPTION
## Purpose

Add a Claude Code skill (`.claude/skills/review-worker-runner/`) that encodes the review lenses distilled from a function-by-function audit of `vllm_omni/worker/*` — the shared `OmniGPUModelRunner` base, the AR and generation runners, and the async-omni-output machinery introduced by #4476 — so future reviews of this area apply the same checks and produce consistent output.

What the skill contains:
- **16 review lenses**, each as *tell → why it matters → fix direction*: upstream-vs-omni fork provenance, dead code (verified by grep/probe, never asserted from reading), deprecated remnants, base↔AR divergent duplicates, model-specific logic that belongs behind an `OmniModelState` capability, wrapper-vs-raw model access (`get_model()`), silent failures, rebase fork-fragility, async/threading correctness (deferred-builder anti-patterns: implicit snapshot boundary, cross-thread live-state access, dual-mode functions, clone-before-copy), implicit cross-phase state, CUDA-graph capture==replay, subsystem-level redundancy, misplaced code units, test coverage.
- A **Priority-0 correctness-bug catalogue** — bug patterns this audit actually confirmed (off-by-one `clamp(max=size)`, an early return shadowing the DP no-tokens guard, silent wrong-data fallbacks, in-place mutation of engine-shared `scheduler_output`, `bool(tensor)` crash, capture≠replay `_dummy_run` gap) so recurrences are caught first.
- `references/reference.md`: key-file roles, the model→feature map (which model needs which model-specific code path), the ~30 `getattr(self.model, …)` capability-probe catalogue, an async-omni-output pipeline map, known gotchas, and the type-first rollup-audit template.

The audit and refactor-design documents the skill was exercised on are kept out of this PR; the skill references them as prior-art sample outputs (branch `tzhouam:dev/worker-runner-audit-comments`).

## Test Plan

Docs-only change (skill markdown); no runtime code touched.
- Skill was exercised end-to-end to produce a full worker/runner audit, an async-output refactor design, and inline `# ISSUE(review):` annotations on a working branch (`tzhouam:dev/worker-runner-audit-comments`), with every annotated file kept `py_compile`-clean.
- Verified `.claude/skills/readme.md` index entry matches the skill's scope.

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 9d8089095

## Test Result

N/A (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
