### PR TITLE
[Core] Accelerate diffusion weight loading with pinned staging and cooperative TP (RFC #4896)

### DIFF
--- a/benchmarks/diffusion/README.md
+++ b/benchmarks/diffusion/README.md
@@ -1,7 +1,87 @@
 
 # Diffusion Serving Benchmark (Image/Video)
 
-This folder contains an online-serving benchmark script for diffusion models.
+## Weight-loading microbenchmark
+
+Use the CUDA-only microbenchmark to compare pageable H2D, pinned H2D,
+dtype-converting H2D, and fused CPU cast plus pinned H2D without downloading a
+model:
+
+```bash
+python benchmarks/diffusion/bench_weight_load_staging.py --size-mb 512 --repeats 5
+```
+
+### End-to-end startup timing
+
+Startup paths emit parseable INFO records without an opt-in flag:
+
+```text
+[StartupTiming] phase=model.pipeline_construct duration_s=... status=ok device=cuda load_format=default
+```
+
+Collect process, snapshot-download, pipeline-construction, weight-loading,
+worker, runtime-setup, warmup, and shutdown spans with:
+
+```bash
+python examples/offline_inference/text_to_video/text_to_video.py \
+  --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+  --height 480 --width 832 --num-frames 9 --num-inference-steps 2 \
+  2>&1 | tee startup.log
+
+grep '\[StartupTiming\]' startup.log
+```
+
+Add `--enable-diffusion-pipeline-profiler` to report synchronized text-encode,
+denoise, and VAE-decode durations, plus a JSON stage summary. GPU synchronization
+makes that mode diagnostic; do not compare its end-to-end time against an
+unprofiled run. The offline example also reports output processing separately
+from generation.
+
+### TP=2 cooperative-loading validation
+
+A real TP=2 run must assign both devices in the deploy config **and** set the
+nested tensor-parallel size. The CLI tensor-parallel flag alone does not assign
+stage devices. The checked-in `wan2_2_tp2.yaml` captures the validated topology.
+For a fixed checkpoint revision, run:
+
+```bash
+MODEL_PATH=$(python - <<'PY'
+from huggingface_hub import snapshot_download
+
+print(snapshot_download(
+    "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+    revision="5be7df9619b54f4e2667b2755bc6a756675b5cd7",
+))
+PY
+)
+
+CUDA_VISIBLE_DEVICES=0,1 python \
+  examples/offline_inference/text_to_video/text_to_video.py \
+  --model "$MODEL_PATH" \
+  --deploy-config benchmarks/diffusion/wan2_2_tp2.yaml \
+  --tensor-parallel-size 2 --enforce-eager \
+  --prompt "A brown and white dog is running on the grass." \
+  --negative-prompt "" --seed 42 \
+  --height 480 --width 832 --num-frames 9 \
+  --num-inference-steps 2 --guidance-scale 4.0 \
+  --output wan22-tp2.mp4 2>&1 | tee wan22-tp2.log
+```
+
+Implementation commit `0a673b4b` (tree `7e504120`) was validated with a
+zero-residency 117.512 GiB checkpoint on one AWS `g7e.12xlarge` with two RTX
+PRO 6000 Blackwell GPUs. Both ranks cooperatively loaded each of the two Wan
+DiTs. Three cold runs completed model loading in
+27.381, 27.886, and 27.792 seconds; a confirmed 100%-resident run took 8.473
+seconds. All runs produced raw frame-tensor SHA256
+`546cbc02c686628e89c61d26daf6a2bb03c2796f7d5e5acd57d8e342060041de`
+and shut down both workers without cooperative fallback or rank loss.
+
+The transport-level regression test is
+`tests/diffusion/model_loader/test_cooperative_staging_cuda.py`. It launches two
+real CUDA processes, uses NCCL collectives with buckets owned by both ranks, and
+checks every received tensor.
+
+This folder also contains an online-serving benchmark script for diffusion models.
 It sends requests to a vLLM OpenAI-compatible endpoint and reports throughput,
 latency percentiles, and optional SLO attainment.
 

--- a/benchmarks/diffusion/bench_weight_load_staging.py
+++ b/benchmarks/diffusion/bench_weight_load_staging.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark for diffusion pinned-staging weight loads.
+
+Example:
+    python benchmarks/diffusion/bench_weight_load_staging.py --size-mb 512 --repeats 5
+"""
+
+import argparse
+import statistics
+import time
+from collections.abc import Callable
+
+import torch
+
+
+def _measure(operation: Callable[[], None], repeats: int) -> float:
+    samples = []
+    for _ in range(repeats):
+        torch.accelerator.synchronize()
+        started = time.perf_counter()
+        operation()
+        torch.accelerator.synchronize()
+        samples.append(time.perf_counter() - started)
+    return statistics.median(samples)
+
+
+def _print_result(name: str, seconds: float, transferred_bytes: int) -> None:
+    gib = transferred_bytes / (1 << 30)
+    print(f"{name:<30} {seconds * 1000:9.2f} ms  {gib / seconds:8.2f} GiB/s")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--size-mb", type=int, default=256, help="FP32 source tensor size in MiB")
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+    if args.size_mb <= 0 or args.repeats <= 0:
+        parser.error("--size-mb and --repeats must be positive")
+    if not torch.cuda.is_available():
+        parser.error("CUDA is required")
+
+    source_bytes = args.size_mb << 20
+    numel = source_bytes // torch.float32.itemsize
+    pageable_fp32 = torch.empty(numel, dtype=torch.float32)
+    pinned_fp32 = torch.empty(numel, dtype=torch.float32, pin_memory=True)
+    pinned_bf16 = torch.empty(numel, dtype=torch.bfloat16, pin_memory=True)
+    gpu_fp32 = torch.empty(numel, dtype=torch.float32, device="cuda")
+    gpu_bf16 = torch.empty(numel, dtype=torch.bfloat16, device="cuda")
+    output_bytes = pinned_bf16.numel() * pinned_bf16.element_size()
+
+    pinned_fp32.copy_(pageable_fp32)
+    pinned_bf16.copy_(pageable_fp32)
+
+    cases = [
+        ("pageable fp32 H2D", lambda: gpu_fp32.copy_(pageable_fp32), source_bytes),
+        ("pinned fp32 H2D", lambda: gpu_fp32.copy_(pinned_fp32, non_blocking=True), source_bytes),
+        (
+            "pinned converting H2D",
+            lambda: gpu_bf16.copy_(pinned_fp32, non_blocking=True),
+            output_bytes,
+        ),
+        (
+            "fused CPU cast + pinned H2D",
+            lambda: (pinned_bf16.copy_(pageable_fp32), gpu_bf16.copy_(pinned_bf16, non_blocking=True)),
+            output_bytes,
+        ),
+    ]
+
+    print(f"CUDA device: {torch.cuda.get_device_name()} | FP32 source: {args.size_mb} MiB")
+    for name, operation, transferred_bytes in cases:
+        operation()
+        seconds = _measure(operation, args.repeats)
+        _print_result(name, seconds, transferred_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/diffusion/wan2_2_tp2.yaml
+++ b/benchmarks/diffusion/wan2_2_tp2.yaml
@@ -1,0 +1,20 @@
+pipeline: wan2_2_ti2v
+stages:
+  - stage_id: 0
+    devices: "0,1"
+    max_num_seqs: 1
+    enforce_eager: true
+    parallel_config:
+      pipeline_parallel_size: 1
+      data_parallel_size: 1
+      tensor_parallel_size: 2
+      enable_expert_parallel: false
+      sequence_parallel_size: 1
+      ulysses_degree: 1
+      ring_degree: 1
+      allgather_degree: 1
+      cfg_parallel_size: 1
+      vae_patch_parallel_size: 1
+      use_hsdp: false
+      hsdp_shard_size: -1
+      hsdp_replicate_size: 1

--- a/docs/user_guide/diffusion/startup_and_loading.md
+++ b/docs/user_guide/diffusion/startup_and_loading.md
@@ -58,3 +58,36 @@ configurations.
 | --- | ---: | ---: | ---: |
 | **Qwen/Qwen-Image** (53.7 GiB) | 168 s | 27 s | **6.2x** |
 | **Wan-AI/Wan2.2-I2V-A14B-Diffusers** (64.5 GiB) | 283 s | 56 s | **5.1x** |
+
+## Automatic Safetensors Startup Staging
+
+Eligible CUDA safetensors loads automatically use bounded pinned-memory staging
+(typically 1–3 GiB of pinned host memory per rank). Floating-point weights are
+converted to their destination dtype while copied into the staging pool,
+avoiding a pageable or dtype-converting H2D transfer. The pinned staging path
+is automatically skipped for quantized weights using torchao strategies,
+non-floating tensors, CPU destination offload, layerwise-offload backends,
+request-scoped pipelines, DeepSpeed CPU offload, and non-quantized HSDP with
+CPU destinations. All excluded paths fall back silently to the existing loader
+without affecting correctness.
+
+With the multiprocessing executor, the parent process also prewarms checkpoint
+pages while GPU workers spawn and import modules. It reads pipeline components
+first, then transformer shards. Before worker model initialization starts, all
+workers wait for the parent readers to stop and join; foreground component
+loading therefore never competes with speculative I/O. The exact model revision
+is resolved from the same local Hugging Face cache used by demand loading.
+Resident files, insufficient host or cgroup memory, and unavailable local
+snapshots degrade to no-op behavior without error.
+
+For tensor-parallel loads, ranks derive the same deterministic bucket schedule.
+One rank stages and uploads each bucket before broadcasting it to the other TP
+ranks. If every participant receives a reported collective failure, all ranks
+replay the unyielded window and remaining stream through local staging.
+Checkpoint source failures abort the group instead of being treated as a
+successful fallback.
+
+No additional configuration is required. Parseable `[StartupTiming]` logs
+report pipeline construction, weight application, worker model load, engine
+initialization, warmup, and shutdown. The staging microbenchmark is available
+at `benchmarks/diffusion/bench_weight_load_staging.py`.

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -591,6 +591,10 @@ def main():
     generation_end = time.perf_counter()
     generation_time = generation_end - generation_start
 
+    profiled_output = frames[0] if isinstance(frames, list) and frames else frames
+    if args.enable_diffusion_pipeline_profiler and isinstance(profiled_output, OmniRequestOutput):
+        print(f"Pipeline stage durations: {json.dumps(profiled_output.stage_durations, sort_keys=True)}")
+
     # Print profiling results
     print(f"Total generation time: {generation_time:.4f} seconds ({generation_time * 1000:.2f} ms)")
 
@@ -598,6 +602,7 @@ def main():
     if peak_mb:
         print(f"Worker peak GPU memory (reserved): {peak_mb:.2f} MiB ({peak_mb / 1024:.2f} GiB)")
 
+    output_processing_start = time.perf_counter()
     audio = None
     audio_sample_rate = args.audio_sample_rate
     if isinstance(frames, list):
@@ -766,6 +771,7 @@ def main():
     else:
         export_to_video(video_array, str(output_path), fps=args.fps)
     print(f"Saved generated video to {output_path}")
+    print(f"Output processing time: {time.perf_counter() - output_processing_start:.4f} seconds")
 
     if profiler_enabled:
         print("\n[Profiler] Stopping profiler and collecting results...")

--- a/tests/diffusion/model_loader/test_cooperative_staging.py
+++ b/tests/diffusion/model_loader/test_cooperative_staging.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.model_loader import cooperative_staging, pinned_staging
+from vllm_omni.diffusion.model_loader.cooperative_staging import (
+    _BucketPlanner,
+    cooperative_staging_weights_iterator,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _FakeGroup:
+    """In-process rendezvous standing in for a TP process group: rank threads
+    meet at barriers for all_reduce/broadcast, mirroring NCCL's blocking
+    collective semantics (including the deadlock-on-divergence property the
+    protocol is designed around — a barrier timeout IS the hang)."""
+
+    def __init__(self, world_size: int):
+        self.world_size = world_size
+        self.barrier = threading.Barrier(world_size, timeout=5)
+        self.vals = [[0]] * world_size
+        self.payload = None
+
+
+class _FakeComm:
+    def __init__(self, group: _FakeGroup, rank: int):
+        self.group = group
+        self.rank = rank
+        self.world_size = group.world_size
+        self.device = torch.device("cpu")
+
+    def all_reduce_max(self, values: list[int]) -> list[int]:
+        self.group.vals[self.rank] = list(values)
+        self.group.barrier.wait()
+        result = [max(v[i] for v in self.group.vals) for i in range(len(values))]
+        self.group.barrier.wait()
+        return result
+
+    def broadcast(self, tensor: torch.Tensor, src: int) -> None:
+        if self.rank == src:
+            self.group.payload = tensor
+        self.group.barrier.wait()
+        if self.rank != src:
+            tensor.copy_(self.group.payload)
+        self.group.barrier.wait()
+
+
+def _run_ranks(
+    world_size,
+    make_stream,
+    per_rank=None,
+    return_errors=False,
+    comm_factory=_FakeComm,
+    **iter_kwargs,
+):
+    """One iterator per rank on its own thread; asserts nobody deadlocked or
+    raised, and returns each rank's collected (name, dtype, device, value).
+    ``per_rank`` optionally supplies each rank's kwargs instead."""
+    group = _FakeGroup(world_size)
+    results = [None] * world_size
+    errors = [None] * world_size
+
+    def _rank_main(rank):
+        try:
+            it = cooperative_staging_weights_iterator(
+                make_stream(rank), comm=comm_factory(group, rank), **(per_rank[rank] if per_rank else iter_kwargs)
+            )
+            results[rank] = [(n, t.dtype, t.device.type, t.clone()) for n, t in it]
+        except RuntimeError as exc:
+            errors[rank] = exc
+
+    threads = [threading.Thread(target=_rank_main, args=(r,)) for r in range(world_size)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+    assert not any(t.is_alive() for t in threads), "rank thread deadlocked"
+    if return_errors:
+        return results, errors
+    assert all(e is None for e in errors), f"rank raised: {errors}"
+    return results
+
+
+# 96 KiB fp32 tensors: above pinned staging's tiny-tensor threshold so the
+# fallback paths stage them too.
+def _stream(n=12, numel=24576):
+    for i in range(n):
+        yield f"layer.{i}.weight", torch.full((numel,), float(i), dtype=torch.float32)
+
+
+def _assert_complete_bf16(rank_out, n, ordered=True):
+    names = [name for name, *_ in rank_out]
+    want = [f"layer.{i}.weight" for i in range(n)]
+    assert (names if ordered else sorted(names)) == (want if ordered else sorted(want))
+    for name, dtype, _, value in rank_out:
+        i = int(name.split(".")[1])
+        assert dtype is torch.bfloat16
+        assert torch.equal(value, torch.full((24576,), float(i), dtype=torch.bfloat16))
+
+
+def test_bucket_plan_determinism_and_ownership():
+    """The plan is a pure function of the metadata stream: every rank computes
+    identical bucket boundaries and owners with no communication. Ownership is
+    greedy least-loaded (balanced bytes), an oversized tensor both evicts the
+    open bucket and closes solo (the one add() that returns two buckets), and
+    packing offsets are 16-byte aligned with the fused-cast OUTPUT sizes."""
+
+    def _plan(world):
+        planner = _BucketPlanner(world, 1 << 20, target_dtypes={"big": torch.float32}, default_dtype=torch.bfloat16)
+        buckets = []
+        for name, t in [
+            ("a", torch.zeros(1000, dtype=torch.float32)),  # -> bf16, 2000 B
+            ("b", torch.zeros(300000, dtype=torch.float32)),  # -> bf16, 600 KB
+            ("big", torch.zeros(1 << 19, dtype=torch.float32)),  # stays fp32: 2 MiB, oversized
+            ("c", torch.zeros(1000, dtype=torch.float32)),
+        ]:
+            buckets.extend(planner.add(name, t))
+        tail = planner.flush()
+        if tail is not None:
+            buckets.append(tail)
+        return buckets
+
+    p1, p2 = _plan(2), _plan(2)
+    assert [[e.name for e in b.entries] for b in p1] == [[e.name for e in b.entries] for b in p2]
+    assert [b.owner for b in p1] == [b.owner for b in p2]
+
+    # 'big' evicted {a,b} and closed solo: two buckets from one add()
+    assert [[e.name for e in b.entries] for b in p1] == [["a", "b"], ["big"], ["c"]]
+    # greedy: bucket0 (602KB) -> rank0, big (2MiB) -> rank1, c -> rank0 (least loaded)
+    assert [b.owner for b in p1] == [0, 1, 0]
+    # fused-cast output sizes and alignment
+    a, b = p1[0].entries
+    assert a.nbytes == 2000 and a.out_dtype is torch.bfloat16
+    assert b.offset % 16 == 0 and b.offset == 2000  # 2000 is already 16-aligned
+    assert p1[1].entries[0].out_dtype is torch.float32  # exact-name map wins
+
+
+def test_cooperative_stream_contract(monkeypatch):
+    """Every rank yields every tensor in checkpoint order on comm.device with
+    the fused cast applied, regardless of which rank owned/staged the bucket;
+    the group stays in lockstep across many buckets and pipeline windows
+    (small bucket_bytes forces multi-bucket, multi-owner, multi-window
+    traffic), and both ranks observe identical bytes."""
+    monkeypatch.setattr(cooperative_staging, "_alloc_pinned", lambda n: torch.empty(n, dtype=torch.uint8))
+    results = _run_ranks(
+        2,
+        lambda rank: _stream(n=12),
+        bucket_bytes=200 << 10,  # 4 bf16 tensors per bucket -> 3 buckets
+        target_dtypes={"layer.0.weight": torch.float32},
+        default_dtype=torch.bfloat16,
+    )
+    for rank_out in results:
+        assert [n for n, *_ in rank_out] == [f"layer.{i}.weight" for i in range(12)]
+        for name, dtype, device, value in rank_out:
+            i = int(name.split(".")[1])
+            want_dtype = torch.float32 if i == 0 else torch.bfloat16
+            assert dtype is want_dtype and device == "cpu"
+            assert torch.equal(value, torch.full((24576,), float(i), dtype=want_dtype))
+    for (_, _, _, v0), (_, _, _, v1) in zip(results[0], results[1]):
+        assert torch.equal(v0, v1)
+
+
+def test_group_degradation_paths(monkeypatch):
+    """Degradation paths preserve each local stream without deadlocking;
+    coordinated source failures abort every rank instead of stranding peers
+    in a collective (a barrier timeout here IS that hang):
+
+    1. Pre-flight veto: one ineligible rank vetoes cooperation for everyone;
+       the eligible rank degrades to per-rank pinned staging, the ineligible
+       one to pass-through.
+    2. Mid-stream stage failure on ONE rank aborts the whole group at the
+       same window boundary via the error all-reduce.
+    3. Rank-divergent source order (the production incident: a completion-
+       order multi-thread shard iterator) is caught by the plan agreement.
+    4. Equal names/bytes with divergent metadata are also rejected.
+    5. Different stream lengths rendezvous on the terminal agreement.
+    6. A source exception aborts every rank without hanging.
+    7. Preflight, agreement, and broadcast collective failures make every
+       rank fall back locally without losing the current window."""
+    monkeypatch.setattr(cooperative_staging, "_alloc_pinned", lambda n: torch.empty(n, dtype=torch.uint8))
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", lambda n: torch.empty(n, dtype=torch.uint8))
+
+    # 1. pre-flight veto (rank1 ineligible)
+    results = _run_ranks(
+        2,
+        lambda rank: _stream(n=6),
+        per_rank=[
+            dict(local_eligible=True, default_dtype=torch.bfloat16),
+            dict(local_eligible=False, default_dtype=torch.bfloat16),
+        ],
+    )
+    _assert_complete_bf16(results[0], 6, ordered=False)  # staged: threads may reorder
+    assert [n for n, *_ in results[1]] == [f"layer.{i}.weight" for i in range(6)]
+    assert all(d is torch.float32 for _, d, _, _ in results[1])  # pass-through: untouched
+
+    # 2. one rank's staging fails mid-stream (whichever rank owns the bucket
+    # headed by layer.4 hits it; the other learns via the all-reduce). Use
+    # enough tensors to leave a partially planned bucket beyond the pipeline
+    # window; fallback must retain that bucket too.
+    real_stage = cooperative_staging._stage_bucket
+    tripped = threading.Event()
+
+    def _flaky_stage(bucket, pool, cap):
+        if bucket.entries[0].name == "layer.4.weight" and not tripped.is_set():
+            tripped.set()
+            bucket.error = RuntimeError("injected stage failure")
+            return
+        real_stage(bucket, pool, cap)
+
+    monkeypatch.setattr(cooperative_staging, "_stage_bucket", _flaky_stage)
+    results = _run_ranks(2, lambda rank: _stream(n=40), bucket_bytes=200 << 10, default_dtype=torch.bfloat16)
+    assert tripped.is_set()
+    for rank_out in results:
+        _assert_complete_bf16(rank_out, 40, ordered=False)
+    monkeypatch.setattr(cooperative_staging, "_stage_bucket", real_stage)
+
+    # 3. divergent source order across ranks
+    def _divergent(rank):
+        items = list(_stream(n=8))
+        return iter(items if rank == 0 else items[::-1])
+
+    results = _run_ranks(2, _divergent, bucket_bytes=200 << 10, default_dtype=torch.bfloat16)
+    for rank_out in results:
+        _assert_complete_bf16(rank_out, 8, ordered=False)
+
+    # 4. Same names and aggregate bytes, but different per-entry metadata.
+    # The agreement signature must include shapes/dtypes/bucket layout rather
+    # than accepting name+window-total equality and broadcasting corrupt views.
+    def _metadata_divergent(rank):
+        sizes = (1024, 2048) if rank == 0 else (2048, 1024)
+        for i, size in enumerate(sizes):
+            yield f"w.{i}", torch.full((size,), float(i))
+
+    results = _run_ranks(2, _metadata_divergent, bucket_bytes=1 << 20)
+    for rank, rank_out in enumerate(results):
+        sizes = (1024, 2048) if rank == 0 else (2048, 1024)
+        assert [(name, value.numel()) for name, _, _, value in rank_out] == [
+            (f"w.{i}", size) for i, size in enumerate(sizes)
+        ]
+        for i, (_, _, _, value) in enumerate(rank_out):
+            assert torch.equal(value, torch.full((sizes[i],), float(i)))
+
+    # 5. Different stream lengths must rendezvous on an explicit terminal
+    # window and fall back locally; the shorter rank must not leave its peer
+    # blocked in the next collective.
+    results = _run_ranks(2, lambda rank: _stream(n=8 if rank == 0 else 12), bucket_bytes=200 << 10)
+    assert [len(rank_out) for rank_out in results] == [8, 12]
+
+    # 6. A source exception is a real checkpoint failure, not a staging
+    # fallback, but it must abort every rank rather than strand peers.
+    def _source_failure(rank):
+        yield from _stream(n=4)
+        if rank == 0:
+            raise RuntimeError("checkpoint corrupt")
+        yield from _stream(n=4)
+
+    _, errors = _run_ranks(2, _source_failure, bucket_bytes=200 << 10, return_errors=True)
+    assert all(isinstance(error, RuntimeError) for error in errors)
+
+    # 7. The fake transport reports the same collective failure to every
+    # participant, as an aborted NCCL communicator does. No item in the
+    # in-flight window has been yielded yet, so every rank can safely replay
+    # that window and the untouched tail through local pinned staging.
+    class _FailingCollectiveComm(_FakeComm):
+        operation = ""
+
+        def __init__(self, group, rank):
+            super().__init__(group, rank)
+            self.all_reduce_calls = 0
+
+        def all_reduce_max(self, values):
+            self.all_reduce_calls += 1
+            if self.operation == "preflight" and self.all_reduce_calls == 1:
+                raise RuntimeError("injected preflight failure")
+            if self.operation == "all_reduce" and self.all_reduce_calls == 2:
+                raise RuntimeError("injected all-reduce failure")
+            return super().all_reduce_max(values)
+
+        def broadcast(self, tensor, src):
+            if self.operation == "broadcast":
+                raise RuntimeError("injected broadcast failure")
+            return super().broadcast(tensor, src)
+
+    for operation in ("preflight", "all_reduce", "broadcast"):
+        comm_type = type(f"Failing{operation.title()}Comm", (_FailingCollectiveComm,), {"operation": operation})
+        results = _run_ranks(
+            2,
+            lambda rank: _stream(n=12),
+            comm_factory=comm_type,
+            bucket_bytes=200 << 10,
+            default_dtype=torch.bfloat16,
+        )
+        for rank_out in results:
+            _assert_complete_bf16(rank_out, 12, ordered=False)

--- a/tests/diffusion/model_loader/test_cooperative_staging_cuda.py
+++ b/tests/diffusion/model_loader/test_cooperative_staging_cuda.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Two-GPU NCCL coverage for cooperative checkpoint staging."""
+
+from collections.abc import Iterator
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import get_open_port
+from vllm_omni.diffusion.model_loader.cooperative_staging import (
+    _TorchDistComm,
+    cooperative_staging_weights_iterator,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.parallel]
+
+
+def _stream() -> Iterator[tuple[str, torch.Tensor]]:
+    # Four entries fit in each 200 KiB BF16 output bucket. Twelve entries
+    # therefore produce three buckets whose deterministic owners are 0, 1, 0.
+    for index in range(12):
+        yield f"layer.{index}.weight", torch.full((24576,), float(index), dtype=torch.float32)
+
+
+def _run_nccl_rank(rank: int, world_size: int, master_port: int) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://127.0.0.1:{master_port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=60),
+    )
+    try:
+        device = torch.device("cuda", rank)
+        comm = _TorchDistComm(dist.group.WORLD, device)
+        count = 0
+        for name, tensor in cooperative_staging_weights_iterator(
+            _stream(),
+            comm=comm,
+            bucket_bytes=200 << 10,
+            default_dtype=torch.bfloat16,
+        ):
+            index = int(name.split(".")[1])
+            assert tensor.device == device
+            assert tensor.dtype is torch.bfloat16
+            assert torch.equal(tensor, torch.full_like(tensor, float(index)))
+            count += 1
+
+        assert count == 12
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=2)
+def test_cooperative_staging_tp2_nccl() -> None:
+    """Both real GPU ranks stage owned buckets and receive identical tensors."""
+    if not dist.is_nccl_available():
+        pytest.skip("NCCL is required for the TP=2 cooperative staging test")
+
+    world_size = 2
+    torch.multiprocessing.spawn(
+        _run_nccl_rank,
+        args=(world_size, get_open_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/diffusion/model_loader/test_pinned_staging.py
+++ b/tests/diffusion/model_loader/test_pinned_staging.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+import time
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.model_loader import pinned_staging
+from vllm_omni.diffusion.model_loader.pinned_staging import pinned_staging_weights_iterator
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+# 32768 fp32 = 128 KiB: above _MIN_STAGE_BYTES so the tensors actually stage
+# (sub-64 KiB tensors intentionally pass through, covered below).
+def _weights(n=8, numel=32768):
+    for i in range(n):
+        yield f"layer.{i}.weight", torch.full((numel,), float(i))
+
+
+@pytest.mark.cpu
+def test_stream_contract_and_producer_lifecycle():
+    """The iterator is transparent to the consumer and its producers respect
+    the read-ahead budget: single-thread runs preserve source order and
+    values; multi-thread runs may reorder but yield every item exactly once;
+    num_staging_threads=0 resolves to auto instead of stranding the consumer
+    with zero producers; producers never run more than max_inflight_bytes
+    ahead; a tensor larger than the whole budget is still admitted (no
+    deadlock); and early generator close joins the producer threads."""
+    # single thread: order + values (checked while iterating, per the
+    # recycling contract - a yielded tensor is valid until the next item)
+    seen = []
+    for name, tensor in pinned_staging_weights_iterator(_weights(), num_staging_threads=1):
+        i = int(name.split(".")[1])
+        assert torch.equal(tensor, torch.full((32768,), float(i)))
+        seen.append(name)
+    assert seen == [f"layer.{i}.weight" for i in range(8)]
+
+    # multi thread: any order, complete, no duplicates; 0 = auto must not hang
+    seen = []
+    for name, tensor in pinned_staging_weights_iterator(_weights(n=32), num_staging_threads=4):
+        i = int(name.split(".")[1])
+        assert torch.equal(tensor, torch.full((32768,), float(i)))
+        seen.append(name)
+    assert sorted(seen) == sorted(f"layer.{i}.weight" for i in range(32))
+    assert len(list(pinned_staging_weights_iterator(_weights(), num_staging_threads=0))) == 8
+
+    # backpressure: producers stay within the in-flight byte budget
+    numel = 1024
+    budget = numel * 4 * 2  # ~2 tensors in flight
+    produced = []
+
+    def _tracked():
+        for i in range(16):
+            produced.append(i)
+            yield f"w.{i}", torch.zeros(numel)
+
+    gen = pinned_staging_weights_iterator(_tracked(), max_inflight_bytes=budget, num_staging_threads=2)
+    next(gen)  # consume one
+    time.sleep(0.2)  # let producers run as far ahead as they can
+    # budget=2 in flight + up to num_staging_threads staging + 1 consumed
+    assert len(produced) <= 6
+    gen.close()
+
+    # oversized tensor admitted when nothing else is in flight
+    out = list(pinned_staging_weights_iterator(iter([("big", torch.zeros(1 << 16))]), max_inflight_bytes=16))
+    assert len(out) == 1
+
+    # early close leaves no producer threads behind
+    before = {t.ident for t in threading.enumerate()}
+    gen = pinned_staging_weights_iterator(_weights(n=64), max_inflight_bytes=64)
+    next(gen)
+    gen.close()
+    time.sleep(0.3)
+    leaked = [t for t in threading.enumerate() if t.name.startswith("pinned-staging") and t.ident not in before]
+    assert not leaked
+
+
+@pytest.mark.cpu
+def test_failure_semantics_and_helpers(monkeypatch):
+    """Source-iterator exceptions PROPAGATE (a corrupt checkpoint must abort);
+    staging-side failures of ANY exception type degrade to pass-through
+    (loading correctness must never depend on staging). Plus the pure
+    helpers: pow2 bucketing with a 1 MiB floor, auto thread count
+    ~usable-cores/4 clamped to [2, 4], bounded free buffers, and _prefault
+    never raising."""
+
+    def _bad():
+        yield "a", torch.zeros(32768)
+        raise RuntimeError("checkpoint corrupt")
+
+    with pytest.raises(RuntimeError, match="checkpoint corrupt"):
+        list(pinned_staging_weights_iterator(_bad()))
+
+    for exc in (RuntimeError("cudaHostAlloc failed"), ValueError("unexpected staging failure")):
+
+        def _boom(nbytes, exc=exc):
+            raise exc
+
+        monkeypatch.setattr(pinned_staging, "_alloc_pinned", _boom)
+        out = list(pinned_staging_weights_iterator(_weights()))
+        assert len(out) == 8
+        for name, t in out:
+            i = int(name.split(".")[1])
+            assert torch.equal(t, torch.full((32768,), float(i)))
+
+    b = pinned_staging._bucket_bytes
+    assert b(1) == 1 << 20
+    assert b(1 << 20) == 1 << 20
+    assert b((1 << 20) + 1) == 1 << 21
+    assert b(3 << 20) == 4 << 20
+
+    for cores, want in ((16, 4), (8, 2), (224, 4)):
+        monkeypatch.setattr(pinned_staging, "_usable_cpu_count", lambda c=cores: c)
+        assert pinned_staging._auto_staging_threads() == want
+
+    # Free size classes cannot accumulate beyond the internal cache cap.
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", lambda n: torch.empty(n, dtype=torch.uint8))
+    pool = pinned_staging._PinnedBufferPool(2 << 20)
+    small = pool.get(1 << 20)
+    large = pool.get(2 << 20)
+    pool.put(small)
+    pool.put(large)
+    assert pool.cached_bytes <= 2 << 20
+    assert pool.drops == 1 and pool.peak_reserved_bytes == 3 << 20
+    reused = pool.get(1 << 20)
+    assert reused.data_ptr() == small.data_ptr() and pool.reuses == 1
+
+    pinned_staging._prefault(torch.zeros(4096))
+    pinned_staging._prefault(torch.zeros(0))
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned allocation requires CUDA")
+def test_pool_recycling_and_fused_cast(monkeypatch):
+    """CUDA behaviors in one pass. Pooling economics: same-shape tensors
+    reuse pooled buffers instead of re-allocating (cudaHostAlloc during
+    in-flight H2D stalls >100ms) and recycle their backing storage; sub-64
+    KiB tensors bypass the pool entirely (no DMA benefit, and the 1 MiB
+    floor would over-allocate up to 256x). Fused-cast three-tier policy,
+    applied during the staging copy so H2D stays on the same-dtype pinned
+    DMA fast path: exact param-name matches win (protecting intentionally-
+    fp32 params); unmapped float names fall back to default_dtype (renamed/
+    fused weights, q/k/v -> qkv: 76% of Wan2.2's bytes); no default ->
+    unchanged; non-float / quantized dtypes are never cast (bit-exact for
+    dequant)."""
+    calls = {"n": 0}
+    real_alloc = pinned_staging._alloc_pinned
+
+    def _counted(nbytes):
+        calls["n"] += 1
+        return real_alloc(nbytes)
+
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _counted)
+    nbytes = 32768 * 4
+    ptrs = []
+    for name, tensor in pinned_staging_weights_iterator(
+        _weights(n=32), max_inflight_bytes=2 * nbytes, num_staging_threads=1
+    ):
+        i = int(name.split(".")[1])
+        assert torch.equal(tensor, torch.full((32768,), float(i)))
+        ptrs.append(tensor.data_ptr())
+    assert calls["n"] <= 4  # 32 identical shapes served almost entirely from reuse
+    assert len(set(ptrs)) < len(ptrs)  # same storage observed more than once
+
+    # tiny tensors: same object out, unpinned; big tensors: staged pinned copy
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", real_alloc)
+    tiny = torch.randn(64, dtype=torch.float32)  # 256 B
+    big = torch.randn(32768, dtype=torch.float32)  # 128 KiB
+    out = {}
+    for name, t in pinned_staging_weights_iterator(iter([("tiny", tiny), ("big", big)]), num_staging_threads=1):
+        out[name] = (t.is_pinned(), t.data_ptr() == (tiny if name == "tiny" else big).data_ptr(), t.clone())
+    assert out["tiny"][1] and not out["tiny"][0]
+    assert out["big"][0]
+    assert torch.equal(out["tiny"][2], tiny) and torch.equal(out["big"][2], big)
+
+    # fused cast policy tiers
+    src = torch.randn(32768, dtype=torch.float32)
+    weights = [
+        ("mapped", src.clone()),  # exact match -> bf16
+        ("norm.weight", src.clone()),  # exact match says KEEP fp32; default must not override
+        ("blocks.0.attn.q.weight", src.clone()),  # renamed: falls back to default bf16
+        ("ints", torch.arange(32768, dtype=torch.int64)),  # non-float: never cast
+        ("quant.scale", src.to(torch.float8_e4m3fn)),  # quantized: never cast
+    ]
+    out = {}
+    for name, t in pinned_staging_weights_iterator(
+        iter(weights),
+        num_staging_threads=1,
+        target_dtypes={"mapped": torch.bfloat16, "norm.weight": torch.float32},
+        default_dtype=torch.bfloat16,
+    ):
+        out[name] = (t.dtype, t.clone())
+    assert out["mapped"][0] is torch.bfloat16 and torch.equal(out["mapped"][1], src.to(torch.bfloat16))
+    assert out["norm.weight"][0] is torch.float32
+    assert out["blocks.0.attn.q.weight"][0] is torch.bfloat16
+    assert out["ints"][0] is torch.int64
+    assert out["quant.scale"][0] is torch.float8_e4m3fn
+
+    # without a default, unmapped floats stage dtype-unchanged
+    out = dict(
+        pinned_staging_weights_iterator(
+            iter([("unmapped", src.clone())]), num_staging_threads=1, target_dtypes={}, default_dtype=None
+        )
+    )
+    assert out["unmapped"].dtype is torch.float32
+
+
+@pytest.mark.cpu
+def test_loader_gate_and_dtype_wiring(monkeypatch):
+    """The loader engages staging automatically for safetensors loads,
+    passing the runtime CUDA/pinnable checks INTO the iterator as
+    `local_eligible` instead of gating the call (a rank-divergent gate would
+    strand TP peers in the pre-flight collective); it silently skips
+    incompatible destinations (cpu offload here), builds the cast map from
+    the model's params with od_config.dtype as the fallback, and disables
+    the blanket fallback for quantized sources (their fp32 scales travel
+    under pre-fusion names; a default cast would corrupt dequantization --
+    exact-name casts still apply)."""
+    from torch import nn
+
+    from vllm_omni.diffusion.model_loader import diffusers_loader as dl
+
+    captured = {}
+
+    def _fake_staging(
+        inner,
+        target_dtypes=None,
+        default_dtype=None,
+        local_eligible=True,
+        max_inflight_bytes=None,
+        context=None,
+    ):
+        captured["called"] = True
+        captured["local_eligible"] = local_eligible
+        captured["target_dtypes"] = target_dtypes
+        captured["default_dtype"] = default_dtype
+        captured["max_inflight_bytes"] = max_inflight_bytes
+        captured["context"] = context
+        return inner
+
+    monkeypatch.setattr(dl, "cooperative_staging_weights_iterator", _fake_staging)
+    monkeypatch.setattr(dl, "safetensors_weights_iterator", lambda *a, **k: iter([]))
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(dl, "is_pin_memory_available", lambda: True)
+    monkeypatch.setattr(
+        dl.DiffusersPipelineLoader,
+        "_prepare_weights",
+        lambda self, *a, **k: ("/tmp", ["x.safetensors"], True),
+    )
+    monkeypatch.setattr(dl.DiffusersPipelineLoader, "_get_checkpoint_adapter", lambda self, *a, **k: None)
+
+    loader = dl.DiffusersPipelineLoader.__new__(dl.DiffusersPipelineLoader)
+    loader.quant_config = None
+    loader.parallel_config = type("PC", (), {"use_hsdp": False})()
+    loader.load_config = type("LC", (), {"safetensors_load_strategy": "eager", "use_tqdm_on_load": False})()
+    loader.od_config = type(
+        "OD",
+        (),
+        {
+            "enable_multithread_weight_load": False,
+            "enable_cpu_offload": False,
+            "enable_layerwise_offload": False,
+            "enable_distributed_layerwise_offload": False,
+            "dtype": torch.bfloat16,
+        },
+    )()
+    src = dl.DiffusersPipelineLoader.ComponentSource(model_or_path="m", subfolder=None, revision=None)
+
+    # default: demand loading stops speculative prewarm, then staging engages.
+    handoff = type(
+        "Prewarm",
+        (),
+        {
+            "stopped": False,
+            "joined": False,
+            "stop": lambda self: setattr(self, "stopped", True),
+            "join": lambda self, timeout=None: setattr(self, "joined", True),
+        },
+    )()
+    loader._weights_prewarm_handle = handoff
+    list(loader._get_weights_iterator(src))
+    assert handoff.stopped and handoff.joined and loader._weights_prewarm_handle is None
+    assert captured.get("called") is True
+    assert captured["local_eligible"] is True
+    assert captured["target_dtypes"] is None and captured["default_dtype"] is None
+
+    # runtime ineligibility (no CUDA) still CALLS the iterator -- it must
+    # join the group vote -- but with local_eligible=False and no cast map
+    captured.clear()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    model_probe = nn.Linear(2, 2)
+    list(loader._get_weights_iterator(src, model=model_probe))
+    assert captured.get("called") is True
+    assert captured["local_eligible"] is False
+    assert captured["target_dtypes"] is None
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    # Incompatible destinations skip staging without disabling the existing
+    # multithread loader, even under TP.
+    import vllm.distributed.parallel_state as parallel_state
+
+    captured.clear()
+    multithread = {"called": False}
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(
+        dl,
+        "multi_thread_safetensors_weights_iterator",
+        lambda *a, **k: multithread.update(called=True) or iter([]),
+    )
+    loader.od_config.enable_multithread_weight_load = True
+
+    # A group preflight veto (including pinned allocation failure) preserves
+    # the configured multithread source before entering local fallback.
+    vetoed_context = type("Context", (), {"comm": None})()
+    monkeypatch.setattr(dl, "prepare_cooperative_staging", lambda eligible: vetoed_context)
+    list(loader._get_weights_iterator(src))
+    assert captured.get("called") is True
+    assert captured["context"] is vetoed_context
+    assert multithread["called"] is True
+
+    captured.clear()
+    multithread["called"] = False
+    loader.od_config.enable_cpu_offload = True
+    list(loader._get_weights_iterator(src))
+    assert captured.get("called") is None
+    assert multithread["called"] is True
+    loader.od_config.enable_cpu_offload = False
+
+    captured.clear()
+    multithread["called"] = False
+    loader.od_config.enable_distributed_layerwise_offload = True
+    list(loader._get_weights_iterator(src))
+    assert captured.get("called") is None
+    assert multithread["called"] is True
+    loader.od_config.enable_distributed_layerwise_offload = False
+
+    loader.od_config.enable_multithread_weight_load = False
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+
+    # unquantized + model: exact-name map + od_config.dtype fallback
+    model = nn.Linear(2, 2)
+    captured.clear()
+    list(loader._get_weights_iterator(src, model=model))
+    assert "weight" in captured["target_dtypes"]
+    assert captured["default_dtype"] is torch.bfloat16
+
+    # quantized source: exact-name casts only, no blanket fallback
+    captured.clear()
+    loader.quant_config = object()
+    list(loader._get_weights_iterator(src, model=model))
+    assert "weight" in captured["target_dtypes"]
+    assert captured["default_dtype"] is None

--- a/tests/diffusion/model_loader/test_prewarm.py
+++ b/tests/diffusion/model_loader/test_prewarm.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+from dataclasses import dataclass
+
+import pytest
+
+from vllm_omni.diffusion.model_loader import prewarm
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@dataclass(frozen=True)
+class _VirtualMemory:
+    available: int
+
+
+def _make_model_dir(tmp_path, sizes):
+    """Create component-like subdirs with safetensors of the given sizes."""
+    for i, (sub, size) in enumerate(sizes):
+        d = tmp_path / sub
+        d.mkdir(exist_ok=True)
+        (d / f"model-{i:05d}.safetensors").write_bytes(os.urandom(size))
+    (tmp_path / "config.json").write_text("{}")  # non-safetensors must be ignored
+    return tmp_path
+
+
+def test_read_order_and_ram_budget(tmp_path, monkeypatch):
+    """The prewarm's two planning inputs in one pass.
+
+    Read order and byte budget: reads are DiT-shards-first (what
+    load_weights consumes; other components are read by from_pretrained
+    inside the prewarm window), keyed on the MODEL-RELATIVE path so an
+    ancestor directory containing 'transformer' cannot poison the ordering;
+    the byte budget is shared across readers (a static split strands half
+    of it when the DiT lands in one partition) and reading stops within one
+    chunk of the cap.
+
+    RAM budget: min(psutil host view, cgroup remaining) — psutil sees the
+    HOST in containers (observed: a 126 GiB slice reporting a 1 TiB host)
+    while page cache is charged to the cgroup. cgroup v2 and v1 files are
+    both parsed, with 'max' / the ~2^63 v1 sentinel meaning unlimited; the
+    final budget reserves proportional headroom plus a runtime-growth
+    margin, and an unknown RAM figure disables prewarm."""
+    base = tmp_path / "transformers-models"  # ancestor name that must not affect the key
+    base.mkdir()
+    d = _make_model_dir(
+        base,
+        [("transformer", 1 << 20), ("text_encoder", 1 << 20), ("transformer_2", 1 << 20), ("vae", 1 << 20)],
+    )
+    files = sorted(
+        (os.path.join(r, n) for r, _, ns in os.walk(d) for n in ns if n.endswith(".safetensors")),
+        key=lambda p: prewarm._read_order_key(os.path.relpath(p, d)),
+    )
+    subdirs = [os.path.basename(os.path.dirname(f)) for f in files]
+    assert subdirs == ["transformer", "transformer_2", "text_encoder", "vae"]
+    parent_files = sorted(
+        files,
+        key=lambda p: prewarm._parent_read_order_key(os.path.relpath(p, d)),
+    )
+    parent_subdirs = [os.path.basename(os.path.dirname(f)) for f in parent_files]
+    assert parent_subdirs == ["text_encoder", "vae", "transformer", "transformer_2"]
+
+    # shared budget: takes succeed until exhausted, crossing zero is admitted once
+    budget = prewarm._Budget(10)
+    assert budget.take(6) and budget.take(6)
+    assert not budget.take(1)
+
+    # cap-then-stop: never reads past the budget to the tail files; loader
+    # handoff stops speculative readers before they touch another chunk.
+    cap = (1 << 20) + (1 << 19)
+    done_bytes, done_files = prewarm._read_files(files, prewarm._Budget(cap))
+    assert done_bytes <= cap + prewarm._CHUNK
+    assert done_files < 4
+    stop = prewarm.threading.Event()
+    stop.set()
+    assert prewarm._read_files(files, prewarm._Budget(cap), stop) == (0, 0)
+
+    # psutil host view (faked module)
+    import sys as _sys
+    import types as _types
+
+    fake = _types.ModuleType("psutil")
+    fake.virtual_memory = lambda: _VirtualMemory(available=42 << 30)
+    monkeypatch.setitem(_sys.modules, "psutil", fake)
+    assert prewarm._host_available_bytes() == 42 << 30
+
+    # cgroup v2 / v1 parsing through redirected paths
+    v2l, v2u = tmp_path / "memory.max", tmp_path / "memory.current"
+    v1l, v1u = tmp_path / "limit_in_bytes", tmp_path / "usage_in_bytes"
+    monkeypatch.setattr(prewarm, "_CGROUP_MEM_PATHS", ((str(v2l), str(v2u)), (str(v1l), str(v1u))))
+    v2l.write_text("1073741824\n")
+    v2u.write_text("73741824\n")
+    assert prewarm._cgroup_available_bytes() == 1073741824 - 73741824
+    v2l.write_text("max\n")
+    assert prewarm._cgroup_available_bytes() is None  # v2 unlimited, no v1 fallthrough
+    v2l.unlink()
+    v1l.write_text(str((1 << 63) - 4096))
+    v1u.write_text("0")
+    assert prewarm._cgroup_available_bytes() is None  # v1 unlimited sentinel
+    v1l.write_text("2147483648")
+    v1u.write_text("147483648")
+    assert prewarm._cgroup_available_bytes() == 2000000000
+    v1l.unlink()
+    v1u.unlink()
+    assert prewarm._cgroup_available_bytes() is None  # nothing present
+
+    # min() merge + headroom math + unknown-RAM gate
+    monkeypatch.setattr(prewarm, "_host_available_bytes", lambda: 1000 << 30)
+    monkeypatch.setattr(prewarm, "_cgroup_available_bytes", lambda: 100 << 30)
+    assert prewarm._available_ram_bytes() == 100 << 30
+    monkeypatch.setattr(prewarm, "_cgroup_available_bytes", lambda: None)
+    assert prewarm._available_ram_bytes() == 1000 << 30
+    rt = prewarm._RUNTIME_HEADROOM
+    monkeypatch.setattr(prewarm, "_available_ram_bytes", lambda: 100 << 30)
+    assert prewarm._prewarm_budget_bytes(100 << 30) == (100 << 30) - (15 << 30) - rt  # 15% proportional
+    assert prewarm._prewarm_budget_bytes(10 << 30) == (100 << 30) - (8 << 30) - rt  # 8 GiB floor
+    monkeypatch.setattr(prewarm, "_available_ram_bytes", lambda: None)
+    assert prewarm._prewarm_budget_bytes(10 << 30) == 0
+
+
+def test_resolve_local_dir_uses_revision_and_cache_dir(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    calls = []
+
+    def _snapshot_download(model, **kwargs):
+        calls.append((model, kwargs))
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snapshot_download)
+
+    resolved = prewarm._resolve_local_dir("org/model", revision="fixed-revision", cache_dir="/model-cache")
+
+    assert resolved == str(tmp_path)
+    assert calls == [
+        (
+            "org/model",
+            {"revision": "fixed-revision", "cache_dir": "/model-cache", "local_files_only": True},
+        )
+    ]
+
+
+def test_gating_and_loader_hook(tmp_path, monkeypatch):
+    """start_weights_prewarm self-gates (local dirs pass through, an uncached
+    repo id resolves to None offline, empty/missing dirs, a sub-threshold
+    budget, and a non-zero TP rank all skip; with budget the daemon runs to
+    completion), and load_model kicks it off unconditionally."""
+    assert prewarm._resolve_local_dir(str(tmp_path)) == str(tmp_path)
+    assert prewarm._resolve_local_dir("definitely/not-a-cached-repo") is None
+    assert prewarm.start_weights_prewarm("/nonexistent/path") is None
+    # A repo id that can never be in the local hub cache: a real model id
+    # here would resolve (and start prewarm) on any machine that has
+    # downloaded it, making the test machine-dependent.
+    assert prewarm.start_weights_prewarm("definitely/not-a-cached-repo") is None
+
+    (tmp_path / "readme.md").write_text("x")
+    assert prewarm.start_weights_prewarm(str(tmp_path)) is None  # no safetensors
+
+    d = _make_model_dir(tmp_path, [("transformer", 1 << 20), ("vae", 1 << 19)])
+    monkeypatch.setattr(prewarm, "_prewarm_budget_bytes", lambda total: 0)
+    assert prewarm.start_weights_prewarm(str(d)) is None  # no budget
+
+    monkeypatch.setattr(prewarm, "_prewarm_budget_bytes", lambda total: 1 << 30)
+    monkeypatch.setattr(prewarm, "_MIN_WORTHWHILE", 0)
+    monkeypatch.setattr(prewarm, "_is_file_fully_resident", lambda path: True)
+    assert prewarm.start_weights_prewarm(str(d)) is None  # resident files skip userspace reads
+    monkeypatch.setattr(prewarm, "_is_file_fully_resident", lambda path: False)
+    monkeypatch.setattr(prewarm, "_is_prewarm_rank", lambda: False)
+    assert prewarm.start_weights_prewarm(str(d)) is None  # non-zero TP rank skips
+
+    monkeypatch.setattr(prewarm, "_is_prewarm_rank", lambda: True)
+    t = prewarm.start_weights_prewarm(str(d))
+    assert t is not None
+    t.join(timeout=10)
+    assert not t.is_alive()
+
+    # loader hook: load_model starts the (self-gated) prewarm with the same
+    # revision and cache directory used by demand loading, and always cancels
+    # it when model construction fails before the native iterator handoff.
+    import torch
+
+    from vllm_omni.diffusion.model_loader import diffusers_loader as dl
+
+    class _Handle:
+        stopped = False
+        joined = False
+
+        def stop(self):
+            self.stopped = True
+
+        def join(self, timeout=None):
+            assert self.stopped
+            self.joined = True
+
+    handle = _Handle()
+    calls = []
+
+    def _start(path, *, revision=None, cache_dir=None):
+        calls.append((path, revision, cache_dir))
+        return handle
+
+    monkeypatch.setattr(dl, "start_weights_prewarm", _start)
+
+    loader = dl.DiffusersPipelineLoader.__new__(dl.DiffusersPipelineLoader)
+    loader.quant_config = None
+    loader.parallel_config = type("PC", (), {"use_hsdp": False})()
+    loader.load_config = type("LC", (), {"download_dir": "/model-cache"})()
+    loader.od_config = type(
+        "OD",
+        (),
+        {"model": str(tmp_path), "revision": "fixed-revision", "dtype": torch.float32},
+    )()
+
+    sentinel = RuntimeError("stop after prewarm hook")
+
+    def _stop(self, *a, **k):
+        raise sentinel
+
+    monkeypatch.setattr(dl.DiffusersPipelineLoader, "_init_from_load_format", _stop)
+    with pytest.raises(RuntimeError) as exc_info:
+        loader.load_model(load_device="cpu")
+    assert exc_info.value is sentinel
+    assert calls == [(str(tmp_path), "fixed-revision", "/model-cache")]
+    assert handle.stopped
+    assert handle.joined
+    assert loader._weights_prewarm_handle is None
+
+
+def test_parent_prewarm_hands_off_before_worker_model_init(monkeypatch):
+    class _Handle:
+        def __init__(self):
+            self.stopped = prewarm.threading.Event()
+            self.joined = False
+
+        def stop(self):
+            self.stopped.set()
+
+        def join(self, timeout=None):
+            assert self.stopped.is_set()
+            self.joined = True
+
+    handle = _Handle()
+    calls = []
+
+    def _start(model, *, revision=None, cache_dir=None, read_order_key=None):
+        calls.append((model, revision, cache_dir, read_order_key))
+        return handle
+
+    monkeypatch.setattr(prewarm, "_start_weights_prewarm", _start)
+
+    with prewarm.parent_weights_prewarm(
+        "org/model",
+        revision="fixed-revision",
+        cache_dir="/model-cache",
+    ) as handoff:
+        assert handoff is not None
+        assert not handle.stopped.is_set()
+        with prewarm.use_parent_weights_prewarm(handoff):
+            assert handle.stopped.is_set()
+            assert handle.joined
+            # The worker's DiffusersPipelineLoader still calls this interface,
+            # but the parent handoff suppresses a duplicate speculative reader.
+            assert prewarm.start_weights_prewarm("org/model") is None
+
+    assert calls == [
+        ("org/model", "fixed-revision", "/model-cache", prewarm._parent_read_order_key),
+    ]
+
+
+def test_worker_proc_hands_off_parent_prewarm_before_worker_creation(monkeypatch):
+    from vllm_omni.diffusion.worker import diffusion_worker as dw
+
+    class _Handle:
+        def __init__(self):
+            self.stopped = prewarm.threading.Event()
+            self.joined = False
+
+        def stop(self):
+            self.stopped.set()
+
+        def join(self, timeout=None):
+            assert self.stopped.is_set()
+            self.joined = True
+
+    handle = _Handle()
+    monkeypatch.setattr(prewarm, "_start_weights_prewarm", lambda *args, **kwargs: handle)
+
+    class _MessageQueue:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @classmethod
+        def create_from_handle(cls, *args, **kwargs):
+            return cls()
+
+        def export_handle(self):
+            return object()
+
+    monkeypatch.setattr(dw, "MessageQueue", _MessageQueue)
+    monkeypatch.setattr(dw.zmq, "Context", lambda **kwargs: object())
+
+    created_worker = object()
+
+    def _create_worker(self, *args, **kwargs):
+        assert handle.stopped.is_set()
+        assert handle.joined
+        assert prewarm.start_weights_prewarm("org/model") is None
+        return created_worker
+
+    monkeypatch.setattr(dw.WorkerProc, "_create_worker", _create_worker)
+    od_config = type("OD", (), {"master_port": 12345, "step_execution": True})()
+
+    with prewarm.parent_weights_prewarm("org/model") as handoff:
+        worker_proc = dw.WorkerProc(
+            od_config=od_config,
+            gpu_id=0,
+            broadcast_handle=object(),
+            wake_event=None,
+            weights_prewarm_handoff=handoff,
+        )
+
+    assert worker_proc.worker is created_worker
+
+
+def test_parent_prewarm_suppresses_duplicate_worker_scan_when_no_reads_start(monkeypatch):
+    calls = []
+
+    def _skip(*args, **kwargs):
+        calls.append((args, kwargs))
+        return None
+
+    monkeypatch.setattr(prewarm, "_start_weights_prewarm", _skip)
+
+    with prewarm.parent_weights_prewarm("org/model") as handoff:
+        assert handoff is not None
+        with prewarm.use_parent_weights_prewarm(handoff):
+            assert prewarm.start_weights_prewarm("org/model") is None
+
+    assert len(calls) == 1
+
+
+def test_diffusers_load_hands_off_prewarm_before_demand_loading(monkeypatch):
+    import torch
+
+    from vllm_omni.diffusion.model_loader import diffusers_loader as dl
+
+    class _Handle:
+        stopped = False
+        joined = False
+
+        def stop(self):
+            self.stopped = True
+
+        def join(self, timeout=None):
+            assert self.stopped
+            self.joined = True
+
+        def is_alive(self):
+            return not self.joined
+
+    handle = _Handle()
+    monkeypatch.setattr(dl, "start_weights_prewarm", lambda *args, **kwargs: handle)
+
+    loader = dl.DiffusersPipelineLoader.__new__(dl.DiffusersPipelineLoader)
+    loader.quant_config = None
+    loader.parallel_config = type("PC", (), {"use_hsdp": False})()
+    loader.load_config = type("LC", (), {"download_dir": None})()
+    loader.od_config = type("OD", (), {"model": "org/model", "revision": None, "dtype": torch.float32})()
+
+    class _Model(torch.nn.Module):
+        def load_weights(self):
+            assert handle.stopped
+            assert handle.joined
+            assert not handle.is_alive()
+
+    model = _Model()
+    monkeypatch.setattr(loader, "_init_from_load_format", lambda *args, **kwargs: model)
+    monkeypatch.setattr(loader, "_process_weights_after_loading", lambda *args, **kwargs: None)
+    monkeypatch.setattr(loader, "_apply_skip_softmax_calibration", lambda *args, **kwargs: None)
+
+    assert loader.load_model(load_device="cpu", load_format="diffusers") is model
+    assert loader._weights_prewarm_handle is None

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -4,6 +4,7 @@
 import asyncio
 import queue
 import threading
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -964,12 +965,21 @@ class TestDiffusionEngine:
         engine.od_config = SimpleNamespace(model_class_name="mock_model", diffusion_load_format="default")
         engine.pre_process_func = mocker.Mock()
         engine.add_req_and_wait_for_response = mocker.Mock(return_value=DiffusionOutput(output=None))
+        phases = []
+
+        @contextmanager
+        def _record_span(_logger, phase, **_labels):
+            phases.append(phase)
+            yield
+
+        mocker.patch("vllm_omni.diffusion.diffusion_engine.startup_span", side_effect=_record_span)
 
         engine._dummy_run()
 
         engine.pre_process_func.assert_not_called()
         admitted_request = engine.add_req_and_wait_for_response.call_args.args[0]
         assert admitted_request.request_id == "dummy_req_id"
+        assert phases == ["engine.dummy_warmup", "engine.dummy_request"]
 
 
 class TestStepScheduler:

--- a/tests/entrypoints/test_omni_base_profiler.py
+++ b/tests/entrypoints/test_omni_base_profiler.py
@@ -1,5 +1,6 @@
 """Unit tests for OmniBase and AsyncOmni profiler methods."""
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -260,3 +261,18 @@ class TestAsyncOmniProfilerSignatureConsistency:
         from vllm_omni.entrypoints.async_omni import AsyncOmni
 
         assert inspect.iscoroutinefunction(AsyncOmni.stop_profile)
+
+
+def test_weak_shutdown_engine_records_finalizer_path(mocker: MockerFixture):
+    from vllm_omni.entrypoints.omni_base import _weak_shutdown_engine, logger
+
+    engine = mocker.MagicMock()
+    startup_span = mocker.patch(
+        "vllm_omni.entrypoints.omni_base.startup_span",
+        return_value=nullcontext(),
+    )
+
+    _weak_shutdown_engine(engine)
+
+    startup_span.assert_called_once_with(logger, "engine.shutdown", trigger="finalizer")
+    engine.shutdown.assert_called_once_with()

--- a/tests/utils/test_startup_timing.py
+++ b/tests/utils/test_startup_timing.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_omni.utils import startup_timing
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, tuple[object, ...]]] = []
+
+    def info(self, message: str, *args: object) -> None:
+        self.records.append((message, args))
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_startup_span_logs_success_with_sorted_labels(monkeypatch):
+    ticks = iter([10.0, 12.5])
+    monkeypatch.setattr(startup_timing.time, "perf_counter", lambda: next(ticks))
+    logger = _RecordingLogger()
+
+    with startup_timing.startup_span(logger, "worker.device_init", rank=1, backend="cuda"):
+        pass
+
+    assert logger.records == [
+        (
+            "[StartupTiming] phase=%s duration_s=%.6f status=%s backend=%s rank=%s",
+            ("worker.device_init", 2.5, "ok", "cuda", 1),
+        )
+    ]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_startup_span_logs_failure_without_swallowing_exception(monkeypatch):
+    ticks = iter([3.0, 3.25])
+    monkeypatch.setattr(startup_timing.time, "perf_counter", lambda: next(ticks))
+    logger = _RecordingLogger()
+
+    with pytest.raises(RuntimeError, match="failed"):
+        with startup_timing.startup_span(logger, "model.construct"):
+            raise RuntimeError("failed")
+
+    assert logger.records == [
+        (
+            "[StartupTiming] phase=%s duration_s=%.6f status=%s",
+            ("model.construct", 0.25, "error"),
+        )
+    ]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_log_process_checkpoint_uses_process_age(monkeypatch):
+    monkeypatch.setattr(startup_timing, "process_age_seconds", lambda: 4.75)
+    logger = _RecordingLogger()
+
+    startup_timing.log_process_checkpoint(logger, "worker.process_to_init", rank=0)
+
+    assert logger.records == [
+        (
+            "[StartupTiming] phase=%s duration_s=%.6f status=%s checkpoint=%s rank=%s",
+            ("worker.process_to_init", 4.75, "ok", True, 0),
+        )
+    ]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_log_process_checkpoint_skips_unsupported_platform(monkeypatch):
+    monkeypatch.setattr(startup_timing, "process_age_seconds", lambda: None)
+    logger = _RecordingLogger()
+
+    startup_timing.log_process_checkpoint(logger, "worker.process_to_init")
+
+    assert logger.records == []

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -49,6 +49,7 @@ from vllm_omni.diffusion.sched.interface import DiffusionRequestStatus
 from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput, RunnerOutput
 from vllm_omni.errors import client_error_from_metadata, is_client_error_status
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
+from vllm_omni.utils.startup_timing import startup_span
 
 if TYPE_CHECKING:
     from vllm_omni.outputs import OmniRequestOutput
@@ -902,9 +903,11 @@ class DiffusionEngine:
             ),
         )
         logger.info("dummy run to warm up the model")
-        output = self.add_req_and_wait_for_response(req)
-        if output.error:
-            raise RuntimeError(f"Dummy run failed: {output.error}")
+        with startup_span(logger, "engine.dummy_warmup"):
+            with startup_span(logger, "engine.dummy_request"):
+                output = self.add_req_and_wait_for_response(req)
+            if output.error:
+                raise RuntimeError(f"Dummy run failed: {output.error}")
 
     def _submit_rpc(
         self,

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -10,6 +10,7 @@ import threading
 import time
 import weakref
 from collections.abc import Callable
+from contextlib import nullcontext
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, Any, cast
@@ -23,6 +24,10 @@ from vllm.v1.executor.multiproc_executor import set_multiprocessing_worker_envs
 from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, AsyncDiffusionOutput, AsyncOutputKind, DiffusionOutput
 from vllm_omni.diffusion.executor.abstract import DiffusionExecutor
 from vllm_omni.diffusion.ipc import DIFFUSION_RPC_RESULT_ENVELOPE, unpack_diffusion_output_shm
+from vllm_omni.diffusion.model_loader.prewarm import (
+    WeightsPrewarmHandoff,
+    parent_weights_prewarm,
+)
 from vllm_omni.diffusion.sched.request_scheduler import build_request_batch_sampling_params_key
 from vllm_omni.diffusion.worker import WorkerProc
 
@@ -294,13 +299,38 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         od_config = self.od_config
         logger.info("Starting server...")
 
-        num_gpus = cast(int, od_config.num_gpus)
         # Without this, every worker inherits one Torch thread per core, so an
         # N-GPU run oversubscribes the host by N x core_count. Honours a
         # user-provided OMP_NUM_THREADS.
         set_multiprocessing_worker_envs()
         mp.set_start_method("spawn", force=True)
-        processes = []
+
+        model_ref = getattr(od_config, "model", None)
+        load_format = getattr(od_config, "diffusion_load_format", "default")
+        prewarm_context = (
+            parent_weights_prewarm(
+                str(model_ref),
+                revision=getattr(od_config, "revision", None),
+            )
+            if model_ref and load_format != "dummy"
+            else nullcontext(None)
+        )
+        with prewarm_context as prewarm_handoff:
+            return self._launch_worker_processes(
+                broadcast_handle,
+                wake_events,
+                prewarm_handoff,
+            )
+
+    def _launch_worker_processes(
+        self,
+        broadcast_handle: Handle,
+        wake_events: list[Event],
+        prewarm_handoff: WeightsPrewarmHandoff | None,
+    ) -> tuple[list[mp.Process], list[Handle]]:
+        od_config = self.od_config
+        num_gpus = cast(int, od_config.num_gpus)
+        processes: list[mp.Process] = []
 
         # Extract worker_extension_cls and custom_pipeline_args from od_config
         worker_extension_cls = od_config.worker_extension_cls
@@ -323,6 +353,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     wake_events[i],
                     worker_extension_cls,
                     custom_pipeline_args,
+                    prewarm_handoff,
                 ),
                 name=f"DiffusionWorker-{i}",
                 daemon=True,

--- a/vllm_omni/diffusion/model_loader/cooperative_staging.py
+++ b/vllm_omni/diffusion/model_loader/cooperative_staging.py
@@ -1,0 +1,606 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cooperative weight staging across a tensor-parallel group (RFC #4896, item 3).
+
+Under TP, every rank drains the same full checkpoint iterator and its layer
+``weight_loader`` keeps only this rank's slice. Measured on Wan2.2 fp32 TP2,
+per-rank pinned staging recovered only 1.05x (vs 1.43x on one GPU) because
+the whole pipeline runs N times: pin+cast burn the same cores N times, N
+interleaved readers break sequential readahead, and the per-rank narrow of a
+staged *pinned* tensor makes the H2D source strided — off the DMA fast path.
+
+This iterator splits the work instead of repeating it. Tensors are packed
+into byte buckets; each bucket has one deterministic owner rank. The owner
+stages its buckets exactly like pinned staging (mmap read, pooled pinned
+buffer, fused dtype cast), pushes the packed bucket to the GPU with one
+contiguous H2D copy, and broadcasts it to the group. Every rank then yields
+GPU-resident tensors in the original checkpoint order, and the layer
+``weight_loader`` narrows on the GPU — cheap, and the strided-pinned problem
+disappears. Per-rank disk faults, pin, cast and H2D all drop to ~1/N.
+
+Buckets are processed in pipeline windows: transfers issue back-to-back on
+a dedicated CUDA stream and the consumer gates on per-bucket events, so
+window N's transfers overlap window N-1's weight_loader copies and window
+N+1's staging (measured: Wan2.2 cold 20.6s -> 15.4s over the serialized
+form — the apparent "disk floor" had serialized transfer time hidden in it).
+
+Lockstep: all ranks walk identical (name, shape, dtype) streams (the local
+safetensors headers), so the bucket plan and ownership are computed
+independently yet identically — no metadata communication. Only owners touch
+tensor *data*; mmap keeps non-owner reads free.
+
+Failure semantics: collectives make one-sided fallback a deadlock, so
+degradation is group-wide. A pre-flight vote (all-reduce) enters cooperative
+mode only if every rank is eligible; a per-window error+plan-agreement vote
+coordinates staging failures and catches rank-divergent source streams. Those
+failures, plus all-reduce or broadcast transport failures reported to the
+participants, replay the unyielded window and remaining stream through plain
+per-rank pinned staging. Checkpoint source errors are coordinated separately
+and raised on every rank. The load never fails because of staging — same
+contract as ``pinned_staging``.
+
+Consumer contract: identical to pinned staging — a yielded tensor is valid
+only until the next item is requested.
+"""
+
+import threading
+import time
+import zlib
+from collections.abc import Generator, Iterator, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import nullcontext
+from dataclasses import dataclass, field
+from itertools import chain
+from types import TracebackType
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.model_loader.pinned_staging import (
+    _alloc_pinned,
+    _bucket_bytes,
+    _prefault,
+    _resolve_out_dtype,
+    pinned_staging_weights_iterator,
+)
+
+logger = init_logger(__name__)
+
+# The bucket count IS the protocol overhead (one broadcast per bucket, one
+# agreement all-reduce per window). 64 MiB packed Wan2.2's ~50 MiB tensors
+# fine (444 buckets) but HunyuanImage MoE's ~31 MiB tensors barely packed:
+# 4273 buckets of collectives ate the entire warm-load win. 256 MiB caps
+# the count while the transient GPU/pinned footprint stays trivial.
+_DEFAULT_BUCKET_BYTES = 256 << 20
+# Offsets inside a bucket are aligned so a uint8 slice can be viewed as any
+# dtype (largest element size is 8 bytes; 16 also keeps copies SIMD-friendly).
+_ALIGN = 16
+# Buckets per pipeline window; also the stagers' plan-ahead depth.
+_WINDOW_BUCKETS = 4
+_STAGE_WORKERS = 4  # concurrent bucket stagings per rank
+_COLLECTIVE_ERRORS = (OSError, RuntimeError, TypeError, ValueError)
+
+
+class _CapturedFailure:
+    """Capture an operation's failure for coordinated cross-rank handling."""
+
+    def __init__(self) -> None:
+        self.error: BaseException | None = None
+
+    def __enter__(self) -> None:
+        self.error = None
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        del exc_type, traceback
+        self.error = exc
+        return exc is not None
+
+
+class _TorchDistComm:
+    """Collectives on a torch process group (NCCL in production)."""
+
+    # [stage_err, source_err, buckets, total, hash,
+    #  -buckets, -total, -hash]
+    _VEC = 8
+
+    def __init__(self, group: torch.distributed.ProcessGroup, device: torch.device):
+        self._group = group
+        self.device = device
+        self.rank = torch.distributed.get_rank(group)
+        self.world_size = torch.distributed.get_world_size(group)
+        self._flag = torch.zeros(self._VEC, dtype=torch.int64, device=device)
+
+    def all_reduce_max(self, values: list[int]) -> list[int]:
+        self._flag.zero_()
+        self._flag[: len(values)] = torch.tensor(values, dtype=torch.int64)
+        torch.distributed.all_reduce(self._flag, op=torch.distributed.ReduceOp.MAX, group=self._group)
+        return self._flag.tolist()[: len(values)]
+
+    def broadcast(self, tensor: torch.Tensor, src: int) -> None:
+        global_src = torch.distributed.get_global_rank(self._group, src)
+        torch.distributed.broadcast(tensor, src=global_src, group=self._group)
+
+
+def _tp_comm() -> _TorchDistComm | None:
+    """The TP group as a comm, or None when not distributed / TP degenerate."""
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return None
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+
+        group = get_tp_group()
+        if group.world_size <= 1:
+            return None
+        device = (
+            torch.device("cuda", torch.accelerator.current_device_index())
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        return _TorchDistComm(group.device_group, device)
+    except (ImportError, AttributeError, AssertionError, RuntimeError, ValueError):
+        return None
+
+
+@dataclass
+class _Entry:
+    name: str
+    src: torch.Tensor
+    out_dtype: torch.dtype
+    offset: int
+    nbytes: int
+
+
+@dataclass
+class _Bucket:
+    owner: int
+    entries: list[_Entry] = field(default_factory=list)
+    total: int = 0  # payload bytes (last entry's offset + nbytes)
+    future: Future[None] | None = None  # owner-side staging task
+    stage_s: float = 0.0  # owner-side read + staging-copy time
+    pinned: torch.Tensor | None = None  # owner-side staged buffer
+    error: BaseException | None = None
+    gpu: torch.Tensor | None = None  # broadcast payload
+    h2d_start: object | None = None  # owner H2D timing event
+    h2d_done: object | None = None  # owner H2D event (travels with pinned buf)
+    ready: object | None = None  # transfer-stream event gating the yields
+
+
+class _BucketPlanner:
+    """Packs the (name, tensor) stream into owned buckets, identically on
+    every rank: ownership is greedy least-loaded-by-bytes (ties to the lower
+    rank), computed purely from the deterministic metadata stream."""
+
+    def __init__(
+        self,
+        world_size: int,
+        bucket_bytes: int,
+        target_dtypes: Mapping[str, torch.dtype] | None,
+        default_dtype: torch.dtype | None,
+    ):
+        self._world = world_size
+        self._cap = bucket_bytes
+        self._target_dtypes = target_dtypes
+        self._default_dtype = default_dtype
+        self._loads = [0] * world_size
+        self._open: list[tuple[str, torch.Tensor, torch.dtype, int]] = []
+        self._open_total = 0
+
+    def _close(self) -> _Bucket | None:
+        if not self._open:
+            return None
+        owner = min(range(self._world), key=lambda r: (self._loads[r], r))
+        self._loads[owner] += self._open_total
+        bucket = _Bucket(owner=owner)
+        offset = 0
+        for name, src, out_dtype, nbytes in self._open:
+            bucket.entries.append(_Entry(name, src, out_dtype, offset, nbytes))
+            offset += -(-nbytes // _ALIGN) * _ALIGN
+        bucket.total = bucket.entries[-1].offset + bucket.entries[-1].nbytes
+        self._open, self._open_total = [], 0
+        return bucket
+
+    def add(self, name: str, tensor: torch.Tensor) -> list[_Bucket]:
+        """Add one tensor; returns the buckets this add closed (0, 1, or 2 —
+        two when an oversized tensor both evicts the open bucket and closes
+        solo)."""
+        out_dtype = _resolve_out_dtype(name, tensor.dtype, self._target_dtypes, self._default_dtype)
+        nbytes = tensor.numel() * out_dtype.itemsize
+        closed = []
+        if self._open and self._open_total + nbytes > self._cap:
+            closed.append(self._close())
+        self._open.append((name, tensor, out_dtype, nbytes))
+        self._open_total += -(-nbytes // _ALIGN) * _ALIGN
+        if self._open_total >= self._cap:
+            closed.append(self._close())
+        return closed
+
+    def flush(self) -> _Bucket | None:
+        return self._close()
+
+
+class _PinnedPool:
+    """Free list of pinned bucket buffers, shared between the consumer loop
+    and the stager threads (hence the lock).
+
+    A buffer may be repooled while its H2D copy is still in flight; the
+    associated event is waited only when the buffer is REUSED (in get, on a
+    stager thread) so the wait stays off the per-bucket consumer path."""
+
+    def __init__(self):
+        self._free: list[tuple[torch.Tensor, object | None]] = []
+        self._lock = threading.Lock()
+
+    def get(self, nbytes: int, floor: int) -> torch.Tensor:
+        need = _bucket_bytes(max(nbytes, 1))
+        with self._lock:
+            found = None
+            for i, (free, event) in enumerate(self._free):
+                if free.numel() >= need:
+                    found = self._free.pop(i)
+                    break
+        if found is not None:
+            buf, event = found
+            if event is not None:
+                event.synchronize()
+            return buf
+        return _alloc_pinned(max(need, _bucket_bytes(floor)))
+
+    def put(self, buf: torch.Tensor, event=None) -> None:
+        with self._lock:
+            self._free.append((buf, event))
+
+
+@dataclass
+class CooperativeStagingContext:
+    """Result of the group preflight performed before source selection."""
+
+    comm: object | None
+    pool: _PinnedPool
+    bucket_bytes: int
+
+
+def prepare_cooperative_staging(
+    local_eligible: bool,
+    max_inflight_bytes: int = 512 << 20,
+) -> CooperativeStagingContext:
+    """Vote on cooperation before choosing a deterministic source iterator."""
+    comm = _tp_comm()
+    pool = _PinnedPool()
+    bucket_bytes = min(_DEFAULT_BUCKET_BYTES, max(1 << 20, max_inflight_bytes))
+    if comm is None:
+        return CooperativeStagingContext(None, pool, bucket_bytes)
+
+    eligible = 0
+    if local_eligible:
+        try:
+            pool.put(_alloc_pinned(_bucket_bytes(bucket_bytes)))
+            eligible = 1
+        except (OSError, RuntimeError, TypeError, ValueError):
+            eligible = 0
+    try:
+        if comm.all_reduce_max([1 - eligible])[0] != 0:
+            comm = None
+    except _COLLECTIVE_ERRORS as exc:
+        logger.warning("Cooperative staging: preflight collective failed (%s); falling back locally.", exc)
+        comm = None
+    return CooperativeStagingContext(comm, pool, bucket_bytes)
+
+
+def _stage_bucket(bucket: _Bucket, pool: _PinnedPool, cap: int) -> None:
+    """Owner-side: pack all entries (fused cast) into one pinned buffer."""
+    started = time.perf_counter()
+    buf = pool.get(bucket.total, cap)
+    bucket.pinned = buf
+    for e in bucket.entries:
+        view = buf[e.offset : e.offset + e.nbytes].view(e.out_dtype).view(e.src.shape)
+        view.copy_(e.src)
+    bucket.stage_s = time.perf_counter() - started
+
+
+def cooperative_staging_weights_iterator(
+    weights_iter: Iterator[tuple[str, torch.Tensor]],
+    comm=None,
+    bucket_bytes: int = _DEFAULT_BUCKET_BYTES,
+    max_inflight_bytes: int = 512 << 20,
+    target_dtypes: Mapping[str, torch.dtype] | None = None,
+    default_dtype: torch.dtype | None = None,
+    local_eligible: bool = True,
+    context: CooperativeStagingContext | None = None,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Stage the checkpoint cooperatively across ``comm``'s ranks.
+
+    Yields ``(name, gpu_tensor)`` in the original order on every rank; the
+    tensors live on ``comm.device`` and are valid until the next item is
+    requested. Falls back to per-rank ``pinned_staging_weights_iterator``
+    (CPU pinned tensors, unchanged semantics) when there is no usable group,
+    when any rank votes not-eligible pre-flight, or group-wide after any
+    rank's mid-stream failure; with ``local_eligible=False`` and no group it
+    passes tensors through unstaged.
+
+    ``local_eligible`` carries the caller's *runtime* staging conditions
+    (CUDA present, pinnable memory, ...). They must be part of the vote, not
+    a caller-side gate: a rank that skipped this call entirely while its
+    peers entered the pre-flight collective would deadlock the group. Only
+    rank-invariant (config-derived) conditions may gate the call itself.
+
+    ``comm`` needs ``rank``/``world_size``/``device``/``all_reduce_max``/
+    ``broadcast``; None resolves the vLLM TP group.
+    """
+    if context is not None:
+        comm = context.comm
+        pool = context.pool
+        bucket_bytes = context.bucket_bytes
+    else:
+        # Backward-compatible lazy preflight for direct callers. The loader
+        # prepares a context eagerly so it can retain multithread loading when
+        # the group vetoes cooperation.
+        if comm is None:
+            context = prepare_cooperative_staging(local_eligible, bucket_bytes)
+            comm = context.comm
+            pool = context.pool
+        else:
+            pool = _PinnedPool()
+            eligible = 0
+            if local_eligible:
+                try:
+                    pool.put(_alloc_pinned(_bucket_bytes(bucket_bytes)))
+                    eligible = 1
+                except (OSError, RuntimeError, TypeError, ValueError):
+                    eligible = 0
+            try:
+                if comm.all_reduce_max([1 - eligible])[0] != 0:
+                    comm = None
+            except _COLLECTIVE_ERRORS as exc:
+                logger.warning("Cooperative staging: preflight collective failed (%s); falling back locally.", exc)
+                comm = None
+
+    src = iter(weights_iter)
+    if comm is None:
+        if not local_eligible:
+            yield from src
+            return
+        yield from pinned_staging_weights_iterator(
+            src,
+            max_inflight_bytes=max_inflight_bytes,
+            target_dtypes=target_dtypes,
+            default_dtype=default_dtype,
+        )
+        return
+
+    planner = _BucketPlanner(comm.world_size, bucket_bytes, target_dtypes, default_dtype)
+    pending: list[_Bucket] = []
+    stager = ThreadPoolExecutor(max_workers=_STAGE_WORKERS, thread_name_prefix="coop-staging")
+    stats = {"own_bytes": 0, "source_s": 0.0, "stage_s": 0.0, "buckets": 0, "aborted": False}
+    h2d_events: list[tuple[object, object]] = []
+    exhausted = False
+    source_error: BaseException | None = None
+
+    def _admit(bucket: _Bucket) -> None:
+        if bucket.owner == comm.rank:
+            for e in bucket.entries:
+                _prefault(e.src)
+            bucket.future = stager.submit(_stage_bucket, bucket, pool, bucket_bytes)
+        pending.append(bucket)
+
+    def _local_fallback(unyielded: list[_Bucket]) -> Iterator[tuple[str, torch.Tensor]]:
+        # Group-wide degrade: wait out in-flight stagings, then hand every
+        # not-yet-yielded tensor plus the untouched stream to plain per-rank
+        # pinned staging (correct, just not cooperative). ``planner`` may hold
+        # an open bucket whose tensors have already been consumed from ``src``;
+        # drain it explicitly or those weights would disappear on fallback.
+        stager.shutdown(wait=True, cancel_futures=True)
+        tail = planner.flush()
+        if tail is not None:
+            unyielded.append(tail)
+        for b in unyielded:
+            if b.pinned is not None:
+                pool.put(b.pinned, b.h2d_done)
+                b.pinned = None
+        remaining = chain(((e.name, e.src) for b in unyielded for e in b.entries), src)
+        return pinned_staging_weights_iterator(
+            remaining,
+            max_inflight_bytes=max_inflight_bytes,
+            target_dtypes=target_dtypes,
+            default_dtype=default_dtype,
+        )
+
+    def _fill_pending() -> None:
+        # Plan ahead so owned buckets stage while transfers and consumer
+        # copies of the current window are still in flight. Fill depth is a
+        # pure function of the stream (never of timing): the window
+        # composition must be identical on every rank.
+        nonlocal exhausted, source_error
+        while not exhausted and len(pending) < _WINDOW_BUCKETS:
+            source_t0 = time.perf_counter()
+            captured = _CapturedFailure()
+            item = None
+            with captured:
+                item = next(src)
+            stats["source_s"] += time.perf_counter() - source_t0
+            if isinstance(captured.error, StopIteration):
+                exhausted = True
+                tail = planner.flush()
+                if tail is not None:
+                    _admit(tail)
+                break
+            if captured.error is not None:
+                source_error = captured.error
+                exhausted = True
+                break
+            assert item is not None
+            for closed in planner.add(*item):
+                _admit(closed)
+
+    def _plan_signature(window: list[_Bucket]) -> tuple[int, int]:
+        """Hash the exact collective schedule and tensor views for a window."""
+        checksum = 0
+        for bucket in window:
+            checksum = zlib.crc32(f"B:{bucket.owner}:{bucket.total}\0".encode(), checksum)
+            for entry in bucket.entries:
+                descriptor = (
+                    f"E:{entry.name}:{tuple(entry.src.shape)}:{entry.src.dtype}:"
+                    f"{entry.out_dtype}:{entry.offset}:{entry.nbytes}\0"
+                )
+                checksum = zlib.crc32(descriptor.encode(), checksum)
+        return sum(bucket.total for bucket in window), checksum
+
+    # Transfers (owner H2D + broadcast) run on a dedicated stream; the
+    # consumer's weight_loader copies stay on the default stream and only
+    # wait on per-bucket events — so bucket k's transfers overlap bucket
+    # k-1's consumption and bucket k+1's staging, instead of the whole
+    # pipeline serializing through one stream sync per bucket.
+    xfer = torch.cuda.Stream(device=comm.device) if comm.device.type == "cuda" else None
+
+    try:
+        _fill_pending()
+        while True:
+            # Every rank enters one agreement for every window, including an
+            # empty terminal window. This keeps an early-EOF rank in lockstep
+            # long enough to detect a peer with additional buckets.
+            window = list(pending)
+            pending.clear()
+            if window:
+                # Refill immediately so stagers keep working while this window
+                # transfers and the previous one is consumed.
+                _fill_pending()
+
+            stage_err = 0
+            for bucket in window:
+                if bucket.future is not None:
+                    future_error = bucket.future.exception()
+                    if future_error is not None:
+                        bucket.error = future_error
+                    bucket.future = None
+                    if bucket.error is not None:
+                        logger.warning("Cooperative staging: local stage failed (%s)", bucket.error)
+                        stage_err = 1
+                try:
+                    bucket.gpu = torch.empty(bucket.total, dtype=torch.uint8, device=comm.device)
+                except (OSError, RuntimeError, TypeError, ValueError) as exc:
+                    logger.warning("Cooperative staging: payload alloc failed (%s)", exc)
+                    stage_err = 1
+
+            # Agree on both errors and the exact collective schedule before
+            # issuing any broadcast. MAX over positive and negative values
+            # gives every rank the group min and max without another call.
+            total, plan_hash = _plan_signature(window)
+            bucket_count = len(window)
+            try:
+                agreed = comm.all_reduce_max(
+                    [
+                        stage_err,
+                        int(source_error is not None),
+                        bucket_count,
+                        total,
+                        plan_hash,
+                        -bucket_count,
+                        -total,
+                        -plan_hash,
+                    ]
+                )
+            except _COLLECTIVE_ERRORS as exc:
+                logger.warning(
+                    "Cooperative staging: schedule collective failed (%s); all ranks falling back locally.",
+                    exc,
+                )
+                stats["aborted"] = True
+                yield from _local_fallback(window + list(pending))
+                return
+            diverged = agreed[2] != -agreed[5] or agreed[3] != -agreed[6] or agreed[4] != -agreed[7]
+            if agreed[1] != 0:
+                stats["aborted"] = True
+                stager.shutdown(wait=True, cancel_futures=True)
+                if source_error is not None:
+                    raise source_error
+                raise RuntimeError("A tensor-parallel peer failed while reading the checkpoint")
+            if diverged:
+                logger.warning(
+                    "Cooperative staging: bucket plan diverged across ranks (different source "
+                    "order, metadata, or length); falling back to per-rank staging."
+                )
+            if agreed[0] != 0 or diverged:
+                stats["aborted"] = True
+                yield from _local_fallback(window + list(pending))
+                return
+            if not window:
+                return
+
+            # Issue the whole window's transfers back-to-back on the
+            # transfer stream; consumers gate on per-bucket events only.
+            collective_error = None
+            with torch.cuda.stream(xfer) if xfer is not None else nullcontext():
+                for bucket in window:
+                    if bucket.owner == comm.rank:
+                        if xfer is not None:
+                            bucket.h2d_start = torch.cuda.Event(enable_timing=True)
+                            bucket.h2d_start.record()
+                        bucket.gpu.copy_(bucket.pinned[: bucket.total], non_blocking=True)
+                        if xfer is not None:
+                            bucket.h2d_done = torch.cuda.Event(enable_timing=True)
+                            bucket.h2d_done.record()
+                    try:
+                        comm.broadcast(bucket.gpu, src=bucket.owner)
+                    except _COLLECTIVE_ERRORS as exc:
+                        collective_error = exc
+                        break
+                    if xfer is not None:
+                        # The payload was allocated under the default stream
+                        # but written here — tell the caching allocator
+                        # before the reference can drop. (Consumer reads on
+                        # the default/allocation stream are auto-tracked.)
+                        bucket.gpu.record_stream(xfer)
+                        bucket.ready = torch.cuda.Event()
+                        bucket.ready.record()
+
+            if collective_error is not None:
+                logger.warning(
+                    "Cooperative staging: broadcast collective failed (%s); all ranks falling back locally.",
+                    collective_error,
+                )
+                stats["aborted"] = True
+                yield from _local_fallback(window + list(pending))
+                return
+
+            for bucket in window:
+                if bucket.ready is not None:
+                    torch.cuda.current_stream().wait_event(bucket.ready)
+                gpu_buf = bucket.gpu
+                for e in bucket.entries:
+                    yield e.name, gpu_buf[e.offset : e.offset + e.nbytes].view(e.out_dtype).view(e.src.shape)
+                bucket.gpu = None
+                # Repool the pinned buffer; its H2D may still be in flight —
+                # the event travels with the buffer and is waited on REUSE,
+                # keeping the sync off the consumer path.
+                if bucket.pinned is not None:
+                    stats["own_bytes"] += bucket.total
+                    stats["stage_s"] += bucket.stage_s
+                    if bucket.h2d_start is not None and bucket.h2d_done is not None:
+                        h2d_events.append((bucket.h2d_start, bucket.h2d_done))
+                    pool.put(bucket.pinned, bucket.h2d_done)
+                    bucket.pinned = None
+                stats["buckets"] += 1
+    finally:
+        stager.shutdown(wait=True, cancel_futures=True)
+        if stats["buckets"] and not stats["aborted"]:
+            h2d_s = 0.0
+            if h2d_events:
+                h2d_events[-1][1].synchronize()
+                h2d_s = sum(start.elapsed_time(done) for start, done in h2d_events) / 1000
+            h2d_bw = stats["own_bytes"] / (1 << 30) / h2d_s if h2d_s > 0 else float("inf")
+            logger.info(
+                "Cooperative staging: %d buckets, %.2f GiB staged by this rank (1/%d of the stream; "
+                "source iterator %.2f s; read+stage copy %.2f s; H2D %.2f s, %.1f GiB/s).",
+                stats["buckets"],
+                stats["own_bytes"] / (1 << 30),
+                comm.world_size,
+                stats["source_s"],
+                stats["stage_s"],
+                h2d_s,
+                h2d_bw,
+            )

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -26,6 +26,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.transformers_utils.repo_utils import file_exists
 from vllm.utils.import_utils import resolve_obj_by_qualname
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 from vllm_omni.diffusion.config import set_current_diffusion_config
@@ -34,9 +35,15 @@ from vllm_omni.diffusion.distributed.hsdp import HSDPInferenceConfig, apply_hsdp
 from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     get_checkpoint_adapter,
 )
+from vllm_omni.diffusion.model_loader.cooperative_staging import (
+    cooperative_staging_weights_iterator,
+    prepare_cooperative_staging,
+)
+from vllm_omni.diffusion.model_loader.prewarm import start_weights_prewarm
 from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import DiffusersAdapterPipeline
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 from vllm_omni.diffusion.registry import initialize_model
+from vllm_omni.utils.startup_timing import startup_span
 
 
 # download_gguf was removed from upstream vLLM (commit 6635279d8).
@@ -226,6 +233,14 @@ class DiffusersPipelineLoader:
 
         return hf_folder, hf_weights_files, use_safetensors
 
+    def _stop_weights_prewarm(self) -> None:
+        """Hand page-cache ownership from speculative prewarm to the loader."""
+        handle = getattr(self, "_weights_prewarm_handle", None)
+        if handle is not None:
+            handle.stop()
+            handle.join()
+            self._weights_prewarm_handle = None
+
     def _get_weights_iterator(
         self,
         source: "ComponentSource",
@@ -239,11 +254,50 @@ class DiffusersPipelineLoader:
             source.fall_back_to_pt,
             source.allow_patterns_overrides,
         )
+        # Executors without a parent handoff may use local prewarm during
+        # pipeline construction. Stop those broad readers before demand
+        # loading so they cannot compete with targeted staging faults.
+        self._stop_weights_prewarm()
 
+        # Decide the static gate before choosing the source iterator. Excluded
+        # paths must retain their existing multi-thread loader rather than pay
+        # the deterministic-order cost for cooperation they will never enter.
+        hsdp_cpu_load = self.parallel_config.use_hsdp and self.quant_config is None
+        use_pinned_staging = (
+            use_safetensors
+            and self.load_config.safetensors_load_strategy != "torchao"
+            and not getattr(self.od_config, "enable_cpu_offload", False)
+            and not getattr(self.od_config, "enable_layerwise_offload", False)
+            and not getattr(self.od_config, "enable_distributed_layerwise_offload", False)
+            and not hsdp_cpu_load
+        )
+        local_eligible = use_pinned_staging and torch.cuda.is_available() and is_pin_memory_available()
+
+        # Cooperative TP staging plans byte buckets from the tensor stream and
+        # runs one collective per bucket, assuming every rank sees the SAME
+        # stream in the SAME order. The multi-thread iterator yields shards in
+        # completion order — nondeterministic, so two ranks would compute
+        # different bucket plans and their collectives would be malformed
+        # (observed as a NCCL watchdog timeout, not an error). Force the
+        # deterministic single-thread order whenever cooperation can engage.
+        tp_cooperative = False
+        try:
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
+
+                tp_cooperative = get_tensor_model_parallel_world_size() > 1
+        except (ImportError, AttributeError, AssertionError, RuntimeError, ValueError):
+            tp_cooperative = False
+
+        cooperative_context = None
+        if use_pinned_staging and tp_cooperative:
+            cooperative_context = prepare_cooperative_staging(local_eligible)
+        cooperation_enabled = cooperative_context is not None and cooperative_context.comm is not None
         use_multithread = (
             use_safetensors
             and getattr(self.od_config, "enable_multithread_weight_load", False)
             and self.load_config.safetensors_load_strategy != "torchao"
+            and not cooperation_enabled
         )
         if use_multithread:
             num_threads = getattr(self.od_config, "num_weight_load_threads", 4)
@@ -255,6 +309,10 @@ class DiffusersPipelineLoader:
                 max_workers=num_threads,
             )
         else:
+            if use_safetensors and tp_cooperative:
+                # Glob order is not contractual; the cooperative plan needs
+                # an identical file order on every rank.
+                hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)
             weights_iterator = safetensors_weights_iterator(
                 hf_weights_files,
                 self.load_config.use_tqdm_on_load,
@@ -264,12 +322,51 @@ class DiffusersPipelineLoader:
         if self.counter_before_loading_weights == 0.0:
             self.counter_before_loading_weights = time.perf_counter()
         # Apply the prefix.
-        prefixed_weights_iterator = ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
+        result_iterator = ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
         if model is not None:
             checkpoint_adapter = self._get_checkpoint_adapter(model, source, use_safetensors)
             if checkpoint_adapter is not None:
-                return checkpoint_adapter.adapt(prefixed_weights_iterator)
-        return prefixed_weights_iterator
+                result_iterator = checkpoint_adapter.adapt(result_iterator)
+
+        # Stage the final tensors (post-adapter) through pooled pinned memory so the
+        # consumer's H2D copies take the DMA fast path. Staging must sit after any
+        # checkpoint adapter: adapters may hold tensors across iterations (e.g.
+        # deferred dequantization), which would violate the recycling contract.
+        # Non-quantized HSDP builds the model on CPU (hsdp_defer_to_cpu) and
+        # loads weights there: no H2D copy exists for pinned DMA to speed up,
+        # so staging would be pure overhead. Runtime eligibility still travels
+        # into the cooperative vote so every TP rank reaches the same decision.
+        if use_pinned_staging:
+            # Destination dtypes so mismatched checkpoints (fp32 ckpt -> bf16
+            # params) are cast while staging: a dtype-converting H2D copy_
+            # falls off the pinned fast path, so without the fused cast staging
+            # gains nothing for such checkpoints. Exact param-name matches win
+            # (protecting intentionally-fp32 params); names the map misses
+            # (renamed/fused weights, q/k/v -> qkv) are cast to default_dtype.
+            target_dtypes = None
+            default_dtype = None
+            if model is not None and local_eligible:
+                target_dtypes = {n: p.dtype for n, p in model.named_parameters()}
+                target_dtypes.update({n: b.dtype for n, b in model.named_buffers()})
+                # The blanket fallback is unsafe for quantized sources: their
+                # fp32 scale tensors travel under pre-fusion checkpoint names
+                # (q_proj.weight_scale -> qkv_proj.weight_scale only inside
+                # load_weights), so the map misses them and a default cast
+                # would corrupt dequantization. Quantized sources cast only on
+                # exact matches; everything else passes through unchanged.
+                if self._get_source_quant_config(source) is None:
+                    default_dtype = getattr(self.od_config, "dtype", None)
+            # Under TP the iterator splits staging across the group and
+            # broadcasts GPU buckets (each rank stages ~1/N); single-GPU and
+            # non-distributed runs degrade to plain per-rank pinned staging.
+            result_iterator = cooperative_staging_weights_iterator(
+                result_iterator,
+                target_dtypes=target_dtypes,
+                default_dtype=default_dtype,
+                local_eligible=local_eligible,
+                context=cooperative_context,
+            )
+        return result_iterator
 
     def _get_source_quant_config(self, source: "ComponentSource") -> object | None:
         quant_config = self.quant_config
@@ -334,6 +431,31 @@ class DiffusersPipelineLoader:
         """Load a model with the given configurations."""
         if load_format is None:
             load_format = "default"
+        # Executors without a parent startup handoff prewarm the exact
+        # checkpoint while the pipeline is built. Demand loading owns the same
+        # revision/cache, and finally cancels speculative I/O on every exit.
+        model_ref = getattr(self.od_config, "model", None)
+        self._weights_prewarm_handle = (
+            start_weights_prewarm(
+                str(model_ref),
+                revision=getattr(self.od_config, "revision", None),
+                cache_dir=self.load_config.download_dir,
+            )
+            if model_ref
+            else None
+        )
+        try:
+            return self._load_model(load_device, load_format, custom_pipeline_name, device)
+        finally:
+            self._stop_weights_prewarm()
+
+    def _load_model(
+        self,
+        load_device: str,
+        load_format: str,
+        custom_pipeline_name: str | type[nn.Module] | None,
+        device: torch.device | None,
+    ) -> nn.Module:
         # CPU offload + quantization: for offline-quantized models (e.g., AutoRound MXFP8),
         # weights are already quantized in the checkpoint — load directly on CPU.
         # For online quantization, load on device so quantization can run on accelerator,
@@ -355,13 +477,16 @@ class DiffusersPipelineLoader:
                 logger.info("Offline-quantized model with CPU offload, loading weights directly on CPU")
 
         target_device = torch.device(load_device)
+        timing_labels = {"device": target_device.type, "load_format": load_format}
         with set_default_torch_dtype(self.od_config.dtype):
             if self.parallel_config.use_hsdp:
-                model = self._load_model_with_hsdp(
-                    target_device=device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
-                )
+                with startup_span(logger, "model.hsdp_load", **timing_labels):
+                    model = self._load_model_with_hsdp(
+                        target_device=device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
+                    )
             else:
-                model = self._init_from_load_format(load_format, target_device, custom_pipeline_name, is_hsdp=False)
+                with startup_span(logger, "model.pipeline_construct", **timing_labels):
+                    model = self._init_from_load_format(load_format, target_device, custom_pipeline_name, is_hsdp=False)
 
                 # Skip load_weights only for DLO+AllGather when the model
                 # supports mmap loading and no online quantization is active.
@@ -377,37 +502,50 @@ class DiffusersPipelineLoader:
 
                 _skip_load = _dist_offload and _use_ag and _supports_mmap and not _has_online_quant
 
-                if _skip_load:
-                    logger.info("DLO+AllGather active: skipping load_weights (will load via mmap in enable())")
-                else:
-                    if _dist_offload and _use_ag and _has_online_quant:
-                        raise ValueError(
-                            "Online quantization is incompatible with DLO+AllGather: "
-                            "the sharding + AllGather mechanism flattens weights by "
-                            "dtype, which breaks quantized weight/scale layouts. "
-                            "Please use --dlo-no-use-allgather or disable online "
-                            "quantization."
-                        )
-                    if _dist_offload and _use_ag and not _supports_mmap:
-                        logger.info(
-                            "DLO+AllGather active but model does not support mmap: loading weights via regular loader."
-                        )
-                    logger.debug("Loading weights on %s ...", load_device)
-                    if offload_after_quant:
-                        marked = self._request_offload_after_quant(model)
-                        if marked:
-                            logger.info(
-                                "Online quantization will return each of %d layers to CPU as it is quantized",
-                                marked,
-                            )
-                    if load_format == "diffusers":
-                        cast(DiffusersAdapterPipeline, model).load_weights()
+                with startup_span(logger, "model.weights_apply", **timing_labels):
+                    if _skip_load:
+                        logger.info("DLO+AllGather active: skipping load_weights (will load via mmap in enable())")
                     else:
-                        self.load_weights(model)
-                    self._process_weights_after_loading(model, target_device)
+                        if _dist_offload and _use_ag and _has_online_quant:
+                            raise ValueError(
+                                "Online quantization is incompatible with DLO+AllGather: "
+                                "the sharding + AllGather mechanism flattens weights by "
+                                "dtype, which breaks quantized weight/scale layouts. "
+                                "Please use --dlo-no-use-allgather or disable online "
+                                "quantization."
+                            )
+                        if _dist_offload and _use_ag and not _supports_mmap:
+                            logger.info(
+                                "DLO+AllGather active but model does not support mmap: "
+                                "loading weights via regular loader."
+                            )
+                        logger.debug("Loading weights on %s ...", load_device)
+                        if offload_after_quant:
+                            marked = self._request_offload_after_quant(model)
+                            if marked:
+                                logger.info(
+                                    "Online quantization will return each of %d layers to CPU as it is quantized",
+                                    marked,
+                                )
+                        if load_format == "diffusers":
+                            # DiffusersAdapterPipeline.load_weights() calls
+                            # DiffusionPipeline.from_pretrained() internally and
+                            # bypasses _get_weights_iterator(), so hand page-cache
+                            # ownership over explicitly before demand loading.
+                            self._stop_weights_prewarm()
+                            cast(DiffusersAdapterPipeline, model).load_weights()
+                        else:
+                            self.load_weights(model)
+
+                # DLO mmap loading owns post-load processing when the regular
+                # loader is skipped. All other non-HSDP paths process here.
+                if not _skip_load:
+                    with startup_span(logger, "model.post_load_processing", **timing_labels):
+                        self._process_weights_after_loading(model, target_device)
 
             if offload_after_quant:
-                model.to("cpu")
+                with startup_span(logger, "model.quantization_offload", **timing_labels):
+                    model.to("cpu")
                 logger.info("Quantization complete, offloaded model back to CPU")
 
         self._apply_skip_softmax_calibration(model)
@@ -537,7 +675,10 @@ class DiffusersPipelineLoader:
 
     def load_weights(self, model: nn.Module) -> None:
         weights_to_load = self._get_expected_parameter_names(model)
-        loaded_weights = model.load_weights(self.get_all_weights(model))
+        # closing(): if load_weights raises, the suspended staging generator
+        # (and its pinned pool) must not be kept alive by the traceback.
+        with contextlib.closing(self.get_all_weights(model)) as all_weights:
+            loaded_weights = model.load_weights(all_weights)
 
         self.counter_after_loading_weights = time.perf_counter()
         logger.info_once(

--- a/vllm_omni/diffusion/model_loader/pinned_staging.py
+++ b/vllm_omni/diffusion/model_loader/pinned_staging.py
@@ -1,0 +1,423 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bounded pinned-memory staging for diffusion weight loading (RFC #4896, item 1).
+
+Wraps a ``(name, tensor)`` weights iterator: staging threads copy each CPU
+tensor into page-locked (pinned) memory so the consumer's ``param.copy_()``
+takes the fast DMA path instead of the pageable-copy path, and staging
+overlaps with the H2D copies of previously yielded tensors.
+
+When ``target_dtypes`` maps a tensor's name to a different floating-point
+dtype (e.g. an fp32 checkpoint loaded into bf16 params), the dtype cast is
+fused into the staging copy. This is required, not just nice: a
+dtype-converting H2D ``copy_`` falls off the pinned fast path entirely
+(measured as slow as a pageable copy), so without the fused cast pinned
+staging buys nothing for mismatched checkpoints. Casting while staging also
+halves the staged bytes and H2D traffic for fp32->bf16.
+
+Pinned buffers come from an internal power-of-two size pool and are recycled
+once the consumer moves past a tensor, so each size class pays ``cudaHostAlloc``
+only a handful of times per load rather than once per tensor — host allocation
+can cost >100 ms per 100 MiB, far more than the copy. The in-flight byte budget
+bounds read-ahead.
+
+Consumer contract: a yielded tensor is only valid until the next item is
+requested from the iterator — its backing buffer is then recycled. This
+matches ``load_weights`` implementations that copy each tensor into model
+parameters before advancing (the standard vLLM weight-loader pattern).
+Consumers that stash raw checkpoint tensors across iterations must not
+enable pinned staging.
+
+Falls back to passing tensors through unpinned on the first allocation
+failure (e.g. ``RLIMIT_MEMLOCK`` in containers); loading then behaves as
+before (pass-through tensors are never recycled).
+"""
+
+import ctypes
+import os
+import queue
+import sys
+import threading
+import time
+from collections.abc import Generator, Iterator, Mapping
+from types import TracebackType
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_SENTINEL = object()
+
+
+class _ForwardThreadFailure:
+    """Forward a producer failure through its output queue.
+
+    ``threading.Thread`` otherwise reports uncaught failures only through the
+    process-wide excepthook, leaving this iterator's consumer blocked.
+    """
+
+    def __init__(self, out_q: queue.Queue[object]):
+        self._out_q = out_q
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        del exc_type, traceback
+        if exc is None:
+            return False
+        self._out_q.put(exc)
+        return True
+
+
+# madvise(MADV_WILLNEED): async readahead of the mmap'd source pages, so staging
+# one tensor overlaps the disk read of the next — the cold-cache win (~2.3x; a
+# no-op on a warm cache). Not MADV_POPULATE_READ, which faults synchronously and
+# serializes the reads (measured slower than no staging at all on a cold cache).
+_MADV_WILLNEED = 3
+_PAGE = 4096
+# madvise via the process's already-linked libc (dlopen(NULL)): no library
+# file lookup, no ldconfig subprocess. There is no stdlib equivalent for
+# foreign memory -- mmap.madvise() only covers mmap objects Python itself
+# created, and the source tensors here are mmap'd inside safetensors.
+_libc = None
+if sys.platform == "linux":
+    try:
+        _libc = ctypes.CDLL(None, use_errno=True)
+    except OSError:
+        _libc = None
+
+
+def _prefault(tensor: torch.Tensor) -> None:
+    """Kick off async readahead of the tensor's backing pages (no-op off Linux)."""
+    if _libc is None:
+        return
+    nbytes = tensor.numel() * tensor.element_size()
+    addr = tensor.data_ptr()
+    start = addr - (addr % _PAGE)
+    _libc.madvise(ctypes.c_void_p(start), ctypes.c_size_t(nbytes + addr - start), _MADV_WILLNEED)
+
+
+def _alloc_pinned(nbytes: int) -> torch.Tensor:
+    return torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+
+
+# Only these source dtypes are eligible for the fused cast: quantized formats
+# (float8 etc.) must reach load_weights bit-exact for dequantization.
+_CASTABLE = (torch.float32, torch.float16, torch.bfloat16)
+
+# Tensors below this stage nothing: a sub-64 KiB H2D copy is latency-bound,
+# so pinned DMA buys nothing, while the 1 MiB pool floor over-allocates it up
+# to 256x (a 17705-tensor quant checkpoint measured ~2000 concurrent 1 MiB
+# buffers ~= 2 GiB transient pinned for kilobytes of live data). Passing tiny
+# tensors through also skips their fused cast; the consumer's dtype-converting
+# copy_ on such tensors moves negligible bytes.
+_MIN_STAGE_BYTES = 64 << 10
+
+
+def _resolve_out_dtype(
+    name: str,
+    src_dtype: torch.dtype,
+    target_dtypes: Mapping[str, torch.dtype] | None,
+    default_dtype: torch.dtype | None,
+) -> torch.dtype:
+    """Destination dtype for the fused staging cast.
+
+    Exact-name matches in ``target_dtypes`` win (protecting params that
+    intentionally keep e.g. fp32); tensors whose checkpoint names don't match
+    any param (renamed/fused weights: q/k/v -> qkv etc.) fall back to
+    ``default_dtype`` — the dtype the model was constructed under.
+    """
+    if src_dtype not in _CASTABLE:
+        return src_dtype
+    want = target_dtypes.get(name) if target_dtypes is not None else None
+    if want is None:
+        want = default_dtype
+    if want is not None and want is not src_dtype and want in _CASTABLE:
+        return want
+    return src_dtype
+
+
+def _usable_cpu_count() -> int:
+    """CPUs this process may actually use: honors cgroup/taskset affinity
+    (os.cpu_count reports HOST cores and over-threads limited containers)."""
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:  # non-Linux
+        return os.cpu_count() or 8
+
+
+def _auto_staging_threads() -> int:
+    """Copy-thread count for ``num_staging_threads=0``.
+
+    ``torch.copy_`` uses intra-op workers of its own, and the source loader
+    and page-cache prewarm may also be active. Cap producers at four to avoid
+    the nested oversubscription observed on 32-vCPU weight-load hosts.
+    """
+    return max(2, min(4, _usable_cpu_count() // 4))
+
+
+def _bucket_bytes(nbytes: int) -> int:
+    """Round a request up to a power-of-two bucket (min 1 MiB).
+
+    cudaHostAlloc synchronizes with in-flight device work, so an allocation
+    issued while the consumer's H2D copies are running can stall for over
+    100 ms regardless of size. Bucketing collapses the thousands of distinct
+    tensor sizes in a checkpoint into ~a dozen size classes so the pool hit
+    rate approaches 100% after the first few tensors of each class.
+    """
+    size = 1 << 20
+    while size < nbytes:
+        size <<= 1
+    return size
+
+
+class _PinnedBufferPool:
+    """Power-of-two pinned buffers with a bounded free-list.
+
+    In-flight buffers may temporarily exceed the cache cap, but once the
+    consumer returns them only ``max_cached_bytes`` remains page-locked. This
+    prevents one-off tensor size classes from accumulating for the lifetime
+    of a large component load.
+    """
+
+    def __init__(self, max_cached_bytes: int):
+        self._max_cached_bytes = max_cached_bytes
+        self._free: dict[int, list[torch.Tensor]] = {}
+        self._lock = threading.Lock()
+        self.cached_bytes = 0
+        self.reserved_bytes = 0
+        self.peak_reserved_bytes = 0
+        self.allocs = 0
+        self.reuses = 0
+        self.drops = 0
+
+    def get(self, nbytes: int) -> torch.Tensor:
+        bucket = _bucket_bytes(nbytes)
+        with self._lock:
+            free = self._free.get(bucket)
+            if free:
+                self.reuses += 1
+                self.cached_bytes -= bucket
+                return free.pop()
+        buf = _alloc_pinned(bucket)
+        with self._lock:
+            self.allocs += 1
+            self.reserved_bytes += bucket
+            self.peak_reserved_bytes = max(self.peak_reserved_bytes, self.reserved_bytes)
+        return buf
+
+    def put(self, buf: torch.Tensor) -> None:
+        size = buf.numel()
+        with self._lock:
+            # The read-ahead budget may be smaller than the 1 MiB pool floor,
+            # or a legitimate tensor may exceed the whole budget. Always allow
+            # one such buffer; otherwise every item reallocates it forever.
+            effective_cap = max(self._max_cached_bytes, size)
+            if self.cached_bytes + size <= effective_cap:
+                self._free.setdefault(size, []).append(buf)
+                self.cached_bytes += size
+                return
+            self.reserved_bytes -= size
+            self.drops += 1
+
+
+def pinned_staging_weights_iterator(
+    weights_iter: Iterator[tuple[str, torch.Tensor]],
+    max_inflight_bytes: int = 512 << 20,
+    num_staging_threads: int = 0,
+    target_dtypes: Mapping[str, torch.dtype] | None = None,
+    default_dtype: torch.dtype | None = None,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Stage CPU tensors into pooled pinned memory on producer threads.
+
+    Yields the same ``(name, tensor)`` pairs as ``weights_iter`` (order may
+    interleave across staging threads); tensors stay on CPU so downstream
+    ``load_weights`` semantics (TP narrowing, QKV fusion) are unchanged.
+    See the module docstring for the buffer-recycling consumer contract.
+
+    Mismatched float checkpoints are cast during the staging copy (see the
+    module docstring): ``target_dtypes`` (param name -> dtype) by exact name,
+    ``default_dtype`` for names it doesn't cover (renamed/fused weights).
+    Non-float and quantized tensors always stage dtype-unchanged.
+
+    ``max_inflight_bytes`` bounds read-ahead in checkpoint bytes; the actual
+    pinned peak can reach ~2x that (power-of-two buffer buckets, 1 MiB floor).
+    The 512 MiB default measured as sufficient (2 GiB gained nothing).
+    """
+    if num_staging_threads <= 0:  # 0 = auto; and 0 producers would strand the consumer
+        num_staging_threads = _auto_staging_threads()
+    out_q: queue.Queue[object] = queue.Queue()
+    lock = threading.Condition()
+    state = {
+        "inflight": 0,
+        "pin_failed": False,
+        "stopped": False,
+        "producers": num_staging_threads,
+    }
+    stats = {
+        "bytes": 0,
+        "source_s": 0.0,
+        "stage_s": 0.0,
+        "consumer_s": 0.0,
+        "casts": 0,
+    }
+    src_lock = threading.Lock()
+    src = iter(weights_iter)
+    # Keep up to two read-ahead windows in the free-list. One window caused
+    # recurring size classes to churn through cudaHostAlloc on Wan2.2 (60+
+    # drops/component); two retained every hot class with only one drop while
+    # preserving the same measured process RSS. Honor the 1 MiB bucket floor
+    # when callers choose a smaller test or memory-constrained read-ahead
+    # budget, otherwise two sub-MiB in-flight tensors can only cache one buffer.
+    pool = _PinnedBufferPool(max(2 * max_inflight_bytes, 2 << 20))
+
+    def _next_item():
+        # Generators are not thread-safe; serialize next() across staging threads.
+        with src_lock:
+            t0 = time.perf_counter()
+            try:
+                return next(src)
+            except StopIteration:
+                return _SENTINEL
+            finally:
+                stats["source_s"] += time.perf_counter() - t0
+
+    def _stage(name: str, tensor: torch.Tensor) -> tuple[str, torch.Tensor, torch.Tensor | None]:
+        """Copy ``tensor`` into a pooled pinned buffer; returns the backing buffer for recycling."""
+        if (
+            state["pin_failed"]
+            or tensor.device.type != "cpu"
+            or tensor.is_pinned()
+            or tensor.numel() * tensor.element_size() < _MIN_STAGE_BYTES
+        ):
+            return name, tensor, None
+        buf = None
+        try:
+            t0 = time.perf_counter()
+            out_dtype = _resolve_out_dtype(name, tensor.dtype, target_dtypes, default_dtype)
+            nbytes = tensor.numel() * out_dtype.itemsize
+            _prefault(tensor)
+            buf = pool.get(nbytes)
+            staged = buf[:nbytes].view(out_dtype).view(tensor.shape)
+            # torch.copy_, not a single-core memcpy: its intra-op parallelism holds
+            # throughput while the consumer's concurrent H2D DMA saturates memory
+            # bandwidth. When out_dtype differs it also performs the cast in the
+            # same pass (the rounding param.copy_ would otherwise do later).
+            staged.copy_(tensor)
+            with lock:
+                stats["bytes"] += nbytes
+                stats["stage_s"] += time.perf_counter() - t0
+                if out_dtype is not tensor.dtype:
+                    stats["casts"] += 1
+            return name, staged, buf
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            # Expected staging failures (pinned alloc under RLIMIT_MEMLOCK or
+            # an invalid view/copy combination) degrade to pass-through and
+            # never abort the load. Loading correctness does not depend on staging.
+            if buf is not None:
+                pool.put(buf)
+            state["pin_failed"] = True
+            logger.warning(
+                "Pinned staging disabled: staging failed (%s); falling back to pageable copies.",
+                exc,
+            )
+            return name, tensor, None
+
+    def _producer():
+        try:
+            with _ForwardThreadFailure(out_q):
+                while True:
+                    if state["stopped"]:
+                        break
+                    item = _next_item()
+                    if item is _SENTINEL:
+                        break
+                    name, tensor = item
+                    nbytes = tensor.numel() * tensor.element_size() if tensor.device.type == "cpu" else 0
+                    with lock:
+                        # Admit an oversized tensor only when nothing else is in flight,
+                        # so a tensor larger than the whole budget cannot deadlock.
+                        while (
+                            not state["stopped"]
+                            and state["inflight"] > 0
+                            and state["inflight"] + nbytes > max_inflight_bytes
+                        ):
+                            lock.wait(timeout=0.1)
+                        if state["stopped"]:
+                            break
+                        state["inflight"] += nbytes
+                    out_q.put((*_stage(name, tensor), nbytes))
+        finally:
+            with lock:
+                state["producers"] -= 1
+                if state["producers"] == 0:
+                    out_q.put(_SENTINEL)
+
+    # Tag thread names per iterator instance so overlapping loads stay distinguishable.
+    uid = f"{id(out_q):x}"
+    threads = [
+        threading.Thread(target=_producer, name=f"pinned-staging-{uid}-{i}", daemon=True)
+        for i in range(num_staging_threads)
+    ]
+    t_start = time.perf_counter()
+    for t in threads:
+        t.start()
+
+    try:
+        while True:
+            item = out_q.get()
+            if item is _SENTINEL:
+                break
+            if isinstance(item, BaseException):
+                raise item
+            name, tensor, buf, nbytes = item
+            consumer_t0 = time.perf_counter()
+            yield name, tensor
+            # Control returned: the consumer has finished with `tensor`
+            # (normally its blocking H2D/weight_loader copy), so its buffer can
+            # be reused. Return it before releasing the read-ahead budget: a
+            # woken producer can then reuse this buffer instead of racing its
+            # return and issuing another cudaHostAlloc.
+            stats["consumer_s"] += time.perf_counter() - consumer_t0
+            if buf is not None:
+                pool.put(buf)
+            with lock:
+                state["inflight"] -= nbytes
+                lock.notify_all()
+    finally:
+        with lock:
+            state["stopped"] = True
+            lock.notify_all()
+        # Shared deadline: a producer parked inside next(src) on a slow read
+        # can't observe `stopped` until the read returns, so cap total close
+        # latency instead of paying the timeout once per thread.
+        deadline = time.monotonic() + 5.0
+        for t in threads:
+            t.join(timeout=max(0.0, deadline - time.monotonic()))
+        if stats["bytes"]:
+            wall = time.perf_counter() - t_start
+            stage_bw = stats["bytes"] / (1 << 30) / stats["stage_s"] if stats["stage_s"] > 0 else float("inf")
+            logger.info(
+                "Pinned staging: %.2f GiB in %.2f s wall (source iterator %.2f s; read+stage copy "
+                "%.2f s, %.1f GiB/s; consumer/H2D %.2f s; %d producers; %d buffer allocs, %d reuses, "
+                "%d drops, %.2f GiB peak pinned, %d dtype casts)",
+                stats["bytes"] / (1 << 30),
+                wall,
+                stats["source_s"],
+                stats["stage_s"],
+                stage_bw,
+                stats["consumer_s"],
+                num_staging_threads,
+                pool.allocs,
+                pool.reuses,
+                pool.drops,
+                pool.peak_reserved_bytes / (1 << 30),
+                stats["casts"],
+            )

--- a/vllm_omni/diffusion/model_loader/prewarm.py
+++ b/vllm_omni/diffusion/model_loader/prewarm.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Best-effort page-cache prewarm of model weights (RFC #4896).
+
+The multiprocessing executor starts readers in its parent before spawning
+workers, overlapping otherwise-idle process imports. The first worker to reach
+model initialization performs a group handoff: speculative readers stop and
+join before any pipeline demand I/O begins. Child-local prewarm remains as a
+fallback for executor implementations without that parent lifecycle.
+
+Cap-then-stop: parent prewarm follows demand order (pipeline components,
+then DiT shards); the child-local fallback reads DiT shards first because its
+pipeline components are already being loaded concurrently. Reading STOPS once
+the RAM budget is spent. Prewarming past available RAM is worse than useless —
+the kernel evicts the head of the model while reading the tail. The budget
+keeps a headroom margin for the page cache and for the runtime's later
+non-evictable allocations.
+
+Page-cache-resident files are detected with sampled ``mincore`` probes and
+skipped without a userspace copy. The parent handoff stops before worker model
+initialization; the child-local fallback stops when demand weight loading
+begins. In both lifecycles, broad speculative reads cannot overlap targeted
+staging faults.
+
+Everything here is advisory: any failure degrades to no-prewarm, never to a
+load failure.
+"""
+
+import ctypes
+import mmap
+import multiprocessing as mp
+import os
+import re
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Protocol
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_CHUNK = 16 << 20  # sequential 16 MiB reads per stream
+_DEFAULT_READERS = 2  # one buffered stream tops out ~2 GiB/s (copy + cache-insert); two saturate a local NVMe
+_MIN_WORTHWHILE = 1 << 30  # below 1 GiB of budget, skip entirely
+# Non-evictable anonymous memory the process grows AFTER the budget snapshot
+# (python + CUDA context + pinned pools, measured ~10-15 GiB): reserve it up
+# front so the prewarmed cache keeps a stable cushion once the runtime is up.
+_RUNTIME_HEADROOM = 8 << 30
+
+_libc = None
+if sys.platform == "linux":
+    try:
+        _libc = ctypes.CDLL(None, use_errno=True)
+    except OSError:
+        _libc = None
+
+
+def _is_file_fully_resident(path: str) -> bool:
+    """Whether sampled regions of ``path`` are already in the page cache.
+
+    A full ``mincore`` walk of a 117 GiB checkpoint added ~13 seconds to a
+    cold start. Sample one page per prewarm read chunk instead: sequentially
+    populated files still classify warm, while an occasional false positive
+    is harmless because demand loading faults any missing pages normally.
+    """
+    if _libc is None:
+        return False
+    try:
+        size = os.path.getsize(path)
+        if size == 0:
+            return True
+        with open(path, "rb", buffering=0) as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_COPY) as mapping:
+            probe = ctypes.c_char.from_buffer(mapping)
+            address = ctypes.addressof(probe)
+            residency = ctypes.c_ubyte()
+            for offset in range(0, size, _CHUNK):
+                if (
+                    _libc.mincore(
+                        ctypes.c_void_p(address + offset),
+                        ctypes.c_size_t(1),
+                        ctypes.byref(residency),
+                    )
+                    != 0
+                    or not residency.value & 1
+                ):
+                    del probe
+                    return False
+            del probe
+            return True
+    except (OSError, ValueError, BufferError):
+        return False
+
+
+def _read_order_key(relpath: str) -> tuple:
+    """DiT shards first, then everything else, natural-sorted within each group.
+
+    Keyed on the path RELATIVE to the model dir (an ancestor directory named
+    e.g. ``transformers-models`` must not turn every file into a DiT hit).
+    load_weights consumes the transformer components (diffusers layout puts
+    them under ``transformer*/``); the other components (text_encoder, vae)
+    are read by ``from_pretrained`` during the model build itself — i.e.
+    inside the prewarm window — so spending the window's budget on them buys
+    nothing. Measured: alphabetical order (text_encoder first) gained ~0;
+    DiT-first ordering is what makes the window count. Layouts without a
+    ``transformer*`` component dir degrade to plain natural order.
+    """
+    first = relpath.split(os.sep, 1)[0]
+    is_dit = 0 if first.startswith("transformer") else 1
+    return (is_dit, [int(s) if s.isdigit() else s for s in re.split(r"(\d+)", relpath)])
+
+
+def _parent_read_order_key(relpath: str) -> tuple:
+    """Demand-loaded components first, then DiT shards.
+
+    Parent prewarm ends before pipeline construction, so its idle startup
+    window should prepare the text encoder/VAE pages needed first. Local
+    fallback prewarm uses the inverse order because those components are
+    already being loaded concurrently in that older lifecycle.
+    """
+    first = relpath.split(os.sep, 1)[0]
+    is_dit = 1 if first.startswith("transformer") else 0
+    return (is_dit, [int(s) if s.isdigit() else s for s in re.split(r"(\d+)", relpath)])
+
+
+def _resolve_local_dir(
+    model: str,
+    *,
+    revision: str | None = None,
+    cache_dir: str | None = None,
+) -> str | None:
+    """Local directory holding the requested weights, or None.
+
+    A HF repo id resolves through the local hub cache (offline — no
+    network), using the same revision and cache directory as demand loading.
+    A previously downloaded model on a restarted node is exactly the
+    cold-cache case prewarm exists for. An uncached repo id returns None; the
+    download that follows populates the page cache by itself.
+    """
+    if os.path.isdir(model):
+        return model
+    try:
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(
+            model,
+            revision=revision,
+            cache_dir=cache_dir,
+            local_files_only=True,
+        )
+    except (ImportError, OSError, ValueError):
+        return None
+
+
+def _host_available_bytes() -> int | None:
+    """Host-view available RAM via psutil (a vllm dependency)."""
+    try:
+        import psutil
+
+        return int(psutil.virtual_memory().available)
+    except (ImportError, AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+# (limit_path, used_path) pairs, cgroup v2 then v1. psutil (like vllm's own
+# memory helpers) reads /proc/meminfo and therefore reports the HOST in
+# containers (observed: a 126 GiB slice reporting the 1 TiB host), while
+# page cache is charged to the cgroup — sizing the prewarm off the host
+# figure over-fills the cgroup and reclaims the very pages just warmed.
+_CGROUP_MEM_PATHS = (
+    ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+    ("/sys/fs/cgroup/memory/memory.limit_in_bytes", "/sys/fs/cgroup/memory/memory.usage_in_bytes"),
+)
+_CGROUP_UNLIMITED = 1 << 60  # v1 reports "no limit" as ~2**63
+
+
+def _cgroup_available_bytes() -> int | None:
+    """Memory left under the cgroup limit, or None when unlimited/absent."""
+    for limit_path, used_path in _CGROUP_MEM_PATHS:
+        try:
+            with open(limit_path) as f:
+                raw = f.read().strip()
+            if raw == "max":
+                return None
+            limit = int(raw)
+            if limit >= _CGROUP_UNLIMITED:
+                return None
+            with open(used_path) as f:
+                used = int(f.read().strip())
+            return max(0, limit - used)
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _available_ram_bytes() -> int | None:
+    host = _host_available_bytes()
+    cgroup = _cgroup_available_bytes()
+    if host is None:
+        return cgroup
+    if cgroup is None:
+        return host
+    return min(host, cgroup)
+
+
+def _prewarm_budget_bytes(total_bytes: int) -> int:
+    """RAM the prewarm may spend: what's available minus headroom."""
+    available = _available_ram_bytes()
+    if available is None:
+        return 0
+    headroom = max(int(0.15 * total_bytes), 8 << 30) + _RUNTIME_HEADROOM
+    return max(0, available - headroom)
+
+
+class _Budget:
+    """Byte budget shared across reader threads (a static per-reader split
+    strands half the budget when the DiT shards land in one partition)."""
+
+    def __init__(self, cap: int):
+        self._left = cap
+        self._lock = threading.Lock()
+
+    def take(self, nbytes: int) -> bool:
+        with self._lock:
+            if self._left <= 0:
+                return False
+            self._left -= nbytes
+            return True
+
+
+def _read_files(
+    files: list[str],
+    budget: "_Budget",
+    stop_event: threading.Event | None = None,
+) -> tuple[int, int]:
+    """Sequentially read files until the budget is spent or loading starts."""
+    done_bytes = 0
+    done_files = 0
+    buf = bytearray(_CHUNK)
+    for path in files:
+        if stop_event is not None and stop_event.is_set():
+            break
+        try:
+            with open(path, "rb", buffering=0) as f:
+                while stop_event is None or not stop_event.is_set():
+                    n = f.readinto(buf)
+                    if not n:
+                        done_files += 1
+                        break
+                    done_bytes += n
+                    if not budget.take(n):
+                        return done_bytes, done_files
+        except OSError:
+            continue
+    return done_bytes, done_files
+
+
+def _is_prewarm_rank() -> bool:
+    """Only TP rank 0 prewarms: the page cache is node-shared, so N ranks
+    reading the same files buys nothing and their interleaved streams break
+    each other's sequential readahead. (Diffusion TP groups are intra-node
+    in practice; a multi-node TP rank skipping here loses only prewarm,
+    never correctness.)"""
+    try:
+        import torch.distributed as dist
+
+        if not (dist.is_available() and dist.is_initialized()):
+            return True
+        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+
+        return get_tensor_model_parallel_rank() == 0
+    except (ImportError, AttributeError, AssertionError, RuntimeError, ValueError):
+        return True
+
+
+class WeightsPrewarmHandle:
+    """Cancelable prewarm task handed off when demand loading begins."""
+
+    def __init__(self, thread: threading.Thread, stop_event: threading.Event):
+        self._thread = thread
+        self._stop_event = stop_event
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._thread.join(timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+
+_parent_prewarm_active: ContextVar[bool] = ContextVar("parent_weights_prewarm_active", default=False)
+
+
+def start_weights_prewarm(
+    model: str,
+    *,
+    revision: str | None = None,
+    cache_dir: str | None = None,
+) -> WeightsPrewarmHandle | None:
+    """Start local prewarm unless a parent process already owns the window."""
+    if _parent_prewarm_active.get():
+        return None
+    return _start_weights_prewarm(model, revision=revision, cache_dir=cache_dir)
+
+
+def _start_weights_prewarm(
+    model: str,
+    *,
+    revision: str | None = None,
+    cache_dir: str | None = None,
+    read_order_key: Callable[[str], tuple] = _read_order_key,
+) -> WeightsPrewarmHandle | None:
+    """Kick off daemon threads reading the model's safetensors into the page
+    cache. ``model`` may be a local directory or a HF repo id resolved from
+    the requested revision and cache directory. Returns a cancelable task
+    handle, or None when skipped (unresolvable model, warm files, non-Linux,
+    or low budget)."""
+    if not _is_prewarm_rank():
+        return None
+    try:
+        model_dir = _resolve_local_dir(model, revision=revision, cache_dir=cache_dir)
+        if model_dir is None:
+            return None
+        files = []
+        for root, _, names in os.walk(model_dir):
+            files.extend(os.path.join(root, n) for n in names if n.endswith(".safetensors"))
+        files.sort(key=lambda p: read_order_key(os.path.relpath(p, model_dir)))
+        total = sum(os.path.getsize(f) for f in files)
+        if not total:
+            return None
+        resident = [f for f in files if _is_file_fully_resident(f)]
+        if resident:
+            resident_set = set(resident)
+            files = [f for f in files if f not in resident_set]
+            logger.info(
+                "Weights prewarm skipped %d page-cache-resident safetensors (%.1f GiB).",
+                len(resident),
+                sum(os.path.getsize(f) for f in resident) / (1 << 30),
+            )
+        if not files:
+            return None
+        remaining = sum(os.path.getsize(f) for f in files)
+        cap = min(remaining, _prewarm_budget_bytes(total))
+        if cap <= 0 or cap < _MIN_WORTHWHILE:
+            logger.debug("Weights prewarm skipped: budget %.1f GiB below threshold.", cap / (1 << 30))
+            return None
+    except OSError:
+        return None
+
+    stop_event = threading.Event()
+
+    def _run():
+        try:
+            t0 = time.perf_counter()
+            budget = _Budget(cap)
+            # Round-robin the (DiT-first) file order across readers so all
+            # streams work the head of the load order; the budget is shared,
+            # so one partition running dry strands nothing.
+            readers = _DEFAULT_READERS
+            parts = [files[i::readers] for i in range(readers)]
+            results = [(0, 0)] * len(parts)
+            workers = []
+            for i, part in enumerate(parts):
+
+                def _one(i=i, part=part):
+                    results[i] = _read_files(part, budget, stop_event)
+
+                w = threading.Thread(target=_one, name=f"weights-prewarm-{i}", daemon=True)
+                w.start()
+                workers.append(w)
+            for w in workers:
+                w.join()
+            done_bytes = sum(b for b, _ in results)
+            done_files = sum(f for _, f in results)
+            dt = time.perf_counter() - t0
+            logger.info(
+                "Weights prewarm%s: %.1f/%.1f GiB (%d/%d files) into page cache in %.1f s (%.1f GiB/s).",
+                " stopped at loader handoff" if stop_event.is_set() else "",
+                done_bytes / (1 << 30),
+                remaining / (1 << 30),
+                done_files,
+                len(files),
+                dt,
+                done_bytes / (1 << 30) / dt if dt > 0 else float("inf"),
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            logger.debug("Weights prewarm aborted: %s", exc)
+
+    logger.info(
+        "Weights prewarm started: %d safetensors, %.1f GiB (budget %.1f GiB).",
+        len(files),
+        remaining / (1 << 30),
+        cap / (1 << 30),
+    )
+    thread = threading.Thread(target=_run, name="weights-prewarm", daemon=True)
+    handle = WeightsPrewarmHandle(thread, stop_event)
+    thread.start()
+    return handle
+
+
+class _ProcessEvent(Protocol):
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+
+@dataclass(frozen=True)
+class WeightsPrewarmHandoff:
+    """Opaque worker token for a parent-owned prewarm window."""
+
+    _requested: _ProcessEvent | None = None
+    _completed: _ProcessEvent | None = None
+
+    def wait(self) -> None:
+        if self._requested is not None and self._completed is not None:
+            self._requested.set()
+            self._completed.wait()
+
+
+@contextmanager
+def parent_weights_prewarm(
+    model: str,
+    *,
+    revision: str | None = None,
+    cache_dir: str | None = None,
+) -> Iterator[WeightsPrewarmHandoff]:
+    """Prewarm during spawned-worker startup, then hand off before model init.
+
+    The returned token is passed unchanged to every worker. The first worker
+    reaching the handoff stops and joins the parent's speculative readers;
+    all workers then cross together, with worker-local prewarm suppressed.
+    """
+    handle = _start_weights_prewarm(
+        model,
+        revision=revision,
+        cache_dir=cache_dir,
+        read_order_key=_parent_read_order_key,
+    )
+    if handle is None:
+        # The parent already performed all resolution, residency, and budget
+        # checks. Suppress an identical scan in rank 0 even when no reads were
+        # needed or possible.
+        yield WeightsPrewarmHandoff()
+        return
+
+    context = mp.get_context("spawn")
+    requested = context.Event()
+    completed = context.Event()
+    handoff = WeightsPrewarmHandoff(requested, completed)
+
+    def _coordinate_handoff() -> None:
+        requested.wait()
+        try:
+            handle.stop()
+            handle.join()
+        finally:
+            completed.set()
+        logger.info("Parent weights prewarm handed off before worker model initialization.")
+
+    coordinator = threading.Thread(
+        target=_coordinate_handoff,
+        name="weights-prewarm-handoff",
+        daemon=True,
+    )
+    coordinator.start()
+    try:
+        yield handoff
+    finally:
+        requested.set()
+        coordinator.join()
+
+
+@contextmanager
+def use_parent_weights_prewarm(handoff: WeightsPrewarmHandoff | None) -> Iterator[None]:
+    """Wait for parent handoff and suppress duplicate local prewarm."""
+    if handoff is None:
+        yield
+        return
+
+    handoff.wait()
+    token = _parent_prewarm_active.set(True)
+    try:
+        yield
+    finally:
+        _parent_prewarm_active.reset(token)

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -63,6 +63,7 @@ from vllm_omni.diffusion.worker.utils import (
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.utils.startup_timing import log_startup_duration
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
 if TYPE_CHECKING:
@@ -274,6 +275,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             time_after_load - time_before_load,
         )
         logger.info("Model runner: Model loaded successfully.")
+        runtime_setup_started = time.perf_counter()
 
         if self.od_config.streaming_output and not getattr(self.od_config, "step_execution", False):
             logger.warning("streaming_output=True requires step_execution=True; enabling step execution.")
@@ -362,6 +364,12 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 model_tag=self.od_config.model_class_name,
             )
 
+        log_startup_duration(
+            logger,
+            "model.runtime_setup",
+            time.perf_counter() - runtime_setup_started,
+            model=self.od_config.model_class_name,
+        )
         logger.info("Model runner: Initialization complete.")
 
     def clear_prompt_embed_cache(self) -> None:

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -14,6 +14,7 @@ import os
 import queue
 import signal
 import threading
+import time
 import traceback
 import uuid
 from collections.abc import Iterator
@@ -50,6 +51,10 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 from vllm_omni.diffusion.forward_context import set_forward_context
 from vllm_omni.diffusion.ipc import DIFFUSION_RPC_RESULT_ENVELOPE, pack_diffusion_output_shm
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager, LoRABackend
+from vllm_omni.diffusion.model_loader.prewarm import (
+    WeightsPrewarmHandoff,
+    use_parent_weights_prewarm,
+)
 from vllm_omni.diffusion.registry import get_diffusion_ir_op_priority_func
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput, KVPrefetchJob
@@ -60,6 +65,11 @@ from vllm_omni.inputs.data import OmniInteractionPrompt
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.profiler import OmniTorchProfilerWrapper, create_omni_profiler
+from vllm_omni.utils.startup_timing import (
+    log_process_checkpoint,
+    log_startup_duration,
+    startup_span,
+)
 from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
 logger = init_logger(__name__)
@@ -208,6 +218,8 @@ class DiffusionWorker:
         od_config: OmniDiffusionConfig,
         skip_load_model: bool = False,
     ):
+        worker_started = time.perf_counter()
+        log_process_checkpoint(logger, "worker.process_to_init", rank=rank)
         self.local_rank = local_rank
         self.rank = rank
         self.od_config = od_config
@@ -221,7 +233,8 @@ class DiffusionWorker:
         # requests, which only carry their request_id in subsequent ticks.
         self._step_lora_state: dict[str, tuple[LoRARequest | None, float]] = {}
         self.stage_id = getattr(od_config, "stage_id", 0)
-        self.init_device()
+        with startup_span(logger, "worker.device_init", rank=rank):
+            self.init_device()
         # Create model runner — one decision chain, in precedence order:
         #   1. explicit od_config.diffusion_model_runner_cls (user override),
         #   2. the runner declared by the engine class that engine_backend
@@ -248,16 +261,20 @@ class DiffusionWorker:
             model_runner_cls_path = engine_runner
         else:
             model_runner_cls_path = current_omni_platform.get_diffusion_model_runner_cls()
-        model_runner_cls = resolve_obj_by_qualname(model_runner_cls_path)
-        self.model_runner = model_runner_cls(
-            vllm_config=self.vllm_config,
-            od_config=self.od_config,
-            device=self.device,
-        )
+        with startup_span(logger, "worker.model_runner_construct", rank=rank):
+            model_runner_cls = resolve_obj_by_qualname(model_runner_cls_path)
+            self.model_runner = model_runner_cls(
+                vllm_config=self.vllm_config,
+                od_config=self.od_config,
+                device=self.device,
+            )
         self.profiler: WorkerProfiler | None = self._create_profiler()
         if not skip_load_model:
-            self.load_model(load_format=self.od_config.diffusion_load_format)
-            self.init_lora_manager()
+            with startup_span(logger, "worker.model_load", rank=rank):
+                self.load_model(load_format=self.od_config.diffusion_load_format)
+            with startup_span(logger, "worker.lora_init", rank=rank):
+                self.init_lora_manager()
+        log_startup_duration(logger, "worker.total", time.perf_counter() - worker_started, rank=rank)
         logger.info(f"Worker {self.rank}: Initialization complete.")
 
     def init_device(self) -> None:
@@ -821,6 +838,7 @@ class WorkerProc:
         wake_event: mp.Event,
         worker_extension_cls: str | None = None,
         custom_pipeline_args: dict[str, Any] | None = None,
+        weights_prewarm_handoff: WeightsPrewarmHandoff | None = None,
     ):
         self.od_config = od_config
         self.gpu_id = gpu_id
@@ -844,8 +862,11 @@ class WorkerProc:
 
         assert od_config.master_port is not None
 
-        # Create worker using WorkerWrapperBase for extension support
-        self.worker = self._create_worker(gpu_id, od_config, worker_extension_cls, custom_pipeline_args)
+        # Parent prewarm overlaps process spawn/import only. All ranks wait for
+        # its readers to stop before any worker starts model initialization,
+        # and the context suppresses the old per-worker speculative readers.
+        with use_parent_weights_prewarm(weights_prewarm_handoff):
+            self.worker = self._create_worker(gpu_id, od_config, worker_extension_cls, custom_pipeline_args)
         self._running = True
 
         self._async_output_queue: queue.Queue | None = None
@@ -891,7 +912,7 @@ class WorkerProc:
             return
 
         # Async path: enqueue compute_done immediately, bg thread does D2H+SHM.
-        if not self.od_config.step_execution and isinstance(output, (DiffusionOutput, BatchRunnerOutput)):
+        if not self.od_config.step_execution and isinstance(output, DiffusionOutput | BatchRunnerOutput):
             async_output_id = WorkerProc._generate_async_output_id()
             gpu_event = current_omni_platform.record_device_event()
             self._async_output_queue.put((output, async_output_id, gpu_event))
@@ -1207,6 +1228,7 @@ class WorkerProc:
         wake_event: mp.Event,
         worker_extension_cls: str | None = None,
         custom_pipeline_args: dict[str, Any] | None = None,
+        weights_prewarm_handoff: WeightsPrewarmHandoff | None = None,
     ) -> None:
         """Worker initialization and execution loops."""
         from vllm_omni.plugins import load_omni_general_plugins
@@ -1242,6 +1264,7 @@ class WorkerProc:
                 wake_event=wake_event,
                 worker_extension_cls=worker_extension_cls,
                 custom_pipeline_args=custom_pipeline_args,
+                weights_prewarm_handoff=weights_prewarm_handoff,
             )
             logger.info(f"Worker {rank}: Scheduler loop started.")
             pipe_writer.send(

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -30,6 +30,7 @@ from vllm_omni.metrics.stats import OrchestratorAggregator
 from vllm_omni.metrics.transfer import OmniTransferMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.utils.startup_timing import log_process_checkpoint, startup_span
 from vllm_omni.utils.tracking_parser import TrackingNamespace
 
 if TYPE_CHECKING:
@@ -58,7 +59,8 @@ class OmniEngineDeadError(EngineDeadError):
 def _weak_shutdown_engine(engine: AsyncOmniEngine) -> None:
     """Best-effort engine cleanup for GC finalization."""
     try:
-        engine.shutdown()
+        with startup_span(logger, "engine.shutdown", trigger="finalizer"):
+            engine.shutdown()
     except Exception:
         pass
 
@@ -161,6 +163,7 @@ class OmniBase(PDDisaggregationMixin):
         model: str,
         **kwargs: Any,
     ) -> None:
+        log_process_checkpoint(logger, "entrypoint.process_to_init", entrypoint=self.__class__.__name__)
         if "engine_args" in kwargs:
             logger.warning(
                 "engine_args were passed as a kwarg to an Omni instance; this is not supported. "
@@ -181,7 +184,8 @@ class OmniBase(PDDisaggregationMixin):
 
         if "log_requests" in kwargs:
             raise TypeError("`log_requests` has been removed in Omni/AsyncOmni. Use `log_stats`.")
-        model = omni_snapshot_download(model)
+        with startup_span(logger, "entrypoint.snapshot_download", entrypoint=self.__class__.__name__):
+            model = omni_snapshot_download(model)
         self.__dict__["_name"] = self.__class__.__name__
         self.model = model
         self.log_stats = log_stats
@@ -198,15 +202,16 @@ class OmniBase(PDDisaggregationMixin):
         # TX-side emit; see Orchestrator._forward_to_next_stage).
         self.transfer_metrics = OmniTransferMetrics(model_name=model, log_stats=log_stats)
         st = time.time()
-        self.engine = AsyncOmniEngine(
-            model=model,
-            init_timeout=init_timeout,
-            stage_init_timeout=stage_init_timeout,
-            diffusion_batch_size=diffusion_batch_size,
-            transfer_emitter=self.transfer_metrics,
-            log_stats=log_stats,
-            **kwargs,
-        )
+        with startup_span(logger, "engine.total", entrypoint=self.__class__.__name__):
+            self.engine = AsyncOmniEngine(
+                model=model,
+                init_timeout=init_timeout,
+                stage_init_timeout=stage_init_timeout,
+                diffusion_batch_size=diffusion_batch_size,
+                transfer_emitter=self.transfer_metrics,
+                log_stats=log_stats,
+                **kwargs,
+            )
         self._shutdown_called = False
         self._weak_finalizer = weakref.finalize(self, _weak_shutdown_engine, self.engine)
         et = time.time()
@@ -331,7 +336,7 @@ class OmniBase(PDDisaggregationMixin):
             if allow_delta_coercion:
                 normalized = coerce_param_message_types(list(normalized), is_streaming=True)
 
-        elif isinstance(sampling_params_list, Sequence) and not isinstance(sampling_params_list, (str, bytes)):
+        elif isinstance(sampling_params_list, Sequence) and not isinstance(sampling_params_list, str | bytes):
             normalized = sampling_params_list
         elif self.num_stages == 1:
             normalized = [sampling_params_list]
@@ -722,4 +727,5 @@ class OmniBase(PDDisaggregationMixin):
         finalizer = getattr(self, "_weak_finalizer", None)
         if finalizer is not None and finalizer.alive:
             finalizer.detach()
-        self.engine.shutdown()
+        with startup_span(logger, "engine.shutdown", entrypoint=self.__class__.__name__):
+            self.engine.shutdown()

--- a/vllm_omni/utils/startup_timing.py
+++ b/vllm_omni/utils/startup_timing.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Low-overhead, parseable timings for startup critical paths."""
+
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Protocol
+
+
+class _Logger(Protocol):
+    def info(self, message: str, *args: object) -> None: ...
+
+
+def log_startup_duration(
+    logger: _Logger,
+    phase: str,
+    duration_s: float,
+    status: str = "ok",
+    **labels: object,
+) -> None:
+    sorted_labels = sorted(labels.items())
+    suffix = "".join(f" {key}=%s" for key, _ in sorted_labels)
+    logger.info(
+        f"[StartupTiming] phase=%s duration_s=%.6f status=%s{suffix}",
+        phase,
+        duration_s,
+        status,
+        *(value for _, value in sorted_labels),
+    )
+
+
+@contextmanager
+def startup_span(logger: _Logger, phase: str, **labels: object) -> Iterator[None]:
+    """Log one startup phase without changing its exception semantics."""
+    started = time.perf_counter()
+    completed = False
+    try:
+        yield
+        completed = True
+    finally:
+        status = "ok" if completed else "error"
+        log_startup_duration(logger, phase, time.perf_counter() - started, status, **labels)
+
+
+def process_age_seconds() -> float | None:
+    """Return this process's age from Linux monotonic clocks when available."""
+    try:
+        stat = open("/proc/self/stat").read()  # noqa: SIM115 - one tiny procfs read
+        fields_after_comm = stat[stat.rfind(")") + 2 :].split()
+        start_ticks = int(fields_after_comm[19])
+        ticks_per_second = os.sysconf("SC_CLK_TCK")
+        return max(0.0, time.clock_gettime(time.CLOCK_BOOTTIME) - start_ticks / ticks_per_second)
+    except (AttributeError, IndexError, OSError, TypeError, ValueError):
+        return None
+
+
+def log_process_checkpoint(logger: _Logger, phase: str, **labels: object) -> None:
+    """Log elapsed process lifetime at a startup checkpoint on Linux."""
+    duration_s = process_age_seconds()
+    if duration_s is not None:
+        log_startup_duration(logger, phase, duration_s, checkpoint=True, **labels)


### PR DESCRIPTION
# [Core] Accelerate diffusion weight loading with pinned staging and cooperative TP

Implements RFC #4896. No new configuration surface — eligibility is auto-detected from model format, device, and load-backend context; the staged fast paths degrade silently to the existing pageable loader when ineligible or under host-memory pressure.

## Why

Diffusion startup repeatedly pays for the same checkpoint bytes: disk reads, pageable host-to-device copies, and — under TP — duplicate per-rank loading even though each rank keeps only a shard. For models like Wan2.2 and HunyuanImage-3.0 this takes 45–90 s on a fresh host.

| term | checkpoint state | typical case | primary bottleneck |
|---|---|---|---|
| **cold** | absent from the OS page cache | node boot, autoscaling | storage |
| **warm** | fully page-cache resident | engine restart | CPU copy + H2D |

## What changed

- **Pinned staging and fused casts:** Eligible CUDA safetensors loads automatically use up to four producers and a reusable page-locked buffer pool. FP32 weights are converted to their destination dtype during the staging copy, reducing H2D traffic; quantized and non-floating tensors remain bit-exact, and tensors below 64 KiB pass through. Ineligible paths fall back to the existing loader.

- **Parent-process page-cache prewarm:** The parent reads checkpoint pages during worker spawn/import, prioritising pipeline components before DiT shards. Readers stop and join before worker model initialisation. Prewarm respects the resolved snapshot, revision, host-memory budget, and existing page-cache residency; executors without this lifecycle retain the local fallback.

- **Cooperative TP loading:** Each rank independently derives the same deterministic 256 MiB bucket plan. One owner stages and uploads each bucket, then broadcasts it to the TP group; four-bucket windows overlap staging, H2D, broadcast, and parameter copies. Compact group votes validate eligibility and schedules. Reported group-wide staging or collective failures replay through per-rank staging, while checkpoint source errors abort consistently; application code cannot recover a rank permanently blocked inside a collective.

- **Startup observability:** Parseable `[StartupTiming]` records cover process startup, download, engine and worker initialisation, pipeline construction, weight application, runtime setup, warmup, and shutdown without adding CUDA synchronisation. The offline example reports output processing separately from generation; the optional synchronising pipeline profiler remains diagnostic only.

## Results

All experiments use fixed checkpoint revisions, the same dependency lock, identical inputs (prompt, seed, resolution, and inference steps), isolated compiler caches, and the same physical host for each A/B pair. **Cold** = 0.000% checkpoint page-cache residency, verified by sampled `mincore` before every run. **Resident** = confirmed 100.000% residency. Results report the mean complete model-loader span, including pipeline construction, weight application, and post-load processing; TP=2 uses the slower rank for each run. Outputs matched between variants within every matrix.

Benchmark baseline: `fa0658ea`. Benchmarked PR commit: `4abf60f3` (tree `4575137e`). Dependency-lock SHA256: `102b2db47c09b2638aaa0ec5a1de31db81bb8ce3a19d4de909d75304197ee367`.

### Wan2.2 T2V A14B (117.512 GiB FP32)

Eager execution, 480×832×9 frames×2 steps, seed 42.

| config | hardware | residency | n per variant | baseline | this PR | speedup |
|---|---|---|---:|---:|---:|---:|
| TP=2 | `g7e.12xlarge`, 2× RTX PRO 6000 Blackwell | cold | 3 | 45.72 s | **31.34 s** | 1.46× |
| TP=2 | same | resident | 1 | 9.48 s | **8.79 s** | 1.08× |
| TP=1 | `g7e.4xlarge`, 1× RTX PRO 6000 Blackwell | cold | 2 | 43.39 s | **37.61 s** | 1.15× |
| TP=1 | same | resident | 2 | 16.31 s | **9.12 s** | 1.79× |

**TP=2 cold detail.** Reverse-interleaved baseline runs were 45.33–46.23 s and PR runs were 31.24–31.48 s. Both ranks cooperatively loaded both Wan DiTs; there was no fallback, rank loss, or shutdown error. All runs produced frame-tensor SHA256 `546cbc02c686628e89c61d26daf6a2bb03c2796f7d5e5acd57d8e342060041de`.

### HunyuanImage-3.0

Eager execution, 1024×1024×20 steps, seed 42. Base BF16 uses the standalone `hunyuan_image3_dit` pipeline with TP=2 / EP and `flashinfer_cutlass`; ModelOpt uses TP=1 / EP and auto-detected quantization.

| checkpoint and config | hardware | residency | n per variant | baseline | this PR | speedup |
|---|---|---|---:|---:|---:|---:|
| 156.965 GiB Base BF16, TP=2 / EP | `g7e.12xlarge`, 2× RTX PRO 6000 Blackwell | cold | 2 | 79.81 s | **35.03 s** | 2.28× |
| same | same | resident | 2 | 16.16 s | **12.31 s** | 1.31× |
| 48.759 GiB ModelOpt NVFP4+FP8, TP=1 / EP | `g7e.4xlarge`, 1× RTX PRO 6000 Blackwell | cold | 2 | 32.44 s | **17.14 s** | 1.89× |
| same | same | resident | 2 | 12.10 s | **10.12 s** | 1.20× |

Every Base BF16 baseline and PR run produced raw RGB SHA256 `e761b822137fcd2a79e77a051ac54dd3cc91943fc9c82c825278e533774b3174`. Every ModelOpt run produced raw RGB SHA256 `1ad198548da0c08084bf334d23b932d3551c675577fcc99b31d743f38ba41a3a`.

### RunAI #2199 comparison

This comparison uses a strict common base: control commit `7b5b3992` (tree `256d9255`) versus the same tree plus the adapted offline RunAI loader patch (tree `1efe645d`). Both variants ran on the same `g7e.4xlarge` with the fixed Wan2.2 revision, TP=1 eager, and isolated compiler caches.

| residency | n per variant | common-base control | RunAI #2199 | RunAI change |
|---|---:|---:|---:|---:|
| cold | 2 | **43.26 s** | 44.00 s | +1.7% |
| resident | 2 | **15.31 s** | 41.22 s | +169.2% |

Every RunAI activation gate passed. The resident RunAI runs read 38.75 GiB from the device on average, versus 0.75 GiB for the control. This local-NVMe result does not characterize RunAI's direct S3, GCS, or Azure streaming paths. All comparison runs produced frame-tensor SHA256 `a261c037ae16dbe5f95457464d211cefac0a49348a4b61351dc45f5bdb1341d4`.

## Testing

### Unit and integration

- `tests/diffusion/model_loader/test_pinned_staging.py` — buffer recycling, backpressure, fused-cast policy, pool floor enforcement.
- `tests/diffusion/model_loader/test_cooperative_staging.py` — planner determinism, rank lockstep, stream contract, preflight veto, mid-stream failure, divergent order / metadata / length, source error, and group-wide staging / schedule / all-reduce / broadcast fallback paths.
- `tests/diffusion/model_loader/test_cooperative_staging_cuda.py` — two-process NCCL with buckets owned by both ranks.
- `tests/diffusion/model_loader/test_prewarm.py` — parent handoff lifecycle, read order, scan suppression, revision / cache resolution.
- `tests/utils/test_startup_timing.py` — parseable record emission.
- `tests/entrypoints/test_omni_base_profiler.py` — explicit and finalizer-driven shutdown timing.
- GPU model-loader suite passed after the final buffer-recycling fix.
- Parent-prewarm and executor suites: `17 passed` and `75 passed`.
- The final focused suite on the measured two-GPU host, including the real NCCL test: `18 passed, 15 warnings`.

### Hardware validation

All E2E runs fixed checkpoint revision, inputs, dependency lock, and residency. Cold runs were reverse-interleaved on the same physical host.

- Wan2.2 TP=2, 117.512 GiB, `g7e.12xlarge`: baseline / PR cold ×3 and resident ×1; no cooperative fallback, rank loss, or shutdown error; frame SHA256 `546cbc02c686628e89c61d26daf6a2bb03c2796f7d5e5acd57d8e342060041de`.
- Wan2.2 TP=1, `g7e.4xlarge`: baseline / PR cold ×2 and resident ×2; frame SHA256 `a261c037ae16dbe5f95457464d211cefac0a49348a4b61351dc45f5bdb1341d4`.
- HunyuanImage-3.0 Base BF16, 156.965 GiB, `g7e.12xlarge`, TP=2 / EP: baseline / PR cold ×2 and resident ×2; RGB SHA256 `e761b822137fcd2a79e77a051ac54dd3cc91943fc9c82c825278e533774b3174`.
- HunyuanImage-3.0 ModelOpt, 48.759 GiB, `g7e.4xlarge`, TP=1 / EP: baseline / PR cold ×2 and resident ×2; RGB SHA256 `1ad198548da0c08084bf334d23b932d3551c675577fcc99b31d743f38ba41a3a`.
- RunAI common-base control / patched comparison: cold ×2 and resident ×2; activation gate passed in every patched run; frame SHA256 `a261c037ae16dbe5f95457464d211cefac0a49348a4b61351dc45f5bdb1341d4`.

### Memory profile

Wan2.2 TP=2 cold peaked at 25.32 GiB process-tree RSS for baseline and 25.25 GiB for the PR, with 50.23 GiB GPU memory per rank. Hunyuan Base BF16 TP=2 cold peaked at 12.77 GiB RSS for baseline and 18.60 GiB for the PR, with 93.99 GiB GPU memory per rank. Pinned staging adds a bounded 1–3 GiB of pinned host memory per rank; GPU peak memory remained unchanged within measurement precision.
