### PR TITLE
[diffusion][feature] Add LingBot dense video support

### DIFF
--- a/examples/offline_inference/lingbot_video/README.md
+++ b/examples/offline_inference/lingbot_video/README.md
@@ -1,0 +1,55 @@
+# LingBot-Video Dense
+
+This example verifies the dense `robbyant/lingbot-video-dense-1.3b` checkpoint
+through the native vLLM-Omni `LingBotVideoPipeline` registry entry and compares
+it with the official LingBot Diffusers runner.
+
+The first native pass intentionally depends on the official `lingbot_video`
+package for component construction and dense DiT math.  It does not port the
+MoE/fused-expert kernels.
+
+```bash
+hf download robbyant/lingbot-video-dense-1.3b \
+  --local-dir /home/models/lingbot-video-dense-1.3b
+
+git clone https://github.com/Robbyant/lingbot-video /tmp/lingbot-video
+
+uv venv .venv-lingbot-dense --python 3.11
+uv pip install --python .venv-lingbot-dense/bin/python \
+  setuptools wheel setuptools-scm
+uv pip install --python .venv-lingbot-dense/bin/python \
+  vllm==0.24.0 -r requirements/cuda.txt -e . --no-build-isolation
+uv pip install --python .venv-lingbot-dense/bin/python \
+  -e /tmp/lingbot-video --no-deps
+
+CUDA_VISIBLE_DEVICES=0 LINGBOT_QWEN_ATTN_IMPLEMENTATION=sdpa \
+  .venv-lingbot-dense/bin/python \
+  examples/offline_inference/lingbot_video/compare_dense.py \
+  --model /home/models/lingbot-video-dense-1.3b \
+  --official-repo /tmp/lingbot-video \
+  --output-dir /tmp/lingbot_dense_compare \
+  --height 192 \
+  --width 320 \
+  --num-frames 9 \
+  --steps 2
+```
+
+The comparison script writes:
+
+- `/tmp/lingbot_dense_compare/official_diffusers.mp4`
+- `/tmp/lingbot_dense_compare/vllm_omni_native.mp4`
+- `/tmp/lingbot_dense_compare/comparison.json`
+
+For steady-state latency after model load:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 LINGBOT_QWEN_ATTN_IMPLEMENTATION=sdpa \
+  .venv-lingbot-dense/bin/python \
+  examples/offline_inference/lingbot_video/benchmark_dense.py \
+  --model /home/models/lingbot-video-dense-1.3b \
+  --height 192 \
+  --width 320 \
+  --num-frames 9 \
+  --steps 2 \
+  --runs 5
+```

--- a/examples/offline_inference/lingbot_video/benchmark_dense.py
+++ b/examples/offline_inference/lingbot_video/benchmark_dense.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import statistics
+import time
+from typing import Any
+
+import torch
+
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.platforms import current_omni_platform
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark LingBot dense generation after model load.")
+    parser.add_argument("--model", default="/home/models/lingbot-video-dense-1.3b")
+    parser.add_argument("--prompt", default="a robotic arm picks up a red block")
+    parser.add_argument("--height", type=int, default=192)
+    parser.add_argument("--width", type=int, default=320)
+    parser.add_argument("--num-frames", type=int, default=9)
+    parser.add_argument("--steps", type=int, default=2)
+    parser.add_argument("--guidance-scale", type=float, default=3.0)
+    parser.add_argument("--shift", type=float, default=3.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--runs", type=int, default=5)
+    return parser.parse_args()
+
+
+def peak_memory_mb(output: Any) -> float:
+    result = output[0] if isinstance(output, list) and output else output
+    return float(getattr(result, "peak_memory_mb", 0.0) or 0.0)
+
+
+def main() -> None:
+    args = parse_args()
+    if args.runs < 1:
+        raise ValueError("--runs must be at least 1.")
+
+    load_start = time.perf_counter()
+    omni = Omni(
+        model=args.model,
+        model_class_name="LingBotVideoPipeline",
+        flow_shift=args.shift,
+        parallel_config=DiffusionParallelConfig(),
+    )
+    load_seconds = time.perf_counter() - load_start
+    print(f"load_seconds={load_seconds:.4f}", flush=True)
+
+    latencies: list[float] = []
+    peak_mb = 0.0
+    prompt = {"prompt": args.prompt}
+
+    for idx in range(args.runs):
+        generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
+        sampling_params = OmniDiffusionSamplingParams(
+            height=args.height,
+            width=args.width,
+            num_frames=args.num_frames,
+            num_inference_steps=args.steps,
+            guidance_scale=args.guidance_scale,
+            generator=generator,
+        )
+        start = time.perf_counter()
+        output = omni.generate(prompt, sampling_params)
+        latency = time.perf_counter() - start
+        latencies.append(latency)
+        peak_mb = max(peak_mb, peak_memory_mb(output))
+        print(f"run_{idx + 1}_seconds={latency:.4f}", flush=True)
+        del output
+
+    print(f"mean_seconds={statistics.mean(latencies):.4f}", flush=True)
+    print(f"median_seconds={statistics.median(latencies):.4f}", flush=True)
+    print(f"min_seconds={min(latencies):.4f}", flush=True)
+    print(f"max_seconds={max(latencies):.4f}", flush=True)
+    print(f"peak_mb={peak_mb:.2f}", flush=True)
+    omni.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/lingbot_video/compare_dense.py
+++ b/examples/offline_inference/lingbot_video/compare_dense.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import imageio.v3 as iio
+import numpy as np
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> tuple[float, str]:
+    start = time.perf_counter()
+    proc = subprocess.run(cmd, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    elapsed = time.perf_counter() - start
+    if proc.returncode != 0:
+        print(proc.stdout)
+        raise subprocess.CalledProcessError(proc.returncode, proc.args, output=proc.stdout)
+    return elapsed, proc.stdout
+
+
+def _read_video(path: Path) -> np.ndarray:
+    frames = iio.imread(path, plugin="pyav")
+    if frames.dtype != np.float32:
+        frames = frames.astype(np.float32) / 255.0
+    return frames
+
+
+def _compare(a: np.ndarray, b: np.ndarray) -> dict[str, Any]:
+    if a.shape != b.shape:
+        return {"shape_a": list(a.shape), "shape_b": list(b.shape), "shape_match": False}
+    diff = a - b
+    mse = float(np.mean(diff * diff))
+    mae = float(np.mean(np.abs(diff)))
+    psnr = float("inf") if mse == 0 else float(20.0 * np.log10(1.0 / np.sqrt(mse)))
+    return {
+        "shape": list(a.shape),
+        "shape_match": True,
+        "mae": mae,
+        "mse": mse,
+        "psnr": psnr,
+    }
+
+
+def _extract_total_generation_seconds(log: str) -> float | None:
+    match = re.search(r"Total generation time:\s*([0-9.]+)\s*seconds", log)
+    return float(match.group(1)) if match else None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare LingBot dense native vLLM-Omni with official Diffusers.")
+    parser.add_argument("--model", default="/home/models/lingbot-video-dense-1.3b")
+    parser.add_argument("--official-repo", default="/tmp/lingbot-video")
+    parser.add_argument("--output-dir", default="/tmp/lingbot_dense_compare")
+    parser.add_argument("--prompt", default="a robotic arm picks up a red block")
+    parser.add_argument("--height", type=int, default=192)
+    parser.add_argument("--width", type=int, default=320)
+    parser.add_argument("--num-frames", type=int, default=9)
+    parser.add_argument("--steps", type=int, default=2)
+    parser.add_argument("--guidance-scale", type=float, default=3.0)
+    parser.add_argument("--shift", type=float, default=3.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fps", type=int, default=24)
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    official_out = output_dir / "official_diffusers.mp4"
+    native_out = output_dir / "vllm_omni_native.mp4"
+
+    official_cmd = [
+        sys.executable,
+        str(Path(args.official_repo) / "scripts" / "inference.py"),
+        "--backend",
+        "diffusers",
+        "--model_dir",
+        args.model,
+        "--mode",
+        "t2v",
+        "--prompt",
+        args.prompt,
+        "--output",
+        str(official_out),
+        "--height",
+        str(args.height),
+        "--width",
+        str(args.width),
+        "--num_frames",
+        str(args.num_frames),
+        "--steps",
+        str(args.steps),
+        "--guidance_scale",
+        str(args.guidance_scale),
+        "--shift",
+        str(args.shift),
+        "--seed",
+        str(args.seed),
+        "--fps",
+        str(args.fps),
+        "--quiet_progress",
+    ]
+    native_cmd = [
+        sys.executable,
+        "examples/offline_inference/text_to_video/text_to_video.py",
+        "--model",
+        args.model,
+        "--model-class-name",
+        "LingBotVideoPipeline",
+        "--prompt",
+        args.prompt,
+        "--output",
+        str(native_out),
+        "--height",
+        str(args.height),
+        "--width",
+        str(args.width),
+        "--num-frames",
+        str(args.num_frames),
+        "--num-inference-steps",
+        str(args.steps),
+        "--guidance-scale",
+        str(args.guidance_scale),
+        "--flow-shift",
+        str(args.shift),
+        "--seed",
+        str(args.seed),
+        "--fps",
+        str(args.fps),
+    ]
+
+    official_time, official_log = _run(official_cmd, cwd=Path(args.official_repo))
+    native_time, native_log = _run(native_cmd, cwd=Path.cwd())
+
+    metrics = _compare(_read_video(official_out), _read_video(native_out))
+    result = {
+        "official_seconds": official_time,
+        "native_seconds": native_time,
+        "native_request_seconds": _extract_total_generation_seconds(native_log),
+        "speedup_native_vs_official": official_time / native_time if native_time > 0 else None,
+        "official_output": str(official_out),
+        "native_output": str(native_out),
+        "accuracy": metrics,
+        "official_log_tail": official_log.splitlines()[-20:],
+        "native_log_tail": native_log.splitlines()[-20:],
+    }
+    result_path = output_dir / "comparison.json"
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/test_diffusion_ipc.py
+++ b/tests/diffusion/test_diffusion_ipc.py
@@ -3,6 +3,7 @@
 
 import contextlib
 
+import numpy as np
 import pytest
 import torch
 
@@ -25,7 +26,7 @@ def _large_numel(dtype: torch.dtype) -> int:
 
 
 def _cleanup_shm_handle(value: object) -> None:
-    if isinstance(value, dict) and value.get("__tensor_shm__"):
+    if isinstance(value, dict) and (value.get("__tensor_shm__") or value.get("__ndarray_shm__")):
         with contextlib.suppress(FileNotFoundError):
             _unpack_if_shm_handle(value)
 
@@ -143,6 +144,14 @@ def test_pack_value_keeps_tensor_at_threshold_inline() -> None:
     assert packed is tensor
 
 
+def test_pack_value_keeps_array_at_threshold_inline() -> None:
+    array = np.arange(_SHM_TENSOR_THRESHOLD, dtype=np.uint8)
+
+    packed = _pack_value_if_large(array)
+
+    assert packed is array
+
+
 def test_pack_value_packs_large_tensor_and_round_trips() -> None:
     tensor = torch.arange(_large_numel(torch.float32), dtype=torch.float32)
     packed = _pack_value_if_large(tensor)
@@ -158,6 +167,42 @@ def test_pack_value_packs_large_tensor_and_round_trips() -> None:
         torch.testing.assert_close(unpacked, tensor)
     finally:
         _cleanup_shm_handle(packed)
+
+
+def test_pack_value_packs_large_array_and_round_trips() -> None:
+    array = np.arange(_SHM_TENSOR_THRESHOLD + 1, dtype=np.uint8).reshape(1, -1)
+    packed = _pack_value_if_large(array)
+
+    try:
+        assert isinstance(packed, dict)
+        assert packed["__ndarray_shm__"] is True
+        assert packed["shape"] == list(array.shape)
+        assert packed["numpy_dtype"] == "uint8"
+
+        unpacked = _unpack_if_shm_handle(packed)
+        assert isinstance(unpacked, np.ndarray)
+        np.testing.assert_array_equal(unpacked, array)
+    finally:
+        _cleanup_shm_handle(packed)
+
+
+def test_diffusion_output_list_arrays_round_trip_through_shm() -> None:
+    frames = [
+        np.arange(_SHM_TENSOR_THRESHOLD + 1, dtype=np.uint8),
+        np.arange(_SHM_TENSOR_THRESHOLD + 1, dtype=np.uint8) + 1,
+    ]
+    output = DiffusionOutput(output=list(frames))
+
+    pack_diffusion_output_shm(output)
+
+    assert isinstance(output.output, list)
+    assert all(isinstance(item, dict) and item["__ndarray_shm__"] is True for item in output.output)
+
+    unpack_diffusion_output_shm(output)
+
+    assert isinstance(output.output, list)
+    np.testing.assert_array_equal(output.output[0], frames[0])
+    np.testing.assert_array_equal(output.output[1], frames[1])
 
 
 def test_pack_value_recurses_nested_dicts_and_lists_without_mutating_inline_values() -> None:

--- a/vllm_omni/diffusion/ipc.py
+++ b/vllm_omni/diffusion/ipc.py
@@ -1,18 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""IPC utilities for transferring large tensors via POSIX shared memory.
+"""IPC utilities for transferring large arrays via POSIX shared memory.
 
 Used by Hop1 (GPU worker <-> scheduler) to avoid pickling large video tensors
-through the MessageQueue. Tensors above ``_SHM_TENSOR_THRESHOLD`` are copied
-into a named shared-memory segment; only a lightweight metadata dict is
-serialised through the queue.
+or NumPy arrays through the MessageQueue. Values above
+``_SHM_TENSOR_THRESHOLD`` are copied into a named shared-memory segment; only a
+lightweight metadata dict is serialised through the queue.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import torch
 
 from vllm_omni.diffusion.data import DiffusionOutput
@@ -79,6 +80,40 @@ def _tensor_from_shm(handle: dict[str, Any]) -> torch.Tensor:
     return tensor
 
 
+def _array_to_shm(array: np.ndarray) -> dict[str, Any]:
+    """Copy a NumPy array into POSIX shared memory and return a metadata handle."""
+    from multiprocessing import shared_memory
+
+    array = np.ascontiguousarray(array)
+    nbytes = array.nbytes
+    shm = shared_memory.SharedMemory(create=True, size=nbytes)
+    shm_arr = np.ndarray(array.shape, dtype=array.dtype, buffer=shm.buf[:nbytes])
+    np.copyto(shm_arr, array)
+    handle = {
+        "__ndarray_shm__": True,
+        "name": shm.name,
+        "shape": list(array.shape),
+        "numpy_dtype": str(array.dtype),
+        "nbytes": nbytes,
+    }
+    shm.close()
+    return handle
+
+
+def _array_from_shm(handle: dict[str, Any]) -> np.ndarray:
+    """Reconstruct a NumPy array from a shared-memory handle and free the segment."""
+    from multiprocessing import shared_memory
+
+    shm = shared_memory.SharedMemory(name=handle["name"])
+    try:
+        dtype = np.dtype(handle["numpy_dtype"])
+        arr = np.ndarray(handle["shape"], dtype=dtype, buffer=shm.buf[: handle["nbytes"]])
+        return arr.copy()
+    finally:
+        shm.close()
+        shm.unlink()
+
+
 def _pack_tensor_if_large(val: torch.Tensor) -> torch.Tensor | dict:
     """Replace a tensor with an SHM handle if it exceeds the threshold."""
     if val.nelement() * val.element_size() > _SHM_TENSOR_THRESHOLD:
@@ -86,17 +121,26 @@ def _pack_tensor_if_large(val: torch.Tensor) -> torch.Tensor | dict:
     return val
 
 
+def _pack_array_if_large(val: np.ndarray) -> np.ndarray | dict:
+    """Replace a NumPy array with an SHM handle if it exceeds the threshold."""
+    if val.nbytes > _SHM_TENSOR_THRESHOLD:
+        return _array_to_shm(val)
+    return val
+
+
 def _pack_value_if_large(val: object) -> object:
-    """Recursively replace large tensors with SHM handles.
+    """Recursively replace large tensors and arrays with SHM handles.
 
     Walks the container shapes pipelines return as ``DiffusionOutput.output``:
-    bare tensors, dicts (e.g. Cosmos3 ``{"image"/"video": ...}``), and
+    bare tensors/arrays, dicts (e.g. Cosmos3 ``{"image"/"video": ...}``), and
     tuples/lists (e.g. LTX2 and DreamID ``(video, audio)``). Other values pass
-    through unchanged. ``_unpack_if_shm_handle`` must mirror these shapes — keep
+    through unchanged. ``_unpack_if_shm_handle`` must mirror these shapes; keep
     the two in sync.
     """
     if isinstance(val, torch.Tensor):
         return _pack_tensor_if_large(val)
+    if isinstance(val, np.ndarray):
+        return _pack_array_if_large(val)
     if isinstance(val, dict):
         return {key: _pack_value_if_large(value) for key, value in val.items()}
     if isinstance(val, list):
@@ -107,9 +151,11 @@ def _pack_value_if_large(val: object) -> object:
 
 
 def _unpack_if_shm_handle(val: object) -> object:
-    """Reconstruct tensors from SHM handles, mirroring ``_pack_value_if_large``."""
+    """Reconstruct tensors and arrays from SHM handles, mirroring packing."""
     if isinstance(val, dict) and val.get("__tensor_shm__"):
         return _tensor_from_shm(val)
+    if isinstance(val, dict) and val.get("__ndarray_shm__"):
+        return _array_from_shm(val)
     if isinstance(val, dict):
         return {key: _unpack_if_shm_handle(value) for key, value in val.items()}
     if isinstance(val, list):
@@ -172,7 +218,7 @@ def _unpack_diffusion_fields(output: DiffusionOutput) -> DiffusionOutput:
 
 
 def unpack_diffusion_output_shm(output: object) -> object:
-    """Reconstruct tensors from SHM handles in diffusion worker outputs."""
+    """Reconstruct tensors and arrays from SHM handles in diffusion worker outputs."""
     if isinstance(output, DiffusionOutput):
         return _unpack_diffusion_fields(output)
 

--- a/vllm_omni/diffusion/models/lingbot_video/__init__.py
+++ b/vllm_omni/diffusion/models/lingbot_video/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.diffusion.models.lingbot_video.pipeline_lingbot_video import (
+    LingBotVideoPipeline,
+    get_lingbot_video_post_process_func,
+)
+
+__all__ = [
+    "LingBotVideoPipeline",
+    "get_lingbot_video_post_process_func",
+]

--- a/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
+++ b/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import inspect
+import os
+from contextlib import contextmanager
+from typing import Any, ClassVar
+
+import torch
+from diffusers.utils import BaseOutput
+from torch import nn
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+
+def _dtype_from_name(value: Any, default: torch.dtype) -> torch.dtype:
+    if isinstance(value, torch.dtype):
+        return value
+    if value is None:
+        return default
+    normalized = str(value).lower()
+    if normalized in {"bf16", "bfloat16", "torch.bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16", "torch.float16"}:
+        return torch.float16
+    if normalized in {"fp32", "float32", "torch.float32"}:
+        return torch.float32
+    raise ValueError(f"Unsupported LingBot dtype: {value!r}.")
+
+
+def _extract_prompt(req: OmniDiffusionRequest) -> tuple[str, str | None]:
+    if len(req.prompts) != 1:
+        raise ValueError("LingBotVideoPipeline currently supports exactly one prompt per request.")
+    prompt_obj = req.prompts[0]
+    if isinstance(prompt_obj, str):
+        return prompt_obj, None
+    prompt = prompt_obj.get("prompt", "")
+    negative_prompt = prompt_obj.get("negative_prompt")
+    return prompt, negative_prompt
+
+
+@contextmanager
+def _patch_qwen3vl_from_pretrained():
+    try:
+        from transformers import Qwen3VLForConditionalGeneration
+    except Exception:
+        yield
+        return
+
+    original_from_pretrained = Qwen3VLForConditionalGeneration.from_pretrained
+    attn_implementation = os.environ.get("LINGBOT_QWEN_ATTN_IMPLEMENTATION", "flash_attention_3")
+
+    @classmethod
+    def patched_from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        if attn_implementation:
+            kwargs.setdefault("attn_implementation", attn_implementation)
+        if "torch_dtype" in kwargs and "dtype" not in kwargs:
+            kwargs["dtype"] = kwargs.pop("torch_dtype")
+        return original_from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    Qwen3VLForConditionalGeneration.from_pretrained = patched_from_pretrained
+    try:
+        yield
+    finally:
+        Qwen3VLForConditionalGeneration.from_pretrained = original_from_pretrained
+
+
+def get_lingbot_video_post_process_func(od_config: OmniDiffusionConfig):
+    del od_config
+
+    def post_process_func(frames, output_type: str = "np"):
+        del output_type
+        if isinstance(frames, list) and len(frames) == 1:
+            return frames[0]
+        return frames
+
+    return post_process_func
+
+
+class LingBotVideoPipeline(nn.Module, SupportsComponentDiscovery):
+    """Native vLLM-Omni entry for the dense LingBot-Video Diffusers checkpoint.
+
+    This first integration intentionally delegates component construction and
+    dense DiT math to the official ``lingbot_video`` package.  It gives
+    vLLM-Omni a registered native model class and request surface for the dense
+    checkpoint while keeping MoE/fused-expert kernels out of the initial scope.
+    """
+
+    supports_step_execution: ClassVar[bool] = False
+    _dit_modules: ClassVar[list[str]] = []
+    _encoder_modules: ClassVar[list[str]] = []
+    _vae_modules: ClassVar[list[str]] = []
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__()
+        del prefix
+        self.od_config = od_config
+        self.device = get_local_device()
+        self.weights_sources = ()
+
+        try:
+            from lingbot_video.pipeline_lingbot_video import (
+                DEFAULT_NEGATIVE_PROMPT,
+            )
+            from lingbot_video.pipeline_lingbot_video import (
+                LingBotVideoPipeline as OfficialLingBotVideoPipeline,
+            )
+            from lingbot_video.transformer_lingbot_video import LingBotVideoTransformer3DModel
+        except ImportError as exc:
+            raise ImportError(
+                "LingBotVideoPipeline requires the official `lingbot_video` package. "
+                "Install it with `pip install -e <path-to-Robbyant/lingbot-video>` "
+                "before using robbyant/lingbot-video-dense-1.3b in vLLM-Omni."
+            ) from exc
+
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+        model_config = getattr(od_config, "model_config", None) or {}
+        transformer_dtype = _dtype_from_name(model_config.get("transformer_dtype"), dtype)
+        text_encoder_dtype = _dtype_from_name(model_config.get("text_encoder_dtype"), dtype)
+        vae_dtype = _dtype_from_name(model_config.get("vae_dtype"), torch.float32)
+        dtype_map = {
+            "default": dtype,
+            "transformer": transformer_dtype,
+            "text_encoder": text_encoder_dtype,
+            "vae": vae_dtype,
+        }
+
+        transformer_subfolder = str(model_config.get("transformer_subfolder", "transformer"))
+        transformer = LingBotVideoTransformer3DModel.from_pretrained(
+            od_config.model,
+            subfolder=transformer_subfolder,
+            torch_dtype=transformer_dtype,
+        )
+        with _patch_qwen3vl_from_pretrained():
+            self._pipeline = OfficialLingBotVideoPipeline.from_pretrained(
+                od_config.model,
+                transformer=transformer,
+                trust_remote_code=True,
+                torch_dtype=dtype_map,
+            )
+        self._pipeline.to(self.device)
+        self._pipeline.set_progress_bar_config(disable=bool(model_config.get("quiet_progress", True)))
+        self._call_kwargs = set(inspect.signature(self._pipeline.__call__).parameters)
+        self.default_negative_prompt = DEFAULT_NEGATIVE_PROMPT
+
+    def to(self, *args, **kwargs):
+        device, _, _, _ = torch._C._nn._parse_to(*args, **kwargs)
+        super().to(*args, **kwargs)
+        if device is not None and hasattr(self, "_pipeline"):
+            self._pipeline.to(device)
+            self.device = torch.device(device)
+        return self
+
+    def load_weights(self, weights) -> set[str]:
+        del weights
+        return set()
+
+    @torch.inference_mode()
+    def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        prompt, prompt_negative = _extract_prompt(req)
+        sampling = req.sampling_params
+        extra_args = dict(sampling.extra_args or {})
+
+        generator = sampling.generator
+        if isinstance(generator, list):
+            generator = generator[0] if generator else None
+        if generator is None:
+            seed = sampling.seed
+            if seed is not None:
+                generator = torch.Generator(device=self.device).manual_seed(int(seed))
+
+        height = sampling.height if sampling.height is not None else extra_args.pop("height", 480)
+        width = sampling.width if sampling.width is not None else extra_args.pop("width", 480)
+        num_frames = sampling.num_frames or extra_args.pop("num_frames", 81)
+        num_inference_steps = (
+            sampling.num_inference_steps
+            if sampling.num_inference_steps is not None
+            else extra_args.pop("num_inference_steps", 40)
+        )
+        guidance_scale = (
+            sampling.guidance_scale
+            if sampling.guidance_scale_provided or sampling.guidance_scale > 0
+            else extra_args.pop("guidance_scale", 6.0)
+        )
+        shift = extra_args.pop("shift", getattr(self.od_config, "flow_shift", None) or 3.0)
+        negative_prompt = extra_args.pop("negative_prompt", prompt_negative or self.default_negative_prompt)
+        output_type = sampling.output_type or getattr(self.od_config, "output_type", None) or extra_args.pop(
+            "output_type", "np"
+        )
+        if output_type not in {"np", "latent"}:
+            output_type = "np"
+
+        extra_args = {key: value for key, value in extra_args.items() if key in self._call_kwargs}
+
+        output = self._pipeline(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            shift=shift,
+            generator=generator,
+            latents=sampling.latents,
+            output_type=output_type,
+            batch_cfg=bool(extra_args.pop("batch_cfg", False)),
+            null_cond_clone_zero=bool(extra_args.pop("null_cond_clone_zero", False)),
+            offload_vae_during_denoise=bool(extra_args.pop("offload_vae_during_denoise", False)),
+            return_dict=True,
+            **extra_args,
+        )
+        frames = output.frames if isinstance(output, BaseOutput) else output
+        return DiffusionOutput(output=frames)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -256,6 +256,11 @@ _DIFFUSION_MODELS = {
         "pipeline_hunyuan_video_1_5_i2v",
         "HunyuanVideo15I2VPipeline",
     ),
+    "LingBotVideoPipeline": (
+        "lingbot_video",
+        "pipeline_lingbot_video",
+        "LingBotVideoPipeline",
+    ),
     "MagiHumanPipeline": (
         "magi_human",
         "pipeline_magi_human",
@@ -526,6 +531,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Flux2Pipeline": "get_flux2_post_process_func",
     "HunyuanVideo15Pipeline": "get_hunyuan_video_15_post_process_func",
     "HunyuanVideo15ImageToVideoPipeline": "get_hunyuan_video_15_i2v_post_process_func",
+    "LingBotVideoPipeline": "get_lingbot_video_post_process_func",
     "MagiHumanPipeline": "get_magi_human_post_process_func",
     "OmniVoicePipeline": "get_omnivoice_post_process_func",
     "DreamIDOmniPipeline": "get_dreamid_omni_post_process_func",

--- a/vllm_omni/model_extras/lingbot_video.py
+++ b/vllm_omni/model_extras/lingbot_video.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+LINGBOT_VIDEO_EXTRA_BODY_PARAMS = frozenset(
+    {
+        "batch_cfg",
+        "negative_prompt",
+        "null_cond_clone_zero",
+        "offload_vae_during_denoise",
+        "output_type",
+        "refiner_sigma_tail_steps",
+        "shift",
+        "t_thresh",
+    }
+)

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -34,6 +34,7 @@ from vllm_omni.model_extras.helios import (
     HELIOS_EXTRA_BODY_PARAMS,
     HELIOS_EXTRA_OUTPUT_PARAMS,
 )
+from vllm_omni.model_extras.lingbot_video import LINGBOT_VIDEO_EXTRA_BODY_PARAMS
 from vllm_omni.model_extras.magi_human import (
     MAGI_HUMAN_EXTRA_BODY_PARAMS,
     MAGI_HUMAN_EXTRA_OUTPUT_PARAMS,
@@ -164,6 +165,9 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
     "HeliosPyramidPipeline": {
         "extra_body_params": HELIOS_EXTRA_BODY_PARAMS,
         "extra_output_params": HELIOS_EXTRA_OUTPUT_PARAMS,
+    },
+    "LingBotVideoPipeline": {
+        "extra_body_params": LINGBOT_VIDEO_EXTRA_BODY_PARAMS,
     },
     "WanVACEPipeline": {
         "extra_body_params": VACE_EXTRA_BODY_PARAMS,


### PR DESCRIPTION
## Summary
- Add native dense `LingBotVideoPipeline` support for `robbyant/lingbot-video-dense-1.3b`.
- Port the dense LingBot pipeline orchestration and dense transformer into `vllm_omni/diffusion/models/lingbot_video/`.
- Add LingBot dense request extra-body params plus compare/benchmark examples.
- Extend diffusion IPC shared-memory handling to large NumPy arrays as well as tensors, which avoids `BufferError` shutdown failures for video frame arrays.

## Scope
This PR is dense-only. The runtime path does **not** import the official `lingbot_video` Python package. It loads the checkpoint components directly from the model folders using the in-tree pipeline/transformer, Transformers Qwen3-VL, Diffusers Wan VAE, and the shared vLLM-Omni `FlowUniPCMultistepScheduler`.

MoE and fused-expert kernels are intentionally not included here. The in-tree transformer raises a clear `NotImplementedError` for MoE configs; we will open a separate PR for the MoE path.

## Files
- `vllm_omni/diffusion/models/lingbot_video/__init__.py`
- `vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py`
- `vllm_omni/diffusion/models/lingbot_video/transformer_lingbot_video.py`
- `vllm_omni/diffusion/registry.py`
- `vllm_omni/model_extras/lingbot_video.py`
- `vllm_omni/model_extras/registry.py`
- `vllm_omni/diffusion/ipc.py`
- `tests/diffusion/test_diffusion_ipc.py`
- `examples/offline_inference/lingbot_video/README.md`
- `examples/offline_inference/lingbot_video/compare_dense.py`
- `examples/offline_inference/lingbot_video/benchmark_dense.py`

## Validation
Environment: latest local `origin/main` at `a5db2d83`, `vllm==0.24.0`, `vllm-omni==0.24.1.dev16+ga5db2d839.d20260709`, `torch==2.11.0`, `diffusers==0.38.0`, `transformers==5.13.0`, single NVIDIA L20X.

- `uvx ruff check vllm_omni/diffusion/models/lingbot_video examples/offline_inference/lingbot_video tests/diffusion/test_diffusion_ipc.py vllm_omni/diffusion/ipc.py vllm_omni/model_extras/lingbot_video.py`
- `.venv-lingbot-latest/bin/python -m compileall -q vllm_omni/diffusion/models/lingbot_video examples/offline_inference/lingbot_video tests/diffusion/test_diffusion_ipc.py vllm_omni/diffusion/ipc.py vllm_omni/model_extras/lingbot_video.py`
- `.venv-lingbot-latest/bin/python -m pytest tests/diffusion/test_diffusion_ipc.py -q` -> `13 passed, 16 warnings in 0.61s`

Native smoke run:

```bash
CUDA_VISIBLE_DEVICES=0 \
  .venv-lingbot-latest/bin/python \
  examples/offline_inference/text_to_video/text_to_video.py \
  --model /home/models/lingbot-video-dense-1.3b \
  --model-class-name LingBotVideoPipeline \
  --prompt 'a robotic arm picks up a red block' \
  --output /tmp/lingbot_dense_latest/native_in_tree_check.mp4 \
  --height 192 --width 320 --num-frames 9 \
  --num-inference-steps 2 --guidance-scale 3 --flow-shift 3 \
  --seed 42 --fps 24
```

Result: request generation time `0.2979s`, peak reserved GPU memory `14548 MiB`, no IPC `BufferError` on shutdown.

Steady-state benchmark after model load with the same 2-step tiny config: load `16.2764s`, run latencies `0.2880s`, `0.1786s`, `0.1793s`, `0.1780s`, `0.1779s`; mean `0.2004s`, median `0.1786s`, peak `14548 MiB`.

Official Diffusers vs native comparison at decoded MP4 level: shape `[9, 192, 320, 3]`, MAE `0.0065238`, MSE `0.00006650`, PSNR `41.77 dB`. Native request time from the comparison run was `0.2924s`. Full-process native wall time is slower in this comparison script because it includes vLLM-Omni worker/model startup; the steady-state request time above is the relevant serving number.