### PR TITLE
[Bugfix][CI] Relax higgs_audio_v2 PCM streaming HNR threshold (fixes #5045)

### DIFF
--- a/tests/e2e/online_serving/test_higgs_audio_v2_expansion.py
+++ b/tests/e2e/online_serving/test_higgs_audio_v2_expansion.py
@@ -92,6 +92,15 @@ class TestHiggsAudioV2OnlineHappyPath:
         higgs_audio_v2.yaml pins ``codec_streaming: true`` + ``async_chunk: false``,
         so the only streaming surface exposed to clients is the WAV/PCM bytes
         served chunk-by-chunk from Stage 1 — exercise it directly.
+
+        NOTE: ``min_hnr_db=-3.0`` keeps the check as a catastrophic-codec-failure
+        guard (white noise / sample scramble measure around -10 dB) while
+        tolerating Higgs sampling variance: legitimate speech for this prompt
+        measured -1.03 dB on L4 (weekly CI, issue #5045) and 1.34 dB on H100, so
+        the default 1.0 dB threshold flakes on hardware-dependent tail samples.
+        Same rationale as the higgs_audio_v3 streaming thresholds (issue #4411);
+        content correctness is separately guarded by the full_model transcript
+        check.
         """
         openai_client.send_audio_speech_request(
             {
@@ -102,6 +111,7 @@ class TestHiggsAudioV2OnlineHappyPath:
                 "response_format": "pcm",
                 "timeout": DEFAULT_SPEECH_TIMEOUT_S,
                 "min_audio_bytes": _MIN_AUDIO_BYTES,
+                "min_hnr_db": -3.0,
             }
         )
 


### PR DESCRIPTION
### Purpose

Fixes #5045 — weekly CI failed `TestHiggsAudioV2OnlineHappyPath::test_plain_text_pcm_streaming` with `HNR=-1.03 dB < 1.0 dB`.

Per the #4411 investigation this is hardware/seed-dependent sampling variance, not a codec regression: the same request measures **1.34 dB on H100** (only 0.34 dB margin over the default threshold) vs **-1.03 dB on the CI L4**, and the SGLang-Omni reference path produces similar low-HNR tail samples. On the same hardware the value is essentially deterministic (1.34 / 1.35 / 1.35 dB across runs), so L4 weekly runs will keep failing without a threshold adjustment.

`higgs_audio_v3` already carries relaxed per-test thresholds for exactly this reason (`min_hnr_db=0.0` single-request streaming / `-2.0` concurrent, from #4411); the v2 test was missed and still used the global 1.0 dB default.

### Change

Set `min_hnr_db=-3.0` on the v2 plain-text PCM streaming test (one request-config line + NOTE docstring):

- ~2 dB margin over the worst measured legitimate output (-1.03 dB on L4, this CI failure)
- still ~7 dB above the catastrophic-failure region: white noise / sample scramble measure ≈ **-10 dB** with `_compute_pcm_hnr_db`, so the assertion keeps its codec-failure guard function
- content correctness remains guarded by the `full_model` Whisper transcript check

### Test

Reproduced/verified at the failing CI commit `b95905de` with vLLM 0.24.0, using the weekly CI command (`pytest -s -v tests/e2e/online_serving/test_higgs_audio_v2_expansion.py::TestHiggsAudioV2OnlineHappyPath::test_plain_text_pcm_streaming -m "slow and L4 and tts" --run-level full_model`):

| run | threshold | measured HNR | result |
|---|---|---|---|
| before (H100) | 1.0 dB | 1.34 dB | PASSED (0.34 dB margin) |
| CI weekly (L4) | 1.0 dB | -1.03 dB | FAILED |
| after, run 1 (H100) | -3.0 dB | 1.35 dB | PASSED |
| after, run 2 (H100) | -3.0 dB | 1.35 dB | PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)