### PR TITLE
[Refactor] Normalize diffusion request extra arguments in Chat serving

### DIFF
--- a/tests/diffusion/models/bagel/test_negative_prompt.py
+++ b/tests/diffusion/models/bagel/test_negative_prompt.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from pytest_mock import MockerFixture
+
+from vllm_omni.diffusion.models.bagel.pipeline_bagel import BagelPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _NegativePromptPreparedError(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("prompt_negative", "extra_negative", "expected"),
+    [
+        ("prompt negative", "legacy negative", "prompt negative"),
+        (None, "legacy negative", "legacy negative"),
+    ],
+    ids=["prompt-owner", "legacy-extra-args"],
+)
+def test_forward_reads_negative_prompt_from_prompt_with_legacy_fallback(
+    mocker: MockerFixture,
+    prompt_negative: str | None,
+    extra_negative: str,
+    expected: str,
+) -> None:
+    pipeline = object.__new__(BagelPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.device = torch.device("cpu")
+    pipeline.od_config = mocker.Mock(dtype=torch.float32)
+    pipeline.tokenizer = mocker.sentinel.tokenizer
+    pipeline.new_token_ids = {}
+    pipeline.language_model = mocker.Mock(vocab_size=10)
+    pipeline.image_processor = None
+    pipeline.vae = None
+
+    bagel = mocker.MagicMock()
+    bagel.max_latent_size = 32
+    bagel.latent_downsample = 8
+    bagel.config.llm_config.num_hidden_layers = 1
+    prepared_prompts: list[str] = []
+
+    def prepare_prompts(*, prompts, **_):
+        prepared_prompts.append(prompts[0])
+        if len(prepared_prompts) == 1:
+            return {"packed_text_ids": torch.tensor([1])}, [1], [1]
+        raise _NegativePromptPreparedError
+
+    bagel.prepare_prompts.side_effect = prepare_prompts
+    pipeline.bagel = bagel
+
+    prompt = {
+        "prompt": "positive",
+        "negative_prompt": prompt_negative,
+    }
+    request = DiffusionRequestBatch(
+        requests=[
+            OmniDiffusionRequest(
+                prompt=prompt,
+                sampling_params=OmniDiffusionSamplingParams(
+                    extra_args={"negative_prompt": extra_negative},
+                ),
+                request_id="test",
+            )
+        ]
+    )
+
+    with pytest.raises(_NegativePromptPreparedError):
+        pipeline.forward(request)
+
+    assert prepared_prompts == ["positive", expected]

--- a/tests/e2e/features/comfyui/test_comfyui_integration.py
+++ b/tests/e2e/features/comfyui/test_comfyui_integration.py
@@ -35,7 +35,7 @@ from vllm.outputs import CompletionOutput, RequestOutput
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni as RealAsyncOmni
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
-from vllm_omni.inputs.data import OmniSamplingParams
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
@@ -417,7 +417,7 @@ def mock_async_omni(
     mock_instance.stage_configs = server_case.stage_configs
     mock_instance.output_modalities = _build_output_modalities(server_case.stage_configs)
     mock_instance.default_sampling_params_list = [
-        SamplingParams() if _stage_type(stage) != "diffusion" else mocker.MagicMock()
+        OmniDiffusionSamplingParams() if _stage_type(stage) == "diffusion" else SamplingParams()
         for stage in server_case.stage_configs
     ]
     mock_instance.errored = False

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -35,15 +35,23 @@ def _request(**kwargs: Any) -> ChatCompletionRequest:
     return ChatCompletionRequest(model="test", messages=[], **kwargs)
 
 
-def _global_sources(key: str, value: object) -> list[dict[str, object]]:
-    return [
-        {key: value},
-        {"extra_body": {key: value}},
-        {"extra_args": {key: value}},
-        {"extra_params": {key: value}},
-        {"extra_body": {"extra_args": {key: value}}},
-        {"extra_body": {"extra_params": {key: value}}},
-    ]
+GLOBAL_SOURCE_PATHS = (
+    "request",
+    "extra_body",
+    "extra_args",
+    "extra_params",
+    "extra_body.extra_args",
+    "extra_body.extra_params",
+)
+
+
+def _global_source(path: str, key: str, value: object) -> dict[str, object]:
+    body: dict[str, object] = {key: value}
+    if path == "request":
+        return body
+    for container in reversed(path.split(".")):
+        body = {container: body}
+    return body
 
 
 def _compile(
@@ -54,6 +62,7 @@ def _compile(
     comprehension_stage_index: int | None = None,
     declared: frozenset[str] = frozenset(),
     fan_out_declared: bool = False,
+    supported_modalities: frozenset[str] = frozenset({"audio", "image", "text"}),
 ) -> DiffusionChatRequestPlan:
     return compile_diffusion_chat_request_plan(
         request=request,
@@ -65,57 +74,49 @@ def _compile(
         control_root_fields=CONTROL_FIELDS,
         declared_extra_fields=declared,
         apply_declared_to_non_diffusion=fan_out_declared,
+        supported_modalities=supported_modalities,
     )
 
 
+@pytest.mark.parametrize("source", GLOBAL_SOURCE_PATHS)
 @pytest.mark.parametrize(
-    "body",
-    _global_sources("model_option", 1),
+    ("dispatcher", "consumer", "key", "value"),
+    [
+        pytest.param("pure", "diffusion", "model_option", 1, id="pure-diffusion"),
+        pytest.param("mixed", "fan-out", "seed", 32, id="mixed-fan-out"),
+        pytest.param("mixed", "defaults", "seed", None, id="mixed-defaults"),
+    ],
 )
-def test_all_global_sources_reach_the_same_diffusion_consumer(body: dict[str, object]) -> None:
-    plan = _compile(_request(**body), declared=frozenset({"model_option"}))
+def test_global_source_dispatcher_consumer_matrix(
+    source: str,
+    dispatcher: str,
+    consumer: str,
+    key: str,
+    value: object,
+) -> None:
+    body = _global_source(source, key, value)
+    if dispatcher == "pure":
+        plan = _compile(_request(**body), declared=frozenset({key}))
+        assert plan.clone_sampling_params_list()[0].extra_args[key] == value
+        return
 
-    assert plan.clone_sampling_params_list()[0].extra_args["model_option"] == 1
-
-
-@pytest.mark.parametrize("body", _global_sources("seed", 32))
-def test_declared_global_sources_reach_the_same_mixed_stage_consumers(body: dict[str, object]) -> None:
     plan = _compile(
         _request(**body),
         stage_types=("llm", "diffusion"),
-        defaults=(
-            SamplingParams(seed=7),
-            OmniDiffusionSamplingParams(extra_args={"default": True}),
-        ),
+        defaults=(SamplingParams(seed=7), OmniDiffusionSamplingParams(extra_args={"default": True})),
         comprehension_stage_index=0,
-        declared=frozenset({"seed"}),
+        declared=frozenset({key}),
         fan_out_declared=True,
     )
-
     ar_params, diffusion_params = plan.clone_sampling_params_list()
-    assert ar_params.seed == 32
-    assert ar_params.extra_args["seed"] == 32
-    assert diffusion_params.extra_args == {"default": True, "seed": 32}
-
-
-@pytest.mark.parametrize("body", _global_sources("seed", None))
-def test_declared_global_none_preserves_mixed_stage_defaults(body: dict[str, object]) -> None:
-    plan = _compile(
-        _request(**body),
-        stage_types=("llm", "diffusion"),
-        defaults=(
-            SamplingParams(seed=7),
-            OmniDiffusionSamplingParams(extra_args={"default": True}),
-        ),
-        comprehension_stage_index=0,
-        declared=frozenset({"seed"}),
-        fan_out_declared=True,
-    )
-
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-    assert ar_params.seed == 7
-    assert "seed" not in (ar_params.extra_args or {})
-    assert diffusion_params.extra_args == {"default": True}
+    if consumer == "fan-out":
+        assert ar_params.seed == value
+        assert ar_params.extra_args[key] == value
+        assert diffusion_params.extra_args == {"default": True, key: value}
+    else:
+        assert ar_params.seed == 7
+        assert key not in (ar_params.extra_args or {})
+        assert diffusion_params.extra_args == {"default": True}
 
 
 @pytest.mark.parametrize(
@@ -282,6 +283,29 @@ def test_request_stage_values_overlay_defaults_once() -> None:
     assert ar_params.output_text_buffer_length == 2
     assert diffusion_params.guidance_scale == 4.0
     assert diffusion_params.extra_args == {"default": 3, "global": 1, "local": 2}
+
+
+def test_stage_replacement_revalidates_sampling_params() -> None:
+    with pytest.raises(ValueError, match="Invalid sampling parameters for stage 0"):
+        _compile(
+            _request(sampling_params_list=[{"top_p": 0}]),
+            stage_types=("llm",),
+            defaults=(SamplingParams(),),
+            comprehension_stage_index=0,
+        )
+
+
+def test_stage_replacement_resets_sampling_params_derived_state() -> None:
+    plan = _compile(
+        _request(sampling_params_list=[{"stop": [], "stop_token_ids": [2]}]),
+        stage_types=("llm",),
+        defaults=(SamplingParams(stop=["END"], stop_token_ids=[1]),),
+        comprehension_stage_index=0,
+    )
+
+    (params,) = plan.clone_sampling_params_list()
+    assert params.output_text_buffer_length == 0
+    assert params._all_stop_token_ids == {2}
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -3,240 +3,363 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.sampling_params import SamplingParams
 
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
-    compile_diffusion_request_overrides,
-    normalize_diffusion_request_extra_args,
+    DiffusionChatRequestPlan,
+    compile_diffusion_chat_request_plan,
 )
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
+SAMPLING_FIELDS = {
+    "height": "height",
+    "width": "width",
+    "seed": "seed",
+    "num_inference_steps": "num_inference_steps",
+    "guidance_scale": "guidance_scale",
+    "cfg_scale": "true_cfg_scale",
+    "true_cfg_scale": "true_cfg_scale",
+    "layers": "layers",
+}
+STANDARD_FIELDS = {"temperature", "max_tokens", "seed"}
+CONTROL_FIELDS = {"size", "negative_prompt", "lora", "modalities"}
 
-def test_normalize_diffusion_request_extra_args_preserves_unknown_model_keys() -> None:
-    extra_args = {"cfg_text_scale": 7.0, "sample_solver": "euler"}
 
-    normalized = normalize_diffusion_request_extra_args(
-        provided_root_fields={"seed"},
-        extra_args=extra_args,
+def _request(**kwargs: Any) -> ChatCompletionRequest:
+    return ChatCompletionRequest(model="test", messages=[], **kwargs)
+
+
+def _compile(
+    request: ChatCompletionRequest,
+    *,
+    stage_types: tuple[str, ...] = ("diffusion",),
+    defaults: tuple[object, ...] = (),
+    comprehension_stage_index: int | None = None,
+    declared: frozenset[str] = frozenset(),
+    fan_out_declared: bool = False,
+) -> DiffusionChatRequestPlan:
+    return compile_diffusion_chat_request_plan(
+        request=request,
+        stage_types=stage_types,
+        default_sampling_params_list=defaults,
+        comprehension_stage_index=comprehension_stage_index,
+        sampling_root_fields=SAMPLING_FIELDS,
+        standard_sampling_fields=STANDARD_FIELDS,
+        control_root_fields=CONTROL_FIELDS,
+        declared_extra_fields=declared,
+        apply_declared_to_non_diffusion=fan_out_declared,
     )
 
-    assert normalized == extra_args
-    assert normalized is not extra_args
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"model_option": 1},
+        {"extra_body": {"model_option": 1}},
+        {"extra_args": {"model_option": 1}},
+        {"extra_params": {"model_option": 1}},
+        {"extra_body": {"extra_args": {"model_option": 1}}},
+        {"extra_body": {"extra_params": {"model_option": 1}}},
+    ],
+)
+def test_all_global_sources_reach_the_same_diffusion_consumer(body: dict[str, object]) -> None:
+    declared = frozenset({"model_option"}) if "model_option" in body or "extra_body" in body else frozenset()
+    plan = _compile(_request(**body), declared=declared)
+
+    assert plan.clone_sampling_params_list()[0].extra_args["model_option"] == 1
 
 
-def test_normalize_diffusion_request_extra_args_accepts_non_overlapping_legacy_keys(mocker) -> None:
-    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
+@pytest.mark.parametrize(
+    "body, expected_sources",
+    [
+        (
+            {"seed": 1, "extra_args": {"seed": 2}},
+            "request.seed, request.extra_args.seed",
+        ),
+        (
+            {"cfg_scale": 1.0, "extra_args": {"true_cfg_scale": 2.0}},
+            "request.cfg_scale, request.extra_args.true_cfg_scale",
+        ),
+        (
+            {"model_option": 1, "extra_body": {"model_option": 2}},
+            "request.model_option, request.extra_body.model_option",
+        ),
+    ],
+)
+def test_global_duplicate_sources_are_rejected(
+    body: dict[str, object],
+    expected_sources: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_sources):
+        _compile(_request(**body), declared=frozenset({"model_option"}))
 
-    normalized = normalize_diffusion_request_extra_args(
-        extra_args={"cfg_text_scale": 7.0},
-        extra_params={"sample_solver": "euler"},
+
+def test_flattened_size_is_compiled_before_pure_diffusion_dispatch() -> None:
+    plan = _compile(_request(size="768x512"))
+
+    params = plan.clone_sampling_params_list()[0]
+    assert (params.height, params.width) == (512, 768)
+    assert plan.controls["height"] == 512
+    assert plan.controls["width"] == 768
+
+
+def test_declared_dimension_keeps_prompt_control_and_moves_sampling_owner() -> None:
+    plan = _compile(_request(height=512), declared=frozenset({"height"}))
+
+    params = plan.clone_sampling_params_list()[0]
+    assert plan.controls["height"] == 512
+    assert params.height is None
+    assert params.extra_args["height"] == 512
+
+
+def test_nested_controls_are_preserved_without_dispatcher_rereads() -> None:
+    plan = _compile(
+        _request(
+            extra_body={
+                "modalities": ["image"],
+                "negative_prompt": "low quality",
+            }
+        )
     )
 
-    assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
-    warning_once.assert_called_once_with(
-        "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
+    assert plan.controls["modalities"] == ["image"]
+    assert plan.controls["negative_prompt"] == "low quality"
+
+
+def test_internal_diffusion_state_is_not_a_public_root_field() -> None:
+    plan = _compile(
+        _request(
+            modules={"must": "not become request state"},
+            extra_args={"modules": {"pipeline": "owned"}},
+        )
     )
 
+    params = plan.clone_sampling_params_list()[0]
+    assert params.modules == {}
+    assert params.extra_args["modules"] == {"pipeline": "owned"}
 
-def test_normalize_diffusion_request_extra_args_merges_non_overlapping_nested_compatibility_form() -> None:
-    normalized = normalize_diffusion_request_extra_args(
-        extra_args={"cfg_text_scale": 7.0},
-        nested_extra_args={"sample_solver": "euler"},
+
+def test_flattened_size_reaches_mixed_final_consumers_and_preserves_defaults() -> None:
+    ar_default = SamplingParams(max_tokens=4353)
+    ar_default.extra_args = {"ar_default": True}
+    diffusion_default = OmniDiffusionSamplingParams(extra_args={"diffusion_default": True})
+
+    plan = _compile(
+        _request(size="768x512"),
+        stage_types=("llm", "diffusion"),
+        defaults=(ar_default, diffusion_default),
+        comprehension_stage_index=0,
     )
 
-    assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
+    assert ar_params.max_tokens == 4353
+    assert ar_params.extra_args == {
+        "ar_default": True,
+        "target_h": 512,
+        "target_w": 768,
+    }
+    assert (diffusion_params.height, diffusion_params.width) == (512, 768)
+    assert diffusion_params.extra_args == {"diffusion_default": True}
 
 
-def test_normalize_diffusion_request_extra_args_rejects_flattened_nested_conflict() -> None:
+@pytest.mark.parametrize("fan_out", [False, True])
+def test_registry_declaration_controls_non_diffusion_fan_out(fan_out: bool) -> None:
+    ar_default = SamplingParams(max_tokens=100)
+    diffusion_default = OmniDiffusionSamplingParams()
+    plan = _compile(
+        _request(max_tokens=32),
+        stage_types=("llm", "diffusion"),
+        defaults=(ar_default, diffusion_default),
+        comprehension_stage_index=0,
+        declared=frozenset({"max_tokens"}),
+        fan_out_declared=fan_out,
+    )
+
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
+    assert ar_params.max_tokens == (32 if fan_out else 100)
+    assert ("max_tokens" in (ar_params.extra_args or {})) is fan_out
+    assert diffusion_params.extra_args["max_tokens"] == 32
+
+
+def test_fanned_out_root_conflicts_with_the_same_non_diffusion_stage_key() -> None:
+    with pytest.raises(ValueError, match="provided more than once"):
+        _compile(
+            _request(
+                max_tokens=32,
+                sampling_params_list=[{"extra_args": {"max_tokens": 64}}],
+            ),
+            stage_types=("llm", "diffusion"),
+            defaults=(SamplingParams(), OmniDiffusionSamplingParams()),
+            comprehension_stage_index=0,
+            declared=frozenset({"max_tokens"}),
+            fan_out_declared=True,
+        )
+
+
+def test_request_stage_values_overlay_defaults_once() -> None:
+    plan = _compile(
+        _request(
+            extra_args={"global": 1},
+            sampling_params_list=[
+                {"temperature": 0.7, "stop": "END"},
+                {"guidance_scale": 4.0, "extra_args": {"local": 2}},
+            ],
+        ),
+        stage_types=("llm", "diffusion"),
+        defaults=(
+            SamplingParams(temperature=0.2, max_tokens=99),
+            OmniDiffusionSamplingParams(extra_args={"default": 3}),
+        ),
+        comprehension_stage_index=0,
+    )
+
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
+    assert (ar_params.temperature, ar_params.max_tokens) == (0.7, 99)
+    assert ar_params.stop == ["END"]
+    assert ar_params.output_text_buffer_length == 2
+    assert diffusion_params.guidance_scale == 4.0
+    assert diffusion_params.extra_args == {"default": 3, "global": 1, "local": 2}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"sampling_params_list": [{"guidance_scale": 4.0}]},
+        {"extra_body": {"sampling_params_list": [{"guidance_scale": 4.0}]}},
+    ],
+)
+def test_stage_list_ingress_reaches_the_same_consumer(body: dict[str, object]) -> None:
+    params = _compile(_request(**body)).clone_sampling_params_list()[0]
+
+    assert params.guidance_scale == 4.0
+
+
+def test_root_and_nested_stage_lists_conflict() -> None:
+    with pytest.raises(ValueError, match="request.sampling_params_list, request.extra_body.sampling_params_list"):
+        _compile(
+            _request(
+                sampling_params_list=[{}],
+                extra_body={"sampling_params_list": [{}]},
+            )
+        )
+
+
+def test_global_and_stage_request_values_cannot_overwrite_each_other() -> None:
     with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"cfg_text_scale"},
-            nested_extra_args={"cfg_text_scale": 7.0},
+        _compile(
+            _request(
+                extra_args={"seed": 1},
+                sampling_params_list=[{"extra_args": {"seed": 2}}],
+            )
         )
 
     assert str(exc_info.value) == (
-        'Parameter "cfg_text_scale" was provided more than once: '
-        "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale."
+        'Parameter "seed" was provided more than once: '
+        "request.extra_args.seed, request.sampling_params_list[0].extra_args.seed."
     )
 
 
-@pytest.mark.parametrize("name", ["extra_args", "extra_params"])
-def test_normalize_diffusion_request_extra_args_rejects_non_object_containers(name: str) -> None:
-    kwargs = {name: ["not", "an", "object"]}
-
-    with pytest.raises(ValueError, match=rf"^{name} must be a JSON object\.$"):
-        normalize_diffusion_request_extra_args(**kwargs)
-
-
-def test_normalize_diffusion_request_extra_args_rejects_non_string_keys() -> None:
-    with pytest.raises(ValueError, match=r"^extra_args must be a JSON object with string keys\.$"):
-        normalize_diffusion_request_extra_args(extra_args={1: "not a JSON object key"})
-
-
-def test_normalize_diffusion_request_extra_args_rejects_root_conflict() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"flow_shift", "extra_args"},
-            extra_args={"flow_shift": 3.0},
+def test_duplicate_detection_precedes_value_parsing() -> None:
+    with pytest.raises(ValueError, match="provided more than once"):
+        _compile(
+            _request(
+                num_inference_steps=[],
+                sampling_params_list=[{"num_inference_steps": 2}],
+            )
         )
 
-    assert str(exc_info.value) == (
-        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
-    )
 
+def test_deprecation_is_logged_only_after_a_request_compiles(mocker) -> None:
+    from vllm_omni.entrypoints.openai import diffusion_request_utils
 
-def test_normalize_diffusion_request_extra_args_rejects_root_alias_conflict() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"cfg_scale", "true_cfg_scale"},
-            root_field_aliases={"cfg_scale": "true_cfg_scale"},
+    warning_once = mocker.patch.object(diffusion_request_utils.logger, "warning_once")
+    _compile(_request(extra_params={"key": 1}))
+    warning_once.assert_called_once()
+
+    warning_once.reset_mock()
+    with pytest.raises(ValueError, match="provided more than once"):
+        _compile(
+            _request(
+                extra_params={"key": 1},
+                sampling_params_list=[{"extra_args": {"key": 2}}],
+            )
         )
-
-    assert str(exc_info.value) == (
-        'Parameter "true_cfg_scale" was provided more than once: request.cfg_scale, request.true_cfg_scale.'
-    )
-
-
-def test_normalize_diffusion_request_extra_args_rejects_alias_conflict_without_warning(mocker) -> None:
-    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            extra_args={"sample_solver": "euler"},
-            extra_params={"sample_solver": "euler"},
-        )
-
     warning_once.assert_not_called()
-    assert str(exc_info.value) == (
-        'Parameter "sample_solver" was provided more than once: '
-        "request.extra_args.sample_solver, request.extra_params.sample_solver."
+
+
+def test_same_key_is_allowed_in_distinct_stages() -> None:
+    plan = _compile(
+        _request(sampling_params_list=[{"extra_args": {"key": 1}}, {"extra_args": {"key": 2}}]),
+        stage_types=("llm", "diffusion"),
     )
 
+    first, second = plan.clone_sampling_params_list()
+    assert first.extra_args["key"] == 1
+    assert second.extra_args["key"] == 2
 
-def test_normalize_diffusion_request_extra_args_reports_all_conflicts_deterministically() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"seed", "flow_shift"},
-            extra_args={"seed": 1, "flow_shift": 3.0},
-            extra_params={"seed": 2},
-        )
 
-    assert str(exc_info.value) == (
-        'Diffusion request parameters were provided more than once: "flow_shift": '
-        'request.flow_shift, request.extra_args.flow_shift; "seed": request.seed, '
-        "request.extra_args.seed, request.extra_params.seed."
+@pytest.mark.parametrize(
+    "field, value, message",
+    [
+        ("num_inference_steps", [], "num_inference_steps must be an integer."),
+        ("layers", 999, "layers must be between 2 and 10"),
+    ],
+)
+def test_value_parsers_run_before_dispatch(field: str, value: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        _compile(_request(**{field: value}))
+
+
+def test_undeclared_container_values_remain_pipeline_owned() -> None:
+    raw = {
+        "layers": "pipeline-specific",
+        "num_inference_steps": {"schedule": "custom"},
+    }
+
+    params = _compile(_request(extra_args=raw)).clone_sampling_params_list()[0]
+
+    assert params.extra_args == raw
+
+
+def test_declared_container_value_uses_the_serving_parser() -> None:
+    params = _compile(
+        _request(extra_args={"num_inference_steps": "12"}),
+        declared=frozenset({"num_inference_steps"}),
+    ).clone_sampling_params_list()[0]
+
+    assert params.extra_args["num_inference_steps"] == 12
+
+
+def test_sampling_params_list_entries_must_be_objects() -> None:
+    with pytest.raises(ValueError, match=r"sampling_params_list\[0\] must be a JSON object"):
+        _compile(_request(sampling_params_list=[None]))
+
+
+def test_unknown_direct_stage_field_is_rejected_by_the_target_stage() -> None:
+    with pytest.raises(ValueError, match="unsupported parameter"):
+        _compile(_request(sampling_params_list=[{"unknown_runtime_field": 1}]))
+
+
+def test_too_many_stage_entries_are_rejected() -> None:
+    with pytest.raises(ValueError, match="pipeline has 1 stages"):
+        _compile(_request(sampling_params_list=[{}, {}]))
+
+
+def test_plan_returns_isolated_stage_parameters() -> None:
+    plan = _compile(
+        _request(extra_args={"nested": {"value": 1}}),
+        defaults=(OmniDiffusionSamplingParams(extra_args={"default": True}),),
     )
 
+    first = plan.clone_sampling_params_list()
+    second = plan.clone_sampling_params_list()
+    first[0].extra_args["nested"]["value"] = 9
 
-def test_normalize_diffusion_request_extra_args_does_not_treat_stage_defaults_as_request_conflicts() -> None:
-    normalized = normalize_diffusion_request_extra_args(
-        provided_root_fields=(),
-        extra_args={"flow_shift": 3.0},
-    )
-
-    assert normalized == {"flow_shift": 3.0}
-
-
-def test_normalize_diffusion_request_extra_args_rejects_stage_request_conflict() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"seed"},
-            stage_extra_args={1: {"seed": 111}},
-        )
-
-    assert str(exc_info.value) == (
-        'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[1].extra_args.seed.'
-    )
-
-
-def test_normalize_diffusion_request_extra_args_allows_same_key_in_distinct_stages() -> None:
-    normalized = normalize_diffusion_request_extra_args(
-        stage_extra_args={
-            1: {"seed": 111},
-            2: {"seed": 222},
-        },
-    )
-
-    assert normalized == {}
-
-
-def test_normalize_diffusion_request_extra_args_rejects_non_object_stage_extra_args() -> None:
-    with pytest.raises(
-        ValueError,
-        match=r"^sampling_params_list\[1\]\.extra_args must be a JSON object\.$",
-    ):
-        normalize_diffusion_request_extra_args(
-            stage_extra_args={1: ["not", "an", "object"]},
-        )
-
-
-def test_compile_routes_registry_declared_root_to_extra_args() -> None:
-    compiled = compile_diffusion_request_overrides(
-        root_values={"max_tokens": 32},
-        nested_root_values={},
-        sampling_root_fields={},
-        declared_extra_fields={"max_tokens"},
-        control_root_fields=set(),
-    )
-
-    assert compiled.sampling_overrides == {}
-    assert compiled.extra_args == {"max_tokens": 32}
-
-
-def test_compile_uses_sampling_alias_without_model_declaration() -> None:
-    compiled = compile_diffusion_request_overrides(
-        root_values={"cfg_scale": 3.0},
-        nested_root_values={},
-        sampling_root_fields={"cfg_scale": "true_cfg_scale"},
-        declared_extra_fields=set(),
-        control_root_fields=set(),
-    )
-
-    assert compiled.sampling_overrides == {"true_cfg_scale": 3.0}
-    assert compiled.extra_args == {}
-
-
-def test_compile_preserves_shared_control_for_model_declared_root() -> None:
-    compiled = compile_diffusion_request_overrides(
-        root_values={"negative_prompt": "avoid blur"},
-        nested_root_values={},
-        sampling_root_fields={},
-        declared_extra_fields={"negative_prompt"},
-        control_root_fields={"negative_prompt"},
-    )
-
-    assert compiled.extra_args == {"negative_prompt": "avoid blur"}
-    assert compiled.control_overrides == {"negative_prompt": "avoid blur"}
-
-
-def test_compile_registry_declaration_changes_cfg_scale_conflict_key() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        compile_diffusion_request_overrides(
-            root_values={"cfg_scale": 3.0},
-            nested_root_values={},
-            sampling_root_fields={"cfg_scale": "true_cfg_scale"},
-            declared_extra_fields={"cfg_scale"},
-            control_root_fields=set(),
-            extra_args={"cfg_scale": 7.0},
-        )
-
-    assert str(exc_info.value) == (
-        'Parameter "cfg_scale" was provided more than once: request.cfg_scale, request.extra_args.cfg_scale.'
-    )
-
-
-def test_compile_uses_model_aware_aliases_for_stage_conflicts() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        compile_diffusion_request_overrides(
-            root_values={"cfg_scale": 3.0},
-            nested_root_values={},
-            sampling_root_fields={"cfg_scale": "true_cfg_scale"},
-            declared_extra_fields={"cfg_scale"},
-            control_root_fields=set(),
-            stage_extra_args={1: {"cfg_scale": 7.0}},
-        )
-
-    assert str(exc_info.value) == (
-        'Parameter "cfg_scale" was provided more than once: '
-        "request.cfg_scale, request.sampling_params_list[1].extra_args.cfg_scale."
-    )
+    assert second[0].extra_args["nested"]["value"] == 1
+    assert second[0].extra_args["default"] is True

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -25,13 +25,35 @@ def test_normalize_diffusion_request_extra_args_preserves_unknown_model_keys() -
 
 
 def test_normalize_diffusion_request_extra_args_accepts_non_overlapping_legacy_keys() -> None:
-    with pytest.warns(DeprecationWarning, match="extra_params is deprecated"):
+    with pytest.warns(FutureWarning, match="extra_params is deprecated"):
         normalized = normalize_diffusion_request_extra_args(
             extra_args={"cfg_text_scale": 7.0},
             extra_params={"sample_solver": "euler"},
         )
 
     assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+
+
+def test_normalize_diffusion_request_extra_args_merges_non_overlapping_nested_compatibility_form() -> None:
+    normalized = normalize_diffusion_request_extra_args(
+        extra_args={"cfg_text_scale": 7.0},
+        nested_extra_args={"sample_solver": "euler"},
+    )
+
+    assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+
+
+def test_normalize_diffusion_request_extra_args_rejects_flattened_nested_conflict() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"cfg_text_scale"},
+            nested_extra_args={"cfg_text_scale": 7.0},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "cfg_text_scale" was provided more than once: '
+        "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale."
+    )
 
 
 @pytest.mark.parametrize("name", ["extra_args", "extra_params"])

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -131,14 +131,6 @@ def test_global_source_dispatcher_consumer_matrix(
             "request.cfg_scale, request.extra_args.true_cfg_scale",
         ),
         (
-            {"cfg_scale": 1.0, "extra_args": {"cfg_scale": 2.0}},
-            "request.cfg_scale, request.extra_args.cfg_scale",
-        ),
-        (
-            {"true_cfg_scale": 1.0, "extra_args": {"cfg_scale": 2.0}},
-            "request.true_cfg_scale, request.extra_args.cfg_scale",
-        ),
-        (
             {"model_option": 1, "extra_body": {"model_option": 2}},
             "request.model_option, request.extra_body.model_option",
         ),
@@ -152,15 +144,6 @@ def test_global_duplicate_sources_are_rejected(
         _compile(_request(**body), declared=frozenset({"model_option"}))
 
 
-def test_flattened_size_is_compiled_before_pure_diffusion_dispatch() -> None:
-    plan = _compile(_request(size="768x512"))
-
-    params = plan.clone_sampling_params_list()[0]
-    assert (params.height, params.width) == (512, 768)
-    assert plan.controls["height"] == 512
-    assert plan.controls["width"] == 768
-
-
 def test_declared_dimension_keeps_prompt_control_and_moves_sampling_owner() -> None:
     plan = _compile(_request(height=512), declared=frozenset({"height"}))
 
@@ -168,26 +151,6 @@ def test_declared_dimension_keeps_prompt_control_and_moves_sampling_owner() -> N
     assert plan.controls["height"] == 512
     assert params.height is None
     assert params.extra_args["height"] == 512
-
-
-def test_nested_controls_are_preserved_without_dispatcher_rereads() -> None:
-    plan = _compile(
-        _request(
-            extra_body={
-                "modalities": ["image"],
-                "negative_prompt": "low quality",
-            }
-        )
-    )
-
-    assert plan.controls["modalities"] == ["image"]
-    assert plan.controls["negative_prompt"] == "low quality"
-
-
-@pytest.mark.parametrize("modalities", ["text", ["text", 1]])
-def test_nested_modalities_must_be_a_list_of_strings(modalities: object) -> None:
-    with pytest.raises(ValueError, match="'modalities' must be a list of strings"):
-        _compile(_request(extra_body={"modalities": modalities}))
 
 
 def test_internal_diffusion_state_is_not_a_public_root_field() -> None:
@@ -201,48 +164,6 @@ def test_internal_diffusion_state_is_not_a_public_root_field() -> None:
     params = plan.clone_sampling_params_list()[0]
     assert params.modules == {}
     assert params.extra_args["modules"] == {"pipeline": "owned"}
-
-
-def test_flattened_size_reaches_mixed_final_consumers_and_preserves_defaults() -> None:
-    ar_default = SamplingParams(max_tokens=4353)
-    ar_default.extra_args = {"ar_default": True}
-    diffusion_default = OmniDiffusionSamplingParams(extra_args={"diffusion_default": True})
-
-    plan = _compile(
-        _request(size="768x512"),
-        stage_types=("llm", "diffusion"),
-        defaults=(ar_default, diffusion_default),
-        comprehension_stage_index=0,
-    )
-
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-    assert ar_params.max_tokens == 4353
-    assert ar_params.extra_args == {
-        "ar_default": True,
-        "target_h": 512,
-        "target_w": 768,
-    }
-    assert (diffusion_params.height, diffusion_params.width) == (512, 768)
-    assert diffusion_params.extra_args == {"diffusion_default": True}
-
-
-@pytest.mark.parametrize("fan_out", [False, True])
-def test_registry_declaration_controls_non_diffusion_fan_out(fan_out: bool) -> None:
-    ar_default = SamplingParams(max_tokens=100)
-    diffusion_default = OmniDiffusionSamplingParams()
-    plan = _compile(
-        _request(max_tokens=32),
-        stage_types=("llm", "diffusion"),
-        defaults=(ar_default, diffusion_default),
-        comprehension_stage_index=0,
-        declared=frozenset({"max_tokens"}),
-        fan_out_declared=fan_out,
-    )
-
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-    assert ar_params.max_tokens == (32 if fan_out else 100)
-    assert ("max_tokens" in (ar_params.extra_args or {})) is fan_out
-    assert diffusion_params.extra_args["max_tokens"] == 32
 
 
 def test_fanned_out_root_conflicts_with_the_same_non_diffusion_stage_key() -> None:

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -10,6 +10,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.sampling_params import SamplingParams
 
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
+    DiffusionChatRequestContext,
     DiffusionChatRequestPlan,
     compile_diffusion_chat_request_plan,
 )
@@ -17,18 +18,7 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
-SAMPLING_FIELDS = {
-    "height": "height",
-    "width": "width",
-    "seed": "seed",
-    "num_inference_steps": "num_inference_steps",
-    "guidance_scale": "guidance_scale",
-    "cfg_scale": "true_cfg_scale",
-    "true_cfg_scale": "true_cfg_scale",
-    "layers": "layers",
-}
 STANDARD_FIELDS = {"temperature", "max_tokens", "seed"}
-CONTROL_FIELDS = {"size", "negative_prompt", "lora", "modalities"}
 
 
 def _request(**kwargs: Any) -> ChatCompletionRequest:
@@ -66,15 +56,15 @@ def _compile(
 ) -> DiffusionChatRequestPlan:
     return compile_diffusion_chat_request_plan(
         request=request,
-        stage_types=stage_types,
-        default_sampling_params_list=defaults,
-        comprehension_stage_index=comprehension_stage_index,
-        sampling_root_fields=SAMPLING_FIELDS,
-        standard_sampling_fields=STANDARD_FIELDS,
-        control_root_fields=CONTROL_FIELDS,
-        declared_extra_fields=declared,
-        apply_declared_to_non_diffusion=fan_out_declared,
-        supported_modalities=supported_modalities,
+        context=DiffusionChatRequestContext(
+            stage_types=stage_types,
+            default_sampling_params_list=defaults,
+            comprehension_stage_index=comprehension_stage_index,
+            standard_sampling_fields=frozenset(STANDARD_FIELDS),
+            declared_extra_fields=declared,
+            apply_declared_to_non_diffusion=fan_out_declared,
+            supported_modalities=supported_modalities,
+        ),
     )
 
 
@@ -117,6 +107,19 @@ def test_global_source_dispatcher_consumer_matrix(
         assert ar_params.seed == 7
         assert key not in (ar_params.extra_args or {})
         assert diffusion_params.extra_args == {"default": True}
+
+
+@pytest.mark.parametrize(
+    "source",
+    ("extra_args", "extra_params", "extra_body.extra_args", "extra_body.extra_params"),
+)
+def test_pipeline_owned_global_none_preserves_stage_default(source: str) -> None:
+    plan = _compile(
+        _request(**_global_source(source, "solver", None)),
+        defaults=(OmniDiffusionSamplingParams(extra_args={"solver": "euler"}),),
+    )
+
+    assert plan.clone_sampling_params_list()[0].extra_args["solver"] == "euler"
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -114,7 +114,7 @@ def test_declared_global_none_preserves_mixed_stage_defaults(body: dict[str, obj
 
     ar_params, diffusion_params = plan.clone_sampling_params_list()
     assert ar_params.seed == 7
-    assert "seed" not in ar_params.extra_args
+    assert "seed" not in (ar_params.extra_args or {})
     assert diffusion_params.extra_args == {"default": True}
 
 

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -35,6 +35,17 @@ def _request(**kwargs: Any) -> ChatCompletionRequest:
     return ChatCompletionRequest(model="test", messages=[], **kwargs)
 
 
+def _global_sources(key: str, value: object) -> list[dict[str, object]]:
+    return [
+        {key: value},
+        {"extra_body": {key: value}},
+        {"extra_args": {key: value}},
+        {"extra_params": {key: value}},
+        {"extra_body": {"extra_args": {key: value}}},
+        {"extra_body": {"extra_params": {key: value}}},
+    ]
+
+
 def _compile(
     request: ChatCompletionRequest,
     *,
@@ -59,20 +70,52 @@ def _compile(
 
 @pytest.mark.parametrize(
     "body",
-    [
-        {"model_option": 1},
-        {"extra_body": {"model_option": 1}},
-        {"extra_args": {"model_option": 1}},
-        {"extra_params": {"model_option": 1}},
-        {"extra_body": {"extra_args": {"model_option": 1}}},
-        {"extra_body": {"extra_params": {"model_option": 1}}},
-    ],
+    _global_sources("model_option", 1),
 )
 def test_all_global_sources_reach_the_same_diffusion_consumer(body: dict[str, object]) -> None:
-    declared = frozenset({"model_option"}) if "model_option" in body or "extra_body" in body else frozenset()
-    plan = _compile(_request(**body), declared=declared)
+    plan = _compile(_request(**body), declared=frozenset({"model_option"}))
 
     assert plan.clone_sampling_params_list()[0].extra_args["model_option"] == 1
+
+
+@pytest.mark.parametrize("body", _global_sources("seed", 32))
+def test_declared_global_sources_reach_the_same_mixed_stage_consumers(body: dict[str, object]) -> None:
+    plan = _compile(
+        _request(**body),
+        stage_types=("llm", "diffusion"),
+        defaults=(
+            SamplingParams(seed=7),
+            OmniDiffusionSamplingParams(extra_args={"default": True}),
+        ),
+        comprehension_stage_index=0,
+        declared=frozenset({"seed"}),
+        fan_out_declared=True,
+    )
+
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
+    assert ar_params.seed == 32
+    assert ar_params.extra_args["seed"] == 32
+    assert diffusion_params.extra_args == {"default": True, "seed": 32}
+
+
+@pytest.mark.parametrize("body", _global_sources("seed", None))
+def test_declared_global_none_preserves_mixed_stage_defaults(body: dict[str, object]) -> None:
+    plan = _compile(
+        _request(**body),
+        stage_types=("llm", "diffusion"),
+        defaults=(
+            SamplingParams(seed=7),
+            OmniDiffusionSamplingParams(extra_args={"default": True}),
+        ),
+        comprehension_stage_index=0,
+        declared=frozenset({"seed"}),
+        fan_out_declared=True,
+    )
+
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
+    assert ar_params.seed == 7
+    assert "seed" not in ar_params.extra_args
+    assert diffusion_params.extra_args == {"default": True}
 
 
 @pytest.mark.parametrize(
@@ -85,6 +128,14 @@ def test_all_global_sources_reach_the_same_diffusion_consumer(body: dict[str, ob
         (
             {"cfg_scale": 1.0, "extra_args": {"true_cfg_scale": 2.0}},
             "request.cfg_scale, request.extra_args.true_cfg_scale",
+        ),
+        (
+            {"cfg_scale": 1.0, "extra_args": {"cfg_scale": 2.0}},
+            "request.cfg_scale, request.extra_args.cfg_scale",
+        ),
+        (
+            {"true_cfg_scale": 1.0, "extra_args": {"cfg_scale": 2.0}},
+            "request.true_cfg_scale, request.extra_args.cfg_scale",
         ),
         (
             {"model_option": 1, "extra_body": {"model_option": 2}},
@@ -130,6 +181,12 @@ def test_nested_controls_are_preserved_without_dispatcher_rereads() -> None:
 
     assert plan.controls["modalities"] == ["image"]
     assert plan.controls["negative_prompt"] == "low quality"
+
+
+@pytest.mark.parametrize("modalities", ["text", ["text", 1]])
+def test_nested_modalities_must_be_a_list_of_strings(modalities: object) -> None:
+    with pytest.raises(ValueError, match="'modalities' must be a list of strings"):
+        _compile(_request(extra_body={"modalities": modalities}))
 
 
 def test_internal_diffusion_state_is_not_a_public_root_field() -> None:

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -81,6 +81,18 @@ def test_normalize_diffusion_request_extra_args_rejects_root_conflict() -> None:
     )
 
 
+def test_normalize_diffusion_request_extra_args_rejects_root_alias_conflict() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"cfg_scale", "true_cfg_scale"},
+            root_field_aliases={"cfg_scale": "true_cfg_scale"},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "true_cfg_scale" was provided more than once: request.cfg_scale, request.true_cfg_scale.'
+    )
+
+
 def test_normalize_diffusion_request_extra_args_rejects_alias_conflict_without_warning() -> None:
     with warnings.catch_warnings(record=True) as warning_records:
         warnings.simplefilter("always")

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import pytest
 
 from vllm_omni.entrypoints.openai.diffusion_request_utils import normalize_diffusion_request_extra_args
@@ -24,14 +22,18 @@ def test_normalize_diffusion_request_extra_args_preserves_unknown_model_keys() -
     assert normalized is not extra_args
 
 
-def test_normalize_diffusion_request_extra_args_accepts_non_overlapping_legacy_keys() -> None:
-    with pytest.warns(FutureWarning, match="extra_params is deprecated"):
-        normalized = normalize_diffusion_request_extra_args(
-            extra_args={"cfg_text_scale": 7.0},
-            extra_params={"sample_solver": "euler"},
-        )
+def test_normalize_diffusion_request_extra_args_accepts_non_overlapping_legacy_keys(mocker) -> None:
+    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
+
+    normalized = normalize_diffusion_request_extra_args(
+        extra_args={"cfg_text_scale": 7.0},
+        extra_params={"sample_solver": "euler"},
+    )
 
     assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+    warning_once.assert_called_once_with(
+        "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
+    )
 
 
 def test_normalize_diffusion_request_extra_args_merges_non_overlapping_nested_compatibility_form() -> None:
@@ -93,16 +95,15 @@ def test_normalize_diffusion_request_extra_args_rejects_root_alias_conflict() ->
     )
 
 
-def test_normalize_diffusion_request_extra_args_rejects_alias_conflict_without_warning() -> None:
-    with warnings.catch_warnings(record=True) as warning_records:
-        warnings.simplefilter("always")
-        with pytest.raises(ValueError) as exc_info:
-            normalize_diffusion_request_extra_args(
-                extra_args={"sample_solver": "euler"},
-                extra_params={"sample_solver": "euler"},
-            )
+def test_normalize_diffusion_request_extra_args_rejects_alias_conflict_without_warning(mocker) -> None:
+    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            extra_args={"sample_solver": "euler"},
+            extra_params={"sample_solver": "euler"},
+        )
 
-    assert not warning_records
+    warning_once.assert_not_called()
     assert str(exc_info.value) == (
         'Parameter "sample_solver" was provided more than once: '
         "request.extra_args.sample_solver, request.extra_params.sample_solver."

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_omni.entrypoints.openai.diffusion_request_utils import normalize_diffusion_request_extra_args
+from vllm_omni.entrypoints.openai.diffusion_request_utils import (
+    compile_diffusion_request_overrides,
+    normalize_diffusion_request_extra_args,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -132,3 +135,108 @@ def test_normalize_diffusion_request_extra_args_does_not_treat_stage_defaults_as
     )
 
     assert normalized == {"flow_shift": 3.0}
+
+
+def test_normalize_diffusion_request_extra_args_rejects_stage_request_conflict() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"seed"},
+            stage_extra_args={1: {"seed": 111}},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[1].extra_args.seed.'
+    )
+
+
+def test_normalize_diffusion_request_extra_args_allows_same_key_in_distinct_stages() -> None:
+    normalized = normalize_diffusion_request_extra_args(
+        stage_extra_args={
+            1: {"seed": 111},
+            2: {"seed": 222},
+        },
+    )
+
+    assert normalized == {}
+
+
+def test_normalize_diffusion_request_extra_args_rejects_non_object_stage_extra_args() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^sampling_params_list\[1\]\.extra_args must be a JSON object\.$",
+    ):
+        normalize_diffusion_request_extra_args(
+            stage_extra_args={1: ["not", "an", "object"]},
+        )
+
+
+def test_compile_routes_registry_declared_root_to_extra_args() -> None:
+    compiled = compile_diffusion_request_overrides(
+        root_values={"max_tokens": 32},
+        nested_root_values={},
+        sampling_root_fields={},
+        declared_extra_fields={"max_tokens"},
+        control_root_fields=set(),
+    )
+
+    assert compiled.sampling_overrides == {}
+    assert compiled.extra_args == {"max_tokens": 32}
+
+
+def test_compile_uses_sampling_alias_without_model_declaration() -> None:
+    compiled = compile_diffusion_request_overrides(
+        root_values={"cfg_scale": 3.0},
+        nested_root_values={},
+        sampling_root_fields={"cfg_scale": "true_cfg_scale"},
+        declared_extra_fields=set(),
+        control_root_fields=set(),
+    )
+
+    assert compiled.sampling_overrides == {"true_cfg_scale": 3.0}
+    assert compiled.extra_args == {}
+
+
+def test_compile_preserves_shared_control_for_model_declared_root() -> None:
+    compiled = compile_diffusion_request_overrides(
+        root_values={"negative_prompt": "avoid blur"},
+        nested_root_values={},
+        sampling_root_fields={},
+        declared_extra_fields={"negative_prompt"},
+        control_root_fields={"negative_prompt"},
+    )
+
+    assert compiled.extra_args == {"negative_prompt": "avoid blur"}
+    assert compiled.control_overrides == {"negative_prompt": "avoid blur"}
+
+
+def test_compile_registry_declaration_changes_cfg_scale_conflict_key() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        compile_diffusion_request_overrides(
+            root_values={"cfg_scale": 3.0},
+            nested_root_values={},
+            sampling_root_fields={"cfg_scale": "true_cfg_scale"},
+            declared_extra_fields={"cfg_scale"},
+            control_root_fields=set(),
+            extra_args={"cfg_scale": 7.0},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "cfg_scale" was provided more than once: request.cfg_scale, request.extra_args.cfg_scale.'
+    )
+
+
+def test_compile_uses_model_aware_aliases_for_stage_conflicts() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        compile_diffusion_request_overrides(
+            root_values={"cfg_scale": 3.0},
+            nested_root_values={},
+            sampling_root_fields={"cfg_scale": "true_cfg_scale"},
+            declared_extra_fields={"cfg_scale"},
+            control_root_fields=set(),
+            stage_extra_args={1: {"cfg_scale": 7.0}},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "cfg_scale" was provided more than once: '
+        "request.cfg_scale, request.sampling_params_list[1].extra_args.cfg_scale."
+    )

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -3,368 +3,136 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.sampling_params import SamplingParams
 
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
-    DiffusionChatRequestContext,
-    DiffusionChatRequestPlan,
-    compile_diffusion_chat_request_plan,
+    apply_normalized_diffusion_request_extra_args,
+    normalize_diffusion_request_extra_args,
 )
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
-STANDARD_FIELDS = {"temperature", "max_tokens", "seed"}
-
-
-def _request(**kwargs: Any) -> ChatCompletionRequest:
-    return ChatCompletionRequest(model="test", messages=[], **kwargs)
-
-
-GLOBAL_SOURCE_PATHS = (
-    "request",
-    "extra_body",
+SOURCE_KWARGS = (
+    "root_extra_args",
     "extra_args",
     "extra_params",
-    "extra_body.extra_args",
-    "extra_body.extra_params",
+    "nested_root_extra_args",
+    "nested_extra_args",
+    "nested_extra_params",
 )
 
 
-def _global_source(path: str, key: str, value: object) -> dict[str, object]:
-    body: dict[str, object] = {key: value}
-    if path == "request":
-        return body
-    for container in reversed(path.split(".")):
-        body = {container: body}
-    return body
+@pytest.mark.parametrize("source", SOURCE_KWARGS)
+def test_normalizer_preserves_pipeline_owned_values(source: str) -> None:
+    normalized = normalize_diffusion_request_extra_args(**{source: {"solver": "euler"}})
+
+    assert normalized == {"solver": "euler"}
 
 
-def _compile(
-    request: ChatCompletionRequest,
-    *,
-    stage_types: tuple[str, ...] = ("diffusion",),
-    defaults: tuple[object, ...] = (),
-    comprehension_stage_index: int | None = None,
-    declared: frozenset[str] = frozenset(),
-    fan_out_declared: bool = False,
-    supported_modalities: frozenset[str] = frozenset({"audio", "image", "text"}),
-) -> DiffusionChatRequestPlan:
-    return compile_diffusion_chat_request_plan(
-        request=request,
-        context=DiffusionChatRequestContext(
-            stage_types=stage_types,
-            default_sampling_params_list=defaults,
-            comprehension_stage_index=comprehension_stage_index,
-            standard_sampling_fields=frozenset(STANDARD_FIELDS),
-            declared_extra_fields=declared,
-            apply_declared_to_non_diffusion=fan_out_declared,
-            supported_modalities=supported_modalities,
-        ),
+@pytest.mark.parametrize("source", SOURCE_KWARGS)
+def test_explicit_none_preserves_stage_default(source: str) -> None:
+    normalized = normalize_diffusion_request_extra_args(**{source: {"solver": None}})
+    sampling_params = OmniDiffusionSamplingParams(extra_args={"solver": "euler"})
+    apply_normalized_diffusion_request_extra_args(sampling_params, normalized)
+
+    assert sampling_params.extra_args["solver"] == "euler"
+
+
+def test_request_extras_overlay_matching_defaults() -> None:
+    sampling_params = OmniDiffusionSamplingParams(
+        extra_args={"solver": "euler", "stage_default": True},
     )
 
+    apply_normalized_diffusion_request_extra_args(sampling_params, {"solver": "ddim"})
 
-@pytest.mark.parametrize("source", GLOBAL_SOURCE_PATHS)
-@pytest.mark.parametrize(
-    ("dispatcher", "consumer", "key", "value"),
-    [
-        pytest.param("pure", "diffusion", "model_option", 1, id="pure-diffusion"),
-        pytest.param("mixed", "fan-out", "seed", 32, id="mixed-fan-out"),
-        pytest.param("mixed", "defaults", "seed", None, id="mixed-defaults"),
-    ],
-)
-def test_global_source_dispatcher_consumer_matrix(
-    source: str,
-    dispatcher: str,
-    consumer: str,
-    key: str,
-    value: object,
-) -> None:
-    body = _global_source(source, key, value)
-    if dispatcher == "pure":
-        plan = _compile(_request(**body), declared=frozenset({key}))
-        assert plan.clone_sampling_params_list()[0].extra_args[key] == value
-        return
+    assert sampling_params.extra_args == {"solver": "ddim", "stage_default": True}
 
-    plan = _compile(
-        _request(**body),
-        stage_types=("llm", "diffusion"),
-        defaults=(SamplingParams(seed=7), OmniDiffusionSamplingParams(extra_args={"default": True})),
-        comprehension_stage_index=0,
-        declared=frozenset({key}),
-        fan_out_declared=True,
+
+def test_non_overlapping_legacy_and_canonical_values_are_merged(mocker) -> None:
+    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
+
+    normalized = normalize_diffusion_request_extra_args(
+        extra_args={"cfg_text_scale": 7.0},
+        nested_extra_params={"sample_solver": "euler"},
     )
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-    if consumer == "fan-out":
-        assert ar_params.seed == value
-        assert ar_params.extra_args[key] == value
-        assert diffusion_params.extra_args == {"default": True, key: value}
-    else:
-        assert ar_params.seed == 7
-        assert key not in (ar_params.extra_args or {})
-        assert diffusion_params.extra_args == {"default": True}
+
+    assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+    warning_once.assert_called_once()
 
 
 @pytest.mark.parametrize(
-    "source",
-    ("extra_args", "extra_params", "extra_body.extra_args", "extra_body.extra_params"),
-)
-def test_pipeline_owned_global_none_preserves_stage_default(source: str) -> None:
-    plan = _compile(
-        _request(**_global_source(source, "solver", None)),
-        defaults=(OmniDiffusionSamplingParams(extra_args={"solver": "euler"}),),
-    )
-
-    assert plan.clone_sampling_params_list()[0].extra_args["solver"] == "euler"
-
-
-@pytest.mark.parametrize(
-    "body, expected_sources",
+    "kwargs, expected_sources",
     [
         (
-            {"seed": 1, "extra_args": {"seed": 2}},
+            {"provided_root_fields": {"seed"}, "extra_args": {"seed": 2}},
             "request.seed, request.extra_args.seed",
         ),
         (
-            {"cfg_scale": 1.0, "extra_args": {"true_cfg_scale": 2.0}},
-            "request.cfg_scale, request.extra_args.true_cfg_scale",
+            {
+                "provided_root_fields": {"cfg_scale"},
+                "nested_provided_root_fields": {"true_cfg_scale"},
+                "root_field_aliases": {"cfg_scale": "true_cfg_scale"},
+            },
+            "request.cfg_scale, request.extra_body.true_cfg_scale",
         ),
         (
-            {"model_option": 1, "extra_body": {"model_option": 2}},
-            "request.model_option, request.extra_body.model_option",
+            {"extra_args": {"solver": "euler"}, "extra_params": {"solver": "ddim"}},
+            "request.extra_args.solver, request.extra_params.solver",
+        ),
+        (
+            {
+                "root_extra_args": {"cfg_text_scale": 7.0},
+                "nested_extra_args": {"cfg_text_scale": 8.0},
+            },
+            "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale",
         ),
     ],
 )
-def test_global_duplicate_sources_are_rejected(
-    body: dict[str, object],
+def test_duplicate_sources_are_rejected(
+    kwargs: dict[str, object],
     expected_sources: str,
 ) -> None:
     with pytest.raises(ValueError, match=expected_sources):
-        _compile(_request(**body), declared=frozenset({"model_option"}))
+        normalize_diffusion_request_extra_args(**kwargs)
 
 
-def test_declared_dimension_keeps_prompt_control_and_moves_sampling_owner() -> None:
-    plan = _compile(_request(height=512), declared=frozenset({"height"}))
+def test_duplicate_validation_precedes_deprecation_warning(mocker) -> None:
+    warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
 
-    params = plan.clone_sampling_params_list()[0]
-    assert plan.controls["height"] == 512
-    assert params.height is None
-    assert params.extra_args["height"] == 512
-
-
-def test_internal_diffusion_state_is_not_a_public_root_field() -> None:
-    plan = _compile(
-        _request(
-            modules={"must": "not become request state"},
-            extra_args={"modules": {"pipeline": "owned"}},
-        )
-    )
-
-    params = plan.clone_sampling_params_list()[0]
-    assert params.modules == {}
-    assert params.extra_args["modules"] == {"pipeline": "owned"}
-
-
-def test_fanned_out_root_conflicts_with_the_same_non_diffusion_stage_key() -> None:
     with pytest.raises(ValueError, match="provided more than once"):
-        _compile(
-            _request(
-                max_tokens=32,
-                sampling_params_list=[{"extra_args": {"max_tokens": 64}}],
-            ),
-            stage_types=("llm", "diffusion"),
-            defaults=(SamplingParams(), OmniDiffusionSamplingParams()),
-            comprehension_stage_index=0,
-            declared=frozenset({"max_tokens"}),
-            fan_out_declared=True,
+        normalize_diffusion_request_extra_args(
+            extra_args={"solver": "euler"},
+            extra_params={"solver": "ddim"},
         )
 
-
-def test_request_stage_values_overlay_defaults_once() -> None:
-    plan = _compile(
-        _request(
-            extra_args={"global": 1},
-            sampling_params_list=[
-                {"temperature": 0.7, "stop": "END"},
-                {"guidance_scale": 4.0, "extra_args": {"local": 2}},
-            ],
-        ),
-        stage_types=("llm", "diffusion"),
-        defaults=(
-            SamplingParams(temperature=0.2, max_tokens=99),
-            OmniDiffusionSamplingParams(extra_args={"default": 3}),
-        ),
-        comprehension_stage_index=0,
-    )
-
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-    assert (ar_params.temperature, ar_params.max_tokens) == (0.7, 99)
-    assert ar_params.stop == ["END"]
-    assert ar_params.output_text_buffer_length == 2
-    assert diffusion_params.guidance_scale == 4.0
-    assert diffusion_params.extra_args == {"default": 3, "global": 1, "local": 2}
-
-
-def test_stage_replacement_revalidates_sampling_params() -> None:
-    with pytest.raises(ValueError, match="Invalid sampling parameters for stage 0"):
-        _compile(
-            _request(sampling_params_list=[{"top_p": 0}]),
-            stage_types=("llm",),
-            defaults=(SamplingParams(),),
-            comprehension_stage_index=0,
-        )
-
-
-def test_stage_replacement_resets_sampling_params_derived_state() -> None:
-    plan = _compile(
-        _request(sampling_params_list=[{"stop": [], "stop_token_ids": [2]}]),
-        stage_types=("llm",),
-        defaults=(SamplingParams(stop=["END"], stop_token_ids=[1]),),
-        comprehension_stage_index=0,
-    )
-
-    (params,) = plan.clone_sampling_params_list()
-    assert params.output_text_buffer_length == 0
-    assert params._all_stop_token_ids == {2}
-
-
-@pytest.mark.parametrize(
-    "body",
-    [
-        {"sampling_params_list": [{"guidance_scale": 4.0}]},
-        {"extra_body": {"sampling_params_list": [{"guidance_scale": 4.0}]}},
-    ],
-)
-def test_stage_list_ingress_reaches_the_same_consumer(body: dict[str, object]) -> None:
-    params = _compile(_request(**body)).clone_sampling_params_list()[0]
-
-    assert params.guidance_scale == 4.0
-
-
-def test_root_and_nested_stage_lists_conflict() -> None:
-    with pytest.raises(ValueError, match="request.sampling_params_list, request.extra_body.sampling_params_list"):
-        _compile(
-            _request(
-                sampling_params_list=[{}],
-                extra_body={"sampling_params_list": [{}]},
-            )
-        )
-
-
-def test_global_and_stage_request_values_cannot_overwrite_each_other() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        _compile(
-            _request(
-                extra_args={"seed": 1},
-                sampling_params_list=[{"extra_args": {"seed": 2}}],
-            )
-        )
-
-    assert str(exc_info.value) == (
-        'Parameter "seed" was provided more than once: '
-        "request.extra_args.seed, request.sampling_params_list[0].extra_args.seed."
-    )
-
-
-def test_duplicate_detection_precedes_value_parsing() -> None:
-    with pytest.raises(ValueError, match="provided more than once"):
-        _compile(
-            _request(
-                num_inference_steps=[],
-                sampling_params_list=[{"num_inference_steps": 2}],
-            )
-        )
-
-
-def test_deprecation_is_logged_only_after_a_request_compiles(mocker) -> None:
-    from vllm_omni.entrypoints.openai import diffusion_request_utils
-
-    warning_once = mocker.patch.object(diffusion_request_utils.logger, "warning_once")
-    _compile(_request(extra_params={"key": 1}))
-    warning_once.assert_called_once()
-
-    warning_once.reset_mock()
-    with pytest.raises(ValueError, match="provided more than once"):
-        _compile(
-            _request(
-                extra_params={"key": 1},
-                sampling_params_list=[{"extra_args": {"key": 2}}],
-            )
-        )
     warning_once.assert_not_called()
 
 
-def test_same_key_is_allowed_in_distinct_stages() -> None:
-    plan = _compile(
-        _request(sampling_params_list=[{"extra_args": {"key": 1}}, {"extra_args": {"key": 2}}]),
-        stage_types=("llm", "diffusion"),
-    )
-
-    first, second = plan.clone_sampling_params_list()
-    assert first.extra_args["key"] == 1
-    assert second.extra_args["key"] == 2
-
-
 @pytest.mark.parametrize(
-    "field, value, message",
-    [
-        ("num_inference_steps", [], "num_inference_steps must be an integer."),
-        ("layers", 999, "layers must be between 2 and 10"),
-    ],
+    "name",
+    ("extra_args", "extra_params", "nested_extra_args", "nested_extra_params"),
 )
-def test_value_parsers_run_before_dispatch(field: str, value: object, message: str) -> None:
-    with pytest.raises(ValueError, match=message):
-        _compile(_request(**{field: value}))
+def test_public_containers_must_be_objects(name: str) -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        normalize_diffusion_request_extra_args(**{name: ["not", "an", "object"]})
 
 
-def test_undeclared_container_values_remain_pipeline_owned() -> None:
-    raw = {
-        "layers": "pipeline-specific",
-        "num_inference_steps": {"schedule": "custom"},
-    }
-
-    params = _compile(_request(extra_args=raw)).clone_sampling_params_list()[0]
-
-    assert params.extra_args == raw
+def test_container_keys_must_be_strings() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object with string keys"):
+        normalize_diffusion_request_extra_args(extra_args={1: "invalid"})
 
 
-def test_declared_container_value_uses_the_serving_parser() -> None:
-    params = _compile(
-        _request(extra_args={"num_inference_steps": "12"}),
-        declared=frozenset({"num_inference_steps"}),
-    ).clone_sampling_params_list()[0]
+def test_multiple_conflicts_are_reported_deterministically() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"flow_shift", "seed"},
+            extra_args={"seed": 1, "flow_shift": 3.0},
+            extra_params={"seed": 2},
+        )
 
-    assert params.extra_args["num_inference_steps"] == 12
-
-
-def test_sampling_params_list_entries_must_be_objects() -> None:
-    with pytest.raises(ValueError, match=r"sampling_params_list\[0\] must be a JSON object"):
-        _compile(_request(sampling_params_list=[None]))
-
-
-def test_unknown_direct_stage_field_is_rejected_by_the_target_stage() -> None:
-    with pytest.raises(ValueError, match="unsupported parameter"):
-        _compile(_request(sampling_params_list=[{"unknown_runtime_field": 1}]))
-
-
-def test_too_many_stage_entries_are_rejected() -> None:
-    with pytest.raises(ValueError, match="pipeline has 1 stages"):
-        _compile(_request(sampling_params_list=[{}, {}]))
-
-
-def test_plan_returns_isolated_stage_parameters() -> None:
-    plan = _compile(
-        _request(extra_args={"nested": {"value": 1}}),
-        defaults=(OmniDiffusionSamplingParams(extra_args={"default": True}),),
+    assert str(exc_info.value) == (
+        'Diffusion request parameters were provided more than once: "flow_shift": '
+        'request.flow_shift, request.extra_args.flow_shift; "seed": request.seed, '
+        "request.extra_args.seed, request.extra_params.seed."
     )
-
-    first = plan.clone_sampling_params_list()
-    second = plan.clone_sampling_params_list()
-    first[0].extra_args["nested"]["value"] = 9
-
-    assert second[0].extra_args["nested"]["value"] == 1
-    assert second[0].extra_args["default"] is True

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from vllm_omni.entrypoints.openai.diffusion_request_utils import normalize_diffusion_request_extra_args
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_normalize_diffusion_request_extra_args_preserves_unknown_model_keys() -> None:
+    extra_args = {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+
+    normalized = normalize_diffusion_request_extra_args(
+        provided_root_fields={"seed"},
+        extra_args=extra_args,
+    )
+
+    assert normalized == extra_args
+    assert normalized is not extra_args
+
+
+def test_normalize_diffusion_request_extra_args_accepts_non_overlapping_legacy_keys() -> None:
+    with pytest.warns(DeprecationWarning, match="extra_params is deprecated"):
+        normalized = normalize_diffusion_request_extra_args(
+            extra_args={"cfg_text_scale": 7.0},
+            extra_params={"sample_solver": "euler"},
+        )
+
+    assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
+
+
+@pytest.mark.parametrize("name", ["extra_args", "extra_params"])
+def test_normalize_diffusion_request_extra_args_rejects_non_object_containers(name: str) -> None:
+    kwargs = {name: ["not", "an", "object"]}
+
+    with pytest.raises(ValueError, match=rf"^{name} must be a JSON object\.$"):
+        normalize_diffusion_request_extra_args(**kwargs)
+
+
+def test_normalize_diffusion_request_extra_args_rejects_non_string_keys() -> None:
+    with pytest.raises(ValueError, match=r"^extra_args must be a JSON object with string keys\.$"):
+        normalize_diffusion_request_extra_args(extra_args={1: "not a JSON object key"})
+
+
+def test_normalize_diffusion_request_extra_args_rejects_root_conflict() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"flow_shift", "extra_args"},
+            extra_args={"flow_shift": 3.0},
+        )
+
+    assert str(exc_info.value) == (
+        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
+    )
+
+
+def test_normalize_diffusion_request_extra_args_rejects_alias_conflict_without_warning() -> None:
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError) as exc_info:
+            normalize_diffusion_request_extra_args(
+                extra_args={"sample_solver": "euler"},
+                extra_params={"sample_solver": "euler"},
+            )
+
+    assert not warning_records
+    assert str(exc_info.value) == (
+        'Parameter "sample_solver" was provided more than once: '
+        "request.extra_args.sample_solver, request.extra_params.sample_solver."
+    )
+
+
+def test_normalize_diffusion_request_extra_args_reports_all_conflicts_deterministically() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        normalize_diffusion_request_extra_args(
+            provided_root_fields={"seed", "flow_shift"},
+            extra_args={"seed": 1, "flow_shift": 3.0},
+            extra_params={"seed": 2},
+        )
+
+    assert str(exc_info.value) == (
+        'Diffusion request parameters were provided more than once: "flow_shift": '
+        'request.flow_shift, request.extra_args.flow_shift; "seed": request.seed, '
+        "request.extra_args.seed, request.extra_params.seed."
+    )
+
+
+def test_normalize_diffusion_request_extra_args_does_not_treat_stage_defaults_as_request_conflicts() -> None:
+    normalized = normalize_diffusion_request_extra_args(
+        provided_root_fields=(),
+        extra_args={"flow_shift": 3.0},
+    )
+
+    assert normalized == {"flow_shift": 3.0}

--- a/tests/entrypoints/openai_api/test_diffusion_request_utils.py
+++ b/tests/entrypoints/openai_api/test_diffusion_request_utils.py
@@ -7,54 +7,53 @@ import pytest
 
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
     apply_normalized_diffusion_request_extra_args,
-    normalize_diffusion_request_extra_args,
+    normalize_diffusion_request_args,
 )
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
-SOURCE_KWARGS = (
-    "root_extra_args",
-    "extra_args",
-    "extra_params",
-    "nested_root_extra_args",
-    "nested_extra_args",
-    "nested_extra_params",
+REQUEST_SOURCES = (
+    "root.declared",
+    "root.extra_args",
+    "root.extra_params",
+    "nested.declared",
+    "nested.extra_args",
+    "nested.extra_params",
 )
 
 
-@pytest.mark.parametrize("source", SOURCE_KWARGS)
-def test_normalizer_preserves_pipeline_owned_values(source: str) -> None:
-    normalized = normalize_diffusion_request_extra_args(**{source: {"solver": "euler"}})
-
-    assert normalized == {"solver": "euler"}
-
-
-@pytest.mark.parametrize("source", SOURCE_KWARGS)
-def test_explicit_none_preserves_stage_default(source: str) -> None:
-    normalized = normalize_diffusion_request_extra_args(**{source: {"solver": None}})
-    sampling_params = OmniDiffusionSamplingParams(extra_args={"solver": "euler"})
-    apply_normalized_diffusion_request_extra_args(sampling_params, normalized)
-
-    assert sampling_params.extra_args["solver"] == "euler"
+def _source_args(source: str, value: object) -> dict[str, object]:
+    scope, container = source.split(".")
+    payload = {"solver": value} if container == "declared" else {container: {"solver": value}}
+    kwargs: dict[str, object] = {scope: payload}
+    if container == "declared":
+        kwargs["registered_extra_fields"] = {"solver"}
+    return kwargs
 
 
-def test_request_extras_overlay_matching_defaults() -> None:
+@pytest.mark.parametrize("source", REQUEST_SOURCES)
+@pytest.mark.parametrize(("value", "expected"), [("ddim", "ddim"), (None, "euler")])
+def test_normalizer_routes_values_without_erasing_defaults(
+    source: str,
+    value: object,
+    expected: str,
+) -> None:
+    normalized, _ = normalize_diffusion_request_args(**_source_args(source, value))
     sampling_params = OmniDiffusionSamplingParams(
         extra_args={"solver": "euler", "stage_default": True},
     )
+    apply_normalized_diffusion_request_extra_args(sampling_params, normalized)
 
-    apply_normalized_diffusion_request_extra_args(sampling_params, {"solver": "ddim"})
-
-    assert sampling_params.extra_args == {"solver": "ddim", "stage_default": True}
+    assert sampling_params.extra_args == {"solver": expected, "stage_default": True}
 
 
 def test_non_overlapping_legacy_and_canonical_values_are_merged(mocker) -> None:
     warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
 
-    normalized = normalize_diffusion_request_extra_args(
-        extra_args={"cfg_text_scale": 7.0},
-        nested_extra_params={"sample_solver": "euler"},
+    normalized, _ = normalize_diffusion_request_args(
+        root={"extra_args": {"cfg_text_scale": 7.0}},
+        nested={"extra_params": {"sample_solver": "euler"}},
     )
 
     assert normalized == {"cfg_text_scale": 7.0, "sample_solver": "euler"}
@@ -65,25 +64,35 @@ def test_non_overlapping_legacy_and_canonical_values_are_merged(mocker) -> None:
     "kwargs, expected_sources",
     [
         (
-            {"provided_root_fields": {"seed"}, "extra_args": {"seed": 2}},
+            {
+                "root": {"seed": 1, "extra_args": {"seed": 2}},
+                "serving_root_fields": {"seed"},
+            },
             "request.seed, request.extra_args.seed",
         ),
         (
             {
-                "provided_root_fields": {"cfg_scale"},
-                "nested_provided_root_fields": {"true_cfg_scale"},
+                "root": {"cfg_scale": 7.0},
+                "nested": {"true_cfg_scale": 2.0},
+                "serving_root_fields": {"true_cfg_scale"},
                 "root_field_aliases": {"cfg_scale": "true_cfg_scale"},
             },
             "request.cfg_scale, request.extra_body.true_cfg_scale",
         ),
         (
-            {"extra_args": {"solver": "euler"}, "extra_params": {"solver": "ddim"}},
+            {
+                "root": {
+                    "extra_args": {"solver": "euler"},
+                    "extra_params": {"solver": "ddim"},
+                }
+            },
             "request.extra_args.solver, request.extra_params.solver",
         ),
         (
             {
-                "root_extra_args": {"cfg_text_scale": 7.0},
-                "nested_extra_args": {"cfg_text_scale": 8.0},
+                "root": {"cfg_text_scale": 7.0},
+                "nested": {"extra_args": {"cfg_text_scale": 8.0}},
+                "registered_extra_fields": {"cfg_text_scale"},
             },
             "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale",
         ),
@@ -92,47 +101,30 @@ def test_non_overlapping_legacy_and_canonical_values_are_merged(mocker) -> None:
 def test_duplicate_sources_are_rejected(
     kwargs: dict[str, object],
     expected_sources: str,
+    mocker,
 ) -> None:
-    with pytest.raises(ValueError, match=expected_sources):
-        normalize_diffusion_request_extra_args(**kwargs)
-
-
-def test_duplicate_validation_precedes_deprecation_warning(mocker) -> None:
     warning_once = mocker.patch("vllm_omni.entrypoints.openai.diffusion_request_utils.logger.warning_once")
 
-    with pytest.raises(ValueError, match="provided more than once"):
-        normalize_diffusion_request_extra_args(
-            extra_args={"solver": "euler"},
-            extra_params={"solver": "ddim"},
-        )
+    with pytest.raises(ValueError, match=expected_sources):
+        normalize_diffusion_request_args(**kwargs)
 
     warning_once.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    "name",
-    ("extra_args", "extra_params", "nested_extra_args", "nested_extra_params"),
+    ("scope", "name"),
+    (
+        ("root", "extra_args"),
+        ("root", "extra_params"),
+        ("nested", "extra_args"),
+        ("nested", "extra_params"),
+    ),
 )
-def test_public_containers_must_be_objects(name: str) -> None:
+def test_public_containers_must_be_objects(scope: str, name: str) -> None:
     with pytest.raises(ValueError, match="must be a JSON object"):
-        normalize_diffusion_request_extra_args(**{name: ["not", "an", "object"]})
+        normalize_diffusion_request_args(**{scope: {name: ["not", "an", "object"]}})
 
 
 def test_container_keys_must_be_strings() -> None:
     with pytest.raises(ValueError, match="must be a JSON object with string keys"):
-        normalize_diffusion_request_extra_args(extra_args={1: "invalid"})
-
-
-def test_multiple_conflicts_are_reported_deterministically() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        normalize_diffusion_request_extra_args(
-            provided_root_fields={"flow_shift", "seed"},
-            extra_args={"seed": 1, "flow_shift": 3.0},
-            extra_params={"seed": 2},
-        )
-
-    assert str(exc_info.value) == (
-        'Diffusion request parameters were provided more than once: "flow_shift": '
-        'request.flow_shift, request.extra_args.flow_shift; "seed": request.seed, '
-        "request.extra_args.seed, request.extra_params.seed."
-    )
+        normalize_diffusion_request_args(root={"extra_args": {1: "invalid"}})

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -175,36 +175,18 @@ def test_openai_sampling_fields_contains_expected_fields():
 
 
 @pytest.mark.parametrize(
-    ("model_class_name", "request_body", "field", "expected_on_ar", "expected_ar_value"),
+    ("model_class_name", "field", "value", "expected_on_ar", "expected_ar_value"),
     [
-        (
-            "BagelPipeline",
-            {"cfg_text_scale": 7.0},
-            "cfg_text_scale",
-            True,
-            None,
-        ),
-        (
-            "SenseNovaU1Pipeline",
-            {"max_tokens": 32},
-            "max_tokens",
-            False,
-            100,
-        ),
-        (
-            "MingImagePipeline",
-            {"seed": 32},
-            "seed",
-            True,
-            32,
-        ),
+        pytest.param("BagelPipeline", "cfg_text_scale", 7.0, True, None, id="custom-fan-out"),
+        pytest.param("SenseNovaU1Pipeline", "max_tokens", 32, False, 100, id="no-fan-out"),
+        pytest.param("MingImagePipeline", "seed", 32, True, 32, id="typed-fan-out"),
     ],
 )
 def test_registry_owns_declared_extra_fan_out(
     serving_chat,
     model_class_name,
-    request_body,
     field,
+    value,
     expected_on_ar,
     expected_ar_value,
 ):
@@ -224,12 +206,12 @@ def test_registry_owns_declared_extra_fan_out(
 
     plan = _compile_diffusion_plan(
         serving_chat,
-        ChatCompletionRequest(model="test", messages=[], **request_body),
+        ChatCompletionRequest(model="test", messages=[], **{field: value}),
     )
     ar_params, diffusion_params = plan.clone_sampling_params_list()
 
     assert (field in (ar_params.extra_args or {})) is expected_on_ar
-    assert diffusion_params.extra_args[field] == next(iter(request_body.values()))
+    assert diffusion_params.extra_args[field] == value
     if expected_ar_value is not None:
         assert getattr(ar_params, field) == expected_ar_value
 
@@ -252,11 +234,6 @@ def test_registry_owns_declared_extra_fan_out(
             {"extra_body": {"modalities": ["audio"]}},
             "Unsupported output modalities audio",
             id="unsupported-audio",
-        ),
-        pytest.param(
-            {"extra_body": {"modalities": ["video"]}},
-            "Unsupported output modalities video",
-            id="unsupported-video",
         ),
     ],
 )
@@ -283,11 +260,9 @@ def test_invalid_request_uses_the_shared_boundary_before_dispatch(
     serving_chat._check_model.assert_not_awaited()
 
 
-@pytest.mark.parametrize("modality", ["image", "text"])
 def test_pure_dispatcher_receives_the_compiled_controls(
     serving_chat,
     mocker: MockerFixture,
-    modality: str,
 ):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
@@ -314,12 +289,16 @@ def test_pure_dispatcher_receives_the_compiled_controls(
         model="test",
         messages=[],
         size="768x512",
-        extra_body={"modalities": [modality]},
+        extra_body={
+            "modalities": ["text"],
+            "negative_prompt": "low quality",
+        },
     )
 
     response = asyncio.run(serving_chat._create_chat_completion(request))
 
-    assert captured["prompt"]["modalities"] == [modality]
+    assert captured["prompt"]["modalities"] == ["text"]
+    assert captured["prompt"]["negative_prompt"] == "low quality"
     (params,) = captured["sampling_params_list"]
     assert (params.height, params.width) == (512, 768)
     assert response.error.message == "No output generated from AsyncOmni"

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -132,6 +132,36 @@ def test_unknown_root_extra_does_not_claim_canonical_extra(serving_chat):
     assert "pipeline_option" not in diffusion_request_args
 
 
+def test_unregistered_cfg_scale_aliases_common_true_cfg_scale(serving_chat):
+    serving_chat._diffusion_extra_body_params = frozenset()
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        cfg_scale=7.0,
+    )
+
+    normalized_extra_args, diffusion_request_args = serving_chat._normalize_diffusion_request_args(request)
+
+    assert normalized_extra_args == {}
+    assert diffusion_request_args == {"true_cfg_scale": 7.0}
+
+
+@pytest.mark.parametrize(
+    ("registered", "request_kwargs"),
+    [
+        ({"cfg_scale"}, {"cfg_scale": 7.0, "extra_args": {"cfg_scale": 8.0}}),
+        (set(), {"cfg_scale": 7.0, "true_cfg_scale": 2.0}),
+    ],
+    ids=["registered-model-extra", "unregistered-common-alias"],
+)
+def test_cfg_scale_owner_conflicts_are_rejected(serving_chat, registered, request_kwargs):
+    serving_chat._diffusion_extra_body_params = frozenset(registered)
+    request = ChatCompletionRequest(model="test", messages=[], **request_kwargs)
+
+    with pytest.raises(ValueError, match="provided more than once"):
+        serving_chat._normalize_diffusion_request_args(request)
+
+
 @pytest.mark.parametrize("diffusion_mode", [True, False], ids=["pure", "mixed"])
 def test_duplicate_extras_return_the_same_bad_request_before_dispatch(
     serving_chat,
@@ -165,7 +195,7 @@ def test_duplicate_extras_return_the_same_bad_request_before_dispatch(
     pure_dispatch.assert_not_awaited()
 
 
-def test_pure_consumer_preserves_stage_defaults(serving_chat, mocker: MockerFixture):
+def test_pure_consumer_preserves_defaults_and_separate_cfg_owners(serving_chat, mocker: MockerFixture):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
     captured: dict[str, object] = {}
@@ -184,7 +214,7 @@ def test_pure_consumer_preserves_stage_defaults(serving_chat, mocker: MockerFixt
         generate=generate,
     )
     serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_scale"})
     serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
     request = ChatCompletionRequest(
         model="test",
@@ -193,13 +223,20 @@ def test_pure_consumer_preserves_stage_defaults(serving_chat, mocker: MockerFixt
         num_inference_steps=7,
         size="768x512",
         negative_prompt="avoid blur",
+        cfg_scale=7.0,
+        true_cfg_scale=2.0,
         extra_body={"extra_args": {"solver": "ddim"}},
     )
 
     response = asyncio.run(serving_chat._create_chat_completion(request))
 
     (sampling_params,) = captured["sampling_params_list"]
-    assert sampling_params.extra_args == {"solver": "ddim", "stage_default": True}
+    assert sampling_params.extra_args == {
+        "cfg_scale": 7.0,
+        "solver": "ddim",
+        "stage_default": True,
+    }
+    assert sampling_params.true_cfg_scale == 2.0
     assert sampling_params.num_inference_steps == 7
     assert (sampling_params.height, sampling_params.width) == (512, 768)
     assert captured["prompt"]["negative_prompt"] == "avoid blur"

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -254,6 +254,51 @@ def test_duplicate_error_uses_the_shared_boundary_before_either_dispatcher(
     serving_chat._check_model.assert_not_awaited()
 
 
+@pytest.mark.parametrize("modalities", ["text", ["video"]])
+def test_nested_modalities_use_the_shared_boundary_before_either_dispatcher(
+    serving_chat,
+    mocker: MockerFixture,
+    modalities,
+):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    diffusion_dispatch = mocker.patch.object(
+        serving_chat,
+        "_create_diffusion_chat_completion",
+        new=mocker.AsyncMock(),
+    )
+    serving_chat._check_model = mocker.AsyncMock(return_value=None)
+    serving_chat.engine_client.output_modalities = ["image"]
+    responses = []
+    for diffusion_mode in (True, False):
+        serving_chat._diffusion_mode = diffusion_mode
+        serving_chat._diffusion_extra_body_params = frozenset()
+        stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
+        defaults = [OmniDiffusionSamplingParams()]
+        serving_chat.engine_client.stage_configs = stages
+        serving_chat.engine_client.default_sampling_params_list = defaults
+        serving_chat.engine_client.get_diffusion_od_config.return_value = None
+        serving_chat._diffusion_engine = SimpleNamespace(
+            stage_configs=stages,
+            default_sampling_params_list=defaults,
+            od_config=None,
+        )
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[],
+            extra_body={"modalities": modalities},
+        )
+        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
+
+    assert [response.error.code for response in responses] == [400, 400]
+    if isinstance(modalities, str):
+        assert all(response.error.message == "'modalities' must be a list of strings." for response in responses)
+    else:
+        assert all("Unsupported output modalities video" in response.error.message for response in responses)
+    diffusion_dispatch.assert_not_awaited()
+    serving_chat._check_model.assert_not_awaited()
+
+
 def test_pure_dispatcher_receives_the_compiled_size(
     serving_chat,
     mocker: MockerFixture,

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -102,6 +102,30 @@ def _compile_diffusion_plan(serving_chat, request):
     )
 
 
+def _configure_single_diffusion_topology(
+    serving_chat,
+    *,
+    diffusion_mode: bool,
+    output_modalities: tuple[str, ...] = ("image",),
+):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
+    defaults = [OmniDiffusionSamplingParams()]
+    serving_chat._diffusion_mode = diffusion_mode
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat.engine_client.stage_configs = stages
+    serving_chat.engine_client.default_sampling_params_list = defaults
+    serving_chat.engine_client.output_modalities = list(output_modalities)
+    serving_chat.engine_client.get_diffusion_od_config.return_value = None
+    serving_chat._diffusion_engine = SimpleNamespace(
+        stage_configs=stages,
+        default_sampling_params_list=defaults,
+        output_modalities=list(output_modalities),
+        od_config=None,
+    )
+
+
 @pytest.fixture
 def mock_request(mocker: MockerFixture):
     """Create a mock request with all OpenAI sampling params set to None."""
@@ -210,98 +234,60 @@ def test_registry_owns_declared_extra_fan_out(
         assert getattr(ar_params, field) == expected_ar_value
 
 
-def test_duplicate_error_uses_the_shared_boundary_before_either_dispatcher(
+@pytest.mark.parametrize("diffusion_mode", [True, False], ids=["pure", "mixed"])
+@pytest.mark.parametrize(
+    ("request_body", "error_message"),
+    [
+        pytest.param(
+            {"seed": 1, "sampling_params_list": [{"seed": 2}]},
+            'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.',
+            id="duplicate",
+        ),
+        pytest.param(
+            {"extra_body": {"modalities": "text"}},
+            "'modalities' must be a list of strings.",
+            id="modalities-type",
+        ),
+        pytest.param(
+            {"extra_body": {"modalities": ["audio"]}},
+            "Unsupported output modalities audio",
+            id="unsupported-audio",
+        ),
+        pytest.param(
+            {"extra_body": {"modalities": ["video"]}},
+            "Unsupported output modalities video",
+            id="unsupported-video",
+        ),
+    ],
+)
+def test_invalid_request_uses_the_shared_boundary_before_dispatch(
     serving_chat,
     mocker: MockerFixture,
+    diffusion_mode: bool,
+    request_body: dict[str, object],
+    error_message: str,
 ):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    diffusion_dispatch = mocker.patch.object(
-        serving_chat,
-        "_create_diffusion_chat_completion",
-        new=mocker.AsyncMock(),
-    )
-    serving_chat._check_model = mocker.AsyncMock()
-    responses = []
-    for diffusion_mode in (True, False):
-        serving_chat._diffusion_mode = diffusion_mode
-        serving_chat._diffusion_extra_body_params = frozenset()
-        stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
-        defaults = [OmniDiffusionSamplingParams()]
-        serving_chat.engine_client.stage_configs = stages
-        serving_chat.engine_client.default_sampling_params_list = defaults
-        serving_chat.engine_client.get_diffusion_od_config.return_value = None
-        serving_chat._diffusion_engine = SimpleNamespace(
-            stage_configs=stages,
-            default_sampling_params_list=defaults,
-            od_config=None,
-        )
-        request = ChatCompletionRequest(
-            model="test",
-            messages=[],
-            seed=1,
-            sampling_params_list=[{"seed": 2}],
-        )
-        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
-
-    assert [response.error.code for response in responses] == [400, 400]
-    assert all(
-        response.error.message
-        == 'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.'
-        for response in responses
-    )
-    diffusion_dispatch.assert_not_awaited()
-    serving_chat._check_model.assert_not_awaited()
-
-
-@pytest.mark.parametrize("modalities", ["text", ["video"]])
-def test_nested_modalities_use_the_shared_boundary_before_either_dispatcher(
-    serving_chat,
-    mocker: MockerFixture,
-    modalities,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
     diffusion_dispatch = mocker.patch.object(
         serving_chat,
         "_create_diffusion_chat_completion",
         new=mocker.AsyncMock(),
     )
     serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    serving_chat.engine_client.output_modalities = ["image"]
-    responses = []
-    for diffusion_mode in (True, False):
-        serving_chat._diffusion_mode = diffusion_mode
-        serving_chat._diffusion_extra_body_params = frozenset()
-        stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
-        defaults = [OmniDiffusionSamplingParams()]
-        serving_chat.engine_client.stage_configs = stages
-        serving_chat.engine_client.default_sampling_params_list = defaults
-        serving_chat.engine_client.get_diffusion_od_config.return_value = None
-        serving_chat._diffusion_engine = SimpleNamespace(
-            stage_configs=stages,
-            default_sampling_params_list=defaults,
-            od_config=None,
-        )
-        request = ChatCompletionRequest(
-            model="test",
-            messages=[],
-            extra_body={"modalities": modalities},
-        )
-        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
+    _configure_single_diffusion_topology(serving_chat, diffusion_mode=diffusion_mode)
+    request = ChatCompletionRequest(model="test", messages=[], **request_body)
+    response = asyncio.run(serving_chat._create_chat_completion(request))
 
-    assert [response.error.code for response in responses] == [400, 400]
-    if isinstance(modalities, str):
-        assert all(response.error.message == "'modalities' must be a list of strings." for response in responses)
-    else:
-        assert all("Unsupported output modalities video" in response.error.message for response in responses)
+    assert response.error.code == 400
+    assert error_message in response.error.message
     diffusion_dispatch.assert_not_awaited()
     serving_chat._check_model.assert_not_awaited()
 
 
-def test_pure_dispatcher_receives_the_compiled_size(
+@pytest.mark.parametrize("modality", ["image", "text"])
+def test_pure_dispatcher_receives_the_compiled_controls(
     serving_chat,
     mocker: MockerFixture,
+    modality: str,
 ):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
@@ -319,15 +305,21 @@ def test_pure_dispatcher_receives_the_compiled_size(
     serving_chat._diffusion_engine = SimpleNamespace(
         stage_configs=[SimpleNamespace(stage_type="diffusion")],
         default_sampling_params_list=[OmniDiffusionSamplingParams()],
+        output_modalities=["image"],
         od_config=None,
         generate=generate,
     )
     serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(model="test", messages=[], size="768x512")
-    plan = _compile_diffusion_plan(serving_chat, request)
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        size="768x512",
+        extra_body={"modalities": [modality]},
+    )
 
-    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request, plan))
+    response = asyncio.run(serving_chat._create_chat_completion(request))
 
+    assert captured["prompt"]["modalities"] == [modality]
     (params,) = captured["sampling_params_list"]
     assert (params.height, params.width) == (512, 768)
     assert response.error.message == "No output generated from AsyncOmni"

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -88,6 +88,20 @@ def serving_chat(mock_engine_client):
     return instance
 
 
+def _compile_diffusion_plan(serving_chat, request):
+    from vllm_omni.entrypoints.openai.diffusion_request_utils import (
+        compile_diffusion_chat_request_plan,
+    )
+
+    return compile_diffusion_chat_request_plan(
+        request=request,
+        sampling_root_fields=serving_chat._diffusion_sampling_root_fields,
+        standard_sampling_fields=serving_chat._OPENAI_SAMPLING_FIELDS,
+        control_root_fields=serving_chat._diffusion_control_root_fields,
+        **serving_chat._get_diffusion_request_plan_inputs(),
+    )
+
+
 @pytest.fixture
 def mock_request(mocker: MockerFixture):
     """Create a mock request with all OpenAI sampling params set to None."""
@@ -109,56 +123,6 @@ def mock_request(mocker: MockerFixture):
     request.model_fields_set = set()
     request.extra_body = {}
     return request
-
-
-def _configure_multistage_diffusion_chat(serving_chat, mocker: MockerFixture):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    async def empty_output():
-        if False:
-            yield None
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
-    serving_chat.models = mocker.MagicMock()
-    serving_chat.models.model_name.return_value = "test-model"
-    serving_chat.renderer = mocker.MagicMock()
-    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
-    serving_chat.parser_cls = None
-    serving_chat.use_harmony = False
-    serving_chat.enable_auto_tools = False
-    serving_chat.exclude_tools_when_tool_choice_none = False
-    serving_chat.trust_request_chat_template = False
-    serving_chat.chat_template = None
-    serving_chat.chat_template_content_format = "string"
-    serving_chat.default_chat_template_kwargs = {}
-    serving_chat.online_renderer = mocker.MagicMock()
-    serving_chat.online_renderer.validate_chat_template.return_value = None
-    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
-    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
-    serving_chat._base_request_id = mocker.Mock(return_value="multistage-request")
-    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
-    serving_chat._build_sampling_params_list_from_request = mocker.Mock(
-        return_value=[
-            OmniDiffusionSamplingParams(),
-            OmniDiffusionSamplingParams(),
-        ]
-    )
-    serving_chat._log_inputs = mocker.Mock()
-    serving_chat.engine_client.errored = False
-    serving_chat.engine_client.output_modalities = ["image"]
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="diffusion"),
-        SimpleNamespace(stage_type="diffusion"),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        OmniDiffusionSamplingParams(),
-        OmniDiffusionSamplingParams(),
-    ]
-    serving_chat.engine_client.generate = mocker.Mock(side_effect=lambda **_: empty_output())
-    return serving_chat.engine_client.generate
 
 
 # =============================================================================
@@ -186,223 +150,72 @@ def test_openai_sampling_fields_contains_expected_fields():
     assert OmniOpenAIServingChat._OPENAI_SAMPLING_FIELDS == expected_fields
 
 
-def test_diffusion_request_overrides_reach_sampling_params(serving_chat):
+@pytest.mark.parametrize(
+    ("model_class_name", "request_body", "field", "expected_on_ar", "expected_ar_value"),
+    [
+        (
+            "BagelPipeline",
+            {"cfg_text_scale": 7.0},
+            "cfg_text_scale",
+            True,
+            None,
+        ),
+        (
+            "SenseNovaU1Pipeline",
+            {"max_tokens": 32},
+            "max_tokens",
+            False,
+            100,
+        ),
+        (
+            "MingImagePipeline",
+            {"seed": 32},
+            "seed",
+            True,
+            32,
+        ),
+    ],
+)
+def test_registry_owns_declared_extra_fan_out(
+    serving_chat,
+    model_class_name,
+    request_body,
+    field,
+    expected_on_ar,
+    expected_ar_value,
+):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        seed=1,
-        cfg_text_scale=7.0,
-        guidance_scale=6.0,
-        extra_args={"sample_solver": "euler"},
-    )
-    sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.seed == 1
-    assert sampling_params.guidance_scale == 6.0
-    assert sampling_params.extra_args == {
-        "stage_default": True,
-        "cfg_text_scale": 7.0,
-        "sample_solver": "euler",
-    }
-
-
-def test_schema_declared_root_reaches_model_extra_consumer(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-    from vllm_omni.model_extras import get_extra_body_params
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
-    request = ChatCompletionRequest(model="test", messages=[], max_tokens=32)
-    sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.extra_args == {
-        "stage_default": True,
-        "max_tokens": 32,
-    }
-
-
-def test_schema_declared_root_conflicts_with_canonical_extra_arg(serving_chat):
-    from vllm_omni.model_extras import get_extra_body_params
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        max_tokens=32,
-        extra_args={"max_tokens": 64},
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        serving_chat._compile_diffusion_request_contract(request)
-
-    assert str(exc_info.value) == (
-        'Parameter "max_tokens" was provided more than once: request.max_tokens, request.extra_args.max_tokens.'
-    )
-
-
-def test_model_declared_cfg_scale_uses_model_extra_consumer(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-    from vllm_omni.model_extras import get_extra_body_params
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
-    request = ChatCompletionRequest(model="test", messages=[], cfg_scale=3.0)
-    sampling_params = OmniDiffusionSamplingParams()
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.true_cfg_scale is None
-    assert sampling_params.extra_args == {"cfg_scale": 3.0}
-
-
-def test_generic_cfg_scale_still_targets_true_cfg_scale(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    request = ChatCompletionRequest(model="test", messages=[], cfg_scale=3.0)
-    sampling_params = OmniDiffusionSamplingParams()
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.true_cfg_scale == 3.0
-    assert sampling_params.extra_args == {}
-
-
-def test_model_declared_dimension_remains_available_to_prompt_consumer(serving_chat):
-    from vllm_omni.model_extras import get_extra_body_params
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = get_extra_body_params("MingImagePipeline")
-    request = ChatCompletionRequest(model="test", messages=[], height=512, width=768)
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-
-    assert contract.sampling_overrides.get("height") is None
-    assert contract.extra_args_overrides["height"] == 512
-    assert contract.control_overrides["height"] == 512
-    assert contract.control_overrides["width"] == 768
-
-
-def test_stage_root_uses_same_model_aware_consumer_as_global_root(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-    from vllm_omni.model_extras import get_extra_body_params
 
     serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
-    serving_chat.engine_client.stage_configs = [SimpleNamespace(stage_type="diffusion")]
-    serving_chat.engine_client.default_sampling_params_list = [OmniDiffusionSamplingParams()]
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        sampling_params_list=[{"cfg_scale": 3.0}],
+    serving_chat._diffusion_extra_body_params = None
+    serving_chat.engine_client.get_diffusion_od_config.return_value = SimpleNamespace(model_class_name=model_class_name)
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(max_tokens=100),
+        OmniDiffusionSamplingParams(),
+    ]
+
+    plan = _compile_diffusion_plan(
+        serving_chat,
+        ChatCompletionRequest(model="test", messages=[], **request_body),
     )
+    ar_params, diffusion_params = plan.clone_sampling_params_list()
 
-    contract = serving_chat._compile_diffusion_request_contract(request)
-
-    assert contract.sampling_params_list is not None
-    sampling_params = contract.sampling_params_list[0]
-    assert sampling_params.true_cfg_scale is None
-    assert sampling_params.extra_args == {"cfg_scale": 3.0}
-
-
-def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        model_specific_option="ignored-root-value",
-        extra_args={"model_specific_option": "canonical-value"},
-    )
-    sampling_params = OmniDiffusionSamplingParams()
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.extra_args == {"model_specific_option": "canonical-value"}
+    assert (field in (ar_params.extra_args or {})) is expected_on_ar
+    assert diffusion_params.extra_args[field] == next(iter(request_body.values()))
+    if expected_ar_value is not None:
+        assert getattr(ar_params, field) == expected_ar_value
 
 
-def test_internal_sampling_state_is_not_a_public_root_field(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        latents="ignored-root-value",
-        extra_args={"latents": "model-specific-value"},
-    )
-    sampling_params = OmniDiffusionSamplingParams()
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
-
-    assert sampling_params.latents is None
-    assert sampling_params.extra_args == {"latents": "model-specific-value"}
-
-
-def test_diffusion_chat_rejects_flattened_nested_control_conflict(serving_chat, mocker: MockerFixture):
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        negative_prompt="root",
-        extra_body={"negative_prompt": "nested"},
-    )
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
-
-    assert response.error.code == 400
-    assert response.error.message == (
-        'Parameter "negative_prompt" was provided more than once: '
-        "request.negative_prompt, request.extra_body.negative_prompt."
-    )
-
-
-def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat, mocker: MockerFixture):
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset({"flow_shift"})
-    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        flow_shift=1.0,
-        extra_args={"flow_shift": 2.0},
-    )
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
-
-    assert response.error.code == 400
-    assert response.error.message == (
-        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
-    )
-
-
-def test_pure_and_multistage_return_the_same_duplicate_error_before_dispatch(
+def test_duplicate_error_uses_the_shared_boundary_before_either_dispatcher(
     serving_chat,
     mocker: MockerFixture,
 ):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
     diffusion_dispatch = mocker.patch.object(
         serving_chat,
         "_create_diffusion_chat_completion",
@@ -412,354 +225,42 @@ def test_pure_and_multistage_return_the_same_duplicate_error_before_dispatch(
     responses = []
     for diffusion_mode in (True, False):
         serving_chat._diffusion_mode = diffusion_mode
-        serving_chat._diffusion_extra_body_params = frozenset({"flow_shift"})
-        serving_chat.engine_client.stage_configs = [
-            SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-        ]
-        request = ChatCompletionRequest(
-            model="test",
-            messages=[],
-            flow_shift=1.0,
-            extra_args={"flow_shift": 2.0},
-        )
-
-        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
-
-    assert [response.error.code for response in responses] == [400, 400]
-    assert [response.error.message for response in responses] == [
-        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.',
-        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.',
-    ]
-    diffusion_dispatch.assert_not_awaited()
-    serving_chat._check_model.assert_not_awaited()
-
-
-def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, mocker: MockerFixture):
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        cfg_text_scale=6.0,
-        extra_body={"extra_args": {"cfg_text_scale": 7.0}},
-    )
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
-
-    assert response.error.code == 400
-    assert response.error.message == (
-        'Parameter "cfg_text_scale" was provided more than once: '
-        "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale."
-    )
-
-
-def test_multistage_stage_extra_args_conflict_is_rejected_before_prompt_work(
-    serving_chat,
-    mocker: MockerFixture,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(),
-        OmniDiffusionSamplingParams(),
-    ]
-    serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    serving_chat._preprocess_chat = mocker.AsyncMock()
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        modalities=["image"],
-        sampling_params_list=[
-            {},
-            {"extra_args": {"seed": 111}},
-        ],
-        extra_args={"seed": 222},
-    )
-
-    result = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert result.error.code == 400
-    assert result.error.message == (
-        'Parameter "seed" was provided more than once: '
-        "request.extra_args.seed, request.sampling_params_list[1].extra_args.seed."
-    )
-    serving_chat._check_model.assert_not_awaited()
-    serving_chat._preprocess_chat.assert_not_awaited()
-
-
-def test_pure_diffusion_stage_override_conflict_is_rejected_before_dispatch(
-    serving_chat,
-    mocker: MockerFixture,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat._diffusion_engine = SimpleNamespace(
-        stage_configs=[SimpleNamespace(stage_type="diffusion")],
-        default_sampling_params_list=[OmniDiffusionSamplingParams()],
-    )
-    diffusion_dispatch = mocker.patch.object(
-        serving_chat,
-        "_create_diffusion_chat_completion",
-        new=mocker.AsyncMock(),
-    )
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        seed=111,
-        sampling_params_list=[{"seed": 222}],
-    )
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert response.error.code == 400
-    assert response.error.message == (
-        'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.'
-    )
-    diffusion_dispatch.assert_not_awaited()
-
-
-def test_pure_diffusion_compiles_non_conflicting_stage_override(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat._diffusion_engine = SimpleNamespace(
-        stage_configs=[SimpleNamespace(stage_type="diffusion")],
-        default_sampling_params_list=[OmniDiffusionSamplingParams()],
-    )
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        sampling_params_list=[{"guidance_scale": 4.0}],
-    )
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-
-    assert contract.sampling_params_list is not None
-    assert contract.sampling_params_list[0].guidance_scale == 4.0
-
-
-def test_non_diffusion_stage_declared_extra_conflict_is_rejected(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(),
-        OmniDiffusionSamplingParams(),
-    ]
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        cfg_text_scale=7.0,
-        sampling_params_list=[
-            {"extra_args": {"cfg_text_scale": 8.0}},
-            {},
-        ],
-    )
-
-    with pytest.raises(ValueError) as exc_info:
-        serving_chat._compile_diffusion_request_contract(request)
-
-    assert str(exc_info.value) == (
-        'Parameter "cfg_text_scale" was provided more than once: '
-        "request.cfg_text_scale, request.sampling_params_list[0].extra_args.cfg_text_scale."
-    )
-
-
-def test_registry_owned_schema_field_has_same_ar_effect_for_flattened_and_nested_forms(
-    serving_chat,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset({"max_tokens"})
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(max_tokens=100),
-        OmniDiffusionSamplingParams(),
-    ]
-    requests = [
-        ChatCompletionRequest(model="test", messages=[], max_tokens=32),
-        ChatCompletionRequest(model="test", messages=[], extra_body={"max_tokens": 32}),
-    ]
-
-    contracts = [serving_chat._compile_diffusion_request_contract(request) for request in requests]
-
-    assert [contract.sampling_params_list[0].max_tokens for contract in contracts] == [
-        100,
-        100,
-    ]
-    assert [contract.declared_extra_args["max_tokens"] for contract in contracts] == [
-        32,
-        32,
-    ]
-
-
-def test_multistage_server_default_is_not_request_provenance(serving_chat):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(),
-        OmniDiffusionSamplingParams(extra_args={"seed": 111, "stage_default": True}),
-    ]
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        sampling_params_list=[{}],
-        extra_args={"seed": 222},
-    )
-
-    contract = serving_chat._compile_diffusion_request_contract(request)
-    assert contract.sampling_params_list is not None
-    diffusion_params = contract.sampling_params_list[1]
-    serving_chat._apply_diffusion_request_contract(diffusion_params, contract)
-
-    assert diffusion_params.extra_args == {"seed": 222, "stage_default": True}
-
-
-@pytest.mark.parametrize(
-    ("field_name", "invalid_value", "expected_message"),
-    [
-        (
-            "layers",
-            999,
-            "Invalid layers value 999. layers must be between 2 and 10 inclusive.",
-        ),
-        (
-            "num_inference_steps",
-            [],
-            "num_inference_steps must be an integer.",
-        ),
-        (
-            "num_inference_steps",
-            {"invalid": "object"},
-            "num_inference_steps must be an integer.",
-        ),
-    ],
-)
-def test_pure_and_multistage_reject_invalid_compiled_values_before_dispatch(
-    serving_chat,
-    mocker: MockerFixture,
-    field_name,
-    invalid_value,
-    expected_message,
-):
-    responses = []
-    for diffusion_mode in (True, False):
-        serving_chat._diffusion_mode = diffusion_mode
         serving_chat._diffusion_extra_body_params = frozenset()
-        serving_chat.engine_client.stage_configs = [
-            SimpleNamespace(stage_type="diffusion", is_comprehension=True),
-        ]
-        serving_chat.engine_client.default_sampling_params_list = [
-            SamplingParams(),
-        ]
-        serving_chat._check_model = mocker.AsyncMock(return_value=None)
-        serving_chat._extract_diffusion_prompt_and_media = mocker.Mock()
+        stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
+        defaults = [OmniDiffusionSamplingParams()]
+        serving_chat.engine_client.stage_configs = stages
+        serving_chat.engine_client.default_sampling_params_list = defaults
+        serving_chat.engine_client.get_diffusion_od_config.return_value = None
+        serving_chat._diffusion_engine = SimpleNamespace(
+            stage_configs=stages,
+            default_sampling_params_list=defaults,
+            od_config=None,
+        )
         request = ChatCompletionRequest(
             model="test",
             messages=[],
-            **{field_name: invalid_value},
+            seed=1,
+            sampling_params_list=[{"seed": 2}],
         )
-
         responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
 
-        serving_chat._check_model.assert_not_awaited()
-        serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
-
     assert [response.error.code for response in responses] == [400, 400]
-    assert [response.error.message for response in responses] == [
-        expected_message,
-        expected_message,
-    ]
-
-
-def test_plain_llm_chat_skips_diffusion_compiler(serving_chat, mocker: MockerFixture):
-    serving_chat._diffusion_mode = False
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-    ]
-    serving_chat._compile_diffusion_request_contract = mocker.Mock()
-    serving_chat._check_model = mocker.AsyncMock(return_value="model-error")
-    request = ChatCompletionRequest(model="test", messages=[])
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert response == "model-error"
-    serving_chat._compile_diffusion_request_contract.assert_not_called()
-
-
-def test_diffusion_request_is_compiled_once_before_dispatch(serving_chat, mocker: MockerFixture):
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_extra_body_params = frozenset()
-    compile_spy = mocker.spy(serving_chat, "_compile_diffusion_request_contract")
-    serving_chat._create_diffusion_chat_completion = mocker.AsyncMock(return_value="ok")
-    request = ChatCompletionRequest(model="test", messages=[], seed=123)
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert response == "ok"
-    compile_spy.assert_called_once_with(request)
-    compiled_contract = compile_spy.spy_return
-    serving_chat._create_diffusion_chat_completion.assert_awaited_once_with(
-        request,
-        compiled_contract,
-        None,
+    assert all(
+        response.error.message
+        == 'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.'
+        for response in responses
     )
+    diffusion_dispatch.assert_not_awaited()
+    serving_chat._check_model.assert_not_awaited()
 
 
-def test_multistage_nested_modalities_is_compiled_once_and_dispatched(
-    serving_chat,
-    mocker: MockerFixture,
-):
-    generate = _configure_multistage_diffusion_chat(serving_chat, mocker)
-    compile_contract = mocker.spy(serving_chat, "_compile_diffusion_request_contract")
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        stream=True,
-        extra_body={"modalities": ["image"]},
-    )
-
-    result = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert hasattr(result, "__aiter__")
-    compile_contract.assert_called_once()
-    generate.assert_called_once()
-    assert generate.call_args.kwargs["output_modalities"] == ["image"]
-
-
-def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extras(
+def test_pure_dispatcher_receives_the_compiled_size(
     serving_chat,
     mocker: MockerFixture,
 ):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
-    captured: dict[str, object] = {}
+    captured = {}
 
     async def generate(**kwargs):
         captured.update(kwargs)
@@ -768,31 +269,97 @@ def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extr
 
     serving_chat._diffusion_mode = True
     serving_chat._diffusion_model_name = "test"
-    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat.engine_client = None
     serving_chat._diffusion_engine = SimpleNamespace(
         stage_configs=[SimpleNamespace(stage_type="diffusion")],
-        default_sampling_params_list=[
-            OmniDiffusionSamplingParams(extra_args={"stage_default": True}),
-        ],
+        default_sampling_params_list=[OmniDiffusionSamplingParams()],
+        od_config=None,
         generate=generate,
     )
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    request = ChatCompletionRequest(model="test", messages=[], size="768x512")
+    plan = _compile_diffusion_plan(serving_chat, request)
+
+    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request, plan))
+
+    (params,) = captured["sampling_params_list"]
+    assert (params.height, params.width) == (512, 768)
+    assert response.error.message == "No output generated from AsyncOmni"
+
+
+def _configure_mixed_diffusion_dispatch(serving_chat, mocker: MockerFixture):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    captured = {}
+
+    async def empty_output():
+        if False:
+            yield None
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._check_model = mocker.AsyncMock(return_value=None)
+    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
+    serving_chat.models = mocker.MagicMock()
+    serving_chat.models.model_name.return_value = "test-model"
+    serving_chat.renderer = mocker.MagicMock()
+    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
+    serving_chat.parser_cls = None
+    serving_chat.use_harmony = False
+    serving_chat.enable_auto_tools = False
+    serving_chat.exclude_tools_when_tool_choice_none = False
+    serving_chat.trust_request_chat_template = False
+    serving_chat.chat_template = None
+    serving_chat.chat_template_content_format = "string"
+    serving_chat.default_chat_template_kwargs = {}
+    serving_chat.online_renderer = mocker.MagicMock()
+    serving_chat.online_renderer.validate_chat_template.return_value = None
+    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
+    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
+    serving_chat._base_request_id = mocker.Mock(return_value="request")
+    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
+    serving_chat._log_inputs = mocker.Mock()
+    serving_chat.engine_client.errored = False
+    serving_chat.engine_client.output_modalities = ["image"]
+    serving_chat.engine_client.get_diffusion_od_config.return_value = None
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(max_tokens=100),
+        OmniDiffusionSamplingParams(),
+    ]
+
+    def generate(**kwargs):
+        captured.update(kwargs)
+        return empty_output()
+
+    serving_chat.engine_client.generate = generate
+    return captured
+
+
+def test_mixed_dispatcher_receives_one_final_stage_plan(
+    serving_chat,
+    mocker: MockerFixture,
+):
+    captured = _configure_mixed_diffusion_dispatch(serving_chat, mocker)
     request = ChatCompletionRequest(
         model="test",
         messages=[],
-        cfg_text_scale=7.0,
-        extra_body={"extra_args": {"sample_solver": "euler"}},
+        stream=True,
+        modalities=["image"],
+        size="768x512",
     )
 
-    response = asyncio.run(serving_chat._create_chat_completion(request))
+    result = asyncio.run(serving_chat._create_chat_completion(request))
 
-    sampling_params_list = captured["sampling_params_list"]
-    assert sampling_params_list[0].extra_args == {
-        "stage_default": True,
-        "cfg_text_scale": 7.0,
-        "sample_solver": "euler",
-    }
-    assert response.error.message == "No output generated from AsyncOmni"
+    assert hasattr(result, "__aiter__")
+    ar_params, diffusion_params = captured["sampling_params_list"]
+    assert ar_params.extra_args["target_h"] == 512
+    assert ar_params.extra_args["target_w"] == 768
+    assert (diffusion_params.height, diffusion_params.width) == (512, 768)
 
 
 # =============================================================================

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 from pytest_mock import MockerFixture
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.sampling_params import SamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -139,7 +140,7 @@ def test_diffusion_request_extra_args_reach_sampling_params(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
     serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    request = SimpleNamespace(model_fields_set={"seed"})
+    request = ChatCompletionRequest(model="test", messages=[], seed=1)
     sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
 
     serving_chat._apply_diffusion_request_extra_args(
@@ -158,17 +159,34 @@ def test_diffusion_request_extra_args_reach_sampling_params(serving_chat):
     }
 
 
+def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_extra_body_params = frozenset()
+    request = ChatCompletionRequest(model="test", messages=[])
+    sampling_params = OmniDiffusionSamplingParams()
+
+    serving_chat._apply_diffusion_request_extra_args(
+        sampling_params,
+        request,
+        {
+            "model_specific_option": "ignored-root-value",
+            "extra_args": {"model_specific_option": "canonical-value"},
+        },
+    )
+
+    assert sampling_params.extra_args == {"model_specific_option": "canonical-value"}
+
+
 def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat, mocker: MockerFixture):
     serving_chat._diffusion_mode = True
     serving_chat._diffusion_extra_body_params = frozenset({"flow_shift"})
     serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = SimpleNamespace(
+    request = ChatCompletionRequest(
+        model="test",
         messages=[],
-        model_fields_set=set(),
-        model_extra={
-            "flow_shift": 1.0,
-            "extra_args": {"flow_shift": 2.0},
-        },
+        flow_shift=1.0,
+        extra_args={"flow_shift": 2.0},
     )
 
     response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -495,6 +495,124 @@ def test_multistage_stage_extra_args_conflict_is_rejected_before_prompt_work(
     serving_chat._preprocess_chat.assert_not_awaited()
 
 
+def test_pure_diffusion_stage_override_conflict_is_rejected_before_dispatch(
+    serving_chat,
+    mocker: MockerFixture,
+):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._diffusion_engine = SimpleNamespace(
+        stage_configs=[SimpleNamespace(stage_type="diffusion")],
+        default_sampling_params_list=[OmniDiffusionSamplingParams()],
+    )
+    diffusion_dispatch = mocker.patch.object(
+        serving_chat,
+        "_create_diffusion_chat_completion",
+        new=mocker.AsyncMock(),
+    )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        seed=111,
+        sampling_params_list=[{"seed": 222}],
+    )
+
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert response.error.code == 400
+    assert response.error.message == (
+        'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.'
+    )
+    diffusion_dispatch.assert_not_awaited()
+
+
+def test_pure_diffusion_compiles_non_conflicting_stage_override(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._diffusion_engine = SimpleNamespace(
+        stage_configs=[SimpleNamespace(stage_type="diffusion")],
+        default_sampling_params_list=[OmniDiffusionSamplingParams()],
+    )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        sampling_params_list=[{"guidance_scale": 4.0}],
+    )
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+
+    assert contract.sampling_params_list is not None
+    assert contract.sampling_params_list[0].guidance_scale == 4.0
+
+
+def test_non_diffusion_stage_declared_extra_conflict_is_rejected(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(),
+        OmniDiffusionSamplingParams(),
+    ]
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        cfg_text_scale=7.0,
+        sampling_params_list=[
+            {"extra_args": {"cfg_text_scale": 8.0}},
+            {},
+        ],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        serving_chat._compile_diffusion_request_contract(request)
+
+    assert str(exc_info.value) == (
+        'Parameter "cfg_text_scale" was provided more than once: '
+        "request.cfg_text_scale, request.sampling_params_list[0].extra_args.cfg_text_scale."
+    )
+
+
+def test_registry_owned_schema_field_has_same_ar_effect_for_flattened_and_nested_forms(
+    serving_chat,
+):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset({"max_tokens"})
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(max_tokens=100),
+        OmniDiffusionSamplingParams(),
+    ]
+    requests = [
+        ChatCompletionRequest(model="test", messages=[], max_tokens=32),
+        ChatCompletionRequest(model="test", messages=[], extra_body={"max_tokens": 32}),
+    ]
+
+    contracts = [serving_chat._compile_diffusion_request_contract(request) for request in requests]
+
+    assert [contract.sampling_params_list[0].max_tokens for contract in contracts] == [
+        100,
+        100,
+    ]
+    assert [contract.declared_extra_args["max_tokens"] for contract in contracts] == [
+        32,
+        32,
+    ]
+
+
 def test_multistage_server_default_is_not_request_provenance(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -88,48 +88,99 @@ def serving_chat(mock_engine_client):
     return instance
 
 
-def _compile_diffusion_plan(serving_chat, request):
-    from vllm_omni.entrypoints.openai.diffusion_request_utils import (
-        compile_diffusion_chat_request_plan,
-        resolve_diffusion_chat_request_context,
+def test_serving_boundary_normalizes_declared_root_and_nested_extras(serving_chat):
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        cfg_text_scale=7.0,
+        extra_body={"extra_args": {"sample_solver": "euler"}},
     )
 
-    context = resolve_diffusion_chat_request_context(
-        engine_client=serving_chat.engine_client,
-        diffusion_engine=serving_chat._diffusion_engine,
-        diffusion_mode=serving_chat._diffusion_mode,
-        standard_sampling_fields=serving_chat._OPENAI_SAMPLING_FIELDS,
-        declared_extra_fields=serving_chat._diffusion_extra_body_params,
-    )
-    serving_chat._diffusion_extra_body_params = context.declared_extra_fields
-    return compile_diffusion_chat_request_plan(
-        request=request,
-        context=context,
-    )
+    assert serving_chat._normalize_diffusion_request_extra_args(request) == {
+        "cfg_text_scale": 7.0,
+        "sample_solver": "euler",
+    }
 
 
-def _configure_single_diffusion_topology(
+def test_unknown_root_extra_does_not_claim_canonical_extra(serving_chat):
+    serving_chat._diffusion_extra_body_params = frozenset()
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        pipeline_option="ignored-root-value",
+        extra_args={"pipeline_option": "canonical-value"},
+    )
+
+    assert serving_chat._normalize_diffusion_request_extra_args(request) == {
+        "pipeline_option": "canonical-value",
+    }
+
+
+@pytest.mark.parametrize("diffusion_mode", [True, False], ids=["pure", "mixed"])
+def test_duplicate_extras_return_the_same_bad_request_before_dispatch(
     serving_chat,
-    *,
+    mocker: MockerFixture,
     diffusion_mode: bool,
-    output_modalities: tuple[str, ...] = ("image",),
 ):
+    serving_chat._diffusion_mode = diffusion_mode
+    serving_chat._diffusion_extra_body_params = frozenset({"sample_solver"})
+    serving_chat.engine_client.stage_configs = [SimpleNamespace(stage_type="diffusion")]
+    check_model = mocker.patch.object(serving_chat, "_check_model", new=mocker.AsyncMock())
+    pure_dispatch = mocker.patch.object(
+        serving_chat,
+        "_create_diffusion_chat_completion",
+        new=mocker.AsyncMock(),
+    )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        sample_solver="euler",
+        extra_args={"sample_solver": "ddim"},
+    )
+
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert response.error.code == 400
+    assert response.error.message == (
+        'Parameter "sample_solver" was provided more than once: '
+        "request.sample_solver, request.extra_args.sample_solver."
+    )
+    check_model.assert_not_awaited()
+    pure_dispatch.assert_not_awaited()
+
+
+def test_pure_consumer_preserves_stage_defaults(serving_chat, mocker: MockerFixture):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
-    stages = [SimpleNamespace(stage_type="diffusion", is_comprehension=False)]
-    defaults = [OmniDiffusionSamplingParams()]
-    serving_chat._diffusion_mode = diffusion_mode
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat.engine_client.stage_configs = stages
-    serving_chat.engine_client.default_sampling_params_list = defaults
-    serving_chat.engine_client.output_modalities = list(output_modalities)
-    serving_chat.engine_client.get_diffusion_od_config.return_value = None
+    captured: dict[str, object] = {}
+
+    async def generate(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield None
+
+    serving_chat._diffusion_model_name = "test"
     serving_chat._diffusion_engine = SimpleNamespace(
-        stage_configs=stages,
-        default_sampling_params_list=defaults,
-        output_modalities=list(output_modalities),
-        od_config=None,
+        stage_configs=[SimpleNamespace(stage_type="diffusion")],
+        default_sampling_params_list=[
+            OmniDiffusionSamplingParams(extra_args={"solver": "euler", "stage_default": True}),
+        ],
+        generate=generate,
     )
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    request = ChatCompletionRequest(model="test", messages=[])
+
+    response = asyncio.run(
+        serving_chat._create_diffusion_chat_completion(
+            request,
+            {"solver": "ddim"},
+        )
+    )
+
+    (sampling_params,) = captured["sampling_params_list"]
+    assert sampling_params.extra_args == {"solver": "ddim", "stage_default": True}
+    assert response.error.message == "No output generated from AsyncOmni"
 
 
 @pytest.fixture
@@ -178,210 +229,6 @@ def test_openai_sampling_fields_contains_expected_fields():
         "presence_penalty",
     }
     assert OmniOpenAIServingChat._OPENAI_SAMPLING_FIELDS == expected_fields
-
-
-@pytest.mark.parametrize(
-    ("model_class_name", "field", "value", "expected_on_ar", "expected_ar_value"),
-    [
-        pytest.param("BagelPipeline", "cfg_text_scale", 7.0, True, None, id="custom-fan-out"),
-        pytest.param("SenseNovaU1Pipeline", "max_tokens", 32, False, 100, id="no-fan-out"),
-        pytest.param("MingImagePipeline", "seed", 32, True, 32, id="typed-fan-out"),
-    ],
-)
-def test_registry_owns_declared_extra_fan_out(
-    serving_chat,
-    model_class_name,
-    field,
-    value,
-    expected_on_ar,
-    expected_ar_value,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = None
-    serving_chat.engine_client.get_diffusion_od_config.return_value = SimpleNamespace(model_class_name=model_class_name)
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(max_tokens=100),
-        OmniDiffusionSamplingParams(),
-    ]
-
-    plan = _compile_diffusion_plan(
-        serving_chat,
-        ChatCompletionRequest(model="test", messages=[], **{field: value}),
-    )
-    ar_params, diffusion_params = plan.clone_sampling_params_list()
-
-    assert (field in (ar_params.extra_args or {})) is expected_on_ar
-    assert diffusion_params.extra_args[field] == value
-    if expected_ar_value is not None:
-        assert getattr(ar_params, field) == expected_ar_value
-
-
-@pytest.mark.parametrize("diffusion_mode", [True, False], ids=["pure", "mixed"])
-@pytest.mark.parametrize(
-    ("request_body", "error_message"),
-    [
-        pytest.param(
-            {"seed": 1, "sampling_params_list": [{"seed": 2}]},
-            'Parameter "seed" was provided more than once: request.seed, request.sampling_params_list[0].seed.',
-            id="duplicate",
-        ),
-        pytest.param(
-            {"extra_body": {"modalities": "text"}},
-            "'modalities' must be a list of strings.",
-            id="modalities-type",
-        ),
-        pytest.param(
-            {"extra_body": {"modalities": ["audio"]}},
-            "Unsupported output modalities audio",
-            id="unsupported-audio",
-        ),
-    ],
-)
-def test_invalid_request_uses_the_shared_boundary_before_dispatch(
-    serving_chat,
-    mocker: MockerFixture,
-    diffusion_mode: bool,
-    request_body: dict[str, object],
-    error_message: str,
-):
-    diffusion_dispatch = mocker.patch.object(
-        serving_chat,
-        "_create_diffusion_chat_completion",
-        new=mocker.AsyncMock(),
-    )
-    serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    _configure_single_diffusion_topology(serving_chat, diffusion_mode=diffusion_mode)
-    request = ChatCompletionRequest(model="test", messages=[], **request_body)
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert response.error.code == 400
-    assert error_message in response.error.message
-    diffusion_dispatch.assert_not_awaited()
-    serving_chat._check_model.assert_not_awaited()
-
-
-def test_pure_dispatcher_receives_the_compiled_controls(
-    serving_chat,
-    mocker: MockerFixture,
-):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    captured = {}
-
-    async def generate(**kwargs):
-        captured.update(kwargs)
-        if False:
-            yield None
-
-    serving_chat._diffusion_mode = True
-    serving_chat._diffusion_model_name = "test"
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat.engine_client = None
-    serving_chat._diffusion_engine = SimpleNamespace(
-        stage_configs=[SimpleNamespace(stage_type="diffusion")],
-        default_sampling_params_list=[OmniDiffusionSamplingParams()],
-        output_modalities=["image"],
-        od_config=None,
-        generate=generate,
-    )
-    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        size="768x512",
-        extra_body={
-            "modalities": ["text"],
-            "negative_prompt": "low quality",
-        },
-    )
-
-    response = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert captured["prompt"]["modalities"] == ["text"]
-    assert captured["prompt"]["negative_prompt"] == "low quality"
-    (params,) = captured["sampling_params_list"]
-    assert (params.height, params.width) == (512, 768)
-    assert response.error.message == "No output generated from AsyncOmni"
-
-
-def _configure_mixed_diffusion_dispatch(serving_chat, mocker: MockerFixture):
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    captured = {}
-
-    async def empty_output():
-        if False:
-            yield None
-
-    serving_chat._diffusion_mode = False
-    serving_chat._diffusion_extra_body_params = frozenset()
-    serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
-    serving_chat.models = mocker.MagicMock()
-    serving_chat.models.model_name.return_value = "test-model"
-    serving_chat.renderer = mocker.MagicMock()
-    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
-    serving_chat.parser_cls = None
-    serving_chat.use_harmony = False
-    serving_chat.enable_auto_tools = False
-    serving_chat.exclude_tools_when_tool_choice_none = False
-    serving_chat.trust_request_chat_template = False
-    serving_chat.chat_template = None
-    serving_chat.chat_template_content_format = "string"
-    serving_chat.default_chat_template_kwargs = {}
-    serving_chat.online_renderer = mocker.MagicMock()
-    serving_chat.online_renderer.validate_chat_template.return_value = None
-    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
-    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
-    serving_chat._base_request_id = mocker.Mock(return_value="request")
-    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
-    serving_chat._log_inputs = mocker.Mock()
-    serving_chat.engine_client.errored = False
-    serving_chat.engine_client.output_modalities = ["image"]
-    serving_chat.engine_client.get_diffusion_od_config.return_value = None
-    serving_chat.engine_client.stage_configs = [
-        SimpleNamespace(stage_type="llm", is_comprehension=True),
-        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
-    ]
-    serving_chat.engine_client.default_sampling_params_list = [
-        SamplingParams(max_tokens=100),
-        OmniDiffusionSamplingParams(),
-    ]
-
-    def generate(**kwargs):
-        captured.update(kwargs)
-        return empty_output()
-
-    serving_chat.engine_client.generate = generate
-    return captured
-
-
-def test_mixed_dispatcher_receives_one_final_stage_plan(
-    serving_chat,
-    mocker: MockerFixture,
-):
-    captured = _configure_mixed_diffusion_dispatch(serving_chat, mocker)
-    request = ChatCompletionRequest(
-        model="test",
-        messages=[],
-        stream=True,
-        modalities=["image"],
-        size="768x512",
-    )
-
-    result = asyncio.run(serving_chat._create_chat_completion(request))
-
-    assert hasattr(result, "__aiter__")
-    ar_params, diffusion_params = captured["sampling_params_list"]
-    assert ar_params.extra_args["target_h"] == 512
-    assert ar_params.extra_args["target_w"] == 768
-    assert (diffusion_params.height, diffusion_params.width) == (512, 768)
 
 
 # =============================================================================

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -91,14 +91,20 @@ def serving_chat(mock_engine_client):
 def _compile_diffusion_plan(serving_chat, request):
     from vllm_omni.entrypoints.openai.diffusion_request_utils import (
         compile_diffusion_chat_request_plan,
+        resolve_diffusion_chat_request_context,
     )
 
+    context = resolve_diffusion_chat_request_context(
+        engine_client=serving_chat.engine_client,
+        diffusion_engine=serving_chat._diffusion_engine,
+        diffusion_mode=serving_chat._diffusion_mode,
+        standard_sampling_fields=serving_chat._OPENAI_SAMPLING_FIELDS,
+        declared_extra_fields=serving_chat._diffusion_extra_body_params,
+    )
+    serving_chat._diffusion_extra_body_params = context.declared_extra_fields
     return compile_diffusion_chat_request_plan(
         request=request,
-        sampling_root_fields=serving_chat._diffusion_sampling_root_fields,
-        standard_sampling_fields=serving_chat._OPENAI_SAMPLING_FIELDS,
-        control_root_fields=serving_chat._diffusion_control_root_fields,
-        **serving_chat._get_diffusion_request_plan_inputs(),
+        context=context,
     )
 
 

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -89,18 +89,30 @@ def serving_chat(mock_engine_client):
 
 
 def test_serving_boundary_normalizes_declared_root_and_nested_extras(serving_chat):
-    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale", "negative_prompt"})
     request = ChatCompletionRequest(
         model="test",
         messages=[],
+        modalities=["image"],
+        num_inference_steps=7,
+        size="768x512",
+        negative_prompt="avoid blur",
+        lora={"name": "adapter"},
         cfg_text_scale=7.0,
         extra_body={"extra_args": {"sample_solver": "euler"}},
     )
 
-    assert serving_chat._normalize_diffusion_request_extra_args(request) == {
+    normalized_extra_args, diffusion_request_args = serving_chat._normalize_diffusion_request_args(request)
+
+    assert normalized_extra_args == {
         "cfg_text_scale": 7.0,
         "sample_solver": "euler",
     }
+    assert diffusion_request_args["num_inference_steps"] == 7
+    assert diffusion_request_args["size"] == "768x512"
+    assert diffusion_request_args["negative_prompt"] == "avoid blur"
+    assert diffusion_request_args["lora"] == {"name": "adapter"}
+    assert diffusion_request_args["modalities"] == ["image"]
 
 
 def test_unknown_root_extra_does_not_claim_canonical_extra(serving_chat):
@@ -112,9 +124,12 @@ def test_unknown_root_extra_does_not_claim_canonical_extra(serving_chat):
         extra_args={"pipeline_option": "canonical-value"},
     )
 
-    assert serving_chat._normalize_diffusion_request_extra_args(request) == {
+    normalized_extra_args, diffusion_request_args = serving_chat._normalize_diffusion_request_args(request)
+
+    assert normalized_extra_args == {
         "pipeline_option": "canonical-value",
     }
+    assert "pipeline_option" not in diffusion_request_args
 
 
 @pytest.mark.parametrize("diffusion_mode", [True, False], ids=["pure", "mixed"])
@@ -168,19 +183,98 @@ def test_pure_consumer_preserves_stage_defaults(serving_chat, mocker: MockerFixt
         ],
         generate=generate,
     )
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
     serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
-    request = ChatCompletionRequest(model="test", messages=[])
-
-    response = asyncio.run(
-        serving_chat._create_diffusion_chat_completion(
-            request,
-            {"solver": "ddim"},
-        )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        modalities=["image"],
+        num_inference_steps=7,
+        size="768x512",
+        negative_prompt="avoid blur",
+        extra_body={"extra_args": {"solver": "ddim"}},
     )
+
+    response = asyncio.run(serving_chat._create_chat_completion(request))
 
     (sampling_params,) = captured["sampling_params_list"]
     assert sampling_params.extra_args == {"solver": "ddim", "stage_default": True}
+    assert sampling_params.num_inference_steps == 7
+    assert (sampling_params.height, sampling_params.width) == (512, 768)
+    assert captured["prompt"]["negative_prompt"] == "avoid blur"
     assert response.error.message == "No output generated from AsyncOmni"
+
+
+def test_mixed_consumer_keeps_root_common_args_with_nested_extras(serving_chat, mocker: MockerFixture):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(),
+        OmniDiffusionSamplingParams(),
+    ]
+    serving_chat.engine_client.output_modalities = ["image"]
+    serving_chat.engine_client.errored = False
+
+    captured: dict[str, object] = {}
+
+    async def results():
+        if False:
+            yield None
+
+    def generate(**kwargs):
+        captured.update(kwargs)
+        return results()
+
+    serving_chat.engine_client.generate = generate
+    serving_chat.__dict__.update(
+        _diffusion_mode=False,
+        _diffusion_extra_body_params=frozenset(),
+        models=SimpleNamespace(model_name=lambda _: "test"),
+        renderer=SimpleNamespace(get_tokenizer=lambda: object()),
+        online_renderer=SimpleNamespace(validate_chat_template=lambda **_: None),
+        parser_cls=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        exclude_tools_when_tool_choice_none=False,
+        trust_request_chat_template=True,
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+    mocker.patch.multiple(
+        serving_chat,
+        _check_model=mocker.AsyncMock(return_value=None),
+        _maybe_get_adapters=mocker.Mock(return_value=None),
+        _effective_chat_template_kwargs=mocker.Mock(return_value={}),
+        _preprocess_chat=mocker.AsyncMock(return_value=([], [{"prompt": "raw"}])),
+        _base_request_id=mocker.Mock(return_value="test"),
+        _extract_diffusion_prompt_and_images_from_messages=mocker.Mock(return_value=("prompt", [])),
+        _log_inputs=mocker.Mock(),
+        chat_completion_full_generator=mocker.AsyncMock(return_value="done"),
+    )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[{"role": "user", "content": "prompt"}],
+        modalities=["image"],
+        num_inference_steps=7,
+        size="768x512",
+        negative_prompt="avoid blur",
+        extra_body={"extra_args": {"solver": "euler"}},
+    )
+
+    assert asyncio.run(serving_chat._create_chat_completion(request)) == "done"
+
+    sampling_params_list = captured["sampling_params_list"]
+    assert sampling_params_list[0].extra_args == {"target_h": 512, "target_w": 768}
+    diffusion_params = sampling_params_list[1]
+    assert diffusion_params.num_inference_steps == 7
+    assert (diffusion_params.height, diffusion_params.width) == (512, 768)
+    assert diffusion_params.extra_args == {"solver": "euler"}
+    assert captured["prompt"]["negative_prompt"] == "avoid blur"
 
 
 @pytest.fixture
@@ -713,124 +807,3 @@ class TestResolveHeightWidth:
         h, w = OmniOpenAIServingChat._resolve_height_width_from_extra_body({"size": "invalid"})
         assert h is None
         assert w is None
-
-
-# =============================================================================
-# Tests for _apply_request_overrides with GLM-Image (target_h/w injection)
-# =============================================================================
-
-
-class TestApplyRequestOverridesGLMImage:
-    """Test target_h/w injection for GLM-Image AR stage.
-
-    max_tokens is NOT computed dynamically — it comes from the deploy YAML
-    default (e.g. 4353). _apply_request_overrides only injects target_h/w
-    into extra_args so the model can build M-RoPE position grids.
-    """
-
-    @pytest.fixture
-    def glm_serving_chat(self, mock_engine_client, mocker: MockerFixture):
-        from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
-
-        instance = object.__new__(OmniOpenAIServingChat)
-        instance.engine_client = mock_engine_client
-        instance._extract_diffusion_prompt_and_images_from_messages = mocker.MagicMock(return_value=("a cat", []))
-        return instance
-
-    @pytest.fixture
-    def glm_request(self, mocker: MockerFixture):
-        req = mocker.MagicMock()
-        req.temperature = None
-        req.top_p = None
-        req.top_k = None
-        req.max_tokens = None
-        req.min_tokens = None
-        req.seed = None
-        req.ignore_eos = None
-        req.stop = None
-        req.stop_token_ids = None
-        req.frequency_penalty = None
-        req.presence_penalty = None
-        req.extra_body = {"height": 1024, "width": 1024}
-        req.model_fields_set = set()
-        return req
-
-    def test_t2i_injects_target_h_w(self, glm_serving_chat, glm_request, default_comprehension_params):
-        """t2i mode: target_h/w injected into extra_args, max_tokens unchanged."""
-        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, glm_request)
-        assert result.extra_args["target_h"] == 1024
-        assert result.extra_args["target_w"] == 1024
-        # max_tokens stays at YAML default (not dynamically computed)
-        assert result.max_tokens == 4353
-
-    def test_i2i_injects_target_h_w(
-        self, glm_serving_chat, glm_request, default_comprehension_params, mocker: MockerFixture
-    ):
-        """i2i mode: target_h/w injected, max_tokens unchanged."""
-        glm_serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.MagicMock(
-            return_value=("edit this", ["fake_image"])
-        )
-        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, glm_request)
-        assert result.extra_args["target_h"] == 1024
-        assert result.extra_args["target_w"] == 1024
-        # max_tokens stays at YAML default regardless of t2i/i2i
-        assert result.max_tokens == 4353
-
-    def test_user_max_tokens_preserved(self, glm_serving_chat, glm_request, default_comprehension_params):
-        """User-provided max_tokens is respected (not overridden by dynamic computation)."""
-        glm_request.max_tokens = 500
-        glm_request.model_fields_set = {"max_tokens"}
-
-        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, glm_request)
-        assert result.max_tokens == 500
-        assert result.extra_args["target_h"] == 1024
-        assert result.extra_args["target_w"] == 1024
-
-    def test_no_height_width_preserves_default(
-        self, glm_serving_chat, mocker: MockerFixture, default_comprehension_params
-    ):
-        """When no height/width in extra_body, keep YAML default max_tokens, no target_h/w."""
-        req = mocker.MagicMock()
-        req.temperature = None
-        req.top_p = None
-        req.top_k = None
-        req.max_tokens = None
-        req.min_tokens = None
-        req.seed = None
-        req.ignore_eos = None
-        req.stop = None
-        req.stop_token_ids = None
-        req.frequency_penalty = None
-        req.presence_penalty = None
-        req.extra_body = {}
-        req.model_fields_set = set()
-
-        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, req)
-        assert result.max_tokens == 4353  # YAML default
-        # No target_h/w injected when dimensions not provided
-        assert not result.extra_args or "target_h" not in (result.extra_args or {})
-
-    def test_size_string_parsed_for_glm_image(
-        self, glm_serving_chat, mocker: MockerFixture, default_comprehension_params
-    ):
-        """'size' in extra_body is parsed as fallback for height/width."""
-        req = mocker.MagicMock()
-        req.temperature = None
-        req.top_p = None
-        req.top_k = None
-        req.max_tokens = None
-        req.min_tokens = None
-        req.seed = None
-        req.ignore_eos = None
-        req.stop = None
-        req.stop_token_ids = None
-        req.frequency_penalty = None
-        req.presence_penalty = None
-        req.extra_body = {"size": "512x512"}
-        req.model_fields_set = set()
-
-        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, req)
-        assert result.extra_args["target_h"] == 512
-        assert result.extra_args["target_w"] == 512
-        # max_tokens stays at YAML default (not dynamically computed)
-        assert result.max_tokens == 4353

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -266,6 +266,61 @@ def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, m
     )
 
 
+def test_multistage_diffusion_duplicate_uses_bad_request_helper(serving_chat, mocker: MockerFixture):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = False
+    serving_chat._check_model = mocker.AsyncMock(return_value=None)
+    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
+    serving_chat.models = mocker.MagicMock()
+    serving_chat.models.model_name.return_value = "test-model"
+    serving_chat.renderer = mocker.MagicMock()
+    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
+    serving_chat.reasoning_parser_cls = None
+    serving_chat.tool_parser = None
+    serving_chat.parser_cls = None
+    serving_chat.use_harmony = False
+    serving_chat.enable_auto_tools = False
+    serving_chat.exclude_tools_when_tool_choice_none = False
+    serving_chat.trust_request_chat_template = False
+    serving_chat.chat_template = None
+    serving_chat.chat_template_content_format = "string"
+    serving_chat.default_chat_template_kwargs = {}
+    serving_chat.online_renderer = mocker.MagicMock()
+    serving_chat.online_renderer.validate_chat_template.return_value = None
+    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
+    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
+    serving_chat._base_request_id = mocker.Mock(return_value="multistage-duplicate")
+    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
+    serving_chat._build_sampling_params_list_from_request = mocker.Mock(return_value=[OmniDiffusionSamplingParams()])
+    serving_chat._apply_diffusion_request_overrides = mocker.Mock(side_effect=ValueError("duplicate parameter"))
+    serving_chat._create_error_response = mocker.Mock(return_value="bad-request")
+    serving_chat.engine_client.errored = False
+    serving_chat.engine_client.output_modalities = ["image"]
+
+    request = SimpleNamespace(
+        tool_choice=None,
+        tools=None,
+        chat_template=None,
+        chat_template_kwargs=None,
+        reasoning_effort=None,
+        messages=[],
+        add_generation_prompt=False,
+        continue_final_message=False,
+        add_special_tokens=False,
+        request_id="multistage-duplicate",
+        modalities=["image"],
+        model_extra={},
+        extra_body=None,
+        stream=False,
+    )
+
+    result = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert result == "bad-request"
+    serving_chat._create_error_response.assert_called_once_with("duplicate parameter", status_code=400)
+
+
 def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extras(
     serving_chat,
     mocker: MockerFixture,

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -136,23 +136,26 @@ def test_openai_sampling_fields_contains_expected_fields():
     assert OmniOpenAIServingChat._OPENAI_SAMPLING_FIELDS == expected_fields
 
 
-def test_diffusion_request_extra_args_reach_sampling_params(serving_chat):
+def test_diffusion_request_overrides_reach_sampling_params(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
     serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
     request = ChatCompletionRequest(model="test", messages=[], seed=1)
     sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
 
-    serving_chat._apply_diffusion_request_extra_args(
+    serving_chat._apply_diffusion_request_overrides(
         sampling_params,
         request,
         {
             "cfg_text_scale": 7.0,
+            "guidance_scale": 6.0,
             "extra_args": {"sample_solver": "euler"},
         },
         {},
     )
 
+    assert sampling_params.seed == 1
+    assert sampling_params.guidance_scale == 6.0
     assert sampling_params.extra_args == {
         "stage_default": True,
         "cfg_text_scale": 7.0,
@@ -167,7 +170,7 @@ def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_
     request = ChatCompletionRequest(model="test", messages=[])
     sampling_params = OmniDiffusionSamplingParams()
 
-    serving_chat._apply_diffusion_request_extra_args(
+    serving_chat._apply_diffusion_request_overrides(
         sampling_params,
         request,
         {
@@ -178,6 +181,50 @@ def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_
     )
 
     assert sampling_params.extra_args == {"model_specific_option": "canonical-value"}
+
+
+def test_internal_sampling_state_is_not_a_public_root_field(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_extra_body_params = frozenset()
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        latents="ignored-root-value",
+        extra_args={"latents": "model-specific-value"},
+    )
+    sampling_params = OmniDiffusionSamplingParams()
+
+    root_extra_body, nested_extra_body = serving_chat._split_diffusion_request_extra_body(request)
+    serving_chat._apply_diffusion_request_overrides(
+        sampling_params,
+        request,
+        root_extra_body,
+        nested_extra_body,
+    )
+
+    assert sampling_params.latents is None
+    assert sampling_params.extra_args == {"latents": "model-specific-value"}
+
+
+def test_diffusion_chat_rejects_flattened_nested_control_conflict(serving_chat, mocker: MockerFixture):
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        negative_prompt="root",
+        extra_body={"negative_prompt": "nested"},
+    )
+
+    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+
+    assert response.error.code == 400
+    assert response.error.message == (
+        'Parameter "negative_prompt" was provided more than once: '
+        "request.negative_prompt, request.extra_body.negative_prompt."
+    )
 
 
 def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat, mocker: MockerFixture):

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -111,6 +111,56 @@ def mock_request(mocker: MockerFixture):
     return request
 
 
+def _configure_multistage_diffusion_chat(serving_chat, mocker: MockerFixture):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    async def empty_output():
+        if False:
+            yield None
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat._check_model = mocker.AsyncMock(return_value=None)
+    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
+    serving_chat.models = mocker.MagicMock()
+    serving_chat.models.model_name.return_value = "test-model"
+    serving_chat.renderer = mocker.MagicMock()
+    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
+    serving_chat.parser_cls = None
+    serving_chat.use_harmony = False
+    serving_chat.enable_auto_tools = False
+    serving_chat.exclude_tools_when_tool_choice_none = False
+    serving_chat.trust_request_chat_template = False
+    serving_chat.chat_template = None
+    serving_chat.chat_template_content_format = "string"
+    serving_chat.default_chat_template_kwargs = {}
+    serving_chat.online_renderer = mocker.MagicMock()
+    serving_chat.online_renderer.validate_chat_template.return_value = None
+    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
+    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
+    serving_chat._base_request_id = mocker.Mock(return_value="multistage-request")
+    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
+    serving_chat._build_sampling_params_list_from_request = mocker.Mock(
+        return_value=[
+            OmniDiffusionSamplingParams(),
+            OmniDiffusionSamplingParams(),
+        ]
+    )
+    serving_chat._log_inputs = mocker.Mock()
+    serving_chat.engine_client.errored = False
+    serving_chat.engine_client.output_modalities = ["image"]
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="diffusion"),
+        SimpleNamespace(stage_type="diffusion"),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        OmniDiffusionSamplingParams(),
+        OmniDiffusionSamplingParams(),
+    ]
+    serving_chat.engine_client.generate = mocker.Mock(side_effect=lambda **_: empty_output())
+    return serving_chat.engine_client.generate
+
+
 # =============================================================================
 # Tests for _OPENAI_SAMPLING_FIELDS constant
 # =============================================================================
@@ -139,20 +189,20 @@ def test_openai_sampling_fields_contains_expected_fields():
 def test_diffusion_request_overrides_reach_sampling_params(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
+    serving_chat._diffusion_mode = True
     serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
-    request = ChatCompletionRequest(model="test", messages=[], seed=1)
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        seed=1,
+        cfg_text_scale=7.0,
+        guidance_scale=6.0,
+        extra_args={"sample_solver": "euler"},
+    )
     sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
 
-    serving_chat._apply_diffusion_request_overrides(
-        sampling_params,
-        request,
-        {
-            "cfg_text_scale": 7.0,
-            "guidance_scale": 6.0,
-            "extra_args": {"sample_solver": "euler"},
-        },
-        {},
-    )
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
 
     assert sampling_params.seed == 1
     assert sampling_params.guidance_scale == 6.0
@@ -163,22 +213,127 @@ def test_diffusion_request_overrides_reach_sampling_params(serving_chat):
     }
 
 
+def test_schema_declared_root_reaches_model_extra_consumer(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+    from vllm_omni.model_extras import get_extra_body_params
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
+    request = ChatCompletionRequest(model="test", messages=[], max_tokens=32)
+    sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
+
+    assert sampling_params.extra_args == {
+        "stage_default": True,
+        "max_tokens": 32,
+    }
+
+
+def test_schema_declared_root_conflicts_with_canonical_extra_arg(serving_chat):
+    from vllm_omni.model_extras import get_extra_body_params
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        max_tokens=32,
+        extra_args={"max_tokens": 64},
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        serving_chat._compile_diffusion_request_contract(request)
+
+    assert str(exc_info.value) == (
+        'Parameter "max_tokens" was provided more than once: request.max_tokens, request.extra_args.max_tokens.'
+    )
+
+
+def test_model_declared_cfg_scale_uses_model_extra_consumer(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+    from vllm_omni.model_extras import get_extra_body_params
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
+    request = ChatCompletionRequest(model="test", messages=[], cfg_scale=3.0)
+    sampling_params = OmniDiffusionSamplingParams()
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
+
+    assert sampling_params.true_cfg_scale is None
+    assert sampling_params.extra_args == {"cfg_scale": 3.0}
+
+
+def test_generic_cfg_scale_still_targets_true_cfg_scale(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
+    request = ChatCompletionRequest(model="test", messages=[], cfg_scale=3.0)
+    sampling_params = OmniDiffusionSamplingParams()
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
+
+    assert sampling_params.true_cfg_scale == 3.0
+    assert sampling_params.extra_args == {}
+
+
+def test_model_declared_dimension_remains_available_to_prompt_consumer(serving_chat):
+    from vllm_omni.model_extras import get_extra_body_params
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = get_extra_body_params("MingImagePipeline")
+    request = ChatCompletionRequest(model="test", messages=[], height=512, width=768)
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+
+    assert contract.sampling_overrides.get("height") is None
+    assert contract.extra_args_overrides["height"] == 512
+    assert contract.control_overrides["height"] == 512
+    assert contract.control_overrides["width"] == 768
+
+
+def test_stage_root_uses_same_model_aware_consumer_as_global_root(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+    from vllm_omni.model_extras import get_extra_body_params
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = get_extra_body_params("SenseNovaU1Pipeline")
+    serving_chat.engine_client.stage_configs = [SimpleNamespace(stage_type="diffusion")]
+    serving_chat.engine_client.default_sampling_params_list = [OmniDiffusionSamplingParams()]
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        sampling_params_list=[{"cfg_scale": 3.0}],
+    )
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+
+    assert contract.sampling_params_list is not None
+    sampling_params = contract.sampling_params_list[0]
+    assert sampling_params.true_cfg_scale is None
+    assert sampling_params.extra_args == {"cfg_scale": 3.0}
+
+
 def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
+    serving_chat._diffusion_mode = True
     serving_chat._diffusion_extra_body_params = frozenset()
-    request = ChatCompletionRequest(model="test", messages=[])
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        model_specific_option="ignored-root-value",
+        extra_args={"model_specific_option": "canonical-value"},
+    )
     sampling_params = OmniDiffusionSamplingParams()
 
-    serving_chat._apply_diffusion_request_overrides(
-        sampling_params,
-        request,
-        {
-            "model_specific_option": "ignored-root-value",
-            "extra_args": {"model_specific_option": "canonical-value"},
-        },
-        {},
-    )
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
 
     assert sampling_params.extra_args == {"model_specific_option": "canonical-value"}
 
@@ -186,6 +341,7 @@ def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_
 def test_internal_sampling_state_is_not_a_public_root_field(serving_chat):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
+    serving_chat._diffusion_mode = True
     serving_chat._diffusion_extra_body_params = frozenset()
     request = ChatCompletionRequest(
         model="test",
@@ -195,13 +351,8 @@ def test_internal_sampling_state_is_not_a_public_root_field(serving_chat):
     )
     sampling_params = OmniDiffusionSamplingParams()
 
-    root_extra_body, nested_extra_body = serving_chat._split_diffusion_request_extra_body(request)
-    serving_chat._apply_diffusion_request_overrides(
-        sampling_params,
-        request,
-        root_extra_body,
-        nested_extra_body,
-    )
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    serving_chat._apply_diffusion_request_contract(sampling_params, contract)
 
     assert sampling_params.latents is None
     assert sampling_params.extra_args == {"latents": "model-specific-value"}
@@ -218,7 +369,8 @@ def test_diffusion_chat_rejects_flattened_nested_control_conflict(serving_chat, 
         extra_body={"negative_prompt": "nested"},
     )
 
-    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
 
     assert response.error.code == 400
     assert response.error.message == (
@@ -238,12 +390,48 @@ def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat
         extra_args={"flow_shift": 2.0},
     )
 
-    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
 
     assert response.error.code == 400
     assert response.error.message == (
         'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
     )
+
+
+def test_pure_and_multistage_return_the_same_duplicate_error_before_dispatch(
+    serving_chat,
+    mocker: MockerFixture,
+):
+    diffusion_dispatch = mocker.patch.object(
+        serving_chat,
+        "_create_diffusion_chat_completion",
+        new=mocker.AsyncMock(),
+    )
+    serving_chat._check_model = mocker.AsyncMock()
+    responses = []
+    for diffusion_mode in (True, False):
+        serving_chat._diffusion_mode = diffusion_mode
+        serving_chat._diffusion_extra_body_params = frozenset({"flow_shift"})
+        serving_chat.engine_client.stage_configs = [
+            SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+        ]
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[],
+            flow_shift=1.0,
+            extra_args={"flow_shift": 2.0},
+        )
+
+        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
+
+    assert [response.error.code for response in responses] == [400, 400]
+    assert [response.error.message for response in responses] == [
+        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.',
+        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.',
+    ]
+    diffusion_dispatch.assert_not_awaited()
+    serving_chat._check_model.assert_not_awaited()
 
 
 def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, mocker: MockerFixture):
@@ -257,7 +445,8 @@ def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, m
         extra_body={"extra_args": {"cfg_text_scale": 7.0}},
     )
 
-    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+    serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
 
     assert response.error.code == 400
     assert response.error.message == (
@@ -266,59 +455,184 @@ def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, m
     )
 
 
-def test_multistage_diffusion_duplicate_uses_bad_request_helper(serving_chat, mocker: MockerFixture):
+def test_multistage_stage_extra_args_conflict_is_rejected_before_prompt_work(
+    serving_chat,
+    mocker: MockerFixture,
+):
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
     serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(),
+        OmniDiffusionSamplingParams(),
+    ]
     serving_chat._check_model = mocker.AsyncMock(return_value=None)
-    serving_chat._maybe_get_adapters = mocker.Mock(return_value=None)
-    serving_chat.models = mocker.MagicMock()
-    serving_chat.models.model_name.return_value = "test-model"
-    serving_chat.renderer = mocker.MagicMock()
-    serving_chat.renderer.get_tokenizer.return_value = mocker.MagicMock()
-    serving_chat.reasoning_parser_cls = None
-    serving_chat.tool_parser = None
-    serving_chat.parser_cls = None
-    serving_chat.use_harmony = False
-    serving_chat.enable_auto_tools = False
-    serving_chat.exclude_tools_when_tool_choice_none = False
-    serving_chat.trust_request_chat_template = False
-    serving_chat.chat_template = None
-    serving_chat.chat_template_content_format = "string"
-    serving_chat.default_chat_template_kwargs = {}
-    serving_chat.online_renderer = mocker.MagicMock()
-    serving_chat.online_renderer.validate_chat_template.return_value = None
-    serving_chat._effective_chat_template_kwargs = mocker.Mock(return_value={})
-    serving_chat._preprocess_chat = mocker.AsyncMock(return_value=([], [{"prompt": "preprocessed"}]))
-    serving_chat._base_request_id = mocker.Mock(return_value="multistage-duplicate")
-    serving_chat._extract_diffusion_prompt_and_images_from_messages = mocker.Mock(return_value=("prompt", []))
-    serving_chat._build_sampling_params_list_from_request = mocker.Mock(return_value=[OmniDiffusionSamplingParams()])
-    serving_chat._apply_diffusion_request_overrides = mocker.Mock(side_effect=ValueError("duplicate parameter"))
-    serving_chat._create_error_response = mocker.Mock(return_value="bad-request")
-    serving_chat.engine_client.errored = False
-    serving_chat.engine_client.output_modalities = ["image"]
-
-    request = SimpleNamespace(
-        tool_choice=None,
-        tools=None,
-        chat_template=None,
-        chat_template_kwargs=None,
-        reasoning_effort=None,
+    serving_chat._preprocess_chat = mocker.AsyncMock()
+    request = ChatCompletionRequest(
+        model="test",
         messages=[],
-        add_generation_prompt=False,
-        continue_final_message=False,
-        add_special_tokens=False,
-        request_id="multistage-duplicate",
         modalities=["image"],
-        model_extra={},
-        extra_body=None,
-        stream=False,
+        sampling_params_list=[
+            {},
+            {"extra_args": {"seed": 111}},
+        ],
+        extra_args={"seed": 222},
     )
 
     result = asyncio.run(serving_chat._create_chat_completion(request))
 
-    assert result == "bad-request"
-    serving_chat._create_error_response.assert_called_once_with("duplicate parameter", status_code=400)
+    assert result.error.code == 400
+    assert result.error.message == (
+        'Parameter "seed" was provided more than once: '
+        "request.extra_args.seed, request.sampling_params_list[1].extra_args.seed."
+    )
+    serving_chat._check_model.assert_not_awaited()
+    serving_chat._preprocess_chat.assert_not_awaited()
+
+
+def test_multistage_server_default_is_not_request_provenance(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_mode = False
+    serving_chat._diffusion_extra_body_params = frozenset()
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+        SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+    ]
+    serving_chat.engine_client.default_sampling_params_list = [
+        SamplingParams(),
+        OmniDiffusionSamplingParams(extra_args={"seed": 111, "stage_default": True}),
+    ]
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        sampling_params_list=[{}],
+        extra_args={"seed": 222},
+    )
+
+    contract = serving_chat._compile_diffusion_request_contract(request)
+    assert contract.sampling_params_list is not None
+    diffusion_params = contract.sampling_params_list[1]
+    serving_chat._apply_diffusion_request_contract(diffusion_params, contract)
+
+    assert diffusion_params.extra_args == {"seed": 222, "stage_default": True}
+
+
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value", "expected_message"),
+    [
+        (
+            "layers",
+            999,
+            "Invalid layers value 999. layers must be between 2 and 10 inclusive.",
+        ),
+        (
+            "num_inference_steps",
+            [],
+            "num_inference_steps must be an integer.",
+        ),
+        (
+            "num_inference_steps",
+            {"invalid": "object"},
+            "num_inference_steps must be an integer.",
+        ),
+    ],
+)
+def test_pure_and_multistage_reject_invalid_compiled_values_before_dispatch(
+    serving_chat,
+    mocker: MockerFixture,
+    field_name,
+    invalid_value,
+    expected_message,
+):
+    responses = []
+    for diffusion_mode in (True, False):
+        serving_chat._diffusion_mode = diffusion_mode
+        serving_chat._diffusion_extra_body_params = frozenset()
+        serving_chat.engine_client.stage_configs = [
+            SimpleNamespace(stage_type="diffusion", is_comprehension=True),
+        ]
+        serving_chat.engine_client.default_sampling_params_list = [
+            SamplingParams(),
+        ]
+        serving_chat._check_model = mocker.AsyncMock(return_value=None)
+        serving_chat._extract_diffusion_prompt_and_media = mocker.Mock()
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[],
+            **{field_name: invalid_value},
+        )
+
+        responses.append(asyncio.run(serving_chat._create_chat_completion(request)))
+
+        serving_chat._check_model.assert_not_awaited()
+        serving_chat._extract_diffusion_prompt_and_media.assert_not_called()
+
+    assert [response.error.code for response in responses] == [400, 400]
+    assert [response.error.message for response in responses] == [
+        expected_message,
+        expected_message,
+    ]
+
+
+def test_plain_llm_chat_skips_diffusion_compiler(serving_chat, mocker: MockerFixture):
+    serving_chat._diffusion_mode = False
+    serving_chat.engine_client.stage_configs = [
+        SimpleNamespace(stage_type="llm", is_comprehension=True),
+    ]
+    serving_chat._compile_diffusion_request_contract = mocker.Mock()
+    serving_chat._check_model = mocker.AsyncMock(return_value="model-error")
+    request = ChatCompletionRequest(model="test", messages=[])
+
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert response == "model-error"
+    serving_chat._compile_diffusion_request_contract.assert_not_called()
+
+
+def test_diffusion_request_is_compiled_once_before_dispatch(serving_chat, mocker: MockerFixture):
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset()
+    compile_spy = mocker.spy(serving_chat, "_compile_diffusion_request_contract")
+    serving_chat._create_diffusion_chat_completion = mocker.AsyncMock(return_value="ok")
+    request = ChatCompletionRequest(model="test", messages=[], seed=123)
+
+    response = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert response == "ok"
+    compile_spy.assert_called_once_with(request)
+    compiled_contract = compile_spy.spy_return
+    serving_chat._create_diffusion_chat_completion.assert_awaited_once_with(
+        request,
+        compiled_contract,
+        None,
+    )
+
+
+def test_multistage_nested_modalities_is_compiled_once_and_dispatched(
+    serving_chat,
+    mocker: MockerFixture,
+):
+    generate = _configure_multistage_diffusion_chat(serving_chat, mocker)
+    compile_contract = mocker.spy(serving_chat, "_compile_diffusion_request_contract")
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        stream=True,
+        extra_body={"modalities": ["image"]},
+    )
+
+    result = asyncio.run(serving_chat._create_chat_completion(request))
+
+    assert hasattr(result, "__aiter__")
+    compile_contract.assert_called_once()
+    generate.assert_called_once()
+    assert generate.call_args.kwargs["output_modalities"] == ["image"]
 
 
 def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extras(
@@ -352,7 +666,7 @@ def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extr
         extra_body={"extra_args": {"sample_solver": "euler"}},
     )
 
-    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+    response = asyncio.run(serving_chat._create_chat_completion(request))
 
     sampling_params_list = captured["sampling_params_list"]
     assert sampling_params_list[0].extra_args == {

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -6,6 +6,7 @@ Tests that standard OpenAI API parameters (max_tokens, temperature, etc.)
 are correctly applied to the comprehension stage while preserving YAML defaults.
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -132,6 +133,50 @@ def test_openai_sampling_fields_contains_expected_fields():
         "presence_penalty",
     }
     assert OmniOpenAIServingChat._OPENAI_SAMPLING_FIELDS == expected_fields
+
+
+def test_diffusion_request_extra_args_reach_sampling_params(serving_chat):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    request = SimpleNamespace(model_fields_set={"seed"})
+    sampling_params = OmniDiffusionSamplingParams(extra_args={"stage_default": True})
+
+    serving_chat._apply_diffusion_request_extra_args(
+        sampling_params,
+        request,
+        {
+            "cfg_text_scale": 7.0,
+            "extra_args": {"sample_solver": "euler"},
+        },
+    )
+
+    assert sampling_params.extra_args == {
+        "stage_default": True,
+        "cfg_text_scale": 7.0,
+        "sample_solver": "euler",
+    }
+
+
+def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat, mocker: MockerFixture):
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset({"flow_shift"})
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    request = SimpleNamespace(
+        messages=[],
+        model_fields_set=set(),
+        model_extra={
+            "flow_shift": 1.0,
+            "extra_args": {"flow_shift": 2.0},
+        },
+    )
+
+    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+
+    assert response.error.code == 400
+    assert response.error.message == (
+        'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
+    )
 
 
 # =============================================================================

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -150,6 +150,7 @@ def test_diffusion_request_extra_args_reach_sampling_params(serving_chat):
             "cfg_text_scale": 7.0,
             "extra_args": {"sample_solver": "euler"},
         },
+        {},
     )
 
     assert sampling_params.extra_args == {
@@ -173,6 +174,7 @@ def test_unknown_root_extra_does_not_conflict_with_canonical_extra_args(serving_
             "model_specific_option": "ignored-root-value",
             "extra_args": {"model_specific_option": "canonical-value"},
         },
+        {},
     )
 
     assert sampling_params.extra_args == {"model_specific_option": "canonical-value"}
@@ -195,6 +197,68 @@ def test_diffusion_chat_returns_bad_request_for_duplicate_parameter(serving_chat
     assert response.error.message == (
         'Parameter "flow_shift" was provided more than once: request.flow_shift, request.extra_args.flow_shift.'
     )
+
+
+def test_diffusion_chat_rejects_mixed_flattened_nested_duplicate(serving_chat, mocker: MockerFixture):
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        cfg_text_scale=6.0,
+        extra_body={"extra_args": {"cfg_text_scale": 7.0}},
+    )
+
+    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+
+    assert response.error.code == 400
+    assert response.error.message == (
+        'Parameter "cfg_text_scale" was provided more than once: '
+        "request.cfg_text_scale, request.extra_body.extra_args.cfg_text_scale."
+    )
+
+
+def test_diffusion_chat_preserves_stage_defaults_with_mixed_non_overlapping_extras(
+    serving_chat,
+    mocker: MockerFixture,
+):
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    captured: dict[str, object] = {}
+
+    async def generate(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield None
+
+    serving_chat._diffusion_mode = True
+    serving_chat._diffusion_model_name = "test"
+    serving_chat._diffusion_extra_body_params = frozenset({"cfg_text_scale"})
+    serving_chat._extract_diffusion_prompt_and_media = mocker.Mock(return_value=("prompt", [], [], []))
+    serving_chat._diffusion_engine = SimpleNamespace(
+        stage_configs=[SimpleNamespace(stage_type="diffusion")],
+        default_sampling_params_list=[
+            OmniDiffusionSamplingParams(extra_args={"stage_default": True}),
+        ],
+        generate=generate,
+    )
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[],
+        cfg_text_scale=7.0,
+        extra_body={"extra_args": {"sample_solver": "euler"}},
+    )
+
+    response = asyncio.run(serving_chat._create_diffusion_chat_completion(request))
+
+    sampling_params_list = captured["sampling_params_list"]
+    assert sampling_params_list[0].extra_args == {
+        "stage_default": True,
+        "cfg_text_scale": 7.0,
+        "sample_solver": "euler",
+    }
+    assert response.error.message == "No output generated from AsyncOmni"
 
 
 # =============================================================================

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -189,7 +189,7 @@ def test_duplicate_extras_return_the_same_bad_request_before_dispatch(
 
     assert response.error.code == 400
     assert response.error.message == (
-        'Parameter "sample_solver" was provided more than once: '
+        'Diffusion request parameters were provided more than once: "sample_solver": '
         "request.sample_solver, request.extra_args.sample_solver."
     )
     check_model.assert_not_awaited()

--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -108,6 +108,7 @@ def test_serving_boundary_normalizes_declared_root_and_nested_extras(serving_cha
         "cfg_text_scale": 7.0,
         "sample_solver": "euler",
     }
+    assert diffusion_request_args["cfg_text_scale"] == 7.0
     assert diffusion_request_args["num_inference_steps"] == 7
     assert diffusion_request_args["size"] == "768x512"
     assert diffusion_request_args["negative_prompt"] == "avoid blur"

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -610,7 +610,8 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
             # cfg_text_context: update with negative prompt (no text condition).
             # When empty, keep cfg_text_context as-is (kv_lens=0) to match
             # original BAGEL.
-            neg_prompt = extra_args.get("negative_prompt", "")
+            prompt_negative = first_prompt.get("negative_prompt") if isinstance(first_prompt, dict) else None
+            neg_prompt = prompt_negative if prompt_negative is not None else extra_args.get("negative_prompt", "")
             if neg_prompt:
                 neg_input, neg_newlens, neg_rope = self.bagel.prepare_prompts(
                     curr_kvlens=cfg_text_context["kv_lens"],

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -25,6 +25,7 @@ def normalize_diffusion_request_extra_args(
     nested_provided_root_fields: Collection[str] = (),
     nested_extra_args: object | None = None,
     nested_extra_params: object | None = None,
+    root_field_aliases: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     """Normalize model-specific diffusion request arguments without overwrites.
 
@@ -41,13 +42,14 @@ def normalize_diffusion_request_extra_args(
     nested_canonical = _copy_request_mapping("extra_body.extra_args", nested_extra_args)
     nested_legacy = _copy_request_mapping("extra_body.extra_params", nested_extra_params)
 
+    aliases = root_field_aliases or {}
     sources_by_key: dict[str, list[str]] = {}
     root_fields = set(provided_root_fields) - {"extra_args", "extra_params"}
-    for key in root_fields:
-        sources_by_key.setdefault(key, []).append(f"request.{key}")
+    for key in sorted(root_fields):
+        sources_by_key.setdefault(aliases.get(key, key), []).append(f"request.{key}")
     nested_root_fields = set(nested_provided_root_fields) - {"extra_args", "extra_params"}
-    for key in nested_root_fields:
-        sources_by_key.setdefault(key, []).append(f"request.extra_body.{key}")
+    for key in sorted(nested_root_fields):
+        sources_by_key.setdefault(aliases.get(key, key), []).append(f"request.extra_body.{key}")
     for key in canonical:
         sources_by_key.setdefault(key, []).append(f"request.extra_args.{key}")
     for key in legacy:

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -268,9 +268,11 @@ def compile_diffusion_chat_request_plan(
                 if height is None:
                     height = parsed_height
                     serving_by_key["height"] = (height, source)
+                    global_values.append(("height", height, source, False))
                 if width is None:
                     width = parsed_width
                     serving_by_key["width"] = (width, source)
+                    global_values.append(("width", width, source, False))
         except ValueError:
             invalid_size = size
 

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -4,10 +4,23 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
 
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CompiledDiffusionRequestOverrides:
+    """Request-owned diffusion values after provenance and ownership checks."""
+
+    request_values: Mapping[str, object]
+    sampling_overrides: Mapping[str, object]
+    declared_extra_args: Mapping[str, object]
+    extra_args: Mapping[str, object]
+    control_overrides: Mapping[str, object]
 
 
 def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
@@ -20,6 +33,17 @@ def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
     return dict(value)
 
 
+def _raise_duplicate_sources(sources_by_key: Mapping[str, list[str]]) -> None:
+    conflicts = {key: sources for key, sources in sources_by_key.items() if len(sources) > 1}
+    if not conflicts:
+        return
+    if len(conflicts) == 1:
+        key, sources = next(iter(conflicts.items()))
+        raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(sources)}.')
+    details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
+    raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
+
+
 def normalize_diffusion_request_extra_args(
     *,
     provided_root_fields: Collection[str] = (),
@@ -29,6 +53,8 @@ def normalize_diffusion_request_extra_args(
     nested_extra_args: object | None = None,
     nested_extra_params: object | None = None,
     root_field_aliases: Mapping[str, str] | None = None,
+    stage_provided_root_fields: Mapping[int, Collection[str]] | None = None,
+    stage_extra_args: Mapping[int, object | None] | None = None,
 ) -> dict[str, object]:
     """Normalize model-specific diffusion request arguments without overwrites.
 
@@ -62,13 +88,29 @@ def normalize_diffusion_request_extra_args(
     for key in nested_legacy:
         sources_by_key.setdefault(key, []).append(f"request.extra_body.extra_params.{key}")
 
-    conflicts = {key: sources for key, sources in sources_by_key.items() if len(sources) > 1}
-    if conflicts:
-        if len(conflicts) == 1:
-            key, sources = next(iter(conflicts.items()))
-            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(sources)}.')
-        details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
-        raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
+    _raise_duplicate_sources(sources_by_key)
+
+    stage_root_fields = stage_provided_root_fields or {}
+    stage_canonical_args = stage_extra_args or {}
+    for stage_index in sorted(set(stage_root_fields) | set(stage_canonical_args)):
+        stage_sources_by_key = {key: list(sources) for key, sources in sources_by_key.items()}
+        provided_stage_fields = set(stage_root_fields.get(stage_index, ())) - {
+            "extra_args",
+            "extra_params",
+        }
+        for key in sorted(provided_stage_fields):
+            stage_sources_by_key.setdefault(aliases.get(key, key), []).append(
+                f"request.sampling_params_list[{stage_index}].{key}"
+            )
+        provided_stage_extra_args = _copy_request_mapping(
+            f"sampling_params_list[{stage_index}].extra_args",
+            stage_canonical_args.get(stage_index),
+        )
+        for key in provided_stage_extra_args:
+            stage_sources_by_key.setdefault(key, []).append(
+                f"request.sampling_params_list[{stage_index}].extra_args.{key}"
+            )
+        _raise_duplicate_sources(stage_sources_by_key)
 
     if extra_params is not None or nested_extra_params is not None:
         logger.warning_once(
@@ -77,3 +119,81 @@ def normalize_diffusion_request_extra_args(
 
     # Duplicate request keys were rejected above, so these mappings are disjoint.
     return {**legacy, **nested_legacy, **canonical, **nested_canonical}
+
+
+def compile_diffusion_request_overrides(
+    *,
+    root_values: Mapping[str, object],
+    nested_root_values: Mapping[str, object],
+    sampling_root_fields: Mapping[str, str],
+    declared_extra_fields: Collection[str],
+    control_root_fields: Collection[str],
+    extra_args: object | None = None,
+    extra_params: object | None = None,
+    nested_extra_args: object | None = None,
+    nested_extra_params: object | None = None,
+    stage_provided_root_fields: Mapping[int, Collection[str]] | None = None,
+    stage_extra_args: Mapping[int, object | None] | None = None,
+) -> CompiledDiffusionRequestOverrides:
+    """Compile all request roots into their model-aware runtime consumers.
+
+    A model registry declaration owns that root field and routes it to
+    ``extra_args``. Otherwise a serving sampling field routes to its mapped
+    sampling attribute. Control fields remain available to dispatchers even
+    when a model declaration also consumes them. Server defaults are absent
+    because they are not request provenance.
+    """
+    declared_extra_fields = frozenset(declared_extra_fields)
+    effective_sampling_fields = {
+        request_field: sampling_field
+        for request_field, sampling_field in sampling_root_fields.items()
+        if request_field not in declared_extra_fields
+    }
+    control_root_fields = frozenset(control_root_fields)
+    consumed_root_fields = declared_extra_fields | effective_sampling_fields.keys() | control_root_fields
+    filtered_root_values = {key: value for key, value in root_values.items() if key in consumed_root_fields}
+    filtered_nested_root_values = {
+        key: value for key, value in nested_root_values.items() if key in consumed_root_fields
+    }
+
+    normalized_extra_args = normalize_diffusion_request_extra_args(
+        provided_root_fields=filtered_root_values,
+        extra_args=extra_args,
+        extra_params=extra_params,
+        nested_provided_root_fields=filtered_nested_root_values,
+        nested_extra_args=nested_extra_args,
+        nested_extra_params=nested_extra_params,
+        root_field_aliases=effective_sampling_fields,
+        stage_provided_root_fields=stage_provided_root_fields,
+        stage_extra_args=stage_extra_args,
+    )
+
+    request_values: dict[str, object] = {}
+    sampling_overrides: dict[str, object] = {}
+    declared_root_extra_args: dict[str, object] = {}
+    control_overrides: dict[str, object] = {}
+    for source in (filtered_root_values, filtered_nested_root_values):
+        for request_field, value in source.items():
+            if value is None:
+                continue
+            request_values[request_field] = value
+            if request_field in declared_extra_fields:
+                declared_root_extra_args[request_field] = value
+            elif request_field in effective_sampling_fields:
+                sampling_overrides[effective_sampling_fields[request_field]] = value
+            if request_field in control_root_fields:
+                control_overrides[request_field] = value
+
+    # Root declarations and argument containers were proven disjoint above.
+    # The expansion is therefore a set union, not a precedence rule.
+    compiled_extra_args = {
+        **declared_root_extra_args,
+        **normalized_extra_args,
+    }
+    return CompiledDiffusionRequestOverrides(
+        request_values=MappingProxyType(request_values),
+        sampling_overrides=MappingProxyType(sampling_overrides),
+        declared_extra_args=MappingProxyType(declared_root_extra_args),
+        extra_args=MappingProxyType(compiled_extra_args),
+        control_overrides=MappingProxyType(control_overrides),
+    )

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Collection, Mapping
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
@@ -68,10 +71,9 @@ def normalize_diffusion_request_extra_args(
         raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
 
     if extra_params is not None or nested_extra_params is not None:
-        warnings.warn(
-            "extra_params is deprecated; use extra_args for model-specific diffusion request parameters.",
-            FutureWarning,
-            stacklevel=2,
+        logger.warning_once(
+            "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
         )
 
+    # Duplicate request keys were rejected above, so these mappings are disjoint.
     return {**legacy, **nested_legacy, **canonical, **nested_canonical}

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, is_dataclass
 from dataclasses import replace as dataclass_replace
 from functools import partial
@@ -15,10 +15,36 @@ from vllm import SamplingParams
 from vllm.logger import init_logger
 
 from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
-from vllm_omni.entrypoints.openai.utils import parse_lora_request
+from vllm_omni.entrypoints.openai.stage_params import get_default_sampling_params_list
+from vllm_omni.entrypoints.openai.utils import (
+    get_stage_type,
+    is_single_stage_diffusion,
+    parse_lora_request,
+    resolve_diffusion_od_config,
+)
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.model_extras import (
+    get_extra_body_params,
+    should_init_extra_args_for_non_diffusion_stages,
+)
 
 logger = init_logger(__name__)
+
+_SAMPLING_ROOT_FIELDS = {
+    "height": "height",
+    "width": "width",
+    "num_outputs_per_prompt": "num_outputs_per_prompt",
+    "seed": "seed",
+    "num_inference_steps": "num_inference_steps",
+    "guidance_scale": "guidance_scale",
+    "true_cfg_scale": "true_cfg_scale",
+    "cfg_scale": "true_cfg_scale",
+    "num_frames": "num_frames",
+    "guidance_scale_2": "guidance_scale_2",
+    "layers": "layers",
+    "resolution": "resolution",
+}
+_CONTROL_ROOT_FIELDS = frozenset({"size", "negative_prompt", "lora", "modalities"})
 
 
 def _clone(params: Any, source: str) -> Any:
@@ -41,6 +67,70 @@ class DiffusionChatRequestPlan:
     def clone_sampling_params_list(self) -> list[Any]:
         """Return isolated parameters for one dispatcher invocation."""
         return [_clone(params, "sampling parameters") for params in self._stage_params]
+
+
+@dataclass(frozen=True)
+class DiffusionChatRequestContext:
+    """Model topology and request-field policy consumed by the compiler."""
+
+    stage_types: tuple[str, ...]
+    default_sampling_params_list: tuple[object, ...]
+    comprehension_stage_index: int | None
+    standard_sampling_fields: frozenset[str]
+    declared_extra_fields: frozenset[str]
+    apply_declared_to_non_diffusion: bool
+    supported_modalities: frozenset[str]
+
+
+def resolve_diffusion_chat_request_context(
+    *,
+    engine_client: object,
+    diffusion_engine: object | None,
+    diffusion_mode: bool,
+    standard_sampling_fields: Collection[str],
+    declared_extra_fields: Collection[str] | None,
+) -> DiffusionChatRequestContext:
+    """Resolve all model-owned compiler policy from the active topology."""
+    stage_owner = diffusion_engine if diffusion_mode else engine_client
+    stage_configs = list(getattr(stage_owner, "stage_configs", ()) or ())
+    declared = frozenset(declared_extra_fields) if declared_extra_fields is not None else None
+    fan_out_declared = False
+    try:
+        od_config = resolve_diffusion_od_config(engine_client, diffusion_engine)
+        model_class_name = getattr(od_config, "model_class_name", None)
+        if isinstance(model_class_name, str):
+            if declared is None:
+                declared = get_extra_body_params(model_class_name)
+            fan_out_declared = should_init_extra_args_for_non_diffusion_stages(model_class_name)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to resolve diffusion request model extras: {exc}") from exc
+
+    supported_modalities = {
+        modality for modality in getattr(stage_owner, "output_modalities", ()) if modality is not None
+    }
+    if is_single_stage_diffusion(stage_owner):
+        supported_modalities.add("text")
+    return DiffusionChatRequestContext(
+        stage_types=tuple(get_stage_type(stage) for stage in stage_configs),
+        default_sampling_params_list=tuple(get_default_sampling_params_list(stage_owner)),
+        comprehension_stage_index=next(
+            (index for index, stage in enumerate(stage_configs) if getattr(stage, "is_comprehension", False)),
+            None,
+        ),
+        standard_sampling_fields=frozenset(standard_sampling_fields),
+        declared_extra_fields=declared or frozenset(),
+        apply_declared_to_non_diffusion=fan_out_declared,
+        supported_modalities=frozenset(supported_modalities),
+    )
+
+
+@dataclass(frozen=True)
+class _Assignment:
+    key: str
+    target: str
+    value: object
+    source: str
+    parse_value: bool
 
 
 def _mapping(
@@ -115,36 +205,33 @@ class _PlanBuilder:
     def __init__(
         self,
         request: object,
-        stage_types: Sequence[str],
-        defaults: Sequence[object],
-        comprehension_stage: int | None,
-        root_fields: Mapping[str, str],
-        standard_fields: Collection[str],
-        control_fields: Collection[str],
-        declared_fields: Collection[str],
-        fan_out_declared: bool,
-        supported_modalities: Collection[str],
+        context: DiffusionChatRequestContext,
     ) -> None:
         self.request = request
-        self.declared = frozenset(declared_fields)
-        self.root_fields = root_fields
-        self.standard_fields = frozenset(standard_fields)
-        self.control_fields = frozenset(control_fields)
-        self.sampling_fields = {key: target for key, target in root_fields.items() if key not in self.declared}
-        self.fan_out_declared = fan_out_declared
-        self.supported_modalities = frozenset(supported_modalities)
-        self.comprehension_stage = comprehension_stage
-        self.types = list(stage_types) or ["diffusion"]
+        self.declared = context.declared_extra_fields
+        self.standard_fields = context.standard_sampling_fields
+        self.sampling_fields = {
+            key: target for key, target in _SAMPLING_ROOT_FIELDS.items() if key not in self.declared
+        }
+        self.fan_out_declared = context.apply_declared_to_non_diffusion
+        self.supported_modalities = context.supported_modalities
+        self.comprehension_stage = context.comprehension_stage_index
+        self.types = list(context.stage_types) or ["diffusion"]
         self.params = [
-            _stage_params(stage_type, defaults[index] if index < len(defaults) else None)
+            _stage_params(
+                stage_type,
+                context.default_sampling_params_list[index]
+                if index < len(context.default_sampling_params_list)
+                else None,
+            )
             for index, stage_type in enumerate(self.types)
         ]
         self.diffusion_stages = [index for index, stage_type in enumerate(self.types) if stage_type == "diffusion"]
-        self.items: list[list[tuple[str, str, object, str, bool]]] = [[] for _ in self.params]
+        self.items: list[list[_Assignment]] = [[] for _ in self.params]
         self.claims: list[dict[str, list[str]]] = [{} for _ in self.params]
 
     def collect_sources(self) -> None:
-        consumed = self.declared | self.sampling_fields.keys() | self.control_fields
+        consumed = self.declared | self.sampling_fields.keys() | _CONTROL_ROOT_FIELDS
         model_extra = getattr(self.request, "model_extra", None)
         self.flat = dict(model_extra) if isinstance(model_extra, Mapping) else {}
         nested_value = self.flat.pop("extra_body", None)
@@ -179,7 +266,7 @@ class _PlanBuilder:
         claims: dict[str, list[str]] = {}
         self.by_key: dict[str, tuple[object, str]] = {}
         for key, value, source, is_container in self.values:
-            conflict_key = key if key in self.declared else self.root_fields.get(key, key)
+            conflict_key = key if key in self.declared else _SAMPLING_ROOT_FIELDS.get(key, key)
             claims.setdefault(conflict_key, []).append(source)
             if not is_container or key in self.declared:
                 self.by_key[key] = (value, source)
@@ -189,7 +276,7 @@ class _PlanBuilder:
         self.controls = {
             key: value
             for key, (value, _source) in self.by_key.items()
-            if key in self.control_fields and key not in {"size", "lora"} and value is not None
+            if key in _CONTROL_ROOT_FIELDS and key not in {"size", "lora"} and value is not None
         }
         modalities = self.controls.get("modalities")
         if modalities is not None:
@@ -237,7 +324,15 @@ class _PlanBuilder:
     ) -> None:
         for stage in (stages,) if isinstance(stages, int) else stages:
             self.claims[stage].setdefault(key, []).append(source)
-            self.items[stage].append((key, target or key, value, source, parse_value))
+            self.items[stage].append(
+                _Assignment(
+                    key=key,
+                    target=target or key,
+                    value=value,
+                    source=source,
+                    parse_value=parse_value,
+                )
+            )
 
     def build_stage_assignments(self) -> None:
         assign = self._assign
@@ -245,7 +340,7 @@ class _PlanBuilder:
         diffusion = self.diffusion_stages
         declared_stages: Collection[int] = range(len(self.types)) if self.fan_out_declared else diffusion
         for key, value, source, is_container in self.values:
-            if value is None and (not is_container or key in self.declared):
+            if value is None:
                 continue
             if key in self.declared:
                 extra(declared_stages, key, value, source)
@@ -328,16 +423,20 @@ class _PlanBuilder:
         for stage, (params, items) in enumerate(zip(self.params, self.items)):
             overrides: dict[str, object] = {}
             extra_args: dict[str, object] = {}
-            for key, target, value, source, parse_value in items:
-                if target == "extra_args":
+            for assignment in items:
+                if assignment.target == "extra_args":
                     if not hasattr(params, "extra_args"):
-                        raise ValueError(f"{source} is not supported by stage {stage}.")
+                        raise ValueError(f"{assignment.source} is not supported by stage {stage}.")
                     destination = extra_args
-                elif hasattr(params, target):
+                elif hasattr(params, assignment.target):
                     destination = overrides
                 else:
-                    raise ValueError(f'{source} targets unsupported parameter "{target}" for stage {stage}.')
-                destination[key if target == "extra_args" else target] = _parse(key, value) if parse_value else value
+                    raise ValueError(
+                        f'{assignment.source} targets unsupported parameter "{assignment.target}" for stage {stage}.'
+                    )
+                destination[assignment.key if assignment.target == "extra_args" else assignment.target] = (
+                    _parse(assignment.key, assignment.value) if assignment.parse_value else assignment.value
+                )
             if not overrides and not extra_args:
                 continue
             if extra_args:
@@ -354,29 +453,10 @@ class _PlanBuilder:
 def compile_diffusion_chat_request_plan(
     *,
     request: object,
-    stage_types: Sequence[str],
-    default_sampling_params_list: Sequence[object],
-    comprehension_stage_index: int | None,
-    sampling_root_fields: Mapping[str, str],
-    standard_sampling_fields: Collection[str],
-    control_root_fields: Collection[str],
-    declared_extra_fields: Collection[str],
-    apply_declared_to_non_diffusion: bool,
-    supported_modalities: Collection[str],
+    context: DiffusionChatRequestContext,
 ) -> DiffusionChatRequestPlan:
     """Compile all Chat request sources into final typed stage parameters."""
-    builder = _PlanBuilder(
-        request,
-        stage_types,
-        default_sampling_params_list,
-        comprehension_stage_index,
-        sampling_root_fields,
-        standard_sampling_fields,
-        control_root_fields,
-        declared_extra_fields,
-        apply_declared_to_non_diffusion,
-        supported_modalities,
-    )
+    builder = _PlanBuilder(request, context)
     builder.collect_sources()
     builder.validate_sources()
     builder.build_stage_assignments()

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -3,28 +3,54 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping
-from dataclasses import dataclass
+import copy
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass, fields, is_dataclass
 from types import MappingProxyType
+from typing import Any
 
+from vllm import SamplingParams
 from vllm.logger import init_logger
+
+from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
+from vllm_omni.entrypoints.openai.utils import parse_lora_request
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 logger = init_logger(__name__)
 
 
+def _clone(params: Any, source: str) -> Any:
+    try:
+        cloned = copy.deepcopy(params)
+    except Exception as exc:
+        raise RuntimeError(f"Unable to isolate {source}: {exc}") from exc
+    if cloned is params:
+        raise RuntimeError(f"Unable to isolate {source}: deepcopy returned the original object.")
+    return cloned
+
+
 @dataclass(frozen=True)
-class CompiledDiffusionRequestOverrides:
-    """Request-owned diffusion values after provenance and ownership checks."""
+class DiffusionChatRequestPlan:
+    """Final controls and private per-stage parameter prototypes."""
 
-    request_values: Mapping[str, object]
-    sampling_overrides: Mapping[str, object]
-    declared_extra_args: Mapping[str, object]
-    extra_args: Mapping[str, object]
-    control_overrides: Mapping[str, object]
+    controls: Mapping[str, object]
+    request_sources: Mapping[str, object]
+    _stage_params: tuple[Any, ...]
+
+    def clone_sampling_params_list(self) -> list[Any]:
+        """Return isolated parameters for one dispatcher invocation."""
+        return [_clone(params, "sampling parameters") for params in self._stage_params]
 
 
-def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
+def _mapping(
+    name: str,
+    value: object | None,
+    *,
+    required: bool = False,
+) -> dict[str, object]:
     if value is None:
+        if required:
+            raise ValueError(f"{name} must be a JSON object.")
         return {}
     if not isinstance(value, Mapping):
         raise ValueError(f"{name} must be a JSON object.")
@@ -33,8 +59,10 @@ def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
     return dict(value)
 
 
-def _raise_duplicate_sources(sources_by_key: Mapping[str, list[str]]) -> None:
-    conflicts = {key: sources for key, sources in sources_by_key.items() if len(sources) > 1}
+def _reject_duplicates(sources_by_key: Mapping[str, list[str]]) -> None:
+    # Registry fan-out may route one source to two stage consumers; only
+    # distinct request source paths are duplicates.
+    conflicts = {key: list(dict.fromkeys(sources)) for key, sources in sources_by_key.items() if len(set(sources)) > 1}
     if not conflicts:
         return
     if len(conflicts) == 1:
@@ -44,156 +72,327 @@ def _raise_duplicate_sources(sources_by_key: Mapping[str, list[str]]) -> None:
     raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
 
 
-def normalize_diffusion_request_extra_args(
+def _parse(key: str, value: object) -> object:
+    if key == "num_inference_steps" and value is not None:
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("num_inference_steps must be an integer.") from exc
+    if key in {"height", "width", "target_h", "target_w"} and value is not None:
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{key} must be an integer.") from exc
+    if key == "layers" and value is not None:
+        return validate_layered_layers(value)
+    return value
+
+
+def _stage_params(stage_type: str, default: object | None) -> Any:
+    cls = OmniDiffusionSamplingParams if stage_type == "diffusion" else SamplingParams
+    if default is None:
+        return cls()
+    if isinstance(default, Mapping):
+        try:
+            return cls(**copy.deepcopy(dict(default)))
+        except Exception as exc:
+            raise RuntimeError(f"Invalid default sampling parameters: {exc}") from exc
+    if isinstance(default, cls):
+        return _clone(default, "default sampling parameters")
+    raise RuntimeError(
+        f"Default sampling parameters for {stage_type} stage have incompatible type {type(default).__name__}."
+    )
+
+
+def _init_values(params: Any) -> dict[str, object]:
+    if is_dataclass(params):
+        names = [field.name for field in fields(params) if field.init]
+    else:
+        names = list(getattr(type(params), "__struct_fields__", ()))
+        if not names:
+            names = list(getattr(params, "__dict__", ()))
+        names = [name for name in names if not name.startswith("_") and name != "output_text_buffer_length"]
+    return {name: getattr(params, name) for name in names}
+
+
+class _Assignments:
+    """Collect provenance, then build final typed stages from cloned defaults."""
+
+    def __init__(self, params: list[Any]) -> None:
+        self.params = params
+        self.items: list[tuple[int, str, str, object, str, bool, bool]] = []
+
+    def add(
+        self,
+        stage: int,
+        key: str,
+        value: object,
+        source: str,
+        *,
+        target: str | None = None,
+        keep_none: bool = False,
+        parse_value: bool = True,
+    ) -> None:
+        self.items.append((stage, key, target or key, value, source, keep_none, parse_value))
+
+    def reject_duplicates(self) -> None:
+        for stage in range(len(self.params)):
+            claims: dict[str, list[str]] = {}
+            for claimed_stage, key, _target, _value, source, _keep_none, _parse_value in self.items:
+                if claimed_stage == stage:
+                    claims.setdefault(key, []).append(source)
+            _reject_duplicates(claims)
+
+    def apply(self) -> None:
+        self.reject_duplicates()
+        for stage, params in enumerate(self.params):
+            overrides: dict[str, object] = {}
+            extra_args: dict[str, object] = {}
+            for item_stage, key, target, value, source, keep_none, parse_value in self.items:
+                if item_stage != stage or (value is None and not keep_none):
+                    continue
+                if target == "extra_args":
+                    if not hasattr(params, "extra_args"):
+                        raise ValueError(f"{source} is not supported by stage {stage}.")
+                    destination = extra_args
+                elif hasattr(params, target):
+                    destination = overrides
+                else:
+                    raise ValueError(f'{source} targets unsupported parameter "{target}" for stage {stage}.')
+                destination[key if target == "extra_args" else target] = _parse(key, value) if parse_value else value
+            if not overrides and not extra_args:
+                continue
+            if extra_args:
+                overrides["extra_args"] = {
+                    **(getattr(params, "extra_args", None) or {}),
+                    **extra_args,
+                }
+            try:
+                self.params[stage] = type(params)(**{**_init_values(params), **overrides})
+            except Exception as exc:
+                raise ValueError(f"Invalid sampling parameters for stage {stage}: {exc}") from exc
+
+
+def compile_diffusion_chat_request_plan(
     *,
-    provided_root_fields: Collection[str] = (),
-    extra_args: object | None = None,
-    extra_params: object | None = None,
-    nested_provided_root_fields: Collection[str] = (),
-    nested_extra_args: object | None = None,
-    nested_extra_params: object | None = None,
-    root_field_aliases: Mapping[str, str] | None = None,
-    stage_provided_root_fields: Mapping[int, Collection[str]] | None = None,
-    stage_extra_args: Mapping[int, object | None] | None = None,
-) -> dict[str, object]:
-    """Normalize model-specific diffusion request arguments without overwrites.
+    request: object,
+    stage_types: Sequence[str],
+    default_sampling_params_list: Sequence[object],
+    comprehension_stage_index: int | None,
+    sampling_root_fields: Mapping[str, str],
+    standard_sampling_fields: Collection[str],
+    control_root_fields: Collection[str],
+    declared_extra_fields: Collection[str],
+    apply_declared_to_non_diffusion: bool,
+) -> DiffusionChatRequestPlan:
+    """Compile all Chat request sources into final typed stage parameters."""
+    declared = frozenset(declared_extra_fields)
+    controls_fields = frozenset(control_root_fields)
+    sampling_fields = {
+        request_key: target_key
+        for request_key, target_key in sampling_root_fields.items()
+        if request_key not in declared
+    }
+    consumed = declared | sampling_fields.keys() | controls_fields
 
-    ``provided_root_fields`` must contain only fields explicitly supplied by the
-    caller, not fields populated by request-model defaults. Unknown keys inside
-    ``extra_args`` remain valid because their schema is owned by each pipeline.
+    model_extra = getattr(request, "model_extra", None)
+    flat = dict(model_extra) if isinstance(model_extra, Mapping) else {}
+    nested_value = flat.pop("extra_body", None)
+    if nested_value is None:
+        nested_value = getattr(request, "extra_body", None)
+    nested = _mapping("extra_body", nested_value)
 
-    Raises:
-        ValueError: If an extra-argument container is not an object or if the
-            same key is present in more than one request source.
-    """
-    canonical = _copy_request_mapping("extra_args", extra_args)
-    legacy = _copy_request_mapping("extra_params", extra_params)
-    nested_canonical = _copy_request_mapping("extra_body.extra_args", nested_extra_args)
-    nested_legacy = _copy_request_mapping("extra_body.extra_params", nested_extra_params)
+    explicit = getattr(request, "model_fields_set", None)
+    if explicit is None:
+        explicit = getattr(request, "__fields_set__", ())
+    explicit = set(explicit) if isinstance(explicit, Collection) else set()
+    for key in explicit:
+        if key not in flat and (key in consumed or key in standard_sampling_fields or key == "sampling_params_list"):
+            flat[key] = getattr(request, key, None)
 
-    aliases = root_field_aliases or {}
-    sources_by_key: dict[str, list[str]] = {}
-    root_fields = set(provided_root_fields) - {"extra_args", "extra_params"}
-    for key in sorted(root_fields):
-        sources_by_key.setdefault(aliases.get(key, key), []).append(f"request.{key}")
-    nested_root_fields = set(nested_provided_root_fields) - {"extra_args", "extra_params"}
-    for key in sorted(nested_root_fields):
-        sources_by_key.setdefault(aliases.get(key, key), []).append(f"request.extra_body.{key}")
-    for key in canonical:
-        sources_by_key.setdefault(key, []).append(f"request.extra_args.{key}")
-    for key in legacy:
-        sources_by_key.setdefault(key, []).append(f"request.extra_params.{key}")
-    for key in nested_canonical:
-        sources_by_key.setdefault(key, []).append(f"request.extra_body.extra_args.{key}")
-    for key in nested_legacy:
-        sources_by_key.setdefault(key, []).append(f"request.extra_body.extra_params.{key}")
+    roots: list[tuple[str, object, str]] = []
+    for values, prefix in ((flat, "request"), (nested, "request.extra_body")):
+        roots.extend((key, values[key], f"{prefix}.{key}") for key in sorted(values) if key in consumed)
 
-    _raise_duplicate_sources(sources_by_key)
+    raw_containers = (
+        ("request.extra_args", flat.get("extra_args")),
+        ("request.extra_params", flat.get("extra_params")),
+        ("request.extra_body.extra_args", nested.get("extra_args")),
+        ("request.extra_body.extra_params", nested.get("extra_params")),
+    )
+    containers = [(name, _mapping(name.removeprefix("request."), value)) for name, value in raw_containers]
+    global_claims: dict[str, list[str]] = {}
+    for key, _value, source in roots:
+        global_claims.setdefault(sampling_fields.get(key, key), []).append(source)
+    for name, values in containers:
+        for key in values:
+            global_claims.setdefault(key, []).append(f"{name}.{key}")
+    _reject_duplicates(global_claims)
 
-    stage_root_fields = stage_provided_root_fields or {}
-    stage_canonical_args = stage_extra_args or {}
-    for stage_index in sorted(set(stage_root_fields) | set(stage_canonical_args)):
-        stage_sources_by_key = {key: list(sources) for key, sources in sources_by_key.items()}
-        provided_stage_fields = set(stage_root_fields.get(stage_index, ())) - {
-            "extra_args",
-            "extra_params",
-        }
-        for key in sorted(provided_stage_fields):
-            stage_sources_by_key.setdefault(aliases.get(key, key), []).append(
-                f"request.sampling_params_list[{stage_index}].{key}"
-            )
-        provided_stage_extra_args = _copy_request_mapping(
-            f"sampling_params_list[{stage_index}].extra_args",
-            stage_canonical_args.get(stage_index),
+    types = list(stage_types) or ["diffusion"]
+    params = [
+        _stage_params(
+            stage_type,
+            default_sampling_params_list[index] if index < len(default_sampling_params_list) else None,
         )
-        for key in provided_stage_extra_args:
-            stage_sources_by_key.setdefault(key, []).append(
-                f"request.sampling_params_list[{stage_index}].extra_args.{key}"
-            )
-        _raise_duplicate_sources(stage_sources_by_key)
+        for index, stage_type in enumerate(types)
+    ]
+    diffusion_stages = [index for index, stage_type in enumerate(types) if stage_type == "diffusion"]
+    assignments = _Assignments(params)
+    root_by_key = {key: (value, source) for key, value, source in roots}
 
-    if extra_params is not None or nested_extra_params is not None:
+    controls = {
+        key: value
+        for key, (value, _source) in root_by_key.items()
+        if key in controls_fields and key not in {"size", "lora"} and value is not None
+    }
+    height = root_by_key.get("height", (None, ""))[0]
+    width = root_by_key.get("width", (None, ""))[0]
+    invalid_size: object | None = None
+    if "size" in root_by_key and (height is None or width is None):
+        size, source = root_by_key["size"]
+        try:
+            if isinstance(size, str) and "x" in size.lower():
+                parsed_width, parsed_height = (int(part) for part in size.lower().split("x"))
+                if height is None:
+                    height = parsed_height
+                    root_by_key["height"] = (height, source)
+                if width is None:
+                    width = parsed_width
+                    root_by_key["width"] = (width, source)
+        except ValueError:
+            invalid_size = size
+
+    for request_key, (value, source) in root_by_key.items():
+        if request_key in declared:
+            targets = diffusion_stages
+            if apply_declared_to_non_diffusion:
+                targets = list(range(len(types)))
+            for stage in targets:
+                assignments.add(stage, request_key, value, source, target="extra_args")
+        elif request_key in sampling_fields:
+            target = sampling_fields[request_key]
+            for stage in diffusion_stages:
+                assignments.add(stage, target, value, source)
+
+    for name, values in containers:
+        for key in sorted(values):
+            value = values[key]
+            for stage in diffusion_stages:
+                assignments.add(
+                    stage,
+                    key,
+                    value,
+                    f"{name}.{key}",
+                    target="extra_args",
+                    keep_none=True,
+                    parse_value=key in declared,
+                )
+
+    if comprehension_stage_index is not None:
+        for key in standard_sampling_fields:
+            if key not in explicit:
+                continue
+            if key in declared and (
+                not apply_declared_to_non_diffusion or types[comprehension_stage_index] == "diffusion"
+            ):
+                continue
+            if types[comprehension_stage_index] == "diffusion" and key in sampling_fields:
+                continue
+            value = getattr(request, key, None)
+            if not isinstance(value, list) or value:
+                assignments.add(comprehension_stage_index, key, value, f"request.{key}")
+        for key, value in (("target_h", height), ("target_w", width)):
+            if value is not None:
+                source_key = "height" if key == "target_h" else "width"
+                assignments.add(
+                    comprehension_stage_index,
+                    key,
+                    value,
+                    root_by_key[source_key][1],
+                    target="extra_args",
+                )
+
+    stage_sources = [
+        (f"{prefix}.sampling_params_list", values["sampling_params_list"])
+        for values, prefix in ((flat, "request"), (nested, "request.extra_body"))
+        if "sampling_params_list" in values
+    ]
+    _reject_duplicates({"sampling_params_list": [source for source, _value in stage_sources]})
+    stage_source, raw_stages = (
+        stage_sources[0]
+        if stage_sources
+        else ("request.sampling_params_list", getattr(request, "sampling_params_list", None))
+    )
+    if raw_stages is not None:
+        if not isinstance(raw_stages, list):
+            raise ValueError(f"{stage_source} must be a JSON array.")
+        if len(raw_stages) > len(params):
+            raise ValueError(
+                f"sampling_params_list has {len(raw_stages)} entries, but the pipeline has {len(params)} stages."
+            )
+        for stage, raw_params in enumerate(raw_stages):
+            stage_values = _mapping(
+                f"{stage_source}[{stage}]",
+                raw_params,
+                required=True,
+            )
+            stage_extras = _mapping(
+                f"{stage_source}[{stage}].extra_args",
+                stage_values.pop("extra_args", None),
+            )
+            is_diffusion = types[stage] == "diffusion"
+            for key in sorted(stage_values):
+                value = stage_values[key]
+                source = f"{stage_source}[{stage}].{key}"
+                if is_diffusion and key in declared:
+                    assignments.add(stage, key, value, source, target="extra_args", keep_none=True)
+                else:
+                    target = sampling_fields.get(key, key) if is_diffusion else key
+                    assignments.add(stage, target, value, source, keep_none=True)
+            for key in sorted(stage_extras):
+                value = stage_extras[key]
+                assignments.add(
+                    stage,
+                    key,
+                    value,
+                    f"{stage_source}[{stage}].extra_args.{key}",
+                    target="extra_args",
+                    keep_none=True,
+                    parse_value=is_diffusion and key in declared,
+                )
+
+    assignments.reject_duplicates()
+    controls.update(
+        {key: _parse(key, value) for key, value in (("height", height), ("width", width)) if value is not None}
+    )
+    if "lora" in root_by_key and root_by_key["lora"][0] is not None:
+        value, source = root_by_key["lora"]
+        try:
+            lora_request, lora_scale = parse_lora_request(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(str(exc)) from exc
+        for stage in diffusion_stages:
+            if lora_request is not None:
+                assignments.add(stage, "lora_request", lora_request, source)
+            if lora_scale is not None:
+                assignments.add(stage, "lora_scale", lora_scale, source)
+
+    assignments.apply()
+    # Source-qualified keys are disjoint; this expansion has no precedence.
+    request_sources = {
+        **{f"request.extra_body.{key}": value for key, value in nested.items()},
+        **{f"request.{key}": value for key, value in flat.items()},
+    }
+    plan = DiffusionChatRequestPlan(
+        controls=MappingProxyType(copy.deepcopy(controls)),
+        request_sources=MappingProxyType(copy.deepcopy(request_sources)),
+        _stage_params=tuple(params),
+    )
+    if invalid_size is not None:
+        logger.warning("Invalid size format: %s", invalid_size)
+    if flat.get("extra_params") is not None or nested.get("extra_params") is not None:
         logger.warning_once(
             "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
         )
-
-    # Duplicate request keys were rejected above, so these mappings are disjoint.
-    return {**legacy, **nested_legacy, **canonical, **nested_canonical}
-
-
-def compile_diffusion_request_overrides(
-    *,
-    root_values: Mapping[str, object],
-    nested_root_values: Mapping[str, object],
-    sampling_root_fields: Mapping[str, str],
-    declared_extra_fields: Collection[str],
-    control_root_fields: Collection[str],
-    extra_args: object | None = None,
-    extra_params: object | None = None,
-    nested_extra_args: object | None = None,
-    nested_extra_params: object | None = None,
-    stage_provided_root_fields: Mapping[int, Collection[str]] | None = None,
-    stage_extra_args: Mapping[int, object | None] | None = None,
-) -> CompiledDiffusionRequestOverrides:
-    """Compile all request roots into their model-aware runtime consumers.
-
-    A model registry declaration owns that root field and routes it to
-    ``extra_args``. Otherwise a serving sampling field routes to its mapped
-    sampling attribute. Control fields remain available to dispatchers even
-    when a model declaration also consumes them. Server defaults are absent
-    because they are not request provenance.
-    """
-    declared_extra_fields = frozenset(declared_extra_fields)
-    effective_sampling_fields = {
-        request_field: sampling_field
-        for request_field, sampling_field in sampling_root_fields.items()
-        if request_field not in declared_extra_fields
-    }
-    control_root_fields = frozenset(control_root_fields)
-    consumed_root_fields = declared_extra_fields | effective_sampling_fields.keys() | control_root_fields
-    filtered_root_values = {key: value for key, value in root_values.items() if key in consumed_root_fields}
-    filtered_nested_root_values = {
-        key: value for key, value in nested_root_values.items() if key in consumed_root_fields
-    }
-
-    normalized_extra_args = normalize_diffusion_request_extra_args(
-        provided_root_fields=filtered_root_values,
-        extra_args=extra_args,
-        extra_params=extra_params,
-        nested_provided_root_fields=filtered_nested_root_values,
-        nested_extra_args=nested_extra_args,
-        nested_extra_params=nested_extra_params,
-        root_field_aliases=effective_sampling_fields,
-        stage_provided_root_fields=stage_provided_root_fields,
-        stage_extra_args=stage_extra_args,
-    )
-
-    request_values: dict[str, object] = {}
-    sampling_overrides: dict[str, object] = {}
-    declared_root_extra_args: dict[str, object] = {}
-    control_overrides: dict[str, object] = {}
-    for source in (filtered_root_values, filtered_nested_root_values):
-        for request_field, value in source.items():
-            if value is None:
-                continue
-            request_values[request_field] = value
-            if request_field in declared_extra_fields:
-                declared_root_extra_args[request_field] = value
-            elif request_field in effective_sampling_fields:
-                sampling_overrides[effective_sampling_fields[request_field]] = value
-            if request_field in control_root_fields:
-                control_overrides[request_field] = value
-
-    # Root declarations and argument containers were proven disjoint above.
-    # The expansion is therefore a set union, not a precedence rule.
-    compiled_extra_args = {
-        **declared_root_extra_args,
-        **normalized_extra_args,
-    }
-    return CompiledDiffusionRequestOverrides(
-        request_values=MappingProxyType(request_values),
-        sampling_overrides=MappingProxyType(sampling_overrides),
-        declared_extra_args=MappingProxyType(declared_root_extra_args),
-        extra_args=MappingProxyType(compiled_extra_args),
-        control_overrides=MappingProxyType(control_overrides),
-    )
+    return plan

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Collection, Mapping
+
+
+def _copy_request_mapping(name: str, value: object | None) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object.")
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{name} must be a JSON object with string keys.")
+    return dict(value)
+
+
+def normalize_diffusion_request_extra_args(
+    *,
+    provided_root_fields: Collection[str] = (),
+    extra_args: object | None = None,
+    extra_params: object | None = None,
+) -> dict[str, object]:
+    """Normalize model-specific diffusion request arguments without overwrites.
+
+    ``provided_root_fields`` must contain only fields explicitly supplied by the
+    caller, not fields populated by request-model defaults. Unknown keys inside
+    ``extra_args`` remain valid because their schema is owned by each pipeline.
+
+    Raises:
+        ValueError: If an extra-argument container is not an object or if the
+            same key is present in more than one request source.
+    """
+    canonical = _copy_request_mapping("extra_args", extra_args)
+    legacy = _copy_request_mapping("extra_params", extra_params)
+
+    sources_by_key: dict[str, list[str]] = {}
+    root_fields = set(provided_root_fields) - {"extra_args", "extra_params"}
+    for key in root_fields:
+        sources_by_key.setdefault(key, []).append(f"request.{key}")
+    for key in canonical:
+        sources_by_key.setdefault(key, []).append(f"request.extra_args.{key}")
+    for key in legacy:
+        sources_by_key.setdefault(key, []).append(f"request.extra_params.{key}")
+
+    conflicts = {key: sources for key, sources in sources_by_key.items() if len(sources) > 1}
+    if conflicts:
+        if len(conflicts) == 1:
+            key, sources = next(iter(conflicts.items()))
+            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(sources)}.')
+        details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
+        raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
+
+    if extra_params is not None:
+        warnings.warn(
+            "extra_params is deprecated; use extra_args for model-specific diffusion request parameters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    return {**legacy, **canonical}

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -3,145 +3,17 @@
 
 from __future__ import annotations
 
-import copy
 from collections.abc import Collection, Mapping
-from dataclasses import dataclass, is_dataclass
-from dataclasses import replace as dataclass_replace
-from functools import partial
-from types import MappingProxyType
-from typing import Any
 
-from vllm import SamplingParams
 from vllm.logger import init_logger
 
-from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
-from vllm_omni.entrypoints.openai.stage_params import get_default_sampling_params_list
-from vllm_omni.entrypoints.openai.utils import (
-    get_stage_type,
-    is_single_stage_diffusion,
-    parse_lora_request,
-    resolve_diffusion_od_config,
-)
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-from vllm_omni.model_extras import (
-    get_extra_body_params,
-    should_init_extra_args_for_non_diffusion_stages,
-)
 
 logger = init_logger(__name__)
 
-_SAMPLING_ROOT_FIELDS = {
-    "height": "height",
-    "width": "width",
-    "num_outputs_per_prompt": "num_outputs_per_prompt",
-    "seed": "seed",
-    "num_inference_steps": "num_inference_steps",
-    "guidance_scale": "guidance_scale",
-    "true_cfg_scale": "true_cfg_scale",
-    "cfg_scale": "true_cfg_scale",
-    "num_frames": "num_frames",
-    "guidance_scale_2": "guidance_scale_2",
-    "layers": "layers",
-    "resolution": "resolution",
-}
-_CONTROL_ROOT_FIELDS = frozenset({"size", "negative_prompt", "lora", "modalities"})
 
-
-def _clone(params: Any, source: str) -> Any:
-    try:
-        cloned = copy.deepcopy(params)
-    except Exception as exc:
-        raise RuntimeError(f"Unable to isolate {source}: {exc}") from exc
-    if cloned is params:
-        raise RuntimeError(f"Unable to isolate {source}: deepcopy returned the original object.")
-    return cloned
-
-
-@dataclass(frozen=True)
-class DiffusionChatRequestPlan:
-    """Final controls and private per-stage parameter prototypes."""
-
-    controls: Mapping[str, object]
-    _stage_params: tuple[Any, ...]
-
-    def clone_sampling_params_list(self) -> list[Any]:
-        """Return isolated parameters for one dispatcher invocation."""
-        return [_clone(params, "sampling parameters") for params in self._stage_params]
-
-
-@dataclass(frozen=True)
-class DiffusionChatRequestContext:
-    """Model topology and request-field policy consumed by the compiler."""
-
-    stage_types: tuple[str, ...]
-    default_sampling_params_list: tuple[object, ...]
-    comprehension_stage_index: int | None
-    standard_sampling_fields: frozenset[str]
-    declared_extra_fields: frozenset[str]
-    apply_declared_to_non_diffusion: bool
-    supported_modalities: frozenset[str]
-
-
-def resolve_diffusion_chat_request_context(
-    *,
-    engine_client: object,
-    diffusion_engine: object | None,
-    diffusion_mode: bool,
-    standard_sampling_fields: Collection[str],
-    declared_extra_fields: Collection[str] | None,
-) -> DiffusionChatRequestContext:
-    """Resolve all model-owned compiler policy from the active topology."""
-    stage_owner = diffusion_engine if diffusion_mode else engine_client
-    stage_configs = list(getattr(stage_owner, "stage_configs", ()) or ())
-    declared = frozenset(declared_extra_fields) if declared_extra_fields is not None else None
-    fan_out_declared = False
-    try:
-        od_config = resolve_diffusion_od_config(engine_client, diffusion_engine)
-        model_class_name = getattr(od_config, "model_class_name", None)
-        if isinstance(model_class_name, str):
-            if declared is None:
-                declared = get_extra_body_params(model_class_name)
-            fan_out_declared = should_init_extra_args_for_non_diffusion_stages(model_class_name)
-    except Exception as exc:
-        raise RuntimeError(f"Failed to resolve diffusion request model extras: {exc}") from exc
-
-    supported_modalities = {
-        modality for modality in getattr(stage_owner, "output_modalities", ()) if modality is not None
-    }
-    if is_single_stage_diffusion(stage_owner):
-        supported_modalities.add("text")
-    return DiffusionChatRequestContext(
-        stage_types=tuple(get_stage_type(stage) for stage in stage_configs),
-        default_sampling_params_list=tuple(get_default_sampling_params_list(stage_owner)),
-        comprehension_stage_index=next(
-            (index for index, stage in enumerate(stage_configs) if getattr(stage, "is_comprehension", False)),
-            None,
-        ),
-        standard_sampling_fields=frozenset(standard_sampling_fields),
-        declared_extra_fields=declared or frozenset(),
-        apply_declared_to_non_diffusion=fan_out_declared,
-        supported_modalities=frozenset(supported_modalities),
-    )
-
-
-@dataclass(frozen=True)
-class _Assignment:
-    key: str
-    target: str
-    value: object
-    source: str
-    parse_value: bool
-
-
-def _mapping(
-    name: str,
-    value: object | None,
-    *,
-    required: bool = False,
-) -> dict[str, object]:
+def _request_mapping(name: str, value: object | None) -> dict[str, object]:
     if value is None:
-        if required:
-            raise ValueError(f"{name} must be a JSON object.")
         return {}
     if not isinstance(value, Mapping):
         raise ValueError(f"{name} must be a JSON object.")
@@ -150,324 +22,72 @@ def _mapping(
     return dict(value)
 
 
-def _reject_duplicates(sources_by_key: Mapping[str, list[str]]) -> None:
-    # Registry fan-out may route one source to two stage consumers; only
-    # distinct request source paths are duplicates.
-    conflicts = {key: list(dict.fromkeys(sources)) for key, sources in sources_by_key.items() if len(set(sources)) > 1}
-    if not conflicts:
-        return
-    if len(conflicts) == 1:
-        key, sources = next(iter(conflicts.items()))
-        raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(sources)}.')
-    details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
-    raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
-
-
-def _parse(key: str, value: object) -> object:
-    if key in {"num_inference_steps", "height", "width", "target_h", "target_w"} and value is not None:
-        try:
-            return int(value)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError(f"{key} must be an integer.") from exc
-    if key == "layers" and value is not None:
-        return validate_layered_layers(value)
-    return value
-
-
-def _stage_params(stage_type: str, default: object | None) -> Any:
-    cls = OmniDiffusionSamplingParams if stage_type == "diffusion" else SamplingParams
-    if default is None:
-        return cls()
-    if isinstance(default, Mapping):
-        try:
-            return cls(**copy.deepcopy(dict(default)))
-        except Exception as exc:
-            raise RuntimeError(f"Invalid default sampling parameters: {exc}") from exc
-    if isinstance(default, cls):
-        return _clone(default, "default sampling parameters")
-    raise RuntimeError(
-        f"Default sampling parameters for {stage_type} stage have incompatible type {type(default).__name__}."
-    )
-
-
-def _replace_params(params: Any, overrides: Mapping[str, object]) -> Any:
-    if is_dataclass(params):
-        return dataclass_replace(params, **overrides)
-    values = {
-        name: getattr(params, name)
-        for name in type(params).__struct_fields__
-        if not name.startswith("_") and name != "output_text_buffer_length"
-    }
-    return type(params)(**(values | overrides))
-
-
-class _PlanBuilder:
-    def __init__(
-        self,
-        request: object,
-        context: DiffusionChatRequestContext,
-    ) -> None:
-        self.request = request
-        self.declared = context.declared_extra_fields
-        self.standard_fields = context.standard_sampling_fields
-        self.sampling_fields = {
-            key: target for key, target in _SAMPLING_ROOT_FIELDS.items() if key not in self.declared
-        }
-        self.fan_out_declared = context.apply_declared_to_non_diffusion
-        self.supported_modalities = context.supported_modalities
-        self.comprehension_stage = context.comprehension_stage_index
-        self.types = list(context.stage_types) or ["diffusion"]
-        self.params = [
-            _stage_params(
-                stage_type,
-                context.default_sampling_params_list[index]
-                if index < len(context.default_sampling_params_list)
-                else None,
-            )
-            for index, stage_type in enumerate(self.types)
-        ]
-        self.diffusion_stages = [index for index, stage_type in enumerate(self.types) if stage_type == "diffusion"]
-        self.items: list[list[_Assignment]] = [[] for _ in self.params]
-        self.claims: list[dict[str, list[str]]] = [{} for _ in self.params]
-
-    def collect_sources(self) -> None:
-        consumed = self.declared | self.sampling_fields.keys() | _CONTROL_ROOT_FIELDS
-        model_extra = getattr(self.request, "model_extra", None)
-        self.flat = dict(model_extra) if isinstance(model_extra, Mapping) else {}
-        nested_value = self.flat.pop("extra_body", None)
-        if nested_value is None:
-            nested_value = getattr(self.request, "extra_body", None)
-        self.nested = _mapping("extra_body", nested_value)
-        explicit = getattr(self.request, "model_fields_set", None)
-        if explicit is None:
-            explicit = getattr(self.request, "__fields_set__", ())
-        self.explicit = set(explicit) if isinstance(explicit, Collection) else set()
-        for key in self.explicit:
-            if key not in self.flat and (
-                key in consumed or key in self.standard_fields or key == "sampling_params_list"
-            ):
-                self.flat[key] = getattr(self.request, key, None)
-
-        self.values: list[tuple[str, object, str, bool]] = [
-            (key, values[key], f"{prefix}.{key}", False)
-            for values, prefix in ((self.flat, "request"), (self.nested, "request.extra_body"))
-            for key in sorted(values)
-            if key in consumed
-        ]
-        for name, value in (
-            ("request.extra_args", self.flat.get("extra_args")),
-            ("request.extra_params", self.flat.get("extra_params")),
-            ("request.extra_body.extra_args", self.nested.get("extra_args")),
-            ("request.extra_body.extra_params", self.nested.get("extra_params")),
-        ):
-            values = _mapping(name.removeprefix("request."), value)
-            self.values.extend((key, values[key], f"{name}.{key}", True) for key in sorted(values))
-
-        claims: dict[str, list[str]] = {}
-        self.by_key: dict[str, tuple[object, str]] = {}
-        for key, value, source, is_container in self.values:
-            conflict_key = key if key in self.declared else _SAMPLING_ROOT_FIELDS.get(key, key)
-            claims.setdefault(conflict_key, []).append(source)
-            if not is_container or key in self.declared:
-                self.by_key[key] = (value, source)
-        _reject_duplicates(claims)
-
-    def validate_sources(self) -> None:
-        self.controls = {
-            key: value
-            for key, (value, _source) in self.by_key.items()
-            if key in _CONTROL_ROOT_FIELDS and key not in {"size", "lora"} and value is not None
-        }
-        modalities = self.controls.get("modalities")
-        if modalities is not None:
-            if not isinstance(modalities, list) or not all(isinstance(modality, str) for modality in modalities):
-                raise ValueError("'modalities' must be a list of strings.")
-            unsupported = set(modalities) - self.supported_modalities
-            if unsupported:
-                raise ValueError(
-                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
-                    f"Supported modalities: {', '.join(sorted(self.supported_modalities))}"
-                )
-
-        self.height = self.by_key.get("height", (None, ""))[0]
-        self.width = self.by_key.get("width", (None, ""))[0]
-        self.invalid_size: object | None = None
-        if "size" in self.by_key and (self.height is None or self.width is None):
-            size, source = self.by_key["size"]
-            try:
-                if isinstance(size, str) and "x" in size.lower():
-                    width, height = (int(part) for part in size.lower().split("x"))
-                    for key, value in (("height", height), ("width", width)):
-                        if getattr(self, key) is None:
-                            setattr(self, key, value)
-                            self.by_key[key] = (value, source)
-                            self.values.append((key, value, source, False))
-            except ValueError:
-                self.invalid_size = size
-        self.controls.update(
-            {
-                key: _parse(key, value)
-                for key, value in (("height", self.height), ("width", self.width))
-                if value is not None
-            }
-        )
-
-    def _assign(
-        self,
-        stages: int | Collection[int],
-        key: str,
-        value: object,
-        source: str,
-        *,
-        target: str | None = None,
-        parse_value: bool = True,
-    ) -> None:
-        for stage in (stages,) if isinstance(stages, int) else stages:
-            self.claims[stage].setdefault(key, []).append(source)
-            self.items[stage].append(
-                _Assignment(
-                    key=key,
-                    target=target or key,
-                    value=value,
-                    source=source,
-                    parse_value=parse_value,
-                )
-            )
-
-    def build_stage_assignments(self) -> None:
-        assign = self._assign
-        extra = partial(assign, target="extra_args")
-        diffusion = self.diffusion_stages
-        declared_stages: Collection[int] = range(len(self.types)) if self.fan_out_declared else diffusion
-        for key, value, source, is_container in self.values:
-            if value is None:
-                continue
-            if key in self.declared:
-                extra(declared_stages, key, value, source)
-            elif is_container:
-                extra(diffusion, key, value, source, parse_value=False)
-            elif key in self.sampling_fields:
-                assign(diffusion, self.sampling_fields[key], value, source)
-
-        stage = self.comprehension_stage
-        if stage is not None:
-            if self.fan_out_declared and self.types[stage] != "diffusion":
-                for key, value, source, _is_container in self.values:
-                    if value is not None and key in self.declared and key in self.standard_fields:
-                        assign(stage, key, value, source)
-            for key in self.standard_fields & self.explicit - self.declared:
-                if self.types[stage] == "diffusion" and key in self.sampling_fields:
-                    continue
-                value = getattr(self.request, key, None)
-                if value is not None and (not isinstance(value, list) or value):
-                    assign(stage, key, value, f"request.{key}")
-            for key, value, source_key in (
-                ("target_h", self.height, "height"),
-                ("target_w", self.width, "width"),
-            ):
-                if value is not None:
-                    extra(stage, key, value, self.by_key[source_key][1])
-
-        stage_sources = [
-            (f"{prefix}.sampling_params_list", values["sampling_params_list"])
-            for values, prefix in ((self.flat, "request"), (self.nested, "request.extra_body"))
-            if "sampling_params_list" in values
-        ]
-        _reject_duplicates({"sampling_params_list": [source for source, _value in stage_sources]})
-        stage_source, raw_stages = (
-            stage_sources[0]
-            if stage_sources
-            else ("request.sampling_params_list", getattr(self.request, "sampling_params_list", None))
-        )
-        if raw_stages is not None:
-            if not isinstance(raw_stages, list):
-                raise ValueError(f"{stage_source} must be a JSON array.")
-            if len(raw_stages) > len(self.params):
-                raise ValueError(
-                    f"sampling_params_list has {len(raw_stages)} entries, "
-                    f"but the pipeline has {len(self.params)} stages."
-                )
-            for stage, raw_params in enumerate(raw_stages):
-                values = _mapping(f"{stage_source}[{stage}]", raw_params, required=True)
-                extras = _mapping(f"{stage_source}[{stage}].extra_args", values.pop("extra_args", None))
-                is_diffusion = self.types[stage] == "diffusion"
-                for key in sorted(values):
-                    target = "extra_args" if is_diffusion and key in self.declared else None
-                    claim = self.sampling_fields.get(key, key) if is_diffusion and target is None else key
-                    assign(stage, claim, values[key], f"{stage_source}[{stage}].{key}", target=target)
-                for key in sorted(extras):
-                    extra(
-                        stage,
-                        key,
-                        extras[key],
-                        f"{stage_source}[{stage}].extra_args.{key}",
-                        parse_value=is_diffusion and key in self.declared,
-                    )
-
-        for claims in self.claims:
-            _reject_duplicates(claims)
-        if "lora" in self.by_key and self.by_key["lora"][0] is not None:
-            value, source = self.by_key["lora"]
-            try:
-                lora_request, lora_scale = parse_lora_request(value)
-            except (TypeError, ValueError, OverflowError) as exc:
-                raise ValueError(str(exc)) from exc
-            if lora_request is not None:
-                assign(diffusion, "lora_request", lora_request, source)
-            if lora_scale is not None:
-                assign(diffusion, "lora_scale", lora_scale, source)
-
-    def apply_assignments(self) -> None:
-        for claims in self.claims:
-            _reject_duplicates(claims)
-        for stage, (params, items) in enumerate(zip(self.params, self.items)):
-            overrides: dict[str, object] = {}
-            extra_args: dict[str, object] = {}
-            for assignment in items:
-                if assignment.target == "extra_args":
-                    if not hasattr(params, "extra_args"):
-                        raise ValueError(f"{assignment.source} is not supported by stage {stage}.")
-                    destination = extra_args
-                elif hasattr(params, assignment.target):
-                    destination = overrides
-                else:
-                    raise ValueError(
-                        f'{assignment.source} targets unsupported parameter "{assignment.target}" for stage {stage}.'
-                    )
-                destination[assignment.key if assignment.target == "extra_args" else assignment.target] = (
-                    _parse(assignment.key, assignment.value) if assignment.parse_value else assignment.value
-                )
-            if not overrides and not extra_args:
-                continue
-            if extra_args:
-                overrides["extra_args"] = {
-                    **(getattr(params, "extra_args", None) or {}),
-                    **extra_args,
-                }
-            try:
-                self.params[stage] = _replace_params(params, overrides)
-            except Exception as exc:
-                raise ValueError(f"Invalid sampling parameters for stage {stage}: {exc}") from exc
-
-
-def compile_diffusion_chat_request_plan(
+def normalize_diffusion_request_extra_args(
     *,
-    request: object,
-    context: DiffusionChatRequestContext,
-) -> DiffusionChatRequestPlan:
-    """Compile all Chat request sources into final typed stage parameters."""
-    builder = _PlanBuilder(request, context)
-    builder.collect_sources()
-    builder.validate_sources()
-    builder.build_stage_assignments()
-    builder.apply_assignments()
-    if builder.invalid_size is not None:
-        logger.warning("Invalid size format: %s", builder.invalid_size)
-    if builder.flat.get("extra_params") is not None or builder.nested.get("extra_params") is not None:
+    provided_root_fields: Collection[str] = (),
+    root_extra_args: object | None = None,
+    extra_args: object | None = None,
+    extra_params: object | None = None,
+    nested_provided_root_fields: Collection[str] = (),
+    nested_root_extra_args: object | None = None,
+    nested_extra_args: object | None = None,
+    nested_extra_params: object | None = None,
+    root_field_aliases: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Normalize model-specific request extras without implicit precedence."""
+    root = _request_mapping("root_extra_args", root_extra_args)
+    nested_root = _request_mapping("nested_root_extra_args", nested_root_extra_args)
+    canonical = _request_mapping("extra_args", extra_args)
+    legacy = _request_mapping("extra_params", extra_params)
+    nested_canonical = _request_mapping("extra_body.extra_args", nested_extra_args)
+    nested_legacy = _request_mapping("extra_body.extra_params", nested_extra_params)
+
+    aliases = root_field_aliases or {}
+    sources_by_key: dict[str, list[str]] = {}
+    sources = (
+        ((set(provided_root_fields) | root.keys()), "request"),
+        ((set(nested_provided_root_fields) | nested_root.keys()), "request.extra_body"),
+        (canonical, "request.extra_args"),
+        (legacy, "request.extra_params"),
+        (nested_canonical, "request.extra_body.extra_args"),
+        (nested_legacy, "request.extra_body.extra_params"),
+    )
+    for keys, prefix in sources:
+        for key in sorted(keys):
+            sources_by_key.setdefault(aliases.get(key, key), []).append(f"{prefix}.{key}")
+
+    conflicts = {key: list(dict.fromkeys(paths)) for key, paths in sources_by_key.items() if len(set(paths)) > 1}
+    if conflicts:
+        if len(conflicts) == 1:
+            key, paths = next(iter(conflicts.items()))
+            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(paths)}.')
+        details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
+        raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
+
+    if extra_params is not None or nested_extra_params is not None:
         logger.warning_once(
             "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
         )
-    return DiffusionChatRequestPlan(
-        controls=MappingProxyType(copy.deepcopy(builder.controls)),
-        _stage_params=tuple(builder.params),
-    )
+
+    # Duplicate request keys were rejected above, so ordering is not precedence.
+    normalized = {
+        **nested_root,
+        **root,
+        **legacy,
+        **nested_legacy,
+        **canonical,
+        **nested_canonical,
+    }
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def apply_normalized_diffusion_request_extra_args(
+    sampling_params: OmniDiffusionSamplingParams,
+    normalized_extra_args: Mapping[str, object],
+) -> None:
+    """Overlay request extras without discarding stage defaults."""
+    if normalized_extra_args:
+        sampling_params.extra_args = {
+            **(sampling_params.extra_args or {}),
+            **normalized_extra_args,
+        }

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -7,6 +7,7 @@ import copy
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, is_dataclass
 from dataclasses import replace as dataclass_replace
+from functools import partial
 from types import MappingProxyType
 from typing import Any
 
@@ -73,12 +74,7 @@ def _reject_duplicates(sources_by_key: Mapping[str, list[str]]) -> None:
 
 
 def _parse(key: str, value: object) -> object:
-    if key == "num_inference_steps" and value is not None:
-        try:
-            return int(value)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError("num_inference_steps must be an integer.") from exc
-    if key in {"height", "width", "target_h", "target_w"} and value is not None:
+    if key in {"num_inference_steps", "height", "width", "target_h", "target_w"} and value is not None:
         try:
             return int(value)
         except (TypeError, ValueError, OverflowError) as exc:
@@ -115,42 +111,224 @@ def _replace_params(params: Any, overrides: Mapping[str, object]) -> Any:
     return type(params)(**(values | overrides))
 
 
-class _Assignments:
-    """Collect provenance, then build final typed stages from cloned defaults."""
-
-    def __init__(self, params: list[Any]) -> None:
-        self.params = params
-        self.items: list[tuple[int, str, str, object, str, bool, bool]] = []
-
-    def add(
+class _PlanBuilder:
+    def __init__(
         self,
-        stage: int,
+        request: object,
+        stage_types: Sequence[str],
+        defaults: Sequence[object],
+        comprehension_stage: int | None,
+        root_fields: Mapping[str, str],
+        standard_fields: Collection[str],
+        control_fields: Collection[str],
+        declared_fields: Collection[str],
+        fan_out_declared: bool,
+        supported_modalities: Collection[str],
+    ) -> None:
+        self.request = request
+        self.declared = frozenset(declared_fields)
+        self.root_fields = root_fields
+        self.standard_fields = frozenset(standard_fields)
+        self.control_fields = frozenset(control_fields)
+        self.sampling_fields = {key: target for key, target in root_fields.items() if key not in self.declared}
+        self.fan_out_declared = fan_out_declared
+        self.supported_modalities = frozenset(supported_modalities)
+        self.comprehension_stage = comprehension_stage
+        self.types = list(stage_types) or ["diffusion"]
+        self.params = [
+            _stage_params(stage_type, defaults[index] if index < len(defaults) else None)
+            for index, stage_type in enumerate(self.types)
+        ]
+        self.diffusion_stages = [index for index, stage_type in enumerate(self.types) if stage_type == "diffusion"]
+        self.items: list[list[tuple[str, str, object, str, bool]]] = [[] for _ in self.params]
+        self.claims: list[dict[str, list[str]]] = [{} for _ in self.params]
+
+    def collect_sources(self) -> None:
+        consumed = self.declared | self.sampling_fields.keys() | self.control_fields
+        model_extra = getattr(self.request, "model_extra", None)
+        self.flat = dict(model_extra) if isinstance(model_extra, Mapping) else {}
+        nested_value = self.flat.pop("extra_body", None)
+        if nested_value is None:
+            nested_value = getattr(self.request, "extra_body", None)
+        self.nested = _mapping("extra_body", nested_value)
+        explicit = getattr(self.request, "model_fields_set", None)
+        if explicit is None:
+            explicit = getattr(self.request, "__fields_set__", ())
+        self.explicit = set(explicit) if isinstance(explicit, Collection) else set()
+        for key in self.explicit:
+            if key not in self.flat and (
+                key in consumed or key in self.standard_fields or key == "sampling_params_list"
+            ):
+                self.flat[key] = getattr(self.request, key, None)
+
+        self.values: list[tuple[str, object, str, bool]] = [
+            (key, values[key], f"{prefix}.{key}", False)
+            for values, prefix in ((self.flat, "request"), (self.nested, "request.extra_body"))
+            for key in sorted(values)
+            if key in consumed
+        ]
+        for name, value in (
+            ("request.extra_args", self.flat.get("extra_args")),
+            ("request.extra_params", self.flat.get("extra_params")),
+            ("request.extra_body.extra_args", self.nested.get("extra_args")),
+            ("request.extra_body.extra_params", self.nested.get("extra_params")),
+        ):
+            values = _mapping(name.removeprefix("request."), value)
+            self.values.extend((key, values[key], f"{name}.{key}", True) for key in sorted(values))
+
+        claims: dict[str, list[str]] = {}
+        self.by_key: dict[str, tuple[object, str]] = {}
+        for key, value, source, is_container in self.values:
+            conflict_key = key if key in self.declared else self.root_fields.get(key, key)
+            claims.setdefault(conflict_key, []).append(source)
+            if not is_container or key in self.declared:
+                self.by_key[key] = (value, source)
+        _reject_duplicates(claims)
+
+    def validate_sources(self) -> None:
+        self.controls = {
+            key: value
+            for key, (value, _source) in self.by_key.items()
+            if key in self.control_fields and key not in {"size", "lora"} and value is not None
+        }
+        modalities = self.controls.get("modalities")
+        if modalities is not None:
+            if not isinstance(modalities, list) or not all(isinstance(modality, str) for modality in modalities):
+                raise ValueError("'modalities' must be a list of strings.")
+            unsupported = set(modalities) - self.supported_modalities
+            if unsupported:
+                raise ValueError(
+                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
+                    f"Supported modalities: {', '.join(sorted(self.supported_modalities))}"
+                )
+
+        self.height = self.by_key.get("height", (None, ""))[0]
+        self.width = self.by_key.get("width", (None, ""))[0]
+        self.invalid_size: object | None = None
+        if "size" in self.by_key and (self.height is None or self.width is None):
+            size, source = self.by_key["size"]
+            try:
+                if isinstance(size, str) and "x" in size.lower():
+                    width, height = (int(part) for part in size.lower().split("x"))
+                    for key, value in (("height", height), ("width", width)):
+                        if getattr(self, key) is None:
+                            setattr(self, key, value)
+                            self.by_key[key] = (value, source)
+                            self.values.append((key, value, source, False))
+            except ValueError:
+                self.invalid_size = size
+        self.controls.update(
+            {
+                key: _parse(key, value)
+                for key, value in (("height", self.height), ("width", self.width))
+                if value is not None
+            }
+        )
+
+    def _assign(
+        self,
+        stages: int | Collection[int],
         key: str,
         value: object,
         source: str,
         *,
         target: str | None = None,
-        keep_none: bool = False,
         parse_value: bool = True,
     ) -> None:
-        self.items.append((stage, key, target or key, value, source, keep_none, parse_value))
+        for stage in (stages,) if isinstance(stages, int) else stages:
+            self.claims[stage].setdefault(key, []).append(source)
+            self.items[stage].append((key, target or key, value, source, parse_value))
 
-    def reject_duplicates(self) -> None:
-        for stage in range(len(self.params)):
-            claims: dict[str, list[str]] = {}
-            for claimed_stage, key, _target, _value, source, _keep_none, _parse_value in self.items:
-                if claimed_stage == stage:
-                    claims.setdefault(key, []).append(source)
+    def build_stage_assignments(self) -> None:
+        assign = self._assign
+        extra = partial(assign, target="extra_args")
+        diffusion = self.diffusion_stages
+        declared_stages: Collection[int] = range(len(self.types)) if self.fan_out_declared else diffusion
+        for key, value, source, is_container in self.values:
+            if value is None and (not is_container or key in self.declared):
+                continue
+            if key in self.declared:
+                extra(declared_stages, key, value, source)
+            elif is_container:
+                extra(diffusion, key, value, source, parse_value=False)
+            elif key in self.sampling_fields:
+                assign(diffusion, self.sampling_fields[key], value, source)
+
+        stage = self.comprehension_stage
+        if stage is not None:
+            if self.fan_out_declared and self.types[stage] != "diffusion":
+                for key, value, source, _is_container in self.values:
+                    if value is not None and key in self.declared and key in self.standard_fields:
+                        assign(stage, key, value, source)
+            for key in self.standard_fields & self.explicit - self.declared:
+                if self.types[stage] == "diffusion" and key in self.sampling_fields:
+                    continue
+                value = getattr(self.request, key, None)
+                if value is not None and (not isinstance(value, list) or value):
+                    assign(stage, key, value, f"request.{key}")
+            for key, value, source_key in (
+                ("target_h", self.height, "height"),
+                ("target_w", self.width, "width"),
+            ):
+                if value is not None:
+                    extra(stage, key, value, self.by_key[source_key][1])
+
+        stage_sources = [
+            (f"{prefix}.sampling_params_list", values["sampling_params_list"])
+            for values, prefix in ((self.flat, "request"), (self.nested, "request.extra_body"))
+            if "sampling_params_list" in values
+        ]
+        _reject_duplicates({"sampling_params_list": [source for source, _value in stage_sources]})
+        stage_source, raw_stages = (
+            stage_sources[0]
+            if stage_sources
+            else ("request.sampling_params_list", getattr(self.request, "sampling_params_list", None))
+        )
+        if raw_stages is not None:
+            if not isinstance(raw_stages, list):
+                raise ValueError(f"{stage_source} must be a JSON array.")
+            if len(raw_stages) > len(self.params):
+                raise ValueError(
+                    f"sampling_params_list has {len(raw_stages)} entries, "
+                    f"but the pipeline has {len(self.params)} stages."
+                )
+            for stage, raw_params in enumerate(raw_stages):
+                values = _mapping(f"{stage_source}[{stage}]", raw_params, required=True)
+                extras = _mapping(f"{stage_source}[{stage}].extra_args", values.pop("extra_args", None))
+                is_diffusion = self.types[stage] == "diffusion"
+                for key in sorted(values):
+                    target = "extra_args" if is_diffusion and key in self.declared else None
+                    claim = self.sampling_fields.get(key, key) if is_diffusion and target is None else key
+                    assign(stage, claim, values[key], f"{stage_source}[{stage}].{key}", target=target)
+                for key in sorted(extras):
+                    extra(
+                        stage,
+                        key,
+                        extras[key],
+                        f"{stage_source}[{stage}].extra_args.{key}",
+                        parse_value=is_diffusion and key in self.declared,
+                    )
+
+        for claims in self.claims:
             _reject_duplicates(claims)
+        if "lora" in self.by_key and self.by_key["lora"][0] is not None:
+            value, source = self.by_key["lora"]
+            try:
+                lora_request, lora_scale = parse_lora_request(value)
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError(str(exc)) from exc
+            if lora_request is not None:
+                assign(diffusion, "lora_request", lora_request, source)
+            if lora_scale is not None:
+                assign(diffusion, "lora_scale", lora_scale, source)
 
-    def apply(self) -> None:
-        self.reject_duplicates()
-        for stage, params in enumerate(self.params):
+    def apply_assignments(self) -> None:
+        for claims in self.claims:
+            _reject_duplicates(claims)
+        for stage, (params, items) in enumerate(zip(self.params, self.items)):
             overrides: dict[str, object] = {}
             extra_args: dict[str, object] = {}
-            for item_stage, key, target, value, source, keep_none, parse_value in self.items:
-                if item_stage != stage or (value is None and not keep_none):
-                    continue
+            for key, target, value, source, parse_value in items:
                 if target == "extra_args":
                     if not hasattr(params, "extra_args"):
                         raise ValueError(f"{source} is not supported by stage {stage}.")
@@ -187,231 +365,29 @@ def compile_diffusion_chat_request_plan(
     supported_modalities: Collection[str],
 ) -> DiffusionChatRequestPlan:
     """Compile all Chat request sources into final typed stage parameters."""
-    declared = frozenset(declared_extra_fields)
-    controls_fields = frozenset(control_root_fields)
-    sampling_fields = {
-        request_key: target_key
-        for request_key, target_key in sampling_root_fields.items()
-        if request_key not in declared
-    }
-    consumed = declared | sampling_fields.keys() | controls_fields
-
-    model_extra = getattr(request, "model_extra", None)
-    flat = dict(model_extra) if isinstance(model_extra, Mapping) else {}
-    nested_value = flat.pop("extra_body", None)
-    if nested_value is None:
-        nested_value = getattr(request, "extra_body", None)
-    nested = _mapping("extra_body", nested_value)
-
-    explicit = getattr(request, "model_fields_set", None)
-    if explicit is None:
-        explicit = getattr(request, "__fields_set__", ())
-    explicit = set(explicit) if isinstance(explicit, Collection) else set()
-    for key in explicit:
-        if key not in flat and (key in consumed or key in standard_sampling_fields or key == "sampling_params_list"):
-            flat[key] = getattr(request, key, None)
-
-    roots: list[tuple[str, object, str]] = []
-    for values, prefix in ((flat, "request"), (nested, "request.extra_body")):
-        roots.extend((key, values[key], f"{prefix}.{key}") for key in sorted(values) if key in consumed)
-
-    raw_containers = (
-        ("request.extra_args", flat.get("extra_args")),
-        ("request.extra_params", flat.get("extra_params")),
-        ("request.extra_body.extra_args", nested.get("extra_args")),
-        ("request.extra_body.extra_params", nested.get("extra_params")),
+    builder = _PlanBuilder(
+        request,
+        stage_types,
+        default_sampling_params_list,
+        comprehension_stage_index,
+        sampling_root_fields,
+        standard_sampling_fields,
+        control_root_fields,
+        declared_extra_fields,
+        apply_declared_to_non_diffusion,
+        supported_modalities,
     )
-    containers = [(name, _mapping(name.removeprefix("request."), value)) for name, value in raw_containers]
-    global_values = [(key, value, source, False) for key, value, source in roots]
-    global_values.extend(
-        (key, values[key], f"{name}.{key}", True) for name, values in containers for key in sorted(values)
-    )
-    global_claims: dict[str, list[str]] = {}
-    for key, _value, source, _is_container in global_values:
-        conflict_key = key if key in declared else sampling_root_fields.get(key, key)
-        global_claims.setdefault(conflict_key, []).append(source)
-    _reject_duplicates(global_claims)
-
-    types = list(stage_types) or ["diffusion"]
-    params = [
-        _stage_params(
-            stage_type,
-            default_sampling_params_list[index] if index < len(default_sampling_params_list) else None,
-        )
-        for index, stage_type in enumerate(types)
-    ]
-    diffusion_stages = [index for index, stage_type in enumerate(types) if stage_type == "diffusion"]
-    assignments = _Assignments(params)
-    serving_by_key = {
-        key: (value, source)
-        for key, value, source, is_container in global_values
-        if not is_container or key in declared
-    }
-
-    controls = {
-        key: value
-        for key, (value, _source) in serving_by_key.items()
-        if key in controls_fields and key not in {"size", "lora"} and value is not None
-    }
-    modalities = controls.get("modalities")
-    if modalities is not None and (
-        not isinstance(modalities, list) or not all(isinstance(modality, str) for modality in modalities)
-    ):
-        raise ValueError("'modalities' must be a list of strings.")
-    if modalities is not None:
-        allowed = set(supported_modalities)
-        unsupported = set(modalities) - allowed
-        if unsupported:
-            raise ValueError(
-                f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
-                f"Supported modalities: {', '.join(sorted(allowed))}"
-            )
-    height = serving_by_key.get("height", (None, ""))[0]
-    width = serving_by_key.get("width", (None, ""))[0]
-    invalid_size: object | None = None
-    if "size" in serving_by_key and (height is None or width is None):
-        size, source = serving_by_key["size"]
-        try:
-            if isinstance(size, str) and "x" in size.lower():
-                parsed_width, parsed_height = (int(part) for part in size.lower().split("x"))
-                if height is None:
-                    height = parsed_height
-                    serving_by_key["height"] = (height, source)
-                    global_values.append(("height", height, source, False))
-                if width is None:
-                    width = parsed_width
-                    serving_by_key["width"] = (width, source)
-                    global_values.append(("width", width, source, False))
-        except ValueError:
-            invalid_size = size
-
-    for request_key, value, source, is_container in global_values:
-        if request_key in declared:
-            targets = list(range(len(types))) if apply_declared_to_non_diffusion else diffusion_stages
-            for stage in targets:
-                assignments.add(
-                    stage,
-                    request_key,
-                    value,
-                    source,
-                    target="extra_args",
-                )
-        elif is_container:
-            for stage in diffusion_stages:
-                assignments.add(
-                    stage,
-                    request_key,
-                    value,
-                    source,
-                    target="extra_args",
-                    keep_none=True,
-                    parse_value=False,
-                )
-        elif request_key in sampling_fields:
-            target = sampling_fields[request_key]
-            for stage in diffusion_stages:
-                assignments.add(stage, target, value, source)
-
-    if comprehension_stage_index is not None:
-        if apply_declared_to_non_diffusion and types[comprehension_stage_index] != "diffusion":
-            for key, value, source, _is_container in global_values:
-                if key in declared and key in standard_sampling_fields:
-                    assignments.add(comprehension_stage_index, key, value, source)
-        for key in standard_sampling_fields:
-            if key not in explicit:
-                continue
-            if key in declared:
-                continue
-            if types[comprehension_stage_index] == "diffusion" and key in sampling_fields:
-                continue
-            value = getattr(request, key, None)
-            if not isinstance(value, list) or value:
-                assignments.add(comprehension_stage_index, key, value, f"request.{key}")
-        for key, value in (("target_h", height), ("target_w", width)):
-            if value is not None:
-                source_key = "height" if key == "target_h" else "width"
-                assignments.add(
-                    comprehension_stage_index,
-                    key,
-                    value,
-                    serving_by_key[source_key][1],
-                    target="extra_args",
-                )
-
-    stage_sources = [
-        (f"{prefix}.sampling_params_list", values["sampling_params_list"])
-        for values, prefix in ((flat, "request"), (nested, "request.extra_body"))
-        if "sampling_params_list" in values
-    ]
-    _reject_duplicates({"sampling_params_list": [source for source, _value in stage_sources]})
-    stage_source, raw_stages = (
-        stage_sources[0]
-        if stage_sources
-        else ("request.sampling_params_list", getattr(request, "sampling_params_list", None))
-    )
-    if raw_stages is not None:
-        if not isinstance(raw_stages, list):
-            raise ValueError(f"{stage_source} must be a JSON array.")
-        if len(raw_stages) > len(params):
-            raise ValueError(
-                f"sampling_params_list has {len(raw_stages)} entries, but the pipeline has {len(params)} stages."
-            )
-        for stage, raw_params in enumerate(raw_stages):
-            stage_values = _mapping(
-                f"{stage_source}[{stage}]",
-                raw_params,
-                required=True,
-            )
-            stage_extras = _mapping(
-                f"{stage_source}[{stage}].extra_args",
-                stage_values.pop("extra_args", None),
-            )
-            is_diffusion = types[stage] == "diffusion"
-            for key in sorted(stage_values):
-                value = stage_values[key]
-                source = f"{stage_source}[{stage}].{key}"
-                if is_diffusion and key in declared:
-                    assignments.add(stage, key, value, source, target="extra_args", keep_none=True)
-                else:
-                    target = sampling_fields.get(key, key) if is_diffusion else key
-                    assignments.add(stage, target, value, source, keep_none=True)
-            for key in sorted(stage_extras):
-                value = stage_extras[key]
-                assignments.add(
-                    stage,
-                    key,
-                    value,
-                    f"{stage_source}[{stage}].extra_args.{key}",
-                    target="extra_args",
-                    keep_none=True,
-                    parse_value=is_diffusion and key in declared,
-                )
-
-    assignments.reject_duplicates()
-    controls.update(
-        {key: _parse(key, value) for key, value in (("height", height), ("width", width)) if value is not None}
-    )
-    if "lora" in serving_by_key and serving_by_key["lora"][0] is not None:
-        value, source = serving_by_key["lora"]
-        try:
-            lora_request, lora_scale = parse_lora_request(value)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError(str(exc)) from exc
-        for stage in diffusion_stages:
-            if lora_request is not None:
-                assignments.add(stage, "lora_request", lora_request, source)
-            if lora_scale is not None:
-                assignments.add(stage, "lora_scale", lora_scale, source)
-
-    assignments.apply()
-    plan = DiffusionChatRequestPlan(
-        controls=MappingProxyType(copy.deepcopy(controls)),
-        _stage_params=tuple(params),
-    )
-    if invalid_size is not None:
-        logger.warning("Invalid size format: %s", invalid_size)
-    if flat.get("extra_params") is not None or nested.get("extra_params") is not None:
+    builder.collect_sources()
+    builder.validate_sources()
+    builder.build_stage_assignments()
+    builder.apply_assignments()
+    if builder.invalid_size is not None:
+        logger.warning("Invalid size format: %s", builder.invalid_size)
+    if builder.flat.get("extra_params") is not None or builder.nested.get("extra_params") is not None:
         logger.warning_once(
             "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
         )
-    return plan
+    return DiffusionChatRequestPlan(
+        controls=MappingProxyType(copy.deepcopy(builder.controls)),
+        _stage_params=tuple(builder.params),
+    )

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Collection, Mapping, Sequence
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, is_dataclass
+from dataclasses import replace as dataclass_replace
 from types import MappingProxyType
 from typing import Any
 
@@ -34,7 +35,6 @@ class DiffusionChatRequestPlan:
     """Final controls and private per-stage parameter prototypes."""
 
     controls: Mapping[str, object]
-    request_sources: Mapping[str, object]
     _stage_params: tuple[Any, ...]
 
     def clone_sampling_params_list(self) -> list[Any]:
@@ -104,15 +104,15 @@ def _stage_params(stage_type: str, default: object | None) -> Any:
     )
 
 
-def _init_values(params: Any) -> dict[str, object]:
+def _replace_params(params: Any, overrides: Mapping[str, object]) -> Any:
     if is_dataclass(params):
-        names = [field.name for field in fields(params) if field.init]
-    else:
-        names = list(getattr(type(params), "__struct_fields__", ()))
-        if not names:
-            names = list(getattr(params, "__dict__", ()))
-        names = [name for name in names if not name.startswith("_") and name != "output_text_buffer_length"]
-    return {name: getattr(params, name) for name in names}
+        return dataclass_replace(params, **overrides)
+    values = {
+        name: getattr(params, name)
+        for name in type(params).__struct_fields__
+        if not name.startswith("_") and name != "output_text_buffer_length"
+    }
+    return type(params)(**(values | overrides))
 
 
 class _Assignments:
@@ -168,7 +168,7 @@ class _Assignments:
                     **extra_args,
                 }
             try:
-                self.params[stage] = type(params)(**{**_init_values(params), **overrides})
+                self.params[stage] = _replace_params(params, overrides)
             except Exception as exc:
                 raise ValueError(f"Invalid sampling parameters for stage {stage}: {exc}") from exc
 
@@ -184,6 +184,7 @@ def compile_diffusion_chat_request_plan(
     control_root_fields: Collection[str],
     declared_extra_fields: Collection[str],
     apply_declared_to_non_diffusion: bool,
+    supported_modalities: Collection[str],
 ) -> DiffusionChatRequestPlan:
     """Compile all Chat request sources into final typed stage parameters."""
     declared = frozenset(declared_extra_fields)
@@ -257,6 +258,14 @@ def compile_diffusion_chat_request_plan(
         not isinstance(modalities, list) or not all(isinstance(modality, str) for modality in modalities)
     ):
         raise ValueError("'modalities' must be a list of strings.")
+    if modalities is not None:
+        allowed = set(supported_modalities)
+        unsupported = set(modalities) - allowed
+        if unsupported:
+            raise ValueError(
+                f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
+                f"Supported modalities: {', '.join(sorted(allowed))}"
+            )
     height = serving_by_key.get("height", (None, ""))[0]
     width = serving_by_key.get("width", (None, ""))[0]
     invalid_size: object | None = None
@@ -395,14 +404,8 @@ def compile_diffusion_chat_request_plan(
                 assignments.add(stage, "lora_scale", lora_scale, source)
 
     assignments.apply()
-    # Source-qualified keys are disjoint; this expansion has no precedence.
-    request_sources = {
-        **{f"request.extra_body.{key}": value for key, value in nested.items()},
-        **{f"request.{key}": value for key, value in flat.items()},
-    }
     plan = DiffusionChatRequestPlan(
         controls=MappingProxyType(copy.deepcopy(controls)),
-        request_sources=MappingProxyType(copy.deepcopy(request_sources)),
         _stage_params=tuple(params),
     )
     if invalid_size is not None:

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -22,6 +22,9 @@ def normalize_diffusion_request_extra_args(
     provided_root_fields: Collection[str] = (),
     extra_args: object | None = None,
     extra_params: object | None = None,
+    nested_provided_root_fields: Collection[str] = (),
+    nested_extra_args: object | None = None,
+    nested_extra_params: object | None = None,
 ) -> dict[str, object]:
     """Normalize model-specific diffusion request arguments without overwrites.
 
@@ -35,15 +38,24 @@ def normalize_diffusion_request_extra_args(
     """
     canonical = _copy_request_mapping("extra_args", extra_args)
     legacy = _copy_request_mapping("extra_params", extra_params)
+    nested_canonical = _copy_request_mapping("extra_body.extra_args", nested_extra_args)
+    nested_legacy = _copy_request_mapping("extra_body.extra_params", nested_extra_params)
 
     sources_by_key: dict[str, list[str]] = {}
     root_fields = set(provided_root_fields) - {"extra_args", "extra_params"}
     for key in root_fields:
         sources_by_key.setdefault(key, []).append(f"request.{key}")
+    nested_root_fields = set(nested_provided_root_fields) - {"extra_args", "extra_params"}
+    for key in nested_root_fields:
+        sources_by_key.setdefault(key, []).append(f"request.extra_body.{key}")
     for key in canonical:
         sources_by_key.setdefault(key, []).append(f"request.extra_args.{key}")
     for key in legacy:
         sources_by_key.setdefault(key, []).append(f"request.extra_params.{key}")
+    for key in nested_canonical:
+        sources_by_key.setdefault(key, []).append(f"request.extra_body.extra_args.{key}")
+    for key in nested_legacy:
+        sources_by_key.setdefault(key, []).append(f"request.extra_body.extra_params.{key}")
 
     conflicts = {key: sources for key, sources in sources_by_key.items() if len(sources) > 1}
     if conflicts:
@@ -53,11 +65,11 @@ def normalize_diffusion_request_extra_args(
         details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
         raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
 
-    if extra_params is not None:
+    if extra_params is not None or nested_extra_params is not None:
         warnings.warn(
             "extra_params is deprecated; use extra_args for model-specific diffusion request parameters.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 
-    return {**legacy, **canonical}
+    return {**legacy, **nested_legacy, **canonical, **nested_canonical}

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -221,12 +221,14 @@ def compile_diffusion_chat_request_plan(
         ("request.extra_body.extra_params", nested.get("extra_params")),
     )
     containers = [(name, _mapping(name.removeprefix("request."), value)) for name, value in raw_containers]
+    global_values = [(key, value, source, False) for key, value, source in roots]
+    global_values.extend(
+        (key, values[key], f"{name}.{key}", True) for name, values in containers for key in sorted(values)
+    )
     global_claims: dict[str, list[str]] = {}
-    for key, _value, source in roots:
-        global_claims.setdefault(sampling_fields.get(key, key), []).append(source)
-    for name, values in containers:
-        for key in values:
-            global_claims.setdefault(key, []).append(f"{name}.{key}")
+    for key, _value, source, _is_container in global_values:
+        conflict_key = key if key in declared else sampling_root_fields.get(key, key)
+        global_claims.setdefault(conflict_key, []).append(source)
     _reject_duplicates(global_claims)
 
     types = list(stage_types) or ["diffusion"]
@@ -239,63 +241,75 @@ def compile_diffusion_chat_request_plan(
     ]
     diffusion_stages = [index for index, stage_type in enumerate(types) if stage_type == "diffusion"]
     assignments = _Assignments(params)
-    root_by_key = {key: (value, source) for key, value, source in roots}
+    serving_by_key = {
+        key: (value, source)
+        for key, value, source, is_container in global_values
+        if not is_container or key in declared
+    }
 
     controls = {
         key: value
-        for key, (value, _source) in root_by_key.items()
+        for key, (value, _source) in serving_by_key.items()
         if key in controls_fields and key not in {"size", "lora"} and value is not None
     }
-    height = root_by_key.get("height", (None, ""))[0]
-    width = root_by_key.get("width", (None, ""))[0]
+    modalities = controls.get("modalities")
+    if modalities is not None and (
+        not isinstance(modalities, list) or not all(isinstance(modality, str) for modality in modalities)
+    ):
+        raise ValueError("'modalities' must be a list of strings.")
+    height = serving_by_key.get("height", (None, ""))[0]
+    width = serving_by_key.get("width", (None, ""))[0]
     invalid_size: object | None = None
-    if "size" in root_by_key and (height is None or width is None):
-        size, source = root_by_key["size"]
+    if "size" in serving_by_key and (height is None or width is None):
+        size, source = serving_by_key["size"]
         try:
             if isinstance(size, str) and "x" in size.lower():
                 parsed_width, parsed_height = (int(part) for part in size.lower().split("x"))
                 if height is None:
                     height = parsed_height
-                    root_by_key["height"] = (height, source)
+                    serving_by_key["height"] = (height, source)
                 if width is None:
                     width = parsed_width
-                    root_by_key["width"] = (width, source)
+                    serving_by_key["width"] = (width, source)
         except ValueError:
             invalid_size = size
 
-    for request_key, (value, source) in root_by_key.items():
+    for request_key, value, source, is_container in global_values:
         if request_key in declared:
-            targets = diffusion_stages
-            if apply_declared_to_non_diffusion:
-                targets = list(range(len(types)))
+            targets = list(range(len(types))) if apply_declared_to_non_diffusion else diffusion_stages
             for stage in targets:
-                assignments.add(stage, request_key, value, source, target="extra_args")
+                assignments.add(
+                    stage,
+                    request_key,
+                    value,
+                    source,
+                    target="extra_args",
+                )
+        elif is_container:
+            for stage in diffusion_stages:
+                assignments.add(
+                    stage,
+                    request_key,
+                    value,
+                    source,
+                    target="extra_args",
+                    keep_none=True,
+                    parse_value=False,
+                )
         elif request_key in sampling_fields:
             target = sampling_fields[request_key]
             for stage in diffusion_stages:
                 assignments.add(stage, target, value, source)
 
-    for name, values in containers:
-        for key in sorted(values):
-            value = values[key]
-            for stage in diffusion_stages:
-                assignments.add(
-                    stage,
-                    key,
-                    value,
-                    f"{name}.{key}",
-                    target="extra_args",
-                    keep_none=True,
-                    parse_value=key in declared,
-                )
-
     if comprehension_stage_index is not None:
+        if apply_declared_to_non_diffusion and types[comprehension_stage_index] != "diffusion":
+            for key, value, source, _is_container in global_values:
+                if key in declared and key in standard_sampling_fields:
+                    assignments.add(comprehension_stage_index, key, value, source)
         for key in standard_sampling_fields:
             if key not in explicit:
                 continue
-            if key in declared and (
-                not apply_declared_to_non_diffusion or types[comprehension_stage_index] == "diffusion"
-            ):
+            if key in declared:
                 continue
             if types[comprehension_stage_index] == "diffusion" and key in sampling_fields:
                 continue
@@ -309,7 +323,7 @@ def compile_diffusion_chat_request_plan(
                     comprehension_stage_index,
                     key,
                     value,
-                    root_by_key[source_key][1],
+                    serving_by_key[source_key][1],
                     target="extra_args",
                 )
 
@@ -366,8 +380,8 @@ def compile_diffusion_chat_request_plan(
     controls.update(
         {key: _parse(key, value) for key, value in (("height", height), ("width", width)) if value is not None}
     )
-    if "lora" in root_by_key and root_by_key["lora"][0] is not None:
-        value, source = root_by_key["lora"]
+    if "lora" in serving_by_key and serving_by_key["lora"][0] is not None:
+        value, source = serving_by_key["lora"]
         try:
             lora_request, lora_scale = parse_lora_request(value)
         except (TypeError, ValueError, OverflowError) as exc:

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -22,31 +22,37 @@ def _request_mapping(name: str, value: object | None) -> dict[str, object]:
     return dict(value)
 
 
-def normalize_diffusion_request_extra_args(
+def normalize_diffusion_request_args(
     *,
-    provided_root_fields: Collection[str] = (),
-    root_extra_args: object | None = None,
-    extra_args: object | None = None,
-    extra_params: object | None = None,
-    nested_provided_root_fields: Collection[str] = (),
-    nested_root_extra_args: object | None = None,
-    nested_extra_args: object | None = None,
-    nested_extra_params: object | None = None,
+    root: object | None = None,
+    nested: object | None = None,
+    explicit_root_args: object | None = None,
+    serving_root_fields: Collection[str] = (),
+    registered_extra_fields: Collection[str] = (),
     root_field_aliases: Mapping[str, str] | None = None,
-) -> dict[str, object]:
-    """Normalize model-specific request extras without implicit precedence."""
-    root = _request_mapping("root_extra_args", root_extra_args)
-    nested_root = _request_mapping("nested_root_extra_args", nested_root_extra_args)
-    canonical = _request_mapping("extra_args", extra_args)
-    legacy = _request_mapping("extra_params", extra_params)
-    nested_canonical = _request_mapping("extra_body.extra_args", nested_extra_args)
-    nested_legacy = _request_mapping("extra_body.extra_params", nested_extra_params)
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Validate request sources and project diffusion consumer arguments."""
+    root_args = _request_mapping("request", root)
+    root_args.update(_request_mapping("explicit_root_args", explicit_root_args))
+    nested_args = _request_mapping("request.extra_body", nested)
 
-    aliases = root_field_aliases or {}
+    registered = set(registered_extra_fields)
+    aliases = {alias: canonical for alias, canonical in (root_field_aliases or {}).items() if alias not in registered}
+    serving_fields = set(serving_root_fields) | aliases.keys()
+    declared_fields = registered - serving_fields
+    consumer_fields = serving_fields | declared_fields
+
+    root_declared = {key: root_args[key] for key in declared_fields if key in root_args}
+    nested_declared = {key: nested_args[key] for key in declared_fields if key in nested_args}
+    canonical = _request_mapping("extra_args", root_args.get("extra_args"))
+    legacy = _request_mapping("extra_params", root_args.get("extra_params"))
+    nested_canonical = _request_mapping("extra_body.extra_args", nested_args.get("extra_args"))
+    nested_legacy = _request_mapping("extra_body.extra_params", nested_args.get("extra_params"))
+
     sources_by_key: dict[str, list[str]] = {}
     sources = (
-        ((set(provided_root_fields) | root.keys()), "request"),
-        ((set(nested_provided_root_fields) | nested_root.keys()), "request.extra_body"),
+        ((root_args.keys() & serving_fields) | root_declared.keys(), "request"),
+        ((nested_args.keys() & serving_fields) | nested_declared.keys(), "request.extra_body"),
         (canonical, "request.extra_args"),
         (legacy, "request.extra_params"),
         (nested_canonical, "request.extra_body.extra_args"),
@@ -64,21 +70,30 @@ def normalize_diffusion_request_extra_args(
         details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
         raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
 
-    if extra_params is not None or nested_extra_params is not None:
+    if root_args.get("extra_params") is not None or nested_args.get("extra_params") is not None:
         logger.warning_once(
             "extra_params is deprecated; use extra_args for model-specific diffusion request parameters."
         )
 
     # Duplicate request keys were rejected above, so ordering is not precedence.
-    normalized = {
-        **nested_root,
-        **root,
+    normalized_extra_args = {
+        **nested_declared,
+        **root_declared,
         **legacy,
         **nested_legacy,
         **canonical,
         **nested_canonical,
     }
-    return {key: value for key, value in normalized.items() if value is not None}
+    normalized_extra_args = {key: value for key, value in normalized_extra_args.items() if value is not None}
+
+    request_args = {
+        **{key: nested_args[key] for key in consumer_fields if key in nested_args},
+        **{key: root_args[key] for key in consumer_fields if key in root_args},
+    }
+    for alias, canonical_name in aliases.items():
+        if alias in request_args:
+            request_args[canonical_name] = request_args.pop(alias)
+    return normalized_extra_args, request_args
 
 
 def apply_normalized_diffusion_request_extra_args(

--- a/vllm_omni/entrypoints/openai/diffusion_request_utils.py
+++ b/vllm_omni/entrypoints/openai/diffusion_request_utils.py
@@ -64,9 +64,6 @@ def normalize_diffusion_request_args(
 
     conflicts = {key: list(dict.fromkeys(paths)) for key, paths in sources_by_key.items() if len(set(paths)) > 1}
     if conflicts:
-        if len(conflicts) == 1:
-            key, paths = next(iter(conflicts.items()))
-            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(paths)}.')
         details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
         raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -153,7 +153,33 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     _supported_speakers: set[str] | None = None
     _diffusion_extra_body_params: frozenset[str] | None = None
     _diffusion_extra_output_params: frozenset[str] | None = None
-    _diffusion_sampling_fields = frozenset(field.name for field in fields(OmniDiffusionSamplingParams))
+    # Only request fields with an explicit Chat serving consumer belong here.
+    # OmniDiffusionSamplingParams also stores runtime-only tensors and KV state;
+    # reflecting the whole dataclass would accidentally expose those internals
+    # as accepted request fields.
+    _diffusion_sampling_root_fields = {
+        "height": "height",
+        "width": "width",
+        "num_outputs_per_prompt": "num_outputs_per_prompt",
+        "seed": "seed",
+        "num_inference_steps": "num_inference_steps",
+        "guidance_scale": "guidance_scale",
+        "true_cfg_scale": "true_cfg_scale",
+        "cfg_scale": "true_cfg_scale",
+        "num_frames": "num_frames",
+        "guidance_scale_2": "guidance_scale_2",
+        "layers": "layers",
+        "resolution": "resolution",
+    }
+    _diffusion_control_root_fields = frozenset(
+        {
+            "size",
+            "negative_prompt",
+            "lora",
+            "modalities",
+        }
+    )
+    _diffusion_root_field_aliases = {"cfg_scale": "true_cfg_scale"}
 
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
@@ -293,7 +319,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = params
         return params
 
-    def _apply_diffusion_request_extra_args(
+    def _apply_diffusion_request_overrides(
         self,
         sampling_params: OmniDiffusionSamplingParams,
         request: ChatCompletionRequest,
@@ -304,9 +330,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         if explicit_fields is None:
             explicit_fields = getattr(request, "__fields_set__", set())
         declared_extra_fields = self._get_diffusion_extra_body_params()
-        consumed_root_fields = declared_extra_fields | self._diffusion_sampling_fields
+        consumed_root_fields = (
+            declared_extra_fields | self._diffusion_sampling_root_fields.keys() | self._diffusion_control_root_fields
+        )
         provided_root_fields = set(root_extra_body) & consumed_root_fields
-        provided_root_fields.update(set(explicit_fields) & self._diffusion_sampling_fields)
+        provided_root_fields.update(set(explicit_fields) & consumed_root_fields)
         nested_provided_root_fields = set(nested_extra_body) & consumed_root_fields
 
         normalized = normalize_diffusion_request_extra_args(
@@ -316,7 +344,25 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             nested_provided_root_fields=nested_provided_root_fields,
             nested_extra_args=nested_extra_body.get("extra_args"),
             nested_extra_params=nested_extra_body.get("extra_params"),
+            root_field_aliases=self._diffusion_root_field_aliases,
         )
+
+        sampling_overrides: dict[str, Any] = {}
+        for request_field, sampling_field in self._diffusion_sampling_root_fields.items():
+            if request_field in explicit_fields:
+                value = getattr(request, request_field, None)
+            elif request_field in root_extra_body:
+                value = root_extra_body[request_field]
+            elif request_field in nested_extra_body:
+                value = nested_extra_body[request_field]
+            else:
+                continue
+            if value is not None:
+                if sampling_field == "num_inference_steps":
+                    value = int(value)
+                sampling_overrides[sampling_field] = value
+        self._set_if_supported(sampling_params, **sampling_overrides)
+
         apply_declared_extra_args(
             sampling_params,
             declared_extra_fields,
@@ -736,7 +782,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
                         sp.num_inference_steps = num_inference_steps
                     if isinstance(sp, OmniDiffusionSamplingParams):
-                        self._apply_diffusion_request_extra_args(
+                        self._apply_diffusion_request_overrides(
                             sp,
                             request,
                             root_extra_body,
@@ -3544,7 +3590,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if true_cfg_scale is not None:
                 gen_params.true_cfg_scale = true_cfg_scale
             try:
-                self._apply_diffusion_request_extra_args(
+                self._apply_diffusion_request_overrides(
                     gen_params,
                     request,
                     root_extra_body,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -28,6 +28,7 @@ from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
     DiffusionChatRequestPlan,
     compile_diffusion_chat_request_plan,
+    resolve_diffusion_chat_request_context,
 )
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
@@ -40,7 +41,6 @@ from vllm_omni.metrics.modality import (
 from vllm_omni.model_extras import (
     get_extra_body_params,
     get_extra_output_params,
-    should_init_extra_args_for_non_diffusion_stages,
 )
 
 try:
@@ -160,33 +160,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     _supported_speakers: set[str] | None = None
     _diffusion_extra_body_params: frozenset[str] | None = None
     _diffusion_extra_output_params: frozenset[str] | None = None
-    # Only request fields with an explicit Chat serving consumer belong here.
-    # OmniDiffusionSamplingParams also stores runtime-only tensors and KV state;
-    # reflecting the whole dataclass would accidentally expose those internals
-    # as accepted request fields.
-    _diffusion_sampling_root_fields = {
-        "height": "height",
-        "width": "width",
-        "num_outputs_per_prompt": "num_outputs_per_prompt",
-        "seed": "seed",
-        "num_inference_steps": "num_inference_steps",
-        "guidance_scale": "guidance_scale",
-        "true_cfg_scale": "true_cfg_scale",
-        "cfg_scale": "true_cfg_scale",
-        "num_frames": "num_frames",
-        "guidance_scale_2": "guidance_scale_2",
-        "layers": "layers",
-        "resolution": "resolution",
-    }
-    _diffusion_control_root_fields = frozenset(
-        {
-            "size",
-            "negative_prompt",
-            "lora",
-            "modalities",
-        }
-    )
-
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
 
@@ -331,50 +304,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
         return any(get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs)
 
-    def _get_diffusion_request_plan_inputs(self) -> dict[str, Any]:
-        """Resolve engine topology and registry policy for the sole compiler."""
-        stage_owner = self._diffusion_engine if self._diffusion_mode else self.engine_client
-        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
-        declared_extra_fields = self._diffusion_extra_body_params
-        apply_declared_to_non_diffusion = False
-        try:
-            od_config = resolve_diffusion_od_config(self.engine_client, self._diffusion_engine)
-            model_class_name = getattr(od_config, "model_class_name", None)
-            if isinstance(model_class_name, str):
-                if declared_extra_fields is None:
-                    declared_extra_fields = get_extra_body_params(model_class_name)
-                # These pipelines have non-diffusion stage processors that
-                # consume the same declared request extras.
-                apply_declared_to_non_diffusion = should_init_extra_args_for_non_diffusion_stages(model_class_name)
-        except Exception as exc:
-            raise RuntimeError(f"Failed to resolve diffusion request model extras: {exc}") from exc
-        if declared_extra_fields is None:
-            declared_extra_fields = frozenset()
-        self._diffusion_extra_body_params = declared_extra_fields
-
-        stage_types = [get_stage_type(stage_config) for stage_config in stage_configs]
-        supported_modalities = {
-            modality for modality in getattr(stage_owner, "output_modalities", ()) if modality is not None
-        }
-        if is_single_stage_diffusion(stage_owner):
-            supported_modalities.add("text")
-        comprehension_stage_index = next(
-            (
-                index
-                for index, stage_config in enumerate(stage_configs)
-                if getattr(stage_config, "is_comprehension", False)
-            ),
-            None,
-        )
-        return {
-            "stage_types": stage_types,
-            "default_sampling_params_list": get_default_sampling_params_list(stage_owner),
-            "comprehension_stage_index": comprehension_stage_index,
-            "declared_extra_fields": declared_extra_fields,
-            "apply_declared_to_non_diffusion": apply_declared_to_non_diffusion,
-            "supported_modalities": supported_modalities,
-        }
-
     def _get_diffusion_extra_output_params(
         self,
         output: object,
@@ -473,12 +402,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         diffusion_plan: DiffusionChatRequestPlan | None = None
         if self._serves_diffusion_requests():
             try:
+                diffusion_context = resolve_diffusion_chat_request_context(
+                    engine_client=self.engine_client,
+                    diffusion_engine=self._diffusion_engine,
+                    diffusion_mode=self._diffusion_mode,
+                    standard_sampling_fields=self._OPENAI_SAMPLING_FIELDS,
+                    declared_extra_fields=self._diffusion_extra_body_params,
+                )
+                self._diffusion_extra_body_params = diffusion_context.declared_extra_fields
                 diffusion_plan = compile_diffusion_chat_request_plan(
                     request=request,
-                    sampling_root_fields=self._diffusion_sampling_root_fields,
-                    standard_sampling_fields=self._OPENAI_SAMPLING_FIELDS,
-                    control_root_fields=self._diffusion_control_root_fields,
-                    **self._get_diffusion_request_plan_inputs(),
+                    context=diffusion_context,
                 )
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -353,6 +353,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = declared_extra_fields
 
         stage_types = [get_stage_type(stage_config) for stage_config in stage_configs]
+        supported_modalities = {
+            modality for modality in getattr(stage_owner, "output_modalities", ()) if modality is not None
+        }
+        if is_single_stage_diffusion(stage_owner):
+            supported_modalities.add("text")
         comprehension_stage_index = next(
             (
                 index
@@ -367,6 +372,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             "comprehension_stage_index": comprehension_stage_index,
             "declared_extra_fields": declared_extra_fields,
             "apply_declared_to_non_diffusion": apply_declared_to_non_diffusion,
+            "supported_modalities": supported_modalities,
         }
 
     def _get_diffusion_extra_output_params(
@@ -476,24 +482,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 )
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)
-
-        if diffusion_plan is not None and "modalities" in diffusion_plan.controls:
-            requested_modalities = diffusion_plan.controls["modalities"]
-            if self._diffusion_mode:
-                allowed_modalities = {"audio", "image", "text"}
-            else:
-                allowed_modalities = {
-                    modality for modality in self.engine_client.output_modalities if modality is not None
-                }
-                if is_single_stage_diffusion(self.engine_client):
-                    allowed_modalities.add("text")
-            unsupported = set(requested_modalities) - allowed_modalities
-            if unsupported:
-                return self._create_error_response(
-                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
-                    f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
-                    status_code=400,
-                )
 
         # Handle diffusion mode
         if self._diffusion_mode:
@@ -3504,11 +3492,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             negative_prompt = diffusion_plan.controls.get("negative_prompt")
 
             logger.info(
-                "Diffusion chat request %s: prompt=%r, ref_images=%d, params=%s",
+                "Diffusion chat request %s: prompt=%r, ref_images=%d",
                 request_id,
                 prompt[:50] + "..." if len(prompt) > 50 else prompt,
                 len(reference_images),
-                {k: v for k, v in diffusion_plan.request_sources.items() if v is not None},
             )
 
             # Decode reference images if provided

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -477,6 +477,24 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)
 
+        if diffusion_plan is not None and "modalities" in diffusion_plan.controls:
+            requested_modalities = diffusion_plan.controls["modalities"]
+            if self._diffusion_mode:
+                allowed_modalities = {"audio", "image", "text"}
+            else:
+                allowed_modalities = {
+                    modality for modality in self.engine_client.output_modalities if modality is not None
+                }
+                if is_single_stage_diffusion(self.engine_client):
+                    allowed_modalities.add("text")
+            unsupported = set(requested_modalities) - allowed_modalities
+            if unsupported:
+                return self._create_error_response(
+                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
+                    f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
+                    status_code=400,
+                )
+
         # Handle diffusion mode
         if self._diffusion_mode:
             assert diffusion_plan is not None
@@ -613,15 +631,16 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         if not isinstance(request.modalities, list) or not all(isinstance(m, str) for m in request.modalities):
             return self.create_error_response("'modalities' must be a list of strings.")
-        allowed_modalities = set(engine_output_modalities)
-        if is_single_stage_diffusion(self.engine_client):
-            allowed_modalities.add("text")
-        unsupported = set(request.modalities) - allowed_modalities
-        if unsupported:
-            return self.create_error_response(
-                f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
-                f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
-            )
+        if diffusion_plan is None:
+            allowed_modalities = set(engine_output_modalities)
+            if is_single_stage_diffusion(self.engine_client):
+                allowed_modalities.add("text")
+            unsupported = set(request.modalities) - allowed_modalities
+            if unsupported:
+                return self.create_error_response(
+                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
+                    f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
+                )
 
         if request.modalities and "audio" in request.modalities:
             audio_format_check = self._resolve_audio_format(request)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3,7 +3,7 @@ import base64
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from dataclasses import fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -297,29 +297,57 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self,
         sampling_params: OmniDiffusionSamplingParams,
         request: ChatCompletionRequest,
-        extra_body: dict[str, Any],
+        root_extra_body: dict[str, Any],
+        nested_extra_body: dict[str, Any],
     ) -> None:
         explicit_fields = getattr(request, "model_fields_set", None)
         if explicit_fields is None:
             explicit_fields = getattr(request, "__fields_set__", set())
-        provided_root_fields = set(extra_body)
+        declared_extra_fields = self._get_diffusion_extra_body_params()
+        consumed_root_fields = declared_extra_fields | self._diffusion_sampling_fields
+        provided_root_fields = set(root_extra_body) & consumed_root_fields
         provided_root_fields.update(set(explicit_fields) & self._diffusion_sampling_fields)
+        nested_provided_root_fields = set(nested_extra_body) & consumed_root_fields
 
         normalized = normalize_diffusion_request_extra_args(
             provided_root_fields=provided_root_fields,
-            extra_args=extra_body.get("extra_args"),
-            extra_params=extra_body.get("extra_params"),
+            extra_args=root_extra_body.get("extra_args"),
+            extra_params=root_extra_body.get("extra_params"),
+            nested_provided_root_fields=nested_provided_root_fields,
+            nested_extra_args=nested_extra_body.get("extra_args"),
+            nested_extra_params=nested_extra_body.get("extra_params"),
         )
         apply_declared_extra_args(
             sampling_params,
-            self._get_diffusion_extra_body_params(),
-            extra_body,
+            declared_extra_fields,
+            nested_extra_body,
+        )
+        apply_declared_extra_args(
+            sampling_params,
+            declared_extra_fields,
+            root_extra_body,
         )
         if normalized:
             sampling_params.extra_args = {
                 **(sampling_params.extra_args or {}),
                 **normalized,
             }
+
+    @staticmethod
+    def _split_diffusion_request_extra_body(
+        request: ChatCompletionRequest,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        root_extra_body = dict(request.model_extra or {})
+        nested_value = root_extra_body.pop("extra_body", None)
+        if nested_value is None:
+            nested_value = getattr(request, "extra_body", None)
+        if nested_value is None:
+            return root_extra_body, {}
+        if not isinstance(nested_value, Mapping):
+            raise ValueError("extra_body must be a JSON object.")
+        if any(not isinstance(key, str) for key in nested_value):
+            raise ValueError("extra_body must be a JSON object with string keys.")
+        return root_extra_body, dict(nested_value)
 
     def _get_diffusion_extra_output_params(
         self,
@@ -561,8 +589,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         num_inference_steps = None
         # The OpenAI client flattens ``extra_body`` into request extras, while
-        # raw HTTP callers may send the nested compatibility form.
-        extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
+        # raw HTTP callers may send the nested compatibility form. Keep both
+        # sources separate until duplicate detection has run.
+        try:
+            root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
+        except ValueError as e:
+            return self.create_error_response(str(e))
+        extra_body = {**nested_extra_body, **root_extra_body}
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
         # processor can construct the correct inputs.
@@ -703,7 +736,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
                         sp.num_inference_steps = num_inference_steps
                     if isinstance(sp, OmniDiffusionSamplingParams):
-                        self._apply_diffusion_request_extra_args(sp, request, extra_body)
+                        self._apply_diffusion_request_extra_args(
+                            sp,
+                            request,
+                            root_extra_body,
+                            nested_extra_body,
+                        )
                     else:
                         apply_declared_extra_args(sp, self._get_diffusion_extra_body_params(), extra_body)
 
@@ -3425,15 +3463,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 messages
             )
 
-            # Extract generation parameters from extra_body (preferred)
+            # Extract generation parameters from root request extras and the
+            # nested compatibility form without discarding either source.
             # Reference: text_to_image.py and text_to_video.py for supported parameters
             # [NOTE] When sending request via openai client Python library,
             #   `extra_body` is flattented and merged into the payload's root.
             #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
             #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
-            extra_body = getattr(request, "extra_body", None)
-            if not extra_body:
-                extra_body = request.model_extra or {}
+            try:
+                root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
+            except ValueError as e:
+                return self._create_error_response(str(e), status_code=400)
+            extra_body = {**nested_extra_body, **root_extra_body}
 
             # Parse size if provided (supports "1024x1024" format)
             height, width = self._resolve_height_width_from_extra_body(extra_body)
@@ -3503,7 +3544,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if true_cfg_scale is not None:
                 gen_params.true_cfg_scale = true_cfg_scale
             try:
-                self._apply_diffusion_request_extra_args(gen_params, request, extra_body)
+                self._apply_diffusion_request_extra_args(
+                    gen_params,
+                    request,
+                    root_extra_body,
+                    nested_extra_body,
+                )
             except ValueError as e:
                 return self._create_error_response(str(e), status_code=400)
             if num_frames is not None:
@@ -3563,12 +3609,26 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             # Generate image or audio (e.g. AudioX) via AsyncOmni
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)
             stage_configs = list(getattr(diffusion_engine, "stage_configs", []) or [])
+            default_sampling_params_list = get_default_sampling_params_list(diffusion_engine)
             sampling_params_list = build_stage_sampling_params_list(
                 stage_configs,
-                get_default_sampling_params_list(diffusion_engine),
+                default_sampling_params_list,
                 diffusion_params=gen_params,
                 replace_diffusion_params=True,
             )
+
+            # This endpoint replaces diffusion sampling params as a whole, but
+            # model-specific stage defaults remain defaults: request extras
+            # override matching keys without discarding unrelated defaults.
+            for idx, (stage_config, sampling_params) in enumerate(zip(stage_configs, sampling_params_list)):
+                if get_stage_type(stage_config) != "diffusion" or idx >= len(default_sampling_params_list):
+                    continue
+                default_extra_args = getattr(default_sampling_params_list[idx], "extra_args", None)
+                if default_extra_args:
+                    sampling_params.extra_args = {
+                        **default_extra_args,
+                        **(getattr(sampling_params, "extra_args", None) or {}),
+                    }
 
             if not sampling_params_list:
                 sampling_params_list = [gen_params]

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -782,12 +782,15 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
                         sp.num_inference_steps = num_inference_steps
                     if isinstance(sp, OmniDiffusionSamplingParams):
-                        self._apply_diffusion_request_overrides(
-                            sp,
-                            request,
-                            root_extra_body,
-                            nested_extra_body,
-                        )
+                        try:
+                            self._apply_diffusion_request_overrides(
+                                sp,
+                                request,
+                                root_extra_body,
+                                nested_extra_body,
+                            )
+                        except ValueError as e:
+                            return self._create_error_response(str(e), status_code=400)
                     else:
                         apply_declared_extra_args(sp, self._get_diffusion_extra_body_params(), extra_body)
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.chat_utils import (
 
 from vllm_omni.diffusion.utils.param_utils import apply_declared_extra_args
 from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.entrypoints.openai.diffusion_request_utils import normalize_diffusion_request_extra_args
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
@@ -152,6 +153,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     _supported_speakers: set[str] | None = None
     _diffusion_extra_body_params: frozenset[str] | None = None
     _diffusion_extra_output_params: frozenset[str] | None = None
+    _diffusion_sampling_fields = frozenset(field.name for field in fields(OmniDiffusionSamplingParams))
 
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
@@ -290,6 +292,34 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         self._diffusion_extra_body_params = params
         return params
+
+    def _apply_diffusion_request_extra_args(
+        self,
+        sampling_params: OmniDiffusionSamplingParams,
+        request: ChatCompletionRequest,
+        extra_body: dict[str, Any],
+    ) -> None:
+        explicit_fields = getattr(request, "model_fields_set", None)
+        if explicit_fields is None:
+            explicit_fields = getattr(request, "__fields_set__", set())
+        provided_root_fields = set(extra_body)
+        provided_root_fields.update(set(explicit_fields) & self._diffusion_sampling_fields)
+
+        normalized = normalize_diffusion_request_extra_args(
+            provided_root_fields=provided_root_fields,
+            extra_args=extra_body.get("extra_args"),
+            extra_params=extra_body.get("extra_params"),
+        )
+        apply_declared_extra_args(
+            sampling_params,
+            self._get_diffusion_extra_body_params(),
+            extra_body,
+        )
+        if normalized:
+            sampling_params.extra_args = {
+                **(sampling_params.extra_args or {}),
+                **normalized,
+            }
 
     def _get_diffusion_extra_output_params(
         self,
@@ -530,7 +560,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 return audio_format_check
 
         num_inference_steps = None
-        extra_body: dict[str, Any] = {}
+        # The OpenAI client flattens ``extra_body`` into request extras, while
+        # raw HTTP callers may send the nested compatibility form.
+        extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
         # processor can construct the correct inputs.
@@ -543,12 +575,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 )
                 if not extracted_prompt:
                     return self.create_error_response("No text prompt found in messages")
-
-                # [NOTE] When sending request via openai client Python library,
-                #   `extra_body` is flattented and merged into the payload's root.
-                #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
-                #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
-                extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
 
                 height, width = self._resolve_height_width_from_extra_body(extra_body)
 
@@ -676,7 +702,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         sp.width = _image_gen_width
                     if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
                         sp.num_inference_steps = num_inference_steps
-                    apply_declared_extra_args(sp, self._get_diffusion_extra_body_params(), extra_body)
+                    if isinstance(sp, OmniDiffusionSamplingParams):
+                        self._apply_diffusion_request_extra_args(sp, request, extra_body)
+                    else:
+                        apply_declared_extra_args(sp, self._get_diffusion_extra_body_params(), extra_body)
 
                 self._log_inputs(
                     request_id,
@@ -3473,7 +3502,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 gen_params.guidance_scale = guidance_scale
             if true_cfg_scale is not None:
                 gen_params.true_cfg_scale = true_cfg_scale
-            apply_declared_extra_args(gen_params, self._get_diffusion_extra_body_params(), extra_body)
+            try:
+                self._apply_diffusion_request_extra_args(gen_params, request, extra_body)
+            except ValueError as e:
+                return self._create_error_response(str(e), status_code=400)
             if num_frames is not None:
                 gen_params.num_frames = num_frames
             if guidance_scale_2 is not None:
@@ -3482,14 +3514,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 gen_params.layers = layers
             if resolution is not None:
                 gen_params.resolution = resolution
-
-            # Pipeline-agnostic escape hatch (mirrors ``extra_params`` on the /v1/videos
-            # endpoint in ``serving_video.py``): a single reserved ``extra_args`` dict in
-            # ``extra_body`` flows straight into ``gen_params.extra_args``, with no keys
-            # hardcoded here.
-            extra_args_body = extra_body.get("extra_args")
-            if isinstance(extra_args_body, dict):
-                gen_params.extra_args.update(extra_args_body)
 
             # Parse per-request LoRA.
             if lora_body and isinstance(lora_body, dict):

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3,7 +3,7 @@ import base64
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from dataclasses import fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -27,7 +27,7 @@ from vllm_omni.diffusion.utils.param_utils import apply_declared_extra_args
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
     apply_normalized_diffusion_request_extra_args,
-    normalize_diffusion_request_extra_args,
+    normalize_diffusion_request_args,
 )
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
@@ -188,6 +188,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         }
     )
     _diffusion_root_field_aliases = {"cfg_scale": "true_cfg_scale"}
+    _diffusion_serving_root_fields = _diffusion_common_root_fields | _diffusion_existing_control_fields
 
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
@@ -332,67 +333,24 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
     ) -> tuple[dict[str, object], dict[str, Any]]:
         """Normalize extras and preserve validated common root fields."""
-        root, nested = self._split_diffusion_request_extra_body(request)
+        root = dict(request.model_extra or {})
+        nested = root.pop("extra_body", None)
+        if nested is None:
+            nested = getattr(request, "extra_body", None)
         explicit = getattr(request, "model_fields_set", None)
         if explicit is None:
             explicit = getattr(request, "__fields_set__", ())
-        explicit = set(explicit)
-
-        registered_extra_fields = self._get_diffusion_extra_body_params()
-        active_root_field_aliases = {
-            alias: canonical
-            for alias, canonical in self._diffusion_root_field_aliases.items()
-            if alias not in registered_extra_fields
+        explicit_root_args = {
+            key: getattr(request, key) for key in explicit if key != "extra_body" and hasattr(request, key)
         }
-        common = self._diffusion_common_root_fields | active_root_field_aliases.keys()
-        consumed_root_fields = common | self._diffusion_existing_control_fields
-        declared = registered_extra_fields - consumed_root_fields
-        consumer_fields = consumed_root_fields | declared
-        root_declared = {
-            key: getattr(request, key, root.get(key)) for key in declared if key in explicit or key in root
-        }
-        nested_declared = {key: nested[key] for key in declared if key in nested}
-        normalized_extra_args = normalize_diffusion_request_extra_args(
-            provided_root_fields=(set(root) | explicit) & consumed_root_fields,
-            root_extra_args=root_declared,
-            extra_args=root.get("extra_args"),
-            extra_params=root.get("extra_params"),
-            nested_provided_root_fields=set(nested) & consumed_root_fields,
-            nested_root_extra_args=nested_declared,
-            nested_extra_args=nested.get("extra_args"),
-            nested_extra_params=nested.get("extra_params"),
-            root_field_aliases=active_root_field_aliases,
+        return normalize_diffusion_request_args(
+            root=root,
+            nested=nested,
+            explicit_root_args=explicit_root_args,
+            serving_root_fields=self._diffusion_serving_root_fields,
+            registered_extra_fields=self._get_diffusion_extra_body_params(),
+            root_field_aliases=self._diffusion_root_field_aliases,
         )
-        root_consumer_args = {
-            key: getattr(request, key, root.get(key)) for key in consumer_fields if key in explicit or key in root
-        }
-        nested_consumer_args = {key: nested[key] for key in consumer_fields if key in nested}
-        # Duplicate logical claims have already been rejected, so these
-        # consumer sources are disjoint rather than precedence-ordered.
-        diffusion_request_args = {
-            **nested_consumer_args,
-            **root_consumer_args,
-        }
-        for alias, canonical in active_root_field_aliases.items():
-            if alias in diffusion_request_args:
-                diffusion_request_args[canonical] = diffusion_request_args.pop(alias)
-        return normalized_extra_args, diffusion_request_args
-
-    @staticmethod
-    def _split_diffusion_request_extra_body(
-        request: ChatCompletionRequest,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        root = dict(request.model_extra or {})
-        nested_value = root.pop("extra_body", None)
-        if nested_value is None:
-            nested_value = getattr(request, "extra_body", None)
-        if nested_value is None:
-            return root, {}
-        if not isinstance(nested_value, Mapping):
-            raise ValueError("extra_body must be a JSON object.")
-        if any(not isinstance(key, str) for key in nested_value):
-            raise ValueError("extra_body must be a JSON object with string keys.")
-        return root, dict(nested_value)
 
     def _get_diffusion_extra_output_params(
         self,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3,11 +3,10 @@ import base64
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
-from dataclasses import dataclass, fields, is_dataclass
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from dataclasses import fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
-from types import MappingProxyType
 from typing import Any, Final, cast
 
 import jinja2
@@ -27,7 +26,8 @@ from vllm.entrypoints.chat_utils import (
 from vllm_omni.diffusion.utils.param_utils import apply_declared_extra_args
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
-    compile_diffusion_request_overrides,
+    DiffusionChatRequestPlan,
+    compile_diffusion_chat_request_plan,
 )
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
@@ -37,7 +37,11 @@ from vllm_omni.metrics.modality import (
     observe_audio_first_packet,
     observe_audio_streaming_finalize,
 )
-from vllm_omni.model_extras import get_extra_body_params, get_extra_output_params
+from vllm_omni.model_extras import (
+    get_extra_body_params,
+    get_extra_output_params,
+    should_init_extra_args_for_non_diffusion_stages,
+)
 
 try:
     import soundfile
@@ -99,7 +103,7 @@ from vllm.utils.collection_utils import as_list
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
-from vllm_omni.entrypoints.openai.image_api_utils import encode_image_base64_with_compression, validate_layered_layers
+from vllm_omni.entrypoints.openai.image_api_utils import encode_image_base64_with_compression
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
 from vllm_omni.entrypoints.openai.protocol.audio import (
     DEFAULT_AUDIO_FORMAT,
@@ -133,30 +137,6 @@ from vllm_omni.outputs.output_metadata import DiffusionMetadataMapping, Diffusio
 from vllm_omni.utils.audio import audio_chunk_pcm_bytes, audio_chunk_sample_rate
 
 logger = init_logger(__name__)
-
-
-@dataclass(frozen=True)
-class _DiffusionRequestSources:
-    root_extra_body: Mapping[str, Any]
-    nested_extra_body: Mapping[str, Any]
-    explicit_root_values: Mapping[str, Any]
-    stage_provided_root_fields: Mapping[int, frozenset[str]]
-    stage_extra_args: Mapping[int, object | None]
-    non_diffusion_stage_extra_args: Mapping[int, object | None]
-    raw_sampling_params_list: object | None
-
-
-@dataclass(frozen=True)
-class _DiffusionRequestContract:
-    request_values: Mapping[str, Any]
-    extra_body: Mapping[str, Any]
-    sampling_overrides: Mapping[str, Any]
-    declared_extra_args: Mapping[str, Any]
-    extra_args_overrides: Mapping[str, Any]
-    control_overrides: Mapping[str, Any]
-    lora_request: LoRARequest | None
-    lora_scale: float | None
-    sampling_params_list: tuple[Any, ...] | None
 
 
 async def _identity_async(value: Any) -> Any:
@@ -345,302 +325,49 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = params
         return params
 
-    def _collect_diffusion_request_sources(
-        self,
-        request: ChatCompletionRequest,
-        declared_extra_fields: frozenset[str],
-    ) -> _DiffusionRequestSources:
-        root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
-        explicit_fields = getattr(request, "model_fields_set", None)
-        if explicit_fields is None:
-            explicit_fields = getattr(request, "__fields_set__", set())
-        consumed_root_fields = (
-            declared_extra_fields | self._diffusion_sampling_root_fields.keys() | self._diffusion_control_root_fields
-        )
-        explicit_root_values = {key: getattr(request, key, None) for key in set(explicit_fields) & consumed_root_fields}
-
-        raw_sampling_params_list = getattr(request, "sampling_params_list", None)
-        if raw_sampling_params_list is not None and not isinstance(raw_sampling_params_list, list):
-            raise ValueError("sampling_params_list must be a JSON array.")
-
-        stage_owner = self._diffusion_engine if self._diffusion_mode else self.engine_client
-        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
-        stage_provided_root_fields: dict[int, frozenset[str]] = {}
-        stage_extra_args: dict[int, object | None] = {}
-        non_diffusion_stage_extra_args: dict[int, object | None] = {}
-        stage_root_field_names = frozenset(self._diffusion_sampling_root_fields) | declared_extra_fields
-        for stage_index, stage_params in enumerate(raw_sampling_params_list or []):
-            if not isinstance(stage_params, Mapping):
-                raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object.")
-            if any(not isinstance(key, str) for key in stage_params):
-                raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object with string keys.")
-            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
-                if not self._diffusion_mode:
-                    non_diffusion_stage_extra_args[stage_index] = stage_params.get("extra_args")
-                continue
-            stage_provided_root_fields[stage_index] = frozenset(stage_params) & stage_root_field_names
-            stage_extra_args[stage_index] = stage_params.get("extra_args")
-
-        return _DiffusionRequestSources(
-            root_extra_body=MappingProxyType(root_extra_body),
-            nested_extra_body=MappingProxyType(nested_extra_body),
-            explicit_root_values=MappingProxyType(explicit_root_values),
-            stage_provided_root_fields=MappingProxyType(stage_provided_root_fields),
-            stage_extra_args=MappingProxyType(stage_extra_args),
-            non_diffusion_stage_extra_args=MappingProxyType(non_diffusion_stage_extra_args),
-            raw_sampling_params_list=raw_sampling_params_list,
-        )
-
-    @staticmethod
-    def _coerce_num_inference_steps(value: object) -> int:
-        try:
-            return int(value)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError("num_inference_steps must be an integer.") from exc
-
     def _serves_diffusion_requests(self) -> bool:
         if self._diffusion_mode:
             return True
         stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
         return any(get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs)
 
-    @staticmethod
-    def _validate_non_diffusion_stage_extra_conflicts(
-        sources: _DiffusionRequestSources,
-        declared_root_extra_args: Mapping[str, Any],
-    ) -> None:
-        conflicts: dict[str, list[str]] = {}
-        for stage_index, stage_extra_args in sources.non_diffusion_stage_extra_args.items():
-            if stage_extra_args is None:
-                continue
-            if not isinstance(stage_extra_args, Mapping):
-                raise ValueError(f"sampling_params_list[{stage_index}].extra_args must be a JSON object.")
-            for key in sorted(set(declared_root_extra_args) & set(stage_extra_args)):
-                root_source = f"request.extra_body.{key}" if key in sources.nested_extra_body else f"request.{key}"
-                conflicts.setdefault(key, [root_source]).append(
-                    f"request.sampling_params_list[{stage_index}].extra_args.{key}"
-                )
-        if not conflicts:
-            return
-        if len(conflicts) == 1:
-            key, conflict_sources = next(iter(conflicts.items()))
-            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(conflict_sources)}.')
-        details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
-        raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
-
-    def _compile_request_sampling_params_list(
-        self,
-        request: ChatCompletionRequest,
-        sources: _DiffusionRequestSources,
-        declared_extra_fields: frozenset[str],
-    ) -> tuple[Any, ...] | None:
+    def _get_diffusion_request_plan_inputs(self) -> dict[str, Any]:
+        """Resolve engine topology and registry policy for the sole compiler."""
         stage_owner = self._diffusion_engine if self._diffusion_mode else self.engine_client
         stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
+        declared_extra_fields = self._diffusion_extra_body_params
+        apply_declared_to_non_diffusion = False
         try:
-            if sources.raw_sampling_params_list is None:
-                if self._diffusion_mode:
-                    return None
-                sampling_params_list = self._build_sampling_params_list_from_request(
-                    request,
-                    excluded_fields=declared_extra_fields,
-                )
-            else:
-                request_sampling_params: list[Any] = []
-                for stage_index, stage_params in enumerate(sources.raw_sampling_params_list):
-                    if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
-                        request_sampling_params.append(
-                            dict(stage_params) if isinstance(stage_params, Mapping) else stage_params
-                        )
-                        continue
+            od_config = resolve_diffusion_od_config(self.engine_client, self._diffusion_engine)
+            model_class_name = getattr(od_config, "model_class_name", None)
+            if isinstance(model_class_name, str):
+                if declared_extra_fields is None:
+                    declared_extra_fields = get_extra_body_params(model_class_name)
+                # These pipelines have non-diffusion stage processors that
+                # consume the same declared request extras.
+                apply_declared_to_non_diffusion = should_init_extra_args_for_non_diffusion_stages(model_class_name)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to resolve diffusion request model extras: {exc}") from exc
+        if declared_extra_fields is None:
+            declared_extra_fields = frozenset()
+        self._diffusion_extra_body_params = declared_extra_fields
 
-                    assert isinstance(stage_params, Mapping)
-                    compiled_stage_params = dict(stage_params)
-                    compiled_stage_extra_args = dict(
-                        cast(Mapping[str, Any], sources.stage_extra_args.get(stage_index)) or {}
-                    )
-                    for request_field in sources.stage_provided_root_fields.get(stage_index, ()):
-                        value = compiled_stage_params.pop(request_field)
-                        if request_field in declared_extra_fields:
-                            compiled_stage_extra_args[request_field] = value
-                        else:
-                            sampling_field = self._diffusion_sampling_root_fields.get(request_field)
-                            if sampling_field is not None:
-                                compiled_stage_params[sampling_field] = value
-                    if "extra_args" in compiled_stage_params or compiled_stage_extra_args:
-                        compiled_stage_params["extra_args"] = compiled_stage_extra_args
-                    request_sampling_params.append(compiled_stage_params)
-                sampling_params_list = self._to_sampling_params_list(
-                    request_sampling_params,
-                    stage_owner=stage_owner,
-                )
-        except TypeError as exc:
-            raise ValueError(f"Invalid sampling_params_list: {exc}") from exc
-
-        for stage_index, sampling_params in enumerate(sampling_params_list):
-            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
-                continue
-
-            provided_root_fields = sources.stage_provided_root_fields.get(stage_index, ())
-            provided_extra_args = sources.stage_extra_args.get(stage_index)
-            provided_extra_fields = set(provided_extra_args) if isinstance(provided_extra_args, Mapping) else set()
-
-            if "num_inference_steps" in declared_extra_fields and (
-                "num_inference_steps" in provided_root_fields or "num_inference_steps" in provided_extra_fields
-            ):
-                stage_extra_args = dict(getattr(sampling_params, "extra_args", None) or {})
-                value = stage_extra_args.get("num_inference_steps")
-                if value is not None:
-                    stage_extra_args["num_inference_steps"] = self._coerce_num_inference_steps(value)
-                    sampling_params.extra_args = stage_extra_args
-            elif "num_inference_steps" in provided_root_fields:
-                value = getattr(sampling_params, "num_inference_steps", None)
-                if value is not None:
-                    sampling_params.num_inference_steps = self._coerce_num_inference_steps(value)
-
-            if "layers" in declared_extra_fields and (
-                "layers" in provided_root_fields or "layers" in provided_extra_fields
-            ):
-                stage_extra_args = dict(getattr(sampling_params, "extra_args", None) or {})
-                value = stage_extra_args.get("layers")
-                if value is not None:
-                    stage_extra_args["layers"] = validate_layered_layers(value)
-                    sampling_params.extra_args = stage_extra_args
-            elif "layers" in provided_root_fields:
-                value = getattr(sampling_params, "layers", None)
-                if value is not None:
-                    sampling_params.layers = validate_layered_layers(value)
-
-        return tuple(clone_sampling_params(sampling_params) for sampling_params in sampling_params_list)
-
-    def _compile_diffusion_request_contract(
-        self,
-        request: ChatCompletionRequest,
-    ) -> _DiffusionRequestContract:
-        declared_extra_fields = self._get_diffusion_extra_body_params()
-        sources = self._collect_diffusion_request_sources(request, declared_extra_fields)
-
-        # Schema fields and Pydantic model extras are the same flattened JSON
-        # source. Collect each root key once before comparing it with nested and
-        # container sources.
-        root_values = {
-            **sources.root_extra_body,
-            **sources.explicit_root_values,
+        stage_types = [get_stage_type(stage_config) for stage_config in stage_configs]
+        comprehension_stage_index = next(
+            (
+                index
+                for index, stage_config in enumerate(stage_configs)
+                if getattr(stage_config, "is_comprehension", False)
+            ),
+            None,
+        )
+        return {
+            "stage_types": stage_types,
+            "default_sampling_params_list": get_default_sampling_params_list(stage_owner),
+            "comprehension_stage_index": comprehension_stage_index,
+            "declared_extra_fields": declared_extra_fields,
+            "apply_declared_to_non_diffusion": apply_declared_to_non_diffusion,
         }
-        compiled = compile_diffusion_request_overrides(
-            root_values=root_values,
-            nested_root_values=sources.nested_extra_body,
-            sampling_root_fields=self._diffusion_sampling_root_fields,
-            declared_extra_fields=declared_extra_fields,
-            control_root_fields=self._diffusion_control_root_fields,
-            extra_args=sources.root_extra_body.get("extra_args"),
-            extra_params=sources.root_extra_body.get("extra_params"),
-            nested_extra_args=sources.nested_extra_body.get("extra_args"),
-            nested_extra_params=sources.nested_extra_body.get("extra_params"),
-            stage_provided_root_fields=sources.stage_provided_root_fields,
-            stage_extra_args=sources.stage_extra_args,
-        )
-        self._validate_non_diffusion_stage_extra_conflicts(
-            sources,
-            compiled.declared_extra_args,
-        )
-
-        request_values = dict(compiled.request_values)
-        sampling_overrides = dict(compiled.sampling_overrides)
-        declared_extra_args = dict(compiled.declared_extra_args)
-        extra_args_overrides = dict(compiled.extra_args)
-        control_overrides = dict(compiled.control_overrides)
-
-        if "num_inference_steps" in sampling_overrides:
-            sampling_overrides["num_inference_steps"] = self._coerce_num_inference_steps(
-                sampling_overrides["num_inference_steps"]
-            )
-        if "num_inference_steps" in declared_extra_fields and "num_inference_steps" in extra_args_overrides:
-            extra_args_overrides["num_inference_steps"] = self._coerce_num_inference_steps(
-                extra_args_overrides["num_inference_steps"]
-            )
-            if "num_inference_steps" in declared_extra_args:
-                declared_extra_args["num_inference_steps"] = extra_args_overrides["num_inference_steps"]
-
-        if "layers" in sampling_overrides:
-            sampling_overrides["layers"] = validate_layered_layers(sampling_overrides["layers"])
-        if "layers" in declared_extra_fields and "layers" in extra_args_overrides:
-            extra_args_overrides["layers"] = validate_layered_layers(extra_args_overrides["layers"])
-            if "layers" in declared_extra_args:
-                declared_extra_args["layers"] = extra_args_overrides["layers"]
-
-        height, width = self._resolve_height_width_from_extra_body(request_values)
-        if height is not None:
-            control_overrides["height"] = height
-            if "height" in sampling_overrides:
-                sampling_overrides["height"] = height
-        if width is not None:
-            control_overrides["width"] = width
-            if "width" in sampling_overrides:
-                sampling_overrides["width"] = width
-
-        try:
-            lora_request, lora_scale = parse_lora_request(control_overrides.get("lora"))
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError(str(exc)) from exc
-
-        # Duplicate consumed keys were rejected above. This union preserves the
-        # complete request for diagnostics; its ordering is not precedence.
-        extra_body = MappingProxyType(
-            {
-                **sources.nested_extra_body,
-                **sources.root_extra_body,
-                **sources.explicit_root_values,
-            }
-        )
-        compiled_sampling_params_list = self._compile_request_sampling_params_list(
-            request,
-            sources,
-            declared_extra_fields,
-        )
-
-        return _DiffusionRequestContract(
-            request_values=MappingProxyType(request_values),
-            extra_body=extra_body,
-            sampling_overrides=MappingProxyType(sampling_overrides),
-            declared_extra_args=MappingProxyType(declared_extra_args),
-            extra_args_overrides=MappingProxyType(extra_args_overrides),
-            control_overrides=MappingProxyType(control_overrides),
-            lora_request=lora_request,
-            lora_scale=lora_scale,
-            sampling_params_list=compiled_sampling_params_list,
-        )
-
-    def _apply_diffusion_request_contract(
-        self,
-        sampling_params: OmniDiffusionSamplingParams,
-        contract: _DiffusionRequestContract,
-    ) -> None:
-        self._set_if_supported(sampling_params, **contract.sampling_overrides)
-        if contract.extra_args_overrides:
-            sampling_params.extra_args = {
-                **(sampling_params.extra_args or {}),
-                **contract.extra_args_overrides,
-            }
-        if contract.lora_request is not None:
-            sampling_params.lora_request = contract.lora_request
-            if contract.lora_scale is not None:
-                sampling_params.lora_scale = contract.lora_scale
-
-    @staticmethod
-    def _split_diffusion_request_extra_body(
-        request: ChatCompletionRequest,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        root_extra_body = dict(request.model_extra or {})
-        nested_value = root_extra_body.pop("extra_body", None)
-        if nested_value is None:
-            nested_value = getattr(request, "extra_body", None)
-        if nested_value is None:
-            return root_extra_body, {}
-        if not isinstance(nested_value, Mapping):
-            raise ValueError("extra_body must be a JSON object.")
-        if any(not isinstance(key, str) for key in nested_value):
-            raise ValueError("extra_body must be a JSON object with string keys.")
-        return root_extra_body, dict(nested_value)
 
     def _get_diffusion_extra_output_params(
         self,
@@ -737,19 +464,25 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | ChatCompletionResponse | ErrorResponse:
-        diffusion_contract: _DiffusionRequestContract | None = None
+        diffusion_plan: DiffusionChatRequestPlan | None = None
         if self._serves_diffusion_requests():
             try:
-                diffusion_contract = self._compile_diffusion_request_contract(request)
+                diffusion_plan = compile_diffusion_chat_request_plan(
+                    request=request,
+                    sampling_root_fields=self._diffusion_sampling_root_fields,
+                    standard_sampling_fields=self._OPENAI_SAMPLING_FIELDS,
+                    control_root_fields=self._diffusion_control_root_fields,
+                    **self._get_diffusion_request_plan_inputs(),
+                )
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)
 
         # Handle diffusion mode
         if self._diffusion_mode:
-            assert diffusion_contract is not None
+            assert diffusion_plan is not None
             return await self._create_diffusion_chat_completion(
                 request,
-                diffusion_contract,
+                diffusion_plan,
                 raw_request,
             )
 
@@ -872,8 +605,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # Some models will return a list like ["text", None, "audio"], better
         # to strip None in the list
         engine_output_modalities = [x for x in self.engine_client.output_modalities if x is not None]
-        if diffusion_contract is not None and "modalities" in diffusion_contract.control_overrides:
-            output_modalities = diffusion_contract.control_overrides["modalities"]
+        if diffusion_plan is not None and "modalities" in diffusion_plan.controls:
+            output_modalities = diffusion_plan.controls["modalities"]
         else:
             output_modalities = getattr(request, "modalities", engine_output_modalities)
         request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
@@ -895,14 +628,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if isinstance(audio_format_check, ErrorResponse):
                 return audio_format_check
 
-        if diffusion_contract is None:
-            try:
-                root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
-            except ValueError as exc:
-                return self.create_error_response(str(exc))
-            extra_body = {**nested_extra_body, **root_extra_body}
-        else:
-            extra_body = diffusion_contract.extra_body
+        extra_body: dict[str, Any] = {}
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
         # processor can construct the correct inputs.
@@ -916,13 +642,15 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 if not extracted_prompt:
                     return self.create_error_response("No text prompt found in messages")
 
-                if diffusion_contract is None:
+                if diffusion_plan is None:
+                    # No configured stage serves diffusion in this legacy branch.
+                    extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
                     height, width = self._resolve_height_width_from_extra_body(extra_body)
                     negative_prompt = extra_body.get("negative_prompt")
                 else:
-                    height = diffusion_contract.control_overrides.get("height")
-                    width = diffusion_contract.control_overrides.get("width")
-                    negative_prompt = diffusion_contract.control_overrides.get("negative_prompt")
+                    height = diffusion_plan.controls.get("height")
+                    width = diffusion_plan.controls.get("width")
+                    negative_prompt = diffusion_plan.controls.get("negative_prompt")
                 engine_prompt_image: dict[str, Any] | None = None
                 if reference_images:
                     # Best-effort decode first reference image for i2i.
@@ -1005,18 +733,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         try:
             for engine_prompt in engine_prompts:
-                if diffusion_contract is None:
+                if diffusion_plan is None:
                     raw_sampling_params_list = getattr(request, "sampling_params_list", None)
                     if raw_sampling_params_list is not None:
                         sampling_params_list = self._to_sampling_params_list(raw_sampling_params_list)
                     else:
                         sampling_params_list = self._build_sampling_params_list_from_request(request)
                 else:
-                    assert diffusion_contract.sampling_params_list is not None
-                    sampling_params_list = [
-                        clone_sampling_params(sampling_params)
-                        for sampling_params in diffusion_contract.sampling_params_list
-                    ]
+                    sampling_params_list = diffusion_plan.clone_sampling_params_list()
 
                 # If this is a streaming (output) request, coerce cumulative outputs
                 # to delta to ensure emitted outputs are correctly drained. Otherwise
@@ -1028,18 +752,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         output_modalities,
                     )
 
-                # Apply user-specified overrides to diffusion stage(s) for image generation
-                for sp in sampling_params_list:
-                    if isinstance(sp, OmniDiffusionSamplingParams):
-                        assert diffusion_contract is not None
-                        self._apply_diffusion_request_contract(sp, diffusion_contract)
-                    elif diffusion_contract is not None and diffusion_contract.declared_extra_args:
-                        apply_declared_extra_args(
-                            sp,
-                            frozenset(diffusion_contract.declared_extra_args),
-                            diffusion_contract.declared_extra_args,
-                        )
-                    elif diffusion_contract is None:
+                if diffusion_plan is None:
+                    # Legacy non-diffusion Chat paths still apply model extras
+                    # here. Diffusion plans already contain final stage params.
+                    for sp in sampling_params_list:
                         apply_declared_extra_args(
                             sp,
                             self._get_diffusion_extra_body_params(),
@@ -1462,12 +1178,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         return new_messages
 
-    def _to_sampling_params_list(
-        self,
-        sampling_params_list: list[dict],
-        *,
-        stage_owner: Any | None = None,
-    ) -> list[Any]:
+    def _to_sampling_params_list(self, sampling_params_list: list[dict]) -> list[Any]:
         """Convert request dicts to stage-typed sampling params objects.
 
         For diffusion stages, build ``OmniDiffusionSamplingParams`` so
@@ -1477,9 +1188,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         (for example AURA has three semantic models but four engine stages),
         append cloned deploy defaults for the omitted tail stages.
         """
-        stage_owner = self.engine_client if stage_owner is None else stage_owner
-        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
-        default_params_list = list(getattr(stage_owner, "default_sampling_params_list", []) or [])
+        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
+        default_params_list = list(getattr(self.engine_client, "default_sampling_params_list", []) or [])
         final_sampling_params_list: list[Any] = []
         for idx, sampling_params in enumerate(sampling_params_list):
             stage_type = get_stage_type(stage_configs[idx]) if idx < len(stage_configs) else "llm"
@@ -1534,8 +1244,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self,
         default_params: SamplingParams,
         request: ChatCompletionRequest,
-        *,
-        excluded_fields: frozenset[str] = frozenset(),
     ) -> SamplingParams:
         """Clone default params and override with user-provided request values.
 
@@ -1562,7 +1270,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             explicit_fields = getattr(request, "__fields_set__", set())
 
         for field_name in self._OPENAI_SAMPLING_FIELDS:
-            if field_name in excluded_fields or field_name not in explicit_fields:
+            if field_name not in explicit_fields:
                 continue
 
             value = getattr(request, field_name, None)
@@ -1615,8 +1323,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     def _build_sampling_params_list_from_request(
         self,
         request: ChatCompletionRequest,
-        *,
-        excluded_fields: frozenset[str] = frozenset(),
     ) -> list[SamplingParams]:
         """Build sampling_params_list using standard OpenAI API parameters.
 
@@ -1640,11 +1346,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if isinstance(default_params, dict):
                 default_params = SamplingParams(**default_params)
             if idx == comprehension_idx:
-                params = self._apply_request_overrides(
-                    default_params,
-                    request,
-                    excluded_fields=excluded_fields,
-                )
+                params = self._apply_request_overrides(default_params, request)
                 sampling_params_list.append(params)
             else:
                 # For other stages, clone default params
@@ -3748,13 +3450,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     async def _create_diffusion_chat_completion(
         self,
         request: ChatCompletionRequest,
-        diffusion_contract: _DiffusionRequestContract,
+        diffusion_plan: DiffusionChatRequestPlan,
         raw_request: Request | None = None,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Generate images via chat completion interface for diffusion models.
 
         Args:
             request: Chat completion request
+            diffusion_plan: Final request controls and typed stage parameters
             raw_request: Raw FastAPI request object
 
         Returns:
@@ -3779,16 +3482,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 messages
             )
 
-            # Request extras were compiled once at the shared serving boundary.
-            extra_body = diffusion_contract.extra_body
-            negative_prompt = diffusion_contract.control_overrides.get("negative_prompt")
+            negative_prompt = diffusion_plan.controls.get("negative_prompt")
 
             logger.info(
                 "Diffusion chat request %s: prompt=%r, ref_images=%d, params=%s",
                 request_id,
                 prompt[:50] + "..." if len(prompt) > 50 else prompt,
                 len(reference_images),
-                {k: v for k, v in extra_body.items() if v is not None},
+                {k: v for k, v in diffusion_plan.request_sources.items() if v is not None},
             )
 
             # Decode reference images if provided
@@ -3806,11 +3507,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 "negative_prompt": negative_prompt,
                 "modalities": ["image"],
             }
-            gen_params = OmniDiffusionSamplingParams()
-            self._apply_diffusion_request_contract(gen_params, diffusion_contract)
-
             # Route text modality for single-stage diffusion (img2text / text2text)
-            requested_modalities = diffusion_contract.control_overrides.get("modalities") or []
+            requested_modalities = diffusion_plan.controls.get("modalities") or []
             is_text_request = "text" in requested_modalities
 
             if is_text_request:
@@ -3840,52 +3538,16 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
             # Generate image or audio (e.g. AudioX) via AsyncOmni
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)
-            stage_configs = list(getattr(diffusion_engine, "stage_configs", []) or [])
-            default_sampling_params_list = get_default_sampling_params_list(diffusion_engine)
-            if diffusion_contract.sampling_params_list is None:
-                sampling_params_list = build_stage_sampling_params_list(
-                    stage_configs,
-                    default_sampling_params_list,
-                    diffusion_params=gen_params,
-                    replace_diffusion_params=True,
-                )
-            else:
-                sampling_params_list = [
-                    clone_sampling_params(sampling_params)
-                    for sampling_params in diffusion_contract.sampling_params_list
-                ]
-                for sampling_params in sampling_params_list:
-                    if isinstance(sampling_params, OmniDiffusionSamplingParams):
-                        self._apply_diffusion_request_contract(
-                            sampling_params,
-                            diffusion_contract,
-                        )
-
-            # This endpoint replaces diffusion sampling params as a whole, but
-            # model-specific stage defaults remain defaults: request extras
-            # override matching keys without discarding unrelated defaults.
-            for idx, (stage_config, sampling_params) in enumerate(zip(stage_configs, sampling_params_list)):
-                if get_stage_type(stage_config) != "diffusion":
+            sampling_params_list = diffusion_plan.clone_sampling_params_list()
+            for sampling_params in sampling_params_list:
+                if not isinstance(sampling_params, OmniDiffusionSamplingParams):
                     continue
-                default_extra_args = (
-                    getattr(default_sampling_params_list[idx], "extra_args", None)
-                    if idx < len(default_sampling_params_list)
-                    else None
-                )
-                if default_extra_args:
-                    sampling_params.extra_args = {
-                        **default_extra_args,
-                        **(getattr(sampling_params, "extra_args", None) or {}),
-                    }
-                if (reference_videos or reference_audios) and sampling_params.extra_args is None:
-                    sampling_params.extra_args = {}
+                if reference_videos or reference_audios:
+                    sampling_params.extra_args = dict(sampling_params.extra_args or {})
                 if reference_videos:
                     sampling_params.extra_args["video_path"] = reference_videos[0]
                 if reference_audios:
                     sampling_params.extra_args["audio_path"] = reference_audios[0]
-
-            if not sampling_params_list:
-                sampling_params_list = [gen_params]
 
             result = None
             async for output in diffusion_engine.generate(

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -180,6 +180,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             "resolution",
         }
     )
+    _diffusion_existing_control_fields = frozenset(
+        {
+            "size",
+            "negative_prompt",
+            "lora",
+            "modalities",
+        }
+    )
     _diffusion_root_field_aliases = {"cfg_scale": "true_cfg_scale"}
 
     # Harmony flag (always False for vllm-omni models)
@@ -320,10 +328,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = params
         return params
 
-    def _normalize_diffusion_request_extra_args(
+    def _normalize_diffusion_request_args(
         self,
         request: ChatCompletionRequest,
-    ) -> dict[str, object]:
+    ) -> tuple[dict[str, object], dict[str, Any]]:
+        """Normalize extras and preserve validated common root fields."""
         root, nested = self._split_diffusion_request_extra_body(request)
         explicit = getattr(request, "model_fields_set", None)
         if explicit is None:
@@ -331,22 +340,35 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         explicit = set(explicit)
 
         common = self._diffusion_common_root_fields
-        declared = self._get_diffusion_extra_body_params() - common
+        consumed_root_fields = common | self._diffusion_existing_control_fields
+        declared = self._get_diffusion_extra_body_params() - consumed_root_fields
+        consumer_fields = consumed_root_fields | declared
         root_declared = {
             key: getattr(request, key, root.get(key)) for key in declared if key in explicit or key in root
         }
         nested_declared = {key: nested[key] for key in declared if key in nested}
-        return normalize_diffusion_request_extra_args(
-            provided_root_fields=(set(root) | explicit) & common,
+        normalized_extra_args = normalize_diffusion_request_extra_args(
+            provided_root_fields=(set(root) | explicit) & consumed_root_fields,
             root_extra_args=root_declared,
             extra_args=root.get("extra_args"),
             extra_params=root.get("extra_params"),
-            nested_provided_root_fields=set(nested) & common,
+            nested_provided_root_fields=set(nested) & consumed_root_fields,
             nested_root_extra_args=nested_declared,
             nested_extra_args=nested.get("extra_args"),
             nested_extra_params=nested.get("extra_params"),
             root_field_aliases=self._diffusion_root_field_aliases,
         )
+        root_consumer_args = {
+            key: getattr(request, key, root.get(key)) for key in consumer_fields if key in explicit or key in root
+        }
+        nested_consumer_args = {key: nested[key] for key in consumer_fields if key in nested}
+        # Duplicate logical claims have already been rejected, so these
+        # consumer sources are disjoint rather than precedence-ordered.
+        diffusion_request_args = {
+            **nested_consumer_args,
+            **root_consumer_args,
+        }
+        return normalized_extra_args, diffusion_request_args
 
     @staticmethod
     def _split_diffusion_request_extra_body(
@@ -464,9 +486,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs
         )
         normalized_extra_args: dict[str, object] = {}
+        diffusion_request_args: dict[str, Any] = {}
         if serves_diffusion:
             try:
-                normalized_extra_args = self._normalize_diffusion_request_extra_args(request)
+                normalized_extra_args, diffusion_request_args = self._normalize_diffusion_request_args(request)
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)
 
@@ -475,6 +498,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             return await self._create_diffusion_chat_completion(
                 request,
                 normalized_extra_args,
+                diffusion_request_args,
                 raw_request,
             )
 
@@ -618,7 +642,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 return audio_format_check
 
         num_inference_steps = None
-        extra_body: dict[str, Any] = {}
+        extra_body = diffusion_request_args
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
         # processor can construct the correct inputs.
@@ -631,12 +655,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 )
                 if not extracted_prompt:
                     return self.create_error_response("No text prompt found in messages")
-
-                # [NOTE] When sending request via openai client Python library,
-                #   `extra_body` is flattented and merged into the payload's root.
-                #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
-                #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
-                extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
 
                 height, width = self._resolve_height_width_from_extra_body(extra_body)
 
@@ -756,8 +774,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         output_modalities,
                     )
 
+                comprehension_idx = (
+                    self._get_comprehension_stage_index()
+                    if _image_gen_height is not None and _image_gen_width is not None
+                    else None
+                )
                 # Apply user-specified overrides to diffusion stage(s) for image generation
                 for idx, sp in enumerate(sampling_params_list):
+                    if idx == comprehension_idx:
+                        extra_args = dict(getattr(sp, "extra_args", {}) or {})
+                        extra_args["target_h"] = int(_image_gen_height)
+                        extra_args["target_w"] = int(_image_gen_width)
+                        sp.extra_args = extra_args
                     if hasattr(sp, "height") and _image_gen_height is not None:
                         sp.height = _image_gen_height
                     if hasattr(sp, "width") and _image_gen_width is not None:
@@ -1261,8 +1289,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         Starts with YAML defaults and only overrides fields that the user
         explicitly provided (non-None values) in the request.
 
-        For models needing spatial metadata (e.g. GLM-Image), target_h/w is
-        injected into extra_args so the runner can build M-RoPE position grids.
         max_tokens is NOT computed dynamically — it uses the deploy YAML default.
 
         Args:
@@ -1287,19 +1313,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             value = getattr(request, field_name, None)
             if (value is not None and not isinstance(value, list)) or (isinstance(value, list) and len(value) > 0):
                 setattr(params, field_name, value)
-
-        # For GLM-Image: compute max_tokens from height/width with mode-aware
-        # budgeting (t2i vs i2i).
-        extra_body = getattr(request, "extra_body", {}) or {}
-        height, width = self._resolve_height_width_from_extra_body(extra_body)
-
-        if height is not None and width is not None:
-            # Keep target size in stage-0 sampling params so runner/model can
-            # build deterministic M-RoPE grids for t2i (no MM features).
-            extra_args = dict(getattr(params, "extra_args", {}) or {})
-            extra_args["target_h"] = int(height)
-            extra_args["target_w"] = int(width)
-            params.extra_args = extra_args
 
         return params
 
@@ -3462,6 +3475,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self,
         request: ChatCompletionRequest,
         normalized_extra_args: dict[str, object],
+        diffusion_request_args: dict[str, Any],
         raw_request: Request | None = None,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Generate images via chat completion interface for diffusion models.
@@ -3469,6 +3483,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         Args:
             request: Chat completion request
             normalized_extra_args: Validated model-specific request arguments
+            diffusion_request_args: Compatibility arguments plus validated common root fields
             raw_request: Raw FastAPI request object
 
         Returns:
@@ -3493,15 +3508,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 messages
             )
 
-            # Extract generation parameters from extra_body (preferred)
             # Reference: text_to_image.py and text_to_video.py for supported parameters
-            # [NOTE] When sending request via openai client Python library,
-            #   `extra_body` is flattented and merged into the payload's root.
-            #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
-            #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
-            extra_body = getattr(request, "extra_body", None)
-            if not extra_body:
-                extra_body = request.model_extra or {}
+            extra_body = diffusion_request_args
 
             # Parse size if provided (supports "1024x1024" format)
             height, width = self._resolve_height_width_from_extra_body(extra_body)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -142,6 +142,7 @@ class _DiffusionRequestSources:
     explicit_root_values: Mapping[str, Any]
     stage_provided_root_fields: Mapping[int, frozenset[str]]
     stage_extra_args: Mapping[int, object | None]
+    non_diffusion_stage_extra_args: Mapping[int, object | None]
     raw_sampling_params_list: object | None
 
 
@@ -358,24 +359,25 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         )
         explicit_root_values = {key: getattr(request, key, None) for key in set(explicit_fields) & consumed_root_fields}
 
-        raw_sampling_params_list = None
-        if not self._diffusion_mode:
-            raw_sampling_params_list = getattr(request, "sampling_params_list", None)
-            if raw_sampling_params_list is not None and not isinstance(raw_sampling_params_list, list):
-                raise ValueError("sampling_params_list must be a JSON array.")
+        raw_sampling_params_list = getattr(request, "sampling_params_list", None)
+        if raw_sampling_params_list is not None and not isinstance(raw_sampling_params_list, list):
+            raise ValueError("sampling_params_list must be a JSON array.")
 
-        stage_configs = [] if self._diffusion_mode else list(getattr(self.engine_client, "stage_configs", []) or [])
+        stage_owner = self._diffusion_engine if self._diffusion_mode else self.engine_client
+        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
         stage_provided_root_fields: dict[int, frozenset[str]] = {}
         stage_extra_args: dict[int, object | None] = {}
+        non_diffusion_stage_extra_args: dict[int, object | None] = {}
         stage_root_field_names = frozenset(self._diffusion_sampling_root_fields) | declared_extra_fields
         for stage_index, stage_params in enumerate(raw_sampling_params_list or []):
-            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
-                continue
-
             if not isinstance(stage_params, Mapping):
                 raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object.")
             if any(not isinstance(key, str) for key in stage_params):
                 raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object with string keys.")
+            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
+                if not self._diffusion_mode:
+                    non_diffusion_stage_extra_args[stage_index] = stage_params.get("extra_args")
+                continue
             stage_provided_root_fields[stage_index] = frozenset(stage_params) & stage_root_field_names
             stage_extra_args[stage_index] = stage_params.get("extra_args")
 
@@ -385,6 +387,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             explicit_root_values=MappingProxyType(explicit_root_values),
             stage_provided_root_fields=MappingProxyType(stage_provided_root_fields),
             stage_extra_args=MappingProxyType(stage_extra_args),
+            non_diffusion_stage_extra_args=MappingProxyType(non_diffusion_stage_extra_args),
             raw_sampling_params_list=raw_sampling_params_list,
         )
 
@@ -401,19 +404,46 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
         return any(get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs)
 
+    @staticmethod
+    def _validate_non_diffusion_stage_extra_conflicts(
+        sources: _DiffusionRequestSources,
+        declared_root_extra_args: Mapping[str, Any],
+    ) -> None:
+        conflicts: dict[str, list[str]] = {}
+        for stage_index, stage_extra_args in sources.non_diffusion_stage_extra_args.items():
+            if stage_extra_args is None:
+                continue
+            if not isinstance(stage_extra_args, Mapping):
+                raise ValueError(f"sampling_params_list[{stage_index}].extra_args must be a JSON object.")
+            for key in sorted(set(declared_root_extra_args) & set(stage_extra_args)):
+                root_source = f"request.extra_body.{key}" if key in sources.nested_extra_body else f"request.{key}"
+                conflicts.setdefault(key, [root_source]).append(
+                    f"request.sampling_params_list[{stage_index}].extra_args.{key}"
+                )
+        if not conflicts:
+            return
+        if len(conflicts) == 1:
+            key, conflict_sources = next(iter(conflicts.items()))
+            raise ValueError(f'Parameter "{key}" was provided more than once: {", ".join(conflict_sources)}.')
+        details = "; ".join(f'"{key}": {", ".join(conflicts[key])}' for key in sorted(conflicts))
+        raise ValueError(f"Diffusion request parameters were provided more than once: {details}.")
+
     def _compile_request_sampling_params_list(
         self,
         request: ChatCompletionRequest,
         sources: _DiffusionRequestSources,
         declared_extra_fields: frozenset[str],
     ) -> tuple[Any, ...] | None:
-        if self._diffusion_mode:
-            return None
-
-        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
+        stage_owner = self._diffusion_engine if self._diffusion_mode else self.engine_client
+        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
         try:
             if sources.raw_sampling_params_list is None:
-                sampling_params_list = self._build_sampling_params_list_from_request(request)
+                if self._diffusion_mode:
+                    return None
+                sampling_params_list = self._build_sampling_params_list_from_request(
+                    request,
+                    excluded_fields=declared_extra_fields,
+                )
             else:
                 request_sampling_params: list[Any] = []
                 for stage_index, stage_params in enumerate(sources.raw_sampling_params_list):
@@ -439,7 +469,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     if "extra_args" in compiled_stage_params or compiled_stage_extra_args:
                         compiled_stage_params["extra_args"] = compiled_stage_extra_args
                     request_sampling_params.append(compiled_stage_params)
-                sampling_params_list = self._to_sampling_params_list(request_sampling_params)
+                sampling_params_list = self._to_sampling_params_list(
+                    request_sampling_params,
+                    stage_owner=stage_owner,
+                )
         except TypeError as exc:
             raise ValueError(f"Invalid sampling_params_list: {exc}") from exc
 
@@ -505,6 +538,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             nested_extra_params=sources.nested_extra_body.get("extra_params"),
             stage_provided_root_fields=sources.stage_provided_root_fields,
             stage_extra_args=sources.stage_extra_args,
+        )
+        self._validate_non_diffusion_stage_extra_conflicts(
+            sources,
+            compiled.declared_extra_args,
         )
 
         request_values = dict(compiled.request_values)
@@ -1425,7 +1462,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         return new_messages
 
-    def _to_sampling_params_list(self, sampling_params_list: list[dict]) -> list[Any]:
+    def _to_sampling_params_list(
+        self,
+        sampling_params_list: list[dict],
+        *,
+        stage_owner: Any | None = None,
+    ) -> list[Any]:
         """Convert request dicts to stage-typed sampling params objects.
 
         For diffusion stages, build ``OmniDiffusionSamplingParams`` so
@@ -1435,8 +1477,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         (for example AURA has three semantic models but four engine stages),
         append cloned deploy defaults for the omitted tail stages.
         """
-        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
-        default_params_list = list(getattr(self.engine_client, "default_sampling_params_list", []) or [])
+        stage_owner = self.engine_client if stage_owner is None else stage_owner
+        stage_configs = list(getattr(stage_owner, "stage_configs", []) or [])
+        default_params_list = list(getattr(stage_owner, "default_sampling_params_list", []) or [])
         final_sampling_params_list: list[Any] = []
         for idx, sampling_params in enumerate(sampling_params_list):
             stage_type = get_stage_type(stage_configs[idx]) if idx < len(stage_configs) else "llm"
@@ -1491,6 +1534,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self,
         default_params: SamplingParams,
         request: ChatCompletionRequest,
+        *,
+        excluded_fields: frozenset[str] = frozenset(),
     ) -> SamplingParams:
         """Clone default params and override with user-provided request values.
 
@@ -1517,7 +1562,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             explicit_fields = getattr(request, "__fields_set__", set())
 
         for field_name in self._OPENAI_SAMPLING_FIELDS:
-            if field_name not in explicit_fields:
+            if field_name in excluded_fields or field_name not in explicit_fields:
                 continue
 
             value = getattr(request, field_name, None)
@@ -1570,6 +1615,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     def _build_sampling_params_list_from_request(
         self,
         request: ChatCompletionRequest,
+        *,
+        excluded_fields: frozenset[str] = frozenset(),
     ) -> list[SamplingParams]:
         """Build sampling_params_list using standard OpenAI API parameters.
 
@@ -1593,7 +1640,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if isinstance(default_params, dict):
                 default_params = SamplingParams(**default_params)
             if idx == comprehension_idx:
-                params = self._apply_request_overrides(default_params, request)
+                params = self._apply_request_overrides(
+                    default_params,
+                    request,
+                    excluded_fields=excluded_fields,
+                )
                 sampling_params_list.append(params)
             else:
                 # For other stages, clone default params
@@ -3787,34 +3838,51 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             status_code=400,
                         )
 
-            if reference_videos:
-                gen_params.extra_args["video_path"] = reference_videos[0]
-            if reference_audios:
-                gen_params.extra_args["audio_path"] = reference_audios[0]
-
             # Generate image or audio (e.g. AudioX) via AsyncOmni
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)
             stage_configs = list(getattr(diffusion_engine, "stage_configs", []) or [])
             default_sampling_params_list = get_default_sampling_params_list(diffusion_engine)
-            sampling_params_list = build_stage_sampling_params_list(
-                stage_configs,
-                default_sampling_params_list,
-                diffusion_params=gen_params,
-                replace_diffusion_params=True,
-            )
+            if diffusion_contract.sampling_params_list is None:
+                sampling_params_list = build_stage_sampling_params_list(
+                    stage_configs,
+                    default_sampling_params_list,
+                    diffusion_params=gen_params,
+                    replace_diffusion_params=True,
+                )
+            else:
+                sampling_params_list = [
+                    clone_sampling_params(sampling_params)
+                    for sampling_params in diffusion_contract.sampling_params_list
+                ]
+                for sampling_params in sampling_params_list:
+                    if isinstance(sampling_params, OmniDiffusionSamplingParams):
+                        self._apply_diffusion_request_contract(
+                            sampling_params,
+                            diffusion_contract,
+                        )
 
             # This endpoint replaces diffusion sampling params as a whole, but
             # model-specific stage defaults remain defaults: request extras
             # override matching keys without discarding unrelated defaults.
             for idx, (stage_config, sampling_params) in enumerate(zip(stage_configs, sampling_params_list)):
-                if get_stage_type(stage_config) != "diffusion" or idx >= len(default_sampling_params_list):
+                if get_stage_type(stage_config) != "diffusion":
                     continue
-                default_extra_args = getattr(default_sampling_params_list[idx], "extra_args", None)
+                default_extra_args = (
+                    getattr(default_sampling_params_list[idx], "extra_args", None)
+                    if idx < len(default_sampling_params_list)
+                    else None
+                )
                 if default_extra_args:
                     sampling_params.extra_args = {
                         **default_extra_args,
                         **(getattr(sampling_params, "extra_args", None) or {}),
                     }
+                if (reference_videos or reference_audios) and sampling_params.extra_args is None:
+                    sampling_params.extra_args = {}
+                if reference_videos:
+                    sampling_params.extra_args["video_path"] = reference_videos[0]
+                if reference_audios:
+                    sampling_params.extra_args["audio_path"] = reference_audios[0]
 
             if not sampling_params_list:
                 sampling_params_list = [gen_params]

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -173,7 +173,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             "num_inference_steps",
             "guidance_scale",
             "true_cfg_scale",
-            "cfg_scale",
             "num_frames",
             "guidance_scale_2",
             "layers",
@@ -339,9 +338,15 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             explicit = getattr(request, "__fields_set__", ())
         explicit = set(explicit)
 
-        common = self._diffusion_common_root_fields
+        registered_extra_fields = self._get_diffusion_extra_body_params()
+        active_root_field_aliases = {
+            alias: canonical
+            for alias, canonical in self._diffusion_root_field_aliases.items()
+            if alias not in registered_extra_fields
+        }
+        common = self._diffusion_common_root_fields | active_root_field_aliases.keys()
         consumed_root_fields = common | self._diffusion_existing_control_fields
-        declared = self._get_diffusion_extra_body_params() - consumed_root_fields
+        declared = registered_extra_fields - consumed_root_fields
         consumer_fields = consumed_root_fields | declared
         root_declared = {
             key: getattr(request, key, root.get(key)) for key in declared if key in explicit or key in root
@@ -356,7 +361,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             nested_root_extra_args=nested_declared,
             nested_extra_args=nested.get("extra_args"),
             nested_extra_params=nested.get("extra_params"),
-            root_field_aliases=self._diffusion_root_field_aliases,
+            root_field_aliases=active_root_field_aliases,
         )
         root_consumer_args = {
             key: getattr(request, key, root.get(key)) for key in consumer_fields if key in explicit or key in root
@@ -368,6 +373,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             **nested_consumer_args,
             **root_consumer_args,
         }
+        for alias, canonical in active_root_field_aliases.items():
+            if alias in diffusion_request_args:
+                diffusion_request_args[canonical] = diffusion_request_args.pop(alias)
         return normalized_extra_args, diffusion_request_args
 
     @staticmethod
@@ -3520,7 +3528,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             # not provide a value.
             num_inference_steps = extra_body.get("num_inference_steps")
             guidance_scale = extra_body.get("guidance_scale")
-            true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
+            true_cfg_scale = extra_body.get("true_cfg_scale")
             seed = extra_body.get("seed")
             if seed is None:
                 seed = getattr(request, "seed", None)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -4,9 +4,10 @@ import json
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
-from dataclasses import fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
+from types import MappingProxyType
 from typing import Any, Final, cast
 
 import jinja2
@@ -25,7 +26,9 @@ from vllm.entrypoints.chat_utils import (
 
 from vllm_omni.diffusion.utils.param_utils import apply_declared_extra_args
 from vllm_omni.entrypoints.async_omni import AsyncOmni
-from vllm_omni.entrypoints.openai.diffusion_request_utils import normalize_diffusion_request_extra_args
+from vllm_omni.entrypoints.openai.diffusion_request_utils import (
+    compile_diffusion_request_overrides,
+)
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
@@ -132,6 +135,29 @@ from vllm_omni.utils.audio import audio_chunk_pcm_bytes, audio_chunk_sample_rate
 logger = init_logger(__name__)
 
 
+@dataclass(frozen=True)
+class _DiffusionRequestSources:
+    root_extra_body: Mapping[str, Any]
+    nested_extra_body: Mapping[str, Any]
+    explicit_root_values: Mapping[str, Any]
+    stage_provided_root_fields: Mapping[int, frozenset[str]]
+    stage_extra_args: Mapping[int, object | None]
+    raw_sampling_params_list: object | None
+
+
+@dataclass(frozen=True)
+class _DiffusionRequestContract:
+    request_values: Mapping[str, Any]
+    extra_body: Mapping[str, Any]
+    sampling_overrides: Mapping[str, Any]
+    declared_extra_args: Mapping[str, Any]
+    extra_args_overrides: Mapping[str, Any]
+    control_overrides: Mapping[str, Any]
+    lora_request: LoRARequest | None
+    lora_scale: float | None
+    sampling_params_list: tuple[Any, ...] | None
+
+
 async def _identity_async(value: Any) -> Any:
     return value
 
@@ -179,7 +205,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             "modalities",
         }
     )
-    _diffusion_root_field_aliases = {"cfg_scale": "true_cfg_scale"}
 
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
@@ -319,65 +344,250 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = params
         return params
 
-    def _apply_diffusion_request_overrides(
+    def _collect_diffusion_request_sources(
         self,
-        sampling_params: OmniDiffusionSamplingParams,
         request: ChatCompletionRequest,
-        root_extra_body: dict[str, Any],
-        nested_extra_body: dict[str, Any],
-    ) -> None:
+        declared_extra_fields: frozenset[str],
+    ) -> _DiffusionRequestSources:
+        root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
         explicit_fields = getattr(request, "model_fields_set", None)
         if explicit_fields is None:
             explicit_fields = getattr(request, "__fields_set__", set())
-        declared_extra_fields = self._get_diffusion_extra_body_params()
         consumed_root_fields = (
             declared_extra_fields | self._diffusion_sampling_root_fields.keys() | self._diffusion_control_root_fields
         )
-        provided_root_fields = set(root_extra_body) & consumed_root_fields
-        provided_root_fields.update(set(explicit_fields) & consumed_root_fields)
-        nested_provided_root_fields = set(nested_extra_body) & consumed_root_fields
+        explicit_root_values = {key: getattr(request, key, None) for key in set(explicit_fields) & consumed_root_fields}
 
-        normalized = normalize_diffusion_request_extra_args(
-            provided_root_fields=provided_root_fields,
-            extra_args=root_extra_body.get("extra_args"),
-            extra_params=root_extra_body.get("extra_params"),
-            nested_provided_root_fields=nested_provided_root_fields,
-            nested_extra_args=nested_extra_body.get("extra_args"),
-            nested_extra_params=nested_extra_body.get("extra_params"),
-            root_field_aliases=self._diffusion_root_field_aliases,
-        )
+        raw_sampling_params_list = None
+        if not self._diffusion_mode:
+            raw_sampling_params_list = getattr(request, "sampling_params_list", None)
+            if raw_sampling_params_list is not None and not isinstance(raw_sampling_params_list, list):
+                raise ValueError("sampling_params_list must be a JSON array.")
 
-        sampling_overrides: dict[str, Any] = {}
-        for request_field, sampling_field in self._diffusion_sampling_root_fields.items():
-            if request_field in explicit_fields:
-                value = getattr(request, request_field, None)
-            elif request_field in root_extra_body:
-                value = root_extra_body[request_field]
-            elif request_field in nested_extra_body:
-                value = nested_extra_body[request_field]
-            else:
+        stage_configs = [] if self._diffusion_mode else list(getattr(self.engine_client, "stage_configs", []) or [])
+        stage_provided_root_fields: dict[int, frozenset[str]] = {}
+        stage_extra_args: dict[int, object | None] = {}
+        stage_root_field_names = frozenset(self._diffusion_sampling_root_fields) | declared_extra_fields
+        for stage_index, stage_params in enumerate(raw_sampling_params_list or []):
+            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
                 continue
-            if value is not None:
-                if sampling_field == "num_inference_steps":
-                    value = int(value)
-                sampling_overrides[sampling_field] = value
-        self._set_if_supported(sampling_params, **sampling_overrides)
 
-        apply_declared_extra_args(
-            sampling_params,
-            declared_extra_fields,
-            nested_extra_body,
+            if not isinstance(stage_params, Mapping):
+                raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object.")
+            if any(not isinstance(key, str) for key in stage_params):
+                raise ValueError(f"sampling_params_list[{stage_index}] must be a JSON object with string keys.")
+            stage_provided_root_fields[stage_index] = frozenset(stage_params) & stage_root_field_names
+            stage_extra_args[stage_index] = stage_params.get("extra_args")
+
+        return _DiffusionRequestSources(
+            root_extra_body=MappingProxyType(root_extra_body),
+            nested_extra_body=MappingProxyType(nested_extra_body),
+            explicit_root_values=MappingProxyType(explicit_root_values),
+            stage_provided_root_fields=MappingProxyType(stage_provided_root_fields),
+            stage_extra_args=MappingProxyType(stage_extra_args),
+            raw_sampling_params_list=raw_sampling_params_list,
         )
-        apply_declared_extra_args(
-            sampling_params,
-            declared_extra_fields,
-            root_extra_body,
+
+    @staticmethod
+    def _coerce_num_inference_steps(value: object) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("num_inference_steps must be an integer.") from exc
+
+    def _serves_diffusion_requests(self) -> bool:
+        if self._diffusion_mode:
+            return True
+        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
+        return any(get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs)
+
+    def _compile_request_sampling_params_list(
+        self,
+        request: ChatCompletionRequest,
+        sources: _DiffusionRequestSources,
+        declared_extra_fields: frozenset[str],
+    ) -> tuple[Any, ...] | None:
+        if self._diffusion_mode:
+            return None
+
+        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
+        try:
+            if sources.raw_sampling_params_list is None:
+                sampling_params_list = self._build_sampling_params_list_from_request(request)
+            else:
+                request_sampling_params: list[Any] = []
+                for stage_index, stage_params in enumerate(sources.raw_sampling_params_list):
+                    if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
+                        request_sampling_params.append(
+                            dict(stage_params) if isinstance(stage_params, Mapping) else stage_params
+                        )
+                        continue
+
+                    assert isinstance(stage_params, Mapping)
+                    compiled_stage_params = dict(stage_params)
+                    compiled_stage_extra_args = dict(
+                        cast(Mapping[str, Any], sources.stage_extra_args.get(stage_index)) or {}
+                    )
+                    for request_field in sources.stage_provided_root_fields.get(stage_index, ()):
+                        value = compiled_stage_params.pop(request_field)
+                        if request_field in declared_extra_fields:
+                            compiled_stage_extra_args[request_field] = value
+                        else:
+                            sampling_field = self._diffusion_sampling_root_fields.get(request_field)
+                            if sampling_field is not None:
+                                compiled_stage_params[sampling_field] = value
+                    if "extra_args" in compiled_stage_params or compiled_stage_extra_args:
+                        compiled_stage_params["extra_args"] = compiled_stage_extra_args
+                    request_sampling_params.append(compiled_stage_params)
+                sampling_params_list = self._to_sampling_params_list(request_sampling_params)
+        except TypeError as exc:
+            raise ValueError(f"Invalid sampling_params_list: {exc}") from exc
+
+        for stage_index, sampling_params in enumerate(sampling_params_list):
+            if stage_index >= len(stage_configs) or get_stage_type(stage_configs[stage_index]) != "diffusion":
+                continue
+
+            provided_root_fields = sources.stage_provided_root_fields.get(stage_index, ())
+            provided_extra_args = sources.stage_extra_args.get(stage_index)
+            provided_extra_fields = set(provided_extra_args) if isinstance(provided_extra_args, Mapping) else set()
+
+            if "num_inference_steps" in declared_extra_fields and (
+                "num_inference_steps" in provided_root_fields or "num_inference_steps" in provided_extra_fields
+            ):
+                stage_extra_args = dict(getattr(sampling_params, "extra_args", None) or {})
+                value = stage_extra_args.get("num_inference_steps")
+                if value is not None:
+                    stage_extra_args["num_inference_steps"] = self._coerce_num_inference_steps(value)
+                    sampling_params.extra_args = stage_extra_args
+            elif "num_inference_steps" in provided_root_fields:
+                value = getattr(sampling_params, "num_inference_steps", None)
+                if value is not None:
+                    sampling_params.num_inference_steps = self._coerce_num_inference_steps(value)
+
+            if "layers" in declared_extra_fields and (
+                "layers" in provided_root_fields or "layers" in provided_extra_fields
+            ):
+                stage_extra_args = dict(getattr(sampling_params, "extra_args", None) or {})
+                value = stage_extra_args.get("layers")
+                if value is not None:
+                    stage_extra_args["layers"] = validate_layered_layers(value)
+                    sampling_params.extra_args = stage_extra_args
+            elif "layers" in provided_root_fields:
+                value = getattr(sampling_params, "layers", None)
+                if value is not None:
+                    sampling_params.layers = validate_layered_layers(value)
+
+        return tuple(clone_sampling_params(sampling_params) for sampling_params in sampling_params_list)
+
+    def _compile_diffusion_request_contract(
+        self,
+        request: ChatCompletionRequest,
+    ) -> _DiffusionRequestContract:
+        declared_extra_fields = self._get_diffusion_extra_body_params()
+        sources = self._collect_diffusion_request_sources(request, declared_extra_fields)
+
+        # Schema fields and Pydantic model extras are the same flattened JSON
+        # source. Collect each root key once before comparing it with nested and
+        # container sources.
+        root_values = {
+            **sources.root_extra_body,
+            **sources.explicit_root_values,
+        }
+        compiled = compile_diffusion_request_overrides(
+            root_values=root_values,
+            nested_root_values=sources.nested_extra_body,
+            sampling_root_fields=self._diffusion_sampling_root_fields,
+            declared_extra_fields=declared_extra_fields,
+            control_root_fields=self._diffusion_control_root_fields,
+            extra_args=sources.root_extra_body.get("extra_args"),
+            extra_params=sources.root_extra_body.get("extra_params"),
+            nested_extra_args=sources.nested_extra_body.get("extra_args"),
+            nested_extra_params=sources.nested_extra_body.get("extra_params"),
+            stage_provided_root_fields=sources.stage_provided_root_fields,
+            stage_extra_args=sources.stage_extra_args,
         )
-        if normalized:
+
+        request_values = dict(compiled.request_values)
+        sampling_overrides = dict(compiled.sampling_overrides)
+        declared_extra_args = dict(compiled.declared_extra_args)
+        extra_args_overrides = dict(compiled.extra_args)
+        control_overrides = dict(compiled.control_overrides)
+
+        if "num_inference_steps" in sampling_overrides:
+            sampling_overrides["num_inference_steps"] = self._coerce_num_inference_steps(
+                sampling_overrides["num_inference_steps"]
+            )
+        if "num_inference_steps" in declared_extra_fields and "num_inference_steps" in extra_args_overrides:
+            extra_args_overrides["num_inference_steps"] = self._coerce_num_inference_steps(
+                extra_args_overrides["num_inference_steps"]
+            )
+            if "num_inference_steps" in declared_extra_args:
+                declared_extra_args["num_inference_steps"] = extra_args_overrides["num_inference_steps"]
+
+        if "layers" in sampling_overrides:
+            sampling_overrides["layers"] = validate_layered_layers(sampling_overrides["layers"])
+        if "layers" in declared_extra_fields and "layers" in extra_args_overrides:
+            extra_args_overrides["layers"] = validate_layered_layers(extra_args_overrides["layers"])
+            if "layers" in declared_extra_args:
+                declared_extra_args["layers"] = extra_args_overrides["layers"]
+
+        height, width = self._resolve_height_width_from_extra_body(request_values)
+        if height is not None:
+            control_overrides["height"] = height
+            if "height" in sampling_overrides:
+                sampling_overrides["height"] = height
+        if width is not None:
+            control_overrides["width"] = width
+            if "width" in sampling_overrides:
+                sampling_overrides["width"] = width
+
+        try:
+            lora_request, lora_scale = parse_lora_request(control_overrides.get("lora"))
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(str(exc)) from exc
+
+        # Duplicate consumed keys were rejected above. This union preserves the
+        # complete request for diagnostics; its ordering is not precedence.
+        extra_body = MappingProxyType(
+            {
+                **sources.nested_extra_body,
+                **sources.root_extra_body,
+                **sources.explicit_root_values,
+            }
+        )
+        compiled_sampling_params_list = self._compile_request_sampling_params_list(
+            request,
+            sources,
+            declared_extra_fields,
+        )
+
+        return _DiffusionRequestContract(
+            request_values=MappingProxyType(request_values),
+            extra_body=extra_body,
+            sampling_overrides=MappingProxyType(sampling_overrides),
+            declared_extra_args=MappingProxyType(declared_extra_args),
+            extra_args_overrides=MappingProxyType(extra_args_overrides),
+            control_overrides=MappingProxyType(control_overrides),
+            lora_request=lora_request,
+            lora_scale=lora_scale,
+            sampling_params_list=compiled_sampling_params_list,
+        )
+
+    def _apply_diffusion_request_contract(
+        self,
+        sampling_params: OmniDiffusionSamplingParams,
+        contract: _DiffusionRequestContract,
+    ) -> None:
+        self._set_if_supported(sampling_params, **contract.sampling_overrides)
+        if contract.extra_args_overrides:
             sampling_params.extra_args = {
                 **(sampling_params.extra_args or {}),
-                **normalized,
+                **contract.extra_args_overrides,
             }
+        if contract.lora_request is not None:
+            sampling_params.lora_request = contract.lora_request
+            if contract.lora_scale is not None:
+                sampling_params.lora_scale = contract.lora_scale
 
     @staticmethod
     def _split_diffusion_request_extra_body(
@@ -490,9 +700,21 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | ChatCompletionResponse | ErrorResponse:
+        diffusion_contract: _DiffusionRequestContract | None = None
+        if self._serves_diffusion_requests():
+            try:
+                diffusion_contract = self._compile_diffusion_request_contract(request)
+            except ValueError as exc:
+                return self._create_error_response(str(exc), status_code=400)
+
         # Handle diffusion mode
         if self._diffusion_mode:
-            return await self._create_diffusion_chat_completion(request, raw_request)
+            assert diffusion_contract is not None
+            return await self._create_diffusion_chat_completion(
+                request,
+                diffusion_contract,
+                raw_request,
+            )
 
         request_timestamp = time.time()
         if raw_request is not None:
@@ -613,7 +835,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # Some models will return a list like ["text", None, "audio"], better
         # to strip None in the list
         engine_output_modalities = [x for x in self.engine_client.output_modalities if x is not None]
-        output_modalities = getattr(request, "modalities", engine_output_modalities)
+        if diffusion_contract is not None and "modalities" in diffusion_contract.control_overrides:
+            output_modalities = diffusion_contract.control_overrides["modalities"]
+        else:
+            output_modalities = getattr(request, "modalities", engine_output_modalities)
         request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
 
         if not isinstance(request.modalities, list) or not all(isinstance(m, str) for m in request.modalities):
@@ -633,15 +858,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if isinstance(audio_format_check, ErrorResponse):
                 return audio_format_check
 
-        num_inference_steps = None
-        # The OpenAI client flattens ``extra_body`` into request extras, while
-        # raw HTTP callers may send the nested compatibility form. Keep both
-        # sources separate until duplicate detection has run.
-        try:
-            root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
-        except ValueError as e:
-            return self.create_error_response(str(e))
-        extra_body = {**nested_extra_body, **root_extra_body}
+        if diffusion_contract is None:
+            try:
+                root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
+            except ValueError as exc:
+                return self.create_error_response(str(exc))
+            extra_body = {**nested_extra_body, **root_extra_body}
+        else:
+            extra_body = diffusion_contract.extra_body
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
         # processor can construct the correct inputs.
@@ -655,16 +879,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 if not extracted_prompt:
                     return self.create_error_response("No text prompt found in messages")
 
-                height, width = self._resolve_height_width_from_extra_body(extra_body)
-
-                num_inference_steps = extra_body.get("num_inference_steps")
-                if num_inference_steps is not None:
-                    try:
-                        num_inference_steps = int(num_inference_steps)
-                    except Exception:
-                        num_inference_steps = None
-
-                negative_prompt = extra_body.get("negative_prompt")
+                if diffusion_contract is None:
+                    height, width = self._resolve_height_width_from_extra_body(extra_body)
+                    negative_prompt = extra_body.get("negative_prompt")
+                else:
+                    height = diffusion_contract.control_overrides.get("height")
+                    width = diffusion_contract.control_overrides.get("width")
+                    negative_prompt = diffusion_contract.control_overrides.get("negative_prompt")
                 engine_prompt_image: dict[str, Any] | None = None
                 if reference_images:
                     # Best-effort decode first reference image for i2i.
@@ -714,13 +935,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     }
 
                 engine_prompts = [tprompt]
-                # Store height/width for applying to diffusion stage sampling params later
-                _image_gen_height = height
-                _image_gen_width = width
             except Exception as e:
                 logger.warning("Failed to build image-generation prompt for omni multistage: %s", e)
-                _image_gen_height = None
-                _image_gen_width = None
         elif request.modalities and ("text" in request.modalities) and is_single_stage_diffusion(self.engine_client):
             # Single-stage diffusion text output (img2text / text2text).
             # Build a diffusion-style prompt with modalities=["text"] so the
@@ -747,21 +963,23 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 engine_prompts = [tprompt]
             except Exception as e:
                 logger.warning("Failed to build text-output prompt for single-stage diffusion: %s", e)
-            _image_gen_height = None
-            _image_gen_width = None
-        else:
-            _image_gen_height = None
-            _image_gen_width = None
 
         # Schedule the request and get the result generator.
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         try:
-            for i, engine_prompt in enumerate(engine_prompts):
-                if hasattr(request, "sampling_params_list"):
-                    sampling_params_list = self._to_sampling_params_list(request.sampling_params_list)
+            for engine_prompt in engine_prompts:
+                if diffusion_contract is None:
+                    raw_sampling_params_list = getattr(request, "sampling_params_list", None)
+                    if raw_sampling_params_list is not None:
+                        sampling_params_list = self._to_sampling_params_list(raw_sampling_params_list)
+                    else:
+                        sampling_params_list = self._build_sampling_params_list_from_request(request)
                 else:
-                    # Use standard OpenAI API parameters for comprehension stage
-                    sampling_params_list = self._build_sampling_params_list_from_request(request)
+                    assert diffusion_contract.sampling_params_list is not None
+                    sampling_params_list = [
+                        clone_sampling_params(sampling_params)
+                        for sampling_params in diffusion_contract.sampling_params_list
+                    ]
 
                 # If this is a streaming (output) request, coerce cumulative outputs
                 # to delta to ensure emitted outputs are correctly drained. Otherwise
@@ -774,25 +992,22 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     )
 
                 # Apply user-specified overrides to diffusion stage(s) for image generation
-                for idx, sp in enumerate(sampling_params_list):
-                    if hasattr(sp, "height") and _image_gen_height is not None:
-                        sp.height = _image_gen_height
-                    if hasattr(sp, "width") and _image_gen_width is not None:
-                        sp.width = _image_gen_width
-                    if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
-                        sp.num_inference_steps = num_inference_steps
+                for sp in sampling_params_list:
                     if isinstance(sp, OmniDiffusionSamplingParams):
-                        try:
-                            self._apply_diffusion_request_overrides(
-                                sp,
-                                request,
-                                root_extra_body,
-                                nested_extra_body,
-                            )
-                        except ValueError as e:
-                            return self._create_error_response(str(e), status_code=400)
-                    else:
-                        apply_declared_extra_args(sp, self._get_diffusion_extra_body_params(), extra_body)
+                        assert diffusion_contract is not None
+                        self._apply_diffusion_request_contract(sp, diffusion_contract)
+                    elif diffusion_contract is not None and diffusion_contract.declared_extra_args:
+                        apply_declared_extra_args(
+                            sp,
+                            frozenset(diffusion_contract.declared_extra_args),
+                            diffusion_contract.declared_extra_args,
+                        )
+                    elif diffusion_contract is None:
+                        apply_declared_extra_args(
+                            sp,
+                            self._get_diffusion_extra_body_params(),
+                            extra_body,
+                        )
 
                 self._log_inputs(
                     request_id,
@@ -3482,6 +3697,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     async def _create_diffusion_chat_completion(
         self,
         request: ChatCompletionRequest,
+        diffusion_contract: _DiffusionRequestContract,
         raw_request: Request | None = None,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Generate images via chat completion interface for diffusion models.
@@ -3512,48 +3728,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 messages
             )
 
-            # Extract generation parameters from root request extras and the
-            # nested compatibility form without discarding either source.
-            # Reference: text_to_image.py and text_to_video.py for supported parameters
-            # [NOTE] When sending request via openai client Python library,
-            #   `extra_body` is flattented and merged into the payload's root.
-            #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
-            #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
-            try:
-                root_extra_body, nested_extra_body = self._split_diffusion_request_extra_body(request)
-            except ValueError as e:
-                return self._create_error_response(str(e), status_code=400)
-            extra_body = {**nested_extra_body, **root_extra_body}
-
-            # Parse size if provided (supports "1024x1024" format)
-            height, width = self._resolve_height_width_from_extra_body(extra_body)
-
-            # Get request parameters from extra_body.
-            # Avoid hardcoded defaults here — let each pipeline's forward()
-            # method apply its own model-specific default when the user does
-            # not provide a value.
-            num_inference_steps = extra_body.get("num_inference_steps")
-            guidance_scale = extra_body.get("guidance_scale")
-            true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
-            seed = extra_body.get("seed")
-            if seed is None:
-                seed = getattr(request, "seed", None)
-            negative_prompt = extra_body.get("negative_prompt")
-            num_outputs_per_prompt = extra_body.get("num_outputs_per_prompt", 1)
-
-            # Text-to-video parameters (ref: text_to_video.py)
-            num_frames = extra_body.get("num_frames")
-            guidance_scale_2 = extra_body.get("guidance_scale_2")
-            lora_body = extra_body.get("lora")
-
-            # Qwen-Image-Layered parameters
-            layers = extra_body.get("layers")
-            resolution = extra_body.get("resolution")
-
-            try:
-                layers = validate_layered_layers(layers)
-            except ValueError as e:
-                return self._create_error_response(str(e), status_code=400)
+            # Request extras were compiled once at the shared serving boundary.
+            extra_body = diffusion_contract.extra_body
+            negative_prompt = diffusion_contract.control_overrides.get("negative_prompt")
 
             logger.info(
                 "Diffusion chat request %s: prompt=%r, ref_images=%d, params=%s",
@@ -3578,51 +3755,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 "negative_prompt": negative_prompt,
                 "modalities": ["image"],
             }
-            gen_params = OmniDiffusionSamplingParams(
-                height=height,
-                width=width,
-                num_outputs_per_prompt=num_outputs_per_prompt,
-                seed=seed,
-            )
-
-            # Only override defaults when the user explicitly provides values
-            if num_inference_steps is not None:
-                gen_params.num_inference_steps = num_inference_steps
-            if guidance_scale is not None:
-                gen_params.guidance_scale = guidance_scale
-            if true_cfg_scale is not None:
-                gen_params.true_cfg_scale = true_cfg_scale
-            try:
-                self._apply_diffusion_request_overrides(
-                    gen_params,
-                    request,
-                    root_extra_body,
-                    nested_extra_body,
-                )
-            except ValueError as e:
-                return self._create_error_response(str(e), status_code=400)
-            if num_frames is not None:
-                gen_params.num_frames = num_frames
-            if guidance_scale_2 is not None:
-                gen_params.guidance_scale_2 = guidance_scale_2
-            if layers is not None:
-                gen_params.layers = layers
-            if resolution is not None:
-                gen_params.resolution = resolution
-
-            # Parse per-request LoRA.
-            if lora_body and isinstance(lora_body, dict):
-                try:
-                    lora_req, lora_scale = parse_lora_request(lora_body)
-                    if lora_req is not None:
-                        gen_params.lora_request = lora_req
-                        if lora_scale is not None:
-                            gen_params.lora_scale = lora_scale
-                except Exception as e:  # pragma: no cover - safeguard
-                    logger.warning("Failed to parse LoRA request: %s", e)
+            gen_params = OmniDiffusionSamplingParams()
+            self._apply_diffusion_request_contract(gen_params, diffusion_contract)
 
             # Route text modality for single-stage diffusion (img2text / text2text)
-            requested_modalities = extra_body.get("modalities") or []
+            requested_modalities = diffusion_contract.control_overrides.get("modalities") or []
             is_text_request = "text" in requested_modalities
 
             if is_text_request:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3,7 +3,7 @@ import base64
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from dataclasses import fields, is_dataclass
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -26,9 +26,8 @@ from vllm.entrypoints.chat_utils import (
 from vllm_omni.diffusion.utils.param_utils import apply_declared_extra_args
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.diffusion_request_utils import (
-    DiffusionChatRequestPlan,
-    compile_diffusion_chat_request_plan,
-    resolve_diffusion_chat_request_context,
+    apply_normalized_diffusion_request_extra_args,
+    normalize_diffusion_request_extra_args,
 )
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.entrypoints.utils import coerce_param_message_types
@@ -103,7 +102,10 @@ from vllm.utils.collection_utils import as_list
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
-from vllm_omni.entrypoints.openai.image_api_utils import encode_image_base64_with_compression
+from vllm_omni.entrypoints.openai.image_api_utils import (
+    encode_image_base64_with_compression,
+    validate_layered_layers,
+)
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
 from vllm_omni.entrypoints.openai.protocol.audio import (
     DEFAULT_AUDIO_FORMAT,
@@ -160,6 +162,26 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     _supported_speakers: set[str] | None = None
     _diffusion_extra_body_params: frozenset[str] | None = None
     _diffusion_extra_output_params: frozenset[str] | None = None
+    # Common fields stay at the request root, but still participate in
+    # conflicts with model-specific compatibility forms.
+    _diffusion_common_root_fields = frozenset(
+        {
+            "height",
+            "width",
+            "num_outputs_per_prompt",
+            "seed",
+            "num_inference_steps",
+            "guidance_scale",
+            "true_cfg_scale",
+            "cfg_scale",
+            "num_frames",
+            "guidance_scale_2",
+            "layers",
+            "resolution",
+        }
+    )
+    _diffusion_root_field_aliases = {"cfg_scale": "true_cfg_scale"}
+
     # Harmony flag (always False for vllm-omni models)
     use_harmony: bool = False
 
@@ -298,11 +320,49 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self._diffusion_extra_body_params = params
         return params
 
-    def _serves_diffusion_requests(self) -> bool:
-        if self._diffusion_mode:
-            return True
-        stage_configs = list(getattr(self.engine_client, "stage_configs", []) or [])
-        return any(get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs)
+    def _normalize_diffusion_request_extra_args(
+        self,
+        request: ChatCompletionRequest,
+    ) -> dict[str, object]:
+        root, nested = self._split_diffusion_request_extra_body(request)
+        explicit = getattr(request, "model_fields_set", None)
+        if explicit is None:
+            explicit = getattr(request, "__fields_set__", ())
+        explicit = set(explicit)
+
+        common = self._diffusion_common_root_fields
+        declared = self._get_diffusion_extra_body_params() - common
+        root_declared = {
+            key: getattr(request, key, root.get(key)) for key in declared if key in explicit or key in root
+        }
+        nested_declared = {key: nested[key] for key in declared if key in nested}
+        return normalize_diffusion_request_extra_args(
+            provided_root_fields=(set(root) | explicit) & common,
+            root_extra_args=root_declared,
+            extra_args=root.get("extra_args"),
+            extra_params=root.get("extra_params"),
+            nested_provided_root_fields=set(nested) & common,
+            nested_root_extra_args=nested_declared,
+            nested_extra_args=nested.get("extra_args"),
+            nested_extra_params=nested.get("extra_params"),
+            root_field_aliases=self._diffusion_root_field_aliases,
+        )
+
+    @staticmethod
+    def _split_diffusion_request_extra_body(
+        request: ChatCompletionRequest,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        root = dict(request.model_extra or {})
+        nested_value = root.pop("extra_body", None)
+        if nested_value is None:
+            nested_value = getattr(request, "extra_body", None)
+        if nested_value is None:
+            return root, {}
+        if not isinstance(nested_value, Mapping):
+            raise ValueError("extra_body must be a JSON object.")
+        if any(not isinstance(key, str) for key in nested_value):
+            raise ValueError("extra_body must be a JSON object with string keys.")
+        return root, dict(nested_value)
 
     def _get_diffusion_extra_output_params(
         self,
@@ -399,30 +459,22 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         request: ChatCompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | ChatCompletionResponse | ErrorResponse:
-        diffusion_plan: DiffusionChatRequestPlan | None = None
-        if self._serves_diffusion_requests():
+        stage_configs = getattr(self.engine_client, "stage_configs", ()) or ()
+        serves_diffusion = self._diffusion_mode or any(
+            get_stage_type(stage_config) == "diffusion" for stage_config in stage_configs
+        )
+        normalized_extra_args: dict[str, object] = {}
+        if serves_diffusion:
             try:
-                diffusion_context = resolve_diffusion_chat_request_context(
-                    engine_client=self.engine_client,
-                    diffusion_engine=self._diffusion_engine,
-                    diffusion_mode=self._diffusion_mode,
-                    standard_sampling_fields=self._OPENAI_SAMPLING_FIELDS,
-                    declared_extra_fields=self._diffusion_extra_body_params,
-                )
-                self._diffusion_extra_body_params = diffusion_context.declared_extra_fields
-                diffusion_plan = compile_diffusion_chat_request_plan(
-                    request=request,
-                    context=diffusion_context,
-                )
+                normalized_extra_args = self._normalize_diffusion_request_extra_args(request)
             except ValueError as exc:
                 return self._create_error_response(str(exc), status_code=400)
 
         # Handle diffusion mode
         if self._diffusion_mode:
-            assert diffusion_plan is not None
             return await self._create_diffusion_chat_completion(
                 request,
-                diffusion_plan,
+                normalized_extra_args,
                 raw_request,
             )
 
@@ -545,30 +597,27 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # Some models will return a list like ["text", None, "audio"], better
         # to strip None in the list
         engine_output_modalities = [x for x in self.engine_client.output_modalities if x is not None]
-        if diffusion_plan is not None and "modalities" in diffusion_plan.controls:
-            output_modalities = diffusion_plan.controls["modalities"]
-        else:
-            output_modalities = getattr(request, "modalities", engine_output_modalities)
+        output_modalities = getattr(request, "modalities", engine_output_modalities)
         request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
 
         if not isinstance(request.modalities, list) or not all(isinstance(m, str) for m in request.modalities):
             return self.create_error_response("'modalities' must be a list of strings.")
-        if diffusion_plan is None:
-            allowed_modalities = set(engine_output_modalities)
-            if is_single_stage_diffusion(self.engine_client):
-                allowed_modalities.add("text")
-            unsupported = set(request.modalities) - allowed_modalities
-            if unsupported:
-                return self.create_error_response(
-                    f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
-                    f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
-                )
+        allowed_modalities = set(engine_output_modalities)
+        if is_single_stage_diffusion(self.engine_client):
+            allowed_modalities.add("text")
+        unsupported = set(request.modalities) - allowed_modalities
+        if unsupported:
+            return self.create_error_response(
+                f"Unsupported output modalities {', '.join(sorted(unsupported))} for this model. "
+                f"Supported modalities: {', '.join(sorted(allowed_modalities))}",
+            )
 
         if request.modalities and "audio" in request.modalities:
             audio_format_check = self._resolve_audio_format(request)
             if isinstance(audio_format_check, ErrorResponse):
                 return audio_format_check
 
+        num_inference_steps = None
         extra_body: dict[str, Any] = {}
         # Omni multistage image generation: Stage-0 (AR) should receive a clean
         # text prompt (and optional conditioning image/size) so the model's own
@@ -583,15 +632,22 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 if not extracted_prompt:
                     return self.create_error_response("No text prompt found in messages")
 
-                if diffusion_plan is None:
-                    # No configured stage serves diffusion in this legacy branch.
-                    extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
-                    height, width = self._resolve_height_width_from_extra_body(extra_body)
-                    negative_prompt = extra_body.get("negative_prompt")
-                else:
-                    height = diffusion_plan.controls.get("height")
-                    width = diffusion_plan.controls.get("width")
-                    negative_prompt = diffusion_plan.controls.get("negative_prompt")
+                # [NOTE] When sending request via openai client Python library,
+                #   `extra_body` is flattented and merged into the payload's root.
+                #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
+                #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
+                extra_body = getattr(request, "extra_body", None) or request.model_extra or {}
+
+                height, width = self._resolve_height_width_from_extra_body(extra_body)
+
+                num_inference_steps = extra_body.get("num_inference_steps")
+                if num_inference_steps is not None:
+                    try:
+                        num_inference_steps = int(num_inference_steps)
+                    except Exception:
+                        num_inference_steps = None
+
+                negative_prompt = extra_body.get("negative_prompt")
                 engine_prompt_image: dict[str, Any] | None = None
                 if reference_images:
                     # Best-effort decode first reference image for i2i.
@@ -641,8 +697,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     }
 
                 engine_prompts = [tprompt]
+                # Store height/width for applying to diffusion stage sampling params later
+                _image_gen_height = height
+                _image_gen_width = width
             except Exception as e:
                 logger.warning("Failed to build image-generation prompt for omni multistage: %s", e)
+                _image_gen_height = None
+                _image_gen_width = None
         elif request.modalities and ("text" in request.modalities) and is_single_stage_diffusion(self.engine_client):
             # Single-stage diffusion text output (img2text / text2text).
             # Build a diffusion-style prompt with modalities=["text"] so the
@@ -669,19 +730,21 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 engine_prompts = [tprompt]
             except Exception as e:
                 logger.warning("Failed to build text-output prompt for single-stage diffusion: %s", e)
+            _image_gen_height = None
+            _image_gen_width = None
+        else:
+            _image_gen_height = None
+            _image_gen_width = None
 
         # Schedule the request and get the result generator.
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         try:
-            for engine_prompt in engine_prompts:
-                if diffusion_plan is None:
-                    raw_sampling_params_list = getattr(request, "sampling_params_list", None)
-                    if raw_sampling_params_list is not None:
-                        sampling_params_list = self._to_sampling_params_list(raw_sampling_params_list)
-                    else:
-                        sampling_params_list = self._build_sampling_params_list_from_request(request)
+            for i, engine_prompt in enumerate(engine_prompts):
+                if hasattr(request, "sampling_params_list"):
+                    sampling_params_list = self._to_sampling_params_list(request.sampling_params_list)
                 else:
-                    sampling_params_list = diffusion_plan.clone_sampling_params_list()
+                    # Use standard OpenAI API parameters for comprehension stage
+                    sampling_params_list = self._build_sampling_params_list_from_request(request)
 
                 # If this is a streaming (output) request, coerce cumulative outputs
                 # to delta to ensure emitted outputs are correctly drained. Otherwise
@@ -693,10 +756,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         output_modalities,
                     )
 
-                if diffusion_plan is None:
-                    # Legacy non-diffusion Chat paths still apply model extras
-                    # here. Diffusion plans already contain final stage params.
-                    for sp in sampling_params_list:
+                # Apply user-specified overrides to diffusion stage(s) for image generation
+                for idx, sp in enumerate(sampling_params_list):
+                    if hasattr(sp, "height") and _image_gen_height is not None:
+                        sp.height = _image_gen_height
+                    if hasattr(sp, "width") and _image_gen_width is not None:
+                        sp.width = _image_gen_width
+                    if hasattr(sp, "num_inference_steps") and num_inference_steps is not None:
+                        sp.num_inference_steps = num_inference_steps
+                    if isinstance(sp, OmniDiffusionSamplingParams):
+                        apply_normalized_diffusion_request_extra_args(sp, normalized_extra_args)
+                    else:
                         apply_declared_extra_args(
                             sp,
                             self._get_diffusion_extra_body_params(),
@@ -3391,14 +3461,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     async def _create_diffusion_chat_completion(
         self,
         request: ChatCompletionRequest,
-        diffusion_plan: DiffusionChatRequestPlan,
+        normalized_extra_args: dict[str, object],
         raw_request: Request | None = None,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Generate images via chat completion interface for diffusion models.
 
         Args:
             request: Chat completion request
-            diffusion_plan: Final request controls and typed stage parameters
+            normalized_extra_args: Validated model-specific request arguments
             raw_request: Raw FastAPI request object
 
         Returns:
@@ -3423,13 +3493,51 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 messages
             )
 
-            negative_prompt = diffusion_plan.controls.get("negative_prompt")
+            # Extract generation parameters from extra_body (preferred)
+            # Reference: text_to_image.py and text_to_video.py for supported parameters
+            # [NOTE] When sending request via openai client Python library,
+            #   `extra_body` is flattented and merged into the payload's root.
+            #   These extra fields are accessible via `model_extra` property (from Pydantic base class).
+            #   When sending raw request with curl, no flattening happens. Directly read the `extra_body` dict.
+            extra_body = getattr(request, "extra_body", None)
+            if not extra_body:
+                extra_body = request.model_extra or {}
+
+            # Parse size if provided (supports "1024x1024" format)
+            height, width = self._resolve_height_width_from_extra_body(extra_body)
+
+            # Get request parameters from extra_body.
+            # Avoid hardcoded defaults here — let each pipeline's forward()
+            # method apply its own model-specific default when the user does
+            # not provide a value.
+            num_inference_steps = extra_body.get("num_inference_steps")
+            guidance_scale = extra_body.get("guidance_scale")
+            true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
+            seed = extra_body.get("seed")
+            if seed is None:
+                seed = getattr(request, "seed", None)
+            negative_prompt = extra_body.get("negative_prompt")
+            num_outputs_per_prompt = extra_body.get("num_outputs_per_prompt", 1)
+
+            # Text-to-video parameters (ref: text_to_video.py)
+            num_frames = extra_body.get("num_frames")
+            guidance_scale_2 = extra_body.get("guidance_scale_2")
+            lora_body = extra_body.get("lora")
+
+            # Qwen-Image-Layered parameters
+            layers = extra_body.get("layers")
+            resolution = extra_body.get("resolution")
+            try:
+                layers = validate_layered_layers(layers)
+            except ValueError as exc:
+                return self._create_error_response(str(exc), status_code=400)
 
             logger.info(
-                "Diffusion chat request %s: prompt=%r, ref_images=%d",
+                "Diffusion chat request %s: prompt=%r, ref_images=%d, params=%s",
                 request_id,
                 prompt[:50] + "..." if len(prompt) > 50 else prompt,
                 len(reference_images),
+                {key: value for key, value in extra_body.items() if value is not None},
             )
 
             # Decode reference images if provided
@@ -3447,8 +3555,43 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 "negative_prompt": negative_prompt,
                 "modalities": ["image"],
             }
+            gen_params = OmniDiffusionSamplingParams(
+                height=height,
+                width=width,
+                num_outputs_per_prompt=num_outputs_per_prompt,
+                seed=seed,
+            )
+
+            # Only override defaults when the user explicitly provides values
+            if num_inference_steps is not None:
+                gen_params.num_inference_steps = num_inference_steps
+            if guidance_scale is not None:
+                gen_params.guidance_scale = guidance_scale
+            if true_cfg_scale is not None:
+                gen_params.true_cfg_scale = true_cfg_scale
+            apply_normalized_diffusion_request_extra_args(gen_params, normalized_extra_args)
+            if num_frames is not None:
+                gen_params.num_frames = num_frames
+            if guidance_scale_2 is not None:
+                gen_params.guidance_scale_2 = guidance_scale_2
+            if layers is not None:
+                gen_params.layers = layers
+            if resolution is not None:
+                gen_params.resolution = resolution
+
+            # Parse per-request LoRA.
+            if lora_body and isinstance(lora_body, dict):
+                try:
+                    lora_req, lora_scale = parse_lora_request(lora_body)
+                    if lora_req is not None:
+                        gen_params.lora_request = lora_req
+                        if lora_scale is not None:
+                            gen_params.lora_scale = lora_scale
+                except Exception as exc:  # pragma: no cover - safeguard
+                    logger.warning("Failed to parse LoRA request: %s", exc)
+
             # Route text modality for single-stage diffusion (img2text / text2text)
-            requested_modalities = diffusion_plan.controls.get("modalities") or []
+            requested_modalities = extra_body.get("modalities") or []
             is_text_request = "text" in requested_modalities
 
             if is_text_request:
@@ -3476,18 +3619,32 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             status_code=400,
                         )
 
+            if reference_videos:
+                gen_params.extra_args["video_path"] = reference_videos[0]
+            if reference_audios:
+                gen_params.extra_args["audio_path"] = reference_audios[0]
+
             # Generate image or audio (e.g. AudioX) via AsyncOmni
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)
-            sampling_params_list = diffusion_plan.clone_sampling_params_list()
-            for sampling_params in sampling_params_list:
-                if not isinstance(sampling_params, OmniDiffusionSamplingParams):
+            stage_configs = list(getattr(diffusion_engine, "stage_configs", []) or [])
+            default_sampling_params_list = get_default_sampling_params_list(diffusion_engine)
+            sampling_params_list = build_stage_sampling_params_list(
+                stage_configs,
+                default_sampling_params_list,
+                diffusion_params=gen_params,
+                replace_diffusion_params=True,
+            )
+            for index, (stage_config, sampling_params) in enumerate(zip(stage_configs, sampling_params_list)):
+                if get_stage_type(stage_config) != "diffusion" or index >= len(default_sampling_params_list):
                     continue
-                if reference_videos or reference_audios:
-                    sampling_params.extra_args = dict(sampling_params.extra_args or {})
-                if reference_videos:
-                    sampling_params.extra_args["video_path"] = reference_videos[0]
-                if reference_audios:
-                    sampling_params.extra_args["audio_path"] = reference_audios[0]
+                default_extra_args = getattr(default_sampling_params_list[index], "extra_args", None)
+                if default_extra_args:
+                    sampling_params.extra_args = {
+                        **default_extra_args,
+                        **(getattr(sampling_params, "extra_args", None) or {}),
+                    }
+            if not sampling_params_list:
+                sampling_params_list = [gen_params]
 
             result = None
             async for output in diffusion_engine.generate(


### PR DESCRIPTION
﻿﻿## Purpose

This PR implements **PR 1: shared contract and Chat adoption** from RFC #5159.

Diffusion requests can carry model-specific arguments through canonical `extra_args`, deprecated `extra_params`, pipeline-declared root fields, or the temporary raw nested `extra_body` compatibility form. The previous Chat paths could discard one source or let a later merge silently overwrite an earlier value.

This change adds a small serving-boundary normalizer. It preserves source provenance until conflicts are rejected, produces one normalized `extra_args` mapping, and overlays that mapping onto the existing diffusion sampling parameters in both diffusion-only and multi-stage Chat paths.

### Request flow

Red nodes are added or refactored by this PR.

```mermaid
flowchart LR
    A["Chat request<br/>root extras / extra_args / extra_params / nested compatibility form"]
    B["normalize_diffusion_request_extra_args()<br/>validate objects and reject duplicate sources"]
    C["normalized extra_args"]
    D["apply_normalized_diffusion_request_extra_args()<br/>overlay request values on stage defaults"]
    E{"Existing Chat path"}
    F["Diffusion-only dispatcher"]
    G["Multi-stage dispatcher"]
    H["Existing engine.generate()"]

    A --> B --> C --> E
    E --> F --> D
    E --> G --> D
    D --> H

    classDef changed fill:#ffebe9,stroke:#cf222e,stroke-width:2px,color:#24292f;
    class B,C,D changed;
```

### Behavior

| Input | Result |
| --- | --- |
| Canonical `extra_args` | Preserved and forwarded to `OmniDiffusionSamplingParams.extra_args`. |
| Deprecated `extra_params` | Accepted when keys do not overlap; logs one deprecation warning after validation succeeds. |
| Temporary raw nested `extra_body` forms | Kept separate from flattened sources until conflict validation finishes. |
| Pipeline-declared model-specific root fields | Normalized into `extra_args` for compatibility. |
| Common root sampling fields | Remain owned by the existing Chat path; they participate only in duplicate/alias detection. |
| Same logical key in two request sources | HTTP 400 with every conflicting source; no merge precedence. |
| Request value versus YAML stage default | Request value overlays the matching default and unrelated defaults remain intact. |
| Explicit global `None` | Does not erase the stage default in any supported source representation. |
| Unknown key inside `extra_args` | Preserved because its schema remains pipeline-owned. |
| Unknown root request extra | Ignored and does not create a false conflict with canonical `extra_args`. |
| Non-object container or non-string key | HTTP 400. |

### Files changed

- `vllm_omni/entrypoints/openai/diffusion_request_utils.py`: shared normalization, conflict detection, deprecation logging, and default-preserving overlay helpers.
- `vllm_omni/entrypoints/openai/serving_chat.py`: normalize once at the Chat boundary; feed the result to the existing diffusion-only and multi-stage consumers without compiling the rest of the request.
- `tests/entrypoints/openai_api/test_diffusion_request_utils.py`: source, alias, duplicate, invalid-container, warning, and `None` contracts.
- `tests/entrypoints/openai_api/test_serving_chat_sampling_params.py`: serving-boundary integration, uniform pure/mixed HTTP 400 behavior, unknown-root behavior, and stage-default preservation.
- `tests/comfyui/test_comfyui_integration.py`: use real diffusion sampling defaults in the mocked engine fixture.

### Explicit non-goals

This PR does **not** compile the complete Chat diffusion request. It does not own `size`, `modalities`, LoRA, negative prompts, `sampling_params_list`, stage topology, model-capability validation, AR-stage routing, or typed reconstruction of all stage parameters. Image and Video adoption remain PR 2 of RFC #5159.

## Test plan

```bash
pytest -q \
  tests/entrypoints/openai_api/test_diffusion_request_utils.py \
  tests/entrypoints/openai_api/test_serving_chat_sampling_params.py \
  tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py \
  tests/entrypoints/openai_api/test_stage_params.py
```

**vLLM Version:** `0.25.0` (`v0.25.0`, `702f4814fe54fabff350d43cb753ae3e47c0c276`)

**vLLM-Omni Commit:** `54b75d4f728e21803e442a6b2f0a1c740e3d8a42`

## Test result

- Focused Chat/request-extra suite: **82 passed** on Python 3.12 with CPU PyTorch 2.10.0 and vLLM `v0.25.0` source.
- `ruff check`, `ruff format --check`, and `git diff --check` passed for the changed files.
- The ComfyUI mock now uses real `OmniDiffusionSamplingParams`; its process-based image-generation cases remain Linux-CI verification.
- Current-head GitHub checks: DCO, pre-commit, and Python 3.11/3.12 wheel builds passed.


