### PR TITLE
Ship non-Python data files in wheels built without git (fixes #4932)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,8 +150,18 @@ where = ["."]
 include = ["vllm_omni*"]
 
 [tool.setuptools.package-data]
-"vllm_omni" = ["_version.py", "py.typed"]
+# NOTE: keep these patterns in sync with the non-Python data files shipped
+# under vllm_omni/. They are required for `pip install` from a source tarball
+# (e.g. a release/tag archive), where setuptools-scm's git file-finder is
+# unavailable and only these declarations get the data into the wheel. A plain
+# git-checkout build happens to include them via the file-finder, which is why
+# CI never caught this. See #4932.
+"vllm_omni" = ["_version.py", "py.typed", "deploy/*.yaml", "deploy/*.md"]
 "vllm_omni.model_executor.stage_configs" = ["*.yaml"]
+"vllm_omni.platforms.xpu" = ["stage_configs/*.yaml"]
+"vllm_omni.model_executor.models.covo_audio" = ["speaker_prompt/*.npy"]
+"vllm_omni.model_executor.models.step_audio2" = ["assets/*.wav"]
+"vllm_omni.experimental.fullduplex" = ["*.md"]
 
 [tool.setuptools_scm]
 # no extra settings needed, presence enables setuptools-scm


### PR DESCRIPTION
## Summary

Fixes #4932. Non-Python data files under `vllm_omni/` are dropped from wheels
built **without a `.git` directory** — e.g. `pip install` from a release/tag
source archive. For Qwen3-Omni this drops `vllm_omni/deploy/*.yaml`, so
multi-GPU stage placement breaks (OOM).

Root-cause and a candidate fix were reported by @JianlongCao in #4932;
credited as co-author.

## Root cause

On a **git checkout**, `setuptools-scm`'s file-finder adds every tracked file
to the build, so git/CI builds ship all data files — which is why this never
surfaced in CI. With **no `.git`**, the finder returns nothing and only the
explicit `[tool.setuptools.package-data]` entries reach the wheel. Those listed
only `_version.py`, `py.typed`, and `model_executor.stage_configs/*.yaml`, so
everything else was silently dropped.

## Fix

Declare the missing data patterns in `package-data`, keyed by the nearest
enclosing package (patterns are relative to that package's dir, so they cover
the non-package data subdirs like `deploy/`).

## Verification (no-`.git` build, simulating a tarball install)

```
SETUPTOOLS_SCM_PRETEND_VERSION=0.24.0 VLLM_OMNI_TARGET_DEVICE=empty \
  python -m pip wheel . --no-deps -w dist   # from a tree with .git removed
```

| | before | after |
|---|---|---|
| `deploy/*.yaml` in wheel | **0** | **59** |
| wheel size | 3.73 MB | 5.27 MB |

After the fix the no-`.git` build also restores `platforms/xpu/stage_configs/*.yaml`,
`covo_audio/speaker_prompt/*.npy` (3), `step_audio2/assets/*.wav` (2), and
`experimental/fullduplex/*.md` — a completeness scan confirmed all 66 previously
dropped data files are now included. Plain git-checkout builds are unchanged
(they already included these via the file-finder).

## Note

A more aggressive alternative is `include-package-data = true` + a `MANIFEST.in`
`recursive-include`, which would auto-catch future data dirs but ships whatever
matches. I went with explicit `package-data` (matching the reporter's proposal)
to keep shipped contents intentional; happy to switch if maintainers prefer the
broader approach.
