### PR TITLE
[BugFix] Fix CI failures caused by stale test expectations after recent stage-payload / deploy-config changes.

### DIFF
--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -34,12 +34,10 @@ def get_cuda_graph_config():
             "stages": {
                 0: {
                     "max_num_seqs": 1,
-                    "gpu_memory_utilization": 0.2,
                     "enforce_eager": True,
                     "async_scheduling": False,
                 },
                 1: {
-                    "gpu_memory_utilization": 0.2,
                     "enforce_eager": True,
                     "async_scheduling": False,
                 },

--- a/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
@@ -247,7 +247,6 @@ def test_thinker2talker_full_payload_packs_complete_tensors() -> None:
     assert payload["ids"]["all"] == [151644, 872, 3]
     assert payload["embed"]["prefill"].device.type == "cpu"
     assert payload["hidden_states"]["output"].device.type == "cpu"
-    assert payload["meta"]["next_stage_prompt_len"] > 0
     assert payload["embed"]["prefill"].shape[0] == 2
     assert payload["hidden_states"]["output"].shape[0] == 2
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Fix CI failures caused by stale test expectations after recent stage-payload / deploy-config changes.
- **Qwen3-TTS CustomVoice offline e2e**: stop overriding `gpu_memory_utilization` to `0.2` in the no-cuda-graph stage config. Let the test inherit the values from `qwen3_tts.yaml` so stage memory settings stay aligned with the production deploy defaults.
- **Qwen3-Omni streaming helpers unit test**: remove the outdated assertion on `payload["meta"]["next_stage_prompt_len"]`. After the stage-input-processor refactor, `thinker2talker_full_payload` only sets `meta.finished` and no longer populates `next_stage_prompt_len`.
## Test Plan

```
pytest -sv tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
pytest -sv tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
```

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result
```
./.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /data/why/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=================================== 39 passed, 17 warnings in 0.46s =================================

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
============================== 1 passed, 20 warnings in 180.28s (0:03:00) ===========================
```
