### PR TITLE
[Perf] Optimize Higgs Audio V3 request-aware decode pipeline

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -3424,6 +3424,49 @@ class TestTTSAsyncOffloading:
         yield server
         server.shutdown()
 
+    @pytest.fixture
+    def higgs_v3_server(self, mocker: MockerFixture):
+        mocker.patch.object(OmniOpenAIServingSpeech, "_load_supported_speakers", return_value=set())
+        mocker.patch.object(OmniOpenAIServingSpeech, "_load_codec_frame_rate", return_value=None)
+        mock_engine_client = mocker.MagicMock()
+        mock_engine_client.errored = False
+        mock_engine_client.model_config = mocker.MagicMock(
+            model="bosonai/higgs-audio-v3-tts-4b",
+            hf_config=mocker.MagicMock(),
+        )
+        mock_engine_client.default_sampling_params_list = [SimpleNamespace(max_tokens=2048, seed=None, extra_args=None)]
+        mock_engine_client.tts_batch_max_items = 64
+        mock_engine_client.generate = mocker.MagicMock(return_value="generator")
+        mock_engine_client.tts_max_instructions_length = None
+        mock_engine_client.stage_configs = [
+            SimpleNamespace(
+                engine_args=SimpleNamespace(model_stage="higgs_audio_v3"),
+                tts_args={},
+            )
+        ]
+        mock_models = mocker.MagicMock()
+        mock_models.is_base_model.return_value = True
+        server = OmniOpenAIServingSpeech(
+            engine_client=mock_engine_client,
+            models=mock_models,
+            request_logger=mocker.MagicMock(),
+        )
+
+        class FakeHiggsV3Adapter:
+            def validate(self, request):
+                return None
+
+            async def build(self, request, sampling_params_list, has_inline_ref_audio):
+                return PreparedRequest(
+                    prompt={"prompt_token_ids": [1, 2, 3]},
+                    tts_params={},
+                    model_type="higgs_audio_v3",
+                )
+
+        mocker.patch.object(server, "_get_tts_adapter", return_value=FakeHiggsV3Adapter())
+        yield server
+        server.shutdown()
+
     def test_prepare_speech_generation_awaits_voxtral_async(self, voxtral_server, mocker: MockerFixture):
         """Voxtral path in _prepare_speech_generation should call the async wrapper."""
         voxtral_server._build_voxtral_prompt_async = mocker.AsyncMock(
@@ -3468,6 +3511,41 @@ class TestTTSAsyncOffloading:
         assert stage0_params.seed == 42
         assert stage0_params.extra_args["tts_local_seed"] == 42
         assert qwen3_tts_server.engine_client.default_sampling_params_list[0].extra_args is None
+
+    def test_prepare_higgs_v3_unseeded_request_resolves_effective_seed_once(
+        self,
+        higgs_v3_server,
+        mocker: MockerFixture,
+    ):
+        randint = mocker.patch(
+            "vllm_omni.entrypoints.openai.serving_speech.random.randint",
+            return_value=123456789,
+        )
+
+        asyncio.run(higgs_v3_server._prepare_speech_generation(OpenAICreateSpeechRequest(input="hello")))
+
+        stage0_params = higgs_v3_server.engine_client.generate.call_args.kwargs["sampling_params_list"][0]
+        assert stage0_params.seed == 123456789
+        assert stage0_params.extra_args["tts_effective_seed"] == 123456789
+        assert higgs_v3_server.engine_client.default_sampling_params_list[0].seed is None
+        assert higgs_v3_server.engine_client.default_sampling_params_list[0].extra_args is None
+        randint.assert_called_once()
+
+    def test_prepare_higgs_v3_explicit_seed_is_the_effective_seed(
+        self,
+        higgs_v3_server,
+        mocker: MockerFixture,
+    ):
+        randint = mocker.patch("vllm_omni.entrypoints.openai.serving_speech.random.randint")
+
+        asyncio.run(
+            higgs_v3_server._prepare_speech_generation(OpenAICreateSpeechRequest(input="hello", seed=987654321))
+        )
+
+        stage0_params = higgs_v3_server.engine_client.generate.call_args.kwargs["sampling_params_list"][0]
+        assert stage0_params.seed == 987654321
+        assert stage0_params.extra_args["tts_effective_seed"] == 987654321
+        randint.assert_not_called()
 
     def test_prepare_speech_generation_uses_adapter_model_type_label(
         self,

--- a/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
@@ -86,6 +86,72 @@ class TestHiggsAudioV3Config:
         assert config.hidden_size == 2560
         assert config.audio_hidden_size == 2560
 
+    def test_audio_runtime_optimization_config_defaults(self):
+        from vllm_omni.transformers_utils.configs.higgs_audio_v3 import (
+            HiggsAudioV3Config,
+        )
+
+        config = HiggsAudioV3Config()
+        assert config.audio_state_step_mode == "legacy"
+        assert config.audio_sampler_mode == "torch"
+
+    def test_audio_runtime_optimization_config_overrides(self):
+        from vllm_omni.transformers_utils.configs.higgs_audio_v3 import (
+            HiggsAudioV3Config,
+        )
+
+        config = HiggsAudioV3Config(
+            audio_state_step_mode="compile",
+            audio_sampler_mode="flashinfer",
+        )
+        assert config.audio_state_step_mode == "compile"
+        assert config.audio_sampler_mode == "flashinfer"
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"audio_state_step_mode": "invalid"}, "audio_state_step_mode"),
+            ({"audio_sampler_mode": "invalid"}, "audio_sampler_mode"),
+        ],
+    )
+    def test_audio_runtime_optimization_config_rejects_invalid_modes(self, kwargs, message):
+        from vllm_omni.transformers_utils.configs.higgs_audio_v3 import (
+            HiggsAudioV3Config,
+        )
+
+        with pytest.raises(ValueError, match=message):
+            HiggsAudioV3Config(**kwargs)
+
+    def test_audio_runtime_mode_uses_config_when_environment_is_unset(self, monkeypatch):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            _resolve_audio_runtime_mode,
+        )
+
+        monkeypatch.delenv("HIGGS_AUDIO_V3_AUDIO_STATE_STEP", raising=False)
+        assert (
+            _resolve_audio_runtime_mode(
+                "HIGGS_AUDIO_V3_AUDIO_STATE_STEP",
+                "compile",
+                {"legacy", "eager", "compile"},
+            )
+            == "compile"
+        )
+
+    def test_audio_runtime_mode_prefers_environment_override(self, monkeypatch):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            _resolve_audio_runtime_mode,
+        )
+
+        monkeypatch.setenv("HIGGS_AUDIO_V3_AUDIO_SAMPLER", "torch")
+        assert (
+            _resolve_audio_runtime_mode(
+                "HIGGS_AUDIO_V3_AUDIO_SAMPLER",
+                "flashinfer",
+                {"torch", "flashinfer"},
+            )
+            == "torch"
+        )
+
 
 # ---- AC-4: Fused Multi-Codebook Modules ----
 
@@ -276,13 +342,32 @@ class TestSamplerMethods:
         t._last_audio_host_staging = None
         t._last_audio_gpu_staging = None
         t._last_audio_staging_event = None
-        t._audio_staging_events = []
-        t._audio_staging_event_cursor = 0
         t._last_audio_codes = None
         t._last_audio_code_valid = []
         t._postprocess_cursor = 0
-        t._postprocess_audio_rows = 0
-        t._postprocess_audio_active_rows = 0
+
+        # Stable request-state pool used by async scheduling.  The pool is
+        # distinct from the contiguous active-row buffers above so tests can
+        # exercise reorder/shrink without constructing the full model.
+        t._request_state_row_by_id = {}
+        t._request_state_free_rows = []
+        t._request_state_next_row = 0
+        t._request_decode_last_codes = torch.zeros_like(t._decode_last_codes)
+        t._request_decode_has_codes = torch.zeros_like(t._decode_has_codes)
+        t._request_decode_delay_count = torch.zeros_like(t._decode_delay_count)
+        t._request_decode_eoc_countdown = torch.full_like(t._decode_eoc_countdown, -1)
+        t._request_decode_generation_done = torch.zeros_like(t._decode_generation_done)
+        t._request_decode_seed = torch.full((num_rows,), -1, dtype=torch.long)
+        t._request_decode_step_count = torch.zeros(num_rows, dtype=torch.long)
+        t._decode_seed = torch.full((num_rows,), -1, dtype=torch.long)
+        t._decode_step_count = torch.zeros(num_rows, dtype=torch.long)
+        t._audio_state_update_mask = torch.zeros(num_rows, dtype=torch.bool)
+        t._active_request_pool_rows = torch.empty(0, dtype=torch.long)
+        t._active_request_ids = ()
+        t._request_sampling_seed_by_id = {}
+        t._fast_audio_direct_request_ids = set()
+        t._audio_state_step_mode = "legacy"
+        t._compiled_audio_state_step = None
 
         cls = mod.HiggsAudioV3TalkerForConditionalGeneration
         for name in (
@@ -298,10 +383,376 @@ class TestSamplerMethods:
             "_update_delay_state_batched",
             "_prefill_row_mask",
             "_audio_seed_mask_from_step_input",
+            "_refresh_request_sampling_seeds",
+            "_prepare_request_state",
+            "_commit_request_state",
+            "_ensure_request_state_capacity",
+            "_reset_request_state_pool_rows",
+            "on_requests_finished",
+            "_mark_audio_direct_requests",
+            "_can_use_logits_free_audio_sampler",
         ):
             setattr(t, name, getattr(cls, name).__get__(t))
+        t._sampling_metadata_requires_text_logits = cls._sampling_metadata_requires_text_logits
         t._device_cache_key = cls._device_cache_key
         return t
+
+    def test_request_state_survives_batch_reorder_and_shrink(self):
+        """Active row numbers may change while request-owned state must not."""
+        t = self._make_batched_sampler_talker(num_rows=4)
+
+        t._prepare_request_state(["req-a", "req-b"], torch.device("cpu"))
+        t._decode_last_codes[0].fill_(11)
+        t._decode_last_codes[1].fill_(22)
+        t._decode_delay_count[:2] = torch.tensor([3, 7])
+        t._decode_has_codes[:2] = True
+        t._commit_request_state(2)
+
+        # req-b moves from active row 1 to active row 0 after req-a leaves.
+        t._prepare_request_state(["req-b"], torch.device("cpu"))
+
+        assert t._decode_last_codes[0].eq(22).all()
+        assert t._decode_delay_count[0].item() == 7
+        assert t._decode_has_codes[0].item() is True
+
+    def test_finished_request_state_row_is_reset_before_reuse(self):
+        """Finish/cancel cleanup must not leak codec state into the next owner."""
+        t = self._make_batched_sampler_talker(num_rows=2)
+
+        first_rows = t._prepare_request_state(["req-a"], torch.device("cpu"))
+        first_pool_row = int(first_rows[0])
+        t._decode_last_codes[0].fill_(77)
+        t._decode_has_codes[0] = True
+        t._decode_delay_count[0] = 6
+        t._decode_seed[0] = 1234
+        t._decode_step_count[0] = 9
+        t._commit_request_state(1)
+
+        t.on_requests_finished({"req-a"})
+        second_rows = t._prepare_request_state(["req-c"], torch.device("cpu"))
+
+        assert int(second_rows[0]) == first_pool_row
+        assert t._decode_last_codes[0].eq(0).all()
+        assert t._decode_has_codes[0].item() is False
+        assert t._decode_delay_count[0].item() == 0
+        assert t._decode_seed[0].item() == -1
+        assert t._decode_step_count[0].item() == 0
+
+    def test_finished_request_loses_logits_free_audio_certification(self):
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t._fast_audio_direct_request_ids.update(("req-a", "req-b"))
+
+        t.on_requests_finished({"req-a"})
+
+        assert t._fast_audio_direct_request_ids == {"req-b"}
+
+    def test_stale_pending_step_cannot_recertify_finished_request(self):
+        """A lagged async resolve must not resurrect cancelled request state."""
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3PendingStep,
+        )
+
+        t = self._make_batched_sampler_talker(num_rows=1)
+        t._prepare_request_state(["req-a"], torch.device("cpu"))
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=["req-a"],
+            host_staging=torch.tensor(
+                [[11, 12, 13, 14, 15, 16, 17, 18, 1, 0]],
+                dtype=torch.int32,
+            ),
+            event=None,
+            num_codebooks=8,
+            release=lambda: None,
+            on_resolve=t._mark_audio_direct_requests,
+        )
+
+        t.on_requests_finished({"req-a"})
+        pending.resolve()
+
+        assert "req-a" not in t._fast_audio_direct_request_ids
+
+    def test_logits_free_audio_certification_is_request_aware_after_reorder(self):
+        """A new request must not inherit an old row's direct-audio fast path."""
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t._fast_audio_direct_request_ids.update(("req-a", "req-b"))
+        t._active_request_ids = ("req-b", "req-a")
+
+        assert t._can_use_logits_free_audio_sampler(2, decode_only=True)
+
+        t._active_request_ids = ("req-b", "req-new")
+        assert not t._can_use_logits_free_audio_sampler(2, decode_only=True)
+
+    def test_compute_logits_skips_text_head_only_for_certified_audio_requests(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t.compute_logits = mod.HiggsAudioV3TalkerForConditionalGeneration.compute_logits.__get__(t)
+        t._last_step_input_ids = torch.tensor([10, 10], dtype=torch.long)
+        t._active_request_ids = ("req-a", "req-b")
+        t._fast_audio_direct_request_ids.update(t._active_request_ids)
+        t._backbone_config = SimpleNamespace(vocab_size=151936)
+        calls = []
+        t.logits_processor = lambda head, hidden: calls.append((head, hidden)) or torch.ones(2, 3)
+        t.lm_head = object()
+        metadata = SimpleNamespace(
+            max_num_logprobs=None,
+            allowed_token_ids_mask=None,
+            bad_words_token_ids=None,
+        )
+        hidden = torch.randn(2, 16)
+
+        assert t.compute_logits(hidden, sampling_metadata=metadata) is None
+        assert t._last_logits_hidden is hidden
+        assert calls == []
+
+        t._active_request_ids = ("req-a", "req-new")
+        logits = t.compute_logits(hidden, sampling_metadata=metadata)
+        assert logits.shape == (2, 3)
+        assert len(calls) == 1
+
+    def test_seeded_audio_sampling_is_request_independent_under_reorder(self):
+        """A request seed must produce the same code row after batch reorder."""
+        t = self._make_batched_sampler_talker(num_rows=2)
+        torch.manual_seed(123)
+        row_logits = torch.randn(8, 1026)
+        logits = torch.stack((row_logits, row_logits), dim=0).reshape(-1, 1026)
+
+        first = t._sample_audio_codes(
+            logits,
+            row_seeds=torch.tensor([111, 222], dtype=torch.long),
+            row_steps=torch.tensor([5, 5], dtype=torch.long),
+        ).view(2, 8)
+        reordered = t._sample_audio_codes(
+            logits,
+            row_seeds=torch.tensor([222, 111], dtype=torch.long),
+            row_steps=torch.tensor([5, 5], dtype=torch.long),
+        ).view(2, 8)
+
+        assert torch.equal(first[0], reordered[1])
+        assert torch.equal(first[1], reordered[0])
+        assert not torch.equal(first[0], first[1])
+
+    def test_fully_seeded_audio_sampling_does_not_run_a_second_rng(self, monkeypatch):
+        """Stateless request sampling must not also launch multinomial."""
+        t = self._make_batched_sampler_talker(num_rows=2)
+        logits = torch.randn(2 * t.num_codebooks, t.codebook_size)
+
+        def unexpected_multinomial(*args, **kwargs):
+            raise AssertionError("fully seeded sampling launched torch.multinomial")
+
+        monkeypatch.setattr(torch, "multinomial", unexpected_multinomial)
+        sampled = t._sample_audio_codes(
+            logits,
+            row_seeds=torch.tensor([111, 222], dtype=torch.long),
+            row_steps=torch.tensor([5, 5], dtype=torch.long),
+        )
+
+        assert sampled.shape == (2 * t.num_codebooks,)
+
+    def test_flashinfer_renorm_sampler_keeps_request_seed_reorder_invariance(self, monkeypatch):
+        """Fused renorm may replace sort/masking without losing request ownership."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        calls = []
+
+        def top_k_renorm(probs, top_k):
+            calls.append(("top_k", top_k))
+            threshold = probs.topk(top_k, dim=-1).values[..., -1:]
+            kept = torch.where(probs >= threshold, probs, torch.zeros_like(probs))
+            return kept / kept.sum(dim=-1, keepdim=True)
+
+        def top_p_renorm(probs, top_p, is_deterministic=False):
+            calls.append(("top_p", top_p, is_deterministic))
+            sorted_probs, sorted_indices = probs.sort(dim=-1, descending=True)
+            remove = sorted_probs.cumsum(dim=-1) > top_p
+            remove[..., 1:] = remove[..., :-1].clone()
+            remove[..., 0] = False
+            mask = torch.zeros_like(remove)
+            mask.scatter_(-1, sorted_indices, remove)
+            kept = probs.masked_fill(mask, 0)
+            return kept / kept.sum(dim=-1, keepdim=True)
+
+        monkeypatch.setattr(mod, "_flashinfer_top_k_renorm_probs", top_k_renorm, raising=False)
+        monkeypatch.setattr(mod, "_flashinfer_top_p_renorm_probs", top_p_renorm, raising=False)
+
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t._audio_sampler_mode = "flashinfer"
+        row_logits = torch.randn(t.num_codebooks, t.codebook_size)
+        logits = torch.stack((row_logits, row_logits), dim=0).reshape(-1, t.codebook_size)
+        first = t._sample_audio_codes(
+            logits,
+            row_seeds=torch.tensor([111, 222], dtype=torch.long),
+            row_steps=torch.tensor([5, 5], dtype=torch.long),
+        ).view(2, t.num_codebooks)
+        reordered = t._sample_audio_codes(
+            logits,
+            row_seeds=torch.tensor([222, 111], dtype=torch.long),
+            row_steps=torch.tensor([5, 5], dtype=torch.long),
+        ).view(2, t.num_codebooks)
+
+        assert torch.equal(first[0], reordered[1])
+        assert torch.equal(first[1], reordered[0])
+        assert [call[0] for call in calls] == ["top_k", "top_p", "top_k", "top_p"]
+
+    def test_flashinfer_renorm_uses_preallocated_compile_safe_ops(self, monkeypatch):
+        """Static workspaces select opaque ops instead of Python JIT wrappers."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        calls = []
+
+        def top_k_op(probs, row_states):
+            calls.append(("top_k", row_states))
+            return probs
+
+        def top_p_op(probs, workspace):
+            calls.append(("top_p", workspace))
+            return probs
+
+        monkeypatch.setattr(mod, "_higgs_flashinfer_top_k_renorm_op", top_k_op, raising=False)
+        monkeypatch.setattr(mod, "_higgs_flashinfer_top_p_renorm_op", top_p_op, raising=False)
+        row_states = torch.empty(16, dtype=torch.uint8)
+        workspace = torch.empty(32, dtype=torch.uint8)
+        sampled = mod.HiggsAudioV3TalkerForConditionalGeneration._sample_audio_codes_tensor(
+            torch.randn(8, 1026),
+            row_seeds=torch.tensor([111], dtype=torch.long),
+            row_steps=torch.tensor([5], dtype=torch.long),
+            num_codebooks=8,
+            use_flashinfer=True,
+            flashinfer_top_k_row_states=row_states,
+            flashinfer_top_p_workspace=workspace,
+        )
+
+        assert sampled.shape == (8,)
+        assert calls == [("top_k", row_states), ("top_p", workspace)]
+
+    def test_tensor_state_step_matches_existing_mask_sample_update_path(self):
+        """The fused region must preserve every quality-sensitive transition."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        reference = self._make_batched_sampler_talker(num_rows=4)
+        fused = self._make_batched_sampler_talker(num_rows=4)
+        logits = torch.randn(4, 8, 1026)
+        rows = torch.arange(4, dtype=torch.long)
+        update_mask = torch.tensor([True, False, True, True])
+        seeds = torch.tensor([11, 22, 33, 44], dtype=torch.long)
+        steps = torch.tensor([0, 2, 7, 4], dtype=torch.long)
+        reference._decode_step_count.copy_(steps)
+        fused._decode_step_count.copy_(steps)
+
+        reference_logits = logits.clone()
+        reference._apply_delay_pattern_masking_batched(reference_logits, rows, all_rows=True)
+        reference_codes = reference._sample_audio_codes(
+            reference_logits.reshape(-1, 1026), row_seeds=seeds, row_steps=steps
+        ).view(4, 8)
+        reference._update_delay_state_batched(
+            reference_codes,
+            rows,
+            4,
+            torch.device("cpu"),
+            code_row_mask=update_mask,
+            all_rows=True,
+        )
+
+        result = mod.HiggsAudioV3TalkerForConditionalGeneration._audio_state_step_tensor(
+            logits.clone(),
+            fused._decode_delay_count,
+            fused._decode_eoc_countdown,
+            fused._decode_generation_done,
+            fused._decode_has_codes,
+            fused._decode_last_codes,
+            steps,
+            seeds,
+            update_mask,
+        )
+        (
+            output_codes,
+            delay_count,
+            eoc_countdown,
+            generation_done,
+            has_codes,
+            last_codes,
+            step_count,
+            valid,
+            done,
+        ) = result
+
+        assert torch.equal(output_codes, reference._last_audio_host_staging[:, :8])
+        assert torch.equal(delay_count, reference._decode_delay_count)
+        assert torch.equal(eoc_countdown, reference._decode_eoc_countdown)
+        assert torch.equal(generation_done, reference._decode_generation_done)
+        assert torch.equal(has_codes, reference._decode_has_codes)
+        assert torch.equal(last_codes, reference._decode_last_codes)
+        assert torch.equal(step_count, reference._decode_step_count)
+        assert torch.equal(valid.to(torch.int32), reference._last_audio_host_staging[:, 8])
+        assert torch.equal(done.to(torch.int32), reference._last_audio_host_staging[:, 9])
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA torch.compile")
+    def test_compiled_tensor_state_step_matches_eager_cuda(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3TalkerForConditionalGeneration,
+            HiggsFusedMultiTextHead,
+        )
+
+        device = torch.device("cuda")
+        torch.manual_seed(20260718)
+        model = HiggsAudioV3TalkerForConditionalGeneration.__new__(HiggsAudioV3TalkerForConditionalGeneration)
+        torch.nn.Module.__init__(model)
+        model.num_codebooks = 8
+        model.modality_head = HiggsFusedMultiTextHead(8, 1026, 64).to(device)
+        torch.nn.init.normal_(model.modality_head.weight, mean=0.0, std=0.02)
+        model._audio_state_step_mode = "compile"
+        model._compiled_audio_state_step = None
+        args = (
+            torch.randn(4, 64, device=device),
+            torch.tensor([0, 7, 3, 1], dtype=torch.long, device=device),
+            torch.tensor([-1, 2, 0, -1], dtype=torch.long, device=device),
+            torch.tensor([False, False, True, False], device=device),
+            torch.tensor([True, True, False, True], device=device),
+            torch.randint(0, 1024, (4, 8), dtype=torch.long, device=device),
+            torch.tensor([0, 2, 7, 4], dtype=torch.long, device=device),
+            torch.tensor([11, 22, 33, 44], dtype=torch.long, device=device),
+            torch.tensor([True, False, True, True], device=device),
+        )
+        eager = model._audio_state_step_from_hidden(*args)
+        compiled_fn = model._get_audio_state_step_callable()
+        compiled = compiled_fn(*args)
+        torch.accelerator.synchronize()
+
+        assert len(compiled) == len(eager)
+        for actual, expected in zip(compiled, eager, strict=True):
+            assert torch.equal(actual, expected)
+
+    def test_compiled_audio_state_step_disables_nested_cudagraphs(self, monkeypatch):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3TalkerForConditionalGeneration,
+        )
+
+        model = HiggsAudioV3TalkerForConditionalGeneration.__new__(HiggsAudioV3TalkerForConditionalGeneration)
+        torch.nn.Module.__init__(model)
+        model._audio_state_step_mode = "compile"
+        model._compiled_audio_state_step = None
+        compile_kwargs = {}
+
+        def fake_compile(fn, **kwargs):
+            compile_kwargs.update(kwargs)
+            return fn
+
+        monkeypatch.setattr(torch, "compile", fake_compile)
+        model._get_audio_state_step_callable()
+
+        assert compile_kwargs["options"] == {"triton.cudagraphs": False}
+        assert "mode" not in compile_kwargs
+
+    @pytest.mark.parametrize(
+        ("num_rows", "expected"),
+        ((0, 1), (1, 1), (2, 2), (3, 4), (8, 8), (9, 16), (15, 16), (16, 16), (17, 32)),
+    )
+    def test_audio_state_step_uses_power_of_two_buckets(self, num_rows, expected):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3TalkerForConditionalGeneration,
+        )
+
+        assert HiggsAudioV3TalkerForConditionalGeneration._audio_state_step_bucket_size(num_rows) == expected
 
     def test_sample_respects_mask(self):
         """Tokens masked to -inf must never be sampled."""
@@ -463,12 +914,13 @@ class TestSamplerMethods:
         t._decode_generation_done = torch.tensor([False, True])
         t._decode_delay_count = torch.zeros(2, dtype=torch.long)
         t._decode_eoc_countdown = torch.full((2,), -1, dtype=torch.long)
-        t._fast_audio_direct_rows = 2
+        t._active_request_ids = ("req-a", "req-b")
+        t._fast_audio_direct_request_ids.update(t._active_request_ids)
         t._last_audio_done_flags = None
         t._fast_audio_sampler_gpu_fallback_reason = lambda **kwargs: None
         t._audio_codebook_logits_from_rows = lambda hidden, rows, all_rows=False: torch.zeros(2, 8, 1026)
         t._apply_delay_pattern_masking_batched = lambda cb_logits, audio_rows, all_rows=False: None
-        t._sample_audio_codes = lambda logits_2d: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
+        t._sample_audio_codes = lambda logits_2d, **kwargs: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
         t._update_delay_state_batched = lambda *args, **kwargs: None
         t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
 
@@ -494,16 +946,52 @@ class TestSamplerMethods:
         t._decode_generation_done = torch.tensor([False, False])
         t._decode_delay_count = torch.zeros(2, dtype=torch.long)
         t._decode_eoc_countdown = torch.full((2,), -1, dtype=torch.long)
-        t._fast_audio_direct_rows = 2
+        t._active_request_ids = ("req-a", "req-b")
+        t._fast_audio_direct_request_ids.update(t._active_request_ids)
         t._last_audio_done_flags = [0, 0]
         t._fast_audio_sampler_gpu_fallback_reason = lambda **kwargs: None
         t._audio_codebook_logits_from_rows = lambda hidden, rows, all_rows=False: torch.zeros(2, 8, 1026)
         t._apply_delay_pattern_masking_batched = lambda cb_logits, audio_rows, all_rows=False: None
-        t._sample_audio_codes = lambda logits_2d: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
+        t._sample_audio_codes = lambda logits_2d, **kwargs: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
         t._update_delay_state_batched = lambda *args, **kwargs: None
         t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
 
         sampler_output = t.sample(torch.zeros(2, 200000), sampling_metadata=object())
+
+        assert sampler_output.sampled_token_ids.tolist() == [[99999], [99999]]
+
+    def test_logits_free_sample_keeps_compute_step_decision_after_certification_changes(self):
+        """Async resolve may update certification after compute_logits returns None."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t._resolve_token_ids = lambda: None
+        t._audio_continuation_id = 99999
+        t._eos_token_id = 151671
+        t._last_step_input_ids = torch.tensor([99999, 99999])
+        t._last_step_query_start_loc = None
+        t._decode_has_codes = torch.tensor([True, True])
+        t._decode_generation_done = torch.tensor([False, False])
+        t._decode_delay_count = torch.zeros(2, dtype=torch.long)
+        t._decode_eoc_countdown = torch.full((2,), -1, dtype=torch.long)
+        t._active_request_ids = ("req-a", "req-b")
+        t._fast_audio_direct_request_ids.update(t._active_request_ids)
+        t._last_audio_done_flags = [0, 0]
+        t._fast_audio_sampler_gpu_fallback_reason = lambda **kwargs: None
+        t._audio_codebook_logits_from_rows = lambda hidden, rows, all_rows=False: torch.zeros(2, 8, 1026)
+        t._apply_delay_pattern_masking_batched = lambda cb_logits, audio_rows, all_rows=False: None
+        t._sample_audio_codes = lambda logits_2d, **kwargs: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
+        t._update_delay_state_batched = lambda *args, **kwargs: None
+        t.compute_logits = mod.HiggsAudioV3TalkerForConditionalGeneration.compute_logits.__get__(t)
+        t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
+
+        logits = t.compute_logits(torch.zeros(2, 16), sampling_metadata=object())
+        assert logits is None
+
+        # Resolving a different pending output can mutate request certification
+        # before sample_tokens() consumes this step's immutable logits result.
+        t._fast_audio_direct_request_ids.clear()
+        sampler_output = t.sample(logits, sampling_metadata=object())
 
         assert sampler_output.sampled_token_ids.tolist() == [[99999], [99999]]
 
@@ -592,6 +1080,120 @@ class TestSamplerMethods:
 
 
 class TestFeedbackMethods:
+    def test_audio_host_staging_pool_ping_pongs_without_aliasing_live_step(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            _HiggsAudioHostStagingPool,
+        )
+
+        pool = _HiggsAudioHostStagingPool(width=10, pin_memory=False)
+        first = pool.acquire(2)
+        second = pool.acquire(2)
+
+        assert first.tensor.data_ptr() != second.tensor.data_ptr()
+        first_ptr = first.tensor.data_ptr()
+        first.release()
+        third = pool.acquire(2)
+        assert third.tensor.data_ptr() == first_ptr
+
+        second.release()
+        third.release()
+
+    def test_pending_audio_step_keeps_immutable_request_row_snapshot(self):
+        """A lagged resolve must use the launch-time request order."""
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3PendingStep,
+        )
+
+        synchronized = []
+        released = []
+        event = SimpleNamespace(synchronize=lambda: synchronized.append(True))
+        host = torch.tensor(
+            [
+                [11, 12, 13, 14, 15, 16, 17, 18, 1, 0],
+                [21, 22, 23, 24, 25, 26, 27, 28, 1, 1],
+            ],
+            dtype=torch.int32,
+        )
+        request_ids = ["req-a", "req-b"]
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=request_ids,
+            host_staging=host,
+            event=event,
+            num_codebooks=8,
+            release=lambda: released.append(True),
+        )
+
+        # Mutating the scheduler-owned list after launch must not change the
+        # pending step's request_id -> row ownership.
+        request_ids[:] = ["req-b", "req-a"]
+        resolved = pending.resolve()
+        host.fill_(99)
+
+        assert synchronized == [True]
+        assert released == [True]
+        assert pending.request_ids == ("req-a", "req-b")
+        assert dict(pending.request_id_to_row) == {"req-a": 0, "req-b": 1}
+        with pytest.raises(TypeError):
+            pending.request_id_to_row["req-c"] = 2
+        assert torch.equal(
+            resolved["req-a"]["codes"]["audio"],
+            torch.tensor([[11, 12, 13, 14, 15, 16, 17, 18]], dtype=torch.int32),
+        )
+        assert torch.equal(
+            resolved["req-b"]["codes"]["audio"],
+            torch.tensor([[21, 22, 23, 24, 25, 26, 27, 28]], dtype=torch.int32),
+        )
+
+    def test_pending_audio_step_keeps_invalid_rows_as_empty_payloads(self):
+        """An authoritative async snapshot must clear stale audio rows."""
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3PendingStep,
+        )
+
+        host = torch.tensor(
+            [[11, 12, 13, 14, 15, 16, 17, 18, 0, 0]],
+            dtype=torch.int32,
+        )
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=["req-a"],
+            host_staging=host,
+            event=None,
+            num_codebooks=8,
+            release=lambda: None,
+        )
+
+        resolved = pending.resolve()
+
+        assert "req-a" in resolved
+        assert resolved["req-a"]["codes"]["audio"].numel() == 0
+
+    def test_pending_audio_step_certifies_request_ids_after_snapshot_resolves(self):
+        """Async resolve must restore the direct-audio state lost by cursor bypass."""
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3PendingStep,
+        )
+
+        ready = []
+        host = torch.tensor(
+            [
+                [11, 12, 13, 14, 15, 16, 17, 18, 1, 0],
+                [21, 22, 23, 24, 25, 26, 27, 28, 0, 0],
+            ],
+            dtype=torch.int32,
+        )
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=["req-a", "req-new"],
+            host_staging=host,
+            event=None,
+            num_codebooks=8,
+            release=lambda: None,
+            on_resolve=lambda request_ids, valid, done: ready.append((request_ids, tuple(valid), tuple(done))),
+        )
+
+        pending.resolve()
+
+        assert ready == [(("req-a", "req-new"), (1, 0), (0, 0))]
+
     def test_postprocess_emits_audio_codes(self):
         """postprocess() should return codes from _last_audio_codes."""
         from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
@@ -651,6 +1253,47 @@ class TestFeedbackMethods:
 
 
 # ---- AC-6: Audio Feedback Method Tests ----
+
+
+class TestBackboneCompileBoundary:
+    def test_external_decode_graph_reenters_compiled_qwen3_model(self):
+        """FULL_DECODE must call Qwen3Model so its compile decorator can run."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        expected = torch.randn(2, 4)
+
+        class RecordingModel:
+            def __init__(self):
+                self.calls = []
+                self.layers = []
+                self.norm = lambda hidden, residual: (hidden, residual)
+
+            def __call__(self, **kwargs):
+                self.calls.append(kwargs)
+                return expected
+
+        class FakeTalker:
+            _use_external_decode_cudagraph = True
+            model = RecordingModel()
+
+        talker = FakeTalker()
+        positions = torch.arange(2)
+        hidden_states = torch.randn(2, 4)
+
+        actual = mod.HiggsAudioV3TalkerForConditionalGeneration._run_qwen3_layers_eager(
+            talker,
+            positions,
+            hidden_states,
+        )
+
+        assert actual is expected
+        assert talker.model.calls == [
+            {
+                "input_ids": None,
+                "positions": positions,
+                "inputs_embeds": hidden_states,
+            }
+        ]
 
 
 class TestAudioFeedback:
@@ -764,6 +1407,27 @@ class TestAudioFeedback:
         t._decode_has_codes[2] = True
         hidden = torch.zeros(4, 16)
 
+        result = t._apply_audio_feedback(hidden, t._last_step_input_ids)
+
+        assert result[2].abs().sum() > 0
+        assert result[0].abs().sum() == 0
+        assert result[1].abs().sum() == 0
+        assert result[3].abs().sum() == 0
+
+    def test_external_decode_graph_dense_qsl_bypasses_dynamic_position_filter(self):
+        """Dense FULL_DECODE capture must not create dynamic boolean-index outputs."""
+        t = self._make_feedback_talker()
+        t._use_external_decode_cudagraph = True
+        t._last_step_input_ids = torch.tensor([10, 11, 12, 13])
+        t._last_step_query_start_loc = torch.tensor([0, 1, 2, 3, 4])
+        t._decode_last_codes[2] = torch.zeros(8, dtype=torch.long)
+        t._decode_has_codes[2] = True
+        hidden = torch.zeros(4, 16)
+
+        def fail_dynamic_filter(*args, **kwargs):
+            raise AssertionError("dense decode must bypass dynamic boolean indexing")
+
+        t._decode_request_token_positions = fail_dynamic_filter
         result = t._apply_audio_feedback(hidden, t._last_step_input_ids)
 
         assert result[2].abs().sum() > 0
@@ -1188,6 +1852,68 @@ class TestStageInputProcessor:
 
 
 class TestRegistry:
+    def test_talker_declares_async_no_hidden_output_capabilities(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3TalkerForConditionalGeneration,
+        )
+
+        assert HiggsAudioV3TalkerForConditionalGeneration.use_async_omni_output is True
+        assert HiggsAudioV3TalkerForConditionalGeneration.eager_omni_postprocess_before_async_output is False
+        assert HiggsAudioV3TalkerForConditionalGeneration.supports_async_omni_postprocess is True
+        assert HiggsAudioV3TalkerForConditionalGeneration.omni_pooler_payload_include_hidden is False
+
+    def test_higgs_deploys_enable_request_aware_stage0_async_only(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        deploy_dir = os.path.join(repo_root, "vllm_omni", "deploy")
+        for name in (
+            "higgs_multimodal_qwen3.yaml",
+            "higgs_multimodal_qwen3_high_throughput.yaml",
+            "higgs_multimodal_qwen3_low_latency.yaml",
+        ):
+            with open(os.path.join(deploy_dir, name), encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            assert config["stages"][0]["async_scheduling"] is True
+            assert config["stages"][0]["enable_prefix_caching"] is False
+            assert config["stages"][1]["async_scheduling"] is False
+
+    def test_high_throughput_deploys_select_validated_audio_runtime(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        deploy_dir = os.path.join(repo_root, "vllm_omni", "deploy")
+        for name in (
+            "higgs_multimodal_qwen3.yaml",
+            "higgs_multimodal_qwen3_high_throughput.yaml",
+        ):
+            with open(os.path.join(deploy_dir, name), encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            overrides = config["stages"][0]["hf_overrides"]
+            assert overrides["audio_state_step_mode"] == "compile"
+            assert overrides["audio_sampler_mode"] == "flashinfer"
+
+    def test_high_throughput_deploy_matches_stage_concurrency(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        yaml_path = os.path.join(
+            repo_root,
+            "vllm_omni",
+            "deploy",
+            "higgs_multimodal_qwen3_high_throughput.yaml",
+        )
+        with open(yaml_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        assert config["stages"][0]["max_num_seqs"] == 64
+        assert config["stages"][1]["max_num_seqs"] == 64
+
     def test_talker_registered(self):
         from vllm_omni.model_executor.models.registry import _OMNI_MODELS
 

--- a/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
@@ -7,6 +7,7 @@ without requiring the actual checkpoint or GPU.
 """
 
 import asyncio
+import hashlib
 import json
 import time
 from collections import OrderedDict, defaultdict
@@ -366,6 +367,7 @@ class TestSamplerMethods:
         t._active_request_ids = ()
         t._request_sampling_seed_by_id = {}
         t._fast_audio_direct_request_ids = set()
+        t._trajectory_recorder = None
         t._audio_state_step_mode = "legacy"
         t._compiled_audio_state_step = None
 
@@ -414,6 +416,59 @@ class TestSamplerMethods:
         assert t._decode_last_codes[0].eq(22).all()
         assert t._decode_delay_count[0].item() == 7
         assert t._decode_has_codes[0].item() is True
+
+    def test_registered_request_seeds_initialize_pool_and_survive_reorder(self):
+        """Effective seeds are request-owned before active rows are materialized."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=4)
+        t.register_request_sampling_seeds = (
+            mod.HiggsAudioV3TalkerForConditionalGeneration.register_request_sampling_seeds.__get__(t)
+        )
+
+        t.register_request_sampling_seeds({"req-a": 111, "req-b": 222})
+        t._prepare_request_state(["req-a", "req-b"], torch.device("cpu"))
+
+        assert t._decode_seed[:2].tolist() == [111, 222]
+
+        t._decode_step_count[:2] = torch.tensor([7, 9])
+        t._commit_request_state(2)
+        t._prepare_request_state(["req-b"], torch.device("cpu"))
+
+        assert t._decode_seed[0].item() == 222
+        assert t._decode_step_count[0].item() == 9
+
+    def test_register_request_sampling_seed_rejects_live_conflict(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t.register_request_sampling_seeds = (
+            mod.HiggsAudioV3TalkerForConditionalGeneration.register_request_sampling_seeds.__get__(t)
+        )
+
+        t.register_request_sampling_seeds({"req-a": 111})
+
+        with pytest.raises(ValueError, match="req-a"):
+            t.register_request_sampling_seeds({"req-a": 222})
+
+    def test_finished_request_seed_is_cleared_before_pool_row_reuse(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=2)
+        t.register_request_sampling_seeds = (
+            mod.HiggsAudioV3TalkerForConditionalGeneration.register_request_sampling_seeds.__get__(t)
+        )
+        t.register_request_sampling_seeds({"req-a": 111})
+        first_rows = t._prepare_request_state(["req-a"], torch.device("cpu"))
+        first_pool_row = int(first_rows[0])
+
+        t.on_requests_finished({"req-a"})
+        t.register_request_sampling_seeds({"req-b": 222})
+        second_rows = t._prepare_request_state(["req-b"], torch.device("cpu"))
+
+        assert int(second_rows[0]) == first_pool_row
+        assert t._decode_seed[0].item() == 222
+        assert "req-a" not in t._request_sampling_seed_by_id
 
     def test_finished_request_state_row_is_reset_before_reuse(self):
         """Finish/cancel cleanup must not leak codec state into the next owner."""
@@ -1143,6 +1198,64 @@ class TestFeedbackMethods:
             resolved["req-b"]["codes"]["audio"],
             torch.tensor([[21, 22, 23, 24, 25, 26, 27, 28]], dtype=torch.int32),
         )
+
+    def test_pending_audio_step_writes_request_trajectory_fingerprint(self, tmp_path):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            HiggsAudioV3PendingStep,
+            _HiggsAudioTrajectoryRecorder,
+        )
+
+        path = tmp_path / "trajectory.jsonl"
+        recorder = _HiggsAudioTrajectoryRecorder(path)
+        host = torch.tensor(
+            [
+                [11, 12, 13, 14, 15, 16, 17, 18, 1, 0],
+                [21, 22, 23, 24, 25, 26, 27, 28, 0, 1],
+            ],
+            dtype=torch.int32,
+        )
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=["req-a", "req-b"],
+            request_seeds=[111, 222],
+            sampling_seeds=[111, 333],
+            sampling_post_steps=[1, 7],
+            hidden_snapshot=torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16),
+            host_staging=host,
+            event=None,
+            num_codebooks=8,
+            release=lambda: None,
+            trajectory_recorder=recorder,
+        )
+
+        pending.resolve()
+
+        records = [json.loads(line) for line in path.read_text().splitlines()]
+        assert [(record["request_id"], record["effective_seed"]) for record in records] == [
+            ("req-a", 111),
+            ("req-b", 222),
+        ]
+        assert [record["sampling_seed"] for record in records] == [111, 333]
+        assert [record["decode_step"] for record in records] == [0, 0]
+        assert [record["sampling_decode_step"] for record in records] == [0, 7]
+        assert [record["sampling_post_step"] for record in records] == [1, 7]
+        expected_hidden_hashes = [
+            hashlib.sha256(row.contiguous().view(torch.uint8).numpy().tobytes()).hexdigest()
+            for row in torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16)
+        ]
+        assert [record["hidden_hash"] for record in records] == expected_hidden_hashes
+        assert [record["valid"] for record in records] == [True, False]
+        assert [record["done"] for record in records] == [False, True]
+        assert records[0]["sampled_codes_hash"] == hashlib.sha256(host[0, :8].numpy().tobytes()).hexdigest()
+        assert records[1]["sampled_codes_hash"] is None
+
+    def test_trajectory_recorder_is_absent_without_opt_in(self, monkeypatch):
+        from vllm_omni.model_executor.models.higgs_audio_v3.higgs_audio_v3_talker import (
+            _create_higgs_audio_trajectory_recorder,
+        )
+
+        monkeypatch.delenv("HIGGS_AUDIO_V3_TRAJECTORY_PATH", raising=False)
+
+        assert _create_higgs_audio_trajectory_recorder() is None
 
     def test_pending_audio_step_keeps_invalid_rows_as_empty_payloads(self):
         """An authoritative async snapshot must clear stale audio rows."""

--- a/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
@@ -8,6 +8,7 @@ without requiring the actual checkpoint or GPU.
 
 import asyncio
 import hashlib
+import inspect
 import json
 import time
 from collections import OrderedDict, defaultdict
@@ -551,8 +552,18 @@ class TestSamplerMethods:
         t.lm_head = object()
         metadata = SimpleNamespace(
             max_num_logprobs=None,
+            logprob_token_ids=None,
             allowed_token_ids_mask=None,
             bad_words_token_ids=None,
+            no_penalties=True,
+            logitsprocs=SimpleNamespace(
+                all=(
+                    SimpleNamespace(min_toks={}),
+                    SimpleNamespace(biases={}),
+                    SimpleNamespace(min_p_count=0),
+                )
+            ),
+            thinking_budget_state_holder=None,
         )
         hidden = torch.randn(2, 16)
 
@@ -564,6 +575,82 @@ class TestSamplerMethods:
         logits = t.compute_logits(hidden, sampling_metadata=metadata)
         assert logits.shape == (2, 3)
         assert len(calls) == 1
+
+    def test_compute_logits_keeps_text_head_when_runner_requires_it(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        cls = mod.HiggsAudioV3TalkerForConditionalGeneration
+        assert "force_text_logits" in inspect.signature(cls.compute_logits).parameters
+
+        t = self._make_batched_sampler_talker(num_rows=1)
+        t.compute_logits = cls.compute_logits.__get__(t)
+        t._last_step_input_ids = torch.tensor([10], dtype=torch.long)
+        t._active_request_ids = ("req-a",)
+        t._fast_audio_direct_request_ids.add("req-a")
+        t.logits_processor = lambda head, hidden: torch.ones(1, 3)
+        t.lm_head = object()
+
+        logits = t.compute_logits(
+            torch.randn(1, 16),
+            sampling_metadata=None,
+            force_text_logits=True,
+        )
+
+        assert logits.shape == (1, 3)
+
+    @pytest.mark.parametrize(
+        "metadata_overrides",
+        [
+            {"logprob_token_ids": {0: [7]}},
+            {"no_penalties": False},
+            {"logitsprocs": SimpleNamespace(all=(SimpleNamespace(min_toks={0: (2, [], {1})}),))},
+            {"logitsprocs": SimpleNamespace(all=(SimpleNamespace(biases={0: {7: 1.0}}),))},
+            {"logitsprocs": SimpleNamespace(all=(SimpleNamespace(min_p_count=1),))},
+            {"logitsprocs": SimpleNamespace(all=(SimpleNamespace(req_info={0: object()}),))},
+            {"logitsprocs": SimpleNamespace(all=(object(),))},
+            {"thinking_budget_state_holder": SimpleNamespace(has_tracked_requests=lambda: True)},
+        ],
+        ids=(
+            "specific-token-logprobs",
+            "penalties",
+            "min-tokens",
+            "logit-bias",
+            "min-p",
+            "adapter-processor",
+            "unknown-custom-processor",
+            "thinking-budget",
+        ),
+    )
+    def test_compute_logits_keeps_text_head_for_active_sampling_dependencies(
+        self,
+        metadata_overrides,
+    ):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=1)
+        t.compute_logits = mod.HiggsAudioV3TalkerForConditionalGeneration.compute_logits.__get__(t)
+        t._last_step_input_ids = torch.tensor([10], dtype=torch.long)
+        t._active_request_ids = ("req-a",)
+        t._fast_audio_direct_request_ids.add("req-a")
+        t.logits_processor = lambda head, hidden: torch.ones(1, 3)
+        t.lm_head = object()
+        metadata_fields = {
+            "max_num_logprobs": None,
+            "logprob_token_ids": None,
+            "allowed_token_ids_mask": None,
+            "bad_words_token_ids": None,
+            "no_penalties": True,
+            "logitsprocs": SimpleNamespace(all=()),
+            "thinking_budget_state_holder": None,
+        }
+        metadata_fields.update(metadata_overrides)
+
+        logits = t.compute_logits(
+            torch.randn(1, 16),
+            sampling_metadata=SimpleNamespace(**metadata_fields),
+        )
+
+        assert logits.shape == (1, 3)
 
     def test_seeded_audio_sampling_is_request_independent_under_reorder(self):
         """A request seed must produce the same code row after batch reorder."""
@@ -2004,7 +2091,23 @@ class TestRegistry:
             config = yaml.safe_load(f)
         overrides = config["stages"][0]["hf_overrides"]
         assert overrides["audio_state_step_mode"] == "compile"
-        assert overrides["audio_sampler_mode"] == "flashinfer"
+        assert overrides["audio_sampler_mode"] == "torch"
+
+    def test_higgs_stage0_deploys_do_not_pin_sampling_seed(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        deploy_dir = os.path.join(repo_root, "vllm_omni", "deploy")
+        for name in (
+            "higgs_multimodal_qwen3.yaml",
+            "higgs_multimodal_qwen3_high_throughput.yaml",
+            "higgs_multimodal_qwen3_low_latency.yaml",
+        ):
+            with open(os.path.join(deploy_dir, name), encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            assert "seed" not in config["stages"][0]["default_sampling_params"]
 
     def test_high_throughput_deploy_selects_c64_full_decode_runtime(self):
         import os

--- a/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
@@ -1880,22 +1880,42 @@ class TestRegistry:
             assert config["stages"][0]["enable_prefix_caching"] is False
             assert config["stages"][1]["async_scheduling"] is False
 
-    def test_high_throughput_deploys_select_validated_audio_runtime(self):
+    def test_default_deploy_selects_validated_audio_runtime(self):
         import os
 
         import yaml
 
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
         deploy_dir = os.path.join(repo_root, "vllm_omni", "deploy")
-        for name in (
-            "higgs_multimodal_qwen3.yaml",
+        with open(os.path.join(deploy_dir, "higgs_multimodal_qwen3.yaml"), encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        overrides = config["stages"][0]["hf_overrides"]
+        assert overrides["audio_state_step_mode"] == "compile"
+        assert overrides["audio_sampler_mode"] == "flashinfer"
+
+    def test_high_throughput_deploy_selects_c64_full_decode_runtime(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        yaml_path = os.path.join(
+            repo_root,
+            "vllm_omni",
+            "deploy",
             "higgs_multimodal_qwen3_high_throughput.yaml",
-        ):
-            with open(os.path.join(deploy_dir, name), encoding="utf-8") as f:
-                config = yaml.safe_load(f)
-            overrides = config["stages"][0]["hf_overrides"]
-            assert overrides["audio_state_step_mode"] == "compile"
-            assert overrides["audio_sampler_mode"] == "flashinfer"
+        )
+        with open(yaml_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        stage0 = config["stages"][0]
+        overrides = stage0["hf_overrides"]
+        assert overrides["audio_state_step_mode"] == "compile"
+        assert overrides["audio_sampler_mode"] == "torch"
+        assert stage0["enforce_eager"] is False
+        compilation = stage0["compilation_config"]
+        assert compilation["custom_ops"] == ["none"]
+        assert compilation["cudagraph_mode"] == "FULL_DECODE_ONLY"
+        assert compilation["cudagraph_capture_sizes"] == [1, 2, 4, 8, 16, 32, 64]
 
     def test_high_throughput_deploy_matches_stage_concurrency(self):
         import os
@@ -1913,6 +1933,24 @@ class TestRegistry:
             config = yaml.safe_load(f)
         assert config["stages"][0]["max_num_seqs"] == 64
         assert config["stages"][1]["max_num_seqs"] == 64
+
+    def test_high_throughput_deploy_uses_large_steady_state_codec_chunks(self):
+        import os
+
+        import yaml
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+        yaml_path = os.path.join(
+            repo_root,
+            "vllm_omni",
+            "deploy",
+            "higgs_multimodal_qwen3_high_throughput.yaml",
+        )
+        with open(yaml_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        connector = config["connectors"]["connector_of_shared_memory"]["extra"]
+        assert connector["codec_chunk_frames"] == 75
+        assert connector["initial_codec_chunk_frames"] == 1
 
     def test_talker_registered(self):
         from vllm_omni.model_executor.models.registry import _OMNI_MODELS

--- a/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/unit/higgs_audio_v3/test_higgs_audio_v3.py
@@ -598,6 +598,16 @@ class TestSamplerMethods:
 
         assert logits.shape == (1, 3)
 
+    def test_logits_processor_checks_all_known_state_containers(self):
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        processor = SimpleNamespace(
+            min_toks={},
+            biases={0: {7: 1.0}},
+        )
+
+        assert mod.HiggsAudioV3TalkerForConditionalGeneration._logits_processor_requires_text_logits(processor)
+
     @pytest.mark.parametrize(
         "metadata_overrides",
         [
@@ -1066,7 +1076,7 @@ class TestSamplerMethods:
         t._update_delay_state_batched = lambda *args, **kwargs: None
         t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
 
-        sampler_output = t.sample(torch.zeros(2, 200000), sampling_metadata=object())
+        sampler_output = t.sample(None, sampling_metadata=object())
 
         assert not getattr(
             mod.HiggsAudioV3TalkerForConditionalGeneration, "supports_sampled_token_ids_cpu_override", False
@@ -1098,9 +1108,55 @@ class TestSamplerMethods:
         t._update_delay_state_batched = lambda *args, **kwargs: None
         t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
 
-        sampler_output = t.sample(torch.zeros(2, 200000), sampling_metadata=object())
+        sampler_output = t.sample(None, sampling_metadata=object())
 
         assert sampler_output.sampled_token_ids.tolist() == [[99999], [99999]]
+
+    def test_nonempty_logits_preserve_stock_sampler_step_decision(self):
+        """A logits-producing step must not be reclassified as direct audio."""
+        from vllm_omni.model_executor.models.higgs_audio_v3 import higgs_audio_v3_talker as mod
+
+        t = self._make_batched_sampler_talker(num_rows=1)
+        t._resolve_token_ids = lambda: None
+        t._audio_continuation_id = 99999
+        t._eos_token_id = 151671
+        t._last_logits_hidden = torch.zeros(1, 16)
+        t._last_step_input_ids = torch.tensor([99999])
+        t._last_step_query_start_loc = None
+        t._decode_has_codes = torch.tensor([True])
+        t._decode_generation_done = torch.tensor([False])
+        t._decode_delay_count = torch.zeros(1, dtype=torch.long)
+        t._decode_eoc_countdown = torch.full((1,), -1, dtype=torch.long)
+        t._active_request_ids = ("req-a",)
+        t._fast_audio_direct_request_ids.add("req-a")
+        t._fast_audio_sampler_gpu_fallback_reason = lambda **kwargs: None
+        t._apply_audio_mode_bias_batched = lambda *args, **kwargs: None
+        t._audio_codebook_logits_from_rows = lambda hidden, rows, all_rows=False: torch.zeros(1, 8, 1026)
+        t._apply_delay_pattern_masking_batched = lambda cb_logits, audio_rows, all_rows=False: None
+        t._sample_audio_codes = lambda logits_2d, **kwargs: torch.zeros(int(logits_2d.shape[0]), dtype=torch.long)
+        t._update_delay_state_batched = lambda *args, **kwargs: None
+        t.sample = mod.HiggsAudioV3TalkerForConditionalGeneration.sample.__get__(t)
+
+        expected_logprobs = object()
+        expected_output = SimpleNamespace(
+            sampled_token_ids=torch.tensor([[99999]]),
+            logprobs_tensors=expected_logprobs,
+        )
+        stock_sampler_calls = []
+
+        def stock_sampler(*, logits, sampling_metadata):
+            stock_sampler_calls.append((logits, sampling_metadata))
+            return expected_output
+
+        t._stock_sampler = stock_sampler
+        logits = torch.zeros(1, 200000)
+        sampling_metadata = SimpleNamespace(logprob_token_ids={0: [7]})
+
+        sampler_output = t.sample(logits, sampling_metadata=sampling_metadata)
+
+        assert sampler_output is expected_output
+        assert stock_sampler_calls == [(logits, sampling_metadata)]
+        assert sampler_output.logprobs_tensors is expected_logprobs
 
     def test_logits_free_sample_keeps_compute_step_decision_after_certification_changes(self):
         """Async resolve may update certification after compute_logits returns None."""

--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -391,6 +391,71 @@ def test_async_omni_output_guard_requires_safe_conditions():
     runner.model.eager_omni_postprocess_before_async_output = True
     assert GPUARModelRunner._should_use_async_omni_output(runner)
 
+    runner.model.eager_omni_postprocess_before_async_output = False
+    runner.model.supports_async_omni_postprocess = True
+    assert GPUARModelRunner._should_use_async_omni_output(runner)
+
+
+def test_resolve_pending_omni_postprocess_builds_snapshot_payload_without_live_request_state():
+    runner = _make_async_output_runner()
+    # The next async scheduler step may already have removed a normally
+    # finished request from runner.requests.  Resolving the previous step must
+    # therefore build that step's immutable wire payload instead of racing on
+    # the runner's mutable request/intermediate-buffer state.
+    runner.requests = {}
+    seen = []
+
+    class Pending:
+        request_ids = ("r-live", "r-finished")
+
+        def resolve(self):
+            return {
+                "r-live": {"codes": {"audio": torch.tensor([[1, 2]], dtype=torch.int32)}},
+                "r-finished": {"codes": {"audio": torch.tensor([[3, 4]], dtype=torch.int32)}},
+            }
+
+    runner._update_intermediate_buffer = lambda req_id, update: seen.append((req_id, update))
+
+    applied, multimodal_outputs = GPUARModelRunner._resolve_pending_omni_postprocess(
+        runner,
+        Pending(),
+        req_ids_snapshot=["r-finished", "r-live"],
+        multimodal_outputs=None,
+    )
+
+    assert applied is True
+    assert seen == []
+    assert torch.equal(multimodal_outputs["codes"]["audio"][0], torch.tensor([[3, 4]], dtype=torch.int32))
+    assert torch.equal(multimodal_outputs["codes"]["audio"][1], torch.tensor([[1, 2]], dtype=torch.int32))
+
+
+def test_model_sampler_can_run_without_text_logits_when_model_opts_in():
+    """A model-owned audio sampler may consume hidden state without an LM head."""
+    runner = GPUARModelRunner.__new__(GPUARModelRunner)
+    seen = []
+
+    class LogitsFreeModel:
+        prefer_model_sampler = True
+        supports_logits_free_model_sampler = True
+
+        def sample(self, logits, sampling_metadata):
+            seen.append((logits, sampling_metadata))
+            return SimpleNamespace(sampled_token_ids=torch.tensor([[7]]))
+
+    metadata = SimpleNamespace()
+    runner.model = LogitsFreeModel()
+    runner.input_batch = SimpleNamespace(
+        sampling_metadata=metadata,
+        update_async_output_token_ids=lambda: None,
+    )
+    runner._sampling_metadata_for_model_sampler = lambda value: value
+    runner.sampler = lambda **kwargs: (_ for _ in ()).throw(AssertionError("stock sampler must not run"))
+
+    output = GPUARModelRunner._sample(runner, None, None)
+
+    assert output.sampled_token_ids.item() == 7
+    assert seen == [(None, metadata)]
+
 
 def test_build_omni_output_skips_hidden_when_model_opts_out(monkeypatch):
     runner = _make_async_output_runner(engine_output_type="latent")

--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -77,6 +77,37 @@ def test_runner_assisted_full_attention_metadata_request_is_opt_in():
     assert request is None
 
 
+def test_register_model_request_sampling_seeds_uses_effective_seed_at_admission():
+    registered = []
+
+    class Model:
+        def register_request_sampling_seeds(self, seeds):
+            registered.append(dict(seeds))
+
+    runner = object.__new__(GPUARModelRunner)
+    runner.model = Model()
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[
+            SimpleNamespace(
+                req_id="req-a",
+                sampling_params=SimpleNamespace(extra_args={"tts_effective_seed": 111}),
+            ),
+            SimpleNamespace(
+                req_id="req-b",
+                sampling_params=SimpleNamespace(extra_args={"tts_effective_seed": 222}),
+            ),
+            SimpleNamespace(
+                req_id="req-unseeded-direct-engine",
+                sampling_params=SimpleNamespace(extra_args=None),
+            ),
+        ]
+    )
+
+    runner._register_model_request_sampling_seeds(scheduler_output)
+
+    assert registered == [{"req-a": 111, "req-b": 222}]
+
+
 def test_runner_assisted_full_attention_metadata_request_and_context_hooks():
     calls = []
 

--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -488,6 +488,43 @@ def test_model_sampler_can_run_without_text_logits_when_model_opts_in():
     assert seen == [(None, metadata)]
 
 
+@pytest.mark.parametrize("has_structured_output_requests", [False, True])
+def test_compute_model_logits_passes_structured_output_requirement(
+    has_structured_output_requests,
+):
+    assert hasattr(GPUARModelRunner, "_compute_model_logits")
+    runner = GPUARModelRunner.__new__(GPUARModelRunner)
+    seen = []
+
+    class Model:
+        supports_force_text_logits = True
+
+        def compute_logits(
+            self,
+            hidden_states,
+            *,
+            sampling_metadata,
+            force_text_logits,
+        ):
+            seen.append((hidden_states, sampling_metadata, force_text_logits))
+            return torch.ones(1, 3)
+
+    metadata = object()
+    hidden_states = torch.randn(1, 4)
+    runner.model = Model()
+    runner.input_batch = SimpleNamespace(sampling_metadata=metadata)
+    scheduler_output = SimpleNamespace(
+        has_structured_output_requests=has_structured_output_requests,
+    )
+
+    logits = runner._compute_model_logits(hidden_states, scheduler_output)
+
+    assert logits.shape == (1, 3)
+    assert seen == [
+        (hidden_states, metadata, has_structured_output_requests),
+    ]
+
+
 def test_build_omni_output_skips_hidden_when_model_opts_out(monkeypatch):
     runner = _make_async_output_runner(engine_output_type="latent")
     runner.model.omni_pooler_payload_include_hidden = False

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -3,11 +3,63 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner, _filter_mrope_kwargs_for_model
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_decode_metadata_runner(model):
+    runner = object.__new__(OmniGPUModelRunner)
+    runner.model = model
+    runner.input_batch = SimpleNamespace(req_ids=["req-a", "req-b"], num_reqs=2)
+    runner._build_model_kwargs_extra = lambda: {}
+    return runner
+
+
+def test_model_forward_omits_request_ids_without_explicit_capability(monkeypatch):
+    calls = []
+
+    class Model:
+        supports_omni_decode_step_metadata = True
+
+        def update_decode_step_metadata(
+            self,
+            *,
+            input_ids,
+            positions,
+            inputs_embeds,
+            omni_query_start_loc,
+        ):
+            calls.append((input_ids, positions, inputs_embeds, omni_query_start_loc))
+
+    monkeypatch.setattr(GPUModelRunner, "_model_forward", lambda self, **kwargs: object())
+    runner = _make_decode_metadata_runner(Model())
+    input_ids = torch.tensor([1, 2])
+
+    OmniGPUModelRunner._model_forward(runner, input_ids=input_ids)
+
+    assert calls == [(input_ids, None, None, None)]
+
+
+def test_model_forward_passes_request_id_snapshot_when_model_requires_it(monkeypatch):
+    calls = []
+
+    class Model:
+        supports_omni_decode_step_metadata = True
+        requires_request_ids_for_decode_state = True
+
+        def update_decode_step_metadata(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(GPUModelRunner, "_model_forward", lambda self, **kwargs: object())
+    runner = _make_decode_metadata_runner(Model())
+
+    OmniGPUModelRunner._model_forward(runner, input_ids=torch.tensor([1, 2]))
+
+    assert calls[0]["req_ids"] == ("req-a", "req-b")
 
 
 class DummyBuffer:

--- a/vllm_omni/deploy/README_higgs_audio_v3.md
+++ b/vllm_omni/deploy/README_higgs_audio_v3.md
@@ -33,7 +33,7 @@ PyTorch sampler) unless they set these `hf_overrides` explicitly.
 
 `higgs_multimodal_qwen3.yaml` is kept as the auto-discovered default deploy
 config for `model_type=higgs_multimodal_qwen3`. It keeps the local MLP graph,
-FlashInfer audio sampler, 25-frame codec chunks, and a conservative
+PyTorch audio sampler, 25-frame codec chunks, and a conservative
 `max_num_seqs: 16`; the explicit high-throughput profile raises both stages to
 64 and uses the full-decode graph, PyTorch sampler, and 75-frame codec chunks.
 

--- a/vllm_omni/deploy/README_higgs_audio_v3.md
+++ b/vllm_omni/deploy/README_higgs_audio_v3.md
@@ -1,24 +1,29 @@
 # Higgs-Audio V3 Deploy Profiles
 
-Higgs-Audio V3 has two Stage 0 graph profiles. They are intentionally separate
-because the graph paths are mutually exclusive.
+Higgs-Audio V3 has separate Stage 0 profiles for high-throughput and
+low-latency serving. Both use full-decode CUDA graphs, but select different
+capture buckets, audio runtimes, and codec chunk sizes for their target loads.
 
 ## High Throughput
 
 Use `higgs_multimodal_qwen3_high_throughput.yaml` for medium/high concurrency
-serving. This profile keeps Stage 0 `enforce_eager: true`, which preserves the
-Higgs-specific local MLP CUDA graph path. It is the default production profile
-for throughput-oriented serving.
+serving. This profile sets Stage 0 `enforce_eager: false` and uses vLLM
+`FULL_DECODE_ONLY` CUDA graph with capture buckets through c64. It is the
+default production profile for throughput-oriented serving.
 
-The high-throughput and auto-discovered profiles also select the validated
-request-aware audio fast path directly in the deploy config:
+The high-throughput and auto-discovered profiles select request-aware audio
+fast paths directly in the deploy config. The high-throughput profile uses:
 
 ```yaml
 enable_prefix_caching: false
 async_scheduling: true
 hf_overrides:
   audio_state_step_mode: compile
-  audio_sampler_mode: flashinfer
+  audio_sampler_mode: torch
+compilation_config:
+  custom_ops: ["none"]
+  cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32, 64]
+  cudagraph_mode: FULL_DECODE_ONLY
 ```
 
 Prefix caching stays disabled because the pending postprocess overlap cannot
@@ -27,9 +32,16 @@ configs retain the compatibility defaults (`legacy` state updates and the
 PyTorch sampler) unless they set these `hf_overrides` explicitly.
 
 `higgs_multimodal_qwen3.yaml` is kept as the auto-discovered default deploy
-config for `model_type=higgs_multimodal_qwen3`. It selects the same audio fast
-path with a conservative `max_num_seqs: 16`; the explicit high-throughput
-profile raises both stages to 64.
+config for `model_type=higgs_multimodal_qwen3`. It keeps the local MLP graph,
+FlashInfer audio sampler, 25-frame codec chunks, and a conservative
+`max_num_seqs: 16`; the explicit high-throughput profile raises both stages to
+64 and uses the full-decode graph, PyTorch sampler, and 75-frame codec chunks.
+
+The explicit high-throughput profile emits 75 new codec frames per steady-state
+chunk while retaining a one-frame initial chunk. The larger steady-state chunk
+amortizes Stage 1 scheduling and codec decode overhead at c64; the small initial
+chunk preserves the early streaming response. The auto-discovered c16 and
+low-latency profiles retain 25-frame steady-state chunks.
 
 ```bash
 vllm-omni serve bosonai/higgs-audio-v3-tts-4b \

--- a/vllm_omni/deploy/README_higgs_audio_v3.md
+++ b/vllm_omni/deploy/README_higgs_audio_v3.md
@@ -10,9 +10,26 @@ serving. This profile keeps Stage 0 `enforce_eager: true`, which preserves the
 Higgs-specific local MLP CUDA graph path. It is the default production profile
 for throughput-oriented serving.
 
+The high-throughput and auto-discovered profiles also select the validated
+request-aware audio fast path directly in the deploy config:
+
+```yaml
+enable_prefix_caching: false
+async_scheduling: true
+hf_overrides:
+  audio_state_step_mode: compile
+  audio_sampler_mode: flashinfer
+```
+
+Prefix caching stays disabled because the pending postprocess overlap cannot
+currently be combined with the Omni prefix-cache state path. Custom deploy
+configs retain the compatibility defaults (`legacy` state updates and the
+PyTorch sampler) unless they set these `hf_overrides` explicitly.
+
 `higgs_multimodal_qwen3.yaml` is kept as the auto-discovered default deploy
-config for `model_type=higgs_multimodal_qwen3`, and matches the high-throughput
-profile.
+config for `model_type=higgs_multimodal_qwen3`. It selects the same audio fast
+path with a conservative `max_num_seqs: 16`; the explicit high-throughput
+profile raises both stages to 64.
 
 ```bash
 vllm-omni serve bosonai/higgs-audio-v3-tts-4b \
@@ -38,6 +55,10 @@ FULL_DECODE is controlled by deploy configuration, not by an environment
 variable. When this external decode graph is active, the Higgs talker disables
 the local MLP CUDA graph automatically.
 
+The low-latency profile enables asynchronous scheduling and keeps prefix
+caching disabled, but intentionally leaves the audio state and sampler at their
+compatibility defaults to avoid compiled-state warm-up at low concurrency.
+
 ```bash
 vllm-omni serve bosonai/higgs-audio-v3-tts-4b \
     --omni --trust-remote-code \
@@ -47,6 +68,10 @@ vllm-omni serve bosonai/higgs-audio-v3-tts-4b \
 ## Notes
 
 - Stage 1 remains `enforce_eager: true` in both profiles.
+- `HIGGS_AUDIO_V3_AUDIO_STATE_STEP` and `HIGGS_AUDIO_V3_AUDIO_SAMPLER` override
+  the corresponding model/deploy-config values for diagnostics and A/B tests.
+  The startup log reports the resolved modes. Production deployments should
+  prefer the explicit `hf_overrides` shown above.
 - Keep `VLLM_USE_DEEP_GEMM=0` and `VLLM_MOE_USE_DEEP_GEMM=0` for this model
   unless DeepGEMM support is revalidated.
 - Revalidate end-to-end throughput and audio quality before changing the default

--- a/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
@@ -1,10 +1,10 @@
 # Higgs-audio v3 deploy: Stage 0 (talker) -> Stage 1 (code2wav) via shared memory.
 #
 # Auto-discovered default for model_type=higgs_multimodal_qwen3. This file is
-# the high-throughput profile and intentionally keeps Stage 0 enforce_eager=true
-# so the Higgs-specific local MLP CUDA graph path remains active. For low
-# concurrency latency-sensitive serving, use
-# higgs_multimodal_qwen3_low_latency.yaml explicitly.
+# a conservative c16 profile and intentionally keeps Stage 0 enforce_eager=true
+# so the Higgs-specific local MLP CUDA graph path remains active. For c64 peak
+# throughput or low-concurrency latency-sensitive serving, use the explicit
+# high-throughput or low-latency profile, respectively.
 #
 # Plain TTS only (no voice cloning). async_chunk streams codec chunks from
 # Stage 0 to Stage 1 as they are produced (TTFA approaches one AR loop's
@@ -40,13 +40,13 @@ stages:
     enforce_eager: true
     attention_backend: FLASHINFER
     trust_remote_code: true
-    # Stage-0 prefix caching is on by default. The talker's HS opt-out and
-    # deferred ``codes.audio`` mm-output write (see higgs_audio_v3_talker.py)
-    # keep per-step bookkeeping negligible; any shared text prefix across
-    # concurrent requests is a net throughput win. Stage 1 (codec decoder)
-    # has no KV cache and stays disabled.
-    enable_prefix_caching: true
-    async_scheduling: false
+    # Request-aware pending postprocess overlap currently requires prefix
+    # caching to stay disabled. Stage 1 has no KV cache and also stays off.
+    enable_prefix_caching: false
+    async_scheduling: true
+    hf_overrides:
+      audio_state_step_mode: compile
+      audio_sampler_mode: flashinfer
     max_num_batched_tokens: 4096
     max_model_len: 8192
     devices: "0"

--- a/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
@@ -46,7 +46,7 @@ stages:
     async_scheduling: true
     hf_overrides:
       audio_state_step_mode: compile
-      audio_sampler_mode: flashinfer
+      audio_sampler_mode: torch
     max_num_batched_tokens: 4096
     max_model_len: 8192
     devices: "0"
@@ -57,7 +57,6 @@ stages:
       top_p: 0.95
       top_k: 50
       max_tokens: 2048
-      seed: 42
       repetition_penalty: 1.0
 
   - stage_id: 1

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -64,7 +64,6 @@ stages:
       top_p: 0.95
       top_k: 50
       max_tokens: 2048
-      seed: 42
       repetition_penalty: 1.0
 
   - stage_id: 1
@@ -86,5 +85,4 @@ stages:
       top_p: 1.0
       top_k: -1
       max_tokens: 65536
-      seed: 42
       repetition_penalty: 1.0

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -48,7 +48,7 @@ stages:
       audio_state_step_mode: compile
       audio_sampler_mode: torch
     compilation_config:
-      # A100 c64 validation is faster with the compileable native ops exposed
+      # A100 c64 validation is faster with the compilable native ops exposed
       # to Inductor than with every custom op kept opaque.
       custom_ops: ["none"]
       cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32, 64]

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -39,13 +39,13 @@ stages:
     enforce_eager: true
     attention_backend: FLASHINFER
     trust_remote_code: true
-    # Stage-0 prefix caching is on by default. The talker's HS opt-out and
-    # deferred ``codes.audio`` mm-output write (see higgs_audio_v3_talker.py)
-    # keep per-step bookkeeping negligible; any shared text prefix across
-    # concurrent requests is a net throughput win. Stage 1 (codec decoder)
-    # has no KV cache and stays disabled.
-    enable_prefix_caching: true
-    async_scheduling: false
+    # Request-aware pending postprocess overlap currently requires prefix
+    # caching to stay disabled. Stage 1 has no KV cache and also stays off.
+    enable_prefix_caching: false
+    async_scheduling: true
+    hf_overrides:
+      audio_state_step_mode: compile
+      audio_sampler_mode: flashinfer
     max_num_batched_tokens: 4096
     max_model_len: 8192
     devices: "0"
@@ -60,7 +60,9 @@ stages:
       repetition_penalty: 1.0
 
   - stage_id: 1
-    max_num_seqs: 16
+    # Match the Stage-0 admission ceiling so c64 waves are not throttled while
+    # pending codec chunks drain through Stage 1.
+    max_num_seqs: 64
     gpu_memory_utilization: 0.25
     enforce_eager: true
     trust_remote_code: true

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -1,9 +1,8 @@
 # Higgs-audio v3 deploy, high-throughput profile.
 #
 # This is the default production profile for medium/high concurrency serving.
-# Stage 0 keeps enforce_eager=true so Higgs' local MLP CUDA graph remains active.
-# Do not enable vLLM FULL_DECODE graph here: it replaces the local MLP graph
-# path instead of stacking on top of it.
+# Stage 0 uses vLLM FULL_DECODE_ONLY CUDA graph with a c64 capture bucket to
+# amortize decode launch overhead at high concurrency.
 #
 # Plain TTS only (no voice cloning). async_chunk streams codec chunks from
 # Stage 0 to Stage 1 as they are produced (TTFA approaches one AR loop's
@@ -24,7 +23,9 @@ connectors:
       #   codec_right_holdback_frames trailing frames held back so the codec
       #                              has future context for emit-region tail samples
       #   initial_codec_chunk_frames smaller first chunk to minimize TTFA
-      codec_chunk_frames: 25
+      # Amortize Stage-1 codec scheduling and decode overhead at c64. Keep the
+      # first chunk small so this throughput profile preserves prompt TTFA.
+      codec_chunk_frames: 75
       codec_left_context_frames: 25
       codec_right_holdback_frames: 4
       initial_codec_chunk_frames: 1
@@ -36,7 +37,7 @@ stages:
   - stage_id: 0
     max_num_seqs: 64
     gpu_memory_utilization: 0.6
-    enforce_eager: true
+    enforce_eager: false
     attention_backend: FLASHINFER
     trust_remote_code: true
     # Request-aware pending postprocess overlap currently requires prefix
@@ -45,7 +46,14 @@ stages:
     async_scheduling: true
     hf_overrides:
       audio_state_step_mode: compile
-      audio_sampler_mode: flashinfer
+      audio_sampler_mode: torch
+    compilation_config:
+      # A100 c64 validation is faster with the compileable native ops exposed
+      # to Inductor than with every custom op kept opaque.
+      custom_ops: ["none"]
+      cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32, 64]
+      cudagraph_mode: FULL_DECODE_ONLY
+      cudagraph_num_of_warmups: 1
     max_num_batched_tokens: 4096
     max_model_len: 8192
     devices: "0"

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
@@ -63,7 +63,6 @@ stages:
       top_p: 0.95
       top_k: 50
       max_tokens: 2048
-      seed: 42
       repetition_penalty: 1.0
 
   - stage_id: 1

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
@@ -45,8 +45,10 @@ stages:
     enforce_eager: false
     attention_backend: FLASHINFER
     trust_remote_code: true
-    enable_prefix_caching: true
-    async_scheduling: false
+    # Keep request-aware async postprocess enabled without adding the compiled
+    # audio-state warm-up cost to this low-concurrency profile.
+    enable_prefix_caching: false
+    async_scheduling: true
     compilation_config:
       cudagraph_capture_sizes: [1, 2, 4, 8, 16]
       cudagraph_mode: FULL_DECODE_ONLY

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -5,6 +5,7 @@ import io
 import json
 import math
 import os
+import random
 import re
 import struct
 import time
@@ -3683,7 +3684,17 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 # Stage-0 needs one extra token beyond ming_max_decode_steps.
                 sampling_params_list[0].max_tokens = int(request.max_new_tokens) + 1
 
-        if request.seed is not None and sampling_params_list:
+        if self._tts_model_type == "higgs_audio_v3" and sampling_params_list:
+            import copy
+
+            effective_seed = int(request.seed) if request.seed is not None else random.randint(0, 2**32 - 1)
+            sampling_params_list = copy.deepcopy(sampling_params_list)
+            stage0_params = sampling_params_list[0]
+            stage0_params.seed = effective_seed
+            if stage0_params.extra_args is None:
+                stage0_params.extra_args = {}
+            stage0_params.extra_args["tts_effective_seed"] = effective_seed
+        elif request.seed is not None and sampling_params_list:
             import copy
 
             sampling_params_list = copy.deepcopy(sampling_params_list)

--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -467,6 +467,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
     # Request-certified audio rows consume hidden states directly; the runner
     # may therefore call sample() with no text-vocabulary logits.
     supports_logits_free_model_sampler: bool = True
+    supports_force_text_logits: bool = True
     # Tell the runner to call postprocess() to emit per-step audio codes.
     have_multimodal_outputs: bool = True
     has_postprocess: bool = True
@@ -1020,28 +1021,72 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
                 self._fast_audio_direct_request_ids.discard(req_id)
 
     @staticmethod
+    def _logits_processor_requires_text_logits(processor: Any) -> bool:
+        """Return whether a loaded processor has active request state.
+
+        vLLM always constructs its builtin processors, so their mere presence
+        cannot disable the logits-free path. Unknown/custom processors are
+        conservative: unless they expose a recognized empty request-state
+        container, preserve text logits.
+        """
+        for state_name in ("min_toks", "biases", "min_p_count", "req_info"):
+            if hasattr(processor, state_name):
+                return bool(getattr(processor, state_name))
+        return True
+
+    @staticmethod
     def _sampling_metadata_requires_text_logits(sampling_metadata: Any) -> bool:
         if sampling_metadata is None:
             return False
         if getattr(sampling_metadata, "max_num_logprobs", None) is not None:
             return True
+        if getattr(sampling_metadata, "logprob_token_ids", None):
+            return True
         if getattr(sampling_metadata, "allowed_token_ids_mask", None) is not None:
             return True
-        return bool(getattr(sampling_metadata, "bad_words_token_ids", None))
+        if getattr(sampling_metadata, "bad_words_token_ids", None):
+            return True
+        if not bool(getattr(sampling_metadata, "no_penalties", True)):
+            return True
+
+        logitsprocs = getattr(sampling_metadata, "logitsprocs", None)
+        if logitsprocs is not None:
+            processors = getattr(logitsprocs, "all", None)
+            if processors is None:
+                return True
+            if callable(processors):
+                processors = processors()
+            if any(
+                HiggsAudioV3TalkerForConditionalGeneration._logits_processor_requires_text_logits(processor)
+                for processor in processors
+            ):
+                return True
+
+        holder = getattr(sampling_metadata, "thinking_budget_state_holder", None)
+        if holder is not None:
+            has_tracked_requests = getattr(holder, "has_tracked_requests", None)
+            if not callable(has_tracked_requests) or has_tracked_requests():
+                return True
+        return False
 
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
         sampling_metadata: Any = None,
+        force_text_logits: bool = False,
     ) -> torch.Tensor | None:
         self._last_logits_hidden = hidden_states
         num_rows = int(hidden_states.shape[0])
         ids = getattr(self, "_last_step_input_ids", None)
         decode_only = isinstance(ids, torch.Tensor) and int(ids.numel()) == num_rows
-        if self._can_use_logits_free_audio_sampler(
-            num_rows,
-            decode_only,
-        ) and not self._sampling_metadata_requires_text_logits(sampling_metadata):
+        if (
+            self._can_use_logits_free_audio_sampler(
+                num_rows,
+                decode_only,
+            )
+            and not force_text_logits
+            and not self._sampling_metadata_requires_text_logits(sampling_metadata)
+        ):
             return None
         return self.logits_processor(self.lm_head, hidden_states)
 

--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -476,6 +476,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
     postprocess_uses_multimodal_outputs: bool = False
     postprocess_uses_req_infos: bool = False
     supports_omni_query_start_loc: bool = True
+    requires_request_ids_for_decode_state: bool = True
     # Stage 1 consumes request-local codes.audio only. Publish those tensors
     # before the async output snapshot and omit the unused talker hidden state.
     use_async_omni_output: bool = True

--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -1029,10 +1029,13 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         conservative: unless they expose a recognized empty request-state
         container, preserve text logits.
         """
+        recognized_state = False
         for state_name in ("min_toks", "biases", "min_p_count", "req_info"):
             if hasattr(processor, state_name):
-                return bool(getattr(processor, state_name))
-        return True
+                recognized_state = True
+                if bool(getattr(processor, state_name)):
+                    return True
+        return not recognized_state
 
     @staticmethod
     def _sampling_metadata_requires_text_logits(sampling_metadata: Any) -> bool:
@@ -1657,7 +1660,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         # for this exact sampling step. Async output resolution may update the
         # live request certification set before sample_tokens consumes it, so
         # do not re-decide a logits-free step from mutable model state here.
-        direct_audio_batch = logits is None or self._can_use_logits_free_audio_sampler(num_rows, decode_only)
+        direct_audio_batch = logits is None
         if not decode_only:
             pfmask = self._prefill_row_mask(num_rows, hidden.device)
             self._reset_decode_state_rows(pfmask, num_rows, hidden.device)

--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -155,6 +155,86 @@ _MODALITY_HEAD_PREFIX = "tied.head.modality_heads.0."
 _CODEC_PREFIX = "tied.embedding.modality_embeddings.0.model."
 
 
+class _HiggsAudioTrajectoryRecorder:
+    """Opt-in request trajectory JSONL recorder for determinism diagnosis."""
+
+    def __init__(self, path: str | os.PathLike[str]):
+        self.path = os.fspath(path)
+        self._lock = threading.Lock()
+        self._next_step_by_id: dict[str, int] = {}
+
+    def record(
+        self,
+        request_ids: tuple[str, ...],
+        request_seeds: tuple[int | None, ...],
+        sampling_seeds: tuple[int | None, ...],
+        sampling_post_steps: tuple[int | None, ...],
+        hidden_snapshot: torch.Tensor | None,
+        host_staging: torch.Tensor,
+        valid: list[int],
+        done: list[int],
+        num_codebooks: int,
+    ) -> None:
+        import hashlib
+        import json
+
+        lines: list[str] = []
+        hidden_cpu = None
+        if hidden_snapshot is not None:
+            hidden_cpu = hidden_snapshot.detach().to(device="cpu").contiguous()
+        with self._lock:
+            snapshots = zip(
+                request_ids,
+                request_seeds,
+                sampling_seeds,
+                sampling_post_steps,
+                strict=True,
+            )
+            for row, (req_id, seed, sampling_seed, sampling_post_step) in enumerate(snapshots):
+                is_valid = bool(valid[row])
+                step = self._next_step_by_id.get(req_id, 0)
+                sampling_decode_step = sampling_post_step
+                if sampling_decode_step is not None and is_valid:
+                    sampling_decode_step -= 1
+                codes_hash = None
+                hidden_hash = None
+                if hidden_cpu is not None:
+                    hidden_row = hidden_cpu[row].contiguous()
+                    hidden_bytes = hidden_row.view(torch.uint8)
+                    hidden_hash = hashlib.sha256(hidden_bytes.numpy().tobytes()).hexdigest()
+                if is_valid:
+                    codes = host_staging[row, :num_codebooks].detach().cpu().contiguous()
+                    codes_hash = hashlib.sha256(codes.numpy().tobytes()).hexdigest()
+                    self._next_step_by_id[req_id] = step + 1
+                lines.append(
+                    json.dumps(
+                        {
+                            "request_id": req_id,
+                            "effective_seed": seed,
+                            "decode_step": step,
+                            "sampling_seed": sampling_seed,
+                            "sampling_decode_step": sampling_decode_step,
+                            "sampling_post_step": sampling_post_step,
+                            "hidden_hash": hidden_hash,
+                            "sampled_codes_hash": codes_hash,
+                            "valid": is_valid,
+                            "done": bool(done[row]),
+                        },
+                        sort_keys=True,
+                    )
+                )
+            parent = os.path.dirname(self.path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(self.path, "a", encoding="utf-8") as trace_file:
+                trace_file.write("\n".join(lines) + "\n")
+
+
+def _create_higgs_audio_trajectory_recorder() -> _HiggsAudioTrajectoryRecorder | None:
+    path = os.getenv("HIGGS_AUDIO_V3_TRAJECTORY_PATH")
+    return _HiggsAudioTrajectoryRecorder(path) if path else None
+
+
 class _HiggsAudioHostStagingLease:
     """Exclusive ownership of one ping-pong host staging slot."""
 
@@ -229,8 +309,13 @@ class HiggsAudioV3PendingStep:
     host_staging: torch.Tensor
     event: Any
     num_codebooks: int
+    request_seeds: tuple[int | None, ...]
+    sampling_seeds: tuple[int | None, ...]
+    sampling_post_steps: tuple[int | None, ...]
+    hidden_snapshot: torch.Tensor | None
     _release: Callable[[], None]
     _on_resolve: Callable[[tuple[str, ...], list[int], list[int]], None] | None
+    _trajectory_recorder: _HiggsAudioTrajectoryRecorder | None
 
     @classmethod
     def create(
@@ -242,6 +327,11 @@ class HiggsAudioV3PendingStep:
         num_codebooks: int,
         release: Callable[[], None],
         on_resolve: Callable[[tuple[str, ...], list[int], list[int]], None] | None = None,
+        request_seeds: Sequence[int | None] | None = None,
+        sampling_seeds: Sequence[int | None] | None = None,
+        sampling_post_steps: Sequence[int | None] | None = None,
+        hidden_snapshot: torch.Tensor | None = None,
+        trajectory_recorder: _HiggsAudioTrajectoryRecorder | None = None,
     ) -> HiggsAudioV3PendingStep:
         ids = tuple(str(req_id) for req_id in request_ids)
         if len(ids) != int(host_staging.shape[0]):
@@ -250,14 +340,37 @@ class HiggsAudioV3PendingStep:
                 "Higgs pending audio rows must match the launch-time request snapshot: "
                 f"{int(host_staging.shape[0])} rows for {len(ids)} requests"
             )
+        seed_snapshot = tuple(request_seeds) if request_seeds is not None else (None,) * len(ids)
+        if len(seed_snapshot) != len(ids):
+            release()
+            raise ValueError(
+                "Higgs pending audio seeds must match the launch-time request snapshot: "
+                f"{len(seed_snapshot)} seeds for {len(ids)} requests"
+            )
+        sampling_seed_snapshot = tuple(sampling_seeds) if sampling_seeds is not None else seed_snapshot
+        sampling_post_step_snapshot = (
+            tuple(sampling_post_steps) if sampling_post_steps is not None else (None,) * len(ids)
+        )
+        if len(sampling_seed_snapshot) != len(ids) or len(sampling_post_step_snapshot) != len(ids):
+            release()
+            raise ValueError("Higgs pending audio sampling state must match the launch-time request snapshot")
+        if hidden_snapshot is not None and int(hidden_snapshot.shape[0]) != len(ids):
+            release()
+            raise ValueError("Higgs pending hidden rows must match the launch-time request snapshot")
+        immutable_hidden = hidden_snapshot.detach().clone() if hidden_snapshot is not None else None
         return cls(
             request_ids=ids,
             request_id_to_row=MappingProxyType({req_id: row for row, req_id in enumerate(ids)}),
             host_staging=host_staging,
             event=event,
             num_codebooks=int(num_codebooks),
+            request_seeds=seed_snapshot,
+            sampling_seeds=sampling_seed_snapshot,
+            sampling_post_steps=sampling_post_step_snapshot,
+            hidden_snapshot=immutable_hidden,
             _release=release,
             _on_resolve=on_resolve,
+            _trajectory_recorder=trajectory_recorder,
         )
 
     def release(self) -> None:
@@ -273,6 +386,18 @@ class HiggsAudioV3PendingStep:
             # in the immutable snapshot even though downstream only consumes
             # valid audio rows; finish/cancel filtering is runner-owned.
             done = self.host_staging[:, self.num_codebooks + 1].tolist()
+            if self._trajectory_recorder is not None:
+                self._trajectory_recorder.record(
+                    self.request_ids,
+                    self.request_seeds,
+                    self.sampling_seeds,
+                    self.sampling_post_steps,
+                    self.hidden_snapshot,
+                    self.host_staging,
+                    valid,
+                    done,
+                    self.num_codebooks,
+                )
             if self._on_resolve is not None:
                 self._on_resolve(self.request_ids, valid, done)
             resolved: dict[str, dict[str, dict[str, torch.Tensor]]] = {}
@@ -439,6 +564,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._last_audio_staging_event: torch.cuda.Event | None = None
         self._last_audio_valid_flags: list[int] | None = None
         self._last_audio_done_flags: list[int] | None = None
+        self._trajectory_hidden_snapshot: torch.Tensor | None = None
         self._audio_host_staging_pool = _HiggsAudioHostStagingPool(
             width=self.num_codebooks + 2,
             pin_memory=torch.cuda.is_available(),
@@ -545,6 +671,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._request_state_next_row: int = 0
         self._active_request_ids: tuple[str, ...] = ()
         self._request_sampling_seed_by_id: dict[str, int] = {}
+        self._trajectory_recorder = _create_higgs_audio_trajectory_recorder()
 
         # PrefixCache compatibility hooks (mirror qwen3_tts pattern):
         # 1. The talker only consumes the last token's hidden state, so the
@@ -1283,6 +1410,20 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         if newly_allocated:
             self._reset_request_state_pool_rows(torch.tensor(newly_allocated, dtype=torch.long, device=device))
 
+        seeded_pool_rows: list[int] = []
+        seeded_values: list[int] = []
+        for req_id, pool_row in zip(req_ids_tuple, pool_rows, strict=True):
+            seed = self._request_sampling_seed_by_id.get(req_id)
+            if seed is not None:
+                seeded_pool_rows.append(pool_row)
+                seeded_values.append(seed)
+        if seeded_pool_rows:
+            self._request_decode_seed.index_copy_(
+                0,
+                torch.tensor(seeded_pool_rows, dtype=torch.long, device=device),
+                torch.tensor(seeded_values, dtype=torch.long, device=device),
+            )
+
         rows = torch.tensor(pool_rows, dtype=torch.long, device=device)
         num_rows = len(pool_rows)
         if num_rows:
@@ -1414,6 +1555,18 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             self._request_sampling_seed_by_id[req_id] = seed
             self._decode_seed[row] = seed
 
+    def register_request_sampling_seeds(self, seeds: Mapping[str, int]) -> None:
+        """Register immutable serving-owned seeds before request materialization."""
+        for req_id, seed_value in seeds.items():
+            req_id = str(req_id)
+            seed = int(seed_value)
+            previous = self._request_sampling_seed_by_id.get(req_id)
+            if previous is not None and previous != seed:
+                raise ValueError(
+                    f"Higgs request {req_id!r} already owns effective seed {previous}, cannot replace it with {seed}"
+                )
+            self._request_sampling_seed_by_id[req_id] = seed
+
     # ------------------------------------------------------------------ sampling
     def sample(self, logits: torch.Tensor | None, sampling_metadata: Any) -> Any:
         """Model-owned sampler with delay-pattern audio dispatch.
@@ -1423,6 +1576,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         and accumulate per-request state.
         """
         self._resolve_token_ids()
+        self._trajectory_hidden_snapshot = None
 
         audio_id = self._audio_continuation_id
 
@@ -1448,6 +1602,8 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             return sampler_output
 
         num_rows = int(hidden.shape[0])
+        if self._trajectory_recorder is not None:
+            self._trajectory_hidden_snapshot = hidden.reshape(-1, hidden.shape[-1])[:num_rows].detach()
         self._ensure_decode_state_capacity(num_rows, hidden.device)
         self._refresh_request_sampling_seeds(sampling_metadata, num_rows)
         ids = getattr(self, "_last_step_input_ids", None)
@@ -1684,13 +1840,25 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         lease = self._last_audio_host_lease
         if host_staging is None or lease is None:
             return None
+        trajectory_recorder = getattr(self, "_trajectory_recorder", None)
+        sampling_seeds: list[int] | None = None
+        sampling_post_steps: list[int] | None = None
+        if trajectory_recorder is not None:
+            num_rows = len(request_ids)
+            sampling_seeds = self._decode_seed[:num_rows].detach().cpu().tolist()
+            sampling_post_steps = self._decode_step_count[:num_rows].detach().cpu().tolist()
         pending = HiggsAudioV3PendingStep.create(
             request_ids=request_ids,
+            request_seeds=[self._request_sampling_seed_by_id.get(str(req_id)) for req_id in request_ids],
+            sampling_seeds=sampling_seeds,
+            sampling_post_steps=sampling_post_steps,
+            hidden_snapshot=self._trajectory_hidden_snapshot,
             host_staging=host_staging,
             event=self._last_audio_staging_event,
             num_codebooks=self.num_codebooks,
             release=lease.release,
             on_resolve=self._mark_audio_direct_requests,
+            trajectory_recorder=trajectory_recorder,
         )
         # Ownership moved to the immutable pending handle. The next sample may
         # acquire the other slot without touching this step's host snapshot.
@@ -1699,6 +1867,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._last_audio_staging_event = None
         self._last_audio_valid_flags = None
         self._last_audio_done_flags = None
+        self._trajectory_hidden_snapshot = None
         self._postprocess_cursor = 0
         return pending
 

--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -22,7 +22,11 @@ Weight loading maps from the HF checkpoint's prefixes:
 from __future__ import annotations
 
 import copy
-from collections.abc import Iterable
+import os
+import threading
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 import torch
@@ -41,7 +45,96 @@ from vllm_omni.transformers_utils.configs.higgs_audio_v3 import (
     HiggsAudioV3Config,
 )
 
-__all__ = ["HiggsAudioV3TalkerForConditionalGeneration"]
+try:
+    from flashinfer.sampling import top_k_renorm_probs as _flashinfer_top_k_renorm_probs
+    from flashinfer.sampling import top_p_renorm_probs as _flashinfer_top_p_renorm_probs
+except (ImportError, RuntimeError):
+    _flashinfer_top_k_renorm_probs = None
+    _flashinfer_top_p_renorm_probs = None
+
+_higgs_flashinfer_sampling_module: Any | None = None
+
+
+def _get_higgs_flashinfer_sampling_module() -> Any:
+    global _higgs_flashinfer_sampling_module
+    if _higgs_flashinfer_sampling_module is None:
+        from flashinfer.sampling import get_sampling_module
+
+        _higgs_flashinfer_sampling_module = get_sampling_module()
+    return _higgs_flashinfer_sampling_module
+
+
+@torch.library.custom_op(
+    "vllm_omni::higgs_flashinfer_top_k_renorm",
+    mutates_args=("row_states",),
+)
+def _higgs_flashinfer_top_k_renorm_op(
+    probs: torch.Tensor,
+    row_states: torch.Tensor,
+) -> torch.Tensor:
+    module = _get_higgs_flashinfer_sampling_module()
+    return module.top_k_renorm_probs(probs, None, 50, row_states)
+
+
+@_higgs_flashinfer_top_k_renorm_op.register_fake
+def _fake_higgs_flashinfer_top_k_renorm_op(
+    probs: torch.Tensor,
+    row_states: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(probs)
+
+
+@torch.library.custom_op(
+    "vllm_omni::higgs_flashinfer_top_p_renorm",
+    mutates_args=("workspace",),
+)
+def _higgs_flashinfer_top_p_renorm_op(
+    probs: torch.Tensor,
+    workspace: torch.Tensor,
+) -> torch.Tensor:
+    module = _get_higgs_flashinfer_sampling_module()
+    return module.top_p_renorm_probs(probs, None, 0.95, True, workspace)
+
+
+@_higgs_flashinfer_top_p_renorm_op.register_fake
+def _fake_higgs_flashinfer_top_p_renorm_op(
+    probs: torch.Tensor,
+    workspace: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(probs)
+
+
+def _flashinfer_top_p_workspace_size(batch_rows: int, vocab_size: int) -> int:
+    """Workspace bytes required by FlashInfer deterministic AIR top-p."""
+
+    def align256(value: int) -> int:
+        return ((value + 255) // 256) * 256
+
+    buf_len = max(align256(vocab_size // 32), 256)
+    return (
+        align256(384 * batch_rows)
+        + align256(8 * 2048 * batch_rows)
+        + align256(4 * 2048 * batch_rows)
+        + align256(4 * buf_len * batch_rows)
+        + align256(4 * buf_len * batch_rows)
+    )
+
+
+def _resolve_audio_runtime_mode(
+    env_var: str,
+    config_value: str,
+    allowed: set[str],
+) -> str:
+    """Resolve a runtime mode with an explicit environment override."""
+    raw_value = os.getenv(env_var)
+    value = str(config_value if raw_value is None else raw_value).strip().lower()
+    if value not in allowed:
+        choices = "/".join(sorted(allowed))
+        raise ValueError(f"{env_var} must be one of {choices}, got {value!r}")
+    return value
+
+
+__all__ = ["HiggsAudioV3PendingStep", "HiggsAudioV3TalkerForConditionalGeneration"]
 
 logger = init_logger(__name__)
 
@@ -60,6 +153,148 @@ _BACKBONE_PREFIX_MAP = {
 _MODALITY_EMBEDDING_PREFIX = "tied.embedding.modality_embeddings.0.embedding."
 _MODALITY_HEAD_PREFIX = "tied.head.modality_heads.0."
 _CODEC_PREFIX = "tied.embedding.modality_embeddings.0.model."
+
+
+class _HiggsAudioHostStagingLease:
+    """Exclusive ownership of one ping-pong host staging slot."""
+
+    def __init__(self, pool: _HiggsAudioHostStagingPool, slot: int, tensor: torch.Tensor):
+        self._pool = pool
+        self._slot = slot
+        self.tensor = tensor
+        self._released = False
+
+    def cuda_event(self) -> torch.cuda.Event:
+        return self._pool.cuda_event(self._slot)
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._pool.release(self._slot)
+
+
+class _HiggsAudioHostStagingPool:
+    """Two pinned host buffers whose leases survive lagged async resolve."""
+
+    def __init__(self, *, width: int, pin_memory: bool):
+        self.width = int(width)
+        self.pin_memory = bool(pin_memory)
+        self._buffers: list[torch.Tensor | None] = [None, None]
+        self._events: list[torch.cuda.Event | None] = [None, None]
+        self._in_use = [False, False]
+        self._cursor = 0
+        self._condition = threading.Condition()
+
+    def acquire(self, num_rows: int) -> _HiggsAudioHostStagingLease:
+        num_rows = max(0, int(num_rows))
+        with self._condition:
+            slot = self._cursor
+            self._cursor ^= 1
+            while self._in_use[slot]:
+                self._condition.wait()
+            self._in_use[slot] = True
+            buf = self._buffers[slot]
+            if buf is None or int(buf.shape[0]) < num_rows:
+                rows = max(num_rows, 16)
+                buf = torch.empty(
+                    (rows, self.width),
+                    dtype=torch.int32,
+                    device="cpu",
+                    pin_memory=self.pin_memory,
+                )
+                self._buffers[slot] = buf
+            return _HiggsAudioHostStagingLease(self, slot, buf[:num_rows])
+
+    def cuda_event(self, slot: int) -> torch.cuda.Event:
+        with self._condition:
+            event = self._events[slot]
+            if event is None:
+                event = torch.cuda.Event(blocking=True)
+                self._events[slot] = event
+            return event
+
+    def release(self, slot: int) -> None:
+        with self._condition:
+            self._in_use[slot] = False
+            self._condition.notify_all()
+
+
+@dataclass(frozen=True)
+class HiggsAudioV3PendingStep:
+    """Immutable launch-time request mapping plus an owned D2H snapshot."""
+
+    request_ids: tuple[str, ...]
+    request_id_to_row: Mapping[str, int]
+    host_staging: torch.Tensor
+    event: Any
+    num_codebooks: int
+    _release: Callable[[], None]
+    _on_resolve: Callable[[tuple[str, ...], list[int], list[int]], None] | None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        request_ids: Sequence[str],
+        host_staging: torch.Tensor,
+        event: Any,
+        num_codebooks: int,
+        release: Callable[[], None],
+        on_resolve: Callable[[tuple[str, ...], list[int], list[int]], None] | None = None,
+    ) -> HiggsAudioV3PendingStep:
+        ids = tuple(str(req_id) for req_id in request_ids)
+        if len(ids) != int(host_staging.shape[0]):
+            release()
+            raise ValueError(
+                "Higgs pending audio rows must match the launch-time request snapshot: "
+                f"{int(host_staging.shape[0])} rows for {len(ids)} requests"
+            )
+        return cls(
+            request_ids=ids,
+            request_id_to_row=MappingProxyType({req_id: row for row, req_id in enumerate(ids)}),
+            host_staging=host_staging,
+            event=event,
+            num_codebooks=int(num_codebooks),
+            _release=release,
+            _on_resolve=on_resolve,
+        )
+
+    def release(self) -> None:
+        self._release()
+
+    def resolve(self) -> dict[str, dict[str, dict[str, torch.Tensor]]]:
+        """Wait for this step only and materialize request-keyed audio rows."""
+        try:
+            if self.event is not None:
+                self.event.synchronize()
+            valid = self.host_staging[:, self.num_codebooks].tolist()
+            # Read done while this lease is held. It is intentionally retained
+            # in the immutable snapshot even though downstream only consumes
+            # valid audio rows; finish/cancel filtering is runner-owned.
+            done = self.host_staging[:, self.num_codebooks + 1].tolist()
+            if self._on_resolve is not None:
+                self._on_resolve(self.request_ids, valid, done)
+            resolved: dict[str, dict[str, dict[str, torch.Tensor]]] = {}
+            for req_id in self.request_ids:
+                row = self.request_id_to_row[req_id]
+                if int(valid[row]) == 0:
+                    resolved[req_id] = {
+                        "codes": {
+                            "audio": torch.empty(0, dtype=torch.int32),
+                        }
+                    }
+                    continue
+                resolved[req_id] = {
+                    "codes": {
+                        # The lease is released before the caller consumes the
+                        # payload, so detach this row from the reusable slot.
+                        "audio": self.host_staging[row : row + 1, : self.num_codebooks].clone(),
+                    }
+                }
+            return resolved
+        finally:
+            self.release()
 
 
 class HiggsFusedMultiTextEmbedding(nn.Module):
@@ -104,6 +339,9 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
 
     # Tell the AR runner to call model.sample() instead of the stock sampler.
     prefer_model_sampler: bool = True
+    # Request-certified audio rows consume hidden states directly; the runner
+    # may therefore call sample() with no text-vocabulary logits.
+    supports_logits_free_model_sampler: bool = True
     # Tell the runner to call postprocess() to emit per-step audio codes.
     have_multimodal_outputs: bool = True
     has_postprocess: bool = True
@@ -112,6 +350,12 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
     postprocess_uses_multimodal_outputs: bool = False
     postprocess_uses_req_infos: bool = False
     supports_omni_query_start_loc: bool = True
+    # Stage 1 consumes request-local codes.audio only. Publish those tensors
+    # before the async output snapshot and omit the unused talker hidden state.
+    use_async_omni_output: bool = True
+    eager_omni_postprocess_before_async_output: bool = False
+    supports_async_omni_postprocess: bool = True
+    omni_pooler_payload_include_hidden: bool = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -195,18 +439,41 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._last_audio_staging_event: torch.cuda.Event | None = None
         self._last_audio_valid_flags: list[int] | None = None
         self._last_audio_done_flags: list[int] | None = None
-        self._audio_staging_events: list[torch.cuda.Event] = []
-        self._audio_staging_event_cursor: int = 0
+        self._audio_host_staging_pool = _HiggsAudioHostStagingPool(
+            width=self.num_codebooks + 2,
+            pin_memory=torch.cuda.is_available(),
+        )
+        self._last_audio_host_lease: _HiggsAudioHostStagingLease | None = None
         self._row_index_cache: dict[tuple[str, int], torch.Tensor] = {}
         self._codebook_index_cache: dict[tuple[str, int], torch.Tensor] = {}
         self._boc_frame_cache: dict[tuple[str, int], torch.Tensor] = {}
-        self._fast_audio_direct_rows: int = 0
+        self._fast_audio_direct_request_ids: set[str] = set()
         scheduler_config = getattr(vllm_config, "scheduler_config", None)
         self._mlp_cudagraph_max_batch = max(1, int(getattr(scheduler_config, "max_num_seqs", 16)))
-        self._postprocess_audio_rows: int = 0
-        self._postprocess_audio_active_rows: int = 0
         self._mlp_graphs: dict[tuple[int, int], dict[str, Any]] = {}
         self._mlp_graph_disabled: set[tuple[int, int]] = set()
+        self._audio_state_step_mode = _resolve_audio_runtime_mode(
+            "HIGGS_AUDIO_V3_AUDIO_STATE_STEP",
+            self.config.audio_state_step_mode,
+            {"legacy", "eager", "compile"},
+        )
+        self._audio_sampler_mode = _resolve_audio_runtime_mode(
+            "HIGGS_AUDIO_V3_AUDIO_SAMPLER",
+            self.config.audio_sampler_mode,
+            {"torch", "flashinfer"},
+        )
+        if self._audio_sampler_mode == "flashinfer" and (
+            _flashinfer_top_k_renorm_probs is None or _flashinfer_top_p_renorm_probs is None
+        ):
+            raise RuntimeError("audio_sampler_mode=flashinfer requires FlashInfer sampling kernels")
+        if self._audio_sampler_mode == "flashinfer":
+            _get_higgs_flashinfer_sampling_module()
+        logger.info_once(
+            "Higgs Audio V3 audio runtime: "
+            f"state_step={self._audio_state_step_mode}, sampler={self._audio_sampler_mode}"
+        )
+        self._compiled_audio_state_step: Any | None = None
+        self._audio_state_hidden_staging: torch.Tensor | None = None
 
         # Pre-allocated decode-step audio feedback buffers (CUDA-graph safe).
         # Populated by sample(), read by forward() via torch.where (no dict).
@@ -222,17 +489,72 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self.register_buffer("_decode_delay_count", torch.zeros(max_bs, dtype=torch.long), persistent=False)
         self.register_buffer("_decode_eoc_countdown", torch.full((max_bs,), -1, dtype=torch.long), persistent=False)
         self.register_buffer("_decode_generation_done", torch.zeros(max_bs, dtype=torch.bool), persistent=False)
+        self.register_buffer("_decode_seed", torch.full((max_bs,), -1, dtype=torch.long), persistent=False)
+        self.register_buffer("_decode_step_count", torch.zeros(max_bs, dtype=torch.long), persistent=False)
+        self.register_buffer("_audio_state_update_mask", torch.zeros(max_bs, dtype=torch.bool), persistent=False)
+        if self._audio_sampler_mode == "flashinfer":
+            flashinfer_batch_rows = self._mlp_cudagraph_max_batch * self.num_codebooks
+            top_p_workspace_size = _flashinfer_top_p_workspace_size(
+                flashinfer_batch_rows,
+                self.codebook_size,
+            )
+            top_k_row_states = torch.zeros(1024 * 1024, dtype=torch.uint8)
+            top_p_workspace = torch.empty(top_p_workspace_size, dtype=torch.uint8)
+        else:
+            top_k_row_states = torch.empty(0, dtype=torch.uint8)
+            top_p_workspace = torch.empty(0, dtype=torch.uint8)
+        self.register_buffer(
+            "_flashinfer_top_k_row_states",
+            top_k_row_states,
+            persistent=False,
+        )
+        self.register_buffer(
+            "_flashinfer_top_p_workspace",
+            top_p_workspace,
+            persistent=False,
+        )
         self._decode_active_audio_count: int = 0
 
-        # PrefixCache opt-outs (mirror qwen3_tts pattern):
+        # Async scheduling may shrink or reorder the active batch while audio
+        # delay state is still live. Keep request-owned state in stable pool
+        # rows and expose contiguous active rows to the existing graph-safe
+        # decode path. The pool is synchronized only when the request layout
+        # changes; the steady-state decode loop pays no gather/scatter cost.
+        self.register_buffer(
+            "_request_decode_last_codes",
+            torch.zeros(max_bs, self.num_codebooks, dtype=torch.long),
+            persistent=False,
+        )
+        self.register_buffer("_request_decode_has_codes", torch.zeros(max_bs, dtype=torch.bool), persistent=False)
+        self.register_buffer("_request_decode_delay_count", torch.zeros(max_bs, dtype=torch.long), persistent=False)
+        self.register_buffer(
+            "_request_decode_eoc_countdown",
+            torch.full((max_bs,), -1, dtype=torch.long),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_request_decode_generation_done",
+            torch.zeros(max_bs, dtype=torch.bool),
+            persistent=False,
+        )
+        self.register_buffer("_request_decode_seed", torch.full((max_bs,), -1, dtype=torch.long), persistent=False)
+        self.register_buffer("_request_decode_step_count", torch.zeros(max_bs, dtype=torch.long), persistent=False)
+        self.register_buffer("_active_request_pool_rows", torch.empty(0, dtype=torch.long), persistent=False)
+        self._request_state_row_by_id: dict[str, int] = {}
+        self._request_state_free_rows: list[int] = []
+        self._request_state_next_row: int = 0
+        self._active_request_ids: tuple[str, ...] = ()
+        self._request_sampling_seed_by_id: dict[str, int] = {}
+
+        # PrefixCache compatibility hooks (mirror qwen3_tts pattern):
         # 1. The talker only consumes the last token's hidden state, so the
         #    runner can skip the per-step full hidden-state GPU->CPU merge
         #    that PrefixCache otherwise does.
         # 2. Per-step ``codes.audio`` rows stay GPU-resident; defer the CPU
         #    write of the prefix-cache mm-output copy to request finish so
-        #    the per-step bookkeeping does not block batching. Stage 0 can
-        #    then set ``enable_prefix_caching: true`` without the regression
-        #    observed in qwen3_tts (#3665).
+        #    the per-step bookkeeping does not block batching.
+        # Request-aware pending postprocess overlap still requires prefix
+        # caching to be disabled; deploy profiles enforce that constraint.
         self.requires_full_prefix_cached_hidden_states = False
         self.deferred_prefix_cache_mm_keys = {"codes.audio"}
 
@@ -342,6 +664,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         positions: torch.Tensor | None = None,
         inputs_embeds: torch.Tensor | None = None,
         omni_query_start_loc: torch.Tensor | None = None,
+        req_ids: list[str] | tuple[str, ...] | None = None,
         **_: Any,
     ) -> None:
         """Update per-step metadata before runner forward or CUDA graph replay."""
@@ -350,6 +673,8 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             self._last_step_input_ids = input_ids
             if self._use_external_decode_cudagraph and input_ids.is_cuda and input_ids.ndim >= 1:
                 self._ensure_decode_state_capacity(int(input_ids.shape[0]), input_ids.device)
+            if req_ids is not None:
+                self._prepare_request_state(req_ids, input_ids.device)
         self._set_last_step_query_start_loc(omni_query_start_loc)
         self._decode_step_metadata_from_runner = True
 
@@ -427,6 +752,17 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         return self._run_qwen3_layers_eager(positions, hidden_states)
 
     def _run_qwen3_layers_eager(self, positions: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self._use_external_decode_cudagraph:
+            # Qwen3Model carries the vLLM support_torch_compile decorator.
+            # Calling it here keeps the audio-feedback embedding outside the
+            # backbone while allowing the transformer to be compiled before
+            # the external FULL_DECODE CUDA graph captures it.
+            return self.model(
+                input_ids=None,
+                positions=positions,
+                inputs_embeds=hidden_states,
+            )
+
         residual: torch.Tensor | None = None
         for layer in self.model.layers:
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -529,8 +865,57 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         q_start = self._last_step_query_start_loc
         return isinstance(q_start, torch.Tensor) and int(q_start.numel()) == batch + 1
 
-    def compute_logits(self, hidden_states: torch.Tensor, sampling_metadata: Any = None) -> torch.Tensor:
+    def _can_use_logits_free_audio_sampler(self, num_rows: int, decode_only: bool) -> bool:
+        request_ids = self._active_request_ids
+        return (
+            decode_only
+            and len(request_ids) == num_rows
+            and all(req_id in self._fast_audio_direct_request_ids for req_id in request_ids)
+        )
+
+    def _mark_audio_direct_requests(
+        self,
+        request_ids: Sequence[str],
+        valid: Sequence[int],
+        done: Sequence[int],
+    ) -> None:
+        """Commit launch-time request IDs whose audio state is authoritative."""
+        for row, req_id in enumerate(request_ids):
+            req_id = str(req_id)
+            # A finish/cancel notification can race a lagged pending resolve.
+            # Request-owned state is the authority: once its row is released,
+            # an older snapshot must not resurrect logits-free certification.
+            if req_id not in self._request_state_row_by_id:
+                self._fast_audio_direct_request_ids.discard(req_id)
+            elif int(valid[row]) or int(done[row]):
+                self._fast_audio_direct_request_ids.add(req_id)
+            else:
+                self._fast_audio_direct_request_ids.discard(req_id)
+
+    @staticmethod
+    def _sampling_metadata_requires_text_logits(sampling_metadata: Any) -> bool:
+        if sampling_metadata is None:
+            return False
+        if getattr(sampling_metadata, "max_num_logprobs", None) is not None:
+            return True
+        if getattr(sampling_metadata, "allowed_token_ids_mask", None) is not None:
+            return True
+        return bool(getattr(sampling_metadata, "bad_words_token_ids", None))
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: Any = None,
+    ) -> torch.Tensor | None:
         self._last_logits_hidden = hidden_states
+        num_rows = int(hidden_states.shape[0])
+        ids = getattr(self, "_last_step_input_ids", None)
+        decode_only = isinstance(ids, torch.Tensor) and int(ids.numel()) == num_rows
+        if self._can_use_logits_free_audio_sampler(
+            num_rows,
+            decode_only,
+        ) and not self._sampling_metadata_requires_text_logits(sampling_metadata):
+            return None
         return self.logits_processor(self.lm_head, hidden_states)
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
@@ -658,14 +1043,19 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         if self._decode_active_audio_count == 0 and not external_decode_graph:
             return hidden_states
 
-        req_rows, token_positions = self._decode_request_token_positions(num_tokens, hidden_states.device)
-        if int(req_rows.numel()) == 0:
-            return hidden_states
+        dense_decode = self._is_single_token_decode_step(num_tokens)
+        if dense_decode:
+            req_rows = torch.arange(num_tokens, dtype=torch.long, device=hidden_states.device)
+            token_positions = req_rows
+        else:
+            req_rows, token_positions = self._decode_request_token_positions(num_tokens, hidden_states.device)
+            if int(req_rows.numel()) == 0:
+                return hidden_states
 
         num_reqs = self._step_request_count(num_tokens)
         self._ensure_decode_state_capacity(num_reqs, hidden_states.device)
 
-        if self._is_single_token_decode_step(num_tokens):
+        if dense_decode:
             codes_slice = self._decode_last_codes[:num_tokens]
             has_codes = self._decode_has_codes[:num_tokens].unsqueeze(-1)
             current_hidden = hidden_states
@@ -677,7 +1067,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         audio_embeds = audio_embeds.to(dtype=hidden_states.dtype)
         replaced = torch.where(has_codes, audio_embeds, current_hidden)
 
-        if self._is_single_token_decode_step(num_tokens):
+        if dense_decode:
             return replaced
         new_hidden = hidden_states.clone()
         new_hidden.index_copy_(0, token_positions, replaced)
@@ -739,6 +1129,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._decode_generation_done[:num_rows].masked_fill_(row_mask, False)
         self._decode_delay_count[:num_rows].masked_fill_(row_mask, 0)
         self._decode_eoc_countdown[:num_rows].masked_fill_(row_mask, -1)
+        self._decode_step_count[:num_rows].masked_fill_(row_mask, 0)
 
     def _ensure_decode_state_capacity(self, num_rows: int, device: torch.device | None = None) -> None:
         """Keep GPU-resident decode state tensors aligned and large enough."""
@@ -748,6 +1139,9 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             self._decode_delay_count = self._decode_delay_count.to(device)
             self._decode_eoc_countdown = self._decode_eoc_countdown.to(device)
             self._decode_generation_done = self._decode_generation_done.to(device)
+            self._decode_seed = self._decode_seed.to(device)
+            self._decode_step_count = self._decode_step_count.to(device)
+            self._audio_state_update_mask = self._audio_state_update_mask.to(device)
 
         cur_rows = int(self._decode_last_codes.shape[0])
         if num_rows <= cur_rows:
@@ -775,6 +1169,149 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         new_generation_done = torch.zeros(new_size, dtype=torch.bool, device=state_device)
         new_generation_done[:cur_rows].copy_(self._decode_generation_done)
         self._decode_generation_done = new_generation_done
+
+        new_seed = torch.full((new_size,), -1, dtype=torch.long, device=state_device)
+        new_seed[:cur_rows].copy_(self._decode_seed)
+        self._decode_seed = new_seed
+
+        new_step_count = torch.zeros(new_size, dtype=torch.long, device=state_device)
+        new_step_count[:cur_rows].copy_(self._decode_step_count)
+        self._decode_step_count = new_step_count
+
+        new_update_mask = torch.zeros(new_size, dtype=torch.bool, device=state_device)
+        new_update_mask[:cur_rows].copy_(self._audio_state_update_mask)
+        self._audio_state_update_mask = new_update_mask
+
+    def _ensure_request_state_capacity(self, num_rows: int, device: torch.device) -> None:
+        """Grow the stable request-owned state pool without losing rows."""
+        names_and_defaults = (
+            ("_request_decode_last_codes", 0),
+            ("_request_decode_has_codes", 0),
+            ("_request_decode_delay_count", 0),
+            ("_request_decode_eoc_countdown", -1),
+            ("_request_decode_generation_done", 0),
+            ("_request_decode_seed", -1),
+            ("_request_decode_step_count", 0),
+        )
+        first = self._request_decode_last_codes
+        if first.device != device:
+            for name, _ in names_and_defaults:
+                setattr(self, name, getattr(self, name).to(device))
+            first = self._request_decode_last_codes
+
+        cur_rows = int(first.shape[0])
+        if num_rows <= cur_rows:
+            return
+        new_size = max(num_rows, max(1, cur_rows * 2))
+        for name, default in names_and_defaults:
+            old = getattr(self, name)
+            shape = (new_size, *old.shape[1:])
+            new = torch.full(shape, default, dtype=old.dtype, device=device)
+            new[:cur_rows].copy_(old)
+            setattr(self, name, new)
+
+    def _reset_request_state_pool_rows(self, rows: torch.Tensor) -> None:
+        if int(rows.numel()) == 0:
+            return
+        rows = rows.to(device=self._request_decode_last_codes.device, dtype=torch.long)
+        self._request_decode_last_codes.index_fill_(0, rows, 0)
+        self._request_decode_has_codes.index_fill_(0, rows, False)
+        self._request_decode_delay_count.index_fill_(0, rows, 0)
+        self._request_decode_eoc_countdown.index_fill_(0, rows, -1)
+        self._request_decode_generation_done.index_fill_(0, rows, False)
+        self._request_decode_seed.index_fill_(0, rows, -1)
+        self._request_decode_step_count.index_fill_(0, rows, 0)
+
+    def _commit_request_state(self, num_rows: int | None = None) -> None:
+        """Commit current active rows to their immutable request-owned rows."""
+        active_ids = self._active_request_ids
+        if num_rows is None:
+            num_rows = len(active_ids)
+        num_rows = min(int(num_rows), len(active_ids))
+        if num_rows <= 0:
+            return
+
+        active_indices: list[int] = []
+        pool_indices: list[int] = []
+        active_pool_rows = self._active_request_pool_rows
+        for active_idx, req_id in enumerate(active_ids[:num_rows]):
+            pool_row = self._request_state_row_by_id.get(req_id)
+            if pool_row is None:
+                continue
+            if active_idx >= int(active_pool_rows.numel()) or int(active_pool_rows[active_idx]) != pool_row:
+                continue
+            active_indices.append(active_idx)
+            pool_indices.append(pool_row)
+        if not active_indices:
+            return
+
+        device = self._decode_last_codes.device
+        active = torch.tensor(active_indices, dtype=torch.long, device=device)
+        pool = torch.tensor(pool_indices, dtype=torch.long, device=device)
+        self._request_decode_last_codes.index_copy_(0, pool, self._decode_last_codes.index_select(0, active))
+        self._request_decode_has_codes.index_copy_(0, pool, self._decode_has_codes.index_select(0, active))
+        self._request_decode_delay_count.index_copy_(0, pool, self._decode_delay_count.index_select(0, active))
+        self._request_decode_eoc_countdown.index_copy_(0, pool, self._decode_eoc_countdown.index_select(0, active))
+        self._request_decode_generation_done.index_copy_(0, pool, self._decode_generation_done.index_select(0, active))
+        self._request_decode_seed.index_copy_(0, pool, self._decode_seed.index_select(0, active))
+        self._request_decode_step_count.index_copy_(0, pool, self._decode_step_count.index_select(0, active))
+
+    def _prepare_request_state(self, req_ids: list[str] | tuple[str, ...], device: torch.device) -> torch.Tensor:
+        """Gather stable request state when the scheduler changes batch rows."""
+        req_ids_tuple = tuple(req_ids)
+        if req_ids_tuple == self._active_request_ids:
+            return self._active_request_pool_rows[: len(req_ids_tuple)]
+
+        self._commit_request_state()
+        self._ensure_decode_state_capacity(len(req_ids_tuple), device)
+
+        pool_rows: list[int] = []
+        newly_allocated: list[int] = []
+        for req_id in req_ids_tuple:
+            pool_row = self._request_state_row_by_id.get(req_id)
+            if pool_row is None:
+                if self._request_state_free_rows:
+                    pool_row = self._request_state_free_rows.pop()
+                else:
+                    pool_row = self._request_state_next_row
+                    self._request_state_next_row += 1
+                self._request_state_row_by_id[req_id] = pool_row
+                newly_allocated.append(pool_row)
+            pool_rows.append(pool_row)
+
+        self._ensure_request_state_capacity(self._request_state_next_row, device)
+        if newly_allocated:
+            self._reset_request_state_pool_rows(torch.tensor(newly_allocated, dtype=torch.long, device=device))
+
+        rows = torch.tensor(pool_rows, dtype=torch.long, device=device)
+        num_rows = len(pool_rows)
+        if num_rows:
+            self._decode_last_codes[:num_rows].copy_(self._request_decode_last_codes.index_select(0, rows))
+            self._decode_has_codes[:num_rows].copy_(self._request_decode_has_codes.index_select(0, rows))
+            self._decode_delay_count[:num_rows].copy_(self._request_decode_delay_count.index_select(0, rows))
+            self._decode_eoc_countdown[:num_rows].copy_(self._request_decode_eoc_countdown.index_select(0, rows))
+            self._decode_generation_done[:num_rows].copy_(self._request_decode_generation_done.index_select(0, rows))
+            self._decode_seed[:num_rows].copy_(self._request_decode_seed.index_select(0, rows))
+            self._decode_step_count[:num_rows].copy_(self._request_decode_step_count.index_select(0, rows))
+
+        self._active_request_pool_rows = rows
+        self._active_request_ids = req_ids_tuple
+        return rows
+
+    def on_requests_finished(self, finished_req_ids: set[str] | list[str]) -> None:
+        """Release request-owned state rows after finish or cancellation."""
+        released: list[int] = []
+        for req_id in finished_req_ids:
+            self._fast_audio_direct_request_ids.discard(req_id)
+            pool_row = self._request_state_row_by_id.pop(req_id, None)
+            self._request_sampling_seed_by_id.pop(req_id, None)
+            if pool_row is not None:
+                released.append(pool_row)
+                self._request_state_free_rows.append(pool_row)
+        if released:
+            self._reset_request_state_pool_rows(
+                torch.tensor(released, dtype=torch.long, device=self._request_decode_last_codes.device)
+            )
 
     def _audio_seed_mask_from_step_input(self, num_rows: int, device: torch.device) -> torch.Tensor | None:
         """Return rows whose previous token is <|audio|> using current step input_ids.
@@ -822,6 +1359,10 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         return None
 
     def _clear_last_audio_outputs(self) -> None:
+        lease = getattr(self, "_last_audio_host_lease", None)
+        if lease is not None:
+            lease.release()
+            self._last_audio_host_lease = None
         self._last_audio_codes = None
         self._last_audio_code_valid = []
         self._last_audio_host_staging = None
@@ -858,8 +1399,23 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         logits.masked_fill_(audio_mask.to(device=logits.device).unsqueeze(1), float("-inf"))
         logits.scatter_(1, target, target_values)
 
+    def _refresh_request_sampling_seeds(self, sampling_metadata: Any, num_rows: int) -> None:
+        """Resolve each request's generator seed once, without advancing it."""
+        generators = getattr(sampling_metadata, "generators", None)
+        if not isinstance(generators, dict) or not self._active_request_ids:
+            return
+        for row, req_id in enumerate(self._active_request_ids[:num_rows]):
+            if req_id in self._request_sampling_seed_by_id:
+                continue
+            generator = generators.get(row)
+            if generator is None:
+                continue
+            seed = int(generator.initial_seed())
+            self._request_sampling_seed_by_id[req_id] = seed
+            self._decode_seed[row] = seed
+
     # ------------------------------------------------------------------ sampling
-    def sample(self, logits: torch.Tensor, sampling_metadata: Any) -> Any:
+    def sample(self, logits: torch.Tensor | None, sampling_metadata: Any) -> Any:
         """Model-owned sampler with delay-pattern audio dispatch.
 
         Mirrors v2's pattern: bias LM logits to force audio continuation,
@@ -871,6 +1427,11 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         audio_id = self._audio_continuation_id
 
         def run_stock_sampler() -> Any:
+            if logits is None:
+                raise RuntimeError(
+                    "Higgs text logits were skipped before every active request "
+                    "entered the request-aware direct-audio path"
+                )
             sampler = getattr(self, "_stock_sampler", None)
             if sampler is None:
                 from vllm.v1.sample.sampler import Sampler
@@ -888,10 +1449,15 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
 
         num_rows = int(hidden.shape[0])
         self._ensure_decode_state_capacity(num_rows, hidden.device)
+        self._refresh_request_sampling_seeds(sampling_metadata, num_rows)
         ids = getattr(self, "_last_step_input_ids", None)
         decode_only = isinstance(ids, torch.Tensor) and int(ids.numel()) == num_rows
+        # ``logits is None`` is the immutable decision made by compute_logits
+        # for this exact sampling step. Async output resolution may update the
+        # live request certification set before sample_tokens consumes it, so
+        # do not re-decide a logits-free step from mutable model state here.
+        direct_audio_batch = logits is None or self._can_use_logits_free_audio_sampler(num_rows, decode_only)
         if not decode_only:
-            self._fast_audio_direct_rows = 0
             pfmask = self._prefill_row_mask(num_rows, hidden.device)
             self._reset_decode_state_rows(pfmask, num_rows, hidden.device)
         prev_audio_mask = self._audio_seed_mask_from_step_input(num_rows, hidden.device)
@@ -899,10 +1465,14 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             prev_audio_mask = torch.zeros(num_rows, dtype=torch.bool, device=hidden.device)
         active_mask = self._decode_has_codes[:num_rows].to(device=hidden.device, dtype=torch.bool)
         done_mask = self._decode_generation_done[:num_rows].to(device=hidden.device, dtype=torch.bool)
-        fast_fallback_reason = self._fast_audio_sampler_gpu_fallback_reason(
-            logits=logits,
-            sampling_metadata=sampling_metadata,
-            num_rows=num_rows,
+        fast_fallback_reason = (
+            None
+            if logits is None and direct_audio_batch
+            else self._fast_audio_sampler_gpu_fallback_reason(
+                logits=logits,
+                sampling_metadata=sampling_metadata,
+                num_rows=num_rows,
+            )
         )
         seed_mask = prev_audio_mask & ~active_mask & ~done_mask
         audio_mask = prev_audio_mask | active_mask | done_mask
@@ -911,10 +1481,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         use_gpu_audio_mode = fast_fallback_reason is None or fast_fallback_reason in gpu_stock_sampler_reasons
 
         if fast_fallback_reason is None:
-            direct_audio_batch = decode_only and self._fast_audio_direct_rows == num_rows
-
             if direct_audio_batch:
-                self._fast_audio_direct_rows = num_rows
                 audio_tokens = torch.full((num_rows,), int(audio_id), dtype=torch.int32, device=hidden.device)
                 if self._eos_token_id is not None:
                     eos_tokens = torch.full_like(audio_tokens, int(self._eos_token_id))
@@ -929,7 +1496,6 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
                     self._clear_last_audio_outputs()
                     return sampler_output
         elif use_gpu_audio_mode:
-            self._fast_audio_direct_rows = 0
             self._apply_audio_mode_bias_batched(logits, audio_mask, done_mask)
             sampler_output = run_stock_sampler()
             sampled = getattr(sampler_output, "sampled_token_ids", None)
@@ -937,7 +1503,6 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
                 self._clear_last_audio_outputs()
                 return sampler_output
         else:
-            self._fast_audio_direct_rows = 0
             sampler_output = run_stock_sampler()
             self._clear_last_audio_outputs()
             return sampler_output
@@ -971,8 +1536,37 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         else:
             audio_row_tensor = self._get_row_indices(num_rows, hidden.device)
 
-        # Per-codebook logits at audio positions
         all_audio_rows = use_gpu_audio_mode
+        if all_audio_rows and self._audio_state_step_mode != "legacy":
+            bucket_rows = self._audio_state_step_bucket_size(num_rows)
+            self._ensure_decode_state_capacity(bucket_rows, hidden.device)
+            hidden_staging = self._get_audio_state_hidden_staging(
+                bucket_rows,
+                hidden.shape[-1],
+                hidden.device,
+                hidden.dtype,
+            )
+            hidden_staging.zero_()
+            hidden_staging[:num_rows].copy_(hidden.reshape(-1, hidden.shape[-1])[:num_rows])
+            update_staging = self._audio_state_update_mask[:bucket_rows]
+            update_staging.zero_()
+            update_staging[:num_rows].copy_(code_row_mask[:num_rows])
+            state_step = self._get_audio_state_step_callable()
+            state_result = state_step(
+                hidden_staging,
+                self._decode_delay_count[:bucket_rows],
+                self._decode_eoc_countdown[:bucket_rows],
+                self._decode_generation_done[:bucket_rows],
+                self._decode_has_codes[:bucket_rows],
+                self._decode_last_codes[:bucket_rows],
+                self._decode_step_count[:bucket_rows],
+                self._decode_seed[:bucket_rows],
+                update_staging,
+            )
+            self._publish_audio_state_step(state_result, num_rows, hidden.device)
+            return sampler_output
+
+        # Per-codebook logits at audio positions
         if use_gpu_audio_mode:
             cb_logits = self._audio_codebook_logits_from_rows(hidden, audio_row_tensor, all_rows=True)
         else:
@@ -983,7 +1577,17 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
 
         # Sample per-codebook
         cb_logits_2d = cb_logits.reshape(-1, cb_logits.shape[-1])
-        codes_2d = self._sample_audio_codes(cb_logits_2d)
+        if all_audio_rows:
+            row_seeds = self._decode_seed[: int(cb_logits.shape[0])]
+            row_steps = self._decode_step_count[: int(cb_logits.shape[0])]
+        else:
+            row_seeds = self._decode_seed.index_select(0, audio_row_tensor)
+            row_steps = self._decode_step_count.index_select(0, audio_row_tensor)
+        codes_2d = self._sample_audio_codes(
+            cb_logits_2d,
+            row_seeds=row_seeds,
+            row_steps=row_steps,
+        )
         codes_flat = codes_2d.view(cb_logits.shape[0], cb_logits.shape[1]).to(torch.long)
 
         self._update_delay_state_batched(
@@ -1014,21 +1618,17 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         return buf[:num_rows]
 
     def _get_audio_host_staging_buffer(self, num_rows: int) -> torch.Tensor:
-        width = self.num_codebooks + 2
-        buf = self._last_audio_host_staging
-        if buf is None or buf.device.type != "cpu" or int(buf.shape[0]) < num_rows:
-            rows = max(num_rows, 16)
-            pin_memory = torch.cuda.is_available()
-            buf = torch.empty((rows, width), dtype=torch.int32, device="cpu", pin_memory=pin_memory)
-            self._last_audio_host_staging = buf
-        return buf[:num_rows]
-
-    def _next_audio_staging_event(self) -> torch.cuda.Event:
-        if not self._audio_staging_events:
-            self._audio_staging_events = [torch.cuda.Event(), torch.cuda.Event()]
-        event = self._audio_staging_events[self._audio_staging_event_cursor]
-        self._audio_staging_event_cursor = (self._audio_staging_event_cursor + 1) % len(self._audio_staging_events)
-        return event
+        pool = getattr(self, "_audio_host_staging_pool", None)
+        if pool is None:
+            pool = _HiggsAudioHostStagingPool(
+                width=self.num_codebooks + 2,
+                pin_memory=torch.cuda.is_available(),
+            )
+            self._audio_host_staging_pool = pool
+        lease = pool.acquire(num_rows)
+        self._last_audio_host_lease = lease
+        self._last_audio_host_staging = lease.tensor
+        return lease.tensor
 
     @staticmethod
     def _device_cache_key(device: torch.device) -> tuple[str, int]:
@@ -1075,6 +1675,33 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         _ = multimodal_outputs
         return self._postprocess_impl()
 
+    def take_pending_omni_postprocess(
+        self,
+        request_ids: Sequence[str],
+    ) -> HiggsAudioV3PendingStep | None:
+        """Detach this step's D2H snapshot for background request-aware resolve."""
+        host_staging = self._last_audio_host_staging
+        lease = self._last_audio_host_lease
+        if host_staging is None or lease is None:
+            return None
+        pending = HiggsAudioV3PendingStep.create(
+            request_ids=request_ids,
+            host_staging=host_staging,
+            event=self._last_audio_staging_event,
+            num_codebooks=self.num_codebooks,
+            release=lease.release,
+            on_resolve=self._mark_audio_direct_requests,
+        )
+        # Ownership moved to the immutable pending handle. The next sample may
+        # acquire the other slot without touching this step's host snapshot.
+        self._last_audio_host_lease = None
+        self._last_audio_host_staging = None
+        self._last_audio_staging_event = None
+        self._last_audio_valid_flags = None
+        self._last_audio_done_flags = None
+        self._postprocess_cursor = 0
+        return pending
+
     def _postprocess_impl(self) -> dict[str, Any]:
         host_staging = self._last_audio_host_staging
         codes_full = self._last_audio_codes
@@ -1091,30 +1718,37 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             self._postprocess_cursor = 0
             return {}
         self._postprocess_cursor = cursor + 1
+        last_row = cursor + 1 >= num_rows
+        try:
+            if host_staging is not None:
+                if self._last_audio_valid_flags is None or self._last_audio_done_flags is None:
+                    self._last_audio_valid_flags = host_staging[:num_rows, self.num_codebooks].tolist()
+                    self._last_audio_done_flags = host_staging[:num_rows, self.num_codebooks + 1].tolist()
+                valid_flag = int(self._last_audio_valid_flags[cursor])
+                if last_row:
+                    request_ids = self._active_request_ids
+                    if len(request_ids) == num_rows:
+                        self._mark_audio_direct_requests(
+                            request_ids,
+                            self._last_audio_valid_flags,
+                            self._last_audio_done_flags,
+                        )
+                if valid_flag == 0:
+                    return {}
+                new_codes = host_staging[cursor : cursor + 1, : self.num_codebooks]
+                return {"codes": {"audio": new_codes}}
 
-        if host_staging is not None:
-            if self._last_audio_valid_flags is None or self._last_audio_done_flags is None:
-                self._last_audio_valid_flags = host_staging[:num_rows, self.num_codebooks].tolist()
-                self._last_audio_done_flags = host_staging[:num_rows, self.num_codebooks + 1].tolist()
-            valid_flag = int(self._last_audio_valid_flags[cursor])
-            done_flag = int(self._last_audio_done_flags[cursor])
-            if valid_flag or done_flag:
-                self._postprocess_audio_active_rows += 1
-            if cursor + 1 >= num_rows:
-                if self._postprocess_audio_rows == num_rows and self._postprocess_audio_active_rows == num_rows:
-                    self._fast_audio_direct_rows = num_rows
-                self._postprocess_audio_rows = 0
-                self._postprocess_audio_active_rows = 0
-            if valid_flag == 0:
+            if cursor >= len(self._last_audio_code_valid) or not self._last_audio_code_valid[cursor]:
                 return {}
-            new_codes = host_staging[cursor : cursor + 1, : self.num_codebooks]
+            slice_codes = codes_full[cursor : cursor + 1]
+            new_codes = slice_codes.to(torch.int32)
             return {"codes": {"audio": new_codes}}
-
-        if cursor >= len(self._last_audio_code_valid) or not self._last_audio_code_valid[cursor]:
-            return {}
-        slice_codes = codes_full[cursor : cursor + 1]
-        new_codes = slice_codes.to(torch.int32)
-        return {"codes": {"audio": new_codes}}
+        finally:
+            if last_row:
+                lease = getattr(self, "_last_audio_host_lease", None)
+                if lease is not None:
+                    lease.release()
+                    self._last_audio_host_lease = None
 
     # ------------------------------------------------------------------ helpers
     def _audio_codebook_logits_from_rows(
@@ -1226,12 +1860,14 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             prev_done = self._decode_generation_done[:num_audio_rows].to(torch.bool)
             prev_has_codes = self._decode_has_codes[:num_audio_rows].to(torch.bool)
             prev_codes = self._decode_last_codes[:num_audio_rows]
+            prev_step_count = self._decode_step_count[:num_audio_rows]
         else:
             prev_delay = self._decode_delay_count.index_select(0, rows)
             prev_rem = self._decode_eoc_countdown.index_select(0, rows)
             prev_done = self._decode_generation_done.index_select(0, rows).to(torch.bool)
             prev_has_codes = self._decode_has_codes.index_select(0, rows).to(torch.bool)
             prev_codes = self._decode_last_codes.index_select(0, rows)
+            prev_step_count = self._decode_step_count.index_select(0, rows)
         if prev_delay.dtype != torch.long:
             prev_delay = prev_delay.to(torch.long)
         if prev_rem.dtype != torch.long:
@@ -1281,6 +1917,7 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         write_done = torch.where(update_mask, done, prev_done)
         write_codes = torch.where(update_mask.unsqueeze(1), codes, prev_codes)
         write_has_codes = torch.where(update_mask, ~done, prev_has_codes)
+        write_step_count = prev_step_count + update_mask.to(prev_step_count.dtype)
 
         if all_rows:
             self._decode_delay_count[:num_audio_rows].copy_(write_delay.to(dtype=self._decode_delay_count.dtype))
@@ -1288,12 +1925,14 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             self._decode_generation_done[:num_audio_rows].copy_(write_done)
             self._decode_last_codes[:num_audio_rows].copy_(write_codes)
             self._decode_has_codes[:num_audio_rows].copy_(write_has_codes)
+            self._decode_step_count[:num_audio_rows].copy_(write_step_count)
         else:
             self._decode_delay_count.index_copy_(0, rows, write_delay.to(dtype=self._decode_delay_count.dtype))
             self._decode_eoc_countdown.index_copy_(0, rows, write_rem.to(dtype=self._decode_eoc_countdown.dtype))
             self._decode_generation_done.index_copy_(0, rows, write_done)
             self._decode_last_codes.index_copy_(0, rows, write_codes)
             self._decode_has_codes.index_copy_(0, rows, write_has_codes)
+            self._decode_step_count.index_copy_(0, rows, write_step_count)
 
         staged_codes = torch.where(update_mask.unsqueeze(1), output_codes, torch.full_like(output_codes, -1))
         if all_rows:
@@ -1319,7 +1958,9 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         host = self._get_audio_host_staging_buffer(num_rows)
         host.copy_(staging, non_blocking=True)
         if device.type == "cuda":
-            event = self._next_audio_staging_event()
+            lease = self._last_audio_host_lease
+            assert lease is not None
+            event = lease.cuda_event()
             event.record(torch.cuda.current_stream(device))
             self._last_audio_staging_event = event
         else:
@@ -1334,35 +1975,367 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
         self._last_audio_done_flags = None
         self._last_audio_code_valid = []
         self._postprocess_cursor = 0
-        self._postprocess_audio_rows = num_rows
-        self._postprocess_audio_active_rows = 0
 
-    def _sample_audio_codes(self, logits_2d: torch.Tensor) -> torch.Tensor:
+    def _audio_state_step_from_hidden(
+        self,
+        hidden: torch.Tensor,
+        prev_delay: torch.Tensor,
+        prev_rem: torch.Tensor,
+        prev_done: torch.Tensor,
+        prev_has_codes: torch.Tensor,
+        prev_codes: torch.Tensor,
+        prev_step_count: torch.Tensor,
+        row_seeds: torch.Tensor,
+        update_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, ...]:
+        cb_logits = self.modality_head.generate(hidden)
+        return HiggsAudioV3TalkerForConditionalGeneration._audio_state_step_tensor(
+            cb_logits,
+            prev_delay,
+            prev_rem,
+            prev_done,
+            prev_has_codes,
+            prev_codes,
+            prev_step_count,
+            row_seeds,
+            update_mask,
+            use_flashinfer=getattr(self, "_audio_sampler_mode", "torch") == "flashinfer",
+            flashinfer_top_k_row_states=getattr(self, "_flashinfer_top_k_row_states", None),
+            flashinfer_top_p_workspace=getattr(self, "_flashinfer_top_p_workspace", None),
+        )
+
+    @staticmethod
+    def _audio_state_step_bucket_size(num_rows: int) -> int:
+        """Use a bounded set of static shapes across batch shrink/reorder."""
+        if num_rows <= 0:
+            return 1
+        return 1 << (int(num_rows) - 1).bit_length()
+
+    def _get_audio_state_hidden_staging(
+        self,
+        num_rows: int,
+        hidden_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        buf = self._audio_state_hidden_staging
+        if (
+            buf is None
+            or buf.device != device
+            or buf.dtype != dtype
+            or int(buf.shape[0]) < num_rows
+            or int(buf.shape[1]) != hidden_size
+        ):
+            rows = max(num_rows, self._mlp_cudagraph_max_batch)
+            buf = torch.empty((rows, hidden_size), dtype=dtype, device=device)
+            self._audio_state_hidden_staging = buf
+        return buf[:num_rows]
+
+    def _get_audio_state_step_callable(self) -> Any:
+        if self._audio_state_step_mode != "compile":
+            return self._audio_state_step_from_hidden
+        if self._compiled_audio_state_step is None:
+            self._compiled_audio_state_step = torch.compile(
+                self._audio_state_step_from_hidden,
+                options={"triton.cudagraphs": False},
+                fullgraph=True,
+                dynamic=False,
+            )
+            logger.info_once("Higgs Audio V3: compiled modality head + sampling + delay/state transition")
+        return self._compiled_audio_state_step
+
+    def _publish_audio_state_step(
+        self,
+        result: tuple[torch.Tensor, ...],
+        num_rows: int,
+        device: torch.device,
+    ) -> None:
+        """Commit a functional state step and publish its static D2H snapshot."""
+        (
+            staged_codes,
+            delay_count,
+            eoc_countdown,
+            generation_done,
+            has_codes,
+            last_codes,
+            step_count,
+            valid,
+            done,
+        ) = result
+        self._decode_delay_count[:num_rows].copy_(delay_count[:num_rows])
+        self._decode_eoc_countdown[:num_rows].copy_(eoc_countdown[:num_rows])
+        self._decode_generation_done[:num_rows].copy_(generation_done[:num_rows])
+        self._decode_has_codes[:num_rows].copy_(has_codes[:num_rows])
+        self._decode_last_codes[:num_rows].copy_(last_codes[:num_rows])
+        self._decode_step_count[:num_rows].copy_(step_count[:num_rows])
+
+        staging = self._get_audio_gpu_staging_buffer(num_rows, device)
+        staging[:, : self.num_codebooks].copy_(staged_codes[:num_rows].to(torch.int32))
+        staging[:, self.num_codebooks].copy_(valid[:num_rows].to(torch.int32))
+        staging[:, self.num_codebooks + 1].copy_(done[:num_rows].to(torch.int32))
+        host = self._get_audio_host_staging_buffer(num_rows)
+        host.copy_(staging, non_blocking=True)
+        if device.type == "cuda":
+            lease = self._last_audio_host_lease
+            assert lease is not None
+            event = lease.cuda_event()
+            event.record(torch.cuda.current_stream(device))
+            self._last_audio_staging_event = event
+        else:
+            self._last_audio_staging_event = None
+
+        self._decode_active_audio_count = num_rows
+        self._last_audio_codes = None
+        self._last_audio_host_staging = host[:num_rows]
+        self._last_audio_valid_flags = None
+        self._last_audio_done_flags = None
+        self._last_audio_code_valid = []
+        self._postprocess_cursor = 0
+
+    def _sample_audio_codes(
+        self,
+        logits_2d: torch.Tensor,
+        *,
+        row_seeds: torch.Tensor | None = None,
+        row_steps: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """Replicate upstream sampling: temperature → top-k → top-p → multinomial."""
+        return HiggsAudioV3TalkerForConditionalGeneration._sample_audio_codes_tensor(
+            logits_2d,
+            row_seeds=row_seeds,
+            row_steps=row_steps,
+            num_codebooks=self.num_codebooks,
+            use_flashinfer=getattr(self, "_audio_sampler_mode", "torch") == "flashinfer",
+            flashinfer_top_k_row_states=getattr(self, "_flashinfer_top_k_row_states", None),
+            flashinfer_top_p_workspace=getattr(self, "_flashinfer_top_p_workspace", None),
+        )
+
+    @staticmethod
+    def _sample_audio_codes_tensor(
+        logits_2d: torch.Tensor,
+        *,
+        row_seeds: torch.Tensor | None,
+        row_steps: torch.Tensor | None,
+        num_codebooks: int,
+        use_flashinfer: bool = False,
+        flashinfer_top_k_row_states: torch.Tensor | None = None,
+        flashinfer_top_p_workspace: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Tensor-only Higgs sampler shared by legacy and compiled paths."""
         x = logits_2d.float()
         top_k = 50
         top_p = 0.95
-        if 0 < top_k < x.shape[-1]:
-            kth = x.topk(top_k, dim=-1).values[..., -1:]
-            x = x.masked_fill(x < kth, float("-inf"))
-        if 0.0 < top_p < 1.0:
-            sorted_logits, sorted_idx = x.sort(dim=-1, descending=True)
-            cumprobs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
-            sorted_mask = cumprobs > top_p
-            sorted_mask[..., 1:] = sorted_mask[..., :-1].clone()
-            sorted_mask[..., 0] = False
-            mask = torch.zeros_like(x, dtype=torch.bool)
-            mask.scatter_(-1, sorted_idx, sorted_mask)
-            x = x.masked_fill(mask, float("-inf"))
-        # Detect all-masked rows BEFORE softmax (softmax of all-inf yields NaN).
-        has_finite = torch.isfinite(x).any(dim=-1)
-        all_masked = ~has_finite
-        # Do not branch on tensor bools here; that synchronizes every audio step.
-        fallback = x.argmax(dim=-1)
-        safe_x = torch.where(all_masked.unsqueeze(-1), torch.zeros_like(x), x)
-        probs = safe_x.softmax(dim=-1)
-        sampled = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        if use_flashinfer:
+            if _flashinfer_top_k_renorm_probs is None or _flashinfer_top_p_renorm_probs is None:
+                raise RuntimeError("FlashInfer audio sampler requested but sampling kernels are unavailable")
+            all_masked = ~torch.isfinite(x).any(dim=-1)
+            fallback = x.argmax(dim=-1)
+            safe_x = torch.where(all_masked.unsqueeze(-1), torch.zeros_like(x), x)
+            probs = safe_x.softmax(dim=-1).contiguous()
+            if (
+                flashinfer_top_k_row_states is not None
+                and flashinfer_top_p_workspace is not None
+                and flashinfer_top_k_row_states.numel() > 0
+                and flashinfer_top_p_workspace.numel() > 0
+            ):
+                probs = _higgs_flashinfer_top_k_renorm_op(
+                    probs,
+                    flashinfer_top_k_row_states,
+                )
+                probs = _higgs_flashinfer_top_p_renorm_op(
+                    probs,
+                    flashinfer_top_p_workspace,
+                )
+            else:
+                probs = _flashinfer_top_k_renorm_probs(probs, top_k)
+                probs = _flashinfer_top_p_renorm_probs(probs, top_p, is_deterministic=True)
+        else:
+            if 0 < top_k < x.shape[-1]:
+                kth = x.topk(top_k, dim=-1).values[..., -1:]
+                x = x.masked_fill(x < kth, float("-inf"))
+            if 0.0 < top_p < 1.0:
+                sorted_logits, sorted_idx = x.sort(dim=-1, descending=True)
+                cumprobs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+                sorted_mask = cumprobs > top_p
+                sorted_mask[..., 1:] = sorted_mask[..., :-1].clone()
+                sorted_mask[..., 0] = False
+                mask = torch.zeros_like(x, dtype=torch.bool)
+                mask.scatter_(-1, sorted_idx, sorted_mask)
+                x = x.masked_fill(mask, float("-inf"))
+            # Detect all-masked rows BEFORE softmax (softmax of all-inf yields NaN).
+            all_masked = ~torch.isfinite(x).any(dim=-1)
+            # Do not branch on tensor bools here; that synchronizes every audio step.
+            fallback = x.argmax(dim=-1)
+            safe_x = torch.where(all_masked.unsqueeze(-1), torch.zeros_like(x), x)
+            probs = safe_x.softmax(dim=-1)
+        if row_seeds is None:
+            sampled = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        else:
+            num_reqs = int(row_seeds.numel())
+            if int(probs.shape[0]) != num_reqs * num_codebooks:
+                raise ValueError(
+                    "Seeded Higgs audio sampling expects one codebook group "
+                    f"per request: got {int(probs.shape[0])} rows for "
+                    f"{num_reqs} requests x {num_codebooks} codebooks"
+                )
+            if row_steps is None or int(row_steps.numel()) != num_reqs:
+                raise ValueError("row_steps must contain one entry per seeded request")
+
+            # Stateless request RNG: each draw is keyed by
+            # (request seed, AR step, codebook). This is batch-order invariant
+            # and pure tensor code, unlike a Python loop over torch.Generator.
+            modulus = 2_147_483_647
+            seeds = torch.remainder(row_seeds.to(device=probs.device, dtype=torch.long), modulus)
+            steps = row_steps.to(device=probs.device, dtype=torch.long)
+            codebooks = torch.arange(num_codebooks, device=probs.device, dtype=torch.long).unsqueeze(0)
+            positions = steps.unsqueeze(1) * num_codebooks + codebooks + 1
+            state = torch.remainder(seeds.unsqueeze(1) + positions * 1_103_515_245, modulus)
+            state = torch.remainder(torch.bitwise_xor(state, state >> 16) * 48_271, modulus)
+            uniforms = (state.to(torch.float32) + 0.5) / float(modulus)
+
+            probs_3d = probs.view(num_reqs, num_codebooks, -1)
+            cdf = probs_3d.cumsum(dim=-1)
+            seeded = (cdf < uniforms.unsqueeze(-1)).sum(dim=-1).clamp_max(probs_3d.shape[-1] - 1)
+            sampled = seeded.reshape(-1)
         return torch.where(all_masked, fallback, sampled)
+
+    @staticmethod
+    def _audio_state_step_tensor(
+        cb_logits: torch.Tensor,
+        prev_delay: torch.Tensor,
+        prev_rem: torch.Tensor,
+        prev_done: torch.Tensor,
+        prev_has_codes: torch.Tensor,
+        prev_codes: torch.Tensor,
+        prev_step_count: torch.Tensor,
+        row_seeds: torch.Tensor,
+        update_mask: torch.Tensor,
+        *,
+        use_flashinfer: bool = False,
+        flashinfer_top_k_row_states: torch.Tensor | None = None,
+        flashinfer_top_p_workspace: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        """Sample audio codes and advance the full delay/EOC state machine.
+
+        This function is deliberately functional: request ownership and D2H
+        publication stay outside the compiled region, while every
+        quality-sensitive GPU transition is represented by tensor operations.
+        """
+        device = cb_logits.device
+        num_rows = int(cb_logits.shape[0])
+        num_codebooks = int(cb_logits.shape[1])
+        q = torch.arange(num_codebooks, dtype=torch.long, device=device).view(1, num_codebooks)
+
+        delay = prev_delay.to(device=device, dtype=torch.long)
+        rem = prev_rem.to(device=device, dtype=torch.long)
+        old_done = prev_done.to(device=device, dtype=torch.bool)
+        old_has_codes = prev_has_codes.to(device=device, dtype=torch.bool)
+        old_codes = prev_codes.to(device=device, dtype=torch.long)
+        step_count = prev_step_count.to(device=device, dtype=torch.long)
+        seeds = row_seeds.to(device=device, dtype=torch.long)
+        updates = update_mask.to(device=device, dtype=torch.bool)
+        ramp = rem >= 0
+
+        # MusicGen delay masking. ``cb_logits`` is the private output of this
+        # state step and has no downstream reader, so mutate it directly rather
+        # than cloning the full [batch, codebook, vocab] tensor every AR step.
+        # Keep the operation ordering identical to the legacy in-place path
+        # because BOC/EOC masking is quality sensitive.
+        masked_logits = cb_logits
+        lock_until = num_codebooks - rem
+        locked = ramp.unsqueeze(1) & (q < lock_until.unsqueeze(1))
+        eoc_logits = masked_logits[:, :, EOC_ID].clone()
+        masked_logits.masked_fill_(locked.unsqueeze(-1), float("-inf"))
+        masked_logits[:, :, EOC_ID] = torch.where(locked, eoc_logits, masked_logits[:, :, EOC_ID])
+
+        ramp_tail = ramp.unsqueeze(1) & (q >= lock_until.unsqueeze(1))
+        masked_logits[:, :, BOC_ID] = torch.where(
+            ramp_tail,
+            torch.full_like(masked_logits[:, :, BOC_ID], float("-inf")),
+            masked_logits[:, :, BOC_ID],
+        )
+        masked_logits[:, :, EOC_ID] = torch.where(
+            ramp_tail,
+            torch.full_like(masked_logits[:, :, EOC_ID], float("-inf")),
+            masked_logits[:, :, EOC_ID],
+        )
+
+        normal = ~ramp
+        allowed_until = torch.clamp(delay + 1, max=num_codebooks)
+        delayed = normal.unsqueeze(1) & (q >= allowed_until.unsqueeze(1))
+        boc_logits = masked_logits[:, :, BOC_ID].clone()
+        masked_logits.masked_fill_(delayed.unsqueeze(-1), float("-inf"))
+        masked_logits[:, :, BOC_ID] = torch.where(delayed, boc_logits, masked_logits[:, :, BOC_ID])
+
+        allowed = normal.unsqueeze(1) & (q < allowed_until.unsqueeze(1))
+        masked_logits[:, :, BOC_ID] = torch.where(
+            allowed,
+            torch.full_like(masked_logits[:, :, BOC_ID], float("-inf")),
+            masked_logits[:, :, BOC_ID],
+        )
+        nonzero_allowed = allowed & (q > 0)
+        masked_logits[:, :, EOC_ID] = torch.where(
+            nonzero_allowed,
+            torch.full_like(masked_logits[:, :, EOC_ID], float("-inf")),
+            masked_logits[:, :, EOC_ID],
+        )
+
+        sampled = HiggsAudioV3TalkerForConditionalGeneration._sample_audio_codes_tensor(
+            masked_logits.reshape(num_rows * num_codebooks, -1),
+            row_seeds=seeds,
+            row_steps=step_count,
+            num_codebooks=num_codebooks,
+            use_flashinfer=use_flashinfer,
+            flashinfer_top_k_row_states=flashinfer_top_k_row_states,
+            flashinfer_top_p_workspace=flashinfer_top_p_workspace,
+        ).view(num_rows, num_codebooks)
+
+        # Leading BOC delay pad.
+        delay_active = (~ramp) & ((delay + 1) < num_codebooks)
+        delay_mask = delay_active.unsqueeze(1) & (q > delay.unsqueeze(1))
+        codes = torch.where(delay_mask, torch.full_like(sampled, BOC_ID), sampled)
+        next_delay = torch.where(delay_active, delay + 1, delay)
+
+        # Trailing EOC ramp-down and new EOC detection.
+        ramp_mask = ramp.unsqueeze(1) & (q < lock_until.unsqueeze(1))
+        codes = torch.where(ramp_mask, torch.full_like(codes, EOC_ID), codes)
+        ramp_next_rem = rem - 1
+        eos_mask = (~ramp).unsqueeze(1) & (codes == EOC_ID)
+        eos_idx_values = torch.where(eos_mask, q.expand_as(codes), torch.full_like(codes, -1))
+        last_eos_idx = eos_idx_values.max(dim=1).values
+        has_eos = last_eos_idx >= 0
+        eos_prefix = has_eos.unsqueeze(1) & (q <= last_eos_idx.unsqueeze(1))
+        codes = torch.where(eos_prefix, torch.full_like(codes, EOC_ID), codes)
+        normal_next_rem = torch.where(
+            has_eos,
+            num_codebooks - last_eos_idx - 1,
+            torch.full_like(last_eos_idx, -1),
+        )
+        next_rem = torch.where(ramp, ramp_next_rem, normal_next_rem)
+        done = ((next_rem >= 0) & (next_rem <= 0)) & updates
+        valid = updates
+
+        next_delay = torch.where(done, torch.zeros_like(next_delay), next_delay)
+        next_rem = torch.where(done, torch.full_like(next_rem, -1), next_rem)
+        write_delay = torch.where(updates, next_delay, delay)
+        write_rem = torch.where(updates, next_rem, rem)
+        write_done = torch.where(updates, done, old_done)
+        write_codes = torch.where(updates.unsqueeze(1), codes, old_codes)
+        write_has_codes = torch.where(updates, ~done, old_has_codes)
+        write_step_count = step_count + updates.to(step_count.dtype)
+        staged_codes = torch.where(updates.unsqueeze(1), codes, torch.full_like(codes, -1))
+
+        return (
+            staged_codes,
+            write_delay,
+            write_rem,
+            write_done,
+            write_has_codes,
+            write_codes,
+            write_step_count,
+            valid,
+            done,
+        )
 
     # ------------------------------------------------------------------ omni output
     def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:

--- a/vllm_omni/transformers_utils/configs/higgs_audio_v3.py
+++ b/vllm_omni/transformers_utils/configs/higgs_audio_v3.py
@@ -95,6 +95,8 @@ class HiggsAudioV3Config(PretrainedConfig):
         audio_continuation_id: int | None = None,
         enable_flashinfer_api_unwrap: bool = True,
         enable_mlp_cudagraph: bool = True,
+        audio_state_step_mode: str = "legacy",
+        audio_sampler_mode: str = "torch",
         **kwargs: Any,
     ) -> None:
         # Legacy perf knob removed: Higgs v3 scheduler tokens now come from
@@ -131,6 +133,14 @@ class HiggsAudioV3Config(PretrainedConfig):
         self.audio_continuation_id = audio_continuation_id
         self.enable_flashinfer_api_unwrap = bool(enable_flashinfer_api_unwrap)
         self.enable_mlp_cudagraph = bool(enable_mlp_cudagraph)
+        self.audio_state_step_mode = str(audio_state_step_mode).strip().lower()
+        if self.audio_state_step_mode not in {"legacy", "eager", "compile"}:
+            raise ValueError(
+                f"audio_state_step_mode must be one of legacy/eager/compile, got {self.audio_state_step_mode!r}"
+            )
+        self.audio_sampler_mode = str(audio_sampler_mode).strip().lower()
+        if self.audio_sampler_mode not in {"torch", "flashinfer"}:
+            raise ValueError(f"audio_sampler_mode must be one of torch/flashinfer, got {self.audio_sampler_mode!r}")
 
         super().__init__(**kwargs)
 

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -40,7 +40,7 @@ from vllm.v1.worker.gpu_model_runner import (
 from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 
-from vllm_omni.data_entry_keys import flatten_payload
+from vllm_omni.data_entry_keys import flatten_payload, unflatten_payload
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
@@ -1419,11 +1419,18 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         if spec_decode_metadata is None:
             model_sample = getattr(self.model, "sample", None)
             self.input_batch.update_async_output_token_ids()
-            if logits is not None and callable(model_sample) and getattr(self.model, "prefer_model_sampler", False):
+            supports_logits_free = bool(
+                logits is None and getattr(self.model, "supports_logits_free_model_sampler", False)
+            )
+            if (
+                (logits is not None or supports_logits_free)
+                and callable(model_sample)
+                and getattr(self.model, "prefer_model_sampler", False)
+            ):
                 # Apply logit bias (min_tokens, allowed_token_ids) before
                 # the custom model sampler — the standard GPU sampler does
                 # this internally, but prefer_model_sampler bypasses it.
-                if hasattr(self.sampler, "logit_bias_state"):
+                if logits is not None and hasattr(self.sampler, "logit_bias_state"):
                     self.sampler.logit_bias_state.apply_logit_bias(
                         logits,
                         self.input_batch.expanded_idx_mapping,
@@ -1559,12 +1566,69 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         model = getattr(self, "model", None)
         if not self._model_omni_flag(model, "use_async_omni_output"):
             return False
-        if self._model_omni_flag(model, "has_postprocess") and not self._model_omni_flag(
-            model, "eager_omni_postprocess_before_async_output"
-        ):
-            return False
+        if self._model_omni_flag(model, "has_postprocess"):
+            eager_postprocess = self._model_omni_flag(model, "eager_omni_postprocess_before_async_output")
+            pending_postprocess = self._model_omni_flag(model, "supports_async_omni_postprocess")
+            if not eager_postprocess and not pending_postprocess:
+                return False
 
         return True
+
+    def _take_pending_omni_postprocess(
+        self,
+        req_ids_snapshot: Sequence[str],
+    ) -> tuple[bool, Any]:
+        model = getattr(self, "model", None)
+        if not self._model_omni_flag(model, "supports_async_omni_postprocess"):
+            return False, None
+        take_pending = getattr(model, "take_pending_omni_postprocess", None)
+        if not callable(take_pending):
+            raise RuntimeError(
+                "Model declares supports_async_omni_postprocess but does not implement take_pending_omni_postprocess()"
+            )
+        return True, take_pending(tuple(req_ids_snapshot))
+
+    def _resolve_pending_omni_postprocess(
+        self,
+        pending: Any,
+        *,
+        req_ids_snapshot: Sequence[str],
+        multimodal_outputs: Any,
+    ) -> tuple[bool, Any]:
+        """Resolve one immutable step directly into that step's wire payload.
+
+        The async scheduler may mutate ``self.requests`` and
+        ``model_intermediate_buffer`` while the background output builder is
+        running.  Pending postprocess therefore must not publish through those
+        runner-owned live dictionaries.  Build a dense, request-ordered payload
+        from the launch-time snapshot instead.
+        """
+        if pending is None:
+            # Async-capable models use an empty pending step for prefill/no-op
+            # iterations; do not fall back to their mutable shared postprocess.
+            return True, multimodal_outputs
+        updates_by_req_id = pending.resolve()
+        flat_by_req_id = {
+            req_id: flatten_payload(update) for req_id, update in updates_by_req_id.items() if isinstance(update, dict)
+        }
+        pending_keys = {key for flat in flat_by_req_id.values() for key in flat}
+        if not pending_keys:
+            return True, multimodal_outputs
+
+        merged_flat = dict(flatten_payload(multimodal_outputs)) if isinstance(multimodal_outputs, dict) else {}
+        for key in pending_keys:
+            exemplar = next(flat[key] for flat in flat_by_req_id.values() if key in flat)
+            values = []
+            for req_id in req_ids_snapshot:
+                value = flat_by_req_id.get(req_id, {}).get(key)
+                if value is None:
+                    if isinstance(exemplar, torch.Tensor):
+                        value = exemplar.new_empty(0)
+                    else:
+                        value = None
+                values.append(value)
+            merged_flat[key] = values
+        return True, unflatten_payload(merged_flat)
 
     def _build_omni_async_snapshot_payload(
         self,
@@ -2025,6 +2089,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
 
         use_async_omni_output = self._should_use_async_omni_output()
         omni_postprocess_already_applied = False
+        pending_omni_postprocess_supported = False
+        pending_omni_postprocess = None
         if use_async_omni_output:
             omni_postprocess_already_applied = self._maybe_run_eager_omni_postprocess_before_async_output(
                 hidden_states=hidden_states,
@@ -2034,6 +2100,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 req_ids_output_copy=req_ids_output_copy,
                 query_start_loc_cpu=query_start_loc_cpu,
             )
+            (
+                pending_omni_postprocess_supported,
+                pending_omni_postprocess,
+            ) = self._take_pending_omni_postprocess(req_ids_output_snapshot)
         output_tensor_snapshot = self._snapshot_omni_output_tensors_for_async_output(
             use_async_omni_output=use_async_omni_output,
             hidden_states=hidden_states,
@@ -2045,12 +2115,24 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             if output_tensor_snapshot.async_payload is not None:
                 with record_function_or_nullcontext("omni_async_output:wait_cpu_payload"):
                     output_tensor_snapshot.async_payload.wait()
+            postprocess_already_applied = omni_postprocess_already_applied
+            resolved_multimodal_outputs = output_tensor_snapshot.multimodal_outputs
+            if pending_omni_postprocess_supported:
+                with record_function_or_nullcontext("omni_async_output:resolve_pending_postprocess"):
+                    (
+                        postprocess_already_applied,
+                        resolved_multimodal_outputs,
+                    ) = self._resolve_pending_omni_postprocess(
+                        pending_omni_postprocess,
+                        req_ids_snapshot=req_ids_output_snapshot,
+                        multimodal_outputs=resolved_multimodal_outputs,
+                    )
             with record_function_or_nullcontext("omni_output_builder:total"):
                 return self._build_omni_model_runner_output_from_snapshot(
                     scheduler_output=scheduler_output_snapshot,
                     hidden_states=output_tensor_snapshot.hidden_states,
                     staged_hidden_states_cpu=output_tensor_snapshot.staged_hidden_states_cpu,
-                    multimodal_outputs=output_tensor_snapshot.multimodal_outputs,
+                    multimodal_outputs=resolved_multimodal_outputs,
                     req_ids_output_copy=req_ids_output_snapshot,
                     req_id_to_index_output_copy=req_id_to_index_output_snapshot,
                     valid_sampled_token_ids=valid_sampled_token_ids_snapshot,
@@ -2063,7 +2145,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     kv_extracted_req_ids=kv_extracted_req_ids,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     query_start_loc_cpu=query_start_loc_cpu,
-                    postprocess_already_applied=omni_postprocess_already_applied,
+                    postprocess_already_applied=postprocess_already_applied,
                 )
 
         if not use_async_omni_output:

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1364,13 +1364,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     )
 
                 sample_hidden_states = hidden_states[logits_indices.to(hidden_states.device)]
-                # Try with sampling_metadata first; fall back to without for models that don't support it
-                try:
-                    logits = self.model.compute_logits(
-                        sample_hidden_states, sampling_metadata=self.input_batch.sampling_metadata
-                    )
-                except TypeError:
-                    logits = self.model.compute_logits(sample_hidden_states)
+                logits = self._compute_model_logits(sample_hidden_states, scheduler_output)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
@@ -1387,13 +1381,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     )
                     logits = None
                 else:
-                    # Try with sampling_metadata first; fall back to without for models that don't support it
-                    try:
-                        logits = self.model.compute_logits(
-                            sample_hidden_states, sampling_metadata=self.input_batch.sampling_metadata
-                        )
-                    except TypeError:
-                        logits = self.model.compute_logits(sample_hidden_states)
+                    logits = self._compute_model_logits(sample_hidden_states, scheduler_output)
 
                 model_output_broadcast_data: dict[str, Any] = {}
                 if logits is not None:
@@ -1428,6 +1416,29 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             self._omni_routed_experts_d2h(scheduler_output)
 
         return None
+
+    def _compute_model_logits(
+        self,
+        sample_hidden_states: torch.Tensor,
+        scheduler_output: SchedulerOutput,
+    ) -> torch.Tensor | None:
+        sampling_metadata = self.input_batch.sampling_metadata
+        if getattr(self.model, "supports_force_text_logits", False):
+            return self.model.compute_logits(
+                sample_hidden_states,
+                sampling_metadata=sampling_metadata,
+                force_text_logits=bool(getattr(scheduler_output, "has_structured_output_requests", False)),
+            )
+
+        # Preserve compatibility with models whose compute_logits predates
+        # sampling_metadata support.
+        try:
+            return self.model.compute_logits(
+                sample_hidden_states,
+                sampling_metadata=sampling_metadata,
+            )
+        except TypeError:
+            return self.model.compute_logits(sample_hidden_states)
 
     def _sample(
         self,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -602,6 +602,24 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         model = getattr(self, "model", None)
         return bool(getattr(model, "requires_full_prefix_cached_hidden_states", True))
 
+    def _register_model_request_sampling_seeds(self, scheduler_output: SchedulerOutput) -> None:
+        """Pass serving-owned request seeds to opt-in models at admission."""
+        register = getattr(self.model, "register_request_sampling_seeds", None)
+        if not callable(register):
+            return
+
+        seeds: dict[str, int] = {}
+        for new_req in scheduler_output.scheduled_new_reqs:
+            sampling_params = getattr(new_req, "sampling_params", None)
+            extra_args = getattr(sampling_params, "extra_args", None)
+            if not isinstance(extra_args, dict):
+                continue
+            effective_seed = extra_args.get("tts_effective_seed")
+            if effective_seed is not None:
+                seeds[str(new_req.req_id)] = int(effective_seed)
+        if seeds:
+            register(seeds)
+
     def _get_runner_assisted_full_attention_metadata_request(
         self,
         *,
@@ -1041,6 +1059,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             # Notify model of finished requests for state cleanup
             if scheduler_output.finished_req_ids and hasattr(self.model, "on_requests_finished"):
                 self.model.on_requests_finished(scheduler_output.finished_req_ids)
+            self._register_model_request_sampling_seeds(scheduler_output)
 
             if has_ec_transfer() and not get_ec_transfer().is_consumer:
                 with self.maybe_get_ec_connector_output(

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1922,6 +1922,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 positions=positions,
                 inputs_embeds=inputs_embeds,
                 omni_query_start_loc=model_kwargs_extra.get("omni_query_start_loc"),
+                req_ids=list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
             )
 
         model_output = super()._model_forward(

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1917,12 +1917,15 @@ class OmniGPUModelRunner(GPUModelRunner):
         model_kwargs_extra = self._build_model_kwargs_extra()
         update_decode_metadata = getattr(self.model, "update_decode_step_metadata", None)
         if getattr(self.model, "supports_omni_decode_step_metadata", False) and callable(update_decode_metadata):
+            decode_metadata_kwargs = {}
+            if getattr(self.model, "requires_request_ids_for_decode_state", False):
+                decode_metadata_kwargs["req_ids"] = tuple(self.input_batch.req_ids[: self.input_batch.num_reqs])
             update_decode_metadata(
                 input_ids=input_ids,
                 positions=positions,
                 inputs_embeds=inputs_embeds,
                 omni_query_start_loc=model_kwargs_extra.get("omni_query_start_loc"),
-                req_ids=list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                **decode_metadata_kwargs,
             )
 
         model_output = super()._model_forward(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Higgs Audio V3 high-concurrency decoding previously serialized each GPU step with D2H synchronization, per-request audio postprocessing, and scheduler/output construction. On A100 c64 this left large host-side bubbles and made vLLM-Omni substantially slower than the matched SGL-Omni path.

This PR:

- introduces request-owned decode and sampling state so batch shrink, reorder, finish, cancel, and row reuse do not leak state across requests;
- overlaps step N audio postprocessing with step N+1 launch using request-aware pending handles and double-buffered pinned-host staging;
- adds compiled tensor audio-state updates and a logits-free direct-audio path, while retaining the stock sampler whenever logits-dependent semantics are requested;
- resolves one immutable effective seed per request and binds seed/step state by request ID;
- aligns the high-throughput profile with the validated A100 c64 configuration;
- scopes request-ID snapshots behind `requires_request_ids_for_decode_state`, so the generic runner does not require unrelated models to consume `req_ids`.

## Test Plan

- [x] Run Higgs V3 and runner unit tests on NVIDIA A100.
- [x] Run Seed-TTS unique500, concurrency 64, single-GPU/single-replica throughput tests.
- [x] Compare against latest SGL-Omni with prefix/Radix cache disabled.
- [x] Run Seed-TTS unique64 UTMOS/WER quality validation.
- [x] Verify request reorder, shrink, finish/cancel, row reuse, seed ownership, logits fallback, and request-ID capability behavior.
- [x] Run Ruff, formatting checks on changed files, compileall, and git diff checks.

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 7b42a84aaa6358010e70e9730ce4e79c0836cab3

## Test Result

### Correctness

Final A100 targeted suite:

```text
181 passed, 19 warnings
```

The request-ID capability regression was verified TDD-style: the old generic runner failed with `unexpected keyword argument 'req_ids'`; the capability-gated implementation passes both the generic-model and Higgs snapshot cases.

### Performance

Test setup: NVIDIA A100 80GB, Seed-TTS unique500, concurrency 64, one GPU, one replica, 500 unique prompts, `max_new_tokens=256`, and prefix/Radix cache disabled.

#### PR vs main baseline

| Metric | Main baseline | PR | Absolute diff | Relative diff |
| --- | ---: | ---: | ---: | ---: |
| Audio throughput | 54.9580 audio-s/s | 95.2728 audio-s/s | +40.3148 audio-s/s | **+73.36%** |
| Request throughput | 12.9300 QPS | 22.5510 QPS | +9.6210 QPS | **+74.41%** |

The main result is the matched old-main A100 c64 baseline. The PR result is the mean of three A100 c64 runs on the final request-aware branch.

#### Throughput gain attribution (conditional A/B)

The end-to-end PR-vs-main result is **+73.36% audio-s/s** and **+74.41% QPS**. The A/B results below answer narrower, conditional questions; they are not additive components of the 73.36% total:

| Conditional A/B | Fixed condition | Before | After | Relative diff |
| --- | --- | ---: | ---: | ---: |
| Steady-state codec chunk: 25 → 75 frames | Pending overlap on | 77.050 audio-s/s | 95.819 audio-s/s | **+24.36%** |
| Request-aware pending overlap: off → on | Chunk size 75 | 82.119 audio-s/s | 95.819 audio-s/s | **+16.68%** |
| Audio state update: legacy → compiled | Chunk size 75, overlap on | 92.545 audio-s/s | 95.819 audio-s/s | **+3.54%** |

The denominators differ: the chunk effect was measured with overlap enabled, while the overlap effect was measured only at chunk size 75. Therefore, adding the three percentages (44.58%) or multiplying them (50.24%) is not a valid decomposition of the PR-vs-main gain.

The total PR-vs-main improvement also contains the rest of the optimized path—logits-free text-logit skipping, c64 CUDA Graph coverage, request-owned state and sampling, high-throughput configuration alignment—and interactions between those changes. An exact factorial attribution would additionally require the missing chunk-25/pending-off cell under the same candidate code and configuration; old main is not that cell because it differs in multiple other paths.

The chunk change keeps the initial chunk at one frame and only increases the steady-state chunk to 75 frames, amortizing Stage1 codec invocations, connector traffic, and audio-chunk publication overhead. Pending overlap instead hides the previous step's D2H/event wait and request routing behind the next decode step.

#### PR vs latest SGL-Omni

| Metric | Latest SGL-Omni | PR | PR relative diff |
| --- | ---: | ---: | ---: |
| Audio throughput | 92.4891 audio-s/s | 95.2728 audio-s/s | **+3.01%** |
| Request throughput | 21.7110 QPS | 22.5510 QPS | **+3.87%** |

Both PR and SGL runs completed 500/500 requests per run. The SGL comparison used the latest validated SGL-Omni environment with the same c64 single-replica shape and cache disabled.

### Quality

Seed-TTS unique64:

| Implementation | UTMOS | WER |
| --- | ---: | ---: |
| Main reference | 3.7689 | 0.0558 |
| PR | 4.3761 | 0.0580 |

All 64 PR outputs were finite with normal amplitude. The request-owned seed lifecycle is deterministic, but full c64 byte-for-byte E2E determinism is not claimed because dynamic batch shapes and GPU kernel numerics can still change the autoregressive trajectory.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)


