### PR TITLE
[BugFix] Align invalid layers DFX tests with 2-10 range (#5044)

### DIFF
--- a/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing.py
@@ -62,8 +62,8 @@ def _finalize_edits_form_data(template: dict[str, Any], server_model: str) -> di
         ),
         pytest.param(
             True,
-            {"prompt": "edit", "model": _IMAGE_EDITS_SERVER_MODEL, "layers": "2"},
-            ("Invalid layers", "3", "1"),
+            {"prompt": "edit", "model": _IMAGE_EDITS_SERVER_MODEL, "layers": "1"},
+            ("Invalid layers", "2", "10"),
             400,
             id="invalid_layers",
         ),

--- a/tests/dfx/reliability/invalid_param_test/test_invalid_image_generation.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_image_generation.py
@@ -87,8 +87,8 @@ def _minimal_images_gen_json(omni_server: OmniServer) -> dict[str, object]:
         pytest.param(
             {"true_cfg_scale": 21.0}, ("true_cfg_scale", "less_than_equal", "20"), id="true_cfg_scale_above_max"
         ),
-        pytest.param({"layers": 2}, ("layers", "value_error", "3", "10"), id="layers_below_min"),
-        pytest.param({"layers": 11}, ("layers", "value_error", "3", "10"), id="layers_above_max"),
+        pytest.param({"layers": 1}, ("layers", "value_error", "2", "10"), id="layers_below_min"),
+        pytest.param({"layers": 11}, ("layers", "value_error", "2", "10"), id="layers_above_max"),
         pytest.param({"seed": -1}, ("seed", "greater_than_equal", "0"), id="seed_negative", marks=_SKIP_ISSUE_3649),
         pytest.param(
             {"seed": 2**32},


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix Weekly CI failures where invalid-param image tests expected HTTP 400 but got 200 because they used a **valid** `layers` value.

`SUPPORTED_LAYERED_LAYERS_RANGE` is `range(2, 11)` (inclusive **2–10**). The failing cases sent `layers=2` / expected outdated bound strings (`3`/`1`), so the server correctly accepted the request.

This PR updates:
- `test_images_edits_invalid_requests[invalid_layers]` → `layers="1"`, expect `"2"`/`"10"`
- `test_images_generations_invalid_requests[layers_below_min]` → `layers=1`
- `layers_above_max` error substrings → `"2"`/`"10"` (value `11` unchanged)

Fixes #5044

## Test Plan

**vLLM Version:** N/A (test expectation-only change)

**vLLM-Omni Commit:** `fix-5044` / this PR HEAD

```bash
# Unit coverage for layers bounds (no GPU / live server required)
pytest tests/entrypoints/openai_api/test_image_server.py::test_image_edit_invalid_layers -q

# DFX invalid-param cases (needs live Qwen-Image / Qwen-Image-Edit server on H100)
pytest tests/dfx/reliability/invalid_param_test/test_invalid_image_editing.py::test_images_edits_invalid_requests -k invalid_layers -q
pytest tests/dfx/reliability/invalid_param_test/test_invalid_image_generation.py::test_images_generations_invalid_requests -k 'layers_below_min or layers_above_max' -q
```

## Test Result
<img width="2322" height="296" alt="64c04c4aaf885ff1cf8497761946cac1" src="https://github.com/user-attachments/assets/2d162875-1715-44da-a04d-bff69840ecec" />
<img width="2332" height="174" alt="5510d43452de6e58fbadbd45c12dda87" src="https://github.com/user-attachments/assets/cf11a865-4eea-497b-96df-0657649088b9" />
<img width="2316" height="122" alt="38cda70aa0a01fa9f50997dd04138471" src="https://github.com/user-attachments/assets/8ed31617-80aa-457f-94de-d656fa43431f" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
