### PR TITLE
[CI] Fix Server Side Trust Remote Code in Benchmarks

### DIFF
--- a/tests/dfx/conftest.py
+++ b/tests/dfx/conftest.py
@@ -6,7 +6,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -14,6 +14,16 @@ from tests.dfx.reliability.helpers import list_remote_process_pids_by_pattern, p
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import modify_stage_config
 from vllm_omni.platforms import current_omni_platform
+
+
+class BenchmarkServerParams(NamedTuple):
+    test_name: str
+    model: str
+    stage_config_path: str | None
+    stage_overrides: str | None
+    extra_cli_args: tuple[str, ...]
+    use_omni: bool
+    trust_remote_code: bool
 
 
 def load_configs(config_path: str) -> list[dict[str, Any]]:
@@ -71,7 +81,7 @@ def _build_serve_args(serve_args: Any) -> list[str]:
 def create_unique_server_params(
     configs: list[dict[str, Any]],
     stage_configs_dir: Path,
-) -> list[tuple[str, str, str | None, str | None, tuple[str, ...], bool]]:
+) -> list[BenchmarkServerParams]:
     """Return one row per unique server configuration.
 
     ``(test_name, model, deploy_yaml_path, stage_overrides_json, extra_cli_args, use_omni)``.
@@ -80,8 +90,8 @@ def create_unique_server_params(
     and **prepended** to ``extra_cli_args`` so perf / stability ``omni_server`` fixtures
     stay identical to main while still honoring ``serve_args`` in benchmark JSON.
     """
-    unique_params: list[tuple[str, str, str | None, str | None, tuple[str, ...], bool]] = []
-    seen: set[tuple[str, str, str | None, str | None, tuple[str, ...], bool]] = set()
+    unique_params: list[BenchmarkServerParams] = []
+    seen: set[BenchmarkServerParams] = set()
     for config in configs:
         test_name = config["test_name"]
         server_params = config["server_params"]
@@ -106,14 +116,16 @@ def create_unique_server_params(
         raw_extra = tuple(server_params.get("extra_cli_args") or ())
         extra_cli_args = tuple(serve_flat) + raw_extra
         use_omni = bool(server_params.get("use_omni", True))
+        trust_remote_code = bool(server_params.get("trust_remote_code", False))
 
-        server_param = (
+        server_param = BenchmarkServerParams(
             test_name,
             model,
             stage_config_path,
             stage_overrides_json,
             extra_cli_args,
             use_omni,
+            trust_remote_code,
         )
         if server_param not in seen:
             seen.add(server_param)

--- a/tests/dfx/conftest.py
+++ b/tests/dfx/conftest.py
@@ -158,18 +158,23 @@ def extract_server_args_by_test_name(configs: list[dict[str, Any]]) -> dict[str,
 def create_reliability_omni_server_params(
     configs: list[dict[str, Any]], stage_configs_dir: Path
 ) -> list[OmniServerParams]:
+    server_params = []
     adjusted_configs = configs_with_platform_stage_configs(configs)
     unique_params = create_unique_server_params(adjusted_configs, stage_configs_dir)
     server_args_by_name = extract_server_args_by_test_name(adjusted_configs)
-    return [
-        OmniServerParams(
-            model=model,
-            stage_config_path=stage_config_path,
-            server_args=server_args_by_name.get(test_name),
-            use_omni=use_omni,
+
+    for p in unique_params:
+        server_args = server_args_by_name.get(p.test_name) or []
+        if p.trust_remote_code:
+            server_args.append("--trust-remote-code")
+        param = OmniServerParams(
+            model=p.model,
+            stage_config_path=p.stage_config_path,
+            server_args=server_args,
+            use_omni=p.use_omni,
         )
-        for test_name, model, stage_config_path, _stage_overrides_json, _extra_cli_args, use_omni in unique_params
-    ]
+        server_params.append(param)
+    return server_params
 
 
 def supports_video_generation(model_name: str) -> bool:

--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -66,14 +66,24 @@ def omni_server(request):
     Uses session scope so the server starts only once for the entire test session.
     Multi-stage initialization can take 10-20+ minutes.
     """
+    (
+        test_name,
+        model,
+        stage_config_path,
+        stage_overrides,
+        extra_cli_args,
+        use_omni,
+        trust_remote_code,
+    ) = request.param
     with _omni_server_lock:
-        test_name, model, stage_config_path, stage_overrides, extra_cli_args, use_omni = request.param
-
         print(f"Starting OmniServer with test: {test_name}, model: {model}")
 
         server_args: list[str] = []
         if use_omni:
             server_args += ["--stage-init-timeout", "600", "--init-timeout", "900"]
+        if trust_remote_code:
+            server_args += ["--trust-remote-code"]
+
         # --deploy-config and --stage-overrides compose at the CLI (see vllm_omni/entrypoints/utils.py):
         # deploy-config sets the base; stage-overrides are applied on top. Both can be set.
         if stage_config_path:

--- a/tests/dfx/stability/conftest.py
+++ b/tests/dfx/stability/conftest.py
@@ -34,16 +34,23 @@ _omni_server_lock = threading.Lock()
 def omni_server(request: pytest.FixtureRequest):
     """Start OmniServer for stability tests, with per-module timeout override."""
     timeout_args = getattr(request.module, "STABILITY_SERVER_TIMEOUT_ARGS", DEFAULT_STABILITY_SERVER_TIMEOUT_ARGS)
-    with _omni_server_lock:
-        # Same tuple and CLI composition as ``tests/dfx/perf/scripts/run_benchmark.py``;
-        # ``serve_args`` from JSON are folded into ``extra_cli_args`` inside
-        # ``create_unique_server_params``.
-        test_name, model, deploy_path, stage_overrides, extra_cli_args, use_omni = request.param
+    (
+        test_name,
+        model,
+        deploy_path,
+        stage_overrides,
+        extra_cli_args,
+        use_omni,
+        trust_remote_code,
+    ) = request.param
 
+    with _omni_server_lock:
         print(f"Starting OmniServer with test: {test_name}, model: {model}")
         server_args: list[str] = []
         if use_omni:
             server_args += list(timeout_args)
+        if trust_remote_code:
+            server_args += ["--trust-remote-code"]
         if deploy_path:
             server_args = ["--deploy-config", deploy_path] + server_args
         if stage_overrides:


### PR DESCRIPTION
## Purpose
Fix for the failing `🌕 TTS · VoxCPM2 · Perf Test` in the nightly build I had run in: https://github.com/vllm-project/vllm-omni/pull/5008. This one is not related to tthe tiny models and is because the benchmark tests in the nightly CI don't correctly set `trust_remote_code` in the omni server fixture. This previously was mostly likely okay because trust remote code had some fallback paths to True until recently, which has since fixed.

To reproduce the crash in the nightly tests:
```bash
pytest -s -v tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_voxcpm2.json
```

which blows up the server with
```
(StageEngineCoreProc_stage0_replica0 pid=2700012) ERROR 07-11 06:53:06 [stage_engine_core_proc.py:176] ValueError: The repository openbmb/VoxCPM2 contains custom code which must be executed to correctly load the model. You can inspect the repository content at https://hf.co/openbmb/VoxCPM2 .
```

this wraps the tuple in a `BenchmarkServerParams` named tuple to be a bit easier to look at and passes `--trust-remote-code` on the server side in the shared fixture. 

@yenuo26 PTAL, thanks!