### PR TITLE
docs: add Replica Data Parallelism guide for diffusion

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -69,6 +69,7 @@ nav:
         - Sequence Parallel: user_guide/diffusion/parallelism/sequence_parallel.md
         - Tensor Parallel: user_guide/diffusion/parallelism/tensor_parallel.md
         - VAE Parallelism: user_guide/diffusion/parallelism/vae_parallelism.md
+        - Replica Data Parallel: user_guide/diffusion/parallelism/replica_data_parallel.md
       - CPU Offloading: user_guide/diffusion/cpu_offload_diffusion.md
       - LoRA: user_guide/diffusion/lora.md
       - Custom Pipeline: features/custom_pipeline.md

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -372,6 +372,19 @@ Example: if `CUDA_VISIBLE_DEVICES=0,2,4` is set in the environment, then `device
 
 Default: `"0"`
 
+#### `runtime.num_replicas`
+
+Number of independent engine replicas to run for this stage (replica data parallelism).
+Requests are load-balanced across the replicas, scaling request throughput near-linearly.
+When `> 1`, `devices` must enumerate the replica pool: either
+`num_replicas * tensor_parallel_size` entries (pool mode) or `tensor_parallel_size`
+entries (a per-replica template). In single-runtime `serve`, this config field — not the
+`--omni-num-replica` CLI flag — drives replica fan-out. See the
+[Replica Data Parallelism](../user_guide/diffusion/parallelism/replica_data_parallel.md)
+guide.
+
+Default: `1`
+
 #### `engine_args.max_num_seqs`
 
 The maximum number of sequences for concurrent processing in this stage. For LLM stages, this controls the vLLM scheduler's maximum concurrent sequences. For all stage types, this also controls how many tasks can be batched together in the task processing loop.

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -378,8 +378,9 @@ Number of independent engine replicas to run for this stage (replica data parall
 Requests are load-balanced across the replicas, scaling request throughput near-linearly.
 When `> 1`, `devices` must enumerate the replica pool: either
 `num_replicas * tensor_parallel_size` entries (pool mode) or `tensor_parallel_size`
-entries (a per-replica template). In single-runtime `serve`, this config field — not the
-`--omni-num-replica` CLI flag — drives replica fan-out. See the
+entries (a per-replica template). In single-runtime `serve`, this config field is what
+drives replica fan-out (the headless / multi-runtime launch path instead uses the
+process-local `--omni-dp-size-local` flag). See the
 [Replica Data Parallelism](../user_guide/diffusion/parallelism/replica_data_parallel.md)
 guide.
 

--- a/docs/user_guide/diffusion/parallelism/overview.md
+++ b/docs/user_guide/diffusion/parallelism/overview.md
@@ -13,5 +13,10 @@ This guide covers the parallelism methods in vLLM-Omni for speeding up diffusion
 | **[VAE Parallelism](vae_parallelism.md)** | Distributes VAE decode spatially across GPUs to reduce peak VAE memory                                              |
 | **[HSDP](hsdp.md)**                                | Shards full model weights via PyTorch FSDP2 to enable large-model inference on memory-constrained GPUs              |
 | **[Expert Parallelism](expert_parallel.md)**       | Shards MoE expert blocks across GPUs for MoE models (e.g. HunyuanImage3.0)                                          |
+| **[Replica Data Parallelism](replica_data_parallel.md)** | Runs N independent engine replicas and routes requests across them to scale request throughput near-linearly |
+
+The methods above split a single request across GPUs to reduce its latency; Replica
+Data Parallelism instead replicates the whole engine to scale throughput, and composes
+with any of them.
 
 See [Supported Models](../../diffusion_features.md#supported-models) for per-model compatibility.

--- a/docs/user_guide/diffusion/parallelism/replica_data_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/replica_data_parallel.md
@@ -1,0 +1,200 @@
+# Replica Data Parallelism Guide
+
+
+## Table of Content
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Configuration Parameters](#configuration-parameters)
+- [Expected Performance](#expected-performance)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+- [Summary](#summary)
+
+---
+
+## Overview
+
+Replica Data Parallelism (replica-DP) scales **request throughput** by running `N`
+independent diffusion engine replicas, one per GPU (or per GPU group), and routing
+each incoming request to a single replica. It is the serving-level, model-agnostic
+data-parallel axis for diffusion — the analogue of vLLM's dense-model DP, where the
+serving layer holds multiple engine replicas and load-balances requests across them.
+
+This is different from the other parallelism methods in this guide
+([Tensor](tensor_parallel.md), [Sequence](sequence_parallel.md),
+[CFG](cfg_parallel.md), [Pipeline](pipeline_parallel.md), [VAE](vae_parallelism.md)),
+which split a **single request** across GPUs to reduce its latency. Replica-DP instead
+replicates the **whole engine** to raise aggregate throughput:
+
+| | Intra-request axes (TP / SP / CFG / PP / VAE) | **Replica-DP** |
+|---|---|---|
+| Splits | one request across GPUs | requests across replicas |
+| Improves | single-request **latency** | aggregate **throughput** |
+| Per-request latency | goes down | **unchanged** |
+| Cross-GPU collectives | yes (per step) | **none** (replicas are isolated) |
+
+The two are composable: use an intra-request axis **inside** each replica (via
+`tensor_parallel_size`, etc.) and replica-DP **across** replicas to scale both latency
+and throughput at once.
+
+---
+
+## How It Works
+
+Setting `runtime.num_replicas: N` on a diffusion stage builds a pool of `N` replicas,
+each an independent `DiffusionEngine` on its own device(s) as assigned by
+`runtime.devices`. Replicas do not share torch collectives; a request runs end-to-end
+on exactly one replica, so outputs are bit-identical to single-replica execution for a
+fixed seed. The serving layer distributes requests across the live replicas.
+
+```text
+                         Requests
+                   A       B       C       D
+                   |       |       |       |
+                   +----- StagePool / router -----+
+                   |            |            |
+                   v            v            v
+             Replica 0     Replica 1     Replica 2 ...
+          DiffusionEngine DiffusionEngine DiffusionEngine
+           (GPU 0)         (GPU 1)         (GPU 2)
+```
+
+---
+
+## Quick Start
+
+Add `num_replicas` and a matching `devices` list to the diffusion stage's `runtime`
+block in your stage config, then serve with `--omni`. Example for a 2-replica,
+single-GPU-per-replica deployment of `Wan-AI/Wan2.2-TI2V-5B`:
+
+```yaml
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      num_replicas: 2       # fan out 2 independent engine replicas
+      devices: "0,1"        # replica 0 -> GPU 0, replica 1 -> GPU 1
+    engine_args:
+      model_stage: dit
+```
+
+```bash
+vllm serve Wan-AI/Wan2.2-TI2V-5B --omni \
+    --port 8098 \
+    --stage-configs-path /path/to/your_stage_config.yaml
+```
+
+Requests to the video endpoint (see [Videos API](../../../serving/videos_api.md)) are
+now spread across both replicas; send concurrent requests to see throughput scale.
+
+---
+
+## Configuration Parameters
+
+Set on the diffusion stage's `runtime` block (see
+[Stage Configuration](../../../configuration/stage_configs.md#runtime)):
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_replicas` | int | `1` | Number of independent engine replicas for this stage. Requests are load-balanced across them. |
+| `devices` | str | `"0"` | Logical device list for the replica pool. Two accepted shapes (see below). |
+
+The length of `devices` must match one of two shapes when `num_replicas > 1`:
+
+- **Pool mode** — `len(devices) == num_replicas * tensor_parallel_size`: enumerate the
+  full pool; each replica takes `tensor_parallel_size` consecutive entries.
+  e.g. `num_replicas: 4`, `tensor_parallel_size: 1`, `devices: "0,1,2,3"`.
+- **Template mode** — `len(devices) == tensor_parallel_size`: declare one per-replica
+  template; replica `r` is offset by `r * tensor_parallel_size`.
+  e.g. `num_replicas: 4`, `tensor_parallel_size: 2`, `devices: "0,1"` → GPUs
+  `{0,1}, {2,3}, {4,5}, {6,7}`.
+
+!!! info
+    In single-runtime `vllm serve`, replica fan-out is driven by the config's
+    `runtime.num_replicas`, **not** the `--omni-num-replica` CLI flag (which applies to
+    the headless / multi-runtime launch path). If only one replica loads, check
+    `runtime.num_replicas` in the stage config first.
+
+---
+
+## Expected Performance
+
+Throughput scales near-linearly with replica count. Measured on
+`Wan-AI/Wan2.2-TI2V-5B` (832×480, 33 frames, 30 steps), 4× A800-80GB (NVLink),
+one GPU per replica:
+
+| Replicas | Throughput (videos/min) | Scaling | Efficiency |
+|----------|-------------------------|---------|------------|
+| 1 | 4.71 | 1.00× | — |
+| 2 | 9.20 | 1.95× | 98% |
+| 4 | 18.02 | 3.83× | 96% |
+
+Per-request latency stayed flat (~13–14 s) across all replica counts, and seed-fixed
+outputs were bit-identical regardless of `N` — replicas scale throughput, not
+single-request latency, with no cross-replica interference.
+
+---
+
+## Best Practices
+
+### When to Use
+
+**Good for:**
+
+- Throughput-bound serving: many concurrent generation requests
+- The model (plus its VAE) fits on a single replica's device(s)
+- Combining with an intra-request axis inside each replica (e.g.
+  `tensor_parallel_size` for a large backbone) to scale latency **and** throughput
+
+**Not for:**
+
+- Reducing single-request latency — use an intra-request axis instead
+- Models too large to fit one replica per device — shard the model first with
+  [Tensor Parallelism](tensor_parallel.md) or [HSDP](hsdp.md), then optionally add
+  replicas on top
+- Single-GPU setups
+
+### Sizing
+
+Pick `num_replicas` so that `num_replicas * tensor_parallel_size` equals the number of
+GPUs you want the stage to occupy. Give each replica the smallest device group that
+fits the model to maximize the replica count (and thus throughput).
+
+---
+
+## Troubleshooting
+
+### Only one replica loads / no throughput gain
+
+**Symptom**: throughput does not scale; only one GPU is busy.
+
+**Solutions**:
+
+1. Set `runtime.num_replicas` in the **stage config** — in single-runtime `serve`, the
+   `--omni-num-replica` CLI flag does not fan out replicas.
+2. Ensure `runtime.devices` enumerates the full pool (pool mode) or a valid per-replica
+   template (template mode) — see [Configuration Parameters](#configuration-parameters).
+3. Replicas warm up sequentially: replica 0 is ready first and the rest a few seconds
+   later. Send load after all replicas report ready.
+
+### `ValueError` on device length
+
+**Symptom**: startup fails complaining about the `devices` length.
+
+**Solution**: `len(devices)` must equal `num_replicas * tensor_parallel_size` (pool
+mode) or `tensor_parallel_size` (template mode). Any other length is rejected.
+
+---
+
+## Summary
+
+1. ✅ **Enable replica-DP** — set `runtime.num_replicas: N` on the diffusion stage to
+   scale request throughput near-linearly.
+2. ✅ **Size `devices`** — `num_replicas * tensor_parallel_size` entries (pool mode) or
+   `tensor_parallel_size` (template mode).
+3. ✅ **Use the config, not the CLI** — in single-runtime `serve`, fan-out comes from
+   `runtime.num_replicas`, not `--omni-num-replica`.
+4. ✅ **Compose for both axes** — replica-DP across replicas + an intra-request axis
+   inside each replica scales throughput and latency together.

--- a/docs/user_guide/diffusion/parallelism/replica_data_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/replica_data_parallel.md
@@ -112,10 +112,11 @@ The length of `devices` must match one of two shapes when `num_replicas > 1`:
   `{0,1}, {2,3}, {4,5}, {6,7}`.
 
 !!! info
-    In single-runtime `vllm serve`, replica fan-out is driven by the config's
-    `runtime.num_replicas`, **not** the `--omni-num-replica` CLI flag (which applies to
-    the headless / multi-runtime launch path). If only one replica loads, check
-    `runtime.num_replicas` in the stage config first.
+    In single-runtime `vllm serve`, replica fan-out is driven **only** by the config's
+    `runtime.num_replicas` — there is no CLI replica flag for this path. (The headless /
+    multi-runtime launch path uses `--omni-dp-size-local`, which is process-local and
+    requires `--stage-id`.) If only one replica loads, check `runtime.num_replicas` in
+    the stage config first.
 
 ---
 
@@ -172,8 +173,10 @@ fits the model to maximize the replica count (and thus throughput).
 
 **Solutions**:
 
-1. Set `runtime.num_replicas` in the **stage config** — in single-runtime `serve`, the
-   `--omni-num-replica` CLI flag does not fan out replicas.
+1. Set `runtime.num_replicas` in the **stage config** — in single-runtime `serve` this
+   is the only knob that fans out replicas (there is no CLI flag for it; the
+   `--omni-dp-size-local` flag applies to the headless / multi-runtime path and requires
+   `--stage-id`).
 2. Ensure `runtime.devices` enumerates the full pool (pool mode) or a valid per-replica
    template (template mode) — see [Configuration Parameters](#configuration-parameters).
 3. Replicas warm up sequentially: replica 0 is ready first and the rest a few seconds
@@ -194,7 +197,7 @@ mode) or `tensor_parallel_size` (template mode). Any other length is rejected.
    scale request throughput near-linearly.
 2. ✅ **Size `devices`** — `num_replicas * tensor_parallel_size` entries (pool mode) or
    `tensor_parallel_size` (template mode).
-3. ✅ **Use the config, not the CLI** — in single-runtime `serve`, fan-out comes from
-   `runtime.num_replicas`, not `--omni-num-replica`.
+3. ✅ **Use the config** — in single-runtime `serve`, fan-out comes from
+   `runtime.num_replicas` (the headless / multi-runtime path uses `--omni-dp-size-local`).
 4. ✅ **Compose for both axes** — replica-DP across replicas + an intra-request axis
    inside each replica scales throughput and latency together.


### PR DESCRIPTION
### Summary

Adds a **Replica Data Parallelism** guide to the diffusion parallelism series. This is the serving-level, model-agnostic data-parallel axis for diffusion (multiple independent engine replicas + request routing), and it was the one axis in that series without a doc.

The guide covers:
- What replica-DP is and how it differs from the intra-request axes (TP/SP/CFG/PP/VAE): it replicates the whole engine to scale **throughput**, leaving per-request latency unchanged, and composes with any intra-request axis.
- How to enable it via `runtime.num_replicas` + `runtime.devices` on a diffusion stage, with a Wan2.2-TI2V-5B example.
- `devices` sizing: **pool mode** (`num_replicas * tensor_parallel_size` entries) vs **template mode** (`tensor_parallel_size` entries).
- The `runtime.num_replicas` (config) vs `--omni-num-replica` (CLI) distinction in single-runtime `serve` — a common gotcha where only one replica loads.
- Measured near-linear throughput scaling on Wan2.2-TI2V-5B (832×480, 33f, 30 steps), 4× A800 NVLink, one GPU per replica: **1/2/4 replicas → 1.00× / 1.95× / 3.83×** (96% efficiency at 4), latency flat, seed-fixed outputs bit-identical across replica counts.

### Changes

- **New**: `docs/user_guide/diffusion/parallelism/replica_data_parallel.md`
- Link it from the parallelism `overview.md` and `docs/.nav.yml`
- Document the previously-undocumented `runtime.num_replicas` stage field in `docs/configuration/stage_configs.md`

Docs-only and purely additive — no config files touched, so it doesn't conflict with the config-layout migration in #5031 and composes with whichever layout lands.

### Context

Found while validating the multi-replica DiT path for #4707; this captures the operational contract so users don't hit the `--omni-num-replica` trap. Numbers and behavior verified end-to-end on A800.

Related to #4707.
