### PR TITLE
[BugFix][GR00T] Register Gr00tN1d7Processor with its config class for transformers 5.x

### DIFF
--- a/vllm_omni/diffusion/models/gr00t/modeling/processing_gr00t_n1d7.py
+++ b/vllm_omni/diffusion/models/gr00t/modeling/processing_gr00t_n1d7.py
@@ -552,4 +552,8 @@ class Gr00tN1d7Processor(ProcessorMixin):
         return cls(**processor_kwargs, transformers_loading_kwargs=transformers_loading_kwargs)
 
 
-AutoProcessor.register("Gr00tN1d7", Gr00tN1d7Processor)
+# Register with the config CLASS (not a str): transformers>=5.x AutoProcessor.register
+# requires a PretrainedConfig subclass as the mapping key.
+from vllm_omni.diffusion.models.gr00t.configs.gr00t_n1d7 import Gr00tN1d7Config  # noqa: E402
+
+AutoProcessor.register(Gr00tN1d7Config, Gr00tN1d7Processor)


### PR DESCRIPTION
## Purpose

GR00T-N1.7 cannot load at all on the transformers version this repo's requirements resolve to (`transformers >= 5.5.3`): importing the processor fails with

```
AttributeError: 'str' object has no attribute '__module__'
```

because `AutoProcessor.register("Gr00tN1d7", Gr00tN1d7Processor)` passes a string key, and transformers ≥ 5.x requires a `PretrainedConfig` subclass. This PR registers with `Gr00tN1d7Config` instead. One file, +5/−1.

Part of a 3-PR transformers-5.x / torchvision-0.26 compat set (disjoint files, independently mergeable): this PR, #5029 (InternVLA-A1 model), #5030 (InternVLA-A1 example).

## Test Plan

**vLLM Version:** 0.24.0
**vLLM-Omni Commit:** ff6f0da2 (branch base; runtime-verified at fe478a95)

On 1× A100-40GB, transformers 5.13.0, torch 2.11.0+cu130:

```bash
python -m pytest tests/e2e/online_serving/test_gr00t_openpi.py -v
```

## Test Result

- `test_gr00t_n1d7_openpi_online` **PASSED**: server starts from `vllm_omni/deploy/Gr00tN1d7.yaml`, OpenPI WebSocket handshake OK, action shapes `eef_9d (1,40,9)` / `gripper_position (1,40,1)` / `joint_position (1,40,7)`, all values finite, reset OK.
- `test_gr00t_n1d7_openpi_precision` fails marginally and pre-existingly: 1/27 elements at abs diff 0.0106 vs `atol=1e-2`, against reference values captured from the Isaac-GR00T ZMQ server on an older torch/transformers stack. This looks like numeric drift from the newer stack, not a functional regression — flagging for maintainers rather than loosening the tolerance here (without this PR the test cannot even load the model).
