### PR TITLE
[Diffusion] runtime_v2: task-centric serving foundation for elastic DiT (RFC #4658)

### DIFF
--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -751,3 +751,29 @@ def test_diffusion_config_field_classification_covers_current_fields():
         "distributed_executor_backend",
     } <= omni_config_module._DIFFUSION_SHARED_CONFIG_FIELDS
     assert "prompt_file_path" in omni_config_module._DIFFUSION_RUNTIME_CONFIG_FIELDS
+
+
+def test_runtime_v2_structured_config_projection_and_forwarding():
+    from types import SimpleNamespace
+
+    from vllm_omni.config.omni_config import _stage_cli_overrides
+    from vllm_omni.config.stage_config import StageExecutionType
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+    settings = {
+        "enable_runtime_v2": True,
+        "runtime_v2_denoise_chunk_size": 4,
+        "runtime_v2_scheduler_policy": "fcfs",
+        "stage_init_timeout": 900,
+    }
+    diffusion_topo = SimpleNamespace(stage_id=1, execution_type=StageExecutionType.DIFFUSION)
+    assert _stage_cli_overrides(diffusion_topo, settings) == settings
+
+    llm_topo = SimpleNamespace(stage_id=0, execution_type=StageExecutionType.LLM_AR)
+    assert not set(settings) & set(_stage_cli_overrides(llm_topo, settings))
+
+    projection = omni_config_module._DiffusionConfigProjection.from_kwargs(**settings)
+    runtime = OmniDiffusionConfig.from_kwargs(model_class_name="QwenImagePipeline", **settings)
+    for key, value in settings.items():
+        assert getattr(projection, key) == value
+        assert getattr(runtime, key) == value

--- a/tests/diffusion/test_runtime_v2_engine_wiring.py
+++ b/tests/diffusion/test_runtime_v2_engine_wiring.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+import contextlib
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _od_config(**overrides) -> OmniDiffusionConfig:
+    kwargs = dict(model_class_name="QwenImagePipeline")
+    kwargs.update(overrides)
+    return OmniDiffusionConfig(**kwargs)
+
+
+@contextlib.contextmanager
+def _stub_process_funcs():
+    with (
+        patch("vllm_omni.diffusion.diffusion_engine.get_diffusion_post_process_func", return_value=None),
+        patch("vllm_omni.diffusion.diffusion_engine.get_diffusion_action_post_process_func", return_value=None),
+        patch("vllm_omni.diffusion.diffusion_engine.get_diffusion_pre_process_func", return_value=None),
+    ):
+        yield
+
+
+def test_flag_off_builds_legacy_path():
+    od_config = _od_config(enable_runtime_v2=False)
+
+    from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+
+    with (
+        _stub_process_funcs(),
+        patch("vllm_omni.diffusion.executor.abstract.DiffusionExecutor.get_class") as get_class,
+        patch.object(DiffusionEngine, "_dummy_run") as dummy_run,
+    ):
+        get_class.return_value = MagicMock()
+
+        engine = DiffusionEngine(od_config)
+        try:
+            assert engine.enable_runtime_v2 is False
+            assert engine.runtime_v2_runner is None
+            assert engine.scheduler is not None
+            assert engine.executor is not None
+            assert engine.execute_fn is not None
+            dummy_run.assert_called_once()
+        finally:
+            engine.close()
+
+
+def test_flag_on_builds_runtime_v2_path_and_skips_warmup():
+    from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+
+    od_config = _od_config(enable_runtime_v2=True)
+
+    with (
+        _stub_process_funcs(),
+        patch("vllm_omni.diffusion.runtime_v2.multiproc_worker.MultiprocWorkerPool.start") as pool_start,
+        patch.object(DiffusionEngine, "_dummy_run") as dummy_run,
+        patch("vllm_omni.diffusion.executor.abstract.DiffusionExecutor.get_class") as get_class,
+    ):
+        get_class.return_value = MagicMock()
+
+        engine = DiffusionEngine(od_config)
+        try:
+            assert engine.enable_runtime_v2 is True
+            assert engine.runtime_v2_runner is not None
+            from vllm_omni.diffusion.runtime_v2.runner import RuntimeV2Runner
+
+            assert isinstance(engine.runtime_v2_runner, RuntimeV2Runner)
+            assert engine.scheduler is None
+            assert engine.executor is None
+            assert engine.execute_fn is None
+            dummy_run.assert_not_called()
+            pool_start.assert_called_once()
+        finally:
+            engine.close()
+
+
+def test_abort_is_handed_to_the_runtime_v2_owner_thread():
+    from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+
+    engine = object.__new__(DiffusionEngine)
+    engine.enable_runtime_v2 = True
+    engine._closed = False
+    engine._cv = threading.Condition()
+    engine._runtime_v2_inflight = {"r"}
+    engine._runtime_v2_commands = queue.Queue()
+
+    engine.abort("r")
+
+    assert engine._runtime_v2_commands.get_nowait() == ("abort", "r")
+
+
+def _bare_runtime_engine(runner):
+    from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+
+    engine = object.__new__(DiffusionEngine)
+    engine.enable_runtime_v2 = True
+    engine.runtime_v2_runner = runner
+    engine.stop_event = threading.Event()
+    engine._cv = threading.Condition()
+    engine._runtime_v2_inflight = {"r"}
+    engine._runtime_v2_commands = queue.Queue()
+    engine._out_queue = {}
+    loop = asyncio.new_event_loop()
+    future = loop.create_future()
+    engine._out_queue["r"] = future
+    return engine, future, loop
+
+
+def test_busy_loop_delivers_finished_request_and_releases_state():
+    request = SimpleNamespace(request_id="r")
+    output = DiffusionOutput(output={"image": "done"})
+    runner = SimpleNamespace(
+        submit=MagicMock(),
+        poll_once=MagicMock(),
+        get_request_status=MagicMock(return_value=("finished", output)),
+        release_request=MagicMock(),
+    )
+    engine, future, loop = _bare_runtime_engine(runner)
+    runner.release_request.side_effect = lambda _request_id: engine.stop_event.set()
+    engine._runtime_v2_commands.put(("submit", request))
+
+    try:
+        engine._runtime_v2_busy_loop()
+        assert future.result() is output
+        runner.submit.assert_called_once_with(request)
+        runner.release_request.assert_called_once_with("r")
+    finally:
+        loop.close()
+
+
+def test_busy_loop_preserves_submit_then_abort_order():
+    calls = []
+    runner = SimpleNamespace(
+        submit=MagicMock(side_effect=lambda _request: calls.append("submit")),
+        abort_request=MagicMock(side_effect=lambda _request_id: calls.append("abort")),
+    )
+    engine, future, loop = _bare_runtime_engine(runner)
+    runner.abort_request.side_effect = lambda _request_id: (calls.append("abort"), engine.stop_event.set())
+    engine._runtime_v2_commands.put(("submit", SimpleNamespace(request_id="r")))
+    engine._runtime_v2_commands.put(("abort", "r"))
+
+    try:
+        engine._runtime_v2_busy_loop()
+        assert calls == ["submit", "abort"]
+        assert future.result().aborted is True
+    finally:
+        loop.close()
+
+
+def test_busy_loop_latches_poll_failure_and_aborts_request():
+    error = RuntimeError("control plane failed")
+    runner = SimpleNamespace(
+        submit=MagicMock(),
+        poll_once=MagicMock(side_effect=error),
+        abort_request=MagicMock(),
+    )
+    engine, future, loop = _bare_runtime_engine(runner)
+    engine._runtime_v2_commands.put(("submit", SimpleNamespace(request_id="r")))
+
+    try:
+        engine._runtime_v2_busy_loop()
+        assert future.result().error
+        assert engine._runtime_v2_fatal_error is error
+        runner.abort_request.assert_called_once_with("r")
+        assert engine.is_backend_dead()
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize("error,expected", [(None, False), (RuntimeError("dead"), True)])
+def test_runtime_v2_backend_health(error, expected):
+    from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+
+    engine = object.__new__(DiffusionEngine)
+    engine.enable_runtime_v2 = True
+    runner = SimpleNamespace(check_health=MagicMock(side_effect=error))
+    engine.runtime_v2_runner = runner
+
+    assert engine.is_backend_dead() is expected

--- a/tests/diffusion/test_runtime_v2_multiproc_worker.py
+++ b/tests/diffusion/test_runtime_v2_multiproc_worker.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+import pickle
+import queue
+import signal
+import threading
+from dataclasses import fields
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.runtime_v2.multiproc_worker import (
+    FetchArtifactsCommand,
+    FetchArtifactsResult,
+    MultiprocWorkerPool,
+    WorkerProcessHandle,
+    _clone_diffusion_output_for_transport,
+    _deserialize_artifact_value,
+    _serialize_artifact_value,
+    _WorkerProcessRuntime,
+)
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactHandle,
+    ArtifactKind,
+    ArtifactLayout,
+    ArtifactValue,
+    ParallelSpec,
+)
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _minimal_od_config() -> Mock:
+    od_config = Mock()
+    od_config.master_port = 30005
+    return od_config
+
+
+def test_clone_for_transport_preserves_all_fields():
+    """SHM transport must preserve every carried DiffusionOutput field."""
+    original = DiffusionOutput(
+        output=torch.zeros(2, 3),
+        trajectory_timesteps=torch.ones(4),
+        trajectory_latents=torch.ones(2, 2),
+        trajectory_log_probs=torch.ones(3),
+        trajectory_decoded=[],
+        error="boom",
+        error_status_code=503,
+        error_type="service_unavailable",
+        aborted=True,
+        abort_message="user aborted",
+        custom_output={"k": "v"},
+        finished=False,
+        chunk_index=7,
+        total_chunks=9,
+        stage_durations={"dit": 1.5},
+        peak_memory_mb=123.0,
+    )
+
+    clone = _clone_diffusion_output_for_transport(original)
+
+    # Every dataclass field must survive the clone (no silent drops). Exclude
+    # to_cpu, which is a construction-time directive rather than carried state.
+    for f in fields(DiffusionOutput):
+        if f.name == "to_cpu":
+            continue
+        orig_val = getattr(original, f.name)
+        clone_val = getattr(clone, f.name)
+        if isinstance(orig_val, torch.Tensor):
+            assert torch.equal(clone_val, orig_val), f"tensor field {f.name} not preserved"
+        else:
+            assert clone_val == orig_val, f"field {f.name} not preserved: {clone_val!r} != {orig_val!r}"
+
+
+def test_serialize_round_trip_pickle_transport():
+    handle = ArtifactHandle(
+        request_id="req-1",
+        artifact_id="latent",
+        kind=ArtifactKind.TENSOR,
+        layout=ArtifactLayout.WORKER_LOCAL,
+    )
+    original = ArtifactValue(handle=handle, value={"data": [1, 2, 3]})
+
+    serialized = _serialize_artifact_value(original)
+    assert serialized.transport == "pickle"
+    assert serialized.handle == handle
+
+    restored = _deserialize_artifact_value(serialized)
+    assert restored.handle == handle
+    assert restored.value == {"data": [1, 2, 3]}
+
+
+# 1.2 MB > the 1 MB _SHM_TENSOR_THRESHOLD, so packing actually creates a segment.
+_LARGE_NUMEL = 300_000
+
+
+def _serialized_shm_names(serialized) -> set[str]:
+    names = set()
+
+    def visit(value):
+        if isinstance(value, dict):
+            if value.get("__tensor_shm__"):
+                names.add(value["name"])
+            else:
+                for item in value.values():
+                    visit(item)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                visit(item)
+        elif isinstance(value, DiffusionOutput):
+            for field in fields(DiffusionOutput):
+                visit(getattr(value, field.name))
+
+    visit(pickle.loads(serialized.payload))
+    return names
+
+
+def _shm_exists(name: str) -> bool:
+    from multiprocessing import shared_memory
+
+    try:
+        shm = shared_memory.SharedMemory(name=name)
+    except FileNotFoundError:
+        return False
+    shm.close()
+    return True
+
+
+def _unlink_shm_by_name(name: str) -> None:
+    """Best-effort unlink of a POSIX SHM segment by name (test cleanup)."""
+    from multiprocessing import shared_memory
+
+    with contextlib.suppress(FileNotFoundError):
+        shm = shared_memory.SharedMemory(name=name)
+        shm.close()
+        shm.unlink()
+
+
+def _output_handle(request_id: str) -> ArtifactHandle:
+    return ArtifactHandle(
+        request_id=request_id,
+        artifact_id="out",
+        kind=ArtifactKind.OUTPUT,  # prefer_shm_output only fires for OUTPUT kind
+        layout=ArtifactLayout.HOST,
+    )
+
+
+@pytest.mark.parametrize(
+    "build, check",
+    [
+        pytest.param(
+            lambda t: DiffusionOutput(output={"image": t}),
+            lambda out, t: torch.testing.assert_close(out.output["image"], t),
+            id="nested-dict-output",
+        ),
+        pytest.param(
+            lambda t: DiffusionOutput(output=torch.zeros(2), trajectory_timesteps=t),
+            lambda out, t: torch.testing.assert_close(out.trajectory_timesteps, t),
+            id="trajectory-timesteps",
+        ),
+    ],
+)
+def test_serialize_shm_transport_round_trips_without_leak(build, check):
+    tensor = torch.arange(_LARGE_NUMEL, dtype=torch.float32)
+    original = ArtifactValue(handle=_output_handle("req-shm"), value=build(tensor))
+
+    serialized = _serialize_artifact_value(original, prefer_shm_output=True)
+    created = _serialized_shm_names(serialized)
+    try:
+        assert serialized.transport == "shm"
+        assert created
+
+        restored = _deserialize_artifact_value(serialized, unpack_shm=True)
+        assert isinstance(restored.value, DiffusionOutput)
+        check(restored.value, tensor)
+        assert not any(_shm_exists(name) for name in created)
+    finally:
+        for name in created:
+            _unlink_shm_by_name(name)
+
+
+def test_serialize_small_output_stays_pickle_and_creates_no_segment():
+    # Everything is below threshold: no handles, so the SHM path is skipped and
+    # the value is pickled inline -- and crucially no segment is orphaned.
+    original = ArtifactValue(
+        handle=_output_handle("req-small"),
+        value=DiffusionOutput(output={"image": torch.zeros(2, 3)}),
+    )
+
+    serialized = _serialize_artifact_value(original, prefer_shm_output=True)
+    assert serialized.transport == "pickle"
+    restored = _deserialize_artifact_value(serialized, unpack_shm=True)
+    torch.testing.assert_close(restored.value.output["image"], torch.zeros(2, 3))
+
+
+def test_worker_installs_parent_death_signal():
+    """The runtime_v2 GPU worker must tie its lifetime to its parent process:
+    register a SIGTERM handler AND arm PR_SET_PDEATHSIG(SIGTERM), so it dies with
+    its owner instead of holding GPU memory / hanging mid-collective."""
+    from vllm_omni.diffusion.runtime_v2.multiproc_worker import _WorkerProcessRuntime
+
+    rt = object.__new__(_WorkerProcessRuntime)
+    with (
+        patch("signal.signal") as sig_signal,
+        patch("vllm_omni.engine.stage_init_utils.set_death_signal") as set_death,
+    ):
+        rt._install_parent_death_signal()
+
+    assert any(c.args and c.args[0] == signal.SIGTERM for c in sig_signal.call_args_list)
+    set_death.assert_called_once_with(signal.SIGTERM)
+
+
+def test_health_check_reports_pipe_forwarder_failure():
+    from vllm_omni.diffusion.runtime_v2.multiproc_worker import MultiprocWorkerPool
+
+    pool = object.__new__(MultiprocWorkerPool)
+    pool._reader_error = EOFError("event pipe closed")
+    pool.worker_handles = {}
+
+    with pytest.raises(RuntimeError, match="pipe forwarder failed"):
+        pool.check_health()
+
+
+def test_fetch_thread_reports_serialization_failure():
+    runtime = object.__new__(_WorkerProcessRuntime)
+    runtime.worker_rank = 0
+    runtime._fetch_stop = threading.Event()
+    runtime._fetch_queue = queue.Queue()
+    command = FetchArtifactsCommand(request_id="r", group_id="g0", artifact_ids=("out",), fetch_id="f")
+    runtime._fetch_queue.put(command)
+    runtime._handle_fetch_artifacts = Mock(side_effect=RuntimeError("cannot serialize"))
+    results = []
+
+    def record_result(result):
+        results.append(result)
+        runtime._fetch_stop.set()
+
+    runtime._send_result = record_result
+    runtime._fetch_loop()
+
+    assert len(results) == 1
+    assert results[0].fetch_id == "f"
+    assert "cannot serialize" in results[0].error
+
+
+def test_discard_fetch_result_shm_unlinks_stale_segment():
+    """A stale fetch result (request aborted before draining) must have its
+    packed POSIX-SHM segment unlinked, not leaked until worker exit."""
+    tensor = torch.arange(_LARGE_NUMEL, dtype=torch.float32)
+    original = ArtifactValue(handle=_output_handle("req-stale"), value=DiffusionOutput(output=tensor))
+
+    sav = _serialize_artifact_value(original, prefer_shm_output=True)
+    assert sav.transport == "shm"
+    created = _serialized_shm_names(sav)
+    try:
+        result = FetchArtifactsResult(request_id="req-stale", worker_rank=0, artifacts=(sav,))
+        MultiprocWorkerPool._discard_fetch_result_shm(result)
+        assert not any(_shm_exists(name) for name in created)
+    finally:
+        for name in created:
+            _unlink_shm_by_name(name)
+
+
+def test_discard_fetch_unlinks_completed_result_shm():
+    """discard_fetch (abort/cleanup) on an ALREADY-completed fetch must unlink its
+    packed POSIX-SHM segment, not just drop the bookkeeping (leak until exit)."""
+    topo = RuntimeTopology.single_group(num_gpus=1, parallel_spec=ParallelSpec())
+    pool = MultiprocWorkerPool(topology=topo, od_config=_minimal_od_config())
+
+    tensor = torch.arange(_LARGE_NUMEL, dtype=torch.float32)
+    original = ArtifactValue(handle=_output_handle("req-abort"), value=DiffusionOutput(output=tensor))
+    sav = _serialize_artifact_value(original, prefer_shm_output=True)
+    assert sav.transport == "shm"
+    created = _serialized_shm_names(sav)
+    try:
+        pool._completed_fetches["fetch-1"] = FetchArtifactsResult(
+            request_id="req-abort", worker_rank=0, artifacts=(sav,)
+        )
+        pool.discard_fetch("fetch-1")
+        assert not any(_shm_exists(name) for name in created)
+        assert "fetch-1" not in pool._completed_fetches
+    finally:
+        for name in created:
+            _unlink_shm_by_name(name)
+
+
+def test_shutdown_unlinks_stranded_result_queue_shm():
+    """A late fetch result the reader queued but no poll ever drained (e.g. the
+    last request was aborted, so its rank is never polled) must have its SHM
+    reclaimed at shutdown, not dropped by _result_queues.clear()."""
+    import queue as _queue
+
+    topo = RuntimeTopology.single_group(num_gpus=1, parallel_spec=ParallelSpec())
+    pool = MultiprocWorkerPool(topology=topo, od_config=_minimal_od_config())
+
+    tensor = torch.arange(_LARGE_NUMEL, dtype=torch.float32)
+    original = ArtifactValue(handle=_output_handle("req-q"), value=DiffusionOutput(output=tensor))
+    sav = _serialize_artifact_value(original, prefer_shm_output=True)
+    created = _serialized_shm_names(sav)
+    try:
+        rank_queue: _queue.Queue = _queue.Queue()
+        rank_queue.put(FetchArtifactsResult(request_id="req-q", worker_rank=0, artifacts=(sav,)))
+        pool._result_queues[0] = rank_queue
+        pool.shutdown()
+        assert not any(_shm_exists(name) for name in created)
+    finally:
+        for name in created:
+            _unlink_shm_by_name(name)
+
+
+def test_shutdown_unlinks_result_left_in_worker_pipe():
+    import multiprocessing as mp
+
+    topo = RuntimeTopology.single_group(num_gpus=1, parallel_spec=ParallelSpec())
+    pool = MultiprocWorkerPool(topology=topo, od_config=_minimal_od_config())
+    tensor = torch.arange(_LARGE_NUMEL, dtype=torch.float32)
+    sav = _serialize_artifact_value(
+        ArtifactValue(handle=_output_handle("req-pipe"), value=DiffusionOutput(output=tensor)),
+        prefer_shm_output=True,
+    )
+    created = _serialized_shm_names(sav)
+    result_r, result_w = mp.Pipe(duplex=False)
+    result_w.send(FetchArtifactsResult(request_id="req-pipe", worker_rank=0, artifacts=(sav,)))
+    result_w.close()
+    process = Mock()
+    process.is_alive.return_value = False
+    pool.worker_handles[0] = WorkerProcessHandle(
+        process=process,
+        worker_rank=0,
+        command_pipe_w=Mock(),
+        event_pipe_r=Mock(),
+        result_pipe_r=result_r,
+    )
+
+    try:
+        pool.shutdown()
+        assert not any(_shm_exists(name) for name in created)
+    finally:
+        result_r.close()
+        for name in created:
+            _unlink_shm_by_name(name)

--- a/tests/diffusion/test_runtime_v2_qwen_compiler.py
+++ b/tests/diffusion/test_runtime_v2_qwen_compiler.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_omni.diffusion.runtime_v2.protocol import ArtifactKind, ArtifactLayout, TaskKind
+from vllm_omni.diffusion.runtime_v2.registry import (
+    get_runtime_v2_adapter,
+    supports_runtime_v2_model,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _request(num_steps=9):
+    from vllm_omni.diffusion.request import OmniDiffusionRequest
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    return OmniDiffusionRequest(
+        request_id="r",
+        prompt="a cat",
+        sampling_params=OmniDiffusionSamplingParams(
+            num_inference_steps=num_steps,
+            height=512,
+            width=512,
+        ),
+    )
+
+
+def _pipeline():
+    pipeline = MagicMock(supports_step_execution=True)
+    for name in ("prepare_encode", "denoise_step", "step_scheduler", "post_decode"):
+        setattr(pipeline, name, MagicMock(name=name))
+    return pipeline
+
+
+def test_qwen_compiler_emits_ragged_linear_dag():
+    adapter = get_runtime_v2_adapter("QwenImagePipeline")
+    compiler = adapter.build_task_compiler(default_denoise_chunk_size=4)
+    plan = compiler.compile_request(adapter.normalize_request(_request(), 4))
+
+    prepare = next(task for task in plan.tasks.values() if task.kind == TaskKind.TEXT_ENCODE)
+    chunks = sorted(
+        (task for task in plan.tasks.values() if task.kind == TaskKind.DIT_STEP_CHUNK),
+        key=lambda task: task.step_range.start,
+    )
+    decode = next(task for task in plan.tasks.values() if task.kind == TaskKind.VAE_DECODE)
+
+    assert [(task.step_range.start, task.step_range.end) for task in chunks] == [
+        (0, 4),
+        (4, 8),
+        (8, 9),
+    ]
+    assert chunks[0].dependencies == (prepare.task_id,)
+    assert chunks[1].dependencies == (chunks[0].task_id,)
+    assert chunks[2].dependencies == (chunks[1].task_id,)
+    assert decode.dependencies == (chunks[2].task_id,)
+    assert plan.terminal_task_ids == (decode.task_id,)
+    assert prepare.outputs[0].kind is ArtifactKind.REQUEST_STATE
+    assert prepare.outputs[0].layout is ArtifactLayout.WORKER_LOCAL
+    assert decode.outputs[0].kind is ArtifactKind.OUTPUT
+    assert plan.initial_artifacts[0].handle == prepare.inputs[0]
+
+
+def test_qwen_compiler_rejects_custom_sigmas():
+    adapter = get_runtime_v2_adapter("QwenImagePipeline")
+    request = _request()
+    request.sampling_params.sigmas = [1.0, 0.5, 0.1]
+
+    with pytest.raises(NotImplementedError, match="custom sigmas"):
+        adapter.build_task_compiler(default_denoise_chunk_size=1).compile_request(adapter.normalize_request(request, 1))
+
+
+def test_qwen_pipeline_validation_and_cache_boundary():
+    adapter = get_runtime_v2_adapter("QwenImagePipeline")
+    pipeline = _pipeline()
+    adapter.validate_pipeline(pipeline, SimpleNamespace(cache_backend=None))
+
+    with pytest.raises(ValueError):
+        adapter.validate_pipeline(SimpleNamespace(supports_step_execution=False), None)
+    with pytest.raises(ValueError, match="cache_backend"):
+        adapter.validate_pipeline(pipeline, SimpleNamespace(cache_backend="cache_dit"))
+
+
+def test_qwen_adapter_surface_and_registry_boundary():
+    adapter = get_runtime_v2_adapter("QwenImagePipeline")
+    request = _request(num_steps=4)
+    normalized = adapter.normalize_request(request, 2)
+    executors = adapter.build_executors(_pipeline())
+
+    assert normalized.denoise_chunk_size == 2
+    assert set(executors) == {
+        TaskKind.TEXT_ENCODE,
+        TaskKind.DIT_STEP_CHUNK,
+        TaskKind.VAE_DECODE,
+    }
+    assert supports_runtime_v2_model("QwenImagePipeline")
+    assert not supports_runtime_v2_model("WanPipeline")
+    with pytest.raises(KeyError):
+        get_runtime_v2_adapter("WanPipeline")

--- a/tests/diffusion/test_runtime_v2_qwen_e2e.py
+++ b/tests/diffusion/test_runtime_v2_qwen_e2e.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import pytest
+
+from tests.helpers.mark import hardware_test
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_qwen_image_generates_through_runtime_v2():
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    engine = Omni(
+        model="tiny-random/Qwen-Image",
+        enable_runtime_v2=True,
+        runtime_v2_denoise_chunk_size=2,
+        enforce_eager=True,
+    )
+    try:
+        outputs = engine.generate(
+            {"prompt": "a red panda walking in snow"},
+            sampling_params_list=OmniDiffusionSamplingParams(
+                num_inference_steps=2,
+                guidance_scale=0.0,
+                height=256,
+                width=256,
+                seed=1234,
+            ),
+        )
+    finally:
+        engine.close()
+
+    assert outputs and outputs[0].finished
+    assert outputs[0].final_output_type == "image"
+    assert outputs[0].images
+    image = np.asarray(outputs[0].images[0])
+    assert image.ndim == 3 and image.shape[2] == 3
+    assert np.isfinite(image).all()

--- a/tests/diffusion/test_runtime_v2_runner_guard.py
+++ b/tests/diffusion/test_runtime_v2_runner_guard.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.runtime_v2.runner import RuntimeV2Runner
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _config(*, tp=1, sp=1, cfg=1, num_gpus=None, ring=1):
+    world_size = tp * sp * cfg
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            sequence_parallel_size=sp,
+            cfg_parallel_size=cfg,
+            ring_degree=ring,
+            world_size=world_size,
+        ),
+        num_gpus=world_size if num_gpus is None else num_gpus,
+    )
+
+
+@pytest.mark.parametrize("tp,sp,cfg", [(1, 1, 1), (2, 1, 1), (1, 2, 1), (1, 1, 2)])
+def test_single_group_topology_matches_parallel_world(tp, sp, cfg):
+    topology = RuntimeV2Runner._build_topology(_config(tp=tp, sp=sp, cfg=cfg))
+    group = topology.groups[0]
+    assert len(topology.groups) == 1
+    assert len(group.ranks) == len(topology.workers) == tp * sp * cfg
+    assert (group.parallel_spec.tp, group.parallel_spec.sp, group.parallel_spec.cfg) == (
+        tp,
+        sp,
+        cfg,
+    )
+
+
+@pytest.mark.parametrize("num_gpus", [2, 8])
+def test_single_group_rejects_mismatched_world_size(num_gpus):
+    with pytest.raises(ValueError, match="single execution group"):
+        RuntimeV2Runner._build_topology(_config(tp=2, sp=2, num_gpus=num_gpus))
+
+
+def test_single_group_rejects_ring_parallelism():
+    with pytest.raises(NotImplementedError, match="ring sequence parallelism"):
+        RuntimeV2Runner._build_topology(_config(sp=2, ring=2))

--- a/tests/diffusion/test_runtime_v2_scheduler_fcfs.py
+++ b/tests/diffusion/test_runtime_v2_scheduler_fcfs.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.runtime_v2.policies.fcfs import FCFSSchedulerPolicy
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactHandle,
+    ArtifactKind,
+    ArtifactLayout,
+    ArtifactValue,
+    InferenceTask,
+    ParallelSpec,
+    RequestExecutionPlan,
+    TaskKind,
+    WorkerEvent,
+    WorkerEventKind,
+    WorkerLocalArtifactRef,
+)
+from vllm_omni.diffusion.runtime_v2.scheduler import GlobalScheduler, InMemoryArtifactStore
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _TwoTaskCompiler:
+    def compile_request(self, request):
+        state = ArtifactHandle(
+            request_id="r",
+            artifact_id="state",
+            kind=ArtifactKind.REQUEST_STATE,
+            layout=ArtifactLayout.WORKER_LOCAL,
+        )
+        output = ArtifactHandle(
+            request_id="r",
+            artifact_id="output",
+            kind=ArtifactKind.OUTPUT,
+            layout=ArtifactLayout.WORKER_LOCAL,
+        )
+        prepare = InferenceTask(
+            task_id="r:prepare",
+            request_id="r",
+            kind=TaskKind.TEXT_ENCODE,
+            group_id="g0",
+            parallel_spec=ParallelSpec(),
+            outputs=(state,),
+        )
+        finish = InferenceTask(
+            task_id="r:finish",
+            request_id="r",
+            kind=TaskKind.VAE_DECODE,
+            group_id="g0",
+            parallel_spec=ParallelSpec(),
+            dependencies=(prepare.task_id,),
+            inputs=(state,),
+            outputs=(output,),
+        )
+        return RequestExecutionPlan(
+            request_id="r",
+            tasks={prepare.task_id: prepare, finish.task_id: finish},
+            terminal_task_ids=(finish.task_id,),
+        )
+
+
+class _EchoPool:
+    def __init__(self):
+        self.events = []
+        self.values = {}
+
+    def dispatch(self, task, inline_inputs, release_after_exec_artifact_ids=()):
+        references = tuple(
+            WorkerLocalArtifactRef(handle=handle, group_id="g0", worker_rank=0) for handle in task.outputs
+        )
+        for handle in task.outputs:
+            self.values[(task.request_id, handle.artifact_id)] = f"value:{handle.artifact_id}"
+        for kind, metadata in (
+            (WorkerEventKind.TASK_LAUNCH_END, {"published_outputs": references}),
+            (WorkerEventKind.TASK_EXEC_END, {}),
+        ):
+            self.events.append(
+                WorkerEvent(
+                    event_id=f"{task.task_id}:{kind.value}",
+                    task_id=task.task_id,
+                    request_id=task.request_id,
+                    group_id="g0",
+                    worker_rank=0,
+                    kind=kind,
+                    timestamp_ns=0,
+                    metadata=metadata,
+                )
+            )
+
+    def poll(self, timeout_s=0.0):
+        events, self.events = self.events, []
+        return events
+
+    def fetch_artifacts(self, request_id, group_id, artifact_ids):
+        artifacts = tuple(
+            ArtifactValue(
+                handle=ArtifactHandle(
+                    request_id=request_id,
+                    artifact_id=artifact_id,
+                    kind=ArtifactKind.OUTPUT,
+                    layout=ArtifactLayout.WORKER_LOCAL,
+                ),
+                value=self.values[(request_id, artifact_id)],
+            )
+            for artifact_id in artifact_ids
+        )
+        return SimpleNamespace(artifacts=artifacts, error=None)
+
+    def evict_request(self, request_id):
+        pass
+
+
+def _scheduler(pool, compiler):
+    topology = RuntimeTopology.single_group(num_gpus=1, parallel_spec=ParallelSpec())
+    return GlobalScheduler(
+        topology=topology,
+        worker_pool=pool,
+        compiler=compiler,
+        artifact_store=InMemoryArtifactStore(),
+        policy=FCFSSchedulerPolicy(topology),
+    )
+
+
+def test_fcfs_executes_plan_and_fetches_terminal_output():
+    scheduler = _scheduler(_EchoPool(), _TwoTaskCompiler())
+    request_id = scheduler.submit_request(object())
+
+    for _ in range(4):
+        scheduler.poll_once()
+        status, output = scheduler.get_request_status(request_id)
+        if status == "finished":
+            break
+
+    assert (status, output) == ("finished", "value:output")
+
+    scheduler.release_request(request_id)
+    assert request_id not in scheduler.cleaned_requests
+    assert not any(key.startswith(f"{request_id}:") for key in scheduler.released_requests)
+
+
+class _SingleTaskCompiler:
+    def compile_request(self, request):
+        output = ArtifactHandle(
+            request_id=request.request_id,
+            artifact_id="output",
+            kind=ArtifactKind.OUTPUT,
+            layout=ArtifactLayout.WORKER_LOCAL,
+        )
+        task = InferenceTask(
+            task_id=f"{request.request_id}:task",
+            request_id=request.request_id,
+            kind=TaskKind.TEXT_ENCODE,
+            group_id="g0",
+            parallel_spec=ParallelSpec(),
+            outputs=(output,),
+        )
+        return RequestExecutionPlan(
+            request_id=request.request_id,
+            tasks={task.task_id: task},
+            terminal_task_ids=(task.task_id,),
+        )
+
+
+class _RecordingPool:
+    def __init__(self):
+        self.calls = []
+
+    def dispatch(self, task, inline_inputs, release_after_exec_artifact_ids=()):
+        self.calls.append(("dispatch", task.request_id))
+
+    def poll(self, timeout_s=0.0):
+        return []
+
+    def evict_request(self, request_id):
+        self.calls.append(("evict", request_id))
+
+
+class _AsyncFetchPool(_RecordingPool):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+        self.fetch_ready = False
+        self.output_handle = None
+
+    def poll(self, timeout_s=0.0):
+        events, self.events = self.events, []
+        return events
+
+    def finish(self, request_id):
+        task_id = f"{request_id}:task"
+        self.output_handle = ArtifactHandle(
+            request_id=request_id,
+            artifact_id="output",
+            kind=ArtifactKind.OUTPUT,
+            layout=ArtifactLayout.WORKER_LOCAL,
+        )
+        reference = WorkerLocalArtifactRef(handle=self.output_handle, group_id="g0", worker_rank=0)
+        self.events.extend(
+            [
+                WorkerEvent(
+                    event_id=f"{task_id}:launch",
+                    task_id=task_id,
+                    request_id=request_id,
+                    group_id="g0",
+                    worker_rank=0,
+                    kind=WorkerEventKind.TASK_LAUNCH_END,
+                    timestamp_ns=0,
+                    metadata={"published_outputs": (reference,)},
+                ),
+                WorkerEvent(
+                    event_id=f"{task_id}:end",
+                    task_id=task_id,
+                    request_id=request_id,
+                    group_id="g0",
+                    worker_rank=0,
+                    kind=WorkerEventKind.TASK_EXEC_END,
+                    timestamp_ns=1,
+                ),
+            ]
+        )
+
+    def start_fetch_artifacts(self, request_id, group_id, artifact_ids):
+        self.calls.append(("start_fetch", request_id))
+        return f"fetch:{request_id}"
+
+    def poll_fetch_artifacts(self, fetch_id):
+        if not self.fetch_ready:
+            return None
+        return SimpleNamespace(
+            artifacts=(ArtifactValue(handle=self.output_handle, value="done"),),
+            error=None,
+        )
+
+    def discard_fetch(self, fetch_id):
+        pass
+
+
+def test_abort_evicts_active_before_promoting_next_request():
+    pool = _RecordingPool()
+    scheduler = _scheduler(pool, _SingleTaskCompiler())
+    scheduler.submit_request(SimpleNamespace(request_id="A"))
+    scheduler.submit_request(SimpleNamespace(request_id="B"))
+    pool.calls.clear()
+
+    scheduler.abort_request("A")
+
+    assert pool.calls == [("evict", "A"), ("dispatch", "B")]
+    assert scheduler.policy.active_request_by_group == {"g0": "B"}
+
+
+def test_abort_queued_request_keeps_active_request():
+    pool = _RecordingPool()
+    scheduler = _scheduler(pool, _SingleTaskCompiler())
+    scheduler.submit_request(SimpleNamespace(request_id="A"))
+    scheduler.submit_request(SimpleNamespace(request_id="B"))
+
+    scheduler.abort_request("B")
+
+    assert scheduler.policy.active_request_by_group == {"g0": "A"}
+    assert not scheduler.policy.pending_requests_by_group.get("g0")
+    assert pool.calls == [("dispatch", "A"), ("evict", "B")]
+
+
+def test_terminal_fetch_finishes_before_evict_and_next_dispatch():
+    pool = _AsyncFetchPool()
+    scheduler = _scheduler(pool, _SingleTaskCompiler())
+    scheduler.submit_request(SimpleNamespace(request_id="A"))
+    scheduler.submit_request(SimpleNamespace(request_id="B"))
+    pool.finish("A")
+
+    scheduler.poll_once()
+    assert scheduler.get_request_status("A") == ("pending", None)
+    assert ("dispatch", "B") not in pool.calls
+
+    pool.fetch_ready = True
+    assert scheduler.get_request_status("A") == ("finished", "done")
+    assert pool.calls.index(("evict", "A")) < pool.calls.index(("dispatch", "B"))
+
+
+def test_start_forwards_worker_timeout():
+    class _Pool:
+        def start(self, timeout_s=600.0):
+            self.timeout_s = timeout_s
+
+    pool = _Pool()
+    scheduler = _scheduler(pool, SimpleNamespace())
+    scheduler.start(timeout_s=123.0)
+    assert pool.timeout_s == 123.0

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -33,6 +33,26 @@ def test_default_stage_config_includes_cache_backend():
     assert engine_args["model_stage"] == "diffusion"
 
 
+def test_default_stage_config_forwards_runtime_v2_settings():
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {
+            "model_class_name": "QwenImagePipeline",
+            "enable_runtime_v2": True,
+            "runtime_v2_denoise_chunk_size": 4,
+            "runtime_v2_scheduler_policy": "fcfs",
+            "stage_init_timeout": 777,
+        }
+    )[0]
+
+    expected = {
+        "enable_runtime_v2": True,
+        "runtime_v2_denoise_chunk_size": 4,
+        "runtime_v2_scheduler_policy": "fcfs",
+        "stage_init_timeout": 777,
+    }
+    assert {key: stage_cfg["engine_args"][key] for key in expected} == expected
+
+
 def test_default_cache_config_used_when_missing():
     """Ensure default cache_config is synthesized when only backend is given."""
     stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
@@ -359,3 +379,27 @@ def test_resolve_stage_configs_injects_additional_config_into_diffusion_stage(mo
 
     assert not hasattr(stage_configs[0].engine_args, "additional_config")
     assert stage_configs[1].engine_args.additional_config == {"torchair_graph_config": {"enabled": True}}
+
+
+def test_resolve_stage_configs_omits_default_stage_init_timeout(mocker):
+    captured = {}
+
+    def _fake(model, stage_configs_path, kwargs, **kw):
+        captured["kwargs"] = kwargs
+        return ("dummy.yaml", [])
+
+    mocker.patch(
+        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
+        side_effect=_fake,
+    )
+
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    engine._strip_single_engine_args = lambda kwargs: kwargs
+
+    engine.stage_init_timeout = 300
+    engine._resolve_stage_configs("dummy-model", {"stage_configs_path": "dummy.yaml"})
+    assert "stage_init_timeout" not in captured["kwargs"]
+
+    engine.stage_init_timeout = 900
+    engine._resolve_stage_configs("dummy-model", {"stage_configs_path": "dummy.yaml"})
+    assert captured["kwargs"]["stage_init_timeout"] == 900

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -31,6 +31,37 @@ def test_serve_parser_accepts_no_async_chunk_and_marks_it_explicit() -> None:
     assert not explicit["async_chunk"]
 
 
+def test_serve_parser_accepts_runtime_v2_flags_and_marks_them_explicit() -> None:
+    """``vllm serve ... --enable-runtime-v2`` (+ the two ``--runtime-v2-*`` knobs)
+    must parse and be forwarded as explicit kwargs. Without registering them on
+    the serve parser, argparse rejects the flags before the value reaches the
+    engine, so runtime_v2 could only be enabled from Python."""
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    cmd = OmniServeCommand()
+    cmd.subparser_init(subparsers)
+
+    argv = [
+        "serve",
+        "fake-model",
+        "--omni",
+        "--enable-runtime-v2",
+        "--runtime-v2-denoise-chunk-size",
+        "4",
+        "--runtime-v2-scheduler-policy",
+        "fcfs",
+    ]
+    args = parser.parse_args(argv)
+    assert args.enable_runtime_v2 is True
+    assert args.runtime_v2_denoise_chunk_size == 4
+    assert args.runtime_v2_scheduler_policy == "fcfs"
+
+    explicit = args.get_explicit_kwargs_dict()
+    assert explicit["enable_runtime_v2"] is True
+    assert explicit["runtime_v2_denoise_chunk_size"] == 4
+    assert explicit["runtime_v2_scheduler_policy"] == "fcfs"
+
+
 def _make_headless_args(**kwargs) -> TrackingNamespace:
     defaults = {
         "model": "fake-model",

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -30,6 +30,7 @@ from vllm_omni.config.stage_config import (
     _deep_merge_stage,
     _resolve_scheduler,
     build_stage_runtime_overrides,
+    forward_runtime_v2_settings_to_diffusion_stage,
     load_deploy_config,
     merge_pipeline_deploy,
     pipeline_cfg_resolver,
@@ -144,6 +145,41 @@ class TestStageConfig:
         assert omega_config.runtime.devices == "0,1"
         # max_batch_size is migrated to engine_args.max_num_seqs
         assert omega_config.engine_args.max_num_seqs == 64
+
+    def test_runtime_v2_settings_reach_only_diffusion_engine_args(self):
+        settings = {
+            "enable_runtime_v2": True,
+            "runtime_v2_denoise_chunk_size": 4,
+            "runtime_v2_scheduler_policy": "fcfs",
+            "stage_init_timeout": 900,
+        }
+        overrides: dict = {}
+        forward_runtime_v2_settings_to_diffusion_stage(StageType.DIFFUSION, settings, overrides)
+        config = StageConfig(
+            stage_id=1,
+            model_stage="diffusion",
+            stage_type=StageType.DIFFUSION,
+            runtime_overrides=overrides,
+        )
+        omega_config = config.to_omegaconf()
+        for key, value in settings.items():
+            assert getattr(omega_config.engine_args, key) == value
+
+        llm_overrides: dict = {}
+        forward_runtime_v2_settings_to_diffusion_stage(StageType.LLM, settings, llm_overrides)
+        assert llm_overrides == {}
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "stage_0_enable_runtime_v2",
+            "stage_0_runtime_v2_denoise_chunk_size",
+            "stage_0_runtime_v2_scheduler_policy",
+        ],
+    )
+    def test_runtime_v2_settings_are_top_level_only(self, key):
+        with pytest.raises(ValueError, match="top level"):
+            build_stage_runtime_overrides(0, {key: True}, internal_keys=frozenset())
 
     def test_to_omegaconf_max_batch_size_deprecation(self):
         """Test that runtime.max_batch_size emits a FutureWarning."""

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -24,6 +24,7 @@ from vllm_omni.config.stage_config import (
     StageConfig,
     StageType,
     build_stage_runtime_overrides,
+    forward_runtime_v2_settings_to_diffusion_stage,
     load_deploy_config,
     merge_pipeline_deploy,
 )
@@ -342,6 +343,9 @@ class StageConfigFactory:
 
         for stage in stages:
             stage.runtime_overrides = cls._merge_cli_overrides(stage, explicit_overrides)
+            forward_runtime_v2_settings_to_diffusion_stage(
+                stage.stage_type, explicit_overrides, stage.runtime_overrides
+            )
 
         return stages
 

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -34,6 +34,7 @@ from vllm_omni.config.stage_config import (
     _scheduler_path,
     _select_processor_funcs,
     build_stage_runtime_overrides,
+    forward_runtime_v2_settings_to_diffusion_stage,
     load_deploy_config,
 )
 
@@ -205,13 +206,16 @@ def _resolve_scheduler_path(execution_type: StageExecutionType, async_scheduling
     return _scheduler_path(_resolve_scheduler(execution_type, async_scheduling))
 
 
-def _stage_cli_overrides(stage_id: int, cli_overrides: Mapping[str, Any]) -> dict[str, Any]:
+def _stage_cli_overrides(topology: StagePipelineConfig, cli_overrides: Mapping[str, Any]) -> dict[str, Any]:
+    stage_id = topology.stage_id
     runtime_overrides = build_stage_runtime_overrides(stage_id, dict(cli_overrides))
     global_stage_fields = _global_stage_cli_fields()
     result: dict[str, Any] = {}
     for key, value in runtime_overrides.items():
         if key in global_stage_fields or f"stage_{stage_id}_{key}" in cli_overrides:
             result[key] = _copy_value(value)
+    stage_type, _ = _resolve_execution_mode(topology.execution_type)
+    forward_runtime_v2_settings_to_diffusion_stage(stage_type, cli_overrides, result)
     return result
 
 
@@ -472,6 +476,10 @@ class _DiffusionConfigProjection:
     force_cutlass_fp8: bool = False
     enable_diffusion_pipeline_profiler: bool = False
     step_execution: bool = False
+    enable_runtime_v2: bool = False
+    runtime_v2_denoise_chunk_size: int = 1
+    runtime_v2_scheduler_policy: str = "fcfs"
+    stage_init_timeout: int = 300
     supports_multimodal_inputs: bool = False
     max_multimodal_image_inputs: int | None = None
     model_paths: dict[str, str] = field(default_factory=dict)
@@ -1274,7 +1282,7 @@ class VllmOmniConfig:
                 deploy_by_id.get(topology.stage_id),
                 _stage_engine_values(
                     deploy_by_id.get(topology.stage_id),
-                    _stage_cli_overrides(topology.stage_id, cli_overrides),
+                    _stage_cli_overrides(topology, cli_overrides),
                 ),
                 model=model,
             )

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -8,7 +8,7 @@ import dataclasses
 import functools
 import re
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
@@ -28,6 +28,32 @@ logger = init_logger(__name__)
 _DEPLOY_DIR = Path(__file__).resolve().parent.parent / "deploy"
 
 _STAGE_OVERRIDE_PATTERN = re.compile(r"^stage_(\d+)_(.+)$")
+
+# runtime_v2 is a pipeline-level opt-in; per-stage forms are ambiguous and are
+# rejected below.
+_RUNTIME_V2_TOPLEVEL_FLAGS = frozenset(
+    {
+        "enable_runtime_v2",
+        "runtime_v2_denoise_chunk_size",
+        "runtime_v2_scheduler_policy",
+    }
+)
+
+_DIFFUSION_STAGE_TOPLEVEL_FORWARD = _RUNTIME_V2_TOPLEVEL_FLAGS | frozenset({"stage_init_timeout"})
+
+
+def forward_runtime_v2_settings_to_diffusion_stage(
+    stage_type: Any,
+    cli_overrides: Mapping[str, Any],
+    runtime_overrides: dict[str, Any],
+) -> None:
+    """Forward pipeline-level runtime_v2 settings to a diffusion stage."""
+    if StageType(stage_type) != StageType.DIFFUSION:
+        return
+    for key in _DIFFUSION_STAGE_TOPLEVEL_FORWARD:
+        value = cli_overrides.get(key)
+        if value is not None:
+            runtime_overrides[key] = value
 
 
 def pipeline_cfg_resolver(config_type: type[PretrainedConfig]):
@@ -81,6 +107,12 @@ def build_stage_runtime_overrides(
         if match is not None:
             override_stage_id = int(match.group(1))
             param_name = match.group(2)
+            if param_name in _RUNTIME_V2_TOPLEVEL_FLAGS:
+                raise ValueError(
+                    f"Per-stage override {key!r} is not supported: runtime_v2 opt-in "
+                    f"must be set at the top level (e.g. Omni(..., enable_runtime_v2=True)), "
+                    f"not per stage."
+                )
             if override_stage_id == stage_id and param_name not in internal_keys:
                 result[param_name] = value
             continue

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -779,6 +779,13 @@ class OmniDiffusionConfig:
     # Step mode settings
     step_execution: bool = False
 
+    # Runtime v2 settings
+    enable_runtime_v2: bool = False
+    runtime_v2_denoise_chunk_size: int = 1
+    runtime_v2_scheduler_policy: str = "fcfs"
+    # Startup timeout for the runtime_v2 worker pool.
+    stage_init_timeout: int = 300
+
     # Streaming mode settings
     streaming_output: bool = False  # Start (video) generation with initial prompt, but streaming output in chunks
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -173,13 +173,36 @@ class DiffusionEngine:
             self.od_config.step_execution = True
             self.step_execution = True
 
-        executor_class = DiffusionExecutor.get_class(od_config)
-        self.executor = executor_class(od_config)
-        self.scheduler: SchedulerInterface = scheduler or (
-            StepScheduler() if self.step_execution else RequestScheduler()
-        )
-        self.scheduler.initialize(od_config)
-        self.supports_request_batch = False if self.step_execution else supports_request_batch(od_config)
+        # runtime_v2 replaces the legacy scheduler/executor behind an opt-in flag.
+        self.enable_runtime_v2 = bool(getattr(od_config, "enable_runtime_v2", False))
+        if getattr(self, "enable_runtime_v2", False):
+            from vllm_omni.diffusion.runtime_v2.runner import RuntimeV2Runner
+
+            logger.info(
+                "runtime_v2 active: enable_runtime_v2=%s denoise_chunk_size=%s scheduler_policy=%s",
+                self.enable_runtime_v2,
+                int(getattr(od_config, "runtime_v2_denoise_chunk_size", 1) or 1),
+                str(getattr(od_config, "runtime_v2_scheduler_policy", "fcfs")),
+            )
+            self.runtime_v2_runner = RuntimeV2Runner(
+                pipeline=None,
+                default_step_chunk_size=int(getattr(od_config, "runtime_v2_denoise_chunk_size", 1) or 1),
+                scheduler_policy=str(getattr(od_config, "runtime_v2_scheduler_policy", "fcfs")),
+                omni_diffusion_config=od_config,
+            )
+            self.scheduler = None
+            self.executor = None
+            self.execute_fn = None
+            self.supports_request_batch = False
+        else:
+            self.runtime_v2_runner = None
+            executor_class = DiffusionExecutor.get_class(od_config)
+            self.executor = executor_class(od_config)
+            self.scheduler: SchedulerInterface = scheduler or (
+                StepScheduler() if self.step_execution else RequestScheduler()
+            )
+            self.scheduler.initialize(od_config)
+            self.supports_request_batch = False if self.step_execution else supports_request_batch(od_config)
         self.main_loop: asyncio.AbstractEventLoop | None = None
         self.stop_event: threading.Event | None = None
         self.worker_thread: threading.Thread | None = None
@@ -193,16 +216,22 @@ class DiffusionEngine:
         self._cv = threading.Condition(self._rpc_lock)
         self._out_queue: dict[str, asyncio.Future] = {}
         self._out_queue_streaming: dict[str, asyncio.Queue[DiffusionOutput]] = {}
+        self._runtime_v2_inflight: set[str] = set()
+        self._runtime_v2_fatal_error: BaseException | None = None
+        # GlobalScheduler is lock-free. Submit and abort commands are handed to
+        # the busy-loop thread, which is its sole owner.
+        self._runtime_v2_commands: queue.Queue[tuple[str, Any]] = queue.Queue()
         self._closed = False
         self._shutdown_complete = False
         self.abort_queue: queue.Queue[str] = queue.Queue()
         self._rpc_queue: queue.Queue[_RpcTask] = queue.Queue()
-        if self.step_execution:
-            self.execute_fn = self.executor.execute_step
-        elif self.supports_request_batch:
-            self.execute_fn = self.executor.execute_batch
-        else:
-            self.execute_fn = self.executor.execute_request
+        if not self.enable_runtime_v2:
+            if self.step_execution:
+                self.execute_fn = self.executor.execute_step
+            elif self.supports_request_batch:
+                self.execute_fn = self.executor.execute_batch
+            else:
+                self.execute_fn = self.executor.execute_request
 
         if self.supports_request_batch:
             logger.info(
@@ -211,12 +240,14 @@ class DiffusionEngine:
                 getattr(od_config, "request_batch_max_wait_ms", None),
             )
 
-        try:
-            self._dummy_run()
-        except Exception as e:
-            logger.error(f"Dummy run failed: {e}")
-            self.close()
-            raise e
+        # runtime_v2 warms lazily on the first request.
+        if not self.enable_runtime_v2:
+            try:
+                self._dummy_run()
+            except Exception as e:
+                logger.error(f"Dummy run failed: {e}")
+                self.close()
+                raise e
 
     async def _check_and_start_background_loop(self):
         if self._closed:
@@ -375,6 +406,12 @@ class DiffusionEngine:
         )
 
     def _busy_loop(self):
+        # runtime_v2 owns its own scheduler/execution; the legacy
+        # schedule()/execute_fn()/update_from_output() body would dereference the
+        # None legacy attributes, so the worker thread runs the runtime_v2 loop.
+        if getattr(self, "enable_runtime_v2", False):
+            self._runtime_v2_busy_loop()
+            return
         while not self.stop_event.is_set():
             self._process_aborts_queue()
             self._process_rpc_queue()
@@ -439,6 +476,123 @@ class DiffusionEngine:
 
         # Engine is stopping: fail any RPCs still queued so callers don't hang.
         self._fail_pending_rpcs(RuntimeError("DiffusionEngine is shutting down."))
+
+    def _runtime_v2_busy_loop(self) -> None:
+        """Drive the lock-free runtime_v2 runner from one owner thread."""
+        while not self.stop_event.is_set():
+            with self._cv:
+                while (
+                    not self._runtime_v2_inflight and self._runtime_v2_commands.empty() and not self.stop_event.is_set()
+                ):
+                    self._cv.wait(timeout=1.0)
+                if self.stop_event.is_set():
+                    break
+
+            while True:
+                try:
+                    operation, payload = self._runtime_v2_commands.get_nowait()
+                except queue.Empty:
+                    break
+                if operation == "submit":
+                    try:
+                        self.runtime_v2_runner.submit(payload)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error("runtime_v2 submit failed for %s", payload.request_id, exc_info=True)
+                        try:
+                            self.runtime_v2_runner.abort_request(payload.request_id)
+                        except Exception as cleanup_exc:  # noqa: BLE001
+                            logger.error("runtime_v2 submit cleanup failed for %s", payload.request_id, exc_info=True)
+                            self._fail_runtime_v2_backend(
+                                cleanup_exc,
+                                list(self._runtime_v2_inflight),
+                            )
+                            break
+                        self._resolve_runtime_v2_request(payload.request_id, DiffusionOutput.from_exception(exc))
+                elif operation == "abort":
+                    try:
+                        self.runtime_v2_runner.abort_request(payload)
+                        output = DiffusionOutput(aborted=True, abort_message=f"Request {payload} aborted.")
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error("runtime_v2 abort failed for %s", payload, exc_info=True)
+                        self._fail_runtime_v2_backend(exc, list(self._runtime_v2_inflight))
+                        break
+                    self._resolve_runtime_v2_request(payload, output)
+
+            if self.stop_event.is_set():
+                break
+
+            with self._cv:
+                inflight = list(self._runtime_v2_inflight)
+            if not inflight:
+                continue
+
+            try:
+                self.runtime_v2_runner.poll_once(timeout_s=0.05)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("runtime_v2 poll_once failed", exc_info=True)
+                self._fail_runtime_v2_backend(exc, inflight)
+                break
+
+            for rid in inflight:
+                if self.stop_event.is_set():
+                    break
+                try:
+                    status, payload = self.runtime_v2_runner.get_request_status(rid)
+                except Exception as exc:  # noqa: BLE001 - propagate to caller
+                    logger.error("runtime_v2 get_request_status failed for %s", rid, exc_info=True)
+                    self._fail_runtime_v2_backend(exc, inflight)
+                    break
+                if status == "pending":
+                    continue
+                if status == "finished":
+                    try:
+                        output = self._materialize_runtime_v2_output(payload)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error("runtime_v2 output materialization failed for %s", rid, exc_info=True)
+                        output = DiffusionOutput.from_exception(exc)
+                else:  # "failed"
+                    output = DiffusionOutput(error=str(payload) if payload is not None else "runtime_v2 request failed")
+                try:
+                    self.runtime_v2_runner.release_request(rid)
+                except Exception:  # noqa: BLE001
+                    logger.debug("runtime_v2 release_request failed for %s", rid, exc_info=True)
+                self._resolve_runtime_v2_request(rid, output)
+
+    def _fail_runtime_v2_backend(
+        self,
+        exc: BaseException,
+        request_ids: Iterable[str],
+    ) -> None:
+        """Latch a control-plane failure and fail every affected request."""
+        self._runtime_v2_fatal_error = exc
+        failure = DiffusionOutput.from_exception(exc)
+        for request_id in dict.fromkeys(request_ids):
+            try:
+                self.runtime_v2_runner.abort_request(request_id)
+            except Exception:  # noqa: BLE001
+                logger.debug("runtime_v2 fatal cleanup failed for %s", request_id, exc_info=True)
+            self._resolve_runtime_v2_request(request_id, failure)
+        self.stop_event.set()
+        with self._cv:
+            self._cv.notify_all()
+
+    def _materialize_runtime_v2_output(self, payload: Any) -> DiffusionOutput:
+        """Materialize a terminal output and release its shared-memory handles."""
+        output = payload if isinstance(payload, DiffusionOutput) else DiffusionOutput(output=payload)
+        if isinstance(output, DiffusionOutput):
+            from vllm_omni.diffusion.ipc import unpack_diffusion_output_shm
+
+            unpack_diffusion_output_shm(output)
+        return output
+
+    def _resolve_runtime_v2_request(self, request_id: str, output: DiffusionOutput) -> None:
+        """Resolve a runtime_v2 request future and stop tracking it."""
+        with self._cv:
+            self._runtime_v2_inflight.discard(request_id)
+            fut = self._out_queue.pop(request_id, None)
+        if fut is None:
+            return
+        self._complete_future(fut, output)
 
     def _wait_for_request_batch_admission_locked(self) -> None:
         """Wait for compatible requests to accumulate before scheduling a wave.
@@ -668,6 +822,8 @@ class DiffusionEngine:
         return engine_class(config, scheduler=scheduler)
 
     def add_request(self, request: OmniDiffusionRequest) -> str:
+        if getattr(self, "enable_runtime_v2", False):
+            return self._add_request_runtime_v2(request)
         with self._cv:
             if self._closed:
                 raise RuntimeError("DiffusionEngine is closed.")
@@ -681,6 +837,27 @@ class DiffusionEngine:
                 self._out_queue_streaming[request_id] = queue
             self._cv.notify_all()
 
+        return request_id
+
+    def _add_request_runtime_v2(self, request: OmniDiffusionRequest) -> str:
+        """Register a request and hand it to the runtime_v2 owner thread."""
+        if self.od_config.streaming_output:
+            raise NotImplementedError("runtime_v2 does not support streaming_output in PR1")
+        if getattr(request, "kv_sender_info", None) is not None:
+            raise NotImplementedError("runtime_v2 (PR1) does not support upstream KV transfer")
+        if getattr(request.sampling_params, "lora_request", None) is not None:
+            raise NotImplementedError("runtime_v2 (PR1) does not support LoRA requests")
+        request_id = request.request_id
+        with self._cv:
+            if self._closed:
+                raise RuntimeError("DiffusionEngine is closed.")
+            if self._runtime_v2_fatal_error is not None:
+                raise RuntimeError("runtime_v2 backend has failed") from self._runtime_v2_fatal_error
+            fut = self.main_loop.create_future()
+            self._out_queue[request_id] = fut
+            self._runtime_v2_inflight.add(request_id)
+            self._runtime_v2_commands.put(("submit", request))
+            self._cv.notify_all()
         return request_id
 
     async def get_result(self, request_id: str) -> DiffusionOutput:
@@ -728,6 +905,8 @@ class DiffusionEngine:
         return self.get_streaming_result(request_id)
 
     def add_req_and_wait_for_response(self, request: OmniDiffusionRequest) -> DiffusionOutput:
+        if getattr(self, "enable_runtime_v2", False):
+            raise NotImplementedError("runtime_v2 requires the asynchronous request path")
         with self._rpc_lock:
             if self._closed:
                 raise RuntimeError("DiffusionEngine is closed.")
@@ -892,6 +1071,12 @@ class DiffusionEngine:
         """
         assert isinstance(method, str), "Only string method names are supported for now"
 
+        if getattr(self, "enable_runtime_v2", False):
+            # The legacy executor does not exist in runtime_v2 mode; the runner's
+            # collective_rpc is not wired in PR1. Fail loudly rather than
+            # dereferencing the None executor.
+            raise NotImplementedError("collective_rpc is not supported in runtime_v2 mode (PR1)")
+
         # If the busy loop hasn't started yet (e.g. during _dummy_run in
         # __init__, or before the first async request after construction),
         # there is no busy-loop thread to drain the RPC queue. Fall back to
@@ -932,6 +1117,15 @@ class DiffusionEngine:
         Mirrors :meth:`async_add_req_and_wait_for_response`: enqueue a task
         keyed by a future and ``await`` the result without blocking the loop.
         """
+        assert isinstance(method, str), "Only string method names are supported for now"
+
+        if getattr(self, "enable_runtime_v2", False):
+            # In runtime_v2 mode the legacy executor / _rpc_queue drain path does
+            # not run (the busy loop is _runtime_v2_busy_loop, which never calls
+            # _process_rpc_queue). Enqueuing here would hang the awaiting caller
+            # forever. Fail fast, mirroring the sync collective_rpc guard.
+            raise NotImplementedError("async_collective_rpc is not supported in runtime_v2 mode (PR1)")
+
         await self._check_and_start_background_loop()
         task = self._submit_rpc(method, timeout, args, kwargs, unique_reply_rank)
         aio_fut = asyncio.wrap_future(task.future)
@@ -1021,12 +1215,39 @@ class DiffusionEngine:
         else:
             self._loop_started = False
 
-        self.scheduler.close()
-        self.executor.shutdown()
+        if getattr(self, "enable_runtime_v2", False):
+            # runtime_v2 owns its scheduler + worker pool; shut the runner down
+            # in place of the legacy scheduler.close()/executor.shutdown().
+            self.runtime_v2_runner.shutdown()
+        else:
+            self.scheduler.close()
+            self.executor.shutdown()
         self._shutdown_complete = True
+
+    def is_backend_dead(self) -> bool:
+        if getattr(self, "enable_runtime_v2", False):
+            if getattr(self, "_runtime_v2_fatal_error", None) is not None:
+                return True
+            try:
+                self.runtime_v2_runner.check_health()
+            except Exception:
+                return True
+            return False
+        executor = getattr(self, "executor", None)
+        return bool(executor and (getattr(executor, "_closed", False) or getattr(executor, "is_failed", False)))
 
     def abort(self, request_id: str | Iterable[str]) -> None:
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
+
+        if getattr(self, "enable_runtime_v2", False):
+            with self._cv:
+                if self._closed:
+                    return
+                for req_id in request_ids:
+                    if req_id in self._runtime_v2_inflight:
+                        self._runtime_v2_commands.put(("abort", req_id))
+                self._cv.notify_all()
+            return
 
         with self._cv:
             if self._closed:

--- a/vllm_omni/diffusion/ipc.py
+++ b/vllm_omni/diffusion/ipc.py
@@ -119,6 +119,41 @@ def _unpack_if_shm_handle(val: object) -> object:
     return val
 
 
+def _value_has_shm_handle(val: object) -> bool:
+    """True iff ``_pack_value_if_large`` placed an SHM handle anywhere in ``val``.
+
+    Mirrors the recursive container walk of ``_pack_value_if_large`` /
+    ``_unpack_if_shm_handle``: a handle can sit at the top level (a bare packed
+    tensor) or nested inside the dict/list/tuple shapes pipelines return as
+    ``DiffusionOutput.output`` (e.g. ``{"image": tensor}``, ``(video, audio)``).
+    Keep this in sync with those two functions.
+    """
+    if isinstance(val, dict):
+        if val.get("__tensor_shm__"):
+            return True
+        return any(_value_has_shm_handle(value) for value in val.values())
+    if isinstance(val, (list, tuple)):
+        return any(_value_has_shm_handle(item) for item in val)
+    return False
+
+
+def diffusion_output_has_shm_handles(output: DiffusionOutput) -> bool:
+    """True iff ``pack_diffusion_output_shm`` created any SHM handle in ``output``.
+
+    Checks every field ``_pack_diffusion_fields`` touches -- ``output`` (walked
+    recursively, since large tensors may be nested in its dict/list/tuple
+    container) and all three ``trajectory_*`` tensors -- so callers can tell a
+    real SHM transport (handles created; receiver must unpack + unlink) apart
+    from a no-op pack (everything under threshold; nothing to unlink).
+    """
+    return (
+        _value_has_shm_handle(output.output)
+        or _value_has_shm_handle(output.trajectory_latents)
+        or _value_has_shm_handle(output.trajectory_timesteps)
+        or _value_has_shm_handle(output.trajectory_log_probs)
+    )
+
+
 def _pack_diffusion_fields(output: DiffusionOutput) -> DiffusionOutput:
     if output.output is not None:
         output.output = _pack_value_if_large(output.output)

--- a/vllm_omni/diffusion/runtime_v2/__init__.py
+++ b/vllm_omni/diffusion/runtime_v2/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_omni/diffusion/runtime_v2/adapters/__init__.py
+++ b/vllm_omni/diffusion/runtime_v2/adapters/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-model runtime_v2 adapters."""
+
+from vllm_omni.diffusion.runtime_v2.adapters.qwen_image import (
+    QwenImageRuntimeV2Adapter,
+    QwenImageTaskCompiler,
+    QwenRuntimeRequest,
+)
+
+__all__ = [
+    "QwenImageRuntimeV2Adapter",
+    "QwenImageTaskCompiler",
+    "QwenRuntimeRequest",
+]

--- a/vllm_omni/diffusion/runtime_v2/adapters/qwen_image.py
+++ b/vllm_omni/diffusion/runtime_v2/adapters/qwen_image.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen-Image runtime_v2 adapter, task compiler, and step-exec executors.
+
+Rather than re-implementing the diffusion forward path with low-level
+primitives, every executor drives the ``QwenImagePipeline`` *step-execution
+stage methods* — ``prepare_encode`` / ``denoise_step`` / ``step_scheduler`` /
+``post_decode`` — exactly as ``DiffusionModelRunner.execute_stepwise`` does.
+
+The single shared artifact passed along the linear DAG is a
+``DiffusionRequestState`` (kind ``REQUEST_STATE``, layout ``WORKER_LOCAL``):
+
+    TEXT_ENCODE  ->  [DIT_STEP_CHUNK] * ceil(num_inference_steps / chunk)
+                 ->  VAE_DECODE   (terminal; its DiffusionOutput is the result)
+
+PR1 is single-group / host-local: there is no cross-group artifact migration.
+The executors require a real GPU pipeline + model and are exercised by the GPU end-to-end test;
+what is CPU-testable now is the compiler, ``validate_pipeline``, import, and
+``build_executors``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any, cast
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.runtime_v2.interfaces import (
+    RuntimeV2Adapter,
+    TaskCompiler,
+    WorkerExecutor,
+)
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactHandle,
+    ArtifactKind,
+    ArtifactLayout,
+    ArtifactValue,
+    InferenceTask,
+    ParallelSpec,
+    RequestExecutionPlan,
+    StepRange,
+    TaskKind,
+)
+
+logger = init_logger(__name__)
+
+
+# Task kinds emitted by the Qwen-Image linear compiler. prepare_encode() bundles
+# prompt encode + latents + timesteps + scheduler setup into the single
+# TEXT_ENCODE task, so there is no separate dit/timestep prepare stage.
+QWEN_TASK_KINDS: tuple[TaskKind, ...] = (
+    TaskKind.TEXT_ENCODE,
+    TaskKind.DIT_STEP_CHUNK,
+    TaskKind.VAE_DECODE,
+)
+
+# Stage methods that define the step-execution contract this adapter drives.
+_REQUIRED_STAGE_METHODS: tuple[str, ...] = (
+    "prepare_encode",
+    "denoise_step",
+    "step_scheduler",
+    "post_decode",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Request wrapper                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class QwenRuntimeRequest:
+    """Normalized runtime_v2 request: an OmniDiffusionRequest + chunk size.
+
+    The compiler only needs the request id, the sampling params (for
+    ``num_inference_steps``) and the denoise chunk size; everything else the
+    executors read straight off the wrapped ``OmniDiffusionRequest``.
+    """
+
+    def __init__(
+        self,
+        diffusion_request: OmniDiffusionRequest,
+        denoise_chunk_size: int = 1,
+        *,
+        priority: int = 0,
+        group_id: str | None = None,
+    ) -> None:
+        if denoise_chunk_size < 1:
+            raise ValueError(f"denoise_chunk_size must be >= 1, got {denoise_chunk_size}")
+        self.diffusion_request = diffusion_request
+        self.request_id = diffusion_request.request_id
+        self.denoise_chunk_size = int(denoise_chunk_size)
+        self.priority = int(priority)
+        self.group_id = group_id
+
+
+# --------------------------------------------------------------------------- #
+# Task compiler                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class QwenImageTaskCompiler(TaskCompiler):
+    """Emit a linear stage DAG for one Qwen-Image request.
+
+    The denoise loop is partitioned into ``ceil(num_steps / chunk)`` contiguous
+    ``DIT_STEP_CHUNK`` tasks, each carrying a ``StepRange(start, end)`` over the
+    step index. Every task consumes the previous task's ``DiffusionRequestState``
+    artifact and produces the (mutated) state, so the scheduler sees a strict
+    linear dependency chain.
+    """
+
+    def __init__(
+        self,
+        default_denoise_chunk_size: int = 1,
+        *,
+        od_config: Any = None,
+        pipeline: Any = None,
+    ) -> None:
+        if default_denoise_chunk_size < 1:
+            raise ValueError("default_denoise_chunk_size must be >= 1")
+        self.default_denoise_chunk_size = int(default_denoise_chunk_size)
+        self.od_config = od_config
+        self.pipeline = pipeline
+
+    def compile_request(self, request: Any) -> RequestExecutionPlan:
+        if not isinstance(request, QwenRuntimeRequest):
+            raise TypeError(f"unsupported runtime_v2 request type: {type(request)!r}")
+
+        req = request.diffusion_request
+        request_id = request.request_id
+        if req.sampling_params.sigmas is not None:
+            raise NotImplementedError("runtime_v2 does not support custom sigmas for Qwen-Image")
+        raw_num_steps = req.sampling_params.num_inference_steps
+        # `or 50` would mask an explicit 0 (making it slip past the `< 1` guard
+        # below and silently run 50 steps); only substitute when unset.
+        num_steps = int(raw_num_steps) if raw_num_steps is not None else 50
+        if num_steps < 1:
+            raise ValueError(f"num_inference_steps must be >= 1, got {num_steps}")
+
+        chunk_size = int(request.denoise_chunk_size or self.default_denoise_chunk_size)
+        if chunk_size < 1:
+            raise ValueError(f"denoise_chunk_size must be >= 1, got {chunk_size}")
+        num_chunks = math.ceil(num_steps / chunk_size)
+
+        group_id = request.group_id
+        priority = request.priority
+        parallel_spec = ParallelSpec()
+
+        tasks: dict[str, InferenceTask] = {}
+
+        def _state_handle(artifact_id: str, producer_task_id: str | None) -> ArtifactHandle:
+            return ArtifactHandle(
+                request_id=request_id,
+                artifact_id=artifact_id,
+                kind=ArtifactKind.REQUEST_STATE,
+                layout=ArtifactLayout.WORKER_LOCAL,
+                producer_task_id=producer_task_id,
+            )
+
+        # ── TEXT_ENCODE: prepare_encode (encode + latents + timesteps) ──
+        prep_task_id = f"{request_id}:text_encode"
+        # The initial input artifact is the raw request itself, seeded into the
+        # plan as an initial_artifact so QwenPrepareExecutor can build the state.
+        request_handle = ArtifactHandle(
+            request_id=request_id,
+            artifact_id=f"{request_id}:request",
+            kind=ArtifactKind.REQUEST_STATE,
+            layout=ArtifactLayout.HOST,
+            producer_task_id=None,
+        )
+        prep_out = _state_handle(f"{request_id}:state_text", prep_task_id)
+        tasks[prep_task_id] = InferenceTask(
+            task_id=prep_task_id,
+            request_id=request_id,
+            kind=TaskKind.TEXT_ENCODE,
+            group_id=group_id,
+            parallel_spec=parallel_spec,
+            priority=priority,
+            dependencies=(),
+            inputs=(request_handle,),
+            outputs=(prep_out,),
+        )
+
+        # ── DIT_STEP_CHUNK * num_chunks ──
+        prev_task_id = prep_task_id
+        prev_out = prep_out
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * chunk_size
+            end = min(start + chunk_size, num_steps)
+            dit_task_id = f"{request_id}:dit:{chunk_idx}"
+            dit_out = _state_handle(f"{request_id}:state_dit:{chunk_idx}", dit_task_id)
+            tasks[dit_task_id] = InferenceTask(
+                task_id=dit_task_id,
+                request_id=request_id,
+                kind=TaskKind.DIT_STEP_CHUNK,
+                group_id=group_id,
+                parallel_spec=parallel_spec,
+                priority=priority,
+                dependencies=(prev_task_id,),
+                inputs=(prev_out,),
+                outputs=(dit_out,),
+                step_range=StepRange(start, end),
+            )
+            prev_task_id = dit_task_id
+            prev_out = dit_out
+
+        # ── VAE_DECODE: post_decode -> DiffusionOutput (terminal) ──
+        # The decoded DiffusionOutput IS the request result: it is fetched from
+        # the worker and unpacked in StageDiffusionProc, which runs the CPU
+        # postprocess. No separate finalize stage is needed.
+        vae_task_id = f"{request_id}:vae_decode"
+        vae_out = ArtifactHandle(
+            request_id=request_id,
+            artifact_id=f"{request_id}:output",
+            kind=ArtifactKind.OUTPUT,
+            layout=ArtifactLayout.WORKER_LOCAL,
+            producer_task_id=vae_task_id,
+        )
+        tasks[vae_task_id] = InferenceTask(
+            task_id=vae_task_id,
+            request_id=request_id,
+            kind=TaskKind.VAE_DECODE,
+            group_id=group_id,
+            parallel_spec=parallel_spec,
+            priority=priority,
+            dependencies=(prev_task_id,),
+            inputs=(prev_out,),
+            outputs=(vae_out,),
+        )
+
+        plan = RequestExecutionPlan(
+            request_id=request_id,
+            tasks=tasks,
+            terminal_task_ids=(vae_task_id,),
+            initial_artifacts=(ArtifactValue(handle=request_handle, value=req),),
+            metadata={
+                "adapter": "qwen_image",
+                "num_steps": num_steps,
+                "chunk_size": chunk_size,
+                "num_chunks": num_chunks,
+            },
+        )
+        logger.debug(
+            "runtime_v2 compile: request_id=%s adapter=qwen_image steps=%s chunk=%s denoise_tasks=%s total_tasks=%s",
+            request_id,
+            num_steps,
+            chunk_size,
+            num_chunks,
+            len(plan.tasks),
+        )
+        return plan
+
+
+# --------------------------------------------------------------------------- #
+# Executors (drive QwenImagePipeline step-exec stage methods)               #
+# --------------------------------------------------------------------------- #
+
+
+class _BaseQwenExecutor(WorkerExecutor):
+    def __init__(self, pipeline: Any) -> None:
+        self.pipeline = pipeline
+
+    @staticmethod
+    def _single_input(task: InferenceTask, resolved_inputs: Mapping[str, Any]) -> Any:
+        if len(task.inputs) != 1:
+            raise ValueError(f"{task.kind} expects exactly one input artifact")
+        artifact_id = task.inputs[0].artifact_id
+        if artifact_id not in resolved_inputs:
+            raise KeyError(f"missing resolved input for artifact {artifact_id}")
+        return resolved_inputs[artifact_id]
+
+
+class QwenPrepareExecutor(_BaseQwenExecutor):
+    """TEXT_ENCODE: build the per-request state and run ``prepare_encode``.
+
+    Mirrors ``DiffusionModelRunner._update_states`` (state construction) +
+    ``_prepare_batch_inputs`` (the ``prepare_encode`` call for new requests).
+    ``prepare_encode`` populates prompt embeds, latents, timesteps, the
+    per-request scheduler, and CFG config on the state.
+    """
+
+    def execute(self, task: InferenceTask, resolved_inputs: Mapping[str, Any]) -> tuple[ArtifactValue, ...]:
+        # Imported lazily so this module imports without torch/worker deps on
+        # the host / in CPU-only collection.
+        import torch
+
+        from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+        req = cast(OmniDiffusionRequest, self._single_input(task, resolved_inputs))
+
+        state = DiffusionRequestState(
+            request_id=task.request_id,
+            sampling=req.sampling_params,
+            prompt=req.prompt,
+            kv_sender_info=req.kv_sender_info,
+        )
+
+        # Match _prepare_batch_inputs: materialize the generator from the seed
+        # before encoding so the initial latent noise is deterministic and
+        # matches the single-group baseline.
+        sampling = state.sampling
+        if sampling.generator is None and sampling.seed is not None:
+            device = getattr(self.pipeline, "device", None)
+            if sampling.generator_device is not None:
+                gen_device = sampling.generator_device
+            elif device is not None and getattr(device, "type", None) == "cpu":
+                gen_device = "cpu"
+            elif device is not None:
+                gen_device = device
+            else:
+                gen_device = "cpu"
+            sampling.generator = torch.Generator(device=gen_device).manual_seed(int(sampling.seed))
+
+        self.pipeline.prepare_encode(state)
+        return (ArtifactValue(handle=task.outputs[0], value=state),)
+
+
+class QwenDenoiseChunkExecutor(_BaseQwenExecutor):
+    """DIT_STEP_CHUNK: run one chunk of denoise steps over the input state.
+
+    Mirrors the per-step inner loop of ``execute_stepwise``: build an
+    ``InputBatch`` from the single state, call ``denoise_step`` to get the
+    batched ``noise_pred``, then slice the per-state row offset and feed it to
+    ``step_scheduler`` (which mutates ``state.latents`` and advances
+    ``step_index``). For a single-request batch the offset slice is the full
+    ``noise_pred`` (``offset == 0``, ``row_num == state.latents.shape[0]``).
+    """
+
+    def execute(self, task: InferenceTask, resolved_inputs: Mapping[str, Any]) -> tuple[ArtifactValue, ...]:
+        if task.step_range is None:
+            raise ValueError("dit_step_chunk requires step_range")
+
+        from vllm_omni.diffusion.worker.input_batch import InputBatch
+        from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+        state = cast(DiffusionRequestState, self._single_input(task, resolved_inputs))
+        if state.latents is None or state.timesteps is None:
+            raise RuntimeError("state is not ready for denoising (missing latents/timesteps)")
+
+        # Clamp the chunk's step range to the request's actual step count so a
+        # final ragged chunk does not over-run the timestep schedule.
+        start = max(0, task.step_range.start)
+        end = min(task.step_range.end, state.total_steps)
+
+        cached_batch: InputBatch | None = None
+        for _ in range(start, end):
+            input_batch = InputBatch.make_batch([state], cached_batch=cached_batch)
+            cached_batch = input_batch
+            noise_pred = self.pipeline.denoise_step(input_batch, states=[state])
+
+            if noise_pred is None:
+                # Interrupted: leave the state as-is and stop the chunk early.
+                break
+
+            # Single-request batch: consume exactly this state's rows, matching
+            # the offset slicing in execute_stepwise.
+            row_num = state.latents.shape[0]
+            self.pipeline.step_scheduler(state, noise_pred[0:row_num])
+
+        return (ArtifactValue(handle=task.outputs[0], value=state),)
+
+
+class QwenDecodeExecutor(_BaseQwenExecutor):
+    """VAE_DECODE: ``post_decode(state)`` -> ``DiffusionOutput``."""
+
+    def execute(self, task: InferenceTask, resolved_inputs: Mapping[str, Any]) -> tuple[ArtifactValue, ...]:
+        from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+        state = cast(DiffusionRequestState, self._single_input(task, resolved_inputs))
+        if state.latents is None:
+            raise RuntimeError("state.latents is None in decode stage")
+        result = self.pipeline.post_decode(state)
+        return (ArtifactValue(handle=task.outputs[0], value=result),)
+
+
+def build_executors(pipeline: Any) -> dict[TaskKind, WorkerExecutor]:
+    """Map each Qwen-Image task kind to its step-exec executor."""
+    return {
+        TaskKind.TEXT_ENCODE: QwenPrepareExecutor(pipeline),
+        TaskKind.DIT_STEP_CHUNK: QwenDenoiseChunkExecutor(pipeline),
+        TaskKind.VAE_DECODE: QwenDecodeExecutor(pipeline),
+    }
+
+
+def validate_pipeline(pipeline: Any, od_config: Any) -> None:
+    """Assert the pipeline implements the step-execution contract."""
+    if pipeline is None:
+        raise ValueError("runtime_v2 qwen-image adapter requires an initialized pipeline")
+    if not getattr(pipeline, "supports_step_execution", False):
+        raise ValueError("runtime_v2 qwen-image adapter requires a pipeline with supports_step_execution=True")
+    for method_name in _REQUIRED_STAGE_METHODS:
+        method = getattr(pipeline, method_name, None)
+        if not callable(method):
+            raise ValueError(f"qwen-image runtime_v2 adapter requires callable pipeline.{method_name}")
+    # Cache backends are OUT of PR1 scope. The runtime_v2 executors call the
+    # pipeline step methods directly, bypassing DiffusionModelRunner.execute_stepwise
+    # -- and thus both its per-request cache refresh (_refresh_cache_for_requests)
+    # AND its "Step mode does not support cache_backend" guard. With a cache
+    # backend enabled on the pipeline (the worker load path does enable it), the
+    # first request would run with stale / unrefreshed cache state instead of
+    # failing. Reject it loudly at startup, mirroring the legacy stepwise guard.
+    cache_backend = getattr(od_config, "cache_backend", None)
+    if cache_backend not in (None, "none"):
+        raise ValueError(
+            f"runtime_v2 (PR1) does not support cache_backend={cache_backend!r}; "
+            "use the legacy path or set cache_backend='none'"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Adapter                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class QwenImageRuntimeV2Adapter(RuntimeV2Adapter):
+    model_class_name = "QwenImagePipeline"
+
+    @property
+    def supported_task_kinds(self) -> tuple[TaskKind, ...]:
+        return QWEN_TASK_KINDS
+
+    def normalize_request(self, request: Any, denoise_chunk_size: int) -> QwenRuntimeRequest:
+        if isinstance(request, QwenRuntimeRequest):
+            return request
+        if not isinstance(request, OmniDiffusionRequest):
+            raise TypeError(f"unsupported runtime_v2 request type: {type(request)!r}")
+        return QwenRuntimeRequest(
+            diffusion_request=request,
+            denoise_chunk_size=denoise_chunk_size,
+        )
+
+    def build_task_compiler(
+        self,
+        default_denoise_chunk_size: int,
+        *,
+        od_config: Any = None,
+        pipeline: Any = None,
+    ) -> TaskCompiler:
+        return QwenImageTaskCompiler(
+            default_denoise_chunk_size=default_denoise_chunk_size,
+            od_config=od_config,
+            pipeline=pipeline,
+        )
+
+    def build_executors(self, pipeline: Any) -> dict[TaskKind, WorkerExecutor]:
+        return build_executors(pipeline)
+
+    def validate_pipeline(self, pipeline: Any, od_config: Any) -> None:
+        validate_pipeline(pipeline, od_config)

--- a/vllm_omni/diffusion/runtime_v2/interfaces.py
+++ b/vllm_omni/diffusion/runtime_v2/interfaces.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactHandle,
+    ArtifactValue,
+    InferenceTask,
+    RequestExecutionPlan,
+    TaskKind,
+    WorkerEvent,
+)
+
+# Re-export ArtifactValue so callers that `from interfaces import ArtifactValue` work.
+__all__ = [
+    "ArtifactStore",
+    "ArtifactValue",
+    "RuntimeV2Adapter",
+    "SchedulerPolicy",
+    "TaskCompiler",
+    "WorkerExecutor",
+]
+
+
+class TaskCompiler(ABC):
+    @abstractmethod
+    def compile_request(self, request: Any) -> RequestExecutionPlan:
+        raise NotImplementedError
+
+
+class ArtifactStore(ABC):
+    @abstractmethod
+    def put(self, artifact: ArtifactHandle, value: Any) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, artifact: ArtifactHandle) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_ready(self, artifact: ArtifactHandle) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def evict_request(self, request_id: str) -> None:
+        raise NotImplementedError
+
+
+class SchedulerPolicy(ABC):
+    @abstractmethod
+    def on_request_submitted(self, plan: RequestExecutionPlan) -> Iterable[InferenceTask]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def on_tasks_runnable(self, tasks: Iterable[InferenceTask]) -> Iterable[InferenceTask]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def on_worker_event(self, event: WorkerEvent) -> Iterable[InferenceTask]:
+        raise NotImplementedError
+
+
+class WorkerExecutor(ABC):
+    @abstractmethod
+    def execute(self, task: InferenceTask, resolved_inputs: Mapping[str, Any]) -> tuple[ArtifactValue, ...]:
+        raise NotImplementedError
+
+
+class RuntimeV2Adapter(ABC):
+    model_class_name: str
+
+    @property
+    @abstractmethod
+    def supported_task_kinds(self) -> tuple[TaskKind, ...]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def normalize_request(self, request: Any, denoise_chunk_size: int) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_task_compiler(
+        self,
+        default_denoise_chunk_size: int,
+        *,
+        od_config: Any = None,
+        pipeline: Any = None,
+    ) -> TaskCompiler:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_executors(self, pipeline: Any) -> dict[TaskKind, WorkerExecutor]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def validate_pipeline(self, pipeline: Any, od_config: Any) -> None:
+        raise NotImplementedError

--- a/vllm_omni/diffusion/runtime_v2/multiproc_worker.py
+++ b/vllm_omni/diffusion/runtime_v2/multiproc_worker.py
@@ -1,0 +1,1374 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""runtime_v2 MultiprocWorkerPool.
+
+Owns its own worker subprocesses (one per topology rank) and reuses the
+existing ``DiffusionWorker`` / ``DiffusionModelRunner`` for model load and
+execution. Each worker process:
+
+* boots a ``DiffusionWorker`` (device + distributed env + model parallel +
+  model load are all done inside ``DiffusionWorker.__init__``),
+* builds per-``TaskKind`` ``WorkerExecutor`` objects from the loaded pipeline
+  via the runtime_v2 registry adapter (imported lazily so importing this
+  module does not require the registry/adapter to exist yet),
+* runs a command loop over a multiprocessing pipe: dispatch a task, fetch
+  artifacts, evict a request, or shut down.
+
+The controller side (:class:`MultiprocWorkerPool`) spawns the processes, owns
+the command/event/result pipes, forwards worker events into a queue the
+scheduler polls, aggregates per-rank task events into one group-level event,
+and exposes the artifact-fetch API the scheduler uses to materialize a
+request's terminal output.
+
+This is the PR1 single-group port. Cross-group artifact migration is out of
+scope: the worker has no migrate command phase.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import multiprocessing as mp
+import pickle
+import queue
+import signal
+import threading
+import time
+import traceback
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from multiprocessing.connection import Connection, wait
+from typing import Any
+
+import torch
+import vllm.distributed.parallel_state as vllm_parallel_state
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.data import (
+    DiffusionOutput,
+    DiffusionParallelConfig,
+    OmniDiffusionConfig,
+)
+from vllm_omni.diffusion.distributed import parallel_state as omni_parallel_state
+from vllm_omni.diffusion.forward_context import set_forward_context
+from vllm_omni.diffusion.ipc import (
+    diffusion_output_has_shm_handles,
+    pack_diffusion_output_shm,
+    unpack_diffusion_output_shm,
+)
+from vllm_omni.diffusion.runtime_v2.interfaces import WorkerExecutor
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactKind,
+    ArtifactValue,
+    ExecutionGroupSpec,
+    InferenceTask,
+    ParallelSpec,
+    WorkerEvent,
+    WorkerEventKind,
+    WorkerLocalArtifactRef,
+)
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class SerializedArtifactValue:
+    handle: Any
+    payload: bytes
+    transport: str = "pickle"
+    payload_nbytes: int = 0
+
+    @property
+    def value(self) -> Any:
+        return _decode_serialized_payload(self)
+
+
+@dataclass(frozen=True)
+class ProcessDispatchTaskCommand:
+    task: InferenceTask
+    inline_inputs: tuple[SerializedArtifactValue, ...]
+    result_owner_rank: int
+    release_after_exec_artifact_ids: tuple[str, ...] = ()
+    group_spec: ExecutionGroupSpec | None = None
+
+
+@dataclass(frozen=True)
+class ShutdownWorkerCommand:
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class FetchArtifactsCommand:
+    request_id: str
+    group_id: str
+    artifact_ids: tuple[str, ...]
+    fetch_id: str = ""
+
+
+@dataclass(frozen=True)
+class EvictRequestCommand:
+    request_id: str
+
+
+@dataclass(frozen=True)
+class FetchArtifactsResult:
+    request_id: str
+    worker_rank: int
+    artifacts: tuple[SerializedArtifactValue | ArtifactValue, ...] = ()
+    error: str | None = None
+    fetch_id: str = ""
+
+
+@dataclass(frozen=True)
+class WorkerReadyMessage:
+    worker_rank: int
+    status: str = "ready"
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class _FixedParallelSession:
+    parallel_spec: ParallelSpec
+    world: Any
+    dp: Any
+    cfg: Any
+    pp: Any
+    sp: Any
+    tp: Any
+    fs: Any
+    dit: Any
+    ep: Any
+
+    @classmethod
+    def capture_current(cls, parallel_spec: ParallelSpec) -> _FixedParallelSession:
+        session = cls(
+            parallel_spec=parallel_spec,
+            world=omni_parallel_state._WORLD,
+            dp=omni_parallel_state._DP,
+            cfg=omni_parallel_state._CFG,
+            pp=omni_parallel_state._PP,
+            sp=omni_parallel_state._SP,
+            tp=vllm_parallel_state._TP,
+            fs=omni_parallel_state._FS,
+            dit=omni_parallel_state._DIT,
+            ep=getattr(vllm_parallel_state, "_EP", None),
+        )
+        session.validate()
+        return session
+
+    def validate(self) -> None:
+        if self.world is None:
+            raise RuntimeError("runtime_v2 worker session requires initialized distributed world group")
+        if self.dp is None or self.cfg is None or self.pp is None or self.sp is None or self.tp is None:
+            raise RuntimeError("runtime_v2 worker session requires initialized legacy parallel groups")
+        if self.tp.world_size != int(self.parallel_spec.tp):
+            raise RuntimeError(
+                f"legacy TP world_size={self.tp.world_size} does not match runtime_v2 tp={self.parallel_spec.tp}"
+            )
+        if self.sp.world_size != int(self.parallel_spec.sp):
+            raise RuntimeError(
+                f"legacy SP world_size={self.sp.world_size} does not match runtime_v2 sp={self.parallel_spec.sp}"
+            )
+        if self.cfg.world_size != int(self.parallel_spec.cfg):
+            raise RuntimeError(
+                f"legacy CFG world_size={self.cfg.world_size} does not match runtime_v2 cfg={self.parallel_spec.cfg}"
+            )
+
+    def activate(self) -> None:
+        omni_parallel_state._WORLD = self.world
+        omni_parallel_state._DP = self.dp
+        omni_parallel_state._CFG = self.cfg
+        omni_parallel_state._PP = self.pp
+        omni_parallel_state._SP = self.sp
+        omni_parallel_state._FS = self.fs
+        omni_parallel_state._DIT = self.dit
+        vllm_parallel_state._DP = self.dp
+        vllm_parallel_state._PP = self.pp
+        vllm_parallel_state._TP = self.tp
+        if hasattr(vllm_parallel_state, "_EP"):
+            vllm_parallel_state._EP = self.ep
+
+
+def _clone_diffusion_output_for_transport(output: DiffusionOutput) -> DiffusionOutput:
+    """Shallow-copy a ``DiffusionOutput`` so SHM packing can swap tensor fields.
+
+    ``pack_diffusion_output_shm`` REASSIGNS the tensor attributes (``output``,
+    ``trajectory_latents``, ``trajectory_timesteps``, ``trajectory_log_probs``)
+    to SHM-handle dicts. We pack a copy so the worker's original stays intact.
+    ``dataclasses.replace`` carries EVERY field of ``DiffusionOutput`` forward
+    (only the copied instance is later mutated), so this transport path stays
+    field-for-field identical to the pickle path -- and adding a new field to
+    ``DiffusionOutput`` can never silently drop it here. Do NOT switch this back
+    to enumerating a subset of fields.
+    """
+    return replace(output)
+
+
+def _decode_serialized_payload(artifact_value: SerializedArtifactValue, *, unpack_shm: bool = True) -> Any:
+    value = pickle.loads(artifact_value.payload)
+    if unpack_shm and artifact_value.transport == "shm" and isinstance(value, DiffusionOutput):
+        unpack_diffusion_output_shm(value)
+    return value
+
+
+def _serialize_artifact_value(
+    artifact_value: ArtifactValue,
+    *,
+    prefer_shm_output: bool = False,
+) -> SerializedArtifactValue:
+    if (
+        prefer_shm_output
+        and artifact_value.handle.kind == ArtifactKind.OUTPUT
+        and isinstance(artifact_value.value, DiffusionOutput)
+    ):
+        try:
+            output_for_transport = _clone_diffusion_output_for_transport(artifact_value.value)
+            pack_diffusion_output_shm(output_for_transport)
+            if diffusion_output_has_shm_handles(output_for_transport):
+                payload = pickle.dumps(output_for_transport, protocol=pickle.HIGHEST_PROTOCOL)
+                return SerializedArtifactValue(
+                    handle=artifact_value.handle,
+                    payload=payload,
+                    transport="shm",
+                    payload_nbytes=len(payload),
+                )
+        except Exception as exc:
+            try:
+                unpack_diffusion_output_shm(output_for_transport)
+            except Exception:
+                pass
+            logger.warning(
+                "runtime_v2 fetch_artifacts shm serialize fallback to pickle: request_id=%s artifact_id=%s error=%s",
+                artifact_value.handle.request_id,
+                artifact_value.handle.artifact_id,
+                exc,
+            )
+
+    payload = pickle.dumps(artifact_value.value, protocol=pickle.HIGHEST_PROTOCOL)
+    return SerializedArtifactValue(
+        handle=artifact_value.handle,
+        payload=payload,
+        transport="pickle",
+        payload_nbytes=len(payload),
+    )
+
+
+def _deserialize_artifact_value(
+    artifact_value: SerializedArtifactValue,
+    *,
+    unpack_shm: bool = True,
+) -> ArtifactValue:
+    return ArtifactValue(
+        handle=artifact_value.handle,
+        value=_decode_serialized_payload(artifact_value, unpack_shm=unpack_shm),
+    )
+
+
+def _discard_artifacts_shm(artifacts: Iterable[SerializedArtifactValue | ArtifactValue]) -> None:
+    """Unlink any POSIX-SHM segment backing artifacts that are being dropped.
+
+    A dropped artifact (a stale/late fetch result, or the ones already packed
+    when a later artifact in the same fetch turns out missing) is never relayed
+    downstream, so its packed handles would otherwise leak until worker exit.
+    Deserializing with ``unpack_shm=True`` reads + unlinks the segment; the
+    reconstructed value is discarded. Best-effort per artifact (a segment may
+    already be gone).
+    """
+    for artifact in artifacts:
+        if isinstance(artifact, SerializedArtifactValue) and artifact.transport == "shm":
+            with contextlib.suppress(Exception):
+                _deserialize_artifact_value(artifact, unpack_shm=True)
+
+
+def _clone_runtime_worker_config(od_config: OmniDiffusionConfig) -> OmniDiffusionConfig:
+    worker_config = copy.deepcopy(od_config)
+    worker_config.enable_runtime_v2 = False
+    return worker_config
+
+
+class _WorkerProcessRuntime:
+    """Single worker subprocess: boots a DiffusionWorker, builds executors, and
+    runs the command loop (dispatch / fetch / evict / shutdown)."""
+
+    def __init__(
+        self,
+        *,
+        worker_rank: int,
+        device_id: int | None,
+        od_config: OmniDiffusionConfig,
+        parallel_spec: ParallelSpec,
+        dist_rank: int | None = None,
+        local_rank: int | None = None,
+        world_size: int | None = None,
+        master_port: int | None = None,
+        group_id: str = "g0",
+        command_pipe_r: Connection,
+        event_pipe_w: Connection,
+        result_pipe_w: Connection,
+    ) -> None:
+        self.worker_rank = worker_rank
+        self.device_id = device_id
+        self.od_config = od_config
+        self.parallel_spec = parallel_spec
+        self.dist_rank = int(worker_rank if dist_rank is None else dist_rank)
+        self.local_rank = int(self.dist_rank if local_rank is None else local_rank)
+        configured_world_size = getattr(od_config, "num_gpus", None) if world_size is None else world_size
+        configured_master_port = getattr(od_config, "master_port", None) if master_port is None else master_port
+        self.world_size = self._safe_positive_int(configured_world_size, default=1)
+        self.master_port = self._safe_positive_int(configured_master_port, default=30005)
+        self.group_id = group_id
+        self.command_pipe_r = command_pipe_r
+        self.event_pipe_w = event_pipe_w
+        self.result_pipe_w = result_pipe_w
+        # Owns the DiffusionWorker (device + distributed env + model
+        # parallel + model load happen inside its __init__).
+        self._worker: Any | None = None
+        self.executors: dict[Any, WorkerExecutor] = {}
+        self.local_artifacts: dict[tuple[str, str, str], ArtifactValue] = {}
+        # PR1 single-group session: captured after model load and re-activated
+        # before each task so global parallel-state pointers stay correct.
+        self.fixed_session: _FixedParallelSession | None = None
+        self._artifacts_lock = threading.RLock()
+        self._result_pipe_lock = threading.Lock()
+        self._fetch_queue: queue.Queue[FetchArtifactsCommand | None] = queue.Queue()
+        self._fetch_thread: threading.Thread | None = None
+        self._fetch_stop = threading.Event()
+        self._fetch_copy_stream: Any | None = None
+
+    @staticmethod
+    def _safe_positive_int(value: Any, *, default: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        if parsed <= 0:
+            return default
+        return parsed
+
+    @staticmethod
+    def _command_name(command: Any) -> str:
+        if isinstance(command, ShutdownWorkerCommand):
+            return "shutdown"
+        if isinstance(command, ProcessDispatchTaskCommand):
+            return "dispatch_task"
+        if isinstance(command, FetchArtifactsCommand):
+            return "fetch_artifacts"
+        if isinstance(command, EvictRequestCommand):
+            return "evict_request"
+        return type(command).__name__
+
+    @staticmethod
+    def _artifact_key(request_id: str, group_id: str, artifact_id: str) -> tuple[str, str, str]:
+        return (request_id, group_id, artifact_id)
+
+    @staticmethod
+    def _require_task_group_id(task: InferenceTask) -> str:
+        if task.group_id is None:
+            raise ValueError(f"task {task.task_id} has no group_id")
+        return task.group_id
+
+    @staticmethod
+    def _validate_task_parallel_spec(task: InferenceTask, spec: ExecutionGroupSpec) -> None:
+        if (
+            int(task.parallel_spec.tp) != int(spec.parallel_spec.tp)
+            or int(task.parallel_spec.sp) != int(spec.parallel_spec.sp)
+            or int(task.parallel_spec.cfg) != int(spec.parallel_spec.cfg)
+            or bool(task.parallel_spec.cfg_parallel) != bool(spec.parallel_spec.cfg_parallel)
+        ):
+            raise ValueError(
+                f"task {task.task_id} parallel_spec does not match group {spec.group_id!r}: "
+                f"task={task.parallel_spec!r} group={spec.parallel_spec!r}"
+            )
+
+    def _activate_group_session(self) -> None:
+        # Reactivating the fixed single-group session is a cheap global pointer
+        # swap before each task.
+        if self.fixed_session is None:
+            raise RuntimeError("runtime_v2 worker session is not initialized")
+        self.fixed_session.activate()
+
+    def _install_parent_death_signal(self) -> None:
+        """Tie this GPU worker's lifetime to its parent process.
+
+        Without this, if the owning diffusion process exits while the
+        worker is mid-task or mid-collective, the child keeps holding GPU memory
+        (or hangs) until it next returns to ``command_pipe_r.recv()`` and observes
+        the closed pipe. Mirror ``DiffusionWorker.worker_main``: install a SIGTERM
+        handler that exits cleanly (runs ``finally: self._shutdown()``) and arm
+        ``PR_SET_PDEATHSIG`` so the OS delivers SIGTERM the instant the parent
+        dies. Best-effort / Linux-only; runs on the worker subprocess main thread.
+        """
+        from vllm_omni.engine.stage_init_utils import set_death_signal
+
+        def _handler(signum, _frame):
+            raise SystemExit(128 + signum)
+
+        with contextlib.suppress(Exception):
+            signal.signal(signal.SIGTERM, _handler)
+        set_death_signal(signal.SIGTERM)
+
+    def run(self) -> None:
+        self._install_parent_death_signal()
+        try:
+            self._initialize()
+            self._start_fetch_thread()
+            self.event_pipe_w.send(WorkerReadyMessage(worker_rank=self.worker_rank))
+            while True:
+                command = self.command_pipe_r.recv()
+                logger.debug(
+                    "runtime_v2 worker command recv: rank=%s cmd=%s",
+                    self.worker_rank,
+                    self._command_name(command),
+                )
+                if isinstance(command, ShutdownWorkerCommand):
+                    break
+                if isinstance(command, ProcessDispatchTaskCommand):
+                    self._execute_task(command)
+                    continue
+                if isinstance(command, FetchArtifactsCommand):
+                    self._prepare_fetch_copy_stream_dependency(command)
+                    self._fetch_queue.put(command)
+                    continue
+                if isinstance(command, EvictRequestCommand):
+                    self._handle_evict_request(command)
+                    continue
+                raise TypeError(f"unsupported runtime_v2 worker command: {type(command)!r}")
+        except Exception:
+            self.event_pipe_w.send(
+                WorkerReadyMessage(
+                    worker_rank=self.worker_rank,
+                    status="failed",
+                    message=traceback.format_exc(),
+                )
+            )
+            raise
+        finally:
+            self._shutdown()
+
+    def _initialize(self) -> None:
+        worker_config = _clone_runtime_worker_config(self.od_config)
+        # Bootstrap params consumed by DiffusionWorker via od_config.
+        worker_config.num_gpus = int(self.world_size)
+        worker_config.master_port = int(self.master_port)
+
+        # Worker bootstrap: DiffusionWorker.__init__ runs init_device()
+        # (init_distributed_environment + initialize_model_parallel) and
+        # load_model(), so the pipeline is ready right after construction.
+        from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
+
+        self._worker = DiffusionWorker(
+            local_rank=self.local_rank,
+            rank=self.dist_rank,
+            od_config=worker_config,
+        )
+        pipeline = getattr(getattr(self._worker, "model_runner", None), "pipeline", None)
+        if pipeline is None:
+            raise RuntimeError(f"worker {self.worker_rank} failed to initialize diffusion pipeline")
+
+        # Lazy registry import: importing this module must not require the
+        # registry / adapter to exist yet.
+        from vllm_omni.diffusion.runtime_v2.registry import get_runtime_v2_adapter
+
+        adapter = get_runtime_v2_adapter(getattr(self.od_config, "model_class_name", None))
+        adapter.validate_pipeline(pipeline, self.od_config)
+        self.executors = adapter.build_executors(pipeline)
+
+        # PR1 single group: capture the parallel session DiffusionWorker just
+        # initialized as the fixed "g0" session.
+        self.fixed_session = _FixedParallelSession.capture_current(self.parallel_spec)
+        self._activate_group_session()
+
+        if torch.cuda.is_available():
+            self._fetch_copy_stream = torch.cuda.Stream()
+        else:
+            self._fetch_copy_stream = None
+        logger.info(
+            "runtime_v2 multiproc worker initialized: worker_rank=%s group=%s dist_rank=%s world_size=%s "
+            "master_port=%s tp=%s sp=%s cfg=%s",
+            self.worker_rank,
+            self.group_id,
+            self.dist_rank,
+            self.world_size,
+            self.master_port,
+            self.parallel_spec.tp,
+            self.parallel_spec.sp,
+            self.parallel_spec.cfg,
+        )
+
+    def _shutdown(self) -> None:
+        self._stop_fetch_thread()
+        if self._worker is not None:
+            try:
+                self._worker.shutdown()
+            except Exception as exc:
+                logger.warning("runtime_v2 worker shutdown failed: rank=%s error=%s", self.worker_rank, exc)
+
+    def _start_fetch_thread(self) -> None:
+        if self._fetch_thread is not None and self._fetch_thread.is_alive():
+            return
+        self._fetch_stop.clear()
+        self._fetch_thread = threading.Thread(
+            target=self._fetch_loop,
+            name=f"runtime-v2-fetch-worker-{self.worker_rank}",
+            daemon=True,
+        )
+        self._fetch_thread.start()
+
+    def _stop_fetch_thread(self) -> None:
+        self._fetch_stop.set()
+        try:
+            self._fetch_queue.put_nowait(None)
+        except queue.Full:  # pragma: no cover - unbounded queue
+            pass
+        thread = self._fetch_thread
+        if thread is not None:
+            thread.join(timeout=5.0)
+            self._fetch_thread = None
+
+    def _fetch_loop(self) -> None:
+        while not self._fetch_stop.is_set():
+            try:
+                command = self._fetch_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if command is None:
+                return
+            try:
+                self._handle_fetch_artifacts(command)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "runtime_v2 artifact fetch failed: request_id=%s fetch_id=%s",
+                    command.request_id,
+                    command.fetch_id,
+                )
+                self._send_result(
+                    FetchArtifactsResult(
+                        request_id=command.request_id,
+                        worker_rank=self.worker_rank,
+                        error=f"{exc}\n{traceback.format_exc()}",
+                        fetch_id=command.fetch_id,
+                    )
+                )
+
+    def _send_result(self, payload: Any) -> None:
+        with self._result_pipe_lock:
+            self.result_pipe_w.send(payload)
+
+    def _prepare_fetch_copy_stream_dependency(self, command: FetchArtifactsCommand) -> None:
+        if self._fetch_copy_stream is None or not torch.cuda.is_available():
+            return
+        producer_stream = torch.cuda.current_stream()
+        self._fetch_copy_stream.wait_stream(producer_stream)
+
+    def _resolve_inputs(
+        self,
+        task: InferenceTask,
+        inline_inputs: tuple[SerializedArtifactValue, ...],
+    ) -> dict[str, Any]:
+        inline_by_id = {
+            artifact_value.handle.artifact_id: _deserialize_artifact_value(artifact_value)
+            for artifact_value in inline_inputs
+        }
+        resolved_inputs: dict[str, Any] = {}
+        group_id = self._require_task_group_id(task)
+        for artifact in task.inputs:
+            key = self._artifact_key(artifact.request_id, group_id, artifact.artifact_id)
+            with self._artifacts_lock:
+                local_value = self.local_artifacts.get(key)
+            if local_value is not None:
+                resolved_inputs[artifact.artifact_id] = local_value.value
+                continue
+            if artifact.artifact_id in inline_by_id:
+                value = inline_by_id[artifact.artifact_id]
+                with self._artifacts_lock:
+                    self.local_artifacts[key] = value
+                resolved_inputs[artifact.artifact_id] = value.value
+                continue
+            raise KeyError(f"worker {self.worker_rank} cannot resolve input artifact {artifact.artifact_id}")
+        return resolved_inputs
+
+    def _make_event(
+        self,
+        task: InferenceTask,
+        kind: WorkerEventKind,
+        *,
+        message: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkerEvent:
+        return WorkerEvent(
+            event_id=str(uuid.uuid4()),
+            task_id=task.task_id,
+            request_id=task.request_id,
+            group_id=self._require_task_group_id(task),
+            worker_rank=self.worker_rank,
+            kind=kind,
+            timestamp_ns=time.monotonic_ns(),
+            message=message,
+            metadata=metadata or {},
+        )
+
+    def _execute_task(self, command: ProcessDispatchTaskCommand) -> None:
+        if self.fixed_session is None:
+            raise RuntimeError("runtime_v2 worker session is not initialized")
+        if self._worker is None:
+            raise RuntimeError("runtime_v2 worker is not initialized")
+        task = command.task
+        # Local, rank-symmetric setup (group/spec validation, session
+        # activation, executor lookup) is safe to downgrade to a per-task
+        # TASK_FAILED: every rank of the group runs the same task, so a failure
+        # here happens identically on all ranks and none is left waiting on a
+        # peer. This keeps one malformed request from killing the worker process
+        # (the worker-init checks above stay fatal -- a missing session/worker is
+        # not per-task recoverable).
+        try:
+            group_id = self._require_task_group_id(task)
+            group_spec = command.group_spec
+            if group_spec is not None:
+                self._validate_task_parallel_spec(task, group_spec)
+            self._activate_group_session()
+            executor = self.executors.get(task.kind)
+            if executor is None:
+                self.event_pipe_w.send(
+                    self._make_event(
+                        task,
+                        WorkerEventKind.TASK_FAILED,
+                        message=f"worker does not support task kind {task.kind}",
+                    )
+                )
+                return
+        except Exception as exc:
+            self.event_pipe_w.send(
+                self._make_event(
+                    task,
+                    WorkerEventKind.TASK_FAILED,
+                    message=f"task setup failed: {exc}\n{traceback.format_exc()}",
+                )
+            )
+            return
+
+        # Input artifacts are rank-symmetric for the fixed execution group.
+        resolved_inputs = self._resolve_inputs(task, command.inline_inputs)
+        self.event_pipe_w.send(self._make_event(task, WorkerEventKind.TASK_EXEC_BEGIN))
+        try:
+            worker = self._worker
+            use_hsdp = bool(
+                getattr(getattr(worker, "od_config", self.od_config), "parallel_config", None) is not None
+                and getattr(getattr(worker, "od_config", self.od_config).parallel_config, "use_hsdp", False)
+            )
+            grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
+            with set_forward_context(
+                vllm_config=getattr(worker, "vllm_config", None),
+                omni_diffusion_config=getattr(worker, "od_config", self.od_config),
+            ):
+                with grad_context:
+                    outputs = executor.execute(task, resolved_inputs)
+            published_outputs: list[WorkerLocalArtifactRef] = []
+            with self._artifacts_lock:
+                for artifact_value in outputs:
+                    key = self._artifact_key(
+                        artifact_value.handle.request_id,
+                        group_id,
+                        artifact_value.handle.artifact_id,
+                    )
+                    self.local_artifacts[key] = artifact_value
+                    if self.worker_rank == command.result_owner_rank:
+                        published_outputs.append(
+                            WorkerLocalArtifactRef(
+                                handle=artifact_value.handle,
+                                group_id=group_id,
+                                worker_rank=self.worker_rank,
+                            )
+                        )
+            self.event_pipe_w.send(
+                self._make_event(
+                    task,
+                    WorkerEventKind.TASK_LAUNCH_END,
+                    metadata={"published_outputs": tuple(published_outputs)},
+                )
+            )
+            with self._artifacts_lock:
+                for artifact_id in command.release_after_exec_artifact_ids:
+                    self.local_artifacts.pop(self._artifact_key(task.request_id, group_id, artifact_id), None)
+            self.event_pipe_w.send(self._make_event(task, WorkerEventKind.TASK_EXEC_END))
+        except Exception as exc:
+            self.event_pipe_w.send(
+                self._make_event(
+                    task,
+                    WorkerEventKind.TASK_FAILED,
+                    message=f"{exc}\n{traceback.format_exc()}",
+                )
+            )
+
+    def _handle_fetch_artifacts(self, command: FetchArtifactsCommand) -> None:
+        # Fetch runs on a background thread. It must not mutate the process-wide
+        # runtime_v2 parallel session while the main worker thread may be inside
+        # model execution.
+        artifacts: list[SerializedArtifactValue] = []
+        stream_context = (
+            torch.cuda.stream(self._fetch_copy_stream)
+            if self._fetch_copy_stream is not None
+            else contextlib.nullcontext()
+        )
+        with stream_context:
+            for artifact_id in command.artifact_ids:
+                key = self._artifact_key(command.request_id, command.group_id, artifact_id)
+                with self._artifacts_lock:
+                    value = self.local_artifacts.get(key)
+                if value is None:
+                    # Unlink any SHM segment already packed for an EARLIER
+                    # artifact in this same fetch: the error result below carries
+                    # no artifacts, so nothing downstream reclaims them and they
+                    # would leak until worker exit. (Latent in PR1, which fetches
+                    # a single artifact, but the loop is written for N.)
+                    _discard_artifacts_shm(artifacts)
+                    self._send_result(
+                        FetchArtifactsResult(
+                            fetch_id=command.fetch_id,
+                            request_id=command.request_id,
+                            worker_rank=self.worker_rank,
+                            error=(
+                                "artifact not found: "
+                                f"request_id={command.request_id}, group_id={command.group_id}, "
+                                f"artifact_id={artifact_id}"
+                            ),
+                        )
+                    )
+                    return
+                serialized = _serialize_artifact_value(value, prefer_shm_output=True)
+                artifacts.append(serialized)
+        self._send_result(
+            FetchArtifactsResult(
+                fetch_id=command.fetch_id,
+                request_id=command.request_id,
+                worker_rank=self.worker_rank,
+                artifacts=tuple(artifacts),
+            )
+        )
+
+    def _handle_evict_request(self, command: EvictRequestCommand) -> None:
+        with self._artifacts_lock:
+            keys = [key for key in self.local_artifacts if key[0] == command.request_id]
+            for key in keys:
+                self.local_artifacts.pop(key, None)
+
+
+def _worker_process_entrypoint(
+    *,
+    worker_rank: int,
+    device_id: int | None,
+    od_config: OmniDiffusionConfig,
+    parallel_spec: ParallelSpec,
+    dist_rank: int | None,
+    local_rank: int | None,
+    world_size: int | None,
+    master_port: int | None,
+    group_id: str,
+    command_pipe_r: Connection,
+    event_pipe_w: Connection,
+    result_pipe_w: Connection,
+) -> None:
+    runtime = _WorkerProcessRuntime(
+        worker_rank=worker_rank,
+        device_id=device_id,
+        od_config=od_config,
+        parallel_spec=parallel_spec,
+        dist_rank=dist_rank,
+        local_rank=local_rank,
+        world_size=world_size,
+        master_port=master_port,
+        group_id=group_id,
+        command_pipe_r=command_pipe_r,
+        event_pipe_w=event_pipe_w,
+        result_pipe_w=result_pipe_w,
+    )
+    runtime.run()
+
+
+@dataclass(frozen=True)
+class WorkerProcessHandle:
+    process: mp.Process
+    worker_rank: int
+    command_pipe_w: Connection
+    event_pipe_r: Connection
+    result_pipe_r: Connection
+
+
+@dataclass
+class _TaskDispatchState:
+    group_id: str
+    expected_ranks: frozenset[int]
+    result_owner_rank: int
+    events_by_kind: dict[WorkerEventKind, dict[int, WorkerEvent]] = field(default_factory=dict)
+
+
+class MultiprocWorkerPool:
+    """Centralized multiprocess worker pool for diffusion runtime_v2."""
+
+    def __init__(
+        self,
+        topology: RuntimeTopology,
+        od_config: OmniDiffusionConfig,
+    ) -> None:
+        self.topology = topology
+        self.od_config = od_config
+        self._mp_ctx = mp.get_context("spawn")
+        self.worker_handles: dict[int, WorkerProcessHandle] = {}
+        self._event_queue: queue.Queue[WorkerEvent | WorkerReadyMessage] = queue.Queue()
+        # Result-channel demux: the reader thread is the single producer but
+        # there can be multiple consumers (fetch drain from the API thread).
+        # Split into per-rank queues so each consumer only sees its own rank.
+        self._result_queues: dict[int, queue.Queue[Any]] = {}
+        self._task_dispatch_state: dict[str, _TaskDispatchState] = {}
+        self._state_lock = threading.RLock()
+        self._reader_stop = threading.Event()
+        self._reader_error: BaseException | None = None
+        self._reader_thread: threading.Thread | None = None
+        self._fetch_lock = threading.RLock()
+        self._inflight_fetches: dict[str, int] = {}
+        self._completed_fetches: dict[str, FetchArtifactsResult] = {}
+
+    def start(self, timeout_s: float = 600.0) -> None:
+        if self.worker_handles:
+            raise RuntimeError("runtime_v2 worker pool is already started")
+        # Shared-world mode: all workers join one global torch.distributed world.
+        global_world_size = len(self.topology.workers)
+        shared_master_port = int(getattr(self.od_config, "master_port", 30005) or 30005)
+        for worker in self.topology.workers:
+            group = max(
+                self.topology.get_groups_for_worker(worker.worker_rank),
+                key=lambda candidate: (
+                    int(candidate.parallel_spec.sp),
+                    int(candidate.parallel_spec.tp),
+                    len(candidate.ranks),
+                ),
+            )
+            group_world_size = len(group.ranks)
+            dist_rank = worker.worker_rank
+            local_rank = int(worker.device_id if worker.device_id is not None else worker.worker_rank)
+            worker_od_config = self._build_worker_od_config(
+                group_spec=group,
+                group_world_size=group_world_size,
+                global_world_size=global_world_size,
+                shared_master_port=shared_master_port,
+            )
+            command_pipe_r, command_pipe_w = self._mp_ctx.Pipe(duplex=False)
+            event_pipe_r, event_pipe_w = self._mp_ctx.Pipe(duplex=False)
+            result_pipe_r, result_pipe_w = self._mp_ctx.Pipe(duplex=False)
+            process = self._mp_ctx.Process(
+                target=_worker_process_entrypoint,
+                kwargs={
+                    "worker_rank": worker.worker_rank,
+                    "device_id": worker.device_id,
+                    "od_config": worker_od_config,
+                    "parallel_spec": group.parallel_spec,
+                    "dist_rank": dist_rank,
+                    "local_rank": local_rank,
+                    "world_size": global_world_size,
+                    "master_port": shared_master_port,
+                    "group_id": group.group_id,
+                    "command_pipe_r": command_pipe_r,
+                    "event_pipe_w": event_pipe_w,
+                    "result_pipe_w": result_pipe_w,
+                },
+                name=f"runtime-v2-worker-{worker.worker_rank}",
+                daemon=True,
+            )
+            process.start()
+            command_pipe_r.close()
+            event_pipe_w.close()
+            result_pipe_w.close()
+            self.worker_handles[worker.worker_rank] = WorkerProcessHandle(
+                process=process,
+                worker_rank=worker.worker_rank,
+                command_pipe_w=command_pipe_w,
+                event_pipe_r=event_pipe_r,
+                result_pipe_r=result_pipe_r,
+            )
+            self._result_queues[worker.worker_rank] = queue.Queue()
+
+        ready_workers: set[int] = set()
+        deadline = time.monotonic() + timeout_s
+        while len(ready_workers) < len(self.worker_handles):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                dead = {
+                    rank: handle.process.exitcode
+                    for rank, handle in self.worker_handles.items()
+                    if not handle.process.is_alive()
+                }
+                self.shutdown()
+                raise TimeoutError(f"timed out waiting for runtime_v2 workers to start; dead={dead}")
+            ready = wait([handle.event_pipe_r for handle in self.worker_handles.values()], timeout=min(0.1, remaining))
+            for reader in ready:
+                try:
+                    event = reader.recv()
+                except EOFError:
+                    # A worker died during startup (OOM / segfault): its event
+                    # pipe closed, so wait() flags it readable and recv() raises.
+                    # Tear the whole pool down -- surviving ranks are stuck in the
+                    # shared-world rendezvous -- instead of letting EOFError escape
+                    # uncaught and orphan them (RuntimeV2Runner.__init__ would then
+                    # unwind with _runner=None, so close() could not reach them).
+                    self.shutdown()
+                    raise RuntimeError("runtime_v2 worker died during startup before signaling ready")
+                if isinstance(event, WorkerReadyMessage):
+                    if event.status != "ready":
+                        self.shutdown()
+                        raise RuntimeError(f"runtime_v2 worker {event.worker_rank} failed to start: {event.message}")
+                    ready_workers.add(event.worker_rank)
+                else:
+                    self._enqueue_event(event)
+        self._reader_stop.clear()
+        self._reader_error = None
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name="runtime-v2-multiproc-forwarder",
+            daemon=True,
+        )
+        self._reader_thread.start()
+        logger.info("runtime_v2 multiproc worker pool started: workers=%s", sorted(self.worker_handles))
+
+    def _build_worker_od_config(
+        self,
+        *,
+        group_spec: ExecutionGroupSpec,
+        group_world_size: int,
+        global_world_size: int,
+        shared_master_port: int,
+    ) -> OmniDiffusionConfig:
+        parallel_spec = group_spec.parallel_spec
+        worker_config = _clone_runtime_worker_config(od_config=self.od_config)
+        base_parallel = worker_config.parallel_config
+        # Keep per-group parallel semantics for execution while still joining a
+        # shared global world. This config is consumed by DiffusionWorker.
+        worker_config.parallel_config = DiffusionParallelConfig(
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            tensor_parallel_size=int(parallel_spec.tp),
+            enable_expert_parallel=bool(getattr(base_parallel, "enable_expert_parallel", False)),
+            sequence_parallel_size=int(parallel_spec.sp),
+            ulysses_degree=int(group_spec.ulysses_degree),
+            ring_degree=int(group_spec.ring_degree),
+            cfg_parallel_size=int(parallel_spec.cfg),
+            vae_patch_parallel_size=int(getattr(base_parallel, "vae_patch_parallel_size", 1)),
+            use_hsdp=False,
+            hsdp_shard_size=-1,
+            hsdp_replicate_size=1,
+        )
+        expected_world_size = int(worker_config.parallel_config.world_size)
+        if expected_world_size != int(group_world_size):
+            raise ValueError(
+                f"invalid runtime_v2 group parallel spec: tp*sp*cfg={expected_world_size} "
+                f"!= group_world_size={group_world_size}"
+            )
+        # Distributed bootstrap params are global in shared-world mode.
+        worker_config.num_gpus = int(global_world_size)
+        worker_config.master_port = int(shared_master_port)
+        return worker_config
+
+    def shutdown(self) -> None:
+        self._reader_stop.set()
+        for handle in self.worker_handles.values():
+            try:
+                handle.command_pipe_w.send(ShutdownWorkerCommand())
+            except Exception:
+                pass
+        reader_thread = self._reader_thread
+        if reader_thread is not None:
+            reader_thread.join(timeout=1.0)
+        for handle in self.worker_handles.values():
+            try:
+                handle.process.join(timeout=5.0)
+            except Exception:
+                pass
+            if handle.process.is_alive():
+                handle.process.terminate()
+                handle.process.join(timeout=5.0)
+                if handle.process.is_alive():
+                    # SIGTERM can't be serviced by a worker wedged in a C-level
+                    # collective (e.g. NCCL); SIGKILL it so it can't linger
+                    # holding GPU memory after the pool reports stopped.
+                    handle.process.kill()
+                    handle.process.join(timeout=5.0)
+        if reader_thread is not None and reader_thread.is_alive():
+            reader_thread.join(timeout=1.0)
+        self._reader_thread = None
+        # The reader stops before worker shutdown so it cannot race cleanup.
+        # A worker fetch thread may still have written a final SHM-backed result
+        # directly to its pipe in that window; drain those raw pipes after the
+        # processes exit and before dropping the handles.
+        stranded_in_pipes: list[FetchArtifactsResult] = []
+        for handle in self.worker_handles.values():
+            try:
+                while handle.result_pipe_r.poll():
+                    payload = handle.result_pipe_r.recv()
+                    if isinstance(payload, FetchArtifactsResult):
+                        stranded_in_pipes.append(payload)
+            except Exception:
+                pass
+        self.worker_handles.clear()
+        with self._state_lock:
+            self._task_dispatch_state.clear()
+        # Drain any results the reader received but no poll ever retrieved (e.g.
+        # the last request was aborted, so its rank is never polled again) before
+        # clearing. The reader thread was joined above, so there are no concurrent
+        # puts. These are reclaimed alongside _completed_fetches below.
+        stranded_in_queues: list[FetchArtifactsResult] = []
+        for result_queue in self._result_queues.values():
+            while True:
+                try:
+                    payload = result_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if isinstance(payload, FetchArtifactsResult):
+                    stranded_in_queues.append(payload)
+        self._result_queues.clear()
+        with self._fetch_lock:
+            self._inflight_fetches.clear()
+            stranded = list(self._completed_fetches.values())
+            self._completed_fetches.clear()
+        # Reclaim packed POSIX-SHM from any completed/queued-but-never-drained
+        # results: the segments were created by the workers and outlive them, so
+        # unlink here rather than leak /dev/shm.
+        for result in (*stranded_in_pipes, *stranded_in_queues, *stranded):
+            self._discard_fetch_result_shm(result)
+        logger.info("runtime_v2 multiproc worker pool stopped")
+
+    def dispatch(
+        self,
+        task: InferenceTask,
+        inline_inputs: tuple[ArtifactValue, ...],
+        release_after_exec_artifact_ids: tuple[str, ...] = (),
+    ) -> None:
+        if task.group_id is None:
+            raise ValueError("task must have an assigned group before dispatch")
+        group = self.topology.get_group(task.group_id)
+        with self._state_lock:
+            self._register_task_dispatch(task)
+        command = ProcessDispatchTaskCommand(
+            task=task,
+            inline_inputs=tuple(_serialize_artifact_value(artifact_value) for artifact_value in inline_inputs),
+            result_owner_rank=self.topology.get_group_leader(task.group_id),
+            release_after_exec_artifact_ids=release_after_exec_artifact_ids,
+            group_spec=group,
+        )
+        for worker_rank in group.ranks:
+            self.worker_handles[worker_rank].command_pipe_w.send(command)
+
+    def poll(self, timeout_s: float = 0.0) -> list[WorkerEvent | WorkerReadyMessage]:
+        self._raise_reader_error()
+        events: list[WorkerEvent | WorkerReadyMessage] = []
+        try:
+            if timeout_s > 0:
+                first = self._event_queue.get(timeout=timeout_s)
+            else:
+                first = self._event_queue.get_nowait()
+        except queue.Empty:
+            self._raise_reader_error()
+            return events
+
+        events.append(first)
+        while True:
+            try:
+                events.append(self._event_queue.get_nowait())
+            except queue.Empty:
+                self._raise_reader_error()
+                return events
+
+    def fetch_artifacts(self, request_id: str, group_id: str, artifact_ids: tuple[str, ...]) -> FetchArtifactsResult:
+        fetch_id = self.start_fetch_artifacts(request_id=request_id, group_id=group_id, artifact_ids=artifact_ids)
+        deadline = time.monotonic() + 30.0
+        while True:
+            result = self.poll_fetch_artifacts(fetch_id)
+            if result is not None:
+                return self._normalize_fetch_result(result)
+            if time.monotonic() >= deadline:
+                self.discard_fetch(fetch_id)
+                raise TimeoutError(f"timed out waiting for FetchArtifactsResult fetch_id={fetch_id}")
+            time.sleep(0.001)
+
+    def start_fetch_artifacts(self, request_id: str, group_id: str, artifact_ids: tuple[str, ...]) -> str:
+        leader_rank = self.topology.get_group_leader(group_id)
+        handle = self.worker_handles[leader_rank]
+        fetch_id = str(uuid.uuid4())
+        with self._fetch_lock:
+            self._inflight_fetches[fetch_id] = leader_rank
+        handle.command_pipe_w.send(
+            FetchArtifactsCommand(
+                fetch_id=fetch_id,
+                request_id=request_id,
+                group_id=group_id,
+                artifact_ids=artifact_ids,
+            )
+        )
+        return fetch_id
+
+    def poll_fetch_artifacts(self, fetch_id: str) -> FetchArtifactsResult | None:
+        with self._fetch_lock:
+            completed = self._completed_fetches.pop(fetch_id, None)
+            if completed is not None:
+                self._inflight_fetches.pop(fetch_id, None)
+                return self._normalize_fetch_result(completed)
+            leader_rank = self._inflight_fetches.get(fetch_id)
+            if leader_rank is None:
+                return None
+
+        self._drain_fetch_results_for_rank(leader_rank)
+        with self._fetch_lock:
+            completed = self._completed_fetches.pop(fetch_id, None)
+            if completed is None:
+                return None
+            self._inflight_fetches.pop(fetch_id, None)
+            return self._normalize_fetch_result(completed)
+
+    def discard_fetch(self, fetch_id: str) -> None:
+        with self._fetch_lock:
+            leader_rank = self._inflight_fetches.pop(fetch_id, None)
+            completed = self._completed_fetches.pop(fetch_id, None)
+        # A discarded fetch (abort/cleanup) never reaches the downstream unpack
+        # site, so its terminal output's packed POSIX-SHM segment would leak until
+        # worker exit. (1) Unlink an already-completed result popped above.
+        if completed is not None:
+            self._discard_fetch_result_shm(completed)
+        # (2) The worker may have the result already queued in the pipe. Drain the
+        # leader rank now: the fetch is untracked, so the reader routes it to
+        # _discard_fetch_result_shm (is_tracked=False) instead of stranding it. A
+        # result the worker sends LATER is reclaimed by the next poll on this rank
+        # or by shutdown cleanup. SHM I/O is done outside the fetch lock.
+        if leader_rank is not None:
+            with contextlib.suppress(Exception):
+                self._drain_fetch_results_for_rank(leader_rank)
+
+    def _drain_fetch_results_for_rank(self, leader_rank: int) -> None:
+        result_queue = self._result_queues.get(leader_rank)
+        if result_queue is None:
+            return
+        while True:
+            try:
+                payload = result_queue.get_nowait()
+            except queue.Empty:
+                return
+            if not isinstance(payload, FetchArtifactsResult):
+                raise RuntimeError(
+                    f"unexpected result type from worker {leader_rank}: expected FetchArtifactsResult, "
+                    f"got {type(payload).__name__}"
+                )
+            fetch_id = payload.fetch_id
+            if not fetch_id:
+                raise RuntimeError(f"received fetch result without fetch_id from worker {leader_rank}")
+            with self._fetch_lock:
+                is_tracked = fetch_id in self._inflight_fetches or fetch_id in self._completed_fetches
+                if is_tracked:
+                    self._completed_fetches[fetch_id] = payload
+            if not is_tracked:
+                # The request was aborted/cleaned up between start_fetch_artifacts
+                # and now, so this result is never drained downstream. Its
+                # artifacts may be SerializedArtifactValue(transport="shm"): the
+                # normal path keeps them packed and unlinks the POSIX-SHM segment
+                # LATER at the final postprocess site, so simply dropping the
+                # payload would leak the segment until worker exit. Unlink here
+                # (outside the fetch lock -- SHM I/O must not block dispatch).
+                self._discard_fetch_result_shm(payload)
+                logger.debug(
+                    "runtime_v2 drop stale fetch result: fetch_id=%s leader_rank=%s",
+                    fetch_id,
+                    leader_rank,
+                )
+
+    @staticmethod
+    def _discard_fetch_result_shm(result: FetchArtifactsResult) -> None:
+        """Unlink any POSIX-SHM segment backing a dropped (stale) fetch result."""
+        _discard_artifacts_shm(result.artifacts)
+
+    @staticmethod
+    def _normalize_fetch_result(result: FetchArtifactsResult) -> FetchArtifactsResult:
+        artifacts: list[ArtifactValue] = []
+        for artifact in result.artifacts:
+            if isinstance(artifact, ArtifactValue):
+                artifacts.append(artifact)
+            else:
+                # Keep SHM handles packed through scheduler/control path; unpack
+                # at the final postprocess site to avoid extra host copies.
+                artifacts.append(_deserialize_artifact_value(artifact, unpack_shm=False))
+        return FetchArtifactsResult(
+            fetch_id=result.fetch_id,
+            request_id=result.request_id,
+            worker_rank=result.worker_rank,
+            artifacts=tuple(artifacts),
+            error=result.error,
+        )
+
+    def evict_request(self, request_id: str) -> None:
+        command = EvictRequestCommand(request_id=request_id)
+        for handle in self.worker_handles.values():
+            handle.command_pipe_w.send(command)
+
+    def check_health(self) -> None:
+        self._raise_reader_error()
+        for handle in self.worker_handles.values():
+            if not handle.process.is_alive():
+                raise RuntimeError(
+                    f"runtime_v2 worker {handle.worker_rank} died unexpectedly with exit code {handle.process.exitcode}"
+                )
+
+    def _raise_reader_error(self) -> None:
+        if self._reader_error is not None:
+            raise RuntimeError("runtime_v2 multiproc pipe forwarder failed") from self._reader_error
+
+    def _reader_loop(self) -> None:
+        try:
+            while not self._reader_stop.is_set():
+                readers = [handle.event_pipe_r for handle in self.worker_handles.values()] + [
+                    handle.result_pipe_r for handle in self.worker_handles.values()
+                ]
+                if not readers:
+                    return
+                ready = wait(readers, timeout=0.1)
+                if not ready:
+                    continue
+                for reader in ready:
+                    worker_rank = self._find_reader_owner_rank(reader)
+                    if worker_rank is None:
+                        continue
+                    handle = self.worker_handles.get(worker_rank)
+                    if handle is None:
+                        continue
+                    try:
+                        payload = reader.recv()
+                    except EOFError as exc:
+                        if self._reader_stop.is_set():
+                            return
+                        self._reader_error = exc
+                        return
+                    if reader is handle.event_pipe_r:
+                        self._enqueue_event(payload)
+                    else:
+                        self._result_queues[worker_rank].put(payload)
+        except BaseException as exc:  # pragma: no cover - defensive path
+            self._reader_error = exc
+            logger.exception("runtime_v2 multiproc pipe forwarder failed")
+
+    def _find_reader_owner_rank(self, reader: Connection) -> int | None:
+        for worker_rank, handle in self.worker_handles.items():
+            if reader is handle.event_pipe_r or reader is handle.result_pipe_r:
+                return worker_rank
+        return None
+
+    def _register_task_dispatch(self, task: InferenceTask) -> None:
+        if task.group_id is None:
+            raise ValueError("task must have an assigned group before registration")
+        group = self.topology.get_group(task.group_id)
+        self._task_dispatch_state[task.task_id] = _TaskDispatchState(
+            group_id=task.group_id,
+            expected_ranks=frozenset(group.ranks),
+            result_owner_rank=self.topology.get_group_leader(task.group_id),
+        )
+
+    def _consume_event(self, event: WorkerEvent | WorkerReadyMessage) -> list[WorkerEvent | WorkerReadyMessage]:
+        if not isinstance(event, WorkerEvent):
+            return [event]
+        if event.kind in (
+            WorkerEventKind.TASK_LAUNCH_END,
+            WorkerEventKind.TASK_EXEC_BEGIN,
+            WorkerEventKind.TASK_EXEC_END,
+            WorkerEventKind.TASK_FAILED,
+        ):
+            with self._state_lock:
+                return self._aggregate_task_event(event)
+        return [event]
+
+    def _enqueue_event(self, event: WorkerEvent | WorkerReadyMessage) -> None:
+        for aggregated_event in self._consume_event(event):
+            if isinstance(aggregated_event, WorkerEvent):
+                logger.debug(
+                    "runtime_v2 event enqueued: request_id=%s task_id=%s kind=%s group=%s worker_rank=%s metadata=%s",
+                    aggregated_event.request_id,
+                    aggregated_event.task_id,
+                    aggregated_event.kind,
+                    aggregated_event.group_id,
+                    aggregated_event.worker_rank,
+                    dict(aggregated_event.metadata),
+                )
+            self._event_queue.put(aggregated_event)
+
+    def _aggregate_task_event(self, event: WorkerEvent) -> list[WorkerEvent]:
+        state = self._task_dispatch_state.get(event.task_id)
+        if state is None:
+            return []
+
+        if event.kind == WorkerEventKind.TASK_FAILED:
+            self._task_dispatch_state.pop(event.task_id, None)
+            return [
+                WorkerEvent(
+                    event_id=f"aggregate:{event.task_id}:{event.kind.value}",
+                    task_id=event.task_id,
+                    request_id=event.request_id,
+                    group_id=state.group_id,
+                    worker_rank=event.worker_rank,
+                    kind=event.kind,
+                    timestamp_ns=event.timestamp_ns,
+                    message=event.message,
+                    metadata={"failed_rank": event.worker_rank},
+                )
+            ]
+
+        seen_by_rank = state.events_by_kind.setdefault(event.kind, {})
+        if event.worker_rank in seen_by_rank:
+            return []
+        seen_by_rank[event.worker_rank] = event
+        if frozenset(seen_by_rank) != state.expected_ranks:
+            logger.debug(
+                "runtime_v2 event pending aggregation: request_id=%s task_id=%s "
+                "kind=%s seen_ranks=%s expected_ranks=%s",
+                event.request_id,
+                event.task_id,
+                event.kind,
+                tuple(sorted(seen_by_rank)),
+                tuple(sorted(state.expected_ranks)),
+            )
+            return []
+
+        aggregated_event = self._build_aggregated_event(
+            state=state,
+            kind=event.kind,
+            events_by_rank=seen_by_rank,
+        )
+        logger.debug(
+            "runtime_v2 event aggregated: request_id=%s task_id=%s kind=%s ranks=%s metadata=%s",
+            aggregated_event.request_id,
+            aggregated_event.task_id,
+            aggregated_event.kind,
+            tuple(sorted(seen_by_rank)),
+            dict(aggregated_event.metadata),
+        )
+        if event.kind == WorkerEventKind.TASK_EXEC_END:
+            self._task_dispatch_state.pop(event.task_id, None)
+        return [aggregated_event]
+
+    def _build_aggregated_event(
+        self,
+        *,
+        state: _TaskDispatchState,
+        kind: WorkerEventKind,
+        events_by_rank: dict[int, WorkerEvent],
+    ) -> WorkerEvent:
+        owner_event = events_by_rank.get(state.result_owner_rank)
+        representative = owner_event or min(
+            events_by_rank.values(),
+            key=lambda event: (event.timestamp_ns, event.worker_rank),
+        )
+        metadata = dict(owner_event.metadata) if owner_event is not None else dict(representative.metadata)
+        metadata["completed_ranks"] = tuple(sorted(events_by_rank))
+        return WorkerEvent(
+            event_id=f"aggregate:{representative.task_id}:{kind.value}",
+            task_id=representative.task_id,
+            request_id=representative.request_id,
+            group_id=state.group_id,
+            worker_rank=state.result_owner_rank,
+            kind=kind,
+            timestamp_ns=max(event.timestamp_ns for event in events_by_rank.values()),
+            message=representative.message,
+            metadata=metadata,
+        )

--- a/vllm_omni/diffusion/runtime_v2/policies/__init__.py
+++ b/vllm_omni/diffusion/runtime_v2/policies/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm_omni.diffusion.runtime_v2.policies.fcfs import FCFSSchedulerPolicy
+
+__all__ = ["FCFSSchedulerPolicy"]

--- a/vllm_omni/diffusion/runtime_v2/policies/fcfs.py
+++ b/vllm_omni/diffusion/runtime_v2/policies/fcfs.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.runtime_v2.interfaces import SchedulerPolicy
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    InferenceTask,
+    RequestExecutionPlan,
+    TaskStatus,
+    WorkerEvent,
+    WorkerEventKind,
+)
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+logger = init_logger(__name__)
+
+
+class FCFSSchedulerPolicy(SchedulerPolicy):
+    """First-come-first-served admission with one active request per execution group.
+
+    PR1 is single-group: a request is bound to the one group that supports every
+    task kind in its plan, and only one request per group runs at a time; the rest
+    queue in arrival order. (Cost-model / multi-group scheduling is deferred.)
+    """
+
+    def __init__(self, topology: RuntimeTopology) -> None:
+        self.topology = topology
+        self.ready_queue: deque[InferenceTask] = deque()
+        self.active_request_by_group: dict[str, str] = {}
+        self.pending_requests_by_group: dict[str, deque[str]] = {}
+        self.blocked_tasks_by_request: dict[str, list[InferenceTask]] = {}
+        self.request_group: dict[str, str] = {}
+
+    def on_request_submitted(self, plan: RequestExecutionPlan) -> Iterable[InferenceTask]:
+        # Bind once at ingress so all downstream tasks inherit the same group_id
+        # and execution never crosses groups.
+        self._bind_request_group(plan)
+        root_tasks = [task for task in plan.tasks.values() if not task.dependencies]
+        return self.on_tasks_runnable(root_tasks)
+
+    def on_tasks_runnable(self, tasks: Iterable[InferenceTask]) -> Iterable[InferenceTask]:
+        for task in tasks:
+            if task.group_id is None:
+                task.group_id = self.request_group.get(task.request_id)
+            if task.group_id is None:
+                raise ValueError(f"request {task.request_id} has runnable task without bound group_id: {task.task_id}")
+            group_id = task.group_id
+            self.request_group.setdefault(task.request_id, group_id)
+
+            active_request = self.active_request_by_group.get(group_id)
+            if active_request is None:
+                self.active_request_by_group[group_id] = task.request_id
+                active_request = task.request_id
+
+            if active_request == task.request_id:
+                task.status = TaskStatus.READY
+                self.ready_queue.append(task)
+                continue
+
+            # Group is busy with another request -> park this one in arrival order.
+            queue_for_group = self.pending_requests_by_group.setdefault(group_id, deque())
+            if task.request_id not in queue_for_group:
+                queue_for_group.append(task.request_id)
+            self.blocked_tasks_by_request.setdefault(task.request_id, []).append(task)
+
+        return self._take_dispatchable_tasks()
+
+    def on_worker_event(self, event: WorkerEvent) -> Iterable[InferenceTask]:
+        if event.kind in (WorkerEventKind.REQUEST_FINISHED, WorkerEventKind.REQUEST_FAILED):
+            request_id = event.request_id
+            # Fall back to the bound group if the event omits group_id, so the
+            # active slot is always released and queued requests are promoted.
+            group_id = event.group_id or self.request_group.get(request_id)
+            was_active = self.active_request_by_group.get(group_id) == request_id
+            if was_active:
+                del self.active_request_by_group[group_id]
+            else:
+                # A queued (non-active) request terminated -- e.g. it was aborted
+                # while parked behind the running request. Remove it from the
+                # pending queue WITHOUT promoting: promoting here would overwrite
+                # the active slot with this now-dead request while the real active
+                # request is still running.
+                queue_for_group = self.pending_requests_by_group.get(group_id)
+                if queue_for_group is not None:
+                    try:
+                        queue_for_group.remove(request_id)
+                    except ValueError:
+                        pass
+                    if not queue_for_group:
+                        self.pending_requests_by_group.pop(group_id, None)
+
+            # Promote the next queued request ONLY when the group's active slot is
+            # now free (never while another request is still active).
+            if group_id is not None and self.active_request_by_group.get(group_id) is None:
+                queue_for_group = self.pending_requests_by_group.get(group_id)
+                if queue_for_group:
+                    while queue_for_group:
+                        next_request_id = queue_for_group.popleft()
+                        blocked_tasks = self.blocked_tasks_by_request.pop(next_request_id, [])
+                        if not blocked_tasks:
+                            continue
+                        self.active_request_by_group[group_id] = next_request_id
+                        for task in blocked_tasks:
+                            task.status = TaskStatus.READY
+                            self.ready_queue.append(task)
+                        break
+                    if not queue_for_group:
+                        self.pending_requests_by_group.pop(group_id, None)
+            self._cleanup_request(request_id)
+
+        return self._take_dispatchable_tasks()
+
+    def _bind_request_group(self, plan: RequestExecutionPlan) -> str:
+        # Select the (single, in PR1) group that supports every task kind in the plan.
+        candidate_group_ids = [
+            group.group_id
+            for group in self.topology.groups
+            if all(task.kind in group.supported_task_kinds for task in plan.tasks.values())
+        ]
+        if not candidate_group_ids:
+            task_kinds = sorted({task.kind.value for task in plan.tasks.values()})
+            raise ValueError(f"no execution group supports all request task kinds: {task_kinds!r}")
+        selected_group_id = candidate_group_ids[0]
+        self.request_group[plan.request_id] = selected_group_id
+        for task in plan.tasks.values():
+            if task.group_id is None:
+                task.group_id = selected_group_id
+        return selected_group_id
+
+    def _cleanup_request(self, request_id: str) -> None:
+        self.request_group.pop(request_id, None)
+        self.blocked_tasks_by_request.pop(request_id, None)
+
+    def _take_dispatchable_tasks(self) -> list[InferenceTask]:
+        dispatchable: list[InferenceTask] = []
+        while self.ready_queue:
+            task = self.ready_queue.popleft()
+            task.status = TaskStatus.DISPATCHED
+            dispatchable.append(task)
+        return dispatchable

--- a/vllm_omni/diffusion/runtime_v2/protocol.py
+++ b/vllm_omni/diffusion/runtime_v2/protocol.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskKind(str, Enum):
+    TEXT_ENCODE = "text_encode"
+    DIT_STEP_CHUNK = "dit_step_chunk"
+    VAE_DECODE = "vae_decode"
+
+
+class ArtifactKind(str, Enum):
+    REQUEST_STATE = "request_state"
+    TENSOR = "tensor"
+    OUTPUT = "output"
+
+
+class ArtifactLayout(str, Enum):
+    HOST = "host"
+    WORKER_LOCAL = "worker_local"
+
+
+class TaskStatus(str, Enum):
+    PENDING = "pending"
+    READY = "ready"
+    DISPATCHED = "dispatched"
+    RUNNING = "running"
+    FINISHED = "finished"
+    FAILED = "failed"
+
+
+class WorkerEventKind(str, Enum):
+    TASK_LAUNCH_END = "task_launch_end"
+    TASK_EXEC_BEGIN = "task_exec_begin"
+    TASK_EXEC_END = "task_exec_end"
+    TASK_FAILED = "task_failed"
+    REQUEST_FINISHED = "request_finished"
+    REQUEST_FAILED = "request_failed"
+
+
+@dataclass(frozen=True)
+class ParallelSpec:
+    """Static parallel metadata for scheduling and fixed worker sessions."""
+
+    tp: int = 1
+    sp: int = 1
+    cfg: int = 1
+    cfg_parallel: bool = False
+
+    def __post_init__(self) -> None:
+        if self.tp < 1:
+            raise ValueError(f"tp must be >= 1, got {self.tp}")
+        if self.sp < 1:
+            raise ValueError(f"sp must be >= 1, got {self.sp}")
+        cfg = int(self.cfg)
+        if cfg < 1:
+            raise ValueError(f"cfg must be >= 1, got {cfg}")
+        if self.cfg_parallel and cfg == 1:
+            cfg = 2
+        object.__setattr__(self, "cfg", cfg)
+        object.__setattr__(self, "cfg_parallel", cfg > 1)
+
+
+@dataclass(frozen=True)
+class ExecutionGroupSpec:
+    group_id: str
+    ranks: tuple[int, ...]
+    parallel_spec: ParallelSpec
+    supported_task_kinds: tuple[TaskKind, ...]
+    ulysses_degree: int = 1
+    ring_degree: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.ranks:
+            raise ValueError("execution group must contain at least one rank")
+        ulysses_degree = int(self.ulysses_degree)
+        ring_degree = int(self.ring_degree)
+        sp = int(self.parallel_spec.sp)
+        if ulysses_degree < 1:
+            raise ValueError(f"ulysses_degree must be >= 1, got {self.ulysses_degree}")
+        if ring_degree < 1:
+            raise ValueError(f"ring_degree must be >= 1, got {self.ring_degree}")
+        if sp != ulysses_degree * ring_degree and ulysses_degree == 1 and ring_degree == 1:
+            ulysses_degree = sp
+            object.__setattr__(self, "ulysses_degree", ulysses_degree)
+        if sp != ulysses_degree * ring_degree:
+            raise ValueError(
+                "execution group sequence parallel mismatch: "
+                f"sp={self.parallel_spec.sp} != ulysses_degree({ulysses_degree}) * ring_degree({ring_degree})"
+            )
+
+
+@dataclass(frozen=True)
+class ArtifactHandle:
+    request_id: str
+    artifact_id: str
+    kind: ArtifactKind
+    layout: ArtifactLayout
+    producer_task_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ArtifactValue:
+    handle: ArtifactHandle
+    value: Any
+
+
+@dataclass(frozen=True)
+class WorkerLocalArtifactRef:
+    handle: ArtifactHandle
+    group_id: str
+    worker_rank: int
+
+
+@dataclass(frozen=True)
+class StepRange:
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if self.start < 0:
+            raise ValueError(f"start must be >= 0, got {self.start}")
+        if self.end <= self.start:
+            raise ValueError(f"end must be greater than start, got start={self.start}, end={self.end}")
+
+
+@dataclass
+class InferenceTask:
+    task_id: str
+    request_id: str
+    kind: TaskKind
+    group_id: str | None
+    parallel_spec: ParallelSpec
+    status: TaskStatus = TaskStatus.PENDING
+    priority: int = 0
+    dependencies: tuple[str, ...] = ()
+    inputs: tuple[ArtifactHandle, ...] = ()
+    outputs: tuple[ArtifactHandle, ...] = ()
+    step_range: StepRange | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RequestExecutionPlan:
+    request_id: str
+    tasks: dict[str, InferenceTask]
+    terminal_task_ids: tuple[str, ...]
+    initial_artifacts: tuple[ArtifactValue, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkerEvent:
+    event_id: str
+    task_id: str
+    request_id: str
+    group_id: str
+    worker_rank: int
+    kind: WorkerEventKind
+    timestamp_ns: int
+    message: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/vllm_omni/diffusion/runtime_v2/registry.py
+++ b/vllm_omni/diffusion/runtime_v2/registry.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Registry mapping diffusion model class names to runtime_v2 adapters.
+
+``multiproc_worker.py`` imports this lazily (so importing the worker module
+does not require the adapters to exist), then calls
+``get_runtime_v2_adapter(model_class_name)`` to obtain the per-model
+``RuntimeV2Adapter`` that builds the task compiler + step-exec executors.
+
+PR1 registers only ``QwenImagePipeline``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vllm_omni.diffusion.runtime_v2.interfaces import RuntimeV2Adapter
+
+
+def _build_qwen_image_adapter() -> RuntimeV2Adapter:
+    # Imported inside the factory so importing the registry stays cheap and does
+    # not eagerly pull in the adapter module's (lazy) torch/worker dependencies.
+    from vllm_omni.diffusion.runtime_v2.adapters.qwen_image import QwenImageRuntimeV2Adapter
+
+    return QwenImageRuntimeV2Adapter()
+
+
+# model_class_name -> zero-arg adapter factory.
+_ADAPTER_FACTORIES: dict[str, Callable[[], RuntimeV2Adapter]] = {
+    "QwenImagePipeline": _build_qwen_image_adapter,
+}
+
+
+def supports_runtime_v2_model(model_class_name: str | None) -> bool:
+    """Return True iff a runtime_v2 adapter is registered for the model class."""
+    return model_class_name in _ADAPTER_FACTORIES
+
+
+def get_runtime_v2_adapter(model_class_name: str | None) -> RuntimeV2Adapter:
+    """Resolve the runtime_v2 adapter for ``model_class_name``.
+
+    Raises ``KeyError`` (with the known names) when the model is unsupported,
+    so callers fail loudly rather than silently falling back to a wrong path.
+    """
+    factory = _ADAPTER_FACTORIES.get(model_class_name) if model_class_name is not None else None
+    if factory is None:
+        raise KeyError(
+            f"no runtime_v2 adapter registered for model_class_name={model_class_name!r}; "
+            f"known models: {sorted(_ADAPTER_FACTORIES)}"
+        )
+    return factory()

--- a/vllm_omni/diffusion/runtime_v2/runner.py
+++ b/vllm_omni/diffusion/runtime_v2/runner.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Single-group runtime_v2 runner backed by the FCFS scheduler.
+
+The runner owns the minimal end-to-end path:
+
+  * one execution group spanning every GPU
+    (``RuntimeTopology.single_group(num_gpus, parallel_spec)``),
+  * a :class:`MultiprocWorkerPool`,
+  * a :class:`GlobalScheduler` driven by :class:`FCFSSchedulerPolicy`,
+  * the per-model adapter resolved through :func:`get_runtime_v2_adapter`.
+
+The ``ParallelSpec`` is derived from ``od_config.parallel_config`` (tp/sp/cfg).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.runtime_v2.interfaces import RuntimeV2Adapter, SchedulerPolicy
+from vllm_omni.diffusion.runtime_v2.multiproc_worker import MultiprocWorkerPool
+from vllm_omni.diffusion.runtime_v2.policies import FCFSSchedulerPolicy
+from vllm_omni.diffusion.runtime_v2.protocol import ParallelSpec
+from vllm_omni.diffusion.runtime_v2.registry import get_runtime_v2_adapter
+from vllm_omni.diffusion.runtime_v2.scheduler import GlobalScheduler, InMemoryArtifactStore
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+logger = init_logger(__name__)
+
+
+class RuntimeV2Runner:
+    """Bootstrap runtime_v2 runner using an explicit model adapter (PR1).
+
+    Owns the single-group topology, worker pool, global scheduler and the
+        per-model adapter. Public API mirrors the engine's expectations:
+    :meth:`submit`, :meth:`poll_once`, :meth:`get_request_status`,
+    :meth:`release_request`, :meth:`abort_request`, :meth:`shutdown`.
+    """
+
+    def __init__(
+        self,
+        pipeline: Any | None = None,
+        default_step_chunk_size: int = 1,
+        *,
+        scheduler_policy: str | SchedulerPolicy = "fcfs",
+        vllm_config: Any = None,
+        omni_diffusion_config: Any = None,
+    ) -> None:
+        self.default_step_chunk_size = default_step_chunk_size
+        if omni_diffusion_config is None:
+            omni_diffusion_config = getattr(pipeline, "od_config", None)
+        if omni_diffusion_config is None:
+            raise ValueError("runtime_v2 runner requires omni_diffusion_config")
+        self.od_config = omni_diffusion_config
+        self.adapter = self._resolve_adapter(omni_diffusion_config)
+        if pipeline is not None:
+            self.adapter.validate_pipeline(pipeline, omni_diffusion_config)
+
+        topology = self._build_topology(omni_diffusion_config)
+        policy = self._build_scheduler_policy(
+            topology=topology,
+            scheduler_policy=scheduler_policy,
+        )
+
+        worker_pool = MultiprocWorkerPool(
+            topology=topology,
+            od_config=omni_diffusion_config,
+        )
+        self.worker_pool = worker_pool
+
+        self.scheduler = GlobalScheduler(
+            topology=topology,
+            worker_pool=worker_pool,
+            compiler=self.adapter.build_task_compiler(
+                default_denoise_chunk_size=default_step_chunk_size,
+                od_config=omni_diffusion_config,
+                pipeline=pipeline,
+            ),
+            artifact_store=InMemoryArtifactStore(),
+            policy=policy,
+        )
+        # Start the worker pool with the configured stage init timeout so a slow
+        # checkpoint load is bounded by --stage-init-timeout (forwarded onto
+        # od_config), not the worker pool's hardcoded default. Fall back to that
+        # default when the field is absent.
+        start_timeout = getattr(self.od_config, "stage_init_timeout", None)
+        self.scheduler.start(timeout_s=float(start_timeout) if start_timeout is not None else None)
+        logger.info(
+            "runtime_v2 runner started: model_class_name=%s adapter=%s default_step_chunk_size=%s "
+            "groups=%s workers=%s policy=%s",
+            getattr(omni_diffusion_config, "model_class_name", None),
+            type(self.adapter).__name__,
+            default_step_chunk_size,
+            len(topology.groups),
+            len(topology.workers),
+            type(self.scheduler.policy).__name__,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers                                                 #
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _resolve_adapter(omni_diffusion_config: Any) -> RuntimeV2Adapter:
+        return get_runtime_v2_adapter(getattr(omni_diffusion_config, "model_class_name", None))
+
+    @staticmethod
+    def _build_topology(omni_diffusion_config: Any) -> RuntimeTopology:
+        """Derive a single execution group spanning all GPUs.
+
+        ``num_gpus`` is taken from ``od_config`` (falling back to
+        ``parallel_config.world_size``); the per-group ``ParallelSpec`` mirrors
+        the configured tensor/sequence/cfg parallel degrees. PR1 uses exactly
+        one group, so ``num_gpus`` must equal the parallel world size.
+        """
+        parallel_config = omni_diffusion_config.parallel_config
+        # PR1 carries sequence parallelism only as a single degree (sp); the
+        # topology then forces ulysses_degree=sp, ring_degree=1 (see
+        # ExecutionGroupSpec.__post_init__). A user-requested ring split would be
+        # silently re-decomposed as pure-ulysses -- the WRONG SP layout -- so
+        # reject it loudly here, mirroring the other PR1 "not yet supported"
+        # guards. Ulysses-only and sp=1 are unaffected.
+        ring_degree = int(getattr(parallel_config, "ring_degree", 1) or 1)
+        if ring_degree > 1:
+            raise NotImplementedError(
+                "runtime_v2 (PR1) does not support ring sequence parallelism "
+                f"(ring_degree={ring_degree}); only ulysses / sp=1 are supported."
+            )
+        num_gpus = int(getattr(omni_diffusion_config, "num_gpus", None) or parallel_config.world_size)
+        parallel_spec = ParallelSpec(
+            tp=int(parallel_config.tensor_parallel_size),
+            sp=int(parallel_config.sequence_parallel_size or 1),
+            cfg=int(parallel_config.cfg_parallel_size),
+        )
+        tp, sp, cfg = parallel_spec.tp, parallel_spec.sp, parallel_spec.cfg
+        # PR1 forms exactly ONE execution group spanning all ranks, so num_gpus
+        # must equal tp*sp*cfg. Intra-group tensor/sequence/CFG parallelism is
+        # supported (the workers reuse vllm-omni's own parallel state). What is
+        # not supported here: data/pipeline parallelism
+        # (num_gpus > tp*sp*cfg) and multiple execution groups.
+        if num_gpus != tp * sp * cfg:
+            raise ValueError(
+                "runtime_v2 forms a single execution group spanning exactly "
+                f"tp*sp*cfg ranks; got tp={tp} sp={sp} cfg={cfg} (={tp * sp * cfg}) "
+                f"but num_gpus={num_gpus}. Data/pipeline parallelism and cross-group "
+                "elastic degrees are deferred to a later PR."
+            )
+        return RuntimeTopology.single_group(num_gpus=num_gpus, parallel_spec=parallel_spec)
+
+    @staticmethod
+    def _build_scheduler_policy(
+        *,
+        topology: RuntimeTopology,
+        scheduler_policy: str | SchedulerPolicy,
+    ) -> SchedulerPolicy:
+        if isinstance(scheduler_policy, SchedulerPolicy):
+            return scheduler_policy
+        policy_name = str(scheduler_policy).lower()
+        if policy_name == "fcfs":
+            return FCFSSchedulerPolicy(topology=topology)
+        raise ValueError(f"runtime_v2 PR1 supports only scheduler_policy='fcfs', got {scheduler_policy!r}")
+
+    # ------------------------------------------------------------------ #
+    # Request lifecycle                                                    #
+    # ------------------------------------------------------------------ #
+    def _to_runtime_request(self, request: Any, *, denoise_chunk_size: int | None = None) -> Any:
+        return self.adapter.normalize_request(
+            request,
+            denoise_chunk_size=int(denoise_chunk_size or self.default_step_chunk_size),
+        )
+
+    def submit(self, request: Any, *, denoise_chunk_size: int | None = None) -> str:
+        runtime_req = self._to_runtime_request(request, denoise_chunk_size=denoise_chunk_size)
+        req = runtime_req.diffusion_request
+        sp = req.sampling_params
+        logger.debug(
+            "runtime_v2 submit: request_id=%s model_class_name=%s chunk=%s steps=%s frames=%s size=%sx%s",
+            runtime_req.request_id,
+            getattr(self.od_config, "model_class_name", None),
+            runtime_req.denoise_chunk_size,
+            getattr(sp, "num_inference_steps", None),
+            getattr(sp, "num_frames", None),
+            getattr(sp, "width", None),
+            getattr(sp, "height", None),
+        )
+        return self.scheduler.submit_request(runtime_req)
+
+    def poll_once(self, timeout_s: float = 0.0) -> None:
+        self.scheduler.poll_once(timeout_s=timeout_s)
+
+    def get_request_status(self, request_id: str) -> tuple[str, Any | None]:
+        return self.scheduler.get_request_status(request_id)
+
+    def _release_request(self, request_id: str) -> None:
+        # Retire all controller-side state for a request once its terminal status
+        # has been delivered, so plans / artifact store / completed-output cache do
+        # not accumulate for the process lifetime.
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "release_request"):
+            scheduler.release_request(request_id)
+
+    def release_request(self, request_id: str) -> None:
+        self._release_request(request_id)
+
+    def abort_request(self, request_id: str) -> None:
+        """Abort an in-flight request, freeing its scheduler policy slot.
+
+        Unlike :meth:`release_request` (which only frees controller-side state),
+        this drives the scheduler's ``abort_request`` so the FCFS active slot for
+        the request's group is released and any queued request is promoted --
+        otherwise aborting the active request deadlocks its group. No-op if the
+        scheduler does not support it (older/alternate schedulers)."""
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "abort_request"):
+            scheduler.abort_request(request_id)
+        else:
+            self._release_request(request_id)
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle                                                            #
+    # ------------------------------------------------------------------ #
+    def shutdown(self) -> None:
+        self.scheduler.shutdown()
+        logger.info("runtime_v2 runner shut down")
+
+    def check_health(self) -> None:
+        if hasattr(self.worker_pool, "check_health"):
+            self.worker_pool.check_health()

--- a/vllm_omni/diffusion/runtime_v2/scheduler.py
+++ b/vllm_omni/diffusion/runtime_v2/scheduler.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.runtime_v2.interfaces import ArtifactStore, SchedulerPolicy, TaskCompiler
+
+# Policy re-export for convenience
+from vllm_omni.diffusion.runtime_v2.policies import FCFSSchedulerPolicy  # noqa: F401
+from vllm_omni.diffusion.runtime_v2.protocol import (
+    ArtifactHandle,
+    ArtifactValue,
+    InferenceTask,
+    RequestExecutionPlan,
+    TaskStatus,
+    WorkerEvent,
+    WorkerEventKind,
+    WorkerLocalArtifactRef,
+)
+from vllm_omni.diffusion.runtime_v2.topology import RuntimeTopology
+
+logger = init_logger(__name__)
+
+# Upper bound on the terminal-output fetch (worker GPU->host copy + serialize).
+# The async fetch path (start_fetch_artifacts / poll_fetch_artifacts) otherwise
+# has NO deadline, so a worker that finishes the terminal task but then wedges
+# (e.g. a CUDA-stuck D2H copy while the process stays alive) would keep the
+# request "pending" forever. Generous -- a real fetch is sub-second to a few
+# seconds even for video.
+_OUTPUT_FETCH_TIMEOUT_S = 300.0
+
+
+class InMemoryArtifactStore(ArtifactStore):
+    def __init__(self) -> None:
+        self._values: dict[tuple[str, str], Any] = {}
+
+    def put(self, artifact: ArtifactHandle, value: Any) -> None:
+        self._values[(artifact.request_id, artifact.artifact_id)] = value
+
+    def get(self, artifact: ArtifactHandle) -> Any:
+        return self._values[(artifact.request_id, artifact.artifact_id)]
+
+    def is_ready(self, artifact: ArtifactHandle) -> bool:
+        return (artifact.request_id, artifact.artifact_id) in self._values
+
+    def evict_request(self, request_id: str) -> None:
+        keys = [key for key in self._values if key[0] == request_id]
+        for key in keys:
+            del self._values[key]
+
+
+class GlobalScheduler:
+    """Minimal event-driven task-graph scheduler for diffusion runtime_v2."""
+
+    def __init__(
+        self,
+        topology: RuntimeTopology,
+        worker_pool: Any,
+        compiler: TaskCompiler,
+        artifact_store: ArtifactStore,
+        policy: SchedulerPolicy,
+    ) -> None:
+        self.topology = topology
+        self.worker_pool = worker_pool
+        self.compiler = compiler
+        self.artifact_store = artifact_store
+        self.policy = policy
+
+        self.plans: dict[str, RequestExecutionPlan] = {}
+        self.task_index: dict[str, InferenceTask] = {}
+        self.pending_dependencies: dict[str, int] = {}
+        self.dependents: dict[str, list[str]] = {}
+        self.failed_requests: dict[str, str] = {}
+        self.released_requests: set[str] = set()
+        self.cleaned_requests: set[str] = set()
+        self.failed_tasks: set[str] = set()
+        self.artifact_refcounts: dict[tuple[str, str], int] = {}
+        self.request_artifacts: dict[str, set[tuple[str, str]]] = {}
+        self.pending_output_fetches: dict[str, _PendingOutputFetch] = {}
+        # request_id -> delivered terminal output. Membership (NOT value identity)
+        # is the "request finished" signal, so a legitimately None/falsy output
+        # still reports finished, and the artifact store + per-request bookkeeping
+        # can be evicted at cleanup without breaking a later get_request_status poll.
+        self._completed_outputs: dict[str, Any] = {}
+
+    def start(self, timeout_s: float | None = None) -> None:
+        # Forward the caller's startup timeout (the runner passes
+        # od_config.stage_init_timeout) so a slow checkpoint load honors
+        # --stage-init-timeout instead of the worker pool's hardcoded default.
+        if timeout_s is not None:
+            self.worker_pool.start(timeout_s=timeout_s)
+        else:
+            self.worker_pool.start()
+
+    def shutdown(self) -> None:
+        self.worker_pool.shutdown()
+
+    def submit_request(self, request: Any) -> str:
+        plan = self.compiler.compile_request(request)
+        return self._submit_compiled_plan(plan)
+
+    def _submit_compiled_plan(self, plan: RequestExecutionPlan) -> str:
+        self.plans[plan.request_id] = plan
+        logger.debug(
+            "runtime_v2 plan compiled: request_id=%s tasks=%s terminal=%s metadata=%s",
+            plan.request_id,
+            len(plan.tasks),
+            len(plan.terminal_task_ids),
+            plan.metadata,
+        )
+
+        for artifact_value in plan.initial_artifacts:
+            self.artifact_store.put(artifact_value.handle, artifact_value.value)
+
+        request_artifacts: set[tuple[str, str]] = set()
+        for task in plan.tasks.values():
+            if task.group_id is not None:
+                group = self.topology.get_group(task.group_id)
+                if task.kind not in group.supported_task_kinds:
+                    raise ValueError(
+                        f"task {task.task_id} is pinned to unsupported group {task.group_id!r} for kind={task.kind}"
+                    )
+            elif self.topology.select_group_for_task(task.kind) is None:
+                raise ValueError(f"no execution group supports task kind {task.kind}")
+            self.task_index[task.task_id] = task
+            self.pending_dependencies[task.task_id] = len(task.dependencies)
+            for artifact in task.inputs:
+                key = (artifact.request_id, artifact.artifact_id)
+                self.artifact_refcounts[key] = self.artifact_refcounts.get(key, 0) + 1
+                request_artifacts.add(key)
+            for artifact in task.outputs:
+                request_artifacts.add((artifact.request_id, artifact.artifact_id))
+            for dependency in task.dependencies:
+                self.dependents.setdefault(dependency, []).append(task.task_id)
+        for artifact_value in plan.initial_artifacts:
+            request_artifacts.add((artifact_value.handle.request_id, artifact_value.handle.artifact_id))
+        self.request_artifacts[plan.request_id] = request_artifacts
+
+        self._dispatch_tasks(self.policy.on_request_submitted(plan))
+        return plan.request_id
+
+    def poll_once(self, timeout_s: float = 0.0) -> None:
+        events = self.worker_pool.poll(timeout_s=timeout_s)
+        for event in events:
+            self._handle_worker_event(event)
+
+    def get_request_status(self, request_id: str) -> tuple[str, Any | None]:
+        """
+        Returns:
+            ("pending", None) if request is not done,
+            ("finished", output) if request completed successfully,
+            ("failed", error_message) if request failed.
+        """
+        if request_id in self.failed_requests:
+            return "failed", self.failed_requests[request_id]
+        if request_id in self._completed_outputs:
+            return "finished", self._completed_outputs[request_id]
+        if request_id not in self.plans and request_id not in self.pending_output_fetches:
+            return "pending", None
+        self._try_collect_request_output(request_id)
+        if request_id in self._completed_outputs:
+            return "finished", self._completed_outputs[request_id]
+        if request_id in self.failed_requests:
+            return "failed", self.failed_requests[request_id]
+        return "pending", None
+
+    def _dispatch_tasks(self, tasks: Iterable[InferenceTask]) -> None:
+        for task in tasks:
+            if task.group_id is None:
+                raise ValueError(f"task {task.task_id} has no assigned group_id before dispatch")
+            group = self.topology.get_group(task.group_id)
+            task.parallel_spec = group.parallel_spec
+            self._finalize_task_dispatch(task)
+
+    def _finalize_task_dispatch(self, task: InferenceTask) -> None:
+        """Assemble inline inputs, apply refcount/release accounting, and dispatch.
+        Called once all of the task's inputs are ready on the task's own group."""
+        inline_inputs: list[ArtifactValue] = []
+        release_after_exec_artifact_ids: list[str] = []
+        for artifact in task.inputs:
+            stored = self.artifact_store.get(artifact)
+            if not isinstance(stored, WorkerLocalArtifactRef):
+                inline_inputs.append(ArtifactValue(handle=artifact, value=stored))
+            key = (artifact.request_id, artifact.artifact_id)
+            remaining = self.artifact_refcounts.get(key)
+            if remaining is not None:
+                remaining -= 1
+                if remaining <= 0:
+                    self.artifact_refcounts.pop(key, None)
+                    release_after_exec_artifact_ids.append(artifact.artifact_id)
+                else:
+                    self.artifact_refcounts[key] = remaining
+        if task.step_range is not None:
+            logger.debug(
+                "runtime_v2 dispatch: request_id=%s task_id=%s kind=%s group=%s step_range=[%s,%s)",
+                task.request_id,
+                task.task_id,
+                task.kind,
+                task.group_id,
+                task.step_range.start,
+                task.step_range.end,
+            )
+        else:
+            logger.debug(
+                "runtime_v2 dispatch: request_id=%s task_id=%s kind=%s group=%s",
+                task.request_id,
+                task.task_id,
+                task.kind,
+                task.group_id,
+            )
+        self.worker_pool.dispatch(
+            task=task,
+            inline_inputs=tuple(inline_inputs),
+            release_after_exec_artifact_ids=tuple(release_after_exec_artifact_ids),
+        )
+
+    def _handle_worker_event(self, event: WorkerEvent) -> None:
+        if event.kind == WorkerEventKind.REQUEST_FINISHED:
+            if not self._mark_request_event_delivered(event.request_id, event.kind):
+                return
+            logger.debug("runtime_v2 request finished: request_id=%s group=%s", event.request_id, event.group_id)
+            self._dispatch_tasks(self.policy.on_worker_event(event))
+            return
+        if event.kind == WorkerEventKind.REQUEST_FAILED:
+            if not self._mark_request_event_delivered(event.request_id, event.kind):
+                return
+            self.failed_requests.setdefault(event.request_id, event.message or f"request {event.request_id} failed")
+            logger.error(
+                "runtime_v2 request failed: request_id=%s group=%s message=%s",
+                event.request_id,
+                event.group_id,
+                event.message,
+            )
+            self._cleanup_request_worker_state(event.request_id)
+            self._dispatch_tasks(self.policy.on_worker_event(event))
+            return
+
+        task = self.task_index.get(event.task_id)
+        if task is None:
+            return
+
+        if event.kind == WorkerEventKind.TASK_EXEC_BEGIN:
+            task.status = TaskStatus.RUNNING
+            if task.step_range is not None:
+                logger.debug(
+                    "runtime_v2 task begin: request_id=%s task_id=%s kind=%s step_range=[%s,%s)",
+                    task.request_id,
+                    task.task_id,
+                    task.kind,
+                    task.step_range.start,
+                    task.step_range.end,
+                )
+            else:
+                logger.debug(
+                    "runtime_v2 task begin: request_id=%s task_id=%s kind=%s",
+                    task.request_id,
+                    task.task_id,
+                    task.kind,
+                )
+            return
+
+        if event.kind == WorkerEventKind.TASK_LAUNCH_END:
+            self._dispatch_tasks(self.policy.on_worker_event(event))
+            published_outputs = event.metadata.get("published_outputs", ())
+            for artifact_ref in published_outputs:
+                self.artifact_store.put(artifact_ref.handle, artifact_ref)
+
+            # Skip dependent scheduling if the request already failed/was retired:
+            # decrementing or dispatching downstream tasks of a dead request would
+            # offer them to the policy (and the bookkeeping may already be gone).
+            newly_runnable: list[InferenceTask] = []
+            if task.request_id not in self.failed_requests:
+                for dependent_id in self.dependents.get(task.task_id, []):
+                    if dependent_id not in self.pending_dependencies:
+                        continue
+                    self.pending_dependencies[dependent_id] -= 1
+                    if self.pending_dependencies[dependent_id] == 0:
+                        newly_runnable.append(self.task_index[dependent_id])
+            self._dispatch_tasks(self.policy.on_tasks_runnable(newly_runnable))
+            return
+
+        if event.kind == WorkerEventKind.TASK_EXEC_END:
+            task.status = TaskStatus.FINISHED
+            logger.debug(
+                "runtime_v2 task end: request_id=%s task_id=%s kind=%s",
+                task.request_id,
+                task.task_id,
+                task.kind,
+            )
+            self._dispatch_tasks(self.policy.on_worker_event(event))
+            if task.task_id in self.plans[task.request_id].terminal_task_ids:
+                # Keep the FCFS slot until the terminal output has been copied
+                # and the worker-local request state has been evicted. The fetch
+                # runs on a worker background thread, so merely enqueueing it
+                # before the next dispatch would not provide that ordering.
+                self._try_start_request_output_fetch(task.request_id)
+            return
+
+        if event.kind == WorkerEventKind.TASK_FAILED:
+            if task.task_id in self.failed_tasks:
+                return
+            self.failed_tasks.add(task.task_id)
+            task.status = TaskStatus.FAILED
+            self.failed_requests.setdefault(task.request_id, event.message or f"task {task.task_id} failed")
+            logger.error(
+                "runtime_v2 task failed: request_id=%s task_id=%s kind=%s message=%s",
+                task.request_id,
+                task.task_id,
+                task.kind,
+                event.message,
+            )
+            self._dispatch_tasks(self.policy.on_worker_event(event))
+            self._cleanup_request_worker_state(task.request_id)
+            self._emit_request_event(
+                request_id=task.request_id,
+                group_id=event.group_id,
+                kind=WorkerEventKind.REQUEST_FAILED,
+                message=event.message,
+            )
+
+    def _try_collect_request_output(self, request_id: str) -> Any | None:
+        if request_id in self._completed_outputs:
+            return self._completed_outputs[request_id]
+        # Use _completed_outputs membership (not "output is not None") as the
+        # finished signal: a fetch can legitimately complete with a None value, and
+        # the finish path pops the plan, so we must NOT fall through to
+        # _try_start_request_output_fetch afterwards (it would KeyError on the plan).
+        self._try_finish_request_output_fetch(request_id)
+        if request_id in self._completed_outputs:
+            return self._completed_outputs[request_id]
+        if request_id not in self.plans:
+            return None
+        self._try_start_request_output_fetch(request_id)
+        if request_id in self._completed_outputs:
+            return self._completed_outputs[request_id]
+        return None
+
+    def _fail_request_from_fetch_error(self, request_id: str, message: str) -> None:
+        # Record an output-fetch failure as a terminal "failed" status (mirroring
+        # a REQUEST_FAILED worker event) and free the request's controller state.
+        logger.error("runtime_v2 output fetch failed: request_id=%s error=%s", request_id, message)
+        group_id = self._resolve_request_group_id(request_id) or ""
+        self.failed_requests.setdefault(request_id, message)
+        self._cleanup_request_worker_state(request_id)
+        self._emit_request_event(
+            request_id=request_id,
+            group_id=group_id,
+            kind=WorkerEventKind.REQUEST_FAILED,
+            message=message,
+        )
+
+    def _try_start_request_output_fetch(self, request_id: str) -> Any | None:
+        plan = self.plans[request_id]
+        unfinished_terminal = [
+            task_id for task_id in plan.terminal_task_ids if self.task_index[task_id].status != TaskStatus.FINISHED
+        ]
+        if unfinished_terminal:
+            return None
+
+        if request_id in self.pending_output_fetches:
+            return None
+
+        terminal_task = self.task_index[plan.terminal_task_ids[0]]
+        if not terminal_task.outputs:
+            return None
+        output_handle = terminal_task.outputs[0]
+        stored = self.artifact_store.get(output_handle)
+
+        if isinstance(stored, WorkerLocalArtifactRef):
+            if not hasattr(self.worker_pool, "start_fetch_artifacts"):
+                fetch = self.worker_pool.fetch_artifacts(
+                    request_id=request_id,
+                    group_id=stored.group_id,
+                    artifact_ids=(output_handle.artifact_id,),
+                )
+                if fetch.error:
+                    self._fail_request_from_fetch_error(request_id, str(fetch.error))
+                    return None
+                if not fetch.artifacts:
+                    self._fail_request_from_fetch_error(
+                        request_id,
+                        f"runtime_v2 fetch returned empty artifacts: request_id={request_id}",
+                    )
+                    return None
+                artifact_value = fetch.artifacts[0]
+                self.artifact_store.put(artifact_value.handle, artifact_value.value)
+                self._completed_outputs[request_id] = artifact_value.value
+                group_id = stored.group_id
+                self._cleanup_request_worker_state(request_id)
+                self._emit_request_event(
+                    request_id=request_id,
+                    group_id=group_id,
+                    kind=WorkerEventKind.REQUEST_FINISHED,
+                )
+                return artifact_value.value
+
+            fetch_start_ns = time.monotonic_ns()
+            fetch_id = self.worker_pool.start_fetch_artifacts(
+                request_id=request_id,
+                group_id=stored.group_id,
+                artifact_ids=(output_handle.artifact_id,),
+            )
+            self.pending_output_fetches[request_id] = _PendingOutputFetch(
+                fetch_id=fetch_id,
+                output_handle=output_handle,
+                group_id=stored.group_id,
+                started_ns=fetch_start_ns,
+            )
+            logger.debug(
+                "runtime_v2 output fetch started: request_id=%s group=%s artifact_id=%s fetch_id=%s",
+                request_id,
+                stored.group_id,
+                output_handle.artifact_id,
+                fetch_id,
+            )
+            return None
+
+        group_id = terminal_task.group_id or ""
+        self._completed_outputs[request_id] = stored
+        self._cleanup_request_worker_state(request_id)
+        self._emit_request_event(
+            request_id=request_id,
+            group_id=group_id,
+            kind=WorkerEventKind.REQUEST_FINISHED,
+        )
+        return stored
+
+    def _try_finish_request_output_fetch(self, request_id: str) -> Any | None:
+        pending = self.pending_output_fetches.get(request_id)
+        if pending is None:
+            return None
+        if not hasattr(self.worker_pool, "poll_fetch_artifacts"):
+            return None
+
+        fetch = self.worker_pool.poll_fetch_artifacts(pending.fetch_id)
+        if fetch is None:
+            if pending.started_ns and (time.monotonic_ns() - pending.started_ns) > int(_OUTPUT_FETCH_TIMEOUT_S * 1e9):
+                # Terminal task finished but the fetch never came back within the
+                # deadline (worker fetch wedged). Fail the request instead of
+                # polling forever -- _fail_request_from_fetch_error ->
+                # _cleanup_request_worker_state pops pending_output_fetches and
+                # discards the fetch.
+                self._fail_request_from_fetch_error(
+                    request_id,
+                    f"runtime_v2 output fetch timed out after {_OUTPUT_FETCH_TIMEOUT_S:.0f}s: "
+                    f"request_id={request_id} fetch_id={pending.fetch_id}",
+                )
+                return None
+            return None
+
+        self.pending_output_fetches.pop(request_id, None)
+        if fetch.error:
+            self._fail_request_from_fetch_error(request_id, str(fetch.error))
+            return None
+        if not fetch.artifacts:
+            self._fail_request_from_fetch_error(
+                request_id,
+                f"runtime_v2 fetch returned empty artifacts: request_id={request_id} fetch_id={pending.fetch_id}",
+            )
+            return None
+        artifact_value = fetch.artifacts[0]
+        self.artifact_store.put(artifact_value.handle, artifact_value.value)
+        self._completed_outputs[request_id] = artifact_value.value
+        self._cleanup_request_worker_state(request_id)
+        self._emit_request_event(
+            request_id=request_id,
+            group_id=pending.group_id,
+            kind=WorkerEventKind.REQUEST_FINISHED,
+        )
+        logger.debug(
+            "runtime_v2 output fetch completed: request_id=%s group=%s artifact_id=%s fetch_id=%s",
+            request_id,
+            pending.group_id,
+            pending.output_handle.artifact_id,
+            pending.fetch_id,
+        )
+        return artifact_value.value
+
+    def _mark_request_event_delivered(self, request_id: str, kind: WorkerEventKind) -> bool:
+        key = f"{request_id}:{kind.value}"
+        if key in self.released_requests:
+            return False
+        self.released_requests.add(key)
+        return True
+
+    def _emit_request_event(
+        self,
+        *,
+        request_id: str,
+        group_id: str,
+        kind: WorkerEventKind,
+        message: str = "",
+    ) -> None:
+        if not self._mark_request_event_delivered(request_id, kind):
+            return
+        self._dispatch_tasks(
+            self.policy.on_worker_event(
+                WorkerEvent(
+                    event_id=f"request:{request_id}:{kind.value}",
+                    task_id="",
+                    request_id=request_id,
+                    group_id=group_id,
+                    worker_rank=-1,
+                    kind=kind,
+                    timestamp_ns=time.monotonic_ns(),
+                    message=message,
+                )
+            )
+        )
+
+    def _cleanup_request_worker_state(self, request_id: str) -> None:
+        if request_id in self.cleaned_requests:
+            return
+        self.cleaned_requests.add(request_id)
+        pending = self.pending_output_fetches.pop(request_id, None)
+        if pending is not None and hasattr(self.worker_pool, "discard_fetch"):
+            self.worker_pool.discard_fetch(pending.fetch_id)
+        for key in self.request_artifacts.pop(request_id, set()):
+            self.artifact_refcounts.pop(key, None)
+        self.worker_pool.evict_request(request_id)
+        # Free controller-side per-request state. The terminal output (if any) has
+        # already been copied into self._completed_outputs by the caller, so evicting
+        # the artifact store here cannot strand a not-yet-delivered result; a later
+        # get_request_status poll is served from _completed_outputs. Without this the
+        # store, plan, and task bookkeeping grew unboundedly for the process lifetime.
+        self.artifact_store.evict_request(request_id)
+        plan = self.plans.pop(request_id, None)
+        if plan is not None:
+            for task_id in plan.tasks:
+                self.failed_tasks.discard(task_id)
+                self.task_index.pop(task_id, None)
+                self.pending_dependencies.pop(task_id, None)
+                self.dependents.pop(task_id, None)
+
+    def _clear_request_tombstones(self, request_id: str) -> None:
+        """Drop small dedupe markers once no late task can reference a request."""
+        self.cleaned_requests.discard(request_id)
+        for kind in (WorkerEventKind.REQUEST_FINISHED, WorkerEventKind.REQUEST_FAILED):
+            self.released_requests.discard(f"{request_id}:{kind.value}")
+
+    def abort_request(self, request_id: str) -> None:
+        """Abort an in-flight request, freeing its policy slot AND controller state.
+
+        A bare :meth:`release_request` only frees controller-side bookkeeping; it
+        does NOT tell the policy the request is gone. For an FCFS group that
+        leaves ``active_request_by_group`` pinned to the aborted id, so the next
+        request for that group is parked in ``pending_requests_by_group`` forever
+        (a single-group deployment ⇒ whole-group deadlock).
+
+        The normal terminal path frees the policy slot by feeding a REQUEST_FAILED
+        ``WorkerEvent`` to ``policy.on_worker_event`` (which pops the active slot
+        and promotes the next pending request, returning its now-dispatchable
+        tasks). Reuse EXACTLY that machinery here: emit a synthetic REQUEST_FAILED
+        event for this request's bound group (dispatching any promoted tasks),
+        THEN free controller state (what ``release_request`` does).
+
+        Guarded to a no-op for an unknown / already-finished / already-aborted id:
+        if the request has no plan and no live bookkeeping it is either never seen
+        or already retired, so there is no slot to free.
+        """
+        group_id = self._resolve_request_group_id(request_id)
+        # No live state for this id: unknown or already retired -> no-op. We
+        # still fall through to release_request()'s cleanup below only when
+        # there is something to clean, so guard here.
+        if (
+            request_id not in self.plans
+            and request_id not in self.failed_requests
+            and request_id not in self._completed_outputs
+            and request_id not in self.pending_output_fetches
+            and group_id is None
+        ):
+            return
+        # Retire controller state + EVICT the aborted request's worker-local
+        # artifacts FIRST, BEFORE the REQUEST_FAILED event below promotes and
+        # dispatches the next queued request. Worker command pipes are FIFO,
+        # so queuing the EvictRequestCommand ahead of the promoted request's
+        # dispatch makes the worker free the aborted latents/output before it
+        # runs the next request -- otherwise they stay resident through it and
+        # can cause an avoidable OOM. (Ordering only matters vs. the promoted
+        # dispatch; the two operate on different request ids, so it is safe.)
+        self._cleanup_request_worker_state(request_id)
+        self._completed_outputs.pop(request_id, None)
+        self.failed_requests.pop(request_id, None)
+        # Free the policy's active slot + promote any queued request for the
+        # group, dispatching its newly-runnable tasks -- the SAME path the
+        # normal REQUEST_FAILED terminal uses. group_id may be "" ; the policy
+        # falls back to its bound request_group mapping in that case.
+        self._emit_request_event(
+            request_id=request_id,
+            group_id=group_id or "",
+            kind=WorkerEventKind.REQUEST_FAILED,
+            message=f"request {request_id} aborted.",
+        )
+        self._clear_request_tombstones(request_id)
+
+    def _resolve_request_group_id(self, request_id: str) -> str | None:
+        """Best-effort lookup of a request's bound execution group id.
+
+        Prefers the policy's ``request_group`` mapping (authoritative once the
+        request was admitted); falls back to any task's ``group_id`` on the plan.
+        Returns ``None`` when nothing is known about the request.
+        """
+        policy_map = getattr(self.policy, "request_group", None)
+        if isinstance(policy_map, dict):
+            group_id = policy_map.get(request_id)
+            if group_id is not None:
+                return group_id
+        plan = self.plans.get(request_id)
+        if plan is not None:
+            for task in plan.tasks.values():
+                if task.group_id is not None:
+                    return task.group_id
+        return None
+
+    def release_request(self, request_id: str) -> None:
+        """Retire a request once its terminal status has been delivered to the
+        caller. Frees the large per-request state (plan, artifact store, task
+        bookkeeping, cached output, and temporary event-deduplication markers.
+        Idempotent and safe to call more than once."""
+        self._cleanup_request_worker_state(request_id)
+        self._completed_outputs.pop(request_id, None)
+        self.failed_requests.pop(request_id, None)
+        self._clear_request_tombstones(request_id)
+
+
+@dataclass(frozen=True)
+class _PendingOutputFetch:
+    fetch_id: str
+    output_handle: ArtifactHandle
+    group_id: str
+    started_ns: int = 0

--- a/vllm_omni/diffusion/runtime_v2/topology.py
+++ b/vllm_omni/diffusion/runtime_v2/topology.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vllm_omni.diffusion.runtime_v2.protocol import ExecutionGroupSpec, ParallelSpec, TaskKind
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    worker_rank: int
+    device_id: int | None = None
+    label: str = ""
+
+
+class RuntimeTopology:
+    """Static runtime_v2 topology."""
+
+    def __init__(self, workers: tuple[WorkerSpec, ...], groups: tuple[ExecutionGroupSpec, ...]) -> None:
+        if not workers:
+            raise ValueError("runtime topology requires at least one worker")
+        if not groups:
+            raise ValueError("runtime topology requires at least one execution group")
+
+        self.workers = workers
+        self.groups = groups
+        self._workers_by_rank = {worker.worker_rank: worker for worker in workers}
+        self._groups_by_id = {group.group_id: group for group in groups}
+        self._groups_by_worker_rank: dict[int, list[ExecutionGroupSpec]] = {
+            worker.worker_rank: [] for worker in workers
+        }
+
+        if len(self._workers_by_rank) != len(workers):
+            raise ValueError("worker ranks must be unique")
+        if len(self._groups_by_id) != len(groups):
+            raise ValueError("group ids must be unique")
+
+        for group in groups:
+            for rank in group.ranks:
+                if rank not in self._workers_by_rank:
+                    raise ValueError(f"group {group.group_id} references unknown worker rank {rank}")
+                self._groups_by_worker_rank[rank].append(group)
+        missing = [rank for rank, groups_for_rank in self._groups_by_worker_rank.items() if not groups_for_rank]
+        if missing:
+            raise ValueError(f"workers must belong to at least one execution group, missing ranks: {missing!r}")
+
+    @classmethod
+    def single_group(cls, num_gpus: int, parallel_spec: ParallelSpec) -> RuntimeTopology:
+        """Build a single-group topology with all TaskKinds supported."""
+        workers = tuple(WorkerSpec(worker_rank=r, device_id=r) for r in range(num_gpus))
+        group = ExecutionGroupSpec(
+            group_id="g0",
+            ranks=tuple(range(num_gpus)),
+            parallel_spec=parallel_spec,
+            supported_task_kinds=tuple(TaskKind),
+        )
+        return cls(workers=workers, groups=(group,))
+
+    def get_group(self, group_id: str) -> ExecutionGroupSpec:
+        return self._groups_by_id[group_id]
+
+    def get_group_leader(self, group_id: str) -> int:
+        return self.get_group(group_id).ranks[0]
+
+    def get_groups_for_worker(self, worker_rank: int) -> tuple[ExecutionGroupSpec, ...]:
+        return tuple(self._groups_by_worker_rank[worker_rank])
+
+    def get_groups_for_task(self, task_kind: TaskKind) -> tuple[ExecutionGroupSpec, ...]:
+        return tuple(group for group in self.groups if task_kind in group.supported_task_kinds)
+
+    def select_group_for_task(self, task_kind: TaskKind) -> str | None:
+        for group in self.groups:
+            if task_kind in group.supported_task_kinds:
+                return group.group_id
+        return None

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -102,6 +102,8 @@ class StageDiffusionProc:
         """
         if self._engine is None:
             return False
+        if hasattr(self._engine, "is_backend_dead"):
+            return self._engine.is_backend_dead()
         executor = getattr(self._engine, "executor", None)
         if executor is None:
             return False

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -467,6 +467,9 @@ class OrchestratorArgs:
     cache_config: str | None = None
     enable_cache_dit_summary: bool = False
     step_execution: bool = False
+    enable_runtime_v2: bool = False
+    runtime_v2_denoise_chunk_size: int = 1
+    runtime_v2_scheduler_policy: str = "fcfs"
     vae_use_slicing: bool = False
     vae_use_tiling: bool = False
     enable_multithread_weight_load: bool = True

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -223,6 +223,9 @@ class AsyncOmniEngine:
         self.model = model
         self.tokenizer = tokenizer
         self.diffusion_batch_size = diffusion_batch_size
+        # Named parameters are absent from **kwargs; retain this one so the
+        # runtime_v2 worker pool receives the outer stage's startup timeout.
+        self.stage_init_timeout = int(stage_init_timeout)
         # Cached by get_diffusion_od_config().
         self._diffusion_od_config_view: Any = None
         startup_timeout = int(init_timeout)
@@ -1016,6 +1019,10 @@ class AsyncOmniEngine:
             "model_config": kwargs.get("model_config", None),
             "additional_config": kwargs.get("additional_config", None),
             "step_execution": kwargs.get("step_execution", False),
+            "enable_runtime_v2": kwargs.get("enable_runtime_v2", False),
+            "runtime_v2_denoise_chunk_size": kwargs.get("runtime_v2_denoise_chunk_size", 1),
+            "runtime_v2_scheduler_policy": kwargs.get("runtime_v2_scheduler_policy", "fcfs"),
+            "stage_init_timeout": kwargs.get("stage_init_timeout", 300),
             "request_batch_max_wait_ms": kwargs.get("request_batch_max_wait_ms", 0.0),
             "vae_use_slicing": kwargs.get("vae_use_slicing", False),
             "vae_use_tiling": kwargs.get("vae_use_tiling", False),
@@ -1154,11 +1161,20 @@ class AsyncOmniEngine:
             else:
                 stage_overrides = stage_overrides_json
 
+        # A default 300 must not override an explicit deploy-YAML value; only a
+        # non-default constructor value is a real runtime override.
+        stage_init_timeout = getattr(self, "stage_init_timeout", 300)
+        configured_kwargs = dict(base_kwargs)
+        if stage_init_timeout != 300:
+            configured_kwargs["stage_init_timeout"] = stage_init_timeout
+
         config_path, stage_configs = load_and_resolve_stage_configs(
             model,
             stage_configs_path,
-            base_kwargs,
-            default_stage_cfg_factory=lambda: self._create_default_diffusion_stage_cfg(kwargs),
+            configured_kwargs,
+            default_stage_cfg_factory=lambda: self._create_default_diffusion_stage_cfg(
+                {**kwargs, "stage_init_timeout": stage_init_timeout}
+            ),
             deploy_config_path=deploy_config_path,
             stage_overrides=stage_overrides,
         )

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -627,6 +627,29 @@ class StageRuntime:
         """Return the master server for local distributed launches, if any."""
         return None
 
+    @staticmethod
+    def _stage_enables_runtime_v2(stage_cfg: Any) -> bool:
+        """Return True when this diffusion stage opts into runtime_v2.
+
+        runtime_v2 requires the engine to run in ``StageDiffusionProc`` instead
+        of the API frontend, so it must not take the inline
+        single-stage/single-replica shortcut. The flag is set on the
+        stage's ``engine_args`` (``enable_runtime_v2``) by the top-level
+        ``Omni(enable_runtime_v2=...)`` opt-in (see
+        ``AsyncOmniEngine._create_default_diffusion_stage_cfg``); it is the same
+        value that ``build_diffusion_config`` surfaces as
+        ``od_config.enable_runtime_v2``. Read it directly (side-effect-free)
+        rather than building the od_config here, which mutates ``engine_args``.
+        """
+        engine_args = getattr(stage_cfg, "engine_args", None)
+        if engine_args is None:
+            return False
+        if hasattr(engine_args, "get"):
+            value = engine_args.get("enable_runtime_v2", False)
+        else:
+            value = getattr(engine_args, "enable_runtime_v2", False)
+        return bool(value)
+
     def _initialize_local_diffusion_replica(
         self,
         plan: ReplicaInitPlan,
@@ -641,13 +664,18 @@ class StageRuntime:
                 if omni_conn_cfg:
                     inject_omni_kv_config(plan.stage_cfg, omni_conn_cfg, omni_from, omni_to)
                 inject_kv_stage_info(plan.stage_cfg, plan.metadata.stage_id, self._stage_configs)
+                # runtime_v2 runs the engine in StageDiffusionProc, so force the
+                # non-inline path even when the legacy runtime would use its
+                # single-stage/single-replica shortcut.
+                enable_runtime_v2 = self._stage_enables_runtime_v2(plan.stage_cfg)
+                use_inline = (self._num_stages == 1 and plan.num_replicas == 1) and not enable_runtime_v2
                 client, resources = launch_diffusion_stage_replica(
                     model=self._model,
                     stage_config=plan.stage_cfg,
                     metadata=plan.metadata,
                     stage_init_timeout=stage_init_timeout,
                     batch_size=self._diffusion_batch_size,
-                    use_inline=self._num_stages == 1 and plan.num_replicas == 1,
+                    use_inline=use_inline,
                     replica_id=plan.replica_id,
                     omni_master_server=self._get_omni_master_server(),
                     omni_coordinator_address=self._get_coordinator_address(),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -557,6 +557,23 @@ class OmniServeCommand(CLISubcommand):
             help="Enable per-step diffusion execution so running requests can be aborted between denoise steps.",
         )
         omni_config_group.add_argument(
+            "--enable-runtime-v2",
+            action="store_true",
+            help="Enable the runtime_v2 task-centric diffusion scheduler (PR1: single-group FCFS Qwen-Image).",
+        )
+        omni_config_group.add_argument(
+            "--runtime-v2-denoise-chunk-size",
+            type=int,
+            default=1,
+            help="runtime_v2: number of denoise steps dispatched per DIT_STEP_CHUNK task (default: 1).",
+        )
+        omni_config_group.add_argument(
+            "--runtime-v2-scheduler-policy",
+            type=str,
+            default="fcfs",
+            help="runtime_v2: global scheduler policy (default: 'fcfs').",
+        )
+        omni_config_group.add_argument(
             "--request-batch-max-wait-ms",
             type=float,
             default=0.0,


### PR DESCRIPTION
## Purpose

Foundational PR of the `runtime_v2` series from **RFC #4658 — [Upstreaming `runtime_v2`: A Task-Centric Elastic Runtime for DiT Serving](https://github.com/vllm-project/vllm-omni/issues/4658)**.

DiT serving today fixes a parallelism layout at admission and holds it for the whole request. That couples two things the RFC wants to separate: different stages (text-encode / denoise / decode) prefer different degrees, and a burst of small latency-sensitive requests cannot preempt a large one holding a wide group (head-of-line blocking). `runtime_v2` reframes serving as a **task-graph runtime**: requests compile to a DAG of `InferenceTask`s, an event-driven scheduler dispatches them over execution groups, and — in later PRs — live artifacts can be resharded across groups to change parallelism mid-flight.

This PR lands the **runnable foundation**, fully **opt-in** behind `--enable-runtime-v2` (default off). With the flag off, the legacy scheduler/executor path is unchanged.

**What's included** (one concept per commit)
1. **Task-graph & topology contracts** — `InferenceTask`, artifact, worker-event, scheduler and adapter protocols plus a single-group topology.
2. **Multiprocess worker transport** — one `DiffusionWorker` process per topology rank, aggregated task events, async terminal-output fetch, and shared-memory cleanup across success / abort / shutdown. Reuses the existing `DiffusionWorker` / `DiffusionModelRunner`; no new execution engine.
3. **Single-group FCFS scheduler** — compiles requests into dependency graphs and dispatches runnable tasks through one execution group; promotion of the next request is delayed until the terminal output is fetched and the finished request is evicted.
4. **Qwen-Image task runner** — compiles a request into `prepare_encode → denoise-chunk → decode` tasks and drives them through the pipeline's existing **step-execution contract** (`prepare_encode` / `denoise_step` / `step_scheduler` / `post_decode`), so CFG, scheduler stepping and normalization stay in one place in the pipeline.
5. **Opt-in configuration** — threads `enable_runtime_v2` / `runtime_v2_denoise_chunk_size` / `runtime_v2_scheduler_policy` through the Python API, `vllm serve` CLI, structured config, registry and deploy-stage resolution.
6. **Engine lifecycle wiring** — activates the runner behind the flag on a single lock-free scheduler-owner thread, propagates abort and fatal-health state, and forces the process-backed diffusion-stage path.

**Parallelism.** PR1 forms **one execution group spanning all ranks**. Intra-group TP / SP (ulysses) / CFG parallelism is supported by reusing vLLM-Omni's own parallel state — the runtime adds no collective code. Layouts that would imply data/pipeline parallelism or multiple groups (`num_gpus != tp*sp*cfg`) and ring-SP are rejected up front (deferred). Only `QwenImagePipeline` is accepted; other pipelines are rejected at startup.

**Deferred to later PRs in the series** (all additive, per the RFC's staged plan): cost model + simulator, artifact migration + online reshard, Group-Free Collectives backend, elastic scheduling policies, and additional model adapters.

## Test Plan

**vLLM Version:** 0.24.0

**vLLM-Omni Commit:** cbd3939 (#5015)

CPU unit tests over every touched area (task graph/protocol, multiproc worker + IPC, FCFS scheduler, Qwen compiler + runner guard, engine wiring, opt-in config surface):

```
pytest tests/diffusion/test_runtime_v2_multiproc_worker.py \
       tests/diffusion/test_runtime_v2_scheduler_fcfs.py \
       tests/diffusion/test_runtime_v2_qwen_compiler.py \
       tests/diffusion/test_runtime_v2_runner_guard.py \
       tests/diffusion/test_runtime_v2_engine_wiring.py \
       tests/diffusion/test_diffusion_ipc.py \
       tests/config/test_omni_config.py \
       tests/entrypoints/test_serve.py \
       tests/entrypoints/test_async_omni_diffusion_config.py \
       tests/test_config_factory.py
```

GPU end-to-end generation test — generate an image through `runtime_v2` with the flag on:

```
pytest tests/diffusion/test_runtime_v2_qwen_e2e.py   # tiny-random/Qwen-Image, 1×GPU
```

Flag-off regression: `enable_runtime_v2=False` builds the legacy path unchanged (`test_runtime_v2_engine_wiring.py::test_flag_off_builds_legacy_path`).

## Test Result

- **CPU:** `278 passed, 1 skipped`.
- **GPU (end-to-end):** `1 passed` — Qwen-Image generated end-to-end through `runtime_v2` on a single card (finite 3-channel image; flag-on path verified genuinely active).
