### PR TITLE
[BugFix][Diffusion] Preserve image payloads with reasoning metadata

### DIFF
--- a/tests/diffusion/test_diffusion_output_formatter.py
+++ b/tests/diffusion/test_diffusion_output_formatter.py
@@ -241,6 +241,41 @@ def test_formatter_preserves_text_envelope_metadata(monkeypatch: pytest.MonkeyPa
     }
 
 
+@pytest.mark.parametrize(
+    "text_metadata",
+    [
+        pytest.param({"think_text": "reasoning"}, id="sensenova-bagel-thinking"),
+        pytest.param({"ar_generated_text": "reasoning"}, id="hunyuan-image3-cot"),
+    ],
+)
+def test_formatter_preserves_image_with_reasoning_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    text_metadata: dict[str, str],
+) -> None:
+    monkeypatch.setattr(output_formatter, "supports_audio_output", lambda _: False)
+    metadata = {"text": text_metadata}
+    postprocess_output = normalize_diffusion_postprocess_output(
+        {
+            "payload": {"image": "image-0"},
+            "metadata": metadata,
+        }
+    )
+
+    [result] = format_diffusion_outputs(
+        request=_request("generate an image"),
+        od_config=_config(),
+        diffusion_output=DiffusionOutput(output=None),
+        output_data=None,
+        postprocess_output=postprocess_output,
+        timings=_timings(),
+    )
+
+    assert postprocess_output.primary_key == "image"
+    assert result.images == ["image-0"]
+    assert result.final_output_type == "image"
+    assert result.multimodal_output == {"metadata": metadata}
+
+
 def test_formatter_preserves_audio_output_with_model_sample_rate_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -149,10 +149,7 @@ def format_diffusion_outputs(
         "postprocess_time_ms": timings.postprocess_time_s * 1000,
     }
 
-    # Detect text output: when the pipeline returns a string (e.g.,
-    # SenseNova-U1 / BAGEL single-stage img2text / text2text), wrap it
-    # as a text-type response instead of an image.
-    is_text_output = postprocess_output.primary_key == "text" or "text" in postprocess_output.metadata
+    is_text_output = postprocess_output.primary_key == "text"
 
     is_audio_output = supports_audio_output(od_config.model_class_name)
     audio_sample_rate = _metadata_audio_sample_rate(postprocess_output.metadata)

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -149,6 +149,8 @@ def format_diffusion_outputs(
         "postprocess_time_ms": timings.postprocess_time_s * 1000,
     }
 
+    # Only the primary payload determines the response type. Some image models
+    # include reasoning text in metadata, but their final output is still an image.
     is_text_output = postprocess_output.primary_key == "text"
 
     is_audio_output = supports_audio_output(od_config.model_class_name)


### PR DESCRIPTION
Resolves #5209

### Purpose

Fix a bug in `vllm_omni/diffusion/output_formatter.py` where image generation models returning auxiliary reasoning or thinking text in metadata (such as SenseNova-U1, BAGEL and HunyuanImage-3.0 when `--think` or CoT is enabled) were incorrectly misclassified as text-only outputs (`final_output_type="text"`). This caused generated image payloads to be discarded (`images=[]`), leading to `AssertionError: No images generated` in CI offline inference tests (`vllm-omni_build_12389_diffusion-star-h100-star-single-gpu.log`).

### Changes

Updated `is_text_output` in `vllm_omni/diffusion/output_formatter.py` to check `postprocess_output.primary_key == "text"` exclusively:
```diff
diff --git a/vllm_omni/diffusion/output_formatter.py b/vllm_omni/diffusion/output_formatter.py
index a36305fc..35f897b9 100644
--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -149,10 +149,7 @@ def format_diffusion_outputs(
         "postprocess_time_ms": timings.postprocess_time_s * 1000,
     }

-    # Detect text output: when the pipeline returns a string (e.g.,
-    # SenseNova-U1 / BAGEL single-stage img2text / text2text), wrap it
-    # as a text-type response instead of an image.
-    is_text_output = postprocess_output.primary_key == "text" or "text" in postprocess_output.metadata
+    is_text_output = postprocess_output.primary_key == "text"
```

When a model generates an image payload (`payload={"image": img}`) alongside thinking text metadata (`metadata={"text": {"think_text": ...}}`), `primary_key` is `"image"`. Checking `primary_key == "text"` ensures image payloads are preserved (`images=[img]`) while dedicated text-generation modes (`img2text` / `text2text`) continue to be formatted correctly.

### Testplan

1. **Unit Tests**:
   - Added `test_formatter_preserves_image_with_reasoning_metadata` in `tests/diffusion/test_diffusion_output_formatter.py`, parametrized for SenseNova-U1/BAGEL thinking metadata (`{"think_text": ...}`) and HunyuanImage-3.0 CoT metadata (`{"ar_generated_text": ...}`).
   - Command:
     ```bash
     pytest tests/diffusion/test_diffusion_output_formatter.py
     ```

2. **End-to-End Tests**:
   - Verified the two failing SenseNova-U1 e2e offline inference tests:
     ```bash
     pytest -sv \
       tests/e2e/offline_inference/test_sensenova_u1_img2img_expansion.py::test_sensenova_u1_img2img_cache_dit \
       tests/e2e/offline_inference/test_sensenova_u1_text2img_expansion.py::test_sensenova_u1_text2img_cache_dit \
       --run-level "full_model"
     ```
   - **Result**: `2 passed, 17 warnings in 147.07s`.
log: [test_sensenova_failing.log](https://github.com/user-attachments/files/30187755/test_sensenova_failing.log)