### PR TITLE
docs: fix P0 CLI and API examples

### DIFF
--- a/docs/cli/bench/serve.md
+++ b/docs/cli/bench/serve.md
@@ -55,7 +55,7 @@ You can use `vllm bench serve --omni --help=all` to get descriptions of all para
                     'Allowed metric names are "ttft", "tpot", "itl", "ttfc", "tpoc", "icl", '
                     '"tpop", "e2el", "audio_ttfp", "audio_rtf", "audio_duration". '
 
-- `-print-stage`
+- `--print-stage`
 Print per-stage benchmark metrics for --omni serving when stage metrics are returned by the server. Disabled by default.
 
 - `--save-result`
@@ -312,7 +312,7 @@ vllm bench serve \
   --ignore-eos \
   --percentile-metrics ttft,tpot,itl \
   --random-output-len 2 \
-  --extra_body '{"modalities": ["text"]}'
+  --extra-body '{"modalities": ["text"]}'
 ```
 
 If successful, you will see the following output:
@@ -390,7 +390,7 @@ vllm bench serve --omni \
   --ignore-eos \
   --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf,ttfc,tpoc,icl \
   --random-output-len 900 \
-  --extra_body '{"modalities": ["text","audio"]}' \
+  --extra-body '{"modalities": ["text","audio"]}' \
   --print-stage
 ```
 

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -2,6 +2,15 @@
 
 In vLLM-Omni, the target model is separated into multiple stages, which are processed by different LLMEngines, DiffusionEngines or other types of engines. Depending on different types of stages, such as Autoregressive (AR) stage or Diffusion transformer (DiT) stage, each can choose corresponding schedulers, model workers to load with the Engines in a plug-in fashion.
 
+This page documents two configuration formats:
+
+| Format | CLI flag | Top-level key | Status |
+|--------|----------|---------------|--------|
+| New deploy schema | `--deploy-config` | `stages` | Recommended; used by YAMLs under `vllm_omni/deploy/`. |
+| Legacy stage schema | `--stage-configs-path` | `stage_args` | Deprecated; retained for models that have not migrated. |
+
+The two flags are mutually exclusive. `--deploy-config` does not take precedence over `--stage-configs-path`; providing both raises an error.
+
 !!! note
     Default deploy config YAMLs (for example, `vllm_omni/deploy/qwen2_5_omni.yaml`, `vllm_omni/deploy/qwen3_omni_moe.yaml`, and `vllm_omni/deploy/qwen3_tts.yaml`) are bundled and loaded automatically when neither `--stage-configs-path` nor `--deploy-config` is provided — the model registry resolves the right pipeline + deploy YAML by `model_type`. The bundled defaults have been verified on 1xH100 for Qwen2.5-Omni and 2xH100 for Qwen3-Omni. Models that have not yet migrated to the new schema continue to use the legacy `vllm_omni/model_executor/stage_configs/<model>.yaml` files via `--stage-configs-path`.
 
@@ -86,7 +95,7 @@ stages:
 
 | Flag | Description |
 |------|-------------|
-| `--deploy-config PATH` | Load a new-schema deploy YAML. Takes precedence over `--stage-configs-path`. **Optional** — when omitted, the bundled `vllm_omni/deploy/<model_type>.yaml` is auto-loaded by the model registry. |
+| `--deploy-config PATH` | Load a new-schema deploy YAML. Mutually exclusive with `--stage-configs-path`. **Optional** — when omitted, the bundled `vllm_omni/deploy/<model_type>.yaml` is auto-loaded by the model registry. |
 | `--stage-overrides JSON` | Per-stage JSON overrides, e.g. `'{"0":{"gpu_memory_utilization":0.5}}'`. Per-stage values always win over global flags. |
 | `--async-chunk` / `--no-async-chunk` | Flip the deploy YAML's `async_chunk:` bool. Unset (default) leaves the YAML value in force. |
 | `--stage-configs-path` | **Deprecated.** Accepts legacy `stage_args` yamls and (auto-detected) new deploy yamls; emits a deprecation warning. Migrate to `--deploy-config`. To be removed in a follow-up PR. |
@@ -210,7 +219,7 @@ Effective config per stage after the merge:
 | 1 | `max_model_len` | `16384` | global CLI |
 | 2 | (all defaults) | — | base YAML (no overrides apply) |
 
-Therefore, as a core part of vLLM-Omni, the stage configs for a model have several main functions:
+Therefore, as a core part of the new deploy schema, the deploy config for a model has several main functions:
 
 - Claim partition of stages and their corresponding class implementation in `model_executor/models`.
 - The disaggregated configuration for each stage and the communication topology among them.
@@ -218,17 +227,17 @@ Therefore, as a core part of vLLM-Omni, the stage configs for a model have sever
 - Input and output dependencies for each stage.
 - Default input parameters.
 
-To override specific parameters, explicitly inject the customized configuration schema
-in both online and offline instantiation flows. Prioritize the `--deploy-config` flag
-when loading the new-schema deploy YAML schemas, reserving the `--stage-configs-path` parameter
-exclusively to maintain compatibility with legacy `stage_args` YAML constructs.
+To override specific parameters in the new schema, pass the customized deploy YAML
+through `--deploy-config` in online serving or the corresponding deploy-config
+argument in offline code. Use `--stage-configs-path` for legacy `stage_args`
+YAMLs; new-schema YAMLs should use `--deploy-config`.
 
 Examples:
 
 For offline (Assume necessary dependencies have been imported):
 ```python
 model_name = "Qwen/Qwen2.5-Omni-7B"
-omni = Omni(model=model_name, stage_configs_path="/path/to/custom_stage_configs.yaml")
+omni = Omni(model=model_name, deploy_config="/path/to/custom_deploy_config.yaml")
 ```
 
 For online serving:
@@ -244,7 +253,12 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 --stage-configs-path /
 !!! important
     We are actively iterating on the definition of stage configs, and we welcome all feedbacks from both community users and developers to help us shape the development!
 
-Below is a specific example of stage_configs.yaml in Qwen2.5-omni.
+## Legacy `stage_args` schema
+
+The following example uses the deprecated `stage_args` schema. It is accepted only
+through `--stage-configs-path`; new deployments should use the deploy schema above.
+
+Below is a specific example of a legacy `stage_configs.yaml` for Qwen2.5-Omni.
 ```python
 # stage config for running qwen2.5-omni with AsyncOmniEngine + Orchestrator runtime.
 stage_args:
@@ -338,7 +352,7 @@ runtime:
 
 ```
 
-## Stage Configuration Arguments
+## Legacy Stage Configuration Arguments
 
 Each stage in the `stage_args` list contains the following configuration options:
 

--- a/docs/serving/image_edit_api.md
+++ b/docs/serving/image_edit_api.md
@@ -252,7 +252,7 @@ Validation errors (missing required fields):
 
 ```bash
 # Check if server is responding
-curl -X http://localhost:8000/v1/images/edit \
+curl -X POST http://localhost:8000/v1/images/edits \
   -F "prompt='test'"
 ```
 

--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -138,7 +138,7 @@ Content-Type: application/json
 | `model` | string | server's model | Model to use (optional, should match server if specified) |
 | `n` | integer | 1 | Number of images to generate (1-10) |
 | `size` | string | model defaults | Image dimensions in WxH format (e.g., "1024x1024", "512x512") |
-| `response_format` | string | "b64_json" | Response format (only "b64_json" supported) |
+| `response_format` | string | "b64_json" | Response format: "b64_json" returns JSON with base64 data; "file" returns the generated image as a file response. |
 | `user` | string | null | User identifier for tracking |
 
 #### vllm-omni Extension Parameters

--- a/docs/user_guide/examples/offline_inference/bagel.md
+++ b/docs/user_guide/examples/offline_inference/bagel.md
@@ -257,7 +257,7 @@ python end2end.py --model ByteDance-Seed/BAGEL-7B-MoT \
 | :------- | :--- | :------ | :---------- |
 | `--deploy-config` | string | `None` | Path to deploy YAML (auto-detected if omitted) |
 | `--stage-configs-path` | string | `None` | [Deprecated] Legacy path to `stage_args` YAML; prefer `--deploy-config` |
-| `--worker-backend` | choice | `process` | `process` or `ray` |
+| `--worker-backend` | choice | `multi_process` | `multi_process` or `ray` |
 | `--ray-address` | string | `None` | Ray cluster address |
 | `--quantization` | string | `None` | Quantization method (e.g. `fp8`) |
 | `--log-stats` | flag | `False` | Enable statistics logging |

--- a/docs/user_guide/examples/offline_inference/glm_image.md
+++ b/docs/user_guide/examples/offline_inference/glm_image.md
@@ -26,18 +26,21 @@ Stage 0 (AR Model)                Stage 1 (Diffusion)
 
 ```python
 from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 if __name__ == "__main__":
     omni = Omni(model="zai-org/GLM-Image")
+    sampling_params_list = list(omni.default_sampling_params_list)
+    sampling_params_list[1] = OmniDiffusionSamplingParams(
+        height=1024,
+        width=1024,
+        num_inference_steps=50,
+        guidance_scale=1.5,
+        seed=42,
+    )
     outputs = omni.generate(
         "A photorealistic mountain landscape at sunset",
-        sampling_params={
-            "height": 1024,
-            "width": 1024,
-            "num_inference_steps": 50,
-            "guidance_scale": 1.5,
-            "seed": 42,
-        },
+        sampling_params_list=sampling_params_list,
     )
     outputs[0].request_output.images[0].save("output.png")
 ```
@@ -46,9 +49,18 @@ if __name__ == "__main__":
 
 ```python
 from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 if __name__ == "__main__":
     omni = Omni(model="zai-org/GLM-Image")
+    sampling_params_list = list(omni.default_sampling_params_list)
+    sampling_params_list[1] = OmniDiffusionSamplingParams(
+        height=1024,
+        width=1024,
+        num_inference_steps=50,
+        guidance_scale=1.5,
+        seed=42,
+    )
     outputs = omni.generate(
         {
             "prompt": "Convert this image to watercolor style",
@@ -56,13 +68,7 @@ if __name__ == "__main__":
                 "image": "input.png",
             },
         },
-        sampling_params={
-            "height": 1024,
-            "width": 1024,
-            "num_inference_steps": 50,
-            "guidance_scale": 1.5,
-            "seed": 42,
-        },
+        sampling_params_list=sampling_params_list,
     )
     outputs[0].request_output.images[0].save("output.png")
 ```


### PR DESCRIPTION
## Summary

- Fix the documented `--print-stage` and `--extra-body` benchmark flags.
- Correct the image-edit troubleshooting endpoint and request method.
- Separate the new deploy schema from legacy `stage_args` documentation and document the mutually exclusive config flags.
- Fix GLM-Image offline sampling parameters to provide AR and diffusion stage entries.
- Correct the BAGEL worker backend values and document `response_format: file` for image generation.

## Why

The previous examples and reference tables contained commands and parameter names that either failed at argument parsing/runtime or contradicted the implemented API.

## Validation

- `git diff --check`
- Parsed both GLM-Image Python examples with Python AST validation.
- Targeted pytest was blocked by the checkout environment's dependency conflict and installed vLLM API mismatch.