### PR TITLE
[Refactor]extract the specific logic for lance from data.py

### DIFF
--- a/tests/entrypoints/test_resolve_dreamzero_config.py
+++ b/tests/entrypoints/test_resolve_dreamzero_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.data import OmniDiffusionConfig, resolve_model_class_name
 from vllm_omni.diffusion.stage_diffusion_proc import StageDiffusionProc
 from vllm_omni.entrypoints.utils import load_stage_configs_from_model, resolve_model_config_path
 
@@ -54,3 +54,46 @@ def test_dreamzero_enrich_config_preserves_explicit_model_class_name(monkeypatch
     proc._enrich_config()
 
     assert od_config.model_class_name == "DreamZeroPipeline"
+
+
+def test_dreamzero_resolve_model_class_name(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "vla", "architectures": ["VLA"]},
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.utils.hf_utils._looks_like_dreamzero",
+        lambda _model: True,
+    )
+
+    assert resolve_model_class_name("GEAR-Dreams/DreamZero-DROID") == "DreamZeroPipeline"
+
+
+def test_non_dreamzero_vla_does_not_use_architecture_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "vla", "architectures": ["VLA"]},
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.utils.hf_utils._looks_like_dreamzero",
+        lambda _model: False,
+    )
+
+    assert resolve_model_class_name("some-vla-model") is None
+
+
+def test_non_dreamzero_vla_still_raises(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "vla", "architectures": ["VLA"]},
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.utils.hf_utils._looks_like_dreamzero",
+        lambda _model: False,
+    )
+
+    od_config = OmniDiffusionConfig(model="some-vla-model")
+    proc = StageDiffusionProc(od_config.model, od_config)
+
+    with pytest.raises(FileNotFoundError):
+        proc._enrich_config()

--- a/tests/entrypoints/test_resolve_lance_config.py
+++ b/tests/entrypoints/test_resolve_lance_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig, resolve_model_class_name
+from vllm_omni.diffusion.stage_diffusion_proc import StageDiffusionProc
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_lance_subfolder_resolves_model_class(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda _path, _model: None,
+    )
+
+    result = resolve_model_class_name("/fake/path/Lance_3B")
+
+    assert result == "LancePipeline"
+
+
+def test_lance_enrich_config_from_subfolder(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda _path, _model: None,
+    )
+
+    od_config = OmniDiffusionConfig(model="/fake/path/Lance_3B")
+    proc = StageDiffusionProc(od_config.model, od_config)
+
+    proc._enrich_config()
+
+    assert od_config.model_class_name == "LancePipeline"

--- a/tests/entrypoints/test_resolve_standard_config.py
+++ b/tests/entrypoints/test_resolve_standard_config.py
@@ -43,7 +43,7 @@ def test_resolve_model_class_name_falls_back_to_single_architecture(monkeypatch)
     assert resolve_model_class_name("fake-model") == "FooPipeline"
 
 
-def test_nextstep_enrich_config_overrides_stale_explicit_model_class(monkeypatch):
+def test_nextstep_enrich_config_preserves_explicit_model_class_name(monkeypatch):
     monkeypatch.setattr(
         "vllm.transformers_utils.config.get_hf_file_to_dict",
         lambda path, _model: None if path == "model_index.json" else {"model_type": "nextstep", "architectures": []},
@@ -51,10 +51,27 @@ def test_nextstep_enrich_config_overrides_stale_explicit_model_class(monkeypatch
 
     od_config = OmniDiffusionConfig(
         model="bytedance-research/NextStep-1-Large",
-        model_class_name="StalePipeline",
+        model_class_name="UserProvidedPipeline",
     )
     proc = StageDiffusionProc(od_config.model, od_config)
 
     proc._enrich_config()
 
-    assert od_config.model_class_name == "NextStep11Pipeline"
+    assert od_config.model_class_name == "UserProvidedPipeline"
+
+
+def test_s2v_enrich_config_preserves_explicit_model_class_name(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "s2v", "architectures": []},
+    )
+
+    od_config = OmniDiffusionConfig(
+        model="Wan-AI/Wan2.2-S2V-14B",
+        model_class_name="UserProvidedPipeline",
+    )
+    proc = StageDiffusionProc(od_config.model, od_config)
+
+    proc._enrich_config()
+
+    assert od_config.model_class_name == "UserProvidedPipeline"

--- a/tests/entrypoints/test_resolve_standard_config.py
+++ b/tests/entrypoints/test_resolve_standard_config.py
@@ -17,10 +17,6 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
         ),
         ({"model_type": "nextstep", "architectures": []}, "NextStep11Pipeline"),
         ({"model_type": "s2v", "architectures": []}, "WanS2VPipeline"),
-        (
-            {"model_type": "other", "architectures": ["Gr00tN1d7"]},
-            "Gr00tN1d7Pipeline",
-        ),
     ],
 )
 def test_standard_model_families_resolve_model_class(monkeypatch, cfg, expected):
@@ -43,6 +39,19 @@ def test_resolve_model_class_name_falls_back_to_single_architecture(monkeypatch)
     assert resolve_model_class_name("fake-model") == "FooPipeline"
 
 
+def test_gr00t_not_resolved_by_resolve_model_class_name(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None
+        if path == "model_index.json"
+        else {"model_type": "other", "architectures": ["Gr00tN1d7"]},
+    )
+
+    # Gr00tN1d7 remains enrich-only by design and should not be surfaced
+    # through the read-only resolve_model_class_name() helper.
+    assert resolve_model_class_name("nvidia/GR00T-N1.5") is None
+
+
 def test_nextstep_enrich_config_preserves_explicit_model_class_name(monkeypatch):
     monkeypatch.setattr(
         "vllm.transformers_utils.config.get_hf_file_to_dict",
@@ -58,6 +67,22 @@ def test_nextstep_enrich_config_preserves_explicit_model_class_name(monkeypatch)
     proc._enrich_config()
 
     assert od_config.model_class_name == "UserProvidedPipeline"
+
+
+def test_gr00t_enrich_config_sets_gr00t_pipeline(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None
+        if path == "model_index.json"
+        else {"model_type": "other", "architectures": ["Gr00tN1d7"]},
+    )
+
+    od_config = OmniDiffusionConfig(model="nvidia/GR00T-N1.5")
+    proc = StageDiffusionProc(od_config.model, od_config)
+
+    proc._enrich_config()
+
+    assert od_config.model_class_name == "Gr00tN1d7Pipeline"
 
 
 def test_s2v_enrich_config_preserves_explicit_model_class_name(monkeypatch):

--- a/tests/entrypoints/test_resolve_standard_config.py
+++ b/tests/entrypoints/test_resolve_standard_config.py
@@ -1,0 +1,58 @@
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig, resolve_model_class_name
+from vllm_omni.diffusion.stage_diffusion_proc import StageDiffusionProc
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("cfg", "expected"),
+    [
+        ({"model_type": "bagel", "architectures": []}, "BagelPipeline"),
+        ({"model_type": "neo_chat", "architectures": []}, "SenseNovaU1Pipeline"),
+        (
+            {"model_type": "ming_flash_omni", "architectures": []},
+            "MingImagePipeline",
+        ),
+        ({"model_type": "nextstep", "architectures": []}, "NextStep11Pipeline"),
+        ({"model_type": "s2v", "architectures": []}, "WanS2VPipeline"),
+        (
+            {"model_type": "other", "architectures": ["Gr00tN1d7"]},
+            "Gr00tN1d7Pipeline",
+        ),
+    ],
+)
+def test_standard_model_families_resolve_model_class(monkeypatch, cfg, expected):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else cfg,
+    )
+
+    assert resolve_model_class_name("fake-model") == expected
+
+
+def test_resolve_model_class_name_falls_back_to_single_architecture(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "unknown", "architectures": ["FooPipeline"]},
+    )
+
+    assert resolve_model_class_name("fake-model") == "FooPipeline"
+
+
+def test_nextstep_enrich_config_overrides_stale_explicit_model_class(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_hf_file_to_dict",
+        lambda path, _model: None if path == "model_index.json" else {"model_type": "nextstep", "architectures": []},
+    )
+
+    od_config = OmniDiffusionConfig(
+        model="bytedance-research/NextStep-1-Large",
+        model_class_name="StalePipeline",
+    )
+    proc = StageDiffusionProc(od_config.model, od_config)
+
+    proc._enrich_config()
+
+    assert od_config.model_class_name == "NextStep11Pipeline"

--- a/tests/entrypoints/test_resolve_standard_config.py
+++ b/tests/entrypoints/test_resolve_standard_config.py
@@ -35,7 +35,9 @@ def test_standard_model_families_resolve_model_class(monkeypatch, cfg, expected)
 def test_resolve_model_class_name_falls_back_to_single_architecture(monkeypatch):
     monkeypatch.setattr(
         "vllm.transformers_utils.config.get_hf_file_to_dict",
-        lambda path, _model: None if path == "model_index.json" else {"model_type": "unknown", "architectures": ["FooPipeline"]},
+        lambda path, _model: None
+        if path == "model_index.json"
+        else {"model_type": "unknown", "architectures": ["FooPipeline"]},
     )
 
     assert resolve_model_class_name("fake-model") == "FooPipeline"

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1005,6 +1005,9 @@ class OmniDiffusionConfig:
         # Some families document ``--model-class-name`` as an explicit override
         # (for example NextStep and Wan S2V), so preserve the caller-provided
         # value when requested instead of replacing it with the inferred class.
+        # In that case we also keep the parsed ``TransformerConfig.from_dict``
+        # result from ``config.json`` instead of resetting it to an empty
+        # ``TransformerConfig()`` like the old branch-local code did.
         if not override_existing and self.model_class_name is not None:
             self.update_multimodal_support()
             return

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -516,7 +516,7 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     """
     from vllm.transformers_utils.config import get_hf_file_to_dict
 
-    from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
+    from vllm_omni.diffusion.model_resolvers import resolve_model_class
 
     if not model:
         return None
@@ -537,7 +537,7 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     except Exception:
         cfg = {}
     architectures = cfg.get("architectures") or []
-    resolution = resolve_model_class_resolution(model, cfg)
+    resolution = resolve_model_class(model, cfg, for_enrich=False)
     if resolution.handled:
         return resolution.model_class_name
     if len(architectures) == 1:
@@ -1002,17 +1002,13 @@ class OmniDiffusionConfig:
         self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
 
     def _apply_resolved_model_class(self, model_class_name: str, *, override_existing: bool = True) -> None:
-        # Some families document ``--model-class-name`` as an explicit override
-        # (for example NextStep and Wan S2V), so preserve the caller-provided
-        # value when requested instead of replacing it with the inferred class.
-        # In that case we also keep the parsed ``TransformerConfig.from_dict``
-        # result from ``config.json`` instead of resetting it to an empty
-        # ``TransformerConfig()`` like the old branch-local code did.
-        if not override_existing and self.model_class_name is not None:
-            self.update_multimodal_support()
-            return
+        # Preserve explicit model_class_name for families that document it as an override.
+        if override_existing or self.model_class_name is None:
+            self.model_class_name = model_class_name
 
-        self.model_class_name = model_class_name
+        # Preserve historical behavior for these branches: even when the explicit
+        # model_class_name is kept, tf_model_config is reset to an empty
+        # TransformerConfig and multimodal metadata is refreshed.
         self.set_tf_model_config(TransformerConfig())
         self.update_multimodal_support()
 
@@ -1025,7 +1021,7 @@ class OmniDiffusionConfig:
         """
         from vllm.transformers_utils.config import get_hf_file_to_dict
 
-        from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
+        from vllm_omni.diffusion.model_resolvers import resolve_model_class
 
         # Default model_class_name for diffusers adapter
         if self.model_class_name is None and self.diffusion_load_format == "diffusers":
@@ -1076,7 +1072,7 @@ class OmniDiffusionConfig:
             else:
                 cfg = get_hf_file_to_dict("config.json", self.model)
                 if cfg is None:
-                    resolution = resolve_model_class_resolution(self.model, None)
+                    resolution = resolve_model_class(self.model, None, for_enrich=True)
                     if resolution.model_class_name is not None:
                         self._apply_resolved_model_class(resolution.model_class_name)
                         return
@@ -1084,15 +1080,11 @@ class OmniDiffusionConfig:
 
                 self.set_tf_model_config(TransformerConfig.from_dict(cfg))
                 architectures = cfg.get("architectures") or []
-                resolution = resolve_model_class_resolution(self.model, cfg)
+                resolution = resolve_model_class(self.model, cfg, for_enrich=True)
                 if resolution.model_class_name is not None:
-                    preserve_explicit_model_class = resolution.model_class_name in {
-                        "NextStep11Pipeline",
-                        "WanS2VPipeline",
-                    }
                     self._apply_resolved_model_class(
                         resolution.model_class_name,
-                        override_existing=not preserve_explicit_model_class,
+                        override_existing=not resolution.preserve_explicit,
                     )
                 elif resolution.handled:
                     raise

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -515,6 +515,7 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     client-side. Returns ``None`` if the pipeline can't be determined.
     """
     from vllm.transformers_utils.config import get_hf_file_to_dict
+
     from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
 
     if not model:
@@ -1000,10 +1001,14 @@ class OmniDiffusionConfig:
         self.supports_multimodal_inputs = metadata.supports_multimodal_inputs
         self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
 
-    def _apply_resolved_model_class(self, model_class_name: str) -> None:
-        # Treat resolver-selected classes as authoritative for known model
-        # families so both resolution entrypoints stay consistent, even if a
-        # caller passed a stale explicit class name before config enrichment.
+    def _apply_resolved_model_class(self, model_class_name: str, *, override_existing: bool = True) -> None:
+        # Some families document ``--model-class-name`` as an explicit override
+        # (for example NextStep and Wan S2V), so preserve the caller-provided
+        # value when requested instead of replacing it with the inferred class.
+        if not override_existing and self.model_class_name is not None:
+            self.update_multimodal_support()
+            return
+
         self.model_class_name = model_class_name
         self.set_tf_model_config(TransformerConfig())
         self.update_multimodal_support()
@@ -1016,6 +1021,7 @@ class OmniDiffusionConfig:
         so we fall back to reading that and mapping model_type manually.
         """
         from vllm.transformers_utils.config import get_hf_file_to_dict
+
         from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
 
         # Default model_class_name for diffusers adapter
@@ -1077,7 +1083,14 @@ class OmniDiffusionConfig:
                 architectures = cfg.get("architectures") or []
                 resolution = resolve_model_class_resolution(self.model, cfg)
                 if resolution.model_class_name is not None:
-                    self._apply_resolved_model_class(resolution.model_class_name)
+                    preserve_explicit_model_class = resolution.model_class_name in {
+                        "NextStep11Pipeline",
+                        "WanS2VPipeline",
+                    }
+                    self._apply_resolved_model_class(
+                        resolution.model_class_name,
+                        override_existing=not preserve_explicit_model_class,
+                    )
                 elif resolution.handled:
                     raise
                 elif architectures and len(architectures) == 1:

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -515,11 +515,10 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     client-side. Returns ``None`` if the pipeline can't be determined.
     """
     from vllm.transformers_utils.config import get_hf_file_to_dict
+    from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
 
     if not model:
         return None
-
-    is_lance_subfolder = os.path.basename(str(model).rstrip("/")) in {"Lance_3B", "Lance_3B_Video"}
 
     # Diffusers models: read _class_name from model_index.json.
     try:
@@ -541,13 +540,9 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
 
     if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
         return "BagelPipeline"
-    if (
-        model_type == "lance"
-        or "LancePipeline" in architectures
-        or cfg.get("model_name") == "Lance"
-        or is_lance_subfolder
-    ):
-        return "LancePipeline"
+    lance_model_class = resolve_lance_model_class_name(model, cfg)
+    if lance_model_class is not None:
+        return lance_model_class
     if model_type == "neo_chat":
         return "SenseNovaU1Pipeline"
     if "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
@@ -1025,21 +1020,6 @@ class OmniDiffusionConfig:
         self.supports_multimodal_inputs = metadata.supports_multimodal_inputs
         self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
 
-    @staticmethod
-    def _looks_like_lance_subfolder(model: str | None) -> bool:
-        """Return True when ``--model`` points at a Lance per-component subfolder.
-
-        Lance's HF repo bundles ``Lance_3B/``, ``Lance_3B_Video/`` and
-        ``Qwen2.5-VL-ViT/`` under a single top-level ``config.json``; users may
-        reasonably hand the AR-style sub-checkpoint path directly.  The
-        ``LancePipeline`` constructor knows to walk up to the repo root from
-        either subfolder name.
-        """
-        if not model:
-            return False
-        base = os.path.basename(str(model).rstrip("/"))
-        return base in {"Lance_3B", "Lance_3B_Video"}
-
     def enrich_config(self) -> None:
         """Load model metadata from HuggingFace and populate config fields.
 
@@ -1048,6 +1028,7 @@ class OmniDiffusionConfig:
         so we fall back to reading that and mapping model_type manually.
         """
         from vllm.transformers_utils.config import get_hf_file_to_dict
+        from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
 
         # Default model_class_name for diffusers adapter
         if self.model_class_name is None and self.diffusion_load_format == "diffusers":
@@ -1102,8 +1083,9 @@ class OmniDiffusionConfig:
                     # the per-checkpoint subfolders (``Lance_3B/`` or
                     # ``Lance_3B_Video/``).  Try to recover that case before
                     # raising.
-                    if self._looks_like_lance_subfolder(self.model):
-                        self.model_class_name = "LancePipeline"
+                    lance_model_class = resolve_lance_model_class_name(self.model, None)
+                    if lance_model_class is not None:
+                        self.model_class_name = lance_model_class
                         self.set_tf_model_config(TransformerConfig())
                         self.update_multimodal_support()
                         return
@@ -1117,68 +1099,65 @@ class OmniDiffusionConfig:
                     self.model_class_name = "BagelPipeline"
                     self.set_tf_model_config(TransformerConfig())
                     self.update_multimodal_support()
-                elif (
-                    model_type == "lance"
-                    or "LancePipeline" in architectures
-                    or cfg.get("model_name") == "Lance"
-                    or self._looks_like_lance_subfolder(self.model)
-                ):
-                    # Lance ships a non-HF top-level config.json (model_name only)
-                    # plus per-component subfolders; resolve to the Lance pipeline.
-                    # Also accept --model pointing directly at the ``Lance_3B`` or
-                    # ``Lance_3B_Video`` subfolder by walking up to the repo root.
-                    self.model_class_name = "LancePipeline"
-                    self.set_tf_model_config(TransformerConfig())
-                    self.update_multimodal_support()
-                elif model_type == "neo_chat":
-                    self.model_class_name = "SenseNovaU1Pipeline"
-                    self.tf_model_config = TransformerConfig()
-                    self.update_multimodal_support()
-                elif "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
-                    "bailingmm_moe_v2_lite",
-                    "ming_flash_omni",
-                    "ming_flash_omni_thinker",
-                ):
-                    # Ming-flash-omni-2.0 — imagegen stage uses the custom
-                    # ``MingImagePipeline`` (ZImage DiT + Qwen2 connector). See
-                    # vllm_omni/diffusion/models/ming_flash_omni/pipeline_ming_imagegen.py.
-                    self.model_class_name = "MingImagePipeline"
-                    self.tf_model_config = TransformerConfig()
-                    self.update_multimodal_support()
-                elif model_type == "nextstep":
-                    if self.model_class_name is None:
-                        self.model_class_name = "NextStep11Pipeline"
-                    self.set_tf_model_config(TransformerConfig())
-                    self.update_multimodal_support()
-                elif model_type == "s2v":
-                    if self.model_class_name is None:
-                        self.model_class_name = "WanS2VPipeline"
-                    self.tf_model_config = TransformerConfig()
-                    self.update_multimodal_support()
-                elif model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
-                    self.model_class_name = "Gr00tN1d7Pipeline"
-                    self.set_tf_model_config(TransformerConfig())
-                    self.update_multimodal_support()
-                elif model_type == "vla":
-                    from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
-
-                    if _looks_like_dreamzero(self.model):
-                        self.model_class_name = "DreamZeroPipeline"
+                else:
+                    lance_model_class = resolve_lance_model_class_name(self.model, cfg)
+                    if lance_model_class is not None:
+                        # Lance ships a non-HF top-level config.json (model_name only)
+                        # plus per-component subfolders; resolve to the Lance pipeline.
+                        # Also accept --model pointing directly at the ``Lance_3B`` or
+                        # ``Lance_3B_Video`` subfolder by walking up to the repo root.
+                        self.model_class_name = lance_model_class
                         self.set_tf_model_config(TransformerConfig())
                         self.update_multimodal_support()
+                    elif model_type == "neo_chat":
+                        self.model_class_name = "SenseNovaU1Pipeline"
+                        self.tf_model_config = TransformerConfig()
+                        self.update_multimodal_support()
+                    elif "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
+                        "bailingmm_moe_v2_lite",
+                        "ming_flash_omni",
+                        "ming_flash_omni_thinker",
+                    ):
+                        # Ming-flash-omni-2.0 — imagegen stage uses the custom
+                        # ``MingImagePipeline`` (ZImage DiT + Qwen2 connector). See
+                        # vllm_omni/diffusion/models/ming_flash_omni/pipeline_ming_imagegen.py.
+                        self.model_class_name = "MingImagePipeline"
+                        self.tf_model_config = TransformerConfig()
+                        self.update_multimodal_support()
+                    elif model_type == "nextstep":
+                        if self.model_class_name is None:
+                            self.model_class_name = "NextStep11Pipeline"
+                        self.set_tf_model_config(TransformerConfig())
+                        self.update_multimodal_support()
+                    elif model_type == "s2v":
+                        if self.model_class_name is None:
+                            self.model_class_name = "WanS2VPipeline"
+                        self.tf_model_config = TransformerConfig()
+                        self.update_multimodal_support()
+                    elif model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
+                        self.model_class_name = "Gr00tN1d7Pipeline"
+                        self.set_tf_model_config(TransformerConfig())
+                        self.update_multimodal_support()
+                    elif model_type == "vla":
+                        from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
+
+                        if _looks_like_dreamzero(self.model):
+                            self.model_class_name = "DreamZeroPipeline"
+                            self.set_tf_model_config(TransformerConfig())
+                            self.update_multimodal_support()
+                        else:
+                            raise
+                    elif architectures and len(architectures) == 1:
+                        architecture = architectures[0]
+                        from vllm_omni.diffusion.registry import DiffusionModelRegistry
+
+                        if (
+                            self.model_class_name is None
+                            or DiffusionModelRegistry._try_load_model_cls(architecture) is not None
+                        ):
+                            self.model_class_name = architecture
                     else:
                         raise
-                elif architectures and len(architectures) == 1:
-                    architecture = architectures[0]
-                    from vllm_omni.diffusion.registry import DiffusionModelRegistry
-
-                    if (
-                        self.model_class_name is None
-                        or DiffusionModelRegistry._try_load_model_cls(architecture) is not None
-                    ):
-                        self.model_class_name = architecture
-                else:
-                    raise
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> "OmniDiffusionConfig":

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -515,7 +515,7 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     client-side. Returns ``None`` if the pipeline can't be determined.
     """
     from vllm.transformers_utils.config import get_hf_file_to_dict
-    from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
+    from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
 
     if not model:
         return None
@@ -535,30 +535,10 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
         cfg = get_hf_file_to_dict("config.json", model) or {}
     except Exception:
         cfg = {}
-    model_type = cfg.get("model_type")
     architectures = cfg.get("architectures") or []
-
-    if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
-        return "BagelPipeline"
-    lance_model_class = resolve_lance_model_class_name(model, cfg)
-    if lance_model_class is not None:
-        return lance_model_class
-    if model_type == "neo_chat":
-        return "SenseNovaU1Pipeline"
-    if "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
-        "bailingmm_moe_v2_lite",
-        "ming_flash_omni",
-        "ming_flash_omni_thinker",
-    ):
-        return "MingImagePipeline"
-    if model_type == "nextstep":
-        return "NextStep11Pipeline"
-    if model_type == "s2v":
-        return "WanS2VPipeline"
-    if model_type == "vla":
-        from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
-
-        return "DreamZeroPipeline" if _looks_like_dreamzero(model) else None
+    resolution = resolve_model_class_resolution(model, cfg)
+    if resolution.handled:
+        return resolution.model_class_name
     if len(architectures) == 1:
         return architectures[0]
     return None
@@ -1020,6 +1000,14 @@ class OmniDiffusionConfig:
         self.supports_multimodal_inputs = metadata.supports_multimodal_inputs
         self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
 
+    def _apply_resolved_model_class(self, model_class_name: str) -> None:
+        # Treat resolver-selected classes as authoritative for known model
+        # families so both resolution entrypoints stay consistent, even if a
+        # caller passed a stale explicit class name before config enrichment.
+        self.model_class_name = model_class_name
+        self.set_tf_model_config(TransformerConfig())
+        self.update_multimodal_support()
+
     def enrich_config(self) -> None:
         """Load model metadata from HuggingFace and populate config fields.
 
@@ -1028,7 +1016,7 @@ class OmniDiffusionConfig:
         so we fall back to reading that and mapping model_type manually.
         """
         from vllm.transformers_utils.config import get_hf_file_to_dict
-        from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
+        from vllm_omni.diffusion.model_resolvers import resolve_model_class_resolution
 
         # Default model_class_name for diffusers adapter
         if self.model_class_name is None and self.diffusion_load_format == "diffusers":
@@ -1079,85 +1067,30 @@ class OmniDiffusionConfig:
             else:
                 cfg = get_hf_file_to_dict("config.json", self.model)
                 if cfg is None:
-                    # Lance ships its top-level config.json one directory above
-                    # the per-checkpoint subfolders (``Lance_3B/`` or
-                    # ``Lance_3B_Video/``).  Try to recover that case before
-                    # raising.
-                    lance_model_class = resolve_lance_model_class_name(self.model, None)
-                    if lance_model_class is not None:
-                        self.model_class_name = lance_model_class
-                        self.set_tf_model_config(TransformerConfig())
-                        self.update_multimodal_support()
+                    resolution = resolve_model_class_resolution(self.model, None)
+                    if resolution.model_class_name is not None:
+                        self._apply_resolved_model_class(resolution.model_class_name)
                         return
                     raise ValueError(f"Could not find config.json or model_index.json for model {self.model}")
 
                 self.set_tf_model_config(TransformerConfig.from_dict(cfg))
-                model_type = cfg.get("model_type")
                 architectures = cfg.get("architectures") or []
+                resolution = resolve_model_class_resolution(self.model, cfg)
+                if resolution.model_class_name is not None:
+                    self._apply_resolved_model_class(resolution.model_class_name)
+                elif resolution.handled:
+                    raise
+                elif architectures and len(architectures) == 1:
+                    architecture = architectures[0]
+                    from vllm_omni.diffusion.registry import DiffusionModelRegistry
 
-                if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
-                    self.model_class_name = "BagelPipeline"
-                    self.set_tf_model_config(TransformerConfig())
-                    self.update_multimodal_support()
-                else:
-                    lance_model_class = resolve_lance_model_class_name(self.model, cfg)
-                    if lance_model_class is not None:
-                        # Lance ships a non-HF top-level config.json (model_name only)
-                        # plus per-component subfolders; resolve to the Lance pipeline.
-                        # Also accept --model pointing directly at the ``Lance_3B`` or
-                        # ``Lance_3B_Video`` subfolder by walking up to the repo root.
-                        self.model_class_name = lance_model_class
-                        self.set_tf_model_config(TransformerConfig())
-                        self.update_multimodal_support()
-                    elif model_type == "neo_chat":
-                        self.model_class_name = "SenseNovaU1Pipeline"
-                        self.tf_model_config = TransformerConfig()
-                        self.update_multimodal_support()
-                    elif "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
-                        "bailingmm_moe_v2_lite",
-                        "ming_flash_omni",
-                        "ming_flash_omni_thinker",
+                    if (
+                        self.model_class_name is None
+                        or DiffusionModelRegistry._try_load_model_cls(architecture) is not None
                     ):
-                        # Ming-flash-omni-2.0 — imagegen stage uses the custom
-                        # ``MingImagePipeline`` (ZImage DiT + Qwen2 connector). See
-                        # vllm_omni/diffusion/models/ming_flash_omni/pipeline_ming_imagegen.py.
-                        self.model_class_name = "MingImagePipeline"
-                        self.tf_model_config = TransformerConfig()
-                        self.update_multimodal_support()
-                    elif model_type == "nextstep":
-                        if self.model_class_name is None:
-                            self.model_class_name = "NextStep11Pipeline"
-                        self.set_tf_model_config(TransformerConfig())
-                        self.update_multimodal_support()
-                    elif model_type == "s2v":
-                        if self.model_class_name is None:
-                            self.model_class_name = "WanS2VPipeline"
-                        self.tf_model_config = TransformerConfig()
-                        self.update_multimodal_support()
-                    elif model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
-                        self.model_class_name = "Gr00tN1d7Pipeline"
-                        self.set_tf_model_config(TransformerConfig())
-                        self.update_multimodal_support()
-                    elif model_type == "vla":
-                        from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
-
-                        if _looks_like_dreamzero(self.model):
-                            self.model_class_name = "DreamZeroPipeline"
-                            self.set_tf_model_config(TransformerConfig())
-                            self.update_multimodal_support()
-                        else:
-                            raise
-                    elif architectures and len(architectures) == 1:
-                        architecture = architectures[0]
-                        from vllm_omni.diffusion.registry import DiffusionModelRegistry
-
-                        if (
-                            self.model_class_name is None
-                            or DiffusionModelRegistry._try_load_model_cls(architecture) is not None
-                        ):
-                            self.model_class_name = architecture
-                    else:
-                        raise
+                        self.model_class_name = architecture
+                else:
+                    raise
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> "OmniDiffusionConfig":

--- a/vllm_omni/diffusion/model_resolvers/__init__.py
+++ b/vllm_omni/diffusion/model_resolvers/__init__.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
 
 from vllm_omni.diffusion.model_resolvers.dreamzero import (
     is_dreamzero_model_family,
@@ -12,16 +10,20 @@ from vllm_omni.diffusion.model_resolvers.dreamzero import (
 )
 from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
 from vllm_omni.diffusion.model_resolvers.standard import resolve_standard_model_class_name
+from vllm_omni.diffusion.model_resolvers.types import ModelConfigLike
 
 
 @dataclass(frozen=True)
 class ModelClassResolution:
     """Resolution result for model-class detection.
 
-    `handled=True` means a resolver claimed the model family, even if it could
-    not resolve a concrete pipeline class. This lets callers preserve
-    family-specific failure behavior without leaking model-specific checks back
-    into shared config code.
+    Attributes:
+        handled: True when a resolver claimed the model family. Callers should
+            stop generic fallback when this is set, even if
+            ``model_class_name`` is ``None``.
+        model_class_name: Resolved pipeline class name for the claimed family,
+            or ``None`` when the family was recognized but could not be mapped
+            to a concrete diffusion pipeline.
     """
 
     handled: bool
@@ -30,8 +32,26 @@ class ModelClassResolution:
 
 def resolve_model_class_resolution(
     model: str | None,
-    cfg: Mapping[str, Any] | None,
+    cfg: ModelConfigLike | None,
 ) -> ModelClassResolution:
+    """Resolve diffusion model family in precedence order.
+
+    Resolver precedence is:
+    1. Lance-specific rules, including subfolder detection.
+    2. DreamZero-specific rules for ``model_type == "vla"``.
+    3. Standard model-family rules keyed by ``model_type`` / ``architectures``.
+
+    Args:
+        model: User-provided model path or HF repo id.
+        cfg: Read-only model config view, typically from
+            ``get_hf_file_to_dict("config.json", model)``. Resolvers currently
+            rely on fields such as ``model_type``, ``architectures``, and
+            ``model_name`` when present.
+
+    Returns:
+        A ``ModelClassResolution`` describing whether a resolver claimed the
+        family and, if so, which concrete pipeline class should be used.
+    """
     lance_model_class = resolve_lance_model_class_name(model, cfg)
     if lance_model_class is not None:
         return ModelClassResolution(handled=True, model_class_name=lance_model_class)
@@ -50,6 +70,7 @@ def resolve_model_class_resolution(
 
 
 __all__ = [
+    "ModelConfigLike",
     "ModelClassResolution",
     "resolve_model_class_resolution",
 ]

--- a/vllm_omni/diffusion/model_resolvers/__init__.py
+++ b/vllm_omni/diffusion/model_resolvers/__init__.py
@@ -24,15 +24,21 @@ class ModelClassResolution:
         model_class_name: Resolved pipeline class name for the claimed family,
             or ``None`` when the family was recognized but could not be mapped
             to a concrete diffusion pipeline.
+        preserve_explicit: When True, callers should keep an already-specified
+            explicit ``model_class_name`` instead of overwriting it with the
+            inferred class for this family.
     """
 
     handled: bool
     model_class_name: str | None = None
+    preserve_explicit: bool = False
 
 
-def resolve_model_class_resolution(
+def resolve_model_class(
     model: str | None,
     cfg: ModelConfigLike | None,
+    *,
+    for_enrich: bool = False,
 ) -> ModelClassResolution:
     """Resolve diffusion model family in precedence order.
 
@@ -47,6 +53,9 @@ def resolve_model_class_resolution(
             ``get_hf_file_to_dict("config.json", model)``. Resolvers currently
             rely on fields such as ``model_type``, ``architectures``, and
             ``model_name`` when present.
+        for_enrich: When True, enable enrich-only families that historically
+            existed only in ``OmniDiffusionConfig.enrich_config()`` and were
+            not part of ``resolve_model_class_name()``.
 
     Returns:
         A ``ModelClassResolution`` describing whether a resolver claimed the
@@ -64,7 +73,22 @@ def resolve_model_class_resolution(
 
     standard_model_class = resolve_standard_model_class_name(model, cfg)
     if standard_model_class is not None:
-        return ModelClassResolution(handled=True, model_class_name=standard_model_class)
+        return ModelClassResolution(
+            handled=True,
+            model_class_name=standard_model_class,
+            preserve_explicit=standard_model_class in {"NextStep11Pipeline", "WanS2VPipeline"},
+        )
+
+    # Gr00tN1d7 is enrich-only by design. Keep it out of
+    # resolve_model_class_name() to preserve historical client-side behavior.
+    if for_enrich and cfg is not None:
+        model_type = cfg.get("model_type")
+        architectures = cfg.get("architectures") or []
+        if model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
+            return ModelClassResolution(
+                handled=True,
+                model_class_name="Gr00tN1d7Pipeline",
+            )
 
     return ModelClassResolution(handled=False)
 
@@ -72,5 +96,5 @@ def resolve_model_class_resolution(
 __all__ = [
     "ModelConfigLike",
     "ModelClassResolution",
-    "resolve_model_class_resolution",
+    "resolve_model_class",
 ]

--- a/vllm_omni/diffusion/model_resolvers/__init__.py
+++ b/vllm_omni/diffusion/model_resolvers/__init__.py
@@ -1,1 +1,55 @@
 """Helpers for resolving model-specific diffusion pipelines."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from vllm_omni.diffusion.model_resolvers.dreamzero import (
+    is_dreamzero_model_family,
+    resolve_dreamzero_model_class_name,
+)
+from vllm_omni.diffusion.model_resolvers.lance import resolve_lance_model_class_name
+from vllm_omni.diffusion.model_resolvers.standard import resolve_standard_model_class_name
+
+
+@dataclass(frozen=True)
+class ModelClassResolution:
+    """Resolution result for model-class detection.
+
+    `handled=True` means a resolver claimed the model family, even if it could
+    not resolve a concrete pipeline class. This lets callers preserve
+    family-specific failure behavior without leaking model-specific checks back
+    into shared config code.
+    """
+
+    handled: bool
+    model_class_name: str | None = None
+
+
+def resolve_model_class_resolution(
+    model: str | None,
+    cfg: Mapping[str, Any] | None,
+) -> ModelClassResolution:
+    lance_model_class = resolve_lance_model_class_name(model, cfg)
+    if lance_model_class is not None:
+        return ModelClassResolution(handled=True, model_class_name=lance_model_class)
+
+    dreamzero_model_class = resolve_dreamzero_model_class_name(model, cfg)
+    if dreamzero_model_class is not None:
+        return ModelClassResolution(handled=True, model_class_name=dreamzero_model_class)
+    if is_dreamzero_model_family(cfg):
+        return ModelClassResolution(handled=True)
+
+    standard_model_class = resolve_standard_model_class_name(model, cfg)
+    if standard_model_class is not None:
+        return ModelClassResolution(handled=True, model_class_name=standard_model_class)
+
+    return ModelClassResolution(handled=False)
+
+
+__all__ = [
+    "ModelClassResolution",
+    "resolve_model_class_resolution",
+]

--- a/vllm_omni/diffusion/model_resolvers/__init__.py
+++ b/vllm_omni/diffusion/model_resolvers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for resolving model-specific diffusion pipelines."""

--- a/vllm_omni/diffusion/model_resolvers/dreamzero.py
+++ b/vllm_omni/diffusion/model_resolvers/dreamzero.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from vllm_omni.diffusion.model_resolvers.types import ModelConfigLike
 
 
-def is_dreamzero_model_family(cfg: Mapping[str, Any] | None) -> bool:
+def is_dreamzero_model_family(cfg: ModelConfigLike | None) -> bool:
     if cfg is None:
         return False
     return cfg.get("model_type") == "vla"
@@ -14,8 +13,12 @@ def is_dreamzero_model_family(cfg: Mapping[str, Any] | None) -> bool:
 
 def resolve_dreamzero_model_class_name(
     model: str | None,
-    cfg: Mapping[str, Any] | None,
+    cfg: ModelConfigLike | None,
 ) -> str | None:
+    """Resolve DreamZero model class from VLA-family configs.
+
+    ``cfg`` is expected to include ``model_type`` when available.
+    """
     if not is_dreamzero_model_family(cfg):
         return None
 

--- a/vllm_omni/diffusion/model_resolvers/dreamzero.py
+++ b/vllm_omni/diffusion/model_resolvers/dreamzero.py
@@ -1,0 +1,24 @@
+"""DreamZero-specific model resolution helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def is_dreamzero_model_family(cfg: Mapping[str, Any] | None) -> bool:
+    if cfg is None:
+        return False
+    return cfg.get("model_type") == "vla"
+
+
+def resolve_dreamzero_model_class_name(
+    model: str | None,
+    cfg: Mapping[str, Any] | None,
+) -> str | None:
+    if not is_dreamzero_model_family(cfg):
+        return None
+
+    from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
+
+    return "DreamZeroPipeline" if _looks_like_dreamzero(model) else None

--- a/vllm_omni/diffusion/model_resolvers/lance.py
+++ b/vllm_omni/diffusion/model_resolvers/lance.py
@@ -7,8 +7,8 @@ that package's heavy pipeline modules from shared config code.
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
-from typing import Any
+
+from vllm_omni.diffusion.model_resolvers.types import ModelConfigLike
 
 
 def looks_like_lance_subfolder(model: str | None) -> bool:
@@ -21,9 +21,13 @@ def looks_like_lance_subfolder(model: str | None) -> bool:
 
 def resolve_lance_model_class_name(
     model: str | None,
-    cfg: Mapping[str, Any] | None,
+    cfg: ModelConfigLike | None,
 ) -> str | None:
-    """Resolve Lance to its pipeline class when config/path markers match."""
+    """Resolve Lance to its pipeline class when config/path markers match.
+
+    ``cfg`` is expected to be a model config view containing optional fields
+    such as ``model_type``, ``architectures``, or ``model_name``.
+    """
     if cfg is None:
         return "LancePipeline" if looks_like_lance_subfolder(model) else None
 

--- a/vllm_omni/diffusion/model_resolvers/lance.py
+++ b/vllm_omni/diffusion/model_resolvers/lance.py
@@ -1,0 +1,39 @@
+"""Lance-specific model resolution helpers.
+
+These helpers intentionally live outside ``models/lance`` to avoid importing
+that package's heavy pipeline modules from shared config code.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def looks_like_lance_subfolder(model: str | None) -> bool:
+    """Return True when ``model`` points at a Lance per-component subfolder."""
+    if not model:
+        return False
+    base = os.path.basename(str(model).rstrip("/"))
+    return base in {"Lance_3B", "Lance_3B_Video"}
+
+
+def resolve_lance_model_class_name(
+    model: str | None,
+    cfg: Mapping[str, Any] | None,
+) -> str | None:
+    """Resolve Lance to its pipeline class when config/path markers match."""
+    if cfg is None:
+        return "LancePipeline" if looks_like_lance_subfolder(model) else None
+
+    model_type = cfg.get("model_type")
+    architectures = cfg.get("architectures") or []
+    if (
+        model_type == "lance"
+        or "LancePipeline" in architectures
+        or cfg.get("model_name") == "Lance"
+        or looks_like_lance_subfolder(model)
+    ):
+        return "LancePipeline"
+    return None

--- a/vllm_omni/diffusion/model_resolvers/standard.py
+++ b/vllm_omni/diffusion/model_resolvers/standard.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from vllm_omni.diffusion.model_resolvers.types import ModelConfigLike
 
 
 def resolve_standard_model_class_name(
     model: str | None,
-    cfg: Mapping[str, Any] | None,
+    cfg: ModelConfigLike | None,
 ) -> str | None:
+    """Resolve straightforward model families by config markers.
+
+    ``cfg`` is expected to be a model config view with optional keys such as
+    ``model_type`` and ``architectures``.
+    """
     del model  # Reserved for future path-based standard-family resolution.
     if cfg is None:
         return None

--- a/vllm_omni/diffusion/model_resolvers/standard.py
+++ b/vllm_omni/diffusion/model_resolvers/standard.py
@@ -35,7 +35,5 @@ def resolve_standard_model_class_name(
         return "NextStep11Pipeline"
     if model_type == "s2v":
         return "WanS2VPipeline"
-    if model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
-        return "Gr00tN1d7Pipeline"
 
     return None

--- a/vllm_omni/diffusion/model_resolvers/standard.py
+++ b/vllm_omni/diffusion/model_resolvers/standard.py
@@ -1,0 +1,37 @@
+"""Shared resolvers for diffusion model families with straightforward rules."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def resolve_standard_model_class_name(
+    model: str | None,
+    cfg: Mapping[str, Any] | None,
+) -> str | None:
+    del model  # Reserved for future path-based standard-family resolution.
+    if cfg is None:
+        return None
+
+    model_type = cfg.get("model_type")
+    architectures = cfg.get("architectures") or []
+
+    if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
+        return "BagelPipeline"
+    if model_type == "neo_chat":
+        return "SenseNovaU1Pipeline"
+    if "BailingMM2NativeForConditionalGeneration" in architectures or model_type in (
+        "bailingmm_moe_v2_lite",
+        "ming_flash_omni",
+        "ming_flash_omni_thinker",
+    ):
+        return "MingImagePipeline"
+    if model_type == "nextstep":
+        return "NextStep11Pipeline"
+    if model_type == "s2v":
+        return "WanS2VPipeline"
+    if model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
+        return "Gr00tN1d7Pipeline"
+
+    return None

--- a/vllm_omni/diffusion/model_resolvers/types.py
+++ b/vllm_omni/diffusion/model_resolvers/types.py
@@ -1,0 +1,13 @@
+"""Shared types for diffusion model resolvers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeAlias
+
+# Resolver inputs come from ``get_hf_file_to_dict(...)`` and similar helpers,
+# which return plain dicts today but are consumed as read-only config views.
+ModelConfigLike: TypeAlias = Mapping[str, Any]
+
+
+__all__ = ["ModelConfigLike"]


### PR DESCRIPTION
## Purpose

Refactor diffusion model-class resolution out of `vllm_omni/diffusion/data.py` into dedicated resolver modules.

### What changed

- Add a unified resolver entrypoint under `vllm_omni/diffusion/model_resolvers/`
- Extract Lance-specific resolution logic into `model_resolvers/lance.py`
- Add `DreamZero` and standard-family resolvers
- Keep `data.py` focused on shared config/enrichment flow
- Unify how resolved `model_class_name` is applied for known model families during config enrichment

## Test Plan

- Added CPU-only regression tests for:
  - Lance resolution
  - DreamZero resolution
  - standard diffusion model-family resolution
- Ran:
  - `python3 -m pytest tests/entrypoints/test_resolve_lance_config.py -q`
  - `python3 -m pytest tests/entrypoints/test_resolve_dreamzero_config.py -q`
  - `python3 -m pytest tests/entrypoints/test_resolve_standard_config.py -q`

**vLLM Version:** `0.24.0`

**vLLM-Omni Commit:** `8e31c9b02`

## Test Result

- `tests/entrypoints/test_resolve_lance_config.py`: `2 passed`
- `tests/entrypoints/test_resolve_dreamzero_config.py`: `6 passed`
- `tests/entrypoints/test_resolve_standard_config.py`: `8 passed`

Notes:
- Tests are CPU-only
- Existing environment warnings remain:
  - `torch.jit.script_method` deprecation warnings
  - vLLM / vLLM-Omni version mismatch warning