### PR TITLE
[Bugfix][Quantization] Remap ModelOpt NVFP4 scale tensors

### DIFF
--- a/tests/diffusion/model_loader/test_modelopt_fp8_adapter.py
+++ b/tests/diffusion/model_loader/test_modelopt_fp8_adapter.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     ModelOptFp8CheckpointAdapter,
+    ModelOptNvFp4CheckpointAdapter,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
@@ -87,6 +88,23 @@ class _QuantizedRemappedModelOptModel(nn.Module):
         if name.startswith(prefix):
             return "runtime.proj." + name[len(prefix) :]
         return name
+
+
+class _RemappedNvFp4Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.runtime = nn.Module()
+        self.runtime.proj = nn.Module()
+        self.runtime.proj.register_parameter(
+            "weight",
+            nn.Parameter(torch.empty(1, 1, dtype=torch.uint8), requires_grad=False),
+        )
+        for name in ("input_scale", "weight_scale", "weight_scale_2"):
+            self.runtime.proj.register_parameter(name, nn.Parameter(torch.empty(1), requires_grad=False))
+
+    @staticmethod
+    def remap_checkpoint_key(name: str) -> str:
+        return name.replace("transformer.orig.proj.", "runtime.proj.")
 
 
 def _make_source() -> SimpleNamespace:
@@ -188,13 +206,36 @@ def test_modelopt_adapter_remaps_and_keeps_scales_for_quantized_target():
     emitted = dict(adapted)
     assert len(adapted) == len(emitted) == 3
 
-    # Both scales are retained (the dropped-scale regression). They keep their
-    # source-checkpoint names; the model's load_weights remaps them downstream.
-    assert torch.equal(emitted["transformer.orig.proj.weight_scale"], weight_scale)
-    assert torch.equal(emitted["transformer.orig.proj.input_scale"], input_scale)
+    # Both scales are retained and emitted under the remapped runtime names.
+    assert torch.equal(emitted["runtime.proj.weight_scale"], weight_scale)
+    assert torch.equal(emitted["runtime.proj.input_scale"], input_scale)
 
     # The FP8 weight is passed through unchanged under the remapped target name
     # (the quantized param is FP8, so it must NOT be dequantized). Compare via
     # float32 since torch.equal has no FP8 CPU kernel.
     assert emitted["runtime.proj.weight"].dtype == torch.float8_e4m3fn
     assert torch.equal(emitted["runtime.proj.weight"].to(torch.float32), fp8_weight.to(torch.float32))
+
+
+def test_modelopt_nvfp4_adapter_remaps_quantized_weights_and_scales():
+    adapter = ModelOptNvFp4CheckpointAdapter(_RemappedNvFp4Model(), _make_source())
+    prefix = "transformer.orig.proj"
+    checkpoint_tensors = [
+        (f"{prefix}.input_scale", torch.tensor([1.0])),
+        (f"{prefix}.weight_scale", torch.tensor([0.5])),
+        (f"{prefix}.weight_scale_2", torch.tensor([0.25])),
+        (f"{prefix}.weight", torch.tensor([[1]], dtype=torch.uint8)),
+    ]
+
+    adapted = list(adapter.adapt(iter(checkpoint_tensors)))
+
+    assert [name for name, _ in adapted] == [
+        name.replace(f"{prefix}.", "runtime.proj.") for name, _ in checkpoint_tensors
+    ]
+
+
+def test_modelopt_nvfp4_adapter_rejects_unconsumed_pre_quant_scale():
+    adapter = ModelOptNvFp4CheckpointAdapter(nn.Module(), _make_source())
+
+    with pytest.raises(ValueError, match="does not consume pre_quant_scale"):
+        list(adapter.adapt(iter([("transformer.proj.pre_quant_scale", torch.tensor([1.0]))])))

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt.py
@@ -11,7 +11,12 @@ from vllm.model_executor.utils import get_packed_modules_mapping
 
 logger = init_logger(__name__)
 
-MODEL_OPT_SCALE_SUFFIXES = (".input_scale", ".weight_scale", ".weight_scale_2", ".weight_scale_inv")
+MODEL_OPT_SCALE_SUFFIXES = (
+    ".input_scale",
+    ".weight_scale",
+    ".weight_scale_2",
+    ".weight_scale_inv",
+)
 DEFAULT_PACKED_MODULES_MAPPING = {
     "to_qkv": ("to_q", "to_k", "to_v"),
     "add_kv_proj": ("add_q_proj", "add_k_proj", "add_v_proj"),
@@ -178,6 +183,7 @@ class ModelOptFp8CheckpointAdapter:
     def _handle_scale_tensor(
         self,
         name: str,
+        output_name: str,
         tensor: torch.Tensor,
         target_name: str | None,
         state: _AdaptState,
@@ -186,7 +192,7 @@ class ModelOptFp8CheckpointAdapter:
         if target_name is None:
             state.skipped_scales += 1
         else:
-            yield name, tensor
+            yield output_name, tensor
         yield from self._flush_pending_weights(name, state)
 
     def _target_dtype_for_dequantization(
@@ -249,7 +255,7 @@ class ModelOptFp8CheckpointAdapter:
         for name, tensor in weights:
             target_name, output_name = self._resolve_target_and_output_names(name)
             if self._is_scale(name):
-                yield from self._handle_scale_tensor(name, tensor, target_name, state)
+                yield from self._handle_scale_tensor(name, output_name, tensor, target_name, state)
                 continue
 
             target_dtype = self._target_dtype_for_dequantization(tensor, target_name)
@@ -264,6 +270,8 @@ class ModelOptFp8CheckpointAdapter:
 
 
 class ModelOptNvFp4CheckpointAdapter(ModelOptFp8CheckpointAdapter):
+    _PRE_QUANT_SCALE_SUFFIX = ".pre_quant_scale"
+
     @staticmethod
     def _is_checkpoint_quant_config(quant_config: object | None) -> bool:
         return (
@@ -272,6 +280,22 @@ class ModelOptNvFp4CheckpointAdapter(ModelOptFp8CheckpointAdapter):
             and quant_config.get_name() == "modelopt_fp4"
             and bool(getattr(quant_config, "is_checkpoint_nvfp4_serialized", False))
         )
+
+    def adapt(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        def validated_weights() -> Generator[tuple[str, torch.Tensor], None, None]:
+            for name, tensor in weights:
+                if name.endswith(self._PRE_QUANT_SCALE_SUFFIX):
+                    raise ValueError(
+                        f"ModelOpt NVFP4 checkpoint tensor {name!r} is unsupported: "
+                        "vLLM does not consume pre_quant_scale. Export the checkpoint "
+                        "with pre-quant scales folded into the weights."
+                    )
+                yield name, tensor
+
+        yield from super().adapt(validated_weights())
 
 
 class ModelOptMixedPrecisionCheckpointAdapter(ModelOptFp8CheckpointAdapter):

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/modelopt.py
@@ -127,6 +127,7 @@ class ModelOptFp8CheckpointAdapter:
 
         for candidate in self._weights_mapper.apply_list([name]):
             if candidate != name and candidate in self._loadable_tensors:
+                # Preserve shard names so downstream packed-weight loaders can route them.
                 return candidate, name
         return None, name
 
@@ -290,7 +291,7 @@ class ModelOptNvFp4CheckpointAdapter(ModelOptFp8CheckpointAdapter):
                 if name.endswith(self._PRE_QUANT_SCALE_SUFFIX):
                     raise ValueError(
                         f"ModelOpt NVFP4 checkpoint tensor {name!r} is unsupported: "
-                        "vLLM does not consume pre_quant_scale. Export the checkpoint "
+                        "vLLM 0.25.0 does not consume pre_quant_scale. Export the checkpoint "
                         "with pre-quant scales folded into the weights."
                     )
                 yield name, tensor


### PR DESCRIPTION
## Purpose

ModelOpt NVFP4 checkpoints use packed weights plus per-tensor scale parameters. Model-specific checkpoint remapping can rename both the packed weight and its associated scales, but the adapter previously emitted scale tensors under the serialized name. A remapped scale could therefore be filtered even when the runtime model registered it under the remapped name.

This change:

- emits supported scale tensors using the model's remapped output name;
- explicitly rejects an unfused `pre_quant_scale`, because vLLM 0.25's `ModelOptNvFp4LinearMethod` does not register or consume that parameter;
- adds NVFP4 regression coverage for remapped packed weights/scales, unknown scale filtering, and rejection of an unconsumed pre-quant scale.

The target Cosmos3 unified NVFP4 checkpoint was inspected directly and contains zero `pre_quant_scale` tensors, so the supported checkpoint path is unaffected by the new validation.

Reproduction before the remap fix:

```bash
vllm-omni serve <modelopt-nvfp4-cosmos3-checkpoint> --omni --enforce-eager --no-guardrails
```

PR #5076 has merged. This branch is rebased onto current `main`; the implementation commits are `175ba04c` and `fbe457a7`.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** `fbe457a7`

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q \
  -p pytest_asyncio.plugin -p pytest_mock \
  tests/diffusion/model_loader/test_modelopt_fp8_adapter.py
```

Hardware smoke command:

```bash
vllm-omni serve <modelopt-nvfp4-cosmos3-checkpoint> \
  --omni --enforce-eager --no-guardrails
```

Then submit a 256x256, 2-step request to `/v1/images/generations`.

## Test Result

- Post-rebase adapter suite: **6 passed, 16 warnings** in the pinned vLLM 0.25.0 container.
- Earlier reviewer-focused suite: **33 passed, 16 warnings** in the pinned vLLM 0.25.0 container.
- Earlier five-file focused suite: **84 passed, 22 warnings** on vLLM 0.25.0, repeated on RTX PRO 6000 Blackwell and B300 containers.
- RTX PRO 6000 Blackwell Server Edition: native `FlashInferCutlassNvFp4LinearKernel` selected; Cosmos3 remap kept `2325/2326` tensors; HTTP 200; valid 256x256 PNG.
- B300 SXM6: native `FlashInferCuteDslNvFp4LinearKernel` selected; Cosmos3 remap kept `2325/2326` tensors; model loaded successfully.
- `ruff check`, `ruff format --check`, and `git diff --check` pass.

Both commits are signed off and the PR is ready for review.