### PR TITLE
ci: raise merge-tier entrypoint timeouts (H100 60->90, L4 30->45)

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -108,7 +108,10 @@ steps:
     depends_on: upload-merge-pipeline
     steps:
       - label: "Entrypoint Test with H100"
-        timeout_in_minutes: 60
+        # The suite relaunches an OmniServer per test class (~30 model loads,
+        # incl. ten ~27.5 GiB Bagel loads); 60 min passed only ~1 in 3 runs
+        # even on main, and vLLM 0.25 weight loading needs ~10 min more.
+        timeout_in_minutes: 90
         commands:
           - pytest -s -v tests/entrypoints/ -m "advanced_model and cuda and H100" --run-level "advanced_model"
         agents:
@@ -146,7 +149,9 @@ steps:
                       type: DirectoryOrCreate
 
       - label: "Entrypoint Test with L4"
-        timeout_in_minutes: 30
+        # 30 min left no headroom for a cold image pull (~11 min for new base
+        # layers) plus per-class engine relaunches; main passed at 26/30.
+        timeout_in_minutes: 45
         commands:
           - pytest -s -v tests/entrypoints/ -m "advanced_model and cuda and L4" --run-level "advanced_model"
         agents:


### PR DESCRIPTION
## Summary
`Entrypoint Test with H100` is chronically over its 60-min budget **on main itself**: it timed out in gate builds 2648 and 2650 and passed 2651 with only 4 min to spare (56/60). The suite relaunches an OmniServer per test class (~30 model loads, including ten ~27.5 GiB Bagel loads in the sleep-mode tests), and checkpoint-load I/O on the runners varies heavily with page-cache state — measured `Model loading took` totals are 34.0-37.9 min on the timed-out main runs vs 34.2 min on the passing one, i.e. the budget only clears when the node draws fast loads. `Entrypoint Test with L4` passes at 26/30 min only when the runner already has the image layers cached; a cold pull alone costs ~8-11 min.

Raising H100 60→90 and L4 30→45 makes the budgets honest. Same change for the align branch in #5038 (where build 2655 hit the identical failure mode).

## Test plan
- Buildkite merge-tier run on this branch: both entrypoint jobs complete within the new budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)