### PR TITLE
[BugFix][Examples] InternVLA-A1: PyAV video decoding and DiffusionRequestBatch API sync

### DIFF
--- a/examples/offline_inference/internvla_a1/end2end.py
+++ b/examples/offline_inference/internvla_a1/end2end.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.internvla_a1 import (  # noqa: E402
 from vllm_omni.diffusion.models.internvla_a1.config import OBS_STATE  # noqa: E402
 from vllm_omni.diffusion.registry import initialize_model  # noqa: E402
 from vllm_omni.diffusion.request import OmniDiffusionRequest  # noqa: E402
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch  # noqa: E402
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams  # noqa: E402
 
 
@@ -158,16 +159,20 @@ def run_pipeline_forward(
     request_id: str,
 ) -> torch.Tensor:
     output = pipeline.forward(
-        OmniDiffusionRequest(
-            prompts=[""],
-            sampling_params=OmniDiffusionSamplingParams(
-                extra_args={
-                    "batch_inputs": batch_inputs,
-                    "noise": noise,
-                    "decode_image": False,
-                }
-            ),
-            request_id=request_id,
+        DiffusionRequestBatch(
+            requests=[
+                OmniDiffusionRequest(
+                    prompt="",  # placeholder: real inputs go via sampling_params.extra_args
+                    sampling_params=OmniDiffusionSamplingParams(
+                        extra_args={
+                            "batch_inputs": batch_inputs,
+                            "noise": noise,
+                            "decode_image": False,
+                        }
+                    ),
+                    request_id=request_id,
+                )
+            ]
         )
     )
     if output.error:

--- a/examples/offline_inference/internvla_a1/internvla_a1_common.py
+++ b/examples/offline_inference/internvla_a1/internvla_a1_common.py
@@ -12,7 +12,6 @@ import numpy as np
 import pyarrow.parquet as pq
 import torch
 import torch.nn.functional as F
-import torchvision
 
 from vllm_omni.diffusion.models.internvla_a1.config import (  # noqa: E402
     OBS_IMAGES,
@@ -79,29 +78,38 @@ def unnormalize_vector(values: torch.Tensor, stats: dict[str, torch.Tensor]) -> 
 
 
 class TorchvisionVideoReaderCache:
+    # torchvision>=0.23 removed the video reading API (VideoReader/read_video was
+    # moved to torchcodec), so decode frames with PyAV directly. Same interface.
     def __init__(self, backend: str = "pyav") -> None:
         self.backend = backend
         self._readers: dict[str, Any] = {}
-        torchvision.set_video_backend(backend)
 
     def get(self, path: str) -> Any:
         reader = self._readers.get(path)
         if reader is None:
-            reader = torchvision.io.VideoReader(path, "video")
+            import av
+
+            reader = av.open(path)
             self._readers[path] = reader
         return reader
 
     def decode_frames(self, path: str, timestamps: list[float], tolerance_s: float = 1e-4) -> torch.Tensor:
-        reader = self.get(path)
+        container = self.get(path)
+        stream = container.streams.video[0]
+        time_base = float(stream.time_base)
         first_ts = min(timestamps)
         last_ts = max(timestamps)
-        reader.seek(first_ts, keyframes_only=self.backend == "pyav")
+
+        # Seek to the keyframe at or before the earliest requested timestamp,
+        # then decode forward and collect frames up to the latest timestamp.
+        container.seek(int(max(first_ts, 0.0) / time_base), stream=stream, backward=True, any_frame=False)
 
         loaded_frames: list[torch.Tensor] = []
         loaded_ts: list[float] = []
-        for frame in reader:
-            current_ts = float(frame["pts"])
-            loaded_frames.append(frame["data"])
+        for frame in container.decode(stream):
+            current_ts = float(frame.pts * time_base)
+            arr = frame.to_ndarray(format="rgb24")  # HxWxC uint8
+            loaded_frames.append(torch.from_numpy(arr).permute(2, 0, 1).contiguous())
             loaded_ts.append(current_ts)
             if current_ts >= last_ts:
                 break


### PR DESCRIPTION
## Purpose

Two independent breakages in the InternVLA-A1 offline example:

1. **torchvision ≥ 0.23 removed the video API** (`torchvision.io.VideoReader` / `read_video` moved to torchcodec), so dataset video decoding crashes with `module 'torchvision.io' has no attribute 'VideoReader'`. This PR reimplements `TorchvisionVideoReaderCache` with **PyAV** — already a core dependency (`av>=14.0.0` in `requirements/common.txt`), so no new dep. Same interface and frame-selection tolerance: seek to the keyframe at or before the earliest requested timestamp, decode forward, collect frames up to the latest timestamp.
2. **The example drifted from the pipeline API**: `pipeline.forward` takes a `DiffusionRequestBatch`, and `OmniDiffusionRequest` takes `prompt` (singular). The example still passed a bare request with `prompts=[...]`, failing with `TypeError: unexpected keyword 'prompts'`. Wrap the request in `DiffusionRequestBatch(requests=[...])`.

Part of a 3-PR transformers-5.x / torchvision-0.26 compat set (disjoint files, independently mergeable): #5028 (GR00T processor registration), #5029 (InternVLA-A1 model compat), this PR. Running this example end-to-end needs #5029 + this PR.

## Test Plan

**vLLM Version:** 0.24.0
**vLLM-Omni Commit:** ff6f0da2 (branch base; runtime-verified at fe478a95)

On 1× A100-40GB, transformers 5.13.0, torchvision 0.26.0+cu130, with the model-compat PR also applied:

```bash
cd examples/offline_inference/internvla_a1
bash run.sh --num-samples 1 --num-episodes 0   # single-sample inference
bash run.sh --num-episodes 1                   # open-loop eval vs ground truth
```

## Test Result

- Single-sample inference: action tensor **[1, 50, 16]** (task *"Put the pen from the table into the pen holder."*).
- Open-loop GT eval (1 episode, 600 steps): **avg MSE 0.00157 / MAE 0.0139**, bit-identical across repeat runs, pred-vs-GT plots generated.
- Note: the example additionally needs `pyarrow` at runtime for the LeRobot parquet dataset; it is not pulled in by core. Left as-is here — can add to example docs or an extras group if preferred.
