### PR TITLE
[Core] Dual OmniConnector infrastructure

### DIFF
--- a/docs/design/feature/async_chunk.md
+++ b/docs/design/feature/async_chunk.md
@@ -228,6 +228,9 @@ sizing.
 - `async_chunk_process_next_stage_input_func: str`: Pipeline-owned chunk processor path
 - `execution_type: StageExecutionType`: Pipeline-owned runtime family
 - `connectors: dict`: Deploy-owned connector definitions
+- `custom_process_next_stage_input_func: str`: Path to custom chunk processing function; receives `(transfer_manager, pooling_output, request)`. For qwen3-omni: `thinker2talker_async_chunk`, `talker2code2wav_async_chunk`
+- `stage_connector_plan: StageConnectorPlan`: Resolved inbound/outbound connector edges
+- `worker_type: str`: Model type, e.g. `"ar"` or `"generation"` (used by OmniChunkTransferAdapter for mode-specific payload handling)
 - `max_num_seqs: int`: Maximum number of sequences for concurrent processing in the stage
 
 ### Connector Configuration

--- a/docs/design/feature/disaggregated_inference.md
+++ b/docs/design/feature/disaggregated_inference.md
@@ -59,6 +59,23 @@ This `metadata` must be passed through the control plane so `get()` can locate t
 
 ## Configuration Model
 
+Connector configuration has two layers:
+
+1. **Deploy configuration**: the top-level `connectors` mapping contains named
+   connector definitions. Each stage's `input_connectors` and
+   `output_connectors` reference those definitions by name and identify the
+   directed stage edge.
+2. **Runtime topology**: the configuration resolver converts those definitions
+   into a per-stage `StageConnectorPlan`. The plan contains at most one inbound
+   and one outbound `StageConnectorSpec`, including the source stage, target
+   stage, and resolved `ConnectorSpec`. It is passed to stage initialization and
+   the worker connector factory.
+
+This separation keeps deployment-owned backend settings independent from the
+runtime representation used by workers. A connector does not infer routing
+from request data, and a `StageConnectorPlan` does not replace the deploy YAML;
+it is the resolved form of that YAML.
+
 Define connectors at the top level of the deploy YAML:
 
 ```yaml

--- a/docs/design/feature/omni_connectors/README.md
+++ b/docs/design/feature/omni_connectors/README.md
@@ -1,0 +1,48 @@
+# OmniConnector architecture
+
+OmniConnectors provide transport and synchronization for data exchanged between vLLM-Omni pipeline stages. They carry stage payloads and KV-cache data, but do not select stages or implement model-specific execution policy.
+
+## Configuration and runtime topology
+
+Deploy configuration names the available connector backends and attaches them to directed stage edges:
+
+```yaml
+connectors:
+  shm:
+    name: SharedMemoryConnector
+
+stages:
+  - stage_id: 0
+    output_connectors: {to_stage_1: shm}
+  - stage_id: 1
+    input_connectors: {from_stage_0: shm}
+```
+
+The configuration has two distinct layers:
+
+- `connectors` is deploy-owned source configuration. Each entry contains a registered connector name and backend-specific `extra` options.
+- `input_connectors` and `output_connectors` declare which directed stage edge uses each named connector.
+- The resolver converts these entries into a per-stage `StageConnectorPlan`. The plan contains the resolved inbound and outbound `StageConnectorSpec` values used during stage initialization and connector construction.
+
+`StageConnectorPlan` is therefore a runtime representation of deployment configuration, not a second user-facing routing mechanism. The orchestrator owns logical stage routing; the connector only transports data for an already selected edge.
+
+## Connector lifecycle
+
+1. The deploy YAML is parsed and connector definitions are validated.
+2. Stage edge references are resolved into `StageConnectorPlan` instances.
+3. The worker-side factory materializes the plan into receive and send connectors for the stage and replica.
+4. Payload and KV operations use the common `put()` / `get()` contract.
+5. Connectors release transport resources on completion, cancellation, failure, and shutdown.
+
+Stages that receive connector-fed payloads must have an explicit inbound edge. Missing required edges fail during initialization rather than silently falling back to an unrelated stage. An omitted connector backend may use `SharedMemoryConnector` where the deployment resolver supports automatic local fallback.
+
+## Backend designs
+
+- [SharedMemoryConnector](shared_memory_connector.md)
+- [MooncakeStoreConnector](mooncake_store_connector.md)
+- [MooncakeTransferEngineConnector](mooncake_transfer_engine_connector.md)
+- [MoriTransferEngineConnector](mori_transfer_engine_connector.md)
+- [YuanrongConnector](yuanrong_connector.md)
+- [YuanrongTransferEngineConnector](yuanrong_transfer_engine_connector.md)
+
+For the complete deploy schema and CLI usage, see the [Pipeline and deploy configuration guide](../../../configuration/stage_configs.md). For the user-oriented setup guide, see [OmniConnectors](../../../user_guide/omni_connectors.md).

--- a/docs/user_guide/omni_connectors.md
+++ b/docs/user_guide/omni_connectors.md
@@ -1,0 +1,44 @@
+# OmniConnectors
+
+OmniConnectors transport payloads and KV-cache data between stages in a multi-stage vLLM-Omni pipeline. The connector transports data; stage routing and execution policy remain owned by the pipeline and orchestrator.
+
+## Configure a connector
+
+Define named connector implementations at the top level of a deploy YAML, then reference them from the sending and receiving stages:
+
+```yaml
+connectors:
+  shm:
+    name: SharedMemoryConnector
+
+stages:
+  - stage_id: 0
+    output_connectors:
+      to_stage_1: shm
+  - stage_id: 1
+    input_connectors:
+      from_stage_0: shm
+```
+
+`connectors` contains deploy-owned connector definitions. The stage mappings identify the directed edge on which each definition is used. The runtime resolves these entries into an inbound/outbound `StageConnectorPlan` for each stage; users normally configure the YAML rather than constructing the plan directly.
+
+If an expected edge has no explicit connector, vLLM-Omni can use the default `SharedMemoryConnector` where supported by the deployment. Configure every edge explicitly when stages run on different hosts or require a specific transport.
+
+## Choose a backend
+
+- `SharedMemoryConnector`: same-host transfers through shared memory.
+- `MooncakeStoreConnector`: remote transfers through the Mooncake store.
+- `MooncakeTransferEngineConnector`: peer-to-peer Mooncake TCP/RDMA transfers.
+- `MoriTransferEngineConnector`: Mori IOEngine TCP/RDMA transfers.
+- `YuanrongConnector`: remote transfers through Yuanrong Datasystem.
+- `YuanrongTransferEngineConnector`: Yuanrong TransferEngine transfers on
+  supported NPU deployments.
+
+Backend-specific options and prerequisites are documented in the [OmniConnector design documentation](../design/feature/disaggregated_inference.md). For the complete deploy schema, see [Pipeline and deploy configurations](../configuration/stage_configs.md).
+
+## Operational requirements
+
+- Use matching connector configuration on both ends of an edge.
+- Ensure remote backends, metadata services, and shared-memory permissions are available before starting the stages.
+- Preserve stable stage and replica routing for requests whose payloads are transferred asynchronously.
+- Treat connector initialization and cleanup errors as deployment errors; the runtime validates required inbound edges during stage initialization.

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -50,6 +50,9 @@ from vllm_omni.config.stage_config import (
     merge_pipeline_deploy,
 )
 from vllm_omni.diffusion.diffusion_kv.config import DiffusionKVCacheMode
+from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    default_stage_connector_plan,
+)
 from vllm_omni.engine.stage_engine_startup import _serialize_stage_config
 from vllm_omni.engine.stage_init_utils import build_legacy_engine_args_dict
 
@@ -1142,10 +1145,11 @@ def test_from_pipeline_config_matches_build_engine_args_dict_behavior_for_repres
     pipeline = _resolve_pipeline_or_skip("qwen3_tts")
     legacy_stage = merge_pipeline_deploy(pipeline, _load_default_deploy(pipeline))[0]
     omega_stage = legacy_stage.to_omegaconf()
+    connector_plan = default_stage_connector_plan(legacy_stage.stage_id)
     legacy_engine_args = build_legacy_engine_args_dict(
         omega_stage,
         model="/tmp/qwen3-tts",
-        stage_connector_spec={"name": "SharedMemoryConnector", "extra": {}},
+        stage_connector_plan=connector_plan,
     )
     omni_stage = _from_pipeline_key("qwen3_tts").stage_by_id(legacy_stage.stage_id)
 
@@ -1154,7 +1158,7 @@ def test_from_pipeline_config_matches_build_engine_args_dict_behavior_for_repres
     assert legacy_engine_args["model_stage"] == omni_stage.model_stage
     assert legacy_engine_args["worker_type"] == omni_stage.worker_type
     assert legacy_engine_args["scheduler_cls"] == omni_stage.scheduler_cls
-    assert legacy_engine_args["stage_connector_spec"] == {"name": "SharedMemoryConnector", "extra": {}}
+    assert legacy_engine_args["stage_connector_plan"] == connector_plan
     assert legacy_engine_args["has_sampling_extra_args"] == bool(
         (omni_stage.model_config.default_sampling_params or {}).get("extra_args")
     )

--- a/tests/distributed/omni_connectors/test_adapter_and_flow.py
+++ b/tests/distributed/omni_connectors/test_adapter_and_flow.py
@@ -7,8 +7,10 @@ from pytest_mock import MockerFixture
 from vllm_omni.distributed.omni_connectors.adapter import try_recv_via_connector, try_send_via_connector
 from vllm_omni.distributed.omni_connectors.connectors.shm_connector import SharedMemoryConnector
 from vllm_omni.distributed.omni_connectors.utils.config import ConnectorSpec, OmniTransferConfig
-from vllm_omni.distributed.omni_connectors.utils.initialization import get_connectors_config_for_stage
-from vllm_omni.engine.stage_init_utils import get_stage_connector_spec
+from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    get_connectors_config_for_stage,
+    resolve_stage_connector_plan,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -201,16 +203,12 @@ def test_get_connectors_for_stage():
 
     # Get config for Stage 1
     # Stage 1 receives from 0 (input) and sends to 2 (output)
-    # get_connectors_config_for_stage ONLY returns INPUT connectors for the worker to initialize
-
     stage_config = get_connectors_config_for_stage(config, stage_id=1)
 
-    # Should contain "from_stage_0"
     assert "from_stage_0" in stage_config
     assert stage_config["from_stage_0"]["spec"]["name"] == "C1"
-
-    # Should NOT contain "from_stage_1" or related to output
-    assert "from_stage_1" not in stage_config
+    assert "to_stage_2" in stage_config
+    assert stage_config["to_stage_2"]["spec"]["name"] == "C2"
 
     # Verify Stage 2
     stage_2_config = get_connectors_config_for_stage(config, stage_id=2)
@@ -218,8 +216,7 @@ def test_get_connectors_for_stage():
     assert stage_2_config["from_stage_1"]["spec"]["name"] == "C2"
 
 
-@pytest.mark.parametrize("async_chunk", [False, True])
-def test_outgoing_stage_uses_sender_connector_spec(async_chunk: bool):
+def test_outgoing_stage_uses_outbound_connector_spec():
     config = OmniTransferConfig(
         connectors={
             ("1", "2"): ConnectorSpec(
@@ -229,10 +226,11 @@ def test_outgoing_stage_uses_sender_connector_spec(async_chunk: bool):
         }
     )
 
-    spec = get_stage_connector_spec(config, stage_id=1, async_chunk=async_chunk)
+    plan = resolve_stage_connector_plan(config, stage_id=1)
 
-    assert spec["name"] == "SharedMemoryConnector"
-    assert spec["extra"] == {"codec_chunk_frames": 25, "role": "sender"}
+    assert plan.outbound is not None
+    assert plan.outbound.spec.name == "SharedMemoryConnector"
+    assert plan.outbound.spec.extra == {"codec_chunk_frames": 25}
 
 
 def test_full_payload_consumer_uses_receiver_connector_spec():
@@ -245,10 +243,11 @@ def test_full_payload_consumer_uses_receiver_connector_spec():
         }
     )
 
-    spec = get_stage_connector_spec(config, stage_id=2, async_chunk=False)
+    plan = resolve_stage_connector_plan(config, stage_id=2)
 
-    assert spec["name"] == "SharedMemoryConnector"
-    assert spec["extra"] == {"codec_chunk_frames": 25, "role": "receiver"}
+    assert plan.inbound is not None
+    assert plan.inbound.spec.name == "SharedMemoryConnector"
+    assert plan.inbound.spec.extra == {"codec_chunk_frames": 25}
 
 
 def test_recv_with_missing_metadata(mocker: MockerFixture):

--- a/tests/distributed/omni_connectors/test_basic_connectors.py
+++ b/tests/distributed/omni_connectors/test_basic_connectors.py
@@ -137,6 +137,30 @@ def test_get_invalid_metadata(shm_connector):
     assert result is None
 
 
+def test_mori_resolves_partial_metadata_at_request_sender(mocker: MockerFixture):
+    import vllm_omni.distributed.omni_connectors.connectors.mori_transfer_engine_connector as mori_module
+
+    connector = object.__new__(mori_module.MoriTransferEngineConnector)
+    connector.sender_host = "default-host"
+    connector.sender_zmq_port = 50051
+    resolved = {
+        "source_host": "replica-host",
+        "source_port": 51075,
+        "data_size": 16,
+        "is_fast_path": False,
+    }
+    connector._query_metadata_at = mocker.Mock(return_value=resolved)
+
+    assert (
+        connector._resolve_metadata(
+            "request-key",
+            {"source_host": "replica-host", "source_port": 51075},
+        )
+        == resolved
+    )
+    connector._query_metadata_at.assert_called_once_with("request-key", "replica-host", 51075)
+
+
 def test_mooncake_connector_defaults_missing_host_to_detected_ip(monkeypatch: pytest.MonkeyPatch):
     import vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector as mooncake_module
 

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -18,11 +18,11 @@ from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayload, OmniPayloadStruct
 from vllm_omni.distributed.omni_connectors.adapter import construct_next_stage_streaming_input_prompt
+from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory, StageConnectorSet
 from vllm_omni.distributed.omni_connectors.transfer_adapter.base import OmniTransferAdapterBase
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
-from vllm_omni.distributed.omni_connectors.utils.config import ConnectorSpec
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -347,9 +347,9 @@ def build_adapter(monkeypatch, mocker: MockerFixture):
 
         monkeypatch.setattr(OmniTransferAdapterBase, "__init__", _fake_base_init)
         monkeypatch.setattr(
-            OmniChunkTransferAdapter,
-            "create_connector",
-            classmethod(lambda cls, _model_config: connector),
+            OmniConnectorFactory,
+            "create_stage_connectors",
+            lambda *_args, **_kwargs: StageConnectorSet(receive=connector, send=connector),
         )
 
         hf_config = SimpleNamespace(
@@ -365,6 +365,7 @@ def build_adapter(monkeypatch, mocker: MockerFixture):
                 )
             )
         model_config = SimpleNamespace(
+            stage_id=stage_id,
             worker_type=model_mode,
             max_num_seqs=max_num_seqs,
             max_model_len=max_model_len,
@@ -404,34 +405,6 @@ def test_talker_attention_policy_controls_streaming_recompute(build_adapter, att
 
     assert adapter._streaming_prompt_previous_chunks == expected_previous_chunks
 
-
-@pytest.mark.parametrize(
-    ("raw_cfg", "expected_name", "expected_extra"),
-    [
-        (None, "SharedMemoryConnector", {}),
-        (SimpleNamespace(name="YuanrongConnector", extra={"k": "v"}), "YuanrongConnector", {"k": "v"}),
-    ],
-)
-def test_create_connector_config_parsing(monkeypatch, raw_cfg, expected_name, expected_extra):
-    captured = {}
-
-    def _fake_create(spec):
-        captured["spec"] = spec
-        return "ok"
-
-    monkeypatch.setattr(
-        "vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter"
-        ".OmniConnectorFactory.create_connector",
-        _fake_create,
-    )
-
-    model_config = SimpleNamespace(stage_connector_config=raw_cfg) if raw_cfg is not None else SimpleNamespace()
-    connector = OmniChunkTransferAdapter.create_connector(model_config)
-
-    assert connector == "ok"
-    assert isinstance(captured["spec"], ConnectorSpec)
-    assert captured["spec"].name == expected_name
-    assert captured["spec"].extra == expected_extra
 
 
 def test_load_poll(build_adapter):

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -406,7 +406,6 @@ def test_talker_attention_policy_controls_streaming_recompute(build_adapter, att
     assert adapter._streaming_prompt_previous_chunks == expected_previous_chunks
 
 
-
 def test_load_poll(build_adapter):
     adapter, connector = build_adapter(stage_id=2, model_mode="ar")
     request = _req("req-1", RequestStatus.WAITING, external_req_id="external-1")
@@ -1718,7 +1717,7 @@ def test_cleanup_and_reregister_discards_inflight_old_segment_chunk(build_adapte
     get_started = threading.Event()
     release_get = threading.Event()
 
-    def blocking_get(*_args):
+    def blocking_get(*_args, **_kwargs):
         get_started.set()
         assert release_get.wait(timeout=5)
         return (

--- a/tests/distributed/omni_connectors/test_omni_connector_configs.py
+++ b/tests/distributed/omni_connectors/test_omni_connector_configs.py
@@ -48,6 +48,7 @@ config_files = get_config_files()
     [
         ("sender", 0, False, True),
         ("receiver", 1, True, False),
+        ("dual", 1, True, True),
         (None, 0, True, False),
         (None, None, True, True),
     ],

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -18,10 +18,9 @@ from vllm_omni.distributed.omni_connectors.utils.config import (
     StageConnectorSpec,
 )
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
-    KV_RANK_PORT_STRIDE,
-    KV_REPLICA_PORT_STRIDE,
     resolve_stage_connector_plan,
 )
+from vllm_omni.distributed.omni_connectors.utils.kv_utils import kv_zmq_port
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -138,10 +137,10 @@ def test_compatible_edges_share_one_dual_instance(created_connectors):
     assert connectors.receive is connectors.send
     assert len(created_connectors) == 1
     extra = created_connectors[0].spec.extra
-    offset = KV_REPLICA_PORT_STRIDE + 2 * KV_RANK_PORT_STRIDE
     assert extra["role"] == "dual"
-    assert extra["zmq_port"] == 50052 + offset
-    assert extra["sender_zmq_port"] == 50051 + offset
+    assert extra["zmq_port"] == kv_zmq_port(50052, 1, local_rank=2, replica_id=1)
+    # The upstream endpoint must not inherit this worker's rank offset.
+    assert extra["sender_zmq_port"] == 50051
 
 
 @pytest.mark.parametrize(

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 
@@ -18,6 +19,7 @@ from vllm_omni.distributed.omni_connectors.utils.config import (
     StageConnectorSpec,
 )
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    resolve_omni_kv_config_for_stage,
     resolve_stage_connector_plan,
 )
 from vllm_omni.distributed.omni_connectors.utils.kv_utils import kv_zmq_port
@@ -68,6 +70,65 @@ def test_plan_resolves_only_edges_attached_to_the_stage():
     assert middle.inbound is not None and middle.outbound is not None
     assert last.inbound is not None
     assert last.outbound is None
+
+
+@pytest.mark.parametrize(
+    ("omni_kv_config", "expected_type", "expected_edge", "expected_role"),
+    [
+        ({"need_recv_cache": True}, "MooncakeTransferEngineConnector", ("0", "1"), "receiver"),
+        ({"need_send_cache": True}, "MoriTransferEngineConnector", ("1", "2"), "sender"),
+    ],
+)
+def test_kv_config_uses_manager_owned_direction_with_equal_tp(
+    omni_kv_config,
+    expected_type,
+    expected_edge,
+    expected_role,
+):
+    transfer_config = OmniTransferConfig(
+        connectors={
+            ("0", "1"): ConnectorSpec(
+                "MooncakeTransferEngineConnector",
+                {"rank_mapping": {"from_tp": 2, "to_tp": 2}},
+            ),
+            ("1", "2"): ConnectorSpec(
+                "MoriTransferEngineConnector",
+                {"rank_mapping": {"from_tp": 2, "to_tp": 2}},
+            ),
+        }
+    )
+    stage_config = SimpleNamespace(engine_args={"omni_kv_config": omni_kv_config})
+
+    connector_config, from_stage, to_stage = resolve_omni_kv_config_for_stage(
+        transfer_config,
+        1,
+        stage_config,
+    )
+
+    assert connector_config is not None
+    assert connector_config["type"] == expected_type
+    assert connector_config["role"] == expected_role
+    assert (from_stage, to_stage) == expected_edge
+
+
+def test_kv_config_rejects_bidirectional_manager():
+    transfer_config = OmniTransferConfig(
+        connectors={
+            ("0", "1"): ConnectorSpec("MooncakeTransferEngineConnector"),
+            ("1", "2"): ConnectorSpec("MoriTransferEngineConnector"),
+        }
+    )
+    stage_config = SimpleNamespace(
+        engine_args={
+            "omni_kv_config": {
+                "need_recv_cache": True,
+                "need_send_cache": True,
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="supports only one directional connector"):
+        resolve_omni_kv_config_for_stage(transfer_config, 1, stage_config)
 
 
 def test_absent_config_preserves_legacy_shm_but_explicit_empty_config_does_not():

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -135,15 +135,15 @@ def test_absent_config_preserves_legacy_shm_but_explicit_empty_config_does_not()
     legacy = resolve_stage_connector_plan(None, 0)
     explicit = resolve_stage_connector_plan(OmniTransferConfig(), 0)
 
-    assert legacy.inbound is not None and legacy.outbound is not None
-    assert legacy.inbound.spec.name == legacy.outbound.spec.name == "SharedMemoryConnector"
+    assert legacy.inbound is None and legacy.outbound is not None
+    assert legacy.outbound.spec.name == "SharedMemoryConnector"
     assert explicit == StageConnectorPlan()
 
 
 def test_legacy_shm_plan_shares_one_dual_instance(created_connectors):
     connectors = OmniConnectorFactory.create_stage_connectors(
-        resolve_stage_connector_plan(None, 0),
-        stage_id=0,
+        resolve_stage_connector_plan(None, 1),
+        stage_id=1,
     )
 
     assert connectors.receive is connectors.send

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -12,6 +12,9 @@ from vllm_omni.distributed.omni_connectors.factory import (
     OmniConnectorFactory,
     StageConnectorSet,
 )
+from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
+    OmniKVTransferManager,
+)
 from vllm_omni.distributed.omni_connectors.utils.config import (
     ConnectorSpec,
     OmniTransferConfig,
@@ -111,13 +114,19 @@ def test_kv_config_uses_manager_owned_direction_with_equal_tp(
     assert (from_stage, to_stage) == expected_edge
 
 
-def test_kv_config_rejects_bidirectional_manager():
-    transfer_config = OmniTransferConfig(
-        connectors={
-            ("0", "1"): ConnectorSpec("MooncakeTransferEngineConnector"),
-            ("1", "2"): ConnectorSpec("MoriTransferEngineConnector"),
-        }
-    )
+@pytest.mark.parametrize(
+    ("transfer_config"),
+    (
+        None,
+        OmniTransferConfig(
+            connectors={
+                ("0", "1"): ConnectorSpec("MooncakeTransferEngineConnector"),
+                ("1", "2"): ConnectorSpec("MoriTransferEngineConnector"),
+            }
+        ),
+    ),
+)
+def test_kv_config_rejects_bidirectional_manager(transfer_config):
     stage_config = SimpleNamespace(
         engine_args={
             "omni_kv_config": {
@@ -126,9 +135,19 @@ def test_kv_config_rejects_bidirectional_manager():
             }
         }
     )
-
     with pytest.raises(ValueError, match="supports only one directional connector"):
         resolve_omni_kv_config_for_stage(transfer_config, 1, stage_config)
+
+
+def test_kv_manager_create_rejects_bidirectional_config():
+    with pytest.raises(ValueError, match="supports only one directional connector"):
+        OmniKVTransferManager._create(
+            {
+                "connector_config": {"type": "SharedMemoryConnector"},
+                "need_recv_cache": True,
+                "need_send_cache": True,
+            }
+        )
 
 
 def test_absent_config_preserves_legacy_shm_but_explicit_empty_config_does_not():

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -22,6 +22,7 @@ from vllm_omni.distributed.omni_connectors.utils.config import (
     StageConnectorSpec,
 )
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    connector_plan_from_model_config,
     resolve_omni_kv_config_for_stage,
     resolve_stage_connector_plan,
 )
@@ -157,6 +158,22 @@ def test_absent_config_preserves_legacy_shm_but_explicit_empty_config_does_not()
     assert legacy.inbound is None and legacy.outbound is not None
     assert legacy.outbound.spec.name == "SharedMemoryConnector"
     assert explicit == StageConnectorPlan()
+
+
+def test_attribute_style_legacy_connector_config_is_normalized():
+    model_config = SimpleNamespace(
+        stage_id=1,
+        stage_connector_plan=None,
+        stage_connector_config=SimpleNamespace(
+            name="SharedMemoryConnector",
+            extra={"role": "sender"},
+        ),
+    )
+
+    plan = connector_plan_from_model_config(model_config)
+
+    assert plan.inbound is None
+    assert plan.outbound == _edge(1, 2, "SharedMemoryConnector", role="sender")
 
 
 def test_legacy_shm_plan_shares_one_dual_instance(created_connectors):

--- a/tests/distributed/omni_connectors/test_stage_connector_plan.py
+++ b/tests/distributed/omni_connectors/test_stage_connector_plan.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm_omni.distributed.omni_connectors.factory import (
+    OmniConnectorFactory,
+    StageConnectorSet,
+)
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    OmniTransferConfig,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
+from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    KV_RANK_PORT_STRIDE,
+    KV_REPLICA_PORT_STRIDE,
+    resolve_stage_connector_plan,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@dataclass
+class _RecordingConnector:
+    spec: ConnectorSpec
+    close_count: int = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+@pytest.fixture
+def created_connectors(monkeypatch):
+    created: list[_RecordingConnector] = []
+
+    def create(_cls, spec: ConnectorSpec):
+        connector = _RecordingConnector(spec)
+        created.append(connector)
+        return connector
+
+    monkeypatch.setattr(OmniConnectorFactory, "create_connector", classmethod(create))
+    return created
+
+
+def _edge(source: int, target: int, name: str, **extra) -> StageConnectorSpec:
+    return StageConnectorSpec(source, target, ConnectorSpec(name, extra))
+
+
+def test_plan_resolves_only_edges_attached_to_the_stage():
+    config = OmniTransferConfig(
+        connectors={
+            ("0", "1"): ConnectorSpec("MooncakeTransferEngineConnector", {"zmq_port": 50051}),
+            ("1", "2"): ConnectorSpec("SharedMemoryConnector"),
+        }
+    )
+
+    first = resolve_stage_connector_plan(config, 0)
+    middle = resolve_stage_connector_plan(config, 1)
+    last = resolve_stage_connector_plan(config, 2)
+
+    assert first.inbound is None
+    assert first.outbound is not None
+    assert middle.inbound is not None and middle.outbound is not None
+    assert last.inbound is not None
+    assert last.outbound is None
+
+
+def test_absent_config_preserves_legacy_shm_but_explicit_empty_config_does_not():
+    legacy = resolve_stage_connector_plan(None, 0)
+    explicit = resolve_stage_connector_plan(OmniTransferConfig(), 0)
+
+    assert legacy.inbound is not None and legacy.outbound is not None
+    assert legacy.inbound.spec.name == legacy.outbound.spec.name == "SharedMemoryConnector"
+    assert explicit == StageConnectorPlan()
+
+
+def test_legacy_shm_plan_shares_one_dual_instance(created_connectors):
+    connectors = OmniConnectorFactory.create_stage_connectors(
+        resolve_stage_connector_plan(None, 0),
+        stage_id=0,
+    )
+
+    assert connectors.receive is connectors.send
+    assert len(created_connectors) == 1
+    assert created_connectors[0].spec.extra["role"] == "dual"
+
+
+@pytest.mark.parametrize(
+    "connectors",
+    [
+        {
+            ("0", "1"): ConnectorSpec("SharedMemoryConnector"),
+            ("2", "1"): ConnectorSpec("SharedMemoryConnector"),
+        },
+        {
+            ("1", "2"): ConnectorSpec("SharedMemoryConnector"),
+            ("1", "3"): ConnectorSpec("SharedMemoryConnector"),
+        },
+    ],
+)
+def test_fan_in_and_fan_out_are_rejected(connectors):
+    with pytest.raises(ValueError, match="Fan-"):
+        resolve_stage_connector_plan(OmniTransferConfig(connectors), 1)
+
+
+def test_compatible_edges_share_one_dual_instance(created_connectors):
+    plan = StageConnectorPlan(
+        inbound=_edge(
+            0,
+            1,
+            "MooncakeTransferEngineConnector",
+            host="auto",
+            zmq_port=50051,
+            sender_zmq_port=50051,
+        ),
+        outbound=_edge(
+            1,
+            2,
+            "MooncakeTransferEngineConnector",
+            host="auto",
+            zmq_port=50052,
+        ),
+    )
+
+    connectors = OmniConnectorFactory.create_stage_connectors(
+        plan,
+        stage_id=1,
+        local_rank=2,
+        replica_id=1,
+    )
+
+    assert connectors.receive is connectors.send
+    assert len(created_connectors) == 1
+    extra = created_connectors[0].spec.extra
+    offset = KV_REPLICA_PORT_STRIDE + 2 * KV_RANK_PORT_STRIDE
+    assert extra["role"] == "dual"
+    assert extra["zmq_port"] == 50052 + offset
+    assert extra["sender_zmq_port"] == 50051 + offset
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["MooncakeStoreConnector", "YuanrongConnector", "MooncakeConnector"],
+)
+def test_compatible_store_edges_share_one_instance(created_connectors, name):
+    plan = StageConnectorPlan(
+        inbound=_edge(0, 1, name, host="store-host"),
+        outbound=_edge(1, 2, name, host="store-host"),
+    )
+
+    connectors = OmniConnectorFactory.create_stage_connectors(plan, stage_id=1)
+
+    assert connectors.receive is connectors.send
+    assert len(created_connectors) == 1
+
+
+def test_dual_merge_preserves_directional_rank_mappings(created_connectors):
+    recv_mapping = {"from_tp": 4, "to_tp": 2}
+    send_mapping = {"from_tp": 2, "to_tp": 1}
+    plan = StageConnectorPlan(
+        inbound=_edge(
+            0,
+            1,
+            "MooncakeTransferEngineConnector",
+            rank_mapping=recv_mapping,
+        ),
+        outbound=_edge(
+            1,
+            2,
+            "MooncakeTransferEngineConnector",
+            rank_mapping=send_mapping,
+        ),
+    )
+
+    OmniConnectorFactory.create_stage_connectors(plan, stage_id=1)
+
+    extra = created_connectors[0].spec.extra
+    assert "rank_mapping" not in extra
+    assert extra["recv_rank_mapping"] == recv_mapping
+    assert extra["send_rank_mapping"] == send_mapping
+
+
+def test_dual_merge_preserves_shared_rank_mapping(created_connectors):
+    mapping = {"from_tp": 2, "to_tp": 2}
+    plan = StageConnectorPlan(
+        inbound=_edge(0, 1, "SharedMemoryConnector", rank_mapping=mapping),
+        outbound=_edge(1, 2, "SharedMemoryConnector", rank_mapping=mapping),
+    )
+
+    OmniConnectorFactory.create_stage_connectors(plan, stage_id=1)
+
+    extra = created_connectors[0].spec.extra
+    assert extra["rank_mapping"] == mapping
+    assert "recv_rank_mapping" not in extra
+    assert "send_rank_mapping" not in extra
+
+
+@pytest.mark.parametrize(
+    ("inbound", "outbound"),
+    [
+        (
+            _edge(0, 1, "MooncakeTransferEngineConnector", host="10.0.0.1"),
+            _edge(1, 2, "MooncakeTransferEngineConnector", host="10.0.0.2"),
+        ),
+        (
+            _edge(0, 1, "MooncakeTransferEngineConnector"),
+            _edge(1, 2, "SharedMemoryConnector"),
+        ),
+    ],
+)
+def test_incompatible_edges_keep_two_directional_instances(
+    created_connectors,
+    inbound,
+    outbound,
+):
+    connectors = OmniConnectorFactory.create_stage_connectors(
+        StageConnectorPlan(inbound, outbound),
+        stage_id=1,
+    )
+
+    assert connectors.receive is not connectors.send
+    assert len(created_connectors) == 2
+    assert created_connectors[0].spec.extra["role"] == "receiver"
+    assert created_connectors[1].spec.extra["role"] == "sender"
+
+
+def test_direction_is_derived_from_the_edge(created_connectors):
+    plan = StageConnectorPlan(
+        inbound=_edge(0, 1, "SharedMemoryConnector", role="sender"),
+        outbound=_edge(1, 2, "MooncakeStoreConnector", role="receiver"),
+    )
+
+    OmniConnectorFactory.create_stage_connectors(plan, stage_id=1)
+
+    assert created_connectors[0].spec.extra["role"] == "receiver"
+    assert created_connectors[1].spec.extra["role"] == "sender"
+
+
+@pytest.mark.parametrize(
+    ("plan", "has_receive", "has_send"),
+    [
+        (StageConnectorPlan(inbound=_edge(0, 1, "SharedMemoryConnector")), True, False),
+        (StageConnectorPlan(outbound=_edge(1, 2, "SharedMemoryConnector")), False, True),
+    ],
+)
+def test_one_way_plan_creates_only_its_direction(
+    created_connectors,
+    plan,
+    has_receive,
+    has_send,
+):
+    connectors = OmniConnectorFactory.create_stage_connectors(plan, stage_id=1)
+
+    assert (connectors.receive is not None) is has_receive
+    assert (connectors.send is not None) is has_send
+    assert len(created_connectors) == 1
+
+
+def test_close_deduplicates_a_shared_dual_instance():
+    connector = _RecordingConnector(ConnectorSpec("test"))
+    StageConnectorSet(receive=connector, send=connector).close()
+    assert connector.close_count == 1

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -193,11 +193,12 @@ def test_default_all_values_are_initialized():
 
     # Test a primitive
     assert cfg.model_stage == "thinker"
-    # Test a field initialized with a default factory
+    assert cfg.stage_connector_plan is None
     assert cfg.stage_connector_config == {
         "name": "SharedMemoryConnector",
         "extra": {},
     }
+    assert cfg.stage_output_connector_config == cfg.stage_connector_config
 
     # Ensure that hf_config is initialized on model_config in the vLLM by ModelConfig's
     # __post_init__, and that the hf_config is copied over to the OmniModelConfig;

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -194,11 +194,11 @@ def test_default_all_values_are_initialized():
     # Test a primitive
     assert cfg.model_stage == "thinker"
     assert cfg.stage_connector_plan is None
-    assert cfg.stage_connector_config == {
+    assert cfg.stage_input_connector_config == {
         "name": "SharedMemoryConnector",
         "extra": {},
     }
-    assert cfg.stage_output_connector_config == cfg.stage_connector_config
+    assert cfg.stage_output_connector_config == cfg.stage_input_connector_config
 
     # Ensure that hf_config is initialized on model_config in the vLLM by ModelConfig's
     # __post_init__, and that the hf_config is copied over to the OmniModelConfig;

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -12,6 +12,11 @@ import types
 import pytest
 
 from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec, normalize_omni_diffusion_kwargs
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from vllm_omni.engine import async_omni_engine as async_omni_engine_module
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import (
@@ -121,7 +126,7 @@ def _make_llm_plan(
                     final_output_type=final_output_type,
                     is_comprehension=is_comprehension and replica_id == 0,
                 ),
-                stage_connector_spec={},
+                stage_connector_plan=StageConnectorPlan(),
                 omni_kv_connector=(None, None, None),
                 stage_vllm_config=vllm_config,
                 executor_class=object,
@@ -155,7 +160,7 @@ def _make_diffusion_plan(
                 launch_mode="local",
                 stage_cfg=stage_cfg,
                 metadata=_make_diffusion_metadata(stage_id, replica_id=replica_id),
-                stage_connector_spec={},
+                stage_connector_plan=StageConnectorPlan(),
                 omni_kv_connector=(None, None, None),
             )
         )
@@ -288,7 +293,7 @@ def test_build_logical_stage_init_plans_handles_stage_without_devices(monkeypatc
         "extract_legacy_stage_metadata",
         lambda cfg: _make_llm_metadata(cfg.stage_id),
     )
-    monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+    monkeypatch.setattr(runtime_mod, "get_stage_connector_plan", lambda **_: StageConnectorPlan())
     monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
     monkeypatch.setattr(runtime_mod, "build_engine_args_dict", lambda *_, **__: {})
     monkeypatch.setattr(runtime_mod, "build_vllm_config", lambda *_args, **_kwargs: (types.SimpleNamespace(), object))
@@ -848,7 +853,7 @@ def test_build_logical_stage_init_plans_applies_replica_device_splits(monkeypatc
         "extract_legacy_stage_metadata",
         lambda cfg: types.SimpleNamespace(**metadata_by_stage[cfg.stage_id].__dict__),
     )
-    monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+    monkeypatch.setattr(runtime_mod, "get_stage_connector_plan", lambda **_: StageConnectorPlan())
     monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
     monkeypatch.setattr(runtime_mod, "build_engine_args_dict", lambda *_, **__: {})
     monkeypatch.setattr(
@@ -1025,7 +1030,7 @@ def test_initialize_local_llm_replica_passes_stage_init_timeout_to_complete_stag
         launch_mode="local",
         stage_cfg=types.SimpleNamespace(engine_args={}, runtime=types.SimpleNamespace(devices="0")),
         metadata=types.SimpleNamespace(stage_id=0, runtime_cfg={"devices": "0"}),
-        stage_connector_spec={},
+        stage_connector_plan=StageConnectorPlan(),
         omni_kv_connector=(None, None, None),
         stage_vllm_config=fake_vllm_config,
         executor_class=object,
@@ -1119,18 +1124,21 @@ def test_build_engine_args_keeps_full_payload_connector_spec():
         engine_args={"async_chunk": False},
         default_sampling_params={},
     )
-    connector_spec = {
-        "name": "SharedMemoryConnector",
-        "extra": {"role": "sender"},
-    }
+    connector_plan = StageConnectorPlan(
+        outbound=StageConnectorSpec(
+            1,
+            2,
+            ConnectorSpec("SharedMemoryConnector"),
+        )
+    )
 
     engine_args = build_engine_args_dict(
         stage_cfg,
         "/parent/model",
-        stage_connector_spec=connector_spec,
+        stage_connector_plan=connector_plan,
     )
 
-    assert engine_args["stage_connector_spec"] == connector_spec
+    assert engine_args["stage_connector_plan"] == connector_plan
 
 
 def test_build_engine_args_keeps_stage_owned_tokenizer_subdir(tmp_path):

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -21,6 +21,11 @@ from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
 
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from vllm_omni.engine.messages import (
     AbortRequestMessage,
     AbortResultMessage,
@@ -781,6 +786,24 @@ async def test_run_async_chunk(orchestrator_factory) -> None:
         [stage0, stage1],
         output_processors=processors,
         async_chunk=True,
+        stage_vllm_configs=[
+            SimpleNamespace(
+                model_config=SimpleNamespace(
+                    max_model_len=64,
+                    stage_connector_plan=StageConnectorPlan(
+                        outbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector"))
+                    ),
+                )
+            ),
+            SimpleNamespace(
+                model_config=SimpleNamespace(
+                    max_model_len=64,
+                    stage_connector_plan=StageConnectorPlan(
+                        inbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector"))
+                    ),
+                )
+            ),
+        ],
     )
     request = SimpleNamespace(request_id="req-async", prompt_token_ids=[1, 2, 3, 4])
 

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -378,6 +378,7 @@ def _build_stage_pools(
     *,
     output_processors: list[FakeOutputProcessor] | None = None,
     stage_vllm_configs: list[object] | None = None,
+    async_chunk: bool = False,
 ) -> list[StagePool]:
     """Build StagePool list from per-stage replica lists.
 
@@ -387,7 +388,31 @@ def _build_stage_pools(
     if output_processors is None:
         output_processors = [FakeOutputProcessor() for _ in stage_clients]
     if stage_vllm_configs is None:
-        stage_vllm_configs = [SimpleNamespace(model_config=SimpleNamespace(max_model_len=64)) for _ in stage_clients]
+        if async_chunk:
+            stage_vllm_configs = []
+            for stage_id in range(num_stages):
+                inbound = (
+                    StageConnectorSpec(stage_id - 1, stage_id, ConnectorSpec("SharedMemoryConnector"))
+                    if stage_id > 0
+                    else None
+                )
+                outbound = (
+                    StageConnectorSpec(stage_id, stage_id + 1, ConnectorSpec("SharedMemoryConnector"))
+                    if stage_id < num_stages - 1
+                    else None
+                )
+                stage_vllm_configs.append(
+                    SimpleNamespace(
+                        model_config=SimpleNamespace(
+                            max_model_len=64,
+                            stage_connector_plan=StageConnectorPlan(inbound=inbound, outbound=outbound),
+                        )
+                    )
+                )
+        else:
+            stage_vllm_configs = [
+                SimpleNamespace(model_config=SimpleNamespace(max_model_len=64)) for _ in stage_clients
+            ]
 
     pools: list[StagePool] = []
     for stage_id in range(num_stages):
@@ -427,6 +452,7 @@ def _build_harness(
             nested_clients,
             output_processors=output_processors,
             stage_vllm_configs=stage_vllm_configs,
+            async_chunk=async_chunk,
         )
 
     ready_future: concurrent.futures.Future[tuple[Orchestrator, janus.Queue, janus.Queue, janus.Queue]] = (

--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -20,6 +20,11 @@ from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.serial_utils import MsgpackEncoder
 
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from vllm_omni.engine.messages import (
     AddCompanionRequestMessage,
     EngineQueueMessage,
@@ -439,7 +444,32 @@ async def test_async_chunk_prewarm_failure_reports_failing_downstream_stage(orch
     stage0 = FakeStageClient(stage_type="llm", final_output=False)
     stage1 = FakeStageClient(stage_type="diffusion", final_output=False, final_output_type="image")
     stage2 = _UnavailableDiffusionStageClient(stage_type="diffusion", final_output=True, final_output_type="image")
-    stage_pools = _build_stage_pools([[stage0], [stage1], [stage2]])
+    stage_vllm_configs = [
+        SimpleNamespace(model_config=SimpleNamespace(max_model_len=64)),
+        SimpleNamespace(
+            model_config=SimpleNamespace(
+                max_model_len=64,
+                stage_connector_plan=StageConnectorPlan(
+                    inbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector"))
+                ),
+            )
+        ),
+        SimpleNamespace(
+            model_config=SimpleNamespace(
+                max_model_len=64,
+                stage_connector_plan=StageConnectorPlan(
+                    inbound=StageConnectorSpec(1, 2, ConnectorSpec("SharedMemoryConnector"))
+                ),
+            )
+        ),
+    ]
+    stage_pools = _build_stage_pools(
+        [[stage0], [stage1], [stage2]], stage_vllm_configs=stage_vllm_configs
+    )
+    # Diffusion pools are built from their client directly by the test helper;
+    # attach the stage config explicitly so prewarm can resolve inbound edges.
+    stage_pools[1]._stage_vllm_config = stage_vllm_configs[1]
+    stage_pools[2]._stage_vllm_config = stage_vllm_configs[2]
     orchestrator_fixture = orchestrator_factory([], stage_pools=stage_pools, async_chunk=True)
 
     try:

--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -463,9 +463,7 @@ async def test_async_chunk_prewarm_failure_reports_failing_downstream_stage(orch
             )
         ),
     ]
-    stage_pools = _build_stage_pools(
-        [[stage0], [stage1], [stage2]], stage_vllm_configs=stage_vllm_configs
-    )
+    stage_pools = _build_stage_pools([[stage0], [stage1], [stage2]], stage_vllm_configs=stage_vllm_configs)
     # Diffusion pools are built from their client directly by the test helper;
     # attach the stage config explicitly so prewarm can resolve inbound edges.
     stage_pools[1]._stage_vllm_config = stage_vllm_configs[1]

--- a/tests/engine/test_orchestrator_kv_sender_info.py
+++ b/tests/engine/test_orchestrator_kv_sender_info.py
@@ -170,6 +170,7 @@ def test_forward_to_diffusion_attaches_kv_sender_info():
     )
 
     output = SimpleNamespace(request_id="req-1", finished=True)
+    sender_pool.select_replica_id("req-1")
     asyncio.run(Orchestrator._forward_to_next_stage(orchestrator, "req-1", sender_pool.stage_id, output, req_state))
 
     assert diffusion_stage.calls[0]["request_id"] == "req-1"
@@ -199,6 +200,7 @@ def test_forward_to_diffusion_uses_engine_input_source_for_kv_sender_info():
     )
 
     output = SimpleNamespace(request_id="req-3", finished=True)
+    source_pool.select_replica_id("req-3")
     asyncio.run(Orchestrator._forward_to_next_stage(orchestrator, "req-3", previous_pool.stage_id, output, req_state))
 
     assert diffusion_stage.calls[0]["kv_sender_info"] == {

--- a/tests/engine/test_orchestrator_kv_sender_info.py
+++ b/tests/engine/test_orchestrator_kv_sender_info.py
@@ -4,6 +4,11 @@ from types import SimpleNamespace
 import pytest
 from vllm import SamplingParams
 
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
 from vllm_omni.engine.messages import OutputMessage
 from vllm_omni.engine.orchestrator import Orchestrator, OrchestratorRequestState
@@ -139,7 +144,18 @@ def test_forward_to_diffusion_attaches_kv_sender_info():
     orchestrator = object.__new__(Orchestrator)
     diffusion_stage = _DummyDiffusionStage(engine_input_source=[0])
     sender_pool = _build_sender_pool(0, {"host": "10.0.0.2", "zmq_port": 50151})
-    diffusion_pool = StagePool(1, diffusion_stage)
+    diffusion_pool = StagePool(
+        1,
+        diffusion_stage,
+        stage_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                stage_id=1,
+                stage_connector_plan=StageConnectorPlan(
+                    inbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector"))
+                ),
+            )
+        ),
+    )
 
     orchestrator.num_stages = 2
     orchestrator.stage_pools = [sender_pool, diffusion_pool]
@@ -239,7 +255,18 @@ def test_prewarm_diffusion_attaches_kv_sender_info():
     orchestrator = object.__new__(Orchestrator)
     diffusion_stage = _DummyDiffusionStage(engine_input_source=[0])
     sender_pool = _build_sender_pool(0, {"host": "10.0.0.3", "zmq_port": 50151})
-    diffusion_pool = StagePool(1, diffusion_stage)
+    diffusion_pool = StagePool(
+        1,
+        diffusion_stage,
+        stage_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                stage_id=1,
+                stage_connector_plan=StageConnectorPlan(
+                    inbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector"))
+                ),
+            )
+        ),
+    )
 
     orchestrator.stage_pools = [sender_pool, diffusion_pool]
     orchestrator.num_stages = 2

--- a/tests/engine/test_orchestrator_kv_sender_info.py
+++ b/tests/engine/test_orchestrator_kv_sender_info.py
@@ -1,5 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import asyncio
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from vllm import SamplingParams
@@ -211,7 +215,7 @@ def test_forward_to_diffusion_uses_engine_input_source_for_kv_sender_info():
 def test_forward_to_diffusion_returns_terminal_error_for_empty_custom_inputs():
     orchestrator = object.__new__(Orchestrator)
     diffusion_stage = _DummyDiffusionStage(engine_input_source=[0])
-    diffusion_stage.custom_process_input_func = lambda *_args, **_kwargs: []
+    diffusion_stage.custom_process_input_func = cast(Any, lambda *_args, **_kwargs: [])
     sender_pool = _build_sender_pool(0, {"host": "10.0.0.2", "zmq_port": 50151})
     diffusion_pool = StagePool(1, diffusion_stage)
 

--- a/tests/engine/test_orchestrator_stage_input_bridge.py
+++ b/tests/engine/test_orchestrator_stage_input_bridge.py
@@ -14,6 +14,7 @@ import pytest
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
+from vllm_omni.engine import ConnectorEndpoint
 from vllm_omni.engine.orchestrator import (
     Orchestrator,
     OrchestratorRequestState,
@@ -106,11 +107,16 @@ class FakeInputProcessor:
 class FakePrewarmPool:
     stage_type = "llm"
 
-    def __init__(self, role: str) -> None:
+    def __init__(self, role: str, stage_id: int) -> None:
+        self.stage_client = self
         self.stage_vllm_config = SimpleNamespace(
             model_config=SimpleNamespace(
                 max_model_len=64,
-                stage_connector_config={"extra": {"role": role}},
+                stage_id=stage_id,
+                stage_connector_config={
+                    "name": "SharedMemoryConnector",
+                    "extra": {"role": role},
+                },
             )
         )
         self.submitted: list[Any] = []
@@ -119,8 +125,17 @@ class FakePrewarmPool:
         self.submitted.append(request)
         return 0
 
+    async def _pick_or_select(self, _request_id):
+        return 0
+
     def get_bound_replica_id(self, _request_id):
         return 0
+
+    def get_bound_client(self, _request_id):
+        return self
+
+    def get_payload_sender_info(self):
+        return None
 
 
 def _duplex_stage_port_submission():
@@ -203,6 +218,23 @@ def _request_output(request_id: str) -> RequestOutput:
     )
 
 
+def test_payload_sender_info_comes_from_the_bound_producer_replica() -> None:
+    expected = ConnectorEndpoint(host="10.0.0.9", zmq_port=52000)
+    bound_client = SimpleNamespace(get_payload_sender_info=lambda: expected)
+    fallback_client = SimpleNamespace(
+        get_payload_sender_info=lambda: ConnectorEndpoint(host="10.0.0.1", zmq_port=51000)
+    )
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator.stage_pools = [
+        SimpleNamespace(
+            stage_client=fallback_client,
+            get_bound_client=lambda request_id: bound_client if request_id == "req-1" else None,
+        )
+    ]
+
+    assert orchestrator._build_payload_sender_info(0, "req-1") is expected
+
+
 @pytest.mark.asyncio
 async def test_forward_text_prompt_uses_target_stage_input_processor() -> None:
     class SourceTokenizer:
@@ -263,9 +295,9 @@ async def test_forward_text_prompt_uses_target_stage_input_processor() -> None:
 @pytest.mark.asyncio
 async def test_async_prewarm_skips_outgoing_only_stage() -> None:
     orchestrator = object.__new__(Orchestrator)
-    stage0 = FakePrewarmPool("sender")
-    stage1 = FakePrewarmPool("sender")
-    stage2 = FakePrewarmPool("receiver")
+    stage0 = FakePrewarmPool("sender", 0)
+    stage1 = FakePrewarmPool("sender", 1)
+    stage2 = FakePrewarmPool("receiver", 2)
     orchestrator.stage_pools = [stage0, stage1, stage2]
     orchestrator._emit_tx_edge = lambda **_kwargs: None
     orchestrator._record_duplex_stage_submission = MagicMock()
@@ -342,7 +374,7 @@ async def test_async_route_forwards_to_outgoing_only_stage() -> None:
         has_companions=lambda _request_id: False,
     )
     stage0 = SimpleNamespace(final_output=False)
-    stage1 = FakePrewarmPool("sender")
+    stage1 = FakePrewarmPool("sender", 1)
     orchestrator.stage_pools = [stage0, stage1]
     orchestrator._forward_to_next_stage = AsyncMock()
     req_state = OrchestratorRequestState(

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -17,6 +17,7 @@ from vllm.v1.engine.utils import EngineZmqAddresses
 
 from vllm_omni.config.config_factory import StageConfigFactory
 from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
+from vllm_omni.distributed.omni_connectors.utils.config import StageConnectorPlan
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_engine_core_client import StageEngineCoreClientBase
 from vllm_omni.engine.stage_engine_startup import (
@@ -80,7 +81,7 @@ def _make_llm_plan(
                 launch_mode=launch_mode,
                 stage_cfg=stage_cfg,
                 metadata=metadata,
-                stage_connector_spec={},
+                stage_connector_plan=StageConnectorPlan(),
                 omni_kv_connector=(None, None, None),
                 stage_vllm_config=vllm_config
                 or SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size_local=1)),
@@ -121,7 +122,7 @@ def _make_diffusion_plan(
                 launch_mode=launch_mode,
                 stage_cfg=stage_cfg,
                 metadata=metadata,
-                stage_connector_spec={},
+                stage_connector_plan=StageConnectorPlan(),
                 omni_kv_connector=(None, None, None),
             )
         ],
@@ -598,7 +599,7 @@ class TestSingleStageInitialization:
                 runtime_cfg={},
             ),
         )
-        monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(runtime_mod, "get_stage_connector_plan", lambda **_: StageConnectorPlan())
         monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         monkeypatch.setattr(runtime_mod, "build_engine_args_dict", lambda *_, **__: {})
         monkeypatch.setattr(runtime_mod, "build_vllm_config", lambda *_, **__: (SimpleNamespace(), object))
@@ -698,7 +699,7 @@ class TestSingleStageInitialization:
                 runtime_cfg={"devices": "0"},
             ),
         )
-        monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(runtime_mod, "get_stage_connector_plan", lambda **_: StageConnectorPlan())
         monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         monkeypatch.setattr(runtime_mod, "build_engine_args_dict", lambda *_, **__: {})
         monkeypatch.setattr(
@@ -764,7 +765,7 @@ class TestSingleStageInitialization:
                 replica_id=0,
             ),
         )
-        monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(runtime_mod, "get_stage_connector_plan", lambda **_: StageConnectorPlan())
         monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         try:
             stage_plans = runtime._build_logical_stage_init_plans(None, [2], {0: ["0", "1"]})

--- a/tests/engine/test_stage_engine_args.py
+++ b/tests/engine/test_stage_engine_args.py
@@ -41,6 +41,11 @@ from vllm_omni.config.stage_config import (
     merge_pipeline_deploy,
 )
 from vllm_omni.diffusion.data import AttentionConfig, OmniDiffusionConfig
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from vllm_omni.engine import stage_init_utils
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.stage_init_utils import (
@@ -350,7 +355,13 @@ def test_typed_llm_engine_args_preserve_upstream_config_objects(tmp_path, stage_
 def test_typed_llm_engine_args_preserve_legacy_adapter_behavior(tmp_path):
     pipeline, deploy, model = _engine_arg_inputs(tmp_path)
     legacy_stages, omni_config = _legacy_and_typed_stages(pipeline, deploy, model)
-    connector_spec = {"name": "SharedMemoryConnector", "extra": {"mode": "test"}}
+    connector_plan = StageConnectorPlan(
+        outbound=StageConnectorSpec(
+            0,
+            1,
+            ConnectorSpec("SharedMemoryConnector", {"mode": "test"}),
+        )
+    )
     cli_tokenizer = "/external/tokenizer"
 
     typed_args_by_stage = {}
@@ -358,13 +369,13 @@ def test_typed_llm_engine_args_preserve_legacy_adapter_behavior(tmp_path):
         legacy_args = build_legacy_engine_args_dict(
             legacy_stages[stage_id],
             model,
-            stage_connector_spec=connector_spec,
+            stage_connector_plan=connector_plan,
             cli_tokenizer=cli_tokenizer,
         )
         typed_args = build_engine_args_dict_from_omni_stage_config(
             omni_config.stage_by_id(stage_id),
             model,
-            stage_connector_spec=connector_spec,
+            stage_connector_plan=connector_plan,
             cli_tokenizer=cli_tokenizer,
         )
         typed_args_by_stage[stage_id] = typed_args
@@ -384,7 +395,7 @@ def test_typed_llm_engine_args_preserve_legacy_adapter_behavior(tmp_path):
     assert thinker_args["model"] == str(tmp_path / "stage-model" / "ar-model")
     assert thinker_args["tokenizer"] == str(tmp_path / "stage-model" / "ar-tokenizer")
     assert thinker_args["stage_id"] == 0
-    assert thinker_args["stage_connector_spec"] == connector_spec
+    assert thinker_args["stage_connector_plan"] == connector_plan
     assert thinker_args["has_sampling_extra_args"] is True
     assert thinker_args["omni_kv_config"] == {"need_send_cache": True}
     assert thinker_args["worker_cls"] == "test.custom.Worker"
@@ -606,18 +617,18 @@ def test_typed_engine_args_preserve_legacy_omni_kv_precedence(tmp_path, cli_over
 def test_build_engine_args_dict_preserves_legacy_api(tmp_path):
     pipeline, deploy, model = _engine_arg_inputs(tmp_path)
     legacy_stages, _ = _legacy_and_typed_stages(pipeline, deploy, model)
-    connector_spec = {"name": "SharedMemoryConnector", "extra": {}}
+    connector_plan = StageConnectorPlan(outbound=StageConnectorSpec(0, 1, ConnectorSpec("SharedMemoryConnector")))
 
     compatibility_args = build_engine_args_dict(
         copy.deepcopy(legacy_stages[0]),
         model,
-        stage_connector_spec=connector_spec,
+        stage_connector_plan=connector_plan,
         cli_tokenizer="/external/tokenizer",
     )
     explicitly_legacy_args = build_legacy_engine_args_dict(
         copy.deepcopy(legacy_stages[0]),
         model,
-        stage_connector_spec=connector_spec,
+        stage_connector_plan=connector_plan,
         cli_tokenizer="/external/tokenizer",
     )
 

--- a/tests/engine/test_stage_engine_core_client.py
+++ b/tests/engine/test_stage_engine_core_client.py
@@ -9,6 +9,14 @@ from types import SimpleNamespace
 import pytest
 from vllm.v1.engine.exceptions import EngineDeadError
 
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
+from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    KV_REPLICA_PORT_STRIDE,
+)
 from vllm_omni.engine.stage_engine_core_client import StageEngineCoreClient
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -30,3 +38,25 @@ def test_check_health_raises_when_resources_engine_dead():
     client = _make_client(engine_dead=True)
     with pytest.raises(EngineDeadError, match="engine core is dead"):
         client.check_health()
+
+
+def test_payload_sender_info_uses_bound_replica_port():
+    client = _make_client()
+    client.stage_id = 1
+    client.replica_id = 2
+    client._stage_connector_plan = StageConnectorPlan(
+        outbound=StageConnectorSpec(
+            1,
+            2,
+            ConnectorSpec(
+                "MooncakeTransferEngineConnector",
+                {"host": "10.0.0.8", "zmq_port": 51000},
+            ),
+        )
+    )
+
+    endpoint = client.get_payload_sender_info()
+
+    assert endpoint is not None
+    assert endpoint.host == "10.0.0.8"
+    assert endpoint.zmq_port == 51000 + 2 * KV_REPLICA_PORT_STRIDE

--- a/tests/engine/test_stage_engine_core_client.py
+++ b/tests/engine/test_stage_engine_core_client.py
@@ -14,9 +14,7 @@ from vllm_omni.distributed.omni_connectors.utils.config import (
     StageConnectorPlan,
     StageConnectorSpec,
 )
-from vllm_omni.distributed.omni_connectors.utils.initialization import (
-    KV_REPLICA_PORT_STRIDE,
-)
+from vllm_omni.distributed.omni_connectors.utils.kv_utils import kv_zmq_port
 from vllm_omni.engine.stage_engine_core_client import StageEngineCoreClient
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -59,4 +57,4 @@ def test_payload_sender_info_uses_bound_replica_port():
 
     assert endpoint is not None
     assert endpoint.host == "10.0.0.8"
-    assert endpoint.zmq_port == 51000 + 2 * KV_REPLICA_PORT_STRIDE
+    assert endpoint.zmq_port == kv_zmq_port(51000, 1, replica_id=2)

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 from pytest_mock import MockerFixture
 
+from vllm_omni.distributed.omni_connectors.utils.config import StageConnectorPlan
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand, run_headless
 from vllm_omni.entrypoints.utils import parse_stage_overrides
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser, TrackingNamespace
@@ -290,8 +291,8 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
         return_value=(None, None, None),
     )
     mock_connector_spec = mocker.patch(
-        "vllm_omni.engine.stage_init_utils.get_stage_connector_spec",
-        return_value={},
+        "vllm_omni.engine.stage_init_utils.get_stage_connector_plan",
+        return_value=StageConnectorPlan(),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.build_engine_args_dict", return_value={})
     mocker.patch(
@@ -328,7 +329,10 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     assert kwargs["omni_stage_config"] is stage_cfg
     assert kwargs["replica_id"] is None
     assert "socket_ownership" not in kwargs
-    assert mock_connector_spec.call_args.kwargs["async_chunk"] is True
+    assert mock_connector_spec.call_args.kwargs == {
+        "omni_transfer_config": None,
+        "stage_id": 0,
+    }
 
     assert mock_manager_cls.call_count == 1
     mgr_kwargs = mock_manager_cls.call_args.kwargs
@@ -369,7 +373,10 @@ def test_run_headless_llm_launches_one_manager_per_omni_dp_size_local(mocker: Mo
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch("vllm_omni.engine.stage_init_utils.get_stage_connector_spec", return_value={})
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.get_stage_connector_plan",
+        return_value=StageConnectorPlan(),
+    )
     mocker.patch("vllm_omni.engine.stage_init_utils.build_engine_args_dict", return_value={})
     mocker.patch(
         "vllm_omni.engine.stage_init_utils.build_vllm_config",

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -19,7 +19,7 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import (
-    get_stage_connector_spec,
+    get_stage_connector_plan,
     load_omni_transfer_config_for_model,
 )
 from vllm_omni.entrypoints.utils import (
@@ -359,21 +359,25 @@ class TestResolveModelConfigPath:
         transfer_config = load_omni_transfer_config_for_model(model, result)
         assert transfer_config is not None
 
-        sender = get_stage_connector_spec(
+        sender_plan = get_stage_connector_plan(
             omni_transfer_config=transfer_config,
             stage_id=1,
-            async_chunk=True,
         )
-        receiver = get_stage_connector_spec(
+        receiver_plan = get_stage_connector_plan(
             omni_transfer_config=transfer_config,
             stage_id=2,
-            async_chunk=True,
         )
-        assert sender["extra"]["role"] == "sender"
-        assert receiver["extra"]["role"] == "receiver"
-        assert sender["extra"]["connector_get_sleep_s"] == 0.01
-        assert sender["extra"]["connector_get_max_wait_first_chunk"] == 3000
-        assert sender["extra"]["connector_get_max_wait"] == 300
+        assert sender_plan.outbound is not None
+        assert sender_plan.outbound.from_stage == 1
+        assert sender_plan.outbound.to_stage == 2
+        assert receiver_plan.inbound is not None
+        assert receiver_plan.inbound.from_stage == 1
+        assert receiver_plan.inbound.to_stage == 2
+        assert sender_plan.outbound.spec.name == "SharedMemoryConnector"
+        assert receiver_plan.inbound.spec.name == "SharedMemoryConnector"
+        assert sender_plan.outbound.spec.extra["connector_get_sleep_s"] == 0.01
+        assert sender_plan.outbound.spec.extra["connector_get_max_wait_first_chunk"] == 3000
+        assert sender_plan.outbound.spec.extra["connector_get_max_wait"] == 300
 
     def test_object_storage_uri_resolves_via_materialized_configs(
         self,

--- a/tests/model_executor/models/fish_speech/test_fish_speech_regressions.py
+++ b/tests/model_executor/models/fish_speech/test_fish_speech_regressions.py
@@ -214,7 +214,7 @@ def test_dac_decoder_dtype_can_be_configured():
     cfg = SimpleNamespace(
         model_config=SimpleNamespace(
             model="unused",
-            stage_connector_config={"extra": {"fish_speech_dac_dtype": "fp16"}},
+            stage_input_connector_config={"extra": {"fish_speech_dac_dtype": "fp16"}},
         )
     )
 

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -157,7 +157,7 @@ def _config(minimum: int = 1, initial: int = 0):
     return SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
-            stage_connector_config={
+            stage_input_connector_config={
                 "extra": {
                     "code2wav_min_batch_size": minimum,
                     "code2wav_initial_batch_size": initial,

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_model_dir.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_model_dir.py
@@ -67,7 +67,7 @@ def test_init_with_fake_path_does_not_resolve(monkeypatch):
     config = SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
-            stage_connector_config=None,
+            stage_input_connector_config=None,
         )
     )
     model = MiniCPMO45Code2Wav(vllm_config=config)
@@ -80,7 +80,7 @@ def test_default_prompt_wav_follows_resolved_model_path(monkeypatch):
     config = SimpleNamespace(
         model_config=SimpleNamespace(
             model="openbmb/MiniCPM-o-4_5",
-            stage_connector_config=None,
+            stage_input_connector_config=None,
         )
     )
     model = MiniCPMO45Code2Wav(vllm_config=config)

--- a/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
+++ b/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
@@ -585,7 +585,7 @@ class TestCodePredictorWrapperConfig:
 
         cp_config, _ = _make_tiny_config(loaded_target_classes)
         vllm_config = _make_vllm_config(mocker, max_num_seqs=2)
-        vllm_config.model_config.stage_connector_config = {
+        vllm_config.model_config.stage_input_connector_config = {
             "extra": {
                 "code_predictor_prefix_graphs": True,
                 "code_predictor_prefix_graph_buckets": [2],

--- a/tests/model_executor/models/qwen3_tts/test_qwen3_tts_code2wav.py
+++ b/tests/model_executor/models/qwen3_tts/test_qwen3_tts_code2wav.py
@@ -107,7 +107,7 @@ def _fake_dec_config():
 
 def _make_model(
     *,
-    stage_connector_config=None,
+    stage_input_connector_config=None,
     async_chunk: bool = False,
     device: torch.device | None = None,
 ) -> Qwen3TTSCode2Wav:
@@ -132,7 +132,7 @@ def _make_model(
                 model_config=SimpleNamespace(
                     model="unused",
                     revision=None,
-                    stage_connector_config=stage_connector_config,
+                    stage_input_connector_config=stage_input_connector_config,
                     async_chunk=async_chunk,
                 ),
                 device_config=SimpleNamespace(device=device or torch.device("cpu")),
@@ -292,7 +292,7 @@ def test_four_frame_first_chunk_uses_configured_initial_size_without_ramp():
 def test_connector_codec_chunking_does_not_override_decode_chunking():
     model = _make_model(
         async_chunk=True,
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "codec_chunk_frames": 25,
                 "codec_left_context_frames": 72,
@@ -321,7 +321,7 @@ def test_connector_codec_chunking_does_not_override_decode_chunking():
 def test_decode_chunking_can_be_overridden_separately():
     model = _make_model(
         async_chunk=True,
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "codec_chunk_frames": 25,
                 "codec_left_context_frames": 72,
@@ -560,7 +560,7 @@ def test_decode_chunking_override_is_passed_to_cudagraph():
     model = _make_model(
         async_chunk=True,
         device=torch.device("cuda"),
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "codec_chunk_frames": 25,
                 "codec_left_context_frames": 72,
@@ -590,7 +590,7 @@ def test_cudagraph_batch_config_is_preserved():
     model = _make_model(
         async_chunk=True,
         device=torch.device("cuda"),
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "decode_cudagraph_batch_sizes": [1, 2, 4, 8],
             }
@@ -623,7 +623,7 @@ def test_async_cudagraph_ignores_stateless_capture_sizes():
     model = _make_model(
         async_chunk=True,
         device=torch.device("cuda"),
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "decode_cudagraph_capture_sizes": [97, 400],
             }
@@ -646,7 +646,7 @@ def test_decode_tf32_can_be_configured():
         model = _make_model(
             async_chunk=True,
             device=torch.device("cuda"),
-            stage_connector_config={
+            stage_input_connector_config={
                 "extra": {
                     "decode_enable_tf32": "true",
                 }
@@ -667,7 +667,7 @@ def test_decode_tf32_can_be_configured():
 def test_decode_batch_max_size_can_be_configured():
     model = _make_model(
         async_chunk=True,
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "decode_batch_max_size": 10,
             }
@@ -682,7 +682,7 @@ def test_decode_batch_max_size_can_be_configured():
 def test_invalid_decode_batch_max_size_is_rejected():
     model = _make_model(
         async_chunk=True,
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "decode_batch_max_size": -1,
             }
@@ -696,7 +696,7 @@ def test_invalid_decode_batch_max_size_is_rejected():
 def test_invalid_decode_chunking_is_rejected():
     model = _make_model(
         async_chunk=True,
-        stage_connector_config={
+        stage_input_connector_config={
             "extra": {
                 "decode_chunk_frames": 0,
             }

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -1348,7 +1348,7 @@ class TestConnectorConfigValidation(unittest.TestCase):
         model_config.stage_connector_plan = None
         model_config.stage_connector_config = {"name": "   "}
 
-        with self.assertRaisesRegex(ValueError, "missing connector name"):
+        with self.assertRaisesRegex(ValueError, "Unknown connector"):
             host.init_omni_connectors(model_config=model_config)
 
 

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -23,8 +23,12 @@ from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
 )
 from vllm_omni.distributed.omni_connectors.utils.config import (
     ConnectorSpec,
+    OmniTransferConfig,
     StageConnectorPlan,
     StageConnectorSpec,
+)
+from vllm_omni.distributed.omni_connectors.utils.initialization import (
+    resolve_omni_kv_config_for_stage,
 )
 from vllm_omni.distributed.omni_connectors.utils.kv_utils import KVTPTopology
 from vllm_omni.outputs import OmniConnectorOutput
@@ -1265,6 +1269,99 @@ class TestRankAwareKVRouting(unittest.TestCase):
         host._send_to_tp = to_tp
         host._local_rank = local_rank
         return host
+
+    def test_middle_stage_uses_owned_direction_in_4_to_2_to_1_topology(self):
+        recv_mapping = {"from_tp": 4, "to_tp": 2}
+        send_mapping = {"from_tp": 2, "to_tp": 1}
+        transfer_config = OmniTransferConfig(
+            connectors={
+                ("0", "1"): ConnectorSpec(
+                    "MooncakeTransferEngineConnector",
+                    {"rank_mapping": recv_mapping},
+                ),
+                ("1", "2"): ConnectorSpec(
+                    "MoriTransferEngineConnector",
+                    {"rank_mapping": send_mapping},
+                ),
+            }
+        )
+
+        cases = (
+            ({"need_recv_cache": True}, "MooncakeTransferEngineConnector", "receiver"),
+            ({"need_send_cache": True}, "MoriTransferEngineConnector", "sender"),
+        )
+        for manager_flags, expected_type, expected_role in cases:
+            with self.subTest(role=expected_role):
+                stage_config = SimpleNamespace(engine_args={"omni_kv_config": manager_flags})
+                connector_config, from_stage, to_stage = resolve_omni_kv_config_for_stage(
+                    transfer_config,
+                    1,
+                    stage_config,
+                )
+                expected_mapping = recv_mapping if expected_role == "receiver" else send_mapping
+                self.assertIsNotNone(connector_config)
+                self.assertEqual(connector_config["type"], expected_type)
+                self.assertEqual(connector_config["role"], expected_role)
+                self.assertEqual(connector_config["rank_mapping"], expected_mapping)
+
+                with patch(
+                    "vllm_omni.distributed.omni_connectors.kv_transfer_manager.get_local_tp_rank",
+                    return_value=1,
+                ):
+                    manager = OmniKVTransferManager._create(
+                        {
+                            **manager_flags,
+                            "omni_from_stage": from_stage,
+                            "omni_to_stage": to_stage,
+                            "stage_id": 1,
+                            "rank_mapping": expected_mapping,
+                        }
+                    )
+
+                model_config = _make_model_config(stage_id=1)
+                model_config.stage_connector_plan = StageConnectorPlan(
+                    inbound=StageConnectorSpec(
+                        0,
+                        1,
+                        ConnectorSpec("MooncakeTransferEngineConnector", {"rank_mapping": recv_mapping}),
+                    ),
+                    outbound=StageConnectorSpec(
+                        1,
+                        2,
+                        ConnectorSpec("MoriTransferEngineConnector", {"rank_mapping": send_mapping}),
+                    ),
+                )
+                with (
+                    patch(
+                        "vllm_omni.worker.omni_connector_model_runner_mixin.get_local_tp_rank",
+                        return_value=1,
+                    ),
+                    patch(
+                        "vllm_omni.worker.omni_connector_model_runner_mixin.OmniConnectorFactory.create_stage_connectors",
+                        return_value=StageConnectorSet(),
+                    ),
+                ):
+                    host = MixinHost()
+                    host.init_omni_connectors(model_config, manager)
+
+                mapping = host.get_kv_rank_mapping()
+                self.assertEqual(mapping["recv"], recv_mapping)
+                self.assertEqual(mapping["send"], send_mapping)
+                if expected_role == "receiver":
+                    self.assertIsNotNone(manager.kv_recv_key_builder)
+                    self.assertIsNone(manager.kv_send_key_builder)
+                    self.assertEqual(
+                        manager.kv_recv_key_builder("req", from_stage=0, to_stage=1),
+                        ["req_0_0_2_1", "req_0_0_3_1"],
+                    )
+                else:
+                    self.assertIsNotNone(manager.kv_send_key_builder)
+                    self.assertIsNone(manager.kv_recv_key_builder)
+                    self.assertEqual(
+                        manager.kv_send_key_builder("req", from_stage=1, to_stage=2),
+                        ["req_1_0_1_0"],
+                    )
+                host.shutdown_omni_connectors()
 
     def test_recv_keys_use_remote_rank_as_from_rank(self):
         host = self._make_host(from_tp=4, to_tp=2, local_rank=1)

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -130,7 +130,8 @@ class _FakeTPGroup:
 )
 def test_init_payload_connector_ownership(role, custom_func, expected):
     model_config = _make_model_config(custom_func=custom_func)
-    # Exercise the legacy role-only configuration path explicitly.
+    # Exercise the legacy config compatibility path; the typed empty plan
+    # takes precedence when present.
     model_config.stage_connector_plan = None
     model_config.stage_connector_config = {
         "name": "MooncakeTransferEngineConnector",
@@ -139,17 +140,21 @@ def test_init_payload_connector_ownership(role, custom_func, expected):
 
     host = MixinHost()
     connector = MockConnector()
+    connector_set = StageConnectorSet(
+        receive=connector if role == "receiver" else None,
+        send=connector if role == "sender" else None,
+    )
     with (
         patch(
             "vllm_omni.worker.omni_connector_model_runner_mixin.OmniConnectorFactory.create_stage_connectors",
-            return_value=StageConnectorSet(receive=connector, send=connector),
+            return_value=connector_set,
         ) as create,
         patch.object(host, "_load_custom_func", return_value=(None, None)),
     ):
         host.init_omni_connectors(model_config)
 
     assert (create.call_count == 1) is expected
-    assert (getattr(host._connectors, "connector", None) is connector) is expected
+    assert (host._connectors is connector_set) is expected
     host.shutdown_omni_connectors()
 
 

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -67,14 +67,11 @@ def _make_model_config(
     async_chunk: bool = False,
     worker_type: str = "ar",
     custom_func: str | None = None,
+    inbound_from: int | None = None,
 ) -> SimpleNamespace:
     inbound = (
-        StageConnectorSpec(
-            from_stage=stage_id - 1,
-            to_stage=stage_id,
-            spec=ConnectorSpec("SharedMemoryConnector"),
-        )
-        if stage_id > 0
+        StageConnectorSpec(inbound_from, stage_id, ConnectorSpec("SharedMemoryConnector"))
+        if inbound_from is not None
         else None
     )
     return SimpleNamespace(
@@ -841,10 +838,10 @@ class TestSendChunkCachesMapping(unittest.TestCase):
 class TestLocalPayloadCacheLifecycle(unittest.TestCase):
     """Unit tests for the local payload cache API (RFC §2.4)."""
 
-    def _make_host(self, stage_id: int = 0) -> MixinHost:
+    def _make_host(self, *, stage_id: int = 0, inbound_from: int | None = None) -> MixinHost:
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=stage_id),
+            model_config=_make_model_config(stage_id=stage_id, inbound_from=inbound_from),
         )
         host._stage_id = stage_id
         return host
@@ -872,9 +869,8 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
         host.shutdown_omni_connectors()
 
     def test_rank0_only_polls_connector_for_tp_full_payload(self):
-        host = self._make_host(stage_id=2)
+        host = self._make_host(stage_id=2, inbound_from=1)
         host._connectors.receive = MagicMock()
-        host._stage_id = 2
         host._local_rank = 0
         host._request_ids_mapping["r1"] = "ext-r1"
         host._get_req_chunk["r1"] = 0
@@ -896,9 +892,8 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
         host.shutdown_omni_connectors()
 
     def test_tp_follower_skips_connector_poll_for_full_payload(self):
-        host = self._make_host(stage_id=2)
+        host = self._make_host(stage_id=2, inbound_from=1)
         host._connectors.receive = MagicMock()
-        host._stage_id = 2
         host._local_rank = 1
         host._request_ids_mapping["r1"] = "ext-r1"
         host._get_req_chunk["r1"] = 0
@@ -938,7 +933,12 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
     def _make_host(self, rank: int) -> MixinHost:
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
+            model_config=_make_model_config(
+                stage_id=2,
+                async_chunk=True,
+                worker_type="gen",
+                inbound_from=1,
+            ),
         )
         host._connectors.receive = MagicMock()
         host._stage_id = 2
@@ -1074,7 +1074,11 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
     def test_send_side_request_payload_not_cleared_before_payload_is_consumable(self):
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+            model_config=_make_model_config(
+                stage_id=1,
+                async_chunk=True,
+                worker_type="ar",
+            ),
         )
         host._request_ids_mapping["r1"] = "r1"
         payload = {
@@ -1130,7 +1134,12 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
     def test_ar_metadata_only_followup_chunk_does_not_rewake_request(self):
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+            model_config=_make_model_config(
+                stage_id=1,
+                async_chunk=True,
+                worker_type="ar",
+                inbound_from=0,
+            ),
         )
         host._connectors.receive = MagicMock()
         host._stage_id = 1
@@ -1169,7 +1178,12 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
     def test_non_ar_recv_does_not_overwrite_unconsumed_staged_chunk(self):
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
+            model_config=_make_model_config(
+                stage_id=2,
+                async_chunk=True,
+                worker_type="gen",
+                inbound_from=1,
+            ),
         )
         host._connectors.receive = MagicMock()
         host._stage_id = 2
@@ -1194,7 +1208,12 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
     def test_non_ar_recv_waits_for_scheduler_handoff_before_fetching_next_chunk(self):
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
+            model_config=_make_model_config(
+                stage_id=2,
+                async_chunk=True,
+                worker_type="gen",
+                inbound_from=1,
+            ),
         )
         host._connectors.receive = MagicMock()
         host._stage_id = 2
@@ -1263,7 +1282,7 @@ class TestRankAwareKVRouting(unittest.TestCase):
         self.assertEqual(host.get_rank_aware_kv_keys("req", from_stage=0, to_stage=1), expected)
         host.shutdown_omni_connectors()
 
-    def test_init_uses_effective_manager_tp2_topology(self):
+    def test_init_uses_effective_manager_tp2_topology_for_owned_direction(self):
         model_config = _make_model_config(stage_id=0)
         model_config.omni_kv_config = {
             "need_send_cache": True,
@@ -1282,12 +1301,17 @@ class TestRankAwareKVRouting(unittest.TestCase):
 
         expected = ["req_0_0_1_1"]
         self.assertEqual(host.get_rank_aware_kv_send_keys("req", from_stage=0, to_stage=1), expected)
-        self.assertEqual(host.get_rank_aware_kv_keys("req", from_stage=0, to_stage=1), expected)
+        self.assertEqual(
+            host.get_rank_aware_kv_keys("req", from_stage=0, to_stage=1),
+            ["omni_0_to_1_kv_cache_req"],
+        )
         rank_mapping = host.get_kv_rank_mapping()
-        self.assertEqual(rank_mapping["recv"]["from_tp"], 2)
-        self.assertEqual(rank_mapping["recv"]["to_tp"], 2)
+        self.assertEqual(rank_mapping["recv"]["from_tp"], 1)
+        self.assertEqual(rank_mapping["recv"]["to_tp"], 1)
         self.assertEqual(rank_mapping["send"]["from_tp"], 2)
         self.assertEqual(rank_mapping["send"]["to_tp"], 2)
+        self.assertIsNotNone(manager.kv_send_key_builder)
+        self.assertIsNone(manager.kv_recv_key_builder)
         host.shutdown_omni_connectors()
 
     def test_send_keys_route_from_rank_gt_to_rank(self):

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -1278,9 +1278,11 @@ class TestRankAwareKVRouting(unittest.TestCase):
         expected = ["req_0_0_1_1"]
         self.assertEqual(host.get_rank_aware_kv_send_keys("req", from_stage=0, to_stage=1), expected)
         self.assertEqual(host.get_rank_aware_kv_keys("req", from_stage=0, to_stage=1), expected)
-        mapping = host.get_kv_rank_mapping()
-        self.assertEqual(mapping["recv"]["from_tp"], 2)
-        self.assertEqual(mapping["recv"]["to_tp"], 2)
+        rank_mapping = host.get_kv_rank_mapping()
+        self.assertEqual(rank_mapping["recv"]["from_tp"], 2)
+        self.assertEqual(rank_mapping["recv"]["to_tp"], 2)
+        self.assertEqual(rank_mapping["send"]["from_tp"], 2)
+        self.assertEqual(rank_mapping["send"]["to_tp"], 2)
         host.shutdown_omni_connectors()
 
     def test_send_keys_route_from_rank_gt_to_rank(self):
@@ -1348,7 +1350,7 @@ class TestConnectorConfigValidation(unittest.TestCase):
         model_config.stage_connector_plan = None
         model_config.stage_connector_config = {"name": "   "}
 
-        with self.assertRaisesRegex(ValueError, "Unknown connector"):
+        with self.assertRaisesRegex(ValueError, "missing connector name"):
             host.init_omni_connectors(model_config=model_config)
 
 

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -17,9 +17,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from vllm_omni.distributed.omni_connectors.factory import StageConnectorSet
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
     OmniKVTransferManager,
 )
+from vllm_omni.distributed.omni_connectors.utils.config import (
+    ConnectorSpec,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
+from vllm_omni.distributed.omni_connectors.utils.kv_utils import KVTPTopology
 from vllm_omni.outputs import OmniConnectorOutput
 from vllm_omni.worker.omni_connector_model_runner_mixin import (
     OmniConnectorModelRunnerMixin,
@@ -61,8 +68,18 @@ def _make_model_config(
     worker_type: str = "ar",
     custom_func: str | None = None,
 ) -> SimpleNamespace:
+    inbound = (
+        StageConnectorSpec(
+            from_stage=stage_id - 1,
+            to_stage=stage_id,
+            spec=ConnectorSpec("SharedMemoryConnector"),
+        )
+        if stage_id > 0
+        else None
+    )
     return SimpleNamespace(
-        stage_connector_config=None,
+        stage_id=stage_id,
+        stage_connector_plan=StageConnectorPlan(inbound=inbound),
         async_chunk=async_chunk,
         worker_type=worker_type,
         custom_process_next_stage_input_func=custom_func,
@@ -82,8 +99,6 @@ def _make_request(req_id: str, external_req_id: str | None = None):
 
 class MixinHost(OmniConnectorModelRunnerMixin):
     """Minimal class that mixes in the mixin for testing."""
-
-    pass
 
 
 class _FakeTPGroup:
@@ -115,6 +130,8 @@ class _FakeTPGroup:
 )
 def test_init_payload_connector_ownership(role, custom_func, expected):
     model_config = _make_model_config(custom_func=custom_func)
+    # Exercise the legacy role-only configuration path explicitly.
+    model_config.stage_connector_plan = None
     model_config.stage_connector_config = {
         "name": "MooncakeTransferEngineConnector",
         "extra": {"role": role},
@@ -123,13 +140,16 @@ def test_init_payload_connector_ownership(role, custom_func, expected):
     host = MixinHost()
     connector = MockConnector()
     with (
-        patch.object(host, "_create_connector", return_value=connector) as create,
+        patch(
+            "vllm_omni.worker.omni_connector_model_runner_mixin.OmniConnectorFactory.create_stage_connectors",
+            return_value=StageConnectorSet(receive=connector, send=connector),
+        ) as create,
         patch.object(host, "_load_custom_func", return_value=(None, None)),
     ):
         host.init_omni_connectors(model_config)
 
     assert (create.call_count == 1) is expected
-    assert (host._omni_connector is connector) is expected
+    assert (getattr(host._connectors, "connector", None) is connector) is expected
     host.shutdown_omni_connectors()
 
 
@@ -143,7 +163,7 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
         sender.init_omni_connectors(
             model_config=_make_model_config(stage_id=0, async_chunk=True),
         )
-        sender._omni_connector = connector
+        sender._connectors.send = connector
         sender._stage_id = 0
         sender._async_chunk = True
 
@@ -179,7 +199,7 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
         sender.init_omni_connectors(
             model_config=_make_model_config(stage_id=0, async_chunk=True),
         )
-        sender._omni_connector = connector
+        sender._connectors.send = connector
         sender._stage_id = 0
         sender._async_chunk = True
 
@@ -336,7 +356,8 @@ class TestMixinNoConnector(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(),
         )
-        self.assertIsNone(host._omni_connector)
+        self.assertIsNone(host._connectors.receive)
+        self.assertIsNone(host._connectors.send)
 
         results = host.recv_full_payload_inputs(scheduler_output=None)
         self.assertIsNone(results)
@@ -413,7 +434,7 @@ class TestFullPayloadSendWithCustomFunc(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(),
         )
-        host._omni_connector = MockConnector(stage_id=0)
+        host._connectors.send = MockConnector(stage_id=0)
         host._stage_id = 0
         host._custom_process_func = full_payload_func
 
@@ -427,7 +448,7 @@ class TestFullPayloadSendWithCustomFunc(unittest.TestCase):
         self.assertEqual(
             seen,
             {
-                "connector": host._omni_connector,
+                "connector": host._connectors.send,
                 "is_finished": True,
                 "data": {"raw": 100},
                 "rid": "req-1",
@@ -447,7 +468,7 @@ class TestFullPayloadSendWithCustomFunc(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(),
         )
-        host._omni_connector = MockConnector(stage_id=0)
+        host._connectors.send = MockConnector(stage_id=0)
         host._stage_id = 0
         host._custom_process_func = full_payload_func
 
@@ -509,7 +530,7 @@ class TestChunkStreamCompletedGuard(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=stage_id, async_chunk=True),
         )
-        host._omni_connector = MockConnector(stage_id=stage_id)
+        host._connectors.receive = MockConnector(stage_id=stage_id)
         host._stage_id = stage_id
         host._async_chunk = True
         return host
@@ -607,7 +628,7 @@ class TestCleanupFinishedRequest(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=stage_id, async_chunk=True),
         )
-        host._omni_connector = MockConnector(stage_id=stage_id)
+        host._connectors.receive = MockConnector(stage_id=stage_id)
         host._stage_id = stage_id
         host._async_chunk = True
         return host
@@ -790,7 +811,7 @@ class TestSendChunkCachesMapping(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=0, async_chunk=True),
         )
-        host._omni_connector = MockConnector(stage_id=0)
+        host._connectors.send = MockConnector(stage_id=0)
         host._stage_id = 0
         host._async_chunk = True
 
@@ -815,13 +836,12 @@ class TestSendChunkCachesMapping(unittest.TestCase):
 class TestLocalPayloadCacheLifecycle(unittest.TestCase):
     """Unit tests for the local payload cache API (RFC §2.4)."""
 
-    def _make_host(self) -> MixinHost:
+    def _make_host(self, stage_id: int = 0) -> MixinHost:
         host = MixinHost()
         host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=0),
+            model_config=_make_model_config(stage_id=stage_id),
         )
-        host._omni_connector = MockConnector(stage_id=0)
-        host._stage_id = 0
+        host._stage_id = stage_id
         return host
 
     def test_put_get_pop(self):
@@ -837,9 +857,6 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
 
     def test_recv_full_payload_inputs_populates_local_cache(self):
         host = self._make_host()
-        host._omni_connector = MockConnector(stage_id=0)
-        host._stage_id = 0
-
         # Simulate a full payload already staged by the bg recv path
         with host._lock:
             host._local_stage_payload_cache["r1"] = {"tok": [10]}
@@ -850,22 +867,22 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
         host.shutdown_omni_connectors()
 
     def test_rank0_only_polls_connector_for_tp_full_payload(self):
-        host = self._make_host()
-        host._omni_connector = MagicMock()
+        host = self._make_host(stage_id=2)
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._local_rank = 0
         host._request_ids_mapping["r1"] = "ext-r1"
         host._get_req_chunk["r1"] = 0
         payload = {"tok": [10], "finished": torch.tensor(True)}
         connector_result = (payload, 123)
-        host._omni_connector.get.return_value = connector_result
+        host._connectors.receive.get.return_value = connector_result
         tp_group = _FakeTPGroup(world_size=2, rank_in_group=0)
 
         with patch("vllm_omni.worker.omni_connector_model_runner_mixin.get_tp_group", return_value=tp_group):
             made_progress = host._poll_single_request("r1")
 
         self.assertTrue(made_progress)
-        host._omni_connector.get.assert_called_once_with("1", "2", "ext-r1_1_0")
+        host._connectors.receive.get.assert_called_once_with("1", "2", "ext-r1_1_0", metadata=None)
         self.assertEqual(tp_group.broadcast_inputs, [])
         self.assertEqual(host.get_local_stage_payload("r1"), payload)
         self.assertIn("r1", host._full_payload_pending_broadcast_req_ids)
@@ -874,8 +891,8 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
         host.shutdown_omni_connectors()
 
     def test_tp_follower_skips_connector_poll_for_full_payload(self):
-        host = self._make_host()
-        host._omni_connector = MagicMock()
+        host = self._make_host(stage_id=2)
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._local_rank = 1
         host._request_ids_mapping["r1"] = "ext-r1"
@@ -886,14 +903,14 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
             made_progress = host._poll_single_request("r1")
 
         self.assertFalse(made_progress)
-        host._omni_connector.get.assert_not_called()
+        host._connectors.receive.get.assert_not_called()
         self.assertEqual(tp_group.broadcast_inputs, [])
         self.assertNotIn("r1", host._local_stage_payload_cache)
         host.shutdown_omni_connectors()
 
     def test_recv_full_payload_inputs_broadcasts_tp_leader_results_to_followers(self):
         host = self._make_host()
-        host._omni_connector = MagicMock()
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._local_rank = 1
         host._pending_load_reqs["r1"] = object()
@@ -918,7 +935,7 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
         )
-        host._omni_connector = MagicMock()
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._async_chunk = True
         host._model_mode = "gen"
@@ -933,14 +950,14 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
             "codes": {"audio": [10, 11]},
             "meta": {"left_context_size": 0, "finished": torch.tensor(False)},
         }
-        host._omni_connector.get.return_value = (payload, 123)
+        host._connectors.receive.get.return_value = (payload, 123)
         tp_group = _FakeTPGroup(world_size=2, rank_in_group=0)
 
         with patch("vllm_omni.worker.omni_connector_model_runner_mixin.get_tp_group", return_value=tp_group):
             made_progress = host._poll_single_request("r1")
 
         self.assertTrue(made_progress)
-        host._omni_connector.get.assert_called_once_with("1", "2", "ext-r1_1_0")
+        host._connectors.receive.get.assert_called_once_with("1", "2", "ext-r1_1_0", metadata=None)
         self.assertEqual(host.get_local_stage_payload("r1"), payload)
         self.assertIn("r1", host._finished_load_reqs)
         self.assertIn("r1", host._async_chunk_updated_req_ids)
@@ -955,7 +972,7 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
             made_progress = host._poll_single_request("r1")
 
         self.assertFalse(made_progress)
-        host._omni_connector.get.assert_not_called()
+        host._connectors.receive.get.assert_not_called()
         self.assertIsNone(host.get_local_stage_payload("r1"))
         self.assertEqual(tp_group.broadcast_inputs, [])
         host.shutdown_omni_connectors()
@@ -1110,14 +1127,14 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
         )
-        host._omni_connector = MagicMock()
+        host._connectors.receive = MagicMock()
         host._stage_id = 1
         host._async_chunk = True
         host._model_mode = "ar"
         host._request_ids_mapping["r1"] = "ext-r1"
         host._get_req_chunk["r1"] = 0
 
-        host._omni_connector.get.side_effect = [
+        host._connectors.receive.get.side_effect = [
             (
                 {
                     "embed": {"decode": torch.ones(1, 2)},
@@ -1149,7 +1166,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
         )
-        host._omni_connector = MagicMock()
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._async_chunk = True
         host._model_mode = "gen"
@@ -1164,7 +1181,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         made_progress = host._poll_single_request("r1")
 
         self.assertFalse(made_progress)
-        host._omni_connector.get.assert_not_called()
+        host._connectors.receive.get.assert_not_called()
         self.assertEqual(host._get_req_chunk["r1"], 1)
 
         host.shutdown_omni_connectors()
@@ -1174,7 +1191,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
         )
-        host._omni_connector = MagicMock()
+        host._connectors.receive = MagicMock()
         host._stage_id = 2
         host._async_chunk = True
         host._model_mode = "gen"
@@ -1189,14 +1206,14 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         made_progress = host._poll_single_request("r1")
 
         self.assertFalse(made_progress)
-        host._omni_connector.get.assert_not_called()
+        host._connectors.receive.get.assert_not_called()
         self.assertEqual(host._get_req_chunk["r1"], 1)
 
         output = host.get_omni_connector_output()
         self.assertEqual(output.request_metadata["r1"]["code_predictor_codes"], [10, 11, 12])
         self.assertEqual(output.chunk_ready_req_ids, {"r1"})
 
-        host._omni_connector.get.return_value = (
+        host._connectors.receive.get.return_value = (
             {
                 "codes": {"audio": [20, 21, 22]},
                 "meta": {"left_context_size": 0, "finished": torch.tensor(False)},
@@ -1206,7 +1223,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         made_progress = host._poll_single_request("r1")
 
         self.assertTrue(made_progress)
-        host._omni_connector.get.assert_called_once()
+        host._connectors.receive.get.assert_called_once()
         self.assertEqual(host._get_req_chunk["r1"], 2)
 
         host.shutdown_omni_connectors()
@@ -1216,8 +1233,12 @@ class TestRankAwareKVRouting(unittest.TestCase):
     def _make_host(self, *, from_tp: int, to_tp: int, local_rank: int) -> MixinHost:
         host = MixinHost()
         host.init_omni_connectors(model_config=_make_model_config(stage_id=1))
-        host._from_tp = from_tp
-        host._to_tp = to_tp
+        host._recv_topology = KVTPTopology(from_tp, to_tp, local_rank)
+        host._send_topology = KVTPTopology(from_tp, to_tp, local_rank)
+        host._recv_from_tp = from_tp
+        host._recv_to_tp = to_tp
+        host._send_from_tp = from_tp
+        host._send_to_tp = to_tp
         host._local_rank = local_rank
         return host
 
@@ -1257,8 +1278,9 @@ class TestRankAwareKVRouting(unittest.TestCase):
         expected = ["req_0_0_1_1"]
         self.assertEqual(host.get_rank_aware_kv_send_keys("req", from_stage=0, to_stage=1), expected)
         self.assertEqual(host.get_rank_aware_kv_keys("req", from_stage=0, to_stage=1), expected)
-        self.assertEqual(host.get_kv_rank_mapping()["from_tp"], 2)
-        self.assertEqual(host.get_kv_rank_mapping()["to_tp"], 2)
+        mapping = host.get_kv_rank_mapping()
+        self.assertEqual(mapping["recv"]["from_tp"], 2)
+        self.assertEqual(mapping["recv"]["to_tp"], 2)
         host.shutdown_omni_connectors()
 
     def test_send_keys_route_from_rank_gt_to_rank(self):
@@ -1323,9 +1345,10 @@ class TestConnectorConfigValidation(unittest.TestCase):
     def test_invalid_connector_name_raises(self):
         host = MixinHost()
         model_config = _make_model_config(stage_id=1)
+        model_config.stage_connector_plan = None
         model_config.stage_connector_config = {"name": "   "}
 
-        with self.assertRaisesRegex(RuntimeError, "missing connector name"):
+        with self.assertRaisesRegex(ValueError, "missing connector name"):
             host.init_omni_connectors(model_config=model_config)
 
 
@@ -1360,7 +1383,7 @@ class TestSendRetry(unittest.TestCase):
         sender.init_omni_connectors(
             model_config=_make_model_config(stage_id=0, async_chunk=True),
         )
-        sender._omni_connector = connector
+        sender._connectors.send = connector
         sender._stage_id = 0
         sender._async_chunk = True
         return sender

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -703,7 +703,6 @@ def _make_full_payload_accumulation_runner(
     runner._custom_process_func = object()
     runner._pending_full_payload_send = {}
     runner._stage_id = 1
-    runner._omni_connector = object()
     return runner
 
 

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -1,4 +1,4 @@
-from dataclasses import MISSING, field
+from dataclasses import MISSING
 from typing import Any
 
 from pydantic import ConfigDict, TypeAdapter
@@ -14,6 +14,7 @@ from vllm.transformers_utils.model_arch_config_convertor import (
 )
 
 import vllm_omni.model_executor.models as me_models
+from vllm_omni.distributed.omni_connectors.utils.config import StageConnectorPlan, StageConnectorSpec
 
 logger = init_logger(__name__)
 
@@ -102,11 +103,9 @@ class OmniModelConfig(ModelConfig):
          engine_output_type: Optional output type specification for the engine.
              Used to route outputs to appropriate processors (e.g., "image",
              "audio", "latents"). If None, output type is inferred.
-         stage_connector_config: Stage connector configuration dictionary.
-             Contains "name" (connector name), "extra" (extra connector config).
+         stage_connector_plan: Independent inbound and outbound stage connectors.
          task_type: Model-defined startup task type. Each model validates its
              supported values and applies the corresponding behavior.
-
 
     The correct way to initialize this class is via vLLM config, as most
     of the logic for handling values is in the ModelConfig's __post_init__.
@@ -136,12 +135,7 @@ class OmniModelConfig(ModelConfig):
     pooling_output_decoder: str | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
-    stage_connector_config: dict[str, Any] = field(
-        default_factory=lambda: {
-            "name": "SharedMemoryConnector",
-            "extra": {},
-        }
-    )
+    stage_connector_plan: StageConnectorPlan | None = None
     subtalker_sampling_params: dict[str, Any] | None = None
     silence_ban_frames: int = 0
     omni_kv_config: dict | None = None
@@ -159,6 +153,36 @@ class OmniModelConfig(ModelConfig):
     @property
     def registry(self):
         return me_models.OmniModelRegistry
+
+    def _connector_config(self, edge: StageConnectorSpec | None) -> dict[str, Any] | None:
+        if edge is None:
+            return None
+        extra = dict(edge.spec.extra)
+        extra.update(
+            stage_id=self.stage_id,
+            from_stage=edge.from_stage,
+            to_stage=edge.to_stage,
+        )
+        return {"name": edge.spec.name, "extra": extra}
+
+    @property
+    def stage_input_connector_config(self) -> dict[str, Any] | None:
+        plan = self.stage_connector_plan
+        if plan is None:
+            return {"name": "SharedMemoryConnector", "extra": {}}
+        return self._connector_config(plan.inbound)
+
+    @property
+    def stage_output_connector_config(self) -> dict[str, Any] | None:
+        plan = self.stage_connector_plan
+        if plan is None:
+            return {"name": "SharedMemoryConnector", "extra": {}}
+        return self._connector_config(plan.outbound)
+
+    @property
+    def stage_connector_config(self) -> dict[str, Any] | None:
+        """Compatibility view for model code that only needs connector extras."""
+        return self.stage_input_connector_config or self.stage_output_connector_config
 
     @property
     def architectures(self) -> list[str]:

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -1,4 +1,5 @@
 from dataclasses import MISSING
+from types import SimpleNamespace
 from typing import Any
 
 from pydantic import ConfigDict, TypeAdapter
@@ -104,6 +105,7 @@ class OmniModelConfig(ModelConfig):
              Used to route outputs to appropriate processors (e.g., "image",
              "audio", "latents"). If None, output type is inferred.
          stage_connector_plan: Independent inbound and outbound stage connectors.
+         stage_connector_config: Deprecated single-connector compatibility field.
          task_type: Model-defined startup task type. Each model validates its
              supported values and applies the corresponding behavior.
 
@@ -178,6 +180,14 @@ class OmniModelConfig(ModelConfig):
         if plan is None:
             return {"name": "SharedMemoryConnector", "extra": {}}
         return self._connector_config(plan.outbound)
+
+    @property
+    def stage_connector_config(self) -> dict[str, Any] | None:
+        """Deprecated single-connector view; prefer ``stage_connector_plan``."""
+        plan = self.stage_connector_plan
+        if plan is None:
+            return {"name": "SharedMemoryConnector", "extra": {}}
+        return self._connector_config(plan.inbound or plan.outbound)
 
     @property
     def architectures(self) -> list[str]:
@@ -307,6 +317,22 @@ class OmniModelConfig(ModelConfig):
         faster than creating the OmniModelConfig directly from the ModelConfig,
         and saves us from having to pass all kwargs to the OmniModelConfig.
         """
+        legacy_connector_config = omni_kwargs.pop("stage_connector_config", MISSING)
+        if legacy_connector_config is not MISSING:
+            if "stage_connector_plan" in omni_kwargs:
+                raise ValueError("Cannot specify both stage_connector_config and stage_connector_plan")
+            from vllm_omni.distributed.omni_connectors.utils.initialization import (
+                connector_plan_from_model_config,
+            )
+
+            omni_kwargs["stage_connector_plan"] = connector_plan_from_model_config(
+                SimpleNamespace(
+                    stage_id=omni_kwargs.get("stage_id", 0),
+                    stage_connector_config=legacy_connector_config,
+                    stage_connector_plan=None,
+                )
+            )
+
         # Add missing defaults to the omni kwargs and ensure values are valid
         cls.add_defaults_to_omni_kwargs(omni_kwargs)
         cls._validate_omni_fields(**omni_kwargs)

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -180,17 +180,6 @@ class OmniModelConfig(ModelConfig):
         return self._connector_config(plan.outbound)
 
     @property
-    def stage_connector_config(self) -> dict[str, Any] | None:
-        """Compatibility view for model code that only needs connector extras.
-
-        Ambiguous on a stage with both an inbound and an outbound edge (a
-        middle/dual stage): this always prefers the inbound config. Producer-side
-        readers on such a stage must use ``stage_output_connector_config`` explicitly
-        instead of this property.
-        """
-        return self.stage_input_connector_config or self.stage_output_connector_config
-
-    @property
     def architectures(self) -> list[str]:
         # Falsy (None or "") means "no stage override": fall back to the
         # checkpoint config's own architectures. The stage-config builder

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -181,7 +181,13 @@ class OmniModelConfig(ModelConfig):
 
     @property
     def stage_connector_config(self) -> dict[str, Any] | None:
-        """Compatibility view for model code that only needs connector extras."""
+        """Compatibility view for model code that only needs connector extras.
+
+        Ambiguous on a stage with both an inbound and an outbound edge (a
+        middle/dual stage): this always prefers the inbound config. Producer-side
+        readers on such a stage must use ``stage_output_connector_config`` explicitly
+        instead of this property.
+        """
         return self.stage_input_connector_config or self.stage_output_connector_config
 
     @property

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -673,7 +673,7 @@ class OmniSchedulerMixin:
         self,
         request_ids: str | Iterable[str] | None,
         finished_status: RequestStatus,
-    ) -> list[Request]:
+    ) -> list[tuple[str, int]]:
         """Finish requests and clean all Omni-owned queue/coordinator state."""
         if isinstance(request_ids, str):
             target_request_ids = {request_ids}
@@ -706,8 +706,8 @@ class OmniSchedulerMixin:
         self._purge_finished_from_running(target_request_ids)
         self._resync_streaming_input_counter()
 
-        for request in finished:
-            self._free_input_coordinator_request(request.request_id)
+        for request_id, _ in finished:
+            self._free_input_coordinator_request(request_id)
         return finished
 
     def make_stats(self, *args, **kwargs) -> SchedulerStats | None:

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -673,7 +673,7 @@ class OmniSchedulerMixin:
         self,
         request_ids: str | Iterable[str] | None,
         finished_status: RequestStatus,
-    ) -> list[tuple[str, int]]:
+    ) -> list[Request]:
         """Finish requests and clean all Omni-owned queue/coordinator state."""
         if isinstance(request_ids, str):
             target_request_ids = {request_ids}
@@ -706,8 +706,8 @@ class OmniSchedulerMixin:
         self._purge_finished_from_running(target_request_ids)
         self._resync_streaming_input_counter()
 
-        for request_id, _ in finished:
-            self._free_input_coordinator_request(request_id)
+        for request in finished:
+            self._free_input_coordinator_request(request.request_id)
         return finished
 
     def make_stats(self, *args, **kwargs) -> SchedulerStats | None:

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -121,6 +121,7 @@ class OmniSchedulingCoordinator:
                     OmniChunkRecvHandle(
                         request_id=request.request_id,
                         external_req_id=getattr(request, "external_req_id", None),
+                        sender_info=getattr(request, "sender_info", None),
                     )
                 )
             elif request.status == RequestStatus.WAITING_FOR_INPUT:
@@ -134,6 +135,7 @@ class OmniSchedulingCoordinator:
                         OmniChunkRecvHandle(
                             request_id=request.request_id,
                             external_req_id=getattr(request, "external_req_id", None),
+                            sender_info=getattr(request, "sender_info", None),
                         )
                     )
         if to_remove:

--- a/vllm_omni/core/sched/output.py
+++ b/vllm_omni/core/sched/output.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field, fields
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 from vllm.v1.request import Request
 
-from vllm_omni.engine import AdditionalInformationPayload
+from vllm_omni.engine import AdditionalInformationPayload, ConnectorEndpoint
 
 
 @dataclass
@@ -95,16 +95,12 @@ class OmniChunkRecvHandle:
     """Minimal identifier carried from scheduler to runner for input-receive
     registration.
 
-    The runner's ``register_chunk_recv`` only consumes ``request_id`` and
-    ``external_req_id`` from each pending request, so we ship just those
-    two fields instead of the full Request object.  Concrete typing
-    keeps msgspec serialization deterministic across IPC (default,
-    PD-disagg, multi-node executor variants) and avoids the
-    ``list[Any]`` fallback path.
+    Carries only the fields needed to register an inbound transfer.
     """
 
     request_id: str
     external_req_id: str | None = None
+    sender_info: ConnectorEndpoint | None = None
 
 
 @dataclass

--- a/vllm_omni/distributed/omni_connectors/__init__.py
+++ b/vllm_omni/distributed/omni_connectors/__init__.py
@@ -22,15 +22,17 @@ try:
     from .connectors.mori_transfer_engine_connector import MoriTransferEngineConnector
 except ImportError:
     MoriTransferEngineConnector = None  # RDMA deps (msgspec/zmq/mori) not installed
-from .factory import OmniConnectorFactory
-from .utils.config import ConnectorSpec, OmniTransferConfig
+from .factory import OmniConnectorFactory, StageConnectorSet
+from .utils.config import ConnectorSpec, OmniTransferConfig, StageConnectorPlan, StageConnectorSpec
 from .utils.initialization import (
     build_stage_connectors,
+    default_stage_connector_plan,
     get_connectors_config_for_stage,
     get_stage_connector_config,
     initialize_connectors_from_config,
     initialize_orchestrator_connectors,
     load_omni_transfer_config,
+    resolve_stage_connector_plan,
 )
 
 # Backward-compatible alias: MooncakeConnector was renamed to MooncakeStoreConnector.
@@ -41,10 +43,13 @@ __all__ = [
     # Config
     "ConnectorSpec",
     "OmniTransferConfig",
+    "StageConnectorPlan",
+    "StageConnectorSpec",
     # Base classes and implementations
     "OmniConnectorBase",
     # Factory
     "OmniConnectorFactory",
+    "StageConnectorSet",
     # Specific implementations
     "MooncakeConnector",  # compat alias → MooncakeStoreConnector
     "MooncakeStoreConnector",
@@ -57,6 +62,8 @@ __all__ = [
     "load_omni_transfer_config",
     "initialize_connectors_from_config",
     "get_connectors_config_for_stage",
+    "default_stage_connector_plan",
+    "resolve_stage_connector_plan",
     # Manager helpers
     "initialize_orchestrator_connectors",
     "get_stage_connector_config",

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -172,11 +172,11 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # The orchestration layer (get_connectors_config_for_stage /
         # kv_transfer_manager) is responsible for injecting the correct role.
         role = str(config.get("role", "sender")).lower()
-        if role not in {"sender", "receiver"}:
+        if role not in {"sender", "receiver", "dual"}:
             raise ValueError(
-                f"Invalid role={role!r} for MooncakeTransferEngineConnector. Expected 'sender' or 'receiver'."
+                f"Invalid role={role!r} for MooncakeTransferEngineConnector. Expected 'sender', 'receiver', or 'dual'."
             )
-        self.can_put = role == "sender"
+        self.can_put = role in {"sender", "dual"}
 
         self.engine_id = str(uuid.uuid4())
 

--- a/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
@@ -536,8 +536,11 @@ class MoriTransferEngineConnector(OmniConnectorBase):
             host = self.sender_host
             port = self.sender_zmq_port
         if not host or not port or str(host).lower() == "auto":
-            logger.debug(f"get() has no routable sender endpoint yet for {get_key}; treating as not ready")
-            return None
+            raise RuntimeError(
+                f"get() requires a routable sender endpoint, but "
+                f"sender_host={host!r}, sender_zmq_port={port!r}. "
+                f"Call update_sender_info(host, port) before receiving."
+            )
         return self._query_metadata_at(get_key, str(host), int(port))
 
     # ----------------------------------------------------------------- get()

--- a/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
@@ -536,7 +536,8 @@ class MoriTransferEngineConnector(OmniConnectorBase):
             host = self.sender_host
             port = self.sender_zmq_port
         if not host or not port or str(host).lower() == "auto":
-            raise RuntimeError("get() requires a routable sender endpoint")
+            logger.debug(f"get() has no routable sender endpoint yet for {get_key}; treating as not ready")
+            return None
         return self._query_metadata_at(get_key, str(host), int(port))
 
     # ----------------------------------------------------------------- get()

--- a/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py
@@ -214,10 +214,12 @@ class MoriTransferEngineConnector(OmniConnectorBase):
         #                upstream sender whose endpoint lives in
         #                ``sender_host`` / ``sender_zmq_port``.
         role = str(config.get("role", "sender")).lower()
-        if role not in {"sender", "receiver"}:
-            raise ValueError(f"Invalid role={role!r} for MoriTransferEngineConnector. Expected 'sender' or 'receiver'.")
+        if role not in {"sender", "receiver", "dual"}:
+            raise ValueError(
+                f"Invalid role={role!r} for MoriTransferEngineConnector. Expected 'sender', 'receiver', or 'dual'."
+            )
         self.role = role
-        self.can_put = role == "sender"
+        self.can_put = role in {"sender", "dual"}
 
         # ---- Mori IOEngine ----
         if self.device_name:
@@ -501,9 +503,9 @@ class MoriTransferEngineConnector(OmniConnectorBase):
             logger.error(f"Put failed for {put_key}: {e}", exc_info=True)
             return False, 0, None
 
-    # ------------------------------------------------ query (no-metadata get)
-    def _query_metadata_from_sender(self, get_key: str) -> dict[str, Any] | None:
-        zmq_addr = f"tcp://{self.sender_host}:{self.sender_zmq_port}"
+    # ------------------------------------------------ metadata query
+    def _query_metadata_at(self, get_key: str, host: str, port: int) -> dict[str, Any] | None:
+        zmq_addr = f"tcp://{host}:{port}"
         req_socket = self._get_req_socket(zmq_addr, timeout_ms=5000)
         try:
             q = QueryRequest(request_id=get_key)
@@ -513,8 +515,8 @@ class MoriTransferEngineConnector(OmniConnectorBase):
                 return None
             qr = msgspec.msgpack.decode(resp, type=QueryResponse)
             return {
-                "source_host": self.sender_host,
-                "source_port": self.sender_zmq_port,
+                "source_host": host,
+                "source_port": port,
                 "data_size": qr.data_size,
                 "is_fast_path": qr.is_fast_path,
             }
@@ -522,6 +524,20 @@ class MoriTransferEngineConnector(OmniConnectorBase):
             self._invalidate_req_socket(zmq_addr)
             logger.debug(f"Metadata query failed for {get_key}: {e}")
             return None
+
+    def _resolve_metadata(self, get_key: str, metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+        if metadata and "data_size" in metadata:
+            return metadata
+
+        if metadata:
+            host = metadata.get("source_host")
+            port = metadata.get("source_port")
+        else:
+            host = self.sender_host
+            port = self.sender_zmq_port
+        if not host or not port or str(host).lower() == "auto":
+            raise RuntimeError("get() requires a routable sender endpoint")
+        return self._query_metadata_at(get_key, str(host), int(port))
 
     # ----------------------------------------------------------------- get()
     def get(
@@ -537,13 +553,9 @@ class MoriTransferEngineConnector(OmniConnectorBase):
         get_key = self._make_key(get_key, from_stage, to_stage)
         _t0 = _time_mod.perf_counter()
 
-        # Resolve metadata
+        metadata = self._resolve_metadata(get_key, metadata)
         if not metadata:
-            if not self.sender_host or not self.sender_zmq_port or str(self.sender_host).lower() == "auto":
-                raise RuntimeError("get(metadata=None) requires sender info. Call update_sender_info() first.")
-            metadata = self._query_metadata_from_sender(get_key)
-            if not metadata:
-                return None
+            return None
 
         _t1 = _time_mod.perf_counter()
         _query_ms = (_t1 - _t0) * 1000

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -59,17 +59,22 @@ class OmniConnectorFactory:
     """Factory for creating OmniConnectors."""
 
     _registry: dict[str, Callable[[dict[str, Any]], OmniConnectorBase]] = {}
+    _dual_role_connectors: set[str] = set()
 
     @classmethod
     def register_connector(
         cls,
         name: str,
         constructor: Callable[[dict[str, Any]], OmniConnectorBase],
+        *,
+        supports_dual: bool = False,
     ) -> None:
         """Register a connector constructor."""
         if name in cls._registry:
             raise ValueError(f"Connector '{name}' is already registered.")
         cls._registry[name] = constructor
+        if supports_dual:
+            cls._dual_role_connectors.add(name)
         logger.debug(f"Registered connector: {name}")
 
     @classmethod
@@ -99,7 +104,12 @@ class OmniConnectorFactory:
         receive = cls.materialize_connector_spec(plan.inbound, "receiver", stage_id, local_rank, replica_id)
         send = cls.materialize_connector_spec(plan.outbound, "sender", stage_id, local_rank, replica_id)
 
-        if receive is not None and send is not None and receive.name == send.name:
+        if (
+            receive is not None
+            and send is not None
+            and receive.name == send.name
+            and receive.name in cls._dual_role_connectors
+        ):
             dual = _merge_dual_config(receive.extra, send.extra)
             if dual is not None:
                 connector = cls.create_connector(ConnectorSpec(receive.name, dual))
@@ -263,29 +273,36 @@ def _merge_dual_config(receive: dict[str, Any], send: dict[str, Any]) -> dict[st
 OmniConnectorFactory.register_connector(
     "MooncakeStoreConnector",
     _create_mooncake_store_connector,
+    supports_dual=True,
 )
 OmniConnectorFactory.register_connector(
     "MooncakeTransferEngineConnector",
     _create_mooncake_transfer_engine_connector,
+    supports_dual=True,
 )
 OmniConnectorFactory.register_connector(
     "SharedMemoryConnector",
     _create_shm_connector,
+    supports_dual=True,
 )
 OmniConnectorFactory.register_connector(
     "YuanrongConnector",
     _create_yuanrong_connector,
+    supports_dual=True,
 )
 OmniConnectorFactory.register_connector(
     "YuanrongTransferEngineConnector",
     _create_yuanrong_transfer_engine_connector,
+    supports_dual=True,
 )
 OmniConnectorFactory.register_connector(
     "MoriTransferEngineConnector",
     _create_mori_transfer_engine_connector,
+    supports_dual=True,
 )
 # Backward-compatible aliases – will be removed in the future
 OmniConnectorFactory.register_connector(
     "MooncakeConnector",
     _create_mooncake_store_connector,
+    supports_dual=True,
 )

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -11,7 +11,6 @@ from .utils.logging import get_connector_logger
 try:
     from .connectors.base import OmniConnectorBase
     from .utils.config import (
-        TRANSFER_ENGINE_CONNECTOR_NAMES,
         ConnectorSpec,
         StageConnectorPlan,
         StageConnectorSpec,
@@ -23,7 +22,6 @@ except ImportError:
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
     from omni_connectors.connectors.base import OmniConnectorBase
     from omni_connectors.utils.config import (
-        TRANSFER_ENGINE_CONNECTOR_NAMES,
         ConnectorSpec,
         StageConnectorPlan,
         StageConnectorSpec,
@@ -32,17 +30,10 @@ except ImportError:
 logger = get_connector_logger(__name__)
 
 
-DualConfigMerger = Callable[[dict[str, Any], dict[str, Any]], dict[str, Any] | None]
-
-
-@dataclass(frozen=True)
-class _ConnectorRegistration:
-    constructor: Callable[[dict[str, Any]], OmniConnectorBase]
-    merge_dual: DualConfigMerger | None = None
-
-
 @dataclass
 class StageConnectorSet:
+    """The receive/send connectors owned by one stage."""
+
     receive: OmniConnectorBase | None = None
     send: OmniConnectorBase | None = None
 
@@ -61,20 +52,18 @@ class StageConnectorSet:
 class OmniConnectorFactory:
     """Factory for creating OmniConnectors."""
 
-    _registry: dict[str, _ConnectorRegistration] = {}
+    _registry: dict[str, Callable[[dict[str, Any]], OmniConnectorBase]] = {}
 
     @classmethod
     def register_connector(
         cls,
         name: str,
         constructor: Callable[[dict[str, Any]], OmniConnectorBase],
-        *,
-        merge_dual: DualConfigMerger | None = None,
     ) -> None:
         """Register a connector constructor."""
         if name in cls._registry:
             raise ValueError(f"Connector '{name}' is already registered.")
-        cls._registry[name] = _ConnectorRegistration(constructor, merge_dual)
+        cls._registry[name] = constructor
         logger.debug(f"Registered connector: {name}")
 
     @classmethod
@@ -83,7 +72,7 @@ class OmniConnectorFactory:
         if spec.name not in cls._registry:
             raise ValueError(f"Unknown connector: {spec.name}. Available: {list(cls._registry.keys())}")
 
-        constructor = cls._registry[spec.name].constructor
+        constructor = cls._registry[spec.name]
         try:
             connector = constructor(spec.extra)
             logger.info(f"Created connector: {spec.name}")
@@ -105,13 +94,10 @@ class OmniConnectorFactory:
         send = cls.materialize_connector_spec(plan.outbound, "sender", stage_id, local_rank, replica_id)
 
         if receive is not None and send is not None and receive.name == send.name:
-            registration = cls._registry.get(receive.name)
-            merger = registration.merge_dual if registration is not None else None
-            if merger is not None:
-                dual = merger(receive.extra, send.extra)
-                if dual is not None:
-                    connector = cls.create_connector(ConnectorSpec(receive.name, dual))
-                    return StageConnectorSet(receive=connector, send=connector)
+            dual = _merge_dual_config(receive.extra, send.extra)
+            if dual is not None:
+                connector = cls.create_connector(ConnectorSpec(receive.name, dual))
+                return StageConnectorSet(receive=connector, send=connector)
 
         return StageConnectorSet(
             receive=cls.create_connector(receive) if receive is not None else None,
@@ -132,13 +118,24 @@ class OmniConnectorFactory:
         extra = dict(edge.spec.extra)
         extra["stage_id"] = stage_id
         extra["role"] = role
-        if edge.spec.name in TRANSFER_ENGINE_CONNECTOR_NAMES:
-            from .utils.initialization import KV_RANK_PORT_STRIDE, KV_REPLICA_PORT_STRIDE
+        from .utils.config import TRANSFER_ENGINE_CONNECTOR_NAMES
 
-            offset = replica_id * KV_REPLICA_PORT_STRIDE + local_rank * KV_RANK_PORT_STRIDE
-            extra["zmq_port"] = int(os.path.expandvars(str(extra.get("zmq_port", 50051)))) + offset
+        if edge.spec.name in TRANSFER_ENGINE_CONNECTOR_NAMES:
+            from .utils.env import expand_env_int
+            from .utils.kv_utils import kv_zmq_port
+
+            base_port = expand_env_int(extra.get("zmq_port", 50051), "zmq_port")
+            extra["zmq_port"] = kv_zmq_port(
+                base_port,
+                edge.from_stage,
+                local_rank=local_rank,
+                replica_id=replica_id,
+            )
+            # This is the upstream endpoint. Its rank and replica belong to
+            # the producer, not this worker; request metadata supplies the
+            # exact endpoint when heterogeneous TP/replica routing is used.
             if extra.get("sender_zmq_port") is not None:
-                extra["sender_zmq_port"] = int(os.path.expandvars(str(extra["sender_zmq_port"]))) + offset
+                extra["sender_zmq_port"] = expand_env_int(extra["sender_zmq_port"], "sender_zmq_port")
         return ConnectorSpec(edge.spec.name, extra)
 
     @classmethod
@@ -255,36 +252,29 @@ def _merge_dual_config(receive: dict[str, Any], send: dict[str, Any]) -> dict[st
 OmniConnectorFactory.register_connector(
     "MooncakeStoreConnector",
     _create_mooncake_store_connector,
-    merge_dual=_merge_dual_config,
 )
 OmniConnectorFactory.register_connector(
     "MooncakeTransferEngineConnector",
     _create_mooncake_transfer_engine_connector,
-    merge_dual=_merge_dual_config,
 )
 OmniConnectorFactory.register_connector(
     "SharedMemoryConnector",
     _create_shm_connector,
-    merge_dual=_merge_dual_config,
 )
 OmniConnectorFactory.register_connector(
     "YuanrongConnector",
     _create_yuanrong_connector,
-    merge_dual=_merge_dual_config,
 )
 OmniConnectorFactory.register_connector(
     "YuanrongTransferEngineConnector",
     _create_yuanrong_transfer_engine_connector,
-    merge_dual=_merge_dual_config,
 )
 OmniConnectorFactory.register_connector(
     "MoriTransferEngineConnector",
     _create_mori_transfer_engine_connector,
-    merge_dual=_merge_dual_config,
 )
 # Backward-compatible aliases – will be removed in the future
 OmniConnectorFactory.register_connector(
     "MooncakeConnector",
     _create_mooncake_store_connector,
-    merge_dual=_merge_dual_config,
 )

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -99,10 +99,15 @@ class OmniConnectorFactory:
                 connector = cls.create_connector(ConnectorSpec(receive.name, dual))
                 return StageConnectorSet(receive=connector, send=connector)
 
-        return StageConnectorSet(
-            receive=cls.create_connector(receive) if receive is not None else None,
-            send=cls.create_connector(send) if send is not None else None,
-        )
+        receive_connector = None
+        try:
+            receive_connector = cls.create_connector(receive) if receive is not None else None
+            send_connector = cls.create_connector(send) if send is not None else None
+        except Exception:
+            if receive_connector is not None:
+                receive_connector.close()
+            raise
+        return StageConnectorSet(receive=receive_connector, send=send_connector)
 
     @staticmethod
     def materialize_connector_spec(

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -3,35 +3,78 @@
 
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from .utils.logging import get_connector_logger
 
 try:
     from .connectors.base import OmniConnectorBase
-    from .utils.config import ConnectorSpec
+    from .utils.config import (
+        TRANSFER_ENGINE_CONNECTOR_NAMES,
+        ConnectorSpec,
+        StageConnectorPlan,
+        StageConnectorSpec,
+    )
 except ImportError:
     # Fallback for direct execution
     import sys
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
     from omni_connectors.connectors.base import OmniConnectorBase
-    from omni_connectors.utils.config import ConnectorSpec
+    from omni_connectors.utils.config import (
+        TRANSFER_ENGINE_CONNECTOR_NAMES,
+        ConnectorSpec,
+        StageConnectorPlan,
+        StageConnectorSpec,
+    )
 
 logger = get_connector_logger(__name__)
+
+
+DualConfigMerger = Callable[[dict[str, Any], dict[str, Any]], dict[str, Any] | None]
+
+
+@dataclass(frozen=True)
+class _ConnectorRegistration:
+    constructor: Callable[[dict[str, Any]], OmniConnectorBase]
+    merge_dual: DualConfigMerger | None = None
+
+
+@dataclass
+class StageConnectorSet:
+    receive: OmniConnectorBase | None = None
+    send: OmniConnectorBase | None = None
+
+    @property
+    def connector(self) -> OmniConnectorBase | None:
+        """Backward-compatible single-connector view."""
+        return self.send or self.receive
+
+    def close(self) -> None:
+        if self.receive is not None:
+            self.receive.close()
+        if self.send is not None and self.send is not self.receive:
+            self.send.close()
 
 
 class OmniConnectorFactory:
     """Factory for creating OmniConnectors."""
 
-    _registry: dict[str, Callable[[dict[str, Any]], OmniConnectorBase]] = {}
+    _registry: dict[str, _ConnectorRegistration] = {}
 
     @classmethod
-    def register_connector(cls, name: str, constructor: Callable[[dict[str, Any]], OmniConnectorBase]) -> None:
+    def register_connector(
+        cls,
+        name: str,
+        constructor: Callable[[dict[str, Any]], OmniConnectorBase],
+        *,
+        merge_dual: DualConfigMerger | None = None,
+    ) -> None:
         """Register a connector constructor."""
         if name in cls._registry:
             raise ValueError(f"Connector '{name}' is already registered.")
-        cls._registry[name] = constructor
+        cls._registry[name] = _ConnectorRegistration(constructor, merge_dual)
         logger.debug(f"Registered connector: {name}")
 
     @classmethod
@@ -40,7 +83,7 @@ class OmniConnectorFactory:
         if spec.name not in cls._registry:
             raise ValueError(f"Unknown connector: {spec.name}. Available: {list(cls._registry.keys())}")
 
-        constructor = cls._registry[spec.name]
+        constructor = cls._registry[spec.name].constructor
         try:
             connector = constructor(spec.extra)
             logger.info(f"Created connector: {spec.name}")
@@ -48,6 +91,55 @@ class OmniConnectorFactory:
         except Exception as e:
             logger.error(f"Failed to create connector {spec.name}: {e}")
             raise ValueError(f"Failed to create connector {spec.name}: {e}")
+
+    @classmethod
+    def create_stage_connectors(
+        cls,
+        plan: StageConnectorPlan,
+        *,
+        stage_id: int,
+        local_rank: int = 0,
+        replica_id: int = 0,
+    ) -> StageConnectorSet:
+        receive = cls.materialize_connector_spec(plan.inbound, "receiver", stage_id, local_rank, replica_id)
+        send = cls.materialize_connector_spec(plan.outbound, "sender", stage_id, local_rank, replica_id)
+
+        if receive is not None and send is not None and receive.name == send.name:
+            registration = cls._registry.get(receive.name)
+            merger = registration.merge_dual if registration is not None else None
+            if merger is not None:
+                dual = merger(receive.extra, send.extra)
+                if dual is not None:
+                    connector = cls.create_connector(ConnectorSpec(receive.name, dual))
+                    return StageConnectorSet(receive=connector, send=connector)
+
+        return StageConnectorSet(
+            receive=cls.create_connector(receive) if receive is not None else None,
+            send=cls.create_connector(send) if send is not None else None,
+        )
+
+    @staticmethod
+    def materialize_connector_spec(
+        edge: StageConnectorSpec | None,
+        role: str,
+        stage_id: int,
+        local_rank: int,
+        replica_id: int,
+    ) -> ConnectorSpec | None:
+        if edge is None:
+            return None
+
+        extra = dict(edge.spec.extra)
+        extra["stage_id"] = stage_id
+        extra["role"] = role
+        if edge.spec.name in TRANSFER_ENGINE_CONNECTOR_NAMES:
+            from .utils.initialization import KV_RANK_PORT_STRIDE, KV_REPLICA_PORT_STRIDE
+
+            offset = replica_id * KV_REPLICA_PORT_STRIDE + local_rank * KV_RANK_PORT_STRIDE
+            extra["zmq_port"] = int(os.path.expandvars(str(extra.get("zmq_port", 50051)))) + offset
+            if extra.get("sender_zmq_port") is not None:
+                extra["sender_zmq_port"] = int(os.path.expandvars(str(extra["sender_zmq_port"]))) + offset
+        return ConnectorSpec(edge.spec.name, extra)
 
     @classmethod
     def list_registered_connectors(cls) -> list[str]:
@@ -125,12 +217,74 @@ def _create_mori_transfer_engine_connector(config: dict[str, Any]) -> OmniConnec
     return MoriTransferEngineConnector(config)
 
 
+_DIRECTIONAL_KEYS = {
+    "from_stage",
+    "rank_mapping",
+    "role",
+    "sender_host",
+    "sender_zmq_port",
+    "stage_id",
+    "to_stage",
+    "zmq_port",
+}
+
+
+def _merge_dual_config(receive: dict[str, Any], send: dict[str, Any]) -> dict[str, Any] | None:
+    """Merge compatible configs for a connector that can send and receive."""
+    shared_keys = (receive.keys() | send.keys()) - _DIRECTIONAL_KEYS
+    if any(receive.get(key) != send.get(key) for key in shared_keys):
+        return None
+
+    merged = dict(send)
+    for key in ("sender_host", "sender_zmq_port"):
+        if receive.get(key) is not None:
+            merged[key] = receive[key]
+    recv_mapping = receive.get("rank_mapping")
+    send_mapping = send.get("rank_mapping")
+    if recv_mapping != send_mapping:
+        merged.pop("rank_mapping", None)
+        if recv_mapping is not None:
+            merged["recv_rank_mapping"] = recv_mapping
+        if send_mapping is not None:
+            merged["send_rank_mapping"] = send_mapping
+    merged["role"] = "dual"
+    return merged
+
+
 # Register connectors
-OmniConnectorFactory.register_connector("MooncakeStoreConnector", _create_mooncake_store_connector)
-OmniConnectorFactory.register_connector("MooncakeTransferEngineConnector", _create_mooncake_transfer_engine_connector)
-OmniConnectorFactory.register_connector("SharedMemoryConnector", _create_shm_connector)
-OmniConnectorFactory.register_connector("YuanrongConnector", _create_yuanrong_connector)
-OmniConnectorFactory.register_connector("YuanrongTransferEngineConnector", _create_yuanrong_transfer_engine_connector)
-OmniConnectorFactory.register_connector("MoriTransferEngineConnector", _create_mori_transfer_engine_connector)
+OmniConnectorFactory.register_connector(
+    "MooncakeStoreConnector",
+    _create_mooncake_store_connector,
+    merge_dual=_merge_dual_config,
+)
+OmniConnectorFactory.register_connector(
+    "MooncakeTransferEngineConnector",
+    _create_mooncake_transfer_engine_connector,
+    merge_dual=_merge_dual_config,
+)
+OmniConnectorFactory.register_connector(
+    "SharedMemoryConnector",
+    _create_shm_connector,
+    merge_dual=_merge_dual_config,
+)
+OmniConnectorFactory.register_connector(
+    "YuanrongConnector",
+    _create_yuanrong_connector,
+    merge_dual=_merge_dual_config,
+)
+OmniConnectorFactory.register_connector(
+    "YuanrongTransferEngineConnector",
+    _create_yuanrong_transfer_engine_connector,
+    merge_dual=_merge_dual_config,
+)
+OmniConnectorFactory.register_connector(
+    "MoriTransferEngineConnector",
+    _create_mori_transfer_engine_connector,
+    merge_dual=_merge_dual_config,
+)
 # Backward-compatible aliases – will be removed in the future
-OmniConnectorFactory.register_connector("MooncakeConnector", _create_mooncake_store_connector)
+OmniConnectorFactory.register_connector(
+    "MooncakeConnector",
+    _create_mooncake_store_connector,
+    merge_dual=_merge_dual_config,
+)

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -269,40 +269,13 @@ def _merge_dual_config(receive: dict[str, Any], send: dict[str, Any]) -> dict[st
     return merged
 
 
-# Register connectors
-OmniConnectorFactory.register_connector(
-    "MooncakeStoreConnector",
-    _create_mooncake_store_connector,
-    supports_dual=True,
-)
-OmniConnectorFactory.register_connector(
-    "MooncakeTransferEngineConnector",
-    _create_mooncake_transfer_engine_connector,
-    supports_dual=True,
-)
-OmniConnectorFactory.register_connector(
-    "SharedMemoryConnector",
-    _create_shm_connector,
-    supports_dual=True,
-)
-OmniConnectorFactory.register_connector(
-    "YuanrongConnector",
-    _create_yuanrong_connector,
-    supports_dual=True,
-)
-OmniConnectorFactory.register_connector(
-    "YuanrongTransferEngineConnector",
-    _create_yuanrong_transfer_engine_connector,
-    supports_dual=True,
-)
-OmniConnectorFactory.register_connector(
-    "MoriTransferEngineConnector",
-    _create_mori_transfer_engine_connector,
-    supports_dual=True,
-)
-# Backward-compatible aliases – will be removed in the future
-OmniConnectorFactory.register_connector(
-    "MooncakeConnector",
-    _create_mooncake_store_connector,
-    supports_dual=True,
-)
+for _name, _constructor in (
+    ("MooncakeStoreConnector", _create_mooncake_store_connector),
+    ("MooncakeTransferEngineConnector", _create_mooncake_transfer_engine_connector),
+    ("SharedMemoryConnector", _create_shm_connector),
+    ("YuanrongConnector", _create_yuanrong_connector),
+    ("YuanrongTransferEngineConnector", _create_yuanrong_transfer_engine_connector),
+    ("MoriTransferEngineConnector", _create_mori_transfer_engine_connector),
+    ("MooncakeConnector", _create_mooncake_store_connector),
+):
+    OmniConnectorFactory.register_connector(_name, _constructor, supports_dual=True)

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -44,9 +44,15 @@ class StageConnectorSet:
 
     def close(self) -> None:
         if self.receive is not None:
-            self.receive.close()
+            try:
+                self.receive.close()
+            except Exception:
+                logger.exception("Error closing receive connector %s", type(self.receive).__name__)
         if self.send is not None and self.send is not self.receive:
-            self.send.close()
+            try:
+                self.send.close()
+            except Exception:
+                logger.exception("Error closing send connector %s", type(self.send).__name__)
 
 
 class OmniConnectorFactory:

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -444,6 +444,9 @@ class OmniKVTransferManager:
         if not cfg or not isinstance(cfg, dict):
             return cls(OmniKVCacheConfig(), async_prefetch=async_prefetch)
 
+        if cfg.get("need_recv_cache") and cfg.get("need_send_cache"):
+            raise ValueError("OmniKVTransferManager supports only one directional connector")
+
         rank_mapping = cfg.get("rank_mapping", {})
         if not isinstance(rank_mapping, dict):
             rank_mapping = {}

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/base.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/base.py
@@ -19,8 +19,6 @@ class OmniTransferAdapterBase:
 
     def __init__(self, config: Any):
         self.config = config
-        if not hasattr(self, "connector"):
-            self.connector = None
         # Requests that are waiting to be polled
         self._pending_load_reqs = deque()
         # Requests that have successfully retrieved data
@@ -40,15 +38,15 @@ class OmniTransferAdapterBase:
         self._receive_failures: dict[str, str] = {}
         self._receive_failure_lock = threading.Lock()
 
-        self.recv_thread = threading.Thread(target=self.recv_loop, daemon=True)
-        self.recv_thread.start()
+        self.recv_thread: threading.Thread | None = None
+        if self._connectors.receive is not None:
+            self.recv_thread = threading.Thread(target=self.recv_loop, daemon=True)
+            self.recv_thread.start()
 
-        self.save_thread = threading.Thread(target=self.save_loop, daemon=True)
-        self.save_thread.start()
-
-    @classmethod
-    def create_connector(cls, model_config: Any):
-        raise NotImplementedError
+        self.save_thread: threading.Thread | None = None
+        if self._connectors.send is not None:
+            self.save_thread = threading.Thread(target=self.save_loop, daemon=True)
+            self.save_thread.start()
 
     def recv_loop(self):
         """Loop to poll for incoming data.
@@ -177,8 +175,8 @@ class OmniTransferAdapterBase:
             self._recv_cond.notify_all()
         with self._save_cond:
             self._save_cond.notify_all()
-        if self.connector is not None:
-            try:
-                self.connector.close()
-            except Exception:
-                pass
+        if self.recv_thread is not None:
+            self.recv_thread.join(timeout=5)
+        if self.save_thread is not None:
+            self.save_thread.join(timeout=5)
+        self._connectors.close()

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -270,9 +270,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         Args:
             request: The request object needing data.
         """
-        stage_id = self._stage_id
-
-        if stage_id == 0 or not self.receives_chunks:
+        if self._stage_id == 0 or not self.receives_chunks:
             return
         if not hasattr(request, "additional_information"):
             request.additional_information = None
@@ -1238,11 +1236,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         """
         if not self.receives_chunks:
             return
-        stage_id = self._stage_id
-
-        if stage_id == 0:
+        if self._stage_id == 0:
             return
-
         if requests is not None:
             self.attach_cached_additional_information(scheduler_output, requests)
         self._clear_chunk_ready(scheduler_output)

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -16,10 +16,13 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import ConstantList
 
 from vllm_omni.data_entry_keys import MetaStruct, OmniPayloadStruct, unflatten_payload
+from vllm_omni.distributed import ConnectorSpec
 
 from ..adapter import construct_next_stage_streaming_input_prompt
 from ..factory import OmniConnectorFactory
-from ..utils.config import ConnectorSpec, stage_receives_chunks
+from ..utils.config import stage_receives_chunks
+from ..utils.initialization import connector_plan_from_model_config
+from ..utils.kv_utils import get_omni_replica_id
 from ..utils.logging import get_connector_logger
 from .base import OmniTransferAdapterBase
 
@@ -130,7 +133,15 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 "race to evict it).",
                 self._active_window,
             )
-        self.connector = self.create_connector(model_config)
+        self._stage_id = int(getattr(model_config, "stage_id", 0))
+        connector_plan = connector_plan_from_model_config(model_config)
+        self._previous_stage_id = connector_plan.inbound.from_stage if connector_plan.inbound is not None else None
+        self._next_stage_id = connector_plan.outbound.to_stage if connector_plan.outbound is not None else None
+        self._connectors = OmniConnectorFactory.create_stage_connectors(
+            connector_plan,
+            stage_id=self._stage_id,
+            replica_id=get_omni_replica_id(),
+        )
         self.receives_chunks = stage_receives_chunks(model_config)
         super().__init__(model_config)
         self.model_mode = getattr(model_config, "worker_type", None) or "ar"
@@ -260,6 +271,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         )
         return OmniConnectorFactory.create_connector(connector_specs)
 
+    @property
+    def connector(self):
+        """Backward-compatible single-connector view."""
+        return self._connectors.connector
+
     def load_async(self, request: Request):
         """Register a request for asynchronous chunk retrieval.
 
@@ -272,7 +288,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         Args:
             request: The request object needing data.
         """
-        stage_id = self.connector.stage_id
+        stage_id = self._stage_id
 
         if stage_id == 0 or not self.receives_chunks:
             return
@@ -337,6 +353,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             segment_generation: generation captured before a resumable stop
                 can apply a queued update to the mutable request
         """
+        if self._connectors.send is None:
+            raise RuntimeError(f"Stage {self._stage_id} has no outbound connector")
         is_finished = request.is_finished() and not request.resumable
         if not hasattr(self, "_segment_generation"):
             self._segment_generation = defaultdict(int)
@@ -420,8 +438,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
     def _poll_single_request(self, entry: _LoadEntry):
         request = entry.request
-        stage_id = self.connector.stage_id
-        target_stage_id = stage_id - 1
+        stage_id = self._stage_id
+        connector = self._connectors.receive
+        target_stage_id = self._previous_stage_id
+        if connector is None or target_stage_id is None:
+            return False
         req_id = request.request_id
         with self._receiver_state_lock:
             if self._registered_load_entries.get(req_id) is not entry:
@@ -432,10 +453,12 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         # Use timeout=0 for non-blocking poll
         try:
-            result = self.connector.get(
+            sender_info = getattr(request, "sender_info", None)
+            result = connector.get(
                 str(target_stage_id),
                 str(stage_id),
                 connector_get_key,
+                metadata=sender_info.as_metadata() if sender_info is not None else None,
             )
         except Exception as e:
             logger.error(f"SharedMemoryConnector get failed for req {connector_get_key}: {e}")
@@ -645,8 +668,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         request = task["request"]
         is_finished = task["is_finished"]
         is_segment_finished = task["is_segment_finished"]
-        stage_id = self.connector.stage_id
-        next_stage_id = stage_id + 1
+        stage_id = self._stage_id
+        connector = self._connectors.send
+        next_stage_id = self._next_stage_id
+        if connector is None or next_stage_id is None:
+            raise RuntimeError(f"Stage {stage_id} has no outbound connector")
         external_req_id = request.external_req_id
         chunk_id = self.put_req_chunk[external_req_id]
         connector_put_key = f"{external_req_id}_{stage_id}_{chunk_id}"
@@ -700,7 +726,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             logger.debug("Skipping cancelled chunk for request %s before connector put", external_req_id)
             return
 
-        success, size, metadata = self.connector.put(
+        success, size, metadata = connector.put(
             from_stage=str(stage_id),
             to_stage=str(next_stage_id),
             put_key=connector_put_key,
@@ -920,7 +946,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         """
         if not self.receives_chunks:
             return
-        if self.connector.stage_id == 0:
+        if self._stage_id == 0:
             return
 
         # Purge deque entries whose request was freed mid-flight (abort →
@@ -1230,7 +1256,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         """
         if not self.receives_chunks:
             return
-        stage_id = self.connector.stage_id
+        stage_id = self._stage_id
 
         if stage_id == 0:
             return

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -16,7 +16,6 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import ConstantList
 
 from vllm_omni.data_entry_keys import MetaStruct, OmniPayloadStruct, unflatten_payload
-from vllm_omni.distributed import ConnectorSpec
 
 from ..adapter import construct_next_stage_streaming_input_prompt
 from ..factory import OmniConnectorFactory
@@ -253,23 +252,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         request.num_prompt_tokens = len(request.prompt_token_ids)
         if getattr(request, "prefill_stats", None) is None:
             request.prefill_stats = PrefillStats()
-
-    @classmethod
-    def create_connector(cls, model_config: Any):
-        connector_config = getattr(model_config, "stage_connector_config", None)
-        if connector_config is None:
-            connector_config = {}
-        elif not isinstance(connector_config, dict):
-            connector_config = {
-                "name": getattr(connector_config, "name", None),
-                "extra": getattr(connector_config, "extra", {}),
-            }
-
-        connector_specs = ConnectorSpec(
-            name=connector_config.get("name", "SharedMemoryConnector"),
-            extra=connector_config.get("extra", {}),
-        )
-        return OmniConnectorFactory.create_connector(connector_specs)
 
     @property
     def connector(self):

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -461,7 +461,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 metadata=sender_info.as_metadata() if sender_info is not None else None,
             )
         except Exception as e:
-            logger.error(f"SharedMemoryConnector get failed for req {connector_get_key}: {e}")
+            logger.error(f"{type(connector).__name__} get failed for req {connector_get_key}: {e}")
             with self._receiver_state_lock:
                 if self._registered_load_entries.get(req_id) is not entry:
                     return True

--- a/vllm_omni/distributed/omni_connectors/utils/config.py
+++ b/vllm_omni/distributed/omni_connectors/utils/config.py
@@ -19,6 +19,16 @@ TRANSFER_ENGINE_CONNECTOR_NAMES = frozenset(
 
 def get_stage_connector_role(model_config: Any) -> str | None:
     """Return the configured stage connector direction, if explicit."""
+    plan = getattr(model_config, "stage_connector_plan", None)
+    if isinstance(plan, StageConnectorPlan):
+        if plan.inbound is not None and plan.outbound is not None:
+            return "dual"
+        if plan.inbound is not None:
+            return "receiver"
+        if plan.outbound is not None:
+            return "sender"
+        return None
+
     connector_config = getattr(model_config, "stage_connector_config", None)
     if isinstance(connector_config, dict):
         extra = connector_config.get("extra")
@@ -32,14 +42,20 @@ def get_stage_connector_role(model_config: Any) -> str | None:
 
 def stage_receives_chunks(model_config: Any) -> bool:
     """Whether connector chunks, rather than the orchestrator, feed a stage."""
+    plan = getattr(model_config, "stage_connector_plan", None)
+    if isinstance(plan, StageConnectorPlan):
+        return plan.inbound is not None
     return get_stage_connector_role(model_config) != "sender"
 
 
 def stage_sends_async_output(model_config: Any) -> bool:
     """Whether async output should be partitioned for connector transport."""
+    plan = getattr(model_config, "stage_connector_plan", None)
+    if isinstance(plan, StageConnectorPlan):
+        return plan.outbound is not None
     role = get_stage_connector_role(model_config)
     if role is not None:
-        return role == "sender"
+        return role in {"sender", "dual"}
     # Preserve legacy partitioning while keeping stage-0 orchestrator bridges
     # on the normal RequestOutput path.
     return getattr(model_config, "stage_id", None) != 0
@@ -51,6 +67,23 @@ class ConnectorSpec:
 
     name: str  # e.g., "MooncakeStoreConnector", "SharedMemoryConnector", "YuanrongConnector"
     extra: dict[str, Any] = field(default_factory=dict)  # backend-specific config
+
+
+@dataclass(frozen=True)
+class StageConnectorSpec:
+    """One connector attached to a directed stage edge."""
+
+    from_stage: int
+    to_stage: int
+    spec: ConnectorSpec
+
+
+@dataclass(frozen=True)
+class StageConnectorPlan:
+    """The optional inbound and outbound connector for one stage."""
+
+    inbound: StageConnectorSpec | None = None
+    outbound: StageConnectorSpec | None = None
 
 
 @dataclass

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -565,12 +565,14 @@ def build_stage_connectors(
 
 
 def resolve_omni_kv_config_for_stage(
-    transfer_cfg: OmniTransferConfig | None, stage_id: int | str
+    transfer_cfg: OmniTransferConfig | None,
+    stage_id: int | str,
+    stage_config: Any | None = None,
 ) -> tuple[dict[str, Any] | None, str | None, str | None]:
     """Resolve connector configuration for a specific stage (Sender/Receiver).
 
-    This determines the primary connector configuration to be injected into the
-    engine arguments, prioritizing outgoing edges (Sender role).
+    Selects the edge owned by the stage's KV manager. Legacy callers that do
+    not provide a stage config retain the outgoing-first behavior.
     """
     if not transfer_cfg or not getattr(transfer_cfg, "connectors", None):
         return None, None, None
@@ -591,13 +593,30 @@ def resolve_omni_kv_config_for_stage(
         if to_stage == stage_id_str
     ]
 
+    omni_kv_config = getattr(stage_config, "omni_kv_config", None)
+    if omni_kv_config is None:
+        engine_args = getattr(stage_config, "engine_args", None)
+        if hasattr(engine_args, "get"):
+            omni_kv_config = engine_args.get("omni_kv_config")
+    if hasattr(omni_kv_config, "get"):
+        need_recv_cache = bool(omni_kv_config.get("need_recv_cache", False))
+        need_send_cache = bool(omni_kv_config.get("need_send_cache", False))
+    else:
+        need_recv_cache = bool(getattr(omni_kv_config, "need_recv_cache", False))
+        need_send_cache = bool(getattr(omni_kv_config, "need_send_cache", False))
+
+    if need_recv_cache and need_send_cache:
+        raise ValueError(
+            f"Stage {stage_id} enables both KV receive and send, but "
+            "OmniKVTransferManager supports only one directional connector"
+        )
+
     omni_conn_cfg = None
     omni_from = None
     omni_to = None
 
-    # Prioritize outgoing (Sender) if exists, else check incoming (Receiver).
     # Inject direction-specific role so the connector initializes correctly.
-    if outgoing:
+    if outgoing and not need_recv_cache:
         if len(outgoing) > 1:
             logger.debug(
                 "Stage-%s has %d outgoing edges; using the smallest to_stage",
@@ -607,15 +626,15 @@ def resolve_omni_kv_config_for_stage(
         outgoing.sort(key=lambda x: int(x[0]) if str(x[0]).isdigit() else str(x[0]))
         to_s, spec = outgoing[0]
         omni_conn_cfg = {"type": spec.name, **(spec.extra or {})}
-        omni_conn_cfg.setdefault("role", "sender")
+        omni_conn_cfg["role"] = "sender"
         omni_from = stage_id_str
         omni_to = str(to_s)
-    elif incoming:
+    elif incoming and not need_send_cache:
         # For receiver, pick one incoming edge to configure the connector
         incoming.sort(key=lambda x: int(x[0]) if str(x[0]).isdigit() else str(x[0]))
         from_s, spec = incoming[0]
         omni_conn_cfg = {"type": spec.name, **(spec.extra or {})}
-        omni_conn_cfg.setdefault("role", "receiver")
+        omni_conn_cfg["role"] = "receiver"
         omni_from = str(from_s)
         omni_to = stage_id_str
 

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -260,7 +260,12 @@ def resolve_stage_connector_plan(
 
 
 def get_connectors_config_for_stage(transfer_config: OmniTransferConfig | None, stage_id: str | int) -> dict[str, Any]:
-    """Return the legacy dict view of a resolved stage connector plan."""
+    """Return the legacy dict view of a resolved stage connector plan.
+
+    Emits both directions when present (``from_stage_*`` for the inbound edge,
+    ``to_stage_*`` for the outbound edge), unlike the pre-dual-connector
+    version of this function, which only ever returned the inbound edge.
+    """
     if transfer_config is None:
         return {}
 

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -579,25 +579,6 @@ def resolve_omni_kv_config_for_stage(
     Selects the edge owned by the stage's KV manager. Legacy callers that do
     not provide a stage config retain the outgoing-first behavior.
     """
-    if not transfer_cfg or not getattr(transfer_cfg, "connectors", None):
-        return None, None, None
-
-    stage_id_str = str(stage_id)
-
-    # Find outgoing edges (Sender logic)
-    outgoing = [
-        (to_stage, spec)
-        for (from_stage, to_stage), spec in transfer_cfg.connectors.items()
-        if from_stage == stage_id_str
-    ]
-
-    # Find incoming edges (Receiver logic)
-    incoming = [
-        (from_stage, spec)
-        for (from_stage, to_stage), spec in transfer_cfg.connectors.items()
-        if to_stage == stage_id_str
-    ]
-
     omni_kv_config = getattr(stage_config, "omni_kv_config", None)
     if omni_kv_config is None:
         engine_args = getattr(stage_config, "engine_args", None)
@@ -616,9 +597,28 @@ def resolve_omni_kv_config_for_stage(
             "OmniKVTransferManager supports only one directional connector"
         )
 
+    if not transfer_cfg or not getattr(transfer_cfg, "connectors", None):
+        return None, None, None
+
     omni_conn_cfg = None
     omni_from = None
     omni_to = None
+
+    stage_id_str = str(stage_id)
+
+    # Find outgoing edges (Sender logic)
+    outgoing = [
+        (to_stage, spec)
+        for (from_stage, to_stage), spec in transfer_cfg.connectors.items()
+        if from_stage == stage_id_str
+    ]
+
+    # Find incoming edges (Receiver logic)
+    incoming = [
+        (from_stage, spec)
+        for (from_stage, to_stage), spec in transfer_cfg.connectors.items()
+        if to_stage == stage_id_str
+    ]
 
     # Inject direction-specific role so the connector initializes correctly.
     if outgoing and not need_recv_cache:

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -189,10 +189,15 @@ def _stage_edge_spec(
 
 
 def default_stage_connector_plan(stage_id: str | int) -> StageConnectorPlan:
-    """Preserve the no-config SHM behavior as an explicit two-way plan."""
+    """
+    Preserve the no-config SHM behavior as an explicit two-way plan.
+
+    Note that there may be an extra SHM connector added to the last stage as the
+    default plan is not aware of the number of stages.
+    """
     stage = _stage_id(stage_id)
     return StageConnectorPlan(
-        inbound=StageConnectorSpec(stage - 1, stage, ConnectorSpec("SharedMemoryConnector")),
+        inbound=StageConnectorSpec(stage - 1, stage, ConnectorSpec("SharedMemoryConnector")) if stage > 0 else None,
         outbound=StageConnectorSpec(stage, stage + 1, ConnectorSpec("SharedMemoryConnector")),
     )
 

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -168,16 +168,19 @@ def _stage_edge_spec(
     target = _stage_id(to_stage)
     extra = dict(spec.extra or {})
     if spec.name in TRANSFER_ENGINE_CONNECTOR_NAMES:
+        from .kv_utils import kv_zmq_port
+
         base_port = expand_env_int(extra.get("zmq_port", 50051), "zmq_port")
-        sender_port = base_port + source
         if inbound:
             extra.setdefault("sender_host", extra.get("host", "127.0.0.1"))
             extra["sender_zmq_port"] = expand_env_int(
-                extra.get("sender_zmq_port", sender_port),
+                extra.get("sender_zmq_port", kv_zmq_port(base_port, source)),
                 "sender_zmq_port",
             )
         else:
-            extra["zmq_port"] = sender_port
+            # Keep the configured value as the base port. The factory adds
+            # the local rank/replica portion when materializing this worker.
+            extra["zmq_port"] = base_port
     return StageConnectorSpec(
         from_stage=source,
         to_stage=target,

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..factory import OmniConnectorFactory
-from .config import TRANSFER_ENGINE_CONNECTOR_NAMES, ConnectorSpec, OmniTransferConfig
+from .config import (
+    TRANSFER_ENGINE_CONNECTOR_NAMES,
+    ConnectorSpec,
+    OmniTransferConfig,
+    StageConnectorPlan,
+    StageConnectorSpec,
+)
 from .env import expand_env_int
 from .local_rank import get_connector_local_rank
 from .logging import get_connector_logger
@@ -143,46 +149,136 @@ def create_connectors_from_config(
     return connectors
 
 
-def get_connectors_config_for_stage(transfer_config: OmniTransferConfig | None, stage_id: str | int) -> dict[str, Any]:
-    """
-    Extract connector configurations relevant for a specific stage worker.
+def _stage_id(value: str | int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Stage id must be an integer, got {value!r}") from exc
 
-    Returns a dict compatible with worker initialization:
-    {
-        "from_stage_X": {
-            "spec": {
-                "name": "ConnectorName",
-                "extra": {...}
-            }
-        },
-        ...
-    }
-    """
-    if not transfer_config:
+
+def _stage_edge_spec(
+    from_stage: str,
+    to_stage: str,
+    spec: ConnectorSpec,
+    *,
+    inbound: bool,
+) -> StageConnectorSpec:
+    """Copy one edge config and resolve its stage-level transfer-engine ports."""
+    source = _stage_id(from_stage)
+    target = _stage_id(to_stage)
+    extra = dict(spec.extra or {})
+    if spec.name in TRANSFER_ENGINE_CONNECTOR_NAMES:
+        base_port = expand_env_int(extra.get("zmq_port", 50051), "zmq_port")
+        sender_port = base_port + source
+        if inbound:
+            extra.setdefault("sender_host", extra.get("host", "127.0.0.1"))
+            extra["sender_zmq_port"] = expand_env_int(
+                extra.get("sender_zmq_port", sender_port),
+                "sender_zmq_port",
+            )
+        else:
+            extra["zmq_port"] = sender_port
+    return StageConnectorSpec(
+        from_stage=source,
+        to_stage=target,
+        spec=ConnectorSpec(name=spec.name, extra=extra),
+    )
+
+
+def default_stage_connector_plan(stage_id: str | int) -> StageConnectorPlan:
+    """Preserve the no-config SHM behavior as an explicit two-way plan."""
+    stage = _stage_id(stage_id)
+    return StageConnectorPlan(
+        inbound=StageConnectorSpec(stage - 1, stage, ConnectorSpec("SharedMemoryConnector")),
+        outbound=StageConnectorSpec(stage, stage + 1, ConnectorSpec("SharedMemoryConnector")),
+    )
+
+
+def connector_plan_from_model_config(model_config: Any) -> StageConnectorPlan:
+    """Read the typed plan, with one compatibility path for legacy configs."""
+    plan = getattr(model_config, "stage_connector_plan", None)
+    # An empty typed plan was used by older runner hosts as a placeholder
+    # while still supplying stage_connector_config.
+    if isinstance(plan, StageConnectorPlan):
+        return plan
+
+    stage = _stage_id(getattr(model_config, "stage_id", 0))
+    missing = object()
+    raw = getattr(model_config, "stage_connector_config", missing)
+    if raw is missing:
+        return default_stage_connector_plan(stage)
+    if raw is None:
+        return StageConnectorPlan()
+
+    if not isinstance(raw, dict):
+        raw = {
+            "name": getattr(raw, "name", None),
+            "extra": getattr(raw, "extra", None),
+        }
+    name = raw.get("name")
+    extra = raw.get("extra") or {}
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Invalid stage_connector_config: missing connector name")
+    if not isinstance(extra, dict):
+        raise TypeError(f"Invalid connector extra: expected dict, got {type(extra).__name__}")
+
+    role = extra.get("role")
+    connector = ConnectorSpec(name, dict(extra))
+    inbound = None
+    outbound = None
+    if role != "sender":
+        inbound = StageConnectorSpec(stage - 1, stage, connector)
+    if role != "receiver":
+        outbound = StageConnectorSpec(stage, stage + 1, connector)
+    return StageConnectorPlan(inbound=inbound, outbound=outbound)
+
+
+def resolve_stage_connector_plan(
+    transfer_config: OmniTransferConfig | None,
+    stage_id: str | int,
+) -> StageConnectorPlan:
+    """Resolve at most one inbound and one outbound edge for a stage."""
+    if transfer_config is None:
+        return default_stage_connector_plan(stage_id)
+
+    stage = _stage_id(stage_id)
+    inbound = None
+    outbound = None
+    for (from_stage, to_stage), spec in transfer_config.connectors.items():
+        if _stage_id(to_stage) == stage:
+            if inbound is not None:
+                raise ValueError(f"Fan-in is not supported for stage {stage}")
+            inbound = _stage_edge_spec(from_stage, to_stage, spec, inbound=True)
+        if _stage_id(from_stage) == stage:
+            if outbound is not None:
+                raise ValueError(f"Fan-out is not supported for stage {stage}")
+            outbound = _stage_edge_spec(from_stage, to_stage, spec, inbound=False)
+    return StageConnectorPlan(inbound=inbound, outbound=outbound)
+
+
+def get_connectors_config_for_stage(transfer_config: OmniTransferConfig | None, stage_id: str | int) -> dict[str, Any]:
+    """Return the legacy dict view of a resolved stage connector plan."""
+    if transfer_config is None:
         return {}
 
-    stage_connectors_config = {}
-    target_stage = str(stage_id)
-
-    # Iterate through all configured edges and inject direction-specific role.
-    # The shared edge-level ConnectorSpec is role-neutral; each stage gets
-    # the correct role ("sender" or "receiver") based on its position in
-    # the edge so that MooncakeTransferEngineConnector (and any future
-    # role-aware connector) initializes correctly.
-    for (from_stage, to_stage), spec in transfer_config.connectors.items():
-        if to_stage == target_stage:
-            # Incoming edge → this stage is the receiver
-            extra = dict(spec.extra) if spec.extra else {}
-            extra.setdefault("role", "receiver")
-            stage_connectors_config[f"from_stage_{from_stage}"] = {"spec": {"name": spec.name, "extra": extra}}
-        elif from_stage == target_stage and target_stage == "0":
-            # Outgoing edge for stage 0 — included for async_chunk spec
-            # extraction (omni_stage.py), NOT for connector instantiation.
-            extra = dict(spec.extra) if spec.extra else {}
-            extra.setdefault("role", "sender")
-            stage_connectors_config[f"to_stage_{to_stage}"] = {"spec": {"name": spec.name, "extra": extra}}
-
-    return stage_connectors_config
+    plan = resolve_stage_connector_plan(transfer_config, stage_id)
+    result: dict[str, Any] = {}
+    for edge, role, key in (
+        (plan.inbound, "receiver", "from_stage"),
+        (plan.outbound, "sender", "to_stage"),
+    ):
+        if edge is None:
+            continue
+        extra = dict(edge.spec.extra)
+        extra["role"] = role
+        peer = edge.from_stage if role == "receiver" else edge.to_stage
+        result[f"{key}_{peer}"] = {
+            "spec": {
+                "name": edge.spec.name,
+                "extra": extra,
+            }
+        }
+    return result
 
 
 def load_omni_transfer_config(

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -2,6 +2,8 @@
 Engine components for vLLM-Omni.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import msgspec
@@ -11,6 +13,22 @@ from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
 )
+
+
+class ConnectorEndpoint(msgspec.Struct, frozen=True):
+    """Network endpoint of the producer bound to a request."""
+
+    host: str
+    zmq_port: int
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise ValueError("Connector endpoint host must not be empty")
+        if not 0 < self.zmq_port <= 65535:
+            raise ValueError(f"Connector endpoint port must be in 1..65535, got {self.zmq_port}")
+
+    def as_metadata(self) -> dict[str, str | int]:
+        return {"source_host": self.host, "source_port": self.zmq_port}
 
 
 class PromptEmbedsPayload(msgspec.Struct):
@@ -79,6 +97,8 @@ class OmniEngineCoreRequest(EngineCoreRequest):
     # GPUModelRunner.model_intermediate_buffer instead of using the deprecated
     # additional_information request transport.
     model_intermediate_buffer: dict[str, Any] | None = None
+    # Endpoint of the upstream producer replica selected for this request.
+    sender_info: ConnectorEndpoint | None = None
 
     @classmethod
     def from_request(
@@ -88,7 +108,8 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         prompt_embeds: torch.Tensor | None = None,
         additional_information: AdditionalInformationPayload | None = None,
         model_intermediate_buffer: dict[str, Any] | None = None,
-    ) -> "OmniEngineCoreRequest":
+        sender_info: ConnectorEndpoint | None = None,
+    ) -> OmniEngineCoreRequest:
         """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides."""
 
         if prompt_embeds is None:
@@ -97,6 +118,8 @@ class OmniEngineCoreRequest(EngineCoreRequest):
             additional_information = getattr(request, "additional_information", None)
         if model_intermediate_buffer is None:
             model_intermediate_buffer = getattr(request, "model_intermediate_buffer", None)
+        if sender_info is None:
+            sender_info = getattr(request, "sender_info", None)
 
         return cls(
             request_id=request.request_id,
@@ -121,6 +144,7 @@ class OmniEngineCoreRequest(EngineCoreRequest):
             abort_immediately=request.abort_immediately,
             additional_information=additional_information,
             model_intermediate_buffer=model_intermediate_buffer,
+            sender_info=sender_info,
         )
 
 

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -6,13 +6,14 @@ import json
 import os
 import tempfile
 from collections.abc import Callable
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from typing import Any, cast
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.logger import init_logger
 
 from vllm_omni.config import OmniModelConfig
+from vllm_omni.distributed.omni_connectors.utils.config import StageConnectorPlan
 from vllm_omni.outputs.output_modality import OutputModality
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.plugins import load_omni_general_plugins
@@ -161,7 +162,7 @@ class OmniEngineArgs(EngineArgs):
         custom_process_next_stage_input_func: Optional path to a custom function for processing
             inputs from previous stages
             If None, default processing is used.
-        stage_connector_spec: Extra configuration for stage connector
+        stage_connector_plan: Independent inbound and outbound stage connectors.
         async_chunk: If set to True, perform async chunk
         session_mode: Request lifecycle mode, either turn-based or duplex
         worker_type: Model Type, e.g., "ar" or "generation"
@@ -189,7 +190,7 @@ class OmniEngineArgs(EngineArgs):
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     requires_full_payload_input: bool = False
-    stage_connector_spec: dict[str, Any] = field(default_factory=dict)
+    stage_connector_plan: StageConnectorPlan | None = None
     subtalker_sampling_params: dict[str, Any] | None = None
     silence_ban_frames: int = 0
     async_chunk: bool = False
@@ -251,10 +252,10 @@ class OmniEngineArgs(EngineArgs):
                 self.worker_cls = current_omni_platform.get_omni_generation_worker_cls()
         load_omni_general_plugins()
 
-        connector_extra = self.stage_connector_spec.get("extra")
-        connector_role = connector_extra.get("role") if isinstance(connector_extra, dict) else None
+        plan = self.stage_connector_plan
+        has_plan_edge = plan is not None and (plan.inbound is not None or plan.outbound is not None)
         needs_connector = bool(
-            self.requires_full_payload_input or self.custom_process_next_stage_input_func or connector_role is not None
+            self.requires_full_payload_input or self.custom_process_next_stage_input_func or has_plan_edge
         )
         validate_worker_omni_connector(self.worker_cls, needs_connector)
         super().__post_init__()
@@ -306,12 +307,9 @@ class OmniEngineArgs(EngineArgs):
         # register omni models to avoid model not found error
         self._ensure_omni_models_registered()
 
-        # Build stage_connector_config from stage_connector_spec
-        stage_connector_config = {
-            "name": self.stage_connector_spec.get("name", "SharedMemoryConnector"),
-            "extra": self.stage_connector_spec.get("extra", {}).copy(),
-        }
-        stage_connector_config["extra"]["stage_id"] = self.stage_id
+        from vllm_omni.distributed.omni_connectors.utils.initialization import default_stage_connector_plan
+
+        connector_plan = self.stage_connector_plan or default_stage_connector_plan(self.stage_id)
 
         hf_overrides = cast(dict[str, Any] | Callable[[Any], Any] | None, getattr(self, "hf_overrides", None))
         # If model_arch is specified, inject it into hf_overrides so vLLM can
@@ -429,7 +427,7 @@ class OmniEngineArgs(EngineArgs):
             hf_config_name=self.hf_config_name,
             custom_process_next_stage_input_func=self.custom_process_next_stage_input_func,
             requires_full_payload_input=self.requires_full_payload_input,
-            stage_connector_config=stage_connector_config,
+            stage_connector_plan=connector_plan,
             subtalker_sampling_params=self.subtalker_sampling_params,
             silence_ban_frames=self.silence_ban_frames,
             omni_kv_config=self.omni_kv_config,

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -529,7 +529,6 @@ class AsyncOmniEngine:
         if not isinstance(mm_data, dict) or not mm_data:
             return
 
-        from vllm.config.multimodal import _get_mm_hasher_algorithm
         from vllm.multimodal.hasher import MultiModalHasher
 
         existing_uuids = prompt.get("multi_modal_uuids")
@@ -556,7 +555,6 @@ class AsyncOmniEngine:
                     base_uuid = None
                 else:
                     base_uuid = MultiModalHasher.hash_kwargs(
-                        _get_mm_hasher_algorithm(),
                         model_id=model_id,
                         **{modality: item},
                     )

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -3025,9 +3025,11 @@ class Orchestrator:
                 continue
 
             sender_pool = self.stage_pools[sender_stage_id]
-            sender_stage = sender_pool.get_bound_client(request_id) if request_id is not None else None
+            sender_stage = (
+                sender_pool.get_bound_client(request_id) if request_id is not None else sender_pool.stage_client
+            )
             if sender_stage is None:
-                sender_stage = sender_pool.stage_client
+                continue
             get_sender_info = getattr(sender_stage, "get_kv_sender_info", None)
             if not callable(get_sender_info):
                 continue
@@ -3051,7 +3053,9 @@ class Orchestrator:
     ) -> ConnectorEndpoint | None:
         """Resolve the endpoint of the producer replica bound to a request."""
         sender_pool = self.stage_pools[sender_stage_id]
-        sender_stage = sender_pool.get_bound_client(request_id) or sender_pool.stage_client
+        sender_stage = sender_pool.get_bound_client(request_id)
+        if sender_stage is None:
+            return None
         get_sender_info = getattr(sender_stage, "get_payload_sender_info", None)
         return get_sender_info() if callable(get_sender_info) else None
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -2912,6 +2912,7 @@ class Orchestrator:
                 # execute before that conditioning payload arrives.
                 continue
 
+            model_config = getattr(next_pool.stage_vllm_config, "model_config", None)
             connector_plan = connector_plan_from_model_config(model_config) if model_config is not None else None
             inbound = connector_plan.inbound if connector_plan is not None else None
             if inbound is None:
@@ -2926,7 +2927,7 @@ class Orchestrator:
             if next_pool.stage_type == "diffusion":
                 submit_kwargs = {
                     "kv_sender_info": self._build_kv_sender_info(
-                        list(getattr(next_pool.stage_client, "engine_input_source", None) or [next_stage_id - 1]),
+                        list(getattr(next_pool.stage_client, "engine_input_source", None) or [sender_stage_id]),
                         request_id=request_id,
                     )
                 }

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -2912,7 +2912,6 @@ class Orchestrator:
                 # execute before that conditioning payload arrives.
                 continue
 
-            model_config = getattr(next_pool.stage_vllm_config, "model_config", None)
             connector_plan = connector_plan_from_model_config(model_config) if model_config is not None else None
             inbound = connector_plan.inbound if connector_plan is not None else None
             if inbound is None:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -36,7 +36,8 @@ from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
 from vllm_omni.distributed.omni_connectors.utils.config import stage_receives_chunks
-from vllm_omni.engine import OmniEngineCoreRequest
+from vllm_omni.distributed.omni_connectors.utils.initialization import connector_plan_from_model_config
+from vllm_omni.engine import ConnectorEndpoint, OmniEngineCoreRequest
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
 from vllm_omni.engine.membership_controller import MembershipController
 from vllm_omni.engine.messages import (
@@ -2149,6 +2150,7 @@ class Orchestrator:
         next_input: Any,
         params: SamplingParams | PoolingParams,
         *,
+        sender_stage_id: int,
         mm_features: list | None = None,
         resumable: bool = False,
     ) -> Any:
@@ -2163,6 +2165,7 @@ class Orchestrator:
                 resumable=resumable,
             )
             request.external_req_id = request.request_id
+            request.sender_info = self._build_payload_sender_info(sender_stage_id, req_id)
             return request
 
         processor = self._get_stage_input_processor(next_stage_id)
@@ -2184,6 +2187,7 @@ class Orchestrator:
         )
         request = self._upgrade_processed_stage_request(request, next_input)
         request.external_req_id = req_id
+        request.sender_info = self._build_payload_sender_info(sender_stage_id, req_id)
         return request
 
     @staticmethod
@@ -2706,6 +2710,7 @@ class Orchestrator:
                     resumable=next_stage_resumable,
                 )
                 request.external_req_id = request.request_id
+                request.sender_info = self._build_payload_sender_info(src_stage_id, req_id)
                 if already_submitted:
                     replica_id = await next_pool.submit_update(req_id, req_state, request)
                 else:
@@ -2827,6 +2832,7 @@ class Orchestrator:
                 next_logical,
                 next_input,
                 params=params,
+                sender_stage_id=src_stage_id,
                 mm_features=mm_features,
                 resumable=next_stage_resumable,
             )
@@ -2906,6 +2912,15 @@ class Orchestrator:
                 # execute before that conditioning payload arrives.
                 continue
 
+            model_config = getattr(next_pool.stage_vllm_config, "model_config", None)
+            connector_plan = connector_plan_from_model_config(model_config) if model_config is not None else None
+            inbound = connector_plan.inbound if connector_plan is not None else None
+            if inbound is None:
+                raise RuntimeError(f"Connector-fed stage {next_stage_id} has no inbound connector edge")
+
+            sender_stage_id = inbound.from_stage
+            # Select and retain the replica that will receive this request
+            await self.stage_pools[sender_stage_id]._pick_or_select(request_id)
             req_state.stage_submit_ts[next_stage_id] = _time.time()
             _t_submit_start = _time.perf_counter()
 
@@ -2955,6 +2970,7 @@ class Orchestrator:
                     resumable=downstream_resumable,
                 )
                 request.external_req_id = request.request_id
+                request.sender_info = self._build_payload_sender_info(sender_stage_id, request_id)
                 submitted = await self._dispatch_or_fail_request(
                     lambda: next_pool.submit_initial(
                         request_id,
@@ -2982,13 +2998,11 @@ class Orchestrator:
                 req_state,
             )
 
-            # async_chunk pre-submit fires per stage edge (N-1 -> N). Source
-            # replica is stage 0's bound replica (single-replica thinker in
-            # all current configs); fall back to 0 if unknown.
+            # async_chunk pre-submit fires once per configured inbound edge.
             _tx_ms = (_time.perf_counter() - _t_submit_start) * 1000.0
-            src_replica = self.stage_pools[next_stage_id - 1].get_bound_replica_id(request_id)
+            src_replica = self.stage_pools[sender_stage_id].get_bound_replica_id(request_id)
             self._emit_tx_edge(
-                from_stage=next_stage_id - 1,
+                from_stage=sender_stage_id,
                 from_replica=src_replica if src_replica is not None else 0,
                 to_stage=next_stage_id,
                 to_pool=next_pool,
@@ -3029,6 +3043,17 @@ class Orchestrator:
             sender_infos[sender_stage_id] = sender_info
 
         return sender_infos or None
+
+    def _build_payload_sender_info(
+        self,
+        sender_stage_id: int,
+        request_id: str,
+    ) -> ConnectorEndpoint | None:
+        """Resolve the endpoint of the producer replica bound to a request."""
+        sender_pool = self.stage_pools[sender_stage_id]
+        sender_stage = sender_pool.get_bound_client(request_id) or sender_pool.stage_client
+        get_sender_info = getattr(sender_stage, "get_payload_sender_info", None)
+        return get_sender_info() if callable(get_sender_info) else None
 
     # ---- Shutdown / lifecycle ----
 

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -19,14 +19,16 @@ from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core_client import AsyncMPClient, DPLBAsyncMPClient
 from vllm.v1.engine.exceptions import EngineDeadError
 
+from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory
 from vllm_omni.distributed.omni_connectors.utils.config import (
     TRANSFER_ENGINE_CONNECTOR_NAMES,
 )
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
     KV_TRANSFER_PORT_OFFSET,
+    connector_plan_from_model_config,
 )
 from vllm_omni.distributed.omni_connectors.utils.kv_utils import kv_zmq_port
-from vllm_omni.engine import OmniEngineCoreOutput, OmniEngineCoreOutputs
+from vllm_omni.engine import ConnectorEndpoint, OmniEngineCoreOutput, OmniEngineCoreOutputs
 from vllm_omni.engine.stage_client import StageClientBase
 from vllm_omni.engine.stage_init_utils import StageMetadata
 
@@ -149,7 +151,9 @@ class StageEngineCoreClientBase(StageClientBase):
 
         self.engine_outputs: Any = None
         self.client_addresses = dict(client_addresses or {})
-        self._omni_kv_config = getattr(getattr(vllm_config, "model_config", None), "omni_kv_config", None)
+        model_config = getattr(vllm_config, "model_config", None)
+        self._stage_connector_plan = connector_plan_from_model_config(model_config)
+        self._omni_kv_config = getattr(model_config, "omni_kv_config", None)
         self._kv_sender_host = self._resolve_contact_host()
         self._kv_sender_info: dict[str, Any] | None = None
         self._kv_sender_initialized = False
@@ -378,6 +382,27 @@ class StageEngineCoreClientBase(StageClientBase):
                 replica_id=self.replica_id,
             ),
         }
+
+    def get_payload_sender_info(self) -> ConnectorEndpoint | None:
+        """Return this replica's transfer-engine endpoint, if it has one."""
+        output = self._stage_connector_plan.outbound
+        if output is None or output.spec.name not in TRANSFER_ENGINE_CONNECTOR_NAMES:
+            return None
+
+        spec = OmniConnectorFactory.materialize_connector_spec(
+            output,
+            "sender",
+            int(self.stage_id),
+            local_rank=0,
+            replica_id=int(self.replica_id),
+        )
+        assert spec is not None
+        host = spec.extra.get("host")
+        if host in {None, "", "auto", "*", "0.0.0.0", "::"}:
+            host = self._resolve_contact_host()
+        if host is None:
+            raise RuntimeError(f"Stage-{self.stage_id} replica-{self.replica_id} has no routable payload sender host")
+        return ConnectorEndpoint(host=str(host), zmq_port=int(spec.extra["zmq_port"]))
 
     def set_engine_outputs(self, engine_outputs: EngineCoreOutput) -> None:
         """Set engine outputs (called by orchestrator)."""

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -278,7 +278,7 @@ class StageEngineCoreClientBase(StageClientBase):
             if not address:
                 continue
             host = urlparse(address).hostname
-            if host in AUTO_HOST_VALUES:
+            if host is None or host in AUTO_HOST_VALUES:
                 continue
             if host in {"localhost", "127.0.0.1"}:
                 detected = self._detect_local_ip()
@@ -390,10 +390,10 @@ class StageEngineCoreClientBase(StageClientBase):
         """Return this replica's transfer-engine endpoint, if it has one."""
         if getattr(self, "_payload_sender_info_initialized", False):
             return getattr(self, "_payload_sender_info", None)
-        self._payload_sender_info_initialized = True
 
         output = self._stage_connector_plan.outbound
         if output is None or output.spec.name not in TRANSFER_ENGINE_CONNECTOR_NAMES:
+            self._payload_sender_info_initialized = True
             return None
 
         spec = OmniConnectorFactory.materialize_connector_spec(
@@ -410,6 +410,7 @@ class StageEngineCoreClientBase(StageClientBase):
         if host is None:
             raise RuntimeError(f"Stage-{self.stage_id} replica-{self.replica_id} has no routable payload sender host")
         self._payload_sender_info = ConnectorEndpoint(host=str(host), zmq_port=int(spec.extra["zmq_port"]))
+        self._payload_sender_info_initialized = True
         return self._payload_sender_info
 
     def set_engine_outputs(self, engine_outputs: EngineCoreOutput) -> None:

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -23,6 +23,7 @@ from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory
 from vllm_omni.distributed.omni_connectors.utils.config import (
     TRANSFER_ENGINE_CONNECTOR_NAMES,
 )
+from vllm_omni.distributed.omni_connectors.utils.env import AUTO_HOST_VALUES
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
     KV_TRANSFER_PORT_OFFSET,
     connector_plan_from_model_config,
@@ -157,6 +158,8 @@ class StageEngineCoreClientBase(StageClientBase):
         self._kv_sender_host = self._resolve_contact_host()
         self._kv_sender_info: dict[str, Any] | None = None
         self._kv_sender_initialized = False
+        self._payload_sender_info: ConnectorEndpoint | None = None
+        self._payload_sender_info_initialized = False
 
         client_name = self.__class__.__name__
         logger.info(
@@ -275,7 +278,7 @@ class StageEngineCoreClientBase(StageClientBase):
             if not address:
                 continue
             host = urlparse(address).hostname
-            if host in {None, "", "*", "0.0.0.0", "::"}:
+            if host in AUTO_HOST_VALUES:
                 continue
             if host in {"localhost", "127.0.0.1"}:
                 detected = self._detect_local_ip()
@@ -296,7 +299,7 @@ class StageEngineCoreClientBase(StageClientBase):
 
     def _resolve_sender_host_from_config(self, connector_config: dict[str, Any]) -> str | None:
         host = connector_config.get("sender_host") or connector_config.get("host")
-        if host in {None, "", "auto", "*", "0.0.0.0", "::"}:
+        if host is None or host in AUTO_HOST_VALUES:
             return self._resolve_contact_host()
         return str(host)
 
@@ -385,6 +388,10 @@ class StageEngineCoreClientBase(StageClientBase):
 
     def get_payload_sender_info(self) -> ConnectorEndpoint | None:
         """Return this replica's transfer-engine endpoint, if it has one."""
+        if getattr(self, "_payload_sender_info_initialized", False):
+            return getattr(self, "_payload_sender_info", None)
+        self._payload_sender_info_initialized = True
+
         output = self._stage_connector_plan.outbound
         if output is None or output.spec.name not in TRANSFER_ENGINE_CONNECTOR_NAMES:
             return None
@@ -398,11 +405,12 @@ class StageEngineCoreClientBase(StageClientBase):
         )
         assert spec is not None
         host = spec.extra.get("host")
-        if host in {None, "", "auto", "*", "0.0.0.0", "::"}:
+        if host is None or host in AUTO_HOST_VALUES:
             host = self._resolve_contact_host()
         if host is None:
             raise RuntimeError(f"Stage-{self.stage_id} replica-{self.replica_id} has no routable payload sender host")
-        return ConnectorEndpoint(host=str(host), zmq_port=int(spec.extra["zmq_port"]))
+        self._payload_sender_info = ConnectorEndpoint(host=str(host), zmq_port=int(spec.extra["zmq_port"]))
+        return self._payload_sender_info
 
     def set_engine_outputs(self, engine_outputs: EngineCoreOutput) -> None:
         """Set engine outputs (called by orchestrator)."""

--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -1491,6 +1491,7 @@ def launch_headless_diffusion_replicas(
     omni_conn_cfg, omni_from, omni_to = initialization.resolve_omni_kv_config_for_stage(
         omni_transfer_config,
         stage_id,
+        stage_cfg,
     )
 
     # Headless diffusion startup and its downstream helpers still consume the

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -50,6 +50,7 @@ from vllm_omni.config.omni_config import (
 )
 from vllm_omni.config.stage_config import StageType
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.distributed.omni_connectors.utils.config import StageConnectorPlan
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.entrypoints.stage_utils import _to_dict, set_stage_devices
 from vllm_omni.entrypoints.utils import filter_dataclass_kwargs, resolve_model_config_path
@@ -71,7 +72,7 @@ class ReplicaInitPlan:
     launch_mode: str
     stage_cfg: Any
     metadata: Any
-    stage_connector_spec: dict[str, Any]
+    stage_connector_plan: StageConnectorPlan
     omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None]
     stage_vllm_config: Any | None = None
     executor_class: type | None = None
@@ -1183,7 +1184,7 @@ def _finalize_engine_args_dict(
     stage_type: str | StageType,
     stage_id: int,
     model: str,
-    stage_connector_spec: dict[str, Any] | None,
+    stage_connector_plan: StageConnectorPlan | None,
     cli_tokenizer: str | None,
     has_sampling_extra_args: bool,
     sampling_extra_args_keys: tuple[str, ...] = (),
@@ -1246,8 +1247,8 @@ def _finalize_engine_args_dict(
     # Stage id must come from stage config instead of inherited CLI kwargs
     # (e.g. `--stage-id` defaulting to None).
     engine_args_dict["stage_id"] = stage_id
-    if stage_connector_spec:
-        engine_args_dict["stage_connector_spec"] = dict(stage_connector_spec or {})
+    if stage_connector_plan is not None:
+        engine_args_dict["stage_connector_plan"] = stage_connector_plan
 
     is_diffusion = stage_type == StageType.DIFFUSION
     if is_diffusion:
@@ -1289,7 +1290,7 @@ def _finalize_engine_args_dict(
 def build_legacy_engine_args_dict(
     stage_config: Any,
     model: str,
-    stage_connector_spec: dict[str, Any] | None = None,
+    stage_connector_plan: StageConnectorPlan | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
     """Implement engine-argument building for the legacy stage representation."""
@@ -1306,7 +1307,7 @@ def build_legacy_engine_args_dict(
         stage_type=_get_attr_or_item(stage_config, "stage_type", "llm"),
         stage_id=stage_config.stage_id,
         model=model,
-        stage_connector_spec=stage_connector_spec,
+        stage_connector_plan=stage_connector_plan,
         cli_tokenizer=cli_tokenizer,
         has_sampling_extra_args=bool(default_sp.get("extra_args")),
         sampling_extra_args_keys=_sampling_extra_args_keys(default_sp),
@@ -1316,7 +1317,7 @@ def build_legacy_engine_args_dict(
 def build_engine_args_dict(
     stage_config: Any,
     model: str,
-    stage_connector_spec: dict[str, Any] | None = None,
+    stage_connector_plan: StageConnectorPlan | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
     """Build engine arguments through the stable production entry point.
@@ -1328,7 +1329,7 @@ def build_engine_args_dict(
     return build_legacy_engine_args_dict(
         stage_config,
         model,
-        stage_connector_spec=stage_connector_spec,
+        stage_connector_plan=stage_connector_plan,
         cli_tokenizer=cli_tokenizer,
     )
 
@@ -1336,7 +1337,7 @@ def build_engine_args_dict(
 def build_engine_args_dict_from_omni_stage_config(
     stage_config: BaseVllmOmniStageConfig,
     model: str,
-    stage_connector_spec: dict[str, Any] | None = None,
+    stage_connector_plan: StageConnectorPlan | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
     """Project one typed stage config into backend engine arguments.
@@ -1353,7 +1354,7 @@ def build_engine_args_dict_from_omni_stage_config(
         stage_type=stage_config.stage_type,
         stage_id=stage_config.stage_id,
         model=model,
-        stage_connector_spec=stage_connector_spec,
+        stage_connector_plan=stage_connector_plan,
         cli_tokenizer=cli_tokenizer,
         has_sampling_extra_args=stage_config.model_config.has_sampling_extra_args,
         sampling_extra_args_keys=_sampling_extra_args_keys(stage_config.model_config.default_sampling_params),
@@ -1431,7 +1432,7 @@ def _check_stage_device_layout(stage_config: Any, engine_args_dict: dict[str, An
 def build_vllm_config(
     stage_config: Any,
     model: str,
-    stage_connector_spec: dict[str, Any] | None = None,
+    stage_connector_plan: StageConnectorPlan | None = None,
     engine_args_dict: dict[str, Any] | None = None,
     headless: bool = False,
 ) -> tuple[Any, type]:
@@ -1444,7 +1445,7 @@ def build_vllm_config(
         engine_args_dict = build_engine_args_dict(
             stage_config,
             model,
-            stage_connector_spec=stage_connector_spec,
+            stage_connector_plan=stage_connector_plan,
         )
 
     filtered_engine_args_dict = filter_dataclass_kwargs(OmniEngineArgs, engine_args_dict)
@@ -1761,29 +1762,14 @@ def load_omni_transfer_config_for_model(model: str, config_path: str | None) -> 
         return None
 
 
-def get_stage_connector_spec(
+def get_stage_connector_plan(
     omni_transfer_config: Any,
     stage_id: int,
-    async_chunk: bool,
-) -> dict[str, Any]:
-    """Return the first connector spec for a stage data-plane edge."""
-    from vllm_omni.distributed.omni_connectors import get_stage_connector_config
+) -> StageConnectorPlan:
+    """Resolve the stage's inbound and outbound connector edges."""
+    from vllm_omni.distributed.omni_connectors import resolve_stage_connector_plan
 
-    stage_connectors_cfg = get_stage_connector_config(omni_transfer_config, stage_id)
-    for cfg in stage_connectors_cfg.values():
-        return dict(cfg.get("spec", {}))
-
-    # A producer does not consume connector data itself. Keep its connector
-    # for both async-chunk and terminal full-payload sends, but mark it
-    # sender-only so the scheduler does not park orchestrator-provided inputs
-    # waiting for an upstream payload.
-    target_stage = str(stage_id)
-    for (from_stage, _to_stage), spec in getattr(omni_transfer_config, "connectors", {}).items():
-        if from_stage == target_stage:
-            extra = dict(spec.extra or {})
-            extra.setdefault("role", "sender")
-            return {"name": spec.name, "extra": extra}
-    return {}
+    return resolve_stage_connector_plan(omni_transfer_config, stage_id)
 
 
 def build_diffusion_config(

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -52,7 +52,7 @@ from vllm_omni.engine.stage_init_utils import (
     build_vllm_config,
     compute_replica_layout,
     extract_legacy_stage_metadata,
-    get_stage_connector_spec,
+    get_stage_connector_plan,
     inject_kv_stage_info,
     inject_omni_kv_connector_config,
     load_omni_transfer_config_for_model,
@@ -354,10 +354,9 @@ class StageRuntime:
                     "orchestrator indexes stage pools by stage_id."
                 )
 
-            stage_connector_spec = get_stage_connector_spec(
+            stage_connector_plan = get_stage_connector_plan(
                 omni_transfer_config=omni_transfer_config,
                 stage_id=stage_id,
-                async_chunk=self._async_chunk,
             )
             omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)
             num_replicas = replicas_per_stage[stage_idx]
@@ -374,7 +373,7 @@ class StageRuntime:
                 engine_args_dict = build_engine_args_dict(
                     stage_cfg,
                     self._model,
-                    stage_connector_spec=stage_connector_spec,
+                    stage_connector_plan=stage_connector_plan,
                     cli_tokenizer=self._tokenizer,
                 )
                 inject_omni_kv_connector_config(
@@ -390,7 +389,7 @@ class StageRuntime:
                 stage_vllm_config, executor_class = build_vllm_config(
                     stage_cfg,
                     self._model,
-                    stage_connector_spec=stage_connector_spec,
+                    stage_connector_plan=stage_connector_plan,
                     engine_args_dict=engine_args_dict,
                 )
 
@@ -410,7 +409,7 @@ class StageRuntime:
                         launch_mode=launch_mode,
                         stage_cfg=replica_cfg,
                         metadata=replica_metadata,
-                        stage_connector_spec=stage_connector_spec,
+                        stage_connector_plan=stage_connector_plan,
                         omni_kv_connector=omni_kv_connector,
                         stage_vllm_config=stage_vllm_config,
                         executor_class=executor_class,

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -358,7 +358,11 @@ class StageRuntime:
                 omni_transfer_config=omni_transfer_config,
                 stage_id=stage_id,
             )
-            omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)
+            omni_kv_connector = resolve_omni_kv_config_for_stage(
+                omni_transfer_config,
+                stage_id,
+                stage_cfg,
+            )
             num_replicas = replicas_per_stage[stage_idx]
             launch_mode = self._get_launch_mode(stage_id)
 

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -1032,7 +1032,11 @@ def run_headless(args: TrackingNamespace) -> None:
         return
 
     omni_transfer_config = load_omni_transfer_config_for_model(model, config_path)
-    omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)
+    omni_kv_connector = resolve_omni_kv_config_for_stage(
+        omni_transfer_config,
+        stage_id,
+        stage_cfg,
+    )
     stage_connector_plan = get_stage_connector_plan(
         omni_transfer_config=omni_transfer_config,
         stage_id=stage_id,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -943,7 +943,7 @@ def run_headless(args: TrackingNamespace) -> None:
     from vllm_omni.engine.stage_init_utils import (
         build_engine_args_dict,
         build_vllm_config,
-        get_stage_connector_spec,
+        get_stage_connector_plan,
         inject_omni_kv_connector_config,
         load_omni_transfer_config_for_model,
         prepare_engine_environment,
@@ -1033,10 +1033,9 @@ def run_headless(args: TrackingNamespace) -> None:
 
     omni_transfer_config = load_omni_transfer_config_for_model(model, config_path)
     omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)
-    stage_connector_spec = get_stage_connector_spec(
+    stage_connector_plan = get_stage_connector_plan(
         omni_transfer_config=omni_transfer_config,
         stage_id=stage_id,
-        async_chunk=bool(stage_cfg.engine_args.get("async_chunk", False)),
     )
 
     # ``runtime_cfg`` is mostly inherited from the parent's
@@ -1049,7 +1048,7 @@ def run_headless(args: TrackingNamespace) -> None:
     engine_args_dict = build_engine_args_dict(
         stage_cfg,
         model,
-        stage_connector_spec=stage_connector_spec,
+        stage_connector_plan=stage_connector_plan,
         cli_tokenizer=getattr(args, "tokenizer", None),
     )
 
@@ -1058,7 +1057,7 @@ def run_headless(args: TrackingNamespace) -> None:
     vllm_config, executor_class = build_vllm_config(
         stage_cfg,
         model,
-        stage_connector_spec=stage_connector_spec,
+        stage_connector_plan=stage_connector_plan,
         engine_args_dict=engine_args_dict,
         headless=True,
     )

--- a/vllm_omni/model_executor/models/audex/audex_code2wav.py
+++ b/vllm_omni/model_executor/models/audex/audex_code2wav.py
@@ -109,7 +109,7 @@ class AudexCode2Wav(nn.Module):
         self._sessions: dict[str, AudexCausalSpeechDecoderSession] = {}
 
     def _connector_extra_config(self) -> dict[str, Any]:
-        connector_cfg = getattr(self.vllm_config.model_config, "stage_connector_config", None)
+        connector_cfg = getattr(self.vllm_config.model_config, "stage_input_connector_config", None)
         if isinstance(connector_cfg, dict):
             extra = connector_cfg.get("extra", connector_cfg)
             return extra if isinstance(extra, dict) else {}

--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -774,7 +774,9 @@ class CodePredictorWrapper(nn.Module):
     @staticmethod
     def _stage_connector_extra_config(vllm_config: VllmConfig) -> dict:
         model_cfg = getattr(vllm_config, "model_config", None)
-        connector_cfg = getattr(model_cfg, "stage_connector_config", None)
+        connector_cfg = getattr(model_cfg, "stage_input_connector_config", None)
+        if connector_cfg is None:
+            connector_cfg = getattr(model_cfg, "stage_output_connector_config", None)
         if isinstance(connector_cfg, dict):
             extra_cfg = connector_cfg.get("extra", connector_cfg)
         else:

--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_dac_decoder.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_dac_decoder.py
@@ -36,7 +36,7 @@ logger = init_logger(__name__)
 
 def _connector_extra_config(vllm_config: VllmConfig) -> dict[str, Any]:
     model_config = getattr(vllm_config, "model_config", None)
-    connector_cfg = getattr(model_config, "stage_connector_config", None)
+    connector_cfg = getattr(model_config, "stage_input_connector_config", None)
     if isinstance(connector_cfg, dict):
         return connector_cfg.get("extra", connector_cfg)
     extra = getattr(connector_cfg, "extra", None)

--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_dac_decoder.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_dac_decoder.py
@@ -38,8 +38,9 @@ def _connector_extra_config(vllm_config: VllmConfig) -> dict[str, Any]:
     model_config = getattr(vllm_config, "model_config", None)
     connector_cfg = getattr(model_config, "stage_input_connector_config", None)
     if isinstance(connector_cfg, dict):
-        return connector_cfg.get("extra", connector_cfg)
-    extra = getattr(connector_cfg, "extra", None)
+        extra = connector_cfg.get("extra", connector_cfg)
+    else:
+        extra = getattr(connector_cfg, "extra", None)
     return extra if isinstance(extra, dict) else {}
 
 

--- a/vllm_omni/model_executor/models/glm_tts/glm_tts_dit_wrapper.py
+++ b/vllm_omni/model_executor/models/glm_tts/glm_tts_dit_wrapper.py
@@ -330,7 +330,7 @@ class GLMTTSDiTForGeneration(nn.Module):
 
     @staticmethod
     def _connector_chunk_config(vllm_config: VllmConfig) -> tuple[int, int]:
-        cc = getattr(vllm_config.model_config, "stage_connector_config", None)
+        cc = getattr(vllm_config.model_config, "stage_input_connector_config", None)
         extra = (cc or {}).get("extra") if isinstance(cc, dict) else getattr(cc, "extra", None)
         if not isinstance(extra, dict):
             return 25, 25

--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
@@ -482,7 +482,7 @@ class MiMoAudioToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
             * getattr(audio_tokenizer_config, "hop_length", 240)
         ) * self.config.group_size
 
-        connector_cfg = getattr(vllm_config.model_config, "stage_connector_config", None)
+        connector_cfg = getattr(vllm_config.model_config, "stage_input_connector_config", None)
         extra_cfg = (
             (
                 connector_cfg.get("extra", connector_cfg)

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -200,7 +200,7 @@ class MiniCPMO45Code2Wav(nn.Module):
 
     def _extra_config(self) -> dict[str, Any]:
         model_config = getattr(self.vllm_config, "model_config", None)
-        connector = getattr(model_config, "stage_connector_config", None)
+        connector = getattr(model_config, "stage_input_connector_config", None)
         if isinstance(connector, Mapping):
             extra = connector.get("extra", connector)
         else:

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
@@ -626,7 +626,7 @@ class MossTTSCodecDecoder(nn.Module):
 
     def _connector_int(self, name: str, default: int = 0) -> int:
         model_cfg = getattr(self.vllm_config, "model_config", None)
-        connector_cfg = getattr(model_cfg, "stage_connector_config", None)
+        connector_cfg = getattr(model_cfg, "stage_input_connector_config", None)
         if isinstance(connector_cfg, dict):
             extra_cfg: dict | None = connector_cfg.get("extra", connector_cfg)
         else:
@@ -843,7 +843,7 @@ class MossTTSCodecDecoder(nn.Module):
         # codec_chunk_frames values used in moss_tts.yaml.
         capture_sizes: list[int] = [4, 8, 16, 25, 32, 50, 64, 100, 128, 200, 256]
         model_cfg = getattr(self.vllm_config, "model_config", None)
-        connector_cfg = getattr(model_cfg, "stage_connector_config", None)
+        connector_cfg = getattr(model_cfg, "stage_input_connector_config", None)
         if isinstance(connector_cfg, dict):
             extra_cfg: dict | None = connector_cfg.get("extra", connector_cfg)
         else:

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -1368,7 +1368,7 @@ class Qwen3OmniMoeForConditionalGeneration(
     def _get_codec_frame_config(self) -> tuple[int, int]:
         """Extract codec_chunk_frames and codec_left_context_frames from stage connector config."""
         model_cfg = getattr(self.vllm_config, "model_config", None)
-        connector_cfg = getattr(model_cfg, "stage_connector_config", None)
+        connector_cfg = getattr(model_cfg, "stage_input_connector_config", None)
         if isinstance(connector_cfg, dict):
             extra = connector_cfg.get("extra", {})
         else:

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -576,6 +576,8 @@ class Qwen3TTSCode2Wav(nn.Module):
             if isinstance(connector_cfg, dict)
             else getattr(connector_cfg, "extra", None)
         )
+        if not isinstance(extra_cfg, dict):
+            extra_cfg = {}
 
         def _get_int_config(name: str, default: int) -> int:
             value = extra_cfg.get(name, default)

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -570,7 +570,7 @@ class Qwen3TTSCode2Wav(nn.Module):
         codec_chunk_frames = 0
         codec_left_context_frames = 0
         model_cfg = getattr(self.vllm_config, "model_config", None)
-        connector_cfg = getattr(model_cfg, "stage_connector_config", None)
+        connector_cfg = getattr(model_cfg, "stage_input_connector_config", None)
         extra_cfg = (
             connector_cfg.get("extra", connector_cfg)
             if isinstance(connector_cfg, dict)

--- a/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
+++ b/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
@@ -131,11 +131,11 @@ class YuanrongTransferEngineConnector(OmniConnectorBase):
         self.sender_zmq_port = self._resolve_optional_port(sender_zmq_port, "sender_zmq_port")
 
         role = str(config.get("role", "sender")).lower()
-        if role not in {"sender", "receiver"}:
+        if role not in {"sender", "receiver", "dual"}:
             raise ValueError(
-                f"Invalid role={role!r} for YuanrongTransferEngineConnector. Expected 'sender' or 'receiver'."
+                f"Invalid role={role!r} for YuanrongTransferEngineConnector. Expected 'sender', 'receiver', or 'dual'."
             )
-        self.can_put = role == "sender"
+        self.can_put = role in {"sender", "dual"}
 
         self.engine = TransferEngine()
         local_endpoint = f"{self.host}:{self.rpc_port}"

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -439,7 +439,7 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             request_id_resolver=self._resolve_global_request_id,
         )
         #  -------------------------------------- Omni-new -------------------------------------------------
-        if hasattr(self, "_omni_connector"):
+        if getattr(self, "_omni_connector_initialized", False):
             for request in getattr(scheduler_output, "pending_input_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -116,7 +116,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
             if kv_connector_metadata is not None:
                 get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
-        if hasattr(self, "_omni_connector"):
+        if getattr(self, "_omni_connector_initialized", False):
             for request in getattr(scheduler_output, "pending_input_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)

--- a/vllm_omni/request.py
+++ b/vllm_omni/request.py
@@ -14,7 +14,12 @@ from vllm.v1.request import Request
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_utils import BlockHash
 
-from vllm_omni.engine import AdditionalInformationPayload, OmniEngineCoreRequest, PromptEmbedsPayload
+from vllm_omni.engine import (
+    AdditionalInformationPayload,
+    ConnectorEndpoint,
+    OmniEngineCoreRequest,
+    PromptEmbedsPayload,
+)
 
 
 class OmniRequest(Request):
@@ -37,6 +42,7 @@ class OmniRequest(Request):
         prompt_embeds: PromptEmbedsPayload | torch.Tensor | None = None,
         # Optional external request ID for tracking
         external_req_id: str | None = None,
+        sender_info: ConnectorEndpoint | None = None,
         additional_information: AdditionalInformationPayload | None = None,
         model_intermediate_buffer: dict | None = None,
         **kwargs,
@@ -54,6 +60,7 @@ class OmniRequest(Request):
         )
         # Optional external request ID for tracking
         self.external_req_id: str | None = external_req_id
+        self.sender_info = sender_info
         # Serialized additional information payload (optional)
         self.additional_information: AdditionalInformationPayload | None = additional_information
         # Runner-owned runtime payload.
@@ -90,6 +97,7 @@ class OmniRequest(Request):
             request_id=request.request_id,
             # Optional external request ID for tracking
             external_req_id=request.external_req_id,
+            sender_info=request.sender_info,
             client_index=request.client_index,
             prompt_token_ids=request.prompt_token_ids,
             prompt_embeds=request.prompt_embeds,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -941,7 +941,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             request_id_resolver=self._resolve_global_request_id,
         )
 
-        if hasattr(self, "_omni_connector"):
+        if getattr(self, "_omni_connector_initialized", False):
             for request in getattr(scheduler_output, "pending_input_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -105,7 +105,7 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
         if self.routed_experts_initialized:
             self.routed_experts_capturer.clear_buffer()
 
-        if hasattr(self, "_omni_connector"):
+        if getattr(self, "_omni_connector_initialized", False):
             for request in getattr(scheduler_output, "pending_input_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -297,10 +297,12 @@ class OmniConnectorModelRunnerMixin:
 
     def shutdown_omni_connectors(self) -> None:
         """Stop background threads and release connector resources."""
-        self._stop_event.set()
-        if self._recv_thread is not None:
+        stop_event = getattr(self, "_stop_event", None)
+        if stop_event is not None:
+            stop_event.set()
+        if getattr(self, "_recv_thread", None) is not None:
             self._recv_thread.join(timeout=5)
-        if self._save_thread is not None:
+        if getattr(self, "_save_thread", None) is not None:
             self._save_thread.join(timeout=5)
         if self._connectors is not None:
             self._connectors.close()
@@ -1669,7 +1671,8 @@ class OmniConnectorModelRunnerMixin:
     @property
     def connector(self) -> Any | None:
         """Backward-compatible single-connector view."""
-        return self._connectors.connector
+        connectors = getattr(self, "_connectors", None)
+        return connectors.connector if connectors is not None else None
 
     # ------------------------------------------------------------------ #
     #  Background I/O threads
@@ -1791,9 +1794,13 @@ class OmniConnectorModelRunnerMixin:
                 )
                 return False
 
-        target_stage_id = self._previous_stage_id
+        # Test doubles and legacy embedders may install a receive connector
+        # without populating the connector plan. In that case retain the
+        # historical adjacent-stage fallback; a missing receive connector
+        # was handled above as an uninitialized/no-inbound path.
+        target_stage_id = getattr(self, "_previous_stage_id", self._stage_id - 1)
         if target_stage_id is None:
-            raise RuntimeError(f"Stage {self._stage_id} has no inbound connector edge")
+            target_stage_id = self._stage_id - 1
         chunk_id = self._get_req_chunk[req_id]
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
         sender_info = getattr(self._pending_load_reqs.get(req_id), "sender_info", None)

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -183,6 +183,9 @@ class OmniConnectorModelRunnerMixin:
         )
         self._local_rank = local_tp_rank
         if self._kv_transfer_manager is not None:
+            manager_config = self._kv_transfer_manager.config
+            need_recv_cache = bool(manager_config.need_recv_cache)
+            need_send_cache = bool(manager_config.need_send_cache)
             kv_topology = getattr(self._kv_transfer_manager, "tp_topology", None)
             effective_mapping = (
                 getattr(kv_topology, "source_tp_size", None),
@@ -192,18 +195,25 @@ class OmniConnectorModelRunnerMixin:
             if all(isinstance(value, int) for value in effective_mapping):
                 override_topology = KVTPTopology(*effective_mapping)
                 validate_kv_tp_topology(override_topology)
-                self._recv_topology = override_topology
-                self._send_topology = override_topology
-                self._local_rank = effective_mapping[2]
+                if need_recv_cache and need_send_cache and self._recv_topology != self._send_topology:
+                    raise ValueError("A single KV transfer manager cannot own asymmetric receive and send topologies")
+                if need_recv_cache:
+                    self._recv_topology = override_topology
+                if need_send_cache:
+                    self._send_topology = override_topology
+                if need_recv_cache or need_send_cache:
+                    self._local_rank = effective_mapping[2]
         self._recv_from_tp = self._recv_topology.source_tp_size
         self._recv_to_tp = self._recv_topology.target_tp_size
         self._send_from_tp = self._send_topology.source_tp_size
         self._send_to_tp = self._send_topology.target_tp_size
         if self._kv_transfer_manager is not None:
-            self._kv_transfer_manager.kv_send_key_builder = self.get_rank_aware_kv_send_keys
-            self._kv_transfer_manager.kv_recv_key_builder = self.get_rank_aware_kv_keys
-            self._kv_transfer_manager.kv_payload_merger = self._merge_rank_sharded_kv_payloads
-            self._kv_transfer_manager.kv_payload_slicer = self._slice_rank_sharded_kv_payload
+            if need_send_cache:
+                self._kv_transfer_manager.kv_send_key_builder = self.get_rank_aware_kv_send_keys
+                self._kv_transfer_manager.kv_payload_slicer = self._slice_rank_sharded_kv_payload
+            if need_recv_cache:
+                self._kv_transfer_manager.kv_recv_key_builder = self.get_rank_aware_kv_keys
+                self._kv_transfer_manager.kv_payload_merger = self._merge_rank_sharded_kv_payloads
 
         # -- chunk index tracking (ported from OmniChunkTransferAdapter) --
         self._put_req_chunk: dict[str, int] = defaultdict(int)
@@ -1797,13 +1807,9 @@ class OmniConnectorModelRunnerMixin:
                 )
                 return False
 
-        # Test doubles and legacy embedders may install a receive connector
-        # without populating the connector plan. In that case retain the
-        # historical adjacent-stage fallback; a missing receive connector
-        # was handled above as an uninitialized/no-inbound path.
-        target_stage_id = getattr(self, "_previous_stage_id", self._stage_id - 1)
+        target_stage_id = self._previous_stage_id
         if target_stage_id is None:
-            target_stage_id = self._stage_id - 1
+            raise RuntimeError(f"Stage {self._stage_id} has no inbound connector edge")
         chunk_id = self._get_req_chunk[req_id]
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
         sender_info = getattr(self._pending_load_reqs.get(req_id), "sender_info", None)

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import inspect
-import os
 import threading
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any
@@ -26,9 +25,19 @@ from vllm.logger import init_logger
 from vllm_omni.data_entry_keys import OmniPayload
 from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory
 from vllm_omni.distributed.omni_connectors.utils.config import (
-    ConnectorSpec,
+    StageConnectorPlan,
     get_stage_connector_role,
 )
+from vllm_omni.distributed.omni_connectors.utils.initialization import connector_plan_from_model_config
+from vllm_omni.distributed.omni_connectors.utils.kv_utils import (
+    KVTPTopology,
+    get_kv_source_ranks,
+    get_kv_target_ranks,
+    get_local_tp_rank,
+    get_omni_replica_id,
+    validate_kv_tp_topology,
+)
+from vllm_omni.engine import ConnectorEndpoint
 from vllm_omni.outputs import OmniConnectorOutput
 from vllm_omni.worker.payload_span import (
     get_tensor_span,
@@ -121,9 +130,6 @@ class OmniConnectorModelRunnerMixin:
             model_config: Stage-level model config with connector settings.
             kv_transfer_manager: Existing KV transfer manager to delegate to.
         """
-        self._omni_connector: OmniConnectorBase | None = (
-            self._create_connector(model_config) if _should_create_payload_connector(model_config) else None
-        )
         self._kv_transfer_manager = kv_transfer_manager
 
         self._async_chunk: bool = getattr(model_config, "async_chunk", False)
@@ -133,38 +139,66 @@ class OmniConnectorModelRunnerMixin:
             stage_id = int(stage_id)
         self._stage_id: int = stage_id if isinstance(stage_id, int) else 0
 
-        self._custom_process_func_path, self._custom_process_func = self._load_custom_func(model_config)
-        self._custom_process_supports_is_finished = self._custom_process_supports_is_finished_kwarg()
-        logger.debug(
-            "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, connector=%s, func_path=%s",
-            self._stage_id,
-            self._async_chunk,
-            self._custom_process_func,
-            type(self._omni_connector).__name__ if self._omni_connector else None,
-            self._custom_process_func_path,
+        local_tp_rank = get_local_tp_rank()
+        connector_plan = connector_plan_from_model_config(model_config)
+        self._previous_stage_id = connector_plan.inbound.from_stage if connector_plan.inbound is not None else None
+        self._next_stage_id = connector_plan.outbound.to_stage if connector_plan.outbound is not None else None
+        next_stage_func = getattr(model_config, "custom_process_next_stage_input_func", None)
+        stage_produces_payload = isinstance(next_stage_func, str) and bool(next_stage_func)
+        runtime_plan = StageConnectorPlan(
+            inbound=None if self._async_chunk else connector_plan.inbound,
+            outbound=(connector_plan.outbound if not self._async_chunk and stage_produces_payload else None),
+        )
+        self._connectors = (
+            OmniConnectorFactory.create_stage_connectors(
+                runtime_plan,
+                stage_id=self._stage_id,
+                local_rank=local_tp_rank,
+                replica_id=get_omni_replica_id(),
+            )
+            if _should_create_payload_connector(model_config)
+            else None
         )
 
-        # -- next stage ID (from connector config or default stage_id + 1) --
-        self._next_stage_id: int = self._resolve_next_stage_id(model_config)
+        self._custom_process_func_path, self._custom_process_func = self._load_custom_func(model_config)
+        self._custom_process_supports_is_finished = self._custom_process_supports_is_finished_kwarg()
+
+        if self._connectors:
+            logger.debug(
+                "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, "
+                "recv_connector=%s, send_connector=%s, dual=%s, func_path=%s",
+                self._stage_id,
+                self._async_chunk,
+                self._custom_process_func,
+                type(self._connectors.receive).__name__ if self._connectors.receive else None,
+                type(self._connectors.send).__name__ if self._connectors.send else None,
+                self._connectors.receive is not None and self._connectors.receive is self._connectors.send,
+                self._custom_process_func_path,
+            )
 
         # -- heterogeneous TP rank support --
-        rank_cfg = self._parse_rank_mapping(model_config)
+        self._recv_topology, self._send_topology = self._resolve_parallel_topologies(
+            connector_plan,
+            local_tp_rank,
+        )
+        self._local_rank = local_tp_rank
         if self._kv_transfer_manager is not None:
-            topology = getattr(self._kv_transfer_manager, "tp_topology", None)
+            kv_topology = getattr(self._kv_transfer_manager, "tp_topology", None)
             effective_mapping = (
-                getattr(topology, "source_tp_size", None),
-                getattr(topology, "target_tp_size", None),
-                getattr(topology, "local_rank", None),
+                getattr(kv_topology, "source_tp_size", None),
+                getattr(kv_topology, "target_tp_size", None),
+                getattr(kv_topology, "local_rank", None),
             )
             if all(isinstance(value, int) for value in effective_mapping):
-                rank_cfg = {
-                    "from_tp": effective_mapping[0],
-                    "to_tp": effective_mapping[1],
-                    "local_rank": effective_mapping[2],
-                }
-        self._from_tp: int = rank_cfg["from_tp"]
-        self._to_tp: int = rank_cfg["to_tp"]
-        self._local_rank: int = rank_cfg["local_rank"]
+                override_topology = KVTPTopology(*effective_mapping)
+                validate_kv_tp_topology(override_topology)
+                self._recv_topology = override_topology
+                self._send_topology = override_topology
+                self._local_rank = effective_mapping[2]
+        self._recv_from_tp = self._recv_topology.source_tp_size
+        self._recv_to_tp = self._recv_topology.target_tp_size
+        self._send_from_tp = self._send_topology.source_tp_size
+        self._send_to_tp = self._send_topology.target_tp_size
         if self._kv_transfer_manager is not None:
             self._kv_transfer_manager.kv_send_key_builder = self.get_rank_aware_kv_send_keys
             self._kv_transfer_manager.kv_recv_key_builder = self.get_rank_aware_kv_keys
@@ -237,16 +271,16 @@ class OmniConnectorModelRunnerMixin:
         self._stop_event = threading.Event()
         self._work_available = threading.Event()
 
-        # Start background threads only when there's a connector
         self._recv_thread: threading.Thread | None = None
         self._save_thread: threading.Thread | None = None
-        if self._omni_connector is not None:
+        if self._connectors is not None and self._connectors.receive is not None:
             self._recv_thread = threading.Thread(
                 target=self._recv_loop,
                 daemon=True,
                 name="omni-mixin-recv",
             )
             self._recv_thread.start()
+        if self._connectors is not None and self._connectors.send is not None:
             self._save_thread = threading.Thread(
                 target=self._save_loop,
                 daemon=True,
@@ -268,11 +302,8 @@ class OmniConnectorModelRunnerMixin:
             self._recv_thread.join(timeout=5)
         if self._save_thread is not None:
             self._save_thread.join(timeout=5)
-        if self._omni_connector is not None:
-            try:
-                self._omni_connector.close()
-            except Exception:
-                pass
+        if self._connectors is not None:
+            self._connectors.close()
 
     def cleanup_finished_request(self, req_id: str) -> None:
         """Clean up per-request state after a request is fully finished.
@@ -605,14 +636,16 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        sender_info: ConnectorEndpoint | None = None,
     ) -> Any:
         """Receive one ordinary non-KV stage payload on the local leader rank only."""
+        metadata = sender_info.as_metadata() if sender_info is not None else None
         tp_group = self._get_local_tp_group()
         if tp_group is None or getattr(tp_group, "world_size", 1) <= 1:
-            return connector.get(from_stage, to_stage, connector_get_key)
+            return connector.get(from_stage, to_stage, connector_get_key, metadata=metadata)
         if not self.is_data_transfer_rank():
             return None
-        return connector.get(from_stage, to_stage, connector_get_key)
+        return connector.get(from_stage, to_stage, connector_get_key, metadata=metadata)
 
     def _recv_full_payload_result(
         self,
@@ -620,6 +653,7 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        sender_info: ConnectorEndpoint | None = None,
     ) -> Any:
         """Receive one full-payload transfer on the local leader rank only."""
         return self._recv_ordinary_stage_result(
@@ -627,6 +661,7 @@ class OmniConnectorModelRunnerMixin:
             from_stage,
             to_stage,
             connector_get_key,
+            sender_info,
         )
 
     def _recv_async_chunk_result(
@@ -635,6 +670,7 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        sender_info: ConnectorEndpoint | None = None,
     ) -> Any:
         """Receive one ordinary async chunk on the local leader rank only."""
         return self._recv_ordinary_stage_result(
@@ -642,6 +678,7 @@ class OmniConnectorModelRunnerMixin:
             from_stage,
             to_stage,
             connector_get_key,
+            sender_info,
         )
 
     @staticmethod
@@ -784,27 +821,6 @@ class OmniConnectorModelRunnerMixin:
         _custom_process_func, both of which are set at init time. Avoid
         the per-step dynamic import inside the model decode loop.
         """
-        if getattr(self, "_omni_connector", None) is None:
-            # No connector at all: send_full_payload_outputs would no-op.
-            # Skip the per-step accumulator+build that would otherwise be
-            # silently discarded.  Defends against a terminal stage whose
-            # custom_process_input_func has a *_full_payload derivative in
-            # the same module (e.g. dynin stage 2 token2image_to_token2audio
-            # in pipelines that don't configure any connector at all).
-            #
-            # Known limitation: a *terminal-consumer* stage that has a
-            # connector configured for receiving upstream input is NOT
-            # caught here -- ``_omni_connector`` is non-None for it, and
-            # ``_load_custom_func`` may still resolve a ``*_full_payload``
-            # derivative from this stage's ``custom_process_input_func``.
-            # In that case the accumulator builds payloads that
-            # ``send_full_payload_outputs`` later drops via its own
-            # connector-side checks (wasted CPU, not a functional bug).
-            # A topology-aware gate (explicit producer field or pipeline
-            # is_terminal info) would close the gap; that change is out
-            # of scope for this PR.
-            self._should_accumulate_full_payload_output_cached = False
-            return False
         cached = getattr(self, "_should_accumulate_full_payload_output_cached", None)
         if cached is not None:
             return cached
@@ -997,7 +1013,7 @@ class OmniConnectorModelRunnerMixin:
 
         Returns list of request IDs successfully enqueued.
         """
-        if self._omni_connector is None:
+        if self._connectors is None or self._connectors.send is None:
             logger.debug("[Stage-%s] send_full_payload_outputs: connector is None, skip", self._stage_id)
             return []
         if not self.is_data_transfer_rank():
@@ -1144,7 +1160,7 @@ class OmniConnectorModelRunnerMixin:
         ``connector.put()`` is done by the background save thread.
         Non-KV data is identical across TP ranks; only rank 0 sends.
         """
-        if self._omni_connector is None:
+        if self._connectors is None or self._connectors.send is None:
             logger.warning("[Stage-%s] send_chunk: connector is None", self._stage_id)
             return False
         if not self.is_data_transfer_rank():
@@ -1319,7 +1335,7 @@ class OmniConnectorModelRunnerMixin:
         For heterogeneous TP receive, the local rank is the target rank and must
         fetch one or more source-rank shards keyed as ``from_rank -> to_rank``.
         """
-        if self._from_tp <= 1 and self._to_tp <= 1:
+        if self._recv_from_tp <= 1 and self._recv_to_tp <= 1:
             resolved_to_stage = self._next_stage_id if to_stage is None else to_stage
             return [f"omni_{from_stage}_to_{resolved_to_stage}_kv_cache_{req_id}"]
 
@@ -1337,15 +1353,7 @@ class OmniConnectorModelRunnerMixin:
 
     def get_kv_target_ranks_for_send(self) -> list[int]:
         """Determine which target ranks this local rank should send KV shards to."""
-        self._validate_kv_tp_topology()
-        if self._from_tp == self._to_tp:
-            return [self._local_rank]
-        if self._from_tp > self._to_tp:
-            tp_ratio = self._from_tp // self._to_tp
-            return [self._local_rank // tp_ratio]
-        tp_ratio = self._to_tp // self._from_tp
-        base_rank = self._local_rank * tp_ratio
-        return [base_rank + i for i in range(tp_ratio)]
+        return get_kv_target_ranks(self._send_topology)
 
     def get_rank_aware_kv_send_keys(
         self,
@@ -1355,7 +1363,7 @@ class OmniConnectorModelRunnerMixin:
         chunk_id: int = 0,
     ) -> list[str]:
         """Build send-side connector keys for this rank's KV shard(s)."""
-        if self._from_tp <= 1 and self._to_tp <= 1:
+        if self._send_from_tp <= 1 and self._send_to_tp <= 1:
             resolved_to_stage = self._next_stage_id if to_stage is None else to_stage
             return [f"omni_{from_stage}_to_{resolved_to_stage}_kv_cache_{req_id}"]
 
@@ -1411,10 +1419,10 @@ class OmniConnectorModelRunnerMixin:
 
     def _slice_rank_sharded_kv_payload(self, payload: dict[str, Any] | None) -> dict[str, Any] | None:
         """Slice a duplicated source-rank KV shard for ``from_tp < to_tp`` cases."""
-        if payload is None or self._from_tp >= self._to_tp:
+        if payload is None or self._recv_from_tp >= self._recv_to_tp:
             return payload
 
-        tp_ratio = self._to_tp // self._from_tp
+        tp_ratio = self._recv_to_tp // self._recv_from_tp
         shard_index = self._local_rank % tp_ratio
         layer_blocks = payload.get("layer_blocks") if isinstance(payload, dict) else None
         if not isinstance(layer_blocks, dict):
@@ -1461,8 +1469,8 @@ class OmniConnectorModelRunnerMixin:
         the TP topology without re-parsing model config.
         """
         return {
-            "from_tp": self._from_tp,
-            "to_tp": self._to_tp,
+            "recv": {"from_tp": self._recv_from_tp, "to_tp": self._recv_to_tp},
+            "send": {"from_tp": self._send_from_tp, "to_tp": self._send_to_tp},
             "local_rank": self._local_rank,
             "remote_ranks": self.get_kv_remote_ranks(),
             "is_data_transfer_rank": self.is_data_transfer_rank(),
@@ -1660,7 +1668,8 @@ class OmniConnectorModelRunnerMixin:
 
     @property
     def connector(self) -> Any | None:
-        return self._omni_connector
+        """Backward-compatible single-connector view."""
+        return self._connectors.connector
 
     # ------------------------------------------------------------------ #
     #  Background I/O threads
@@ -1765,9 +1774,9 @@ class OmniConnectorModelRunnerMixin:
 
     def _poll_single_request(self, req_id: str) -> bool:
         """Poll connector for one chunk of a request (non-blocking)."""
-        connector = self._omni_connector
-        if connector is None:
+        if self._connectors is None or self._connectors.receive is None:
             return False
+        connector = self._connectors.receive
 
         if self._async_chunk and self._model_mode != "ar":
             with self._lock:
@@ -1782,9 +1791,12 @@ class OmniConnectorModelRunnerMixin:
                 )
                 return False
 
-        target_stage_id = self._stage_id - 1
+        target_stage_id = self._previous_stage_id
+        if target_stage_id is None:
+            raise RuntimeError(f"Stage {self._stage_id} has no inbound connector edge")
         chunk_id = self._get_req_chunk[req_id]
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
+        sender_info = getattr(self._pending_load_reqs.get(req_id), "sender_info", None)
         connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
         if self._async_chunk:
@@ -1793,6 +1805,7 @@ class OmniConnectorModelRunnerMixin:
                 str(target_stage_id),
                 str(self._stage_id),
                 connector_get_key,
+                sender_info,
             )
         else:
             result = self._recv_full_payload_result(
@@ -1800,6 +1813,7 @@ class OmniConnectorModelRunnerMixin:
                 str(target_stage_id),
                 str(self._stage_id),
                 connector_get_key,
+                sender_info,
             )
 
         if result is None:
@@ -1977,9 +1991,9 @@ class OmniConnectorModelRunnerMixin:
         ``success=False``), returns False **without** decrementing
         ``_pending_save_counts`` so the caller can retry or clean up.
         """
-        connector = self._omni_connector
-        if connector is None:
+        if self._connectors is None or self._connectors.send is None:
             return True
+        connector = self._connectors.send
 
         request_id = task.get("request_id")
         payload_data = task.get("data")
@@ -2114,34 +2128,22 @@ class OmniConnectorModelRunnerMixin:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _create_connector(model_config: Any) -> OmniConnectorBase | None:
-        """Create a connector from model_config, or None if unconfigured."""
-        connector_config = getattr(model_config, "stage_connector_config", None)
-        if connector_config is None:
-            return None
+    def _resolve_parallel_topologies(
+        plan: StageConnectorPlan,
+        local_rank: int,
+    ) -> tuple[KVTPTopology, KVTPTopology]:
+        def topology(edge: Any | None) -> KVTPTopology:
+            mapping = edge.spec.extra.get("rank_mapping") if edge is not None else None
+            mapping = mapping if isinstance(mapping, dict) else {}
+            result = KVTPTopology(
+                source_tp_size=int(mapping.get("from_tp", 1)),
+                target_tp_size=int(mapping.get("to_tp", 1)),
+                local_rank=local_rank,
+            )
+            validate_kv_tp_topology(result)
+            return result
 
-        if not isinstance(connector_config, dict):
-            connector_config = {
-                "name": getattr(connector_config, "name", None),
-                "extra": getattr(connector_config, "extra", None),
-            }
-
-        name = connector_config.get("name")
-        if not isinstance(name, str) or not name.strip():
-            raise RuntimeError("Invalid stage connector config: missing connector name")
-        name = name.strip()
-
-        extra = connector_config.get("extra")
-        if extra is None:
-            extra = {}
-        elif not isinstance(extra, dict):
-            raise RuntimeError(f"Invalid extra config for connector {name}: expected dict, got {type(extra).__name__}")
-
-        spec = ConnectorSpec(name=name, extra=extra)
-        try:
-            return OmniConnectorFactory.create_connector(spec)
-        except Exception as exc:
-            raise RuntimeError(f"Failed to create connector {name}") from exc
+        return topology(plan.inbound), topology(plan.outbound)
 
     @staticmethod
     def _load_custom_func(model_config: Any) -> tuple[str | None, Any | None]:
@@ -2238,83 +2240,13 @@ class OmniConnectorModelRunnerMixin:
                 return ext
         return fallback_req_id
 
-    def _resolve_next_stage_id(self, model_config: Any) -> int:
-        """Determine the downstream stage ID from connector config.
-
-        Falls back to ``stage_id + 1`` when the config does not specify
-        a ``to_stage`` explicitly.
-        """
-        connector_config = getattr(model_config, "stage_connector_config", None)
-        if connector_config is not None:
-            if isinstance(connector_config, dict):
-                to_stage = connector_config.get("to_stage")
-            else:
-                to_stage = getattr(connector_config, "to_stage", None)
-            if isinstance(to_stage, int):
-                return to_stage
-            if isinstance(to_stage, str) and to_stage.strip():
-                return int(to_stage)
-        return self._stage_id + 1
-
-    @staticmethod
-    def _parse_rank_mapping(model_config: Any) -> dict[str, int]:
-        """Parse rank_mapping from connector config (optional).
-
-        Returns ``{"from_tp": int, "to_tp": int, "local_rank": int}``.
-        When ``rank_mapping`` is absent, assumes 1:1 homogeneous mapping.
-        """
-        connector_config = getattr(model_config, "stage_connector_config", None)
-        if connector_config is not None and not isinstance(connector_config, dict):
-            connector_config = getattr(connector_config, "__dict__", {})
-
-        rank_mapping: dict = {}
-        if isinstance(connector_config, dict):
-            rank_mapping = connector_config.get("rank_mapping", {})
-
-        from_tp = int(rank_mapping.get("from_tp", 1))
-        to_tp = int(rank_mapping.get("to_tp", 1))
-
-        local_rank = 0
-        try:
-            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-        except (ValueError, TypeError):
-            pass
-
-        return {"from_tp": from_tp, "to_tp": to_tp, "local_rank": local_rank}
-
     # ------------------------------------------------------------------ #
     #  Heterogeneous TP rank support
     # ------------------------------------------------------------------ #
 
-    def _validate_kv_tp_topology(self) -> None:
-        """Reject heterogeneous TP mappings that cannot be routed losslessly."""
-        if self._from_tp <= 0 or self._to_tp <= 0:
-            raise ValueError(f"Invalid KV TP mapping: from_tp={self._from_tp}, to_tp={self._to_tp}")
-        larger = max(self._from_tp, self._to_tp)
-        smaller = min(self._from_tp, self._to_tp)
-        if larger % smaller != 0:
-            raise ValueError(
-                f"KV TP mapping must be divisible for rank-aware routing: from_tp={self._from_tp}, to_tp={self._to_tp}"
-            )
-
     def get_kv_remote_ranks(self) -> list[int]:
-        """Determine which remote ranks this local rank exchanges KV with.
-
-        Follows vLLM's ``TpKVTopology.get_target_remote_ranks()`` pattern:
-        - ``from_tp > to_tp``: each to-rank reads from multiple from-ranks
-        - ``from_tp < to_tp``: multiple to-ranks read from the same from-rank
-        - ``from_tp == to_tp``: 1:1 mapping
-        """
-        self._validate_kv_tp_topology()
-        if self._from_tp == self._to_tp:
-            return [self._local_rank]
-
-        if self._from_tp > self._to_tp:
-            tp_ratio = self._from_tp // self._to_tp
-            return [self._local_rank * tp_ratio + i for i in range(tp_ratio)]
-        else:
-            tp_ratio = self._to_tp // self._from_tp
-            return [self._local_rank // tp_ratio]
+        """Return the source ranks used by this stage's inbound KV edge."""
+        return get_kv_source_ranks(self._recv_topology)
 
     def is_data_transfer_rank(self) -> bool:
         """Whether this rank should participate in data (non-KV) transfer.

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -1015,7 +1015,8 @@ class OmniConnectorModelRunnerMixin:
 
         Returns list of request IDs successfully enqueued.
         """
-        if self._connectors is None or self._connectors.send is None:
+        connectors = getattr(self, "_connectors", None)
+        if connectors is None or connectors.send is None:
             logger.debug("[Stage-%s] send_full_payload_outputs: connector is None, skip", self._stage_id)
             return []
         if not self.is_data_transfer_rank():
@@ -1162,7 +1163,8 @@ class OmniConnectorModelRunnerMixin:
         ``connector.put()`` is done by the background save thread.
         Non-KV data is identical across TP ranks; only rank 0 sends.
         """
-        if self._connectors is None or self._connectors.send is None:
+        connectors = getattr(self, "_connectors", None)
+        if connectors is None or connectors.send is None:
             logger.warning("[Stage-%s] send_chunk: connector is None", self._stage_id)
             return False
         if not self.is_data_transfer_rank():
@@ -1777,9 +1779,10 @@ class OmniConnectorModelRunnerMixin:
 
     def _poll_single_request(self, req_id: str) -> bool:
         """Poll connector for one chunk of a request (non-blocking)."""
-        if self._connectors is None or self._connectors.receive is None:
+        connectors = getattr(self, "_connectors", None)
+        if connectors is None or connectors.receive is None:
             return False
-        connector = self._connectors.receive
+        connector = connectors.receive
 
         if self._async_chunk and self._model_mode != "ar":
             with self._lock:
@@ -1998,9 +2001,10 @@ class OmniConnectorModelRunnerMixin:
         ``success=False``), returns False **without** decrementing
         ``_pending_save_counts`` so the caller can retry or clean up.
         """
-        if self._connectors is None or self._connectors.send is None:
+        connectors = getattr(self, "_connectors", None)
+        if connectors is None or connectors.send is None:
             return True
-        connector = self._connectors.send
+        connector = connectors.send
 
         request_id = task.get("request_id")
         payload_data = task.get("data")

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -210,9 +210,9 @@ class OmniConnectorModelRunnerMixin:
         if self._kv_transfer_manager is not None:
             if need_send_cache:
                 self._kv_transfer_manager.kv_send_key_builder = self.get_rank_aware_kv_send_keys
-                self._kv_transfer_manager.kv_payload_slicer = self._slice_rank_sharded_kv_payload
             if need_recv_cache:
                 self._kv_transfer_manager.kv_recv_key_builder = self.get_rank_aware_kv_keys
+                self._kv_transfer_manager.kv_payload_slicer = self._slice_rank_sharded_kv_payload
                 self._kv_transfer_manager.kv_payload_merger = self._merge_rank_sharded_kv_payloads
 
         # -- chunk index tracking (ported from OmniChunkTransferAdapter) --


### PR DESCRIPTION
## Purpose

Introduce the dual OmniConnector infrastructure with independent inbound and outbound payload/chunk connector specifications. Compatible same-type edges may collapse into one shared connector instance when that connector explicitly supports `role="dual"`. Implements #5431.

This enables:

- separate inbound and outbound connector configuration
- hybrid payload topologies such as Mooncake inbound and SharedMemory outbound
- independent inbound and outbound TP mappings for KV routing
- one shared connector object for compatible, dual-capable same-type edges
- stage 0 initialization without a synthetic inbound edge
- per-request transfer-engine routing to the selected producer replica

Follow-up PR #5141 builds on this infrastructure for Qwen3-Omni Mooncake transfer-engine support.

cc: @natureofnature

### Workflow

Setup (once per stage during engine configuration):

    Deploy config edges (OmniTransferConfig) -> resolve_stage_connector_plan(stage_id) [utils/initialization.py]
    -> one StageConnectorPlan(inbound, outbound) per stage
    -> threaded through build_engine_args_dict / build_legacy_engine_args_dict
    -> OmniModelConfig.stage_connector_plan [config/model.py]

Construction (per replica, at model-runner or transfer-adapter initialization):

    init_omni_connectors() / OmniChunkTransferAdapter.__init__()
    -> connector_plan_from_model_config()
    -> OmniConnectorFactory.create_stage_connectors() [factory.py]:
        - same connector type, supports_dual=True, compatible non-directional config -> one role="dual" object
        - same connector type with incompatible config -> two directional objects
        - different connector types -> two directional objects
        - one-way plan -> one directional object

Runtime ownership may filter the resolved plan:

    - OmniChunkTransferAdapter owns async-chunk connectors.
    - The non-async model runner creates an inbound payload connector and creates
      an outbound payload connector only when the stage produces downstream payload.
    - OmniKVTransferManager owns KV-only transfer and is separate from StageConnectorSet.

Per-request routing (multi-replica transfer-engine pipelines):

    Orchestrator resolves the endpoint of the producer replica bound to the request:
    StageEngineCoreClient.get_payload_sender_info() -> ConnectorEndpoint
    -> request.sender_info
    -> connector.get(..., metadata=sender_info.as_metadata())

This avoids applying the receiver's rank or replica offset to the upstream sender port. Store and shared-memory connectors do not require this network endpoint.

Teardown:

    shutdown_omni_connectors() / adapter teardown -> StageConnectorSet.close()
    -> closes receive and send independently
    -> closes once when .receive is .send

### Design

Each stage resolves its inbound and outbound edges independently via `resolve_stage_connector_plan()`:

```python
StageConnectorPlan(
    inbound: StageConnectorSpec | None,
    outbound: StageConnectorSpec | None,
)
```

Fan-in and fan-out are not supported. Resolving more than one edge in either direction raises an error.

At connector construction time (`OmniConnectorFactory.create_stage_connectors`):

- no edges produce an empty `StageConnectorSet`
- a single inbound or outbound edge produces one connector in that direction
- compatible same-type edges collapse only when the connector was registered with `supports_dual=True`
- incompatible same-type edges remain separate
- different connector types remain separate
- third-party registrations default to `supports_dual=False`

Sharing guarantees one connector object and that object's backend state. The factory does not independently guarantee a particular backend pool or memory-sharing implementation.

#### Overall dual connector design

```mermaid
flowchart LR
    CFG["OmniTransferConfig<br/>edges: 0->1, 1->2"] --> RESOLVE["resolve_stage_connector_plan(stage_id=1)<br/>returns StageConnectorPlan"]
    RESOLVE --> PLAN["OmniModelConfig.stage_connector_plan"]
    PLAN --> BUILD["create_stage_connectors<br/>called by the owning runtime"]

    subgraph S0["Stage 0"]
        S0MR["ModelRunner"]
        S0PUT["outbound payload connector<br/>role=sender<br/>edge: 0->1"]
        S0MR --> S0PUT
    end

    subgraph S1["Stage 1"]
        S1MR["ModelRunner"]
        subgraph DUAL["Compatible dual-capable connector"]
            GET["receive reference"]
            PUT["send reference"]
            OBJ["one connector object<br/>role=dual"]
            GET --- OBJ
            PUT --- OBJ
        end
        GET --> S1MR --> PUT
    end

    subgraph S2["Stage 2"]
        S2GET["inbound payload connector<br/>role=receiver<br/>edge: 1->2"]
        S2MR["ModelRunner"]
        S2GET --> S2MR
    end

    S0PUT -- "payload/chunks from 0->1" --> GET
    PUT -- "payload/chunks from 1->2" --> S2GET
```

This diagram describes payload/chunk connector ownership. KV connector construction remains separate and is owned by `OmniKVTransferManager`; KV connectors are not merged into the payload connector's dual instance.

#### Direction-specific connector specifications

```mermaid
flowchart LR
    CFG["OmniTransferConfig<br/>edges: 0->1, 1->2"] --> STAGE0["Stage 0"]
    CFG --> STAGE1["Stage 1"]
    CFG --> STAGE2["Stage 2"]

    STAGE0 --> S0OUT["inbound=None<br/>outbound: edge 0->1"]
    STAGE1 --> S1SPECS["inbound: edge 0->1<br/>outbound: edge 1->2"]
    STAGE2 --> S2IN["inbound: edge 1->2<br/>outbound=None"]

    S0OUT --> S0ARGS["stage_input_connector_config=None<br/>stage_output_connector_config=..."]
    S1SPECS --> S1ARGS["stage_input_connector_config=...<br/>stage_output_connector_config=..."]
    S2IN --> S2ARGS["stage_input_connector_config=...<br/>stage_output_connector_config=None"]
```

There is no synthetic receive edge on stage 0. Similarly, a terminal stage has no outbound edge when the deployment configuration does not define one. With no transfer configuration, the existing SharedMemoryConnector default remains, but stage 0 still does not receive an invalid edge from stage `-1`.

#### Same-type dual collapse

```mermaid
flowchart LR
    S0["Stage 0<br/>sender"] -->|"inbound edge 0->1"| D

    subgraph S1["Stage 1"]
        MR["ModelRunner"]
        subgraph D["One connector object"]
            ROLE["role=dual"]
            STATE["shared object state"]
            ROLE --- STATE
        end
        D -->|"get path"| MR
        MR -->|"put path"| D
    end

    D -->|"outbound edge 1->2"| S2["Stage 2<br/>receiver"]
    NOTE["receive and send reference<br/>the same object"]
    D -.-> NOTE
```

The collapse occurs only when both edges use the same registered connector name, that registration has `supports_dual=True`, and `_merge_dual_config()` finds the non-directional configuration compatible. Otherwise, the factory creates separate receive and send objects. All current built-in registrations declare dual-role support; third-party connectors must opt in.

#### Hybrid connector topology

```mermaid
flowchart LR
    S0["Stage 0"] -->|"edge 0->1"| IN_CONN
    OUT_CONN -->|"edge 1->2"| S2["Stage 2"]

    subgraph S1["Stage 1"]
        direction LR
        subgraph INBOUND["Inbound side"]
            direction TB
            IN_SPEC["Mooncake configuration"]
            IN_CONN["Mooncake connector<br/>role=receiver"]
            IN_SPEC -.-> IN_CONN
        end

        MR["ModelRunner"]

        subgraph OUTBOUND["Outbound side"]
            direction TB
            OUT_CONN["SharedMemory connector<br/>role=sender"]
            OUT_SPEC["SharedMemory configuration"]
            OUT_SPEC -.-> OUT_CONN
        end

        IN_CONN -->|"received payload"| MR
        MR -->|"outbound payload"| OUT_CONN
    end
```

When the inbound and outbound connector types differ, the owning runtime creates independent connector objects for the directions it uses. Each direction retains its own connector configuration and lifecycle.

#### Heterogeneous TP rank mapping

Example: stage 0 uses TP=4, stage 1 uses TP=2, and stage 2 uses TP=1.

The middle stage parses the receive topology from its inbound edge and the send topology from its outbound edge. Receive keys and receive-side shard merging or slicing use the inbound topology; send keys use the outbound topology.

```mermaid
flowchart LR
    subgraph ST0["Stage 0 - TP=4"]
        S0R0["rank 0"]
        S0R1["rank 1"]
        S0R2["rank 2"]
        S0R3["rank 3"]
    end

    subgraph ST1["Stage 1 - TP=2"]
        G10["recv mapping<br/>edge 0->1<br/>source ranks 0,1"]
        M10["rank 0"]
        P10["send mapping<br/>edge 1->2<br/>target rank 0"]
        G11["recv mapping<br/>edge 0->1<br/>source ranks 2,3"]
        M11["rank 1"]
        P11["send mapping<br/>edge 1->2<br/>target rank 0"]
        G10 --> M10 --> P10
        G11 --> M11 --> P11
    end

    subgraph ST2["Stage 2 - TP=1"]
        S2R0["rank 0"]
    end

    S0R0 --> G10
    S0R1 --> G10
    S0R2 --> G11
    S0R3 --> G11
    P10 --> S2R0
    P11 --> S2R0
```

KV connector configuration is selected from the direction owned by the manager: the inbound edge for a receive-only manager and the outbound edge for a send-only manager. A single `OmniKVTransferManager` currently supports only one directional connector. A stage with both `need_recv_cache` and `need_send_cache` is rejected.

#### Replica-local connector instances

Each replica constructs its own connector state for the directions owned by that runtime. A stage with compatible inbound and outbound connector types owns one dual object per replica, while a hybrid payload stage must own separate inbound and outbound objects per replica.

```mermaid
flowchart LR
    subgraph R0["Replica 0"]
        S0R0["Stage 0"]
        M1R0["Stage 1 ModelRunner"]
        subgraph D0["One dual object"]
            D0IN[".receive"]
            D0OUT[".send"]
        end
        S2R0["Stage 2"]
        S0R0 --> D0IN --> M1R0 --> D0OUT --> S2R0
        D0IN --- D0OUT
    end

    subgraph R1["Replica 1"]
        S0R1["Stage 0"]
        M1R1["Stage 1 ModelRunner"]
        subgraph D1["One dual object"]
            D1IN[".receive"]
            D1OUT[".send"]
        end
        S2R1["Stage 2"]
        S0R1 --> D1IN --> M1R1 --> D1OUT --> S2R1
        D1IN --- D1OUT
    end

    SPEC["same resolved StageConnectorPlan<br/>materialized per replica"] -.-> D0
    SPEC -.-> D1
    NOTE["close shared direction references once"]
    D0 -.-> NOTE
    D1 -.-> NOTE
```

## Test Plan

L1, L2, L3 tests; model tests for BAGEL and Qwen3-Omni.

```bash
pytest tests/distributed/omni_connectors \
  tests/distributed/omni_coordinator \
  tests/worker/test_omni_connector_mixin.py \
  tests/worker/test_omni_gpu_model_runner.py \
  tests/engine \
  tests/entrypoints/test_serve.py \
  tests/e2e/online_serving/test_bagel.py \
  tests/e2e/online_serving/test_qwen3_omni.py \
  -sv --run-level=advanced_model -m advanced_model
```

**VLLM Version:** 0.26.0

**VLLM-Omni Commit:** bae2fb9

## Test Result

**L1:** 790 passed, 2 skipped, 40 deselected, 19 warnings, 2 subtests passed in 101.12s (0:01:41)

**L2-L3:** WIP (pending hardware availability)

Pre-merge tests: WIP (pending hardware availability)

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
