### PR TITLE
[Core][Benchmark]Omniinteract for Minicpm-o4.5

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -19,9 +19,10 @@ steps:
         mirror_hardwares: h100_2
 
       - label: ":full_moon: Omni · MiniCPM-o 4.5 Duplex Test"
-        timeout_in_minutes: 50
+        timeout_in_minutes: 120
         commands:
-          - pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py -m "full_model and cuda and H100 and omni" --run-level "full_model"
+          - export VLLM_OMNI_RUN_OMNIINTERACT_E2E=1
+          - pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py 'tests/e2e/online_serving/test_minicpmo_4_5_duplex.py::test_minicpmo_4_5_omniinteract_e2e' -m "full_model and cuda and H100 and omni" --run-level "full_model"
         mirror_hardwares: h100_1
 
       - label: ":full_moon: Omni · Doc Test with L4"

--- a/benchmarks/omniinteract/README.md
+++ b/benchmarks/omniinteract/README.md
@@ -1,0 +1,7 @@
+# OmniInteract MiniCPM Duplex Benchmark
+
+Run `vllm bench serve --omni --backend minicpmo-realtime --endpoint /v1/realtime --model openbmb/MiniCPM-o-4_5 --trust-remote-code --dataset-name omniinteract --dataset-path lucky-lance/OmniInteract --omniinteract-subsets 1q1a,1q1a_math,1qna --omniinteract-realtime-ref-audio /path/to/ref.wav --omniinteract-official-output-dir ./omniinteract-output --no-oversample --num-prompts 2 --max-concurrency 2`.
+
+Use `--omniinteract-root` for extracted data. Successful Sessions write `.done`, WAV, transcript, and manifest artifacts; failures write `.failed.json`. Final input processing is mandatory, and `speak` also requires a completed response.
+
+Run `python benchmarks/omniinteract/run_official_eval.py ...` with the upstream repository, ASR/aligner checkpoints, and `JUDGE_API_KEY` to enable official accuracy scoring.

--- a/benchmarks/omniinteract/run_official_eval.py
+++ b/benchmarks/omniinteract/run_official_eval.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Run the upstream OmniInteract data-prep and judge pipeline.
+
+The benchmark produces official-compatible artifacts and an explicit manifest.
+This wrapper deliberately executes a checked-out upstream evaluator instead of
+vendoring its ASR, forced aligner, judge prompts, and metric implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--official-repo", type=Path, required=True, help="Checkout of Lucky-Lance/OmniInteract.")
+    parser.add_argument(
+        "--output-root", type=Path, required=True, help="Directory passed to --omniinteract-official-output-dir."
+    )
+    parser.add_argument("--asr-model", default=os.environ.get("ASR_MODEL", ""))
+    parser.add_argument("--align-model", default=os.environ.get("ALIGN_MODEL", ""))
+    parser.add_argument("--gpu-ids", default="0")
+    parser.add_argument("--num-workers", type=int, default=int(os.environ.get("EVAL_WORKERS", "4")))
+    parser.add_argument(
+        "--judge-api-url", default=os.environ.get("JUDGE_API_URL", "https://api.openai.com/v1/chat/completions")
+    )
+    parser.add_argument("--judge-api-model", default=os.environ.get("JUDGE_API_MODEL", "gpt-4o-2024-08-06"))
+    parser.add_argument("--judge-api-key", default=os.environ.get("JUDGE_API_KEY", ""))
+    parser.add_argument(
+        "--skip-data-prep", action="store_true", help="Score wav_transcript.json without ASR truncation/alignment."
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Evaluate successful samples even when benchmark batch_summary.json contains failures.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Reuse existing ASR/alignment/judge outputs. Default reruns all derived evaluation work.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing them.")
+    return parser.parse_args()
+
+
+def _run(command: list[str], *, cwd: Path, dry_run: bool, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(command))
+    if not dry_run:
+        subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def _precise_manifest(output_root: Path, *, model_json_name: str) -> Path:
+    source = output_root / "official_eval_manifest.jsonl"
+    if not source.is_file():
+        raise FileNotFoundError(f"Missing benchmark manifest: {source}")
+    destination = output_root / f"official_eval_manifest.{Path(model_json_name).stem}.jsonl"
+    rows: list[dict[str, object]] = []
+    for line in source.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        current_model_json = Path(str(row["model_json"]))
+        row["model_json"] = str(current_model_json.with_name(model_json_name))
+        rows.append(row)
+    with destination.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return destination
+
+
+def _load_object(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a JSON object: {path}")
+    return value
+
+
+def _validate_model_outputs(manifest: Path) -> int:
+    rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines() if line.strip()]
+    missing = [str(row.get("model_json")) for row in rows if not Path(str(row.get("model_json"))).is_file()]
+    if missing:
+        raise RuntimeError(f"Official data prep did not produce {len(missing)} model JSON file(s): {missing[:3]}")
+    return len(rows)
+
+
+def main() -> int:
+    args = _parse_args()
+    official_repo = args.official_repo.expanduser().resolve()
+    output_root = args.output_root.expanduser().resolve()
+    batch_summary = output_root / "batch_summary.json"
+    if not (official_repo / "eval" / "run_eval.py").is_file():
+        raise FileNotFoundError(f"Invalid OmniInteract checkout: {official_repo}")
+    if not batch_summary.is_file():
+        raise FileNotFoundError(f"Missing benchmark summary: {batch_summary}")
+    batch = _load_object(batch_summary)
+    total = int(batch.get("total") or 0)
+    success = int(batch.get("success") or 0)
+    failed = int(batch.get("failed") or 0)
+    if total <= 0 or success <= 0 or success + failed != total:
+        raise ValueError(
+            f"Invalid benchmark counts in {batch_summary}: total={total}, success={success}, failed={failed}"
+        )
+    if failed and not args.allow_partial:
+        raise RuntimeError(
+            f"Benchmark produced {failed}/{total} failed samples; fix or rerun them before official scoring "
+            "(use --allow-partial only for explicit partial diagnostics)."
+        )
+
+    if args.skip_data_prep:
+        model_json_name = "wav_transcript.json"
+    else:
+        if not args.asr_model or not args.align_model:
+            raise ValueError("--asr-model and --align-model are required unless --skip-data-prep is used")
+        _run(
+            [
+                sys.executable,
+                "eval/data_prep/data_prep_batch.py",
+                "--batch_summary_json",
+                str(batch_summary),
+                "--output_root",
+                str(output_root),
+                "--asr_model",
+                args.asr_model,
+                "--align_model",
+                args.align_model,
+                "--gpu_ids",
+                args.gpu_ids,
+                "--num_workers",
+                str(args.num_workers),
+                "--fail_fast",
+                *([] if args.resume else ["--force_asr", "--force_precise"]),
+            ],
+            cwd=official_repo,
+            dry_run=args.dry_run,
+        )
+        model_json_name = "precise_truncation.json"
+
+    if not args.judge_api_key and not args.dry_run:
+        raise ValueError("--judge-api-key or JUDGE_API_KEY is required")
+    manifest = _precise_manifest(output_root, model_json_name=model_json_name)
+    out_dir = output_root / "unified_eval"
+    if not args.dry_run:
+        manifest_count = _validate_model_outputs(manifest)
+        if manifest_count != success:
+            raise RuntimeError(
+                f"Evaluator manifest contains {manifest_count} samples but benchmark reports {success} successes"
+            )
+        if not args.skip_data_prep:
+            prep = _load_object(output_root / "data_prep_batch_summary.json")
+            prep_summary = prep.get("summary")
+            prep_summary = prep_summary if isinstance(prep_summary, dict) else {}
+            if int(prep_summary.get("failed") or 0) != 0 or int(prep_summary.get("finished") or 0) != success:
+                raise RuntimeError(f"Official ASR/alignment did not complete all {success} samples: {prep_summary}")
+        if not args.resume:
+            shutil.rmtree(out_dir, ignore_errors=True)
+    command = [
+        sys.executable,
+        "eval/run_eval.py",
+        "--manifest",
+        str(manifest),
+        "--out_dir",
+        str(out_dir),
+        "--num_workers",
+        str(args.num_workers),
+        "--judge_api_url",
+        args.judge_api_url,
+        "--judge_api_model",
+        args.judge_api_model,
+    ]
+    if args.resume:
+        command.append("--skip_existing")
+    evaluator_env = os.environ.copy()
+    if args.judge_api_key:
+        evaluator_env["JUDGE_API_KEY"] = args.judge_api_key
+    _run(command, cwd=official_repo, dry_run=args.dry_run, env=evaluator_env)
+    result_path = out_dir / "unified_eval_summary.json"
+    if not args.dry_run:
+        result = _load_object(result_path)
+        summary = result.get("summary")
+        summary = summary if isinstance(summary, dict) else {}
+        if int(summary.get("failed_or_skipped") or 0) != 0:
+            raise RuntimeError(f"Official evaluator reported failed/skipped samples: {summary}")
+        if int(summary.get("num_items") or 0) != success:
+            raise RuntimeError(f"Official evaluator scored {summary.get('num_items')} samples; expected {success}")
+    print(f"Official OmniInteract results: {result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -17,12 +17,24 @@ from vllm.benchmarks.lib.endpoint_request_func import RequestFuncInput
 
 from vllm_omni.benchmarks.patch.patch import (
     MixRequestFuncOutput,
+    _is_omniinteract_dataset,
     async_request_openai_chat_omni_completions,
     async_request_openai_realtime_duplex,
 )
 from vllm_omni.experimental.fullduplex.client import RealtimeEventCollector
 
 pytestmark = [pytest.mark.core_model, pytest.mark.benchmark, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (SimpleNamespace(dataset_name="omniinteract"), True),
+        (SimpleNamespace(dataset_name="random", omniinteract_root="/tmp/OmniInteract"), False),
+    ],
+)
+def test_omniinteract_root_does_not_override_dataset_selection(args, expected):
+    assert _is_omniinteract_dataset(args) is expected
 
 
 class MockResponse:

--- a/tests/benchmarks/test_omniinteract.py
+++ b/tests/benchmarks/test_omniinteract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from vllm_omni.benchmarks.data_modules import omniinteract as oi
+from vllm_omni.experimental.fullduplex.client import RealtimeEventCollector
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _collector(*events: dict[str, object]) -> RealtimeEventCollector:
+    collector = RealtimeEventCollector()
+    for index, event in enumerate(events):
+        collector.add(event, received_at_s=1 + index / 10)
+    return collector
+
+
+def _audio(response_id: str = "r1", value: int = 1) -> dict[str, object]:
+    return {
+        "type": "response.audio.delta",
+        "response_id": response_id,
+        "format": "pcm16",
+        "sample_rate_hz": 24_000,
+        "delta": base64.b64encode(bytes((value, 0)) * 2400).decode(),
+    }
+
+
+def _identity(event_type: str, seq: int = 7, **extra: object) -> dict[str, object]:
+    key = "accepted_input_seq" if event_type.endswith("committed") else "processed_input_seq"
+    return {"type": event_type, "session_id": "s", "epoch": 2, key: seq, **extra}
+
+
+@pytest.mark.asyncio
+async def test_final_watermark_accepts_exact_precommit_speak():
+    await oi._wait_final(
+        _collector(
+            _identity("input_audio_buffer.processed", outcome="speak", response_id="r1"),
+            {"type": "response.created", "response": {"id": "r1"}},
+            _audio(),
+            {"type": "response.done", "response": {"id": "r1", "status": "completed"}},
+            _identity("input_audio_buffer.committed"),
+        ),
+        0,
+        0.1,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("events", "error"),
+    [
+        ([_identity("input_audio_buffer.processed", outcome="listen")], TimeoutError),
+        (
+            [_identity("input_audio_buffer.committed"), _identity("input_audio_buffer.processed", 8, outcome="listen")],
+            TimeoutError,
+        ),
+        (
+            [_identity("input_audio_buffer.committed"), _identity("input_audio_buffer.processed", outcome="unknown")],
+            RuntimeError,
+        ),
+        ([_identity("input_audio_buffer.committed"), {"type": "session.closed", "reason": "timeout"}], RuntimeError),
+    ],
+)
+async def test_final_watermark_fails_closed(events: list[dict[str, object]], error: type[Exception]):
+    with pytest.raises(error):
+        await oi._wait_final(_collector(*events), 0, 0.03)

--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -251,11 +251,12 @@ def test_stage0_streaming_update_keeps_all_computed_tokens_without_placeholder()
 
 def test_explicit_streaming_payload_replaces_placeholder_prompt() -> None:
     sched = _make_scheduler(stage_id=1)
+    session = _make_request()
     sched.chunk_transfer_adapter = SimpleNamespace(
         receives_chunks=False,
         segment_finished_requests=set(),
+        requests_num_chunks_sent={session.external_req_id: 59},
     )
-    session = _make_request()
     session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
     update = _make_update([10, 20])
     update.additional_information = {
@@ -276,29 +277,33 @@ def test_explicit_streaming_payload_replaces_placeholder_prompt() -> None:
         "meta": {"turn_eos_token_id": 99},
     }
     assert session.status == RequestStatus.WAITING
+    assert sched.chunk_transfer_adapter.requests_num_chunks_sent == {}
 
 
 def test_model_intermediate_streaming_payload_replaces_computed_prompt() -> None:
     sched = _make_scheduler(stage_id=1)
+    session = _make_request()
     sched.chunk_transfer_adapter = SimpleNamespace(
         receives_chunks=False,
         segment_finished_requests=set(),
+        requests_num_chunks_sent={session.external_req_id: 4064},
+        _max_model_len=4096,
     )
-    session = _make_request()
     session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
-    session.prompt_token_ids = [0] * 59
+    session.prompt_token_ids = [0] * 4064
     session._all_token_ids.clear()
     session._all_token_ids.extend(session.prompt_token_ids)
-    session.num_prompt_tokens = 59
-    session.num_computed_tokens = 59
+    session.num_prompt_tokens = 4064
+    session.num_computed_tokens = 4064
     update = _make_update([0] * 10)
     update.additional_information = None
     update.model_intermediate_buffer = {
+        "native_duplex": True,
         "ids": {"tts": list(range(8))},
         "hidden_states": {"tts": [[0.0]] * 8},
         "meta": {
-            "replace_streaming_prompt": True,
             "next_stage_prompt_len": 10,
+            "next_stage_generation_tokens": 26,
         },
     }
 
@@ -311,3 +316,4 @@ def test_model_intermediate_streaming_payload_replaces_computed_prompt() -> None
     assert session.additional_information is None
     assert session.model_intermediate_buffer == update.model_intermediate_buffer
     assert session.status == RequestStatus.WAITING
+    assert sched.chunk_transfer_adapter.requests_num_chunks_sent == {}

--- a/tests/core/sched/test_omni_generation_scheduler_update_session.py
+++ b/tests/core/sched/test_omni_generation_scheduler_update_session.py
@@ -410,12 +410,13 @@ class TestRealignRequestStatusToQueues:
         assert stale.status == RequestStatus.RUNNING
         assert clean.status == RequestStatus.RUNNING
 
-    def test_finished_request_is_skipped(self) -> None:
+    def test_non_resumable_finished_request_is_skipped(self) -> None:
         """Already-finished requests must not be touched -- they may
         have legitimate finished statuses (FINISHED_STOPPED etc.) that
         a status flip would corrupt.
         """
         req = _make_request(request_id="req-finished")
+        req.resumable = False
         req.status = RequestStatus.FINISHED_STOPPED
 
         sched = _RealignSchedulerStub(

--- a/tests/core/sched/test_omni_scheduler_finish_requests_purge.py
+++ b/tests/core/sched/test_omni_scheduler_finish_requests_purge.py
@@ -157,3 +157,15 @@ def test_finish_requests_leaves_healthy_running_intact(
     )
 
     assert scheduler.running == [alive]
+
+
+@pytest.mark.parametrize("scheduler_cls", [OmniARScheduler, OmniGenerationScheduler])
+def test_finish_requests_does_not_reopen_off_queue_deferred_free_terminal(scheduler_cls) -> None:
+    terminal = _StubRequest("req-deferred-free", RequestStatus.FINISHED_STOPPED)
+    terminal.resumable = True
+    scheduler = _make_scheduler(scheduler_cls, requests={terminal.request_id: terminal}, running=[], waiting=[])
+    scheduler._free_request = lambda *args, **kwargs: pytest.fail("off-queue request was freed")
+
+    assert scheduler_cls.finish_requests(scheduler, [terminal.request_id], RequestStatus.FINISHED_ABORTED) == []
+    assert scheduler.requests == {terminal.request_id: terminal}
+    assert terminal.status == RequestStatus.FINISHED_STOPPED

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -3,8 +3,8 @@
 
 import threading
 from collections import deque
-from types import SimpleNamespace
-from unittest.mock import patch
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -13,6 +13,7 @@ from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
 from vllm.v1.metrics.stats import PrefillStats, PromptTokenStats
 from vllm.v1.request import RequestStatus
 
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayload, OmniPayloadStruct
 from vllm_omni.distributed.omni_connectors.adapter import construct_next_stage_streaming_input_prompt
@@ -32,11 +33,16 @@ class DummyWaitingQueue(list):
     def add_request(self, request):
         self.append(request)
 
+    def remove_requests(self, requests):
+        remove = set(requests)
+        self[:] = [request for request in self if request not in remove]
+
 
 def _req(req_id: str, status: RequestStatus, external_req_id: str | None = None):
-    return SimpleNamespace(
+    request = Mock(
         request_id=req_id,
         external_req_id=external_req_id or req_id,
+        client_index=0,
         status=status,
         prompt_token_ids=[],
         num_prompt_tokens=0,
@@ -44,8 +50,9 @@ def _req(req_id: str, status: RequestStatus, external_req_id: str | None = None)
         num_output_placeholders=0,
         prefill_stats=None,
         additional_information=None,
-        is_finished=lambda: status == RequestStatus.FINISHED_STOPPED,
     )
+    request.is_finished = lambda: RequestStatus.is_finished(request.status)
+    return request
 
 
 def test_streaming_payload_can_replace_placeholder_prompt(mocker: MockerFixture) -> None:
@@ -106,6 +113,8 @@ def build_adapter(monkeypatch, mocker: MockerFixture):
         stage_id: int = 1,
         model_mode: str = "ar",
         max_num_seqs: int = 2,
+        max_model_len: int = 0,
+        tts_max_model_len: int = 0,
         active_stream_window: int = 0,
         connector_extra: dict | None = None,
     ):
@@ -136,6 +145,8 @@ def build_adapter(monkeypatch, mocker: MockerFixture):
         model_config = SimpleNamespace(
             worker_type=model_mode,
             max_num_seqs=max_num_seqs,
+            max_model_len=max_model_len,
+            hf_config=SimpleNamespace(tts_config=SimpleNamespace(max_position_embeddings=tts_max_model_len)),
             active_stream_window=active_stream_window,
             stage_connector_config={
                 "name": "SharedMemoryConnector",
@@ -198,6 +209,77 @@ def test_load_poll(build_adapter):
     assert "req-1" in adapter._finished_load_reqs
     assert "req-1" in adapter.upstream_exhausted_requests
     assert "req-1" not in adapter._pending_load_reqs
+
+
+def test_adapter_uses_nested_tts_context_limit(build_adapter):
+    adapter, _ = build_adapter(
+        stage_id=1,
+        model_mode="ar",
+        max_model_len=8192,
+        tts_max_model_len=4096,
+    )
+    assert adapter._max_model_len == 4096
+
+
+def test_load_poll_ar_rolls_over_over_budget_running_prompt(build_adapter):
+    adapter, connector = build_adapter(
+        stage_id=1,
+        model_mode="ar",
+        max_model_len=8192,
+        tts_max_model_len=4096,
+    )
+    request = _req("req-rollover", RequestStatus.RUNNING, external_req_id="external-rollover")
+    request.resumable = True
+    request.prompt_token_ids = [0] * 4064
+    request._all_token_ids = [0] * 4064
+    request._output_token_ids = []
+    request.num_prompt_tokens = 4064
+    request.num_computed_tokens = 4064
+    request.sampling_params = SimpleNamespace(min_tokens=0)
+    request.update_block_hashes = Mock()
+    adapter.get_req_chunk[request.request_id] = 1
+    adapter.requests_num_chunks_sent[request.external_req_id] = 4064
+    adapter.request_ids_mapping[request.request_id] = request.external_req_id
+    connector.get.return_value = (
+        {
+            "native_duplex": True,
+            "ids": {"prompt": [1]},
+            "meta": {
+                "next_stage_prompt_len": 10,
+                "next_stage_generation_tokens": 26,
+                "finished": False,
+            },
+        },
+        1,
+    )
+
+    assert adapter._poll_single_request(request) is True
+    assert request.num_computed_tokens == 0
+    assert request.prompt_token_ids == [0] * 10
+    assert request.request_id in adapter.replaced_streaming_prompt_ids
+    assert adapter.requests_num_chunks_sent[request.external_req_id] == 4064
+
+    # A running request must be admitted as scheduled-new so the worker
+    # replaces its cached prompt row instead of only resetting its position.
+    request.status = RequestStatus.WAITING_FOR_CHUNK
+    running_queue = [request]
+    waiting_queue = DummyWaitingQueue()
+    adapter.process_pending_chunks(waiting_queue, running_queue)
+    assert running_queue == []
+    assert waiting_queue == [request]
+    assert request.status == RequestStatus.WAITING
+
+    # Consume the marker and reset the latest sender watermark only at the
+    # scheduled-new boundary, after any old-row output has been accounted for.
+    adapter.requests_num_chunks_sent[request.external_req_id] = 4090
+    adapter.postprocess_scheduler_output(
+        SimpleNamespace(
+            scheduled_new_reqs=[SimpleNamespace(req_id=request.request_id)],
+            scheduled_cached_reqs=SimpleNamespace(req_ids=[]),
+        )
+    )
+    assert request.request_id not in adapter.replaced_streaming_prompt_ids
+    assert request.external_req_id not in adapter.requests_num_chunks_sent
 
 
 def test_load_poll_generation_tensor_codes_use_placeholder_prompt(build_adapter):
@@ -563,6 +645,57 @@ def test_load_poll_non_ar_merges_into_existing_additional_information(build_adap
     assert request.additional_information["kv_metadata"] == {"foo": "bar"}
     assert "req-non-ar" in adapter._finished_load_reqs
     assert "req-non-ar" in adapter.upstream_exhausted_requests
+
+
+def test_load_poll_generation_segment_marker_replaces_previous_chunk(build_adapter):
+    adapter, connector = build_adapter(stage_id=2, model_mode="generation")
+    request = _req("req-marker", RequestStatus.WAITING, external_req_id="external-marker")
+    request.additional_information = {
+        "codes": {"audio": torch.tensor([1, 2])},
+        "meta": {"cache_epoch": 0, "chunk_seq": 2, "last_chunk": True},
+    }
+    connector.get.return_value = (
+        {
+            "meta": {
+                "finished": torch.tensor(False, dtype=torch.bool),
+                "is_segment_finished": torch.tensor(True, dtype=torch.bool),
+                "request_finished": torch.tensor(False, dtype=torch.bool),
+                "replace_runtime_additional_information": True,
+            }
+        },
+        1,
+    )
+
+    assert adapter._poll_single_request(request) is True
+
+    assert "codes" not in request.additional_information
+    assert not {"cache_epoch", "chunk_seq", "last_chunk"}.intersection(request.additional_information["meta"])
+    assert request.request_id in adapter.segment_finished_requests
+
+
+def test_load_poll_generation_without_snapshot_marker_keeps_incremental_state(build_adapter):
+    adapter, connector = build_adapter(stage_id=2, model_mode="generation")
+    request = _req("req-incremental", RequestStatus.WAITING, external_req_id="external-incremental")
+    request.additional_information = {
+        "codes": {"audio": torch.tensor([1, 2])},
+        "meta": {"cache_epoch": 3, "chunk_seq": 2},
+    }
+    connector.get.return_value = (
+        {
+            "meta": {
+                "finished": torch.tensor(False, dtype=torch.bool),
+                "phase": "decode",
+            }
+        },
+        1,
+    )
+
+    assert adapter._poll_single_request(request) is False
+
+    assert torch.equal(request.additional_information["codes"]["audio"], torch.tensor([1, 2]))
+    assert request.additional_information["meta"]["cache_epoch"] == 3
+    assert request.additional_information["meta"]["chunk_seq"] == 2
+    assert request.additional_information["meta"]["phase"] == "decode"
 
 
 def test_load_poll_ar_request_additional_information_concats_tensors(build_adapter):
@@ -1039,26 +1172,76 @@ def test_finish_requests_removes_zombies_from_chunk_waiting_deques(build_adapter
     assert "req-zombie" not in adapter.upstream_exhausted_requests
 
 
-def test_finish_requests_releases_active_stream_slot(build_adapter):
-    adapter, _ = build_adapter(stage_id=1, max_num_seqs=1, active_stream_window=1)
-    aborted = _req("req-aborted", RequestStatus.RUNNING)
-    waiting = _req("req-waiting", RequestStatus.WAITING)
-    waiting_queue = DummyWaitingQueue([waiting])
-    running_queue = []
-    adapter._active_streams[aborted.request_id] = aborted
-    adapter._held_non_active.append(aborted)
-
-    adapter.finish_requests(
-        [aborted.request_id],
-        RequestStatus.FINISHED_ABORTED,
-        {aborted.request_id: aborted},
+@pytest.mark.parametrize(
+    "scheduler_cls",
+    [
+        pytest.param(OmniGenerationScheduler, id="generation"),
+        pytest.param(OmniARScheduler, id="ar"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("placement", "origin_status"),
+    [
+        pytest.param("hidden", RequestStatus.RUNNING, id="hidden"),
+        pytest.param("running", RequestStatus.WAITING, id="stale-origin"),
+        pytest.param("waiting", RequestStatus.WAITING, id="waiting"),
+    ],
+)
+def test_finish_requests_reclaims_resumable_segment_and_reuses_capacity(
+    build_adapter,
+    scheduler_cls,
+    placement,
+    origin_status,
+):
+    """Close frees a live segment-stop once and releases its capacity."""
+    adapter, _ = build_adapter(stage_id=1, active_stream_window=2)
+    request = _req(
+        "req-segment-stop",
+        RequestStatus.FINISHED_STOPPED,
+        external_req_id="ext-segment-stop",
     )
-    adapter.process_pending_chunks(waiting_queue, running_queue)
+    request.resumable = True
+    request.is_finished = lambda: RequestStatus.is_finished(request.status)
+    adapter.requests_origin_status[request.request_id] = origin_status
+    if placement == "hidden":
+        adapter.waiting_for_chunk_running_requests.append(request)
+    adapter._active_streams[request.request_id] = request
 
-    assert aborted.request_id not in adapter._active_streams
-    assert [request.request_id for request in adapter._held_non_active] == []
-    assert list(adapter._active_streams) == [waiting.request_id]
-    assert waiting.status == RequestStatus.WAITING_FOR_CHUNK
+    scheduler = scheduler_cls.__new__(scheduler_cls)
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.input_coordinator = None
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = [request] if placement == "running" else []
+    scheduler.waiting = DummyWaitingQueue([request] if placement == "waiting" else [])
+    scheduler.skipped_waiting = DummyWaitingQueue()
+
+    freed: list[str] = []
+
+    def fake_free_request(self, live, delay_free_blocks=False):
+        del delay_free_blocks
+        freed.append(live.request_id)
+        self.requests.pop(live.request_id)
+        return None, None
+
+    scheduler._free_request = MethodType(fake_free_request, scheduler)
+
+    first = scheduler_cls.finish_requests(scheduler, [request.request_id], RequestStatus.FINISHED_ABORTED)
+    second = scheduler_cls.finish_requests(scheduler, [request.request_id], RequestStatus.FINISHED_ABORTED)
+
+    assert len(first) == 1
+    assert second == []
+    assert freed == [request.request_id]
+    assert request.request_id not in scheduler.requests
+    assert request.request_id not in adapter._active_streams
+    assert not adapter.waiting_for_chunk_running_requests
+    assert scheduler.running == []
+    assert list(scheduler.waiting) == []
+
+    fresh_a = _req("req-fresh-a", RequestStatus.WAITING)
+    fresh_b = _req("req-fresh-b", RequestStatus.WAITING)
+    assert adapter._ensure_active_stream(fresh_a)
+    assert adapter._ensure_active_stream(fresh_b)
+    assert set(adapter._active_streams) == {fresh_a.request_id, fresh_b.request_id}
 
 
 def test_restore_queues_skips_requests_missing_from_scheduler_requests(build_adapter):

--- a/tests/e2e/features/fullduplex/test_client.py
+++ b/tests/e2e/features/fullduplex/test_client.py
@@ -73,10 +73,15 @@ async def test_realtime_client_configure_omits_ref_audio_by_default():
 
     client = Client()
 
-    await client.configure("openbmb/MiniCPM-o-4_5", timeout_s=1)
+    await client.configure(
+        "openbmb/MiniCPM-o-4_5",
+        idle_timeout_s=900,
+        timeout_s=1,
+    )
 
     session = client.sent[0]["session"]
     assert "ref_audio" not in session
+    assert session["idle_timeout_s"] == 900
 
 
 @pytest.mark.asyncio
@@ -100,6 +105,7 @@ async def test_realtime_client_configure_sends_explicit_ref_audio():
 
     session = client.sent[0]["session"]
     assert session["ref_audio"] == "data:audio/wav;base64,AAAA"
+    assert "idle_timeout_s" not in session
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/online_serving/test_minicpmo_4_5_duplex.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_duplex.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import uuid
 from pathlib import Path
 
 import pytest
 import websockets
 
+from tests.e2e.accuracy.qwen3_omni.qwen3_omni_acc_bench_core import (
+    find_vllm_cli,
+    run_vllm_bench_subprocess,
+)
 from tests.e2e.online_serving.helpers.minicpmo_4_5_duplex import (
     SERVER_PARAMS,
     demo_args,
@@ -26,6 +31,7 @@ from tests.e2e.online_serving.run_minicpmo_realtime_duplex_multi_session import 
     run_multi_session,
 )
 from tests.helpers.mark import hardware_test
+from vllm_omni.benchmarks.data_modules.omniinteract import OmniInteractConfig, OmniInteractDataset
 from vllm_omni.experimental.fullduplex.client import build_realtime_url
 
 pytestmark = pytest.mark.omni
@@ -174,3 +180,58 @@ def test_duplex_two_sessions_resume_and_takeover(omni_server, model_prefix: str,
     for session in result["sessions"]:
         _assert_request_metrics(session["request_metrics"], expected_count=1)
         _assert_session_metrics(session["session_metrics"], expected_count=1)
+
+
+@pytest.mark.full_model
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.skipif(os.environ.get("VLLM_OMNI_RUN_OMNIINTERACT_E2E") != "1", reason="enable real OmniInteract E2E")
+@pytest.mark.parametrize("subset", ("1q1a", "1q1a_math", "1qna"))
+@pytest.mark.parametrize("omni_server", SERVER_PARAMS, indirect=True)
+def test_minicpmo_4_5_omniinteract_e2e(
+    omni_server,
+    model_prefix: str,
+    tmp_path: Path,
+    subset: str,
+) -> None:
+    local = os.environ.get("OMNIINTERACT_ROOT", "").strip()
+    root = Path(local).expanduser() if local else None
+    if root:
+        try:
+            OmniInteractDataset(None, data_root=str(root), subsets=[subset], config=OmniInteractConfig())
+        except (FileNotFoundError, ValueError):
+            root = None
+
+    source = ["--omniinteract-root", str(root.resolve())] if root else ["--dataset-path", "lucky-lance/OmniInteract"]
+    output = tmp_path / "omniinteract"
+    run_vllm_bench_subprocess(
+        find_vllm_cli(),
+        [
+            "bench",
+            "serve",
+            "--omni",
+            "--trust-remote-code",
+            f"--host={omni_server.host}",
+            f"--port={omni_server.port}",
+            "--backend=minicpmo-realtime",
+            "--endpoint=/v1/realtime",
+            f"--model={omni_server.model}",
+            "--dataset-name=omniinteract",
+            *source,
+            f"--omniinteract-subsets={subset}",
+            f"--omniinteract-realtime-ref-audio={resolve_ref_audio(model_prefix)}",
+            f"--omniinteract-official-output-dir={output}",
+            "--num-warmups=0",
+            "--num-prompts=4",
+            "--max-concurrency=2",
+            "--no-oversample",
+            "--disable-shuffle",
+        ],
+    )
+    summary = json.loads((output / "batch_summary.json").read_text())
+    assert (summary["total"], summary["success"], summary["failed"]) == (4, 4, 0)
+    for result in summary["results"]:
+        assert result["input_audio_chunks"] > 0 and result["input_video_frames"] > 0
+        sample = Path(result["output_dir"])
+        assert all((sample / name).is_file() for name in (".done", "output.wav", "wav_transcript.json"))
+        assert json.loads((sample / "wav_transcript.json").read_text())["chunks"]
+    assert len((output / "official_eval_manifest.jsonl").read_text().splitlines()) == 4

--- a/tests/engine/test_multimodal_accumulation.py
+++ b/tests/engine/test_multimodal_accumulation.py
@@ -47,3 +47,14 @@ def test_chunk_accumulation_policy_replaces_snapshots_and_drains_delta_state():
     assert "meta.tts_is_last_chunk" not in merged
     assert "meta.turn_end" not in merged
     assert merged.metadata["meta.stable_request_value"] == "keep"
+
+
+def test_chunk_accumulation_replaces_duplex_input_seq_snapshot():
+    accumulated = MultimodalPayload.from_dict({"meta.duplex_input_seq": torch.tensor(7)})
+    incoming = MultimodalPayload.from_dict({"meta.duplex_input_seq": torch.tensor(8)})
+    assert accumulated is not None and incoming is not None
+    replace_snapshot_keys(accumulated, incoming)
+    merged = accumulated.merged_with(incoming)
+    assert merged.tensors["meta.duplex_input_seq"].item() == 8
+    drain_delta_payload(merged)
+    assert "meta.duplex_input_seq" not in merged

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -47,6 +47,7 @@ from vllm_omni.experimental.fullduplex.openai.serving import (
 from vllm_omni.experimental.fullduplex.openai.websocket import DuplexWebSocketActor
 from vllm_omni.experimental.fullduplex.output import attach_duplex_output_decision
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.outputs.mm_outputs import MultimodalPayload
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -62,6 +63,30 @@ def test_native_input_append_supports_explicit_session_opt_out():
 
     session.config.extra_body["minicpmo45_native_duplex"] = False
     assert OmniDuplexSessionHandler._uses_native_input_append(session) is False
+
+
+def test_accepted_input_seq_reads_only_control_result_contract_paths():
+    assert OmniDuplexSessionHandler._accepted_input_seq({"accepted_input_seq": 3}) == 3
+    assert (
+        OmniDuplexSessionHandler._accepted_input_seq({"stage_results": [{"result": {"supported": True, "seq": 7}}]})
+        == 7
+    )
+    assert (
+        OmniDuplexSessionHandler._accepted_input_seq({"data_plane_outputs": [{"metadata": {"accepted_input_seq": 99}}]})
+        is None
+    )
+
+
+def test_cancelled_acceptance_preserves_other_deferred_processed_identity():
+    state = MiniCPMO45ServingSessionState()
+    state.begin_input_acceptance()
+    assert state.defer_input_processed(epoch=0, seq=2, outcome="listen", response_id=None)
+
+    state.cancel_input_acceptance()
+    assert state.input_acceptances_inflight == 0
+    state.begin_input_acceptance()
+    assert state.record_accepted_input(epoch=0, seq=2, model_turn_id=0) == ("listen", None)
+    assert state.deferred_processed_inputs == {}
 
 
 class _ModelConfig:
@@ -1414,6 +1439,24 @@ def _install_direct_silence_scheduler(
     native.silence_continuation_scheduler = _schedule
 
 
+def _capture_pending_continuations(
+    handler: OmniDuplexSessionHandler,
+    session: DuplexSession,
+    *accepted: tuple[int, int],
+) -> list[dict[str, object]]:
+    native = handler._minicpmo_session_state(session)
+    for seq, turn_id in accepted:
+        native.record_accepted_input(epoch=session.epoch, seq=seq, model_turn_id=turn_id)
+    captured: list[dict[str, object]] = []
+
+    async def _schedule(payload: dict[str, object], **_kwargs: object) -> bool:
+        captured.append(payload)
+        return True
+
+    native.silence_continuation_scheduler = _schedule
+    return captured
+
+
 def test_minicpmo_pcm_append_buffer_flush_preserves_accumulated_speech_marker():
     buffer = MiniCPMO45PcmAppendBuffer()
     payload = _native_audio_payload(samples=8000)
@@ -1443,57 +1486,6 @@ def test_minicpmo_pcm_append_buffer_drops_serving_new_user_turn_marker():
     assert "new_user_turn" not in emitted
     assert "new_user_turn_prefix_variant" not in emitted
     assert "force_speak" not in emitted
-
-
-def test_minicpmo_merge_native_audio_payloads_preserves_speech_marker():
-    first = _native_audio_payload(samples=8000)
-    second = _native_audio_payload(samples=8000, value=0.0, is_speech=False)
-
-    merged = OmniDuplexSessionHandler._merge_native_audio_payloads(first, second)
-
-    assert merged["is_speech"] is True
-
-
-def test_minicpmo_merge_drops_serving_new_user_turn_marker():
-    first = _native_audio_payload(samples=8000)
-    first.update(
-        new_user_turn=True,
-        new_user_turn_prefix_variant="clean_response_done",
-        force_speak=True,
-    )
-    second = _native_audio_payload(samples=8000, is_speech=False)
-
-    merged = OmniDuplexSessionHandler._merge_native_audio_payloads(first, second)
-
-    assert merged["is_speech"] is True
-    assert "new_user_turn" not in merged
-    assert "new_user_turn_prefix_variant" not in merged
-    assert "force_speak" not in merged
-
-
-@pytest.mark.asyncio
-async def test_minicpmo_clear_continuation_does_not_cancel_pending_silence_task():
-    async def _pending() -> bool:
-        await asyncio.sleep(3600)
-        return True
-
-    native = MiniCPMO45ServingSessionState()
-    task = asyncio.create_task(_pending())
-    native.continuation_owner_id = "owner"
-    native.continuation_units = 1
-    native.pending_silence_task = task
-    native.pending_silence_owner_id = "owner"
-
-    native.clear_continuation()
-
-    assert native.continuation_owner_id is None
-    assert native.continuation_units == 0
-    assert native.pending_silence_task is None
-    assert native.pending_silence_owner_id is None
-    assert not task.cancelled()
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
 
 
 def test_auto_response_playback_overlap_keeps_model_owned_listen_speak_decision():
@@ -2139,10 +2131,19 @@ def test_duplex_listen_latent_does_not_poison_cumulative_audio_offset():
 
 
 def test_direct_listen_decision_survives_inner_completion_metadata():
+    raw_metadata = MultimodalPayload(
+        metadata={
+            "meta": {
+                "duplex_epoch": 0,
+                "duplex_input_seq": 7,
+                "duplex_turn_id": 2,
+            }
+        }
+    )
     inner_output = SimpleNamespace(
         outputs=[
             SimpleNamespace(
-                multimodal_output={"special_token_ids": {"listen_token_id": 151705}},
+                multimodal_output=raw_metadata,
             )
         ]
     )
@@ -2151,7 +2152,10 @@ def test_direct_listen_decision_survives_inner_completion_metadata():
         final_stage_id=1,
         segment_finished=True,
         segment_token_ids=(151705,),
-        segment_output_metadata={"special_token_ids": {"listen_token_id": 151705}},
+        segment_output_metadata={
+            **dict(raw_metadata),
+            "special_token_ids": {"listen_token_id": 151705},
+        },
         output=inner_output,
     )
     assert decision is not None
@@ -2182,6 +2186,8 @@ def test_direct_listen_decision_survives_inner_completion_metadata():
     assert results[0]["is_listen"] is True
     assert results[0]["model_listen"] is True
     assert results[0]["listen_source"] == "model_listen"
+    assert results[0]["input_seq"] == 7
+    assert results[0]["model_turn_id"] == 2
     assert results[0]["stage_metrics"] == output.metrics["stage_metrics"]
 
 
@@ -2389,6 +2395,7 @@ def test_duplex_data_plane_listen_preserves_model_turn_identity():
             "duplex_native_decision": "listen",
             "meta.duplex_turn_id": np.array([2], dtype=np.int32),
             "meta.duplex_epoch": np.array([0], dtype=np.int32),
+            "meta.duplex_input_seq": np.array([9], dtype=np.int32),
         },
     )
 
@@ -2397,6 +2404,7 @@ def test_duplex_data_plane_listen_preserves_model_turn_identity():
     assert len(results) == 1
     assert results[0]["is_listen"] is True
     assert results[0]["model_turn_id"] == 2
+    assert results[0]["input_seq"] == 9
 
 
 def test_duplex_data_plane_does_not_drop_future_model_turn_while_response_active():
@@ -2748,7 +2756,7 @@ def test_duplex_auto_response_releases_buffered_audio_on_text_only_terminal():
 
 @pytest.mark.asyncio
 async def test_native_append_propagates_current_turn_fence_to_engine():
-    engine = FakeEngineClient()
+    engine = FakeEngineClient(control_result={"ok": True, "stage_results": [{"result": {"supported": True, "seq": 7}}]})
     handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
     session = DuplexSession(
         session_id="sid-fenced-append",
@@ -2756,7 +2764,8 @@ async def test_native_append_propagates_current_turn_fence_to_engine():
     )
     session.capabilities = DuplexCapabilities.minicpmo45_native()
     session.turn_id = 2
-    session.begin_response(turn_id=2)
+    session.bind_request("duplex-sid-fenced-append-e0-stage0")
+    continuations = _capture_pending_continuations(handler, session)
     ws = TimedWebSocket()
 
     await handler._append_runtime_input(
@@ -2769,6 +2778,8 @@ async def test_native_append_propagates_current_turn_fence_to_engine():
     )
 
     assert engine.appended_fences == [DuplexFence("sid-fenced-append", epoch=0, turn_id=2)]
+    assert len(continuations) == 1
+    assert continuations[0]["duplex_origin_input_seq"] == 7
 
 
 @pytest.mark.asyncio
@@ -2922,7 +2933,7 @@ async def test_minicpmo_pre_response_continuation_drops_after_model_turn_ends():
 
 
 @pytest.mark.asyncio
-async def test_minicpmo_auto_response_continuation_has_no_semantic_unit_cap():
+async def test_minicpmo_auto_response_continuation_uses_large_safety_cap():
     request_id = "duplex-sid-long-response-e0-stage0"
     engine = FakeEngineClient()
     handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
@@ -2938,7 +2949,7 @@ async def test_minicpmo_auto_response_continuation_has_no_semantic_unit_cap():
     _install_direct_silence_scheduler(handler, session)
     ws = TimedWebSocket()
 
-    for _ in range(9):
+    for _ in range(handler._NATIVE_AUTO_RESPONSE_FORCE_LISTEN_UNITS):
         await handler._maybe_continue_native_response(
             ws.send_json,
             session=session,
@@ -2946,24 +2957,28 @@ async def test_minicpmo_auto_response_continuation_has_no_semantic_unit_cap():
         )
     await asyncio.sleep(0.02)
 
-    assert len(engine.appended) == 9
+    assert len(engine.appended) == handler._NATIVE_AUTO_RESPONSE_FORCE_LISTEN_UNITS
     assert all(payload["duplex_turn_id"] == 0 for _, _, payload, _ in engine.appended)
-    assert all("force_speak" not in payload for _, _, payload, _ in engine.appended)
+    assert all(not {"force_speak", "force_listen"} & payload.keys() for _, _, payload, _ in engine.appended[:-1])
+    assert engine.appended[-1][2]["force_listen"] is True
 
 
 @pytest.mark.asyncio
-async def test_minicpmo_auto_response_pre_speak_listen_continues_same_response():
-    request_id = "duplex-sid-pre-speak-listen-e0-stage0"
+@pytest.mark.parametrize("audio_sent", (False, True), ids=("pre-speak", "post-speak"))
+async def test_minicpmo_auto_response_nonterminal_listen_continues_same_response(audio_sent: bool):
+    request_id = "duplex-sid-nonterminal-listen-e0-stage0"
     engine = FakeEngineClient()
     handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
     session = DuplexSession(
-        session_id="sid-pre-speak-listen",
+        session_id="sid-nonterminal-listen",
         config=DuplexSessionConfig(extra_body={"auto_response": True}),
     )
     session.capabilities = DuplexCapabilities.minicpmo45_native()
     response_id = session.begin_response(turn_id=0)
     session.turn_id = 1
     session.bind_request(request_id)
+    if audio_sent:
+        session.mark_audio_sent(100)
     _install_direct_silence_scheduler(handler, session)
     ws = TimedWebSocket()
 
@@ -3028,29 +3043,21 @@ async def test_minicpmo_auto_response_listen_before_response_keeps_resumable_req
     assert ws.sent_types().count("response.listen") == 1
 
 
-@pytest.mark.asyncio
-async def test_minicpmo_auto_response_listen_without_response_does_not_defer_commit():
-    session_id = "sid-listen-before-response-commit"
-    request_id = duplex_resource_request_id(DuplexFence(session_id), "stage0")
-    inner_output = SimpleNamespace(
-        outputs=[
-            SimpleNamespace(
-                multimodal_output={"special_token_ids": {"listen_token_id": 151705}},
-            )
-        ]
-    )
+def _native_listen_append_result(session_id: str, request_id: str, seq: int) -> dict[str, object]:
+    metadata = MultimodalPayload(metadata={"meta": {"duplex_epoch": 0, "duplex_input_seq": seq, "duplex_turn_id": 0}})
+    inner = SimpleNamespace(outputs=[SimpleNamespace(multimodal_output=metadata)])
     decision = MiniCPMO45DuplexRuntimeExtension().decide_output(
         stage_id=0,
         final_stage_id=1,
         segment_finished=True,
         segment_token_ids=(151705,),
-        segment_output_metadata={"special_token_ids": {"listen_token_id": 151705}},
-        output=inner_output,
+        segment_output_metadata={**dict(metadata), "special_token_ids": {"listen_token_id": 151705}},
+        output=inner,
     )
     assert decision is not None
     listen_output = attach_duplex_output_decision(
         OmniRequestOutput.from_stage_output(
-            inner_output,
+            inner,
             request_id=request_id,
             finished=True,
             stage_id=0,
@@ -3058,28 +3065,138 @@ async def test_minicpmo_auto_response_listen_without_response_does_not_defer_com
         ),
         decision,
     )
-    append_result = {
+    return {
         "operation": "append",
         "session_id": session_id,
         "ok": True,
-        "unsupported_count": 0,
-        "error_count": 0,
-        "stage_results": [
-            {
-                "stage_id": 0,
-                "replica_id": 0,
-                "result": {
-                    "supported": True,
-                    "implementation_level": "model_native_duplex",
-                    "data_plane_append": True,
-                    "request_id": request_id,
-                    "response_stage_id": 1,
-                },
-            }
-        ],
+        "stage_results": [{"result": {"supported": True, "data_plane_append": True, "seq": seq}}],
         "data_plane_outputs": [listen_output],
     }
-    engine = FakeEngineClient(append_result=append_result)
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_emits_processed_watermark_when_output_precedes_append_result():
+    control_result = {
+        "operation": "append",
+        "ok": True,
+        "stage_results": [{"result": {"supported": True, "seq": 2}}],
+    }
+    engine = FakeEngineClient(control_result=control_result)
+    handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
+    session = DuplexSession(
+        session_id="sid-processed-before-accepted",
+        config=DuplexSessionConfig(extra_body={"auto_response": True}),
+    )
+    session.capabilities = DuplexCapabilities.minicpmo45_native()
+    ws = TimedWebSocket()
+    request_id = "duplex-sid-processed-before-accepted-stage0"
+    session.bind_request(request_id)
+    continuations = _capture_pending_continuations(handler, session)
+    native = handler._minicpmo_session_state(session)
+    native.record_accepted_input(epoch=0, seq=1, model_turn_id=0)
+    native.record_final_input(epoch=0, seq=1)
+    original_append = engine.append_duplex_input_async
+    listen = {
+        "supported": True,
+        "stage_role": "llm",
+        "is_listen": True,
+        "data_plane_request_id": request_id,
+        "input_seq": 2,
+        "end_of_turn": False,
+    }
+
+    async def output_before_append_result(session_id: str, **kwargs: Any):
+        await handler._send_one_native_duplex_event(
+            ws.send_json,
+            {**listen, "model_listen": False},
+            session=session,
+            expected_epoch=0,
+        )
+        assert "input.processed" not in ws.sent_types()
+        assert continuations == []
+        session.begin_response(turn_id=0)
+        session.mark_audio_sent(1)
+        await handler._send_one_native_duplex_event(
+            ws.send_json, {**listen, "model_listen": True}, session=session, expected_epoch=0
+        )
+        assert "input.processed" not in ws.sent_types()
+        kwargs.pop("expected_epoch", None)
+        return await original_append(session_id, **kwargs)
+
+    engine.append_duplex_input_async = output_before_append_result  # type: ignore[method-assign]
+
+    append_ok, _ = await handler._append_runtime_input(
+        session,
+        {"audio": "", "format": "pcm_f32le"},
+        final=True,
+        send_json=ws.send_json,
+        mode="append_audio_chunk",
+        expected_epoch=0,
+    )
+
+    assert append_ok is True
+    assert continuations == []
+    processed = [(e["processed_input_seq"], e["outcome"]) for e in ws.sent if e.get("type") == "input.processed"]
+    assert processed == [(2, "listen")]
+    assert handler._minicpmo_session_state(session).pending_input_identity(epoch=0) == (1, 0)
+    assert handler._minicpmo_session_state(session).final_input_identity(epoch=0) is None
+    assert "response.done" in ws.sent_types()
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_acceptance_promotes_unresolved_input_after_turn_completion():
+    engine = FakeEngineClient(control_result={"ok": True, "stage_results": [{"result": {"supported": True, "seq": 1}}]})
+    handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
+    session = DuplexSession(
+        session_id="sid-accept-turn-race", config=DuplexSessionConfig(extra_body={"auto_response": True})
+    )
+    session.capabilities = DuplexCapabilities.minicpmo45_native()
+    session.bind_request(handler._native_stage0_request_id(session, 0))
+    continuations = _capture_pending_continuations(handler, session)
+    original_append = engine.append_duplex_input_async
+
+    async def complete_turn_before_ack(session_id: str, **kwargs: Any):
+        session.complete_model_turn(0)
+        kwargs.pop("expected_epoch", None)
+        return await original_append(session_id, **kwargs)
+
+    engine.append_duplex_input_async = complete_turn_before_ack  # type: ignore[method-assign]
+    send_json = TimedWebSocket().send_json
+    assert (await handler._append_runtime_input(session, {}, final=False, send_json=send_json))[0]
+    native = handler._minicpmo_session_state(session)
+    assert native.pending_input_identity(epoch=0) == (1, 1)
+    assert continuations == []
+    session.complete_model_turn(1)
+    await handler._continue_pending_native_input(send_json, session=session, expected_epoch=0, final_commit=True)
+    assert native.pending_input_identity(epoch=0) == (1, 2)
+    assert len(continuations) == 1
+    assert continuations[0]["duplex_turn_id"] == 2
+    assert continuations[0]["duplex_origin_input_seq"] == 1
+    assert native.final_input_identity(epoch=0) == 1
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_auto_response_listen_without_response_does_not_defer_commit():
+    session_id = "sid-listen-before-response-commit"
+    request_id = duplex_resource_request_id(DuplexFence(session_id), "stage0")
+
+    class BlockingFinalAppendEngine(FakeEngineClient):
+        def __init__(self):
+            super().__init__(
+                append_results=[_native_listen_append_result(session_id, request_id, seq) for seq in (1, 2)]
+            )
+            self.final_append_started = asyncio.Event()
+            self.release_final_append = asyncio.Event()
+
+        async def append_duplex_input_async(self, session_id: str, **kwargs):
+            kwargs.pop("expected_epoch", None)
+            result = await super().append_duplex_input_async(session_id, **kwargs)
+            if kwargs.get("final") is True:
+                self.final_append_started.set()
+                await self.release_final_append.wait()
+            return result
+
+    engine = BlockingFinalAppendEngine()
     handler = OmniDuplexSessionHandler(
         chat_service=FakeChatService(engine),
         config_timeout_s=0.1,
@@ -3121,7 +3238,11 @@ async def test_minicpmo_auto_response_listen_without_response_does_not_defer_com
         }
     )
 
-    await handler.handle_realtime_session(ws)
+    handler_task = asyncio.create_task(handler.handle_realtime_session(ws))
+    await asyncio.wait_for(engine.final_append_started.wait(), timeout=1)
+    assert "input_audio_buffer.committed" not in ws.sent_types()
+    engine.release_final_append.set()
+    await asyncio.wait_for(handler_task, timeout=2)
 
     committed = [event for event in ws.sent if event.get("type") == "input_audio_buffer.committed"]
     assert len(engine.appended) == 2
@@ -3129,6 +3250,9 @@ async def test_minicpmo_auto_response_listen_without_response_does_not_defer_com
     assert len(committed) == 1
     assert committed[0].get("event", {}).get("overlap_deferred") is not True
     assert committed[0].get("event", {}).get("response_create_deferred") is not True
+    assert committed[0]["accepted_input_seq"] == 2
+    processed = [event for event in ws.sent if event.get("type") == "input_audio_buffer.processed"]
+    assert [event["processed_input_seq"] for event in processed] == [1, 2]
     assert "response.created" not in ws.sent_types()
 
 
@@ -3200,21 +3324,41 @@ async def test_minicpmo_pcm_f32_residual_commit_releases_pending_input_bytes():
 
 
 @pytest.mark.asyncio
-async def test_minicpmo_auto_response_post_speak_listen_continues_same_response():
-    request_id = "duplex-sid-post-speak-listen-e0-stage0"
+async def test_minicpmo_final_pending_listen_completes_active_response():
+    request_id = "duplex-sid-final-pending-listen-e0-stage0"
     engine = FakeEngineClient()
     handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
     session = DuplexSession(
-        session_id="sid-post-speak-listen",
+        session_id="sid-final-pending-listen",
         config=DuplexSessionConfig(extra_body={"auto_response": True}),
     )
     session.capabilities = DuplexCapabilities.minicpmo45_native()
-    response_id = session.begin_response(turn_id=0)
-    session.turn_id = 1
+    response_id = session.begin_response(turn_id=3)
     session.bind_request(request_id)
-    session.mark_audio_sent(100)
-    _install_direct_silence_scheduler(handler, session)
+    native = handler._minicpmo_session_state(session)
+    native.record_accepted_input(epoch=0, seq=300, model_turn_id=4)
+    native.record_final_input(epoch=0, seq=300)
     ws = TimedWebSocket()
+
+    await handler._send_one_native_duplex_event(
+        ws.send_json,
+        {
+            "supported": True,
+            "stage_role": "tts",
+            "is_listen": False,
+            "data_plane_request_id": request_id,
+            "text": "old answer",
+            "audio_data": "audio",
+            "audio_format": "pcm16",
+            "audio_duration_ms": 100,
+            "end_of_turn": False,
+            "model_turn_id": 3,
+            "input_seq": 300,
+        },
+        session=session,
+        expected_epoch=0,
+    )
+    assert native.pending_input_identity(epoch=0) is None
 
     await handler._send_one_native_duplex_event(
         ws.send_json,
@@ -3225,20 +3369,31 @@ async def test_minicpmo_auto_response_post_speak_listen_continues_same_response(
             "model_listen": True,
             "data_plane_request_id": request_id,
             "end_of_turn": False,
+            "model_turn_id": 3,
+            "input_seq": 300,
             "uses_model_runner_scheduler": True,
             "runner_kv_backed": True,
             "runtime_impl": "scheduler_data_plane",
         },
         session=session,
-        expected_epoch=session.epoch,
+        expected_epoch=0,
     )
-    await asyncio.sleep(0.01)
 
-    assert len(engine.appended) == 1
-    assert session.active_response_id == response_id
+    processed = next(event for event in ws.sent if event.get("type") == "input.processed")
+    assert processed == {
+        "type": "input.processed",
+        "session_id": session.session_id,
+        "epoch": 0,
+        "processed_input_seq": 300,
+        "outcome": "speak",
+        "response_id": response_id,
+    }
+    assert "response.listen" in ws.sent_types()
+    assert any(event.get("type") == "response.done" and event.get("response_id") == response_id for event in ws.sent)
+    assert session.active_response_id is None
     assert session.active_request_id == request_id
-    assert "response.listen" not in ws.sent_types()
-    assert "response.done" not in ws.sent_types()
+    assert session.history[-1] == {"role": "assistant", "content": "old answer"}
+    assert handler._minicpmo_data_plane.is_terminal(request_id)
 
 
 @pytest.mark.asyncio
@@ -3252,6 +3407,7 @@ async def test_minicpmo_auto_response_turn_end_preserves_resumable_request():
     session.capabilities = DuplexCapabilities.minicpmo45_native()
     session.begin_response(turn_id=0)
     session.bind_request(request_id)
+    continuations = _capture_pending_continuations(handler, session, (6, 0), (7, 1))
     ws = TimedWebSocket()
 
     await handler._send_one_native_duplex_event(
@@ -3267,6 +3423,7 @@ async def test_minicpmo_auto_response_turn_end_preserves_resumable_request():
             "audio_duration_ms": 100,
             "end_of_turn": True,
             "model_turn_id": 0,
+            "input_seq": 6,
             "uses_model_runner_scheduler": True,
             "runner_kv_backed": True,
             "runtime_impl": "scheduler_data_plane",
@@ -3278,6 +3435,8 @@ async def test_minicpmo_auto_response_turn_end_preserves_resumable_request():
     assert session.active_response_id is None
     assert session.active_request_id == request_id
     assert "response.done" in ws.sent_types()
+    assert len(continuations) == 1
+    assert continuations[0]["duplex_origin_input_seq"] == 7
 
 
 @pytest.mark.asyncio
@@ -3290,6 +3449,7 @@ async def test_minicpmo_auto_response_empty_turn_end_emits_model_listen():
     )
     session.capabilities = DuplexCapabilities.minicpmo45_native()
     session.bind_request(request_id)
+    continuations = _capture_pending_continuations(handler, session, (6, 0), (7, 1))
     ws = TimedWebSocket()
 
     close_reason, emitted = await handler._send_one_native_duplex_event(
@@ -3305,6 +3465,7 @@ async def test_minicpmo_auto_response_empty_turn_end_emits_model_listen():
             "end_of_turn": True,
             "abort_data_plane_request": True,
             "model_turn_id": 0,
+            "input_seq": 6,
             "uses_model_runner_scheduler": True,
             "runner_kv_backed": True,
             "runtime_impl": "scheduler_data_plane",
@@ -3318,9 +3479,12 @@ async def test_minicpmo_auto_response_empty_turn_end_emits_model_listen():
     assert session.turn_id == 1
     assert session.active_request_id == request_id
     assert session.active_response_id is None
-    assert ws.sent_types() == ["response.listen"]
-    assert ws.sent[0]["model_listen"] is True
-    assert ws.sent[0]["reason"] == "model_turn_completed_without_output"
+    assert ws.sent_types() == ["input.processed", "response.listen"]
+    assert ws.sent[1]["model_listen"] is True
+    assert ws.sent[1]["reason"] == "model_turn_completed_without_output"
+    assert len(continuations) == 1
+    assert continuations[0]["duplex_turn_id"] == 1
+    assert continuations[0]["duplex_origin_input_seq"] == 7
 
 
 @pytest.mark.asyncio
@@ -3590,12 +3754,12 @@ async def test_minicpmo_native_duplex_session_close_cleans_auto_response_data_pl
 
     event = _native_session_create(session_id)
     event["session"]["extra_body"]["auto_response"] = True
+    event["session"]["idle_timeout_s"] = 3
     ws = TimedWebSocket()
     ws.put(event)
     ws.put({"type": "session.close"})
 
     await handler.handle_session(ws)
-
     assert not handler._minicpmo_data_plane.has_request(request_id)
     assert session_id not in handler._minicpmo_sessions
 
@@ -5347,6 +5511,7 @@ async def test_failed_final_append_keeps_committed_audio_for_response_retry():
     assert len(engine.appended) == 2
     assert engine.appended[0][2]["audio"] == engine.appended[1][2]["audio"]
     assert engine.append_operation_ids[0] == engine.append_operation_ids[1]
+    assert any(event.get("code") == "runtime_append_failed" for event in ws.sent)
 
 
 @pytest.mark.asyncio
@@ -5838,10 +6003,7 @@ async def test_minicpmo_auto_response_restarts_drain_when_append_races_idle_exit
 ):
     request_id = "duplex-sid-native-late-output-e0-stage0"
     late_output = object()
-    engine = FakeEngineClient(
-        collect_outputs=[[], [], [], [late_output]],
-        collect_delay_s=0.05,
-    )
+    engine = FakeEngineClient(collect_outputs=[[], [], [], [late_output]], collect_delay_s=0.05)
     handler = OmniDuplexSessionHandler(
         chat_service=FakeChatService(engine),
         config_timeout_s=0.1,
@@ -5854,6 +6016,7 @@ async def test_minicpmo_auto_response_restarts_drain_when_append_races_idle_exit
     session.capabilities = DuplexCapabilities.minicpmo45_native()
     session.bind_request(request_id)
     native = handler._minicpmo_session_state(session)
+    ws = TimedWebSocket()
     projected_batches: list[object] = []
     projected = asyncio.Event()
 
@@ -5878,7 +6041,7 @@ async def test_minicpmo_auto_response_restarts_drain_when_append_races_idle_exit
 
     assert (
         await handler._start_native_data_plane_stream_task(
-            None,
+            ws.send_json,
             result,
             session=session,
             expected_epoch=session.epoch,
@@ -5891,7 +6054,7 @@ async def test_minicpmo_auto_response_restarts_drain_when_append_races_idle_exit
 
     assert (
         await handler._start_native_data_plane_stream_task(
-            None,
+            ws.send_json,
             result,
             session=session,
             expected_epoch=session.epoch,
@@ -5903,6 +6066,87 @@ async def test_minicpmo_auto_response_restarts_drain_when_append_races_idle_exit
 
     assert len(engine.collected) == 4
     assert projected_batches == [{"data_plane_outputs": [late_output]}]
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_closing_session_is_not_restarted_after_continuation_wait(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    request_id = "duplex-sid-native-close-during-continuation-e0-stage0"
+    engine = FakeEngineClient(collect_outputs=[[], [], []])
+    handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
+    session = DuplexSession(
+        session_id="sid-native-close-during-continuation",
+        config=DuplexSessionConfig(extra_body={"auto_response": True}),
+    )
+    session.capabilities = DuplexCapabilities.minicpmo45_native()
+    session.bind_request(request_id)
+    native = handler._minicpmo_session_state(session)
+    native.record_accepted_input(epoch=0, seq=7, model_turn_id=0)
+    continuation_started = asyncio.Event()
+    release_continuation = asyncio.Event()
+
+    async def blocked_continuation(payload: object, **kwargs: Any) -> bool:
+        continuation_started.set()
+        await release_continuation.wait()
+        if handler._native_silence_continuation_is_stale(
+            session,
+            request_id=kwargs["request_id"],
+            response_id=kwargs["response_id"],
+            response_owned=kwargs["response_owned"],
+            expected_epoch=kwargs["expected_epoch"],
+            expected_incarnation=kwargs["expected_incarnation"],
+            expected_model_turn_id=kwargs["expected_model_turn_id"],
+        ):
+            return False
+        append_ok, _ = await handler._append_runtime_input(
+            session,
+            payload,
+            final=False,
+            send_json=kwargs["send_json"],
+            mode="append_audio_chunk",
+            expected_epoch=kwargs["expected_epoch"],
+        )
+        return append_ok
+
+    native.silence_continuation_scheduler = blocked_continuation
+    monkeypatch.setattr(handler, "_runtime_control_timeout_s", lambda _session: 0.001)
+    result = {
+        "stage_results": [
+            {
+                "result": {
+                    "data_plane_append": True,
+                    "request_id": request_id,
+                    "response_stage_id": 1,
+                }
+            }
+        ]
+    }
+
+    assert await handler._start_native_data_plane_stream_task(
+        TimedWebSocket().send_json,
+        result,
+        session=session,
+        expected_epoch=0,
+    )
+    drain = native.data_plane_task
+    assert drain is not None
+    assert not await handler._start_native_data_plane_stream_task(
+        TimedWebSocket().send_json,
+        result,
+        session=session,
+        expected_epoch=0,
+    )
+    await asyncio.wait_for(continuation_started.wait(), timeout=1)
+
+    session.mark_closing()
+    release_continuation.set()
+    await asyncio.wait_for(drain, timeout=1)
+
+    assert session.active_request_id == request_id
+    assert native.data_plane_task is None
+    assert engine.appended == []
+    assert len(engine.collected) == 3
 
 
 @pytest.mark.asyncio
@@ -6051,22 +6295,24 @@ async def test_minicpmo_native_duplex_accepts_next_append_after_response_done():
 
 @pytest.mark.asyncio
 async def test_minicpmo_native_auto_response_commit_finalizes_after_streamed_full_chunk():
-    control_result = {
-        "operation": "append",
-        "session_id": "sid-native-auto-finalize",
-        "ok": True,
-        "unsupported_count": 0,
-        "error_count": 0,
-        "stage_results": [],
-    }
-    engine = FakeEngineClient(control_result=control_result)
+    session_id = "sid-native-auto-finalize"
+    request_id = f"duplex-{session_id}-stage0"
+    stage_result = {"supported": True, "data_plane_append": True, "seq": 1}
+    stage_result.update(request_id=request_id, response_stage_id=1)
+    first = {"ok": True, "stage_results": [{"result": stage_result}]}
+    engine = FakeEngineClient(append_results=[first, _native_listen_append_result(session_id, request_id, 1)])
     handler = OmniDuplexSessionHandler(
         chat_service=FakeChatService(engine),
         config_timeout_s=0.1,
         idle_timeout_s=1,
     )
-    ws = TimedWebSocket()
-    event = _native_session_create("sid-native-auto-finalize")
+
+    def close_on_listen(ws: TimedWebSocket, data: dict[str, Any]) -> None:
+        if data.get("type") == "response.listen":
+            ws.put({"type": "session.close"})
+
+    ws = TimedWebSocket(on_send=close_on_listen, receive_timeout_s=3)
+    event = _native_session_create(session_id)
     event["session"]["extra_body"]["auto_response"] = True
     ws.put(event)
     ws.put(
@@ -6078,13 +6324,18 @@ async def test_minicpmo_native_auto_response_commit_finalizes_after_streamed_ful
         }
     )
     ws.put({"type": "input_audio_buffer.commit", "final": True})
-    ws.put({"type": "session.close"})
 
     await handler.handle_session(ws)
 
-    assert len(engine.appended) == 1
+    assert len(engine.appended) == 2
     assert engine.appended[0][3] is False
+    assert engine.appended[1][2]["duplex_origin_input_seq"] == 1
     assert "response.created" not in ws.sent_types()
+    committed = next(message for message in ws.sent if message.get("type") == "input.committed")
+    assert [committed[key] for key in ("session_id", "epoch", "accepted_input_seq")] == [session_id, 0, 1]
+    processed = next(message for message in ws.sent if message.get("type") == "input.processed")
+    keys = ("session_id", "epoch", "processed_input_seq", "outcome")
+    assert [processed[key] for key in keys] == [session_id, 0, 1, "listen"]
 
 
 @pytest.mark.asyncio

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -284,6 +284,7 @@ def test_code2wav_projects_duplex_metadata_to_final_audio_output():
         {
             "duplex_epoch": 3,
             "duplex_turn_id": 7,
+            "duplex_input_seq": 11,
             "llm_output_text_utf8": segment_text_utf8,
             "tts_is_last_chunk": True,
             "turn_end": False,
@@ -309,6 +310,7 @@ def test_code2wav_projects_duplex_metadata_to_final_audio_output():
     assert "meta" not in payload
     assert payload["meta.duplex_epoch"][0].item() == 3
     assert payload["meta.duplex_turn_id"][0].item() == 7
+    assert payload["meta.duplex_input_seq"][0].item() == 11
     torch.testing.assert_close(
         payload["meta.llm_output_text_utf8"][0],
         segment_text_utf8,

--- a/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
@@ -329,7 +329,7 @@ def test_talker_projects_request_aligned_duplex_metadata(mocker) -> None:
         {
             "request_id": "req-a",
             "native_duplex": True,
-            "duplex": {"epoch": 3, "turn_id": 7},
+            "duplex": {"epoch": 3, "turn_id": 7, "input_seq": 11},
             "ids": {"tts": [41]},
             "meta": {
                 "native_duplex_segment_text": "first",
@@ -340,7 +340,7 @@ def test_talker_projects_request_aligned_duplex_metadata(mocker) -> None:
         {
             "request_id": "req-b",
             "native_duplex": True,
-            "duplex": {"epoch": 4, "turn_id": 8},
+            "duplex": {"epoch": 4, "turn_id": 8, "input_seq": 12},
             "ids": {"tts": [42, 99]},
             "meta": {
                 "native_duplex_segment_text": "second",
@@ -360,6 +360,7 @@ def test_talker_projects_request_aligned_duplex_metadata(mocker) -> None:
     assert [value.item() for value in meta["native_duplex"]] == [True, True]
     assert [value.item() for value in meta["duplex_epoch"]] == [3, 4]
     assert [value.item() for value in meta["duplex_turn_id"]] == [7, 8]
+    assert [value.item() for value in meta["duplex_input_seq"]] == [11, 12]
     assert "native_duplex_segment_text" not in meta
     assert [bytes(value.tolist()).decode("utf-8") for value in meta["llm_output_text_utf8"]] == [
         "first",

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
@@ -47,6 +47,7 @@ def _duplex_delta(
     *codes: int,
     epoch: int = 3,
     turn_id: int = 7,
+    input_seq: int = 11,
     text: str = "segment",
     turn_end: bool = False,
 ):
@@ -58,6 +59,7 @@ def _duplex_delta(
             "native_duplex": torch.tensor(True),
             "duplex_epoch": torch.tensor(epoch),
             "duplex_turn_id": torch.tensor(turn_id),
+            "duplex_input_seq": torch.tensor(input_seq),
             "llm_output_text_utf8": text_utf8,
             "turn_end": torch.tensor(turn_end),
         },
@@ -179,8 +181,10 @@ def test_first_chunk_forwards_reference_voice_and_duplex_identity() -> None:
     )
     assert payload.meta.duplex_epoch == 3
     assert payload.meta.duplex_turn_id == 7
+    assert payload.meta.duplex_input_seq == 11
     assert payload.meta.tts_is_last_chunk is True
     assert payload.meta.turn_end is True
+    assert payload.meta.replace_runtime_additional_information is True
 
 
 def test_full_payload_forwards_all_codes_and_request_metadata() -> None:
@@ -194,7 +198,7 @@ def test_full_payload_forwards_all_codes_and_request_metadata() -> None:
             "segment_end": True,
             "turn_end": True,
         },
-        "duplex": {"epoch": 3, "model_turn_id": 7},
+        "duplex": {"epoch": 3, "model_turn_id": 7, "input_seq": 11},
     }
 
     payload = tts2code2wav_full_payload(
@@ -220,8 +224,10 @@ def test_full_payload_forwards_all_codes_and_request_metadata() -> None:
     assert payload.meta.native_duplex_segment_text == "hello"
     assert payload.meta.duplex_epoch == 3
     assert payload.meta.duplex_turn_id == 7
+    assert payload.meta.duplex_input_seq == 11
     assert payload.meta.segment_end is True
     assert payload.meta.turn_end is True
+    assert payload.meta.replace_runtime_additional_information is True
 
 
 def test_sync_token_only_reserves_codec_and_silence_slots() -> None:
@@ -423,6 +429,12 @@ def test_duplex_turn_end_closes_epoch_and_next_turn_restarts_sequence() -> None:
         request,
         True,
     )
+    duplicate_boundary = tts2code2wav_async_chunk(
+        manager,
+        _duplex_delta(turn_id=7, turn_end=True),
+        request,
+        True,
+    )
     next_turn = tts2code2wav_async_chunk(
         manager,
         _duplex_delta(20, turn_id=8),
@@ -435,6 +447,8 @@ def test_duplex_turn_end_closes_epoch_and_next_turn_restarts_sequence() -> None:
     assert turn_end.meta.last_chunk is True
     assert turn_end.meta.turn_end is True
     assert turn_end.meta.is_segment_finished.item() is True
+    assert duplicate_boundary is not None
+    assert duplicate_boundary.meta.replace_runtime_additional_information is True
     assert next_turn.meta.cache_epoch == turn_end.meta.cache_epoch + 1
     assert next_turn.meta.chunk_seq == 0
     assert next_turn.meta.last_chunk is False

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -111,6 +111,7 @@ def test_native_duplex_speak_segment_reaches_split_talker() -> None:
                 "chunk_eos_token_id": 9308,
                 "chunk_tts_eos_token_id": 9309,
                 "turn_eos_token_id": 9310,
+                "duplex_input_seq": 11,
             },
         },
     )
@@ -135,6 +136,7 @@ def test_native_duplex_speak_segment_reaches_split_talker() -> None:
     assert info["meta"]["segment_end"] is True
     assert info["duplex"]["epoch"] == 3
     assert info["duplex"]["turn_id"] == 7
+    assert info["duplex"]["input_seq"] == 11
 
 
 def test_native_duplex_continuation_appends_only_new_talker_condition() -> None:

--- a/tests/utils/test_mm_outputs_partition.py
+++ b/tests/utils/test_mm_outputs_partition.py
@@ -52,6 +52,7 @@ def test_partition_duplex_audio_transcript_metadata_to_client_mm():
     payload = {
         "model_outputs": torch.zeros(1, 2400),
         "meta.duplex_epoch": torch.tensor([3], dtype=torch.int32),
+        "meta.duplex_input_seq": torch.tensor([7], dtype=torch.int32),
         "meta.duplex_turn_id": torch.tensor([2], dtype=torch.int32),
         "meta.llm_output_text_utf8": torch.tensor([104, 105], dtype=torch.uint8),
         "meta.audio_text_total_chars": torch.tensor([2], dtype=torch.int32),
@@ -65,7 +66,9 @@ def test_partition_duplex_audio_transcript_metadata_to_client_mm():
     assert "meta.llm_output_text_utf8" in client
     assert "meta.audio_text_total_chars" in client
     assert "meta.duplex_epoch" in client
+    assert "meta.duplex_input_seq" in client
     assert "meta.duplex_turn_id" in client
+    assert "meta.duplex_input_seq" in inter
     assert "meta.tts_is_last_chunk" in client
     assert "meta.turn_end" in client
     assert "meta.native_duplex_segment_text" not in client

--- a/tests/worker/test_native_duplex_hooks.py
+++ b/tests/worker/test_native_duplex_hooks.py
@@ -507,6 +507,9 @@ def test_minicpmo_stage0_routes_duplex_metadata_per_batched_request():
                 "duplex": {
                     "duplex_prompt_token_ids": [101, 102],
                     "special_token_ids": {"listen_token_id": 701},
+                    "epoch": 3,
+                    "seq": 11,
+                    "turn_id": 7,
                 },
             },
             {
@@ -514,6 +517,10 @@ def test_minicpmo_stage0_routes_duplex_metadata_per_batched_request():
                 "duplex": {
                     "duplex_prompt_token_ids": [201, 202, 203],
                     "special_token_ids": {"listen_token_id": 702},
+                    "epoch": 4,
+                    "seq": 12,
+                    "input_seq": 9,
+                    "turn_id": 8,
                 },
             },
         ],
@@ -521,10 +528,13 @@ def test_minicpmo_stage0_routes_duplex_metadata_per_batched_request():
 
     prompt_rows = output.multimodal_outputs["duplex_prompt_token_ids"]
     listen_rows = output.multimodal_outputs["meta"]["listen_token_id"]
+    input_seq_rows = output.multimodal_outputs["meta"]["duplex_input_seq"]
     assert to_payload_element(prompt_rows, 0, 0, 2) == [101, 102]
     assert to_payload_element(prompt_rows, 1, 2, 4) == [201, 202, 203]
     assert int(to_payload_element(listen_rows, 0, 0, 2).reshape(-1)[0]) == 701
     assert int(to_payload_element(listen_rows, 1, 2, 4).reshape(-1)[0]) == 702
+    assert int(to_payload_element(input_seq_rows, 0, 0, 2).reshape(-1)[0]) == 11
+    assert int(to_payload_element(input_seq_rows, 1, 2, 4).reshape(-1)[0]) == 9
 
 
 def test_minicpmo_stage0_rejects_invalid_resolved_ref_audio():

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -520,6 +520,7 @@ def test_update_additional_information_deserializes_new_request_payload():
     from vllm_omni.engine.serialization import serialize_additional_information
 
     runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    runner.model.replace_runtime_additional_information = True
     conditioning = {
         "tts_token_ids": torch.tensor([1, 2]),
         "tts_hidden_states": torch.ones(2, 4),
@@ -528,6 +529,7 @@ def test_update_additional_information_deserializes_new_request_payload():
         scheduled_new_reqs=[
             SimpleNamespace(
                 req_id="r1",
+                model_intermediate_buffer={},
                 additional_information=serialize_additional_information(conditioning),
             )
         ],
@@ -541,6 +543,53 @@ def test_update_additional_information_deserializes_new_request_payload():
         runner.model_intermediate_buffer["r1"]["tts_hidden_states"],
         conditioning["tts_hidden_states"],
     )
+
+
+def test_streaming_new_request_marker_replaces_terminal_chunk_snapshot():
+    from vllm_omni.engine.serialization import serialize_additional_information
+
+    runner = _make_runner(req_ids=("r1", "r2"), hidden_size=4)
+    runner.model.replace_runtime_additional_information = True
+    terminal = {
+        "codes": {"audio": torch.tensor([1, 2])},
+        "meta": {"cache_epoch": 0, "chunk_seq": 2, "last_chunk": True},
+    }
+    peer = {
+        "codes": {"audio": torch.tensor([9])},
+        "meta": {"cache_epoch": 3, "chunk_seq": 1, "last_chunk": False},
+    }
+    runner.model_intermediate_buffer.update(r1=terminal, r2=peer)
+    marker = {
+        "meta": {
+            "finished": False,
+            "is_segment_finished": True,
+            "request_finished": False,
+        }
+    }
+    new_req = SimpleNamespace(
+        req_id="r1",
+        model_intermediate_buffer=marker,
+        additional_information=serialize_additional_information(terminal),
+    )
+
+    OmniGPUModelRunner._update_streaming_input_additional_info(runner, new_req, "r1")
+    OmniGPUModelRunner._update_additional_information(
+        runner,
+        SimpleNamespace(
+            scheduled_new_reqs=[new_req],
+            scheduled_cached_reqs=SimpleNamespace(),
+        ),
+    )
+
+    info = runner.model_intermediate_buffer["r1"]
+    assert "codes" not in info
+    assert info["meta"] == {
+        **marker["meta"],
+        "num_processed_tokens": 0,
+        "resumable": True,
+    }
+    assert runner.requests["r1"].additional_information_cpu == info
+    assert runner.model_intermediate_buffer["r2"] == peer
 
 
 def test_update_intermediate_buffer_skips_empty_update():
@@ -565,7 +614,7 @@ def test_streaming_input_update_merges_model_intermediate_buffer():
     runner = _make_runner(req_ids=("r1",), hidden_size=4)
     runner.model_intermediate_buffer["r1"] = {
         "duplex": {
-            "session_id": "sid",
+            "input_seq": 1,
             "seq": 1,
         }
     }
@@ -573,7 +622,7 @@ def test_streaming_input_update_merges_model_intermediate_buffer():
     new_req_data = SimpleNamespace(
         model_intermediate_buffer={
             "duplex": {
-                "session_id": "sid",
+                "input_seq": 2,
                 "seq": 2,
                 "payload": {"type": "audio"},
             }
@@ -584,7 +633,7 @@ def test_streaming_input_update_merges_model_intermediate_buffer():
     OmniGPUModelRunner._update_streaming_input_additional_info(runner, new_req_data, "r1")
 
     info = runner.model_intermediate_buffer["r1"]
-    assert info["duplex"]["session_id"] == "sid"
+    assert info["duplex"]["input_seq"] == 2
     assert info["duplex"]["seq"] == 2
     assert info["duplex"]["payload"] == {"type": "audio"}
     assert runner.requests["r1"].additional_information_cpu is info

--- a/vllm_omni/benchmarks/data_modules/omniinteract.py
+++ b/vllm_omni/benchmarks/data_modules/omniinteract.py
@@ -1,0 +1,903 @@
+"""OmniInteract full-video benchmark for MiniCPM native duplex serving."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import contextlib
+import io
+import json
+import math
+import os
+import random
+import shutil
+import subprocess
+import tarfile
+import time
+import wave
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from vllm.benchmarks.datasets import BenchmarkDataset, SampleRequest
+from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.hf import get_cached_tokenizer
+
+from vllm_omni.experimental.fullduplex.client import (
+    PCM16_BYTES_PER_SAMPLE,
+    PCM16_SAMPLE_RATE,
+    RealtimeDuplexClient,
+    RealtimeEventCollector,
+    _event_stage_metrics,
+    build_realtime_url,
+    wait_for,
+)
+
+_SUBSETS = {"1q1a", "1q1a_math", "1qna"}
+_OUTPUT_RATE = 24_000
+
+
+@dataclass(frozen=True)
+class OmniInteractConfig:
+    chunk_ms: int = 200
+    video_fps: float = 1.0
+    ref_audio: str | None = None
+    pace: bool = True
+    timeout_s: float = 900.0
+    output_root: str | None = None
+
+
+@dataclass(frozen=True)
+class OmniInteractCase:
+    subset: str
+    video_rel: str
+    video_path: str
+    annotation_path: str
+    scene_type: str
+    config: OmniInteractConfig
+
+
+@dataclass
+class OmniInteractSampleRequest(SampleRequest):
+    omniinteract: OmniInteractCase | None = None
+
+
+@dataclass
+class OmniInteractResult:
+    success: bool = False
+    error: str = ""
+    latency_s: float = 0.0
+    ttft_s: float = 0.0
+    audio_rtf: float = 0.0
+    generated_text: str = ""
+    pacing_mean_lag_s: float = 0.0
+    pacing_max_lag_s: float = 0.0
+    turn_metrics: list[dict[str, Any]] = field(default_factory=list)
+    official_summary: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _data_dir(root: Path) -> Path:
+    for candidate in (root, root / "data"):
+        if (candidate / "1q1a").is_dir():
+            return candidate
+    raise FileNotFoundError(f"OmniInteract data not found under {root}")
+
+
+def _safe_extract(handle: tarfile.TarFile, target: Path) -> None:
+    root = target.resolve()
+    members = handle.getmembers()
+    for member in members:
+        path = Path(member.name)
+        destination = (root / path).resolve()
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or (destination != root and root not in destination.parents)
+            or not (member.isdir() or member.isfile())
+        ):
+            raise ValueError(f"Unsafe path in OmniInteract archive: {member.name!r}")
+    handle.extractall(target, members=members)
+
+
+def _extract(archive: Path, target: Path) -> Path:
+    marker = target / ".source"
+    fingerprint = f"{archive.stat().st_size}:{archive.stat().st_mtime_ns}"
+    if marker.is_file() and marker.read_text().strip() == fingerprint:
+        try:
+            return _data_dir(target)
+        except FileNotFoundError:
+            pass
+    shutil.rmtree(target, ignore_errors=True)
+    target.mkdir(parents=True)
+    with tarfile.open(archive, "r:*") as handle:
+        _safe_extract(handle, target)
+    marker.write_text(fingerprint)
+    return _data_dir(target)
+
+
+def resolve_omniinteract_root(dataset_path: str | None, explicit_root: str | None = None) -> Path:
+    value = explicit_root or dataset_path
+    if not value:
+        value = "lucky-lance/OmniInteract"
+    local = Path(value).expanduser()
+    if explicit_root and not local.is_dir():
+        raise FileNotFoundError(f"--omniinteract-root is not a directory: {local.resolve()}")
+    if local.is_dir():
+        try:
+            return _data_dir(local.resolve())
+        except FileNotFoundError:
+            for name in ("data.tar.gz", "data.tar"):
+                archive = local / name
+                if archive.is_file():
+                    return _extract(archive, local / ".vllm_omni_extracted")
+            raise
+    from huggingface_hub import hf_hub_download
+
+    archive: Path | None = None
+    for name in ("data.tar.gz", "data.tar"):
+        try:
+            archive = Path(hf_hub_download(repo_id=value, filename=name, repo_type="dataset"))
+            break
+        except Exception:
+            continue
+    if archive is None:
+        raise FileNotFoundError(f"Could not download OmniInteract data archive from {value!r}")
+    cache = Path(os.environ.get("HF_HOME", Path.home() / ".cache")) / "vllm_omni" / "omniinteract"
+    return _extract(archive, cache / value.replace("/", "__"))
+
+
+class OmniInteractDataset(BenchmarkDataset):
+    SUPPORTED_DATASET_PATHS = {"lucky-lance/OmniInteract"}
+    DEFAULT_OUTPUT_LEN = 1
+    IS_MULTIMODAL = True
+
+    def __init__(
+        self,
+        dataset_path: str | None,
+        *,
+        data_root: str | None,
+        subsets: list[str],
+        config: OmniInteractConfig,
+        random_seed: int = 0,
+        disable_shuffle: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        invalid = set(subsets) - _SUBSETS
+        if invalid:
+            raise ValueError(f"Unsupported OmniInteract subsets: {sorted(invalid)}")
+        self.config = config
+        self.subsets = subsets
+        self.root = resolve_omniinteract_root(dataset_path, data_root)
+        super().__init__(
+            dataset_path=dataset_path or str(self.root),
+            random_seed=random_seed,
+            disable_shuffle=disable_shuffle,
+            **kwargs,
+        )
+        self.data = self._cases()
+        if not self.data:
+            raise ValueError(f"No OmniInteract sessions found under {self.root}")
+        if not disable_shuffle:
+            random.Random(random_seed).shuffle(self.data)
+
+    def _cases(self) -> list[OmniInteractCase]:
+        cases: list[OmniInteractCase] = []
+        for subset in self.subsets:
+            root = self.root / subset
+            if subset != "1qna":
+                mapping = root / "video_json_map.json"
+                entries = json.loads(mapping.read_text()).get("entries", []) if mapping.is_file() else []
+                for row in entries:
+                    video_rel, annotation_rel = str(row.get("video") or ""), str(row.get("annotation") or "")
+                    video, annotation = root / video_rel, root / annotation_rel
+                    if video.is_file() and annotation.is_file():
+                        cases.append(
+                            OmniInteractCase(
+                                subset,
+                                video_rel,
+                                str(video.resolve()),
+                                str(annotation.resolve()),
+                                str(row.get("scene_type") or "multi_turn").lower(),
+                                self.config,
+                            )
+                        )
+                continue
+            videos, annotations = root / "videos_bench", root / "annotations"
+            for video in sorted(videos.rglob("*.mp4")) if videos.is_dir() else []:
+                relative = video.relative_to(videos)
+                annotation = (annotations / relative).with_suffix(".json")
+                if annotation.is_file():
+                    cases.append(
+                        OmniInteractCase(
+                            subset,
+                            str(video.relative_to(root)),
+                            str(video.resolve()),
+                            str(annotation.resolve()),
+                            "1qna",
+                            self.config,
+                        )
+                    )
+        return cases
+
+    def sample(
+        self,
+        tokenizer: TokenizerLike,
+        num_requests: int,
+        output_len: int | None = None,
+        request_id_prefix: str = "",
+        no_oversample: bool = False,
+        **_: Any,
+    ) -> list[SampleRequest]:
+        tokenizer = get_cached_tokenizer(tokenizer)
+        requests: list[SampleRequest] = []
+        for index, case in enumerate(self.data[:num_requests]):
+            prompt = f"OmniInteract: {case.subset}/{case.video_rel}"
+            requests.append(
+                OmniInteractSampleRequest(
+                    prompt=prompt,
+                    prompt_len=len(tokenizer.encode(prompt)),
+                    expected_output_len=output_len or self.DEFAULT_OUTPUT_LEN,
+                    request_id=f"{request_id_prefix}{index}",
+                    omniinteract=case,
+                )
+            )
+        self.maybe_oversample_requests(requests, num_requests, request_id_prefix, no_oversample)
+        return requests
+
+
+def validate_config(config: OmniInteractConfig) -> None:
+    if not 0 < config.chunk_ms <= 1000:
+        raise ValueError("OmniInteract chunk_ms must be in [1, 1000]")
+    if not math.isfinite(config.video_fps) or not 0 < config.video_fps <= 1:
+        raise ValueError("MiniCPM duplex supports video_fps in (0, 1]")
+    if config.output_root and (not config.pace or config.chunk_ms != 200 or config.video_fps != 1):
+        raise ValueError("Official OmniInteract output requires realtime pacing, 200 ms audio, and 1 FPS video")
+
+
+def _run(command: list[str], *, text: bool = False) -> subprocess.CompletedProcess:
+    result = subprocess.run(command, capture_output=True, check=False, text=text)
+    if result.returncode:
+        error = result.stderr if text else result.stderr.decode("utf-8", "ignore")
+        raise RuntimeError(f"Command failed: {error.strip()}")
+    return result
+
+
+def prepare_media(video: Path, fps: float) -> tuple[float, bytes, list[str | None]]:
+    duration = float(
+        _run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(video),
+            ],
+            text=True,
+        ).stdout.strip()
+    )
+    pcm = _run(
+        [
+            "ffmpeg",
+            "-loglevel",
+            "error",
+            "-i",
+            str(video),
+            "-vn",
+            "-f",
+            "s16le",
+            "-ac",
+            "1",
+            "-ar",
+            str(PCM16_SAMPLE_RATE),
+            "pipe:1",
+        ]
+    ).stdout
+    target = math.ceil(duration) * PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE
+    pcm = (pcm + bytes(max(0, target - len(pcm))))[:target]
+
+    import imageio.v3 as iio
+    from PIL import Image
+
+    source_fps = float(iio.immeta(str(video)).get("fps") or 30)
+    indices = [int((index + 0.5) * source_fps / fps) for index in range(math.ceil(duration * fps))]
+    frames: list[str | None] = [None] * len(indices)
+    cursor = 0
+    for index, frame in enumerate(iio.imiter(str(video))):
+        if cursor == len(indices):
+            break
+        if index < indices[cursor]:
+            continue
+        image = Image.fromarray(frame)
+        image.thumbnail((640, 640))
+        output = io.BytesIO()
+        image.save(output, "JPEG", quality=85)
+        while cursor < len(indices) and index >= indices[cursor]:
+            frames[cursor] = base64.b64encode(output.getvalue()).decode()
+            cursor += 1
+    return duration, pcm, frames
+
+
+@dataclass(frozen=True)
+class _AudioSegment:
+    response_id: str
+    start_s: float
+    samples: int
+    rate: int
+
+
+class _Playback:
+    def __init__(self) -> None:
+        self.cursor = 0
+        self.end_s = 0.0
+        self.segments: list[_AudioSegment] = []
+        self.acked: dict[str, int] = {}
+        self.completed: set[str] = set()
+        self.completion_acked: set[str] = set()
+
+    async def acknowledge(self, client: RealtimeDuplexClient, now: float | None = None) -> None:
+        events = client.events
+        while self.cursor < len(events.events):
+            index, self.cursor = self.cursor, self.cursor + 1
+            event = events.events[index]
+            if event.get("type") == "response.done":
+                if response_id := events.response_id(event):
+                    self.completed.add(response_id)
+                continue
+            if event.get("type") != "response.audio.delta":
+                continue
+            response_id, encoded = events.response_id(event), event.get("delta") or event.get("audio")
+            if not response_id or not isinstance(encoded, str):
+                continue
+            samples = len(base64.b64decode(encoded)) // PCM16_BYTES_PER_SAMPLE
+            rate = int(event.get("sample_rate_hz") or events.output_sample_rate_hz or _OUTPUT_RATE)
+            start = max(events.event_received_at_s[index], self.end_s)
+            self.segments.append(_AudioSegment(response_id, start, samples, rate))
+            self.end_s = start + samples / rate
+        now = time.monotonic() if now is None else now
+        played: dict[str, int] = {}
+        for segment in self.segments:
+            samples = min(segment.samples, max(0, round((now - segment.start_s) * segment.rate)))
+            played[segment.response_id] = played.get(segment.response_id, 0) + samples * 1000 // segment.rate
+        for response_id, played_ms in played.items():
+            completion_due = response_id in self.completed and response_id not in self.completion_acked
+            if played_ms <= self.acked.get(response_id, -1) and not completion_due:
+                continue
+            await client.send(
+                {
+                    "type": "playback.ack",
+                    "response_id": response_id,
+                    "item_id": f"item_{response_id}",
+                    "played_ms": played_ms,
+                    "committed_ms": played_ms,
+                }
+            )
+            self.acked[response_id] = played_ms
+            if response_id in self.completed:
+                self.completion_acked.add(response_id)
+
+
+async def _stream(
+    client: RealtimeDuplexClient,
+    pcm: bytes,
+    frames: list[str | None],
+    config: OmniInteractConfig,
+    playback: _Playback,
+) -> tuple[int, int, float, float]:
+    chunk_bytes = PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE * config.chunk_ms // 1000
+    bytes_per_second = PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE
+    start, frame_cursor, sent_frames = time.monotonic(), 0, 0
+    lags: list[float] = []
+    for offset in range(0, len(pcm), chunk_bytes):
+        end = min(offset + chunk_bytes, len(pcm))
+        end_ms = end * 1000 // bytes_per_second
+        lags.append(max(0.0, time.monotonic() - (start + offset / bytes_per_second)))
+        ready: list[str] = []
+        while frame_cursor < len(frames) and end_ms >= (frame_cursor + 0.5) * 1000 / config.video_fps:
+            if frames[frame_cursor]:
+                ready.append(frames[frame_cursor] or "")
+            frame_cursor += 1
+        payload: dict[str, object] = {
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(pcm[offset:end]).decode(),
+            "input_audio_format": "pcm16",
+            "sample_rate_hz": PCM16_SAMPLE_RATE,
+            "duration_ms": (end - offset) * 1000 // bytes_per_second,
+            "audio_end_ms": end_ms,
+        }
+        if ready:
+            payload["video_frames"] = ready
+        await client.send(payload)
+        sent_frames += len(ready)
+        if config.pace:
+            await playback.acknowledge(client)
+            await asyncio.sleep(max(0.0, start + end_ms / 1000 - time.monotonic()))
+    lags.append(max(0.0, time.monotonic() - (start + len(pcm) / bytes_per_second)))
+    return math.ceil(len(pcm) / chunk_bytes), sent_frames, sum(lags) / len(lags), max(lags)
+
+
+def _identity(event: dict[str, object], prefix: str) -> tuple[str, int, int] | None:
+    session_id, epoch, seq = event.get("session_id"), event.get("epoch"), event.get(f"{prefix}_input_seq")
+    if (
+        isinstance(session_id, str)
+        and bool(session_id)
+        and isinstance(epoch, int)
+        and not isinstance(epoch, bool)
+        and isinstance(seq, int)
+        and not isinstance(seq, bool)
+        and seq > 0
+    ):
+        return session_id, epoch, seq
+    return None
+
+
+def _done_for(collector: RealtimeEventCollector, response_id: str) -> dict[str, object] | None:
+    return next(
+        (
+            event
+            for event in collector.events
+            if event.get("type") == "response.done" and collector.response_id(event) == response_id
+        ),
+        None,
+    )
+
+
+def _needs_legacy_drain(pcm: bytes, events: list[dict[str, object]]) -> bool:
+    period_ms = 1000
+    for event in reversed(events):
+        session = event.get("session")
+        capabilities = session.get("capabilities") if isinstance(session, dict) else None
+        value = capabilities.get("chunk_period_ms") if isinstance(capabilities, dict) else None
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            period_ms = value
+            break
+    unit_bytes = PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE * period_ms // 1000
+    active = sum(event.get("type") == "response.created" for event in events) > sum(
+        event.get("type") == "response.done" for event in events
+    )
+    return active or bool(unit_bytes and len(pcm) % unit_bytes)
+
+
+def _legacy_decision(events: list[dict[str, object]], committed_index: int) -> bool:
+    return any(
+        event.get("type") == "response.listen"
+        or (event.get("type") == "response.done" and _status(event) != "cancelled")
+        for event in events[committed_index + 1 :]
+    )
+
+
+def _status(event: dict[str, object]) -> str | None:
+    response = event.get("response")
+    return str(response.get("status")) if isinstance(response, dict) and response.get("status") else event.get("status")  # type: ignore[return-value]
+
+
+def _raise_if_session_terminated(events: list[dict[str, object]], from_index: int) -> None:
+    for event in events[from_index:]:
+        event_type = event.get("type")
+        if event_type not in {"session.expired", "session.closed"}:
+            continue
+        nested = event.get("event")
+        reason = event.get("reason")
+        if reason is None and isinstance(nested, dict):
+            reason = nested.get("reason")
+        detail = f": {reason}" if reason else ""
+        raise RuntimeError(f"{event_type}{detail}")
+
+
+async def _wait_final(collector: RealtimeEventCollector, commit_from: int, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        errors = collector.errors()
+        if errors:
+            raise RuntimeError(str(errors[-1]))
+        _raise_if_session_terminated(collector.events, commit_from)
+        commit = next(
+            (event for event in collector.events[commit_from:] if event.get("type") == "input_audio_buffer.committed"),
+            None,
+        )
+        key = _identity(commit, "accepted") if commit else None
+        if commit is not None and key is None:
+            raise RuntimeError("input_audio_buffer.committed must include session_id, epoch, and accepted_input_seq")
+        if key is None:
+            await asyncio.sleep(0.02)
+            continue
+        processed = next(
+            (
+                event
+                for event in collector.events
+                if event.get("type") == "input_audio_buffer.processed" and _identity(event, "processed") == key
+            ),
+            None,
+        )
+        if processed:
+            outcome = processed.get("outcome")
+            if outcome == "failed":
+                raise RuntimeError("final input processing failed")
+            if outcome == "listen":
+                return
+            if outcome != "speak":
+                raise RuntimeError(f"invalid final input processing outcome: {outcome!r}")
+            response_id = processed.get("response_id")
+            if not isinstance(response_id, str) or not response_id:
+                raise RuntimeError("processed speak outcome has no response_id")
+            done = _done_for(collector, response_id)
+            if done:
+                if _status(done) != "completed":
+                    raise RuntimeError(f"final response status is {_status(done)!r}")
+                if not collector.audio_bytes(response_id):
+                    raise RuntimeError("processed speak response has no audio")
+                return
+        await asyncio.sleep(0.02)
+    raise TimeoutError("final accepted input was not processed before timeout")
+
+
+async def _wait_committed(collector: RealtimeEventCollector, commit_from: int, timeout_s: float) -> int:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        errors = collector.errors()
+        if errors:
+            raise RuntimeError(str(errors[-1]))
+        _raise_if_session_terminated(collector.events, commit_from)
+        for index in range(commit_from, len(collector.events)):
+            if collector.events[index].get("type") == "input_audio_buffer.committed":
+                return index
+        await asyncio.sleep(0.02)
+    raise TimeoutError("input_audio_buffer.committed was not received before timeout")
+
+
+def _response_text(collector: RealtimeEventCollector, response_id: str) -> str:
+    return "".join(
+        str(event.get("delta") or "")
+        for event in collector.events
+        if collector.response_id(event) == response_id
+        and event.get("type") in {"response.audio_transcript.delta", "response.output_text.delta"}
+    )
+
+
+def _positive_ms(value: object) -> float:
+    try:
+        milliseconds = float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return milliseconds / 1000 if math.isfinite(milliseconds) and milliseconds > 0 else 0.0
+
+
+def _turn_metrics(collector: RealtimeEventCollector, stream_start: float) -> list[dict[str, Any]]:
+    metrics: list[dict[str, Any]] = []
+    rate = collector.output_sample_rate_hz or _OUTPUT_RATE
+    for turn_index, response_id in enumerate(collector.response_ids):
+        created: float | None = None
+        first_text: float | None = None
+        first_audio: float | None = None
+        done: float | None = None
+        stage0_metrics: dict[str, object] | None = None
+        for event, received in zip(collector.events, collector.event_received_at_s, strict=True):
+            if collector.response_id(event) != response_id:
+                continue
+            event_type = event.get("type")
+            if event_type == "response.created" and created is None:
+                created = received
+            if event_type in {"response.output_text.delta", "response.audio_transcript.delta"} and first_text is None:
+                first_text = received
+            if event_type == "response.audio.delta" and first_audio is None:
+                first_audio = received
+            if event_type == "response.done":
+                done = received
+            stage_metrics = _event_stage_metrics(event)
+            stage0 = stage_metrics.get("0") if isinstance(stage_metrics, dict) else None
+            if isinstance(stage0, dict):
+                stage0_metrics = stage0
+        origin = created if created is not None else stream_start
+        audio_s = len(collector.audio_bytes(response_id)) / (rate * PCM16_BYTES_PER_SAMPLE)
+        generation_s = max(0.0, done - created) if done is not None and created is not None else 0.0
+        first_output = first_text if first_text is not None else first_audio
+        observed_ttft = max(0.0, first_output - origin) if first_output is not None else 0.0
+        stage_ttft = _positive_ms((stage0_metrics or {}).get("vllm_ttft_ms"))
+        stage_tpot = _positive_ms((stage0_metrics or {}).get("vllm_tpot_ms"))
+        metrics.append(
+            {
+                "turn_index": turn_index,
+                "response_id": response_id,
+                "video_time_s": max(0.0, origin - stream_start),
+                "ttft_s": stage_ttft or observed_ttft,
+                "tpot_s": stage_tpot,
+                "rtf": generation_s / audio_s if generation_s > 0 and audio_s > 0 else 0.0,
+                "audio_duration_s": audio_s,
+                "response_generation_s": generation_s,
+                "generated_text": _response_text(collector, response_id),
+                "success": bool(_response_text(collector, response_id).strip() or audio_s > 0),
+                "error": "",
+            }
+        )
+    return metrics
+
+
+def validate_output(collector: RealtimeEventCollector) -> int:
+    sample_rate: int | None = None
+    created = {
+        response_id
+        for event in collector.events
+        if event.get("type") == "response.created" and (response_id := collector.response_id(event)) is not None
+    }
+    for event in collector.events:
+        response = event.get("response") if isinstance(event.get("response"), dict) else {}
+        details = event.get("status_details") if isinstance(event.get("status_details"), dict) else {}
+        response_details = response.get("status_details") if isinstance(response.get("status_details"), dict) else {}
+        states = {event.get("status"), response.get("status"), details.get("type"), response_details.get("type")}
+        if event.get("type") == "response.done" and "failed" in states:
+            raise ValueError("response.done reports failure")
+        if event.get("type") != "response.audio.delta":
+            continue
+        response_id = collector.response_id(event)
+        if not response_id or response_id not in created:
+            raise ValueError("response audio has no matching response.created")
+        if event.get("format") != "pcm16":
+            raise ValueError("official output requires pcm16 audio")
+        rate = event.get("sample_rate_hz")
+        if isinstance(rate, bool) or not isinstance(rate, int) or rate <= 0 or sample_rate not in (None, rate):
+            raise ValueError("response audio sample rate is missing or inconsistent")
+        sample_rate = rate
+        encoded = event.get("delta") or event.get("audio")
+        if not isinstance(encoded, str) or not encoded:
+            raise ValueError("response audio payload is missing")
+        try:
+            raw = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError("response audio is not valid base64") from exc
+        if len(raw) % PCM16_BYTES_PER_SAMPLE:
+            raise ValueError("response audio is not PCM16 aligned")
+    return sample_rate or _OUTPUT_RATE
+
+
+def _output_dir(root: Path, case: OmniInteractCase) -> Path:
+    relative = case.video_rel.replace("\\", "/")
+    if case.subset == "1qna" and relative.startswith("videos_bench/"):
+        relative = relative.removeprefix("videos_bench/")
+    return root / case.subset / relative.removesuffix(".mp4").replace("/", "__")
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+
+
+def _write_wav(path: Path, pcm: bytes, rate: int) -> None:
+    with wave.open(str(path), "wb") as output:
+        output.setparams((1, PCM16_BYTES_PER_SAMPLE, rate, 0, "NONE", "not compressed"))
+        output.writeframes(pcm)
+
+
+def write_artifacts(
+    root: Path,
+    case: OmniInteractCase,
+    collector: RealtimeEventCollector,
+    stream_start: float,
+    duration: float,
+    inference_s: float,
+    stats: dict[str, Any],
+) -> dict[str, Any]:
+    directory = _output_dir(root, case)
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in (".done", ".failed.json", "output.json", "wav_transcript_aligned.json", "precise_truncation.json"):
+        (directory / name).unlink(missing_ok=True)
+    try:
+        rate = validate_output(collector)
+        horizon = math.ceil(duration)
+        output = bytearray(horizon * rate * PCM16_BYTES_PER_SAMPLE)
+        cursor_s = 0.0
+        response_times: dict[str, list[float]] = {}
+        for event, received in zip(collector.events, collector.event_received_at_s, strict=True):
+            if event.get("type") != "response.audio.delta":
+                continue
+            response_id = collector.response_id(event)
+            assert response_id is not None
+            raw = base64.b64decode(str(event.get("delta") or event.get("audio")), validate=True)
+            start = max(received - stream_start, cursor_s)
+            end = start + len(raw) / (rate * PCM16_BYTES_PER_SAMPLE)
+            offset = round(start * rate) * PCM16_BYTES_PER_SAMPLE
+            output[offset : min(len(output), offset + len(raw))] = raw[: max(0, len(output) - offset)]
+            cursor_s = end
+            timing = response_times.setdefault(response_id, [start, end])
+            timing[0], timing[1] = min(timing[0], start), max(timing[1], end)
+        chunks = []
+        for response_id in collector.response_ids:
+            text, timing = _response_text(collector, response_id), response_times.get(response_id)
+            if text and timing and timing[0] < horizon:
+                chunks.append(
+                    {
+                        "text": text,
+                        "timestamp": [round(timing[0], 6), round(min(timing[1], horizon), 6)],
+                    }
+                )
+        _write_wav(directory / "output.wav", bytes(output), rate)
+        _write_json(directory / "wav_transcript.json", {"text": " ".join(c["text"] for c in chunks), "chunks": chunks})
+        summary = {
+            "video": str(Path(case.video_path).resolve()),
+            "output_dir": str(directory.resolve()),
+            "annotation": str(Path(case.annotation_path).resolve()),
+            "subset": case.subset,
+            "scene_type": "1QnA" if case.scene_type == "1qna" else case.scene_type,
+            "duration_sec": round(duration, 6),
+            "inference_sec": round(inference_s, 6),
+            "paced_e2e_ratio": round(inference_s / duration, 6),
+            "status": "ok",
+            **stats,
+        }
+        _write_json(directory / ".done", summary)
+        return summary
+    except Exception as exc:
+        failure_summary(root, case, str(exc))
+        raise ValueError(str(exc)) from exc
+
+
+def failure_summary(root: Path, case: OmniInteractCase, error: str) -> dict[str, Any]:
+    directory = _output_dir(root, case)
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in (".done", "output.json", "wav_transcript_aligned.json", "precise_truncation.json"):
+        (directory / name).unlink(missing_ok=True)
+    summary = {
+        "video": case.video_path,
+        "output_dir": str(directory.resolve()),
+        "annotation": case.annotation_path,
+        "subset": case.subset,
+        "scene_type": "1QnA" if case.scene_type == "1qna" else case.scene_type,
+        "status": "error",
+        "error": error,
+    }
+    _write_json(directory / ".failed.json", summary)
+    return summary
+
+
+def write_batch(root: Path, summaries: list[dict[str, Any]]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    successes = [row for row in summaries if row.get("status") == "ok"]
+    _write_json(
+        root / "batch_summary.json",
+        {
+            "total": len(summaries),
+            "success": len(successes),
+            "failed": len(summaries) - len(successes),
+            "results": summaries,
+        },
+    )
+    rows = [
+        {
+            "sample_id": f"{row['subset']}__{Path(row['output_dir']).name}",
+            "gt_json": row["annotation"],
+            "model_json": str((Path(row["output_dir"]) / "wav_transcript.json").resolve()),
+            "scene_type": row["scene_type"],
+        }
+        for row in successes
+    ]
+    (root / "official_eval_manifest.jsonl").write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows)
+    )
+
+
+def _ws_url(api_url: str, model: str, session_id: str) -> str:
+    parts = urlsplit(api_url)
+    if parts.scheme in {"http", "https"}:
+        parts = parts._replace(scheme="ws" if parts.scheme == "http" else "wss")
+    return build_realtime_url(urlunsplit(parts), model, autostart=False, session_id=session_id)
+
+
+def _ref_audio(config: OmniInteractConfig) -> str | None:
+    if not config.ref_audio:
+        return None
+    path = Path(config.ref_audio).expanduser()
+    return "data:audio/wav;base64," + base64.b64encode(path.read_bytes()).decode()
+
+
+async def probe_omniinteract(case: OmniInteractCase, api_url: str, model: str) -> None:
+    """Check the Realtime endpoint without replaying an entire benchmark video."""
+    validate_config(case.config)
+    session_id = f"omniinteract:probe:{time.monotonic_ns()}"
+    async with RealtimeDuplexClient(_ws_url(api_url, model, session_id)) as client:
+        await client.configure(
+            model,
+            ref_audio=_ref_audio(case.config),
+            session_id=session_id,
+            idle_timeout_s=case.config.timeout_s,
+            timeout_s=min(case.config.timeout_s, 20),
+        )
+        await client.close_session(timeout_s=min(case.config.timeout_s, 20))
+
+
+async def run_omniinteract(case: OmniInteractCase, api_url: str, model: str, request_id: str) -> OmniInteractResult:
+    result = OmniInteractResult()
+    validate_config(case.config)
+    output_root = Path(case.config.output_root) if case.config.output_root and request_id else None
+    session_started: float | None = None
+    try:
+        preprocess = time.monotonic()
+        duration, pcm, frames = await asyncio.to_thread(prepare_media, Path(case.video_path), case.config.video_fps)
+        preprocess_s = time.monotonic() - preprocess
+        session_started = time.monotonic()
+        session_id = f"omniinteract:{case.subset}:{request_id or 'probe'}"
+        async with RealtimeDuplexClient(_ws_url(api_url, model, session_id)) as client:
+            await client.configure(
+                model,
+                ref_audio=_ref_audio(case.config),
+                session_id=session_id,
+                idle_timeout_s=case.config.timeout_s,
+                timeout_s=case.config.timeout_s,
+            )
+            try:
+                stream_start, playback = time.monotonic(), _Playback()
+                chunks, frame_count, mean_lag, max_lag = await _stream(client, pcm, frames, case.config, playback)
+                commit_from = len(client.events.events)
+                await client.commit()
+                if output_root:
+                    await _wait_final(client.events, commit_from, case.config.timeout_s)
+                else:
+                    committed_index = await _wait_committed(client.events, commit_from, case.config.timeout_s)
+                    if _needs_legacy_drain(pcm, client.events.events[: committed_index + 1]):
+                        await wait_for(
+                            lambda: _legacy_decision(client.events.events, committed_index),
+                            timeout_s=case.config.timeout_s,
+                            label="post-commit model decision or response drain",
+                        )
+                await wait_for(
+                    lambda: client.events.count("response.created") <= client.events.count("response.done"),
+                    timeout_s=case.config.timeout_s,
+                    label="responses drained",
+                )
+                finished = time.monotonic()
+                if case.config.pace:
+                    await playback.acknowledge(client, finished)
+                else:
+                    await client.acknowledge_playback()
+            except Exception:
+                with contextlib.suppress(Exception):
+                    await client.close_session(timeout_s=min(case.config.timeout_s, 20))
+                raise
+            await client.close_session(timeout_s=min(case.config.timeout_s, 20))
+            result.latency_s = finished - session_started
+            result.pacing_mean_lag_s, result.pacing_max_lag_s = mean_lag, max_lag
+            result.turn_metrics = _turn_metrics(client.events, stream_start)
+            result.ttft_s = result.turn_metrics[0]["ttft_s"] if result.turn_metrics else 0.0
+            rtfs = [metric["rtf"] for metric in result.turn_metrics if metric["rtf"] > 0]
+            result.audio_rtf = sum(rtfs) / len(rtfs) if rtfs else 0.0
+            result.generated_text = "\n".join(
+                text
+                for response_id in client.events.response_ids
+                if (text := _response_text(client.events, response_id))
+            )
+            result.success = not client.events.errors()
+            if not result.success:
+                result.error = str(client.events.errors()[-1])
+            if output_root:
+                writer = write_artifacts if result.success else failure_summary
+                args = (
+                    (
+                        output_root,
+                        case,
+                        client.events,
+                        stream_start,
+                        duration,
+                        finished - stream_start,
+                        {
+                            "preprocess_sec": round(preprocess_s, 6),
+                            "input_audio_chunks": chunks,
+                            "input_video_frames": frame_count,
+                            "pacing_mean_lag_sec": round(mean_lag, 6),
+                            "pacing_max_lag_sec": round(max_lag, 6),
+                        },
+                    )
+                    if result.success
+                    else (output_root, case, result.error)
+                )
+                result.official_summary = await asyncio.to_thread(writer, *args)
+    except Exception as exc:
+        result.error, result.success = str(exc), False
+        if session_started is not None:
+            result.latency_s = max(0.0, time.monotonic() - session_started)
+        if output_root:
+            result.official_summary = await asyncio.to_thread(failure_summary, output_root, case, result.error)
+    return result

--- a/vllm_omni/benchmarks/metrics/metrics.py
+++ b/vllm_omni/benchmarks/metrics/metrics.py
@@ -188,6 +188,7 @@ def print_metrics(
     outputs: list[RequestFuncOutput] | None = None,
     selected_percentiles: list[float] | None = None,
     print_stage: bool = False,
+    continuous_session: bool = False,
 ):
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
@@ -204,9 +205,13 @@ def print_metrics(
         print("{:<40} {:<10.2f}".format("Peak concurrent requests:", metrics.max_concurrent_requests))
     if task_type != TaskType.GENERATION or "e2el" in selected_percentile_metrics:
         process_one_metric("e2el", metrics)
-    print_text_metrics(task_type, selected_percentile_metrics, metrics)
+    if continuous_session:
+        print("{:<40} {:<10}".format("Token / TPOT / ITL metrics:", "N/A"))
+        print("Use OmniInteract response metrics for response latency and audio RTF.")
+    else:
+        print_text_metrics(task_type, selected_percentile_metrics, metrics)
     if task_type == TaskType.GENERATION:
-        if _has_audio_output(metrics):
+        if not continuous_session and _has_audio_output(metrics):
             print_audio_metrics(selected_percentile_metrics, metrics)
         if _has_image_output(metrics):
             print_image_metrics(selected_percentiles or [], metrics)
@@ -698,6 +703,7 @@ def calculate_metrics(
     request_rate,
     benchmark_duration,
     print_stage: bool = False,
+    continuous_session: bool = False,
 ) -> tuple[BenchmarkMetrics, list[int]]:
     """Calculate the metrics for the benchmark.
 
@@ -961,5 +967,6 @@ def calculate_metrics(
         outputs=outputs,
         selected_percentiles=selected_percentiles,
         print_stage=print_stage,
+        continuous_session=continuous_session,
     )
     return metrics, actual_output_lens

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import copy
 import io
 import json
 import mimetypes
@@ -45,6 +46,17 @@ from vllm_omni.benchmarks.data_modules.daily_omni_dataset import (
     daily_omni_local_qa_json,
     daily_omni_local_videos_dir,
     resolve_daily_omni_local_root,
+)
+from vllm_omni.benchmarks.data_modules.omniinteract import (
+    OmniInteractCase,
+    OmniInteractConfig,
+    OmniInteractDataset,
+    OmniInteractResult,
+    OmniInteractSampleRequest,
+    failure_summary,
+    probe_omniinteract,
+    run_omniinteract,
+    write_batch,
 )
 from vllm_omni.benchmarks.data_modules.random_multi_modal_dataset import OmniRandomMultiModalDataset
 from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
@@ -151,6 +163,7 @@ def _pcm_s16le_to_seed_tts_wer_bytes(
 get_samples_old = datasets.get_samples
 
 _DEFAULT_DAILY_OMNI_REPO = "liarliar/Daily-Omni"
+_DEFAULT_OMNIINTERACT_REPO = "lucky-lance/OmniInteract"
 
 
 def _seed_tts_capture_pcm_for_wer() -> bool:
@@ -221,28 +234,142 @@ def _attach_seed_tts_to_request_func_input(sample: SampleRequest, rfi: RequestFu
     rfi.extra_body = base
 
 
-def _daily_omni_repo_from_args(args) -> str | None:
-    """Resolve HuggingFace repo id for Daily-Omni from CLI args.
+def _attach_omniinteract(sample: SampleRequest, request: RequestFuncInput) -> None:
+    if isinstance(sample, OmniInteractSampleRequest):
+        request.omniinteract = sample.omniinteract
 
-    vLLM allows ``--dataset-path`` to be a local path while the real HF id is
-    passed via ``--hf-name``. Upstream ``get_samples`` for ``hf`` only matches
-    a fixed elif-chain and never discovers Omni's loader, so we must detect
-    Daily-Omni here using either field.
-    """
-    dp = getattr(args, "dataset_path", None)
-    hn = getattr(args, "hf_name", None)
-    if dp in DailyOmniDataset.SUPPORTED_DATASET_PATHS:
-        return dp
-    if hn in DailyOmniDataset.SUPPORTED_DATASET_PATHS:
-        return hn
+
+def _hf_repo_from_args(args, supported_paths: set[str]) -> str | None:
+    for value in (getattr(args, "dataset_path", None), getattr(args, "hf_name", None)):
+        if value in supported_paths:
+            return value
     return None
 
 
+def _is_local_omniinteract_root(value: str | None) -> bool:
+    if not value:
+        return False
+    root = Path(value).expanduser()
+    return root.is_dir() and any(
+        path.exists()
+        for path in (
+            root / "1q1a",
+            root / "data" / "1q1a",
+            root / "data.tar.gz",
+            root / "data.tar",
+        )
+    )
+
+
+def _is_omniinteract_dataset(args) -> bool:
+    return args.dataset_name == "omniinteract" or (
+        args.dataset_name == "hf"
+        and (
+            _is_local_omniinteract_root(getattr(args, "dataset_path", None))
+            or _hf_repo_from_args(args, OmniInteractDataset.SUPPORTED_DATASET_PATHS) is not None
+        )
+    )
+
+
+def _project_omniinteract_result(
+    result: dict[str, Any], outputs: list[Any], input_requests: list[SampleRequest]
+) -> None:
+    invalid_metrics = ("ttft", "tpot", "itl", "audio_")
+    for key in list(result):
+        if key != "generated_texts" and any(metric in key for metric in invalid_metrics):
+            result.pop(key)
+    for key in (
+        "total_input_tokens",
+        "total_output_tokens",
+        "output_throughput",
+        "total_token_throughput",
+        "total_audio_duration_s",
+        "total_audio_frames",
+        "audio_throughput",
+        "total_images",
+        "image_throughput",
+        "average_pixels_per_image",
+        "mean_denoise_step_latency_ms",
+        "input_lens",
+        "output_lens",
+        "ttfts",
+        "itls",
+        "max_output_tokens_per_s",
+        "rtfx",
+    ):
+        result.pop(key, None)
+    result["omniinteract_realtime_metric_scope"] = (
+        "continuous_session; generic token, TPOT, ITL, and output-modality throughput metrics are undefined"
+    )
+    sessions = []
+    for output, request in zip(outputs, input_requests, strict=True):
+        case = request.omniinteract if isinstance(request, OmniInteractSampleRequest) else None
+        session = output.omniinteract
+        if session is None:
+            error = output.error or "OmniInteract request completed without a Session result"
+            session = OmniInteractResult(success=False, error=error).as_dict()
+        if case and case.config.output_root and not session.get("official_summary"):
+            error = session.get("error") or "OmniInteract Session completed without an official artifact summary"
+            session.update(
+                success=False,
+                error=error,
+                official_summary=failure_summary(Path(case.config.output_root), case, error),
+            )
+        sessions.append(session)
+    result["omniinteract_sessions"] = sessions
+    turns = [turn for session in sessions for turn in session.get("turn_metrics", [])]
+    positive_ttfts = [turn["ttft_s"] for turn in turns if turn.get("ttft_s", 0) > 0]
+    positive_tpots = [turn["tpot_s"] for turn in turns if turn.get("tpot_s", 0) > 0]
+    positive_rtfs = [turn["rtf"] for turn in turns if turn.get("rtf", 0) > 0]
+    successful = [session for session in sessions if session.get("success")]
+    first_ttfts = [session["ttft_s"] for session in successful if session.get("ttft_s", 0) > 0]
+    pacing_mean = [session.get("pacing_mean_lag_s", 0) for session in sessions]
+    pacing_max = [session.get("pacing_max_lag_s", 0) for session in sessions]
+    result.update(
+        {
+            "omniinteract_realtime_session_count": len(successful),
+            "omniinteract_realtime_session_first_response_ttft_mean_s": (
+                sum(first_ttfts) / len(first_ttfts) if first_ttfts else None
+            ),
+            "omniinteract_pacing_mean_lag_s": sum(pacing_mean) / len(pacing_mean) if pacing_mean else 0.0,
+            "omniinteract_pacing_max_lag_s": max(pacing_max, default=0.0),
+            "omniinteract_realtime_turn_count": len(turns),
+            "omniinteract_realtime_turn_ttft_mean_s": (
+                sum(positive_ttfts) / len(positive_ttfts) if positive_ttfts else None
+            ),
+            "omniinteract_realtime_turn_tpot_mean_s": (
+                sum(positive_tpots) / len(positive_tpots) if positive_tpots else None
+            ),
+            "omniinteract_realtime_turn_rtf_mean": (sum(positive_rtfs) / len(positive_rtfs) if positive_rtfs else None),
+            "omniinteract_realtime_turn_metrics": turns,
+        }
+    )
+    if turns:
+        print("\n================ OmniInteract Duplex Result ================")
+        print(f"Completed Sessions: {sum(bool(session.get('success')) for session in sessions)}")
+        print(f"Model responses: {len(turns)}")
+        if result["omniinteract_realtime_turn_ttft_mean_s"] is not None:
+            print(f"Mean TTFT / response (ms): {result['omniinteract_realtime_turn_ttft_mean_s'] * 1000:.2f}")
+        if result["omniinteract_realtime_turn_tpot_mean_s"] is not None:
+            print(f"Mean TPOT / response (ms): {result['omniinteract_realtime_turn_tpot_mean_s'] * 1000:.2f}")
+        if result["omniinteract_realtime_turn_rtf_mean"] is not None:
+            print(f"Mean audio RTF / response: {result['omniinteract_realtime_turn_rtf_mean']:.3f}")
+        print("=" * 59)
+    case = input_requests[0].omniinteract if isinstance(input_requests[0], OmniInteractSampleRequest) else None
+    if case and case.config.output_root:
+        summaries = [row["official_summary"] for row in sessions if row.get("official_summary")]
+        write_batch(Path(case.config.output_root), summaries)
+
+
 def get_samples(args, tokenizer):
+    global _BENCH_NO_STREAM
+    _BENCH_NO_STREAM = bool(getattr(args, "no_stream", False))
+
     # Daily-Omni: explicit dataset name, or hf + matching path/hf-name
     is_daily_omni = args.dataset_name == "daily-omni" or (
-        args.dataset_name == "hf" and _daily_omni_repo_from_args(args) is not None
+        args.dataset_name == "hf" and _hf_repo_from_args(args, DailyOmniDataset.SUPPORTED_DATASET_PATHS) is not None
     )
+    is_omniinteract = _is_omniinteract_dataset(args)
     is_seed_tts = args.dataset_name in (
         "seed-tts",
         "seed-tts-text",
@@ -257,8 +384,9 @@ def get_samples(args, tokenizer):
         "openai-audio-speech",
         "openai-realtime-duplex",
         "daily-omni",
+        "minicpmo-realtime",
     ]
-    is_omni_dataset = is_daily_omni or is_seed_tts or args.dataset_name == "random-mm"
+    is_omni_dataset = is_daily_omni or is_omniinteract or is_seed_tts or args.dataset_name == "random-mm"
 
     if not is_omni_backend and not is_omni_dataset:
         # Not an omni-related request, delegate to original implementation
@@ -328,7 +456,7 @@ def get_samples(args, tokenizer):
                 disable_shuffle=getattr(args, "disable_shuffle", False),
             )
         else:
-            repo_id = _daily_omni_repo_from_args(args)
+            repo_id = _hf_repo_from_args(args, DailyOmniDataset.SUPPORTED_DATASET_PATHS)
             if args.dataset_name == "daily-omni":
                 if repo_id is None:
                     # Prefer an on-disk copy over the Hub id so offline runs keep working.
@@ -436,7 +564,35 @@ def get_samples(args, tokenizer):
             turns_per_session=turns_per_session,
         )
 
-    # Handle random-mm dataset (Omni's synthetic multimodal dataset)
+    if is_omniinteract:
+        if args.backend != "minicpmo-realtime":
+            raise ValueError("OmniInteract requires --backend minicpmo-realtime")
+        output_root = getattr(args, "omniinteract_official_output_dir", None)
+        config = OmniInteractConfig(
+            chunk_ms=getattr(args, "omniinteract_realtime_chunk_ms", 200),
+            video_fps=getattr(args, "omniinteract_realtime_video_fps", 1.0),
+            ref_audio=getattr(args, "omniinteract_realtime_ref_audio", None),
+            pace=not getattr(args, "omniinteract_realtime_no_pace", False),
+            timeout_s=getattr(args, "omniinteract_realtime_timeout_s", 900.0),
+            output_root=output_root,
+        )
+        if output_root and not getattr(args, "no_oversample", False):
+            raise ValueError("Official OmniInteract evaluation requires --no-oversample")
+        dataset = OmniInteractDataset(
+            getattr(args, "dataset_path", None) or _DEFAULT_OMNIINTERACT_REPO,
+            data_root=getattr(args, "omniinteract_root", None),
+            subsets=[value.strip() for value in getattr(args, "omniinteract_subsets", "").split(",") if value.strip()],
+            config=config,
+            random_seed=args.seed,
+            disable_shuffle=getattr(args, "disable_shuffle", False),
+        )
+        return dataset.sample(
+            tokenizer,
+            args.num_prompts,
+            request_id_prefix=args.request_id_prefix,
+            no_oversample=args.no_oversample,
+        )
+
     if args.dataset_name == "random-mm":
         dataset = OmniRandomMultiModalDataset(random_seed=args.seed, dataset_path=args.dataset_path)
         input_requests = dataset.sample(
@@ -467,6 +623,7 @@ if _serve_mod is not None:
 
 @dataclass
 class MixRequestFuncOutput(RequestFuncOutput):
+    omniinteract: dict[str, Any] | None = None
     audio_ttfp: float = 0.0
     audio_duration: float = 0.0
     audio_frames: int = 0
@@ -1312,6 +1469,38 @@ async def async_request_openai_audio_speech(
     return output
 
 
+async def async_request_minicpmo_realtime(
+    request_func_input: RequestFuncInput,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> MixRequestFuncOutput:
+    del session
+    output = MixRequestFuncOutput(prompt_len=0, start_time=time.perf_counter())
+    case = getattr(request_func_input, "omniinteract", None)
+    try:
+        if not isinstance(case, OmniInteractCase):
+            raise ValueError("minicpmo-realtime requires an OmniInteract request")
+        model = request_func_input.model_name or request_func_input.model
+        request_id = str(request_func_input.request_id or "")
+        if not request_id:
+            await probe_omniinteract(case, request_func_input.api_url, model)
+            output.success = True
+        else:
+            result = await run_omniinteract(case, request_func_input.api_url, model, request_id)
+            output.success, output.error = result.success, result.error
+            output.latency, output.ttft = result.latency_s, result.ttft_s
+            output.audio_rtf, output.generated_text = result.audio_rtf, result.generated_text
+            output.omniinteract = result.as_dict()
+    except Exception:
+        output.error = traceback.format_exc()
+        output.success = False
+        if isinstance(case, OmniInteractCase):
+            output.omniinteract = OmniInteractResult(success=False, error=output.error).as_dict()
+    if pbar:
+        pbar.update(1)
+    return output
+
+
 def _realtime_websocket_url(api_url: str) -> str:
     parts = urlsplit(api_url)
     scheme = "wss" if parts.scheme == "https" else "ws"
@@ -1387,8 +1576,10 @@ async def async_request_openai_realtime_duplex(
                 )
                 await client.send({"type": "response.create"})
                 await wait_for(
-                    lambda: client.events.count("response.done") > done_before
-                    or len(client.events.errors()) > errors_before,
+                    lambda: (
+                        client.events.count("response.done") > done_before
+                        or len(client.events.errors()) > errors_before
+                    ),
                     timeout_s=180.0,
                     label=f"Seed-TTS Realtime TTS turn {request_index} response.done",
                 )
@@ -1511,6 +1702,8 @@ ASYNC_REQUEST_FUNCS["daily-omni"] = async_request_openai_chat_omni_completions
 if "daily-omni" not in OPENAI_COMPATIBLE_BACKENDS:
     OPENAI_COMPATIBLE_BACKENDS.append("daily-omni")
 
+ASYNC_REQUEST_FUNCS["minicpmo-realtime"] = async_request_minicpmo_realtime
+
 # ruff: noqa: E402
 # Prevent import order from causing patch failures
 from vllm.benchmarks import serve
@@ -1538,6 +1731,15 @@ def _merge_overrides(base: dict | None, overrides: dict | None) -> dict | None:
     merged = dict(base or {})
     merged.update(overrides or {})
     return merged
+
+
+def _prepare_omniinteract_warmup(test_input: RequestFuncInput, warmup_index: int) -> RequestFuncInput:
+    warmup_input = copy.deepcopy(test_input)
+    warmup_input.request_id = f"warmup-{warmup_index}-{time.monotonic_ns()}"
+    case = getattr(warmup_input, "omniinteract", None)
+    if isinstance(case, OmniInteractCase):
+        warmup_input.omniinteract = replace(case, config=replace(case.config, output_root=None))
+    return warmup_input
 
 
 async def benchmark(
@@ -1576,6 +1778,11 @@ async def benchmark(
         request_func = ASYNC_REQUEST_FUNCS[endpoint_type]
     except KeyError:
         raise ValueError(f"Unknown backend: {endpoint_type}") from None
+    continuous_omniinteract = endpoint_type == "minicpmo-realtime"
+    if continuous_omniinteract and profile:
+        raise ValueError("OmniInteract Realtime does not support benchmark profiler control requests")
+    if continuous_omniinteract and set(goodput_config_dict) & {"ttft", "tpot", "audio_ttft"}:
+        raise ValueError("OmniInteract continuous Sessions support only Session-level e2el goodput")
 
     # Reuses connections across requests to reduce TLS handshake overhead.
     ssl_setting = ssl_context if ssl_context is not None else ("https://" in api_url)
@@ -1624,10 +1831,17 @@ async def benchmark(
         extra_body=test_extra_body,
         chat_messages=test_chat_messages,
     )
+    setattr(test_input, "no_stream", _BENCH_NO_STREAM)
     _attach_daily_omni_to_request_func_input(input_requests[0], test_input)
     _attach_seed_tts_to_request_func_input(input_requests[0], test_input)
+    _attach_omniinteract(input_requests[0], test_input)
 
-    if ready_check_timeout_sec > 0:
+    if endpoint_type == "minicpmo-realtime":
+        # A realtime request is a complete 150-300 second source video, not a
+        # cheap endpoint probe. Replaying the first sample here would duplicate
+        # its model state, artifacts, and accuracy contribution.
+        print("Skipping initial prompt test for continuous OmniInteract sessions.")
+    elif ready_check_timeout_sec > 0:
         test_output = await wait_for_endpoint(
             request_func,
             test_input,
@@ -1651,12 +1865,15 @@ async def benchmark(
         warmup_semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else contextlib.nullcontext()
         warmup_tasks = []
 
-        async def warmup_limited_request_func():
+        async def warmup_limited_request_func(warmup_index: int):
             async with warmup_semaphore:
-                return await request_func(request_func_input=test_input, session=session, pbar=warmup_pbar)
+                warmup_input = test_input
+                if continuous_omniinteract:
+                    warmup_input = _prepare_omniinteract_warmup(test_input, warmup_index)
+                return await request_func(request_func_input=warmup_input, session=session, pbar=warmup_pbar)
 
-        for _ in range(num_warmups):
-            request_task = asyncio.create_task(warmup_limited_request_func())
+        for warmup_index in range(num_warmups):
+            request_task = asyncio.create_task(warmup_limited_request_func(warmup_index))
             warmup_tasks.append(request_task)
         _ = await asyncio.gather(*warmup_tasks)
 
@@ -1689,8 +1906,10 @@ async def benchmark(
             extra_body=test_extra_body,
             chat_messages=test_chat_messages,
         )
+        setattr(profile_input, "no_stream", _BENCH_NO_STREAM)
         _attach_daily_omni_to_request_func_input(input_requests[0], profile_input)
         _attach_seed_tts_to_request_func_input(input_requests[0], profile_input)
+        _attach_omniinteract(input_requests[0], profile_input)
         profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler started")
@@ -1799,8 +2018,10 @@ async def benchmark(
             request_id=request_id,
             chat_messages=request.chat_messages,
         )
+        setattr(request_func_input, "no_stream", _BENCH_NO_STREAM)
         _attach_daily_omni_to_request_func_input(request, request_func_input)
         _attach_seed_tts_to_request_func_input(request, request_func_input)
+        _attach_omniinteract(request, request_func_input)
         tasks.append(
             asyncio.create_task(limited_request_func(request_func_input=request_func_input, session=session, pbar=pbar))
         )
@@ -1829,6 +2050,7 @@ async def benchmark(
             request_rate=request_rate,
             benchmark_duration=benchmark_duration,
             print_stage=_PRINT_STAGE,
+            continuous_session=continuous_omniinteract,
         )
     else:
         metrics = calculate_metrics_for_embeddings(
@@ -1995,6 +2217,9 @@ async def benchmark(
         profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler stopped")
+
+    if continuous_omniinteract:
+        _project_omniinteract_result(result, outputs, input_requests)
 
     await session.close()
     return result

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -19,6 +19,7 @@ from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
 from vllm_omni.core.sched.utils import omni_routed_experts_for_request
+from vllm_omni.distributed.omni_connectors.adapter import should_replace_next_stage_streaming_prompt
 from vllm_omni.engine import OmniEngineCoreOutput
 from vllm_omni.engine.serialization import deserialize_additional_information
 
@@ -672,10 +673,10 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             getattr(update, "model_intermediate_buffer", None),
             getattr(update, "additional_information", None),
         )
+        max_model_len = getattr(self.chunk_transfer_adapter, "_max_model_len", None)
         replace_streaming_prompt = any(
             isinstance(info, dict)
-            and isinstance(info.get("meta"), dict)
-            and info["meta"].get("replace_streaming_prompt") is True
+            and should_replace_next_stage_streaming_prompt(info, session, max_model_len=max_model_len)
             for info in update_infos
         )
         if replace_streaming_prompt:

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -149,6 +149,9 @@ class OmniSchedulerMixin:
         adapter = getattr(self, "chunk_transfer_adapter", None)
         if adapter is not None:
             adapter.segment_finished_requests.discard(session.request_id)
+            watermark = getattr(adapter, "requests_num_chunks_sent", None)
+            if watermark is not None:
+                watermark.pop(session.external_req_id, None)
         session._output_token_ids.clear()
         session._all_token_ids.clear()
         # In-flight outputs from the previous segment were optimistically
@@ -654,11 +657,22 @@ class OmniSchedulerMixin:
 
         for rid in ids_to_align:
             req = self.requests.get(rid)
-            if req is None or req.is_finished():
+            if req is None:
+                continue
+            # A persistent Session may be closed after its current segment
+            # reached FINISHED_STOPPED but while it is still owned by a live
+            # scheduler/connector queue. vLLM skips already-finished requests
+            # in finish_requests(), leaking the KV and worker slot. Only
+            # recover requests with positive queue ownership; an off-queue
+            # terminal can legitimately be waiting for deferred block free.
+            resumable_segment_stop = bool(
+                getattr(req, "resumable", False) and req.status == RequestStatus.FINISHED_STOPPED
+            )
+            if req.is_finished() and not resumable_segment_stop:
                 continue
             if rid in running_ids and req.status != RequestStatus.RUNNING:
                 req.status = RequestStatus.RUNNING
-            elif rid in waiting_ids and req.status == RequestStatus.RUNNING:
+            elif rid in waiting_ids and (req.status == RequestStatus.RUNNING or resumable_segment_stop):
                 req.status = RequestStatus.WAITING
 
     def _purge_finished_from_running(self) -> None:

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -74,6 +74,7 @@ class OmniPayloadMeta(TypedDict, total=False):
     override_keys: list[tuple[str, str]]
     num_processed_tokens: int
     next_stage_prompt_len: int
+    next_stage_generation_tokens: int
     replace_streaming_prompt: bool
     ar_width: int
     eol_token_id: int
@@ -174,7 +175,9 @@ class MetaStruct(_StructBase):
     override_keys: list[tuple[str, str]] | None = None
     num_processed_tokens: int | None = None
     next_stage_prompt_len: int | None = None
+    next_stage_generation_tokens: int | None = None
     replace_streaming_prompt: bool | None = None
+    replace_runtime_additional_information: bool | None = None
     ar_width: int | None = None
     eol_token_id: int | None = None
     visual_token_start_id: int | None = None

--- a/vllm_omni/deploy/minicpmo_4_5_duplex.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_duplex.yaml
@@ -6,7 +6,10 @@
 base_config: minicpmo_4_5.yaml
 pipeline: minicpmo_4_5
 session_mode: duplex
-active_stream_window: 1
+# Keep the connector admission window aligned with the declared duplex
+# Session and per-stage sequence capacity. A smaller global window serializes
+# downstream Talker/Code2Wav work and can starve the second live Session.
+active_stream_window: 2
 duplex_session:
   idle_ttl_s: 300
   disconnect_grace_s: 30

--- a/vllm_omni/distributed/omni_connectors/adapter.py
+++ b/vllm_omni/distributed/omni_connectors/adapter.py
@@ -216,13 +216,40 @@ def compute_talker_prompt_ids_length(prompt_ids: list[int]) -> int:
     return sum_user_len + assistant_len
 
 
-def construct_next_stage_streaming_input_prompt(payload_data: dict[str, Any], request: Any) -> None:
+def should_replace_next_stage_streaming_prompt(
+    payload_data: dict[str, Any], request: Any, *, max_model_len: int | None = None
+) -> bool:
+    meta = payload_data.get("meta", {})
+    if not isinstance(meta, dict):
+        return False
+    if meta.get("replace_streaming_prompt") is True:
+        return True
+    next_prompt_len = meta.get("next_stage_prompt_len")
+    next_generation_tokens = meta.get("next_stage_generation_tokens")
+    min_tokens = getattr(getattr(request, "sampling_params", None), "min_tokens", 0)
+    generation_reserve = max(
+        next_generation_tokens if isinstance(next_generation_tokens, int) else 0,
+        min_tokens if isinstance(min_tokens, int) else 0,
+    )
+    return (
+        payload_data.get("native_duplex") is True
+        and isinstance(max_model_len, int)
+        and max_model_len > 0
+        and isinstance(next_prompt_len, int)
+        and request.num_computed_tokens + next_prompt_len + generation_reserve > max_model_len
+    )
+
+
+def construct_next_stage_streaming_input_prompt(
+    payload_data: dict[str, Any], request: Any, *, max_model_len: int | None = None
+) -> bool:
     """Update a downstream streaming request prompt from connector payload ids.
 
     Async-chunk downstream stages are prewarmed before the real Talker prompt is
     known. When a Thinker payload carries ``ids.prompt``, this helper:
 
-    * Preserves ``num_computed_tokens`` (the scheduler token watermark).
+    * Preserves ``num_computed_tokens`` while extending the current prompt.
+      Explicit replacements and capacity rollovers reset it with the prompt.
     * Moves already-computed output tokens into ``prompt_token_ids``.
     * Appends a new placeholder prompt slice sized from the upstream ids.
     * Refreshes block hashes so the scheduler allocates KV slots for the
@@ -230,8 +257,8 @@ def construct_next_stage_streaming_input_prompt(payload_data: dict[str, Any], re
     """
     ids = payload_data.get("ids", {})
     meta = payload_data.get("meta", {})
-    replace_prompt = isinstance(meta, dict) and meta.get("replace_streaming_prompt") is True
     next_stage_prompt_len = meta.get("next_stage_prompt_len") if isinstance(meta, dict) else None
+    replace_prompt = should_replace_next_stage_streaming_prompt(payload_data, request, max_model_len=max_model_len)
     if replace_prompt and isinstance(next_stage_prompt_len, int) and next_stage_prompt_len > 0:
         # Some downstream stages consume complete, independently conditioned
         # segments instead of extending an existing KV prefix. The producer
@@ -244,10 +271,10 @@ def construct_next_stage_streaming_input_prompt(payload_data: dict[str, Any], re
         request.num_computed_tokens = 0
         request.num_prompt_tokens = next_stage_prompt_len
         request.update_block_hashes()
-        return
+        return True
     prompt_token_ids = ids.get("prompt", None)
     if not prompt_token_ids:
-        return
+        return False
     num_computed_tokens = request.num_computed_tokens
     kept_output_tokens = request._all_token_ids[request.num_prompt_tokens : num_computed_tokens]
     del request._all_token_ids[num_computed_tokens:]
@@ -264,3 +291,4 @@ def construct_next_stage_streaming_input_prompt(payload_data: dict[str, Any], re
     request.prompt_token_ids.extend(new_prompt or ())
     request.update_block_hashes()
     request.num_prompt_tokens = len(request.prompt_token_ids)
+    return False

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -43,6 +43,18 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
     def __init__(self, vllm_config: Any):
         model_config = vllm_config.model_config
         self.scheduler_max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+        self._max_model_len = int(getattr(model_config, "max_model_len", 0) or 0)
+        tts_config = getattr(getattr(model_config, "hf_config", None), "tts_config", None)
+        tts_max_model_len = (
+            tts_config.get("max_position_embeddings", 0)
+            if isinstance(tts_config, Mapping)
+            else getattr(tts_config, "max_position_embeddings", 0)
+        )
+        tts_max_model_len = int(tts_max_model_len or 0)
+        if tts_max_model_len > 0:
+            self._max_model_len = (
+                min(self._max_model_len, tts_max_model_len) if self._max_model_len else tts_max_model_len
+            )
         active_stream_window = int(getattr(model_config, "active_stream_window", 0) or 0)
         model_max_num_seqs = int(getattr(model_config, "max_num_seqs", self.scheduler_max_num_seqs) or 0)
         if model_max_num_seqs <= 0:
@@ -84,6 +96,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.waiting_for_chunk_waiting_requests: deque[Any] = deque()
         self.waiting_for_chunk_running_requests: deque[Any] = deque()
         self.requests_with_ready_chunks = set()
+        self.replaced_streaming_prompt_ids: set[str] = set()
         self.requests_origin_status = {}
         self._active_streams: dict[str, Any] = {}
         # Private hold-queue for non-active running requests. Restored to
@@ -246,7 +259,13 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 replace_prompt = meta.get("replace_streaming_prompt") is True
                 if getattr(request, "resumable", False) and (chunk_id > 0 or replace_prompt):
                     # For new streaming input segment, we should update prompt from payload
-                    construct_next_stage_streaming_input_prompt(payload_data, request)
+                    replaced = construct_next_stage_streaming_input_prompt(
+                        payload_data,
+                        request,
+                        max_model_len=self._max_model_len,
+                    )
+                    if replaced:
+                        self.replaced_streaming_prompt_ids.add(req_id)
 
                 if payload_finished:
                     self.upstream_exhausted_requests.add(req_id)
@@ -275,8 +294,12 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 else:
                     prompt_token_ids = new_ids
                 request.prompt_token_ids = prompt_token_ids
+                # Models that produce complete per-step snapshots opt in on
+                # the wire. Incremental generation/diffusion payloads retain
+                # merge semantics.
                 prev_info = getattr(request, "additional_information", None)
-                info = dict(prev_info) if isinstance(prev_info, dict) else {}
+                replace_snapshot = meta.get("replace_runtime_additional_information") is True
+                info = {} if replace_snapshot else (dict(prev_info) if isinstance(prev_info, dict) else {})
                 for key, value in payload_data.items():
                     if key == "codes":
                         if use_tensor_codes and isinstance(value, dict):
@@ -455,6 +478,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.segment_finished_requests.discard(request_id)
         self.get_req_chunk.pop(request_id, None)
         self.requests_with_ready_chunks.discard(request_id)
+        self.replaced_streaming_prompt_ids.discard(request_id)
         self.request_ids_mapping.pop(request_id, None)
         self.requests_origin_status.pop(request_id, None)
         self._discard_from_chunk_deque(self.waiting_for_chunk_waiting_requests, request_id)
@@ -564,6 +588,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 RequestStatus.RUNNING,
                 self._finished_load_reqs,
             )
+            self._requeue_replaced_prompts(waiting_queue, running_queue)
             while len(running_queue) > self.scheduler_max_num_seqs:
                 request = running_queue.pop()
                 request.status = RequestStatus.PREEMPTED
@@ -578,8 +603,22 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self._process_chunk_queue(
             running_queue, self.waiting_for_chunk_running_requests, RequestStatus.RUNNING, self._finished_load_reqs
         )
+        self._requeue_replaced_prompts(waiting_queue, running_queue)
         self._promote_active_streams(waiting_queue)
         self._preempt_non_active_running(waiting_queue, running_queue)
+
+    def _requeue_replaced_prompts(self, waiting_queue: Any, running_queue: list[Request]) -> None:
+        for request in list(running_queue):
+            request_id = request.request_id
+            if (
+                request_id not in self.replaced_streaming_prompt_ids
+                or request_id not in self.requests_with_ready_chunks
+            ):
+                continue
+            running_queue.remove(request)
+            request.status = RequestStatus.WAITING
+            self.requests_origin_status[request_id] = RequestStatus.WAITING
+            waiting_queue.add_request(request)
 
     def _promote_active_streams(self, queue: Any) -> None:
         if len(self._active_streams) >= self._active_window:
@@ -852,6 +891,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             for req_data in scheduler_output.scheduled_new_reqs:
                 if req_data.req_id in self.requests_with_ready_chunks:
                     self.requests_with_ready_chunks.remove(req_data.req_id)
+                if req_data.req_id in self.replaced_streaming_prompt_ids:
+                    external_req_id = self.request_ids_mapping.get(req_data.req_id)
+                    if external_req_id is not None:
+                        self.requests_num_chunks_sent.pop(external_req_id, None)
+                    self.replaced_streaming_prompt_ids.remove(req_data.req_id)
 
         if scheduler_output.scheduled_cached_reqs:
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
@@ -872,8 +916,13 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         # First pass: collect requests to remove from queues
         for req_id in request_ids:
             request = requests.get(req_id) if requests else None
-            if request is None or request.is_finished():
+            if request is None:
                 # Invalid request ID.
+                continue
+            resumable_segment_stop = bool(
+                getattr(request, "resumable", False) and request.status == RequestStatus.FINISHED_STOPPED
+            )
+            if request.is_finished() and not resumable_segment_stop:
                 continue
             if req_id in self.requests_origin_status:
                 request.status = self.requests_origin_status.pop(req_id)
@@ -891,11 +940,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         )
 
         for req_id in request_ids:
-            self._active_streams.pop(req_id, None)
-            self.requests_with_ready_chunks.discard(req_id)
-            self.upstream_exhausted_requests.discard(req_id)
-            self._finished_load_reqs.discard(req_id)
-            self._cancelled_load_reqs.add(req_id)
-            self._waiting_since.pop(req_id, None)
+            self.cleanup_receiver(req_id)
 
         return []

--- a/vllm_omni/entrypoints/cli/benchmark/cli_args.py
+++ b/vllm_omni/entrypoints/cli/benchmark/cli_args.py
@@ -186,8 +186,56 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_omniinteract_cli_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("OmniInteract")
+    group.add_argument(
+        "--omniinteract-root",
+        default=None,
+        help="Local extracted OmniInteract data root (otherwise download from Hugging Face).",
+    )
+    group.add_argument(
+        "--omniinteract-subsets",
+        default="1q1a,1q1a_math,1qna",
+        help="Comma-separated dataset subsets.",
+    )
+    group.add_argument(
+        "--omniinteract-official-output-dir",
+        default=None,
+        help="Write official evaluator artifacts below this directory.",
+    )
+    group.add_argument(
+        "--omniinteract-realtime-ref-audio",
+        default=None,
+        help="Reference WAV for MiniCPM-o voice cloning.",
+    )
+    group.add_argument(
+        "--omniinteract-realtime-chunk-ms",
+        type=int,
+        default=200,
+        help="PCM append chunk size.",
+    )
+    group.add_argument(
+        "--omniinteract-realtime-video-fps",
+        type=float,
+        default=1.0,
+        help="Video frame sampling rate.",
+    )
+    group.add_argument(
+        "--omniinteract-realtime-timeout-s",
+        type=float,
+        default=900.0,
+        help="Per-session timeout.",
+    )
+    group.add_argument(
+        "--omniinteract-realtime-no-pace",
+        action="store_true",
+        help="Disable realtime pacing for load/debug runs.",
+    )
+
+
 _OMNI_BENCH_DATASET_CHOICES = (
     "daily-omni",
+    "omniinteract",
     "seed-tts",
     "seed-tts-text",
     "seed-tts-design",
@@ -210,7 +258,11 @@ def extend_omni_choices(parser: argparse.ArgumentParser) -> None:
                 if extra:
                     action.choices = list(action.choices) + extra
             if action.dest == "backend" and action.choices is not None:
-                extra = [choice for choice in ("openai-image-edits-omni",) if choice not in action.choices]
+                extra = [
+                    choice
+                    for choice in ("openai-image-edits-omni", "minicpmo-realtime")
+                    if choice not in action.choices
+                ]
                 if extra:
                     action.choices = list(action.choices) + extra
 
@@ -254,6 +306,7 @@ def update_omni_help(parser: argparse.ArgumentParser) -> None:
 def add_omni_args(parser: argparse.ArgumentParser) -> None:
     """Register all vLLM-Omni serving benchmark arguments."""
     add_daily_omni_cli_args(parser)
+    add_omniinteract_cli_args(parser)
     add_seed_tts_cli_args(parser)
     add_multi_stage_cli_args(parser)
     add_diffusion_cli_args(parser)

--- a/vllm_omni/experimental/fullduplex/client.py
+++ b/vllm_omni/experimental/fullduplex/client.py
@@ -418,6 +418,7 @@ class RealtimeDuplexClient:
         temperature: float | None = None,
         extra_body: dict[str, object] | None = None,
         session_id: str | None = None,
+        idle_timeout_s: float | None = None,
         timeout_s: float = 20.0,
     ) -> None:
         session_extra_body = dict(extra_body or {})
@@ -453,6 +454,8 @@ class RealtimeDuplexClient:
             extra_body["duplex_initial_user_text"] = initial_user_text
         if session_id:
             session["session_id"] = session_id
+        if idle_timeout_s is not None:
+            session["idle_timeout_s"] = idle_timeout_s
         await self.send({"type": "session.update", "session": session})
         await wait_for(
             lambda: self.events.count("session.created") > 0,

--- a/vllm_omni/experimental/fullduplex/minicpmo45/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/data_plane.py
@@ -133,11 +133,14 @@ class MiniCPMO45DataPlaneSession:
     ) -> Iterator[dict[str, object]]:
         context = context or MiniCPMO45DataPlaneContext()
         stage_metrics = _output_stage_metrics(output)
+        output_input_seq: int | None = None
 
         def runtime_result(**values: object) -> dict[str, object]:
             result = _runtime_result(**values)
             if stage_metrics is not None:
                 result["stage_metrics"] = stage_metrics
+            if output_input_seq is not None and output_input_seq > 0:
+                result["input_seq"] = output_input_seq
             return result
 
         request_id = getattr(output, "request_id", None)
@@ -177,6 +180,7 @@ class MiniCPMO45DataPlaneSession:
 
         output_turn_id = output_turn_id_from_metadata(mm_output)
         output_epoch = output_epoch_from_metadata(mm_output)
+        output_input_seq = output_input_seq_from_metadata(mm_output)
         expected_turn_id = context.active_response_turn_id
         stale_turn = expected_turn_id is not None and output_turn_id is not None and output_turn_id < expected_turn_id
         if expected_turn_id is None and output_turn_id is not None:
@@ -569,6 +573,10 @@ def output_turn_id_from_metadata(mm_output: dict[str, object]) -> int | None:
 
 def output_epoch_from_metadata(mm_output: dict[str, object]) -> int | None:
     return _first_metadata_int(mm_output, "duplex_epoch", "epoch")
+
+
+def output_input_seq_from_metadata(mm_output: dict[str, object]) -> int | None:
+    return _first_metadata_int(mm_output, "duplex_input_seq", "input_seq", "seq")
 
 
 def _first_metadata_int(mm_output: dict[str, object], *names: str) -> int | None:

--- a/vllm_omni/experimental/fullduplex/minicpmo45/input.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/input.py
@@ -223,6 +223,10 @@ class MiniCPMO45PcmAppendBuffer:
         flush: bool = False,
         allow_emit: bool = True,
     ) -> MiniCPMO45PcmAppendReservation | None:
+        # Serving adds this field only to internal silence continuations.
+        # Never let a client choose which accepted input a model output ACKs.
+        payload = dict(payload)
+        payload.pop("duplex_origin_input_seq", None)
         fmt = payload.get("format")
         sample_rate_hz = payload.get("sample_rate_hz")
         audio = payload.get("audio")

--- a/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from base64 import b64decode
 from binascii import Error as BinasciiError
+from collections.abc import Mapping
 from typing import Any
 
 from vllm.sampling_params import SamplingParams
@@ -135,29 +136,36 @@ def build_duplex_data_plane_prompt(
         and payload.get("force_listen") is not True
     ):
         payload = {**payload, "force_listen": True}
+    duplex_info: dict[str, Any] = {
+        "fence": fence,
+        "session_id": fence.session_id,
+        "incarnation": fence.incarnation,
+        "epoch": fence.epoch,
+        "seq": seq,
+        "input_seq": seq,
+        "turn_id": fence.turn_id,
+        "response_seq": fence.response_seq,
+        "turn_seq": turn_seq,
+        "mode": mode.value,
+        "payload": payload,
+        "final": final,
+        "data_plane": True,
+        "session_config": dict(session_config),
+        "runtime_config": dict(runtime_config),
+        "scheduler_token_budget": token_budget,
+        "scheduler_token_id": token_id,
+    }
+    origin_input_seq = payload.get("duplex_origin_input_seq") if isinstance(payload, dict) else None
+    if isinstance(origin_input_seq, int) and not isinstance(origin_input_seq, bool) and origin_input_seq > 0:
+        # Serving adds this field only to internal silence continuations. Keep the
+        # control sequence separate while attributing its model decision to the user input.
+        duplex_info["input_seq"] = origin_input_seq
     return {
         "prompt_token_ids": [token_id] * token_budget,
         "model_intermediate_buffer": {
             "request_id": request_id,
             "global_request_id": [fence.session_id],
-            "duplex": {
-                "fence": fence,
-                "session_id": fence.session_id,
-                "incarnation": fence.incarnation,
-                "epoch": fence.epoch,
-                "seq": seq,
-                "turn_id": fence.turn_id,
-                "response_seq": fence.response_seq,
-                "turn_seq": turn_seq,
-                "mode": mode.value,
-                "payload": payload,
-                "final": final,
-                "data_plane": True,
-                "session_config": dict(session_config),
-                "runtime_config": dict(runtime_config),
-                "scheduler_token_budget": token_budget,
-                "scheduler_token_id": token_id,
-            },
+            "duplex": duplex_info,
         },
     }
 
@@ -197,10 +205,10 @@ def _first_completion(output: object) -> object | None:
 
 def _multimodal_output(output: object, completion: object | None) -> dict[str, Any]:
     metadata = getattr(output, "multimodal_output", None)
-    if isinstance(metadata, dict):
-        return metadata
+    if isinstance(metadata, Mapping):
+        return dict(metadata)
     metadata = getattr(completion, "multimodal_output", None) if completion is not None else None
-    return metadata if isinstance(metadata, dict) else {}
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
 
 
 def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:

--- a/vllm_omni/experimental/fullduplex/minicpmo45/session.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/session.py
@@ -28,6 +28,114 @@ class MiniCPMO45ServingSessionState:
     pending_silence_task: asyncio.Task[bool] | None = None
     pending_silence_owner_id: str | None = None
     silence_continuation_scheduler: Callable[..., Awaitable[bool]] | None = None
+    accepted_input_epoch: int = -1
+    accepted_input_seq: int = 0
+    accepted_input_seqs: set[int] = field(default_factory=set)
+    accepted_input_turns: dict[int, int] = field(default_factory=dict)
+    final_input_epoch: int = -1
+    final_input_seq: int = 0
+    input_acceptances_inflight: int = 0
+    final_input_acceptances_inflight: int = 0
+    deferred_processed_inputs: dict[tuple[int, int], tuple[str, str | None]] = field(default_factory=dict)
+
+    def begin_input_acceptance(self) -> None:
+        self.input_acceptances_inflight += 1
+
+    def cancel_input_acceptance(self) -> None:
+        self.input_acceptances_inflight = max(0, self.input_acceptances_inflight - 1)
+
+    def begin_final_input_acceptance(self) -> None:
+        self.final_input_acceptances_inflight += 1
+
+    def finish_final_input_acceptance(self) -> None:
+        self.final_input_acceptances_inflight = max(0, self.final_input_acceptances_inflight - 1)
+
+    def final_input_acceptance_pending(self) -> bool:
+        return self.final_input_acceptances_inflight > 0
+
+    def record_accepted_input(
+        self,
+        *,
+        epoch: int,
+        seq: int,
+        model_turn_id: int | None = None,
+    ) -> tuple[str, str | None] | None:
+        if epoch != self.accepted_input_epoch:
+            self.accepted_input_epoch = epoch
+            self.accepted_input_seq = 0
+            self.accepted_input_seqs.clear()
+            self.accepted_input_turns.clear()
+            self.deferred_processed_inputs = {
+                key: value for key, value in self.deferred_processed_inputs.items() if key[0] == epoch
+            }
+        if seq > self.accepted_input_seq:
+            self.accepted_input_seq = seq
+        deferred = self.deferred_processed_inputs.pop((epoch, seq), None)
+        if deferred is None:
+            self.accepted_input_seqs.add(seq)
+            if model_turn_id is not None:
+                self.accepted_input_turns[seq] = int(model_turn_id)
+        self.input_acceptances_inflight = max(0, self.input_acceptances_inflight - 1)
+        return deferred
+
+    def accepted_input_watermark(self, *, epoch: int) -> int | None:
+        if epoch != self.accepted_input_epoch or self.accepted_input_seq <= 0:
+            return None
+        return self.accepted_input_seq
+
+    def mark_input_processed(self, *, epoch: int, seq: int) -> bool:
+        if seq <= 0 or epoch != self.accepted_input_epoch or seq not in self.accepted_input_seqs:
+            return False
+        # Removal deduplicates output and bounds state to the pending backlog.
+        self.accepted_input_seqs.remove(seq)
+        self.accepted_input_turns.pop(seq, None)
+        return True
+
+    def defer_input_processed(
+        self,
+        *,
+        epoch: int,
+        seq: int,
+        outcome: str,
+        response_id: str | None,
+    ) -> bool:
+        if (
+            self.input_acceptances_inflight <= 0
+            or epoch < self.accepted_input_epoch
+            or (epoch == self.accepted_input_epoch and seq <= self.accepted_input_seq)
+        ):
+            return False
+        self.deferred_processed_inputs.setdefault((epoch, seq), (outcome, response_id))
+        return True
+
+    def pending_input_identity(self, *, epoch: int) -> tuple[int, int] | None:
+        if epoch != self.accepted_input_epoch:
+            return None
+        pending = [
+            (seq, turn_id) for seq, turn_id in self.accepted_input_turns.items() if seq in self.accepted_input_seqs
+        ]
+        return max(pending) if pending else None
+
+    def promote_pending_input_turn(self, *, epoch: int, seq: int, model_turn_id: int) -> None:
+        if epoch == self.accepted_input_epoch and seq in self.accepted_input_seqs:
+            current = self.accepted_input_turns.get(seq)
+            if current is not None and current < model_turn_id:
+                self.accepted_input_turns[seq] = model_turn_id
+
+    def record_final_input(self, *, epoch: int, seq: int) -> None:
+        if seq > 0:
+            self.final_input_epoch = epoch
+            self.final_input_seq = seq
+
+    def final_input_identity(self, *, epoch: int) -> int | None:
+        if epoch != self.final_input_epoch or self.final_input_seq <= 0:
+            return None
+        return self.final_input_seq
+
+    def resolve_final_input(self, *, epoch: int, seq: int) -> None:
+        if epoch == self.final_input_epoch and seq == self.final_input_seq:
+            self.final_input_epoch = -1
+            self.final_input_seq = 0
 
     def retain_committed_audio(
         self,

--- a/vllm_omni/experimental/fullduplex/openai/realtime_output.py
+++ b/vllm_omni/experimental/fullduplex/openai/realtime_output.py
@@ -218,14 +218,27 @@ class RealtimeOutputProjector:
                 self._conversation_items[item_id] = item
                 created_payload.extend(self._conversation_item_added_events(item))
             item["status"] = "completed"
-            payloads = created_payload + [
-                self._input_audio_buffer_committed_event(item_id=item_id, event=event),
-            ]
+            committed_event = self._input_audio_buffer_committed_event(item_id=item_id, event=event)
+            for key in ("session_id", "epoch", "accepted_input_seq"):
+                if key in event:
+                    committed_event[key] = event[key]
+            payloads = created_payload + [committed_event]
             transcription_event = self._input_audio_transcription_completed_event(item_id, item)
             if transcription_event is not None:
                 payloads.append(transcription_event)
             payloads.append(self._conversation_item_done_event(item))
             return payloads
+        if event_type == "input.processed":
+            return [
+                {
+                    "type": "input_audio_buffer.processed",
+                    "session_id": event.get("session_id"),
+                    "epoch": event.get("epoch"),
+                    "processed_input_seq": event.get("processed_input_seq"),
+                    "outcome": event.get("outcome"),
+                    **({"response_id": event["response_id"]} if isinstance(event.get("response_id"), str) else {}),
+                }
+            ]
         if event_type == "input.cancelled":
             return [{"type": "input_audio_buffer.cleared"}]
         if event_type == "input_audio_buffer.cleared":

--- a/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
+++ b/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
@@ -77,6 +77,47 @@ class ServingRuntimeSessionState(Protocol):
     pending_silence_owner_id: str | None
     silence_continuation_scheduler: Callable[..., Awaitable[bool]] | None
 
+    def begin_input_acceptance(self) -> None: ...
+
+    def cancel_input_acceptance(self) -> None: ...
+
+    def begin_final_input_acceptance(self) -> None: ...
+
+    def finish_final_input_acceptance(self) -> None: ...
+
+    def final_input_acceptance_pending(self) -> bool: ...
+
+    def record_accepted_input(
+        self,
+        *,
+        epoch: int,
+        seq: int,
+        model_turn_id: int | None = None,
+    ) -> tuple[str, str | None] | None: ...
+
+    def accepted_input_watermark(self, *, epoch: int) -> int | None: ...
+
+    def mark_input_processed(self, *, epoch: int, seq: int) -> bool: ...
+
+    def defer_input_processed(
+        self,
+        *,
+        epoch: int,
+        seq: int,
+        outcome: str,
+        response_id: str | None,
+    ) -> bool: ...
+
+    def pending_input_identity(self, *, epoch: int) -> tuple[int, int] | None: ...
+
+    def promote_pending_input_turn(self, *, epoch: int, seq: int, model_turn_id: int) -> None: ...
+
+    def record_final_input(self, *, epoch: int, seq: int) -> None: ...
+
+    def final_input_identity(self, *, epoch: int) -> int | None: ...
+
+    def resolve_final_input(self, *, epoch: int, seq: int) -> None: ...
+
     def retain_committed_audio(
         self,
         payload: dict[str, object],

--- a/vllm_omni/experimental/fullduplex/openai/runtime_bridge.py
+++ b/vllm_omni/experimental/fullduplex/openai/runtime_bridge.py
@@ -99,6 +99,7 @@ class NativeRuntimeBridgeMixin:
         send_json,
         mode: str = "append_tokens",
         expected_epoch: int | None = None,
+        track_input_watermark: bool = True,
     ) -> tuple[bool, bool]:
         if not session.capabilities.supports_input_append:
             return True, False
@@ -107,6 +108,25 @@ class NativeRuntimeBridgeMixin:
             return True, False
         if expected_epoch is not None and session.epoch != expected_epoch:
             return True, False
+        watermark_state = self._runtime_session_state(session) if track_input_watermark else None
+        explicit_model_turn_id = payload_turn_id(payload)
+        input_model_turn_id = explicit_model_turn_id
+        if input_model_turn_id is None:
+            input_model_turn_id = (
+                session.active_response_turn_id if session.active_response_turn_id is not None else session.turn_id
+            )
+        pending_model_turn_id = input_model_turn_id
+        if explicit_model_turn_id is None and session.active_response_turn_id is not None:
+            pending_model_turn_id = max(session.turn_id, session.active_response_turn_id + 1)
+        if watermark_state is not None:
+            watermark_state.begin_input_acceptance()
+        final_acceptance = bool(watermark_state is not None and final and self._session_auto_responds(session))
+        if final_acceptance:
+            old_final_seq = watermark_state.final_input_identity(epoch=session.epoch)
+            if old_final_seq is not None:
+                watermark_state.resolve_final_input(epoch=session.epoch, seq=old_final_seq)
+            watermark_state.begin_final_input_acceptance()
+        final_output_resolved = False
         try:
             append_kwargs = {
                 "mode": mode,
@@ -119,29 +139,34 @@ class NativeRuntimeBridgeMixin:
             if expected_epoch is not None and self._callable_accepts_keyword(append_input, "expected_epoch"):
                 append_kwargs["expected_epoch"] = expected_epoch
             if self._callable_accepts_keyword(append_input, "fence"):
-                payload_turn = payload_turn_id(payload)
                 append_kwargs["fence"] = DuplexFence(
                     session.session_id,
                     epoch=session.epoch,
-                    turn_id=(
-                        payload_turn
-                        if payload_turn is not None
-                        else (
-                            session.active_response_turn_id
-                            if session.active_response_turn_id is not None
-                            else session.turn_id
-                        )
-                    ),
+                    turn_id=input_model_turn_id,
                     incarnation=session.incarnation,
                 )
             if self._callable_accepts_keyword(append_input, "collect_outputs"):
                 append_kwargs["collect_outputs"] = False
             result = await append_input(session.session_id, **append_kwargs)
+        except asyncio.CancelledError:
+            if watermark_state is not None:
+                watermark_state.cancel_input_acceptance()
+            if final_acceptance:
+                watermark_state.finish_final_input_acceptance()
+            raise
         except Exception as exc:
+            if watermark_state is not None:
+                watermark_state.cancel_input_acceptance()
+            if final_acceptance:
+                watermark_state.finish_final_input_acceptance()
             logger.exception("Failed to append duplex runtime input: %s", exc)
             await self._send_runtime_error(send_json, "runtime_append_failed", exc, session=session)
             return False, False
         if isinstance(result, dict) and self._runtime_control_failed(result):
+            if watermark_state is not None:
+                watermark_state.cancel_input_acceptance()
+            if final_acceptance:
+                watermark_state.finish_final_input_acceptance()
             await self._send_runtime_control_error(
                 send_json,
                 "runtime_append_failed",
@@ -151,9 +176,54 @@ class NativeRuntimeBridgeMixin:
             )
             return False, False
         if expected_epoch is not None and session.epoch != expected_epoch:
+            if watermark_state is not None:
+                watermark_state.cancel_input_acceptance()
+            if final_acceptance:
+                watermark_state.finish_final_input_acceptance()
             return True, False
+        if watermark_state is not None and isinstance(result, dict):
+            accepted_input_seq = self._accepted_input_seq(result)
+            if accepted_input_seq is not None:
+                accepted_model_turn_id = pending_model_turn_id
+                if self._session_auto_responds(session):
+                    accepted_model_turn_id = max(accepted_model_turn_id, session.turn_id)
+                    if explicit_model_turn_id is None and session.active_response_turn_id is not None:
+                        accepted_model_turn_id = max(accepted_model_turn_id, session.active_response_turn_id + 1)
+                deferred_processed = watermark_state.record_accepted_input(
+                    epoch=session.epoch,
+                    seq=accepted_input_seq,
+                    model_turn_id=accepted_model_turn_id,
+                )
+                deferred_outcome = deferred_processed[0] if deferred_processed is not None else None
+                final_output_resolved = final and deferred_outcome in {"listen", "failed"}
+                if final and self._session_auto_responds(session) and not final_output_resolved:
+                    watermark_state.record_final_input(epoch=session.epoch, seq=accepted_input_seq)
+                if final_acceptance:
+                    watermark_state.finish_final_input_acceptance()
+                    final_acceptance = False
+                if deferred_processed is not None:
+                    outcome, response_id = deferred_processed
+                    await self._send_input_processed_event(
+                        send_json,
+                        session=session,
+                        input_seq=accepted_input_seq,
+                        outcome=outcome,
+                        response_id=response_id,
+                    )
+            else:
+                watermark_state.cancel_input_acceptance()
+        elif watermark_state is not None:
+            watermark_state.cancel_input_acceptance()
+        if final_acceptance:
+            watermark_state.finish_final_input_acceptance()
         await self._send_runtime_control_if_needed(send_json, result, session=session)
         request_id, _ = self._data_plane_request_info(result) if isinstance(result, dict) else (None, None)
+        if (
+            request_id is not None
+            and (not track_input_watermark or final_output_resolved)
+            and self._serving_runtime_adapter.data_plane.is_terminal(request_id)
+        ):
+            return True, True
         if request_id is not None:
             self._serving_runtime_adapter.data_plane.begin_request(request_id)
         close_reason, emitted_response = await self._send_native_duplex_events(
@@ -174,6 +244,20 @@ class NativeRuntimeBridgeMixin:
             expected_epoch=expected_epoch,
         ):
             emitted_response = True
+        pending_silence = watermark_state.pending_silence_task if watermark_state is not None else None
+        if (
+            close_reason is None
+            and final
+            and not final_output_resolved
+            and watermark_state is not None
+            and self._session_auto_responds(session)
+            and (pending_silence is None or pending_silence.done())
+        ):
+            await self._continue_pending_native_input(
+                send_json,
+                session=session,
+                expected_epoch=expected_epoch,
+            )
         if close_reason is not None:
             if not await self._close_runtime_session(session, reason=close_reason, send_json=send_json):
                 return False, emitted_response
@@ -187,6 +271,29 @@ class NativeRuntimeBridgeMixin:
             )
             return False, emitted_response
         return True, emitted_response
+
+    @staticmethod
+    def _accepted_input_seq(value: object) -> int | None:
+        if not isinstance(value, dict):
+            return None
+
+        def supported_seq(result: object) -> int | None:
+            if not isinstance(result, dict) or result.get("supported") is not True:
+                return None
+            seq = result.get("seq")
+            return seq if isinstance(seq, int) and not isinstance(seq, bool) and seq > 0 else None
+
+        seq = value.get("accepted_input_seq")
+        if isinstance(seq, int) and not isinstance(seq, bool) and seq > 0:
+            return seq
+        if (seq := supported_seq(value.get("result"))) is not None:
+            return seq
+        stage_results = value.get("stage_results")
+        if isinstance(stage_results, list | tuple):
+            for stage_result in stage_results:
+                if isinstance(stage_result, dict) and (seq := supported_seq(stage_result.get("result"))) is not None:
+                    return seq
+        return None
 
     @staticmethod
     def _callable_accepts_keyword(fn, name: str) -> bool:
@@ -229,7 +336,7 @@ class NativeRuntimeBridgeMixin:
         expected_epoch: int | None = None,
     ) -> bool:
         request_id, _ = self._data_plane_request_info(result)
-        if request_id is None or self._data_plane_outputs_finished(result):
+        if request_id is None or self._data_plane_outputs_finished(result) or session.state != DuplexSessionState.OPEN:
             return False
         session.bind_request(request_id)
 
@@ -301,15 +408,34 @@ class NativeRuntimeBridgeMixin:
                     # must survive drain-task turnover or every unit re-sends
                     # the reply audio from the start.
                     self._serving_runtime_adapter.data_plane.close_stream(request_id)
-            if restart_requested:
+            pending_input = native.pending_input_identity(epoch=session.epoch) if close_reason is None else None
+            if pending_input is not None:
+                await self._maybe_continue_native_response(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                    expected_model_turn_id=pending_input[1],
+                    origin_input_seq=pending_input[0],
+                )
+            if (
+                restart_requested
+                and session.state == DuplexSessionState.OPEN
+                and session.active_request_id == request_id
+                and (expected_epoch is None or session.epoch == expected_epoch)
+                and (native.data_plane_task is None or native.data_plane_task.done())
+            ):
                 await self._start_native_data_plane_stream_task(
                     send_json,
                     result,
                     session=session,
                     expected_epoch=expected_epoch,
                 )
-            elif close_reason is None:
-                await self._maybe_continue_native_response(send_json, session=session, expected_epoch=expected_epoch)
+            elif close_reason is None and pending_input is None:
+                await self._maybe_continue_native_response(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                )
 
         task = asyncio.create_task(_run())
         native.data_plane_task = task
@@ -320,6 +446,7 @@ class NativeRuntimeBridgeMixin:
     # silence while the assistant speaks; replies span multiple units.
     _NATIVE_SILENCE_UNIT_PAYLOAD_AUDIO = base64.b64encode(bytes(16000 * 4)).decode("ascii")
     _NATIVE_RESPONSE_MAX_CONTINUATION_UNITS = 8
+    _NATIVE_AUTO_RESPONSE_FORCE_LISTEN_UNITS = 64
 
     def _native_silence_unit_payload(self) -> dict[str, object]:
         return {
@@ -349,7 +476,7 @@ class NativeRuntimeBridgeMixin:
         expected_model_turn_id: int | None,
     ) -> bool:
         stale_common_owner = (
-            session.state == DuplexSessionState.CLOSED
+            session.state != DuplexSessionState.OPEN
             or session.incarnation != expected_incarnation
             or session.active_request_id != request_id
             or (expected_epoch is not None and session.epoch != expected_epoch)
@@ -367,6 +494,7 @@ class NativeRuntimeBridgeMixin:
         session: DuplexSession,
         expected_epoch: int | None,
         expected_model_turn_id: int | None = None,
+        origin_input_seq: int | None = None,
     ) -> None:
         """Give an active model turn another silence unit.
 
@@ -377,9 +505,16 @@ class NativeRuntimeBridgeMixin:
         """
         response_id = session.active_response_id
         native = self._runtime_session_state(session)
-        if session.state == DuplexSessionState.CLOSED:
+        if session.state != DuplexSessionState.OPEN:
             native.clear_continuation()
             return
+        final_input_seq = (
+            native.final_input_identity(epoch=session.epoch)
+            if not native.input_since_commit and not native.final_input_acceptance_pending()
+            else None
+        )
+        if final_input_seq is not None:
+            origin_input_seq = final_input_seq
         request_id = session.active_request_id
         if request_id is None:
             native.clear_continuation()
@@ -403,7 +538,11 @@ class NativeRuntimeBridgeMixin:
         if not auto_response and count >= self._NATIVE_RESPONSE_MAX_CONTINUATION_UNITS:
             return
         payload = self._native_silence_unit_payload()
+        if auto_response and count + 1 >= self._NATIVE_AUTO_RESPONSE_FORCE_LISTEN_UNITS:
+            payload["force_listen"] = True
         payload["duplex_turn_id"] = payload_turn_id
+        if origin_input_seq is not None and origin_input_seq > 0:
+            payload["duplex_origin_input_seq"] = origin_input_seq
 
         scheduler = native.silence_continuation_scheduler
         if scheduler is None:
@@ -427,8 +566,45 @@ class NativeRuntimeBridgeMixin:
             native.continuation_owner_id = owner_id
             native.continuation_units = count + 1
 
+    async def _continue_pending_native_input(
+        self,
+        send_json,
+        *,
+        session: DuplexSession,
+        expected_epoch: int | None,
+        final_commit: bool = False,
+    ) -> None:
+        native = self._runtime_session_state(session)
+        if native.final_input_acceptance_pending() and not final_commit:
+            return
+        pending = native.pending_input_identity(epoch=session.epoch)
+        if final_commit and pending is None and session.active_response_id is not None:
+            final_input_seq = native.accepted_input_watermark(epoch=session.epoch)
+            if final_input_seq is not None:
+                pending = (final_input_seq, session.turn_id)
+        if pending is None:
+            return
+        if final_commit:
+            native.record_final_input(epoch=session.epoch, seq=pending[0])
+        if (
+            session.active_response_id is None
+            and not native.input_since_commit
+            and native.final_input_identity(epoch=session.epoch) == pending[0]
+            and pending[1] < session.turn_id
+        ):
+            native.promote_pending_input_turn(epoch=session.epoch, seq=pending[0], model_turn_id=session.turn_id)
+            pending = (pending[0], session.turn_id)
+        await self._maybe_continue_native_response(
+            send_json,
+            session=session,
+            expected_epoch=expected_epoch,
+            expected_model_turn_id=pending[1],
+            origin_input_seq=pending[0],
+        )
+
     async def _cancel_native_data_plane_stream(self, session: DuplexSession) -> bool:
         native = self._runtime_session_state(session)
+        native.clear_continuation()
         task = native.data_plane_task
         native.data_plane_task = None
         native.data_plane_restart_requested = False
@@ -702,10 +878,18 @@ class NativeRuntimeBridgeMixin:
                 return None
             if session.state == DuplexSessionState.CLOSED:
                 return None
+            poll_timeout = self._runtime_control_timeout_s(session)
+            native = self._runtime_session_state(session)
+            if (
+                self._session_auto_responds(session)
+                and not native.input_since_commit
+                and native.final_input_identity(epoch=session.epoch) is not None
+            ):
+                poll_timeout = min(poll_timeout, max(1.0, session.capabilities.chunk_period_ms / 1000.0))
             outputs = await collect_outputs(
                 request_id,
                 response_stage_id=response_stage_id,
-                timeout=self._runtime_control_timeout_s(session),
+                timeout=poll_timeout,
             )
             if expected_epoch is not None and session.epoch != expected_epoch:
                 return None
@@ -799,6 +983,13 @@ class NativeRuntimeBridgeMixin:
             return close_reason, emitted_response
         if isinstance(native_result.get("error_code"), str):
             response_id = session.active_response_id
+            await self._emit_input_processed(
+                send_json,
+                session=session,
+                native_result=native_result,
+                outcome="failed",
+                response_id=response_id,
+            )
             await send_json(
                 {
                     "type": "error",
@@ -825,6 +1016,12 @@ class NativeRuntimeBridgeMixin:
                         "playback": session.playback.as_dict(),
                     }
                 )
+            failed_input_seq = coerce_int(native_result.get("input_seq"))
+            if failed_input_seq is not None:
+                self._runtime_session_state(session).resolve_final_input(
+                    epoch=session.epoch,
+                    seq=failed_input_seq,
+                )
             return close_reason, True
         if native_result.get("requires_stage_handoff") is True or native_result.get("requires_tts_stage") is True:
             # Stage0 announces a talker handoff before Stage1 has produced
@@ -836,7 +1033,31 @@ class NativeRuntimeBridgeMixin:
         is_listen = native_result.get("is_listen")
         model_turn_id = coerce_int(native_result.get("model_turn_id"))
         if native_result.get("is_buffering") is True or native_result.get("prefill_success") is False:
-            if native_result.get("data_plane_request_id") == session.active_request_id:
+            native = self._runtime_session_state(session)
+            if native.final_input_acceptance_pending():
+                payload = {
+                    "type": "response.listen",
+                    "session_id": session.session_id,
+                    "epoch": session.epoch,
+                    "reason": native_result.get("reason") or "buffering",
+                    "model_listen": False,
+                    "buffering": True,
+                }
+                self._attach_native_runtime_metadata(payload, native_result)
+                await send_json(payload)
+                return close_reason, emitted_response
+            final_input_seq = (
+                native.final_input_identity(epoch=session.epoch) if not native.input_since_commit else None
+            )
+            if final_input_seq is not None:
+                await self._maybe_continue_native_response(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                    expected_model_turn_id=model_turn_id,
+                    origin_input_seq=final_input_seq,
+                )
+            elif native_result.get("data_plane_request_id") == session.active_request_id:
                 session.clear_request()
             payload = {
                 "type": "response.listen",
@@ -861,13 +1082,51 @@ class NativeRuntimeBridgeMixin:
                 and not session.active_response_accepts_model_turn(model_turn_id)
             ):
                 return close_reason, emitted_response
+            native = self._runtime_session_state(session)
+            input_seq = coerce_int(native_result.get("input_seq"))
+            final_input_seq = native.final_input_identity(epoch=session.epoch)
+            final_acceptance_pending = native.final_input_acceptance_pending()
+            final_input_decision = (
+                not native.input_since_commit and input_seq is not None and input_seq == final_input_seq
+            )
+            final_model_listen = (final_input_decision or final_acceptance_pending) and native_result.get(
+                "model_listen"
+            ) is True
+            if (
+                self._session_auto_responds(session)
+                and final_acceptance_pending
+                and native_result.get("model_listen") is False
+            ):
+                return close_reason, emitted_response
+            if (
+                self._session_auto_responds(session)
+                and native_result.get("model_listen") is False
+                and (final_input_decision or session.active_response_id is None)
+            ):
+                await self._maybe_continue_native_response(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                    expected_model_turn_id=model_turn_id,
+                    origin_input_seq=input_seq,
+                )
+                return close_reason, emitted_response
             non_terminal_auto_listen = (
                 self._session_auto_responds(session)
                 and session.active_response_id is not None
                 and session.active_request_id is not None
                 and native_result.get("end_of_turn") is not True
+                and not final_model_listen
             )
             if non_terminal_auto_listen:
+                if not final_input_decision:
+                    await self._emit_input_processed(
+                        send_json,
+                        session=session,
+                        native_result=native_result,
+                        outcome="speak",
+                        response_id=session.active_response_id,
+                    )
                 await self._maybe_continue_native_response(
                     send_json,
                     session=session,
@@ -881,7 +1140,7 @@ class NativeRuntimeBridgeMixin:
             if not isinstance(model_listen, bool):
                 model_listen = native_result.get("reason") in {None, "", "model_listen"}
             response_id = session.active_response_id
-            if isinstance(data_plane_request_id, str) and not auto_response:
+            if isinstance(data_plane_request_id, str) and (not auto_response or final_model_listen):
                 self._serving_runtime_adapter.data_plane.mark_terminal(data_plane_request_id)
             emitted_response = True
             payload = {
@@ -891,6 +1150,12 @@ class NativeRuntimeBridgeMixin:
                 "reason": native_result.get("reason") or "model_listen",
                 "model_listen": model_listen,
             }
+            await self._emit_input_processed(
+                send_json,
+                session=session,
+                native_result=native_result,
+                outcome="listen",
+            )
             self._attach_native_runtime_metadata(payload, native_result)
             await send_json(payload)
             if native_result.get("abort_data_plane_request") is True and isinstance(data_plane_request_id, str):
@@ -913,16 +1178,30 @@ class NativeRuntimeBridgeMixin:
                         expected_epoch=expected_epoch,
                     )
                     return close_reason, emitted_response
-                session.end_response(commit_text=False, preserve_request=auto_response)
+                should_commit = self._should_commit_response_to_history(session, response_id)
+                committed_message = session.end_response(
+                    commit_text=should_commit,
+                    preserve_request=auto_response,
+                )
+                if should_commit:
+                    session.register_history_item(f"item_{response_id}", committed_message)
                 await send_json(
                     {
                         "type": "response.done",
                         "session_id": session.session_id,
                         "response_id": response_id,
                         "epoch": session.epoch,
-                        "committed": False,
+                        "committed": committed_message is not None,
                         "playback": session.playback.as_dict(),
                     }
+                )
+            if final_model_listen and input_seq is not None:
+                native.resolve_final_input(epoch=session.epoch, seq=input_seq)
+            if auto_response and not final_model_listen:
+                await self._continue_pending_native_input(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
                 )
             return close_reason, emitted_response
 
@@ -945,6 +1224,7 @@ class NativeRuntimeBridgeMixin:
                     session=session,
                     expected_epoch=expected_epoch,
                     expected_model_turn_id=model_turn_id,
+                    origin_input_seq=coerce_int(native_result.get("input_seq")),
                 )
             return close_reason, emitted_response
         if end_of_turn and not has_text and not has_audio and session.active_response_id is None:
@@ -956,7 +1236,6 @@ class NativeRuntimeBridgeMixin:
             if model_turn_id is not None:
                 session.complete_model_turn(model_turn_id)
             if self._session_auto_responds(session):
-                self._runtime_session_state(session).clear_continuation()
                 emitted_response = True
                 payload = {
                     "type": "response.listen",
@@ -965,8 +1244,26 @@ class NativeRuntimeBridgeMixin:
                     "reason": "model_turn_completed_without_output",
                     "model_listen": True,
                 }
+                await self._emit_input_processed(
+                    send_json,
+                    session=session,
+                    native_result=native_result,
+                    outcome="listen",
+                )
+                terminal_input_seq = coerce_int(native_result.get("input_seq"))
+                if terminal_input_seq is not None:
+                    self._runtime_session_state(session).resolve_final_input(
+                        epoch=session.epoch,
+                        seq=terminal_input_seq,
+                    )
+                self._runtime_session_state(session).clear_continuation()
                 self._attach_native_runtime_metadata(payload, native_result)
                 await send_json(payload)
+                await self._continue_pending_native_input(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                )
             return close_reason, emitted_response
         if session.active_response_id is None and model_turn_id is not None and model_turn_id < session.turn_id:
             # A continuation append can already be in flight when the prior
@@ -998,6 +1295,13 @@ class NativeRuntimeBridgeMixin:
                     epoch=session.epoch,
                 )
             )
+        await self._emit_input_processed(
+            send_json,
+            session=session,
+            native_result=native_result,
+            outcome="speak",
+            response_id=response_id,
+        )
         response_stage_metrics = session.accumulate_response_stage_metrics(
             native_result.get("stage_metrics") if isinstance(native_result.get("stage_metrics"), Mapping) else None
         )
@@ -1125,7 +1429,68 @@ class NativeRuntimeBridgeMixin:
                     "playback": session.playback.as_dict(),
                 }
             )
+            terminal_input_seq = coerce_int(native_result.get("input_seq"))
+            if terminal_input_seq is not None:
+                self._runtime_session_state(session).resolve_final_input(
+                    epoch=session.epoch,
+                    seq=terminal_input_seq,
+                )
+            if self._session_auto_responds(session):
+                await self._continue_pending_native_input(
+                    send_json,
+                    session=session,
+                    expected_epoch=expected_epoch,
+                )
         return close_reason, emitted_response
+
+    async def _emit_input_processed(
+        self,
+        send_json,
+        *,
+        session: DuplexSession,
+        native_result: dict[str, object],
+        outcome: str,
+        response_id: str | None = None,
+    ) -> None:
+        native = self._runtime_session_state(session)
+        input_seq = coerce_int(native_result.get("input_seq"))
+        if input_seq is None or input_seq <= 0:
+            return
+        if native.mark_input_processed(epoch=session.epoch, seq=input_seq):
+            await self._send_input_processed_event(
+                send_json,
+                session=session,
+                input_seq=input_seq,
+                outcome=outcome,
+                response_id=response_id,
+            )
+        else:
+            native.defer_input_processed(
+                epoch=session.epoch,
+                seq=input_seq,
+                outcome=outcome,
+                response_id=response_id,
+            )
+
+    @staticmethod
+    async def _send_input_processed_event(
+        send_json,
+        *,
+        session: DuplexSession,
+        input_seq: int,
+        outcome: str,
+        response_id: str | None,
+    ) -> None:
+        payload: dict[str, object] = {
+            "type": "input.processed",
+            "session_id": session.session_id,
+            "epoch": session.epoch,
+            "processed_input_seq": input_seq,
+            "outcome": outcome,
+        }
+        if isinstance(response_id, str) and response_id:
+            payload["response_id"] = response_id
+        await send_json(payload)
 
     async def _end_active_response_before_future_model_turn(
         self,

--- a/vllm_omni/experimental/fullduplex/openai/serving.py
+++ b/vllm_omni/experimental/fullduplex/openai/serving.py
@@ -1259,13 +1259,14 @@ class OmniDuplexSessionHandler(
             session.register_history_item(realtime_item_id, committed.message)
         return committed
 
-    @staticmethod
     def _native_audio_committed_payload(
+        self,
         session: DuplexSession,
         *,
         committed: DuplexCommittedInput | None = None,
         realtime_item_id: object | None = None,
         transcript: object | None = None,
+        include_accepted_input_watermark: bool = False,
     ) -> dict[str, object]:
         message = committed.message if committed is not None else None
         if not isinstance(message, dict):
@@ -1292,6 +1293,12 @@ class OmniDuplexSessionHandler(
             payload["transcript"] = transcript
         if isinstance(realtime_item_id, str) and realtime_item_id:
             payload["realtime_item_id"] = realtime_item_id
+        if include_accepted_input_watermark:
+            accepted_input_seq = self._runtime_session_state(session).accepted_input_watermark(
+                epoch=int(payload["epoch"]),
+            )
+            if accepted_input_seq is not None:
+                payload["accepted_input_seq"] = accepted_input_seq
         return payload
 
     @staticmethod

--- a/vllm_omni/experimental/fullduplex/openai/session_runner.py
+++ b/vllm_omni/experimental/fullduplex/openai/session_runner.py
@@ -355,6 +355,7 @@ class DuplexSessionRunnerMixin:
                         send_json=emit_event,
                         mode="append_audio_chunk",
                         expected_epoch=append_epoch,
+                        track_input_watermark=not silence_continuation,
                     )
                     if append_ok:
                         if pcm_reservation is not None:
@@ -503,22 +504,21 @@ class DuplexSessionRunnerMixin:
             clear_completed_pending_silence()
             pending_silence = native.pending_silence_task
             if pending_silence is not None and not pending_silence.done():
-                if pending_silence is asyncio.current_task():
-                    return False
-                try:
-                    if not await pending_silence:
+                if pending_silence is not asyncio.current_task():
+                    try:
+                        if not await pending_silence:
+                            return False
+                    except asyncio.CancelledError:
+                        current = asyncio.current_task()
+                        if current is not None and current.cancelling():
+                            raise
                         return False
-                except asyncio.CancelledError:
-                    current = asyncio.current_task()
-                    if current is not None and current.cancelling():
-                        raise
-                    return False
-                except Exception:
-                    return False
-                clear_completed_pending_silence()
-                pending_silence = native.pending_silence_task
-                if pending_silence is not None and not pending_silence.done():
-                    return False
+                    except Exception:
+                        return False
+                    clear_completed_pending_silence()
+                    pending_silence = native.pending_silence_task
+                    if pending_silence is not None and not pending_silence.done():
+                        return False
             append_tail = actor.native_append_tail
             if (append_tail is None or append_tail.done()) and real_native_input_waiting():
                 return False
@@ -1632,16 +1632,8 @@ class DuplexSessionRunnerMixin:
                                 transcript=event.get("transcript"),
                                 turn_id=data_plane_turn_id,
                             )
-                            await emit_event(
-                                self._native_audio_committed_payload(
-                                    session,
-                                    committed=committed,
-                                    realtime_item_id=event.get("realtime_item_id"),
-                                    transcript=event.get("transcript"),
-                                )
-                            )
                             if final_payload is not None:
-                                await start_native_append(
+                                append_task = await start_native_append(
                                     {
                                         **final_payload,
                                         "duplex_turn_id": data_plane_turn_id,
@@ -1650,6 +1642,24 @@ class DuplexSessionRunnerMixin:
                                     precreate_response=False,
                                     operation_id=commit_reservation.operation_id,
                                     retained_committed_payload=final_payload,
+                                )
+                                if append_task is None or not await append_task:
+                                    continue
+                            await emit_event(
+                                self._native_audio_committed_payload(
+                                    session,
+                                    committed=committed,
+                                    realtime_item_id=event.get("realtime_item_id"),
+                                    transcript=event.get("transcript"),
+                                    include_accepted_input_watermark=True,
+                                )
+                            )
+                            if final_payload is None:
+                                await self._continue_pending_native_input(
+                                    emit_event,
+                                    session=session,
+                                    expected_epoch=session.epoch,
+                                    final_commit=True,
                                 )
                             continue
                     if self._uses_native_input_append(session) and event_type == "response.create":

--- a/vllm_omni/model_executor/models/minicpmo_4_5/__init__.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/__init__.py
@@ -6,3 +6,5 @@
 # both the model registry and pipeline registry import submodules
 # directly — heavy imports here would be loaded as a side effect
 # even though nothing depends on these re-exports.
+
+MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK = 26

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -69,6 +69,17 @@ def _codec_tensor(value: Any, fallback: torch.Tensor) -> torch.Tensor:
 # OmniGPUModelRunner._preprocess and the NPU _gather_runtime_additional_information
 # override). A step carrying only these has no producer payload at all.
 _RUNNER_STAMPED_KEYS = frozenset({"request_id", "req_id", "generated_len", "meta"})
+_PRODUCER_META_KEYS = frozenset(
+    {
+        "cache_epoch",
+        "chunk_seq",
+        "code_flat_numel",
+        "last_chunk",
+        "prompt_cache_id",
+        "prompt_wav",
+        "ref_audio_sr",
+    }
+)
 
 
 def _carries_stage_payload(info: Mapping[str, Any], meta: Mapping[str, Any]) -> bool:
@@ -77,9 +88,12 @@ def _carries_stage_payload(info: Mapping[str, Any], meta: Mapping[str, Any]) -> 
     Any real async-chunk payload brings producer metadata along, whether the
     transport delivers it nested under ``meta`` or as flattened ``meta.*`` keys.
     """
+    codes = info.get("codes")
+    if isinstance(codes, Mapping) and any(value is not None for value in codes.values()):
+        return True
     if any(key not in _RUNNER_STAMPED_KEYS for key in info):
         return True
-    return meta is not info and any(key not in _RUNNER_STAMPED_KEYS for key in meta)
+    return any(meta.get(key) is not None for key in _PRODUCER_META_KEYS)
 
 
 @dataclass(frozen=True)
@@ -113,6 +127,7 @@ class _WorkItem:
     runtime_prompt_key: str | None
     duplex_epoch: int
     duplex_turn_id: int
+    duplex_input_seq: int
     segment_text_utf8: torch.Tensor
     tts_is_last_chunk: bool
     segment_end: bool
@@ -126,6 +141,7 @@ class MiniCPMO45Code2Wav(nn.Module):
     input_modalities = "audio"
     have_multimodal_outputs = True
     enable_update_additional_information = True
+    replace_runtime_additional_information = True
     requires_raw_input_tokens = True
     requires_request_ids = True
     has_preprocess = False
@@ -354,6 +370,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                 runtime_prompt_key=None,
                 duplex_epoch=-1,
                 duplex_turn_id=-1,
+                duplex_input_seq=-1,
                 segment_text_utf8=torch.empty(0, dtype=torch.uint8),
                 tts_is_last_chunk=False,
                 segment_end=False,
@@ -451,6 +468,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             runtime_prompt_key=runtime_prompt_key,
             duplex_epoch=int(_scalar(meta.get("duplex_epoch"), -1)),
             duplex_turn_id=int(_scalar(meta.get("duplex_turn_id"), -1)),
+            duplex_input_seq=int(_scalar(meta.get("duplex_input_seq"), -1)),
             segment_text_utf8=segment_text_utf8,
             tts_is_last_chunk=tts_is_last_chunk,
             segment_end=bool(_scalar(meta.get("segment_end"), False)),
@@ -708,6 +726,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                 # processor before the full-duplex data plane consumes them.
                 "meta.duplex_epoch": [torch.tensor(item.duplex_epoch, dtype=torch.int32) for item in items],
                 "meta.duplex_turn_id": [torch.tensor(item.duplex_turn_id, dtype=torch.int32) for item in items],
+                "meta.duplex_input_seq": [torch.tensor(item.duplex_input_seq, dtype=torch.int32) for item in items],
                 "meta.llm_output_text_utf8": [item.segment_text_utf8 for item in items],
                 "meta.tts_is_last_chunk": [torch.tensor(item.tts_is_last_chunk, dtype=torch.bool) for item in items],
                 "meta.segment_end": [torch.tensor(item.segment_end, dtype=torch.bool) for item in items],

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -380,6 +380,13 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         )
         update_result = dict(result)
         update_result.pop("inputs_embeds", None)
+        update_result.update(
+            {
+                key: duplex[key]
+                for key in ("session_id", "incarnation", "epoch", "seq", "input_seq", "turn_id")
+                if key in duplex
+            }
+        )
         if result.get("success") is not True:
             embeds = input_embeds if input_embeds is not None else self.get_input_embeddings(input_ids)
             return input_ids, embeds, {"duplex": update_result}
@@ -607,6 +614,30 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
                         ]
                         for key in sorted(special_keys)
                     }
+                duplex_meta = multimodal_outputs.setdefault("meta", {})
+                for output_key, input_key in (
+                    ("duplex_epoch", "epoch"),
+                    ("duplex_input_seq", "input_seq"),
+                    ("duplex_turn_id", "turn_id"),
+                ):
+                    duplex_meta[output_key] = [
+                        (
+                            torch.tensor(
+                                [int(value)],
+                                dtype=torch.long,
+                                device=text_hidden_states.device,
+                            )
+                            if isinstance(value, int) and not isinstance(value, bool)
+                            else None
+                        )
+                        for duplex_info in duplex_rows
+                        for value in [
+                            duplex_info.get(
+                                input_key,
+                                duplex_info.get("seq") if input_key == "input_seq" else None,
+                            )
+                        ]
+                    ]
             return OmniOutput(
                 text_hidden_states=text_hidden_states,
                 multimodal_outputs=multimodal_outputs,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -27,6 +27,7 @@ from vllm.model_executor.models.utils import maybe_prefix
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_omni.experimental.fullduplex.engine.intermediate import get_tts_handoff
+from vllm_omni.model_executor.models.minicpmo_4_5 import MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK
 from vllm_omni.model_executor.models.output_templates import OmniOutput
 from vllm_omni.platforms import current_omni_platform
 
@@ -45,7 +46,6 @@ _CODEC_TOP_K = 25
 _CODEC_TOP_P = 0.85
 _CODEC_REPETITION_PENALTY = 1.05
 _CODEC_MIN_TOKENS = 50
-_DUPLEX_CODEC_TOKENS_PER_CHUNK = 26
 
 
 @dataclass(slots=True)
@@ -360,8 +360,8 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 bool(meta.get("turn_start", False)) or bool(meta.get("turn_end", False))
             )
             if native_duplex:
-                max_tokens = _DUPLEX_CODEC_TOKENS_PER_CHUNK
-                min_tokens = 0 if duplex_boundary else _DUPLEX_CODEC_TOKENS_PER_CHUNK
+                max_tokens = MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK
+                min_tokens = 0 if duplex_boundary else MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK
             else:
                 max_tokens = _max_audio_tokens(int(token_ids.numel()))
                 min_tokens = self._codec_min_tokens
@@ -502,6 +502,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         native_duplex_flags: list[torch.Tensor] = []
         duplex_epochs: list[torch.Tensor] = []
         duplex_turn_ids: list[torch.Tensor] = []
+        duplex_input_seqs: list[torch.Tensor] = []
         segment_texts_utf8: list[torch.Tensor] = []
         turn_end_flags: list[torch.Tensor] = []
         empty_delta = hidden.new_empty((0, 1), dtype=torch.long)
@@ -517,6 +518,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                     duplex_info = {}
                 epoch = duplex_info.get("epoch", -1)
                 turn_id = duplex_info.get("turn_id", -1)
+                input_seq = duplex_info.get("input_seq", -1)
                 if native_duplex and not all(
                     isinstance(value, int) and not isinstance(value, bool) and value >= 0 for value in (epoch, turn_id)
                 ):
@@ -544,6 +546,9 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 native_duplex_flags.append(torch.tensor(native_duplex, dtype=torch.bool))
                 duplex_epochs.append(torch.tensor(epoch if isinstance(epoch, int) else -1, dtype=torch.long))
                 duplex_turn_ids.append(torch.tensor(turn_id if isinstance(turn_id, int) else -1, dtype=torch.long))
+                duplex_input_seqs.append(
+                    torch.tensor(input_seq if isinstance(input_seq, int) else -1, dtype=torch.long)
+                )
                 segment_texts_utf8.append(
                     torch.tensor(
                         list(segment_text.encode("utf-8")),
@@ -655,6 +660,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                     "native_duplex": native_duplex_flags,
                     "duplex_epoch": duplex_epochs,
                     "duplex_turn_id": duplex_turn_ids,
+                    "duplex_input_seq": duplex_input_seqs,
                     "llm_output_text_utf8": segment_texts_utf8,
                     "turn_end": turn_end_flags,
                 }

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -16,6 +16,7 @@ from vllm_omni.experimental.fullduplex.engine.intermediate import (
     set_tts_handoff,
 )
 from vllm_omni.inputs.data import OmniTokensPrompt
+from vllm_omni.model_executor.models.minicpmo_4_5 import MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK
 
 logger = logging.getLogger(__name__)
 _MINICPMO45_ASYNC_STATE = "_minicpmo45_async_codec_state"
@@ -32,6 +33,7 @@ class _MiniCPMO45MetaStruct(MetaStruct):
     llm_output_text_utf8: torch.Tensor | None = None
     duplex_turn_id: int | None = None
     duplex_epoch: int | None = None
+    duplex_input_seq: int | None = None
     segment_end: bool | None = None
     turn_end: bool | None = None
     tts_is_last_chunk: bool | None = None
@@ -219,6 +221,7 @@ def tts2code2wav_async_chunk(
     native_duplex = bool(_coerce_int(output_meta.get("native_duplex")))
     duplex_epoch = _coerce_int(output_meta.get("duplex_epoch"))
     duplex_turn_id = _coerce_int(output_meta.get("duplex_turn_id"))
+    duplex_input_seq = _coerce_int(output_meta.get("duplex_input_seq"))
     segment_text_utf8 = output_meta.get("llm_output_text_utf8")
     if not isinstance(segment_text_utf8, torch.Tensor):
         segment_text_utf8 = None
@@ -260,7 +263,14 @@ def tts2code2wav_async_chunk(
         return None
 
     if native_duplex and turn_end and record.get("last_terminal_turn") == duplex_turn_key:
-        return None
+        # The connector still emits a control-only segment boundary when the
+        # terminal payload was already sent. Mark that boundary as a complete
+        # snapshot so the receiver clears, rather than replays, the previous
+        # terminal Code2Wav payload.
+        return OmniPayloadStruct(
+            meta=_MiniCPMO45MetaStruct(replace_runtime_additional_information=True),
+            request_id=request_id,
+        )
 
     state = container.get(_MINICPMO45_ASYNC_STATE)
     if not isinstance(state, dict):
@@ -370,9 +380,11 @@ def tts2code2wav_async_chunk(
             req_id=[request_id],
             duplex_epoch=duplex_epoch,
             duplex_turn_id=duplex_turn_id,
+            duplex_input_seq=duplex_input_seq,
             llm_output_text_utf8=segment_text_utf8,
             tts_is_last_chunk=flush_pending,
             turn_end=turn_end and last_chunk,
+            replace_runtime_additional_information=True,
             ref_audio_sr=ref_audio_sr,
         ),
         request_id=request_id,
@@ -432,6 +444,7 @@ def tts2code2wav_full_payload(
             finished=finished,
             req_id=[request_id],
             ref_audio_sr=_coerce_int(meta_info.get("ref_audio_sr")),
+            replace_runtime_additional_information=True,
             native_duplex_segment_text=(
                 str(meta_info["native_duplex_segment_text"])
                 if isinstance(meta_info.get("native_duplex_segment_text"), str)
@@ -439,6 +452,7 @@ def tts2code2wav_full_payload(
             ),
             duplex_turn_id=_coerce_int(duplex_info.get("model_turn_id", duplex_info.get("turn_id"))),
             duplex_epoch=_coerce_int(duplex_info.get("epoch")),
+            duplex_input_seq=_coerce_int(duplex_info.get("input_seq", duplex_info.get("seq"))),
             segment_end=bool(meta_info.get("segment_end", False)),
             turn_end=bool(meta_info.get("turn_end", False)),
             tts_is_last_chunk=True,
@@ -625,7 +639,10 @@ def _native_duplex_segment_output_ids(
     return segment_ids, segment_text, turn_start
 
 
-def _native_duplex_data_plane_metadata(streaming_context) -> dict[str, object] | None:
+def _native_duplex_data_plane_metadata(
+    streaming_context,
+    mm_output: Mapping[str, object] | None = None,
+) -> dict[str, object] | None:
     bridge_states = getattr(streaming_context, "bridge_states", None)
     if not isinstance(bridge_states, dict):
         return None
@@ -646,6 +663,17 @@ def _native_duplex_data_plane_metadata(streaming_context) -> dict[str, object] |
     turn_id = duplex_state.get("model_turn_id", duplex_state.get("turn_id"))
     if isinstance(turn_id, int):
         metadata["turn_id"] = turn_id
+    mm_meta = mm_output.get("meta") if isinstance(mm_output, Mapping) else None
+    if isinstance(mm_meta, Mapping):
+        input_seq = _coerce_int(mm_meta.get("duplex_input_seq"))
+        output_epoch = _coerce_int(mm_meta.get("duplex_epoch"))
+        output_turn_id = _coerce_int(mm_meta.get("duplex_turn_id"))
+        if input_seq is not None:
+            metadata["input_seq"] = input_seq
+        if output_epoch is not None:
+            metadata["epoch"] = output_epoch
+        if output_turn_id is not None:
+            metadata["turn_id"] = output_turn_id
     session_config = duplex_state.get("session_config")
     if isinstance(session_config, dict):
         metadata["session_config"] = dict(session_config)
@@ -905,7 +933,7 @@ def llm2tts(
         if is_native_duplex_handoff:
             turn_eos_id = special_token_ids.get("turn_eos_token_id")
             meta = model_intermediate_buffer.setdefault("meta", {})
-            data_plane_metadata = _native_duplex_data_plane_metadata(_streaming_context)
+            data_plane_metadata = _native_duplex_data_plane_metadata(_streaming_context, mm_output)
             if data_plane_metadata is not None:
                 model_intermediate_buffer["duplex"] = data_plane_metadata
             meta["native_duplex_segment_text"] = thinker_text
@@ -948,6 +976,8 @@ def llm2tts(
             scheduler_prompt_token_ids = [0] * condition_length
             handoff_meta = model_intermediate_buffer.setdefault("meta", {})
             handoff_meta["next_stage_prompt_len"] = condition_length
+            if is_native_duplex_handoff:
+                handoff_meta["next_stage_generation_tokens"] = MINICPMO45_DUPLEX_CODEC_TOKENS_PER_CHUNK
             # Native duplex resumes one Talker request within a turn, but a new
             # assistant turn must discard the previous turn's prompt and KV.
             if not is_native_duplex_handoff or native_turn_start:

--- a/vllm_omni/outputs/multimodal_accumulation.py
+++ b/vllm_omni/outputs/multimodal_accumulation.py
@@ -9,6 +9,7 @@ CHUNK_METADATA_KEYS: frozenset[str] = frozenset(
     {
         "audio_text_total_chars",
         "duplex_epoch",
+        "duplex_input_seq",
         "duplex_turn_id",
         "llm_output_text_utf8",
         "segment_end",

--- a/vllm_omni/utils/mm_outputs.py
+++ b/vllm_omni/utils/mm_outputs.py
@@ -30,6 +30,7 @@ _CLIENT_MM_META_KEYS: frozenset[str] = frozenset(
     {
         "audio_text_total_chars",
         "duplex_epoch",
+        "duplex_input_seq",
         "duplex_turn_id",
         "llm_output_text_utf8",
         "segment_end",

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1494,14 +1494,18 @@ class OmniGPUModelRunner(GPUModelRunner):
                 self.inputs_embeds.gpu[start_offset : start_offset + overlay_len].copy_(src)
 
     def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
+        replace = getattr(self.model, "replace_runtime_additional_information", False)
+        update_buffer = self._replace_intermediate_buffer if replace else self._update_intermediate_buffer
         for new_req in scheduler_output.scheduled_new_reqs:
             model_buffer = getattr(new_req, "model_intermediate_buffer", None)
             if isinstance(model_buffer, dict) and model_buffer:
-                self._update_intermediate_buffer(new_req.req_id, model_buffer)
+                update_buffer(new_req.req_id, model_buffer)
+                if replace:
+                    continue
             payload_info = getattr(new_req, "additional_information", None)
             decoded_info = deserialize_additional_information(payload_info)
             if decoded_info:
-                self._update_intermediate_buffer(new_req.req_id, decoded_info)
+                update_buffer(new_req.req_id, decoded_info)
 
         if hasattr(scheduler_output.scheduled_cached_reqs, "additional_information"):
             cached_infos = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", {})
@@ -1509,7 +1513,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 for req_id, req_infos in cached_infos.items():
                     decoded_info = deserialize_additional_information(req_infos)
                     if decoded_info:
-                        self._update_intermediate_buffer(req_id, decoded_info)
+                        update_buffer(req_id, decoded_info)
 
     def _maybe_attach_mimo_audio_req_infos(
         self,
@@ -2039,6 +2043,27 @@ class OmniGPUModelRunner(GPUModelRunner):
         # Backward compatible: mirror to old setattr location
         setattr(req_state, "additional_information_cpu", existing)
 
+    def _replace_intermediate_buffer(self, req_id: str, upd: dict) -> None:
+        """Replace one request's runtime payload with the current chunk."""
+        if not isinstance(upd, dict):
+            return
+        req_state = self.requests.get(req_id)
+        if req_state is None:
+            return
+        snapshot = dict(upd)
+        previous = self.model_intermediate_buffer.get(req_id)
+        previous_meta = previous.get("meta") if isinstance(previous, dict) else None
+        incoming_meta = snapshot.get("meta")
+        meta = dict(incoming_meta) if isinstance(incoming_meta, dict) else {}
+        if isinstance(previous_meta, dict):
+            for key in ("num_processed_tokens", "resumable"):
+                if key not in meta and key in previous_meta:
+                    meta[key] = previous_meta[key]
+        if meta or "meta" in snapshot:
+            snapshot["meta"] = meta
+        self.model_intermediate_buffer[req_id] = snapshot
+        setattr(req_state, "additional_information_cpu", snapshot)
+
     def _update_streaming_input_additional_info(self, new_req_data, req_id):
         # For streaming input prefill case only. Update buffer from last segment input.
         cached_additional_info = self.model_intermediate_buffer.get(req_id, {})
@@ -2046,6 +2071,15 @@ class OmniGPUModelRunner(GPUModelRunner):
         if not isinstance(inc_info, dict) or not inc_info:
             payload_info = getattr(new_req_data, "additional_information", None)
             inc_info = deserialize_additional_information(payload_info)
+        if getattr(self.model, "replace_runtime_additional_information", False):
+            snapshot = dict(inc_info) if isinstance(inc_info, dict) else {}
+            meta = snapshot.get("meta")
+            meta = dict(meta) if isinstance(meta, dict) else {}
+            meta["num_processed_tokens"] = 0
+            meta["resumable"] = True
+            snapshot["meta"] = meta
+            self._replace_intermediate_buffer(req_id, snapshot)
+            return
         if not isinstance(inc_info, dict) or not inc_info:
             return
         merged_info = dict(cached_additional_info) if isinstance(cached_additional_info, dict) else {}


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Add a production-ready OmniInteract workflow for MiniCPM-o 4.5 native full-duplex video/audio serving, exposed through `vllm bench serve --omni`.

This PR:

- supports the official OmniInteract layouts and the `1q1a`, `1q1a_math`, and `1qna` subsets;
- preserves real-time media pacing and exact Session completion semantics;
- writes scoreable artifacts (`.done`, `output.wav`, `wav_transcript.json`, and `official_eval_manifest.jsonl`), while failed samples remain explicitly unscoreable;
- hardens input watermarking, final-input continuation, response completion, chunk metadata replacement, and Session cleanup/reuse paths found during real H800 E2E testing;
- adds an opt-in, single-GPU Nightly E2E using the real OmniInteract dataset.

### Runtime correctness changes worth calling out

- **Code2Wav runtime snapshots:** Talker-to-Code2Wav generation chunks are complete per-step snapshots, not incremental dictionaries. The generic runner previously deep-merged a marker-only chunk into the previous terminal chunk, retaining stale `codes.audio`, `cache_epoch`, `chunk_seq`, and `last_chunk`. That could replay terminal audio or report a stale/reordered chunk. `MiniCPMO45Code2Wav` now explicitly opts into replacement through `replace_runtime_additional_information = True`; the runner replaces only that request's producer payload while retaining runner-owned `num_processed_tokens` and `resumable` state. Models without the opt-in keep the existing merge behavior.
- **Connector snapshot boundary:** generation-mode connector payloads also replace the previous chunk before reaching the runner. Diffusion and other incremental payloads retain their prior merge semantics.
- **Exact input identity through Code2Wav:** `duplex_epoch`, `duplex_turn_id`, and `duplex_input_seq` are propagated through Stage 0, Talker, Code2Wav, and the data plane. This lets Serving emit `input.processed` for the exact accepted input instead of merely observing that some output arrived.
- **Per-chunk metadata accumulation:** `duplex_input_seq` is treated as a replace-and-drain chunk snapshot. Without this rule, repeated scalar tensors accumulated into a list, were not coercible to an input sequence on non-final deltas, and could leave the final Session waiting indefinitely.
- **Duplex lifecycle and cleanup:** the Serving/runtime changes handle output-before-ACK, residual final input, silence continuation/restart ownership, CLOSING cancellation, model-turn promotion, and same-server request/KV cleanup without reviving terminal requests.

The current E2E is a **functional-correctness gate**, not an accuracy claim. It verifies that real video/audio inputs complete with exact input identity, non-empty generated audio/transcript artifacts, and clean multi-Session execution. It does not run external ASR, forced alignment, or an LLM-as-judge API.

Accuracy evaluation is retained as a follow-up workflow in `benchmarks/omniinteract/run_official_eval.py`. A future opt-in accuracy job will:

1. provision the official OmniInteract evaluator checkout, ASR checkpoint, forced-aligner checkpoint, and judge API credentials;
2. consume `official_eval_manifest.jsonl` from the functional E2E;
3. run official ASR/truncation/alignment and the LLM judge;
4. validate `unified_eval_summary.json` with no failed/skipped samples and define accuracy thresholds before making it a required gate.

## Test Plan

The real-data E2E is opt-in with `VLLM_OMNI_RUN_OMNIINTERACT_E2E=1`; the H100 Omni Nightly step enables it automatically.

Workflow:

1. Use `OMNIINTERACT_ROOT` when a valid local dataset is available; otherwise download `lucky-lance/OmniInteract` from Hugging Face.
2. Start the MiniCPM-o 4.5 Stage 0/1/2 duplex pipeline on one GPU with capacity for two concurrent Sessions.
3. Run `vllm bench serve --omni` against `/v1/realtime` with real-time pacing, `--no-oversample`, and deterministic sample ordering.
4. Exercise `1q1a`, `1q1a_math`, and `1qna`, four videos per subset, with `--max-concurrency=2` (12 videos total).
5. Require every final committed input to receive its matching processed identity; a `speak` outcome must also finish the corresponding response with audio.
6. Assert 4/4 success per subset, non-zero audio/video input chunks, `.done`, non-empty WAV/transcript artifacts, and four manifest rows per subset.

The Nightly gate intentionally uses four distinct samples per subset. With concurrency 2, this produces two admission/cleanup waves, so it tests concurrent execution and same-server slot reuse instead of only a single batch. Running all three dataset layouts still covers the important protocol and artifact paths, while real-time pacing keeps the job within the CI time budget. This is a functional gate rather than a statistically meaningful accuracy sample; the current official archive contains 150 `1q1a`, 60 `1q1a_math`, and 40 `1qna` sessions (250 total), whose full run at concurrency 2 takes several hours.

For a full-dataset run, keep `--no-oversample` and change the parameterization to carry each subset's actual size, then replace the fixed `--num-prompts=4`, `(4, 4, 0)` summary assertion, and four-row manifest assertion with that size (150/60/40 for the current archive). An equivalent standalone run can select all three subsets with `--num-prompts=250`; it should use a separate output directory and be scheduled outside the regular Nightly timeout. Dataset counts should be derived again if the upstream archive revision changes.

Focused regressions additionally cover terminal-chunk-to-marker replacement at both connector and runner boundaries, preservation of the default runner merge behavior for non-opt-in models, scalar `duplex_input_seq` replacement/drain, final input ACK ordering, continuation ownership, and reusable Session capacity after cleanup.

Manual command:

```bash
VLLM_OMNI_RUN_OMNIINTERACT_E2E=1 \
OMNIINTERACT_ROOT=/path/to/OmniInteract \
CUDA_VISIBLE_DEVICES=0 \
python3 -m pytest -s -v --color=yes \
  'tests/e2e/online_serving/test_minicpmo_4_5_duplex.py::test_minicpmo_4_5_omniinteract_e2e' \
  --run-level advanced_model
```

Optional official accuracy alignment (not executed in this PR):

```bash
JUDGE_API_KEY=... python benchmarks/omniinteract/run_official_eval.py \
  --official-repo /path/to/OmniInteract \
  --output-root /path/to/omniinteract-output \
  --asr-model /path/to/asr-checkpoint \
  --align-model /path/to/forced-aligner
```

## Test Result

- Relevant vLLM 0.25 regression matrix: 465 passed.
- Ruff check/format and git diff --check: passed.
- Public one-GPU Nightly-shaped OmniInteract E2E: 12/12 sessions passed, with 12 .done files, WAVs, non-empty transcripts, and manifest entries.
- Stage 0 8 GiB long-pair reproduction: 0/2; the same pair at 9 GiB: 2/2. A second long pair also passed 2/2 at 9 GiB.
- Infinite-SPEAK stress reproduction: 5/8 before the force-LISTEN boundary; 8/8 after it, with non-empty WAV/transcript artifacts.
- Full three-subset sweep started before the force-LISTEN fix: 249/250 (150/150, 59/60, 40/40). All 249 successes had non-empty WAV/transcript artifacts. The sole failure was the infinite-SPEAK case reproduced and closed by the post-fix 8/8 stress run; this full sweep is reported as pre-fix evidence, not as a post-fix all-green run.

This remains a functional-correctness and liveness gate, not an accuracy claim. 
<img width="1818" height="625" alt="image" src="https://github.com/user-attachments/assets/9d27300b-c6cf-468f-978f-9f1110c220e0" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
