### PR TITLE
fix(cosmos3): explicitly pass role='self' and role='cross' to Framewo…

### DIFF
--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -540,6 +540,7 @@ class Cosmos3CausalAttention(nn.Module):
             softmax_scale=1.0 / (self.head_dim**0.5),
             num_kv_heads=self.num_kv_heads,
             skip_sequence_parallel=True,
+            role="self",
         )
 
     def forward(
@@ -647,6 +648,7 @@ class Cosmos3CrossAttention(nn.Module):
             causal=False,
             softmax_scale=1.0 / (self.head_dim**0.5),
             num_kv_heads=self.num_kv_heads,
+            role="cross"
         )
 
     # TODO(follow-up): collapse _forward_local and _forward_sp into a single


### PR DESCRIPTION
Cosmos3CausalAttention and Cosmos3CrossAttention both instantiated FrameworkAttention without a **role** argument, causing both to default to role='self'. This prevented per-role backend selection from dispatching cross-attention to its configured backend.

Fixes: 
       role='self' at line 543 (CausalAttention)
       role='cross' at line 651 (CrossAttention)


