### PR TITLE
[Bugfix] Disable unintended CFG for Z-Image Turbo

### DIFF
--- a/tests/diffusion/test_diffusion_request.py
+++ b/tests/diffusion/test_diffusion_request.py
@@ -6,6 +6,7 @@ import random
 import pytest
 
 from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
+from vllm_omni.diffusion.utils.param_utils import resolve_guidance_scale
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
@@ -72,3 +73,28 @@ def test_tp_seed_same_across_ranks_and_varies_across_requests():
 
     # Seeds must vary across requests (non-determinism preserved).
     assert len(set(seeds)) == n_requests, f"Expected {n_requests} unique seeds but got {len(set(seeds))}: {seeds}"
+
+
+@pytest.mark.parametrize(
+    ("sampling_kwargs", "normalized_scale", "scale_provided", "expected_scale"),
+    [
+        pytest.param({}, 1.0, False, 0.0, id="omitted"),
+        pytest.param({"guidance_scale": 0.0}, 1.0, False, 0.0, id="explicit-zero"),
+        pytest.param({"guidance_scale": 3.5}, 3.5, True, 3.5, id="explicit-positive"),
+    ],
+)
+def test_guidance_scale_resolution_after_request_normalization(
+    sampling_kwargs: dict[str, float],
+    normalized_scale: float,
+    scale_provided: bool,
+    expected_scale: float,
+) -> None:
+    request = OmniDiffusionRequest(
+        prompt={"prompt": "test prompt"},
+        sampling_params=OmniDiffusionSamplingParams(**sampling_kwargs),
+        request_id="test-request",
+    )
+
+    assert request.sampling_params.guidance_scale == normalized_scale
+    assert request.sampling_params.guidance_scale_provided is scale_provided
+    assert resolve_guidance_scale(request.sampling_params, default=0.0) == expected_scale

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -43,6 +43,7 @@ from vllm_omni.diffusion.models.z_image.z_image_transformer import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -167,6 +168,13 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
+
+    @staticmethod
+    def _resolve_guidance_scale(sampling_params: OmniDiffusionSamplingParams) -> float:
+        """Honor an explicit guidance scale; otherwise use Z-Image's no-CFG default."""
+        if sampling_params.guidance_scale_provided:
+            return float(sampling_params.guidance_scale)
+        return 0.0
 
     def __init__(
         self,
@@ -457,7 +465,7 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         generator = req.sampling_params.generator
         sigmas = req.sampling_params.sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or 512
-        guidance_scale = req.sampling_params.guidance_scale
+        guidance_scale = self._resolve_guidance_scale(req.sampling_params)
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt if req.sampling_params.num_outputs_per_prompt > 0 else 1
         )

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -44,7 +44,6 @@ from vllm_omni.diffusion.models.z_image.z_image_transformer import (
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.param_utils import resolve_guidance_scale
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -42,6 +42,7 @@ from vllm_omni.diffusion.models.z_image.z_image_transformer import (
     ZImageTransformer2DModel,
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.utils.param_utils import resolve_guidance_scale
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.model_executor.model_loader.weight_utils import (
@@ -168,13 +169,6 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
     _vae_modules: ClassVar[list[str]] = ["vae"]
-
-    @staticmethod
-    def _resolve_guidance_scale(sampling_params: OmniDiffusionSamplingParams) -> float:
-        """Honor an explicit guidance scale; otherwise use Z-Image's no-CFG default."""
-        if sampling_params.guidance_scale_provided:
-            return float(sampling_params.guidance_scale)
-        return 0.0
 
     def __init__(
         self,
@@ -465,7 +459,7 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsComponen
         generator = req.sampling_params.generator
         sigmas = req.sampling_params.sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or 512
-        guidance_scale = self._resolve_guidance_scale(req.sampling_params)
+        guidance_scale = resolve_guidance_scale(req.sampling_params, default=0.0)
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt if req.sampling_params.num_outputs_per_prompt > 0 else 1
         )

--- a/vllm_omni/diffusion/utils/param_utils.py
+++ b/vllm_omni/diffusion/utils/param_utils.py
@@ -6,6 +6,22 @@ from __future__ import annotations
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 
+def resolve_guidance_scale(
+    sampling_params: OmniDiffusionSamplingParams,
+    *,
+    default: float,
+) -> float:
+    """Resolve an explicit guidance scale or use a model-specific default.
+
+    ``OmniDiffusionRequest`` normalizes omitted and false-like scales before a
+    pipeline sees them, so consumers must use ``guidance_scale_provided`` to
+    distinguish an explicit positive value from the normalized sentinel.
+    """
+    if sampling_params.guidance_scale_provided:
+        return float(sampling_params.guidance_scale)
+    return float(default)
+
+
 def apply_declared_extra_args(
     sampling_params: OmniDiffusionSamplingParams,
     declared_params: frozenset[str],


### PR DESCRIPTION
## Purpose

Fix Z-Image-Turbo unexpectedly running classifier-free guidance (CFG) when the request omits `guidance_scale` or sets it to `0.0`.

The shared request parser normalizes a false-like guidance scale (including `0.0`) to `1.0` and leaves `guidance_scale_provided` unset. `ZImagePipeline` previously consumed the normalized value directly and enabled CFG for any value greater than zero. This caused two text encoder calls and doubled the DiT batch, making inference significantly slower than the expected no-CFG path.

This PR resolves the value inside `ZImagePipeline`:

- preserve an explicitly provided positive `guidance_scale`; and
- otherwise use Z-Image's no-CFG default, `0.0`.

The fix is model-scoped and does not change shared request parsing or other diffusion pipelines.

## Test Plan

Start the profiled server and send the same request before and after the fix:

```bash
vllm serve Tongyi-MAI/Z-Image-Turbo --omni \
  --port 30000 --diffusion-attention-backend FLASH_ATTN \
  --enable-diffusion-pipeline-profiler --log-stats
```

```bash
curl -sS http://127.0.0.1:30000/v1/images/generations \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Tongyi-MAI/Z-Image-Turbo",
    "prompt": "一只戴着宇航员头盔的橘猫，坐在月球表面，电影级光影",
    "size": "512x512",
    "n": 1,
    "num_inference_steps": 8,
    "guidance_scale": 0.0,
    "seed": 42,
    "response_format": "b64_json"
  }'
```

Also verify that an explicitly provided positive guidance scale still enables CFG.

## Test Result

Single-request A/B measurement with the same model, prompt, resolution, steps, seed, and attention backend:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Text encoder calls | 2 | 1 | Negative branch removed |
| Denoising latency | 57.115 ms/step | 33.527 ms/step | 1.70x |
| Pipeline forward | 434.091 ms | 244.601 ms | 1.77x |
| End-to-end latency | 458.771 ms | 270.151 ms | 1.70x |

- Python compilation: passed
- `git diff --check`: passed

**vLLM Version:** `0.24.0`

**vLLM-Omni Commit:** `c1d94d88bf2e03af84e6e172c5073d6da5608d5d`

**Hardware / Software:** NVIDIA H800, driver `570.148.08`; `FLASH_ATTN` backend.
