### PR TITLE
[Refactor] Use FastAPI SSE utilities for event formatting

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -34,3 +34,5 @@ pydantic-settings>=2.0.0
 # base image does not ship it, so declare it explicitly. The loader also guards
 # this import so a missing gguf no longer breaks all diffusion model loading.
 gguf>=0.10.0
+# Required for fastapi.sse.EventSourceResponse
+fastapi[standard] >= 0.135.0

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -26,6 +26,7 @@ import numpy as np
 import vllm.envs as envs
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, WebSocket
 from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from fastapi.sse import EventSourceResponse
 from PIL import Image
 from pydantic import BaseModel, Field
 from starlette.datastructures import State
@@ -1231,7 +1232,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                             headers=metrics_header(metrics_header_format),
                         )
 
-    return StreamingResponse(content=generator, media_type="text/event-stream")
+    return EventSourceResponse(content=generator)
 
 
 _remove_route_from_router(router, "/v1/audio/speech", {"POST"})
@@ -2286,10 +2287,7 @@ async def edit_images(
                 raw_request=raw_request,
             )
             if stream and not isinstance(generation_result, ErrorResponse):
-                return StreamingResponse(
-                    content=generation_result,
-                    media_type="text/event-stream",
-                )
+                return EventSourceResponse(content=generation_result)
             if isinstance(generation_result, ErrorResponse):
                 raise HTTPException(
                     status_code=generation_result.error.code if generation_result.error else 400,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -12,6 +12,7 @@ from typing import Any, Final, cast
 import jinja2
 import torch
 from fastapi import Request
+from fastapi.sse import format_sse_event
 from openai.types.chat.chat_completion_audio import ChatCompletionAudio as OpenAIChatCompletionAudio
 from PIL import Image
 from pydantic import TypeAdapter
@@ -1438,8 +1439,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         except Exception as e:
             logger.exception("Error in tool parser creation.")
             data = self.create_streaming_error_response(e)
-            yield f"data: {data}\n\n"
-            yield "data: [DONE]\n\n"
+            yield format_sse_event(data_str=data)
+            yield format_sse_event(data_str="[DONE]")
             return
 
         stream_options = request.stream_options
@@ -1523,7 +1524,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             )
 
                         data = chunk.model_dump_json(exclude_unset=True)
-                        yield f"data: {data}\n\n"
+                        yield format_sse_event(data_str=data)
 
                     # Send response to echo the input portion of the
                     # last message
@@ -1556,7 +1557,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                                     )
 
                                 data = chunk.model_dump_json(exclude_unset=True)
-                                yield f"data: {data}\n\n"
+                                yield format_sse_event(data_str=data)
                     first_iteration_dict[final_output_type] = False
 
                 if final_output_type == "text":
@@ -2042,7 +2043,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             )
 
                         data = chunk.model_dump_json(exclude_unset=True)
-                        yield f"data: {data}\n\n"
+                        yield format_sse_event(data_str=data)
 
                 elif final_output_type == "audio":
                     # Observe audio_ttfp_s on first audio packet for this request_id
@@ -2129,7 +2130,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         total_tokens=num_prompt_tokens,
                     )
                     data = chunk.model_dump_json(exclude_unset=True)
-                    yield f"data: {data}\n\n"
+                    yield format_sse_event(data_str=data)
 
                 elif final_output_type == "image":
                     role = self.get_chat_request_role(request)
@@ -2168,7 +2169,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     # of the full generator. TODO (Alex): Add support for usage on all stages for
                     # both streaming and non-streaming.
                     data = chunk.model_dump_json(exclude_unset=True)
-                    yield f"data: {data}\n\n"
+                    yield format_sse_event(data_str=data)
 
                 else:
                     logger.warning(f"Unsupported streaming final output type: {final_output_type}")
@@ -2192,7 +2193,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         model=model_name,
                     )
                     data = stop_chunk.model_dump_json(exclude_unset=True)
-                    yield f"data: {data}\n\n"
+                    yield format_sse_event(data_str=data)
             # Emit audio_underrun_s + audio_continuity_ok_total once per
             # request after the audio chunk stream is exhausted. The
             # captured reference (req_state_audio_ref) outlives the inner
@@ -2233,7 +2234,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     metrics=self._filter_stage_metrics_detail(last_metrics, request),
                 )
                 final_usage_data = final_usage_chunk.model_dump_json(exclude_unset=True, exclude_none=True)
-                yield f"data: {final_usage_data}\n\n"
+                yield format_sse_event(data_str=final_usage_data)
 
             # report to FastAPI middleware aggregate usage across all choices
             num_completion_tokens = sum(previous_num_tokens)
@@ -2268,7 +2269,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 e,
             )
             data = self.create_streaming_error_response(e)
-            yield f"data: {data}\n\n"
+            yield format_sse_event(data_str=data)
             # Actively signal shutdown instead of waiting for the watchdog
             # (5s polling interval).
             if raw_request is not None:
@@ -2279,9 +2280,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         except Exception as e:
             logger.exception("Error in chat completion stream generator.")
             data = self.create_streaming_error_response(e)
-            yield f"data: {data}\n\n"
+            yield format_sse_event(data_str=data)
         # Send the final done message after all response.n are finished
-        yield "data: [DONE]\n\n"
+        yield format_sse_event(data_str="[DONE]")
 
     async def chat_completion_full_generator(
         self,
@@ -3363,7 +3364,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             model=model,
                             metrics=metrics,
                         )
-                        yield f"data: {chunk.model_dump_json()}\n\n"
+                        yield format_sse_event(data_str=chunk.model_dump_json())
                 elif final_output_type == "image":
                     images = self._flatten_diffusion_images(getattr(output.request_output, "images", []))
                     if not images:
@@ -3387,14 +3388,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         model=model,
                         metrics=metrics,
                     )
-                    yield f"data: {chunk.model_dump_json()}\n\n"
+                    yield format_sse_event(data_str=chunk.model_dump_json())
                     emitted_image = True
             if not emitted_image:
                 raise RuntimeError("Streaming image edit completed without a final image output.")
         except EngineDeadError as exc:
             logger.error("EngineDeadError during streaming image edit: %s", exc)
             data = self.create_streaming_error_response(exc)
-            yield f"data: {data}\n\n"
+            yield format_sse_event(data_str=data)
             if raw_request is not None:
                 terminate_if_errored(
                     server=raw_request.app.state.server,
@@ -3416,7 +3417,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     "code": exc.status_code,
                 },
             )
-            yield f"data: {chunk.model_dump_json()}\n\n"
+            yield format_sse_event(data_str=chunk.model_dump_json())
         except Exception as exc:
             logger.exception("Streaming image edit failed: %s", exc)
             chunk = ImageEditStreamError(
@@ -3428,8 +3429,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     "code": 500,
                 },
             )
-            yield f"data: {chunk.model_dump_json()}\n\n"
-        yield "data: [DONE]\n\n"
+            yield format_sse_event(data_str=chunk.model_dump_json())
+        yield format_sse_event(data_str="[DONE]")
 
     @staticmethod
     def _flatten_diffusion_images(images: Any) -> list[Image.Image]:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -20,6 +20,7 @@ import soundfile as sf
 import torch
 from fastapi import HTTPException, Request, UploadFile
 from fastapi.responses import Response, StreamingResponse
+from fastapi.sse import EventSourceResponse, format_sse_event
 from transformers.utils.hub import cached_file
 from vllm.entrypoints.generate.base.serving import GenerateBaseServing as OpenAIServing
 from vllm.entrypoints.launcher import terminate_if_errored
@@ -2484,14 +2485,14 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                     "response_format": response_format,
                 }
                 data = json.dumps(payload, separators=(",", ":"))
-                yield f"event: speech.audio.delta\ndata: {data}\n\n"
+                yield format_sse_event(data_str=data, event="speech.audio.delta")
             done_payload: dict[str, Any] = {"type": "speech.audio.done"}
             if request is not None:
                 # Streaming path: output_tokens = sum of stage-0 deltas.
                 usage = self._build_speech_usage(request, tts_params or {}, usage_acc.total())
                 done_payload["usage"] = usage.model_dump()
             done = json.dumps(done_payload, separators=(",", ":"))
-            yield f"event: speech.audio.done\ndata: {done}\n\n"
+            yield format_sse_event(data_str=done, event="speech.audio.done")
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -2505,7 +2506,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 },
             }
             data = json.dumps(payload, separators=(",", ":"))
-            yield f"event: speech.audio.error\ndata: {data}\n\n"
+            yield format_sse_event(data_str=data, event="speech.audio.error")
 
     @staticmethod
     def _extract_audio_output(res) -> tuple[dict | None, str | None]:
@@ -3838,7 +3839,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                     return error
 
                 _, generator, sse_tts_params = await self._prepare_speech_generation(request, request_id=request_id)
-                return StreamingResponse(
+                return EventSourceResponse(
                     self._generate_audio_sse_events(
                         generator,
                         request_id,
@@ -3848,7 +3849,6 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                         request=request,
                         tts_params=sse_tts_params,
                     ),
-                    media_type="text/event-stream",
                 )
 
             audio_bytes, media_type = await self._generate_audio_bytes(request, request_id=request_id)


### PR DESCRIPTION
## Purpose

Replace hand-rolled SSE string formatting with format_sse_event() from fastapi.sse, and replace StreamingResponse(media_type="text/event-stream") with EventSourceResponse.

Reference: https://github.com/fastapi/fastapi/blob/afe41126/fastapi/sse.py#L20-L33
Reference: https://github.com/fastapi/fastapi/blob/afe41126/fastapi/sse.py#L159-L227

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 0a276f11992fe2ac8679ed5d0124f4abd4ed01b8

```
pytest tests/entrypoints/openai_api/test_serving_speech.py
pytest tests/e2e/online_serving/test_qwen3_omni.py
```

## Test Result

`test_serving_speech.py` passes, doesn't currently have enough GPUs to run `test_qwen3_omni.py`
