### PR TITLE
[Config] Disable Async Chunk for Unsupported Pipelines

### DIFF
--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -21,6 +21,7 @@ from vllm_omni.config.omni_config import (
     OmniStageParallelConfig,
     OmniStageRuntimeConfig,
     OmniStageSchedulerConfig,
+    StagePipelineConfig,
     VllmOmniARStageConfig,
     VllmOmniConfig,
     VllmOmniDiffusionStageConfig,
@@ -762,3 +763,31 @@ def test_diffusion_config_projection_keeps_mapping_quantization_config_serializa
     cfg = omni_config_module._DiffusionConfigProjection.from_kwargs(quantization_config=quantization_config)
 
     assert cfg.quantization_config == quantization_config
+
+
+def test_async_chunk_auto_disabled_without_processor():
+    """Ensure a multi-stage model that doesn't support async chunk turns it off by default."""
+    pipeline = PipelineConfig(
+        model_type="test_no_async",
+        model_arch="TestNoAsync",
+        stages=(
+            StagePipelineConfig(
+                stage_id=0,
+                model_stage="ar",
+                execution_type=StageExecutionType.LLM_AR,
+                final_output=True,
+            ),
+            StagePipelineConfig(
+                stage_id=1,
+                model_stage="generation",
+                execution_type=StageExecutionType.LLM_GENERATION,
+                input_sources=(0,),
+            ),
+        ),
+    )
+
+    deploy = DeployConfig()
+    # async chunk should not try to default to True in this case,
+    # since doing so will just raise a ValueError in validation.
+    merge_pipeline_deploy(pipeline, deploy)
+    assert not deploy.async_chunk

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -21,7 +21,6 @@ from vllm_omni.config.omni_config import (
     OmniStageParallelConfig,
     OmniStageRuntimeConfig,
     OmniStageSchedulerConfig,
-    StagePipelineConfig,
     VllmOmniARStageConfig,
     VllmOmniConfig,
     VllmOmniDiffusionStageConfig,
@@ -763,31 +762,3 @@ def test_diffusion_config_projection_keeps_mapping_quantization_config_serializa
     cfg = omni_config_module._DiffusionConfigProjection.from_kwargs(quantization_config=quantization_config)
 
     assert cfg.quantization_config == quantization_config
-
-
-def test_async_chunk_auto_disabled_without_processor():
-    """Ensure a multi-stage model that doesn't support async chunk turns it off by default."""
-    pipeline = PipelineConfig(
-        model_type="test_no_async",
-        model_arch="TestNoAsync",
-        stages=(
-            StagePipelineConfig(
-                stage_id=0,
-                model_stage="ar",
-                execution_type=StageExecutionType.LLM_AR,
-                final_output=True,
-            ),
-            StagePipelineConfig(
-                stage_id=1,
-                model_stage="generation",
-                execution_type=StageExecutionType.LLM_GENERATION,
-                input_sources=(0,),
-            ),
-        ),
-    )
-
-    deploy = DeployConfig()
-    # async chunk should not try to default to True in this case,
-    # since doing so will just raise a ValueError in validation.
-    merge_pipeline_deploy(pipeline, deploy)
-    assert not deploy.async_chunk

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -2094,14 +2094,10 @@ class TestSentinelDefaultPrecedence:
         assert stage1.sync_process_input_func is not None
         assert stage1.sync_process_input_func.endswith("thinker2talker_token_only")
 
-        # async_chunk=True must now be rejected: removing the fake hook means
-        # there is no next-stage input processor for the validator to accept.
-        # (Positive consequence -- users can't accidentally enable async_chunk
-        # on an arch that doesn't actually support it.)
-        import pytest as _pytest
-
-        with _pytest.raises(ValueError, match="async_chunk=True"):
-            merge_pipeline_deploy(pipeline, DeployConfig(async_chunk=True))
+        # ensure merging the pipeline deploy with async chunk set to True disables it,
+        # since currently it is not supported for this pipeline.
+        stage_configs = merge_pipeline_deploy(pipeline, DeployConfig(async_chunk=True))
+        assert all([not stg_cfg.yaml_engine_args["async_chunk"] for stg_cfg in stage_configs])
 
         # async_chunk=False merges cleanly and stage-0 yaml_engine_args carries
         # no spurious full-payload hook.

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -2171,3 +2171,42 @@ class TestAsyncChunkDefaults:
         # since doing so will just raise a ValueError in validation.
         merge_pipeline_deploy(pipeline, deploy)
         assert not deploy.async_chunk
+
+    def test_async_chunk_auto_disabled_when_yaml_omits_key(self, tmp_path):
+        """Ensure a multi-stage model that doesn't support async chunk turns it off by default
+        when a deploy config is provided that doesn't explicitly set it."""
+
+        deploy_path = tmp_path / "no_async_chunk.yaml"
+        deploy_path.write_text(
+            """
+stages:
+  - stage_id: 0
+    devices: "0"
+  - stage_id: 1
+    devices: "0"
+""",
+            encoding="utf-8",
+        )
+        deploy = load_deploy_config(deploy_path)
+
+        pipeline = PipelineConfig(
+            model_type="test_no_async",
+            model_arch="TestNoAsync",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                    final_output=True,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="generation",
+                    execution_type=StageExecutionType.LLM_GENERATION,
+                    input_sources=(0,),
+                ),
+            ),
+        )
+
+        merge_pipeline_deploy(pipeline, deploy)
+        assert not deploy.async_chunk

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -2142,3 +2142,32 @@ class TestPipelineConfigResolvers:
             pass
 
         assert resolver(NotTheRightHfConfig()) is None
+
+
+class TestAsyncChunkDefaults:
+    def test_async_chunk_auto_disabled_without_processor(self):
+        """Ensure a multi-stage model that doesn't support async chunk turns it off by default."""
+        pipeline = PipelineConfig(
+            model_type="test_no_async",
+            model_arch="TestNoAsync",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                    final_output=True,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="generation",
+                    execution_type=StageExecutionType.LLM_GENERATION,
+                    input_sources=(0,),
+                ),
+            ),
+        )
+
+        deploy = DeployConfig()
+        # async chunk should not try to default to True in this case,
+        # since doing so will just raise a ValueError in validation.
+        merge_pipeline_deploy(pipeline, deploy)
+        assert not deploy.async_chunk

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -366,7 +366,7 @@ class StageConfigFactory:
         if cli_async_chunk is not None:
             deploy_cfg.async_chunk = bool(cli_async_chunk)
 
-        stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
+        stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg)
 
         # Overlay declarative parallel strategies (opt-in) before CLI overrides.
         applied = cls._apply_strategy_specs(stages, strategy_specs)

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -36,7 +36,6 @@ from vllm_omni.config.stage_config import (
     build_stage_runtime_overrides,
     get_default_async_chunk_enabled,
     load_deploy_config,
-    validate_async_chunk_support,
 )
 
 _EXECUTION_TYPE_TO_STAGE_WORKER: dict[StageExecutionType, tuple[StageType, str | None]] = {
@@ -1241,12 +1240,10 @@ class VllmOmniConfig:
                 f"Pipeline {pipeline_key!r} did not resolve to a concrete PipelineConfig without an HF config"
             )
 
-        deploy.async_chunk = (
-            bool(cli_overrides["async_chunk"])
-            if "async_chunk" in cli_overrides
-            else get_default_async_chunk_enabled(pipeline, deploy)
-        )
-        validate_async_chunk_support(deploy.async_chunk, pipeline)
+        if "async_chunk" in cli_overrides:
+            deploy.async_chunk = bool(cli_overrides["async_chunk"])
+
+        deploy.async_chunk = get_default_async_chunk_enabled(pipeline, deploy)
 
         for name in _PIPELINE_DEPLOY_CLI_FIELDS:
             if cli_overrides.get(name) is not None:

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -1243,14 +1243,13 @@ class VllmOmniConfig:
         if "async_chunk" in cli_overrides:
             deploy.async_chunk = bool(cli_overrides["async_chunk"])
 
-        deploy.async_chunk = get_default_async_chunk_enabled(pipeline, deploy)
-
         for name in _PIPELINE_DEPLOY_CLI_FIELDS:
             if cli_overrides.get(name) is not None:
                 setattr(deploy, name, _copy_value(cli_overrides[name]))
 
         deploy = _apply_platform_overrides(deploy)
         deploy_by_id = {stage.stage_id: stage for stage in deploy.stages}
+        deploy.async_chunk = get_default_async_chunk_enabled(pipeline, deploy)
         model = cli_overrides.get("model")
 
         stage_configs = tuple(

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -34,7 +34,9 @@ from vllm_omni.config.stage_config import (
     _scheduler_path,
     _select_processor_funcs,
     build_stage_runtime_overrides,
+    get_default_async_chunk_enabled,
     load_deploy_config,
+    validate_async_chunk_support,
 )
 
 _EXECUTION_TYPE_TO_STAGE_WORKER: dict[StageExecutionType, tuple[StageType, str | None]] = {
@@ -177,21 +179,6 @@ def _first_defined(*values: Any) -> Any:
         if value is not None:
             return _copy_value(value)
     return None
-
-
-def _validate_async_chunk_support(pipeline: PipelineConfig, deploy: DeployConfig) -> None:
-    has_inter_stage_edges = any(stage.input_sources for stage in pipeline.stages)
-    if (
-        deploy.async_chunk
-        and has_inter_stage_edges
-        and not any(stage.async_chunk_process_next_stage_input_func for stage in pipeline.stages)
-    ):
-        raise ValueError(
-            f"Pipeline {pipeline.model_type!r} has async_chunk=True in deploy but no stage "
-            "declares a dedicated async-chunk next-stage processor "
-            "(``async_chunk_process_next_stage_input_func``). "
-            "Either set async_chunk=False or implement an async-chunk producer on the pipeline."
-        )
 
 
 def _resolve_execution_mode(execution_type: StageExecutionType) -> tuple[StageType, str | None]:
@@ -1254,22 +1241,25 @@ class VllmOmniConfig:
                 f"Pipeline {pipeline_key!r} did not resolve to a concrete PipelineConfig without an HF config"
             )
 
-        deploy_for_registry = copy.deepcopy(deploy)
-        if cli_overrides.get("async_chunk") is not None:
-            deploy_for_registry.async_chunk = bool(cli_overrides["async_chunk"])
+        deploy.async_chunk = (
+            bool(cli_overrides["async_chunk"])
+            if "async_chunk" in cli_overrides
+            else get_default_async_chunk_enabled(pipeline, deploy)
+        )
+        validate_async_chunk_support(deploy.async_chunk, pipeline)
+
         for name in _PIPELINE_DEPLOY_CLI_FIELDS:
             if cli_overrides.get(name) is not None:
-                setattr(deploy_for_registry, name, _copy_value(cli_overrides[name]))
+                setattr(deploy, name, _copy_value(cli_overrides[name]))
 
-        deploy_for_registry = _apply_platform_overrides(deploy_for_registry)
-        _validate_async_chunk_support(pipeline, deploy_for_registry)
-        deploy_by_id = {stage.stage_id: stage for stage in deploy_for_registry.stages}
+        deploy = _apply_platform_overrides(deploy)
+        deploy_by_id = {stage.stage_id: stage for stage in deploy.stages}
         model = cli_overrides.get("model")
 
         stage_configs = tuple(
             _build_stage_config(
                 pipeline,
-                deploy_for_registry,
+                deploy,
                 topology,
                 deploy_by_id.get(topology.stage_id),
                 _stage_engine_values(

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -415,7 +415,9 @@ class DeployConfig:
     individual ``StageDeployConfig`` entries under ``stages:``.
     """
 
-    async_chunk: bool = True
+    # Async chunk's default depends on whether or not the pipeline supports it.
+    async_chunk: bool | None = None
+
     # Stage-1 active stream slots; 0 preserves legacy all-stream cycling.
     active_stream_window: int = 0
     connectors: dict[str, Any] | None = None
@@ -452,6 +454,22 @@ _STAGE_RESERVED_KEYS = frozenset(
     }
 )
 
+# Pipeline-wide DeployConfig fields that are propagated to every stage's
+# engine args during merge. These live at top level of the deploy YAML.
+PIPELINE_WIDE_ENGINE_FIELDS: tuple[str, ...] = (
+    "trust_remote_code",
+    "distributed_executor_backend",
+    "dtype",
+    "quantization",
+    "enable_prefix_caching",
+    "enable_chunked_prefill",
+    "data_parallel_size",
+    "pipeline_parallel_size",
+    "active_stream_window",
+    "custom_voice_dir",
+)
+
+
 # Fields on StageDeployConfig that are populated from engine_args dict
 _STAGE_DEPLOY_FIELDS = {f.name: f for f in fields(StageDeployConfig) if f.name not in _STAGE_RESERVED_KEYS}
 
@@ -464,7 +482,7 @@ def deploy_runtime_override_keys() -> frozenset[str]:
     They must remain overridable even if they are also modeled on
     ``OrchestratorArgs`` for top-level CLI parsing.
     """
-    return frozenset(_STAGE_DEPLOY_FIELDS) | frozenset(_PIPELINE_WIDE_ENGINE_FIELDS)
+    return frozenset(_STAGE_DEPLOY_FIELDS) | frozenset(PIPELINE_WIDE_ENGINE_FIELDS)
 
 
 def _parse_stage_deploy(stage_data: dict[str, Any]) -> StageDeployConfig:
@@ -605,6 +623,7 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
 
     stages = [_parse_stage_deploy(s) for s in raw_dict.get("stages", [])]
 
+    # TODO (Alex): Clean this up, we should not have fallback values here
     kwargs: dict[str, Any] = {
         "async_chunk": raw_dict.get("async_chunk", True),
         "active_stream_window": int(raw_dict.get("active_stream_window", 0) or 0),
@@ -616,17 +635,7 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
     }
     # Pipeline-wide engine settings: only set if explicitly present in YAML
     # so the DeployConfig dataclass defaults take effect otherwise.
-    for name in (
-        "trust_remote_code",
-        "distributed_executor_backend",
-        "dtype",
-        "quantization",
-        "enable_prefix_caching",
-        "enable_chunked_prefill",
-        "data_parallel_size",
-        "pipeline_parallel_size",
-        "custom_voice_dir",
-    ):
+    for name in PIPELINE_WIDE_ENGINE_FIELDS:
         if name in raw_dict:
             kwargs[name] = raw_dict[name]
     return DeployConfig(**kwargs)
@@ -737,23 +746,6 @@ def _select_processor_funcs(
     return input_proc, next_stage_proc
 
 
-# Pipeline-wide DeployConfig fields that are propagated to every stage's
-# engine args during merge. These live at top level of the deploy YAML.
-_PIPELINE_WIDE_ENGINE_FIELDS: tuple[str, ...] = (
-    "trust_remote_code",
-    "distributed_executor_backend",
-    "dtype",
-    "quantization",
-    "enable_prefix_caching",
-    "enable_chunked_prefill",
-    "data_parallel_size",
-    "pipeline_parallel_size",
-    "active_stream_window",
-    "custom_voice_dir",
-)
-PIPELINE_WIDE_ENGINE_FIELDS = _PIPELINE_WIDE_ENGINE_FIELDS
-
-
 def _build_engine_args(
     ps: StagePipelineConfig,
     ds: StageDeployConfig | None,
@@ -783,7 +775,7 @@ def _build_engine_args(
         engine_args["tokenizer_subdir"] = ps.tokenizer_subdir
 
     # Pipeline-wide top-level DeployConfig settings, applied to every stage.
-    for name in _PIPELINE_WIDE_ENGINE_FIELDS:
+    for name in PIPELINE_WIDE_ENGINE_FIELDS:
         value = getattr(deploy, name)
         if value is not None:
             engine_args[name] = value
@@ -828,37 +820,49 @@ def _build_extras(
     return extras
 
 
-def merge_pipeline_deploy(
+def get_default_async_chunk_enabled(
     pipeline: PipelineConfig,
     deploy: DeployConfig,
-    cli_overrides: dict[str, Any] | None = None,
-) -> list[StageConfig]:
-    """Merge pipeline + deploy + platform overrides → list[StageConfig]."""
-    if cli_overrides is None:
-        cli_overrides = {}
+) -> bool:
+    """Given the pipeline config and deploy config, determine the value of async_chunk
+    for when it hasn't been explicitly set by the CLI.
 
-    deploy = _apply_platform_overrides(deploy)
-    deploy_by_id = {s.stage_id: s for s in deploy.stages}
-
-    # async_chunk is irrelevant for single-stage pipelines, so we always disable it
+    The default is True if the model actually supports async chunk and is multistage,
+    and False otherwise. If the user tried to enable async chunk through the deploy
+    config, but its inapplicable or unsupported, it will be disabled with a warning.
+    """
+    # Single stage should never use async chunk
     if len(pipeline.stages) <= 1:
-        deploy.async_chunk = False
+        if deploy.async_chunk:
+            logger.warning(
+                "Deploy config set async_chunk=True, but async chunk is inapplicable "
+                "to single stage models. As such, it will be disabled."
+            )
+        return False
 
-    # async_chunk only applies to multi-stage pipelines: a pipeline with no
-    # consumer stages (every stage has empty input_sources) has no inter-stage
-    # edges, so async_chunk is a no-op and we skip the check entirely.
-    # For pipelines that DO have inter-stage edges, require a dedicated per-step
-    # async producer (``async_chunk_process_next_stage_input_func``).
-    # ``custom_process_next_stage_input_func`` is the full-payload / connector-path
-    # producer and does NOT imply async_chunk support — pipelines like qwen2_5_omni
-    # and covo_audio have it but removed their consumer-side ``custom_process_input_func``
-    # because they don't support async_chunk, so accepting them here would silently
-    # miswire the consumer stage instead of raising a clear error.
-    _has_inter_stage_edges = any(ps.input_sources for ps in pipeline.stages)
+    # If async chunk was set, pass it through
+    if deploy.async_chunk is not None:
+        return deploy.async_chunk
+
+    has_inter_stage_edges = any(stage.input_sources for stage in pipeline.stages)
+    has_next_stage_inps = any(stage.async_chunk_process_next_stage_input_func for stage in pipeline.stages)
+
+    if has_inter_stage_edges and has_next_stage_inps:
+        return True if not deploy.async_chunk else deploy.async_chunk
+
+    if deploy.async_chunk:
+        logger.warning(
+            "Deploy config set async_chunk=True, but the pipeline config does not support it; it will be disabled."
+        )
+    return False
+
+
+def validate_async_chunk_support(async_chunk_enabled: bool, pipeline: PipelineConfig) -> None:
+    has_inter_stage_edges = any(stage.input_sources for stage in pipeline.stages)
     if (
-        deploy.async_chunk
-        and _has_inter_stage_edges
-        and not any(ps.async_chunk_process_next_stage_input_func for ps in pipeline.stages)
+        async_chunk_enabled
+        and has_inter_stage_edges
+        and not any(stage.async_chunk_process_next_stage_input_func for stage in pipeline.stages)
     ):
         raise ValueError(
             f"Pipeline {pipeline.model_type!r} has async_chunk=True in deploy but no stage "
@@ -866,6 +870,22 @@ def merge_pipeline_deploy(
             "(``async_chunk_process_next_stage_input_func``). "
             "Either set async_chunk=False or implement an async-chunk producer on the pipeline."
         )
+
+
+def merge_pipeline_deploy(
+    pipeline: PipelineConfig,
+    deploy: DeployConfig,
+) -> list[StageConfig]:
+    """Merge pipeline + deploy + platform overrides → list[StageConfig]."""
+    deploy = _apply_platform_overrides(deploy)
+    deploy_by_id = {s.stage_id: s for s in deploy.stages}
+
+    # NOTE: The CLI override is applied to the Deployconfig for async chunk prior
+    # to this point. We are in the process of better organizing the creation of the
+    # DeployConfig/PipelineConfig, and this path will be removed with the incorporation
+    # of the OmniConfig.
+    deploy.async_chunk = get_default_async_chunk_enabled(pipeline, deploy)
+    validate_async_chunk_support(deploy.async_chunk, pipeline)
 
     result: list[StageConfig] = []
     for ps in pipeline.stages:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -626,7 +626,6 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
     # TODO (Alex): Clean this up, we should not have fallback values here
     kwargs: dict[str, Any] = {
         "async_chunk": raw_dict.get("async_chunk"),
-        "active_stream_window": raw_dict.get("active_stream_window", 0),
         "connectors": raw_dict.get("connectors", None),
         "edges": raw_dict.get("edges", None),
         "stages": stages,

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -626,7 +626,7 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
     # TODO (Alex): Clean this up, we should not have fallback values here
     kwargs: dict[str, Any] = {
         "async_chunk": raw_dict.get("async_chunk"),
-        "active_stream_window": int(raw_dict.get("active_stream_window", 0) or 0),
+        "active_stream_window": raw_dict.get("active_stream_window", 0),
         "connectors": raw_dict.get("connectors", None),
         "edges": raw_dict.get("edges", None),
         "stages": stages,
@@ -829,7 +829,7 @@ def get_default_async_chunk_enabled(
 
     The default is True if the model actually supports async chunk and is multistage,
     and False otherwise. If the user tried to enable async chunk through the deploy
-    config, but its inapplicable or unsupported, it will be disabled with a warning.
+    config, but it's inapplicable or unsupported, it will be disabled with a warning.
     """
     # Single stage should never use async chunk
     if len(pipeline.stages) <= 1:
@@ -840,20 +840,21 @@ def get_default_async_chunk_enabled(
             )
         return False
 
-    # If async chunk was set, pass it through
-    if deploy.async_chunk is not None:
-        return deploy.async_chunk
-
     has_inter_stage_edges = any(stage.input_sources for stage in pipeline.stages)
     has_next_stage_inps = any(stage.async_chunk_process_next_stage_input_func for stage in pipeline.stages)
 
-    if has_inter_stage_edges and has_next_stage_inps:
-        return True if not deploy.async_chunk else deploy.async_chunk
+    # If async chunk was set, make sure it's supported if
+    # requested; otherwise warn and disable it.
+    if deploy.async_chunk is not None:
+        if deploy.async_chunk and not (has_inter_stage_edges and has_next_stage_inps):
+            logger.warning(
+                "Deploy config set async_chunk=True, but the pipeline config does not support it; it will be disabled."
+            )
+            return False
+        return deploy.async_chunk
 
-    if deploy.async_chunk:
-        logger.warning(
-            "Deploy config set async_chunk=True, but the pipeline config does not support it; it will be disabled."
-        )
+    if has_inter_stage_edges and has_next_stage_inps:
+        return True
     return False
 
 

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -625,7 +625,7 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
 
     # TODO (Alex): Clean this up, we should not have fallback values here
     kwargs: dict[str, Any] = {
-        "async_chunk": raw_dict.get("async_chunk", True),
+        "async_chunk": raw_dict.get("async_chunk"),
         "active_stream_window": int(raw_dict.get("active_stream_window", 0) or 0),
         "connectors": raw_dict.get("connectors", None),
         "edges": raw_dict.get("edges", None),

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -824,8 +824,7 @@ def get_default_async_chunk_enabled(
     pipeline: PipelineConfig,
     deploy: DeployConfig,
 ) -> bool:
-    """Given the pipeline config and deploy config, determine the value of async_chunk
-    for when it hasn't been explicitly set by the CLI.
+    """Given the pipeline config and deploy config, determine the value of async_chunk.
 
     The default is True if the model actually supports async chunk and is multistage,
     and False otherwise. If the user tried to enable async chunk through the deploy
@@ -858,21 +857,6 @@ def get_default_async_chunk_enabled(
     return False
 
 
-def validate_async_chunk_support(async_chunk_enabled: bool, pipeline: PipelineConfig) -> None:
-    has_inter_stage_edges = any(stage.input_sources for stage in pipeline.stages)
-    if (
-        async_chunk_enabled
-        and has_inter_stage_edges
-        and not any(stage.async_chunk_process_next_stage_input_func for stage in pipeline.stages)
-    ):
-        raise ValueError(
-            f"Pipeline {pipeline.model_type!r} has async_chunk=True in deploy but no stage "
-            "declares a dedicated async-chunk next-stage processor "
-            "(``async_chunk_process_next_stage_input_func``). "
-            "Either set async_chunk=False or implement an async-chunk producer on the pipeline."
-        )
-
-
 def merge_pipeline_deploy(
     pipeline: PipelineConfig,
     deploy: DeployConfig,
@@ -886,7 +870,6 @@ def merge_pipeline_deploy(
     # DeployConfig/PipelineConfig, and this path will be removed with the incorporation
     # of the OmniConfig.
     deploy.async_chunk = get_default_async_chunk_enabled(pipeline, deploy)
-    validate_async_chunk_support(deploy.async_chunk, pipeline)
 
     result: list[StageConfig] = []
     for ps in pipeline.stages:


### PR DESCRIPTION
## Purpose
Currently, async chunk defaults to True for multistage pipelines that don't set it to False in their pipeline/deploy configs. This means that if we forget to disable it for new multistage models when they are first added, it'll crash in validation, which is unintuitive behavior. 

Rather than crashing, I think the more correct behavior is as follows:
- If async chunk is not supported and explicitly requested, disable it and log a warning
- async chunk should default to true if and only if the pipeline is multi-stage and it actually is supported

This also makes some small cleanups in config around hardcoded pipeline engine fields, and makes the corresponding async chunk default value setting + validation in the Omni Config path (which has not yet been migrated to production).