### PR TITLE
[BugFix][Ming-TTS] Use uploaded direct speaker embeddings by voice

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -39,7 +39,8 @@ from vllm_omni.entrypoints.openai.serving_speech import (
     OmniOpenAIServingSpeech,
     _create_wav_header,
 )
-from vllm_omni.entrypoints.openai.tts_adapters.base import PreparedRequest
+from vllm_omni.entrypoints.openai.tts_adapters.base import PreparedRequest, SpeechServingContext
+from vllm_omni.entrypoints.openai.tts_adapters.ming_tts import MingTTSAdapter
 from vllm_omni.model_executor.models.fish_speech.prompt_utils import (
     FISH_TEXT_ONLY_SYSTEM_PROMPT,
     build_fish_voice_clone_prompt_ids,
@@ -973,6 +974,29 @@ class TestTTSMethods:
                 )
             )
 
+    def test_upload_ming_voice_embedding_wrong_dims_rejected_without_replacing_existing(self, speech_server):
+        """Ming embedding uploads must be 192-dim before replacing stored voices."""
+        speech_server._tts_model_type = "ming_tts"
+        existing = {
+            "name": "bad_emb_voice",
+            "file_path": "/tmp/voice_samples/bad_emb_voice.safetensors",
+            "mime_type": "application/x-safetensors",
+            "embedding_source": "direct",
+            "embedding_dim": 192,
+        }
+        speech_server.uploaded_speakers = {"bad_emb_voice": existing.copy()}
+
+        with pytest.raises(ValueError, match="Ming speaker embedding must have 192 dims, got 191"):
+            asyncio.run(
+                speech_server.upload_voice_embedding(
+                    embedding_json=json.dumps([0.0] * 191),
+                    consent="consent",
+                    name="bad_emb_voice",
+                )
+            )
+
+        assert speech_server.uploaded_speakers["bad_emb_voice"] == existing
+
     def test_base_task_requires_ref_audio_or_speaker_embedding(self, speech_server):
         """Base task without ref_audio or speaker_embedding is rejected."""
         req = OpenAICreateSpeechRequest(input="Hello", task_type="Base")
@@ -1556,6 +1580,86 @@ class TestTTSMethods:
         assert params["task_type"] == ["Base"]
         assert params["x_vector_only_mode"] == [True]
         assert "ref_audio" not in params
+
+    def test_ming_adapter_uploaded_direct_embedding_uses_embedding_not_audio(
+        self, speech_server, mocker: MockerFixture
+    ):
+        """Ming uploaded direct embeddings are loaded into prompt construction."""
+        speech_server.uploaded_speakers = {
+            "emb_voice": {
+                "name": "emb_voice",
+                "file_path": "/tmp/voice_samples/emb_voice.safetensors",
+                "mime_type": "application/x-safetensors",
+                "embedding_source": "direct",
+                "embedding_dim": 192,
+            }
+        }
+        fake_embedding = [0.1] * 192
+        mock_get_emb = mocker.patch.object(
+            speech_server, "_get_uploaded_speaker_embedding", return_value=fake_embedding
+        )
+        mock_get_audio = mocker.patch.object(speech_server, "_get_uploaded_audio_data")
+        mock_prompt = mocker.patch.object(
+            speech_server,
+            "_build_ming_dense_prompt",
+            return_value={"additional_information": {"speaker_count": 1}},
+        )
+
+        adapter = MingTTSAdapter(SpeechServingContext(server=speech_server))
+        req = OpenAICreateSpeechRequest(input="Hello", voice="emb_voice")
+        prepared = asyncio.run(adapter.build(req, [], False))
+
+        mock_get_emb.assert_called_once_with("emb_voice")
+        mock_get_audio.assert_not_called()
+        mock_prompt.assert_called_once_with(req, ref_audio_data=None)
+        prompt_request = mock_prompt.call_args.args[0]
+        assert prompt_request.speaker_embedding == fake_embedding
+        assert len(prompt_request.speaker_embedding) == 192
+        assert prepared.prompt["additional_information"]["speaker_count"] == 1
+        assert prepared.model_type == "ming_tts"
+
+    def test_ming_adapter_uploaded_audio_path_preserves_ref_text(self, speech_server, mocker: MockerFixture):
+        """Ming uploaded audio voices still resolve audio and stored ref_text."""
+        speech_server.uploaded_speakers = {
+            "audio_voice": {
+                "name": "audio_voice",
+                "file_path": "/tmp/voice_samples/audio_voice.wav",
+                "mime_type": "audio/wav",
+                "ref_text": "Reference transcript.",
+            }
+        }
+        ref_audio_source = "data:audio/wav;base64,ZmFrZWF1ZGlv"
+        ref_audio_data = ([0.0, 0.1], 16000)
+        fake_embedding = [0.2] * 192
+        mock_get_audio = mocker.patch.object(speech_server, "_get_uploaded_audio_data", return_value=ref_audio_source)
+        mock_get_emb = mocker.patch.object(speech_server, "_get_uploaded_speaker_embedding")
+        mocker.patch.object(
+            speech_server,
+            "_resolve_ref_audio",
+            new=mocker.AsyncMock(return_value=ref_audio_data),
+        )
+        mock_extract = mocker.patch.object(
+            speech_server,
+            "_extract_ming_speaker_embeddings_from_ref_audio",
+            return_value=[fake_embedding],
+        )
+        mock_prompt = mocker.patch.object(
+            speech_server,
+            "_build_ming_dense_prompt",
+            return_value={"additional_information": {"speaker_count": 1}},
+        )
+
+        adapter = MingTTSAdapter(SpeechServingContext(server=speech_server))
+        req = OpenAICreateSpeechRequest(input="Hello", voice="audio_voice")
+        prepared = asyncio.run(adapter.build(req, [], False))
+
+        mock_get_audio.assert_called_once_with("audio_voice")
+        mock_get_emb.assert_not_called()
+        mock_extract.assert_called_once_with([ref_audio_data])
+        mock_prompt.assert_called_once_with(req, ref_audio_data=ref_audio_data)
+        assert req.ref_text == "Reference transcript."
+        assert req.speaker_embedding == fake_embedding
+        assert prepared.model_type == "ming_tts"
 
     # ── regression: full flow from issue #1603 ──
 

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1395,7 +1395,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         emb_dim = len(embedding)
         if self._tts_model_type == "ming_tts":
             if emb_dim != 192:
-                logger.warning("speaker_embedding has %d dimensions; Ming dense expects 192", emb_dim)
+                raise ValueError(f"Ming speaker embedding must have 192 dims, got {emb_dim}")
         else:
             dim_err = self._validate_qwen_tts_speaker_embedding_dim(emb_dim)
             if dim_err is not None:

--- a/vllm_omni/entrypoints/openai/tts_adapters/ming_tts.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/ming_tts.py
@@ -25,9 +25,18 @@ class MingTTSAdapter(ARTTSAdapter):
         ref_audio_source = request.ref_audio
         voice_lower = request.voice.lower() if isinstance(request.voice, str) else None
         if ref_audio_source is None and voice_lower in server.uploaded_speakers:
-            ref_audio_source = server._get_uploaded_audio_data(request.voice)
-            if request.ref_text is None:
-                request.ref_text = server.uploaded_speakers[voice_lower].get("ref_text")
+            speaker_info = server.uploaded_speakers[voice_lower]
+            if speaker_info.get("embedding_source") == "direct":
+                if request.speaker_embedding is None:
+                    request.speaker_embedding = server._get_uploaded_speaker_embedding(request.voice)
+                if request.speaker_embedding is None:
+                    raise ValueError(f"Speaker embedding for uploaded voice '{request.voice}' is missing")
+            else:
+                ref_audio_source = server._get_uploaded_audio_data(request.voice)
+                if not ref_audio_source:
+                    raise ValueError(f"Audio file for uploaded voice '{request.voice}' is missing")
+                if request.ref_text is None:
+                    request.ref_text = speaker_info.get("ref_text")
         ref_audio_data = None
         if isinstance(ref_audio_source, list):
             ref_audio_data = await server._resolve_ref_audio_many(ref_audio_source)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix Ming-TTS uploaded voice reuse when the voice was registered with a direct `speaker_embedding`.

Previously, Ming-TTS only tried to resolve uploaded voices as reference audio, so voices registered via `speaker_embedding` were not actually consumed by the Ming adapter. This PR loads direct uploaded speaker embeddings into `request.speaker_embedding`, while keeping the existing uploaded audio/ref_text path unchanged.

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** aff21312

## Test Result

- Start Ming-TTS service:

```bash

vllm serve /home/admin/model \
  --host 0.0.0.0 \
  --port 8000 \
  --omni
```

Health check:

```bash
curl http://127.0.0.1:8000/health
```

- Generate a 192-dim Ming speaker embedding from reference audio:

```bash
python -c '
import json
from vllm_omni.model_executor.models.ming_tts.speaker_extractor import MingSpeakerEmbeddingExtractor

extractor = MingSpeakerEmbeddingExtractor("/home/admin/model", target_sr=16000)
emb = extractor.extract_from_file("/home/ming_stream_main.wav").detach().reshape(-1).float().cpu()
assert emb.numel() == 192, emb.numel()
open("/home/ming_stream_main_spk_emb_192.json", "w").write(json.dumps(emb.tolist()))
print("wrote /home/ming_stream_main_spk_emb_192.json")
'
```

Upload the 192-dim direct speaker embedding:

```bash
curl http://127.0.0.1:8000/v1/audio/voices \
  -F "name=upload_emb_voice_verify" \
  -F "consent=local_smoke_test" \
  -F "speaker_embedding=</home/ming_stream_main_spk_emb_192.json"
```

Result:

```json
{
  "success": true,
  "voice": {
    "name": "upload_emb_voice_verify",
    "consent": "local_smoke_test",
    "embedding_source": "direct",
    "embedding_dim": 192
  }
}
```

Generate speech using only the uploaded `voice` name:

```bash
curl http://127.0.0.1:8000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/home/admin/model",
    "input": "Hello, this is a Ming TTS uploaded embedding voice-only test after the fix.",
    "voice": "upload_emb_voice_verify",
    "response_format": "wav"
  }' \
  --output /home/ming_uploaded_emb_voice_only_fixed.wav
```

Result:

```text
HTTP 200
duration=6.72s, rms=0.0529, peak=0.392
```

- Negative test with invalid 191-dim direct speaker embedding:

```bash
python -c '
import json
json.dump([0.0] * 191, open("/tmp/ming_bad_191_embedding.json", "w"))
'

curl -s -o /tmp/ming_bad_191_upload_response.json -w "%{http_code}" \
  http://127.0.0.1:8000/v1/audio/voices \
  -F "name=ming_bad_191_verify" \
  -F "consent=local_smoke_test" \
  -F "speaker_embedding=</tmp/ming_bad_191_embedding.json"

cat /tmp/ming_bad_191_upload_response.json
```

Result:

```text
400
```

```json
{
  "error": {
    "message": "Ming speaker embedding must have 192 dims, got 191",
    "type": "BadRequestError",
    "param": null,
    "code": 400
  }
}
```

The invalid uploaded voice was not persisted.

- Regression check for existing uploaded audio/ref_text voice path:

Generate reference audio:

```bash
curl http://127.0.0.1:8000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/home/admin/model",
    "input": "Hello, this is a raw audio streaming test.",
    "response_format": "wav"
  }' \
  --output /home/ming_stream_main.wav
```

Upload voice with `audio_sample` and `ref_text`:

```bash
curl http://127.0.0.1:8000/v1/audio/voices \
  -F "name=upload_voice_main_ref_text" \
  -F "consent=local_smoke_test" \
  -F "audio_sample=@/home/ming_stream_main.wav;type=audio/wav" \
  -F "ref_text=Hello, this is a raw audio streaming test."
```

Generate speech using only the uploaded `voice` name:

```bash
curl http://127.0.0.1:8000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/home/admin/model",
    "input": "Hello, this is a regression test for uploaded audio voice.",
    "voice": "upload_voice_main_ref_text",
    "response_format": "wav"
  }' \
  --output /home/ming_uploaded_audio_voice_regression.wav
```

Result:

```text
HTTP 200
duration=6.08s, rms=0.118, peak=0.981
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)