### PR TITLE
[Perf][Qwen3-TTS] Use hybrid outer CUDA graph for MTP

### DIFF
--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -1,9 +1,13 @@
+import gc
+import weakref
 from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.config import CUDAGraphMode
 
+from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner, _filter_mrope_kwargs_for_model
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
@@ -245,6 +249,155 @@ def test_talker_mtp_forward_cpu_empty_batch_noop(monkeypatch):
 
     # Ensure no changes were made
     assert torch.allclose(inputs_embeds, before)
+
+
+def test_talker_mtp_graph_capture_sizes_only_cover_reachable_batches():
+    runner = object.__new__(OmniGPUModelRunner)
+    runner.talker_mtp_uses_outer_graph = True
+    runner.max_num_reqs = 64
+    runner.compilation_config = SimpleNamespace(
+        cudagraph_capture_sizes=[1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 128, 256, 512]
+    )
+
+    runner.talker_mtp_outer_graph_max_batch_size = 8
+    assert runner._talker_mtp_graph_capture_sizes() == [1, 2, 4, 8]
+
+    runner.talker_mtp_outer_graph_max_batch_size = None
+    assert runner._talker_mtp_graph_capture_sizes() == [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64]
+
+
+def test_gpu_ar_runner_shutdown_releases_eager_talker_reference(monkeypatch):
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
+    from vllm.compilation.cuda_graph import CUDAGraphWrapper
+
+    import vllm_omni.worker.gpu_ar_model_runner as ar_mod
+
+    class TalkerOwner:
+        def talker_mtp(self):
+            pass
+
+    monkeypatch.setattr(ar_mod.gc, "unfreeze", lambda: None)
+    monkeypatch.setattr(CUDAGraphWrapper, "clear_all_graphs", staticmethod(lambda: None))
+    monkeypatch.setattr(BreakableCUDAGraphWrapper, "clear_all_graphs", staticmethod(lambda: None))
+    monkeypatch.setattr(OmniGPUModelRunner, "shutdown", lambda self: setattr(self, "model", None))
+
+    runner = object.__new__(GPUARModelRunner)
+    owner = TalkerOwner()
+    owner_ref = weakref.ref(owner)
+    runner.model = owner
+    runner._talker_mtp_eager = owner.talker_mtp
+    runner.talker_mtp = None
+    runner.has_talker_mtp = True
+    runner.input_ids = None
+    runner.inputs_embeds = None
+    runner._downstream_payload_cache = {}
+    runner.model_intermediate_buffer = {}
+
+    del owner
+    runner.shutdown()
+    gc.collect()
+
+    assert runner._talker_mtp_eager is None
+    assert owner_ref() is None
+
+
+def test_talker_mtp_forward_uses_eager_path_above_graph_batch_limit(monkeypatch):
+    import vllm_omni.worker.gpu_model_runner as mod
+
+    seen_context = {}
+
+    @contextmanager
+    def capture_forward_context(*args, **kwargs):
+        seen_context.update(kwargs)
+        yield
+
+    monkeypatch.setattr(mod.current_omni_platform, "set_forward_context", capture_forward_context)
+    monkeypatch.setattr(mod.current_omni_platform, "is_cuda", lambda: True)
+
+    runner = _make_runner(req_ids=("r1", "r2"), hidden_size=4)
+    runner.talker_mtp_uses_outer_graph = True
+    runner.talker_mtp_outer_graph_max_batch_size = 1
+    runner.requests["r1"].sampling_params = SimpleNamespace(
+        seed=11,
+        extra_args={"tts_local_seed": 11},
+    )
+    runner.requests["r2"].sampling_params = SimpleNamespace(
+        seed=22,
+        extra_args={"tts_local_seed": 22},
+    )
+    runner.talker_mtp = CaptureTalkerMTP()
+    assert not hasattr(runner, "_talker_mtp_eager")
+    runner.model = SimpleNamespace(
+        talker_mtp_output_key=("codes", "audio"),
+        talker_mtp_accepts_per_row_generators=False,
+        talker_mtp_supports_per_row_generators=True,
+    )
+
+    def fake_determine(self, num_tokens, num_reqs, num_scheduled_tokens_np, max_num_scheduled_tokens, use_cascade_attn):
+        batch_desc = SimpleNamespace(num_tokens=int(num_tokens))
+        return CUDAGraphMode.FULL, batch_desc, None, None, None
+
+    monkeypatch.setattr(runner, "_determine_batch_execution_and_padding", fake_determine.__get__(runner, type(runner)))
+
+    inputs_embeds = torch.zeros((6, 4), dtype=torch.float32)
+    OmniGPUModelRunner._talker_mtp_forward(runner, ["r1", "r2"], inputs_embeds)
+
+    assert seen_context["cudagraph_runtime_mode"] == CUDAGraphMode.NONE
+    assert [call["batch_size"] for call in runner.talker_mtp.calls] == [2]
+    assert runner.talker_mtp.calls[0]["generator"] is None
+    row_generators = runner.talker_mtp.calls[0]["generators"]
+    assert [generator.initial_seed() for generator in row_generators] == [11, 22]
+    assert runner._talker_mtp_generators == {
+        "r1": row_generators[0],
+        "r2": row_generators[1],
+    }
+
+
+def test_talker_mtp_outer_graph_keeps_default_seeded_requests_batched(monkeypatch):
+    import vllm_omni.worker.gpu_model_runner as mod
+
+    seen_context = {}
+
+    @contextmanager
+    def capture_forward_context(*args, **kwargs):
+        seen_context.update(kwargs)
+        yield
+
+    monkeypatch.setattr(mod.current_omni_platform, "set_forward_context", capture_forward_context)
+    monkeypatch.setattr(mod.current_omni_platform, "is_cuda", lambda: True)
+
+    runner = _make_runner(req_ids=("r1", "r2"), hidden_size=4)
+    runner.talker_mtp_uses_outer_graph = True
+    runner.talker_mtp_outer_graph_max_batch_size = 8
+    runner.requests["r1"].sampling_params = SimpleNamespace(
+        seed=11,
+        extra_args={"tts_local_seed": 11},
+    )
+    runner.requests["r2"].sampling_params = SimpleNamespace(
+        seed=22,
+        extra_args={"tts_local_seed": 22},
+    )
+    runner.talker_mtp = CaptureTalkerMTP()
+    runner.model = SimpleNamespace(
+        talker_mtp_output_key=("codes", "audio"),
+        talker_mtp_accepts_per_row_generators=False,
+        talker_mtp_supports_per_row_generators=True,
+    )
+
+    def fake_determine(self, num_tokens, num_reqs, num_scheduled_tokens_np, max_num_scheduled_tokens, use_cascade_attn):
+        batch_desc = SimpleNamespace(num_tokens=int(num_tokens))
+        return CUDAGraphMode.FULL, batch_desc, None, None, None
+
+    monkeypatch.setattr(runner, "_determine_batch_execution_and_padding", fake_determine.__get__(runner, type(runner)))
+
+    inputs_embeds = torch.zeros((6, 4), dtype=torch.float32)
+    OmniGPUModelRunner._talker_mtp_forward(runner, ["r1", "r2"], inputs_embeds)
+
+    assert seen_context["cudagraph_runtime_mode"] == CUDAGraphMode.FULL
+    assert [call["batch_size"] for call in runner.talker_mtp.calls] == [2]
+    assert runner.talker_mtp.calls[0]["generator"] is None
+    assert runner.talker_mtp.calls[0]["generators"] is None
+    assert not hasattr(runner, "_talker_mtp_generators")
 
 
 def test_talker_mtp_forward_ignores_default_sampling_seed_without_request_marker(monkeypatch):

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -325,24 +325,16 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # per-request additional_information.
         self.talker_mtp_output_key = ("codes", "audio")
         self.talker_mtp_graph_safe = True
-        # talker_mtp samples with per-row generators, so explicitly-seeded
-        # requests stay batched instead of one scalar forward per row (#4883).
-        # This is only valid while talker_mtp receives the *unpadded* active
-        # batch, i.e. when it is NOT graph-wrapped. The runner wraps talker_mtp
-        # (padded batches + a single captured RNG stream) whenever full
-        # cudagraphs are enabled, so disable per-row generators in that case.
-        # Consequence: under full cudagraphs, per-request ``tts_local_seed`` is
-        # not reproducible (matching Qwen3-Omni, which has no per-row seeding);
-        # eager mode keeps the per-row generator fast-path.
-        # TODO(#4923): the model should not read ``cudagraph_mode`` — it is an
-        # upstream (runner) concern, and the runner already re-derives the same
-        # wrap decision in ``_init_talker_mtp``. Once all TTS models declare
-        # ``talker_mtp_graph_safe`` we should move this gating into the model
-        # runner (models only expose the static capability flag, and users can
-        # then configure ``cudagraph_mode`` freely). This also means mtp seeding
-        # is silently dropped when the decode batch > 1 under full cudagraphs;
-        # the follow-up should refactor the per-row generator in the runner to
-        # be cudagraph-safe so seeded batches stay reproducible.
+        # CUDA graph replay saves launch overhead for small decode batches. At
+        # larger batches the predictor is compute-bound, so keep the compiled
+        # eager path and avoid the high-concurrency regression.
+        self.talker_mtp_outer_graph_max_batch_size = 8
+        # talker_mtp intrinsically supports one generator per active row. The
+        # CUDA runner uses this capability to keep full-graph configurations
+        # batched while the config-dependent flag below selects RNG behavior.
+        self.talker_mtp_supports_per_row_generators = True
+        # This is only valid while talker_mtp receives the unpadded active
+        # batch. Existing NPU graph behavior still uses the conservative flag.
         cudagraph_mode = getattr(vllm_config.compilation_config, "cudagraph_mode", None)
         talker_mtp_graph_wrapped = (
             self.talker_mtp_graph_safe and cudagraph_mode is not None and cudagraph_mode.has_full_cudagraphs()

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -505,6 +505,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         gc.unfreeze()
 
         # 2. Destroy talker MTP CUDA graph wrapper to release captured graphs.
+        if hasattr(self, "_talker_mtp_eager"):
+            self._talker_mtp_eager = None
         if hasattr(self, "talker_mtp") and self.talker_mtp is not None:
             self.talker_mtp = None
         self.has_talker_mtp = False
@@ -542,7 +544,9 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         from vllm.compilation.monitor import set_cudagraph_capturing_enabled
         from vllm.distributed.parallel_state import graph_capture
 
-        capture_sizes = self.compilation_config.cudagraph_capture_sizes
+        capture_sizes = self._talker_mtp_graph_capture_sizes()
+        if not capture_sizes:
+            return
         num_warmups = self.compilation_config.cudagraph_num_of_warmups
         capture_sizes = sorted(capture_sizes, reverse=True)
         logger.info("Capturing talker_mtp graphs for sizes %s", capture_sizes)

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -201,23 +201,57 @@ class OmniGPUModelRunner(GPUModelRunner):
         if talker_mtp is None:
             return
         self.talker_mtp = talker_mtp  # type: ignore[assignment]
+        self._talker_mtp_eager = talker_mtp
         self.has_talker_mtp = True
+        self.talker_mtp_uses_outer_graph = False
+        is_cuda = current_omni_platform.is_cuda()
+        graph_batch_limit = getattr(self.model, "talker_mtp_outer_graph_max_batch_size", None) if is_cuda else None
+        self.talker_mtp_outer_graph_max_batch_size = int(graph_batch_limit) if graph_batch_limit is not None else None
         cudagraph_mode = self.compilation_config.cudagraph_mode
         assert cudagraph_mode is not None
         has_separate_talker = getattr(self.model, "talker", None) is not None
         talker_mtp_graph_safe = getattr(self.model, "talker_mtp_graph_safe", False)
         if cudagraph_mode.has_full_cudagraphs() and (has_separate_talker or talker_mtp_graph_safe):
             graph_wrapper_cls = current_omni_platform.get_graph_wrapper_cls()
-            self.talker_mtp = graph_wrapper_cls(talker_mtp, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)
+            self.talker_mtp = graph_wrapper_cls(
+                talker_mtp,
+                self.vllm_config,
+                runtime_mode=CUDAGraphMode.FULL,
+            )
+            self.talker_mtp_uses_outer_graph = True
+            logger.info(
+                "Enabled outer talker_mtp graph with max graph batch size %s",
+                self.talker_mtp_outer_graph_max_batch_size or "unlimited",
+            )
         # TTS exposes mtp_hidden_size; Omni uses hf_text_config.hidden_size.
         hidden_size = int(
             getattr(self.model, "mtp_hidden_size", 0) or getattr(self.model_config.hf_text_config, "hidden_size")
         )
-        max_batch_size = max(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size)
+        capture_sizes = (
+            self._talker_mtp_graph_capture_sizes() if is_cuda else list(self.compilation_config.cudagraph_capture_sizes)
+        )
+        max_batch_size = max(self.max_num_reqs, max(capture_sizes, default=0))
         self.talker_mtp_input_ids = self._make_buffer(max_batch_size, dtype=torch.int32)
         self.talker_mtp_inputs_embeds = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.last_talker_hidden = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.text_step = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
+
+    def _talker_mtp_graph_capture_sizes(self) -> list[int]:
+        """Return only graph buckets reachable by one-token MTP decode batches."""
+        if not getattr(self, "talker_mtp_uses_outer_graph", False):
+            return []
+        capture_sizes = sorted({int(size) for size in self.compilation_config.cudagraph_capture_sizes if size > 0})
+        if not capture_sizes:
+            return []
+        runtime_limit = int(self.max_num_reqs)
+        graph_limit = getattr(self, "talker_mtp_outer_graph_max_batch_size", None)
+        if graph_limit is not None:
+            runtime_limit = min(runtime_limit, int(graph_limit))
+        sizes = [size for size in capture_sizes if size < runtime_limit]
+        ceiling = next((size for size in capture_sizes if size >= runtime_limit), None)
+        if ceiling is not None:
+            sizes.append(ceiling)
+        return sizes
 
     def _prewarm_attention_capture_workspaces(self) -> None:
         capture_sizes = getattr(self.compilation_config, "cudagraph_capture_sizes", None)
@@ -1796,11 +1830,17 @@ class OmniGPUModelRunner(GPUModelRunner):
         # When talker_mtp is not wrapped by the platform's full-graph wrapper,
         # it manages its own device graphs internally (code_predictor has its
         # own bucket sizes).
-        if not isinstance(self.talker_mtp, current_omni_platform.get_graph_wrapper_cls()):
+        graph_batch_limit = getattr(self, "talker_mtp_outer_graph_max_batch_size", None)
+        use_outer_graph = getattr(self, "talker_mtp_uses_outer_graph", False) and (
+            graph_batch_limit is None or decode_batch_size <= graph_batch_limit
+        )
+        if not use_outer_graph:
             _cudagraph_mode = CUDAGraphMode.NONE
             num_tokens_padded = decode_batch_size
+            talker_mtp = getattr(self, "_talker_mtp_eager", self.talker_mtp)
         else:
             num_tokens_padded = batch_desc.num_tokens
+            talker_mtp = self.talker_mtp
         req_input_ids = self.talker_mtp_input_ids.gpu[:num_tokens_padded]
         req_embeds = self.talker_mtp_inputs_embeds.gpu[:num_tokens_padded]
         last_talker_hidden = self.last_talker_hidden.gpu[:num_tokens_padded]
@@ -1832,7 +1872,18 @@ class OmniGPUModelRunner(GPUModelRunner):
                 cache[req_id] = generator
             return generator
 
-        row_generators = [_row_generator(req_id) for req_id in decode_req_ids]
+        accepts_per_row_generators = getattr(self.model, "talker_mtp_accepts_per_row_generators", False)
+        supports_per_row_generators = current_omni_platform.is_cuda() and getattr(
+            self.model, "talker_mtp_supports_per_row_generators", False
+        )
+        can_batch_per_row_generators = accepts_per_row_generators or supports_per_row_generators
+        if use_outer_graph and supports_per_row_generators and not accepts_per_row_generators:
+            # A full CUDA graph configuration owns its RNG state. Keep hybrid
+            # execution on the same batched RNG path instead of scalarizing
+            # every default seeded request.
+            row_generators = [None] * decode_batch_size
+        else:
+            row_generators = [_row_generator(req_id) for req_id in decode_req_ids]
         cache = getattr(self, "_talker_mtp_generators", None)
         if cache:
             # Generators live as long as their request; drop finished ones.
@@ -1842,7 +1893,7 @@ class OmniGPUModelRunner(GPUModelRunner):
         if (
             decode_batch_size > 1
             and any(generator is not None for generator in row_generators)
-            and not getattr(self.model, "talker_mtp_accepts_per_row_generators", False)
+            and not can_batch_per_row_generators
         ):
             # A torch.Generator is a single stream. Using one generator for a
             # multi-row batch would make explicitly-seeded requests depend on
@@ -1885,7 +1936,7 @@ class OmniGPUModelRunner(GPUModelRunner):
         with current_omni_platform.set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
-            req_embeds, code_predictor_codes = self.talker_mtp(
+            req_embeds, code_predictor_codes = talker_mtp(
                 req_input_ids,
                 req_embeds,
                 last_talker_hidden,


### PR DESCRIPTION
## Motivation

Qwen3-TTS runs multiple MTP prediction steps for every talker decode step. Launching these steps separately introduces significant CPU and CUDA launch overhead, especially for small and medium request batches.

## Changes

- Wrap the Qwen3-TTS MTP prediction loop with an outer CUDA graph.
- Capture only reachable batch buckets up to batch size 8.
- Pad graph-enabled requests to the nearest captured bucket.
- Preserve the original eager callable and use it directly for larger batches.
- Preserve per-request sampling behavior.
- Release both graph and eager MTP references during runner shutdown.
- Add tests for graph bucket selection, eager fallback, sampling behavior, and resource cleanup.

## Performance

Benchmarked with Qwen3-TTS 12Hz 0.6B Base using the official deployment configuration.

| Concurrency | Audio throughput | Mean E2EL | Mean audio RTF |
| --- | ---: | ---: | ---: |
| 8 | +11.7% | -9.5% | -8.3% |
| 16 | +2.4% | -2.6% | -2.5% |

TTFP showed run-to-run variance at higher concurrency. Throughput, E2EL, and audio RTF consistently improved in the final runs.

All c8 and c16 requests completed successfully. English and Chinese smoke-test WAV outputs were byte-identical between outer graph and baseline runs.

## Test Plan

- Python compilation checks for all changed files
- CUDA graph and eager routing unit tests
- Shutdown resource-release regression test
- Qwen3-TTS serving benchmarks at concurrency 1, 4, 8, and 16
- English and Chinese output consistency smoke tests