### PR TITLE
ci: raise merge-tier entrypoint timeouts (H100 60->90, L4 30->45)

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -108,7 +108,10 @@ steps:
     depends_on: upload-merge-pipeline
     steps:
       - label: "Entrypoint Test with H100"
-        timeout_in_minutes: 60
+        # The suite relaunches an OmniServer per test class (~30 model loads,
+        # incl. ten ~27.5 GiB Bagel loads); 60 min passed only ~1 in 3 runs
+        # even on main, and vLLM 0.25 weight loading needs ~10 min more.
+        timeout_in_minutes: 90
         commands:
           - pytest -s -v tests/entrypoints/ -m "advanced_model and cuda and H100" --run-level "advanced_model"
         agents:
@@ -146,7 +149,9 @@ steps:
                       type: DirectoryOrCreate
 
       - label: "Entrypoint Test with L4"
-        timeout_in_minutes: 30
+        # 30 min left no headroom for a cold image pull (~11 min for new base
+        # layers) plus per-class engine relaunches; main passed at 26/30.
+        timeout_in_minutes: 45
         commands:
           - pytest -s -v tests/entrypoints/ -m "advanced_model and cuda and L4" --run-level "advanced_model"
         agents:


### PR DESCRIPTION
## Summary
Both merge-tier entrypoint jobs are killed by `timeout_in_minutes` while their tests are still passing — no failing test is involved.

The root cause is **high variance in checkpoint-load I/O on the CI runners**, not any code change: the suite relaunches an OmniServer per test class (~30 model loads, including ten ~27.5 GiB Bagel loads in the sleep-mode tests), and total load time swings run-to-run with node page-cache state. Extracted `Model loading took` totals for the H100 job:

| build | branch / wheel | load total | outcome |
|---|---|---|---|
| 2651 | main / 0.24 | 34.2 min (31 loads) | passed 56/60 min |
| 2650 | main / 0.24 | 34.0 min (28 loads) | **timed out** |
| 2648 | main / 0.24 | 37.9 min (25 loads) | **timed out** |
| 2655 | align / 0.25 | 42.8 min (25 loads) | **timed out** |

So even on main the 60-min budget only clears when the runner draws fast loads (~1 in 3 recently). The L4 job additionally pays up to ~11 min for a cold image pull (30-min budget, main passed at 26/30 with warm layers).

Raising H100 60→90 and L4 30→45 gives the jobs variance-proof headroom.

## Test plan
- Buildkite run on this branch (build 2659): entrypoint jobs should complete all 17 (H100) / 16 (L4) tests within the new budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)