### PR TITLE
[Bugfix][VoxCPM2] Restore max_num_seqs to 32 to fix throughput regression (#5064)

### DIFF
--- a/vllm_omni/deploy/voxcpm2.yaml
+++ b/vllm_omni/deploy/voxcpm2.yaml
@@ -8,17 +8,16 @@ dtype: bfloat16
 
 stages:
   - stage_id: 0
-    max_num_seqs: 8
+    max_num_seqs: 32
     gpu_memory_utilization: 0.9
     # Right-size the KV cache instead of letting it fill gpu_memory_utilization.
-    # max_num_seqs(8) * max_model_len(4096) ~= 32k tokens; 6 GiB leaves headroom
-    # for longer live requests while keeping VoxCPM2 TTS decode batches small
-    # enough to avoid the high ITL observed with large admission caps.
+    # max_num_seqs(32) * max_model_len(4096) ~= 131k tokens; 6 GiB holds ~175k
+    # (42x concurrency, above the 32-seq scheduler cap, so no throughput loss).
     # The remaining VRAM stays free for the VoxCPM2 diffusion side-path
     # (LocDiT / AudioVAE / code2wav + batch CUDA-graph pools), which allocates
     # outside vLLM's KV accounting during inference. Keeps peak ~13 GiB on any
     # card and avoids per-rebase OOM tuning on small CI GPUs.
-    # Assumes prefix caching off and typical live decode concurrency <= ~8;
+    # Assumes prefix caching off and max_num_seqs*max_model_len <= ~175k tokens;
     # raise this cap if either grows or enable_prefix_caching is turned on.
     kv_cache_memory_bytes: 6442450944  # 6 GiB
     enforce_eager: true


### PR DESCRIPTION
## Summary

Fixes #5064 — VoxCPM2 performance metrics regressed by >10% compared to baseline.

## Root Cause

PR #4606 changed `max_num_seqs` from 32 to 8 in `voxcpm2.yaml`. The VoxCPM2OmniARAsyncScheduler already defers new waiting admissions when a pure-decode batch is active (keeping decode batch sizes small), so the `max_num_seqs` reduction was an unnecessary additional constraint that capped throughput.

The scheduler deferral mechanism is the right tool for preventing high ITL, not a hard cap on concurrency. With `max_num_seqs=8`, the CI tests at c=8 hit the scheduler cap, reducing batch sizes and GPU utilization:

| Test | Metric | Regression |
|------|--------|------------|
| c=8, n=80 | audio_throughput | -23.70% |
| c=8, n=80 | median_audio_ttfp_ms | +29.15% |
| n=100, qbs=2.0 | median_audio_ttfp_ms | +22.56% |
| n=100, qbs=2.0 | audio_throughput | -6.31% |

## Fix

Restore `max_num_seqs: 8 → 32` in `vllm_omni/deploy/voxcpm2.yaml`.

## Risk

Low. The 6 GiB KV cache was already sized for 32 seqs (the original value before #4606). The scheduler deferral in `VoxCPM2OmniARAsyncScheduler` continues to gate decode batch sizes. The ITL concern that motivated the `max_num_seqs` reduction is handled by the scheduler, not the hard cap.

cc @Sy0307 @congw729 @hsliuustc0106

🤖 Generated with [Claude Code](https://claude.com/claude-code)