### PR TITLE
[Core][Quantization] Add ModelOpt-native FP8/NVFP4 blockwise loaders

### DIFF
--- a/tests/diffusion/model_loader/test_diffusers_loader.py
+++ b/tests/diffusion/model_loader/test_diffusers_loader.py
@@ -132,6 +132,58 @@ def test_qwen_model_class_selects_qwen_gguf_adapter():
     assert adapter.__class__.__name__ == "QwenImageGGUFAdapter"
 
 
+def test_get_weights_iterator_preserves_remote_id_and_passes_resolved_root(monkeypatch, tmp_path):
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        parallel_config=SimpleNamespace(use_hsdp=False),
+        quantization_config=None,
+        enable_multithread_weight_load=False,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    resolved_root = tmp_path / "snapshot"
+    transformer_dir = resolved_root / "transformer"
+    transformer_dir.mkdir(parents=True)
+    weight_path = transformer_dir / "model.safetensors"
+    weight_path.write_bytes(b"stub")
+
+    source = DiffusersPipelineLoader.ComponentSource(
+        model_or_path="owner/remote-model",
+        subfolder="transformer",
+        revision="rev",
+        prefix="transformer.",
+    )
+    seen = {}
+
+    monkeypatch.setattr(
+        loader,
+        "_prepare_weights",
+        lambda *args, **kwargs: (str(resolved_root), str(transformer_dir), [str(weight_path)], True),
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.model_loader.diffusers_loader.safetensors_weights_iterator",
+        lambda *_args, **_kwargs: iter([("weight", torch.ones(2, 2))]),
+    )
+
+    def fake_adapter(_model, adapted_source, use_safetensors):
+        seen["model_or_path"] = adapted_source.model_or_path
+        seen["resolved_model_or_path"] = adapted_source.resolved_model_or_path
+        seen["subfolder"] = adapted_source.subfolder
+        seen["use_safetensors"] = use_safetensors
+        return None
+
+    monkeypatch.setattr(loader, "_get_checkpoint_adapter", fake_adapter)
+
+    out = list(loader._get_weights_iterator(source, model=nn.Linear(2, 2, bias=False)))
+
+    assert out[0][0] == "transformer.weight"
+    assert seen == {
+        "model_or_path": "owner/remote-model",
+        "resolved_model_or_path": str(resolved_root),
+        "subfolder": "transformer",
+        "use_safetensors": True,
+    }
+
+
 class _ConfigAwareModel(nn.Module):
     def __init__(self, *, od_config):
         super().__init__()

--- a/tests/diffusion/model_loader/test_modelopt_native.py
+++ b/tests/diffusion/model_loader/test_modelopt_native.py
@@ -364,11 +364,9 @@ def test_detect_paths(tmp_path):
 
 
 def test_get_checkpoint_adapter_engages_without_quant_config(tmp_path, monkeypatch):
-    # default: W8A16-resident is now the DEFAULT for the fp8_blockwise checkpoint; the
-    # dequant-on-load native adapter is the explicit diagnostic fallback. Opt out so this
-    # test exercises the dequant adapter's sidecar-driven engagement (its intent). The
-    # default->W8A16 and opt-out->dequant routing is covered in test_modelopt_native_fp8_w8a16.
-    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+    # Default route stays dequant-on-load; the resident W8A16 path is an explicit opt-in
+    # covered in test_modelopt_native_fp8_w8a16.
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
     root = _write_model_dir(tmp_path, _authoritative_sidecar())
     model = _TinyModel()
     adapter = get_checkpoint_adapter(

--- a/tests/diffusion/model_loader/test_modelopt_native.py
+++ b/tests/diffusion/model_loader/test_modelopt_native.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for the ModelOpt-native (state-dict export) FP8-blockwise adapter.
+
+The checkpoint format under test: FP8 (e4m3) weight codes at diffusers names
+plus ``<module>.weight_quantizer._scale`` (2D block grid) and ``._amax`` (4D)
+tensors, described by a ``quantization_config.json`` sidecar at the model root
+(recipe ``fp8_blockwise_mixed``).
+"""
+
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
+    get_checkpoint_adapter,
+)
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
+    modelopt_native as mn,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+# --- fixtures ---------------------------------------------------------------
+
+def _authoritative_sidecar(n_quantized=2, n_scale=4):
+    """Sidecar dict mirroring the real deliverable's quantization_config.json."""
+    return {
+        "recipe": "fp8_blockwise_mixed",
+        "weight_only": True,
+        "quant_lmhead": True,
+        "mixed_precision": {
+            "quantized": ["mlp.*", "mlp_moe_gen.*", "lm_head"],
+            "bf16_kept": ["self_attn.*"],
+            "n_quantized": n_quantized,
+        },
+        "scale_layout": {
+            "granularity": "blockwise-128x128",
+            "block_sizes": {"rows": 128, "cols": 128},
+            "n_quantized_weight": n_quantized,
+            "n_scale": n_scale,
+        },
+    }
+
+
+def _stale_sidecar():
+    """The stale per-tensor export's sidecar (must be rejected loudly)."""
+    return {
+        "recipe": "fp8",
+        "weight_only": True,
+        "quant_lmhead": True,
+        "exclusions": ["embed_tokens", "*norm*"],
+        "scale_layout": {
+            "weight_scale_suffixes": ["_amax", "_scale"],
+            "n_scale": 1010,
+            "granularity": "per-tensor",
+        },
+    }
+
+
+def _fp8(t):
+    return t.to(torch.float8_e4m3fn)
+
+
+def _quantized_pair(_name, out_blocks=2, in_blocks=2, block=128, scale_val=0.5):
+    """(weight, scale2d, amax4d) synthetic tensors; *_name* documents the call site."""
+    shape = (out_blocks * block, in_blocks * block)
+    weight = _fp8(torch.full(shape, 2.0))
+    scale = torch.full((out_blocks, in_blocks), scale_val, dtype=torch.bfloat16)
+    amax = (scale * 448.0).reshape(out_blocks, 1, in_blocks, 1)
+    return weight, scale, amax
+
+
+def _stream(*, prefix="transformer.", order="scale_first"):
+    """Synthetic checkpoint stream: 2 quantized modules + 1 bf16 passthrough."""
+    w1, s1, a1 = _quantized_pair("layers.0.mlp.gate_proj.weight")
+    w2, s2, a2 = _quantized_pair("layers.0.mlp_moe_gen.down_proj.weight", scale_val=0.25)
+    passthrough = torch.ones(4, 4, dtype=torch.bfloat16)
+    items = {
+        f"{prefix}layers.0.mlp.gate_proj.weight": w1,
+        f"{prefix}layers.0.mlp.gate_proj.weight_quantizer._scale": s1,
+        f"{prefix}layers.0.mlp.gate_proj.weight_quantizer._amax": a1,
+        f"{prefix}layers.0.mlp_moe_gen.down_proj.weight": w2,
+        f"{prefix}layers.0.mlp_moe_gen.down_proj.weight_quantizer._scale": s2,
+        f"{prefix}layers.0.mlp_moe_gen.down_proj.weight_quantizer._amax": a2,
+        f"{prefix}layers.0.self_attn.to_q.weight": passthrough,
+    }
+    names = list(items)
+    if order == "weight_first":
+        names = sorted(names, key=lambda n: ("_quantizer." in n, n))
+    else:
+        names = sorted(names, key=lambda n: ("_quantizer." not in n, n))
+    return [(n, items[n]) for n in names]
+
+
+def _write_model_dir(tmp_path, sidecar, tensors=None):
+    """Model dir with sidecar + transformer/diffusion_pytorch_model.safetensors."""
+    from safetensors.torch import save_file
+
+    root = tmp_path / "model"
+    (root / "transformer").mkdir(parents=True)
+    if sidecar is not None:
+        (root / "quantization_config.json").write_text(json.dumps(sidecar))
+    if tensors is None:
+        tensors = {name: t for name, t in _stream(prefix="")}
+    save_file(tensors, str(root / "transformer" / "diffusion_pytorch_model.safetensors"))
+    return str(root)
+
+
+def _source(model_or_path="unused"):
+    return SimpleNamespace(
+        model_or_path=model_or_path, subfolder=None, prefix="transformer."
+    )
+
+
+class _TinyModel(nn.Module):
+    def __init__(self, dtype=torch.bfloat16):
+        super().__init__()
+        self.linear = nn.Linear(2, 2, bias=False, dtype=dtype)
+
+
+# --- parse_quant_spec --------------------------------------------------------
+
+def test_parse_spec_accepts_authoritative_sidecar():
+    spec = mn.parse_quant_spec(_authoritative_sidecar())
+    assert spec.n_quantized == 2
+    assert spec.n_scale == 4
+    assert spec.block_rows == 128 and spec.block_cols == 128
+    assert "mlp.*" in spec.quantized_patterns
+    assert "self_attn.*" in spec.kept_patterns
+
+
+def test_parse_spec_rejects_stale_sidecar_naming_mismatches():
+    with pytest.raises(mn.CheckpointIntegrityError) as exc:
+        mn.parse_quant_spec(_stale_sidecar())
+    msg = str(exc.value)
+    assert "fp8_blockwise_mixed" in msg  # expected recipe named
+    assert "per-tensor" in msg or "granularity" in msg
+
+
+def test_parse_spec_rejects_inconsistent_scale_count():
+    bad = _authoritative_sidecar(n_quantized=2, n_scale=3)  # must be 2*n
+    with pytest.raises(mn.CheckpointIntegrityError):
+        mn.parse_quant_spec(bad)
+
+
+# --- name/dtype calculations -------------------------------------------------
+
+def test_scale_name_roundtrip():
+    w = "layers.0.mlp.gate_proj.weight"
+    s = mn.scale_name_for(w)
+    assert s == "layers.0.mlp.gate_proj.weight_quantizer._scale"
+    assert mn.weight_name_for(s) == w
+    assert mn.weight_name_for("not_a_scale") is None
+
+
+def test_classify_tensor_kinds():
+    assert mn.classify_name("x.weight_quantizer._scale") is mn.TensorKind.QUANTIZER_SCALE
+    assert mn.classify_name("x.weight_quantizer._amax") is mn.TensorKind.QUANTIZER_AMAX
+    assert mn.classify_name("x.weight") is mn.TensorKind.OTHER
+    assert mn.is_fp8_dtype(torch.float8_e4m3fn)
+    assert not mn.is_fp8_dtype(torch.bfloat16)
+    assert mn.is_fp8_dtype_str("F8_E4M3")
+    assert not mn.is_fp8_dtype_str("BF16")
+
+
+def test_pattern_matching_with_and_without_prefix():
+    spec = mn.parse_quant_spec(_authoritative_sidecar())
+    assert mn.matches_any("layers.0.mlp.gate_proj", spec.quantized_patterns)
+    assert mn.matches_any("layers.3.mlp_moe_gen.up_proj", spec.quantized_patterns)
+    assert mn.matches_any("lm_head", spec.quantized_patterns)
+    assert not mn.matches_any("layers.0.self_attn.to_q", spec.quantized_patterns)
+    assert mn.matches_any("layers.0.self_attn.to_q", spec.kept_patterns)
+
+
+# --- scale expansion & dequant ------------------------------------------------
+
+def test_expand_block_scale_broadcasts_per_block():
+    scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    full = mn.expand_block_scale(scale, (4, 4), block=(2, 2))
+    assert full.shape == (4, 4)
+    assert full[0, 0] == 1.0 and full[0, 3] == 2.0
+    assert full[3, 0] == 3.0 and full[3, 3] == 4.0
+
+
+def test_expand_block_scale_rejects_grid_mismatch():
+    scale = torch.ones(2, 2)
+    with pytest.raises(mn.CheckpointIntegrityError):
+        mn.expand_block_scale(scale, (256, 384), block=(128, 128))  # grid 2x3
+
+
+def test_dequantize_weight_multiplies_codes_by_block_scale():
+    weight, scale, _ = _quantized_pair("m.weight", scale_val=0.5)
+    out = mn.dequantize_weight(weight, scale, torch.bfloat16, block=(128, 128))
+    assert out.dtype == torch.bfloat16
+    assert out.shape == weight.shape
+    assert torch.allclose(out.float(), torch.full_like(out.float(), 1.0))
+
+
+def test_dequantize_applies_scale_at_full_precision():
+    # Pins the exact dequant value for a non-trivial (bf16-inexact) scale:
+    # 36 (exact in e4m3) x bf16(0.1) = 3.609375. A regression that mishandled
+    # the scale (e.g. used _amax instead of _scale, or skipped the fp32 upcast
+    # on a platform where bf16 mul rounds per-op) would miss this value.
+    # NOTE: on CPU the fp32 vs bf16 intermediate cannot be distinguished by
+    # output (e4m3 is exactly representable in bf16 and torch CPU bf16-mul
+    # accumulates in fp32); the .to(torch.float32) cast is for GPU parity, so
+    # this test pins the numeric contract rather than the intermediate dtype.
+    weight = _fp8(torch.full((1, 1), 36.0))
+    scale = torch.full((1, 1), 0.1, dtype=torch.bfloat16)
+    out = mn.dequantize_weight(weight, scale, torch.bfloat16, block=(1, 1))
+    fp32_ref = (weight.to(torch.float32) * scale.to(torch.float32)).to(torch.bfloat16)
+    assert out.dtype == torch.bfloat16
+    assert torch.equal(out, fp32_ref)
+    assert abs(out.item() - 3.609375) < 1e-6
+
+
+def test_dequantize_reconstructs_random_weight_within_tolerance():
+    # Real e4m3 blockwise round-trip (spec: "reconstructs the base weight",
+    # median rel err < 5%). Uses a NON-128-divisible, asymmetric shape so a
+    # wrong block boundary or transposed grid fails — locks Correctness-F1
+    # (declared block must be honored, not inferred from shapes).
+    torch.manual_seed(0)
+    rows, cols, block = 200, 384, 128           # 200 not divisible by 128
+    ob, ib = (rows + block - 1) // block, (cols + block - 1) // block  # 2, 3
+    ref = torch.randn(rows, cols, dtype=torch.float32) * 0.05
+    # per-block amax -> scale = amax/448; quantize codes = round-to-e4m3(w/scale)
+    scale = torch.zeros(ob, ib, dtype=torch.float32)
+    codes = torch.zeros(rows, cols, dtype=torch.float32)
+    for i in range(ob):
+        for j in range(ib):
+            r0, r1 = i * block, min((i + 1) * block, rows)
+            c0, c1 = j * block, min((j + 1) * block, cols)
+            blk = ref[r0:r1, c0:c1]
+            s = blk.abs().max().item() / 448.0 or 1e-8
+            scale[i, j] = s
+            codes[r0:r1, c0:c1] = (blk / s).to(torch.float8_e4m3fn).to(torch.float32)
+    w8 = codes.to(torch.float8_e4m3fn)
+    out = mn.dequantize_weight(w8, scale.to(torch.bfloat16), torch.bfloat16, block=(block, block))
+    assert out.shape == (rows, cols)
+    rel = (out.float() - ref).abs() / (ref.abs() + 1e-6)
+    assert rel.median().item() < 0.05, rel.median().item()
+    # A wrong (inferred-from-shape) block would misplace the row-128 boundary:
+    wrong = mn.dequantize_weight(w8, scale.to(torch.bfloat16), torch.bfloat16,
+                                 block=(math.ceil(rows / ob), math.ceil(cols / ib)))
+    assert not torch.equal(out, wrong)
+
+
+# --- unified verification (shared by adapter and CLI probe) -------------------
+
+def _infos_from(items, prefix="transformer."):
+    return [
+        mn.TensorInfo(name[len(prefix):], mn.is_fp8_dtype(t.dtype), tuple(t.shape))
+        for name, t in items
+    ]
+
+
+def test_verify_observations_happy_path_is_clean():
+    spec = mn.parse_quant_spec(_authoritative_sidecar())
+    assert mn.verify_observations(_infos_from(_stream()), spec) == []
+
+
+def test_verify_observations_flags_quantized_excluded_module():
+    spec = mn.parse_quant_spec(_authoritative_sidecar())
+    infos = _infos_from(_stream())
+    infos.append(mn.TensorInfo("layers.0.self_attn.to_q.weight", True, (256, 256)))
+    violations = mn.verify_observations(infos, spec)
+    assert any("self_attn" in v for v in violations)
+
+
+def test_verify_observations_flags_count_drift_and_missing_scale():
+    spec = mn.parse_quant_spec(_authoritative_sidecar(n_quantized=3, n_scale=6))
+    violations = mn.verify_observations(_infos_from(_stream()), spec)
+    assert any("3" in v and "2" in v for v in violations)  # declared vs observed
+
+    spec2 = mn.parse_quant_spec(_authoritative_sidecar())
+    infos = [i for i in _infos_from(_stream()) if not i.name.endswith("._scale")]
+    violations = mn.verify_observations(infos, spec2)
+    assert any("_scale" in v or "scale" in v for v in violations)
+
+
+def test_verify_observations_flags_scale_grid_mismatch():
+    spec = mn.parse_quant_spec(_authoritative_sidecar())
+    infos = [
+        mn.TensorInfo(i.name, i.is_fp8, (3, 3)) if i.name.endswith("._scale") else i
+        for i in _infos_from(_stream())
+    ]
+    violations = mn.verify_observations(infos, spec)
+    assert any("grid" in v or "shape" in v for v in violations)
+
+
+# --- adapter shell -------------------------------------------------------------
+
+def _detect(tmp_path, sidecar, tensors=None, dtype=torch.bfloat16):
+    root = _write_model_dir(tmp_path, sidecar, tensors)
+    return mn.ModelOptNativeFp8CheckpointAdapter.detect(
+        _source(root), target_dtype=dtype
+    )
+
+
+@pytest.mark.parametrize("order", ["scale_first", "weight_first"])
+def test_adapt_dequantizes_and_consumes_quantizer_tensors(tmp_path, order):
+    adapter = _detect(tmp_path, _authoritative_sidecar())
+    adapted = dict(adapter.adapt(iter(_stream(order=order))))
+    assert set(adapted) == {
+        "transformer.layers.0.mlp.gate_proj.weight",
+        "transformer.layers.0.mlp_moe_gen.down_proj.weight",
+        "transformer.layers.0.self_attn.to_q.weight",
+    }
+    assert all(t.dtype == torch.bfloat16 for t in adapted.values())
+    gate = adapted["transformer.layers.0.mlp.gate_proj.weight"]
+    assert torch.allclose(gate.float(), torch.full_like(gate.float(), 1.0))
+    moe = adapted["transformer.layers.0.mlp_moe_gen.down_proj.weight"]
+    assert torch.allclose(moe.float(), torch.full_like(moe.float(), 0.5))
+
+
+def test_adapt_aggregates_violations_into_one_error(tmp_path):
+    adapter = _detect(tmp_path, _authoritative_sidecar())
+    bad = [
+        (n, t) for n, t in _stream() if not n.endswith("._scale")
+    ]  # both scales missing
+    with pytest.raises(mn.CheckpointIntegrityError) as exc:
+        list(adapter.adapt(iter(bad)))
+    msg = str(exc.value)
+    assert "gate_proj" in msg and "down_proj" in msg  # aggregated, not first-hit
+
+
+def test_adapt_bounds_pending_buffer(tmp_path):
+    n = mn.MAX_PENDING_FP8 + 1
+    sidecar = _authoritative_sidecar(n_quantized=n, n_scale=2 * n)
+    weights = []
+    for i in range(n):
+        w, _, _ = _quantized_pair(f"layers.{i}.mlp.up_proj.weight", 1, 1)
+        weights.append((f"transformer.layers.{i}.mlp.up_proj.weight", w))
+    adapter = _detect(tmp_path, sidecar)
+    with pytest.raises(mn.CheckpointIntegrityError):
+        list(adapter.adapt(iter(weights)))
+
+
+def test_validate_source_sidecar_is_a_loader_preflight(tmp_path):
+    # Called before weight-file discovery: no-op for plain and valid dirs,
+    # loud for a mislabeled (stale) sidecar (FA ordering: the integrity
+    # report must be the primary serve-path error, not a generic file error).
+    plain = _write_model_dir(tmp_path / "plain", None)
+    mn.ModelOptNativeFp8CheckpointAdapter.validate_source_sidecar(_source(plain))
+    good = _write_model_dir(tmp_path / "good", _authoritative_sidecar())
+    mn.ModelOptNativeFp8CheckpointAdapter.validate_source_sidecar(_source(good))
+    stale = _write_model_dir(tmp_path / "stale", _stale_sidecar())
+    with pytest.raises(mn.CheckpointIntegrityError):
+        mn.ModelOptNativeFp8CheckpointAdapter.validate_source_sidecar(_source(stale))
+
+
+def test_detect_paths(tmp_path):
+    assert _detect(tmp_path / "plain", None) is None  # no sidecar -> not quantized
+    with pytest.raises(mn.CheckpointIntegrityError):
+        _detect(tmp_path / "stale", _stale_sidecar())  # stale -> loud
+    adapter = _detect(tmp_path / "good", _authoritative_sidecar())
+    assert adapter is not None
+
+
+def test_get_checkpoint_adapter_engages_without_quant_config(tmp_path, monkeypatch):
+    # default: W8A16-resident is now the DEFAULT for the fp8_blockwise checkpoint; the
+    # dequant-on-load native adapter is the explicit diagnostic fallback. Opt out so this
+    # test exercises the dequant adapter's sidecar-driven engagement (its intent). The
+    # default->W8A16 and opt-out->dequant routing is covered in test_modelopt_native_fp8_w8a16.
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+    root = _write_model_dir(tmp_path, _authoritative_sidecar())
+    model = _TinyModel()
+    adapter = get_checkpoint_adapter(
+        model=model, source=_source(root), quant_config=None, use_safetensors=True
+    )
+    assert isinstance(adapter, mn.ModelOptNativeFp8CheckpointAdapter)
+
+    plain = _write_model_dir(tmp_path / "plain", None)
+    assert (
+        get_checkpoint_adapter(
+            model=model, source=_source(plain), quant_config=None, use_safetensors=True
+        )
+        is None
+    )
+
+
+# --- fp8 guard -----------------------------------------------------------------
+
+def test_assert_not_fp8_guard():
+    mn.assert_not_fp8("x.weight", torch.bfloat16)  # no raise
+    with pytest.raises(mn.CheckpointIntegrityError) as exc:
+        mn.assert_not_fp8("x.weight", torch.float8_e4m3fn)
+    assert "x.weight" in str(exc.value)
+
+
+# --- CLI probe (header-only) ----------------------------------------------------
+
+def test_cli_probe_exit_codes(tmp_path, capsys):
+    good = _write_model_dir(tmp_path / "good", _authoritative_sidecar())
+    assert mn.main([good]) == 0
+    out = capsys.readouterr().out
+    assert "OK" in out and "2" in out  # observed counts reported
+
+    stale = _write_model_dir(tmp_path / "stale", _stale_sidecar())
+    assert mn.main([stale]) != 0
+
+    nosidecar = _write_model_dir(tmp_path / "none", None)
+    assert mn.main([nosidecar]) != 0  # probe on unquantized dir: explicit failure
+
+    truncated = _write_model_dir(
+        tmp_path / "trunc",
+        _authoritative_sidecar(),
+        tensors={n: t for n, t in _stream(prefix="") if "gate_proj" not in n},
+    )
+    assert mn.main([truncated]) != 0

--- a/tests/diffusion/model_loader/test_modelopt_native.py
+++ b/tests/diffusion/model_loader/test_modelopt_native.py
@@ -28,6 +28,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 # --- fixtures ---------------------------------------------------------------
 
+
 def _authoritative_sidecar(n_quantized=2, n_scale=4):
     """Sidecar dict mirroring the real deliverable's quantization_config.json."""
     return {
@@ -113,9 +114,7 @@ def _write_model_dir(tmp_path, sidecar, tensors=None):
 
 
 def _source(model_or_path="unused"):
-    return SimpleNamespace(
-        model_or_path=model_or_path, subfolder=None, prefix="transformer."
-    )
+    return SimpleNamespace(model_or_path=model_or_path, subfolder=None, prefix="transformer.")
 
 
 class _TinyModel(nn.Module):
@@ -125,6 +124,7 @@ class _TinyModel(nn.Module):
 
 
 # --- parse_quant_spec --------------------------------------------------------
+
 
 def test_parse_spec_accepts_authoritative_sidecar():
     spec = mn.parse_quant_spec(_authoritative_sidecar())
@@ -150,6 +150,7 @@ def test_parse_spec_rejects_inconsistent_scale_count():
 
 
 # --- name/dtype calculations -------------------------------------------------
+
 
 def test_scale_name_roundtrip():
     w = "layers.0.mlp.gate_proj.weight"
@@ -179,6 +180,7 @@ def test_pattern_matching_with_and_without_prefix():
 
 
 # --- scale expansion & dequant ------------------------------------------------
+
 
 def test_expand_block_scale_broadcasts_per_block():
     scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
@@ -226,7 +228,7 @@ def test_dequantize_reconstructs_random_weight_within_tolerance():
     # wrong block boundary or transposed grid fails — locks Correctness-F1
     # (declared block must be honored, not inferred from shapes).
     torch.manual_seed(0)
-    rows, cols, block = 200, 384, 128           # 200 not divisible by 128
+    rows, cols, block = 200, 384, 128  # 200 not divisible by 128
     ob, ib = (rows + block - 1) // block, (cols + block - 1) // block  # 2, 3
     ref = torch.randn(rows, cols, dtype=torch.float32) * 0.05
     # per-block amax -> scale = amax/448; quantize codes = round-to-e4m3(w/scale)
@@ -246,18 +248,17 @@ def test_dequantize_reconstructs_random_weight_within_tolerance():
     rel = (out.float() - ref).abs() / (ref.abs() + 1e-6)
     assert rel.median().item() < 0.05, rel.median().item()
     # A wrong (inferred-from-shape) block would misplace the row-128 boundary:
-    wrong = mn.dequantize_weight(w8, scale.to(torch.bfloat16), torch.bfloat16,
-                                 block=(math.ceil(rows / ob), math.ceil(cols / ib)))
+    wrong = mn.dequantize_weight(
+        w8, scale.to(torch.bfloat16), torch.bfloat16, block=(math.ceil(rows / ob), math.ceil(cols / ib))
+    )
     assert not torch.equal(out, wrong)
 
 
 # --- unified verification (shared by adapter and CLI probe) -------------------
 
+
 def _infos_from(items, prefix="transformer."):
-    return [
-        mn.TensorInfo(name[len(prefix):], mn.is_fp8_dtype(t.dtype), tuple(t.shape))
-        for name, t in items
-    ]
+    return [mn.TensorInfo(name[len(prefix) :], mn.is_fp8_dtype(t.dtype), tuple(t.shape)) for name, t in items]
 
 
 def test_verify_observations_happy_path_is_clean():
@@ -287,8 +288,7 @@ def test_verify_observations_flags_count_drift_and_missing_scale():
 def test_verify_observations_flags_scale_grid_mismatch():
     spec = mn.parse_quant_spec(_authoritative_sidecar())
     infos = [
-        mn.TensorInfo(i.name, i.is_fp8, (3, 3)) if i.name.endswith("._scale") else i
-        for i in _infos_from(_stream())
+        mn.TensorInfo(i.name, i.is_fp8, (3, 3)) if i.name.endswith("._scale") else i for i in _infos_from(_stream())
     ]
     violations = mn.verify_observations(infos, spec)
     assert any("grid" in v or "shape" in v for v in violations)
@@ -296,11 +296,10 @@ def test_verify_observations_flags_scale_grid_mismatch():
 
 # --- adapter shell -------------------------------------------------------------
 
+
 def _detect(tmp_path, sidecar, tensors=None, dtype=torch.bfloat16):
     root = _write_model_dir(tmp_path, sidecar, tensors)
-    return mn.ModelOptNativeFp8CheckpointAdapter.detect(
-        _source(root), target_dtype=dtype
-    )
+    return mn.ModelOptNativeFp8CheckpointAdapter.detect(_source(root), target_dtype=dtype)
 
 
 @pytest.mark.parametrize("order", ["scale_first", "weight_first"])
@@ -321,9 +320,7 @@ def test_adapt_dequantizes_and_consumes_quantizer_tensors(tmp_path, order):
 
 def test_adapt_aggregates_violations_into_one_error(tmp_path):
     adapter = _detect(tmp_path, _authoritative_sidecar())
-    bad = [
-        (n, t) for n, t in _stream() if not n.endswith("._scale")
-    ]  # both scales missing
+    bad = [(n, t) for n, t in _stream() if not n.endswith("._scale")]  # both scales missing
     with pytest.raises(mn.CheckpointIntegrityError) as exc:
         list(adapter.adapt(iter(bad)))
     msg = str(exc.value)
@@ -369,21 +366,15 @@ def test_get_checkpoint_adapter_engages_without_quant_config(tmp_path, monkeypat
     monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
     root = _write_model_dir(tmp_path, _authoritative_sidecar())
     model = _TinyModel()
-    adapter = get_checkpoint_adapter(
-        model=model, source=_source(root), quant_config=None, use_safetensors=True
-    )
+    adapter = get_checkpoint_adapter(model=model, source=_source(root), quant_config=None, use_safetensors=True)
     assert isinstance(adapter, mn.ModelOptNativeFp8CheckpointAdapter)
 
     plain = _write_model_dir(tmp_path / "plain", None)
-    assert (
-        get_checkpoint_adapter(
-            model=model, source=_source(plain), quant_config=None, use_safetensors=True
-        )
-        is None
-    )
+    assert get_checkpoint_adapter(model=model, source=_source(plain), quant_config=None, use_safetensors=True) is None
 
 
 # --- fp8 guard -----------------------------------------------------------------
+
 
 def test_assert_not_fp8_guard():
     mn.assert_not_fp8("x.weight", torch.bfloat16)  # no raise
@@ -393,6 +384,7 @@ def test_assert_not_fp8_guard():
 
 
 # --- CLI probe (header-only) ----------------------------------------------------
+
 
 def test_cli_probe_exit_codes(tmp_path, capsys):
     good = _write_model_dir(tmp_path / "good", _authoritative_sidecar())

--- a/tests/diffusion/model_loader/test_modelopt_native.py
+++ b/tests/diffusion/model_loader/test_modelopt_native.py
@@ -117,6 +117,15 @@ def _source(model_or_path="unused"):
     return SimpleNamespace(model_or_path=model_or_path, subfolder=None, prefix="transformer.")
 
 
+def _remote_source(repo_id, resolved_model_or_path):
+    return SimpleNamespace(
+        model_or_path=repo_id,
+        resolved_model_or_path=resolved_model_or_path,
+        subfolder=None,
+        prefix="transformer.",
+    )
+
+
 class _TinyModel(nn.Module):
     def __init__(self, dtype=torch.bfloat16):
         super().__init__()
@@ -360,6 +369,12 @@ def test_detect_paths(tmp_path):
     assert adapter is not None
 
 
+def test_detect_uses_resolved_model_root_for_remote_sources(tmp_path):
+    root = _write_model_dir(tmp_path, _authoritative_sidecar())
+    adapter = mn.ModelOptNativeFp8CheckpointAdapter.detect(_remote_source("owner/repo", root))
+    assert adapter is not None
+
+
 def test_get_checkpoint_adapter_engages_without_quant_config(tmp_path, monkeypatch):
     # Default route stays dequant-on-load; the resident W8A16 path is an explicit opt-in
     # covered in test_modelopt_native_fp8_w8a16.
@@ -371,6 +386,18 @@ def test_get_checkpoint_adapter_engages_without_quant_config(tmp_path, monkeypat
 
     plain = _write_model_dir(tmp_path / "plain", None)
     assert get_checkpoint_adapter(model=model, source=_source(plain), quant_config=None, use_safetensors=True) is None
+
+
+def test_probe_main_reports_header_read_error(tmp_path, capsys):
+    root = _write_model_dir(tmp_path, _authoritative_sidecar())
+    shard = tmp_path / "model" / "transformer" / "diffusion_pytorch_model.safetensors"
+    shard.write_bytes(b"bad")
+
+    rc = mn.main([root])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "INTEGRITY FAIL" in captured.out
 
 
 # --- fp8 guard -----------------------------------------------------------------

--- a/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for the FP8-blockwise W8A16 resident checkpoint adapter.
+
+The on-disk format mirrors the dequant adapter's FP8 ``<m>.weight`` plus bf16
+2D ``._scale`` grid and ``._amax`` twin. The adapter keeps MLP targets
+FP8-resident and dequantizes ``lm_head``.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
+    ModelOptNativeFp8CheckpointAdapter,
+    ModelOptNativeFp8W8A16CheckpointAdapter,
+    get_checkpoint_adapter,
+    modelopt_native_fp8_w8a16 as mw8,
+)
+from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import (
+    CheckpointIntegrityError,
+    dequantize_weight,
+    is_fp8_dtype,
+    parse_quant_spec,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+BLOCK = 128
+# out, in (both multiples of 128 so the block grid is exact)
+_TARGETS = {
+    "layers.0.mlp.gate_proj": (256, 128),
+    "layers.0.mlp_moe_gen.down_proj": (128, 256),
+}
+_LM_HEAD = ("lm_head", (256, 128))
+
+
+def _grid(out, inn):
+    return ((out + BLOCK - 1) // BLOCK, (inn + BLOCK - 1) // BLOCK)
+
+
+def _sidecar(n_quantized=3, n_scale=None):
+    if n_scale is None:
+        n_scale = 2 * n_quantized
+    return {
+        "recipe": "fp8_blockwise_mixed",
+        "weight_only": True,
+        "mixed_precision": {
+            "quantized": ["mlp.*", "mlp_moe_gen.*", "lm_head"],
+            "bf16_kept": ["self_attn.*"],
+            "n_quantized": n_quantized,
+        },
+        "scale_layout": {
+            "granularity": "blockwise-128x128",
+            "block_sizes": {"rows": BLOCK, "cols": BLOCK},
+            "n_scale": n_scale,
+        },
+    }
+
+
+def _fp8(out, inn):
+    return (torch.randn(out, inn) * 0.1).to(torch.float8_e4m3fn)
+
+
+def _scale(out, inn, nan=False):
+    g = _grid(out, inn)
+    s = (torch.rand(*g) + 0.5).to(torch.bfloat16)
+    if nan:
+        s = s.to(torch.float32)
+        s[0, 0] = float("nan")
+        s = s.to(torch.bfloat16)
+    return s
+
+
+def _amax(out, inn):
+    r, c = _grid(out, inn)
+    return torch.rand(r, 1, c, 1).to(torch.bfloat16)
+
+
+def _stream(prefix="transformer.", nan_target_scale=False, extra=None):
+    items = []
+    for name, (out, inn) in _TARGETS.items():
+        items.append((f"{prefix}{name}.weight", _fp8(out, inn)))
+        nan = nan_target_scale and name.endswith("gate_proj")
+        items.append((f"{prefix}{name}.weight_quantizer._scale", _scale(out, inn, nan=nan)))
+        items.append((f"{prefix}{name}.weight_quantizer._amax", _amax(out, inn)))
+    name, (out, inn) = _LM_HEAD
+    items.append((f"{prefix}{name}.weight", _fp8(out, inn)))
+    items.append((f"{prefix}{name}.weight_quantizer._scale", _scale(out, inn)))
+    items.append((f"{prefix}{name}.weight_quantizer._amax", _amax(out, inn)))
+    # one non-target BF16 passthrough
+    items.append((f"{prefix}layers.0.self_attn.to_q.weight", torch.ones(128, 128, dtype=torch.bfloat16)))
+    if extra:
+        items.extend(extra)
+    return items
+
+
+def _adapter(sidecar=None):
+    spec = parse_quant_spec(sidecar or _sidecar())
+    return mw8.ModelOptNativeFp8W8A16CheckpointAdapter(
+        spec=spec, source_prefix="transformer.", target_dtype=torch.bfloat16
+    )
+
+
+# --- resident vs dequant routing --------------------------------------------
+
+
+def test_adapt_targets_resident_lm_head_dequant_and_amax_dropped():
+    out = dict(_adapter().adapt(_stream()))
+
+    # MLP targets stay FP8-resident, scale renamed to the method's param name
+    gp = "transformer.layers.0.mlp.gate_proj"
+    assert out[f"{gp}.weight"].dtype == torch.float8_e4m3fn
+    assert out[f"{gp}.weight"].element_size() == 1
+    assert out[f"{gp}.weight_scale"].dtype == torch.bfloat16
+    dp = "transformer.layers.0.mlp_moe_gen.down_proj"
+    assert out[f"{dp}.weight"].dtype == torch.float8_e4m3fn
+    assert f"{dp}.weight_scale" in out
+
+    # lm_head dequantized to BF16 (not resident); its scale is consumed, not emitted
+    assert out["transformer.lm_head.weight"].dtype == torch.bfloat16
+    assert "transformer.lm_head.weight_scale" not in out
+
+    # BF16 non-target passes through unchanged
+    assert out["transformer.layers.0.self_attn.to_q.weight"].dtype == torch.bfloat16
+
+    # no raw quantizer tensors leak into the output stream
+    assert not any(".weight_quantizer." in k for k in out)
+
+
+def test_adapt_count_mismatch_aborts():
+    # sidecar declares 4 quantized but the stream carries 3 fp8 weights
+    with pytest.raises(CheckpointIntegrityError, match="count mismatch"):
+        dict(_adapter(_sidecar(n_quantized=4, n_scale=8)).adapt(_stream()))
+
+
+def test_adapt_forbidden_module_quantized_aborts():
+    # a bf16_kept module (self_attn) present as an FP8 weight -> integrity abort
+    extra = [
+        ("transformer.layers.0.self_attn.to_k.weight", _fp8(128, 128)),
+        ("transformer.layers.0.self_attn.to_k.weight_quantizer._scale", _scale(128, 128)),
+        ("transformer.layers.0.self_attn.to_k.weight_quantizer._amax", _amax(128, 128)),
+    ]
+    with pytest.raises(CheckpointIntegrityError):
+        dict(_adapter(_sidecar(n_quantized=4, n_scale=8)).adapt(_stream(extra=extra)))
+
+
+def test_adapt_nan_scale_aborts():
+    with pytest.raises(CheckpointIntegrityError, match="NaN/Inf"):
+        dict(_adapter().adapt(_stream(nan_target_scale=True)))
+
+
+# --- detection + probe -------------------------------------------------------
+
+
+def _write_model_dir(tmp_path, sidecar=None):
+    from safetensors.torch import save_file
+
+    root = tmp_path / "model"
+    (root / "transformer").mkdir(parents=True)
+    (root / "quantization_config.json").write_text(json.dumps(sidecar or _sidecar()))
+    tensors = {k[len("transformer."):]: v for k, v in _stream()}
+    save_file(tensors, str(root / "transformer" / "model.safetensors"))
+    return str(root)
+
+
+def _source(model_or_path):
+    return SimpleNamespace(model_or_path=model_or_path, subfolder="transformer", prefix="transformer.")
+
+
+def test_detect_engages_on_fp8_sidecar(tmp_path):
+    root = _write_model_dir(tmp_path)
+    adapter = mw8.ModelOptNativeFp8W8A16CheckpointAdapter.detect(_source(root))
+    assert adapter is not None
+
+
+def test_detect_none_without_sidecar(tmp_path):
+    root = tmp_path / "empty"
+    (root / "transformer").mkdir(parents=True)
+    assert mw8.ModelOptNativeFp8W8A16CheckpointAdapter.detect(_source(str(root))) is None
+
+
+def test_probe_main_exit0(tmp_path, capsys):
+    root = _write_model_dir(tmp_path)
+    rc = mw8.main([root])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "2 MLP targets resident" in captured.out
+    assert "1 non-target(s) dequant" in captured.out
+
+
+def test_probe_main_usage():
+    assert mw8.main([]) == 2
+
+
+# --- recipe-gated dispatch (default: W8A16 default, dequant via opt-out) --------
+
+
+def test_dispatch_default_selects_w8a16(tmp_path, monkeypatch):
+    # No env flag needed: the fp8_blockwise recipe makes W8A16 the default.
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    root = _write_model_dir(tmp_path)
+    adapter = get_checkpoint_adapter(
+        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
+    )
+    assert isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
+
+
+def test_dispatch_opt_out_selects_dequant(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+    root = _write_model_dir(tmp_path)
+    adapter = get_checkpoint_adapter(
+        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
+    )
+    assert isinstance(adapter, ModelOptNativeFp8CheckpointAdapter)
+    assert not isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
+
+
+def test_dispatch_default_inert_without_fp8_sidecar(tmp_path, monkeypatch):
+    # No FP8 sidecar (mirrors NVFP4-dist, which has no root quantization_config.json):
+    # the recipe predicate is False, so W8A16 does not engage and NVFP4 is unaffected.
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    root = tmp_path / "no_sidecar"
+    (root / "transformer").mkdir(parents=True)
+    adapter = get_checkpoint_adapter(
+        torch.nn.Module(), _source(str(root)), quant_config=None, use_safetensors=True
+    )
+    # No sidecar at all -> no adapter engages (W8A16 declines, dequant/NVFP4 find no
+    # sidecar); assert the exact None (stronger than "not W8A16", which None also satisfies).
+    assert adapter is None
+
+
+def test_adapter_rejects_declared_forbidden_family():
+    # A sidecar whose manifest DECLARES a forbidden family (self_attn.*) as quantized ->
+    # fail-fast at adapter construction, before any weight is routed resident.
+    bad = _sidecar()
+    bad["mixed_precision"]["quantized"] = ["mlp.*", "self_attn.*"]
+    with pytest.raises(CheckpointIntegrityError, match="target family"):
+        _adapter(bad)
+
+
+# --- adapter numerical correctness + edge cases (sharded-review hardening) ---
+
+
+def test_adapt_lm_head_dequant_numerically_correct():
+    w = _fp8(256, 128)
+    s = _scale(256, 128)
+    stream = [
+        ("transformer.lm_head.weight", w),
+        ("transformer.lm_head.weight_quantizer._scale", s),
+        ("transformer.lm_head.weight_quantizer._amax", _amax(256, 128)),
+    ]
+    out = dict(_adapter(_sidecar(n_quantized=1, n_scale=2)).adapt(stream))
+    got = out["transformer.lm_head.weight"]
+    assert got.dtype == torch.bfloat16
+    torch.testing.assert_close(got, dequantize_weight(w, s, torch.bfloat16, (128, 128)))
+
+
+def test_adapt_scale_before_weight_flushes_pending():
+    # non-target (lm_head) scale arrives BEFORE its weight -> dequant still correct
+    w = _fp8(256, 128)
+    s = _scale(256, 128)
+    stream = [
+        ("transformer.lm_head.weight_quantizer._scale", s),
+        ("transformer.lm_head.weight", w),
+        ("transformer.lm_head.weight_quantizer._amax", _amax(256, 128)),
+    ]
+    out = dict(_adapter(_sidecar(n_quantized=1, n_scale=2)).adapt(stream))
+    torch.testing.assert_close(
+        out["transformer.lm_head.weight"], dequantize_weight(w, s, torch.bfloat16, (128, 128))
+    )
+
+
+def test_adapt_max_pending_overflow_aborts():
+    # >8 non-target fp8 weights buffered without scales -> fail-fast (no GB buffering)
+    stream = [(f"transformer.extra{i}.weight", _fp8(128, 128)) for i in range(9)]
+    with pytest.raises(CheckpointIntegrityError, match="pending"):
+        dict(_adapter(_sidecar(n_quantized=9, n_scale=18)).adapt(stream))
+
+
+def test_is_fp8_dtype_classifies_storage_dtypes():
+    # Float8 resident weights are FP8; BF16 dequant output and uint8 packed
+    # NVFP4 storage are not.
+    assert is_fp8_dtype(torch.float8_e4m3fn) is True
+    assert is_fp8_dtype(torch.bfloat16) is False
+    assert is_fp8_dtype(torch.uint8) is False

--- a/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
@@ -27,6 +27,7 @@ from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import
     is_fp8_dtype,
     parse_quant_spec,
 )
+from vllm_omni.quantization.fp8_blockwise_w8a16 import build_fp8_blockwise_w8a16_config
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
@@ -172,9 +173,24 @@ def _source(model_or_path):
     return SimpleNamespace(model_or_path=model_or_path, subfolder="transformer", prefix="transformer.")
 
 
+def _remote_source(repo_id, resolved_model_or_path):
+    return SimpleNamespace(
+        model_or_path=repo_id,
+        resolved_model_or_path=resolved_model_or_path,
+        subfolder="transformer",
+        prefix="transformer.",
+    )
+
+
 def test_detect_engages_on_fp8_sidecar(tmp_path):
     root = _write_model_dir(tmp_path)
     adapter = mw8.ModelOptNativeFp8W8A16CheckpointAdapter.detect(_source(root))
+    assert adapter is not None
+
+
+def test_detect_uses_resolved_model_root_for_remote_sources(tmp_path):
+    root = _write_model_dir(tmp_path)
+    adapter = mw8.ModelOptNativeFp8W8A16CheckpointAdapter.detect(_remote_source("owner/repo", root))
     assert adapter is not None
 
 
@@ -211,8 +227,16 @@ def test_dispatch_default_selects_dequant(tmp_path, monkeypatch):
 def test_dispatch_opt_in_selects_w8a16(tmp_path, monkeypatch):
     monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     root = _write_model_dir(tmp_path)
-    adapter = get_checkpoint_adapter(torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True)
+    cfg = build_fp8_blockwise_w8a16_config()
+    adapter = get_checkpoint_adapter(torch.nn.Module(), _source(root), quant_config=cfg, use_safetensors=True)
     assert isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
+
+
+def test_dispatch_opt_in_rejects_missing_w8a16_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+    root = _write_model_dir(tmp_path)
+    with pytest.raises(CheckpointIntegrityError, match="W8A16"):
+        get_checkpoint_adapter(torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True)
 
 
 def test_dispatch_default_inert_without_fp8_sidecar(tmp_path, monkeypatch):

--- a/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
@@ -194,21 +194,11 @@ def test_probe_main_usage():
     assert mw8.main([]) == 2
 
 
-# --- recipe-gated dispatch (default: W8A16 default, dequant via opt-out) --------
+# --- recipe-gated dispatch (default: dequant, W8A16 via explicit opt-in) --------
 
 
-def test_dispatch_default_selects_w8a16(tmp_path, monkeypatch):
-    # No env flag needed: the fp8_blockwise recipe makes W8A16 the default.
-    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
-    root = _write_model_dir(tmp_path)
-    adapter = get_checkpoint_adapter(
-        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
-    )
-    assert isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
-
-
-def test_dispatch_opt_out_selects_dequant(tmp_path, monkeypatch):
-    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+def test_dispatch_default_selects_dequant(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
     root = _write_model_dir(tmp_path)
     adapter = get_checkpoint_adapter(
         torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
@@ -217,10 +207,19 @@ def test_dispatch_opt_out_selects_dequant(tmp_path, monkeypatch):
     assert not isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
 
 
+def test_dispatch_opt_in_selects_w8a16(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+    root = _write_model_dir(tmp_path)
+    adapter = get_checkpoint_adapter(
+        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
+    )
+    assert isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
+
+
 def test_dispatch_default_inert_without_fp8_sidecar(tmp_path, monkeypatch):
     # No FP8 sidecar (mirrors NVFP4-dist, which has no root quantization_config.json):
     # the recipe predicate is False, so W8A16 does not engage and NVFP4 is unaffected.
-    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     root = tmp_path / "no_sidecar"
     (root / "transformer").mkdir(parents=True)
     adapter = get_checkpoint_adapter(

--- a/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py
@@ -6,6 +6,7 @@ The on-disk format mirrors the dequant adapter's FP8 ``<m>.weight`` plus bf16
 2D ``._scale`` grid and ``._amax`` twin. The adapter keeps MLP targets
 FP8-resident and dequantizes ``lm_head``.
 """
+
 import json
 from types import SimpleNamespace
 
@@ -16,6 +17,8 @@ from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     ModelOptNativeFp8CheckpointAdapter,
     ModelOptNativeFp8W8A16CheckpointAdapter,
     get_checkpoint_adapter,
+)
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     modelopt_native_fp8_w8a16 as mw8,
 )
 from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import (
@@ -160,7 +163,7 @@ def _write_model_dir(tmp_path, sidecar=None):
     root = tmp_path / "model"
     (root / "transformer").mkdir(parents=True)
     (root / "quantization_config.json").write_text(json.dumps(sidecar or _sidecar()))
-    tensors = {k[len("transformer."):]: v for k, v in _stream()}
+    tensors = {k[len("transformer.") :]: v for k, v in _stream()}
     save_file(tensors, str(root / "transformer" / "model.safetensors"))
     return str(root)
 
@@ -200,9 +203,7 @@ def test_probe_main_usage():
 def test_dispatch_default_selects_dequant(tmp_path, monkeypatch):
     monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
     root = _write_model_dir(tmp_path)
-    adapter = get_checkpoint_adapter(
-        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
-    )
+    adapter = get_checkpoint_adapter(torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True)
     assert isinstance(adapter, ModelOptNativeFp8CheckpointAdapter)
     assert not isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
 
@@ -210,9 +211,7 @@ def test_dispatch_default_selects_dequant(tmp_path, monkeypatch):
 def test_dispatch_opt_in_selects_w8a16(tmp_path, monkeypatch):
     monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     root = _write_model_dir(tmp_path)
-    adapter = get_checkpoint_adapter(
-        torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True
-    )
+    adapter = get_checkpoint_adapter(torch.nn.Module(), _source(root), quant_config=None, use_safetensors=True)
     assert isinstance(adapter, ModelOptNativeFp8W8A16CheckpointAdapter)
 
 
@@ -222,9 +221,7 @@ def test_dispatch_default_inert_without_fp8_sidecar(tmp_path, monkeypatch):
     monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     root = tmp_path / "no_sidecar"
     (root / "transformer").mkdir(parents=True)
-    adapter = get_checkpoint_adapter(
-        torch.nn.Module(), _source(str(root)), quant_config=None, use_safetensors=True
-    )
+    adapter = get_checkpoint_adapter(torch.nn.Module(), _source(str(root)), quant_config=None, use_safetensors=True)
     # No sidecar at all -> no adapter engages (W8A16 declines, dequant/NVFP4 find no
     # sidecar); assert the exact None (stronger than "not W8A16", which None also satisfies).
     assert adapter is None
@@ -266,9 +263,7 @@ def test_adapt_scale_before_weight_flushes_pending():
         ("transformer.lm_head.weight_quantizer._amax", _amax(256, 128)),
     ]
     out = dict(_adapter(_sidecar(n_quantized=1, n_scale=2)).adapt(stream))
-    torch.testing.assert_close(
-        out["transformer.lm_head.weight"], dequantize_weight(w, s, torch.bfloat16, (128, 128))
-    )
+    torch.testing.assert_close(out["transformer.lm_head.weight"], dequantize_weight(w, s, torch.bfloat16, (128, 128)))
 
 
 def test_adapt_max_pending_overflow_aborts():

--- a/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for the ModelOpt-native NVFP4 (weight-only, blockwise) adapter.
+
+The checkpoint format under test (`nvfp4_blockwise_mixed_v1`): per
+target module three tensors — ``<m>.weight_packed`` (uint8 packed E2M1),
+``<m>.weight_block_scale`` (float8_e4m3fn, ``[rows, ceil(cols/16)]``) and
+``<m>.weight_global_scale`` (float32, ``[1]``) — described by a
+``transformer/nvfp4_blockwise_mixed_v1.json`` sidecar. Non-target tensors stay
+BF16. Unlike the FP8-native adapter, this adapter NEVER dequantizes a target:
+it renames on-disk names to vLLM's W4A16 param names and passes bytes through so
+the target modules remain FP4-resident.
+"""
+
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
+    get_checkpoint_adapter,
+)
+from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
+    modelopt_native_nvfp4 as mn4,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+BLOCK = 16
+# Two real target names (one UND mlp, one GEN mlp_moe_gen) + shapes small but
+# 16-divisible so packed/scale grids are exact.
+_TARGETS = {
+    "layers.0.mlp.gate_proj.weight": (32, 64),          # out=32, in=64
+    "layers.0.mlp_moe_gen.down_proj.weight": (64, 32),  # out=64, in=32
+}
+
+
+# --- fixtures ---------------------------------------------------------------
+
+def _packed_width(cols: int) -> int:
+    return (cols + 1) // 2
+
+
+def _scale_grid(shape):
+    rows, cols = shape
+    return [rows, math.ceil(cols / BLOCK)]
+
+
+def _authoritative_sidecar():
+    """Sidecar dict mirroring the real deliverable's structure."""
+    tensors = {}
+    for name, (out, inn) in _TARGETS.items():
+        tensors[name] = {
+            "weight_shape": [out, inn],
+            "packed_shape": [out, _packed_width(inn)],
+            "block_scale_shape": _scale_grid((out, inn)),
+        }
+    return {
+        "recipe": "nvfp4_blockwise_mixed_v1",
+        "block_size": BLOCK,
+        "expected_quantized_count": len(_TARGETS),
+        "target_patterns": [r"^layers\.\d+\.mlp\.", r"^layers\.\d+\.mlp_moe_gen\."],
+        "forbidden_patterns": [
+            "embed_tokens", "lm_head", "self_attn", "norm", "time_embedder",
+            "proj_in", "proj_out", "audio_", "action_", "blocks.",
+        ],
+        "scale_encoding": {
+            "block_along": "last_dim",
+            "block_scale_dtype": "float8_e4m3fn",
+            "block_size": BLOCK,
+            "global_scale_dtype": "float32",
+            "packed_dtype": "uint8",
+        },
+        "tensors": tensors,
+    }
+
+
+def _awq_sidecar():
+    """An old AWQ-style sidecar that must be rejected (wrong recipe)."""
+    s = _authoritative_sidecar()
+    s["recipe"] = "nvfp4_awq"
+    return s
+
+
+def _target_triplet(out, inn, *, scale_val=1.0, nan=False):
+    packed = torch.randint(0, 256, (out, _packed_width(inn)), dtype=torch.uint8)
+    grid = _scale_grid((out, inn))
+    block = torch.full(tuple(grid), scale_val, dtype=torch.float8_e4m3fn)
+    if nan:
+        block[0, 0] = torch.tensor(float("nan"), dtype=torch.float32).to(torch.float8_e4m3fn)
+    glob = torch.full((1,), 0.5, dtype=torch.float32)
+    return packed, block, glob
+
+
+def _tensors(nan=False):
+    out_t = {}
+    for name, (out, inn) in _TARGETS.items():
+        base = name[: -len(".weight")]
+        packed, block, glob = _target_triplet(out, inn, nan=nan and base.endswith("gate_proj"))
+        out_t[base + ".weight_packed"] = packed
+        out_t[base + ".weight_block_scale"] = block
+        out_t[base + ".weight_global_scale"] = glob
+    # one non-target BF16 passthrough
+    out_t["layers.0.self_attn.to_q.weight"] = torch.ones(8, 8, dtype=torch.bfloat16)
+    return out_t
+
+
+def _stream(prefix="transformer.", nan=False):
+    return [(f"{prefix}{n}", t) for n, t in _tensors(nan=nan).items()]
+
+
+def _write_model_dir(tmp_path, sidecar, tensors=None):
+    from safetensors.torch import save_file
+
+    root = tmp_path / "model"
+    (root / "transformer").mkdir(parents=True)
+    if sidecar is not None:
+        (root / "transformer" / "nvfp4_blockwise_mixed_v1.json").write_text(json.dumps(sidecar))
+    if tensors is None:
+        tensors = _tensors()
+    save_file(tensors, str(root / "transformer" / "model.safetensors"))
+    return str(root)
+
+
+def _source(model_or_path="unused"):
+    return SimpleNamespace(model_or_path=model_or_path, subfolder=None, prefix="transformer.")
+
+
+# --- parse_nvfp4_spec --------------------------------------------------------
+
+def test_parse_spec_accepts_authoritative_sidecar():
+    spec = mn4.parse_nvfp4_spec(_authoritative_sidecar())
+    assert spec.recipe == "nvfp4_blockwise_mixed_v1"
+    assert spec.block_size == 16
+    assert spec.expected_count == 2
+    assert "layers.0.mlp.gate_proj.weight" in spec.tensors
+
+
+def test_parse_spec_rejects_wrong_recipe():
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        mn4.parse_nvfp4_spec(_awq_sidecar())
+    assert "nvfp4_blockwise_mixed_v1" in str(exc.value)
+
+
+def test_parse_spec_rejects_bad_scale_encoding():
+    bad = _authoritative_sidecar()
+    bad["scale_encoding"]["block_scale_dtype"] = "bfloat16"
+    with pytest.raises(mn4.CheckpointIntegrityError):
+        mn4.parse_nvfp4_spec(bad)
+
+
+# --- pure name/shape calculations -------------------------------------------
+
+def test_remap_name_roundtrip():
+    assert mn4.remap_name("x.mlp.gate_proj.weight_packed") == "x.mlp.gate_proj.weight"
+    assert mn4.remap_name("x.mlp.gate_proj.weight_block_scale") == "x.mlp.gate_proj.weight_scale"
+    assert mn4.remap_name("x.mlp.gate_proj.weight_global_scale") == "x.mlp.gate_proj.weight_scale_2"
+    assert mn4.remap_name("x.self_attn.to_q.weight") == "x.self_attn.to_q.weight"  # untouched
+
+
+def test_matches_target_and_forbidden():
+    spec = mn4.parse_nvfp4_spec(_authoritative_sidecar())
+    assert mn4.matches_any("layers.0.mlp.gate_proj", spec.target_patterns)
+    assert mn4.matches_any("layers.3.mlp_moe_gen.up_proj", spec.target_patterns)
+    assert not mn4.matches_any("layers.0.self_attn.to_q", spec.target_patterns)
+    assert mn4.matches_any("layers.0.self_attn.to_q", spec.forbidden_patterns)
+
+
+def test_expected_packed_width_and_grid():
+    assert mn4.expected_packed_width(64) == 32
+    assert mn4.expected_packed_width(63) == 32  # ceil
+    assert mn4.expected_scale_grid((32, 64), 16) == (32, 4)
+
+
+# --- adapter detect ---------------------------------------------------------
+
+def test_detect_engages_on_sidecar(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
+    adapter = mn4.ModelOptNativeNvfp4CheckpointAdapter.detect(_source(model_dir))
+    assert isinstance(adapter, mn4.ModelOptNativeNvfp4CheckpointAdapter)
+
+
+def test_detect_returns_none_without_sidecar(tmp_path):
+    model_dir = _write_model_dir(tmp_path, None)
+    adapter = mn4.ModelOptNativeNvfp4CheckpointAdapter.detect(_source(model_dir))
+    assert adapter is None
+
+
+def test_detect_raises_on_malformed_sidecar(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _awq_sidecar())
+    with pytest.raises(mn4.CheckpointIntegrityError):
+        mn4.ModelOptNativeNvfp4CheckpointAdapter.detect(_source(model_dir))
+
+
+def test_registry_selects_nvfp4_native_before_generic(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
+    model = torch.nn.Linear(2, 2)
+    adapter = get_checkpoint_adapter(model, _source(model_dir), quant_config=None, use_safetensors=True)
+    assert isinstance(adapter, mn4.ModelOptNativeNvfp4CheckpointAdapter)
+
+
+# --- adapt: rename + passthrough, no dequant --------------------------------
+
+def _run_adapt(stream, sidecar=None):
+    spec = mn4.parse_nvfp4_spec(sidecar or _authoritative_sidecar())
+    adapter = mn4.ModelOptNativeNvfp4CheckpointAdapter(spec=spec, source_prefix="transformer.")
+    return list(adapter.adapt(stream))
+
+
+def test_adapt_renames_and_passes_through_unchanged():
+    out = dict(_run_adapt(_stream()))
+    # packed weight renamed to .weight, still uint8, byte-identical
+    key = "transformer.layers.0.mlp.gate_proj.weight"
+    assert key in out
+    assert out[key].dtype == torch.uint8
+    assert "transformer.layers.0.mlp.gate_proj.weight_scale" in out
+    assert "transformer.layers.0.mlp.gate_proj.weight_scale_2" in out
+    # no *.weight_packed leaks through
+    assert not any(k.endswith(".weight_packed") for k in out)
+
+
+def test_adapt_never_emits_floating_target_weight():
+    out = _run_adapt(_stream())
+    for name, tensor in out:
+        if name.endswith(".weight") and ".mlp" in name:
+            assert tensor.dtype == torch.uint8, f"{name} must stay packed uint8, got {tensor.dtype}"
+
+
+def test_adapt_passes_non_target_bf16_through():
+    out = dict(_run_adapt(_stream()))
+    key = "transformer.layers.0.self_attn.to_q.weight"
+    assert out[key].dtype == torch.bfloat16
+
+
+def test_adapt_aborts_on_nan_scale():
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(_stream(nan=True))
+    assert "nan" in str(exc.value).lower() or "inf" in str(exc.value).lower()
+
+
+def test_adapt_rejects_forbidden_quantized(tmp_path):
+    # Inject a packed tensor on a forbidden module.
+    bad = _tensors()
+    bad["layers.0.self_attn.to_q.weight_packed"] = torch.zeros(8, 4, dtype=torch.uint8)
+    bad["layers.0.self_attn.to_q.weight_block_scale"] = torch.zeros(8, 1, dtype=torch.float8_e4m3fn)
+    bad["layers.0.self_attn.to_q.weight_global_scale"] = torch.zeros(1, dtype=torch.float32)
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError):
+        _run_adapt(stream)
+
+
+def test_adapt_rejects_count_mismatch():
+    # Drop one target's triplet -> observed count < declared.
+    partial = {k: v for k, v in _tensors().items() if "mlp_moe_gen" not in k}
+    stream = [(f"transformer.{n}", t) for n, t in partial.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError):
+        _run_adapt(stream)
+
+
+def test_adapt_rejects_wrong_packed_width():
+    bad = _tensors()
+    # gate_proj in=64 -> packed width should be 32; give 16.
+    bad["layers.0.mlp.gate_proj.weight_packed"] = torch.zeros(32, 16, dtype=torch.uint8)
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError):
+        _run_adapt(stream)
+
+
+# --- CLI probe --------------------------------------------------------------
+
+def test_cli_probe_passes_on_good_dir(tmp_path, capsys):
+    model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
+    rc = mn4.main([model_dir])
+    assert rc == 0
+
+
+def test_cli_probe_fails_on_awq_dir(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _awq_sidecar())
+    rc = mn4.main([model_dir])
+    assert rc == 1
+
+
+def test_cli_probe_usage_error():
+    assert mn4.main([]) == 2
+
+
+# --- additional integrity scenarios (spec-mandated) --------------------------
+
+def test_adapt_rejects_wrong_block_scale_grid():
+    bad = _tensors()
+    # gate_proj in=64 -> grid should be (32, 4); give (32, 3).
+    bad["layers.0.mlp.gate_proj.weight_block_scale"] = torch.zeros(32, 3, dtype=torch.float8_e4m3fn)
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(stream)
+    assert "grid" in str(exc.value).lower()
+
+
+def test_adapt_rejects_missing_block_scale_companion():
+    bad = _tensors()
+    del bad["layers.0.mlp.gate_proj.weight_block_scale"]  # keep packed + global, drop block scale
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(stream)
+    assert "weight_block_scale" in str(exc.value)
+
+
+def test_adapt_rejects_missing_global_scale_companion():
+    bad = _tensors()
+    del bad["layers.0.mlp.gate_proj.weight_global_scale"]
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(stream)
+    assert "weight_global_scale" in str(exc.value)
+
+
+def test_adapt_rejects_packed_outside_target_patterns():
+    # A packed module matching NEITHER target NOR forbidden patterns, absent
+    # from the manifest -> must be rejected (unexpected quantized module).
+    bad = _tensors()
+    bad["layers.0.router.gate.weight_packed"] = torch.zeros(16, 8, dtype=torch.uint8)
+    bad["layers.0.router.gate.weight_block_scale"] = torch.zeros(16, 1, dtype=torch.float8_e4m3fn)
+    bad["layers.0.router.gate.weight_global_scale"] = torch.zeros(1, dtype=torch.float32)
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(stream)
+    assert "outside target patterns" in str(exc.value) or "not declared" in str(exc.value)
+
+
+def test_adapt_aborts_on_inf_global_scale():
+    bad = _tensors()
+    bad["layers.0.mlp.gate_proj.weight_global_scale"] = torch.tensor([float("inf")], dtype=torch.float32)
+    stream = [(f"transformer.{n}", t) for n, t in bad.items()]
+    with pytest.raises(mn4.CheckpointIntegrityError) as exc:
+        _run_adapt(stream)
+    assert "inf" in str(exc.value).lower() or "nan" in str(exc.value).lower()

--- a/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
@@ -32,12 +32,13 @@ BLOCK = 16
 # Two real target names (one UND mlp, one GEN mlp_moe_gen) + shapes small but
 # 16-divisible so packed/scale grids are exact.
 _TARGETS = {
-    "layers.0.mlp.gate_proj.weight": (32, 64),          # out=32, in=64
+    "layers.0.mlp.gate_proj.weight": (32, 64),  # out=32, in=64
     "layers.0.mlp_moe_gen.down_proj.weight": (64, 32),  # out=64, in=32
 }
 
 
 # --- fixtures ---------------------------------------------------------------
+
 
 def _packed_width(cols: int) -> int:
     return (cols + 1) // 2
@@ -63,8 +64,16 @@ def _authoritative_sidecar():
         "expected_quantized_count": len(_TARGETS),
         "target_patterns": [r"^layers\.\d+\.mlp\.", r"^layers\.\d+\.mlp_moe_gen\."],
         "forbidden_patterns": [
-            "embed_tokens", "lm_head", "self_attn", "norm", "time_embedder",
-            "proj_in", "proj_out", "audio_", "action_", "blocks.",
+            "embed_tokens",
+            "lm_head",
+            "self_attn",
+            "norm",
+            "time_embedder",
+            "proj_in",
+            "proj_out",
+            "audio_",
+            "action_",
+            "blocks.",
         ],
         "scale_encoding": {
             "block_along": "last_dim",
@@ -130,6 +139,7 @@ def _source(model_or_path="unused"):
 
 # --- parse_nvfp4_spec --------------------------------------------------------
 
+
 def test_parse_spec_accepts_authoritative_sidecar():
     spec = mn4.parse_nvfp4_spec(_authoritative_sidecar())
     assert spec.recipe == "nvfp4_blockwise_mixed_v1"
@@ -153,6 +163,7 @@ def test_parse_spec_rejects_bad_scale_encoding():
 
 # --- pure name/shape calculations -------------------------------------------
 
+
 def test_remap_name_roundtrip():
     assert mn4.remap_name("x.mlp.gate_proj.weight_packed") == "x.mlp.gate_proj.weight"
     assert mn4.remap_name("x.mlp.gate_proj.weight_block_scale") == "x.mlp.gate_proj.weight_scale"
@@ -175,6 +186,7 @@ def test_expected_packed_width_and_grid():
 
 
 # --- adapter detect ---------------------------------------------------------
+
 
 def test_detect_engages_on_sidecar(tmp_path):
     model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
@@ -202,6 +214,7 @@ def test_registry_selects_nvfp4_native_before_generic(tmp_path):
 
 
 # --- adapt: rename + passthrough, no dequant --------------------------------
+
 
 def _run_adapt(stream, sidecar=None):
     spec = mn4.parse_nvfp4_spec(sidecar or _authoritative_sidecar())
@@ -270,6 +283,7 @@ def test_adapt_rejects_wrong_packed_width():
 
 # --- CLI probe --------------------------------------------------------------
 
+
 def test_cli_probe_passes_on_good_dir(tmp_path, capsys):
     model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
     rc = mn4.main([model_dir])
@@ -287,6 +301,7 @@ def test_cli_probe_usage_error():
 
 
 # --- additional integrity scenarios (spec-mandated) --------------------------
+
 
 def test_adapt_rejects_wrong_block_scale_grid():
     bad = _tensors()

--- a/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
+++ b/tests/diffusion/model_loader/test_modelopt_native_nvfp4.py
@@ -25,6 +25,7 @@ from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
 from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     modelopt_native_nvfp4 as mn4,
 )
+from vllm_omni.quantization.nvfp4_blockwise import build_nvfp4_blockwise_w4a16_config
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
@@ -120,6 +121,15 @@ def _stream(prefix="transformer.", nan=False):
     return [(f"{prefix}{n}", t) for n, t in _tensors(nan=nan).items()]
 
 
+def _remote_source(repo_id, resolved_model_or_path):
+    return SimpleNamespace(
+        model_or_path=repo_id,
+        resolved_model_or_path=resolved_model_or_path,
+        subfolder="transformer",
+        prefix="transformer.",
+    )
+
+
 def _write_model_dir(tmp_path, sidecar, tensors=None):
     from safetensors.torch import save_file
 
@@ -194,6 +204,12 @@ def test_detect_engages_on_sidecar(tmp_path):
     assert isinstance(adapter, mn4.ModelOptNativeNvfp4CheckpointAdapter)
 
 
+def test_detect_uses_resolved_model_root_for_remote_sources(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
+    adapter = mn4.ModelOptNativeNvfp4CheckpointAdapter.detect(_remote_source("owner/repo", model_dir))
+    assert isinstance(adapter, mn4.ModelOptNativeNvfp4CheckpointAdapter)
+
+
 def test_detect_returns_none_without_sidecar(tmp_path):
     model_dir = _write_model_dir(tmp_path, None)
     adapter = mn4.ModelOptNativeNvfp4CheckpointAdapter.detect(_source(model_dir))
@@ -209,8 +225,16 @@ def test_detect_raises_on_malformed_sidecar(tmp_path):
 def test_registry_selects_nvfp4_native_before_generic(tmp_path):
     model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
     model = torch.nn.Linear(2, 2)
-    adapter = get_checkpoint_adapter(model, _source(model_dir), quant_config=None, use_safetensors=True)
+    cfg = build_nvfp4_blockwise_w4a16_config()
+    adapter = get_checkpoint_adapter(model, _source(model_dir), quant_config=cfg, use_safetensors=True)
     assert isinstance(adapter, mn4.ModelOptNativeNvfp4CheckpointAdapter)
+
+
+def test_registry_rejects_nvfp4_sidecar_without_matching_config(tmp_path):
+    model_dir = _write_model_dir(tmp_path, _authoritative_sidecar())
+    model = torch.nn.Linear(2, 2)
+    with pytest.raises(mn4.CheckpointIntegrityError, match="NVFP4"):
+        get_checkpoint_adapter(model, _source(model_dir), quant_config=None, use_safetensors=True)
 
 
 # --- adapt: rename + passthrough, no dequant --------------------------------

--- a/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
+++ b/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
@@ -5,6 +5,7 @@
 The tests cover target selection, recipe-gated dispatch, resident weight
 allocation, and per-op dequantized GEMM behavior.
 """
+
 import json
 from types import SimpleNamespace
 
@@ -139,9 +140,7 @@ def test_omni_diffusion_config_opt_in_wires_fp8_w8a16(tmp_path, monkeypatch):
 def test_fp8_w8a16_selected_declines_non_fp8_blockwise(tmp_path, monkeypatch):
     monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     # foreign recipe (mirrors NVFP4) -> declines (predicate is False, no raise here)
-    assert w8.fp8_w8a16_selected(
-        _sidecar_dir(tmp_path / "nv", recipe="nvfp4_blockwise_mixed_v1")
-    ) is False
+    assert w8.fp8_w8a16_selected(_sidecar_dir(tmp_path / "nv", recipe="nvfp4_blockwise_mixed_v1")) is False
     # missing sidecar (plain BF16 dir) -> declines
     (tmp_path / "bf16").mkdir()
     assert w8.fp8_w8a16_selected(str(tmp_path / "bf16")) is False

--- a/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
+++ b/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
@@ -104,29 +104,40 @@ def _sidecar_dir(root, recipe="fp8_blockwise_mixed"):
     return str(root)
 
 
-def test_fp8_dequant_forced(monkeypatch):
-    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
-    assert w8.fp8_dequant_forced() is False
-    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
-    assert w8.fp8_dequant_forced() is True
-    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "0")  # only "1" opts out
-    assert w8.fp8_dequant_forced() is False
+def test_fp8_w8a16_forced(monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
+    assert w8.fp8_w8a16_forced() is False
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+    assert w8.fp8_w8a16_forced() is True
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "0")  # only "1" opts in
+    assert w8.fp8_w8a16_forced() is False
 
 
-def test_fp8_w8a16_selected_default_on_for_fp8_blockwise(tmp_path, monkeypatch):
-    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
-    # the fp8_blockwise recipe -> W8A16 is the default, no opt-in flag needed
-    assert w8.fp8_w8a16_selected(_sidecar_dir(tmp_path / "fp8")) is True
+def test_fp8_w8a16_selected_default_off_for_fp8_blockwise(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", raising=False)
+    assert w8.fp8_w8a16_selected(_sidecar_dir(tmp_path / "fp8")) is False
 
 
-def test_fp8_w8a16_selected_opt_out_forces_dequant(tmp_path, monkeypatch):
+def test_fp8_w8a16_selected_explicit_opt_in(tmp_path, monkeypatch):
     root = _sidecar_dir(tmp_path / "fp8")
-    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
-    assert w8.fp8_w8a16_selected(root) is False
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+    assert w8.fp8_w8a16_selected(root) is True
+
+
+def test_omni_diffusion_config_opt_in_wires_fp8_w8a16(tmp_path, monkeypatch):
+    from vllm_omni.diffusion.data import OmniDiffusionConfig, TransformerConfig
+
+    root = _sidecar_dir(tmp_path / "fp8")
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+
+    config = OmniDiffusionConfig(model=root, tf_model_config=TransformerConfig.from_dict({}))
+
+    assert config.quantization_config is not None
+    assert config.quantization_config.LinearMethodCls.__name__ == "Fp8BlockwiseW8A16LinearMethod"
 
 
 def test_fp8_w8a16_selected_declines_non_fp8_blockwise(tmp_path, monkeypatch):
-    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
     # foreign recipe (mirrors NVFP4) -> declines (predicate is False, no raise here)
     assert w8.fp8_w8a16_selected(
         _sidecar_dir(tmp_path / "nv", recipe="nvfp4_blockwise_mixed_v1")

--- a/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
+++ b/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for the FP8 W8A16 blockwise config + weight-only linear method.
+
+The tests cover target selection, recipe-gated dispatch, resident weight
+allocation, and per-op dequantized GEMM behavior.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_omni.quantization import fp8_blockwise_w8a16 as w8
+from vllm_omni.quantization.fp8_blockwise_w8a16 import Fp8BlockwiseW8A16LinearMethod
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _method(block=(128, 128)):
+    return Fp8BlockwiseW8A16LinearMethod(SimpleNamespace(weight_block_size=list(block)))
+
+
+# --- target selection (Gated construction) ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "language_model.layers.0.mlp.gate_proj",
+        "language_model.layers.5.mlp.up_proj",
+        "language_model.layers.35.mlp.down_proj",
+        "gen_layers.0.mlp_moe_gen.gate_proj",
+        "gen_layers.12.mlp_moe_gen.up_proj",
+        "gen_layers.35.mlp_moe_gen.down_proj",
+    ],
+)
+def test_is_target_prefix_matches_mlp(prefix):
+    assert w8.is_target_prefix(prefix) is True
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "lm_head",
+        "language_model.layers.0.self_attn.to_q",
+        "language_model.layers.0.self_attn.to_out",
+        "proj_in",
+        "proj_out",
+        "time_embedder",
+        "embed_tokens",
+        "action_proj_in.fc",
+        # a parameter name, not a module prefix -> must NOT match.
+        "language_model.layers.0.mlp.gate_proj.weight",
+    ],
+)
+def test_is_target_prefix_excludes_nontargets(prefix):
+    assert w8.is_target_prefix(prefix) is False
+
+
+# --- gated build -------------------------------------------------------------
+
+
+def test_maybe_build_disabled_returns_active_unchanged():
+    sentinel = SimpleNamespace(name="active")
+    assert w8.maybe_build_fp8_blockwise_w8a16_config(False, sentinel) is sentinel
+    assert w8.maybe_build_fp8_blockwise_w8a16_config(False, None) is None
+
+
+def test_maybe_build_disabled_does_not_call_build(monkeypatch):
+    def boom():
+        raise AssertionError("build must not be called when disabled")
+
+    monkeypatch.setattr(w8, "build_fp8_blockwise_w8a16_config", boom)
+    assert w8.maybe_build_fp8_blockwise_w8a16_config(False, None) is None
+
+
+def test_maybe_build_enabled_builds_target_inclusion_config():
+    cfg = w8.maybe_build_fp8_blockwise_w8a16_config(True, None)
+    assert cfg.is_target_module("language_model.layers.0.mlp.gate_proj")
+    assert cfg.is_target_module("gen_layers.0.mlp_moe_gen.down_proj")
+    # target-inclusion: everything else is excluded -> Unquantized (BF16)
+    assert cfg.is_layer_excluded("lm_head")
+    assert cfg.is_layer_excluded("language_model.layers.0.self_attn.to_q")
+    assert not cfg.is_layer_excluded("language_model.layers.0.mlp.gate_proj")
+    assert cfg.LinearMethodCls.__name__ == "Fp8BlockwiseW8A16LinearMethod"
+    assert list(cfg.weight_block_size) == [128, 128]
+
+
+def test_maybe_build_enabled_never_overrides_active_config():
+    # e.g. the NVFP4 W4A16 config already built by the NVFP4 hook must be kept.
+    nvfp4 = SimpleNamespace(get_name=lambda: "modelopt_fp4")
+    assert w8.maybe_build_fp8_blockwise_w8a16_config(True, nvfp4) is nvfp4
+
+
+# --- recipe-gated default selection -----------------------------------------
+
+
+def _sidecar_dir(root, recipe="fp8_blockwise_mixed"):
+    """Write a minimal root quantization_config.json and return the dir path."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "quantization_config.json").write_text(json.dumps({"recipe": recipe}))
+    return str(root)
+
+
+def test_fp8_dequant_forced(monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    assert w8.fp8_dequant_forced() is False
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+    assert w8.fp8_dequant_forced() is True
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "0")  # only "1" opts out
+    assert w8.fp8_dequant_forced() is False
+
+
+def test_fp8_w8a16_selected_default_on_for_fp8_blockwise(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    # the fp8_blockwise recipe -> W8A16 is the default, no opt-in flag needed
+    assert w8.fp8_w8a16_selected(_sidecar_dir(tmp_path / "fp8")) is True
+
+
+def test_fp8_w8a16_selected_opt_out_forces_dequant(tmp_path, monkeypatch):
+    root = _sidecar_dir(tmp_path / "fp8")
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", "1")
+    assert w8.fp8_w8a16_selected(root) is False
+
+
+def test_fp8_w8a16_selected_declines_non_fp8_blockwise(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_FP8_BLOCKWISE_DEQUANT", raising=False)
+    # foreign recipe (mirrors NVFP4) -> declines (predicate is False, no raise here)
+    assert w8.fp8_w8a16_selected(
+        _sidecar_dir(tmp_path / "nv", recipe="nvfp4_blockwise_mixed_v1")
+    ) is False
+    # missing sidecar (plain BF16 dir) -> declines
+    (tmp_path / "bf16").mkdir()
+    assert w8.fp8_w8a16_selected(str(tmp_path / "bf16")) is False
+    # no path -> declines
+    assert w8.fp8_w8a16_selected(None) is False
+
+
+# --- linear method: residency, weight-only, JIT dequant ----------------------
+
+
+def test_create_weights_registers_resident_fp8_and_block_scale(monkeypatch):
+    # vLLM Parameters read the TP rank/size at construction; pin single-rank so this
+    # stays a hermetic CPU test (no distributed init).
+    import vllm.model_executor.parameter as vp
+
+    monkeypatch.setattr(vp, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(vp, "get_tensor_model_parallel_world_size", lambda: 1)
+    method = _method()
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=128,
+        output_partition_sizes=[256],
+        input_size=128,
+        output_size=256,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    # resident FP8 weight (1 byte/elem), NOT dequantized to BF16
+    assert layer.weight.dtype == torch.float8_e4m3fn
+    assert layer.weight.element_size() == 1
+    assert tuple(layer.weight.shape) == (256, 128)
+    # 2D block scale grid [ceil(256/128), ceil(128/128)] = [2, 1], bf16
+    assert layer.weight_scale.dtype == torch.bfloat16
+    assert tuple(layer.weight_scale.shape) == (2, 1)
+    # weight-only: no activation input_scale
+    assert not hasattr(layer, "input_scale")
+    assert layer.weight_block_size == [128, 128]
+
+
+def test_apply_dequantizes_per_op_then_gemm():
+    from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import (
+        dequantize_weight,
+    )
+
+    method = _method()
+    out, inn, batch = 128, 128, 4
+    w_fp8 = (torch.randn(out, inn) * 0.1).to(torch.float8_e4m3fn)
+    scale = (torch.rand(1, 1) + 0.5).to(torch.bfloat16)
+    x = torch.randn(batch, inn, dtype=torch.bfloat16)
+    layer = SimpleNamespace(weight=w_fp8, weight_scale=scale, weight_block_size=[128, 128])
+
+    got = method.apply(layer, x)
+    ref_w = dequantize_weight(w_fp8, scale, x.dtype, (128, 128))
+    ref = F.linear(x, ref_w)
+
+    assert tuple(got.shape) == (batch, out)  # no transpose bug
+    torch.testing.assert_close(got, ref)
+
+
+def test_process_weights_after_loading_passes_on_fp8_with_valid_scale_grid():
+    method = _method()
+    # 256x128, block 128x128 -> scale grid (ceil(256/128), ceil(128/128)) = (2, 1)
+    layer = SimpleNamespace(
+        weight=torch.zeros(256, 128).to(torch.float8_e4m3fn),
+        weight_scale=torch.ones(2, 1, dtype=torch.bfloat16),
+        output_size_per_partition=256,
+        input_size_per_partition=128,
+        weight_block_size=[128, 128],
+    )
+    method.process_weights_after_loading(layer)  # must not raise
+
+
+def test_process_weights_after_loading_rejects_bf16_silent_dequant():
+    method = _method()
+    layer = SimpleNamespace(
+        weight=torch.zeros(128, 128, dtype=torch.bfloat16),
+        weight_block_size=[128, 128],
+    )
+    # residency check fires before the scale-grid check (no scale attrs needed)
+    with pytest.raises(ValueError, match="residency"):
+        method.process_weights_after_loading(layer)
+
+
+def test_process_weights_after_loading_rejects_wrong_scale_grid():
+    method = _method()
+    # transposed grid (1, 2) != expected (2, 1) -> malformed scale rejected
+    layer = SimpleNamespace(
+        weight=torch.zeros(256, 128).to(torch.float8_e4m3fn),
+        weight_scale=torch.ones(1, 2, dtype=torch.bfloat16),
+        output_size_per_partition=256,
+        input_size_per_partition=128,
+        weight_block_size=[128, 128],
+    )
+    with pytest.raises(ValueError, match="scale-grid"):
+        method.process_weights_after_loading(layer)

--- a/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
+++ b/tests/diffusion/quantization/test_fp8_blockwise_w8a16.py
@@ -125,6 +125,14 @@ def test_fp8_w8a16_selected_explicit_opt_in(tmp_path, monkeypatch):
     assert w8.fp8_w8a16_selected(root) is True
 
 
+def test_fp8_w8a16_selected_uses_resolved_model_root(tmp_path, monkeypatch):
+    root = _sidecar_dir(tmp_path / "fp8")
+    source = SimpleNamespace(model_or_path="owner/repo", resolved_model_or_path=root)
+    monkeypatch.setenv("VLLM_OMNI_FP8_BLOCKWISE_W8A16", "1")
+
+    assert w8.fp8_w8a16_selected(source) is True
+
+
 def test_omni_diffusion_config_opt_in_wires_fp8_w8a16(tmp_path, monkeypatch):
     from vllm_omni.diffusion.data import OmniDiffusionConfig, TransformerConfig
 

--- a/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
+++ b/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
@@ -38,6 +38,9 @@ needs_w4a16 = pytest.mark.skipif(
         "language_model.layers.7.mlp.down_proj",
         "gen_layers.0.mlp.gate_proj",
         "gen_layers.35.mlp.down_proj",
+        "gen_layers.0.mlp_moe_gen.gate_proj",
+        "gen_layers.10.mlp_moe_gen.up_proj",
+        "gen_layers.35.mlp_moe_gen.down_proj",
     ],
 )
 def test_target_prefixes_included(prefix):
@@ -80,6 +83,7 @@ def test_config_quantizes_only_targets():
     # targets NOT excluded (get the W4A16 FP4 method)
     assert cfg.is_layer_excluded("language_model.layers.0.mlp.gate_proj") is False
     assert cfg.is_layer_excluded("gen_layers.10.mlp.down_proj") is False
+    assert cfg.is_layer_excluded("gen_layers.10.mlp_moe_gen.down_proj") is False
     # non-targets excluded (stay BF16 / UnquantizedLinearMethod)
     assert cfg.is_layer_excluded("language_model.layers.0.self_attn.to_q") is True
     assert cfg.is_layer_excluded("lm_head") is True
@@ -99,3 +103,14 @@ def test_maybe_build_builds_for_recipe_when_no_active():
     cfg = nb.maybe_build_nvfp4_blockwise_config(nb.RECIPE, None)
     assert cfg is not None
     assert cfg.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
+
+
+@needs_w4a16
+def test_transformer_config_quant_recipe_builds_w4a16_config():
+    from vllm_omni.diffusion.data import TransformerConfig
+
+    tf_config = TransformerConfig.from_dict({"quant_recipe": nb.RECIPE})
+
+    assert tf_config.quant_config is not None
+    assert tf_config.quant_config.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
+    assert tf_config.quant_method == nb.RECIPE

--- a/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
+++ b/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
@@ -23,12 +23,11 @@ except Exception:  # pragma: no cover - depends on installed vLLM
     _HAS_W4A16 = False
     ModelOptNvFp4W4A16LinearMethod = None  # bound for skip-guarded references
 
-needs_w4a16 = pytest.mark.skipif(
-    not _HAS_W4A16, reason="vLLM ModelOptNvFp4W4A16LinearMethod not available in this env"
-)
+needs_w4a16 = pytest.mark.skipif(not _HAS_W4A16, reason="vLLM ModelOptNvFp4W4A16LinearMethod not available in this env")
 
 
 # --- pure prefix predicate --------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "prefix",
@@ -69,6 +68,7 @@ def test_non_target_prefixes_excluded(prefix):
 
 # --- config build -----------------------------------------------------------
 
+
 @needs_w4a16
 def test_build_selects_w4a16_method():
     cfg = nb.build_nvfp4_blockwise_w4a16_config()
@@ -91,6 +91,7 @@ def test_config_quantizes_only_targets():
 
 
 # --- resolution helper ------------------------------------------------------
+
 
 def test_maybe_build_returns_active_for_non_recipe():
     sentinel = object()

--- a/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
+++ b/tests/model_executor/quantization/test_nvfp4_blockwise_config.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the NVFP4 blockwise W4A16 target-inclusion quant config.
+
+Verifies the wiring that serves the weight-only nvfp4_blockwise_mixed_v1
+artifact FP4-resident: the config must select vLLM's W4A16 method (Marlin, bf16
+activations — no input_scale) and quantize ONLY the MLP / MLP-MoE-gen projections.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# The pure prefix predicate does not need vLLM; the config build does.
+from vllm_omni.quantization import nvfp4_blockwise as nb  # noqa: E402
+
+_HAS_W4A16 = True
+try:
+    from vllm.model_executor.layers.quantization.modelopt import (  # noqa: E402
+        ModelOptNvFp4W4A16LinearMethod,
+    )
+except Exception:  # pragma: no cover - depends on installed vLLM
+    _HAS_W4A16 = False
+    ModelOptNvFp4W4A16LinearMethod = None  # bound for skip-guarded references
+
+needs_w4a16 = pytest.mark.skipif(
+    not _HAS_W4A16, reason="vLLM ModelOptNvFp4W4A16LinearMethod not available in this env"
+)
+
+
+# --- pure prefix predicate --------------------------------------------------
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "language_model.layers.0.mlp.gate_proj",
+        "language_model.layers.35.mlp.up_proj",
+        "language_model.layers.7.mlp.down_proj",
+        "gen_layers.0.mlp.gate_proj",
+        "gen_layers.35.mlp.down_proj",
+    ],
+)
+def test_target_prefixes_included(prefix):
+    assert nb.is_target_prefix(prefix) is True
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "language_model.layers.0.self_attn.to_q",
+        "language_model.layers.0.self_attn.to_out",
+        "gen_layers.0.self_attn.add_q_proj",
+        "proj_in",
+        "proj_out",
+        "language_model.embed_tokens",
+        "lm_head",
+        "time_embedder.linear_1",
+        "action_proj_in",
+        "audio_proj_out",
+        "language_model.layers.0.mlp",  # the container, not a projection
+    ],
+)
+def test_non_target_prefixes_excluded(prefix):
+    assert nb.is_target_prefix(prefix) is False
+
+
+# --- config build -----------------------------------------------------------
+
+@needs_w4a16
+def test_build_selects_w4a16_method():
+    cfg = nb.build_nvfp4_blockwise_w4a16_config()
+    assert cfg.get_name() == "modelopt_fp4"
+    assert cfg.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
+    assert cfg.group_size == 16
+
+
+@needs_w4a16
+def test_config_quantizes_only_targets():
+    cfg = nb.build_nvfp4_blockwise_w4a16_config()
+    # targets NOT excluded (get the W4A16 FP4 method)
+    assert cfg.is_layer_excluded("language_model.layers.0.mlp.gate_proj") is False
+    assert cfg.is_layer_excluded("gen_layers.10.mlp.down_proj") is False
+    # non-targets excluded (stay BF16 / UnquantizedLinearMethod)
+    assert cfg.is_layer_excluded("language_model.layers.0.self_attn.to_q") is True
+    assert cfg.is_layer_excluded("lm_head") is True
+    assert cfg.is_layer_excluded("proj_out") is True
+
+
+# --- resolution helper ------------------------------------------------------
+
+def test_maybe_build_returns_active_for_non_recipe():
+    sentinel = object()
+    assert nb.maybe_build_nvfp4_blockwise_config(None, sentinel) is sentinel
+    assert nb.maybe_build_nvfp4_blockwise_config("some_other_recipe", sentinel) is sentinel
+
+
+@needs_w4a16
+def test_maybe_build_builds_for_recipe_when_no_active():
+    cfg = nb.maybe_build_nvfp4_blockwise_config(nb.RECIPE, None)
+    assert cfg is not None
+    assert cfg.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -585,20 +585,35 @@ class _DiffusionConfigProjection:
 
     def _propagate_quantization_from_tf_config(self, tf_config: Any) -> None:
         quant_config = getattr(tf_config, "quant_config", None)
-        if quant_config is None:
-            return
-        quant_method = getattr(tf_config, "quant_method", None)
-        is_checkpoint_fp8 = bool(getattr(quant_config, "is_checkpoint_fp8_serialized", False))
-        is_checkpoint_nvfp4 = bool(getattr(quant_config, "is_checkpoint_nvfp4_serialized", False))
-        should_use_checkpoint_config = (
-            self.quantization_config is None
-            or (is_checkpoint_fp8 and self._is_generic_fp8_quant_config(self.quantization_config))
-            or (is_checkpoint_nvfp4 and self._is_generic_nvfp4_quant_config(self.quantization_config))
+        if quant_config is not None:
+            quant_method = getattr(tf_config, "quant_method", None)
+            is_checkpoint_fp8 = bool(getattr(quant_config, "is_checkpoint_fp8_serialized", False))
+            is_checkpoint_nvfp4 = bool(getattr(quant_config, "is_checkpoint_nvfp4_serialized", False))
+            should_use_checkpoint_config = (
+                self.quantization_config is None
+                or (is_checkpoint_fp8 and self._is_generic_fp8_quant_config(self.quantization_config))
+                or (is_checkpoint_nvfp4 and self._is_generic_nvfp4_quant_config(self.quantization_config))
+            )
+            if should_use_checkpoint_config:
+                self.quantization_config = quant_config
+                if quant_method is not None:
+                    self.additional_config.setdefault("auto_detected_quant_method", quant_method)
+
+        self._propagate_fp8_w8a16_from_model_root()
+
+    def _propagate_fp8_w8a16_from_model_root(self) -> None:
+        from vllm_omni.quantization.fp8_blockwise_w8a16 import (
+            fp8_w8a16_selected,
+            maybe_build_fp8_blockwise_w8a16_config,
         )
-        if should_use_checkpoint_config:
-            self.quantization_config = quant_config
-            if quant_method is not None:
-                self.additional_config.setdefault("auto_detected_quant_method", quant_method)
+
+        resolved_config = maybe_build_fp8_blockwise_w8a16_config(
+            fp8_w8a16_selected(self.model),
+            self.quantization_config,
+        )
+        if resolved_config is not self.quantization_config:
+            self.quantization_config = resolved_config
+            self.additional_config.setdefault("auto_detected_quant_method", "fp8_blockwise_w8a16")
 
     @staticmethod
     def _is_generic_fp8_quant_config(quant_config: object) -> bool:

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -872,7 +872,7 @@ class OmniDiffusionConfig:
             f"Failed to find available port after {max_attempts} attempts (started from port {original_port})"
         )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.master_port = self._resolve_master_port()
         self.request_batch_max_wait_ms = float(self.request_batch_max_wait_ms or 0.0)
         if self.request_batch_max_wait_ms < 0:

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -347,6 +347,17 @@ class TransformerConfig:
             if quant_config is not None:
                 quant_method = raw_quant_method if raw_quant_method is not None else quant_config.get_name()
 
+        quant_recipe = params.get("quant_recipe")
+        if isinstance(quant_recipe, str):
+            from vllm_omni.quantization.nvfp4_blockwise import (
+                maybe_build_nvfp4_blockwise_config,
+            )
+
+            resolved_config = maybe_build_nvfp4_blockwise_config(quant_recipe, quant_config)
+            if resolved_config is not quant_config:
+                quant_config = resolved_config
+                quant_method = quant_recipe
+
         return cls(params=params, quant_method=quant_method, quant_config=quant_config)
 
     def to_dict(self) -> dict[str, Any]:
@@ -962,22 +973,36 @@ class OmniDiffusionConfig:
             )
 
     def _propagate_quantization_from_tf_config(self, tf_config: "TransformerConfig") -> None:
-        if tf_config.quant_config is None:
-            return
-
-        is_checkpoint_fp8 = bool(getattr(tf_config.quant_config, "is_checkpoint_fp8_serialized", False))
-        is_checkpoint_nvfp4 = bool(getattr(tf_config.quant_config, "is_checkpoint_nvfp4_serialized", False))
-        should_use_checkpoint_config = (
-            self.quantization_config is None
-            or (is_checkpoint_fp8 and self._is_generic_fp8_quant_config(self.quantization_config))
-            or (is_checkpoint_nvfp4 and self._is_generic_nvfp4_quant_config(self.quantization_config))
-        )
-        if should_use_checkpoint_config:
-            self.quantization_config = tf_config.quant_config
-            logger.info(
-                "Auto-detected quantization '%s' from model config",
-                tf_config.quant_method,
+        if tf_config.quant_config is not None:
+            is_checkpoint_fp8 = bool(getattr(tf_config.quant_config, "is_checkpoint_fp8_serialized", False))
+            is_checkpoint_nvfp4 = bool(getattr(tf_config.quant_config, "is_checkpoint_nvfp4_serialized", False))
+            should_use_checkpoint_config = (
+                self.quantization_config is None
+                or (is_checkpoint_fp8 and self._is_generic_fp8_quant_config(self.quantization_config))
+                or (is_checkpoint_nvfp4 and self._is_generic_nvfp4_quant_config(self.quantization_config))
             )
+            if should_use_checkpoint_config:
+                self.quantization_config = tf_config.quant_config
+                logger.info(
+                    "Auto-detected quantization '%s' from model config",
+                    tf_config.quant_method,
+                )
+
+        self._propagate_fp8_w8a16_from_model_root()
+
+    def _propagate_fp8_w8a16_from_model_root(self) -> None:
+        from vllm_omni.quantization.fp8_blockwise_w8a16 import (
+            fp8_w8a16_selected,
+            maybe_build_fp8_blockwise_w8a16_config,
+        )
+
+        resolved_config = maybe_build_fp8_blockwise_w8a16_config(
+            fp8_w8a16_selected(self.model),
+            self.quantization_config,
+        )
+        if resolved_config is not self.quantization_config:
+            self.quantization_config = resolved_config
+            self.additional_config.setdefault("auto_detected_quant_method", "fp8_blockwise_w8a16")
 
     @staticmethod
     def _is_generic_fp8_quant_config(quant_config: object) -> bool:

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
@@ -50,19 +50,13 @@ def get_checkpoint_adapter(
         # the explicit opt-in is set and the root recipe matches, so dequant is
         # the default and NVFP4 is unaffected.
         if fp8_w8a16_selected(getattr(source, "model_or_path", None)):
-            w8a16_adapter = ModelOptNativeFp8W8A16CheckpointAdapter.detect(
-                source, target_dtype=_model_dtype(model)
-            )
+            w8a16_adapter = ModelOptNativeFp8W8A16CheckpointAdapter.detect(source, target_dtype=_model_dtype(model))
             if w8a16_adapter is not None:
                 return w8a16_adapter
-        native_adapter = ModelOptNativeFp8CheckpointAdapter.detect(
-            source, target_dtype=_model_dtype(model)
-        )
+        native_adapter = ModelOptNativeFp8CheckpointAdapter.detect(source, target_dtype=_model_dtype(model))
         if native_adapter is not None:
             return native_adapter
-        nvfp4_native_adapter = ModelOptNativeNvfp4CheckpointAdapter.detect(
-            source, target_dtype=_model_dtype(model)
-        )
+        nvfp4_native_adapter = ModelOptNativeNvfp4CheckpointAdapter.detect(source, target_dtype=_model_dtype(model))
         if nvfp4_native_adapter is not None:
             return nvfp4_native_adapter
     if ModelOptFp8CheckpointAdapter.is_compatible(source, quant_config, use_safetensors):

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
@@ -3,15 +3,22 @@
 import torch
 from torch import nn
 
-from vllm_omni.quantization.fp8_blockwise_w8a16 import fp8_w8a16_selected
+from vllm_omni.quantization.fp8_blockwise_w8a16 import (
+    fp8_w8a16_selected,
+    is_fp8_blockwise_w8a16_config,
+)
+from vllm_omni.quantization.nvfp4_blockwise import is_nvfp4_blockwise_w4a16_config
 
 from .modelopt import (
     ModelOptFp8CheckpointAdapter,
     ModelOptMixedPrecisionCheckpointAdapter,
     ModelOptNvFp4CheckpointAdapter,
 )
-from .modelopt_native import ModelOptNativeFp8CheckpointAdapter
+from .modelopt_native import CheckpointIntegrityError, ModelOptNativeFp8CheckpointAdapter
 from .modelopt_native_fp8_w8a16 import ModelOptNativeFp8W8A16CheckpointAdapter
+from .modelopt_native_nvfp4 import (
+    CheckpointIntegrityError as Nvfp4CheckpointIntegrityError,
+)
 from .modelopt_native_nvfp4 import ModelOptNativeNvfp4CheckpointAdapter
 
 # Recipe-gated dispatch: the FP8-blockwise resident W8A16 path is explicit
@@ -39,17 +46,22 @@ def get_checkpoint_adapter(
     | None
 ):
     if use_safetensors:
-        # Checkpoint-driven (sidecar) detection; independent of quant_config.
-        # Raises CheckpointIntegrityError on a present-but-unsupported sidecar
-        # (fail fast), returns None for unquantized checkpoints. NVFP4 and FP8
-        # native adapters key off distinct sidecar filenames, so order is safe;
-        # both must precede the generic quant_config-driven adapters below.
+        # Checkpoint-driven sidecar detection. The load-time FP8 dequant path is
+        # independent of quant_config because it emits full-precision weights.
+        # Resident native adapters must match the active config, otherwise the
+        # loaded tensor names/dtypes can disagree with the constructed layers.
         #
         # The optional FP8 W8A16 path must precede the dequant FP8 adapter
         # because both key off the same sidecar. The predicate is false unless
         # the explicit opt-in is set and the root recipe matches, so dequant is
         # the default and NVFP4 is unaffected.
-        if fp8_w8a16_selected(getattr(source, "model_or_path", None)):
+        if fp8_w8a16_selected(source):
+            if not is_fp8_blockwise_w8a16_config(quant_config):
+                raise CheckpointIntegrityError(
+                    "FP8 W8A16 resident checkpoint sidecar detected, but the active quant_config is not "
+                    "the FP8 blockwise W8A16 config. Refusing to load resident FP8 weights into "
+                    "incompatible layers."
+                )
             w8a16_adapter = ModelOptNativeFp8W8A16CheckpointAdapter.detect(source, target_dtype=_model_dtype(model))
             if w8a16_adapter is not None:
                 return w8a16_adapter
@@ -58,6 +70,12 @@ def get_checkpoint_adapter(
             return native_adapter
         nvfp4_native_adapter = ModelOptNativeNvfp4CheckpointAdapter.detect(source, target_dtype=_model_dtype(model))
         if nvfp4_native_adapter is not None:
+            if not is_nvfp4_blockwise_w4a16_config(quant_config):
+                raise Nvfp4CheckpointIntegrityError(
+                    "NVFP4 native checkpoint sidecar detected, but the active quant_config is not "
+                    "the NVFP4 blockwise W4A16 config. Refusing to load resident NVFP4 weights into "
+                    "incompatible layers."
+                )
             return nvfp4_native_adapter
     if ModelOptFp8CheckpointAdapter.is_compatible(source, quant_config, use_safetensors):
         return ModelOptFp8CheckpointAdapter(model, source)

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
@@ -14,9 +14,9 @@ from .modelopt_native import ModelOptNativeFp8CheckpointAdapter
 from .modelopt_native_fp8_w8a16 import ModelOptNativeFp8W8A16CheckpointAdapter
 from .modelopt_native_nvfp4 import ModelOptNativeNvfp4CheckpointAdapter
 
-# Recipe-gated dispatch: an FP8-blockwise checkpoint is served W8A16-resident
-# by default, keyed on its root ``quantization_config.json`` recipe.
-# ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1`` forces the dequant-on-load path.
+# Recipe-gated dispatch: the FP8-blockwise resident W8A16 path is explicit
+# opt-in via ``VLLM_OMNI_FP8_BLOCKWISE_W8A16=1`` and still requires the root
+# ``quantization_config.json`` recipe. Load-time dequant remains the default.
 
 
 def _model_dtype(model: nn.Module) -> torch.dtype:
@@ -45,11 +45,10 @@ def get_checkpoint_adapter(
         # native adapters key off distinct sidecar filenames, so order is safe;
         # both must precede the generic quant_config-driven adapters below.
         #
-        # The FP8-blockwise checkpoint is served W8A16-resident by default
-        # (fp8_w8a16_selected reads the root quantization_config.json recipe). This must
-        # precede the dequant FP8 adapter (both key off the same sidecar). The predicate is
-        # False for the NVFP4 sidecar and when VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1, so NVFP4 is unaffected
-        # and the dequant fallback stays reachable.
+        # The optional FP8 W8A16 path must precede the dequant FP8 adapter
+        # because both key off the same sidecar. The predicate is false unless
+        # the explicit opt-in is set and the root recipe matches, so dequant is
+        # the default and NVFP4 is unaffected.
         if fp8_w8a16_selected(getattr(source, "model_or_path", None)):
             w8a16_adapter = ModelOptNativeFp8W8A16CheckpointAdapter.detect(
                 source, target_dtype=_model_dtype(model)

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/__init__.py
@@ -1,12 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
 from torch import nn
+
+from vllm_omni.quantization.fp8_blockwise_w8a16 import fp8_w8a16_selected
 
 from .modelopt import (
     ModelOptFp8CheckpointAdapter,
     ModelOptMixedPrecisionCheckpointAdapter,
     ModelOptNvFp4CheckpointAdapter,
 )
+from .modelopt_native import ModelOptNativeFp8CheckpointAdapter
+from .modelopt_native_fp8_w8a16 import ModelOptNativeFp8W8A16CheckpointAdapter
+from .modelopt_native_nvfp4 import ModelOptNativeNvfp4CheckpointAdapter
+
+# Recipe-gated dispatch: an FP8-blockwise checkpoint is served W8A16-resident
+# by default, keyed on its root ``quantization_config.json`` recipe.
+# ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1`` forces the dequant-on-load path.
+
+
+def _model_dtype(model: nn.Module) -> torch.dtype:
+    param = next(model.parameters(), None)
+    return param.dtype if param is not None else torch.bfloat16
 
 
 def get_checkpoint_adapter(
@@ -14,7 +29,43 @@ def get_checkpoint_adapter(
     source: object,
     quant_config: object | None,
     use_safetensors: bool,
-) -> ModelOptFp8CheckpointAdapter | ModelOptNvFp4CheckpointAdapter | ModelOptMixedPrecisionCheckpointAdapter | None:
+) -> (
+    ModelOptFp8CheckpointAdapter
+    | ModelOptNvFp4CheckpointAdapter
+    | ModelOptMixedPrecisionCheckpointAdapter
+    | ModelOptNativeFp8CheckpointAdapter
+    | ModelOptNativeFp8W8A16CheckpointAdapter
+    | ModelOptNativeNvfp4CheckpointAdapter
+    | None
+):
+    if use_safetensors:
+        # Checkpoint-driven (sidecar) detection; independent of quant_config.
+        # Raises CheckpointIntegrityError on a present-but-unsupported sidecar
+        # (fail fast), returns None for unquantized checkpoints. NVFP4 and FP8
+        # native adapters key off distinct sidecar filenames, so order is safe;
+        # both must precede the generic quant_config-driven adapters below.
+        #
+        # The FP8-blockwise checkpoint is served W8A16-resident by default
+        # (fp8_w8a16_selected reads the root quantization_config.json recipe). This must
+        # precede the dequant FP8 adapter (both key off the same sidecar). The predicate is
+        # False for the NVFP4 sidecar and when VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1, so NVFP4 is unaffected
+        # and the dequant fallback stays reachable.
+        if fp8_w8a16_selected(getattr(source, "model_or_path", None)):
+            w8a16_adapter = ModelOptNativeFp8W8A16CheckpointAdapter.detect(
+                source, target_dtype=_model_dtype(model)
+            )
+            if w8a16_adapter is not None:
+                return w8a16_adapter
+        native_adapter = ModelOptNativeFp8CheckpointAdapter.detect(
+            source, target_dtype=_model_dtype(model)
+        )
+        if native_adapter is not None:
+            return native_adapter
+        nvfp4_native_adapter = ModelOptNativeNvfp4CheckpointAdapter.detect(
+            source, target_dtype=_model_dtype(model)
+        )
+        if nvfp4_native_adapter is not None:
+            return nvfp4_native_adapter
     if ModelOptFp8CheckpointAdapter.is_compatible(source, quant_config, use_safetensors):
         return ModelOptFp8CheckpointAdapter(model, source)
     if ModelOptNvFp4CheckpointAdapter.is_compatible(source, quant_config, use_safetensors):
@@ -27,6 +78,9 @@ def get_checkpoint_adapter(
 __all__ = [
     "ModelOptFp8CheckpointAdapter",
     "ModelOptMixedPrecisionCheckpointAdapter",
+    "ModelOptNativeFp8CheckpointAdapter",
+    "ModelOptNativeFp8W8A16CheckpointAdapter",
+    "ModelOptNativeNvfp4CheckpointAdapter",
     "ModelOptNvFp4CheckpointAdapter",
     "get_checkpoint_adapter",
 ]

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
@@ -124,9 +124,7 @@ def parse_quant_spec(config: Mapping) -> BlockwiseQuantSpec:
     scale_layout = config.get("scale_layout") or {}
     granularity = scale_layout.get("granularity")
     if granularity != EXPECTED_GRANULARITY:
-        violations.append(
-            f"scale granularity: expected {EXPECTED_GRANULARITY!r}, found {granularity!r}"
-        )
+        violations.append(f"scale granularity: expected {EXPECTED_GRANULARITY!r}, found {granularity!r}")
     block_sizes = scale_layout.get("block_sizes") or {}
     block_rows = block_sizes.get("rows")
     block_cols = block_sizes.get("cols")
@@ -146,9 +144,7 @@ def parse_quant_spec(config: Mapping) -> BlockwiseQuantSpec:
     if not isinstance(n_scale, int):
         violations.append(f"scale_layout.n_scale: expected int, found {n_scale!r}")
     elif isinstance(n_quantized, int) and n_scale != 2 * n_quantized:
-        violations.append(
-            f"scale_layout.n_scale: expected 2*n_quantized = {2 * n_quantized}, found {n_scale}"
-        )
+        violations.append(f"scale_layout.n_scale: expected 2*n_quantized = {2 * n_quantized}, found {n_scale}")
 
     if violations:
         raise CheckpointIntegrityError(
@@ -245,10 +241,7 @@ def expand_block_scale(
             f"grid {expected} for weight {tuple(weight_shape)} at block {block}"
         )
     rows, cols = weight_shape
-    return (
-        scale.repeat_interleave(block[0], dim=0)[:rows]
-        .repeat_interleave(block[1], dim=1)[:, :cols]
-    )
+    return scale.repeat_interleave(block[0], dim=0)[:rows].repeat_interleave(block[1], dim=1)[:, :cols]
 
 
 def dequantize_weight(
@@ -306,8 +299,7 @@ def verify_observations(
         module_path = name[: -len(WEIGHT_SUFFIX)]
         if matches_any(module_path, spec.kept_patterns):
             violations.append(
-                f"excluded (bf16-kept) module found quantized: {name} "
-                f"(kept patterns: {list(spec.kept_patterns)})"
+                f"excluded (bf16-kept) module found quantized: {name} (kept patterns: {list(spec.kept_patterns)})"
             )
         elif not matches_any(module_path, spec.quantized_patterns):
             violations.append(
@@ -321,8 +313,7 @@ def verify_observations(
             expected = _expected_grid(shape, block)
             if scales[scale_name] != expected:
                 violations.append(
-                    f"scale grid shape mismatch for {name}: scale "
-                    f"{scales[scale_name]} vs expected grid {expected}"
+                    f"scale grid shape mismatch for {name}: scale {scales[scale_name]} vs expected grid {expected}"
                 )
 
     for scale_name in sorted(scales):
@@ -331,10 +322,7 @@ def verify_observations(
             violations.append(f"orphan quantizer scale without fp8 weight: {scale_name}")
 
     if len(fp8_weights) != spec.n_quantized:
-        violations.append(
-            f"quantized-weight count mismatch: declared {spec.n_quantized}, "
-            f"observed {len(fp8_weights)}"
-        )
+        violations.append(f"quantized-weight count mismatch: declared {spec.n_quantized}, observed {len(fp8_weights)}")
     n_scale_family = len(scales) + n_amax
     if n_scale_family != spec.n_scale:
         violations.append(
@@ -402,9 +390,7 @@ class ModelOptNativeFp8CheckpointAdapter:
             with open(sidecar_path) as f:
                 config = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
-            raise CheckpointIntegrityError(
-                f"unreadable quantization sidecar {sidecar_path}: {e}"
-            ) from e
+            raise CheckpointIntegrityError(f"unreadable quantization sidecar {sidecar_path}: {e}") from e
         return parse_quant_spec(config)
 
     @classmethod
@@ -435,7 +421,11 @@ class ModelOptNativeFp8CheckpointAdapter:
         logger.info(
             "ModelOpt-native FP8-blockwise checkpoint detected at %s "
             "(declared: %d quantized modules, %d scale tensors, %dx%d blocks)",
-            model_dir, spec.n_quantized, spec.n_scale, spec.block_rows, spec.block_cols,
+            model_dir,
+            spec.n_quantized,
+            spec.n_scale,
+            spec.block_rows,
+            spec.block_cols,
         )
         return cls(
             spec=spec,
@@ -445,7 +435,7 @@ class ModelOptNativeFp8CheckpointAdapter:
 
     def _strip_prefix(self, name: str) -> str:
         if self._prefix and name.startswith(self._prefix):
-            return name[len(self._prefix):]
+            return name[len(self._prefix) :]
         return name
 
     def adapt(
@@ -489,9 +479,7 @@ class ModelOptNativeFp8CheckpointAdapter:
                     continue  # flagged by verify_observations at end of stream
                 if scale_name in scales:
                     dequantized += 1
-                    yield full_name, dequantize_weight(
-                        tensor, scales[scale_name], self._target_dtype, block
-                    )
+                    yield full_name, dequantize_weight(tensor, scales[scale_name], self._target_dtype, block)
                 else:
                     pending.setdefault(scale_name, []).append((full_name, tensor))
                     n_pending += 1
@@ -513,9 +501,11 @@ class ModelOptNativeFp8CheckpointAdapter:
                 f"({len(violations)} violation(s)):\n  " + "\n  ".join(violations)
             )
         logger.info(
-            "ModelOpt-native FP8 adapter: dequantized %d/%d quantized weights "
-            "to %s (marker: %s)",
-            dequantized, self._spec.n_quantized, self._target_dtype, FP8_BLOCKWISE_MARKER,
+            "ModelOpt-native FP8 adapter: dequantized %d/%d quantized weights to %s (marker: %s)",
+            dequantized,
+            self._spec.n_quantized,
+            self._target_dtype,
+            FP8_BLOCKWISE_MARKER,
         )
 
 
@@ -543,10 +533,7 @@ def _read_safetensors_header(path: str) -> dict:
 
 def header_tensor_infos(header: Mapping) -> list[TensorInfo]:
     """Pure: safetensors header dict -> normalized TensorInfo list."""
-    return [
-        TensorInfo(name, is_fp8_dtype_str(entry["dtype"]), tuple(entry["shape"]))
-        for name, entry in header.items()
-    ]
+    return [TensorInfo(name, is_fp8_dtype_str(entry["dtype"]), tuple(entry["shape"])) for name, entry in header.items()]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ModelOpt-native (state-dict export) FP8-blockwise checkpoint adapter.
+
+Loads checkpoints produced by quantizing with NVIDIA ModelOpt and saving the
+model ``state_dict`` directly to safetensors (as opposed to the HF-style
+export the sibling :mod:`.modelopt` adapter handles). On-disk format:
+
+- FP8 (e4m3) weight codes at their original (diffusers) parameter names,
+  e.g. ``layers.0.mlp.gate_proj.weight``;
+- per-module quantizer tensors ``<module>.weight_quantizer._scale`` (2D block
+  grid ``[ceil(rows/block), ceil(cols/block)]``, multiply-to-dequantize) and
+  ``<module>.weight_quantizer._amax`` (4D twin; ``_scale == _amax/448``);
+- a ``quantization_config.json`` sidecar at the model root declaring recipe
+  ``fp8_blockwise_mixed``, the block size, the quantized/kept module patterns
+  and the expected tensor counts. The ``modelopt_state.pt`` pickle sidecar is
+  intentionally never opened.
+
+The adapter engages purely checkpoint-driven (sidecar present), dequantizes
+every FP8 weight to the model dtype with an fp32 intermediate, consumes the
+quantizer tensors, and yields a plain full-precision stream. Integrity is
+verified fail-fast: a present-but-invalid
+sidecar (e.g. a stale per-tensor export) aborts at detection; stream-level
+count/exclusion/shape violations abort before serving, aggregated into a
+single :class:`CheckpointIntegrityError`.
+
+Run ``python -m vllm_omni.diffusion.model_loader.checkpoint_adapters.\
+modelopt_native <model_dir>`` for a GPU-free integrity probe over the
+safetensors headers (exit 0 = pass, 1 = fail).
+
+Pure calculations (no I/O): :func:`parse_quant_spec`, :func:`classify_name`,
+:func:`scale_name_for`, :func:`weight_name_for`, :func:`matches_any`,
+:func:`expand_block_scale`, :func:`dequantize_weight`,
+:func:`verify_observations`, :func:`assert_not_fp8`.
+Actions: :meth:`ModelOptNativeFp8CheckpointAdapter.detect` (sidecar read),
+:meth:`~ModelOptNativeFp8CheckpointAdapter.adapt` (stream orchestration),
+:func:`main` (CLI probe).
+"""
+
+import enum
+import glob
+import json
+import math
+import os
+import struct
+import sys
+from collections.abc import Generator, Iterable, Mapping
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+from vllm.logger import init_logger
+
+from .modelopt import FP8_DTYPES
+
+logger = init_logger(__name__)
+
+# Deploy-side marker for the mount-shadowing probe: its presence (and value)
+# distinguishes the patched tree from a stock installation at runtime.
+FP8_BLOCKWISE_MARKER = "modelopt-fp8-blockwise"
+
+SIDECAR_FILENAME = "quantization_config.json"
+EXPECTED_RECIPE = "fp8_blockwise_mixed"
+EXPECTED_GRANULARITY = "blockwise-128x128"
+SCALE_SUFFIX = ".weight_quantizer._scale"
+AMAX_SUFFIX = ".weight_quantizer._amax"
+WEIGHT_SUFFIX = ".weight"
+FP8_HEADER_DTYPES = frozenset({"F8_E4M3", "F8_E5M2", "F8_E4M3FNUZ", "F8_E5M2FNUZ"})
+
+# Bound on FP8 weights buffered while waiting for their scale tensor. The
+# real checkpoint interleaves weights and scales per module, so more than a
+# handful pending means the scales are systematically absent — fail early
+# with a partial report instead of buffering gigabytes.
+MAX_PENDING_FP8 = 8
+
+
+class CheckpointIntegrityError(ValueError):
+    """Quantized-checkpoint integrity violation. Fail fast."""
+
+
+class TensorKind(enum.Enum):
+    QUANTIZER_SCALE = "quantizer_scale"
+    QUANTIZER_AMAX = "quantizer_amax"
+    OTHER = "other"
+
+
+class TensorInfo(NamedTuple):
+    """Normalized view of one checkpoint tensor (shared by stream + header)."""
+
+    name: str
+    is_fp8: bool
+    shape: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class BlockwiseQuantSpec:
+    """Parsed sidecar declaration (Data)."""
+
+    recipe: str
+    n_quantized: int
+    n_scale: int
+    block_rows: int
+    block_cols: int
+    quantized_patterns: tuple[str, ...]
+    kept_patterns: tuple[str, ...]
+
+
+# --- pure calculations -------------------------------------------------------
+
+
+def parse_quant_spec(config: Mapping) -> BlockwiseQuantSpec:
+    """Validate and parse a ``quantization_config.json`` dict.
+
+    Raises :class:`CheckpointIntegrityError` naming every expected-vs-found
+    discrepancy (e.g. for the stale per-tensor export: recipe ``fp8`` and
+    granularity ``per-tensor``).
+    """
+    violations: list[str] = []
+
+    recipe = config.get("recipe")
+    if recipe != EXPECTED_RECIPE:
+        violations.append(f"recipe: expected {EXPECTED_RECIPE!r}, found {recipe!r}")
+
+    scale_layout = config.get("scale_layout") or {}
+    granularity = scale_layout.get("granularity")
+    if granularity != EXPECTED_GRANULARITY:
+        violations.append(
+            f"scale granularity: expected {EXPECTED_GRANULARITY!r}, found {granularity!r}"
+        )
+    block_sizes = scale_layout.get("block_sizes") or {}
+    block_rows = block_sizes.get("rows")
+    block_cols = block_sizes.get("cols")
+    if not (isinstance(block_rows, int) and isinstance(block_cols, int)):
+        violations.append(f"block_sizes: expected integer rows/cols, found {block_sizes!r}")
+
+    mixed = config.get("mixed_precision") or {}
+    quantized_patterns = tuple(mixed.get("quantized") or ())
+    kept_patterns = tuple(mixed.get("bf16_kept") or ())
+    n_quantized = mixed.get("n_quantized")
+    if not quantized_patterns:
+        violations.append("mixed_precision.quantized: missing or empty")
+    if not isinstance(n_quantized, int) or n_quantized <= 0:
+        violations.append(f"mixed_precision.n_quantized: expected positive int, found {n_quantized!r}")
+
+    n_scale = scale_layout.get("n_scale")
+    if not isinstance(n_scale, int):
+        violations.append(f"scale_layout.n_scale: expected int, found {n_scale!r}")
+    elif isinstance(n_quantized, int) and n_scale != 2 * n_quantized:
+        violations.append(
+            f"scale_layout.n_scale: expected 2*n_quantized = {2 * n_quantized}, found {n_scale}"
+        )
+
+    if violations:
+        raise CheckpointIntegrityError(
+            "quantization_config.json is not the supported ModelOpt-native "
+            "FP8-blockwise deliverable:\n  " + "\n  ".join(violations)
+        )
+    # Narrow for the type checker: a clean violations list implies these hold.
+    assert (
+        isinstance(recipe, str)
+        and isinstance(n_quantized, int)
+        and isinstance(n_scale, int)
+        and isinstance(block_rows, int)
+        and isinstance(block_cols, int)
+    )
+    return BlockwiseQuantSpec(
+        recipe=recipe,
+        n_quantized=n_quantized,
+        n_scale=n_scale,
+        block_rows=block_rows,
+        block_cols=block_cols,
+        quantized_patterns=quantized_patterns,
+        kept_patterns=kept_patterns,
+    )
+
+
+def classify_name(name: str) -> TensorKind:
+    if name.endswith(SCALE_SUFFIX):
+        return TensorKind.QUANTIZER_SCALE
+    if name.endswith(AMAX_SUFFIX):
+        return TensorKind.QUANTIZER_AMAX
+    return TensorKind.OTHER
+
+
+def is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in FP8_DTYPES
+
+
+def is_fp8_dtype_str(dtype_str: str) -> bool:
+    """FP8 test for safetensors-header dtype tags (e.g. ``"F8_E4M3"``)."""
+    return dtype_str.upper() in FP8_HEADER_DTYPES
+
+
+def scale_name_for(weight_name: str) -> str | None:
+    """``X.weight`` -> ``X.weight_quantizer._scale``; None for non-weights."""
+    if weight_name.endswith(WEIGHT_SUFFIX):
+        return weight_name[: -len(WEIGHT_SUFFIX)] + SCALE_SUFFIX
+    return None
+
+
+def weight_name_for(scale_name: str) -> str | None:
+    """``X.weight_quantizer._scale`` -> ``X.weight``; None otherwise."""
+    if scale_name.endswith(SCALE_SUFFIX):
+        return scale_name[: -len(SCALE_SUFFIX)] + WEIGHT_SUFFIX
+    return None
+
+
+def matches_any(module_path: str, patterns: Iterable[str]) -> bool:
+    """Sidecar pattern semantics: ``P.*`` matches any module with a path
+    component ``P``; a bare pattern matches the exact module path (top-level
+    or as a trailing component)."""
+    for pattern in patterns:
+        if pattern.endswith(".*"):
+            component = pattern[: -len(".*")]
+            if f".{component}." in f".{module_path}.":
+                return True
+        elif module_path == pattern or module_path.endswith(f".{pattern}"):
+            return True
+    return False
+
+
+def _expected_grid(shape: tuple[int, ...], block: tuple[int, int]) -> tuple[int, int]:
+    return (math.ceil(shape[0] / block[0]), math.ceil(shape[1] / block[1]))
+
+
+def expand_block_scale(
+    scale: torch.Tensor,
+    weight_shape: tuple[int, ...],
+    block: tuple[int, int],
+) -> torch.Tensor:
+    """Broadcast a 2D per-block scale grid to the full weight shape.
+
+    Pure; returns a new tensor. Raises :class:`CheckpointIntegrityError` when
+    the grid does not equal the ceil-div block grid of the weight shape.
+    """
+    if len(weight_shape) != 2 or scale.ndim != 2:
+        raise CheckpointIntegrityError(
+            f"blockwise dequant needs 2D weight and 2D scale, got weight "
+            f"{tuple(weight_shape)} and scale {tuple(scale.shape)}"
+        )
+    expected = _expected_grid(weight_shape, block)
+    if tuple(scale.shape) != expected:
+        raise CheckpointIntegrityError(
+            f"scale grid shape mismatch: scale {tuple(scale.shape)} vs expected "
+            f"grid {expected} for weight {tuple(weight_shape)} at block {block}"
+        )
+    rows, cols = weight_shape
+    return (
+        scale.repeat_interleave(block[0], dim=0)[:rows]
+        .repeat_interleave(block[1], dim=1)[:, :cols]
+    )
+
+
+def dequantize_weight(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    target_dtype: torch.dtype,
+    block: tuple[int, int],
+) -> torch.Tensor:
+    """Dequantize FP8 codes with their 2D block-scale grid (fp32 intermediate).
+
+    *block* is the DECLARED block size (from the sidecar), not inferred from the
+    tensor shapes. Inferring `ceil(weight/scale)` would place block boundaries
+    wrong for any weight dimension not divisible by the block (the last block is
+    partial), silently dequantizing with the wrong per-block scale while
+    :func:`verify_observations` — which also uses the declared block — still
+    passes. `expand_block_scale` rejects a scale grid that disagrees with the
+    declared block, so a mismatch raises here (before the weight is yielded)
+    rather than corrupting silently. Pure; returns a new tensor.
+    """
+    full_scale = expand_block_scale(scale.to(torch.float32), tuple(weight.shape), block)
+    return (weight.to(torch.float32) * full_scale).to(target_dtype)
+
+
+def verify_observations(
+    infos: Iterable[TensorInfo],
+    spec: BlockwiseQuantSpec,
+) -> list[str]:
+    """Stream/header verification against the sidecar contract (pure).
+
+    Checks fp8 tensors against the declared quantized/kept patterns, pairs
+    each fp8 weight with a correctly-shaped ``_scale`` grid, and compares the
+    observed counts with the sidecar declaration. Returns human-readable
+    violations; ``[]`` when clean.
+    """
+    infos = list(infos)
+    fp8_weights: dict[str, tuple[int, ...]] = {}
+    scales: dict[str, tuple[int, ...]] = {}
+    n_amax = 0
+    violations: list[str] = []
+
+    for info in infos:
+        kind = classify_name(info.name)
+        if kind is TensorKind.QUANTIZER_SCALE:
+            scales[info.name] = info.shape
+        elif kind is TensorKind.QUANTIZER_AMAX:
+            n_amax += 1
+        elif info.is_fp8:
+            if not info.name.endswith(WEIGHT_SUFFIX):
+                violations.append(f"unexpected fp8 tensor (not a .weight): {info.name}")
+                continue
+            fp8_weights[info.name] = info.shape
+
+    block = (spec.block_rows, spec.block_cols)
+    for name, shape in sorted(fp8_weights.items()):
+        module_path = name[: -len(WEIGHT_SUFFIX)]
+        if matches_any(module_path, spec.kept_patterns):
+            violations.append(
+                f"excluded (bf16-kept) module found quantized: {name} "
+                f"(kept patterns: {list(spec.kept_patterns)})"
+            )
+        elif not matches_any(module_path, spec.quantized_patterns):
+            violations.append(
+                f"fp8 tensor outside declared quantized patterns: {name} "
+                f"(quantized patterns: {list(spec.quantized_patterns)})"
+            )
+        scale_name = scale_name_for(name)
+        if scale_name not in scales:
+            violations.append(f"missing {SCALE_SUFFIX} companion for fp8 weight {name}")
+        elif len(shape) == 2:
+            expected = _expected_grid(shape, block)
+            if scales[scale_name] != expected:
+                violations.append(
+                    f"scale grid shape mismatch for {name}: scale "
+                    f"{scales[scale_name]} vs expected grid {expected}"
+                )
+
+    for scale_name in sorted(scales):
+        weight_name = weight_name_for(scale_name)
+        if weight_name not in fp8_weights:
+            violations.append(f"orphan quantizer scale without fp8 weight: {scale_name}")
+
+    if len(fp8_weights) != spec.n_quantized:
+        violations.append(
+            f"quantized-weight count mismatch: declared {spec.n_quantized}, "
+            f"observed {len(fp8_weights)}"
+        )
+    n_scale_family = len(scales) + n_amax
+    if n_scale_family != spec.n_scale:
+        violations.append(
+            f"scale-tensor count mismatch: declared {spec.n_scale}, "
+            f"observed {n_scale_family} ({len(scales)} _scale + {n_amax} _amax)"
+        )
+    return violations
+
+
+def assert_not_fp8(name: str, dtype: torch.dtype) -> None:
+    """Last-line guard: no fp8 tensor may reach weight loading unadapted.
+
+    An unadapted fp8 tensor would be silently cast without its dequant scale
+    (weights off by the per-block scale factor). Raises
+    :class:`CheckpointIntegrityError`.
+    """
+    if is_fp8_dtype(dtype):
+        raise CheckpointIntegrityError(
+            f"fp8 tensor {name!r} reached weight loading without dequantization; "
+            "quantized checkpoints require the ModelOpt-native checkpoint adapter "
+            f"(sidecar {SIDECAR_FILENAME} at the model root)"
+        )
+
+
+# --- adapter (Action shell) ----------------------------------------------------
+
+
+class ModelOptNativeFp8CheckpointAdapter:
+    """Streams a ModelOpt-native FP8-blockwise checkpoint as full precision."""
+
+    def __init__(
+        self,
+        spec: BlockwiseQuantSpec,
+        source_prefix: str,
+        target_dtype: torch.dtype,
+    ) -> None:
+        self._spec = spec
+        self._prefix = source_prefix
+        self._target_dtype = target_dtype
+
+    @staticmethod
+    def _is_transformer_source(source: object) -> bool:
+        if getattr(source, "subfolder", None) == "transformer":
+            return True
+        return str(getattr(source, "prefix", "")).startswith("transformer.")
+
+    @classmethod
+    def _parse_source_sidecar(cls, source: object) -> BlockwiseQuantSpec | None:
+        """Read + validate the source dir's sidecar (Action at the boundary).
+
+        Returns None when the source is not a local transformer dir with a
+        sidecar. Raises :class:`CheckpointIntegrityError` when a sidecar
+        exists but does not describe the supported deliverable (fail fast —
+        never load a mislabeled checkpoint).
+        """
+        if not cls._is_transformer_source(source):
+            return None
+        model_dir = getattr(source, "model_or_path", None)
+        if not isinstance(model_dir, (str, os.PathLike)) or not os.path.isdir(model_dir):
+            return None
+        sidecar_path = os.path.join(model_dir, SIDECAR_FILENAME)
+        if not os.path.exists(sidecar_path):
+            return None
+        try:
+            with open(sidecar_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise CheckpointIntegrityError(
+                f"unreadable quantization sidecar {sidecar_path}: {e}"
+            ) from e
+        return parse_quant_spec(config)
+
+    @classmethod
+    def validate_source_sidecar(cls, source: object) -> None:
+        """Pre-flight check: raise on a present-but-invalid sidecar.
+
+        Called by the loader *before* weight-file discovery so a mislabeled
+        quantized checkpoint dies with the integrity report rather than a
+        generic file-discovery error.
+        """
+        cls._parse_source_sidecar(source)
+
+    @classmethod
+    def detect(
+        cls,
+        source: object,
+        target_dtype: torch.dtype = torch.bfloat16,
+    ) -> "ModelOptNativeFp8CheckpointAdapter | None":
+        """Engage iff the source's local model dir carries a supported sidecar.
+
+        Returns None for unquantized checkpoints (no sidecar); raises like
+        :meth:`validate_source_sidecar` on an invalid one.
+        """
+        spec = cls._parse_source_sidecar(source)
+        if spec is None:
+            return None
+        model_dir = getattr(source, "model_or_path", None)
+        logger.info(
+            "ModelOpt-native FP8-blockwise checkpoint detected at %s "
+            "(declared: %d quantized modules, %d scale tensors, %dx%d blocks)",
+            model_dir, spec.n_quantized, spec.n_scale, spec.block_rows, spec.block_cols,
+        )
+        return cls(
+            spec=spec,
+            source_prefix=str(getattr(source, "prefix", "") or ""),
+            target_dtype=target_dtype,
+        )
+
+    def _strip_prefix(self, name: str) -> str:
+        if self._prefix and name.startswith(self._prefix):
+            return name[len(self._prefix):]
+        return name
+
+    def adapt(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """Dequantize fp8 weights, consume quantizer tensors, verify at end.
+
+        Yields a full-precision stream. Raises
+        :class:`CheckpointIntegrityError` (aggregated) on any integrity
+        violation, before the caller can finish loading.
+        """
+        scales: dict[str, torch.Tensor] = {}
+        pending: dict[str, list[tuple[str, torch.Tensor]]] = {}
+        n_pending = 0
+        infos: list[TensorInfo] = []
+        dequantized = 0
+        block = (self._spec.block_rows, self._spec.block_cols)  # declared, not inferred
+
+        for full_name, tensor in weights:
+            name = self._strip_prefix(full_name)
+            kind = classify_name(name)
+            infos.append(TensorInfo(name, is_fp8_dtype(tensor.dtype), tuple(tensor.shape)))
+
+            if kind is TensorKind.QUANTIZER_SCALE:
+                scales[name] = tensor
+                for pending_full_name, pending_weight in pending.pop(name, ()):
+                    n_pending -= 1
+                    dequantized += 1
+                    yield (
+                        pending_full_name,
+                        dequantize_weight(pending_weight, tensor, self._target_dtype, block),
+                    )
+                continue
+            if kind is TensorKind.QUANTIZER_AMAX:
+                continue  # informational twin of _scale; consumed
+
+            if is_fp8_dtype(tensor.dtype):
+                scale_name = scale_name_for(name)
+                if scale_name is None:
+                    continue  # flagged by verify_observations at end of stream
+                if scale_name in scales:
+                    dequantized += 1
+                    yield full_name, dequantize_weight(
+                        tensor, scales[scale_name], self._target_dtype, block
+                    )
+                else:
+                    pending.setdefault(scale_name, []).append((full_name, tensor))
+                    n_pending += 1
+                    if n_pending > MAX_PENDING_FP8:
+                        waiting = ", ".join(sorted(pending))
+                        raise CheckpointIntegrityError(
+                            f"more than {MAX_PENDING_FP8} fp8 weights pending without "
+                            f"their quantizer scales — scales appear systematically "
+                            f"absent; first missing: {waiting}"
+                        )
+                continue
+
+            yield full_name, tensor
+
+        violations = verify_observations(infos, self._spec)
+        if violations:
+            raise CheckpointIntegrityError(
+                "quantized checkpoint failed integrity verification "
+                f"({len(violations)} violation(s)):\n  " + "\n  ".join(violations)
+            )
+        logger.info(
+            "ModelOpt-native FP8 adapter: dequantized %d/%d quantized weights "
+            "to %s (marker: %s)",
+            dequantized, self._spec.n_quantized, self._target_dtype, FP8_BLOCKWISE_MARKER,
+        )
+
+
+# --- CLI probe (header-only, GPU-free) -------------------------------------------
+
+
+# safetensors reference caps the JSON header at 100 MB; bound the read so a
+# malformed/hostile length field cannot request an arbitrary allocation (the
+# probe only runs against the trusted :ro mount, so this is defense-in-depth).
+_MAX_SAFETENSORS_HEADER_BYTES = 100 * 1024 * 1024
+
+
+def _read_safetensors_header(path: str) -> dict:
+    with open(path, "rb") as f:
+        (header_len,) = struct.unpack("<Q", f.read(8))
+        if header_len > _MAX_SAFETENSORS_HEADER_BYTES:
+            raise CheckpointIntegrityError(
+                f"safetensors header of {path} is {header_len} bytes "
+                f"(> {_MAX_SAFETENSORS_HEADER_BYTES}); refusing to read"
+            )
+        header = json.loads(f.read(header_len))
+    header.pop("__metadata__", None)
+    return header
+
+
+def header_tensor_infos(header: Mapping) -> list[TensorInfo]:
+    """Pure: safetensors header dict -> normalized TensorInfo list."""
+    return [
+        TensorInfo(name, is_fp8_dtype_str(entry["dtype"]), tuple(entry["shape"]))
+        for name, entry in header.items()
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Integrity probe: exit 0 iff *model_dir* is the supported deliverable."""
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print("usage: python -m ...modelopt_native <model_dir>", file=sys.stderr)
+        return 2
+    model_dir = args[0]
+
+    sidecar_path = os.path.join(model_dir, SIDECAR_FILENAME)
+    if not os.path.exists(sidecar_path):
+        print(f"INTEGRITY FAIL: no {SIDECAR_FILENAME} sidecar in {model_dir}")
+        return 1
+    try:
+        with open(sidecar_path) as f:
+            spec = parse_quant_spec(json.load(f))
+    except (OSError, json.JSONDecodeError, CheckpointIntegrityError) as e:
+        print(f"INTEGRITY FAIL: {e}")
+        return 1
+
+    shard_paths = sorted(glob.glob(os.path.join(model_dir, "transformer", "*.safetensors")))
+    if not shard_paths:
+        print(f"INTEGRITY FAIL: no transformer/*.safetensors under {model_dir}")
+        return 1
+    infos: list[TensorInfo] = []
+    for shard_path in shard_paths:
+        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+
+    n_fp8 = sum(1 for i in infos if i.is_fp8)
+    n_scale_family = sum(1 for i in infos if classify_name(i.name) is not TensorKind.OTHER)
+    violations = verify_observations(infos, spec)
+    print(
+        f"declared: {spec.n_quantized} quantized / {spec.n_scale} scale tensors; "
+        f"observed: {n_fp8} fp8 / {n_scale_family} quantizer tensors "
+        f"({len(infos)} total, {len(shard_paths)} shard(s))"
+    )
+    if violations:
+        print(f"INTEGRITY FAIL ({len(violations)} violation(s)):")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+    print(f"INTEGRITY OK: {model_dir} (marker: {FP8_BLOCKWISE_MARKER})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native.py
@@ -46,6 +46,7 @@ import struct
 import sys
 from collections.abc import Generator, Iterable, Mapping
 from dataclasses import dataclass
+from os import PathLike
 from typing import NamedTuple
 
 import torch
@@ -347,6 +348,19 @@ def assert_not_fp8(name: str, dtype: torch.dtype) -> None:
         )
 
 
+def resolved_model_root(source: object) -> str | PathLike | None:
+    """Return the resolved local model root for sidecar reads.
+
+    ``model_or_path`` remains the user-facing repo ID/path. The diffusers
+    loader sets ``resolved_model_or_path`` after HF download/local resolution
+    so checkpoint adapters can inspect sidecars in the actual local snapshot.
+    """
+    resolved = getattr(source, "resolved_model_or_path", None)
+    if resolved is not None:
+        return resolved
+    return getattr(source, "model_or_path", None)
+
+
 # --- adapter (Action shell) ----------------------------------------------------
 
 
@@ -380,7 +394,7 @@ class ModelOptNativeFp8CheckpointAdapter:
         """
         if not cls._is_transformer_source(source):
             return None
-        model_dir = getattr(source, "model_or_path", None)
+        model_dir = resolved_model_root(source)
         if not isinstance(model_dir, (str, os.PathLike)) or not os.path.isdir(model_dir):
             return None
         sidecar_path = os.path.join(model_dir, SIDECAR_FILENAME)
@@ -417,7 +431,7 @@ class ModelOptNativeFp8CheckpointAdapter:
         spec = cls._parse_source_sidecar(source)
         if spec is None:
             return None
-        model_dir = getattr(source, "model_or_path", None)
+        model_dir = resolved_model_root(source)
         logger.info(
             "ModelOpt-native FP8-blockwise checkpoint detected at %s "
             "(declared: %d quantized modules, %d scale tensors, %dx%d blocks)",
@@ -561,7 +575,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     infos: list[TensorInfo] = []
     for shard_path in shard_paths:
-        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        try:
+            infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        except (OSError, ValueError, struct.error, json.JSONDecodeError) as e:
+            print(f"INTEGRITY FAIL: unreadable safetensors header {shard_path}: {e}")
+            return 1
 
     n_fp8 = sum(1 for i in infos if i.is_fp8)
     n_scale_family = sum(1 for i in infos if classify_name(i.name) is not TensorKind.OTHER)

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
@@ -47,6 +47,7 @@ from .modelopt_native import (
     SCALE_SUFFIX,
     SIDECAR_FILENAME,
     WEIGHT_SUFFIX,
+    BlockwiseQuantSpec,
     CheckpointIntegrityError,
     ModelOptNativeFp8CheckpointAdapter,
     TensorInfo,
@@ -87,7 +88,7 @@ def assert_scale_finite(name: str, tensor: torch.Tensor) -> None:
 _ALLOWED_QUANT_FAMILIES = ("mlp", "mlp_moe_gen", "lm_head")
 
 
-def assert_target_family(spec) -> None:
+def assert_target_family(spec: BlockwiseQuantSpec) -> None:
     """Fail-fast: every declared quantized pattern is in the W8A16 target family.
 
     Defends a sidecar whose manifest *declares* a forbidden family (e.g. ``self_attn.*``),
@@ -106,7 +107,7 @@ def assert_target_family(spec) -> None:
 class ModelOptNativeFp8W8A16CheckpointAdapter:
     """Streams the FP8-blockwise checkpoint W8A16-resident (MLP resident, lm_head BF16)."""
 
-    def __init__(self, spec, source_prefix: str, target_dtype: torch.dtype) -> None:
+    def __init__(self, spec: BlockwiseQuantSpec, source_prefix: str, target_dtype: torch.dtype) -> None:
         assert_target_family(spec)  # fail-fast before any weight is routed resident
         self._spec = spec
         self._prefix = source_prefix

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
@@ -76,8 +76,7 @@ def assert_scale_finite(name: str, tensor: torch.Tensor) -> None:
     """Raise on any NaN/Inf scale byte (owner decision: abort, do not clamp)."""
     if not torch.isfinite(tensor.to(torch.float32)).all():
         raise CheckpointIntegrityError(
-            f"scale tensor {name!r} contains NaN/Inf; the artifact is corrupt. "
-            "Refusing to serve W8A16-resident."
+            f"scale tensor {name!r} contains NaN/Inf; the artifact is corrupt. Refusing to serve W8A16-resident."
         )
 
 
@@ -123,15 +122,14 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
         Reuses the dequant adapter's sidecar parse so detection is identical; the
         dispatcher decides W8A16-vs-dequant via ``fp8_w8a16_selected`` (explicit
         opt-in; dequant is default). Construction asserts the declared target
-        family, so a mis-declared sidecar fails fast here rather than mid-load.
+        family, so an incorrectly declared sidecar fails fast here rather than mid-load.
         """
         spec = ModelOptNativeFp8CheckpointAdapter._parse_source_sidecar(source)
         if spec is None:
             return None
         model_dir = getattr(source, "model_or_path", None)
         logger.info(
-            "ModelOpt-native FP8 W8A16-RESIDENT path engaged at %s "
-            "(declared %d quantized modules, block %dx%d)",
+            "ModelOpt-native FP8 W8A16-RESIDENT path engaged at %s (declared %d quantized modules, block %dx%d)",
             model_dir,
             spec.n_quantized,
             spec.block_rows,
@@ -145,7 +143,7 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
 
     def _strip_prefix(self, name: str) -> str:
         if self._prefix and name.startswith(self._prefix):
-            return name[len(self._prefix):]
+            return name[len(self._prefix) :]
         return name
 
     @staticmethod
@@ -185,9 +183,7 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
                     for pend_full, pend_w in pending.pop(name, ()):
                         n_pending -= 1
                         n_dequant += 1
-                        yield pend_full, dequantize_weight(
-                            pend_w, tensor, self._target_dtype, self._block
-                        )
+                        yield pend_full, dequantize_weight(pend_w, tensor, self._target_dtype, self._block)
                 continue
 
             if is_fp8_dtype(tensor.dtype):
@@ -202,9 +198,7 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
                     continue  # flagged by verify_observations at end of stream
                 if scale_name in scales:
                     n_dequant += 1
-                    yield full_name, dequantize_weight(
-                        tensor, scales[scale_name], self._target_dtype, self._block
-                    )
+                    yield full_name, dequantize_weight(tensor, scales[scale_name], self._target_dtype, self._block)
                 else:
                     pending.setdefault(scale_name, []).append((full_name, tensor))
                     n_pending += 1
@@ -228,15 +222,12 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
             raise CheckpointIntegrityError(
                 f"routing count mismatch: {n_resident} resident + {n_dequant} dequant "
                 f"= {n_resident + n_dequant} != declared {self._spec.n_quantized} fp8 "
-                "weights (some target/non-target was mis-routed or dropped)."
+                "weights (some target/non-target was routed incorrectly or dropped)."
             )
         if n_pending:
-            raise CheckpointIntegrityError(
-                f"{n_pending} non-target fp8 weight(s) never received a scale."
-            )
+            raise CheckpointIntegrityError(f"{n_pending} non-target fp8 weight(s) never received a scale.")
         logger.info(
-            "FP8 W8A16 adapter: %d MLP targets FP8-resident, %d non-target(s) "
-            "dequantized to %s (marker: %s)",
+            "FP8 W8A16 adapter: %d MLP targets FP8-resident, %d non-target(s) dequantized to %s (marker: %s)",
             n_resident,
             n_dequant,
             self._target_dtype,
@@ -279,18 +270,12 @@ def main(argv: list[str] | None = None) -> int:
 
     violations = verify_observations(infos, spec)
     n_resident = sum(
-        1
-        for i in infos
-        if i.is_fp8
-        and i.name.endswith(WEIGHT_SUFFIX)
-        and is_target_prefix(_module_of_weight(i.name))
+        1 for i in infos if i.is_fp8 and i.name.endswith(WEIGHT_SUFFIX) and is_target_prefix(_module_of_weight(i.name))
     )
     n_dequant = sum(
         1
         for i in infos
-        if i.is_fp8
-        and i.name.endswith(WEIGHT_SUFFIX)
-        and not is_target_prefix(_module_of_weight(i.name))
+        if i.is_fp8 and i.name.endswith(WEIGHT_SUFFIX) and not is_target_prefix(_module_of_weight(i.name))
     )
     print(
         f"declared: {spec.n_quantized} fp8 weights; W8A16 split: "

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ModelOpt-native FP8-blockwise W8A16 resident checkpoint adapter.
+
+Loads the SAME on-disk deliverable as the sibling dequant adapter
+(:mod:`.modelopt_native`) — recipe ``fp8_blockwise_mixed``, blockwise-128x128, FP8
+``<m>.weight`` + 2D ``<m>.weight_quantizer._scale`` (bf16) + ``._amax`` twin, described
+by the root ``quantization_config.json`` — but streams it for the **weight-resident**
+W8A16 path instead of dequantizing on load:
+
+- the 216 ``mlp.*``/``mlp_moe_gen.*`` targets stay **FP8-resident** (bytes unchanged);
+  their ``.weight_quantizer._scale`` is renamed to ``.weight_scale`` (the param name
+  :class:`...fp8_blockwise_w8a16.Fp8BlockwiseW8A16LinearMethod` allocates) and passed
+  through resident;
+- ``lm_head`` and any other non-target FP8 weight are **dequantized to BF16** (reusing
+  :func:`.modelopt_native.dequantize_weight`), so only the MLP targets are resident and
+  ``lm_head`` stays BF16 at compute;
+- BF16 non-targets (attention, norms, projections) pass through unchanged;
+- ``._amax`` twins are consumed (informational).
+
+Integrity is fail-fast, reusing the dequant adapter's
+:func:`.modelopt_native.verify_observations` on the input stream (same count / pattern
+/ grid checks) plus a scale-finiteness check and a routing-count check. The
+``transformer/modelopt_state.pt`` pickle is never opened. A GPU-free header probe is
+available as ``python -m ...modelopt_native_fp8_w8a16 <model_dir>``.
+
+Selected by the dispatcher **by default** for the FP8-blockwise checkpoint (see
+``fp8_w8a16_selected`` in ``checkpoint_adapters/__init__.py``); ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1``
+routes to the dequant adapter instead. A checkpoint whose sidecar declares a
+quantized target family outside ``mlp.*``/``mlp_moe_gen.*``/``lm_head`` fails fast.
+"""
+
+import glob
+import os
+import sys
+from collections.abc import Generator, Iterable
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.quantization.fp8_blockwise_w8a16 import W8A16_MARKER, is_target_prefix
+
+from .modelopt_native import (
+    MAX_PENDING_FP8,
+    SCALE_SUFFIX,
+    SIDECAR_FILENAME,
+    WEIGHT_SUFFIX,
+    CheckpointIntegrityError,
+    ModelOptNativeFp8CheckpointAdapter,
+    TensorInfo,
+    TensorKind,
+    _read_safetensors_header,
+    classify_name,
+    dequantize_weight,
+    header_tensor_infos,
+    is_fp8_dtype,
+    parse_quant_spec,
+    scale_name_for,
+    verify_observations,
+    weight_name_for,
+)
+
+logger = init_logger(__name__)
+
+_RESIDENT_SCALE_SUFFIX = ".weight_scale"  # param name allocated by the W8A16 method
+
+
+def _module_of_weight(weight_name: str) -> str:
+    """``X.weight`` -> ``X`` (module prefix), else the name unchanged (pure)."""
+    if weight_name.endswith(WEIGHT_SUFFIX):
+        return weight_name[: -len(WEIGHT_SUFFIX)]
+    return weight_name
+
+
+def assert_scale_finite(name: str, tensor: torch.Tensor) -> None:
+    """Raise on any NaN/Inf scale byte (owner decision: abort, do not clamp)."""
+    if not torch.isfinite(tensor.to(torch.float32)).all():
+        raise CheckpointIntegrityError(
+            f"scale tensor {name!r} contains NaN/Inf; the artifact is corrupt. "
+            "Refusing to serve W8A16-resident."
+        )
+
+
+# The families W8A16 may ever quantize: the MLP projections stay FP8-resident and
+# ``lm_head`` is dequant-to-BF16. Any other declared quantized family is refused fail-fast.
+_ALLOWED_QUANT_FAMILIES = ("mlp", "mlp_moe_gen", "lm_head")
+
+
+def assert_target_family(spec) -> None:
+    """Fail-fast: every declared quantized pattern is in the W8A16 target family.
+
+    Defends a sidecar whose manifest *declares* a forbidden family (e.g. ``self_attn.*``),
+    which the end-of-stream :func:`verify_observations` would otherwise accept as a
+    'declared' pattern. Pure calculation over the parsed spec; raises before any load.
+    """
+    for pattern in spec.quantized_patterns:
+        family = pattern.split(".", 1)[0]
+        if family not in _ALLOWED_QUANT_FAMILIES:
+            raise CheckpointIntegrityError(
+                f"quantized pattern {pattern!r} is outside the W8A16 target family "
+                f"{_ALLOWED_QUANT_FAMILIES}; refusing to serve W8A16-resident."
+            )
+
+
+class ModelOptNativeFp8W8A16CheckpointAdapter:
+    """Streams the FP8-blockwise checkpoint W8A16-resident (MLP resident, lm_head BF16)."""
+
+    def __init__(self, spec, source_prefix: str, target_dtype: torch.dtype) -> None:
+        assert_target_family(spec)  # fail-fast before any weight is routed resident
+        self._spec = spec
+        self._prefix = source_prefix
+        self._target_dtype = target_dtype
+        self._block = (spec.block_rows, spec.block_cols)  # declared 128x128
+
+    @classmethod
+    def detect(
+        cls,
+        source: object,
+        target_dtype: torch.dtype = torch.bfloat16,
+    ) -> "ModelOptNativeFp8W8A16CheckpointAdapter | None":
+        """Engage iff the source carries the FP8-blockwise sidecar (same as dequant).
+
+        Reuses the dequant adapter's sidecar parse so detection is identical; the
+        dispatcher decides W8A16-vs-dequant via ``fp8_w8a16_selected`` (W8A16 by default;
+        ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1`` opts out). Construction asserts the declared target family
+       , so a mis-declared sidecar fails fast here rather than mid-load.
+        """
+        spec = ModelOptNativeFp8CheckpointAdapter._parse_source_sidecar(source)
+        if spec is None:
+            return None
+        model_dir = getattr(source, "model_or_path", None)
+        logger.info(
+            "ModelOpt-native FP8 W8A16-RESIDENT path engaged at %s "
+            "(declared %d quantized modules, block %dx%d)",
+            model_dir,
+            spec.n_quantized,
+            spec.block_rows,
+            spec.block_cols,
+        )
+        return cls(
+            spec=spec,
+            source_prefix=str(getattr(source, "prefix", "") or ""),
+            target_dtype=target_dtype,
+        )
+
+    def _strip_prefix(self, name: str) -> str:
+        if self._prefix and name.startswith(self._prefix):
+            return name[len(self._prefix):]
+        return name
+
+    @staticmethod
+    def _rename_scale(full_name: str) -> str:
+        """``...<m>.weight_quantizer._scale`` -> ``...<m>.weight_scale`` (pure)."""
+        return full_name[: -len(SCALE_SUFFIX)] + _RESIDENT_SCALE_SUFFIX
+
+    def adapt(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """Yield MLP targets FP8-resident, dequant lm_head/non-targets, verify at end."""
+        scales: dict[str, torch.Tensor] = {}  # non-target scale buffer (lm_head)
+        pending: dict[str, list[tuple[str, torch.Tensor]]] = {}
+        n_pending = 0
+        infos: list[TensorInfo] = []
+        n_resident = 0
+        n_dequant = 0
+
+        for full_name, tensor in weights:
+            name = self._strip_prefix(full_name)
+            kind = classify_name(name)
+            infos.append(TensorInfo(name, is_fp8_dtype(tensor.dtype), tuple(tensor.shape)))
+
+            if kind is TensorKind.QUANTIZER_AMAX:
+                continue  # informational twin of _scale; consumed
+
+            if kind is TensorKind.QUANTIZER_SCALE:
+                assert_scale_finite(name, tensor)
+                module = _module_of_weight(weight_name_for(name) or name)
+                if is_target_prefix(module):
+                    # resident: rename to the W8A16 method's scale param, pass bf16 through
+                    yield self._rename_scale(full_name), tensor
+                else:
+                    # non-target (lm_head): buffer for dequant + flush any pending weight
+                    scales[name] = tensor
+                    for pend_full, pend_w in pending.pop(name, ()):
+                        n_pending -= 1
+                        n_dequant += 1
+                        yield pend_full, dequantize_weight(
+                            pend_w, tensor, self._target_dtype, self._block
+                        )
+                continue
+
+            if is_fp8_dtype(tensor.dtype):
+                module = _module_of_weight(name)
+                if is_target_prefix(module):
+                    n_resident += 1
+                    yield full_name, tensor  # FP8-resident, bytes unchanged
+                    continue
+                # non-target fp8 (lm_head): dequant to BF16 (pair with its scale)
+                scale_name = scale_name_for(name)
+                if scale_name is None:
+                    continue  # flagged by verify_observations at end of stream
+                if scale_name in scales:
+                    n_dequant += 1
+                    yield full_name, dequantize_weight(
+                        tensor, scales[scale_name], self._target_dtype, self._block
+                    )
+                else:
+                    pending.setdefault(scale_name, []).append((full_name, tensor))
+                    n_pending += 1
+                    if n_pending > MAX_PENDING_FP8:
+                        waiting = ", ".join(sorted(pending))
+                        raise CheckpointIntegrityError(
+                            f"more than {MAX_PENDING_FP8} non-target fp8 weights pending "
+                            f"without their scales; first missing: {waiting}"
+                        )
+                continue
+
+            yield full_name, tensor  # BF16 passthrough (attention, norms, projections)
+
+        violations = verify_observations(infos, self._spec)
+        if violations:
+            raise CheckpointIntegrityError(
+                "FP8 W8A16 checkpoint failed integrity verification "
+                f"({len(violations)} violation(s)):\n  " + "\n  ".join(violations)
+            )
+        if n_resident + n_dequant != self._spec.n_quantized:
+            raise CheckpointIntegrityError(
+                f"routing count mismatch: {n_resident} resident + {n_dequant} dequant "
+                f"= {n_resident + n_dequant} != declared {self._spec.n_quantized} fp8 "
+                "weights (some target/non-target was mis-routed or dropped)."
+            )
+        if n_pending:
+            raise CheckpointIntegrityError(
+                f"{n_pending} non-target fp8 weight(s) never received a scale."
+            )
+        logger.info(
+            "FP8 W8A16 adapter: %d MLP targets FP8-resident, %d non-target(s) "
+            "dequantized to %s (marker: %s)",
+            n_resident,
+            n_dequant,
+            self._target_dtype,
+            W8A16_MARKER,
+        )
+
+
+# --- CLI probe (header-only, GPU-free) --------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Integrity probe: exit 0 iff *model_dir* is the supported FP8 deliverable and
+    reports the W8A16 resident/dequant split (216 resident MLP targets + lm_head)."""
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print("usage: python -m ...modelopt_native_fp8_w8a16 <model_dir>", file=sys.stderr)
+        return 2
+    model_dir = args[0]
+
+    sidecar_path = os.path.join(model_dir, SIDECAR_FILENAME)
+    if not os.path.exists(sidecar_path):
+        print(f"INTEGRITY FAIL: no {SIDECAR_FILENAME} sidecar in {model_dir}")
+        return 1
+    import json
+
+    try:
+        with open(sidecar_path) as f:
+            spec = parse_quant_spec(json.load(f))
+    except (OSError, json.JSONDecodeError, CheckpointIntegrityError) as e:
+        print(f"INTEGRITY FAIL: {e}")
+        return 1
+
+    shard_paths = sorted(glob.glob(os.path.join(model_dir, "transformer", "*.safetensors")))
+    if not shard_paths:
+        print(f"INTEGRITY FAIL: no transformer/*.safetensors under {model_dir}")
+        return 1
+    infos: list[TensorInfo] = []
+    for shard_path in shard_paths:
+        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+
+    violations = verify_observations(infos, spec)
+    n_resident = sum(
+        1
+        for i in infos
+        if i.is_fp8
+        and i.name.endswith(WEIGHT_SUFFIX)
+        and is_target_prefix(_module_of_weight(i.name))
+    )
+    n_dequant = sum(
+        1
+        for i in infos
+        if i.is_fp8
+        and i.name.endswith(WEIGHT_SUFFIX)
+        and not is_target_prefix(_module_of_weight(i.name))
+    )
+    print(
+        f"declared: {spec.n_quantized} fp8 weights; W8A16 split: "
+        f"{n_resident} MLP targets resident + {n_dequant} non-target(s) dequant "
+        f"({len(infos)} tensors, {len(shard_paths)} shard(s))"
+    )
+    if violations:
+        print(f"INTEGRITY FAIL ({len(violations)} violation(s)):")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+    print(f"INTEGRITY OK: {model_dir} (marker: {W8A16_MARKER})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
@@ -24,9 +24,9 @@ Integrity is fail-fast, reusing the dequant adapter's
 ``transformer/modelopt_state.pt`` pickle is never opened. A GPU-free header probe is
 available as ``python -m ...modelopt_native_fp8_w8a16 <model_dir>``.
 
-Selected by the dispatcher **by default** for the FP8-blockwise checkpoint (see
-``fp8_w8a16_selected`` in ``checkpoint_adapters/__init__.py``); ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1``
-routes to the dequant adapter instead. A checkpoint whose sidecar declares a
+Selected by the dispatcher only when ``VLLM_OMNI_FP8_BLOCKWISE_W8A16=1`` and
+the checkpoint root recipe matches (see ``fp8_w8a16_selected`` in
+``checkpoint_adapters/__init__.py``). A checkpoint whose sidecar declares a
 quantized target family outside ``mlp.*``/``mlp_moe_gen.*``/``lm_head`` fails fast.
 """
 
@@ -121,9 +121,9 @@ class ModelOptNativeFp8W8A16CheckpointAdapter:
         """Engage iff the source carries the FP8-blockwise sidecar (same as dequant).
 
         Reuses the dequant adapter's sidecar parse so detection is identical; the
-        dispatcher decides W8A16-vs-dequant via ``fp8_w8a16_selected`` (W8A16 by default;
-        ``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1`` opts out). Construction asserts the declared target family
-       , so a mis-declared sidecar fails fast here rather than mid-load.
+        dispatcher decides W8A16-vs-dequant via ``fp8_w8a16_selected`` (explicit
+        opt-in; dequant is default). Construction asserts the declared target
+        family, so a mis-declared sidecar fails fast here rather than mid-load.
         """
         spec = ModelOptNativeFp8CheckpointAdapter._parse_source_sidecar(source)
         if spec is None:

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_fp8_w8a16.py
@@ -31,7 +31,9 @@ quantized target family outside ``mlp.*``/``mlp_moe_gen.*``/``lm_head`` fails fa
 """
 
 import glob
+import json
 import os
+import struct
 import sys
 from collections.abc import Generator, Iterable
 
@@ -251,8 +253,6 @@ def main(argv: list[str] | None = None) -> int:
     if not os.path.exists(sidecar_path):
         print(f"INTEGRITY FAIL: no {SIDECAR_FILENAME} sidecar in {model_dir}")
         return 1
-    import json
-
     try:
         with open(sidecar_path) as f:
             spec = parse_quant_spec(json.load(f))
@@ -266,7 +266,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     infos: list[TensorInfo] = []
     for shard_path in shard_paths:
-        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        try:
+            infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        except (OSError, ValueError, struct.error, json.JSONDecodeError) as e:
+            print(f"INTEGRITY FAIL: unreadable safetensors header {shard_path}: {e}")
+            return 1
 
     violations = verify_observations(infos, spec)
     n_resident = sum(

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
@@ -1,0 +1,520 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ModelOpt-native NVFP4 (weight-only, blockwise) checkpoint adapter.
+
+Loads ``nvfp4_blockwise_mixed_v1`` checkpoints. On-disk format, per quantized target module
+(``layers.*.mlp.*`` and ``layers.*.mlp_moe_gen.*`` only):
+
+- ``<module>.weight_packed``       uint8, packed E2M1 FP4 (two codes / byte
+                                   along the last dim), shape ``[out, ceil(in/2)]``;
+- ``<module>.weight_block_scale``  float8_e4m3fn per-16-block scales, shape
+                                   ``[out, ceil(in/16)]`` (blocked along last dim);
+- ``<module>.weight_global_scale`` float32 per-tensor scale, shape ``[1]``.
+
+Non-target tensors (attention, embeddings, ``lm_head``, norms, projections,
+audio/action modules) stay BF16. A ``transformer/nvfp4_blockwise_mixed_v1.json``
+sidecar declares the recipe, block size, scale encoding, the exact quantized
+target set (name -> shapes), and the target/forbidden patterns.
+
+Unlike the sibling FP8 native adapter (:mod:`.modelopt_native`), this adapter
+**never dequantizes a target weight**. It renames the on-disk names to the
+param names vLLM's ``ModelOptNvFp4W4A16LinearMethod`` allocates
+(``weight_packed -> weight``, ``weight_block_scale -> weight_scale``,
+``weight_global_scale -> weight_scale_2``) and passes the bytes through
+unchanged, so target modules remain FP4-resident. Integrity is verified
+fail-fast: a present-but-invalid sidecar aborts at detection; count /
+pattern / shape / dtype violations and any NaN/Inf scale byte abort before
+serving, aggregated into a single :class:`CheckpointIntegrityError`.
+
+Run ``python -m vllm_omni.diffusion.model_loader.checkpoint_adapters.\
+modelopt_native_nvfp4 <model_dir>`` for a GPU-free header and sidecar
+probe (exit 0 = pass, 1 = fail, 2 = usage).
+
+Pure calculations (no I/O): :func:`parse_nvfp4_spec`, :func:`remap_name`,
+:func:`weight_key_for`, :func:`classify_suffix`, :func:`matches_any`,
+:func:`expected_packed_width`, :func:`expected_scale_grid`,
+:func:`dtype_tag`, :func:`verify_observations`, :func:`assert_scales_finite`.
+Actions: :meth:`ModelOptNativeNvfp4CheckpointAdapter.detect`,
+:meth:`~ModelOptNativeNvfp4CheckpointAdapter.adapt`, :func:`main`.
+"""
+
+import glob
+import json
+import math
+import os
+import re
+import struct
+import sys
+from collections.abc import Generator, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Deploy-side marker for the mount-shadowing probe (mirrors the FP8 adapter):
+# its presence distinguishes the patched tree from a stock install at runtime.
+NVFP4_BLOCKWISE_MARKER = "modelopt-nvfp4-blockwise"
+
+SIDECAR_FILENAME = "nvfp4_blockwise_mixed_v1.json"
+EXPECTED_RECIPE = "nvfp4_blockwise_mixed_v1"
+BLOCK_SIZE = 16
+
+PACKED_SUFFIX = ".weight_packed"
+BLOCK_SUFFIX = ".weight_block_scale"
+GLOBAL_SUFFIX = ".weight_global_scale"
+WEIGHT_SUFFIX = ".weight"
+# Target param names allocated by vLLM's ModelOptNvFp4W4A16LinearMethod.
+REMAP = {
+    PACKED_SUFFIX: ".weight",
+    BLOCK_SUFFIX: ".weight_scale",
+    GLOBAL_SUFFIX: ".weight_scale_2",
+}
+
+# Normalized dtype tags (unify torch dtypes with safetensors header dtype tags).
+TAG_U8 = "u8"
+TAG_F8E4M3 = "f8e4m3"
+TAG_F32 = "f32"
+TAG_BF16 = "bf16"
+
+
+class CheckpointIntegrityError(ValueError):
+    """NVFP4 checkpoint integrity violation. Fail fast."""
+
+
+class TensorInfo(NamedTuple):
+    """Normalized view of one checkpoint tensor (shared by stream + header)."""
+
+    name: str
+    tag: str
+    shape: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class Nvfp4BlockwiseSpec:
+    """Parsed ``nvfp4_blockwise_mixed_v1.json`` sidecar (Data)."""
+
+    recipe: str
+    block_size: int
+    expected_count: int
+    target_patterns: tuple[str, ...]
+    forbidden_patterns: tuple[str, ...]
+    packed_tag: str
+    block_scale_tag: str
+    global_scale_tag: str
+    # weight-name -> {"weight_shape", "packed_shape", "block_scale_shape"}
+    tensors: Mapping[str, Mapping[str, Sequence[int]]]
+
+
+# --- pure calculations -------------------------------------------------------
+
+
+def dtype_tag(dtype: "torch.dtype | str") -> str:
+    """Normalize a torch dtype or safetensors header dtype string to a tag."""
+    if isinstance(dtype, str):
+        return {
+            "U8": TAG_U8,
+            "F8_E4M3": TAG_F8E4M3,
+            "F32": TAG_F32,
+            "BF16": TAG_BF16,
+        }.get(dtype.upper(), dtype.upper())
+    return {
+        torch.uint8: TAG_U8,
+        getattr(torch, "float8_e4m3fn", None): TAG_F8E4M3,
+        torch.float32: TAG_F32,
+        torch.bfloat16: TAG_BF16,
+    }.get(dtype, str(dtype))
+
+
+def parse_nvfp4_spec(config: Mapping) -> Nvfp4BlockwiseSpec:
+    """Validate + parse the sidecar, naming every discrepancy (fail fast)."""
+    violations: list[str] = []
+
+    recipe = config.get("recipe")
+    if recipe != EXPECTED_RECIPE:
+        violations.append(f"recipe: expected {EXPECTED_RECIPE!r}, found {recipe!r}")
+
+    block_size = config.get("block_size")
+    if block_size != BLOCK_SIZE:
+        violations.append(f"block_size: expected {BLOCK_SIZE}, found {block_size!r}")
+
+    enc = config.get("scale_encoding") or {}
+    if enc.get("packed_dtype") != "uint8":
+        violations.append(f"scale_encoding.packed_dtype: expected 'uint8', found {enc.get('packed_dtype')!r}")
+    if enc.get("block_scale_dtype") != "float8_e4m3fn":
+        violations.append(
+            f"scale_encoding.block_scale_dtype: expected 'float8_e4m3fn', found {enc.get('block_scale_dtype')!r}"
+        )
+    if enc.get("global_scale_dtype") != "float32":
+        violations.append(
+            f"scale_encoding.global_scale_dtype: expected 'float32', found {enc.get('global_scale_dtype')!r}"
+        )
+
+    target_patterns = tuple(config.get("target_patterns") or ())
+    forbidden_patterns = tuple(config.get("forbidden_patterns") or ())
+    if not target_patterns:
+        violations.append("target_patterns: missing or empty")
+
+    tensors = config.get("tensors")
+    if not isinstance(tensors, Mapping) or not tensors:
+        violations.append("tensors: missing or empty manifest")
+        tensors = {}
+    else:
+        for tname, decl in tensors.items():
+            ws = decl.get("weight_shape") if isinstance(decl, Mapping) else None
+            if not (isinstance(ws, (list, tuple)) and len(ws) == 2 and all(isinstance(d, int) for d in ws)):
+                violations.append(
+                    f"tensors[{tname!r}].weight_shape: expected [rows, cols] ints, found {ws!r}"
+                )
+
+    expected_count = config.get("expected_quantized_count")
+    if not isinstance(expected_count, int) or expected_count <= 0:
+        violations.append(f"expected_quantized_count: expected positive int, found {expected_count!r}")
+    elif tensors and len(tensors) != expected_count:
+        violations.append(
+            f"expected_quantized_count: declared {expected_count} but manifest lists {len(tensors)} tensors"
+        )
+
+    if violations:
+        raise CheckpointIntegrityError(
+            "nvfp4_blockwise_mixed_v1.json is not the supported NVFP4 deliverable:\n  "
+            + "\n  ".join(violations)
+        )
+    assert isinstance(recipe, str) and isinstance(block_size, int) and isinstance(expected_count, int)
+    return Nvfp4BlockwiseSpec(
+        recipe=recipe,
+        block_size=block_size,
+        expected_count=expected_count,
+        target_patterns=target_patterns,
+        forbidden_patterns=forbidden_patterns,
+        packed_tag=TAG_U8,
+        block_scale_tag=TAG_F8E4M3,
+        global_scale_tag=TAG_F32,
+        tensors=tensors,
+    )
+
+
+def classify_suffix(name: str) -> str | None:
+    """Return which NVFP4 target-tensor family *name* belongs to, or None."""
+    for suffix in (PACKED_SUFFIX, BLOCK_SUFFIX, GLOBAL_SUFFIX):
+        if name.endswith(suffix):
+            return suffix
+    return None
+
+
+def remap_name(name: str) -> str:
+    """Rename an on-disk NVFP4 tensor to vLLM's W4A16 param name (pure).
+
+    ``*.weight_packed`` -> ``*.weight``; ``*.weight_block_scale`` ->
+    ``*.weight_scale``; ``*.weight_global_scale`` -> ``*.weight_scale_2``.
+    Any other name (BF16 passthrough) is returned unchanged.
+    """
+    for suffix, target in REMAP.items():
+        if name.endswith(suffix):
+            return name[: -len(suffix)] + target
+    return name
+
+
+def weight_key_for(name: str) -> str | None:
+    """Map any target family tensor name to its sidecar weight-name key.
+
+    ``X.weight_packed``/``X.weight_block_scale``/``X.weight_global_scale`` ->
+    ``X.weight``; None for non-target names.
+    """
+    suffix = classify_suffix(name)
+    if suffix is None:
+        return None
+    return name[: -len(suffix)] + WEIGHT_SUFFIX
+
+
+def module_of(weight_name: str) -> str:
+    return weight_name[: -len(WEIGHT_SUFFIX)] if weight_name.endswith(WEIGHT_SUFFIX) else weight_name
+
+
+def matches_any(module_path: str, patterns: Iterable[str]) -> bool:
+    """True if *module_path* matches any pattern (regex; plain substrings are
+    valid regexes and match as substrings)."""
+    return any(re.search(pattern, module_path) for pattern in patterns)
+
+
+def expected_packed_width(cols: int) -> int:
+    """Packed last-dim width: two FP4 codes per uint8 byte."""
+    return (cols + 1) // 2
+
+
+def expected_scale_grid(shape: tuple[int, ...], block: int) -> tuple[int, int]:
+    """Block-scale grid for a 2D weight, blocked along the last dim."""
+    rows, cols = shape
+    return (rows, math.ceil(cols / block))
+
+
+def assert_scales_finite(name: str, tensor: torch.Tensor) -> None:
+    """Raise on any NaN/Inf scale byte (owner decision: abort, do not clamp)."""
+    as_f32 = tensor.to(torch.float32)
+    if not torch.isfinite(as_f32).all():
+        raise CheckpointIntegrityError(
+            f"scale tensor {name!r} contains NaN/Inf bytes; the artifact is corrupt "
+            "(the producer guarantees finite scales). Refusing to serve."
+        )
+
+
+def verify_observations(infos: Iterable[TensorInfo], spec: Nvfp4BlockwiseSpec) -> list[str]:
+    """Structural verification against the sidecar manifest (pure).
+
+    Uses the sidecar ``tensors`` manifest as the authoritative target set:
+    every declared target must have a correctly-shaped/typed packed + block +
+    global companion; no undeclared or forbidden module may be packed; counts
+    must match. Returns human-readable violations; ``[]`` when clean. (Does not
+    inspect values; NaN/Inf is checked in :meth:`adapt`.)
+    """
+    packed: dict[str, TensorInfo] = {}
+    block: dict[str, TensorInfo] = {}
+    glob: dict[str, TensorInfo] = {}
+    for info in infos:
+        wkey = weight_key_for(info.name)
+        if wkey is None:
+            continue
+        if info.name.endswith(PACKED_SUFFIX):
+            packed[wkey] = info
+        elif info.name.endswith(BLOCK_SUFFIX):
+            block[wkey] = info
+        elif info.name.endswith(GLOBAL_SUFFIX):
+            glob[wkey] = info
+
+    violations: list[str] = []
+
+    if len(packed) != spec.expected_count:
+        violations.append(
+            f"quantized-target count mismatch: declared {spec.expected_count}, observed {len(packed)}"
+        )
+
+    for wname, info in sorted(packed.items()):
+        module = module_of(wname)
+        if matches_any(module, spec.forbidden_patterns):
+            violations.append(f"forbidden module found quantized: {info.name}")
+        if not matches_any(module, spec.target_patterns):
+            violations.append(f"packed tensor outside target patterns: {info.name}")
+        if wname not in spec.tensors:
+            violations.append(f"packed tensor not declared in sidecar manifest: {info.name}")
+        else:
+            decl = spec.tensors[wname]
+            wshape = tuple(decl["weight_shape"])
+            exp_packed = (wshape[0], expected_packed_width(wshape[-1]))
+            if info.shape != exp_packed:
+                violations.append(
+                    f"packed shape mismatch for {info.name}: found {info.shape}, expected {exp_packed}"
+                )
+        if info.tag != TAG_U8:
+            violations.append(f"packed tensor {info.name} must be uint8, found {info.tag}")
+
+        # companions
+        binfo = block.get(wname)
+        if binfo is None:
+            violations.append(f"missing {BLOCK_SUFFIX} companion for {info.name}")
+        else:
+            if binfo.tag != TAG_F8E4M3:
+                violations.append(f"block scale {binfo.name} must be float8_e4m3fn, found {binfo.tag}")
+            if wname in spec.tensors:
+                wshape = tuple(spec.tensors[wname]["weight_shape"])
+                exp_grid = expected_scale_grid(wshape, spec.block_size)
+                if binfo.shape != exp_grid:
+                    violations.append(
+                        f"block-scale grid mismatch for {binfo.name}: found {binfo.shape}, expected {exp_grid}"
+                    )
+        ginfo = glob.get(wname)
+        if ginfo is None:
+            violations.append(f"missing {GLOBAL_SUFFIX} companion for {info.name}")
+        else:
+            if ginfo.tag != TAG_F32:
+                violations.append(f"global scale {ginfo.name} must be float32, found {ginfo.tag}")
+            if math.prod(ginfo.shape) != 1:
+                violations.append(f"global scale {ginfo.name} must have exactly 1 element, found shape {ginfo.shape}")
+
+    for wname in spec.tensors:
+        if wname not in packed:
+            violations.append(f"declared target missing its packed weight: {wname}")
+
+    for wname in block:
+        if wname not in packed:
+            violations.append(f"orphan block scale without packed weight: {wname}")
+    for wname in glob:
+        if wname not in packed:
+            violations.append(f"orphan global scale without packed weight: {wname}")
+
+    return violations
+
+
+# --- adapter (Action shell) --------------------------------------------------
+
+
+class ModelOptNativeNvfp4CheckpointAdapter:
+    """Streams the NVFP4 blockwise checkpoint FP4-resident (rename, no dequant)."""
+
+    def __init__(self, spec: Nvfp4BlockwiseSpec, source_prefix: str = "") -> None:
+        self._spec = spec
+        self._prefix = source_prefix
+
+    @staticmethod
+    def _is_transformer_source(source: object) -> bool:
+        if getattr(source, "subfolder", None) == "transformer":
+            return True
+        return str(getattr(source, "prefix", "")).startswith("transformer.")
+
+    @classmethod
+    def _sidecar_path(cls, model_dir: "str | os.PathLike") -> str:
+        return os.path.join(model_dir, "transformer", SIDECAR_FILENAME)
+
+    @classmethod
+    def _parse_source_sidecar(cls, source: object) -> Nvfp4BlockwiseSpec | None:
+        """Read + validate the source's ``transformer/`` sidecar (Action).
+
+        Returns None when the source is not a local transformer dir carrying the
+        NVFP4 sidecar. Raises :class:`CheckpointIntegrityError` when a sidecar is
+        present but does not describe the supported deliverable (fail fast).
+        """
+        if not cls._is_transformer_source(source):
+            return None
+        model_dir = getattr(source, "model_or_path", None)
+        if not isinstance(model_dir, (str, os.PathLike)) or not os.path.isdir(model_dir):
+            return None
+        sidecar_path = cls._sidecar_path(model_dir)
+        if not os.path.exists(sidecar_path):
+            return None
+        try:
+            with open(sidecar_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise CheckpointIntegrityError(f"unreadable NVFP4 sidecar {sidecar_path}: {e}") from e
+        return parse_nvfp4_spec(config)
+
+    @classmethod
+    def validate_source_sidecar(cls, source: object) -> None:
+        """Pre-flight check: raise on a present-but-invalid sidecar."""
+        cls._parse_source_sidecar(source)
+
+    @classmethod
+    def detect(
+        cls,
+        source: object,
+        target_dtype: torch.dtype = torch.bfloat16,  # accepted for parity; unused (no dequant)
+    ) -> "ModelOptNativeNvfp4CheckpointAdapter | None":
+        spec = cls._parse_source_sidecar(source)
+        if spec is None:
+            return None
+        model_dir = getattr(source, "model_or_path", None)
+        logger.info(
+            "ModelOpt-native NVFP4 checkpoint detected at %s (declared: %d quantized targets, block %d)",
+            model_dir, spec.expected_count, spec.block_size,
+        )
+        return cls(spec=spec, source_prefix=str(getattr(source, "prefix", "") or ""))
+
+    def _strip_prefix(self, name: str) -> str:
+        if self._prefix and name.startswith(self._prefix):
+            return name[len(self._prefix):]
+        return name
+
+    def adapt(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """Rename target tensors and pass all bytes through unchanged.
+
+        Yields ``(remapped_full_name, tensor)``. Target packed/scale tensors are
+        renamed to vLLM's W4A16 param names; scales are checked NaN/Inf-finite;
+        no target is ever dequantized. Raises aggregated
+        :class:`CheckpointIntegrityError` at end-of-stream on any violation.
+        """
+        infos: list[TensorInfo] = []
+        for full_name, tensor in weights:
+            name = self._strip_prefix(full_name)
+            suffix = classify_suffix(name)
+            infos.append(TensorInfo(name, dtype_tag(tensor.dtype), tuple(tensor.shape)))
+            if suffix in (BLOCK_SUFFIX, GLOBAL_SUFFIX):
+                assert_scales_finite(name, tensor)
+            # rename (target families) or pass through (BF16 non-targets), never dequant
+            yield remap_name(full_name), tensor
+
+        violations = verify_observations(infos, self._spec)
+        if violations:
+            raise CheckpointIntegrityError(
+                f"NVFP4 checkpoint failed integrity verification ({len(violations)} violation(s)):\n  "
+                + "\n  ".join(violations)
+            )
+        logger.info(
+            "ModelOpt-native NVFP4 adapter: passed %d FP4-resident targets through (marker: %s)",
+            self._spec.expected_count, NVFP4_BLOCKWISE_MARKER,
+        )
+
+
+# --- CLI probe (header-only, GPU-free) --------------------------------------
+
+_MAX_SAFETENSORS_HEADER_BYTES = 100 * 1024 * 1024
+
+
+def _read_safetensors_header(path: str) -> dict:
+    with open(path, "rb") as f:
+        (header_len,) = struct.unpack("<Q", f.read(8))
+        if header_len > _MAX_SAFETENSORS_HEADER_BYTES:
+            raise CheckpointIntegrityError(
+                f"safetensors header of {path} is {header_len} bytes "
+                f"(> {_MAX_SAFETENSORS_HEADER_BYTES}); refusing to read"
+            )
+        header = json.loads(f.read(header_len))
+    header.pop("__metadata__", None)
+    return header
+
+
+def header_tensor_infos(header: Mapping) -> list[TensorInfo]:
+    """Pure: safetensors header dict -> normalized TensorInfo list."""
+    return [
+        TensorInfo(name, dtype_tag(entry["dtype"]), tuple(entry["shape"]))
+        for name, entry in header.items()
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Integrity probe: exit 0 iff *model_dir* is the supported NVFP4 deliverable."""
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print("usage: python -m ...modelopt_native_nvfp4 <model_dir>", file=sys.stderr)
+        return 2
+    model_dir = args[0]
+
+    sidecar_path = ModelOptNativeNvfp4CheckpointAdapter._sidecar_path(model_dir)
+    if not os.path.exists(sidecar_path):
+        print(f"INTEGRITY FAIL: no transformer/{SIDECAR_FILENAME} sidecar in {model_dir}")
+        return 1
+    try:
+        with open(sidecar_path) as f:
+            spec = parse_nvfp4_spec(json.load(f))
+    except (OSError, json.JSONDecodeError, CheckpointIntegrityError) as e:
+        print(f"INTEGRITY FAIL: {e}")
+        return 1
+
+    shard_paths = sorted(glob.glob(os.path.join(model_dir, "transformer", "*.safetensors")))
+    if not shard_paths:
+        print(f"INTEGRITY FAIL: no transformer/*.safetensors under {model_dir}")
+        return 1
+    infos: list[TensorInfo] = []
+    for shard_path in shard_paths:
+        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+
+    n_packed = sum(1 for i in infos if i.name.endswith(PACKED_SUFFIX))
+    violations = verify_observations(infos, spec)
+    print(
+        f"declared: {spec.expected_count} quantized targets (block {spec.block_size}); "
+        f"observed: {n_packed} packed weights ({len(infos)} tensors, {len(shard_paths)} shard(s))"
+    )
+    if violations:
+        print(f"INTEGRITY FAIL ({len(violations)} violation(s)):")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+    print(f"INTEGRITY OK: {model_dir} (marker: {NVFP4_BLOCKWISE_MARKER})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
@@ -165,9 +165,7 @@ def parse_nvfp4_spec(config: Mapping) -> Nvfp4BlockwiseSpec:
         for tname, decl in tensors.items():
             ws = decl.get("weight_shape") if isinstance(decl, Mapping) else None
             if not (isinstance(ws, (list, tuple)) and len(ws) == 2 and all(isinstance(d, int) for d in ws)):
-                violations.append(
-                    f"tensors[{tname!r}].weight_shape: expected [rows, cols] ints, found {ws!r}"
-                )
+                violations.append(f"tensors[{tname!r}].weight_shape: expected [rows, cols] ints, found {ws!r}")
 
     expected_count = config.get("expected_quantized_count")
     if not isinstance(expected_count, int) or expected_count <= 0:
@@ -179,8 +177,7 @@ def parse_nvfp4_spec(config: Mapping) -> Nvfp4BlockwiseSpec:
 
     if violations:
         raise CheckpointIntegrityError(
-            "nvfp4_blockwise_mixed_v1.json is not the supported NVFP4 deliverable:\n  "
-            + "\n  ".join(violations)
+            "nvfp4_blockwise_mixed_v1.json is not the supported NVFP4 deliverable:\n  " + "\n  ".join(violations)
         )
     assert isinstance(recipe, str) and isinstance(block_size, int) and isinstance(expected_count, int)
     return Nvfp4BlockwiseSpec(
@@ -286,9 +283,7 @@ def verify_observations(infos: Iterable[TensorInfo], spec: Nvfp4BlockwiseSpec) -
     violations: list[str] = []
 
     if len(packed) != spec.expected_count:
-        violations.append(
-            f"quantized-target count mismatch: declared {spec.expected_count}, observed {len(packed)}"
-        )
+        violations.append(f"quantized-target count mismatch: declared {spec.expected_count}, observed {len(packed)}")
 
     for wname, info in sorted(packed.items()):
         module = module_of(wname)
@@ -303,9 +298,7 @@ def verify_observations(infos: Iterable[TensorInfo], spec: Nvfp4BlockwiseSpec) -
             wshape = tuple(decl["weight_shape"])
             exp_packed = (wshape[0], expected_packed_width(wshape[-1]))
             if info.shape != exp_packed:
-                violations.append(
-                    f"packed shape mismatch for {info.name}: found {info.shape}, expected {exp_packed}"
-                )
+                violations.append(f"packed shape mismatch for {info.name}: found {info.shape}, expected {exp_packed}")
         if info.tag != TAG_U8:
             violations.append(f"packed tensor {info.name} must be uint8, found {info.tag}")
 
@@ -406,13 +399,15 @@ class ModelOptNativeNvfp4CheckpointAdapter:
         model_dir = getattr(source, "model_or_path", None)
         logger.info(
             "ModelOpt-native NVFP4 checkpoint detected at %s (declared: %d quantized targets, block %d)",
-            model_dir, spec.expected_count, spec.block_size,
+            model_dir,
+            spec.expected_count,
+            spec.block_size,
         )
         return cls(spec=spec, source_prefix=str(getattr(source, "prefix", "") or ""))
 
     def _strip_prefix(self, name: str) -> str:
         if self._prefix and name.startswith(self._prefix):
-            return name[len(self._prefix):]
+            return name[len(self._prefix) :]
         return name
 
     def adapt(
@@ -444,7 +439,8 @@ class ModelOptNativeNvfp4CheckpointAdapter:
             )
         logger.info(
             "ModelOpt-native NVFP4 adapter: passed %d FP4-resident targets through (marker: %s)",
-            self._spec.expected_count, NVFP4_BLOCKWISE_MARKER,
+            self._spec.expected_count,
+            NVFP4_BLOCKWISE_MARKER,
         )
 
 
@@ -468,10 +464,7 @@ def _read_safetensors_header(path: str) -> dict:
 
 def header_tensor_infos(header: Mapping) -> list[TensorInfo]:
     """Pure: safetensors header dict -> normalized TensorInfo list."""
-    return [
-        TensorInfo(name, dtype_tag(entry["dtype"]), tuple(entry["shape"]))
-        for name, entry in header.items()
-    ]
+    return [TensorInfo(name, dtype_tag(entry["dtype"]), tuple(entry["shape"])) for name, entry in header.items()]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt_native_nvfp4.py
@@ -52,6 +52,8 @@ from typing import NamedTuple
 import torch
 from vllm.logger import init_logger
 
+from .modelopt_native import resolved_model_root
+
 logger = init_logger(__name__)
 
 # Deploy-side marker for the mount-shadowing probe (mirrors the FP8 adapter):
@@ -369,7 +371,7 @@ class ModelOptNativeNvfp4CheckpointAdapter:
         """
         if not cls._is_transformer_source(source):
             return None
-        model_dir = getattr(source, "model_or_path", None)
+        model_dir = resolved_model_root(source)
         if not isinstance(model_dir, (str, os.PathLike)) or not os.path.isdir(model_dir):
             return None
         sidecar_path = cls._sidecar_path(model_dir)
@@ -396,7 +398,7 @@ class ModelOptNativeNvfp4CheckpointAdapter:
         spec = cls._parse_source_sidecar(source)
         if spec is None:
             return None
-        model_dir = getattr(source, "model_or_path", None)
+        model_dir = resolved_model_root(source)
         logger.info(
             "ModelOpt-native NVFP4 checkpoint detected at %s (declared: %d quantized targets, block %d)",
             model_dir,
@@ -492,7 +494,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     infos: list[TensorInfo] = []
     for shard_path in shard_paths:
-        infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        try:
+            infos.extend(header_tensor_infos(_read_safetensors_header(shard_path)))
+        except (OSError, ValueError, struct.error, json.JSONDecodeError) as e:
+            print(f"INTEGRITY FAIL: unreadable safetensors header {shard_path}: {e}")
+            return 1
 
     n_packed = sum(1 for i in infos if i.name.endswith(PACKED_SUFFIX))
     violations = verify_observations(infos, spec)

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -8,7 +8,7 @@ import re
 import time
 from collections.abc import Generator, Iterable
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -77,6 +77,10 @@ def download_gguf(
 logger = init_logger(__name__)
 
 
+class _CheckpointAdapter(Protocol):
+    def adapt(self, weights: Iterable[tuple[str, torch.Tensor]]) -> Iterable[tuple[str, torch.Tensor]]: ...
+
+
 def _natural_sort_key(filepath: str) -> list:
     """Natural sort key for filenames with numeric components, e.g.
     model-00001-of-00005.safetensors -> ['model-', 1, '-of-', 5, '.safetensors']."""
@@ -137,7 +141,7 @@ class DiffusersPipelineLoader:
     counter_before_loading_weights: float = 0.0
     counter_after_loading_weights: float = 0.0
 
-    def __init__(self, load_config: LoadConfig, od_config: OmniDiffusionConfig):
+    def __init__(self, load_config: LoadConfig, od_config: OmniDiffusionConfig) -> None:
         self.load_config = load_config
         self.od_config = od_config
         self.quant_config = od_config.quantization_config
@@ -291,7 +295,7 @@ class DiffusersPipelineLoader:
         model: nn.Module,
         source: "ComponentSource",
         use_safetensors: bool,
-    ):
+    ) -> _CheckpointAdapter | None:
         return get_checkpoint_adapter(
             model=model,
             source=source,

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -131,6 +131,9 @@ class DiffusersPipelineLoader:
         allow_patterns_overrides: list[str] | None = None
         """If defined, weights will load exclusively using these patterns."""
 
+        resolved_model_or_path: str | None = None
+        """The local model root after download/resolution, if different from model_or_path."""
+
     counter_before_loading_weights: float = 0.0
     counter_after_loading_weights: float = 0.0
 
@@ -147,7 +150,7 @@ class DiffusersPipelineLoader:
         revision: str | None,
         fall_back_to_pt: bool,
         allow_patterns_overrides: list[str] | None,
-    ) -> tuple[Path | str, list[str], bool]:
+    ) -> tuple[Path | str, Path | str, list[str], bool]:
         """Prepare weights for the model.
 
         If the model is not local, it will be downloaded."""
@@ -196,6 +199,7 @@ class DiffusersPipelineLoader:
         else:
             hf_folder = model_name_or_path
 
+        resolved_model_or_path = hf_folder
         if subfolder is not None:
             hf_folder = os.path.join(hf_folder, subfolder)
 
@@ -228,7 +232,7 @@ class DiffusersPipelineLoader:
         if len(hf_weights_files) == 0:
             raise RuntimeError(f"Cannot find any model weights with `{model_name_or_path}`")
 
-        return hf_folder, hf_weights_files, use_safetensors
+        return resolved_model_or_path, hf_folder, hf_weights_files, use_safetensors
 
     def _get_weights_iterator(
         self,
@@ -236,13 +240,14 @@ class DiffusersPipelineLoader:
         model: nn.Module | None = None,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
-        _, hf_weights_files, use_safetensors = self._prepare_weights(
+        resolved_model_or_path, _, hf_weights_files, use_safetensors = self._prepare_weights(
             source.model_or_path,
             source.subfolder,
             source.revision,
             source.fall_back_to_pt,
             source.allow_patterns_overrides,
         )
+        adapter_source = dataclasses.replace(source, resolved_model_or_path=str(resolved_model_or_path))
 
         use_multithread = (
             use_safetensors
@@ -270,7 +275,7 @@ class DiffusersPipelineLoader:
         # Apply the prefix.
         prefixed_weights_iterator = ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
         if model is not None:
-            checkpoint_adapter = self._get_checkpoint_adapter(model, source, use_safetensors)
+            checkpoint_adapter = self._get_checkpoint_adapter(model, adapter_source, use_safetensors)
             if checkpoint_adapter is not None:
                 return checkpoint_adapter.adapt(prefixed_weights_iterator)
         return prefixed_weights_iterator

--- a/vllm_omni/quantization/fp8_blockwise_w8a16.py
+++ b/vllm_omni/quantization/fp8_blockwise_w8a16.py
@@ -38,6 +38,7 @@ import torch
 import torch.nn.functional as F
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
 
@@ -59,7 +60,16 @@ def fp8_w8a16_forced() -> bool:
     return os.environ.get(FP8_W8A16_FLAG) == "1"
 
 
-def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
+def _resolved_model_root(model_or_source: object | None) -> object | None:
+    if model_or_source is None or isinstance(model_or_source, (str, os.PathLike)):
+        return model_or_source
+    resolved = getattr(model_or_source, "resolved_model_or_path", None)
+    if resolved is not None:
+        return resolved
+    return getattr(model_or_source, "model_or_path", None)
+
+
+def _is_fp8_blockwise_dir(model_dir: object | None) -> bool:
     """True iff *model_dir*'s root ``quantization_config.json`` declares the fp8_blockwise
     recipe (a disk read that returns data; no mutation).
 
@@ -68,6 +78,7 @@ def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
     recipe-matching but incorrectly declared checkpoint fails loudly there rather than being
     silently routed incorrectly here. A missing/unreadable sidecar (plain BF16, NVFP4) ⇒ False.
     """
+    model_dir = _resolved_model_root(model_dir)
     if not model_dir:
         return False
     # Single-source the sidecar filename AND the recipe string from the dequant adapter's
@@ -89,7 +100,7 @@ def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
     return isinstance(data, dict) and data.get("recipe") == EXPECTED_RECIPE
 
 
-def fp8_w8a16_selected(model_dir: str | None) -> bool:
+def fp8_w8a16_selected(model_dir: object | None) -> bool:
     """Single source of truth for the experimental FP8-blockwise W8A16 path.
 
     The opt-in flag alone is insufficient: the checkpoint root must also carry
@@ -236,7 +247,7 @@ class Fp8BlockwiseW8A16LinearMethod(LinearMethodBase):
         return F.linear(x, weight, bias)
 
 
-def build_fp8_blockwise_w8a16_config():
+def build_fp8_blockwise_w8a16_config() -> QuantizationConfig:
     """Build the weight-only W8A16 FP8-blockwise config (target-inclusion).
 
     Subclasses vLLM's ``ModelOptFp8Config`` (mirroring how the NVFP4 W4A16 config
@@ -269,6 +280,7 @@ def build_fp8_blockwise_w8a16_config():
     # The method reads the declared block size; pin it and the weight-only method.
     cfg.weight_block_size = list(BLOCK)
     cfg.LinearMethodCls = Fp8BlockwiseW8A16LinearMethod
+    cfg.vllm_omni_quant_recipe = RECIPE
     logger.info(
         "Built FP8 blockwise W8A16 config (recipe=%s): target-inclusion on "
         "'.mlp|.mlp_moe_gen.{gate,up,down}_proj', method=%s, block=%s",
@@ -279,7 +291,18 @@ def build_fp8_blockwise_w8a16_config():
     return cfg
 
 
-def maybe_build_fp8_blockwise_w8a16_config(enabled, active_quant_config=None):
+def is_fp8_blockwise_w8a16_config(quant_config: QuantizationConfig | None) -> bool:
+    return (
+        quant_config is not None
+        and getattr(quant_config, "vllm_omni_quant_recipe", None) == RECIPE
+        and getattr(quant_config, "LinearMethodCls", None) is Fp8BlockwiseW8A16LinearMethod
+    )
+
+
+def maybe_build_fp8_blockwise_w8a16_config(
+    enabled: bool,
+    active_quant_config: QuantizationConfig | None = None,
+) -> QuantizationConfig | None:
     """Return the W8A16 config when *enabled*, else *active_quant_config* unchanged.
 
     *enabled* is the resolved :func:`fp8_w8a16_selected` decision. Mirrors the intent of

--- a/vllm_omni/quantization/fp8_blockwise_w8a16.py
+++ b/vllm_omni/quantization/fp8_blockwise_w8a16.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W8A16 FP8-blockwise config + weight-only linear method.
+
+The FP8-dist deliverable (recipe ``fp8_blockwise_mixed``, blockwise-128x128) stores
+each quantized module as an FP8 (e4m3) ``<m>.weight`` plus a 2D per-block
+``<m>.weight_quantizer._scale`` grid (bf16, ``[ceil(rows/128), ceil(cols/128)]``) and
+an ``._amax`` twin. The default vllm-omni FP8 path *dequantizes* every such weight to
+BF16 on load (:mod:`...checkpoint_adapters.modelopt_native`), so weights are
+BF16-resident and FP8 buys no VRAM relief.
+
+This module is the weight-resident alternative: ``mlp.*`` and ``mlp_moe_gen.*``
+targets stay FP8-resident (1 byte/elem) and are dequantized to BF16 **per operation**
+for a normal BF16 GEMM (W8A16: weights FP8, activations BF16), reusing the tested
+:func:`...modelopt_native.dequantize_weight` calculation. ``lm_head`` and every
+non-target stay/become BF16 at compute. It mirrors the NVFP4 W4A16 structure
+(:mod:`vllm_omni.quantization.nvfp4_blockwise`).
+
+Selection is disk-recipe-gated: a checkpoint's ``transformer/config.json`` may carry no
+``quant_recipe`` (unlike NVFP4), but its root ``quantization_config.json`` declares
+``recipe: fp8_blockwise_mixed``. That disk signal, not an operator flag, makes W8A16 the
+**default** served path for the FP8-blockwise checkpoint; :func:`fp8_w8a16_selected` reads
+it, and the load dispatch consults the same predicate. The
+dequant-on-load path stays reachable as an explicit diagnostic fallback via
+``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1``.
+
+Pure calculation: :func:`is_target_prefix`. Disk selection reads the sidecar at
+the adapter/config boundary. Compute action at the GEMM boundary:
+:class:`Fp8BlockwiseW8A16LinearMethod`. Config
+factories: :func:`build_fp8_blockwise_w8a16_config`,
+:func:`maybe_build_fp8_blockwise_w8a16_config`.
+"""
+
+import json
+import os
+import re
+
+import torch
+import torch.nn.functional as F
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearMethodBase
+
+logger = init_logger(__name__)
+
+RECIPE = "fp8_blockwise_mixed"
+BLOCK = (128, 128)  # blockwise-128x128 (declared in quantization_config.json)
+
+# Deploy-side marker (mirrors the native adapters): its presence + this string in the
+# serve log proves the W8A16-resident path (not dequant-on-load) is engaged.
+W8A16_MARKER = "modelopt-fp8-blockwise-w8a16"
+
+# Explicit diagnostic opt-out: force the dequant-on-load fallback for the
+# FP8-blockwise checkpoint. W8A16 is the default for that checkpoint, so this
+# is the only knob needed.
+FP8_DEQUANT_FLAG = "VLLM_OMNI_FP8_BLOCKWISE_DEQUANT"
+
+
+def fp8_dequant_forced() -> bool:
+    """True iff the diagnostic dequant opt-out env flag is set."""
+    return os.environ.get(FP8_DEQUANT_FLAG) == "1"
+
+
+def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
+    """True iff *model_dir*'s root ``quantization_config.json`` declares the fp8_blockwise
+    recipe (a disk read that returns data; no mutation).
+
+    Keys on ``recipe`` only. The quantized target family is enforced fail-fast at adapter
+    engagement (:func:`...modelopt_native_fp8_w8a16.assert_target_family`), so a
+    recipe-matching but mis-declared checkpoint fails loudly there rather than being
+    silently mis-routed here. A missing/unreadable sidecar (plain BF16, NVFP4) ⇒ False.
+    """
+    if not model_dir:
+        return False
+    # Single-source the sidecar filename AND the recipe string from the dequant adapter's
+    # constants, so this selection predicate compares against the SAME recipe the adapter's
+    # parse_quant_spec validates against. They cannot drift into a select-vs-reject
+    # split-brain (both describe the one fp8_blockwise deliverable).
+    from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import (
+        EXPECTED_RECIPE,
+        SIDECAR_FILENAME,
+    )
+
+    try:
+        with open(os.path.join(model_dir, SIDECAR_FILENAME)) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError, TypeError):
+        # Fail-closed on ANY unreadable/malformed sidecar (missing file, bad JSON,
+        # non-UTF-8, or a non-path model_dir). Return False, never crash the load.
+        return False
+    return isinstance(data, dict) and data.get("recipe") == EXPECTED_RECIPE
+
+
+def fp8_w8a16_selected(model_dir: str | None) -> bool:
+    """Single source of truth: serve the FP8-blockwise checkpoint W8A16-resident by
+    default, unless the diagnostic dequant opt-out is set.
+    """
+    return _is_fp8_blockwise_dir(model_dir) and not fp8_dequant_forced()
+
+# Quantized MLP projections (``mlp.*`` and ``mlp_moe_gen.*``).
+# ``lm_head`` is deliberately excluded: it stays BF16 at compute; the
+# FP8 ``lm_head`` is dequantized to BF16 by the adapter). Anchored on the module
+# prefix (e.g. ``language_model.layers.0.mlp.gate_proj``), not a parameter name.
+_TARGET_RE = re.compile(r"\.(mlp|mlp_moe_gen)\.(gate_proj|up_proj|down_proj)$")
+
+
+def is_target_prefix(prefix: str) -> bool:
+    """True iff *prefix* is one of the quantized MLP projections (pure).
+
+    Matches the module prefix, not a parameter name; ``lm_head``, attention, and the
+    small projections never match.
+    """
+    return bool(_TARGET_RE.search(prefix))
+
+
+class Fp8BlockwiseW8A16LinearMethod(LinearMethodBase):
+    """Weight-only FP8 blockwise (W8A16) linear method: resident FP8 + JIT dequant.
+
+    Keeps the target weight resident as ``float8_e4m3fn`` (1 byte/elem) plus its 2D
+    128x128 block scale, and computes each op by dequantizing the weight to the
+    activation dtype (BF16) per forward, then a plain GEMM. No activation
+    quantization (weight-only): no ``input_scale`` is created. Mirrors
+    ``ModelOptNvFp4W4A16LinearMethod`` but with a JIT dequant + ``F.linear`` compute
+    path (no fused kernel), which is the guaranteed-correct route on sm_120.
+    """
+
+    def __init__(self, quant_config) -> None:
+        self.quant_config = quant_config
+        self.block = tuple(getattr(quant_config, "weight_block_size", BLOCK))
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        block_n, block_k = self.block
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = [block_n, block_k]
+
+        from vllm.model_executor.parameter import (
+            BlockQuantScaleParameter,
+            ModelWeightParameter,
+        )
+
+        # Resident FP8 weight (1 byte/elem) — never dequantized on load.
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        # 2D per-block scale grid (bf16 on disk), blocked 128x128 along both dims.
+        scale_rows = (output_size_per_partition + block_n - 1) // block_n
+        scale_cols = (input_size_per_partition + block_k - 1) // block_k
+        weight_scale = BlockQuantScaleParameter(
+            data=torch.empty(scale_rows, scale_cols, dtype=torch.bfloat16),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Assert real FP8 residency + a well-formed block-scale grid, then log proof.
+
+        Residency (``element_size()==1`` — kills silent dequant-on-load) AND scale-grid
+        shape (``ceil(out/128) x ceil(in/128)`` — kills a malformed/transposed scale that
+        would corrupt the per-op dequant) are checked fail-fast; a violation raises and
+        serving does not start.
+        """
+        weight = layer.weight
+        if weight.dtype != torch.float8_e4m3fn or weight.element_size() != 1:
+            raise ValueError(
+                f"W8A16 residency violated: weight dtype={weight.dtype} "
+                f"element_size={weight.element_size()} (expected float8_e4m3fn, 1 "
+                "byte). A silent dequant-on-load would defeat the VRAM goal."
+            )
+        block_n, block_k = layer.weight_block_size
+        expected = (
+            (layer.output_size_per_partition + block_n - 1) // block_n,
+            (layer.input_size_per_partition + block_k - 1) // block_k,
+        )
+        got = tuple(layer.weight_scale.shape)
+        if got != expected:
+            raise ValueError(
+                f"W8A16 scale-grid shape {got} != expected {expected} for block "
+                f"{(block_n, block_k)} on "
+                f"{layer.output_size_per_partition}x{layer.input_size_per_partition}; "
+                "a malformed/transposed scale would corrupt the per-op dequant."
+            )
+        logger.info(
+            "W8A16 resident target: dtype=%s elem=%d shape=%s scale=%s block=%s (marker: %s)",
+            weight.dtype,
+            weight.element_size(),
+            tuple(weight.shape),
+            got,
+            layer.weight_block_size,
+            W8A16_MARKER,
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Dequantize the resident FP8 weight to ``x.dtype`` per op, then GEMM.
+
+        Reuses the same block-scale dequant calculation as the load-time dequant
+        path, so W8A16 is numerically a *deferred* form of it (near-bit-exact parity).
+        """
+        from vllm_omni.diffusion.model_loader.checkpoint_adapters.modelopt_native import (  # noqa: E501
+            dequantize_weight,
+        )
+
+        weight = dequantize_weight(
+            layer.weight, layer.weight_scale, x.dtype, tuple(layer.weight_block_size)
+        )
+        return F.linear(x, weight, bias)
+
+
+def build_fp8_blockwise_w8a16_config():
+    """Build the weight-only W8A16 FP8-blockwise config (target-inclusion).
+
+    Subclasses vLLM's ``ModelOptFp8Config`` (mirroring how the NVFP4 W4A16 config
+    subclasses ``ModelOptNvFp4Config``): inverts layer selection to quantize ONLY the
+    ``.mlp``/``.mlp_moe_gen.{gate,up,down}_proj`` targets and pins
+    :class:`Fp8BlockwiseW8A16LinearMethod` as the linear method; every other Linear
+    (attention, ``lm_head``, projections, norms) resolves to
+    ``UnquantizedLinearMethod`` (BF16).
+    """
+    from vllm.model_executor.layers.quantization.modelopt import ModelOptFp8Config
+
+    class Fp8BlockwiseW8A16Config(ModelOptFp8Config):
+        """W8A16 FP8-blockwise with target-inclusion selection (only MLP projs)."""
+
+        def is_target_module(self, prefix: str) -> bool:
+            return is_target_prefix(prefix)
+
+        def is_layer_excluded(self, prefix: str, *args, **kwargs) -> bool:
+            # Invert vLLM's exclusion default: quantize ONLY the MLP targets; every
+            # other Linear is excluded -> UnquantizedLinearMethod (BF16). *args/**kwargs
+            # tolerate base-signature drift across vLLM builds.
+            return not self.is_target_module(prefix)
+
+    cfg = Fp8BlockwiseW8A16Config(
+        quant_method="FP8",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+    )
+    # The method reads the declared block size; pin it and the weight-only method.
+    cfg.weight_block_size = list(BLOCK)
+    cfg.LinearMethodCls = Fp8BlockwiseW8A16LinearMethod
+    logger.info(
+        "Built FP8 blockwise W8A16 config (recipe=%s): target-inclusion on "
+        "'.mlp|.mlp_moe_gen.{gate,up,down}_proj', method=%s, block=%s",
+        RECIPE,
+        cfg.LinearMethodCls.__name__,
+        tuple(BLOCK),
+    )
+    return cfg
+
+
+def maybe_build_fp8_blockwise_w8a16_config(enabled, active_quant_config=None):
+    """Return the W8A16 config when *enabled*, else *active_quant_config* unchanged.
+
+    *enabled* is the resolved :func:`fp8_w8a16_selected` decision (W8A16 is the default for
+    the FP8-blockwise checkpoint; the dequant opt-out yields False). Mirrors the intent of
+    :func:`vllm_omni.quantization.nvfp4_blockwise.maybe_build_nvfp4_blockwise_config`, but
+    gated on the checkpoint's on-disk ``quantization_config.json`` recipe rather than a
+    ``quant_recipe`` in ``transformer/config.json`` (which the FP8-dist checkpoint lacks).
+    Never overrides an already-active config (e.g. the NVFP4 W4A16 config): W8A16 only fills
+    the FP8-dist case where no ``quant_recipe`` hook produced one.
+    """
+    if not enabled:
+        return active_quant_config
+    if active_quant_config is not None:
+        logger.info(
+            "fp8_w8a16 selected but a quant_config (%s) is already active; "
+            "keeping it (W8A16 does not override NVFP4/explicit configs).",
+            getattr(active_quant_config, "get_name", lambda: active_quant_config)(),
+        )
+        return active_quant_config
+    return build_fp8_blockwise_w8a16_config()

--- a/vllm_omni/quantization/fp8_blockwise_w8a16.py
+++ b/vllm_omni/quantization/fp8_blockwise_w8a16.py
@@ -33,6 +33,7 @@ factories: :func:`build_fp8_blockwise_w8a16_config`,
 import json
 import os
 import re
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -136,7 +137,7 @@ class Fp8BlockwiseW8A16LinearMethod(LinearMethodBase):
     path (no fused kernel), which is the guaranteed-correct route on sm_120.
     """
 
-    def __init__(self, quant_config) -> None:
+    def __init__(self, quant_config: QuantizationConfig) -> None:
         self.quant_config = quant_config
         self.block = tuple(getattr(quant_config, "weight_block_size", BLOCK))
 
@@ -144,11 +145,11 @@ class Fp8BlockwiseW8A16LinearMethod(LinearMethodBase):
         self,
         layer: torch.nn.Module,
         input_size_per_partition: int,
-        output_partition_sizes: list,
+        output_partition_sizes: list[int],
         input_size: int,
         output_size: int,
         params_dtype: torch.dtype,
-        **extra_weight_attrs,
+        **extra_weight_attrs: Any,
     ) -> None:
         del input_size, output_size
         output_size_per_partition = sum(output_partition_sizes)
@@ -265,7 +266,7 @@ def build_fp8_blockwise_w8a16_config() -> QuantizationConfig:
         def is_target_module(self, prefix: str) -> bool:
             return is_target_prefix(prefix)
 
-        def is_layer_excluded(self, prefix: str, *args, **kwargs) -> bool:
+        def is_layer_excluded(self, prefix: str, *args: Any, **kwargs: Any) -> bool:
             # Invert vLLM's exclusion default: quantize ONLY the MLP targets; every
             # other Linear is excluded -> UnquantizedLinearMethod (BF16). *args/**kwargs
             # tolerate base-signature drift across vLLM builds.

--- a/vllm_omni/quantization/fp8_blockwise_w8a16.py
+++ b/vllm_omni/quantization/fp8_blockwise_w8a16.py
@@ -16,13 +16,12 @@ for a normal BF16 GEMM (W8A16: weights FP8, activations BF16), reusing the teste
 non-target stay/become BF16 at compute. It mirrors the NVFP4 W4A16 structure
 (:mod:`vllm_omni.quantization.nvfp4_blockwise`).
 
-Selection is disk-recipe-gated: a checkpoint's ``transformer/config.json`` may carry no
-``quant_recipe`` (unlike NVFP4), but its root ``quantization_config.json`` declares
-``recipe: fp8_blockwise_mixed``. That disk signal, not an operator flag, makes W8A16 the
-**default** served path for the FP8-blockwise checkpoint; :func:`fp8_w8a16_selected` reads
-it, and the load dispatch consults the same predicate. The
-dequant-on-load path stays reachable as an explicit diagnostic fallback via
-``VLLM_OMNI_FP8_BLOCKWISE_DEQUANT=1``.
+Selection is opt-in and disk-recipe-gated: a checkpoint's
+``transformer/config.json`` may carry no ``quant_recipe`` (unlike NVFP4), but
+its root ``quantization_config.json`` declares ``recipe: fp8_blockwise_mixed``.
+``VLLM_OMNI_FP8_BLOCKWISE_W8A16=1`` enables this resident path only when that
+disk recipe matches. The dequant-on-load path remains the default until a fused
+or cached W8A16 kernel avoids per-forward full-weight dequantization.
 
 Pure calculation: :func:`is_target_prefix`. Disk selection reads the sidecar at
 the adapter/config boundary. Compute action at the GEMM boundary:
@@ -49,15 +48,15 @@ BLOCK = (128, 128)  # blockwise-128x128 (declared in quantization_config.json)
 # serve log proves the W8A16-resident path (not dequant-on-load) is engaged.
 W8A16_MARKER = "modelopt-fp8-blockwise-w8a16"
 
-# Explicit diagnostic opt-out: force the dequant-on-load fallback for the
-# FP8-blockwise checkpoint. W8A16 is the default for that checkpoint, so this
-# is the only knob needed.
-FP8_DEQUANT_FLAG = "VLLM_OMNI_FP8_BLOCKWISE_DEQUANT"
+# Explicit opt-in: the resident path saves weight memory but currently
+# dequantizes the full weight per forward, so the load-time dequant path stays
+# the default.
+FP8_W8A16_FLAG = "VLLM_OMNI_FP8_BLOCKWISE_W8A16"
 
 
-def fp8_dequant_forced() -> bool:
-    """True iff the diagnostic dequant opt-out env flag is set."""
-    return os.environ.get(FP8_DEQUANT_FLAG) == "1"
+def fp8_w8a16_forced() -> bool:
+    """True iff the explicit resident-W8A16 opt-in env flag is set."""
+    return os.environ.get(FP8_W8A16_FLAG) == "1"
 
 
 def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
@@ -91,10 +90,12 @@ def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
 
 
 def fp8_w8a16_selected(model_dir: str | None) -> bool:
-    """Single source of truth: serve the FP8-blockwise checkpoint W8A16-resident by
-    default, unless the diagnostic dequant opt-out is set.
+    """Single source of truth for the experimental FP8-blockwise W8A16 path.
+
+    The opt-in flag alone is insufficient: the checkpoint root must also carry
+    the expected FP8-blockwise recipe.
     """
-    return _is_fp8_blockwise_dir(model_dir) and not fp8_dequant_forced()
+    return fp8_w8a16_forced() and _is_fp8_blockwise_dir(model_dir)
 
 # Quantized MLP projections (``mlp.*`` and ``mlp_moe_gen.*``).
 # ``lm_head`` is deliberately excluded: it stays BF16 at compute; the
@@ -282,8 +283,7 @@ def build_fp8_blockwise_w8a16_config():
 def maybe_build_fp8_blockwise_w8a16_config(enabled, active_quant_config=None):
     """Return the W8A16 config when *enabled*, else *active_quant_config* unchanged.
 
-    *enabled* is the resolved :func:`fp8_w8a16_selected` decision (W8A16 is the default for
-    the FP8-blockwise checkpoint; the dequant opt-out yields False). Mirrors the intent of
+    *enabled* is the resolved :func:`fp8_w8a16_selected` decision. Mirrors the intent of
     :func:`vllm_omni.quantization.nvfp4_blockwise.maybe_build_nvfp4_blockwise_config`, but
     gated on the checkpoint's on-disk ``quantization_config.json`` recipe rather than a
     ``quant_recipe`` in ``transformer/config.json`` (which the FP8-dist checkpoint lacks).

--- a/vllm_omni/quantization/fp8_blockwise_w8a16.py
+++ b/vllm_omni/quantization/fp8_blockwise_w8a16.py
@@ -65,8 +65,8 @@ def _is_fp8_blockwise_dir(model_dir: str | None) -> bool:
 
     Keys on ``recipe`` only. The quantized target family is enforced fail-fast at adapter
     engagement (:func:`...modelopt_native_fp8_w8a16.assert_target_family`), so a
-    recipe-matching but mis-declared checkpoint fails loudly there rather than being
-    silently mis-routed here. A missing/unreadable sidecar (plain BF16, NVFP4) ⇒ False.
+    recipe-matching but incorrectly declared checkpoint fails loudly there rather than being
+    silently routed incorrectly here. A missing/unreadable sidecar (plain BF16, NVFP4) ⇒ False.
     """
     if not model_dir:
         return False
@@ -96,6 +96,7 @@ def fp8_w8a16_selected(model_dir: str | None) -> bool:
     the expected FP8-blockwise recipe.
     """
     return fp8_w8a16_forced() and _is_fp8_blockwise_dir(model_dir)
+
 
 # Quantized MLP projections (``mlp.*`` and ``mlp_moe_gen.*``).
 # ``lm_head`` is deliberately excluded: it stays BF16 at compute; the
@@ -231,9 +232,7 @@ class Fp8BlockwiseW8A16LinearMethod(LinearMethodBase):
             dequantize_weight,
         )
 
-        weight = dequantize_weight(
-            layer.weight, layer.weight_scale, x.dtype, tuple(layer.weight_block_size)
-        )
+        weight = dequantize_weight(layer.weight, layer.weight_scale, x.dtype, tuple(layer.weight_block_size))
         return F.linear(x, weight, bias)
 
 

--- a/vllm_omni/quantization/nvfp4_blockwise.py
+++ b/vllm_omni/quantization/nvfp4_blockwise.py
@@ -91,7 +91,8 @@ def build_nvfp4_blockwise_w4a16_config():
     logger.info(
         "Built NVFP4 blockwise W4A16 config (recipe=%s): target-inclusion on "
         "'.mlp|.mlp_moe_gen.{gate,up,down}_proj', method=%s",
-        RECIPE, cfg.LinearMethodCls.__name__,
+        RECIPE,
+        cfg.LinearMethodCls.__name__,
     )
     return cfg
 

--- a/vllm_omni/quantization/nvfp4_blockwise.py
+++ b/vllm_omni/quantization/nvfp4_blockwise.py
@@ -24,6 +24,7 @@ this config via :func:`maybe_build_nvfp4_blockwise_config` at construction time.
 """
 
 import re
+from typing import Any
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
@@ -43,7 +44,7 @@ def is_target_prefix(prefix: str) -> bool:
     return bool(_TARGET_RE.search(prefix))
 
 
-def _load_base_config_cls():
+def _load_base_config_cls() -> type[QuantizationConfig]:
     """Import the vLLM ModelOpt NVFP4 config lazily (only when serving NVFP4)."""
     from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
 
@@ -64,7 +65,7 @@ def build_nvfp4_blockwise_w4a16_config() -> QuantizationConfig:
         def is_target_module(self, prefix: str) -> bool:
             return is_target_prefix(prefix)
 
-        def is_layer_excluded(self, prefix: str, *args, **kwargs) -> bool:
+        def is_layer_excluded(self, prefix: str, *args: Any, **kwargs: Any) -> bool:
             # Invert vLLM's exclusion default: quantize ONLY the MLP targets;
             # every other Linear is excluded -> UnquantizedLinearMethod (BF16).
             # *args/**kwargs tolerate the base signature (some vLLM builds pass

--- a/vllm_omni/quantization/nvfp4_blockwise.py
+++ b/vllm_omni/quantization/nvfp4_blockwise.py
@@ -26,6 +26,7 @@ this config via :func:`maybe_build_nvfp4_blockwise_config` at construction time.
 import re
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
 
@@ -49,7 +50,7 @@ def _load_base_config_cls():
     return ModelOptNvFp4Config
 
 
-def build_nvfp4_blockwise_w4a16_config():
+def build_nvfp4_blockwise_w4a16_config() -> QuantizationConfig:
     """Build the W4A16 target-inclusion NVFP4 config for the blockwise recipe."""
     base_cls = _load_base_config_cls()
 
@@ -78,6 +79,7 @@ def build_nvfp4_blockwise_w4a16_config():
         exclude_modules=[],
         group_size=16,
     )
+    cfg.vllm_omni_quant_recipe = RECIPE
     # Fail fast if this vLLM build does not resolve the weight-only W4A16 method:
     # a stock/older vLLM could otherwise silently attach the W4A4 method, which
     # needs an activation input_scale this artifact does not carry.
@@ -97,12 +99,23 @@ def build_nvfp4_blockwise_w4a16_config():
     return cfg
 
 
-def _is_generic_nvfp4(quant_config: object) -> bool:
+def _is_generic_nvfp4(quant_config: QuantizationConfig) -> bool:
     getter = getattr(quant_config, "get_name", None)
     return callable(getter) and getter() in {"fp4", "nvfp4", "modelopt_fp4"}
 
 
-def maybe_build_nvfp4_blockwise_config(quant_recipe, active_quant_config=None):
+def is_nvfp4_blockwise_w4a16_config(quant_config: QuantizationConfig | None) -> bool:
+    return (
+        quant_config is not None
+        and getattr(quant_config, "vllm_omni_quant_recipe", None) == RECIPE
+        and getattr(getattr(quant_config, "LinearMethodCls", None), "__name__", "") == "ModelOptNvFp4W4A16LinearMethod"
+    )
+
+
+def maybe_build_nvfp4_blockwise_config(
+    quant_recipe: str | None,
+    active_quant_config: QuantizationConfig | None = None,
+) -> QuantizationConfig | None:
     """Resolve the NVFP4 blockwise W4A16 config from a transformer's recipe.
 
     Rules (mirroring the intent of ``resolve_quant_config_from_disk``):

--- a/vllm_omni/quantization/nvfp4_blockwise.py
+++ b/vllm_omni/quantization/nvfp4_blockwise.py
@@ -13,8 +13,10 @@ requires:
 2. **target-inclusion** layer selection: vLLM's ``ModelOptNvFp4Config`` is
    exclusion-based ("quantize every Linear except ``exclude_modules``"), which
    for a selective checkpoint would need every non-target enumerated. We invert
-   it: quantize **only** ``...mlp.{gate,up,down}_proj``, leaving attention, embeddings, ``lm_head``,
-   norms, projections, audio and action modules BF16 (``UnquantizedLinearMethod``).
+   it: quantize **only** ``...mlp`` / ``...mlp_moe_gen``
+   ``.{gate,up,down}_proj``, leaving attention, embeddings, ``lm_head``,
+   norms, projections, audio and action modules BF16
+   (``UnquantizedLinearMethod``).
 
 The transformer's own ``config.json`` carries ``quant_recipe`` at top level (not
 in a nested ``quantization_config`` block), so model construction resolves
@@ -28,10 +30,11 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 RECIPE = "nvfp4_blockwise_mixed_v1"
-# Target modules end in ``.mlp.{gate,up,down}_proj``. Attention uses
+# Target modules end in ``.mlp`` / ``.mlp_moe_gen``
+# ``.{gate,up,down}_proj``. Attention uses
 # ``to_q``/``to_k``/``to_v``/``to_out``/``add_*_proj``; small projections,
 # embeddings, and heads stay unquantized.
-_TARGET_RE = re.compile(r"\.mlp\.(gate_proj|up_proj|down_proj)$")
+_TARGET_RE = re.compile(r"\.(mlp|mlp_moe_gen)\.(gate_proj|up_proj|down_proj)$")
 
 
 def is_target_prefix(prefix: str) -> bool:
@@ -87,7 +90,7 @@ def build_nvfp4_blockwise_w4a16_config():
         )
     logger.info(
         "Built NVFP4 blockwise W4A16 config (recipe=%s): target-inclusion on "
-        "'.mlp.{gate,up,down}_proj', method=%s",
+        "'.mlp|.mlp_moe_gen.{gate,up,down}_proj', method=%s",
         RECIPE, cfg.LinearMethodCls.__name__,
     )
     return cfg

--- a/vllm_omni/quantization/nvfp4_blockwise.py
+++ b/vllm_omni/quantization/nvfp4_blockwise.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W4A16 NVFP4 config for ``nvfp4_blockwise_mixed_v1`` checkpoints.
+
+The checkpoint is weight-only NVFP4 (packed FP4 weights + FP8 block
+scales + FP32 global scale, **no** activation ``input_scale``) and quantizes
+only selected MLP projections. Serving it FP4-resident therefore
+requires:
+
+1. the **W4A16** ModelOpt path (``ModelOptNvFp4W4A16LinearMethod``, pinned to the
+   Marlin FP4 kernel) rather than the default W4A4 path, which would demand an
+   ``input_scale`` the artifact lacks and would quantize activations; and
+2. **target-inclusion** layer selection: vLLM's ``ModelOptNvFp4Config`` is
+   exclusion-based ("quantize every Linear except ``exclude_modules``"), which
+   for a selective checkpoint would need every non-target enumerated. We invert
+   it: quantize **only** ``...mlp.{gate,up,down}_proj``, leaving attention, embeddings, ``lm_head``,
+   norms, projections, audio and action modules BF16 (``UnquantizedLinearMethod``).
+
+The transformer's own ``config.json`` carries ``quant_recipe`` at top level (not
+in a nested ``quantization_config`` block), so model construction resolves
+this config via :func:`maybe_build_nvfp4_blockwise_config` at construction time.
+"""
+
+import re
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+RECIPE = "nvfp4_blockwise_mixed_v1"
+# Target modules end in ``.mlp.{gate,up,down}_proj``. Attention uses
+# ``to_q``/``to_k``/``to_v``/``to_out``/``add_*_proj``; small projections,
+# embeddings, and heads stay unquantized.
+_TARGET_RE = re.compile(r"\.mlp\.(gate_proj|up_proj|down_proj)$")
+
+
+def is_target_prefix(prefix: str) -> bool:
+    """True iff *prefix* is one of the quantized MLP projections (pure)."""
+    return bool(_TARGET_RE.search(prefix))
+
+
+def _load_base_config_cls():
+    """Import the vLLM ModelOpt NVFP4 config lazily (only when serving NVFP4)."""
+    from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
+
+    return ModelOptNvFp4Config
+
+
+def build_nvfp4_blockwise_w4a16_config():
+    """Build the W4A16 target-inclusion NVFP4 config for the blockwise recipe."""
+    base_cls = _load_base_config_cls()
+
+    class Nvfp4BlockwiseW4A16Config(base_cls):
+        """W4A16 NVFP4 with target-inclusion selection (only MLP projections).
+
+        ``get_name()`` stays ``"modelopt_fp4"`` (inherited) so downstream
+        ModelOpt-NVFP4 handling keeps working; only layer selection is inverted.
+        """
+
+        def is_target_module(self, prefix: str) -> bool:
+            return is_target_prefix(prefix)
+
+        def is_layer_excluded(self, prefix: str, *args, **kwargs) -> bool:
+            # Invert vLLM's exclusion default: quantize ONLY the MLP targets;
+            # every other Linear is excluded -> UnquantizedLinearMethod (BF16).
+            # *args/**kwargs tolerate the base signature (some vLLM builds pass
+            # exclude_modules as a 2nd positional) so selection can't silently
+            # mismatch across versions.
+            return not self.is_target_module(prefix)
+
+    cfg = Nvfp4BlockwiseW4A16Config(
+        quant_method="W4A16_NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        group_size=16,
+    )
+    # Fail fast if this vLLM build does not resolve the weight-only W4A16 method:
+    # a stock/older vLLM could otherwise silently attach the W4A4 method, which
+    # needs an activation input_scale this artifact does not carry.
+    method_name = getattr(cfg.LinearMethodCls, "__name__", "")
+    if method_name != "ModelOptNvFp4W4A16LinearMethod":
+        raise RuntimeError(
+            f"nvfp4_blockwise requires vLLM's ModelOptNvFp4W4A16LinearMethod but this build "
+            f"resolved {method_name!r}. Serve with the version-matched vllm-omni image "
+            "(vLLM 0.24.0 with W4A16_NVFP4 support)."
+        )
+    logger.info(
+        "Built NVFP4 blockwise W4A16 config (recipe=%s): target-inclusion on "
+        "'.mlp.{gate,up,down}_proj', method=%s",
+        RECIPE, cfg.LinearMethodCls.__name__,
+    )
+    return cfg
+
+
+def _is_generic_nvfp4(quant_config: object) -> bool:
+    getter = getattr(quant_config, "get_name", None)
+    return callable(getter) and getter() in {"fp4", "nvfp4", "modelopt_fp4"}
+
+
+def maybe_build_nvfp4_blockwise_config(quant_recipe, active_quant_config=None):
+    """Resolve the NVFP4 blockwise W4A16 config from a transformer's recipe.
+
+    Rules (mirroring the intent of ``resolve_quant_config_from_disk``):
+      - ``quant_recipe`` is not the blockwise recipe: return *active* unchanged.
+      - an explicit, non-generic active config is present: respect it (do not
+        silently override an operator's choice).
+      - otherwise: build and return the W4A16 target-inclusion config.
+    """
+    if quant_recipe != RECIPE:
+        return active_quant_config
+    if active_quant_config is not None and not _is_generic_nvfp4(active_quant_config):
+        logger.info(
+            "nvfp4_blockwise recipe present but a specific quant_config (%s) is active; keeping it.",
+            getattr(active_quant_config, "get_name", lambda: active_quant_config)(),
+        )
+        return active_quant_config
+    return build_nvfp4_blockwise_w4a16_config()


### PR DESCRIPTION
## Summary

- Add ModelOpt-native FP8 blockwise sidecar loading for `fp8_blockwise_mixed` checkpoints.
- Add NVFP4 blockwise sidecar loading and W4A16 target-inclusion config for `nvfp4_blockwise_mixed_v1` checkpoints.
- Keep the FP8 resident W8A16 path opt-in while load-time dequant remains the default.

## Tests

- `.venv-mig-s2/bin/python -m pytest -q tests/diffusion/quantization/test_fp8_blockwise_w8a16.py tests/diffusion/model_loader/test_modelopt_native.py tests/diffusion/model_loader/test_modelopt_native_fp8_w8a16.py tests/diffusion/model_loader/test_modelopt_native_nvfp4.py tests/model_executor/quantization/test_nvfp4_blockwise_config.py tests/model_executor/quantization/test_modelopt_nvfp4_nan_clamp.py`  
  `128 passed, 18 warnings`
- `.venv-mig-s2/bin/python -m compileall -q vllm_omni`
- `.venv-mig-s2/bin/python -m pre_commit run --files $(git diff --name-only "$BASE"...HEAD)`
- `bash scripts/build_wheel.sh --python .venv-mig-s2/bin/python`

## Notes

- DCO signed on all commits.
- No downstream model-specific code or model weights included.
- No GPU benchmark claim in this PR.
