### PR TITLE
[Core] Support tensor prompt cache keys for verl-omni

### DIFF
--- a/tests/diffusion/cache/test_prompt_embed_cache.py
+++ b/tests/diffusion/cache/test_prompt_embed_cache.py
@@ -8,9 +8,10 @@ Covers the module :mod:`vllm_omni.diffusion.cache.prompt_embed_cache`:
 
 * :class:`PromptEmbedCache` LRU semantics, stats and thread-safety.
 * :func:`_hashable` safe-input classification (scalars, torch dtype/device,
-  numpy scalars, nested containers, tensors/PIL bypass).
+  token tensors, numpy scalars, nested containers, unsupported tensor/PIL
+  bypass).
 * :func:`install_prompt_embed_cache` / :func:`uninstall_prompt_embed_cache`
-  behaviour: caching, bypass on tensors, bypass on precomputed embeds,
+  behaviour: caching, bypass on unsupported tensors and precomputed embeds,
   idempotent install, restore on uninstall, detachment of cached tensors.
 * :func:`resolve_prompt_embed_cache_config` env-var overrides.
 """
@@ -84,7 +85,24 @@ class TestHashable:
         assert a == b
         assert hash(a) is not None
 
-    def test_tensor_is_not_hashable(self):
+    @pytest.mark.parametrize(
+        ("value", "dtype"),
+        [([1, 2, 3], torch.int64), ([True, False, True], torch.bool)],
+    )
+    def test_token_tensor_is_hashable_by_value(self, value, dtype):
+        tensor = torch.tensor(value, dtype=dtype)
+        cloned = tensor.clone()
+        out = _hashable(tensor)
+        assert out == _hashable(cloned)
+        assert out[0] == "__torch_tensor__"
+        assert hash(out) is not None
+
+    def test_tensor_shape_is_part_of_key(self):
+        flat = torch.tensor([1, 2], dtype=torch.int64)
+        batched = torch.tensor([[1, 2]], dtype=torch.int64)
+        assert _hashable(flat) != _hashable(batched)
+
+    def test_float_tensor_is_not_hashable(self):
         assert _hashable(torch.zeros(2)) is _NOT_HASHABLE
 
     def test_list_containing_tensor_is_not_hashable(self):
@@ -272,12 +290,29 @@ class TestBuildKey:
         sig = _make_sig(encode)
         assert _build_key(sig, "m1", ("a",), {}) != _build_key(sig, "m2", ("a",), {})
 
-    def test_tensor_argument_bypasses(self):
+    def test_float_tensor_argument_bypasses(self):
         def encode(prompt, extra=None):
             return None
 
         sig = _make_sig(encode)
         assert _build_key(sig, "m", ("hi",), {"extra": torch.zeros(1)}) is None
+
+    def test_token_tensor_argument_is_keyed_by_value(self):
+        def encode(prompt_ids, attention_mask=None):
+            return None
+
+        sig = _make_sig(encode)
+        ids = torch.tensor([1, 2, 3], dtype=torch.int64)
+        mask = torch.tensor([True, True, False], dtype=torch.bool)
+        key = _build_key(sig, "m", (), {"prompt_ids": ids, "attention_mask": mask})
+        cloned_key = _build_key(
+            sig,
+            "m",
+            (),
+            {"prompt_ids": ids.clone(), "attention_mask": mask.clone()},
+        )
+        assert key is not None
+        assert key == cloned_key
 
     def test_precomputed_prompt_embeds_bypasses(self):
         def encode(prompt=None, prompt_embeds=None):
@@ -324,6 +359,17 @@ class _FakePipeline:
         return torch.tensor([float(self.call_count)])
 
 
+class _TensorPromptPipeline:
+    """Pipeline matching the token-ID encode contract used by rollout adapters."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    def encode_prompt(self, prompt_ids, attention_mask=None):
+        self.call_count += 1
+        return torch.tensor([float(self.call_count)])
+
+
 class TestInstallAndUninstall:
     def test_returns_none_when_pipeline_has_no_encode_prompt(self):
         class Empty:
@@ -363,22 +409,37 @@ class TestInstallAndUninstall:
         assert pipe.call_count == 2
         assert cache.stats()["misses"] == 2
 
-    def test_tensor_argument_bypasses_and_increments_counter(self):
+    def test_cloned_token_tensors_hit_same_cache_entry(self):
+        pipe = _TensorPromptPipeline()
+        cache = install_prompt_embed_cache(pipe)
+        ids = torch.tensor([1, 2, 3], dtype=torch.int64)
+        mask = torch.tensor([True, True, False], dtype=torch.bool)
+
+        pipe.encode_prompt(ids, attention_mask=mask)
+        pipe.encode_prompt(ids.clone(), attention_mask=mask.clone())
+
+        assert pipe.call_count == 1
+        assert cache.stats()["hits"] == 1
+        assert cache.stats()["bypassed"] == 0
+
+    def test_changed_token_tensor_content_misses(self):
+        pipe = _TensorPromptPipeline()
+        cache = install_prompt_embed_cache(pipe)
+
+        pipe.encode_prompt(torch.tensor([1, 2], dtype=torch.int64))
+        pipe.encode_prompt(torch.tensor([1, 3], dtype=torch.int64))
+
+        assert pipe.call_count == 2
+        assert cache.stats()["misses"] == 2
+
+    def test_unsupported_tensor_argument_bypasses_and_increments_counter(self):
         pipe = _FakePipeline()
         cache = install_prompt_embed_cache(pipe)
-        # Put a tensor into a non-precomputed-embed slot to trigger bypass.
-        pipe.encode_prompt("cat", device=torch.device("cpu"), num_images_per_prompt=1)
-
-        # Now pass a fake tensor via a harmless positional-like call: use
-        # the negative_prompt slot with an unhashable object.
-        class Unhashable:
-            pass
-
-        pipe.encode_prompt("cat", negative_prompt=Unhashable())  # type: ignore[arg-type]
-        pipe.encode_prompt("cat", negative_prompt=Unhashable())  # type: ignore[arg-type]
+        # Float tensors are not token-like and remain on the bypass path.
+        pipe.encode_prompt("cat", negative_prompt=torch.zeros(1))  # type: ignore[arg-type]
+        pipe.encode_prompt("cat", negative_prompt=torch.zeros(1))  # type: ignore[arg-type]
         assert cache.stats()["bypassed"] == 2
-        # All three calls actually executed the underlying function.
-        assert pipe.call_count == 3
+        assert pipe.call_count == 2
 
     def test_precomputed_embeds_bypass_cache(self):
         pipe = _FakePipeline()

--- a/vllm_omni/diffusion/cache/prompt_embed_cache.py
+++ b/vllm_omni/diffusion/cache/prompt_embed_cache.py
@@ -20,10 +20,10 @@ Design points:
       pipeline has loaded, so each runner process owns its own cache.
     * Cache keys are derived from the bound ``encode_prompt`` arguments. Only
       inputs we can safely hash (``str`` / ``int`` / ``float`` / ``bool`` /
-      ``None`` / ``bytes`` / ``torch.device`` / ``torch.dtype`` / numpy
-      scalars / nested lists/tuples/dicts of those) participate in the key.
-      If any argument is a tensor, PIL image, or other non-trivial object, we
-      bypass the cache for that call to guarantee correctness.
+      ``None`` / ``bytes`` / ``torch.device`` / ``torch.dtype`` / token tensors /
+      numpy scalars / nested lists/tuples/dicts of those) participate in the
+      key. Token tensors are restricted to ``torch.int64`` and ``torch.bool``;
+      other tensors, PIL images, and non-trivial objects bypass the cache.
     * If a caller passes precomputed ``*_embeds`` into ``encode_prompt`` the
       wrapper also bypasses the cache because the call is already short-circuit.
     * Cache values are detached tensors. Downstream pipeline code typically
@@ -67,14 +67,44 @@ _PRECOMPUTED_EMBED_ARGS = (
     "negative_prompt_embeds_mask",
 )
 
+# Token IDs produced by Hugging Face tokenizers use int64, while callers may
+# supply attention masks as either int64 or bool. Restricting tensor keys to
+# these dtypes keeps large floating-point embeddings and latents on the bypass
+# path even when they appear in an argument not covered above.
+_HASHABLE_TENSOR_DTYPES = frozenset((torch.int64, torch.bool))
+
+
+def _hashable_tensor(obj: torch.Tensor) -> Any:
+    """Return an exact value key for a token tensor, or ``_NOT_HASHABLE``.
+
+    Shape, dtype, and device are part of the key. The contiguous CPU bytes make
+    different tensor objects with the same content share a cache entry without
+    converting token values to Python lists.
+    """
+    if obj.dtype not in _HASHABLE_TENSOR_DTYPES or obj.layout != torch.strided or obj.device.type == "meta":
+        return _NOT_HASHABLE
+
+    try:
+        content = obj.detach().to(device="cpu").contiguous().numpy().tobytes()
+    except (RuntimeError, TypeError, ValueError, NotImplementedError):
+        return _NOT_HASHABLE
+    return (
+        "__torch_tensor__",
+        str(obj.dtype),
+        tuple(obj.shape),
+        str(obj.device),
+        content,
+    )
+
 
 def _hashable(obj: Any) -> Any:
     """Convert *obj* into a hashable representation or return ``_NOT_HASHABLE``.
 
-    Only inputs whose textual / scalar identity fully determines the
-    ``encode_prompt`` output are considered safe. Tensors and PIL images (which
-    flow through e.g. image-edit pipelines) deliberately disable caching for
-    that call rather than risk stale results. Common value-like configuration
+    Only inputs whose value identity fully determines the ``encode_prompt``
+    output are considered safe. Int64 token tensors and int64/bool attention
+    masks are keyed by exact content; other tensors and PIL images (which flow
+    through e.g. image-edit pipelines) deliberately disable caching for that
+    call rather than risk stale results. Common value-like configuration
     objects such as ``torch.device`` and ``torch.dtype`` are normalized to
     stable string forms so they can participate in cache keys safely.
     """
@@ -84,6 +114,8 @@ def _hashable(obj: Any) -> Any:
         return ("__torch_device__", str(obj))
     if isinstance(obj, torch.dtype):
         return ("__torch_dtype__", str(obj))
+    if isinstance(obj, torch.Tensor):
+        return _hashable_tensor(obj)
     if type(obj).__module__.split(".", 1)[0] == "numpy" and hasattr(obj, "item"):
         try:
             return _hashable(obj.item())
@@ -105,7 +137,7 @@ def _hashable(obj: Any) -> Any:
                 return _NOT_HASHABLE
             items.append((repr(k), v))
         return ("__dict__", tuple(items))
-    # torch.Tensor, PIL.Image, np.ndarray, and any other object → not safe.
+    # PIL.Image, np.ndarray, and any other object → not safe.
     return _NOT_HASHABLE
 
 


### PR DESCRIPTION

## Purpose

The prompt embedding cache currently bypasses `encode_prompt` calls whenever
any argument is a tensor. This prevents cache reuse for downstream rollout
integrations such as verl-omni, which pass pre-tokenized prompts as tensors.
In the current verl-omni integration, prompt IDs use `torch.int64`, while
attention masks use either `torch.int64` or `torch.bool`.

This PR:

- Adds cache-key support for strided `torch.int64` and `torch.bool` tensors,
  including tensors on accelerator devices.
- Builds exact tensor keys from dtype, shape, device, and contiguous content
  bytes. Device tensor content is copied directly to CPU bytes for hashing.
- Allows different tensor objects with identical content to share the same
  prompt embedding cache entry.
- Avoids converting tensor values to Python lists.
- Keeps floating-point, meta, and non-strided tensors on the existing
  cache-bypass path.
- Preserves the existing bypass behavior for precomputed prompt embeddings.

## Test Plan

Added unit coverage for:

- `torch.int64` token ID tensors.
- `torch.bool` attention-mask tensors.
- Cache hits across cloned tensors with identical values.
- Cache misses when tensor content or shape changes.
- Cache bypass for unsupported floating-point tensors.
- Cache bypass for precomputed prompt embeddings.

Static checks:

```bash
ruff format --check \
  vllm_omni/diffusion/cache/prompt_embed_cache.py \
  tests/diffusion/cache/test_prompt_embed_cache.py

ruff check \
  vllm_omni/diffusion/cache/prompt_embed_cache.py \
  tests/diffusion/cache/test_prompt_embed_cache.py

git diff --check
```

Focused unit-test command:

```bash
python3 -m pytest -q tests/diffusion/cache/test_prompt_embed_cache.py
```

**vLLM Version:** `0.24.0` (the current verl-omni compatibility target)

**vLLM-Omni Commit:** `485f1be246b5a6498ddd72ce123b08956b50e1a1`  
Rebased onto `main` at `109942465fa4d8e140f9ccac3430bfd90b7cf6de`.

## Test Result

- `ruff format --check`: passed.
- `ruff check`: passed.
- `git diff --check`: passed.
- Focused CPU smoke test: passed.
  - Identical cloned token tensors produced a cache hit.
  - Different token values produced different cache keys.
  - Floating-point tensors continued to bypass the cache.
- The focused pytest command was not completed locally because the current
  Python environment does not have `pytest` installed (`No module named
  pytest`). The corresponding unit tests are included for CI execution.

**BEFORE SUBMITTING:** read
[`CONTRIBUTING.md`](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md)
and run the
[`precheck-pr` skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md)
with the code agent for a self-check against project conventions.
