### PR TITLE
chore(ci): speedup CI image build with cache service

### DIFF
--- a/.buildkite/pipeline-npu.yaml
+++ b/.buildkite/pipeline-npu.yaml
@@ -71,6 +71,9 @@ steps:
         --local context=. \
         --local dockerfile=./docker \
         --opt filename=Dockerfile.npu.ci \
+        --build-arg APTMIRROR=cache-service.nginx-pypi-cache.svc.cluster.local:8081
+        --build-arg PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+        --build-arg VLLM_ASCEND_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/vllm-ascend-ci
         --secret id=dockerconfig,src=/home/user/.docker/config.json \
         --output type=image,name=$${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG},push=true \
         --progress=plain

--- a/.buildkite/pipeline-npu.yaml
+++ b/.buildkite/pipeline-npu.yaml
@@ -71,9 +71,9 @@ steps:
         --local context=. \
         --local dockerfile=./docker \
         --opt filename=Dockerfile.npu.ci \
-        --build-arg APTMIRROR=cache-service.nginx-pypi-cache.svc.cluster.local:8081
-        --build-arg PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-        --build-arg VLLM_ASCEND_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/vllm-ascend-ci
+        --opt build-arg:APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081 \
+        --opt build-arg:PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
+        --opt build-arg:VLLM_ASCEND_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/vllm-ascend-ci \
         --secret id=dockerconfig,src=/home/user/.docker/config.json \
         --output type=image,name=$${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG},push=true \
         --progress=plain

--- a/docker/Dockerfile.npu.ci
+++ b/docker/Dockerfile.npu.ci
@@ -25,8 +25,8 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip config set global.index-url ${PIP_INDEX_URL} && \
-    pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"
+RUN python3 -m pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ "${PIP_INDEX_URL#http://}" != "${PIP_INDEX_URL}" ]; then pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"; fi
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -43,7 +43,7 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "opencv-python>=4.12.0.88" \
       "imageio[ffmpeg]>=0.6.0" \
       --default-timeout=60 && \
-    pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
+    python3 -m pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
       --default-timeout=60
 
 ENV VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/docker/Dockerfile.npu.ci
+++ b/docker/Dockerfile.npu.ci
@@ -1,10 +1,15 @@
 ARG VLLM_ASCEND_IMAGE=quay.io/atlas-ci/vllm-ascend
 ARG VLLM_ASCEND_TAG=v0.24.0
 FROM ${VLLM_ASCEND_IMAGE}:${VLLM_ASCEND_TAG}
-
+# example: https://repo.huaweicloud.com/pypi/simple
+ARG PIP_INDEX_URL="https://pypi.org/simple/"
+# example: https://repo.huaweicloud.com
+ARG APTMIRROR=""
 ARG APP_DIR=/vllm-workspace/vllm-omni
 WORKDIR ${APP_DIR}
 COPY . .
+
+RUN if [ -n "$APTMIRROR" ];then sed -i "s@^\(deb.*\)https\?://[a-z0-9.-]*\.ubuntu\.com@\1$APTMIRROR@g" /etc/apt/sources.list ;fi
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -20,11 +25,13 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"
+
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
-    python3 -m pip install -U pip && \
-    python3 -m pip install -v \
+    pip install -v \
       "pytest>=7.0.0" \
       "pytest-asyncio>=0.21.0" \
       "pytest-cov>=4.0.0" \
@@ -35,12 +42,8 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "pyttsx3>=2.99" \
       "opencv-python>=4.12.0.88" \
       "imageio[ffmpeg]>=0.6.0" \
-      --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
-      --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
       --default-timeout=60 && \
-    python3 -m pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
-      --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
-      --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
+    pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
       --default-timeout=60
 
 ENV VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/docker/Dockerfile.npu.ci
+++ b/docker/Dockerfile.npu.ci
@@ -31,7 +31,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
-    pip install -v \
+    python3 -m pip install -v \
       "pytest>=7.0.0" \
       "pytest-asyncio>=0.21.0" \
       "pytest-cov>=4.0.0" \

--- a/docker/Dockerfile.npu.ci.a3
+++ b/docker/Dockerfile.npu.ci.a3
@@ -25,13 +25,13 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip config set global.index-url ${PIP_INDEX_URL} && \
-    pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"
+RUN python3 -m pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ "${PIP_INDEX_URL#http://}" != "${PIP_INDEX_URL}" ]; then pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"; fi
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
-    pip install -v \
+    python3 -m pip install -v \
       "pytest>=7.0.0" \
       "pytest-asyncio>=0.21.0" \
       "pytest-cov>=4.0.0" \
@@ -43,7 +43,7 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "opencv-python>=4.12.0.88" \
       "imageio[ffmpeg]>=0.6.0" \
       --default-timeout=60 && \
-    pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
+    python3 -m pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
       --default-timeout=60
 
 ENV VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/docker/Dockerfile.npu.ci.a3
+++ b/docker/Dockerfile.npu.ci.a3
@@ -1,10 +1,15 @@
 ARG VLLM_ASCEND_IMAGE=quay.io/atlas-ci/vllm-ascend
 ARG VLLM_ASCEND_TAG=v0.24.0-a3
 FROM ${VLLM_ASCEND_IMAGE}:${VLLM_ASCEND_TAG}
-
+# example: https://repo.huaweicloud.com/pypi/simple
+ARG PIP_INDEX_URL="https://pypi.org/simple/"
+# example: https://repo.huaweicloud.com
+ARG APTMIRROR=""
 ARG APP_DIR=/vllm-workspace/vllm-omni
 WORKDIR ${APP_DIR}
 COPY . .
+
+RUN if [ -n "$APTMIRROR" ];then sed -i "s@^\(deb.*\)https\?://[a-z0-9.-]*\.ubuntu\.com@\1$APTMIRROR@g" /etc/apt/sources.list ;fi
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -20,11 +25,13 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    pip config set global.trusted-host "$(echo ${PIP_INDEX_URL} | awk -F/ '{print $3}')"
+
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
-    python3 -m pip install -U pip && \
-    python3 -m pip install -v \
+    pip install -v \
       "pytest>=7.0.0" \
       "pytest-asyncio>=0.21.0" \
       "pytest-cov>=4.0.0" \
@@ -35,12 +42,8 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "pyttsx3>=2.99" \
       "opencv-python>=4.12.0.88" \
       "imageio[ffmpeg]>=0.6.0" \
-      --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
-      --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
       --default-timeout=60 && \
-    python3 -m pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
-      --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
-      --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
+    pip install -v -e /vllm-workspace/vllm-omni/ --no-build-isolation \
       --default-timeout=60
 
 ENV VLLM_WORKER_MULTIPROC_METHOD=spawn


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
To speedup the CI build, try to introduce the infra cache service

## Test Plan


**vLLM Version:**
NA
**vLLM-Omni Commit:**
NA
## Test Result
These services are already used by [vllm-ascend](https://github.com/vllm-project/vllm-ascend/blob/main/.github/workflows/_e2e_nightly_single_node.yaml#L111-L115)

more info can be found [here](https://ascend-gha-runners.github.io/docs/feature/#cache-service)