### PR TITLE
docs: fix broken nav entries and glob collisions

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -94,6 +94,9 @@ nav:
     - contributing/README.md
     - glob: contributing/*
       flatten_single_child_sections: true
+      ignore:
+        - README.md
+        - DOCS_GUIDE.md
   - Model Implementation:
     - contributing/model/README.md
     - contributing/model/adding_omni_model.md
@@ -117,7 +120,6 @@ nav:
       - design/feature/cache_dit.md
       - design/feature/teacache.md
       - design/feature/async_chunk.md
-      - design/feature/vae_parallel.md
       - design/feature/diffusion_step_execution.md
       - design/feature/diffusion_request_level_batching.md
       - design/feature/diffusion_continuous_batching.md

--- a/docs/contributing/ci/.nav.yaml
+++ b/docs/contributing/ci/.nav.yaml
@@ -2,5 +2,5 @@ nav:
   - CI_5levels.md
   - failures.md
   - test_guide.md
-  - test_markers.md
-  - test_style.md
+  - tests_markers.md
+  - tests_style.md


### PR DESCRIPTION
## Summary

Batch 1 of the docs cleanup plan (see [spec](https://github.com/vllm-project/vllm-omni/blob/main/docs/superpowers/specs/2026-07-13-docs-cleanup-design.md) and [plan](https://github.com/vllm-project/vllm-omni/blob/main/docs/superpowers/plans/2026-07-13-docs-cleanup.md)).

Mechanical nav fixes — no content changes.

## Changes

- **Fix CI sub-nav singular/plural mismatch**: `docs/contributing/ci/.nav.yaml` referenced `test_markers.md` and `test_style.md` (singular), but the files on disk are `tests_markers.md` and `tests_style.md` (plural). Two nav entries were broken.
- **Remove duplicate `vae_parallel` nav entry**: `design/feature/vae_parallel.md` was listed twice in the Feature Design section of `.nav.yml`.
- **Resolve `contributing/*` glob-vs-explicit collisions**: `contributing/README.md` and `contributing/DOCS_GUIDE.md` were each reachable twice (explicit entry + `glob: contributing/*` expansion). Added `ignore: [README.md, DOCS_GUIDE.md]` to the glob so only `metrics.md` and `profiling.md` are picked up by the glob.

## Deviation from plan

The plan's Task 4 (delete `docs/user_guide/examples/online_serving/text_to_audio.md` as a stale orphan) was **cancelled**. On investigation, the example source dir `examples/online_serving/stable_audio` exists and has content — the doc is not stale. It's hook-managed by `generate_examples.py` and appears in nav at build time. The earlier audit incorrectly reported the source dir as gone.

## Verification

- `mkdocs build --strict` passes (exit 0).
- `grep -c "design/feature/vae_parallel.md" docs/.nav.yml` → `1`
- `grep -E "tests_markers\.md|tests_style\.md" docs/contributing/ci/.nav.yaml` → both present
- `grep -E "test_markers\.md|test_style\.md" docs/contributing/ci/.nav.yaml` → no output (singular forms gone)