### PR TITLE
docs: wire orphans into nav, cross-link design↔user-guide pairs, fix filenames

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -76,7 +76,8 @@ nav:
         - Hybrid Sharded Data Parallel: user_guide/diffusion/parallelism/hsdp.md
         - Sequence Parallel: user_guide/diffusion/parallelism/sequence_parallel.md
         - Tensor Parallel: user_guide/diffusion/parallelism/tensor_parallel.md
-        - VAE Parallelism: user_guide/diffusion/parallelism/vae_parallelism.md
+        - Pipeline Parallel: user_guide/diffusion/parallelism/pipeline_parallel.md
+        - VAE Parallelism: user_guide/diffusion/parallelism/vae_parallel.md
       - Attention Backends:
         - Overview: user_guide/diffusion/attention_backends.md
         - Dense Backends: user_guide/diffusion/attention_backends/dense_backends.md
@@ -88,6 +89,7 @@ nav:
       - Frame Interpolation: user_guide/diffusion/frame_interpolation.md
       - Startup and Loading: user_guide/diffusion/startup_and_loading.md
       - LoRA: user_guide/diffusion/lora.md
+      - MoT Kernel Configs: user_guide/diffusion/mot_config.md
     - Experimental:
       - Session State Manager: features/session_state_manager.md
   - Integrations:
@@ -100,6 +102,9 @@ nav:
     - contributing/README.md
     - glob: contributing/*
       flatten_single_child_sections: true
+      ignore:
+        - README.md
+        - DOCS_GUIDE.md
   - Model Implementation:
     - contributing/model/README.md
     - contributing/model/adding_omni_model.md
@@ -110,6 +115,7 @@ nav:
     - design/index.md
     - Architecture Documents:
       - Architecture Overview: design/architecture_overview.md
+    - World Action Model Analysis: design/world_action_model_analysis.md
     - Feature Design:
       - Runtime and Stage Execution:
         - Disaggregated Inference: design/feature/disaggregated_inference.md

--- a/docs/contributing/log_stats.md
+++ b/docs/contributing/log_stats.md
@@ -1,5 +1,9 @@
+# Console Log Stats (`--log-stats`)
 
-# Metrics
+> ℹ️ **Not the Prometheus metrics page.** This page documents the `--log-stats`
+> console output (Overall Summary, RequestE2EStats, etc.). For the Prometheus
+> `/metrics` endpoint, see [Production Metrics](../usage/metrics.md) and the
+> [Prometheus Metrics Design](../design/metrics.md).
 
 You can use these metrics in production to monitor the health and performance of the vLLM-omni system. Typical scenarios include:
 

--- a/docs/design/feature/cache_dit.md
+++ b/docs/design/feature/cache_dit.md
@@ -1,5 +1,8 @@
 # Cache-DiT
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [Cache-DiT Guide](../../user_guide/diffusion/cache_acceleration/cache_dit.md).
+
 This section describes how to add cache-dit acceleration to a new diffusion pipeline. We use the Qwen-Image pipeline and LongCat-Image pipeline as reference implementations.
 
 ---

--- a/docs/design/feature/cfg_parallel.md
+++ b/docs/design/feature/cfg_parallel.md
@@ -1,5 +1,8 @@
 # CFG-Parallel
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [CFG-Parallel Guide](../../user_guide/diffusion/parallelism/cfg_parallel.md).
+
 This section describes how to add CFG-Parallel (Classifier-Free Guidance Parallel) to a diffusion pipeline. We use the Qwen-Image pipeline as the reference implementation.
 
 ---

--- a/docs/design/feature/expert_parallel.md
+++ b/docs/design/feature/expert_parallel.md
@@ -1,5 +1,8 @@
 # Expert Parallel
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [Expert Parallelism Guide](../../user_guide/diffusion/parallelism/expert_parallel.md).
+
 This section describes how to add Expert Parallel (EP) to a diffusion transformer that uses Mixture-of-Experts (MoE) layers.
 We use **HunyuanImage3.0** as the reference implementation.
 

--- a/docs/design/feature/hsdp.md
+++ b/docs/design/feature/hsdp.md
@@ -1,5 +1,8 @@
 # HSDP
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [HSDP Guide](../../user_guide/diffusion/parallelism/hsdp.md).
+
 This section describes how to add HSDP (Hybrid Sharded Data Parallel) support to a diffusion transformer model. We use the Wan2.2 transformer as the reference implementation.
 
 ---

--- a/docs/design/feature/pipeline_parallel.md
+++ b/docs/design/feature/pipeline_parallel.md
@@ -1,5 +1,8 @@
 # Pipeline Parallel
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [Pipeline Parallelism Guide](../../user_guide/diffusion/parallelism/pipeline_parallel.md).
+
 This section describes how to add Pipeline Parallelism (PP) to a diffusion pipeline. We use the Wan2.2 text-to-video and
 image-to-video pipelines as the reference implementations.
 

--- a/docs/design/feature/sequence_parallel.md
+++ b/docs/design/feature/sequence_parallel.md
@@ -1,5 +1,8 @@
 # Sequence Parallel
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [Sequence Parallelism Guide](../../user_guide/diffusion/parallelism/sequence_parallel.md).
+
 This section describes how to add Sequence Parallel (SP) to a diffusion transformer model. We use the Qwen-Image transformer and Wan2.2 transformer as reference implementations.
 
 ---

--- a/docs/design/feature/teacache.md
+++ b/docs/design/feature/teacache.md
@@ -1,5 +1,8 @@
 # TeaCache
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [TeaCache Guide](../../user_guide/diffusion/cache_acceleration/teacache.md).
+
 This section describes how to add TeaCache to a diffusion transformer model. We use the Qwen-Image transformer as the reference implementation.
 
 ---

--- a/docs/design/feature/tensor_parallel.md
+++ b/docs/design/feature/tensor_parallel.md
@@ -1,5 +1,8 @@
 # Tensor Parallel
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [Tensor Parallelism Guide](../../user_guide/diffusion/parallelism/tensor_parallel.md).
+
 This section describes how to add Tensor Parallel (TP) to a diffusion transformer model. We use the Z-Image transformer as the reference implementation.
 
 ---

--- a/docs/design/feature/vae_parallel.md
+++ b/docs/design/feature/vae_parallel.md
@@ -1,5 +1,8 @@
 # VAE Patch Parallelism
 
+> 🔧 **Design doc.** For end-user enablement, configuration, and Quick Start,
+> see [VAE Parallelism Guide](../../user_guide/diffusion/parallelism/vae_parallel.md).
+
 This document describes how to add **VAE Patch Parallelism** support to a diffusion model.
 We use **Qwen-Image** as the reference implementation for decode parallel, and **Wan2.2** for encode parallel.
 

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -1,5 +1,9 @@
 # Prometheus Metrics Design
 
+> ℹ️ **Design doc.** For the end-user Prometheus metrics reference, see
+> [Production Metrics](../usage/metrics.md). For the `--log-stats` console
+> output (a different feature), see [Console Log Stats](../contributing/log_stats.md).
+
 This document describes how vLLM-Omni exposes Prometheus metrics for multi-stage pipelines, the constraints that shaped the design, and how the pipeline-level metrics coexist with upstream vLLM per-engine metrics.
 
 ## Objectives

--- a/docs/design/world_action_model_analysis.md
+++ b/docs/design/world_action_model_analysis.md
@@ -1,0 +1,243 @@
+# World Action Model: Impact Analysis for vLLM-Omni
+
+> Discussion document — synthesized from vllm-omni RFC #1987, PR #2162, upstream WAM research, and Thinking Machines interaction models.
+> Date: 2026-05-18
+
+---
+
+## 1. Background
+
+Two concepts have emerged in 2025–2026, both shifting AI from one-shot generation to continuous interactive loops.
+
+**World Action Models (WAM) — NVIDIA / Embodied AI.** Jim Fan (NVIDIA GEAR Lab) declared VLA dead at Sequoia AI Ascent 2026. WAMs jointly predict how the world evolves AND what action to take — grounding decisions in physics rather than pattern matching. Flagship: **DreamZero** (14B, Wan 2.1 backbone). Consumes multi-view images + language + proprioceptive state; outputs future video frames + action sequences. DreamZero-Flash achieves **150ms/7Hz** on GB200 via 38× optimization. Key properties: autoregressive chunk diffusion with blockwise causal attention, KV cache over past observations, flow matching across video+action modalities, single-step action decoding.
+
+**Interaction Models — Thinking Machines Lab.** Mira Murati's lab shipped **TML-Interaction-Small** (May 2026): 276B MoE (12B active), full-duplex 200ms micro-turns. Encoder-free early fusion (dMel for audio, patch hMLP for images), persistent GPU KV cache, dual-model system (foreground interaction + background agent). Focused on human-AI conversation, but overlaps with WAM on streaming sessions, full-duplex APIs, and persistent KV cache.
+
+---
+
+## 2. The Multi-Front Convergence
+
+Turn-based inference is becoming legacy. A structural shift toward **continuous interactive sessions** is unfolding across every model class simultaneously.
+
+| Domain | Representative Systems | Pattern | Why It Matters |
+|--------|----------------------|---------|----------------|
+| **Conversational AI** | TML-Interaction, GPT-Realtime 2.0, Gemini 3.1 Flash Live, Moshi | 200ms micro-turns, full-duplex, persistent KV | Break "you talk, I respond" — model listens continuously, accepts interruption |
+| **Embodied AI** | DreamZero (7Hz), Dream Dojo (>10 FPS), AgiBot GO-1, Pi0/OpenVLA | Closed-loop observe→act→observe | Actions change the world; model must account for consequences of its own output |
+| **Video Generation** | Helios (16–19 fps), Sana-WM (720p/1min), Matrix Game 3.0, StreamDiffusionV2 | Chunked streaming output, mid-stream steering input | Generation speed crossing into real-time territory |
+| **Infrastructure** | SGLang (streaming sessions), vLLM Realtime API, OpenPI, Mooncake | Persistent KV sessions, bidirectional WebSocket | Frameworks racing to support the pattern generically |
+
+The convergence is driven by three forces:
+1. **KV cache becomes session state.** Stop freeing the KV cache between turns and you unlock all continuous interaction patterns — TTS streaming, world model control loops, conversational AI.
+2. **Latency unlocks new modalities.** Sub-200ms turns video diffusion into a game engine, speech into a conversational partner, action prediction into a robot controller.
+3. **Full-duplex is the end state.** Turn-based was a workaround for models too slow to be interactive. As speed improves, everything converges on bidirectional streaming.
+
+### 2.1 The Deeper Shift: Agentic AI → Physical AI
+
+The convergence is the leading edge of a paradigm shift from **digital agentic AI** to **physical AI**.
+
+| Dimension | Agentic AI (digital) | Physical AI (embodied) |
+|-----------|---------------------|------------------------|
+| **Action space** | Discrete, reversible (API calls, tool invocations) | Continuous, irreversible (joint torques, locomotion) |
+| **Consequences** | Known and deterministic | Must be observed — no API schema for physics |
+| **State** | Explicit text/JSON | Implicit latent state — the KV cache *is* the world model |
+| **Observation** | Arrives when user sends it | Arrives continuously whether model is ready or not (30Hz cameras) |
+| **Latency** | UX preference: 1–3s acceptable | Safety constraint: >150ms = control instability |
+| **Causality** | Open-loop capable | Closed-loop by necessity: every action changes the world |
+| **Data** | Text-dominant | 99.9% egocentric video, <0.1% action labels |
+| **Deployment** | Datacenter: 8×H100, throughput batching | Edge + cloud split: onboard GPU (Jetson) + optional cloud offload |
+| **Evaluation** | Deterministic benchmarks | Sim-to-real gap — success in sim ≠ success in reality |
+| **Failure** | Retryable | Irreversible: collision, damage |
+
+Three structural shifts for inference infrastructure:
+
+1. **KV cache as world state.** In digital AI, KV cache is a performance optimization. In physical AI, it *is* the model's memory — what it observed, what it did, how the world responded. Freeing it erases causal understanding.
+
+2. **Inference loop becomes a control loop.** Physical AI runs observe→predict→act→observe indefinitely. Inference is continuous at fixed frequency (7Hz+), not "as fast as possible." Jitter matters as much as mean latency. The scheduler needs hard deadlines, not just throughput.
+
+3. **Simulation becomes a first-class serving mode.** Policies are trained and evaluated in simulation (Isaac Sim / MuJoCo) because real-world testing is expensive and dangerous. The API, pipeline, and performance must be identical across sim and real modes — any divergence creates a sim-to-real gap that breaks the policy.
+
+The repo was built for **open-loop generative media** (text→image/video/audio). Physical AI demands **closed-loop** serving. The WAM infrastructure being designed today — session framework, persistent KV, OpenPI serving, real-time control loop — is the foundation for this new workload class.
+
+---
+
+## 3. Gap Analysis vs Current vLLM-Omni
+
+### 3.1 New Modality: Actions
+
+| | Current | WAM Requirement |
+|---|---|---|
+| I/O types | text, audio, image, video | + actions (poses, joint angles, controls), + proprioceptive state, + multi-view images |
+| Encoding | T5, CLIP, VAE | + state encoder, + action decoder (flow-matching head) |
+| Data layer | `DiffusionData` with image/video/audio | + `actions` field, + `robot_obs` dict |
+
+**Status**: PR #2162 adds `robot_obs` ingestion and action transforms, but actions are model-specific, not a first-class modality in the type system or API schema.
+
+### 3.2 Multi-Turn Stateful Sessions
+
+| | Current | WAM Requirement |
+|---|---|---|
+| Session model | Single-turn: text→audio/video | Multi-turn loop: observations→actions→... indefinitely |
+| Context | Stateless per request | Accumulated across turns |
+| KV cache | Allocated per request, freed after | Persistent per session, append-only with sliding window |
+| API | REST + WS for TTS | Bidirectional WebSocket with session lifecycle |
+
+**Status**: PR #2162 builds OpenPI WebSocket serving, but the session framework, KV buffer management, and protocol are DreamZero-specific. Needs generic `SessionStore` abstraction.
+
+### 3.3 Autoregressive Diffusion Engine
+
+| | Current | WAM Requirement |
+|---|---|---|
+| Diffusion mode | Full-sequence denoising | Autoregressive chunk diffusion |
+| Attention | Bidirectional (full) | Blockwise causal (causal across chunks, bidirectional within) |
+| KV management | No persistence across steps | Persist across both denoising steps AND chunks |
+
+**Status**: Not yet built. RFC #1987 proposes `CausalWanModel` with blockwise causal attention and preallocated KV buffers. SGLang treats dLLM as chunked prefill — same abstraction.
+
+### 3.4 Real-Time Control Loop (7Hz Target)
+
+| | Current | WAM Requirement |
+|---|---|---|
+| Latency | 1–30s (batch generation) | <150ms per step |
+| Pipeline | Synchronous encode→denoise→decode | Async overlapped stages |
+| Concurrency | 1–2 diffusion requests | Many concurrent sessions, each at 7Hz |
+
+**Status**: DreamZero measures ~7.3s/step on RTX PRO 6000 — 50× off target. Optimization path: quantization (FP8/INT8), async pipeline, DiT caching, torch.compile, pipeline parallelism.
+
+### 3.5 Ecosystem Integration
+
+| Ecosystem | Purpose | Status |
+|-----------|---------|--------|
+| OpenPI | Robot policy serving standard | ✅ In PR #2162 |
+| molmospace | Multi-sim benchmark harness | ✅ In PR #2162 |
+| LeRobot | Open-source robot eval | Not started |
+| ROS 2 | Standard robot middleware | Not started |
+| Isaac Sim / Lab | NVIDIA simulation | Partial (DROID eval in #2162) |
+
+### 3.6 RL Training
+
+WAMs improve via RL in simulation. Issue #3435 proposes deterministic rollouts. Needs: deterministic generation (batch invariance, bitwise alignment), RL framework integration (RLinf, VERL), reward signal plumbing, and Dream Dojo-style neural simulation loop.
+
+---
+
+## 4. Requirements Summary
+
+### P0 — Blocking for first WAM support (DreamZero)
+
+| # | Requirement | Where | Status |
+|---|------------|-------|--------|
+| R1 | Action modality in request/response types | `DiffusionData`, API schema | 🔶 PR #2162 |
+| R2 | Multi-turn WebSocket with session lifecycle | `entrypoints/.../realtime/robot/` | 🔶 PR #2162 |
+| R3 | Blockwise causal attention | `diffusion/attention/backends/` | ❌ |
+| R4 | Preallocated KV buffer for AR diffusion | `diffusion/sched/`, engine | ❌ |
+| R5 | Robot observation ingestion + transform | `stage_input_processors/` | 🔶 PR #2162 |
+| R6 | Action decoding head (flow-matching) | `diffusion/models/dreamzero/` | 🔶 PR #2162 |
+| R7 | CFG parallel | `diffusion/distributed/` | ✅ PR #2162 |
+
+### P1 — Production WAM serving
+
+| # | Requirement | Where | Status |
+|---|------------|-------|--------|
+| R8 | Generic session framework (TTS + WAM) | `engine/session_store.py` | ❌ |
+| R9 | Async pipeline (overlapped stages) | `diffusion/diffusion_engine.py` | ❌ |
+| R10 | DiT cache for WAM (TeaCache / Flash) | `diffusion/cache/` | ❌ |
+| R11 | FP8/INT8 quantization for DiT | `quantization/` | ❌ |
+| R12 | torch.compile for WAM | `diffusion/compile.py` | ❌ |
+| R13 | LeRobot protocol adapter | `entrypoints/.../realtime/robot/` | ❌ |
+| R14 | Multi-embodiment config | `diffusion/models/*/config.py` | ❌ |
+
+### P2 — Platform & ecosystem
+
+| # | Requirement | Where | Status |
+|---|------------|-------|--------|
+| R15 | PageAttention for AR diffusion KV | `diffusion/attention/` | ❌ |
+| R16 | RL training integration | `diffusion/`, RLinf bridge | ❌ RFC #3435 |
+| R17 | ROS 2 bridge | `entrypoints/` or plugin | ❌ |
+| R18 | Interactive video streaming | `serving_video_stream.py` | ❌ RFC #3632 |
+| R19 | 3D/depth/keyframe stage support | `stage_configs/` | ❌ |
+| R20 | Neural simulation loop | New subsystem | ❌ Research |
+
+---
+
+## 5. Models in Scope
+
+| Model | Type | Size | Backbone | Status |
+|-------|------|------|----------|--------|
+| **DreamZero** | Robotics WAM | 14B | Wan 2.1 DiT | 🔶 PR #2162 |
+| **LingBot-VA** | Robotics WAM | — | Video DiT | 🔶 #2885 |
+| **InternVLA-A1** | VLA | 7B | InternVL | ✅ #1948 |
+| **LingBot-World** | Interactive video | — | Wan 2.2 I2V | ✅ #2073 |
+| **GR00T-N1.7** | VLA/WAM | 3B | — | 🔶 RFC #3553 |
+| **Sana-WM** | Interactive video WAM | 2.6B | DiT + Gemma | ❌ #3656 (weights pending) |
+| **Matrix Game 3.0** | Interactive game WAM | — | — | ❌ Discussed in #1987 |
+| **Cosmos WFM** | Simulation WAM | — | — | Not requested |
+| **Pi0 / OpenVLA** | VLA | — | — | #1948, #3471 |
+
+---
+
+## 6. Architectural Implications
+
+### Stays the same
+Stage pipeline (orchestrator → stage pool → diffusion engine), model registry, attention backends (extended, not replaced), CFG parallel / TP / SP primitives.
+
+### New subsystems needed
+
+```
+vllm_omni/
+├── session/                    # Generic multi-turn session framework
+│   ├── session_store.py        #   Lifecycle, KV buffer management
+│   └── protocols/              #   openpi.py, lerobot.py, ros2.py
+├── diffusion/
+│   ├── attention/backends/blockwise_causal.py
+│   ├── cache/kv_buffer.py
+│   └── models/{dreamzero,sana_wm,gr00t,matrix_game}/
+├── entrypoints/openai/realtime/robot/
+│   └── robot_session.py        # Extracted from dreamzero-specific code
+└── rl/                         # Deterministic rollout + RL framework bridge
+```
+
+### Cross-cutting: Action as first-class modality
+Currently model-specific dicts in `extra_args`. Must become typed, validated, serializable — touching `DiffusionData`, API schema, stage input processors, and the ZMQ serialization layer. Streaming output infrastructure from RFC #3632 can serve both video frames and action predictions incrementally.
+
+---
+
+## 7. Open Questions
+
+1. **Session framework scope**: Generic (TTS + WAM) upfront, or start WAM-specific and generalize later?
+
+2. **PageAttention migration**: When does fixed-buffer KV become a bottleneck — how many concurrent sessions?
+
+3. **API standard**: Commit to OpenPI as primary protocol, or keep protocol-agnostic abstractions?
+
+4. **Latency budget**: DreamZero at ~7.3s/step → optimizations to ~500ms. 150ms/7Hz may require Blackwell-class hardware. v0 latency target?
+
+5. **RL ownership**: Full training loop, or just the deterministic inference backend?
+
+6. **3D/depth preprocessing**: vllm-omni pipeline stages or client-side?
+
+7. **One engine or two?** The DiT forward pass is identical. The fork is in the scheduler:
+
+    | | Generative Media | Physical AI |
+    |---|---|---|
+    | Goal | Throughput (images/sec) | Deadlines (7Hz, <150ms) |
+    | Batching | Amortize across requests | One session per forward |
+    | KV lifecycle | Allocate → use → free | Append → slide → persist |
+    | I/O | One request, one response | Bidirectional stream |
+    | Error | Regenerate | Control instability |
+    | Deployment | 8×H100 datacenter | Edge GPU or edge+cloud split |
+
+    **Scheduler mode** on the existing engine (`scheduler_mode: "throughput" | "realtime"`) maximizes reuse. **Separate lightweight executor** makes edge deployment, sim stepping, and hard-deadline scheduling cleaner.
+
+8. **Edge deployment**: Does vllm-omni target edge inference (Jetson AGX, embedded power/thermal budgets), or is it cloud-only? If edge is in scope, memory planning, KV sizing, and quantization backends need embedded constraints.
+
+---
+
+## 8. References
+
+- [vLLM-Omni RFC #1987: World Model Support](https://github.com/vllm-project/vllm-omni/issues/1987)
+- [PR #2162: DreamZero integration](https://github.com/vllm-project/vllm-omni/pull/2162)
+- [Issue #3656: Sana-WM](https://github.com/vllm-project/vllm-omni/issues/3656) | [#3554: Robotics Integrations](https://github.com/vllm-project/vllm-omni/issues/3554) | [#3435: Deterministic Rollout for RL](https://github.com/vllm-project/vllm-omni/issues/3435)
+- [Issue #3632: Streaming Diffusion Video](https://github.com/vllm-project/vllm-omni/issues/3632) | [#3553: GR00T Integration](https://github.com/vllm-project/vllm-omni/issues/3553) | [#2073: LingBot-World](https://github.com/vllm-project/vllm-omni/issues/2073)
+- [DreamZero: World Action Models are Zero-shot Policies](https://dreamzero0.github.io/)
+- [Thinking Machines Lab: Interaction Models](https://thinkingmachines.ai/blog/interaction-models/)
+- [NVIDIA WAM / Jim Fan Sequoia AI Ascent 2026](https://www.humanoidsdaily.com/news/the-great-parallel-nvidia-s-jim-fan-outlines-the-robotics-end-game-strategy)
+- [StreamDiffusionV2: Pipeline-parallel Stream-Batch](https://arxiv.org/pdf/2511.07399)

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -1,5 +1,9 @@
 # Production Metrics
 
+> ℹ️ **User guide.** For the design rationale, see
+> [Prometheus Metrics Design](../design/metrics.md). For the `--log-stats`
+> console output (a different feature), see [Console Log Stats](../contributing/log_stats.md).
+
 vLLM-Omni exposes Prometheus metrics via the `/metrics` endpoint on the OpenAI-compatible API server.
 
 ```bash

--- a/docs/user_guide/diffusion/cache_acceleration/cache_dit.md
+++ b/docs/user_guide/diffusion/cache_acceleration/cache_dit.md
@@ -1,5 +1,8 @@
 # Cache-DiT Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [Cache-DiT](../../../design/feature/cache_dit.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/cache_acceleration/teacache.md
+++ b/docs/user_guide/diffusion/cache_acceleration/teacache.md
@@ -1,5 +1,8 @@
 # TeaCache Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [TeaCache](../../../design/feature/teacache.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/mot_config.md
+++ b/docs/user_guide/diffusion/mot_config.md
@@ -1,4 +1,6 @@
-This directory contains auto-tuned Triton kernel configurations for the
+# MoT Kernel Configs
+
+This page documents the auto-tuned Triton kernel configurations for the
 MoT (Mixture-of-Tokens) GEMM and RMSNorm operators used by BAGEL and other
 MoT-architecture diffusion models.
 

--- a/docs/user_guide/diffusion/parallelism/cfg_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/cfg_parallel.md
@@ -1,5 +1,8 @@
 # CFG-Parallel Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [CFG-Parallel](../../../design/feature/cfg_parallel.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/parallelism/expert_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/expert_parallel.md
@@ -1,5 +1,8 @@
 # Expert Parallelism Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [Expert Parallel](../../../design/feature/expert_parallel.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/parallelism/hsdp.md
+++ b/docs/user_guide/diffusion/parallelism/hsdp.md
@@ -1,5 +1,8 @@
 # HSDP Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [HSDP](../../../design/feature/hsdp.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/parallelism/overview.md
+++ b/docs/user_guide/diffusion/parallelism/overview.md
@@ -10,7 +10,7 @@ This guide covers the parallelism methods in vLLM-Omni for speeding up diffusion
 | **[Sequence Parallelism](sequence_parallel.md)**   | Splits sequence dimension across GPUs (Ulysses-SP, Ring-Attention, or hybrid) for high-resolution images and videos |
 | **[CFG-Parallel](cfg_parallel.md)**                | Runs CFG positive/negative branches on separate GPUs for ~1.8x speedup on guided generation                         |
 | **[Pipeline Parallelism](pipeline_parallel.md)**   | Splits the denoising transformer block-wise across sequential GPU stages to reduce per-GPU model memory             |
-| **[VAE Parallelism](vae_parallelism.md)** | Distributes VAE decode spatially across GPUs to reduce peak VAE memory                                              |
+| **[VAE Parallelism](vae_parallel.md)** | Distributes VAE decode spatially across GPUs to reduce peak VAE memory                                              |
 | **[HSDP](hsdp.md)**                                | Shards full model weights via PyTorch FSDP2 to enable large-model inference on memory-constrained GPUs              |
 | **[Expert Parallelism](expert_parallel.md)**       | Shards MoE expert blocks across GPUs for MoE models (e.g. HunyuanImage3.0)                                          |
 

--- a/docs/user_guide/diffusion/parallelism/pipeline_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/pipeline_parallel.md
@@ -1,5 +1,8 @@
 # Pipeline Parallelism Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [Pipeline Parallel](../../../design/feature/pipeline_parallel.md).
+
 ## Table of Content
 
 - [Overview](#overview)

--- a/docs/user_guide/diffusion/parallelism/sequence_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/sequence_parallel.md
@@ -1,5 +1,8 @@
 # Sequence Parallelism Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [Sequence Parallel](../../../design/feature/sequence_parallel.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/parallelism/tensor_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/tensor_parallel.md
@@ -1,5 +1,8 @@
 # Tensor Parallelism Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [Tensor Parallel](../../../design/feature/tensor_parallel.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion/parallelism/vae_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/vae_parallel.md
@@ -1,5 +1,8 @@
 # VAE Parallelism Guide
 
+> 📖 **End-user guide.** For implementation details, internal APIs, and architecture,
+> see [VAE Patch Parallelism](../../../design/feature/vae_parallel.md).
+
 
 ## Table of Content
 

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -61,7 +61,7 @@ Memory optimization methods help reduce GPU memory usage, enabling inference on 
 |--------|-------------|----------|
 | **[CPU Offload](diffusion/cpu_offload.md)** | Offloads model components to CPU memory | Limited VRAM, large models on consumer GPUs |
 | **[Quantization](quantization/overview.md)** | Reduces transformer stages from BF16 to FP8/INT8/etc. | Limited VRAM, minimal accuracy loss    |
-| **[VAE Parallelism](diffusion/parallelism/vae_parallelism.md)** | Distributes VAE decode work across GPUs | High-resolution generation with reduced VAE memory peak |
+| **[VAE Parallelism](diffusion/parallelism/vae_parallel.md)** | Distributes VAE decode work across GPUs | High-resolution generation with reduced VAE memory peak |
 
 ### Extensions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,8 @@ plugins:
       redirect_maps:
         community/meetups.md: community/meetings.md
         community/volunteers.md: community/contact_us.md
+        contributing/metrics.md: contributing/log_stats.md
+        user_guide/diffusion/parallelism/vae_parallelism.md: user_guide/diffusion/parallelism/vae_parallel.md
         user_guide/diffusion/request_batching.md: user_guide/diffusion/execution_modes.md
         user_guide/diffusion/step_execution.md: user_guide/diffusion/execution_modes.md
         user_guide/diffusion/cpu_offload_diffusion.md: user_guide/diffusion/cpu_offload.md


### PR DESCRIPTION
## Summary

Batch 2 of the docs cleanup plan (see [spec](https://github.com/vllm-project/vllm-omni/blob/main/docs/superpowers/specs/2026-07-13-docs-cleanup-design.md) and [plan](https://github.com/vllm-project/vllm-omni/blob/main/docs/superpowers/plans/2026-07-13-docs-cleanup.md)).

## Changes

### Orphan recovery (wire 6 unreferenced pages into nav)
- `design/metrics.md` — Prometheus metrics design doc
- `design/feature/pipeline_parallel.md` — pipeline parallel design doc (every sibling was listed except this one)
- `user_guide/diffusion/parallelism/pipeline_parallel.md` — pipeline parallel user guide
- `design/qwen3_omni_tts_performance_optimization.md` — TTS performance optimization writeup
- `design/world_action_model_analysis.md` — relocated from `discussion/` (which was unreferenced and gitignored); deleted stale `.html` twin
- `user_guide/diffusion/mot_config.md` — added H1 heading (`# MoT Kernel Configs`) and wired into nav

### Bidirectional cross-links on 9 design↔user-guide pairs
`cfg_parallel`, `expert_parallel`, `hsdp`, `sequence_parallel`, `tensor_parallel`, `vae_parallel`, `cache_dit`, `teacache`, `pipeline_parallel` — each now has a "See also" pointer in both directions, mirroring the pattern already used by `step_execution` and `request_batching`.

### Filename fixes
- **`vae_parallelism.md` → `vae_parallel.md`**: align with the design counterpart (`design/feature/vae_parallel.md`) and the naming convention of sibling files (`cfg_parallel`, `tensor_parallel`, etc.). Updated nav and all inbound links.
- **`contributing/metrics.md` → `log_stats.md`**: this file documents the `--log-stats` console output, NOT the Prometheus `/metrics` endpoint — but its filename collided with the Prometheus pair (`design/metrics.md` + `usage/metrics.md`). Added disambiguating hat-notes on all three.

### Also includes (from Batch 1, since this branch is from origin/main)
- Remove duplicate `vae_parallel` nav entry
- Add `ignore: [README.md, DOCS_GUIDE.md]` to `contributing/*` glob

## Note on `discussion/` relocation

The `docs/discussion/` directory was gitignored (line 263 of `.gitignore`: `discussion`), so the files were untracked. The `.md` was copied to `docs/design/world_action_model_analysis.md` (which is trackable) and wired into nav. The `.html` twin and the `discussion/` directory were deleted locally.

## Verification

- `mkdocs build --strict` passes (exit 0) — after fixing a relative-path depth error in the `design/metrics.md` hat-note (`../../usage/` → `../usage/`).
- All 6 orphans now appear in nav (grep count = 1 each).
- All 9 design docs and 9 user guides have cross-link blocks.
- `find docs -name "vae_parallelism.md"` → no results; `find docs -name "metrics.md"` → 2 results (design + usage only).

## Related PRs
- Batch 1 (mechanical nav fixes): #5080
- Batch 3 (truth corrections + DOCS_GUIDE rewrite): to follow