### PR TITLE
[Bugfix] Wan2.2 TI2V-5B stage config: use registry key WanPipeline

### DIFF
--- a/vllm_omni/model_executor/stage_configs/wan2_2_ti2v_dit_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/wan2_2_ti2v_dit_fp8.yaml
@@ -13,10 +13,11 @@ stage_args:
       max_batch_size: 1
     engine_args:
       model_stage: dit
-      # Wan2.2 TI2V-5B is served by the base Wan22Pipeline, which auto-detects
-      # expand_timesteps (TI2V-5B mode) from model_index.json. (The standalone
-      # Wan22TI2VPipeline was consolidated into Wan22Pipeline upstream.)
-      model_class_name: Wan22Pipeline
+      # Wan2.2 TI2V-5B is served by the base Wan22Pipeline class, registered
+      # under the `WanPipeline` key, which auto-detects expand_timesteps
+      # (TI2V-5B mode) from model_index.json. (`model_class_name` is the
+      # diffusion-registry key, not the class name.)
+      model_class_name: WanPipeline
       max_num_seqs: 1
       enforce_eager: true
       trust_remote_code: true


### PR DESCRIPTION
### Summary

`vllm_omni/model_executor/stage_configs/wan2_2_ti2v_dit_fp8.yaml` sets `model_class_name: Wan22Pipeline` (the pipeline **class** name), but the diffusion model registry (`_DIFFUSION_MODELS`) registers that pipeline under the **key** `WanPipeline`. Serving with this config fails at startup:

```
ValueError: Model class Wan22Pipeline not found in diffusion model registry.
```

Other diffusion stage configs are unaffected — e.g. `hunyuan_video_15_dit_fp8.yaml` uses `HunyuanVideo15Pipeline`, where the registry key happens to equal the class name.

### Fix

Point `model_class_name` at the registry key `WanPipeline` (which resolves to the `Wan22Pipeline` class), and clarify in the comment that this field takes the registry key, not the class name.

### Verification

Served `Wan-AI/Wan2.2-TI2V-5B` (diffusers) end-to-end on A800 with this config after the change — both single-replica and multi-replica (`runtime.num_replicas`) start and generate correctly. Found while validating replica-DP for #4707.
