### PR TITLE
[Bugfix] fix issue 5065

### DIFF
--- a/tests/model_tests/conftest.py
+++ b/tests/model_tests/conftest.py
@@ -22,7 +22,7 @@ def tiny_model_paths(request, run_level):
         if not hasattr(item, "callspec"):
             continue
         model_name = item.callspec.params.get("model_name")
-        if model_name is None:
+        if model_name is None or model_name not in DIFFUSION_TEST_SETTINGS:
             continue
         if model_name not in model_paths:
             settings = DIFFUSION_TEST_SETTINGS[model_name]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
related issue #5065 

The `tiny_model_paths` in `tests/model_tests/conftest.py` is a session-scoped fixture. It will iterate through all the test cases in `request.session.items` that have `callspec.params["model_name"]`, and use that value to index `DIFFUSION_TEST_SETTINGS`. 
The problem lies in the fact that within the same pytest session, many unrelated tests also use the same parameter name 'model_name' (for example, in tests/diffusion/batching/test_diffusion_batching.py, there is 'tiny-random/Qwen-Image'), but these values are not the keys of DIFFUSION_TEST_SETTINGS (the actual keys are pipeline names like Flux2KleinPipeline).
## Test Plan

pytest -v -s -m "core_model and cuda and L4 and not distributed_cuda"  --ignore=tests/e2e  --ignore=tests/dfx

**vLLM Version:**
0.25.0
**vLLM-Omni Commit:**
2d58070f6024130a907f5291cebc59457d584843
## Test Result
```
tests/model_tests/diffusion/test_common_offline.py::test_pipeline_on_supported_tasks[Flux2KleinPipeline] Initializing tiny models...
Calling tiny model builder for: Flux2KleinPipeline

Writing model shards:   0%|          | 0/1 [00:00<?, ?it/s]
Writing model shards: 100%|██████████| 1/1 [00:00<00:00, 52.33it/s]
--- Running test: test_pipeline_on_supported_tasks[Flux2KleinPipeline]
INFO 07-15 02:54:08 [omni_base.py:167] [Omni] Initializing with model /tmp/vllm-omni-tiny-models/Flux2KleinPipeline
INFO 07-15 02:54:08 [async_omni_engine.py:244] [AsyncOmniEngine] Initializing with model /tmp/vllm-omni-tiny-models/Flux2KleinPipeline
INFO 07-15 02:54:08 [async_omni_engine.py:317] [AsyncOmniEngine] Launching Orchestrator thread with 1 stages
INFO 07-15 02:54:08 [stage_utils.py:167] Stage 0 logical-to-physical device mapping: 0->4
INFO 07-15 02:54:08 [multiproc_executor.py:188] Starting server...
INFO 07-15 02:54:15 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-15 02:54:16 [patch.py:481] [cumem-cuda] CuMemAllocator._python_free_callback patched: asleep guard extended to all platforms.
INFO 07-15 02:54:18 [diffusion_worker.py:776] Worker 0 created result MessageQueue
INFO 07-15 02:54:18 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 07-15 02:54:18 [vllm.py:1042] Asynchronous scheduling is enabled.
INFO 07-15 02:54:18 [kernel.py:292] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 07-15 02:54:18 [diffusion_worker.py:291] Final IR op priority after setting vLLM-Omni overrides: IrOpPriorityConfig(rms_norm=['vllm_c', 'native'], fused_add_rms_norm=['vllm_c', 'native'])
INFO 07-15 02:54:18 [diffusion_worker.py:303] Worker 0: Initialized device and distributed environment.
INFO 07-15 02:54:18 [parallel_state.py:603] Building SP subgroups from explicit sp_group_ranks (sp_size=1, ulysses=1, ring=1, use_ulysses_low=True).
INFO 07-15 02:54:18 [parallel_state.py:645] SP group details for rank 0: sp_group=[0], ulysses_group=[0], ring_group=[0]

Loading weights:   0%|          | 0/311 [00:00<?, ?it/s]
Loading weights: 100%|██████████| 311/311 [00:00<00:00, 10102.53it/s]
INFO 07-15 02:54:19 [selector.py:87] Resolved diffusion attention backend 'FLASH_ATTN' for role='self' via platform default

Multi-thread loading shards:   0% Completed | 0/1 [00:00<?, ?it/s]

Multi-thread loading shards: 100% Completed | 1/1 [00:00<00:00, 345.92it/s]

INFO 07-15 02:54:19 [diffusers_loader.py:483] Loading weights took 0.00 seconds
INFO 07-15 02:54:20 [diffusion_model_runner.py:209] Model loading took 0.0192 GiB and 2.181204 seconds
INFO 07-15 02:54:20 [diffusion_model_runner.py:214] Model runner: Model loaded successfully.
INFO 07-15 02:54:20 [diffusion_model_runner.py:288] Model runner: Initialization complete.
INFO 07-15 02:54:20 [diffusion_worker.py:361] Worker 0: Process-scoped GPU memory after model loading: 0.00 GiB.
INFO 07-15 02:54:20 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 07-15 02:54:20 [diffusion_worker.py:252] Worker 0: Initialization complete.
INFO 07-15 02:54:20 [diffusion_worker.py:1012] Worker 0: Scheduler loop started.
INFO 07-15 02:54:20 [diffusion_worker.py:904] Worker 0 ready to receive requests via shared memory
INFO 07-15 02:54:20 [diffusion_engine.py:805] dummy run to warm up the model
INFO 07-15 02:54:21 [inline_stage_diffusion_client.py:72] [InlineStageDiffusionClient] stage-0 [rep-0] initialized inline (batch_size=1)
INFO 07-15 02:54:21 [stage_runtime.py:656] [StageRuntime] Stage 0 replica 0 initialized (diffusion, batch_size=1)
INFO 07-15 02:54:21 [orchestrator.py:332] [Orchestrator] Starting event loop
INFO 07-15 02:54:21 [async_omni_engine.py:344] [AsyncOmniEngine] Orchestrator ready with 1 stages
INFO 07-15 02:54:21 [omni_base.py:185] [Omni] AsyncOmniEngine initialized in 13.47 seconds
INFO 07-15 02:54:21 [omni_base.py:205] [Omni] Initialized with 1 stages for model /tmp/vllm-omni-tiny-models/Flux2KleinPipeline

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  5.64it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  5.63it/s]
SUBPASSED[text_to_image]
Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  2.59it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  2.59it/s]

tests/model_tests/diffusion/test_common_offline.py::test_pipeline_on_supported_tasks[Flux2KleinPipeline] SUBPASSED[image_to_image]
Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  6.57it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  6.57it/s]

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  6.64it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  6.63it/s]

tests/model_tests/diffusion/test_common_offline.py::test_pipeline_on_supported_tasks[Flux2KleinPipeline] SUBPASSED[determinism]
Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  3.50it/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  3.50it/s]

tests/model_tests/diffusion/test_common_offline.py::test_pipeline_on_supported_tasks[Flux2KleinPipeline] SUBPASSED[multi_output]INFO 07-15 02:54:22 [omni_base.py:623] [Omni] Shutting down
INFO 07-15 02:54:22 [async_omni_engine.py:1545] [AsyncOmniEngine] Shutting down Orchestrator
INFO 07-15 02:54:22 [orchestrator.py:420] [Orchestrator] Received shutdown signal
INFO 07-15 02:54:22 [orchestrator.py:1638] [Orchestrator] Shutting down all 1 client(s)
INFO 07-15 02:54:22 [diffusion_worker.py:944] Worker 0: Received shutdown message
INFO 07-15 02:54:22 [diffusion_worker.py:965] event loop terminated.
INFO 07-15 02:54:22 [diffusion_worker.py:1035] Worker 0: Shutdown complete.
INFO 07-15 02:54:24 [stage_pool.py:1204] [StagePool] Stage 0 replica 0 shut down

tests/model_tests/diffusion/test_common_offline.py::test_pipeline_on_supported_tasks[Flux2KleinPipeline] PASSED
```
--- Running Summary
= 63 passed, 26 skipped, 5498 deselected, 22 warnings, 8 subtests passed in 716.30s (0:11:56) =


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
