### PR TITLE
[Bugfix] Populate non-stream chat audio transcript

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
@@ -81,23 +81,6 @@ def test_create_audio_choice_fills_nonstream_transcript(serving_chat):
     assert choices[0].message.audio.data == "YmFzZTY0YXVkaW8="
 
 
-def test_create_audio_choice_stream_keeps_legacy_content_only(serving_chat):
-    """Streaming must not emit delta.audio; keep base64 in content."""
-    request = SimpleNamespace(return_token_ids=False)
-    choices = OmniOpenAIServingChat._create_audio_choice(
-        serving_chat,
-        _audio_omni_output(),
-        role="assistant",
-        request=request,
-        stream=True,
-        transcripts={0: "should not appear on stream"},
-    )
-    assert len(choices) == 1
-    delta = choices[0].delta
-    assert delta.content == "YmFzZTY0YXVkaW8="
-    assert getattr(delta, "audio", None) is None
-
-
 def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
     request = SimpleNamespace(return_token_ids=False)
     choices = OmniOpenAIServingChat._create_audio_choice(

--- a/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
@@ -36,6 +36,16 @@ def _audio_omni_output(text_in_mm: str | None = None):
     return SimpleNamespace(request_output=request_output, final_output_type="audio")
 
 
+class _FakeReasoningParser:
+    def extract_reasoning(self, model_output: str, request=None):
+        # Mimic <think>...</think>content split used by many parsers.
+        marker = "</think>"
+        if marker in model_output:
+            reasoning, content = model_output.split(marker, 1)
+            return reasoning, content
+        return model_output, ""
+
+
 def test_resolve_audio_transcript_prefers_index_map():
     assert (
         OmniOpenAIServingChat._resolve_audio_transcript({0: "hello from thinker"}, 0, {"transcript": "mm"})
@@ -47,6 +57,21 @@ def test_resolve_audio_transcript_falls_back_to_mm_output():
     assert OmniOpenAIServingChat._resolve_audio_transcript({}, 0, {"transcript": "from mm"}) == "from mm"
     assert OmniOpenAIServingChat._resolve_audio_transcript(None, 0, {"text": "from text"}) == "from text"
     assert OmniOpenAIServingChat._resolve_audio_transcript(None, 0, None) == ""
+
+
+def test_visible_content_for_transcript_strips_reasoning():
+    request = SimpleNamespace()
+    raw = "<think>hidden plan</think>Hello world"
+    assert OmniOpenAIServingChat._visible_content_for_transcript(raw, request, _FakeReasoningParser()) == "Hello world"
+    assert OmniOpenAIServingChat._visible_content_for_transcript(raw, request, None) == raw
+
+
+def test_transcript_stream_delta_is_incremental():
+    assert OmniOpenAIServingChat._transcript_stream_delta("Hello", "") == "Hello"
+    assert OmniOpenAIServingChat._transcript_stream_delta("Hello world", "Hello") == " world"
+    assert OmniOpenAIServingChat._transcript_stream_delta("Hello world", "Hello world") == ""
+    # Non-prefix rewrite sends full text for client replace.
+    assert OmniOpenAIServingChat._transcript_stream_delta("Hi", "Hello") == "Hi"
 
 
 def test_create_audio_choice_fills_transcript(serving_chat):
@@ -65,24 +90,54 @@ def test_create_audio_choice_fills_transcript(serving_chat):
     assert choices[0].message.audio.data == "YmFzZTY0YXVkaW8="
 
 
-def test_create_audio_choice_stream_emits_delta_audio(serving_chat):
+def test_create_audio_choice_stream_stable_id_and_incremental_transcript(serving_chat):
     request = SimpleNamespace(return_token_ids=False)
-    choices = OmniOpenAIServingChat._create_audio_choice(
+    stream_state: dict = {"ids": {}, "expires_at": {}, "transcripts_sent": {}}
+
+    first = OmniOpenAIServingChat._create_audio_choice(
         serving_chat,
         _audio_omni_output(),
         role="assistant",
         request=request,
         stream=True,
-        transcripts={0: "stream transcript"},
+        transcripts={0: "Hello"},
+        stream_state=stream_state,
     )
-    assert len(choices) == 1
-    delta = choices[0].delta
-    assert delta.content == "YmFzZTY0YXVkaW8="
-    audio = getattr(delta, "audio", None)
-    assert isinstance(audio, dict)
-    assert audio["data"] == "YmFzZTY0YXVkaW8="
-    assert audio["transcript"] == "stream transcript"
-    assert audio["id"].startswith("audio-")
+    second = OmniOpenAIServingChat._create_audio_choice(
+        serving_chat,
+        _audio_omni_output(),
+        role="assistant",
+        request=request,
+        stream=True,
+        transcripts={0: "Hello world"},
+        stream_state=stream_state,
+    )
+    third = OmniOpenAIServingChat._create_audio_choice(
+        serving_chat,
+        _audio_omni_output(),
+        role="assistant",
+        request=request,
+        stream=True,
+        transcripts={0: "Hello world"},
+        stream_state=stream_state,
+    )
+
+    audio1 = getattr(first[0].delta, "audio", None)
+    audio2 = getattr(second[0].delta, "audio", None)
+    audio3 = getattr(third[0].delta, "audio", None)
+    assert isinstance(audio1, dict) and isinstance(audio2, dict) and isinstance(audio3, dict)
+
+    # Stable id / expires_at across chunks.
+    assert audio1["id"] == audio2["id"] == audio3["id"]
+    assert audio1["expires_at"] == audio2["expires_at"] == audio3["expires_at"]
+
+    # Incremental transcript deltas (clients concatenate).
+    assert audio1["transcript"] == "Hello"
+    assert audio2["transcript"] == " world"
+    assert audio3["transcript"] == ""
+
+    # Legacy content path unchanged.
+    assert first[0].delta.content == "YmFzZTY0YXVkaW8="
 
 
 def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
@@ -96,3 +151,15 @@ def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
         transcripts=None,
     )
     assert choices[0].message.audio.transcript == "mm transcript"
+
+
+def test_resolve_prefers_mm_over_empty_prompt_map():
+    # Diffusion callers must not inject prompt via transcripts map; mm wins.
+    assert (
+        OmniOpenAIServingChat._resolve_audio_transcript(
+            None,
+            0,
+            {"transcript": "model transcript"},
+        )
+        == "model transcript"
+    )

--- a/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for ChatCompletionAudio.transcript population."""
+"""Unit tests for non-stream ChatCompletionAudio.transcript population."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
 @pytest.fixture
-def serving_chat(monkeypatch):
+def serving_chat():
     chat = object.__new__(OmniOpenAIServingChat)
     chat.create_audio = MagicMock(return_value=SimpleNamespace(audio_data="YmFzZTY0YXVkaW8=", media_type="audio/wav"))
     return chat
@@ -38,7 +38,6 @@ def _audio_omni_output(text_in_mm: str | None = None):
 
 class _FakeReasoningParser:
     def extract_reasoning(self, model_output: str, request=None):
-        # Mimic <think>...</think>content split used by many parsers.
         marker = "</think>"
         if marker in model_output:
             reasoning, content = model_output.split(marker, 1)
@@ -66,15 +65,7 @@ def test_visible_content_for_transcript_strips_reasoning():
     assert OmniOpenAIServingChat._visible_content_for_transcript(raw, request, None) == raw
 
 
-def test_transcript_stream_delta_is_incremental():
-    assert OmniOpenAIServingChat._transcript_stream_delta("Hello", "") == "Hello"
-    assert OmniOpenAIServingChat._transcript_stream_delta("Hello world", "Hello") == " world"
-    assert OmniOpenAIServingChat._transcript_stream_delta("Hello world", "Hello world") == ""
-    # Non-prefix rewrite sends full text for client replace.
-    assert OmniOpenAIServingChat._transcript_stream_delta("Hi", "Hello") == "Hi"
-
-
-def test_create_audio_choice_fills_transcript(serving_chat):
+def test_create_audio_choice_fills_nonstream_transcript(serving_chat):
     request = SimpleNamespace(return_token_ids=False)
     choices = OmniOpenAIServingChat._create_audio_choice(
         serving_chat,
@@ -90,54 +81,21 @@ def test_create_audio_choice_fills_transcript(serving_chat):
     assert choices[0].message.audio.data == "YmFzZTY0YXVkaW8="
 
 
-def test_create_audio_choice_stream_stable_id_and_incremental_transcript(serving_chat):
+def test_create_audio_choice_stream_keeps_legacy_content_only(serving_chat):
+    """Streaming must not emit delta.audio; keep base64 in content."""
     request = SimpleNamespace(return_token_ids=False)
-    stream_state: dict = {"ids": {}, "expires_at": {}, "transcripts_sent": {}}
-
-    first = OmniOpenAIServingChat._create_audio_choice(
+    choices = OmniOpenAIServingChat._create_audio_choice(
         serving_chat,
         _audio_omni_output(),
         role="assistant",
         request=request,
         stream=True,
-        transcripts={0: "Hello"},
-        stream_state=stream_state,
+        transcripts={0: "should not appear on stream"},
     )
-    second = OmniOpenAIServingChat._create_audio_choice(
-        serving_chat,
-        _audio_omni_output(),
-        role="assistant",
-        request=request,
-        stream=True,
-        transcripts={0: "Hello world"},
-        stream_state=stream_state,
-    )
-    third = OmniOpenAIServingChat._create_audio_choice(
-        serving_chat,
-        _audio_omni_output(),
-        role="assistant",
-        request=request,
-        stream=True,
-        transcripts={0: "Hello world"},
-        stream_state=stream_state,
-    )
-
-    audio1 = getattr(first[0].delta, "audio", None)
-    audio2 = getattr(second[0].delta, "audio", None)
-    audio3 = getattr(third[0].delta, "audio", None)
-    assert isinstance(audio1, dict) and isinstance(audio2, dict) and isinstance(audio3, dict)
-
-    # Stable id / expires_at across chunks.
-    assert audio1["id"] == audio2["id"] == audio3["id"]
-    assert audio1["expires_at"] == audio2["expires_at"] == audio3["expires_at"]
-
-    # Incremental transcript deltas (clients concatenate).
-    assert audio1["transcript"] == "Hello"
-    assert audio2["transcript"] == " world"
-    assert audio3["transcript"] == ""
-
-    # Legacy content path unchanged.
-    assert first[0].delta.content == "YmFzZTY0YXVkaW8="
+    assert len(choices) == 1
+    delta = choices[0].delta
+    assert delta.content == "YmFzZTY0YXVkaW8="
+    assert getattr(delta, "audio", None) is None
 
 
 def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
@@ -151,15 +109,3 @@ def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
         transcripts=None,
     )
     assert choices[0].message.audio.transcript == "mm transcript"
-
-
-def test_resolve_prefers_mm_over_empty_prompt_map():
-    # Diffusion callers must not inject prompt via transcripts map; mm wins.
-    assert (
-        OmniOpenAIServingChat._resolve_audio_transcript(
-            None,
-            0,
-            {"transcript": "model transcript"},
-        )
-        == "model transcript"
-    )

--- a/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ChatCompletionAudio.transcript population."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.fixture
+def serving_chat(monkeypatch):
+    chat = object.__new__(OmniOpenAIServingChat)
+    chat.create_audio = MagicMock(return_value=SimpleNamespace(audio_data="YmFzZTY0YXVkaW8=", media_type="audio/wav"))
+    return chat
+
+
+def _audio_omni_output(text_in_mm: str | None = None):
+    mm_output = {"audio": torch.zeros(8, dtype=torch.float32), "sr": 24000}
+    if text_in_mm is not None:
+        mm_output["transcript"] = text_in_mm
+    completion = SimpleNamespace(
+        index=0,
+        multimodal_output=mm_output,
+        finish_reason="stop",
+        stop_reason=None,
+        token_ids=[],
+    )
+    request_output = SimpleNamespace(outputs=[completion])
+    return SimpleNamespace(request_output=request_output, final_output_type="audio")
+
+
+def test_resolve_audio_transcript_prefers_index_map():
+    assert (
+        OmniOpenAIServingChat._resolve_audio_transcript({0: "hello from thinker"}, 0, {"transcript": "mm"})
+        == "hello from thinker"
+    )
+
+
+def test_resolve_audio_transcript_falls_back_to_mm_output():
+    assert OmniOpenAIServingChat._resolve_audio_transcript({}, 0, {"transcript": "from mm"}) == "from mm"
+    assert OmniOpenAIServingChat._resolve_audio_transcript(None, 0, {"text": "from text"}) == "from text"
+    assert OmniOpenAIServingChat._resolve_audio_transcript(None, 0, None) == ""
+
+
+def test_create_audio_choice_fills_transcript(serving_chat):
+    request = SimpleNamespace(return_token_ids=False)
+    choices = OmniOpenAIServingChat._create_audio_choice(
+        serving_chat,
+        _audio_omni_output(),
+        role="assistant",
+        request=request,
+        stream=False,
+        transcripts={0: "Spoken reply from thinker."},
+    )
+    assert len(choices) == 1
+    assert choices[0].message.audio is not None
+    assert choices[0].message.audio.transcript == "Spoken reply from thinker."
+    assert choices[0].message.audio.data == "YmFzZTY0YXVkaW8="
+
+
+def test_create_audio_choice_stream_emits_delta_audio(serving_chat):
+    request = SimpleNamespace(return_token_ids=False)
+    choices = OmniOpenAIServingChat._create_audio_choice(
+        serving_chat,
+        _audio_omni_output(),
+        role="assistant",
+        request=request,
+        stream=True,
+        transcripts={0: "stream transcript"},
+    )
+    assert len(choices) == 1
+    delta = choices[0].delta
+    assert delta.content == "YmFzZTY0YXVkaW8="
+    audio = getattr(delta, "audio", None)
+    assert isinstance(audio, dict)
+    assert audio["data"] == "YmFzZTY0YXVkaW8="
+    assert audio["transcript"] == "stream transcript"
+    assert audio["id"].startswith("audio-")
+
+
+def test_create_audio_choice_uses_mm_transcript_fallback(serving_chat):
+    request = SimpleNamespace(return_token_ids=False)
+    choices = OmniOpenAIServingChat._create_audio_choice(
+        serving_chat,
+        _audio_omni_output(text_in_mm="mm transcript"),
+        role="assistant",
+        request=request,
+        stream=False,
+        transcripts=None,
+    )
+    assert choices[0].message.audio.transcript == "mm transcript"

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3,7 +3,7 @@ import base64
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from dataclasses import fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -1257,6 +1257,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         # Always track previous_texts for comprehensive output logging
         previous_texts = [""] * num_choices
+        # Accumulate thinker text even when "text" is not in request.modalities,
+        # so audio chunks can populate OpenAI ChatCompletionAudio.transcript.
+        audio_transcripts: dict[int, str] = {i: "" for i in range(num_choices)}
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
@@ -1297,6 +1300,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             async for omni_res in result_generator:
                 final_output_type = omni_res.final_output_type
                 res = omni_res.request_output
+                # Harvest thinker text for audio.transcript before modality filtering.
+                if final_output_type == "text" and res is not None:
+                    for output in res.outputs:
+                        delta_text = output.text or ""
+                        if delta_text:
+                            audio_transcripts[output.index] = audio_transcripts.get(output.index, "") + delta_text
                 if final_output_type not in first_iteration_dict:
                     logger.warning(f"final output type: {final_output_type} is not needed by the request")
                     continue
@@ -1924,7 +1933,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         )
 
                     role = self.get_chat_request_role(request)
-                    choices_data = self._create_audio_choice(omni_res, role, request, stream=True)
+                    choices_data = self._create_audio_choice(
+                        omni_res,
+                        role,
+                        request,
+                        stream=True,
+                        transcripts=audio_transcripts,
+                    )
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
                     for choice in choices_data:
@@ -2153,6 +2168,22 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             set(request.modalities) if hasattr(request, "modalities") and request.modalities else None
         )
 
+        # Harvest thinker text for audio.transcript even when "text" is filtered
+        # out of the response (e.g. modalities=["audio"]).
+        audio_transcripts: dict[int, str] = {}
+        for omni_outputs in final_outputs:
+            if omni_outputs.final_output_type != "text":
+                continue
+            if omni_outputs.request_output is None:
+                text_body = self._get_diffusion_text_output(omni_outputs)
+                if text_body:
+                    audio_transcripts[0] = text_body
+                continue
+            for output in omni_outputs.request_output.outputs:
+                text = output.text or ""
+                if text:
+                    audio_transcripts[output.index] = text
+
         for omni_outputs in final_outputs:
             choices_data = []
             if omni_outputs.request_output is not None and not getattr(omni_outputs.request_output, "finished", False):
@@ -2196,7 +2227,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         )
                     ]
             elif omni_outputs.final_output_type == "audio":
-                choices_data = self._create_audio_choice(omni_outputs, role, request, stream=False)
+                choices_data = self._create_audio_choice(
+                    omni_outputs,
+                    role,
+                    request,
+                    stream=False,
+                    transcripts=audio_transcripts,
+                )
             elif omni_outputs.final_output_type == "image":
                 choices_data = self._create_image_choice(omni_outputs, role, request, stream=False)
             else:
@@ -2522,8 +2559,39 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         return choices, usage, prompt_logprobs, prompt_token_ids, kv_transfer_params
 
+    @staticmethod
+    def _resolve_audio_transcript(
+        transcripts: dict[int, str] | None,
+        index: int,
+        mm_output: Mapping[str, Any] | None = None,
+    ) -> str:
+        """Best-effort spoken transcript for OpenAI ChatCompletionAudio.transcript.
+
+        Prefer thinker text accumulated for this choice index. Fall back to any
+        transcript-like field the stage attached on multimodal_output.
+        """
+        if transcripts:
+            text = transcripts.get(index)
+            if isinstance(text, str) and text:
+                return text
+        if isinstance(mm_output, Mapping):
+            for key in ("transcript", "text", "spoken_text"):
+                value = mm_output.get(key)
+                if isinstance(value, str) and value:
+                    return value
+                if isinstance(value, (list, tuple)):
+                    joined = "".join(str(item) for item in value if item is not None)
+                    if joined:
+                        return joined
+        return ""
+
     def _create_audio_choice(
-        self, omni_outputs: OmniRequestOutput, role: str, request: ChatCompletionRequest, stream: bool = False
+        self,
+        omni_outputs: OmniRequestOutput,
+        role: str,
+        request: ChatCompletionRequest,
+        stream: bool = False,
+        transcripts: dict[int, str] | None = None,
     ):
         choices: list[ChatCompletionResponseChoice] = []
         final_res = omni_outputs.request_output
@@ -2578,19 +2646,33 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # Set expiration time (e.g., 24 hours from now) as Unix timestamp
         expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
 
-        # Create OpenAIChatCompletionAudio object with all required fields
-        audio_obj = OpenAIChatCompletionAudio(
-            id=audio_id,
-            data=audio_base64,
-            expires_at=expires_at,
-            transcript="",  # Empty transcript if not available
-        )
-
         for output in final_res.outputs:
+            transcript = self._resolve_audio_transcript(transcripts, output.index, mm_output)
+            # Create OpenAIChatCompletionAudio object with all required fields
+            completion_audio = OpenAIChatCompletionAudio(
+                id=audio_id,
+                data=audio_base64,
+                expires_at=expires_at,
+                transcript=transcript,
+            )
+
             if stream:
+                # Keep content=base64 for existing Omni clients; also emit
+                # OpenAI-style delta.audio so SDKs can read data/transcript.
                 choice_data = ChatCompletionResponseStreamChoice(
                     index=output.index,
-                    delta=DeltaMessage(role=role, content=audio_base64),
+                    delta=DeltaMessage.model_validate(
+                        {
+                            "role": role,
+                            "content": audio_base64,
+                            "audio": {
+                                "id": audio_id,
+                                "data": audio_base64,
+                                "transcript": transcript,
+                                "expires_at": expires_at,
+                            },
+                        }
+                    ),
                     logprobs=None,
                     finish_reason=output.finish_reason,
                     stop_reason=output.stop_reason,
@@ -2599,7 +2681,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             else:
                 choice_data = ChatCompletionResponseChoice(
                     index=output.index,
-                    message=ChatMessage(role=role, audio=audio_obj),
+                    message=ChatMessage(role=role, audio=completion_audio),
                     logprobs=None,
                     finish_reason="stop",
                     stop_reason=output.stop_reason,
@@ -3526,13 +3608,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 audio_base64 = audio_response.audio_data
                 audio_id = f"audio-{uuid.uuid4().hex[:16]}"
                 expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
+                transcript = self._resolve_audio_transcript(
+                    {0: prompt} if prompt else None,
+                    0,
+                    multimodal_output if isinstance(multimodal_output, Mapping) else None,
+                )
                 message = ChatMessage(
                     role="assistant",
                     audio=OpenAIChatCompletionAudio(
                         id=audio_id,
                         data=audio_base64,
                         expires_at=expires_at,
-                        transcript="",
+                        transcript=transcript,
                     ),
                 )
             else:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1257,19 +1257,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         # Always track previous_texts for comprehensive output logging
         previous_texts = [""] * num_choices
-        # Accumulate thinker text even when "text" is not in request.modalities,
-        # so audio chunks can populate OpenAI ChatCompletionAudio.transcript.
-        # Keep raw cumulative text for reasoning re-parse; expose only
-        # user-visible content via audio_transcripts.
-        audio_transcripts_raw: dict[int, str] = {i: "" for i in range(num_choices)}
-        audio_transcripts: dict[int, str] = {i: "" for i in range(num_choices)}
-        # Stable per-choice audio id / expires_at / already-sent transcript
-        # across streaming audio chunks (OpenAI aggregates by id + transcript deltas).
-        audio_stream_state: dict[str, Any] = {
-            "ids": {},
-            "expires_at": {},
-            "transcripts_sent": {},
-        }
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
@@ -1310,20 +1297,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             async for omni_res in result_generator:
                 final_output_type = omni_res.final_output_type
                 res = omni_res.request_output
-                # Harvest thinker text for audio.transcript before modality filtering.
-                # Strip reasoning so hidden thinking never leaks into transcript.
-                if final_output_type == "text" and res is not None:
-                    for output in res.outputs:
-                        delta_text = output.text or ""
-                        if not delta_text:
-                            continue
-                        idx = output.index
-                        audio_transcripts_raw[idx] = audio_transcripts_raw.get(idx, "") + delta_text
-                        audio_transcripts[idx] = self._visible_content_for_transcript(
-                            audio_transcripts_raw[idx],
-                            request,
-                            reasoning_parser,
-                        )
                 if final_output_type not in first_iteration_dict:
                     logger.warning(f"final output type: {final_output_type} is not needed by the request")
                     continue
@@ -1951,14 +1924,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         )
 
                     role = self.get_chat_request_role(request)
-                    choices_data = self._create_audio_choice(
-                        omni_res,
-                        role,
-                        request,
-                        stream=True,
-                        transcripts=audio_transcripts,
-                        stream_state=audio_stream_state,
-                    )
+                    choices_data = self._create_audio_choice(omni_res, role, request, stream=True)
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
                     for choice in choices_data:
@@ -2627,16 +2593,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         return joined
         return ""
 
-    @staticmethod
-    def _transcript_stream_delta(full_transcript: str, previously_sent: str) -> str:
-        """Compute OpenAI-style incremental transcript for one audio chunk."""
-        if not full_transcript:
-            return ""
-        if full_transcript.startswith(previously_sent):
-            return full_transcript[len(previously_sent) :]
-        # Non-prefix update (rare): send full text so clients can replace.
-        return full_transcript
-
     def _create_audio_choice(
         self,
         omni_outputs: OmniRequestOutput,
@@ -2644,7 +2600,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
         stream: bool = False,
         transcripts: dict[int, str] | None = None,
-        stream_state: dict[str, Any] | None = None,
     ):
         choices: list[ChatCompletionResponseChoice] = []
         final_res = omni_outputs.request_output
@@ -2693,51 +2648,28 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         audio_response: AudioResponse = self.create_audio(audio_obj)
         audio_base64 = audio_response.audio_data
 
-        # Non-stream: one-shot id. Stream: reuse stable id/expires_at from stream_state.
-        default_expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
+        # Generate unique ID for the audio
+        audio_id = f"audio-{uuid.uuid4().hex[:16]}"
+
+        # Set expiration time (e.g., 24 hours from now) as Unix timestamp
+        expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
 
         for output in final_res.outputs:
-            full_transcript = self._resolve_audio_transcript(transcripts, output.index, mm_output)
-            if stream and stream_state is not None:
-                ids: dict[int, str] = stream_state.setdefault("ids", {})
-                expires_map: dict[int, int] = stream_state.setdefault("expires_at", {})
-                sent_map: dict[int, str] = stream_state.setdefault("transcripts_sent", {})
-                audio_id = ids.setdefault(output.index, f"audio-{uuid.uuid4().hex[:16]}")
-                expires_at = expires_map.setdefault(output.index, default_expires_at)
-                previously_sent = sent_map.get(output.index, "")
-                transcript_delta = self._transcript_stream_delta(full_transcript, previously_sent)
-                sent_map[output.index] = full_transcript
-            else:
-                audio_id = f"audio-{uuid.uuid4().hex[:16]}"
-                expires_at = default_expires_at
-                transcript_delta = full_transcript
-
-            # Create OpenAIChatCompletionAudio object with all required fields
+            # Non-stream only: fill reasoning-stripped transcript (or mm fallback).
+            # Streaming keeps legacy delta.content=base64; OpenAI-style delta.audio
+            # is intentionally not added here (needs a separate streaming design).
+            transcript = "" if stream else self._resolve_audio_transcript(transcripts, output.index, mm_output)
             completion_audio = OpenAIChatCompletionAudio(
                 id=audio_id,
                 data=audio_base64,
                 expires_at=expires_at,
-                transcript=full_transcript,
+                transcript=transcript,
             )
 
             if stream:
-                # Keep content=base64 for existing Omni clients; also emit
-                # OpenAI-style delta.audio so SDKs can read data/transcript.
-                # transcript here is an incremental delta (may be empty).
                 choice_data = ChatCompletionResponseStreamChoice(
                     index=output.index,
-                    delta=DeltaMessage.model_validate(
-                        {
-                            "role": role,
-                            "content": audio_base64,
-                            "audio": {
-                                "id": audio_id,
-                                "data": audio_base64,
-                                "transcript": transcript_delta,
-                                "expires_at": expires_at,
-                            },
-                        }
-                    ),
+                    delta=DeltaMessage(role=role, content=audio_base64),
                     logprobs=None,
                     finish_reason=output.finish_reason,
                     stop_reason=output.stop_reason,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1259,7 +1259,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         previous_texts = [""] * num_choices
         # Accumulate thinker text even when "text" is not in request.modalities,
         # so audio chunks can populate OpenAI ChatCompletionAudio.transcript.
+        # Keep raw cumulative text for reasoning re-parse; expose only
+        # user-visible content via audio_transcripts.
+        audio_transcripts_raw: dict[int, str] = {i: "" for i in range(num_choices)}
         audio_transcripts: dict[int, str] = {i: "" for i in range(num_choices)}
+        # Stable per-choice audio id / expires_at / already-sent transcript
+        # across streaming audio chunks (OpenAI aggregates by id + transcript deltas).
+        audio_stream_state: dict[str, Any] = {
+            "ids": {},
+            "expires_at": {},
+            "transcripts_sent": {},
+        }
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
@@ -1301,11 +1311,19 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 final_output_type = omni_res.final_output_type
                 res = omni_res.request_output
                 # Harvest thinker text for audio.transcript before modality filtering.
+                # Strip reasoning so hidden thinking never leaks into transcript.
                 if final_output_type == "text" and res is not None:
                     for output in res.outputs:
                         delta_text = output.text or ""
-                        if delta_text:
-                            audio_transcripts[output.index] = audio_transcripts.get(output.index, "") + delta_text
+                        if not delta_text:
+                            continue
+                        idx = output.index
+                        audio_transcripts_raw[idx] = audio_transcripts_raw.get(idx, "") + delta_text
+                        audio_transcripts[idx] = self._visible_content_for_transcript(
+                            audio_transcripts_raw[idx],
+                            request,
+                            reasoning_parser,
+                        )
                 if final_output_type not in first_iteration_dict:
                     logger.warning(f"final output type: {final_output_type} is not needed by the request")
                     continue
@@ -1939,6 +1957,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         request,
                         stream=True,
                         transcripts=audio_transcripts,
+                        stream_state=audio_stream_state,
                     )
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
@@ -2169,7 +2188,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         )
 
         # Harvest thinker text for audio.transcript even when "text" is filtered
-        # out of the response (e.g. modalities=["audio"]).
+        # out of the response (e.g. modalities=["audio"]). Use reasoning-stripped
+        # content so thinking tokens are not exposed on the audio object.
         audio_transcripts: dict[int, str] = {}
         for omni_outputs in final_outputs:
             if omni_outputs.final_output_type != "text":
@@ -2180,7 +2200,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     audio_transcripts[0] = text_body
                 continue
             for output in omni_outputs.request_output.outputs:
-                text = output.text or ""
+                text = self._visible_content_for_transcript(
+                    output.text or "",
+                    request,
+                    reasoning_parser,
+                )
                 if text:
                     audio_transcripts[output.index] = text
 
@@ -2560,6 +2584,24 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         return choices, usage, prompt_logprobs, prompt_token_ids, kv_transfer_params
 
     @staticmethod
+    def _visible_content_for_transcript(
+        raw_text: str,
+        request: ChatCompletionRequest,
+        reasoning_parser: ReasoningParser | None,
+    ) -> str:
+        """Return user-visible content suitable for audio.transcript.
+
+        When a reasoning parser is enabled, strip hidden thinking so transcript
+        never leaks reasoning tokens that chat content already filters out.
+        """
+        if not raw_text:
+            return ""
+        if reasoning_parser is None:
+            return raw_text
+        _, content = reasoning_parser.extract_reasoning(raw_text, request=request)
+        return content or ""
+
+    @staticmethod
     def _resolve_audio_transcript(
         transcripts: dict[int, str] | None,
         index: int,
@@ -2585,6 +2627,16 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         return joined
         return ""
 
+    @staticmethod
+    def _transcript_stream_delta(full_transcript: str, previously_sent: str) -> str:
+        """Compute OpenAI-style incremental transcript for one audio chunk."""
+        if not full_transcript:
+            return ""
+        if full_transcript.startswith(previously_sent):
+            return full_transcript[len(previously_sent) :]
+        # Non-prefix update (rare): send full text so clients can replace.
+        return full_transcript
+
     def _create_audio_choice(
         self,
         omni_outputs: OmniRequestOutput,
@@ -2592,6 +2644,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
         stream: bool = False,
         transcripts: dict[int, str] | None = None,
+        stream_state: dict[str, Any] | None = None,
     ):
         choices: list[ChatCompletionResponseChoice] = []
         final_res = omni_outputs.request_output
@@ -2640,25 +2693,37 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         audio_response: AudioResponse = self.create_audio(audio_obj)
         audio_base64 = audio_response.audio_data
 
-        # Generate unique ID for the audio
-        audio_id = f"audio-{uuid.uuid4().hex[:16]}"
-
-        # Set expiration time (e.g., 24 hours from now) as Unix timestamp
-        expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
+        # Non-stream: one-shot id. Stream: reuse stable id/expires_at from stream_state.
+        default_expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
 
         for output in final_res.outputs:
-            transcript = self._resolve_audio_transcript(transcripts, output.index, mm_output)
+            full_transcript = self._resolve_audio_transcript(transcripts, output.index, mm_output)
+            if stream and stream_state is not None:
+                ids: dict[int, str] = stream_state.setdefault("ids", {})
+                expires_map: dict[int, int] = stream_state.setdefault("expires_at", {})
+                sent_map: dict[int, str] = stream_state.setdefault("transcripts_sent", {})
+                audio_id = ids.setdefault(output.index, f"audio-{uuid.uuid4().hex[:16]}")
+                expires_at = expires_map.setdefault(output.index, default_expires_at)
+                previously_sent = sent_map.get(output.index, "")
+                transcript_delta = self._transcript_stream_delta(full_transcript, previously_sent)
+                sent_map[output.index] = full_transcript
+            else:
+                audio_id = f"audio-{uuid.uuid4().hex[:16]}"
+                expires_at = default_expires_at
+                transcript_delta = full_transcript
+
             # Create OpenAIChatCompletionAudio object with all required fields
             completion_audio = OpenAIChatCompletionAudio(
                 id=audio_id,
                 data=audio_base64,
                 expires_at=expires_at,
-                transcript=transcript,
+                transcript=full_transcript,
             )
 
             if stream:
                 # Keep content=base64 for existing Omni clients; also emit
                 # OpenAI-style delta.audio so SDKs can read data/transcript.
+                # transcript here is an incremental delta (may be empty).
                 choice_data = ChatCompletionResponseStreamChoice(
                     index=output.index,
                     delta=DeltaMessage.model_validate(
@@ -2668,7 +2733,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             "audio": {
                                 "id": audio_id,
                                 "data": audio_base64,
-                                "transcript": transcript,
+                                "transcript": transcript_delta,
                                 "expires_at": expires_at,
                             },
                         }
@@ -3608,8 +3673,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 audio_base64 = audio_response.audio_data
                 audio_id = f"audio-{uuid.uuid4().hex[:16]}"
                 expires_at = int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())
+                # Prefer model-emitted transcript fields. Do not fall back to the
+                # user prompt: for diffusion TTA (AudioX / Stable Audio) the prompt
+                # is a sound description, not a speech transcript.
                 transcript = self._resolve_audio_transcript(
-                    {0: prompt} if prompt else None,
+                    None,
                     0,
                     multimodal_output if isinstance(multimodal_output, Mapping) else None,
                 )


### PR DESCRIPTION
## Purpose

Non-stream Chat Completions already return `message.audio.data`, but
`message.audio.transcript` has always been `""`. For `modalities=["audio"]`
(text choice filtered), clients have no spoken text unless they keep a parallel
text modality.
This PR only fills non-stream `message.audio.transcript`:
- Prefer reasoning-stripped thinker content when available
- Fall back to `multimodal_output` transcript-like fields
- Diffusion TTA keeps `""` unless the model emits a real transcript field
  (never use the user prompt as a speech transcript)


## Test Plan

**vLLM Version:** vllm 0.25.0

**vLLM-Omni Commit:** current commit

- [x] Unit: `tests/entrypoints/openai_api/test_serving_chat_audio_transcript.py`
  - reasoning strip
  - non-stream transcript fill
  - mm fallback

## Test Result

```
.....                                                                    [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1276
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1276: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: anyio
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
5 passed, 1 warning in 0.12s
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
