### PR TITLE
[Model] Add Z-Image step execution support

### DIFF
--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -136,7 +136,7 @@ The following tables show which models support each feature:
 | **SenseNova-U1**         |     ❌     |     ✅      |           ❌           |       ✅        |         ✅         |          ❌          |   ❌    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Stable-Diffusion-XL**  |     ❌     |     ❌      |           ✅           |       ✅        |         ✅         |          ❌          |   ✅    |             ✅             |      ✅ (decode)      |       ❌        |        ❌         |
 | **Stable-Diffusion3.5**  |     ❌     |     ✅      |           ❌           |       ✅        |         ✅         |          ❌          |   ❌    |             ✅             |      ✅ (decode)      |       ❌        |        ❌         |
-| **Z-Image**              |     ✅     |     ✅      |           ✅           |       ❓        |   ✅ (TP=2 only)   |          ❌          |   ✅    |             ❌             |      ✅ (decode)      |       ✅        |        ❌         |
+| **Z-Image**              |     ✅     |     ✅      |           ✅           |       ❓        |   ✅ (TP=2 only)   |          ❌          |   ✅    |             ❌             |      ✅ (decode)      |       ✅        |        ✅         |
 | **ERNIE-Image**          |     ❌     |     ✅      |           ✅           |       ❓        |         ✅         |          ❌          |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Cosmos3**              |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |          ❌          |   ✅    |             ✅             |      ✅ (decode)      |       ✅        |        ❌         |
 

--- a/tests/dfx/perf/tests/test_zimage_step_execution_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_zimage_step_execution_vllm_omni.json
@@ -1,0 +1,118 @@
+[
+  {
+    "test_name": "test_zimage_step_execution_baseline_serial",
+    "description": "Z-Image request-level serial baseline",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Tongyi-MAI/Z-Image-Turbo",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "512x512_steps8_t2i_serial",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 8,
+        "num-prompts": 16,
+        "max-concurrency": 1,
+        "warmup-requests": 4,
+        "warmup-concurrency": 1,
+        "warmup-num-inference-steps": 8
+      },
+      {
+        "name": "1024x1024_steps8_t2i_serial",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 8,
+        "num-prompts": 8,
+        "max-concurrency": 1,
+        "warmup-requests": 4,
+        "warmup-concurrency": 1,
+        "warmup-num-inference-steps": 8
+      }
+    ]
+  },
+  {
+    "test_name": "test_zimage_step_execution_batch2",
+    "description": "Z-Image step-wise batching sweep",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Tongyi-MAI/Z-Image-Turbo",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true,
+        "step-execution": true,
+        "max-num-seqs": 2
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "512x512_steps8_t2i_step_batch2",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 8,
+        "num-prompts": [
+          16,
+          32
+        ],
+        "max-concurrency": [
+          1,
+          2
+        ],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 8
+      },
+      {
+        "name": "1024x1024_steps8_t2i_step_batch2",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 1024,
+        "height": 1024,
+        "num-inference-steps": 8,
+        "num-prompts": [
+          8,
+          16
+        ],
+        "max-concurrency": [
+          1,
+          2
+        ],
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 8
+      },
+      {
+        "name": "512x512_steps8_t2i_step_batch2_variable_prompts",
+        "dataset": "custom",
+        "dataset-path-inline": {
+          "type": "jsonl",
+          "content": [
+            {
+              "prompt": "A red fox resting in snow."
+            },
+            {
+              "prompt": "A cinematic wide-angle photograph of a quiet mountain observatory at blue hour, with warm light glowing through tall windows, a detailed brass telescope beneath the open dome, layered clouds below the ridge, subtle stars appearing overhead, realistic stone and metal textures, frost along the railings, and a lone astronomer in a dark coat studying handwritten notes beside the instrument while distant peaks fade into the evening haze."
+            }
+          ]
+        },
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 8,
+        "num-prompts": 32,
+        "max-concurrency": 2,
+        "warmup-requests": 4,
+        "warmup-concurrency": 2,
+        "warmup-num-inference-steps": 8
+      }
+    ]
+  }
+]

--- a/tests/diffusion/models/z_image/test_zimage_attention_mask.py
+++ b/tests/diffusion/models/z_image/test_zimage_attention_mask.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from vllm_omni.diffusion.models.z_image import z_image_transformer
+from vllm_omni.diffusion.models.z_image.z_image_transformer import (
+    ZImageAttention,
+    ZImageTransformerBlock,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _IdentityQKV(nn.Module):
+    num_heads = 1
+    num_kv_heads = 1
+
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return torch.cat([hidden_states, hidden_states, hidden_states], dim=-1), None
+
+
+class _RecordingMaskedAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.masks: list[torch.Tensor | None] = []
+        self.use_ring = False
+        self._no_parallel_strategy = object()
+        self.active_parallel_strategy = self._no_parallel_strategy
+
+    def _get_active_parallel_strategy(self):
+        return self.active_parallel_strategy
+
+    def forward(self, query, key, value, attn_metadata=None):
+        attention_mask = None if attn_metadata is None else attn_metadata.attn_mask
+        self.masks.append(attention_mask)
+        if attention_mask is not None:
+            attention_mask = attention_mask[:, None, None, :]
+
+        output = F.scaled_dot_product_attention(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            attn_mask=attention_mask,
+        )
+        return output.transpose(1, 2)
+
+
+class _ZeroFeedForward(nn.Module):
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.zeros_like(hidden_states)
+
+
+class _MainTransformerModulation(nn.Module):
+    def forward(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        zeros = torch.zeros_like(adaln_input)
+        return torch.cat([zeros, torch.ones_like(adaln_input), zeros, zeros], dim=-1)
+
+
+def _make_attention() -> ZImageAttention:
+    attention = ZImageAttention.__new__(ZImageAttention)
+    nn.Module.__init__(attention)
+    attention.head_dim = 4
+    attention.to_qkv = _IdentityQKV()
+    attention.norm_q = nn.Identity()
+    attention.norm_k = nn.Identity()
+    attention.rope = object()
+    attention.attn = _RecordingMaskedAttention()
+    attention.to_out = nn.ModuleList([nn.Identity()])
+    return attention
+
+
+def _make_block(*, modulation: bool) -> ZImageTransformerBlock:
+    block = ZImageTransformerBlock.__new__(ZImageTransformerBlock)
+    nn.Module.__init__(block)
+    block.modulation = modulation
+    block.attention = _make_attention()
+    block.feed_forward = _ZeroFeedForward()
+    block.attention_norm1 = nn.Identity()
+    block.attention_norm2 = nn.Identity()
+    block.ffn_norm1 = nn.Identity()
+    block.ffn_norm2 = nn.Identity()
+    if modulation:
+        block.adaLN_modulation = _MainTransformerModulation()
+    return block
+
+
+@pytest.mark.parametrize(
+    "modulation",
+    [
+        pytest.param(False, id="context-refiner"),
+        pytest.param(True, id="main-transformer"),
+    ],
+)
+def test_valid_tokens_are_invariant_to_other_prompt_padding(monkeypatch, modulation: bool):
+    """A short sample must not attend to padding introduced by a longer peer."""
+    monkeypatch.setattr(
+        z_image_transformer,
+        "apply_rope_to_qk",
+        lambda _rope, query, key, _freqs: (query, key),
+    )
+    block = _make_block(modulation=modulation)
+
+    short = torch.tensor([[[1.0, 0.5, 0.25, 0.75], [0.5, 1.0, 0.75, 0.25], [0.25, 0.75, 1.0, 0.5]]])
+    valid_length = short.shape[1]
+    padded_length = 6
+    padded_short = torch.cat(
+        [short, torch.full((1, padded_length - valid_length, short.shape[-1]), 10.0)],
+        dim=1,
+    )
+    long_peer = torch.linspace(0.1, 2.4, padded_length * short.shape[-1]).reshape(1, padded_length, short.shape[-1])
+    batched = torch.cat([padded_short, long_peer], dim=0)
+
+    single_mask = torch.ones((1, valid_length), dtype=torch.bool)
+    batched_mask = torch.tensor(
+        [
+            [True, True, True, False, False, False],
+            [True, True, True, True, True, True],
+        ]
+    )
+    single_rope = torch.zeros((1, valid_length, 1))
+    batched_rope = torch.zeros((2, padded_length, 1))
+    single_adaln = torch.zeros((1, short.shape[-1])) if modulation else None
+    batched_adaln = torch.zeros((2, short.shape[-1])) if modulation else None
+
+    single_output = block(short, single_mask, single_rope, single_rope, single_adaln)
+    batched_output = block(batched, batched_mask, batched_rope, batched_rope, batched_adaln)
+
+    torch.testing.assert_close(batched_output[0, :valid_length], single_output[0])
+    recorded_masks = block.attention.attn.masks
+    assert len(recorded_masks) == 2
+    assert all(mask is not None and mask.ndim == 2 for mask in recorded_masks)
+    assert torch.equal(recorded_masks[0], single_mask)
+    assert torch.equal(recorded_masks[1], batched_mask)
+
+
+def test_variable_padding_mask_rejects_active_ring_attention(monkeypatch):
+    monkeypatch.setattr(
+        z_image_transformer,
+        "apply_rope_to_qk",
+        lambda _rope, query, key, _freqs: (query, key),
+    )
+    attention = _make_attention()
+    attention.attn.use_ring = True
+    attention.attn.active_parallel_strategy = object()
+
+    hidden_states = torch.ones((2, 4, 4))
+    attention_mask = torch.tensor(
+        [
+            [True, True, False, False],
+            [True, True, True, True],
+        ]
+    )
+    rope = torch.zeros((2, 4, 1))
+
+    with pytest.raises(ValueError, match="not supported with ring sequence parallelism"):
+        attention(hidden_states, attention_mask, rope, rope)

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -1033,6 +1033,167 @@ class TestSupportedPipelines:
         assert supports_step_execution(pipeline) is True
         assert isinstance(pipeline, SupportsStepExecution) is True
 
+    def test_z_image_supports_step_execution(self):
+        from vllm_omni.diffusion.models.interface import SupportsStepExecution, supports_step_execution
+        from vllm_omni.diffusion.models.z_image.pipeline_z_image import ZImagePipeline
+
+        # Avoid loading model weights; protocol membership depends on the class contract.
+        pipeline = object.__new__(ZImagePipeline)
+
+        assert pipeline.supports_step_execution is True
+        assert supports_step_execution(pipeline) is True
+        assert isinstance(pipeline, SupportsStepExecution) is True
+
+
+@pytest.mark.cpu
+class TestZImageStepExecution:
+    """CPU-only regressions for Z-Image request-local CFG metadata."""
+
+    @staticmethod
+    def _make_state(
+        request_id: str,
+        *,
+        timestep: float,
+        cfg_truncation: float | None,
+        cfg_normalization: float,
+    ) -> StepRequestState:
+        sampling = OmniDiffusionSamplingParams(guidance_scale=2.0)
+        state = StepRequestState(request_id=request_id, sampling=sampling, prompt="prompt")
+        state.latents = torch.zeros((1, 1, 1, 1), dtype=torch.float32)
+        state.timesteps = torch.tensor([timestep], dtype=torch.float32)
+        state.guidance = torch.tensor([2.0], dtype=torch.float32)
+        state.do_true_cfg = True
+        state.extra["z_image_cfg_normalization"] = torch.tensor([cfg_normalization], dtype=torch.float32)
+        state.extra["z_image_cfg_truncation"] = cfg_truncation
+        state.extra["z_image_guidance_scale"] = 2.0
+        state.extra["z_image_normalized_timesteps"] = [(1000 - timestep) / 1000]
+        state.extra["z_image_output_type"] = "pil"
+        return state
+
+    @staticmethod
+    def _make_input_batch(states: list[StepRequestState]) -> SimpleNamespace:
+        batch_size = len(states)
+        return SimpleNamespace(
+            latents=torch.cat([state.latents for state in states], dim=0),
+            timesteps=torch.stack([state.timesteps[0] for state in states]),
+            prompt_embeds=torch.zeros((batch_size, 1, 1), dtype=torch.float32),
+            prompt_embeds_mask=torch.ones((batch_size, 1), dtype=torch.bool),
+            negative_prompt_embeds=torch.zeros((batch_size, 1, 1), dtype=torch.float32),
+            negative_prompt_embeds_mask=torch.ones((batch_size, 1), dtype=torch.bool),
+            guidance=torch.tensor([2.0] * batch_size, dtype=torch.float32),
+            do_true_cfg=True,
+            states=states,
+        )
+
+    @staticmethod
+    def _make_pipeline(transformer):
+        from vllm_omni.diffusion.models.z_image.pipeline_z_image import ZImagePipeline
+
+        pipeline = object.__new__(ZImagePipeline)
+        torch.nn.Module.__init__(pipeline)
+        pipeline.od_config = SimpleNamespace(dtype=torch.float32)
+        pipeline.transformer = transformer
+        return pipeline
+
+    def test_prepare_encode_preserves_disabled_cfg_truncation(self, mocker: MockerFixture):
+        from vllm_omni.diffusion.models.z_image.pipeline_z_image import ZImagePipeline
+
+        pipeline = object.__new__(ZImagePipeline)
+        torch.nn.Module.__init__(pipeline)
+        pipeline.scheduler = SimpleNamespace()
+        context = {
+            "prompt_embeds": [torch.zeros((2, 3), dtype=torch.float32)],
+            "negative_prompt_embeds": [torch.zeros((2, 3), dtype=torch.float32)],
+            "latents": torch.zeros((1, 1, 1, 1), dtype=torch.float32),
+            "timesteps": torch.tensor([800.0, 200.0]),
+            "do_classifier_free_guidance": True,
+            "guidance_scale": 2.0,
+            "cfg_normalization": 0.5,
+            "cfg_truncation": None,
+            "output_type": "latent",
+        }
+        mocker.patch.object(pipeline, "_prepare_generation_context", return_value=context)
+        state = StepRequestState(
+            request_id="req-none-truncation",
+            sampling=OmniDiffusionSamplingParams(guidance_scale=2.0),
+            prompt="prompt",
+        )
+
+        pipeline.prepare_encode(state)
+
+        assert state.extra["z_image_cfg_truncation"] is None
+        assert state.extra["z_image_guidance_scale"] == 2.0
+        assert state.extra["z_image_normalized_timesteps"] == pytest.approx([0.2, 0.8])
+
+    def test_prepare_encode_normalizes_late_i2i_latents_to_fp32(self, mocker: MockerFixture):
+        from vllm_omni.diffusion.models.z_image.pipeline_z_image import ZImagePipeline
+
+        pipeline = object.__new__(ZImagePipeline)
+        torch.nn.Module.__init__(pipeline)
+        pipeline.scheduler = SimpleNamespace()
+        context = {
+            "prompt_embeds": [torch.zeros((2, 3), dtype=torch.bfloat16)],
+            "negative_prompt_embeds": [],
+            "latents": torch.zeros((1, 1, 1, 1), dtype=torch.bfloat16),
+            "timesteps": torch.tensor([800.0, 200.0]),
+            "do_classifier_free_guidance": False,
+            "guidance_scale": 0.0,
+            "cfg_normalization": False,
+            "cfg_truncation": 1.0,
+            "output_type": "latent",
+        }
+        mocker.patch.object(pipeline, "_prepare_generation_context", return_value=context)
+        states = [
+            StepRequestState(
+                request_id=request_id,
+                sampling=OmniDiffusionSamplingParams(guidance_scale=0.0),
+                prompt="prompt",
+            )
+            for request_id in ("running-i2i", "new-i2i")
+        ]
+
+        pipeline.prepare_encode(states[0])
+        states[0].step_index = 1
+        states[0].latents = states[0].latents.float()
+        pipeline.prepare_encode(states[1])
+
+        assert all(state.latents.dtype == torch.float32 for state in states)
+        batch = InputBatch.make_batch(states)
+        assert batch.latents.dtype == torch.float32
+        assert batch.latents.shape[0] == 2
+
+    def test_denoise_applies_mixed_row_cfg_on_device(self, mocker: MockerFixture):
+        states = [
+            self._make_state("active-normalized", timestep=800.0, cfg_truncation=0.5, cfg_normalization=0.5),
+            self._make_state("active-untruncated", timestep=200.0, cfg_truncation=None, cfg_normalization=0.0),
+            self._make_state("truncated", timestep=200.0, cfg_truncation=0.5, cfg_normalization=0.5),
+        ]
+        positive = [torch.full((1, 1, 1, 1), 2.0) for _ in states]
+        negative = [torch.full((1, 1, 1, 1), 1.0) for _ in states]
+        transformer = mocker.Mock(return_value=(positive + negative,))
+        pipeline = self._make_pipeline(transformer)
+
+        output = pipeline.denoise_step(self._make_input_batch(states))
+
+        torch.testing.assert_close(output.flatten(), torch.tensor([-1.0, -4.0, -2.0]))
+        latent_model_input = transformer.call_args.args[0]
+        assert len(latent_model_input) == 2 * len(states)
+
+    def test_denoise_skips_negative_branch_when_all_rows_are_truncated(self, mocker: MockerFixture):
+        states = [
+            self._make_state("truncated-1", timestep=200.0, cfg_truncation=0.5, cfg_normalization=0.5),
+            self._make_state("truncated-2", timestep=100.0, cfg_truncation=0.5, cfg_normalization=0.5),
+        ]
+        positive = [torch.full((1, 1, 1, 1), 2.0) for _ in states]
+        transformer = mocker.Mock(return_value=(positive,))
+        pipeline = self._make_pipeline(transformer)
+
+        output = pipeline.denoise_step(self._make_input_batch(states))
+
+        torch.testing.assert_close(output.flatten(), torch.tensor([-2.0, -2.0]))
+        latent_model_input = transformer.call_args.args[0]
+        assert len(latent_model_input) == len(states)
+
 
 @hardware_test(
     res={"cuda": "L4"},

--- a/tests/e2e/online_serving/test_zimage_expansion.py
+++ b/tests/e2e/online_serving/test_zimage_expansion.py
@@ -2,13 +2,14 @@
 Tests of common diffusion feature combinations in online serving mode
 for Z-Image.
 
-Coverage is intentionally limited to the minimal 4xL4 cases that
-exercise Z-Image's supported feature combinations:
+Coverage is intentionally limited to the minimal L4 cases that exercise
+Z-Image's supported feature combinations and step-execution batching:
 - CacheDiT + FP8 + Ring=2 + TP=2
 - TeaCache + FP8 + Ulysses=2 + Ring=2
 - Layerwise CPU offload + Ulysses=2 + Ring=2
 - Layerwise CPU offload + TP=2
 - Layerwise CPU offload + HSDP
+- Step execution with two concurrent, variable-length prompts
 """
 
 import pytest
@@ -20,6 +21,15 @@ pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
 
 MODEL = "Tongyi-MAI/Z-Image-Turbo"
 PROMPT = "A high-detail studio photo of an orange tabby cat sitting on a laptop keyboard."
+STEP_EXECUTION_PROMPTS = [
+    "A red fox resting in fresh snow.",
+    (
+        "A cinematic wide-angle photograph of a quiet mountain observatory at blue hour, "
+        "with warm window light, a detailed brass telescope, layered clouds below the ridge, "
+        "subtle stars appearing overhead, realistic stone textures, and a lone astronomer "
+        "wearing a dark coat beside the open dome."
+    ),
+]
 
 FOUR_CARD_MARKS = hardware_marks(res={"cuda": "L4"}, num_cards=4)
 
@@ -103,6 +113,22 @@ def _get_diffusion_feature_cases():
     ]
 
 
+STEP_EXECUTION_CASE = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            server_args=[
+                "--step-execution",
+                "--max-num-seqs",
+                "2",
+            ],
+        ),
+        id="step_execution_batch2_variable_prompt_lengths",
+        marks=hardware_marks(res={"cuda": "L4"}, num_cards=1),
+    )
+]
+
+
 @pytest.mark.parametrize(
     "omni_server",
     _get_diffusion_feature_cases(),
@@ -126,3 +152,32 @@ def test_zimage(
     }
 
     openai_client.send_diffusion_request(request_config)
+
+
+@pytest.mark.parametrize(
+    "omni_server",
+    STEP_EXECUTION_CASE,
+    indirect=True,
+)
+def test_zimage_step_execution_batches_variable_length_prompts(
+    omni_server: OmniServer,
+    openai_client: OpenAIClientHandler,
+):
+    """Send two distinct prompt lengths concurrently through one step batch."""
+    request_configs = [
+        {
+            "model": omni_server.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "extra_body": {
+                "height": 512,
+                "width": 512,
+                "num_inference_steps": 2,
+                "seed": 42 + request_idx,
+            },
+        }
+        for request_idx, prompt in enumerate(STEP_EXECUTION_PROMPTS)
+    ]
+
+    responses = openai_client.send_diffusion_request(request_configs)
+
+    assert len(responses) == 2

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -15,11 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import inspect
 import json
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import PIL.Image
 import torch
@@ -28,6 +29,7 @@ from diffusers.image_processor import VaeImageProcessor
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from diffusers.utils import logging
 from diffusers.utils.torch_utils import randn_tensor
+from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -47,7 +49,25 @@ from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
 
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.input_batch import InputBatch
+    from vllm_omni.diffusion.worker.utils import StepRequestState
+
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+def _broadcast_rows(tensor: torch.Tensor, num_rows: int, name: str) -> torch.Tensor:
+    """Validate and broadcast a scalar or 1D tensor to ``num_rows`` rows."""
+    if tensor.ndim == 0:
+        tensor = tensor.unsqueeze(0)
+    elif tensor.ndim != 1:
+        raise ValueError(f"{name} must be scalar or 1D, got ndim={tensor.ndim}.")
+
+    if tensor.shape[0] == num_rows:
+        return tensor
+    if tensor.shape[0] == 1:
+        return tensor.expand(num_rows)
+    raise ValueError(f"Expected 1 or {num_rows} values for {name}, got {tensor.shape[0]}.")
 
 
 def get_post_process_func(
@@ -163,6 +183,7 @@ def retrieve_timesteps(
 
 class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery):
     supports_request_batch = False
+    supports_step_execution: ClassVar[bool] = True
 
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
@@ -263,7 +284,11 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
                 negative_prompt = ["" for _ in prompt]
             else:
                 negative_prompt = [negative_prompt] if isinstance(negative_prompt, str) else negative_prompt
-            assert len(prompt) == len(negative_prompt)
+            if len(prompt) != len(negative_prompt):
+                raise ValueError(
+                    "`prompt` and `negative_prompt` must have the same batch size, "
+                    f"but got {len(prompt)} and {len(negative_prompt)}, respectively."
+                )
             negative_prompt_embeds = self._encode_prompt(
                 prompt=negative_prompt,
                 device=device,
@@ -411,26 +436,162 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         return self._interrupt
 
     def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        # Shared setup with the step-execution path lives in
+        # ``_prepare_generation_context`` so request-mode and step-mode do not
+        # drift.  ``forward`` owns only the per-step denoise loop + decode.
+        ctx = self._prepare_generation_context(req.prompts, req.sampling_params)
+
+        prompt_embeds = ctx["prompt_embeds"]
+        negative_prompt_embeds = ctx["negative_prompt_embeds"]
+        latents = ctx["latents"]
+        timesteps = ctx["timesteps"]
+        do_classifier_free_guidance = bool(ctx["do_classifier_free_guidance"])
+        guidance_scale = ctx["guidance_scale"]
+        cfg_normalization = ctx["cfg_normalization"]
+        cfg_truncation = ctx["cfg_truncation"]
+        output_type = ctx["output_type"]
+        actual_batch_size = ctx["actual_batch_size"]
+        device = self._execution_device
+
+        callback_on_step_end: Callable[[int, int, dict], None] | None = None
+        callback_on_step_end_tensor_inputs = ["latents"]
+
+        # Precompute normalized timesteps once to avoid per-step GPU->CPU sync (.item() causes cudaStreamSynchronize)
+        if isinstance(timesteps, torch.Tensor):
+            timesteps_tensor = timesteps.to(device=device, dtype=torch.float32)
+        else:
+            timesteps_tensor = torch.as_tensor(timesteps, device=device, dtype=torch.float32)
+        norm_timesteps = (1000 - timesteps_tensor) / 1000
+        t_norm_list = norm_timesteps.cpu().tolist()
+        if not isinstance(t_norm_list, list):
+            t_norm_list = [t_norm_list]
+
+        # 6. Denoising loop
+        for i, t in enumerate(timesteps):
+            # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
+            timestep = t.expand(latents.shape[0])
+            timestep = (1000 - timestep) / 1000
+            # Normalized time for time-aware config (0 at start, 1 at end);
+            # use precomputed to avoid .item() sync per step
+            t_norm = t_norm_list[i]
+
+            # Handle cfg truncation
+            current_guidance_scale = guidance_scale
+            if do_classifier_free_guidance and cfg_truncation is not None and float(cfg_truncation) <= 1:
+                if t_norm > cfg_truncation:
+                    current_guidance_scale = 0.0
+
+            # Run CFG only if configured AND scale is non-zero
+            apply_cfg = do_classifier_free_guidance and current_guidance_scale > 0
+            latents_typed = latents.to(self.od_config.dtype)
+
+            if apply_cfg:
+                latent_model_input = latents_typed.repeat(2, 1, 1, 1)
+                prompt_embeds_model_input = prompt_embeds + negative_prompt_embeds
+                timestep_model_input = timestep.repeat(2)
+            else:
+                latent_model_input = latents_typed
+                prompt_embeds_model_input = prompt_embeds
+                timestep_model_input = timestep
+
+            latent_model_input = latent_model_input.unsqueeze(2)
+            latent_model_input_list = list(latent_model_input.unbind(dim=0))
+
+            model_out_list = self.transformer(
+                latent_model_input_list,
+                timestep_model_input,
+                prompt_embeds_model_input,
+            )[0]
+
+            if apply_cfg:
+                # Perform CFG
+                pos_out = model_out_list[:actual_batch_size]
+                neg_out = model_out_list[actual_batch_size:]
+
+                noise_pred = []
+                for j in range(actual_batch_size):
+                    pos = pos_out[j].float()
+                    neg = neg_out[j].float()
+
+                    pred = pos + current_guidance_scale * (pos - neg)
+
+                    # Renormalization (torch.where avoids GPU->CPU sync from Python if/scalar comparison)
+                    if cfg_normalization and float(cfg_normalization) > 0.0:
+                        ori_pos_norm = torch.linalg.vector_norm(pos)
+                        new_pos_norm = torch.linalg.vector_norm(pred)
+                        max_new_norm = ori_pos_norm * float(cfg_normalization)
+                        scale = torch.where(
+                            new_pos_norm > max_new_norm,
+                            (max_new_norm / new_pos_norm.clamp(min=1e-12)).to(pred.dtype),
+                            pred.new_tensor(1.0),
+                        )
+                        pred = pred * scale
+
+                    noise_pred.append(pred)
+
+                noise_pred = torch.stack(noise_pred, dim=0)
+            else:
+                noise_pred = torch.stack([t.float() for t in model_out_list], dim=0)
+
+            noise_pred = noise_pred.squeeze(2)
+            noise_pred = -noise_pred
+
+            # compute the previous noisy sample x_t -> x_t-1
+            latents = self.scheduler.step(noise_pred.to(torch.float32), t, latents, return_dict=False)[0]
+            if latents.dtype != torch.float32:
+                raise ValueError(
+                    "Z-Image scheduler must return FP32 latents to preserve the continuous-batching dtype invariant, "
+                    f"but returned {latents.dtype}."
+                )
+
+            if callback_on_step_end is not None:
+                callback_kwargs = {}
+                for k in callback_on_step_end_tensor_inputs:
+                    callback_kwargs[k] = locals()[k]
+                callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+
+                latents = callback_outputs.pop("latents", latents)
+                prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+        if output_type == "latent":
+            image = latents
+        else:
+            latents = latents.to(self.vae.dtype)
+            latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+
+            image = self.vae.decode(latents, return_dict=False)[0]
+            # image = self.image_processor.postprocess(image, output_type=output_type)
+
+        stage_durations = self.stage_durations if hasattr(self, "stage_durations") else None
+        return DiffusionOutput(output=image, stage_durations=stage_durations)
+
+    def _prepare_generation_context(
+        self,
+        prompts,
+        sampling,
+    ) -> dict[str, Any]:
+        """Prepare step-execution state with the same request setup as forward()."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
         # TODO: May be some data formatting operations on the API side. Hack for now.
-        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts]
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in prompts]
 
-        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
+        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in prompts):
             negative_prompt = None
-        elif req.prompts:
-            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
+        elif prompts:
+            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in prompts]
 
         prompt_embeds = None
         negative_prompt_embeds = None
 
         image = None
-        if req.prompts:
-            if len(req.prompts) > 1:
+        if prompts:
+            if len(prompts) > 1:
                 logger.warning(
                     "This model only supports a single prompt for img2img, not a batched request. "
                     "Taking only the first image for now."
                 )
-            first_prompt = req.prompts[0]
+            first_prompt = prompts[0]
             if not isinstance(first_prompt, str):
                 raw_image = first_prompt.get("multi_modal_data", {}).get("image")
                 if raw_image is not None:
@@ -439,8 +600,8 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
                     else:
                         image = PIL.Image.open(raw_image) if isinstance(raw_image, str) else raw_image
 
-        explicit_strength = req.sampling_params.strength is not None
-        strength = req.sampling_params.strength if explicit_strength else 0.6
+        explicit_strength = sampling.strength is not None
+        strength = sampling.strength if explicit_strength else 0.6
         if explicit_strength and image is None:
             logger.warning(
                 "strength parameter (%.2f) is only applicable for image-to-image (I2I) generation. "
@@ -451,24 +612,18 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         if image is not None and strength is not None and (strength < 0 or strength > 1):
             raise ValueError(f"The value of strength should be in [0.0, 1.0] but is {strength}")
 
-        height = req.sampling_params.height or 1024
-        width = req.sampling_params.width or 1024
-        num_inference_steps = req.sampling_params.num_inference_steps or 50
-        generator = req.sampling_params.generator
-        sigmas = req.sampling_params.sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or 512
-        guidance_scale = req.sampling_params.guidance_scale
-        num_images_per_prompt = (
-            req.sampling_params.num_outputs_per_prompt if req.sampling_params.num_outputs_per_prompt > 0 else 1
-        )
-        latents = req.sampling_params.latents
+        height = sampling.height or 1024
+        width = sampling.width or 1024
+        num_inference_steps = sampling.num_inference_steps or 50
+        generator = sampling.generator
+        sigmas = sampling.sigmas
+        max_sequence_length = sampling.max_sequence_length or 512
+        guidance_scale = sampling.guidance_scale
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        latents = sampling.latents
 
-        cfg_normalization = req.sampling_params.cfg_normalize
-        cfg_truncation = req.sampling_params.extra_args.get("cfg_truncation", 1.0)
-        joint_attention_kwargs: dict[str, Any] | None = None
-        callback_on_step_end: Callable[[int, int, dict], None] | None = None
-        callback_on_step_end_tensor_inputs = ["latents"]
-        output_type = req.sampling_params.output_type or "pil"
+        cfg_normalization = sampling.cfg_normalize
+        cfg_truncation = sampling.extra_args.get("cfg_truncation", 1.0)
 
         vae_scale = self.vae_scale_factor * 2
         if height % vae_scale != 0:
@@ -484,11 +639,12 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
 
         device = self._execution_device
 
-        self._guidance_scale = guidance_scale
-        self._joint_attention_kwargs = joint_attention_kwargs
-        self._interrupt = False
-        self._cfg_normalization = cfg_normalization
-        self._cfg_truncation = cfg_truncation
+        # NOTE: Intentionally NOT mutating pipeline-level ``self._*`` here.  In
+        # step-mode this method runs once per admitted request, and every write
+        # would race with the previous request under continuous batching.
+        # ``forward`` (request-mode) reads these values from local variables
+        # returned in the ctx dict below.
+        do_classifier_free_guidance = guidance_scale > 0
         # 2. Define call parameters
         batch_size = len(prompt)
 
@@ -498,7 +654,7 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         ) = self.encode_prompt(
             prompt=prompt,
             negative_prompt=negative_prompt,
-            do_classifier_free_guidance=self.do_classifier_free_guidance,
+            do_classifier_free_guidance=do_classifier_free_guidance,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
             device=device,
@@ -577,12 +733,10 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         # Repeat prompt_embeds for num_images_per_prompt
         if num_images_per_prompt > 1:
             prompt_embeds = [pe for pe in prompt_embeds for _ in range(num_images_per_prompt)]
-            if self.do_classifier_free_guidance and negative_prompt_embeds:
+            if do_classifier_free_guidance and negative_prompt_embeds:
                 negative_prompt_embeds = [npe for npe in negative_prompt_embeds for _ in range(num_images_per_prompt)]
 
-        actual_batch_size = batch_size * num_images_per_prompt
-
-        # 5. Prepare timesteps
+        # 5. Prepare timesteps (T2I path only; I2I path resolved them above)
         if image is None:
             image_seq_len = (latents.shape[2] // 2) * (latents.shape[3] // 2)
             mu = calculate_shift(
@@ -603,118 +757,303 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
                 **scheduler_kwargs,
             )
 
-        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
         self._num_timesteps = len(timesteps)
 
-        # Precompute normalized timesteps once to avoid per-step GPU->CPU sync (.item() causes cudaStreamSynchronize)
+        return {
+            "prompt_embeds": prompt_embeds,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "latents": latents,
+            "timesteps": timesteps,
+            "do_classifier_free_guidance": do_classifier_free_guidance,
+            "guidance_scale": guidance_scale,
+            "cfg_normalization": cfg_normalization,
+            "cfg_truncation": cfg_truncation,
+            "output_type": sampling.output_type or "pil",
+            "actual_batch_size": batch_size * num_images_per_prompt,
+        }
+
+    @staticmethod
+    def _prompt_embeds_to_padded(
+        prompt_embeds: list[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        seq_lens = [int(prompt_embed.shape[0]) for prompt_embed in prompt_embeds]
+        padded = pad_sequence(prompt_embeds, batch_first=True, padding_value=0.0)
+        mask = torch.zeros(padded.shape[:2], dtype=torch.bool, device=padded.device)
+        for i, seq_len in enumerate(seq_lens):
+            mask[i, :seq_len] = True
+        return padded, mask, seq_lens
+
+    @staticmethod
+    def _padded_prompt_embeds_to_list(
+        prompt_embeds: torch.Tensor | list[torch.Tensor],
+        prompt_embeds_mask: torch.Tensor | None = None,
+    ) -> list[torch.Tensor]:
+        if isinstance(prompt_embeds, list):
+            return prompt_embeds
+
+        if prompt_embeds.ndim == 2:
+            prompt_embeds = prompt_embeds.unsqueeze(0)
+        if prompt_embeds_mask is not None and prompt_embeds_mask.ndim == 1:
+            prompt_embeds_mask = prompt_embeds_mask.unsqueeze(0)
+
+        embeds_list = []
+        for i in range(prompt_embeds.shape[0]):
+            if prompt_embeds_mask is None:
+                embeds_list.append(prompt_embeds[i])
+            else:
+                embeds_list.append(prompt_embeds[i][prompt_embeds_mask[i].bool()])
+        return embeds_list
+
+    @staticmethod
+    def _extra_row_tensor(
+        states,
+        extra_key: str,
+        *,
+        device: torch.device,
+        none_value: float,
+    ) -> torch.Tensor:
+        """Gather per-request scalar/vector metadata without a device sync.
+
+        Used for per-row broadcast of scalars like ``cfg_normalization``.
+        """
+        values: list[torch.Tensor] = []
+        for state in states:
+            value = state.extra.get(extra_key)
+            row_count = int(state.latents.shape[0])
+            if value is None:
+                value = none_value
+            if isinstance(value, torch.Tensor):
+                row_values = value.detach().to(device=device, dtype=torch.float32)
+            else:
+                row_values = torch.as_tensor(value, device=device, dtype=torch.float32)
+
+            values.append(_broadcast_rows(row_values, row_count, extra_key))
+
+        return torch.cat(values, dim=0)
+
+    @staticmethod
+    def _normalized_timestep_values(
+        timesteps: torch.Tensor | list[torch.Tensor],
+    ) -> list[float]:
+        """Materialize CPU timestep metadata once during request admission."""
         if isinstance(timesteps, torch.Tensor):
-            timesteps_tensor = timesteps.to(device=device, dtype=torch.float32)
+            timestep_tensor = timesteps.detach().to(dtype=torch.float32).reshape(-1)
         else:
-            timesteps_tensor = torch.as_tensor(timesteps, device=device, dtype=torch.float32)
-        norm_timesteps = (1000 - timesteps_tensor) / 1000
-        t_norm_list = norm_timesteps.cpu().tolist()
-        if not isinstance(t_norm_list, list):
-            t_norm_list = [t_norm_list]
+            timestep_tensor = torch.stack(
+                [torch.as_tensor(timestep, dtype=torch.float32) for timestep in timesteps],
+                dim=0,
+            ).reshape(-1)
+        values = ((1000 - timestep_tensor) / 1000).cpu().tolist()
+        return [float(value) for value in values]
 
-        # 6. Denoising loop
-        for i, t in enumerate(timesteps):
-            if self.interrupt:
-                continue
+    @staticmethod
+    def _cfg_active_rows(states) -> list[bool]:
+        """Resolve per-row CFG activity entirely from admission-time CPU metadata."""
+        active_rows: list[bool] = []
+        for state in states:
+            normalized_timesteps = state.extra.get("z_image_normalized_timesteps")
+            if normalized_timesteps is None or state.step_index >= len(normalized_timesteps):
+                raise ValueError(f"Missing normalized timestep metadata for Z-Image request {state.request_id}.")
 
-            # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
-            timestep = t.expand(latents.shape[0])
-            timestep = (1000 - timestep) / 1000
-            # Normalized time for time-aware config (0 at start, 1 at end);
-            # use precomputed to avoid .item() sync per step
-            t_norm = t_norm_list[i]
+            guidance_scale = float(state.extra.get("z_image_guidance_scale", 0.0))
+            cfg_truncation = state.extra.get("z_image_cfg_truncation")
+            if isinstance(cfg_truncation, torch.Tensor):
+                raise ValueError("Z-Image CFG truncation must be stored as CPU metadata.")
 
-            # Handle cfg truncation
-            current_guidance_scale = self.guidance_scale
-            if (
-                self.do_classifier_free_guidance
-                and self._cfg_truncation is not None
-                and float(self._cfg_truncation) <= 1
-            ):
-                if t_norm > self._cfg_truncation:
-                    current_guidance_scale = 0.0
+            active = guidance_scale > 0
+            if cfg_truncation is not None and float(cfg_truncation) <= 1:
+                active = active and normalized_timesteps[state.step_index] <= float(cfg_truncation)
+            active_rows.extend([active] * int(state.latents.shape[0]))
+        return active_rows
 
-            # Run CFG only if configured AND scale is non-zero
-            apply_cfg = self.do_classifier_free_guidance and current_guidance_scale > 0
-            latents_typed = latents.to(self.od_config.dtype)
+    def prepare_encode(
+        self,
+        state: "StepRequestState",
+        **kwargs: Any,
+    ) -> "StepRequestState":
+        del kwargs
+        prompts = [state.prompt] if state.prompt is not None else []
+        ctx = self._prepare_generation_context(prompts, state.sampling)
 
-            if apply_cfg:
-                latent_model_input = latents_typed.repeat(2, 1, 1, 1)
-                prompt_embeds_model_input = prompt_embeds + negative_prompt_embeds
-                timestep_model_input = timestep.repeat(2)
-            else:
-                latent_model_input = latents_typed
-                prompt_embeds_model_input = prompt_embeds
-                timestep_model_input = timestep
+        req_scheduler = copy.deepcopy(self.scheduler)
 
-            latent_model_input = latent_model_input.unsqueeze(2)
-            latent_model_input_list = list(latent_model_input.unbind(dim=0))
+        prompt_embeds, prompt_embeds_mask, txt_seq_lens = self._prompt_embeds_to_padded(ctx["prompt_embeds"])
+        state.prompt_embeds = prompt_embeds
+        state.prompt_embeds_mask = prompt_embeds_mask
+        state.txt_seq_lens = txt_seq_lens
 
-            model_out_list = self.transformer(
-                latent_model_input_list,
-                timestep_model_input,
-                prompt_embeds_model_input,
-            )[0]
+        if ctx["negative_prompt_embeds"]:
+            negative_prompt_embeds, negative_prompt_embeds_mask, negative_txt_seq_lens = self._prompt_embeds_to_padded(
+                ctx["negative_prompt_embeds"]
+            )
+            state.negative_prompt_embeds = negative_prompt_embeds
+            state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
+            state.negative_txt_seq_lens = negative_txt_seq_lens
+        else:
+            state.negative_prompt_embeds = None
+            state.negative_prompt_embeds_mask = None
+            state.negative_txt_seq_lens = None
 
-            if apply_cfg:
-                # Perform CFG
-                pos_out = model_out_list[:actual_batch_size]
-                neg_out = model_out_list[actual_batch_size:]
+        # Keep the persistent step state in the scheduler's FP32 domain. I2I
+        # admission can otherwise produce BF16 latents while an already-running
+        # I2I request has been promoted to FP32 by scheduler.step(), making a
+        # later continuous-batching join fail with mixed latent dtypes.
+        state.latents = ctx["latents"].to(torch.float32)
+        state.timesteps = ctx["timesteps"]
+        state.step_index = 0
+        state.scheduler = req_scheduler
+        state.do_true_cfg = bool(ctx["do_classifier_free_guidance"])
+        state.guidance = torch.full(
+            (state.latents.shape[0],),
+            float(ctx["guidance_scale"]),
+            dtype=state.latents.dtype,
+            device=state.latents.device,
+        )
+        cfg_normalization = ctx["cfg_normalization"]
+        cfg_normalization_row = (
+            None
+            if cfg_normalization is None
+            else torch.full(
+                (state.latents.shape[0],),
+                float(cfg_normalization),
+                dtype=torch.float32,
+                device=state.latents.device,
+            )
+        )
+        cfg_truncation = ctx["cfg_truncation"]
+        state.extra["z_image_cfg_normalization"] = cfg_normalization_row
+        state.extra["z_image_cfg_truncation"] = None if cfg_truncation is None else float(cfg_truncation)
+        state.extra["z_image_guidance_scale"] = float(ctx["guidance_scale"])
+        state.extra["z_image_normalized_timesteps"] = self._normalized_timestep_values(ctx["timesteps"])
+        state.extra["z_image_output_type"] = ctx["output_type"]
 
-                noise_pred = []
-                for j in range(actual_batch_size):
-                    pos = pos_out[j].float()
-                    neg = neg_out[j].float()
+        return state
 
-                    pred = pos + current_guidance_scale * (pos - neg)
+    def denoise_step(
+        self,
+        input_batch: "InputBatch",
+        **kwargs: Any,
+    ) -> torch.Tensor | None:
+        del kwargs
 
-                    # Renormalization (torch.where avoids GPU->CPU sync from Python if/scalar comparison)
-                    if self._cfg_normalization and float(self._cfg_normalization) > 0.0:
-                        ori_pos_norm = torch.linalg.vector_norm(pos)
-                        new_pos_norm = torch.linalg.vector_norm(pred)
-                        max_new_norm = ori_pos_norm * float(self._cfg_normalization)
-                        scale = torch.where(
-                            new_pos_norm > max_new_norm,
-                            (max_new_norm / new_pos_norm.clamp(min=1e-12)).to(pred.dtype),
-                            pred.new_tensor(1.0),
-                        )
-                        pred = pred * scale
+        prompt_embeds = self._padded_prompt_embeds_to_list(
+            input_batch.prompt_embeds,
+            input_batch.prompt_embeds_mask,
+        )
+        if input_batch.negative_prompt_embeds is None:
+            negative_prompt_embeds = None
+        else:
+            negative_prompt_embeds = self._padded_prompt_embeds_to_list(
+                input_batch.negative_prompt_embeds,
+                input_batch.negative_prompt_embeds_mask,
+            )
 
-                    noise_pred.append(pred)
+        actual_batch_size = int(input_batch.latents.shape[0])
+        timestep = input_batch.timesteps.to(device=input_batch.latents.device, dtype=torch.float32)
+        timestep = _broadcast_rows(timestep, actual_batch_size, "Z-Image timesteps")
+        timestep = (1000 - timestep) / 1000
+        active_cfg_rows = self._cfg_active_rows(input_batch.states) if input_batch.do_true_cfg else []
+        apply_cfg = input_batch.do_true_cfg and any(active_cfg_rows)
+        latents_typed = input_batch.latents.to(self.od_config.dtype)
 
-                noise_pred = torch.stack(noise_pred, dim=0)
-            else:
-                noise_pred = torch.stack([t.float() for t in model_out_list], dim=0)
+        if apply_cfg:
+            if negative_prompt_embeds is None:
+                raise ValueError("negative_prompt_embeds must be initialized when Z-Image CFG is active.")
+            if input_batch.guidance is None:
+                raise ValueError("guidance must be initialized when Z-Image CFG is active.")
 
-            noise_pred = noise_pred.squeeze(2)
-            noise_pred = -noise_pred
+            guidance_scales = torch.as_tensor(
+                input_batch.guidance,
+                dtype=torch.float32,
+                device=input_batch.latents.device,
+            )
+            guidance_scales = _broadcast_rows(guidance_scales, actual_batch_size, "Z-Image guidance")
 
-            # compute the previous noisy sample x_t -> x_t-1
-            latents = self.scheduler.step(noise_pred.to(torch.float32), t, latents, return_dict=False)[0]
-            assert latents.dtype == torch.float32
+            cfg_normalizations = self._extra_row_tensor(
+                input_batch.states,
+                "z_image_cfg_normalization",
+                device=input_batch.latents.device,
+                none_value=0.0,
+            )
+            active_cfg_mask = torch.tensor(active_cfg_rows, dtype=torch.bool, device=input_batch.latents.device)
+            guidance_scales = torch.where(
+                active_cfg_mask,
+                guidance_scales,
+                torch.zeros_like(guidance_scales),
+            )
 
-            if callback_on_step_end is not None:
-                callback_kwargs = {}
-                for k in callback_on_step_end_tensor_inputs:
-                    callback_kwargs[k] = locals()[k]
-                callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+            latent_model_input = latents_typed.repeat(2, 1, 1, 1)
+            prompt_embeds_model_input = prompt_embeds + negative_prompt_embeds
+            timestep_model_input = timestep.repeat(2)
+        else:
+            latent_model_input = latents_typed
+            prompt_embeds_model_input = prompt_embeds
+            timestep_model_input = timestep
 
-                latents = callback_outputs.pop("latents", latents)
-                prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
-                negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+        latent_model_input = latent_model_input.unsqueeze(2)
+        latent_model_input_list = list(latent_model_input.unbind(dim=0))
 
+        model_out_list = self.transformer(
+            latent_model_input_list,
+            timestep_model_input,
+            prompt_embeds_model_input,
+        )[0]
+
+        if apply_cfg:
+            pos_out = torch.stack([out.float() for out in model_out_list[:actual_batch_size]], dim=0)
+            neg_out = torch.stack([out.float() for out in model_out_list[actual_batch_size:]], dim=0)
+
+            row_shape = (actual_batch_size,) + (1,) * (pos_out.ndim - 1)
+            noise_pred = pos_out + guidance_scales.view(row_shape) * (pos_out - neg_out)
+
+            norm_dims = tuple(range(1, noise_pred.ndim))
+            ori_pos_norm = torch.linalg.vector_norm(pos_out, dim=norm_dims)
+            new_pos_norm = torch.linalg.vector_norm(noise_pred, dim=norm_dims)
+            max_new_norm = ori_pos_norm * cfg_normalizations
+            normalize_rows = (guidance_scales > 0) & (cfg_normalizations > 0) & (new_pos_norm > max_new_norm)
+            normalization_scale = torch.where(
+                normalize_rows,
+                max_new_norm / new_pos_norm.clamp(min=1e-12),
+                torch.ones_like(new_pos_norm),
+            )
+            noise_pred = noise_pred * normalization_scale.view(row_shape)
+        else:
+            noise_pred = torch.stack([t.float() for t in model_out_list], dim=0)
+
+        noise_pred = noise_pred.squeeze(2)
+        return -noise_pred
+
+    def step_scheduler(
+        self,
+        state: "StepRequestState",
+        noise_pred: torch.Tensor,
+        **kwargs: Any,
+    ) -> None:
+        del kwargs
+        state.latents = state.scheduler.step(
+            noise_pred.to(torch.float32), state.current_timestep, state.latents, return_dict=False
+        )[0]
+        if state.latents.dtype != torch.float32:
+            raise ValueError(
+                "Z-Image scheduler must return FP32 latents to preserve the continuous-batching join invariant for "
+                f"request {state.request_id!r}, but returned {state.latents.dtype}."
+            )
+        state.step_index += 1
+
+    def post_decode(
+        self,
+        state: "StepRequestState",
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        output_type = kwargs.get("output_type")
+        if not output_type:
+            output_type = state.extra.get("z_image_output_type") or "pil"
         if output_type == "latent":
-            image = latents
+            image = state.latents
         else:
-            latents = latents.to(self.vae.dtype)
+            latents = state.latents.to(self.vae.dtype)
             latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
-
             image = self.vae.decode(latents, return_dict=False)[0]
-            # image = self.image_processor.postprocess(image, output_type=output_type)
 
         stage_durations = self.stage_durations if hasattr(self, "stage_durations") else None
         return DiffusionOutput(output=image, stage_durations=stage_durations)

--- a/vllm_omni/diffusion/models/z_image/z_image_transformer.py
+++ b/vllm_omni/diffusion/models/z_image/z_image_transformer.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         QuantizationConfig,
     )
 
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.cache.base import CachedTransformer
 from vllm_omni.diffusion.distributed.sp_plan import (
@@ -320,7 +321,7 @@ class ZImageAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor,
+        attention_mask: torch.Tensor | None,
         cos: torch.Tensor,
         sin: torch.Tensor,
     ):
@@ -342,16 +343,33 @@ class ZImageAttention(nn.Module):
         dtype = query.dtype
         query, key = query.to(dtype), key.to(dtype)
 
-        # From [batch, seq_len] to [batch, 1, 1, seq_len] -> broadcast to [batch, heads, seq_len, seq_len]
-        if attention_mask is not None and attention_mask.ndim == 2:
-            attention_mask = attention_mask[:, None, None, :]
+        attn_metadata = None
+        if attention_mask is not None:
+            # Keep the canonical [batch, sequence] key-padding layout. Mask-aware
+            # backends either unpad it directly (FlashAttention) or broadcast it
+            # to [batch, heads, query, key] internally (SDPA).
+            attn_metadata = AttentionMetadata(attn_mask=attention_mask)
+
+            # Ring kernels do not consume padding masks. Context/noise refiners
+            # run outside the SP-sharded region and therefore still use local
+            # masked attention even when ring parallelism is configured.
+            ring_is_active = (
+                getattr(self.attn, "use_ring", False)
+                and self.attn._get_active_parallel_strategy() is not self.attn._no_parallel_strategy
+            )
+            if ring_is_active:
+                raise ValueError(
+                    "Z-Image variable-length batching is not supported with ring "
+                    "sequence parallelism because ring attention cannot apply padding masks. "
+                    "Use ring_degree=1 or batch requests with equal sequence lengths."
+                )
 
         # Compute joint attention
         hidden_states = self.attn(
             query,
             key,
             value,
-            # attn_mask=attention_mask, # we don't support multi prompts now.
+            attn_metadata,
         )
 
         # Reshape back
@@ -459,7 +477,7 @@ class ZImageTransformerBlock(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        attn_mask: torch.Tensor,
+        attn_mask: torch.Tensor | None,
         cos: torch.Tensor,
         sin: torch.Tensor,
         adaln_input: torch.Tensor | None = None,
@@ -975,9 +993,11 @@ class ZImageTransformer2DModel(CachedTransformer):
         x = pad_sequence(x, batch_first=True, padding_value=0.0)
         x_cos = pad_sequence(x_cos, batch_first=True, padding_value=0.0)
         x_sin = pad_sequence(x_sin, batch_first=True, padding_value=0.0)
-        x_attn_mask = torch.zeros((bsz, x_max_item_seqlen), dtype=torch.bool, device=device)
-        for i, seq_len in enumerate(x_item_seqlens):
-            x_attn_mask[i, :seq_len] = 1
+        x_attn_mask = None
+        if len(set(x_item_seqlens)) > 1:
+            x_attn_mask = torch.zeros((bsz, x_max_item_seqlen), dtype=torch.bool, device=device)
+            for i, seq_len in enumerate(x_item_seqlens):
+                x_attn_mask[i, :seq_len] = 1
 
         for layer in self.noise_refiner:
             x = layer(x, x_attn_mask, x_cos, x_sin, adaln_input)
@@ -1004,9 +1024,11 @@ class ZImageTransformer2DModel(CachedTransformer):
         cap_feats = pad_sequence(cap_feats, batch_first=True, padding_value=0.0)
         cap_cos = pad_sequence(cap_cos, batch_first=True, padding_value=0.0)
         cap_sin = pad_sequence(cap_sin, batch_first=True, padding_value=0.0)
-        cap_attn_mask = torch.zeros((bsz, cap_max_item_seqlen), dtype=torch.bool, device=device)
-        for i, seq_len in enumerate(cap_item_seqlens):
-            cap_attn_mask[i, :seq_len] = 1
+        cap_attn_mask = None
+        if len(set(cap_item_seqlens)) > 1:
+            cap_attn_mask = torch.zeros((bsz, cap_max_item_seqlen), dtype=torch.bool, device=device)
+            for i, seq_len in enumerate(cap_item_seqlens):
+                cap_attn_mask[i, :seq_len] = 1
 
         for layer in self.context_refiner:
             cap_feats = layer(cap_feats, cap_attn_mask, cap_cos, cap_sin)
@@ -1016,6 +1038,12 @@ class ZImageTransformer2DModel(CachedTransformer):
         unified, unified_cos, unified_sin, unified_attn_mask = self.unified_prepare(
             x, x_cos, x_sin, cap_feats, cap_cos, cap_sin, x_item_seqlens, cap_item_seqlens
         )
+        unified_item_seqlens = [x_len + cap_len for x_len, cap_len in zip(x_item_seqlens, cap_item_seqlens)]
+        if len(set(unified_item_seqlens)) == 1:
+            # Preserve the dense fast path, including ring attention. This is
+            # decided from replicated Python lengths so every SP rank makes the
+            # same choice without a device-to-host sync.
+            unified_attn_mask = None
 
         # Main transformer blocks
         for layer in self.layers:


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Z-Image currently uses a monolithic, request-level `forward()`. Each request has to wait for the previous one to finish all 8 steps.

This PR adds `--step-execution` support, allowing requests to interleave by step and share GPU time within the same tick.

On 1× H800 with 8 steps, FA3, `torch.compile`, and CFG off:

- 512², concurrency=2 vs serial: **+23.4%** QPS (3.79 vs 3.07)
- 1024², concurrency=2 vs serial: **+8.5%** QPS (0.93 vs 0.86)

### What changed

| File | Change |
| --- | --- |
| `pipeline_z_image.py` | Adds the `prepare_encode`, `denoise_step`, `step_scheduler`, and `post_decode` stage hooks. `forward()` now reuses `_prepare_generation_context`, removing about 150 duplicate lines. |
| `z_image_transformer.py` | Adds the variable-length batch support required by step execution. |
| Tests, perf config, and docs | Adds regression coverage, a reproduction script, and updates the feature matrix. |

### Why the transformer changes are required

| Change | Without it |
| --- | --- |
| Wire up the commented-out `attn_mask=` path | **Silently incorrect images:** padding tokens enter softmax when prompts have different lengths, shifting the subject for shorter prompts. |
| Use the `mask=None` fast path for equal-length batches | About 40% lower performance due to the masked SDPA kernel and `torch.compile` graph cache misses. |
| Reject ring attention with variable-length inputs | **Silently incorrect images:** the ring kernel ignores the padding mask and corrupts cross-device QK results. |
| Clear `attn_mask=None` in unified blocks for equal-length inputs | About 50–70% lower performance because the main transformer stack takes the masked path and falls back to SDPA when ring degree > 1. |

The first two are correctness fixes. Step execution may run without them, but its output is wrong. The last two preserve the performance gain.

### Related cleanup

- Moves guidance, CFG, joint-attention, and interrupt values from shared instance fields to per-request `state.extra["z_image_*"]`, preventing cross-request state contamination.
- Removes three dead `if self.interrupt: return` checks that are never toggled under continuous batching.
- Deduplicates about 150 lines of prompt parsing, image extraction, validation, encoding, latent setup, and timestep logic. `forward()` is now a thin wrapper around the shared helper, denoising loop, and decode.

## Test Plan

Run the Z-Image attention-mask and step-execution regression tests:

```bash
pytest -q tests/diffusion/models/z_image/test_zimage_attention_mask.py \
    tests/diffusion/test_diffusion_step_pipeline.py::TestSupportedPipelines \
    tests/diffusion/test_diffusion_step_pipeline.py::TestZImageStepExecution
```

Run the performance harness on 1× H800:

```bash
export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
export PERF_CONFIG=dfx/perf/tests/test_zimage_step_execution_vllm_omni.json
bash tests/dfx/perf/scripts/run_zimage_step_execution_pr.sh perf
```

> [!IMPORTANT]
> `benchmark_params` must explicitly include `extra-body: {guidance_scale: 0.0}`. The benchmark client does not set it automatically. Since #4999, the server maps `None → 1.0`, silently enabling CFG and cutting QPS in half.

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** c1a2046730693f2962f0a362d9f765e1c26af104

## Test Result

### CPU regression tests

Passed locally and on `origin/main`:

```text
10 passed
```

Coverage includes:

- Padding masks do not affect real rows.
- Ring attention rejects variable-length inputs.
- Per-row CFG gating handles zero-scale, all-active, and all-truncated cases.
- Late I2I inputs are promoted to FP32.
- Deferred `z_image_cfg_normalization` values are restored.

### Performance

| Resolution | Serial QPS | Step c=2 QPS | Gain |
| --- | ---: | ---: | ---: |
| 512² | 3.07 | **3.79** | **+23.4%** |
| 1024² | 0.86 | **0.93** | **+8.5%** |

<details>
<summary>Full benchmark results</summary>

| Mode | Resolution | Completed/Requests | QPS |
| --- | ---: | ---: | ---: |
| Serial | 512² | 16/16 | 3.07 |
| Step c=1 | 512² | 16/16 | 2.80 |
| Step c=2 | 512² | 32/32 | **3.79** |
| Step c=2, varlen | 512² | 32/32 | 2.42 |
| Serial | 1024² | 8/8 | 0.86 |
| Step c=1 | 1024² | 8/8 | 0.85 |
| Step c=2 | 1024² | 16/16 | **0.93** |

</details>

### Visual check

Ran two prompts of different lengths with `seed=42`, once at c=1 and once at c=2. The results are not pixel-identical because batch shape changes FP16 accumulation order and advances the shared generator differently.

They are semantically consistent: same subject, composition, and lighting, with no CFG oversaturation, cross-prompt bleed, or padding artifacts.