### PR TITLE
[BugFix] Suppress audio output during tool-call turns

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -613,6 +613,83 @@ def test_text_to_audio_long_output_001(omni_server, openai_client) -> None:
     assert word_count >= 200, f"Expected at least 200 words in long output, got {word_count}"
 
 
+_TOOL_CALL_TEST_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string", "description": "City name"}},
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+tool_call_params = [
+    pytest.param(
+        OmniServerParams(
+            model=model,
+            stage_config_path=default_path,
+            server_args=[
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "hermes",
+            ],
+        ),
+        id="tool_call",
+    ),
+]
+
+
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", tool_call_params, indirect=True)
+def test_tool_call_suppresses_audio(omni_server, openai_client) -> None:
+    """When the model calls a tool, audio chunks must be suppressed."""
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        content_text="What is the weather in Paris right now?",
+    )
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "modalities": ["text", "audio"],
+        "tools": _TOOL_CALL_TEST_TOOLS,
+        "tool_choice": "auto",
+        "stream": True,
+    }
+    responses = openai_client.send_omni_request(request_config, request_num=1)
+    resp = responses[0]
+    assert resp.tool_calls, "Expected model to call get_weather"
+    assert resp.tool_calls[0]["name"] == "get_weather"
+    assert not resp.audio_data, f"Expected no audio when tool calls are present, got {len(resp.audio_data)} chunks"
+
+
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", tool_call_params, indirect=True)
+def test_no_tool_call_produces_audio(omni_server, openai_client) -> None:
+    """When tools are available but the model answers directly, audio must still be produced."""
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        content_text="What is the capital of China? Answer in 20 words.",
+    )
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "modalities": ["text", "audio"],
+        "tools": _TOOL_CALL_TEST_TOOLS,
+        "tool_choice": "auto",
+        "stream": True,
+    }
+    responses = openai_client.send_omni_request(request_config, request_num=1)
+    resp = responses[0]
+    assert not resp.tool_calls, f"Expected no tool calls for arithmetic, got {resp.tool_calls}"
+    assert resp.audio_data, "Expected audio output when no tool calls are made"
+    assert resp.text_content, "Expected text output"
+
+
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
 @pytest.mark.parametrize("omni_server", test_params[:1], indirect=True)
 def test_invalid_audio_format_rejected(omni_server, openai_client) -> None:

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -547,7 +547,9 @@ def assert_omni_response(response: Any, request_config: dict[str, Any], run_leve
     if run_level in {"advanced_model", "full_model"}:
         transcript = _resolve_audio_transcript(response, request_config, run_level, speech_api=False)
         # Verify output success
-        if "audio" in modalities:
+        # When tool calls are present, audio is intentionally suppressed,
+        # the talker would vocalize tool-call JSON syntax as garbled speech.
+        if "audio" in modalities and not getattr(response, "tool_calls", None):
             assert _response_has_audio_output(response), "No audio output is generated"
             if transcript is not None:
                 print(f"audio content is: {transcript}")
@@ -582,7 +584,7 @@ def assert_omni_response(response: Any, request_config: dict[str, Any], run_leve
                     )
 
         # Verify similarity (Whisper transcript vs streamed/detokenized text)
-        if "audio" in modalities:
+        if "audio" in modalities and not getattr(response, "tool_calls", None):
             audio_ref_text = request_config.get("audio_ref_text")
             similarity_threshold = request_config.get("similarity_threshold", 0.8)
             if "text" in modalities:

--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -762,6 +762,7 @@ class OmniResponse:
     prompt_tokens: int | None = None
     cached_tokens: int | None = None
     logprobs: list | None = None
+    tool_calls: list[dict[str, str]] | None = None
     #: HTTP status + error text for the error-handling path (e.g. validator
     #: rejections); populated when the OpenAI client raises an APIError.
     status_code: int | None = None
@@ -884,14 +885,22 @@ class OpenAIClientHandler:
         try:
             text_content = ""
             audio_data = []
+            tool_calls_by_idx: dict[int, dict[str, str]] = {}
             for chunk in chat_completion:
                 for choice in chunk.choices:
-                    content = getattr(getattr(choice, "delta", None), "content", None)
+                    delta = getattr(choice, "delta", None)
+                    content = getattr(delta, "content", None)
                     modality = getattr(chunk, "modality", None)
                     if modality == "audio" and content:
                         audio_data.append(content)
                     elif modality == "text" and content:
                         text_content += content
+                    for tc in getattr(delta, "tool_calls", None) or []:
+                        entry = tool_calls_by_idx.setdefault(tc.index, {"name": "", "arguments": ""})
+                        if tc.function and tc.function.name:
+                            entry["name"] = tc.function.name
+                        if tc.function and tc.function.arguments:
+                            entry["arguments"] += tc.function.arguments
                 # Usage is yielded after the last token
                 if chunk.usage:
                     result.prompt_tokens = chunk.usage.prompt_tokens
@@ -905,6 +914,7 @@ class OpenAIClientHandler:
                 result.audio_bytes = wav_buf.getvalue()
             result.text_content = text_content
             result.audio_data = audio_data
+            result.tool_calls = list(tool_calls_by_idx.values()) or None
             result.e2e_latency = time.perf_counter() - wall_start
             result.success = True
         except Exception as e:
@@ -1613,6 +1623,10 @@ class OpenAIClientHandler:
             "stream": stream,
             "modalities": modalities,
         }
+        if "tools" in request_config:
+            create_kwargs["tools"] = request_config["tools"]
+        if "tool_choice" in request_config:
+            create_kwargs["tool_choice"] = request_config["tool_choice"]
         if "logprobs" in request_config:
             create_kwargs["logprobs"] = request_config["logprobs"]
         if "top_logprobs" in request_config:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1897,6 +1897,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         yield f"data: {data}\n\n"
 
                 elif final_output_type == "audio":
+                    if any(tools_streamed):
+                        continue
+
                     # Observe audio_ttfp_s on first audio packet for this request_id
                     # (once-per-request guard via first_audio_ts). The same hook
                     # also captures (stage, replica) for the streaming-continuity


### PR DESCRIPTION
## Purpose

When the thinker generates tool calls with audio modality enabled, the talker vocalizes tool-call JSON syntax, producing garbled audio.  Per Alibaba's own documentation: "The model only needs text information when obtaining tool information.  To avoid generating unnecessary audio [...] you need to skip the audio data chunks."

Skip audio chunks in the streaming response when tool calls are detected.  The tools_streamed flag is already set by the Hermes (and other) tool parsers on the text stream, which structurally leads the audio stream since the talker depends on thinker output.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** db064d4418f2e9d675a9e2bb9ccf56b290f31d07

```
pytest -s -v tests/e2e/online_serving/test_qwen3_omni_expansion.py -k "test_tool_call_suppresses_audio or test_no_tool_call_produces_audio" --run-level full_model
```

## Test Result

PASSED