### PR TITLE
[Feature] Support fine-tuned MoE tiling configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ datasets/
 !tests/dfx/perf/tests/*.json
 !apps/ComfyUI-vLLM-Omni/example_workflows/*.json
 !tests/assets/soulxsinger/*.json
+!vllm_omni/model_executor/layers/fused_moe/configs/*.json
 *.jsonl
 *.parquet
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,11 @@ where = ["."]
 include = ["vllm_omni*"]
 
 [tool.setuptools.package-data]
-"vllm_omni" = ["_version.py", "py.typed"]
+"vllm_omni" = [
+    "_version.py",
+    "py.typed",
+    "model_executor/layers/fused_moe/configs/*.json",
+]
 
 [tool.setuptools_scm]
 # no extra settings needed, presence enables setuptools-scm

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -434,9 +434,21 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
 
 def prepare_engine_environment() -> None:
     """One-time global setup: load plugins, set multiprocessing spawn method."""
+    from vllm_omni.model_executor.layers.fused_moe import (
+        get_fused_moe_configs_dir,
+        maybe_set_vllm_tuned_config_folder,
+    )
     from vllm_omni.plugins import load_omni_general_plugins
 
     load_omni_general_plugins()
+
+    # Prefer omni-shipped fused_moe tile JSONs when the user has not set a
+    # custom folder. Upstream still falls back to vLLM's packaged configs.
+    if maybe_set_vllm_tuned_config_folder():
+        logger.info(
+            "[stage_init] Set VLLM_TUNED_CONFIG_FOLDER=%s (omni fused_moe configs)",
+            get_fused_moe_configs_dir(),
+        )
 
     if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn":
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

--- a/vllm_omni/model_executor/layers/fused_moe/__init__.py
+++ b/vllm_omni/model_executor/layers/fused_moe/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Omni-shipped fused MoE Triton tile configs (consumed via vLLM loader)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Same env as upstream vLLM fused_moe / MoT GEMM.
+_TUNED_CONFIG_FOLDER_ENV = "VLLM_TUNED_CONFIG_FOLDER"
+
+
+def get_fused_moe_configs_dir() -> Path:
+    """Return the package directory that stores fused_moe tile JSON files."""
+    return Path(__file__).resolve().parent / "configs"
+
+
+def maybe_set_vllm_tuned_config_folder() -> bool:
+    """Point ``VLLM_TUNED_CONFIG_FOLDER`` at omni configs if unset.
+
+    Upstream ``get_moe_configs`` checks this env first, then falls back to
+    vLLM's built-in ``fused_moe/configs/``. Setting the env here does **not**
+    disable that fallback: missing shapes still use vLLM's packaged JSONs.
+
+    Returns True if this call set the environment variable.
+    """
+    if os.environ.get(_TUNED_CONFIG_FOLDER_ENV):
+        return False
+
+    configs_dir = get_fused_moe_configs_dir()
+    if not configs_dir.is_dir():
+        return False
+
+    os.environ[_TUNED_CONFIG_FOLDER_ENV] = str(configs_dir)
+    return True
+
+
+__all__ = [
+    "get_fused_moe_configs_dir",
+    "maybe_set_vllm_tuned_config_folder",
+]

--- a/vllm_omni/model_executor/layers/fused_moe/configs/E=16,N=3072,device_name=NVIDIA_L20X.json
+++ b/vllm_omni/model_executor/layers/fused_moe/configs/E=16,N=3072,device_name=NVIDIA_L20X.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/vllm_omni/model_executor/layers/fused_moe/configs/E=32,N=3072,device_name=NVIDIA_L20X.json
+++ b/vllm_omni/model_executor/layers/fused_moe/configs/E=32,N=3072,device_name=NVIDIA_L20X.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/vllm_omni/model_executor/layers/fused_moe/configs/E=64,N=1536,device_name=NVIDIA_L20X.json
+++ b/vllm_omni/model_executor/layers/fused_moe/configs/E=64,N=1536,device_name=NVIDIA_L20X.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/vllm_omni/model_executor/layers/fused_moe/configs/README
+++ b/vllm_omni/model_executor/layers/fused_moe/configs/README
@@ -1,0 +1,24 @@
+This directory contains omni-shipped tuned configurations for the upstream
+vLLM fused_moe Triton kernel (same JSON schema as
+``vllm/model_executor/layers/fused_moe/configs/``).
+
+For different settings of
+- E (number of experts)
+- N (intermediate size; often TP/EP sharded)
+- device_name (from ``torch.cuda.get_device_name()``, spaces → ``_``)
+- optional dtype / block_shape
+the JSON file maps batch size M → tile config
+(``BLOCK_SIZE_*``, ``GROUP_SIZE_M``, ``num_warps``, ``num_stages``).
+
+At runtime, vLLM-Omni sets ``VLLM_TUNED_CONFIG_FOLDER`` to this directory when
+the env is unset. vLLM still falls back to its own packaged configs if a
+filename is missing here.
+
+Generate files with upstream vLLM's script, then copy JSON here:
+
+```bash
+# from a vLLM checkout / editable install
+python benchmarks/kernels/benchmark_moe.py \
+  --model <moe-model> --tune \
+  --save-dir /path/to/vllm_omni/model_executor/layers/fused_moe/configs
+```


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
### Background
vLLM implements its fused MoE layer as a Triton kernel (fused_moe_kernel). Like most tiled GEMM kernels, its performance is highly sensitive to tiling parameters (BLOCK_SIZE_M/N/K, num_warps, num_stages, group_size_m): the optimal tiling differs across hardware (SM count, shared mem, TMA availability) and across input sizes (the M dimension — tokens routed to each expert — which varies from M=1 in decode to M=thousands in prefill).

To handle this, vLLM ships a set of default tile configs keyed by (E, N, K, topk, dtype, device) and, at runtime, picks the best tile for the actual shape. It also exposes the VLLM_TUNED_CONFIG_FOLDER environment variable so users/deployments can point the loader at a custom folder of tuned JSONs, which takes precedence over the built-in defaults (with fallback to the built-in configs for any shape not covered).

If no config, it will output warning:
```
Using default MoE config. Performance might be sub-optimal! Config file not found at <user_path>/E=.., <vllm_builtin_path>/E=..
```

### What this PR does
+ vllm-omni adds a default tuned-config path
+ Initialize L20X configs. Provide bf16 tuned configs for the HunyuanImage-3.0 MoE shapes on L20X

## Test Plan
### performance
```
python -m pytest -s tests/dfx/perf/scripts/run_diffusion_benchmark.py  --test-config-file tests/dfx/perf/tests/test_hunyuan_image_tp4.json
```
```
python -m pytest -s tests/dfx/perf/scripts/run_diffusion_benchmark.py  --test-config-file tests/dfx/perf/tests/test_hunyuan_image3_it2i.json
```
### ncu profiling

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

### fused_moe_kernel
| Op | Default | This pr | Speedup |
|----|---------|-------|---------|
| `fused_moe_kernel` | 1.382s (avg 1.349ms) | 1.242s (avg 1.213ms × 1024) | **1.113× (~10.1% faster)** |


### end2end
| Benchmark | baseline qps | tuned qps | speedup |
|---|---|---|---|
| diffusion tp4 | 0.3933 | 0.4117 | +4.67% |
| it2i | 0.3650 | 0.3821 | +4.70% |


### Moe ncu profiling
**before**:
<img width="2728" height="416" alt="image" src="https://github.com/user-attachments/assets/3f4990ee-1ff6-44b0-80be-0876d7d29847" />
**after**:
<img width="2746" height="432" alt="image" src="https://github.com/user-attachments/assets/b620dcc2-7d7e-4d15-abf0-52378ccaafeb" />




**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
