### PR TITLE
[Bugfix] Migrate CreateAudio from deprecated class Config to ConfigDict

### DIFF
--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -2,7 +2,7 @@ import math
 from typing import Any, Literal
 
 import numpy as np
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 _MAX_EMBEDDING_DIM = 8192
 
@@ -370,14 +370,13 @@ class OpenAICreateAudioGenerateRequest(BaseModel):
 
 
 class CreateAudio(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     audio_tensor: np.ndarray
     sample_rate: int = 24000
     response_format: str = "wav"
     speed: float = 1.0
     base64_encode: bool = True
-
-    class Config:
-        arbitrary_types_allowed = True
 
 
 class AudioResponse(BaseModel):


### PR DESCRIPTION
## Purpose

Pydantic V2 deprecated class-based `Config` in favor of `model_config = ConfigDict(...)`. This will be removed in Pydantic V3.

Saw this warning while running pytest.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** adb33e317f8148d364fcbb39823a9442ce703574

```
python3 -c "from vllm_omni.entrypoints.openai.protocol.audio import CreateAudio"
```

## Test Result

The class imports.