### PR TITLE
[Bugfix] Fix Cosmos3 distilled scheduler test isinstance check (#5182)

### DIFF
--- a/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
@@ -716,10 +716,9 @@ def test_distilled_pipeline_initializes_sde_scheduler(
     stub_real_pipeline_init,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from diffusers import FlowMatchEulerDiscreteScheduler
-
     from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import (
         Cosmos3OmniDiffusersPipeline,
+        FlowMatchEulerDiscreteScheduler,
     )
 
     t_list = [1.0, 0.9375, 0.8333333333333334, 0.625]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes #5182.

`test_distilled_pipeline_initializes_sde_scheduler` failed in Ready/Merge CI because it used `isinstance(..., diffusers.FlowMatchEulerDiscreteScheduler)` while `Cosmos3OmniDiffusersPipeline` instantiates the vendored scheduler from `vllm_omni.diffusion.models.schedulers.scheduling_flow_match_euler_discrete`. Those are different Python classes, so the assertion failed even though the scheduler was initialized correctly.

Import `FlowMatchEulerDiscreteScheduler` from `pipeline_cosmos3` (same module the pipeline uses) so the type check matches the actual instance.

## Test Plan

```bash
pytest tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py::test_distilled_pipeline_initializes_sde_scheduler
```

## Test Result
<img width="2338" height="152" alt="11e52429-9ded-407d-ba10-941c41e5072b" src="https://github.com/user-attachments/assets/74980a4f-a58a-4650-a90d-c28cf896cb35" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
