### PR TITLE
[Bug] Fix Ming feature extractor/processor registration crash under transformers >= 5.x

### DIFF
--- a/vllm_omni/transformers_utils/processors/ming.py
+++ b/vllm_omni/transformers_utils/processors/ming.py
@@ -24,6 +24,8 @@ from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 from transformers.utils import logging
 
+from vllm_omni.transformers_utils.configs.ming_flash_omni import BailingMM2Config
+
 try:
     from transformers import AutoVideoProcessor
 except ImportError:
@@ -479,5 +481,10 @@ class MingFlashOmniProcessor(ProcessorMixin):
         return list(dict.fromkeys(names))
 
 
-AutoFeatureExtractor.register("MingWhisperFeatureExtractor", MingWhisperFeatureExtractor)
-AutoProcessor.register("MingFlashOmniProcessor", MingFlashOmniProcessor)
+# transformers >= 5.x requires the config *class* (not a string) as the first
+# arg to AutoFeatureExtractor/AutoProcessor.register — it does `key.__module__`
+# internally. Passing "MingWhisperFeatureExtractor" raises:
+#   AttributeError: 'str' object has no attribute '__module__'
+# Same API change as minicpmo_4_5_omni_llm.py / processing_gr00t_n1d7.py.
+AutoFeatureExtractor.register(BailingMM2Config, MingWhisperFeatureExtractor, exist_ok=True)
+AutoProcessor.register(BailingMM2Config, MingFlashOmniProcessor, exist_ok=True)


### PR DESCRIPTION
## Purpose

Registering the Ming feature extractor/processor crashed at import time under transformers >= 5.x (`AttributeError: 'str' object has no attribute '__module__'`). Because it runs at import, it broke loading of unrelated models (e.g. AudioX) in weekly CI.

Fixes #5208

## Test Plan

**vLLM Version:** 0.25.0
**vLLM-Omni Commit:** e24bddfb (branch base)

Relies on the weekly CI e2e tests (`test_audiox_model_expansion.py`); no local GPU available.

## Test Result

Baseline: [#12389](https://buildkite.com/vllm/vllm-omni/builds/12389), the scheduled weekly build on `main` that #5208 was filed from. Build [#12428](https://buildkite.com/vllm/vllm-omni/builds/12428) runs the same weekly pipeline (identical 22 steps), so the two are directly comparable.

The AudioX regression runs inside the `Diffusion · L4` step:

|  | #12389 (`main`) | #12428 (this PR) |
|---|---|---|
| `test_audiox_model[...]` | `ERROR ... Orchestrator initialization failed: 'str' object has no attribute` ← #5208 | gone |
| `test_audiox_t2a_online[t2a]` | `ERROR Server processes exited with code 1` | gone |
| step totals | 12 passed, 2 errors | 19 passed, 5 errors |
| log evidence | `Error in loading model architecture 'AudioXPipeline'` | `[Omni] Initialized with 1 stages for model zhangj1an/audiox_random` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
