### PR TITLE
[Bugfix] Fix MiniCPM-o 4.5 audio >30s preprocessing TypeError

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_long_audio_processing.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_long_audio_processing.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for MiniCPM-o 4.5 >30s audio preprocessing.
+
+Covers:
+  - ``_minicpmo_field_config``: <=30s audio keeps the batched layout
+  - >30s audio switches to ``flat`` with one slice per source audio
+  - mixed long + short audios group chunks by source audio
+  - no audio inputs -> batched (default path unchanged)
+  - ``process_audios``: >30s audio unpads per chunk without ``TypeError``
+  - multiple >30s audios unpad in chunk order
+  - <=30s audio unpadding byte-identical to the pre-fix behavior
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm.multimodal.inputs import (
+    MultiModalBatchedField,
+    MultiModalFlatField,
+)
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
+    MiniCPMO45OmniLLMMultiModalProcessor,
+    MiniCPMOMultiModalDataParser,
+    _minicpmo_field_config,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_SAMPLE_RATE = 16_000
+_FEAT_DIM = 128
+# Whisper pads every 30s chunk to 3000 mel frames.
+_CHUNK_FRAMES = 3000
+
+
+class TestMiniCPMOFieldConfig:
+    def test_short_audios_stay_batched(self) -> None:
+        # two <=30s audios: one feature entry + one 1-element lens per audio
+        hf_inputs = {
+            "audio_features": [torch.zeros(_FEAT_DIM, _CHUNK_FRAMES)] * 2,
+            "audio_feature_lens": [torch.tensor([980]), torch.tensor([1500])],
+        }
+
+        config = _minicpmo_field_config(hf_inputs)
+
+        assert isinstance(config["audio_features"].field, MultiModalBatchedField)
+
+    def test_long_audio_groups_chunks_per_audio(self) -> None:
+        # one 45s audio -> 2 chunks but a single lens tensor
+        hf_inputs = {
+            "audio_features": [torch.zeros(_FEAT_DIM, _CHUNK_FRAMES)] * 2,
+            "audio_feature_lens": [torch.tensor([_CHUNK_FRAMES, 1500])],
+        }
+
+        config = _minicpmo_field_config(hf_inputs)
+
+        field = config["audio_features"].field
+        assert isinstance(field, MultiModalFlatField)
+        assert field.slices == [slice(0, 2)]
+
+    def test_mixed_long_and_short_audios(self) -> None:
+        # 45s audio (2 chunks) + 10s audio (1 chunk)
+        hf_inputs = {
+            "audio_features": [torch.zeros(_FEAT_DIM, _CHUNK_FRAMES)] * 3,
+            "audio_feature_lens": [
+                torch.tensor([_CHUNK_FRAMES, 1500]),
+                torch.tensor([980]),
+            ],
+        }
+
+        config = _minicpmo_field_config(hf_inputs)
+
+        field = config["audio_features"].field
+        assert isinstance(field, MultiModalFlatField)
+        assert field.slices == [slice(0, 2), slice(2, 3)]
+
+    def test_no_audio_inputs_stay_batched(self) -> None:
+        config = _minicpmo_field_config({})
+
+        assert isinstance(config["audio_features"].field, MultiModalBatchedField)
+
+
+def _make_processor(
+    fake_hf_outputs: dict[str, list[torch.Tensor]],
+) -> MiniCPMO45OmniLLMMultiModalProcessor:
+    """Build a processor without a checkpoint: only what ``process_audios``
+    touches, with the HF processor call returning canned Whisper-style output."""
+    processor = object.__new__(MiniCPMO45OmniLLMMultiModalProcessor)
+    processor.info = SimpleNamespace(audio_pattern="(<audio>./</audio>)")
+    processor.data_parser = MiniCPMOMultiModalDataParser(target_sr=_SAMPLE_RATE)
+
+    def fake_base_call_hf_processor(prompts, mm_data, mm_kwargs, tok_kwargs, *, out_keys):
+        return {key: fake_hf_outputs[key] for key in out_keys}
+
+    processor._base_call_hf_processor = fake_base_call_hf_processor
+    return processor
+
+
+def _audio_seconds(seconds: float) -> np.ndarray:
+    return np.zeros(int(seconds * _SAMPLE_RATE), dtype=np.float32)
+
+
+class TestProcessAudiosUnpadding:
+    def test_long_audio_unpads_per_chunk(self) -> None:
+        # 45s audio: 2 padded chunks, one lens tensor -> pre-fix TypeError
+        chunk_lens = [_CHUNK_FRAMES, 1500]
+        fake_outputs = {
+            "audio_features": [torch.randn(_FEAT_DIM, _CHUNK_FRAMES) for _ in chunk_lens],
+            "audio_feature_lens": [torch.tensor(chunk_lens)],
+        }
+        processor = _make_processor(fake_outputs)
+
+        result = processor.process_audios({"audios": [_audio_seconds(45)]}, {}, {})
+
+        features = result["audio_features"]
+        assert [feat.shape[-1] for feat in features] == chunk_lens
+        for feat, padded, length in zip(features, fake_outputs["audio_features"], chunk_lens):
+            assert torch.equal(feat, padded[:, :length])
+
+    def test_multiple_long_audios(self) -> None:
+        # two >30s audios: 4 chunks total, 2-element lens tensor each
+        fake_outputs = {
+            "audio_features": [torch.randn(_FEAT_DIM, _CHUNK_FRAMES) for _ in range(4)],
+            "audio_feature_lens": [
+                torch.tensor([_CHUNK_FRAMES, 1200]),
+                torch.tensor([_CHUNK_FRAMES, 800]),
+            ],
+        }
+        processor = _make_processor(fake_outputs)
+
+        result = processor.process_audios({"audios": [_audio_seconds(42), _audio_seconds(38)]}, {}, {})
+
+        widths = [feat.shape[-1] for feat in result["audio_features"]]
+        assert widths == [_CHUNK_FRAMES, 1200, _CHUNK_FRAMES, 800]
+
+    def test_short_audio_unchanged(self) -> None:
+        # <=30s audio: single-chunk unpadding identical to pre-fix behavior
+        fake_outputs = {
+            "audio_features": [torch.randn(_FEAT_DIM, _CHUNK_FRAMES)],
+            "audio_feature_lens": [torch.tensor([980])],
+        }
+        processor = _make_processor(fake_outputs)
+
+        result = processor.process_audios({"audios": [_audio_seconds(9.8)]}, {}, {})
+
+        features = result["audio_features"]
+        assert len(features) == 1
+        assert features[0].shape == (_FEAT_DIM, 980)
+        assert torch.equal(features[0], fake_outputs["audio_features"][0][:, :980])

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -2916,6 +2916,10 @@ class MiniCPMO45OmniLLMProcessingInfo(BaseProcessingInfo):
             if isinstance(val, np.ndarray):
                 setattr(image_processor, attr, val.tolist())
 
+        # vLLM's vendored MiniCPMOProcessor defaults to pool_step=2 (MiniCPM-o 2.6).
+        # Sync from hf_config (4.5 uses 5) so audio placeholder counts match the encoder.
+        hf_processor.pool_step = self.get_default_audio_pool_step()
+
         return hf_processor
 
     def get_hf_image_processor(self) -> MiniCPMVImageProcessor:

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -3167,9 +3167,22 @@ class MiniCPMOAudioEmbeddingItems(DictEmbeddingItems):
 
 
 def _minicpmo_field_config(hf_inputs: Mapping[str, torch.Tensor]):
+    audio_features = hf_inputs.get("audio_features", [])
+    audio_feature_lens = hf_inputs.get("audio_feature_lens", [])
+
+    # >30s audio: one audio_features entry per 30s chunk but one lens tensor
+    # per audio — group chunks by audio (flat: unpadded features vary in length).
+    if len(audio_features) > len(audio_feature_lens):
+        idxs = [0]
+        for lens in audio_feature_lens:
+            idxs.append(idxs[-1] + lens.numel())
+        audio_features_cfg = MultiModalFieldConfig.flat("audio", [slice(a, b) for a, b in zip(idxs, idxs[1:])])
+    else:
+        audio_features_cfg = MultiModalFieldConfig.batched("audio")
+
     return dict(
         **_minicpmv_field_config(hf_inputs),
-        audio_features=MultiModalFieldConfig.batched("audio"),
+        audio_features=audio_features_cfg,
         audio_feature_lens=MultiModalFieldConfig.batched("audio"),
         audio_embeds=MultiModalFieldConfig.batched("audio"),
     )
@@ -3361,11 +3374,14 @@ class MiniCPMO45OmniLLMMultiModalProcessor(BaseMultiModalProcessor[MiniCPMO45Omn
                 out_keys={"audio_features", "audio_feature_lens"},
             )
 
+            # Flatten per-audio chunk lengths to one length per chunk
+            # (>30s audio spans multiple 30s chunks).
+            flat_feature_lens = torch.hstack(list(audio_inputs["audio_feature_lens"])).tolist()
             unpadded_audio_features = [
                 feat[:, :feature_len]
                 for feat, feature_len in zip(
                     audio_inputs["audio_features"],
-                    audio_inputs["audio_feature_lens"],
+                    flat_feature_lens,
                 )
             ]
             audio_inputs["audio_features"] = unpadded_audio_features

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -760,7 +760,9 @@ class MiniCPMVImageProcessor(BaseImageProcessor):
         )
 
 
-AutoImageProcessor.register("MiniCPMVImageProcessor", MiniCPMVImageProcessor)
+# transformers >= 5.5 requires the config *class* (not a string) as the first arg,
+# same as the gr00t fix in diffusion/models/gr00t/modeling/processing_gr00t_n1d7.py.
+AutoImageProcessor.register(MiniCPMOConfig, MiniCPMVImageProcessor)
 
 
 # ============== SigLIP Vision Transformer Classes ==============


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Fix #5110
MiniCPM-o 4.5 rejects any audio input >30s with HTTP 400: the Whisper feature extractor emits one `audio_features` entry per 30s chunk but one `audio_feature_lens` tensor per audio, and `process_audios` zips them 1:1, using a multi-element length tensor as a slice index (`TypeError`). Fix mirrors upstream vLLM `minicpmo.py`; ≤30s audio is unchanged (byte-identical to main).

- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py` — flatten lengths to one per chunk before unpadding in `process_audios`, and group per-chunk `audio_features` by audio (`MultiModalFieldConfig.flat`) in `_minicpmo_field_config`.

Note: after preprocessing succeeds, audio requests still hit the separate engine-side crash tracked in #5109.
## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** a432b8a3

Terminal A:

```shell
vllm serve openbmb/MiniCPM-o-4_5 --omni --trust-remote-code --host 127.0.0.1 --port 8099
```

Terminal B:

```shell
vllm bench serve --omni \
  --backend openai-chat-omni \
  --endpoint /v1/chat/completions \
  --host 127.0.0.1 \
  --port 8099 \
  --model openbmb/MiniCPM-o-4_5 \
  --trust-remote-code \
  --dataset-name random-mm \
  --random-input-len 100 \
  --random-output-len 32 \
  --random-range-ratio 0.0 \
  --num-prompts 1 \
  --num-warmups 0 \
  --max-concurrency 1 \
  --request-rate inf \
  --random-mm-base-items-per-request 1 \
  --random-mm-num-mm-items-range-ratio 0.0 \
  --random-mm-limit-mm-per-prompt '{"audio": 1}' \
  --random-mm-bucket-config '{(0, 45, 1): 1.0}' \
  --extra-body '{"modalities": ["text"]}'

curl -sS -i http://127.0.0.1:8099/health
```

## Test Result
Before (main): 45s audio → `TypeError` in `process_audios` → HTTP 400.

<details>
<summary>Log from #5110</summary>

```
(APIServer pid=103441) INFO:     Started server process [103441]
(APIServer pid=103441) INFO:     Waiting for application startup.
(APIServer pid=103441) INFO:     Application startup complete.
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435] Error in preprocessing prompt inputs
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435] Traceback (most recent call last):
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 413, in _create_chat_completion
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     conversation, engine_prompts = await self._preprocess_chat(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 698, in _preprocess_chat
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     (conversation,), (engine_prompt,) = await renderer.render_chat_async(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/base.py", line 1099, in render_chat_async
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     eng_prompts = await asyncio.gather(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                   ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/base.py", line 975, in process_for_engine_async
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     engine_input = await self._process_singleton_async(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/base.py", line 887, in _process_singleton_async
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     return await self._process_tokens_async(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/hf.py", line 1228, in _process_tokens_async
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     engine_input = await super()._process_tokens_async(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/base.py", line 844, in _process_tokens_async
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     engine_input = await self._process_multimodal_async(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/thread.py", line 59, in run
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     result = self.fn(*self.args, **self.kwargs)
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/base.py", line 762, in _process_multimodal
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/processing/processor.py", line 1685, in apply
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     ) = self._cached_apply_hf_processor(inputs, timing_ctx)
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/processing/processor.py", line 1474, in _cached_apply_hf_processor
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     ) = self._apply_hf_processor_main(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py", line 3268, in _apply_hf_processor_main
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     mm_processed_data = self._apply_hf_processor_mm_only(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/processing/processor.py", line 1232, in _apply_hf_processor_mm_only
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     _, mm_processed_data, _ = self._apply_hf_processor_text_mm(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/processing/processor.py", line 1153, in _apply_hf_processor_text_mm
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     processed_data = self._call_hf_processor(
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]          ^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py", line 3293, in _call_hf_processor
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     mm_inputs = self.process_mm_inputs(mm_data, mm_kwargs, tok_kwargs)
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py", line 3440, in process_mm_inputs
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     **self.process_audios(mm_data, mm_kwargs, tok_kwargs),
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]   File "/root/vllm-omni/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py", line 3365, in process_audios
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     feat[:, :feature_len]
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435]     ~~~~^^^^^^^^^^^^^^^^^
(APIServer pid=103441) ERROR 07-14 13:51:11 [serving_chat.py:435] TypeError:only integer tensors of a single element can be converted to an index
(APIServer pid=103441) INFO:     127.0.0.1:57254 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
(APIServer pid=103441) INFO:     127.0.0.1:32828 - "GET /health HTTP/1.1" 200 OK
```

</details>

After (this PR): 45s audio passes preprocessing (chunks unpadded to 3000+1500 frames), no TypeError/400 in the log; the request then reaches the engine and hits the separate #5109 crash.

<details>
<summary>Server log (this PR, 45s audio)</summary>

```
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] StageEngineCoreProc encountered a fatal error.
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] Traceback (most recent call last):
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/model_executor/models/utils.py", line 545, in _merge_multimodal_embeddings
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     inputs_embeds[is_multimodal] = mm_embeds_flat.to(dtype=input_dtype)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] RuntimeError: shape mismatch: value tensor of shape [450, 4096] cannot be broadcast to indexing result of shape [1125, 4096]
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] 
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] The above exception was the direct cause of the following exception:
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] 
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] Traceback (most recent call last):
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/vllm_omni/engine/stage_engine_core_proc.py", line 169, in run_stage_core
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     engine_core.run_busy_loop()
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1265, in run_busy_loop
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     self._process_engine_step()
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1304, in _process_engine_step
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     outputs, model_executed = self.step_fn()
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]                               ^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 549, in step_with_batch_queue
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     exec_future = self.model_executor.execute_model(
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/executor/uniproc_executor.py", line 120, in execute_model
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     output.result()
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return self.__get_result()
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     raise self._exception
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/executor/uniproc_executor.py", line 98, in collective_rpc
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     result = run_method(self.driver_worker, method, args, kwargs)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/serial_utils.py", line 510, in run_method
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return func(*args, **kwargs)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/worker/worker_base.py", line 351, in execute_model
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return self.worker.execute_model(scheduler_output)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return func(*args, **kwargs)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 1015, in execute_model
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     output = self.model_runner.execute_model(
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return func(*args, **kwargs)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/vllm_omni/worker/gpu_ar_model_runner.py", line 1218, in execute_model
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     ) = self._preprocess(scheduler_output, num_tokens_padded, intermediate_tensors)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/vllm_omni/worker/gpu_model_runner.py", line 1554, in _preprocess
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     inputs_embeds_scheduled = self.model.embed_input_ids(
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py", line 182, in embed_input_ids
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return super().embed_input_ids(input_ids, multimodal_embeddings, is_multimodal=is_multimodal)
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/model_executor/models/interfaces.py", line 404, in embed_input_ids
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     return _merge_multimodal_embeddings(
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/model_executor/models/utils.py", line 553, in _merge_multimodal_embeddings
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178]     raise ValueError(
(StageEngineCoreProc_stage0_replica0 pid=126648) ERROR 07-15 12:07:56 [stage_engine_core_proc.py:178] ValueError: Attempted to assign 450 = 450 multimodal tokens to 1125 placeholders
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114] [StagePool] _poll_stage_raw failed for stage-0 replica-0
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114] Traceback (most recent call last):
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]   File "/root/vllm-omni/vllm_omni/engine/stage_pool.py", line 1105, in poll_llm_raw_output
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]     return await asyncio.wait_for(
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]            ^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]   File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]     return await fut
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]            ^^^^^^^^^
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]   File "/root/vllm-omni/vllm_omni/engine/stage_pool.py", line 1057, in _poll_stage_raw
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]     outputs = await client.get_output_async()
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 1061, in get_output_async
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114]     raise self._format_exception(outputs) from None
(APIServer pid=126066) ERROR 07-15 12:07:56 [stage_pool.py:1114] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) ERROR 07-15 12:07:56 [orchestrator.py:717] [Orchestrator] Stage-0 is dead: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) INFO 07-15 12:07:56 [orchestrator.py:363] [Orchestrator] Engine dead during shutdown: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) INFO 07-15 12:07:56 [orchestrator.py:1638] [Orchestrator] Shutting down all 2 client(s)
(APIServer pid=126066) ERROR 07-15 12:07:56 [async_omni.py:720] [AsyncOmni] Engine dead: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) INFO 07-15 12:07:56 [core_client.py:655] [shutdown] MPClient: start timeout=default
(APIServer pid=126066) ERROR 07-15 12:07:56 [async_omni.py:612] [AsyncOmni] Orchestrator error for req=chatcmpl-bench-a20230db-0-a4a0b5da stage-0: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) INFO 07-15 12:07:56 [core_client.py:657] [shutdown] MPClient: stopping engine manager
(APIServer pid=126066) INFO 07-15 12:07:56 [async_omni.py:825] [AsyncOmni] Aborted request(s) chatcmpl-bench-a20230db-0-a4a0b5da
(APIServer pid=126066) INFO 07-15 12:07:56 [async_omni.py:448] [AsyncOmni] Request chatcmpl-bench-a20230db-0-a4a0b5da failed (input error): EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) ERROR 07-15 12:07:56 [serving_chat.py:2096] EngineDeadError during streaming for request chatcmpl-bench-a20230db-0: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=126066) INFO:     Shutting down
(APIServer pid=126066) INFO:     Waiting for application shutdown.
(APIServer pid=126066) INFO:     Application shutdown complete.
(APIServer pid=126066) INFO:     Finished server process [126066]
(APIServer pid=126066) INFO 07-15 12:07:56 [omni_base.py:623] [AsyncOmni] Shutting down
(APIServer pid=126066) INFO 07-15 12:07:56 [async_omni_engine.py:1545] [AsyncOmniEngine] Shutting down Orchestrator
(APIServer pid=126066) INFO 07-15 12:07:57 [core_client.py:659] [shutdown] MPClient: engine manager stopped
(APIServer pid=126066) INFO 07-15 12:07:57 [core_client.py:660] [shutdown] MPClient: cleaning up background resources
(APIServer pid=126066) INFO 07-15 12:07:57 [core_client.py:662] [shutdown] MPClient: complete
(APIServer pid=126066) INFO 07-15 12:07:57 [stage_pool.py:1204] [StagePool] Stage 0 replica 0 shut down
(APIServer pid=126066) INFO 07-15 12:07:57 [core_client.py:655] [shutdown] MPClient: start timeout=default
(APIServer pid=126066) INFO 07-15 12:07:59 [stage_pool.py:1204] [StagePool] Stage 1 replica 0 shut down
/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

</details>

<details>
<summary>Bench output (this PR, 45s audio)</summary>

```
/root/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.1.dev2210+ga432b8a32
 --> vLLM version 0.25.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
INFO 07-15 12:07:49 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-15 12:07:49 [patch.py:481] [cumem-cuda] CuMemAllocator._python_free_callback patched: asleep guard extended to all platforms.
INFO 07-15 12:07:51 [main.py:54] Delegating entrypoint handling to vllm-omni
TrackingNamespace(subparser='bench', bench_type='serve', dispatch_function=<function OmniBenchmarkServingSubcommand.cmd at 0x725aefb972e0>, omni=True, trust_remote_code=True, seed=0, num_prompts=1, dataset_name='random-mm', no_stream=False, dataset_path=None, no_oversample=False, skip_chat_template=False, enable_multimodal_chat=False, disable_shuffle=False, custom_output_len=256, custom_ensure_client_side_data=False, spec_bench_output_len=256, spec_bench_category=None, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, timed_trace_chunk_hash_size=16, timed_trace_sec_multiplier=1, timed_trace_label_timestamp='timestamp', timed_trace_label_input_length='input_length', timed_trace_label_output_length='output_length', timed_trace_label_hash_ids='hash_ids', blazedit_min_distance=0.0, blazedit_max_distance=1.0, asr_max_audio_len_sec=inf, asr_min_audio_len_sec=0.0, random_input_len=100, random_output_len=32, random_range_ratio='0.0', random_prefix_len=0, random_batch_size=1, no_reranker=False, random_mm_base_items_per_request=1, random_mm_num_mm_items_range_ratio=0.0, random_mm_limit_mm_per_prompt={'audio': 1}, random_mm_bucket_config={(0, 45, 1): 1.0}, hf_subset=None, hf_split=None, hf_name=None, hf_output_len=None, bfcl_categories=None, prefix_repetition_prefix_len=256, prefix_repetition_suffix_len=256, prefix_repetition_num_prefixes=10, prefix_repetition_output_len=128, speed_bench_dataset_subset='qualitative', speed_bench_output_len=4096, speed_bench_category=None, label=None, backend='openai-chat-omni', base_url=None, host='127.0.0.1', port=8099, endpoint='/v1/chat/completions', header=None, max_concurrency=1, model='openbmb/MiniCPM-o-4_5', input_len=None, output_len=None, tokenizer=None, tokenizer_mode='auto', use_beam_search=False, logprobs=None, request_rate=inf, burstiness=1.0, disable_tqdm=False, num_warmups=0, profile=False, save_result=False, save_detailed=False, append_result=False, metadata=None, result_dir=None, result_filename=None, ignore_eos=False, self_timed=None, percentile_metrics=None, metric_percentiles='99', goodput=None, request_id_prefix='bench-a20230db-', top_p=None, top_k=None, min_p=None, temperature=None, frequency_penalty=None, presence_penalty=None, repetition_penalty=None, served_model_name=None, lora_modules=None, lora_assignment='random', ramp_up_strategy=None, ramp_up_start_rps=None, ramp_up_end_rps=None, ready_check_timeout_sec=0, chat_template_kwargs=None, extra_body={'modalities': ['text'], 'bot_task': 'think'}, skip_tokenizer_init=False, insecure=False, plot_timeline=False, timeline_itl_thresholds='25,50', plot_dataset_stats=False, daily_omni_qa_json=None, daily_omni_video_dir=None, daily_omni_inline_local_video=False, daily_omni_input_mode='all', daily_omni_save_eval_items=False, seed_tts_locale='en', seed_tts_root=None, seed_tts_file_ref_audio=False, seed_tts_inline_ref_audio=False, seed_tts_system_prompt=None, seed_tts_wer_eval=False, seed_tts_wer_save_items=False, print_stage=False, image_edits_bot_task='think')
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
INFO 07-15 12:07:55 [utils.py:90] Sampling input_len from [100, 100] and output_len from [32, 32]
INFO 07-15 12:07:55 [datasets.py:1093] Normalized bucket config: {(0, 45, 1): 1.0}
INFO 07-15 12:07:55 [datasets.py:1105] Updated mm-limit-per-prompt: {'audio': 1}
INFO 07-15 12:07:55 [datasets.py:1127] Sampling number of multimodal items from [1, 1]
WARNING: vllm bench serve no longer sets temperature==0 (greedy) in requests by default. The default will be determined on the server side and can be model/API specific. For the old behavior, include --temperature=0.
Starting initial single prompt test run...
Skipping endpoint ready check.
Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 1
100%|█| 1/1 [00:00<00:00,  2.88
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     1         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  0.35      
Request throughput (req/s):              2.88      
Peak concurrent requests:                1.00      
================== Text Result ===================
Total input tokens:                      100       
Total generated tokens:                  0         
Output token throughput (tok/s):         0.00      
Peak output token throughput (tok/s):    1.00      
Peak concurrent requests:                1.00      
Total Token throughput (tok/s):          288.45    
==================================================
curl: (7) Failed to connect to 127.0.0.1 port 8099 after 0 ms: Connection refused
```

</details>


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
