### PR TITLE
[CI] Fix core_model Level for non-Diffusion Models

### DIFF
--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -2826,7 +2826,7 @@ def iter_omni_server(
         # be ideal to cleanup consistently everywhere.
         original_model = model_prefix + params.model
         model = original_model
-        if run_level == "core_model":
+        if run_level == "core_model" and request.node.get_closest_marker("diffusion"):
             model = resolve_tiny_model_path(model)
         port = params.port
         stage_config_path = stage_config_path_for_run_level(params.stage_config_path, run_level)
@@ -2917,7 +2917,7 @@ def iter_omni_runner(
             extra_omni_kwargs = dict(extra) if extra is not None else {}
         stage_config_path = stage_config_path_for_run_level(stage_config_path, run_level)
         model = model_prefix + model
-        if run_level == "core_model":
+        if run_level == "core_model" and request.node.get_closest_marker("diffusion"):
             model = resolve_tiny_model_path(model)
         with OmniRunner(model, seed=42, stage_configs_path=stage_config_path, **extra_omni_kwargs) as runner:
             print("OmniRunner started successfully")

--- a/tests/model_tests/diffusion/utils.py
+++ b/tests/model_tests/diffusion/utils.py
@@ -13,18 +13,13 @@ logger = logging.getLogger(__name__)
 def resolve_tiny_model_path(model: str) -> str:
     """Given a real model name/path, resolve it to a tiny model path.
 
-    Returns the original model path if no suitable tiny builder is found."""
+    Raises ValueError if the pipeline class cannot be determined (invalid
+    model). Returns the original model path if no tiny builder exists yet."""
     pipeline_class = resolve_model_class_name(model)
     if pipeline_class is None:
-        # resolve_model_class_name is currently diffusion only, but this is also integrated
-        # into the non-common tests so that the tiny builders can be used for diffusion e2e
-        # tests. If we can't find a pipeline_class, it is most likely because the test is
-        # for a non-diffusion model.
-        logger.warning(
-            "Could not resolve the pipeline config for %s; is it a diffusion model?",
-            model,
+        raise ValueError(
+            f"Cannot resolve pipeline class for model: {model}. The model path may be invalid or its config unreadable."
         )
-        return model
 
     test_opts = DIFFUSION_TEST_SETTINGS.get(pipeline_class)
     if test_opts is None:

--- a/tests/model_tests/diffusion/utils.py
+++ b/tests/model_tests/diffusion/utils.py
@@ -13,13 +13,18 @@ logger = logging.getLogger(__name__)
 def resolve_tiny_model_path(model: str) -> str:
     """Given a real model name/path, resolve it to a tiny model path.
 
-    Raises ValueError if the pipeline class cannot be determined (invalid
-    model). Returns the original model path if no tiny builder exists yet."""
+    Returns the original model path if no suitable tiny builder is found."""
     pipeline_class = resolve_model_class_name(model)
     if pipeline_class is None:
-        raise ValueError(
-            f"Cannot resolve pipeline class for model: {model}. The model path may be invalid or its config unreadable."
+        # resolve_model_class_name is currently diffusion only, but this is also integrated
+        # into the non-common tests so that the tiny builders can be used for diffusion e2e
+        # tests. If we can't find a pipeline_class returns None, it is most likely because
+        # the test is for a non-diffusion model.
+        logger.warning(
+            "Could not resolve the pipeline config for %s; is it a diffusion model?",
+            model,
         )
+        return model
 
     test_opts = DIFFUSION_TEST_SETTINGS.get(pipeline_class)
     if test_opts is None:

--- a/tests/model_tests/diffusion/utils.py
+++ b/tests/model_tests/diffusion/utils.py
@@ -18,8 +18,8 @@ def resolve_tiny_model_path(model: str) -> str:
     if pipeline_class is None:
         # resolve_model_class_name is currently diffusion only, but this is also integrated
         # into the non-common tests so that the tiny builders can be used for diffusion e2e
-        # tests. If we can't find a pipeline_class returns None, it is most likely because
-        # the test is for a non-diffusion model.
+        # tests. If we can't find a pipeline_class, it is most likely because the test is
+        # for a non-diffusion model.
         logger.warning(
             "Could not resolve the pipeline config for %s; is it a diffusion model?",
             model,


### PR DESCRIPTION
## Test Result

Fix for: https://github.com/vllm-project/vllm-omni/issues/5004

The issue is that I had also integrated the tiny model builder into the Omni server fixture so that core model level for diffusion  tests will automatically pick up the tiny models builder. However, since `resolve_model_class_name` is a Diffusion only util, it won't resolve to anything if it's a non-diffusion Omni model. So the fix is to just return the model as is, since there is no tiny builder

```bash
pytest -s -v tests/e2e/online_serving/test_voxcpm2_tts.py -m 'core_model' --run-level 'core_model'
```


```
==================== 1 passed, 1 deselected, 17 warnings in 233.36s (0:03:53) =====================
```