### PR TITLE
[Bugfix][Quantization] Initialize component quantization base state

### DIFF
--- a/vllm_omni/quantization/component_config.py
+++ b/vllm_omni/quantization/component_config.py
@@ -80,6 +80,7 @@ class ComponentQuantizationConfig(QuantizationConfig):
         component_configs: dict[str, QuantizationConfig | None],
         default_config: QuantizationConfig | None = None,
     ) -> None:
+        super().__init__()
         self._components = component_configs
         self._default = default_config
         self._sorted_prefixes = sorted(self._components.keys(), key=len, reverse=True)


### PR DESCRIPTION
## Summary

- initialize `QuantizationConfig` base state in `ComponentQuantizationConfig`

## Root cause

`ComponentQuantizationConfig` subclasses `QuantizationConfig` but did not call its initializer. With vLLM 0.25, models using `SupportsQuant` update `quant_config.packed_modules_mapping` during model construction. Component-routed quantization therefore failed with an `AttributeError` before loading weights.

The parent initializer only creates the per-instance mapping. This change does not alter component routing or the underlying quantization configs.

## Validation

- verified `packed_modules_mapping` is initialized and can be updated
- `77 passed` across component routing, FP8 config, and encoder quantization tests
- `pre-commit run --all-files`
