### PR TITLE
[Profiler] Add execution trace capture to OmniTorchProfilerWrapper

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -31,6 +31,7 @@ Supported fields:
 | `torch_profiler_with_memory` | Enable memory profiling and attempt to dump `memory_snapshot_rank*.pickle`. The pickle is only generated when the current backend supports memory history and snapshot APIs. |
 | `torch_profiler_with_flops` | Enable FLOPs collection in `torch.profiler`. This does not add a separate output file. |
 | `torch_profiler_dump_cuda_time_total` | Export an additional text summary `profiler_out_<rank>.txt` sorted by `self_cuda_time_total`. |
+| `torch_profiler_execution_trace` | Also capture a PyTorch execution trace (ET) per rank via an `ExecutionTraceObserver`, written as `execution_trace_rank*.json` in the session dir. Local trace dirs only. |
 | `delay_iterations` | Number of worker iterations to skip before profiling starts. |
 | `max_iterations` | Maximum number of worker iterations to capture before auto-stop. |
 | `wait_iterations` | Torch-profiler wait iterations before warmup. |

--- a/vllm_omni/profiler/omni_torch_profiler.py
+++ b/vllm_omni/profiler/omni_torch_profiler.py
@@ -77,6 +77,11 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
             )
 
         self.dump_cpu_time_total = "CPU" in activities and len(activities) == 1
+        # ET capture enabled via vLLM's flag (getattr: no-op on older vLLM).
+        self._capture_et = getattr(profiler_config, "torch_profiler_execution_trace", False) and not _is_uri_path(
+            self._trace_dir
+        )
+        self.execution_trace_observer = None
         self.profiler = self._create_profiler(profiler_config, activities)
 
     def _rank(self) -> int:
@@ -383,9 +388,27 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         self._artifact_paths[name] = path
         return path
 
+    def _start_execution_trace(self) -> None:
+        if not self._capture_et or not hasattr(torch.profiler, "ExecutionTraceObserver"):
+            return
+        et_file = self._artifact_path("execution_trace", ".json")
+        self.execution_trace_observer = torch.profiler.ExecutionTraceObserver()
+        self.execution_trace_observer.register_callback(et_file)
+        self.execution_trace_observer.start()
+        if self._rank() == 0:
+            logger.info_once("Execution trace capture enabled: %s", et_file)
+
+    def _stop_execution_trace(self) -> None:
+        if self.execution_trace_observer is None:
+            return
+        self.execution_trace_observer.stop()
+        self.execution_trace_observer.cleanup()
+        self._artifact_paths["execution_trace"] = self.execution_trace_observer.get_output_file_path()
+
     @override
     def _start(self) -> None:
         self._ensure_session_dir()
+        self._start_execution_trace()
         self._try_enable_memory_history()
         self.profiler.start()
 
@@ -393,6 +416,7 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
     def _stop(self) -> None:
         """Stop profiler, export trace via on_trace_ready, and dump table."""
         self.profiler.stop()
+        self._stop_execution_trace()
         try:
             self._on_stop_hook()
         finally:
@@ -487,6 +511,13 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
 
         if self.dump_cpu_time_total and rank == 0:
             logger.info(self.profiler.key_averages().table(sort_by="self_cpu_time_total", row_limit=50))
+
+    @override
+    def shutdown(self) -> None:
+        super().shutdown()
+        # Safety net: cleanup() is idempotent, so this is safe after _stop() too.
+        if self.execution_trace_observer is not None:
+            self.execution_trace_observer.cleanup()
 
     @override
     def annotate_context_manager(self, name: str):


### PR DESCRIPTION
## Summary

Adds PyTorch **execution trace (ET)** capture to `OmniTorchProfilerWrapper`, gated by vLLM's `ProfilerConfig.torch_profiler_execution_trace` flag. When enabled, an `ExecutionTraceObserver` writes `execution_trace_rank<N>.json` (one per rank) into the profiling session directory, alongside the existing Kineto trace — no per-model code changes.

This is the vLLM-Omni counterpart to the upstream vLLM change that added `torch_profiler_execution_trace` to `ProfilerConfig` and wired it into `TorchProfilerWrapper` (vllm-project/vllm#46336). vLLM-Omni already imports vLLM's `ProfilerConfig`, so no new config field is needed here — only the wrapper needs to honor the flag.

## Changes

- **`vllm_omni/profiler/omni_torch_profiler.py`**:
  - `__init__`: compute `self._capture_et` from `getattr(profiler_config, "torch_profiler_execution_trace", False)` (getattr → no-op on older vLLM) and only for local trace dirs (`_is_uri_path` guard).
  - `_start()`: register + start an `ExecutionTraceObserver` writing `execution_trace_rank<N>.json` under the finalized session dir. Registered here (not in `__init__`) because the session dir is set after construction via `set_trace_filename()`. Skipped on torch builds without `ExecutionTraceObserver`.
  - `_stop()`: stop + `cleanup()` the observer and record its path in `_artifact_paths` (so it flows through `get_results()`).
  - `shutdown()`: idempotent `cleanup()` safety net for an observer registered but never stopped.

Runs the observer standalone (its own `start()`/`stop()`) rather than via `torch.profiler.profile(execution_trace_observer=...)`, which keeps it compatible with omni's lazy session-dir model and the NPU subclass (whose `_create_profiler` uses `torch_npu.profiler`).

## Usage

```bash
python examples/offline_inference/text_to_video/text_to_video.py \
  --model Wan-AI/Wan2.2-T2V-A14B-Diffusers ... \
  --profiler-config '{"profiler":"torch","torch_profiler_dir":"/tmp/prof","torch_profiler_execution_trace":true}'
```

Produces `execution_trace_rank<N>.json` per rank in the session dir, next to the Kineto trace.

## Testing

Verified end-to-end on Intel XPU (4× Arc Pro B60, TP=4) with Wan2.2-T2V-A14B, for both the `aot_eager` and pure-eager (`--enforce-eager`) compile backends:
- The `--profiler-config` flow enabled ET capture (log: `Execution trace capture enabled: .../execution_trace_rank0.json`) and produced 4 valid per-rank ET files (~1.5 GB each, Chakra schema `1.1.1-chakra.0.0.4`, ~1.3M nodes, `finish_ts` present) alongside the Kineto traces.
- Compared against traces captured by hand-editing the model runner's forward: op-name sets match, and the aten-op totals differ by only +151 nodes (+0.01%) — entirely profiler `record_function` region markers (`pipeline_forward`/`diffusion_forward`) and observer start/stop bookkeeping, not model compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)