### PR TITLE
fix(quantization): support compressed-tensors MLP-only on Qwen-Image

### DIFF
--- a/tests/diffusion/quantization/test_compressed_tensors_qwen_image.py
+++ b/tests/diffusion/quantization/test_compressed_tensors_qwen_image.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression coverage for compressed-tensors MLP-only (ignore attn) on Qwen-Image.
+
+These tests pin the three defects fixed in the compressed-tensors MLP-only
+Qwen-Image support so the silent prompt-conditioning failure path is protected
+in CI:
+
+1. ``compressed-tensors`` method-name canonicalization (hyphen vs underscore) and
+   the ``from_config`` fallback in ``_build_single``.
+2. ``QwenImagePipeline`` exposing the transformer's ``packed_modules_mapping`` so
+   fused attention projections can be expanded during ignore matching.
+3. The ``.attn.to_out.0`` -> ``.attn.to_out`` ignore-list rewrite.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_compressed_tensors_method_canonicalization_and_from_config(monkeypatch):
+    """Hyphenated and underscore spellings resolve to the same canonical method,
+    and ``_build_single`` falls back to ``from_config`` (injecting the canonical
+    ``quant_method``) when the config is not constructible from raw kwargs.
+
+    CompressedTensorsConfig.from_config expects a full checkpoint config
+    (config_groups / format / scheme), so we stub the class to verify the
+    canonicalization + fallback contract without depending on that structure.
+    """
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
+        CompressedTensorsConfig,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    seen: dict = {}
+
+    def fake_init(self, *args, **kwargs):
+        # Simulate "not constructible from raw kwargs" -> triggers from_config.
+        raise TypeError("simulated signature mismatch")
+
+    def fake_from_config(cls, config):
+        seen["config"] = dict(config)
+        return object()  # sentinel; callers only need a returned object
+
+    monkeypatch.setattr(CompressedTensorsConfig, "__init__", fake_init)
+    monkeypatch.setattr(
+        CompressedTensorsConfig, "from_config", classmethod(fake_from_config)
+    )
+
+    # Canonical (hyphenated) spelling reaches from_config with the method set.
+    build_quant_config("compressed-tensors", ignore=["lm_head"])
+    assert seen["config"]["quant_method"] == "compressed-tensors"
+
+    # Underscore spelling normalizes to the same canonical method.
+    seen.clear()
+    build_quant_config("compressed_tensors", ignore=["lm_head"])
+    assert seen["config"]["quant_method"] == "compressed-tensors"
+
+
+def test_qwen_image_pipeline_exposes_transformer_packed_modules_mapping():
+    """The pipeline must expose the transformer's packed_modules_mapping so that
+    configure_quant_config() populates quant_config.packed_modules_mapping and
+    should_ignore_layer can expand fused attn projections (to_qkv/add_kv_proj)
+    when matching the ignore list on GPU."""
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import (
+        QwenImagePipeline,
+    )
+    from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
+        QwenImageTransformer2DModel,
+    )
+
+    transformer_mapping = QwenImageTransformer2DModel.packed_modules_mapping
+    assert transformer_mapping, "transformer must define a packed_modules_mapping"
+
+    pipeline_mapping = QwenImagePipeline.packed_modules_mapping
+    assert pipeline_mapping == transformer_mapping
+
+    # Must be a copy, not the transformer's class attribute, so downstream
+    # mutations (configure_quant_config) don't leak back onto the transformer.
+    assert pipeline_mapping is not transformer_mapping
+
+
+def test_qwen_image_ct_ignore_name_rewrite():
+    """The ``.attn.to_out.0`` -> ``.attn.to_out`` rewrite lets the fused output
+    projection be matched against the diffusers-style ignore list, and the
+    pipeline opts in via the ``_ct_ignore_name_rewrites`` marker attribute."""
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import (
+        QwenImagePipeline,
+    )
+    from vllm_omni.diffusion.registry import _apply_ignore_rewrite
+
+    rewrites = QwenImagePipeline._ct_ignore_name_rewrites
+    assert rewrites == {".attn.to_out.0": ".attn.to_out"}
+
+    # Fused output projection (diffusers name) is rewritten to the vLLM fused name.
+    assert (
+        _apply_ignore_rewrite("transformer_blocks.0.attn.to_out.0", rewrites)
+        == "transformer_blocks.0.attn.to_out"
+    )
+    # Non-matching names are left untouched.
+    assert (
+        _apply_ignore_rewrite("transformer_blocks.0.ff.net.0_proj", rewrites)
+        == "transformer_blocks.0.ff.net.0_proj"
+    )

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -273,6 +273,27 @@ class QwenImagePipeline(
 
     supports_step_execution: ClassVar[bool] = True
 
+    # Expose the transformer's packed_modules_mapping on the pipeline class so
+    # that configure_quant_config() populates quant_config.packed_modules_mapping
+    # and CompressedTensorsConfig.should_ignore_layer can expand fused attention
+    # projections (to_qkv/add_kv_proj) when matching the ignore list.
+    #
+    # _prepare_diffusion_quant_config() passes this *pipeline* class (not the
+    # transformer) to vLLM's configure_quant_config(), which reads
+    # packed_modules_mapping off model_class. Without this attribute the mapping
+    # stays empty on GPU (the CUDA platform's get_diffusion_packed_modules_mapping
+    # returns None, unlike NPU), so MLP-only (ignore attn) compressed-tensors
+    # checkpoints fail to ignore the fused attn layers and run them with an
+    # uninitialized weight_scale, destroying text conditioning.
+    packed_modules_mapping = dict(QwenImageTransformer2DModel.packed_modules_mapping)
+
+    # The compressed-tensors ignore list uses diffusers names. The attention
+    # output projection is `.attn.to_out.0` in diffusers but the vLLM fused
+    # layer is `.attn.to_out`. load_weights already renames for weight loading;
+    # this mapping lets _prepare_diffusion_quant_config normalise the ignore
+    # list so should_ignore_layer matches the fused layer.
+    _ct_ignore_name_rewrites: dict[str, str] = {".attn.to_out.0": ".attn.to_out"}
+
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -336,6 +336,18 @@ _NO_CACHE_ACCELERATION = {
 }
 
 
+def _apply_ignore_rewrite(name: str, rewrites: dict[str, str]) -> str:
+    """Apply suffix-based ignore-name rewrites for compressed-tensors ignore.
+
+    Each entry maps a diffusers suffix to the vLLM fused suffix (e.g.
+    ".attn.to_out.0" -> ".attn.to_out").
+    """
+    for old, new in rewrites.items():
+        if name.endswith(old):
+            return name[: -len(old)] + new
+    return name
+
+
 def _prepare_diffusion_quant_config(
     od_config: OmniDiffusionConfig,
     model_class: type[nn.Module],
@@ -350,6 +362,20 @@ def _prepare_diffusion_quant_config(
     if diffusion_packed_modules_mapping is not None:
         model_class.packed_modules_mapping = diffusion_packed_modules_mapping
     configure_quant_config(quant_config, model_class)
+
+    # Some diffusion models use diffusers names in the compressed-tensors ignore
+    # list that differ from the vLLM fused layer names. Qwen-Image's ignore list
+    # uses `.attn.to_out.0` while the vLLM fused layer is `.attn.to_out`.
+    # load_weights already renames `.to_out.0.` -> `.to_out.` for weight loading,
+    # but should_ignore_layer matches against the raw ignore list, so without
+    # this the output projection is not ignored and MLP-only (ignore attn)
+    # compressed-tensors checkpoints run it as FP8 with an uninitialized
+    # weight_scale. Models opt in via the `_ct_ignore_name_rewrites` mapping.
+    rewrites = getattr(model_class, "_ct_ignore_name_rewrites", None)
+    if rewrites:
+        ignore = getattr(quant_config, "ignore", None)
+        if ignore:
+            quant_config.ignore = [_apply_ignore_rewrite(n, rewrites) for n in ignore]
 
 
 def initialize_model(

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -289,23 +289,42 @@ def _build_single(method: str, **kwargs: Any) -> QuantizationConfig:
 
     Resolution: _OVERRIDES first, then vLLM registry via from_config().
     """
+    raw_method = method
     method = _normalize_method_name(method)
 
     if method in _OVERRIDES:
         return _OVERRIDES[method](**kwargs)
 
-    if method not in QUANTIZATION_METHODS:
-        raise ValueError(f"Unknown quantization method: {method!r}. Supported: {SUPPORTED_QUANTIZATION_METHODS}")
+    # QUANTIZATION_METHODS stores the canonical (hyphenated) names from
+    # QuantizationMethods, but _normalize_method_name turns hyphens into
+    # underscores (e.g. "compressed-tensors" -> "compressed_tensors"). Resolve
+    # the canonical spelling against both forms so hyphenated methods match.
+    # compressed-tensors is currently the only vLLM quant method with a hyphen,
+    # so it is the only one affected.
+    canonical = next(
+        (c for c in (str(raw_method), method, method.replace("_", "-")) if c in QUANTIZATION_METHODS),
+        None,
+    )
+    if canonical is None:
+        raise ValueError(f"Unknown quantization method: {raw_method!r}. Supported: {SUPPORTED_QUANTIZATION_METHODS}")
 
-    config_cls = get_quantization_config(method)
+    config_cls = get_quantization_config(canonical)
 
     try:
         return config_cls(**kwargs)
-    except TypeError:
-        sig = inspect.signature(config_cls.__init__)
-        raise TypeError(
-            f"Cannot instantiate {config_cls.__name__} with kwargs {kwargs}. Expected signature: {sig}"
-        ) from None
+    except TypeError as direct_exc:
+        # Some configs (e.g. CompressedTensorsConfig) are not constructible from
+        # raw kwargs and must be built via from_config(). Only fall back when the
+        # config actually supports it; otherwise surface the original error so
+        # genuine runtime TypeErrors inside __init__ are not swallowed.
+        if not hasattr(config_cls, "from_config"):
+            raise
+        from_config_kwargs = dict(kwargs)
+        from_config_kwargs.setdefault("quant_method", canonical)
+        try:
+            return config_cls.from_config(from_config_kwargs)
+        except TypeError:
+            raise direct_exc
 
 
 def _is_per_component_dict(spec: dict[str, Any]) -> bool:


### PR DESCRIPTION
Summary
  
  When serving an offline-quantized (llm-compressor) Qwen-Image checkpoint whose quantization_config.ignore list
  excludes the attention layers (only MLP Linears are FP8, attention stays bf16 — "MLP-only"), vLLM-omni fails to
  honor the ignore list for the fused attention projections. The attention layers are erroneously treated as
  quantized, registered with uninitialized weight_scale placeholders, and run with garbage scales — which
  silently destroys text conditioning (all generated images become identical regardless of prompt). The same
  checkpoint quantized on all linears (attn included, "all-linear") works correctly.

  Three independent defects combine to cause this; this PR fixes all three. Each is vLLM-omni-side (not
  llm-compressor-side).

  Root cause

  For Qwen-Image the attention projections are fused in vLLM (to_q+to_k+to_v → to_qkv, etc.), while the
  checkpoint's ignore list (diffusers naming) lists the unfused names, e.g.:

  "ignore": [
    "transformer_blocks.0.attn.to_q",
    "transformer_blocks.0.attn.to_out.0",
    "transformer_blocks.0.attn.to_add_out",
    ...
  ]

  CompressedTensorsConfig.should_ignore_layer relies on packed_modules_mapping to expand a fused module name
  (to_qkv) back to its parts (to_q/to_k/to_v) before matching against ignore. That mapping is empty at serve time
  for Qwen-Image on GPU, so the fused attention layers are never ignored. The causal chain:

  1. ignore-list attn layers are not ignored → treated as FP8, registered with weight_scale placeholders;
  2. but the checkpoint stores attention weights as bf16 with no scale → placeholders never loaded → attention
  runs with uninitialized scales;
  3. → text conditioning destroyed → all images byte-identical across prompts.

  The three defects & fixes

  Defect 1 — compressed-tensors cannot be loaded at all (vllm_omni/quantization/factory.py)
  _normalize_method_name replaces - with _, turning compressed-tensors into compressed_tensors. _build_single
  then checks method not in QUANTIZATION_METHODS, but QUANTIZATION_METHODS stores the hyphenated
  compressed-tensors → every compressed-tensors checkpoint raises Unknown quantization method: 
  'compressed_tensors'. (compressed-tensors is the only vLLM quant method with a hyphen, so it's the only one
  hit.) Also _build_single called config_cls(**kwargs), but CompressedTensorsConfig must be built via
  from_config.

  Fix: resolve the canonical method name against both spellings (raw / underscored / hyphenated) and pass the
  canonical form to get_quantization_config; fall back to from_config(kwargs) on TypeError.

  Defect 2 — packed_modules_mapping is empty for Qwen-Image on GPU (vllm_omni/diffusion/registry.py + platform
  interface)
  _prepare_diffusion_quant_config calls current_omni_platform.get_diffusion_packed_modules_mapping(model_class),
  which returns None on GPU (only NPU overrides it). It then calls vLLM's configure_quant_config(quant_config, 
  model_class) with model_class = QwenImagePipeline (the pipeline class, not the transformer). QwenImagePipeline
  had no packed_modules_mapping (the mapping lives on QwenImageTransformer2DModel), so configure_quant_config's
  getattr(model_class, "packed_modules_mapping", None) returns None and quant_config.packed_modules_mapping stays
  {}. → should_ignore_layer cannot expand to_qkv/add_kv_proj.

  Probe output (unpatched, MLP-only serve):
  [PREP] model_class=QwenImagePipeline packed_modules_mapping=None
  [PREP] after configure: qc.packed_modules_mapping={}
  to_qkv:      should_ignore=False   # wrong
  add_kv_proj: should_ignore=False   # wrong
  to_out:      should_ignore=False   # wrong

  Fix: expose packed_modules_mapping (the same mapping the transformer defines) on QwenImagePipeline so
  configure_quant_config populates quant_config.packed_modules_mapping.

  Defect 3 — to_out.0 vs to_out naming mismatch (vllm_omni/diffusion/registry.py)
  The ignore list uses the diffusers name .attn.to_out.0 while the vLLM fused layer is .attn.to_out. load_weights
  already renames .to_out.0. → .to_out. for weight loading, but should_ignore_layer matches against the raw
  ignore list, so the output projection is not ignored even after Defect 2 is fixed.

  Fix: in _prepare_diffusion_quant_config, for QwenImagePipeline, normalise .attn.to_out.0 → .attn.to_out in
  quant_config.ignore (mirroring the existing load_weights rename).

  Verification

  Verified on a single RTX PRO 5000 (Blackwell, 48 GB), vllm-omni 0.22.0, model
  Qwen-Image-2512-Lightning-ngr-merged, FP8_DYNAMIC quantized offline with llmcompressor 0.12.

  With all three fixes applied (originally validated via sitecustomize injection against 0.22.0, then ported to
  main), serving the MLP-only checkpoint:
  - All fused attn layers (to_qkv, add_kv_proj, to_out, to_add_out): should_ignore=True (bf16) ✅
  - MLP layers: should_ignore=False (FP8) ✅
  - weight_scale ... not initialized warnings: 0 ✅

  Regression — all-linear checkpoint (exercises the same load_weights weight_scale routing path): 12 distinct
  images across distinct prompts, p50 2.683 s, peak 45.7 GB. The factory fix (Defect 1) is a prerequisite:
  without it no compressed-tensors diffusion checkpoint loads at all.

  without it no compressed-tensors diffusion checkpoint loads at all.

  Notes / scope

  - These fixes do not change the all-linear path (already working) — they only make the ignore-attn (MLP-only)
  path correct.
  - The factory fix is independent of Qwen-Image and benefits any compressed-tensors diffusion checkpoint.

  Alternatives considered

  - Platform interface for Defect 2: implement get_diffusion_packed_modules_mapping on the CUDA platform
  (currently only NPU overrides it). More general (covers any diffusion model whose pipeline lacks the mapping)
  but touches the platform layer; the pipeline-attribute fix is the minimal, lowest-risk change, and the platform
  fix can be a follow-up.
  - should_ignore_layer suffix matching for Defect 3: teach it to strip a trailing .0. Rejected — it would affect
  every model; the rename belongs to Qwen-Image's name-mapping surface, consistent with the existing
  load_weights rename.