### PR TITLE
[Bugfix] Qwen2.5-Omni: route talker phases by runner metadata and han…

### DIFF
--- a/tests/model_executor/models/qwen2_5_omni/test_qwen2_5_omni_talker_preprocess.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_qwen2_5_omni_talker_preprocess.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for the Qwen2.5-Omni talker preprocess phase routing and the
+stateless decode-span embedding assembly.
+
+Regression tests for the span-length prefill/decode heuristic: a
+speculative-decoding verify step schedules num_draft_tokens + 1 decode
+positions in one span, and a chunked prefill can end in a 1-token tail —
+both misroute under ``span_len > 1``. The decode path must also assemble
+one ``thinker_reply`` row per position, statelessly, so a preempt/resume
+replay span reconstructs exactly the embeddings the original steps used.
+"""
+
+import functools
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+HIDDEN = 4
+
+
+@functools.lru_cache(maxsize=1)
+def _qwen2_5_omni_mod():
+    """Import lazily so collection does not pull model_executor too early."""
+    import vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni as m
+
+    return m
+
+
+def _fake_embed_input_ids(ids: torch.Tensor) -> torch.Tensor:
+    # Deterministic, id-distinguishing stand-in for the codec embedding table.
+    return ids.reshape(-1, 1).to(torch.float32).expand(-1, HIDDEN).contiguous()
+
+
+def _make_minimal_model():
+    cls = _qwen2_5_omni_mod().Qwen2_5OmniForConditionalGeneration
+    # ``__new__`` skips ``__init__`` (no weights, no config); set only what
+    # the decode path touches.
+    model = cls.__new__(cls)
+    model.talker = SimpleNamespace(embed_input_ids=_fake_embed_input_ids)
+    return model
+
+
+def _thinker_reply(num_rows: int) -> torch.Tensor:
+    # Row k filled with 100 * (k + 1) so any offset error is visible.
+    return (torch.arange(1, num_rows + 1, dtype=torch.float32).reshape(-1, 1) * 100.0).expand(-1, HIDDEN).contiguous()
+
+
+def test_spec_verify_span_gets_one_thinker_row_per_position():
+    # A verify step with 2 draft tokens schedules a 3-position decode span at
+    # generation offset 2 (prompt_len 4, num_computed 6). Every position must
+    # get thinker_reply[offset + i] + codec_embedding(token_i).
+    model = _make_minimal_model()
+    input_ids = torch.tensor([11, 22, 33], dtype=torch.long)
+    q = _thinker_reply(8)
+
+    out_ids, out_embeds, update = model.talker_preprocess(
+        input_ids,
+        None,
+        embed={"thinker_reply": q},
+        _omni_is_prefill=False,
+        _omni_prompt_len=4,
+        _omni_num_computed_tokens=6,
+    )
+
+    assert torch.equal(out_ids, input_ids)
+    expected = _fake_embed_input_ids(input_ids) + q[2:5]
+    assert torch.equal(out_embeds, expected)
+    # Stateless: the reply buffer must not be consumed or rewritten.
+    assert update == {}
+    assert torch.equal(q, _thinker_reply(8))
+
+
+def test_decode_span_is_replayable():
+    # Preempt/resume replays already-generated tokens as one multi-token span.
+    # Because the reply buffer is never consumed, calling preprocess twice with
+    # the same metadata must produce identical embeddings (the stock consuming
+    # path would have shifted by one queue row per call).
+    model = _make_minimal_model()
+    input_ids = torch.tensor([7, 8], dtype=torch.long)
+    payload = dict(
+        embed={"thinker_reply": _thinker_reply(6)},
+        _omni_is_prefill=False,
+        _omni_prompt_len=3,
+        _omni_num_computed_tokens=4,
+    )
+
+    _, first, _ = model.talker_preprocess(input_ids, None, **payload)
+    _, second, _ = model.talker_preprocess(input_ids, None, **payload)
+
+    assert torch.equal(first, second)
+
+
+def test_positions_past_thinker_reply_keep_codec_embedding():
+    # Near the end of the thinker text the span can extend past the last
+    # reply row; those positions keep the plain codec embedding (the verifier
+    # rejects drafts there naturally).
+    model = _make_minimal_model()
+    input_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+    q = _thinker_reply(6)
+
+    _, out_embeds, _ = model.talker_preprocess(
+        input_ids,
+        None,
+        embed={"thinker_reply": q},
+        _omni_is_prefill=False,
+        _omni_prompt_len=2,
+        _omni_num_computed_tokens=7,  # offset 5: one reply row left
+    )
+
+    base = _fake_embed_input_ids(input_ids)
+    assert torch.equal(out_embeds[0], base[0] + q[5])
+    assert torch.equal(out_embeds[1:], base[1:])
+
+
+def test_one_token_prefill_tail_routes_to_prefill():
+    # Chunked prefill can end in a span_len == 1 tail. With the runner
+    # metadata saying is_prefill, the row must go down the prefill path and
+    # must not touch the decode-side reply buffer (the span heuristic would
+    # have misrouted it to decode and consumed one row).
+    model = _make_minimal_model()
+    sentinel = (torch.tensor([0]), torch.zeros(1, HIDDEN), {"via": "prefill"})
+    calls = []
+
+    def fake_prefill_process(input_ids, input_embeds, payload):
+        calls.append(input_ids)
+        return sentinel
+
+    model.thinker_to_talker_process = fake_prefill_process
+
+    out = model.talker_preprocess(
+        torch.tensor([5], dtype=torch.long),
+        None,
+        embed={"thinker_reply": _thinker_reply(4)},
+        _omni_is_prefill=True,
+        _omni_prompt_len=8,
+        _omni_num_computed_tokens=7,
+    )
+
+    assert len(calls) == 1
+    assert out == sentinel
+
+
+def test_missing_runner_metadata_falls_back_to_legacy_single_step():
+    # Out-of-tree callers that predate the #3662 runner metadata must keep the
+    # stock consuming single-step behavior, bit for bit.
+    model = _make_minimal_model()
+    sentinel = (torch.tensor([9]), torch.ones(1, HIDDEN), {"via": "legacy"})
+    calls = []
+
+    def fake_one_step(input_ids, input_embeds, payload):
+        calls.append(input_ids)
+        return sentinel
+
+    model.thinker_to_talker_decode_one_step = fake_one_step
+
+    out = model.talker_preprocess(
+        torch.tensor([9], dtype=torch.long),
+        None,
+        embed={"thinker_reply": _thinker_reply(4)},
+    )
+
+    assert len(calls) == 1
+    assert out == sentinel

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -677,26 +677,38 @@ class Qwen2_5OmniForConditionalGeneration(
         # Mixed-mode support: In a single step, both Prefill*n and Decode*n are supported.
         # Rules:
         # - Prefill segments are wrapped with special tokens: [BOS][PAD...][EOS]
-        # - Decode segments consist of a single non-special token.
+        # - Decode segments may span one position (sequential decoding) or several
+        #   (speculative-decoding verification, preempt/resume KV replay).
         # - If additional_information is provided (can be a list split by request or a
         #   concatenated tensor plus a list of shapes), then for each request, reconstruct
         #   the thinker→talker input embeddings for the Prefill segments;
-        # - For Decode segments, if per-request auxiliary decode embeddings are provided (optional),
-        #   add them; otherwise, keep the original embedding.
+        # - For Decode segments, add the request's ``thinker_reply`` row for each
+        #   position; past the end of the thinker reply, keep the codec embedding.
 
         payload: OmniPayload = info_dict
 
-        # Ensure we have base embeddings when only ids are provided
-        if input_embeds is None and input_ids is not None:
-            input_embeds = self.talker.embed_input_ids(input_ids)
-
-        span_len = input_ids.shape[0]
-        if span_len > 1:
-            # prefill
-            return self.thinker_to_talker_process(input_ids, input_embeds, payload)
+        span_len = int(input_ids.shape[0])
+        # Phase must come from the runner's per-request metadata (#3662), not from
+        # the span length: a speculative-decoding verify step schedules span_len ==
+        # num_draft_tokens + 1 decode positions, and a chunked prefill can end in a
+        # 1-token tail — both misroute under the span_len > 1 heuristic.
+        is_prefill_raw = payload.get("_omni_is_prefill")
+        if isinstance(is_prefill_raw, bool):
+            is_prefill = is_prefill_raw
         else:
-            # decode
-            return self.thinker_to_talker_decode_one_step(input_ids, input_embeds, payload)
+            try:
+                is_prefill = int(payload["_omni_num_computed_tokens"]) < int(payload["_omni_prompt_len"])
+            except (KeyError, TypeError, ValueError):
+                # Legacy callers without the runner metadata: fall back to the
+                # span-length heuristic (pre-#3662 behavior).
+                is_prefill = span_len > 1
+
+        if is_prefill:
+            # Ensure we have base embeddings when only ids are provided
+            if input_embeds is None and input_ids is not None:
+                input_embeds = self.talker.embed_input_ids(input_ids)
+            return self.thinker_to_talker_process(input_ids, input_embeds, payload)
+        return self.thinker_to_talker_decode(input_ids, input_embeds, payload)
 
     def thinker_to_talker_process(
         self,
@@ -786,6 +798,55 @@ class Qwen2_5OmniForConditionalGeneration(
                 torch.Tensor(prompt_token_ids_processed).to(torch.int64).to(self._module_device(self.talker))
             )
         return prompt_token_ids_processed, prompt_embeds
+
+    def thinker_to_talker_decode(self, input_ids, input_embeds, payload: OmniPayload):
+        """Assemble decode-side embeddings for a span of one or more positions.
+
+        Each decode position needs ``thinker_reply[k] + codec_embedding`` where
+        ``k`` is the position's generation offset. The offset is derived
+        statelessly from the runner metadata (``_omni_num_computed_tokens -
+        _omni_prompt_len``) instead of consuming one queue row per call, so the
+        same call handles the sequential single-token step, the multi-position
+        span of a speculative-decoding verify step, and the multi-token replay
+        span submitted when a preempted request resumes — a replay reconstructs
+        exactly the embeddings the original steps used. Positions past the end
+        of the thinker reply keep the plain codec embedding.
+
+        When the runner metadata is absent (legacy out-of-tree callers), the
+        single-position stateful path :meth:`thinker_to_talker_decode_one_step`
+        is used unchanged.
+        """
+        try:
+            offset = max(
+                0,
+                int(payload["_omni_num_computed_tokens"]) - int(payload["_omni_prompt_len"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            # Pre-#3662 callers: keep the consuming single-step behavior.
+            if input_embeds is None and input_ids is not None:
+                input_embeds = self.talker.embed_input_ids(input_ids)
+            return self.thinker_to_talker_decode_one_step(input_ids, input_embeds, payload)
+
+        span_len = int(input_ids.shape[0])
+        # Build the span embeddings from the codec ids rather than trusting the
+        # incoming buffer: in a mixed batch the runner hands decode requests a
+        # slice of a ``torch.empty`` scratch tensor (uninitialized memory), and
+        # this is the only embedding build for the span (the entry-point one is
+        # prefill-only).
+        out_dtype = input_embeds.dtype if input_embeds is not None else None
+        input_embeds = self.talker.embed_input_ids(input_ids)
+        if out_dtype is not None and input_embeds.dtype != out_dtype:
+            input_embeds = input_embeds.to(out_dtype)
+
+        embed = payload.get("embed", {})
+        q = embed.get("thinker_reply", None)
+        if isinstance(q, torch.Tensor) and q.numel() > 0:
+            rows = q[offset : offset + span_len]
+            n = int(rows.shape[0])
+            if n > 0:
+                input_embeds[:n] = input_embeds[:n] + rows.to(dtype=input_embeds.dtype, device=input_embeds.device)
+        # Stateless: ``thinker_reply`` is not consumed, so no update to merge.
+        return input_ids, input_embeds, {}
 
     def thinker_to_talker_decode_one_step(self, input_ids, input_embeds, payload: OmniPayload):
         embed = payload.get("embed", {})


### PR DESCRIPTION
## Purpose

FIX #5018

**What breaks.** `talker_preprocess` for Qwen2.5-Omni infers prefill vs decode from
the span length (`span_len > 1`). Any decode step that schedules more than one
position — a speculative-decoding verify step (`num_speculative_tokens + 1`
positions), or the multi-token replay span of a preempted request resuming (the
Qwen2.5-Omni analog of #4471/#4472) — is misrouted into the prompt-rebuilding prefill
branch, so every position is conditioned on the beginning of the talker prompt. Even
on the decode branch only one position is filled (rows past the first stay on the
runner's uninitialized `torch.empty` scratch slice), and one `thinker_reply` row is
consumed per call, so the text/codec alignment drifts after any multi-token accept or
replay.

**Root cause.** The model ignores the per-request phase metadata the runner has passed
since #3662 (`_omni_is_prefill` / `_omni_prompt_len` / `_omni_num_computed_tokens`;
`qwen3_tts_talker.py` already consumes it) and re-guesses the phase from the span
shape; the decode path additionally assumes `span_len == 1` and keeps mutable queue
state that cannot survive multi-token steps or replays.

**Fix.**

- Route by `_omni_is_prefill`, falling back to `_omni_num_computed_tokens <
  _omni_prompt_len`, then to the span heuristic — the same layered pattern
  `qwen3_tts_talker.py` uses.
- Add `thinker_to_talker_decode`, a stateless span-aware decode path: position `i`
  gets `thinker_reply[offset + i] + codec_embedding(token_i)` with
  `offset = _omni_num_computed_tokens - _omni_prompt_len`. The span embeddings are
  built exactly once from `embed_input_ids` (never trusting the possibly-uninitialized
  scratch slice; the entry-point embedding build is now prefill-only, so sequential
  decode does one build per step where the old path did two), and the reply buffer is
  never consumed.
- Keep `thinker_to_talker_decode_one_step` unchanged; callers without the runner
  metadata take exactly that path.

**Offset semantics** (matching the previous queue behavior):

- Prefill stores `thinker_reply = thinker_result[1:]` (row 0 is fused into the last
  prompt position). The first decode step has `num_computed == prompt_len`, i.e.
  offset 0 → `thinker_result[1]` — the row the old queue head held. For
  metadata-aware sequential decode, step k reads the same `thinker_reply[k]` row the
  previous queue-head implementation consumed.
- The offset is clamped at 0; with correct phase routing it cannot go negative.
- Positions past the end of `thinker_reply` keep the plain codec embedding — the same
  conditioning the sequential path produces once the reply queue is exhausted (the
  `embed["decode"]` / `thinker_reply_part` fallbacks are not populated in the serving
  path for this model; the latter is only set by the memory-profile mock).
- Replaying the same span is idempotent (covered by a test), so a preempt/resume
  replay reconstructs exactly the embeddings the original steps used.

The reply buffer no longer shrinks during decode; peak memory is unchanged (prefill
already stores the full reply).

Out of scope, noted for #4382: the runner's `seg_len = min(span_len,
req_embeds.shape[0])` still silently tolerates short returns over `torch.empty` for
other models; with this fix the Qwen2.5-Omni decode path always returns full-span
tensors. The same span-length heuristic exists in several other talker-style models
(see the scope section of the linked issue); the stateless assembly here is intended
to be reusable for those migrations.

## Test Plan

    pytest tests/model_executor/models/qwen2_5_omni/test_qwen2_5_omni_talker_preprocess.py

New CPU-only tests (no weights; construction mirrors the #4472 test file): per-position
thinker rows on a verify span; replay idempotence; positions past the reply tail; the
1-token prefill tail routing (the #4382 regression case); the no-metadata legacy
fallback.

Runnable repro: the same pytest command on current main — the four regression tests
fail by entering the wrong branch; the fifth (the legacy-compat guard) passes on both
main and this PR, by design.

The new tests are CPU-only and deterministic (no weights, no GPU). Happy to run and
attach L1/L2 results when this is considered for the `ready` label — a GPU
environment is available.

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** 9a44e7e

## Test Result

- This PR: 5/5 pass. Current main: 4/5 fail (the misroute observed directly), 1/5
  pass (compat guard).
- End-to-end (Qwen2.5-Omni-7B, vLLM 0.24.0 + vllm-omni 0.24.0, a draft proposer on
  the talker stage, out-of-tree equivalent of this patch): greedy spec-on vs spec-off
  codec token streams identical over full generations (3 prompts × ~250 codec
  tokens); deployment-sampling (temperature 0.9) ASR WER back from ≈ 1.0 to the
  sequential baseline range; acceptance 1.47 tokens/step with a research draft head.

---

AI tooling disclosure: this fix was developed with assistance from Claude (Anthropic),
including the forensic analysis and the regression tests; all changes were reviewed and
validated by the author.