### PR TITLE
[Bugfix] Fix stale pipeline resolver test call

### DIFF
--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1232,7 +1232,7 @@ stages:
         assert deploy.stages[1].devices == "1"
 
     def test_step_audio2_dispatches_sync_and_async_chunk_processors(self):
-        pipeline = StageConfigFactory.resolve_pipeline_config("step_audio_2")
+        pipeline = resolve_pipeline_config("step_audio_2")
         assert isinstance(pipeline, PipelineConfig)
 
         sync_stages = merge_pipeline_deploy(pipeline, DeployConfig(async_chunk=False))


### PR DESCRIPTION
<!-- markdownlint-disable -->

  ## Purpose

  Fixes #5192.

  ### What broke

  The ready and merge CI jobs fail in
  `TestDeployConfigLoading.test_step_audio2_dispatches_sync_and_async_chunk_processors`
  with:

  ```text
  AttributeError: type object 'StageConfigFactory' has no attribute
  'resolve_pipeline_config'
  ```

  ### Reproduction

  ```bash
  python -m pytest -q \
    tests/test_config_factory.py::TestDeployConfigLoading::test_step_audio2_dispatches_sync_and_async_chunk_processors
  ```

  The test fails on `main` when it calls the removed
  `StageConfigFactory.resolve_pipeline_config()` method.

  ### Root cause

  PR #4818 moved registry-key resolution from
  `StageConfigFactory.resolve_pipeline_config()` to the module-level
  `pipeline_registry.resolve_pipeline_config()` helper.

  PR #5031 subsequently added the Step-Audio2 test using the stale class-method
  call.

  ### Fix

  Use the already imported module-level `resolve_pipeline_config()` helper.

  This is a test-only one-line change and does not modify runtime behavior.

  ## Test Plan

  ```bash
  python -m pytest -q \
    tests/test_config_factory.py::TestDeployConfigLoading::test_step_audio2_dispatches_sync_and_async_chunk_processors

  python -m pytest -q tests/test_config_factory.py

  ruff check tests/test_config_factory.py
  ruff format --check tests/test_config_factory.py
  ```

  **vLLM Version:** 0.25.0

  **vLLM-Omni Commit:** b8c1b363e34d86732a7f1f34e4ebdea2a438206a

  ## Test Result

  ```text
  Targeted regression test: 1 passed
  Config factory test suite: 186 passed
  Ruff check: All checks passed
  Ruff format: 1 file already formatted
  Commit-time pre-commit hooks: passed
  ```