### PR TITLE
docs: document Cosmos3-Super AutoRound world-model support

### DIFF
--- a/docs/user_guide/quantization/autoround.md
+++ b/docs/user_guide/quantization/autoround.md
@@ -3,7 +3,7 @@
 ## Overview
 
 [AutoRound](https://github.com/intel/auto-round) produces pre-quantized
-checkpoints for LLMs, VLMs, and diffusion models. vLLM-Omni reads the
+checkpoints for LLMs, VLMs, diffusion models, and world models. vLLM-Omni reads the
 checkpoint's `config.json` and auto-detects
 `quantization_config.quant_method = "auto-round"`.
 
@@ -35,6 +35,13 @@ guide. AutoRound is Intel-supported.
 | Wan2.2-I2V | `Intel/Wan2.2-I2V-A14B-Diffusers-int4-AutoRound` | Diffusion transformer | W4A16 | GPTQ-Marlin or Intel-supported AutoRound backend |
 | Wan2.2-T2V | `Intel/Wan2.2-T2V-A14B-Diffusers-int4-AutoRound` | Diffusion transformer | W4A16 | GPTQ-Marlin or Intel-supported AutoRound backend |
 | Wan2.2-TI2V | `Intel/Wan2.2-TI2V-5B-Diffusers-int4-AutoRound` | Diffusion transformer | W4A16 | GPTQ-Marlin or Intel-supported AutoRound backend |
+
+### World Model (Cosmos3)
+
+| Model | Checkpoint | Scope | Scheme | Backend |
+|-------|------------|-------|--------|---------|
+| Cosmos3-Nano | `Intel/Cosmos3-Nano-int4-AutoRound` | World-model transformer | W4A16 | GPTQ-Marlin or Intel-supported AutoRound backend |
+| Cosmos3-Super | `Intel/Cosmos3-Super-int4-AutoRound` | World-model transformer | W4A16 | GPTQ-Marlin or Intel-supported AutoRound backend |
 
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 


### PR DESCRIPTION
### Serve command

Validated with the local Omni environment and a local packed checkpoint:

```bash
CUDA_VISIBLE_DEVICES=2 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
/home/yiliu7/workspace/omni-wm/.venv/bin/python -m vllm.entrypoints.cli.main serve \
  /storage/yiliu7/Intel/Cosmos3-Super-int4-AutoRound \
  --omni \
  --host 127.0.0.1 \
  --port 8033 \
  --model-class-name Cosmos3OmniDiffusersPipeline \
  --no-guardrails \
  --enable-layerwise-offload \
  --init-timeout 2400 \
  --stage-init-timeout 2400
```

Expected load signal in logs:

```text
Auto-detected quantization 'auto-round' from model config
Starting vLLM API server on http://127.0.0.1:8033
```

### Video request command

Use async video generation for the default Cosmos3-Super T2V config:

```bash
curl -sS -X POST http://127.0.0.1:8033/v1/videos \
  -F 'model=Intel/Cosmos3-Super-int4-AutoRound' \
  --form-string "prompt=$(jq -c . /storage/yiliu7/nvidia/Cosmos3-Super/assets/example_t2v_prompt.json)" \
  --form-string "negative_prompt=$(jq -c . /storage/yiliu7/nvidia/Cosmos3-Super/assets/negative_prompt.json)" \
  -F 'size=1280x720' \
  -F 'num_frames=189' \
  -F 'fps=24' \
  -F 'num_inference_steps=35' \
  -F 'guidance_scale=6.0' \
  -F 'max_sequence_length=4096' \
  -F 'flow_shift=10.0' \
  -F 'seed=17' \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}'
```

Poll and download:

```bash
curl -sS http://127.0.0.1:8033/v1/videos/<video_id> | jq

curl -sS -L \
  http://127.0.0.1:8033/v1/videos/<video_id>/content \
  -o /home/yiliu7/workspace/omni-wm/generated_videos/cosmos3_super/cosmos3_super_intel_autoround_full_gpu2_20260713_async.mp4
```

- bf16

https://github.com/user-attachments/assets/07c7f719-c5c5-47cb-8618-a4e59a93e709

- W4A16

https://github.com/user-attachments/assets/6fcd91a3-3b53-4ca4-a4e7-b688bb1eecf6

