### PR TITLE
[recipe][NPU] add cosmos3-super recipe on 8xA3

### DIFF
--- a/recipes/cosmos3/Cosmos3-Super.md
+++ b/recipes/cosmos3/Cosmos3-Super.md
@@ -128,12 +128,52 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
 
 ## NPU
 
-Requires the `vllm-omni` package (or the `vllm/vllm-omni:cosmos3` container),
-which provides the `vllm serve … --omni` entrypoint used below.
-
 ### 8× Ascend910 (A2, A3)
 
+#### Environment
+
+- OS: Linux
+- Python: 3.10+
+- Driver / runtime: Ascend NPU driver with CANN toolkit
+- Recommended operator library: **mindie-sd** (Ascend high-performance fused
+  operators — enables `adalayernorm` and other fused kernels automatically upon
+  installation)
+- vLLM version: Match the repository requirements for your checkout
+- vLLM-Omni version or commit: Use the commit you are deploying from
+
+A pre-built Docker image is available on
+[Docker Hub](https://hub.docker.com/r/vllm/vllm-omni) and
+[Quay.io](https://quay.io/ascend/vllm-omni). Ensure the image tag matches your
+vLLM-Omni checkout so that NPU-specific code is in sync with the container.
+
+#### Prerequisites
+
+Install the **mindie-sd** operator library to enable Ascend-optimized fused
+operators (`adalayernorm`, etc.):
+
 ```bash
+git clone https://gitcode.com/Ascend/MindIE-SD.git && cd MindIE-SD
+
+# Comment out the tik_ops build step (not needed for this use case)
+sed -i 's|^\(\s*\)source ${current_script_dir}/build_tik_ops.sh|\1# source ${current_script_dir}/build_tik_ops.sh|' build/build_ops.sh
+
+python setup.py bdist_wheel
+cd dist
+pip install mindiesd-*.whl
+```
+
+After installation, enable the Laser Attention kernel for significant
+long-sequence speedups:
+
+```bash
+export MINDIE_SD_FA_TYPE=ascend_laser_attention
+```
+
+#### Command
+
+```bash
+export MINDIE_SD_FA_TYPE=ascend_laser_attention
+
 vllm serve nvidia/Cosmos3-Super \
   --omni \
   --host 0.0.0.0 --port 8000 \

--- a/recipes/cosmos3/Cosmos3-Super.md
+++ b/recipes/cosmos3/Cosmos3-Super.md
@@ -131,7 +131,7 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
 Requires the `vllm-omni` package (or the `vllm/vllm-omni:cosmos3` container),
 which provides the `vllm serve … --omni` entrypoint used below.
 
-### 8× Ascend910 (65,536 MB HBM each, verified with CANN 9.0.0)
+### 8× Ascend910 (A2, A3)
 
 ```bash
 vllm serve nvidia/Cosmos3-Super \

--- a/recipes/cosmos3/Cosmos3-Super.md
+++ b/recipes/cosmos3/Cosmos3-Super.md
@@ -125,3 +125,84 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
   under the top-level `action` field. Verified on the 64B Super under
   `--cfg-parallel-size 2`: async `policy` returns the predicted action (`[16, 10]`)
   and the rollout video reliably.
+
+## NPU
+
+Requires the `vllm-omni` package (or the `vllm/vllm-omni:cosmos3` container),
+which provides the `vllm serve … --omni` entrypoint used below.
+
+### 8× Ascend910 (65,536 MB HBM each, verified with CANN 9.0.0)
+
+```bash
+vllm serve nvidia/Cosmos3-Super \
+  --omni \
+  --host 0.0.0.0 --port 8000 \
+  --tensor-parallel-size 8 \
+  --model-class-name Cosmos3OmniDiffusersPipeline \
+  --no-guardrails \
+  --init-timeout 1800
+```
+
+#### Verification
+
+Same requests as the GPU section above. Quick smoke tests:
+
+```bash
+curl http://localhost:8000/v1/models
+
+# T2I smoke (256², 2 steps, fast check)
+curl -sS -X POST http://localhost:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/Cosmos3-Super",
+    "prompt": "A photorealistic red sports car on a city street at golden hour.",
+    "size": "256x256", "n": 1, "response_format": "b64_json",
+    "num_inference_steps": 2, "guidance_scale": 1.0,
+    "flow_shift": 3.0, "seed": 42
+  }' | python3 -c "import sys,json,base64; open('cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
+
+# T2V smoke (256², 5 frames, 2 steps)
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" \
+  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
+  -F "size=256x256" -F "num_frames=5" -F "fps=1" \
+  -F "num_inference_steps=2" -F "guidance_scale=1.0" \
+  -F "flow_shift=3.0" -F "seed=17" \
+  -o cosmos3_super_t2v.mp4
+
+# Full T2V (1280×720, 189 frames, 35 steps — official params)
+curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" -F "prompt=A robot arm is cleaning a plate in the kitchen" \
+  -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
+  -F "guidance_scale=6.0" -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":false}' \
+  -F "seed=17" -o cosmos3_super_t2v.mp4
+
+# I2V — add an uploaded reference image
+curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" -F "prompt=The scene comes to life with smooth, natural motion." \
+  -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
+  -F "guidance_scale=6.0" -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":false}' \
+  -F "seed=1111" -F "input_reference=@/path/to/reference.jpg;type=image/jpeg" \
+  -o cosmos3_super_i2v.mp4
+
+# V2V — add an uploaded reference video. condition_video_keep can be "first" or "last".
+curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" -F "prompt=Continue the same scene with smooth natural motion." \
+  -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
+  -F "guidance_scale=6.0" -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F 'extra_params={"condition_frame_indexes_vision":[0,1],"condition_video_keep":"first","guardrails":false}' \
+  -F "seed=2222" -F "input_reference=@/path/to/reference.mp4;type=video/mp4" \
+  -o cosmos3_super_v2v.mp4
+```
+
+#### Notes
+
+- **Parallelism:** `--tensor-parallel-size 8` matches the model's 8 KV heads (`num_key_value_heads: 8`, `num_attention_heads: 64` → GQA). This uses 8 davinci devices (NPU 0–3, both cores each). The remaining NPU 4–7 stay idle.
+- **Model config:** 64 layers × 5120 hidden size × 64 attention heads, ~120 GB transformer on disk (27 shards). Each NPU device loads ~15 GB of model weights.
+- **Peak HBM:** ~22.7 GB per device at startup (bf16 weights). Additional memory is allocated per-generation for KV cache and activations — resolution and frame count drive the peak.
+- **Performance (verified on 8× Ascend910):** T2I 256² / 2 steps / guidance 1.0 → ~1.5 s.
+- **Guardrails** are disabled with `--no-guardrails` (guards are on by default). The gated `nvidia/Cosmos-1.0-Guardrail` model and `cosmos-guardrail` package are not shipped. Add `guardrails: false` in `extra_params` for per-request overrides when the server has guardrails enabled.
+- **Known limitations:** FP8 quantization not yet validated on Ascend NPU. `--enable-layerwise-offload` is available but untested on NPU.

--- a/recipes/cosmos3/Cosmos3-Super.md
+++ b/recipes/cosmos3/Cosmos3-Super.md
@@ -185,33 +185,24 @@ vllm serve nvidia/Cosmos3-Super \
 
 #### Verification
 
-Same requests as the GPU section above. Quick smoke tests:
+Same requests as the GPU section above — all modes (T2I, T2V, I2V, V2V,
+T2VS, I2VS) work identically on NPU. Quick reference with
+`--no-guardrails`:
 
 ```bash
 curl http://localhost:8000/v1/models
 
-# T2I smoke (256², 2 steps, fast check)
+# T2I (1024x1024, 50 steps)
 curl -sS -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "model": "nvidia/Cosmos3-Super",
-    "prompt": "A photorealistic red sports car on a city street at golden hour.",
-    "size": "256x256", "n": 1, "response_format": "b64_json",
-    "num_inference_steps": 2, "guidance_scale": 1.0,
-    "flow_shift": 3.0, "seed": 42
-  }' | python3 -c "import sys,json,base64; open('cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
+    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
+    "size": "1024x1024", "n": 1, "response_format": "b64_json",
+    "num_inference_steps": 50, "guidance_scale": 7.0, "seed": 42
+  }' | python3 -c "import sys,json,base64; open('cosmos3_super_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
 
-# T2V smoke (256², 5 frames, 2 steps)
-curl -sS -X POST http://localhost:8000/v1/videos/sync \
-  -H "Accept: video/mp4" \
-  -F "model=nvidia/Cosmos3-Super" \
-  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
-  -F "size=256x256" -F "num_frames=5" -F "fps=1" \
-  -F "num_inference_steps=2" -F "guidance_scale=1.0" \
-  -F "flow_shift=3.0" -F "seed=17" \
-  -o cosmos3_super_t2v.mp4
-
-# Full T2V (1280×720, 189 frames, 35 steps — official params)
+# T2V (1280×720, 189 frames, 35 steps — official params)
 curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
   -F "model=nvidia/Cosmos3-Super" -F "prompt=A robot arm is cleaning a plate in the kitchen" \
   -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
@@ -236,6 +227,25 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
   -F 'extra_params={"condition_frame_indexes_vision":[0,1],"condition_video_keep":"first","guardrails":false}' \
   -F "seed=2222" -F "input_reference=@/path/to/reference.mp4;type=video/mp4" \
   -o cosmos3_super_v2v.mp4
+
+# T2V + sound — add generate_sound/sound_duration (output muxes AAC 48 kHz stereo)
+curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" -F "prompt=A robot arm is cleaning a plate in the kitchen" \
+  -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
+  -F "guidance_scale=6.0" -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F "generate_sound=true" -F "sound_duration=7.875" \
+  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":false}' \
+  -F "seed=17" -o cosmos3_super_t2vs.mp4
+
+# I2V + sound — reference image with synchronized audio
+curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" \
+  -F "model=nvidia/Cosmos3-Super" -F "prompt=The scene comes to life with smooth, natural motion and ambient sound." \
+  -F "size=1280x720" -F "num_frames=189" -F "fps=24" -F "num_inference_steps=35" \
+  -F "guidance_scale=6.0" -F "max_sequence_length=4096" -F "flow_shift=10.0" \
+  -F "generate_sound=true" -F "sound_duration=7.875" \
+  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":false}' \
+  -F "seed=1111" -F "input_reference=@/path/to/reference.jpg;type=image/jpeg" \
+  -o cosmos3_super_i2vs.mp4
 ```
 
 #### Notes

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -55,6 +55,9 @@ class RMSNorm(_VllmRMSNorm):
     def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_native(x)
 
+    def forward_npu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x)
+
 
 def _get_ulysses_state() -> tuple[int, int, dist.ProcessGroup | None]:
     """Return (ulysses_size, ulysses_rank, ulysses_pg) from vllm-omni parallel state.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Add an NPU recipe for 64B Cosmos3-Super (8 KV heads), enabling the world model on 8x Ascend910 NPUs with TP=8, as proposed in #4340.

Also fixed a pytest failure described in #4992 

cc: @bjf-frz @gcanlin @FayeSpica @amy-why-3459 

## Test Plan

**vLLM Version:**  0.24.0 

**vLLM-Omni Commit:**  7d4decc1d (docker container), based on 66b9ad2 (main)

Ran the commands mentioned in the recipe, by serving

```bash
vllm serve nvidia/Cosmos3-Super \
  --omni \
  --host 0.0.0.0 --port 8000 \
  --tensor-parallel-size 8 \
  --model-class-name Cosmos3OmniDiffusersPipeline \
  --no-guardrails \
  --init-timeout 1800
```

Also ran all the pytests. 

```bash
python -m pytest tests/diffusion/models/cosmos3/ -v --tb=short
```

## Test Result

| # | Mode | Prompt | Input | Output | Size / Steps | Time |
|---|---|---|---|---|---|---|
| 1 | T2I | "A photorealistic red sports car on a city street at golden hour, cinematic lighting." | -- | <img width="1024" height="1024" alt="cosmos3_super_t2i_hq" src="https://github.com/user-attachments/assets/704cca18-9efd-44a9-9bea-acb424adb2b1" /> (3.1 MB) | 1024x1024 | -- |
| 2 | T2V | "A robot arm is cleaning a plate in the kitchen" | -- |[cosmos3_super_t2v_1280x720_189f_35steps.zip](https://github.com/user-attachments/files/29995221/cosmos3_super_t2v_1280x720_189f_35steps.zip)  | 1280x720 189f / 35 | 8m18s |
| 3 | I2V | "A car (viewed from dashcam POV) is traveling fast along a coastal mountain road, surrounded by steep rocky cliffs. Suddenly, rocks and debris tumble down from the cliff face onto the road, forcing the car to make an emergency stop. Dust clouds billow as rocks crash around the vehicle." |<img width="3034" height="1754" alt="cosmos3_super_i2v_input" src="https://github.com/user-attachments/assets/0c2c80c7-33e1-442e-bfd1-ebb195107edd" /> | [cosmos3_super_i2v_1280x720_189f_35steps.zip](https://github.com/user-attachments/files/29995241/cosmos3_super_i2v_1280x720_189f_35steps.zip) | 1280x720 189f / 35 | 10m43s |
| 4 | V2V | "A robotic arm is carefully cleaning a white plate in a bright kitchen. The robot arm moves methodically, wiping the plate surface with a cloth, with kitchen appliances visible in the background." |[ `cosmos3_super_v2v_input.mp4` (1.7 MB, `example_t2v_diffusers_output.mp4`) ](https://github.com/user-attachments/assets/861df700-f481-4882-8e3b-0d30b61bcad2)| [cosmos3_super_v2v_1280x720_189f_35steps.zip](https://github.com/user-attachments/files/29995367/cosmos3_super_v2v_1280x720_189f_35steps.zip) | 1280x720 189f / 35 | 8m22s |

Also, all 63 tests pass. 

<details><summary> raw test output</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /vllm-workspace/vllm-omni
configfile: pyproject.toml
plugins: asyncio-1.4.0, xdist-3.6.1, anyio-4.14.1
collected 63 items

tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_registered_and_exported PASSED [  1%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_skips_tokenizer_when_sound_disabled PASSED [  3%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_rebuilds_scheduler_with_cosmos3_defaults PASSED [  4%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_set_flow_shift_restores_checkpoint_scheduler_mode PASSED [  6%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_pipeline_init_passes_tokenizer_attrs_into_transformer PASSED [  7%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_preprocess_i2v_image_and_action_video_inputs PASSED [  9%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_config_media_helpers_and_preprocess_budget PASSED [ 11%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_fps_matches_resolved_frame_rate_precedence PASSED [ 12%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_edge_uses_rgb_canny PASSED [ 14%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_transfer_blur_uses_scaled_bilateral PASSED [ 15%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_postprocess_handles_image_video_audio_and_validation PASSED [ 17%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_action_postprocess_handles_robolab_policy_outputs PASSED [ 19%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_ir_op_priority_hook_preserves_platform_fields PASSED [ 20%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prompt_formatting_and_checkpoint_key_remap PASSED [ 22%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_latents_for_video_image_sound_and_action PASSED [ 23%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_latents_i2v_encodes_only_conditioning_frame PASSED [ 25%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_action_video_latents_encodes_only_conditioning_frame[policy] PASSED [ 26%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_action_video_latents_encodes_only_conditioning_frame[forward_dynamics] PASSED [ 28%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_prepare_inverse_dynamics_latents_encodes_full_video PASSED [ 30%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_covers_cfg_i2v_and_multimodal_steps PASSED [ 31%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_applies_control_cfg PASSED [ 33%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_skips_idle_cfg_branches PASSED [ 34%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_transfer_interval_switches_branch_counts PASSED [ 36%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_uses_source_fps_except_wsm[edge-8.0] PASSED [ 38%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_uses_source_fps_except_wsm[wsm-10.0] PASSED [ 39%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_forward_transfer_runs_multichunk_overlap_path PASSED [ 41%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_diffuse_keeps_paired_cfg_when_cache_dit_active PASSED [ 42%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_defaults_and_mode_selection[prompt0-sampling_params0-expected0] PASSED [ 44%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_defaults_and_mode_selection[A warehouse robot-sampling_params1-expected1] PASSED [ 46%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_i2v_sound_and_action_routes PASSED [ 47%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_dispatches_robolab_policy_flow PASSED [ 49%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt0-sampling_params0-single prompt] PASSED [ 50%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt1-sampling_params1-both image and video] PASSED [ 52%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt2-sampling_params2-only for video] PASSED [ 53%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt3-sampling_params3-transfer inference is supported only for video outputs] PASSED [ 55%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt4-sampling_params4-cannot be combined with sound generation] PASSED [ 57%]
tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::TestForwardRouting::test_forward_rejects_invalid_public_requests[prompt5-sampling_params5-cannot be combined with action generation] PASSED [ 58%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_from_config_loads_local_diffusers_component PASSED [ 60%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_from_config_downloads_component_from_hf_repo PASSED [ 61%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_default_component_requires_diffusers_checkpoint_name[None-no AVAE sound tokenizer checkpoint] PASSED [ 63%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_default_component_requires_diffusers_checkpoint_name[model.safetensors-diffusion_pytorch_model.safetensors] PASSED [ 65%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_component_config_precedence_and_conflict_detection PASSED [ 66%]
tests/diffusion/models/cosmos3/test_cosmos3_sound_tokenizer.py::test_avae_uses_diffusers_decoder_state_dict_layout PASSED [ 68%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_mrope_position_ids_cover_text_video_sound_and_action PASSED [ 69%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[qk_norm_for_diffusion-False] PASSED [ 71%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[qk_norm_for_text-False] PASSED [ 73%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[position_embedding_type-rotary] PASSED [ 74%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[unified_3d_mrope_reset_spatial_ids-False] PASSED [ 76%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_validate_supported_config_rejects_unsupported_flags[joint_attn_implementation-one_way] PASSED [ 77%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_sharding_offload_and_patch_round_trip_contracts PASSED [ 79%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_prediction PASSED [ 80%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_accepts_transfer_control_latents PASSED [ 82%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_gathers_gen_tokens_before_unpatchify PASSED [ 84%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_and_action_modules_follow_config PASSED [ 85%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs0] PASSED [ 87%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs1] PASSED [ 88%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_transformer_requires_sound_dim_and_fps_when_sound_gen_true[kwargs2] PASSED [ 90%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_and_action_pack_unpack_validate_shapes PASSED [ 92%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config0-transformer_kwargs0-extra_kwargs0-expected_shapes0] PASSED [ 93%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_returns_video_plus_optional_modality_predictions[config1-transformer_kwargs1-extra_kwargs1-expected_shapes1] PASSED [ 95%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_forward_with_sound_ulysses_error_mentions_combined_sequence PASSED [ 96%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_sound_latent_frames_padded_for_sequence_parallel PASSED [ 98%]
tests/diffusion/models/cosmos3/test_cosmos3_transformer.py::test_compute_rope_freqs_places_text_video_action_and_sound_positions PASSED [100%]

======================= 63 passed, 20 warnings in 3.54s ========================
```

</details>


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
