### PR TITLE
[Refactor] Extract load_callable helper for dynamic loading

### DIFF
--- a/tests/utils/test_dynamic_import.py
+++ b/tests/utils/test_dynamic_import.py
@@ -1,0 +1,51 @@
+import pytest
+
+from vllm_omni.utils.dynamic_import import (
+    load_callable,
+)
+
+# A real callable in the standard library — no vllm_omni import needed.
+_VALID_PATH = "math.sqrt"
+_CTX = "test context"
+
+
+class TestLoadCallable:
+    def test_valid_path_returns_callable(self):
+        import math
+
+        func = load_callable(_VALID_PATH, context=_CTX)
+        assert func is math.sqrt
+
+    def test_no_dot_raises_value_error(self):
+        with pytest.raises(ValueError, match="nodot"):
+            load_callable("nodot", context=_CTX)
+
+    def test_empty_path_raises_value_error(self):
+        with pytest.raises(ValueError):
+            load_callable("", context=_CTX)
+
+    def test_missing_module_raises_import_error(self):
+        with pytest.raises(ImportError, match="nonexistent_module_xyz_abc"):
+            load_callable("nonexistent_module_xyz_abc.some_func", context=_CTX)
+
+    def test_missing_attr_raises_attribute_error(self):
+        with pytest.raises(AttributeError, match="nonexistent_func_xyz_abc"):
+            load_callable("math.nonexistent_func_xyz_abc", context=_CTX)
+
+    def test_not_callable_raises_type_error(self):
+        with pytest.raises(TypeError, match="float"):
+            load_callable("math.pi", context=_CTX)
+
+    @pytest.mark.parametrize(
+        "bad_path,exc_type",
+        [
+            ("nodot", ValueError),
+            ("nonexistent_module_xyz_abc.func", ImportError),
+            ("math.nonexistent_func_xyz_abc", AttributeError),
+            ("math.pi", TypeError),
+        ],
+    )
+    def test_context_appears_in_every_error_message(self, bad_path, exc_type):
+        ctx = "stage 1 custom_process_input_func"
+        with pytest.raises(exc_type, match="stage 1"):
+            load_callable(bad_path, context=ctx)

--- a/tests/utils/test_dynamic_import.py
+++ b/tests/utils/test_dynamic_import.py
@@ -24,28 +24,28 @@ class TestLoadCallable:
         with pytest.raises(ValueError):
             load_callable("", context=_CTX)
 
-    def test_missing_module_raises_import_error(self):
-        with pytest.raises(ImportError, match="nonexistent_module_xyz_abc"):
+    def test_missing_module_raises_value_error(self):
+        with pytest.raises(ValueError, match="nonexistent_module_xyz_abc"):
             load_callable("nonexistent_module_xyz_abc.some_func", context=_CTX)
 
-    def test_missing_attr_raises_attribute_error(self):
-        with pytest.raises(AttributeError, match="nonexistent_func_xyz_abc"):
+    def test_missing_attr_raises_value_error(self):
+        with pytest.raises(ValueError, match="nonexistent_func_xyz_abc"):
             load_callable("math.nonexistent_func_xyz_abc", context=_CTX)
 
-    def test_not_callable_raises_type_error(self):
-        with pytest.raises(TypeError, match="float"):
+    def test_not_callable_raises_value_error(self):
+        with pytest.raises(ValueError, match="float"):
             load_callable("math.pi", context=_CTX)
 
     @pytest.mark.parametrize(
-        "bad_path,exc_type",
+        "bad_path",
         [
-            ("nodot", ValueError),
-            ("nonexistent_module_xyz_abc.func", ImportError),
-            ("math.nonexistent_func_xyz_abc", AttributeError),
-            ("math.pi", TypeError),
+            "nodot",
+            "nonexistent_module_xyz_abc.func",
+            "math.nonexistent_func_xyz_abc",
+            "math.pi",
         ],
     )
-    def test_context_appears_in_every_error_message(self, bad_path, exc_type):
+    def test_context_appears_in_every_error_message(self, bad_path):
         ctx = "stage 1 custom_process_input_func"
-        with pytest.raises(exc_type, match="stage 1"):
+        with pytest.raises(ValueError, match="stage 1"):
             load_callable(bad_path, context=ctx)

--- a/vllm_omni/diffusion/attention/selector.py
+++ b/vllm_omni/diffusion/attention/selector.py
@@ -10,7 +10,6 @@ This module resolves diffusion attention backends from:
 
 from __future__ import annotations
 
-import importlib
 from functools import cache
 from typing import TYPE_CHECKING
 
@@ -19,6 +18,7 @@ from vllm.logger import init_logger
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionBackend,
 )
+from vllm_omni.utils.dynamic_import import load_callable
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
@@ -36,15 +36,7 @@ def _load_backend_cls(cls_path: str) -> type[AttentionBackend]:
     Returns:
         The loaded backend class
     """
-    module_path, class_name = cls_path.rsplit(".", 1)
-    try:
-        module = importlib.import_module(module_path)
-        backend_class = getattr(module, class_name)
-        return backend_class
-    except ImportError as e:
-        raise ImportError(f"Failed to import module {module_path}: {e}")
-    except AttributeError as e:
-        raise AttributeError(f"Class {class_name} not found in module: {e}")
+    return load_callable(cls_path, context=f"diffusion attention backend {cls_path!r}")
 
 
 @cache

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -17,7 +17,6 @@ import numpy as np
 import PIL.Image
 import torch
 from vllm.logger import init_logger
-from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.diffusion.data import (
@@ -50,6 +49,7 @@ from vllm_omni.diffusion.sched.interface import DiffusionRequestStatus
 from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput, RunnerOutput
 from vllm_omni.errors import client_error_from_metadata, is_client_error_status
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
+from vllm_omni.utils.dynamic_import import load_callable
 
 if TYPE_CHECKING:
     from vllm_omni.outputs import OmniRequestOutput
@@ -88,10 +88,10 @@ def _resolve_custom_pipeline_cls(custom_pipeline_args: dict[str, Any] | None) ->
     if isinstance(pipeline_cls, type):
         return pipeline_cls
     if isinstance(pipeline_cls, str):
-        try:
-            return resolve_obj_by_qualname(pipeline_cls)
-        except (AttributeError, ImportError, ValueError) as exc:
-            raise ValueError(f"Failed to resolve custom diffusion pipeline class {pipeline_cls!r}.") from exc
+        return load_callable(
+            pipeline_cls,
+            context="_resolve_custom_pipeline_cls pipeline_class",
+        )
     raise TypeError(
         f"custom_pipeline_args['pipeline_class'] must be a qualified name string or a class, "
         f"got {type(pipeline_cls).__name__}"
@@ -640,12 +640,10 @@ class DiffusionEngine:
         if backend == "default":
             return DiffusionEngine
         if isinstance(backend, str):
-            try:
-                engine_class = resolve_obj_by_qualname(backend)
-            except (ImportError, ValueError) as e:
-                raise ValueError(
-                    f"Failed to load engine_backend '{backend}'. Ensure it is a valid python path. Error: {e}"
-                ) from e
+            engine_class = load_callable(
+                backend,
+                context="DiffusionEngine.resolve_engine_class engine_backend",
+            )
             if not issubclass(engine_class, DiffusionEngine):
                 raise TypeError(f"engine_backend must resolve to a DiffusionEngine subclass. Got {engine_class}.")
             return engine_class

--- a/vllm_omni/diffusion/executor/abstract.py
+++ b/vllm_omni/diffusion/executor/abstract.py
@@ -4,9 +4,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from vllm.utils.import_utils import resolve_obj_by_qualname
-
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.utils.dynamic_import import load_callable
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
@@ -43,13 +42,10 @@ class DiffusionExecutor(ABC):
         elif distributed_executor_backend == "external_launcher":
             raise NotImplementedError("external_launcher backend is not yet supported.")
         elif isinstance(distributed_executor_backend, str):
-            try:
-                executor_class = resolve_obj_by_qualname(distributed_executor_backend)
-            except (ImportError, ValueError) as e:
-                raise ValueError(
-                    f"Failed to load executor backend '{distributed_executor_backend}'. "
-                    f"Ensure it is a valid python path. Error: {e}"
-                ) from e
+            executor_class = load_callable(
+                distributed_executor_backend,
+                context="DiffusionExecutor.__init__ distributed_executor_backend",
+            )
 
             if not issubclass(executor_class, DiffusionExecutor):
                 raise TypeError(

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -26,7 +26,6 @@ from vllm.model_executor.model_loader.weight_utils import (
     safetensors_weights_iterator,
 )
 from vllm.transformers_utils.repo_utils import file_exists
-from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 from vllm_omni.diffusion.config import set_current_diffusion_config
@@ -38,6 +37,7 @@ from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
 from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import DiffusersAdapterPipeline
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 from vllm_omni.diffusion.registry import initialize_model
+from vllm_omni.utils.dynamic_import import load_callable
 
 
 # download_gguf was removed from upstream vLLM (commit 6635279d8).
@@ -96,7 +96,10 @@ def _resolve_custom_pipeline_cls(custom_pipeline_name: str | type | None) -> typ
     if custom_pipeline_name is None:
         raise ValueError("custom_pipeline_name is required for load_format='custom_pipeline'")
     if isinstance(custom_pipeline_name, str):
-        return resolve_obj_by_qualname(custom_pipeline_name)
+        return load_callable(
+            custom_pipeline_name,
+            context="_resolve_custom_pipeline_cls custom_pipeline_name",
+        )
     if isinstance(custom_pipeline_name, type):
         return custom_pipeline_name
     raise TypeError(

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import importlib
 
 import torch.nn as nn
 from vllm.logger import init_logger
@@ -16,6 +15,7 @@ from vllm_omni.diffusion.forward_context import get_forward_context
 from vllm_omni.diffusion.hooks.sequence_parallel import apply_sequence_parallel
 from vllm_omni.diffusion.utils.tf_utils import find_module_with_attr
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.utils.dynamic_import import load_callable
 
 logger = init_logger(__name__)
 
@@ -653,8 +653,10 @@ def _load_process_func(od_config: OmniDiffusionConfig, func_name: str):
     else:
         # Built-in model (relative path convention)
         module_name = f"vllm_omni.diffusion.models.{mod_folder}.{mod_relname}"
-    module = importlib.import_module(module_name)
-    func = getattr(module, func_name)
+    func = load_callable(
+        f"{module_name}.{func_name}",
+        context=f"_load_process_func({od_config.model_class_name!r}) {func_name}",
+    )
     return func(od_config)
 
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -25,7 +25,6 @@ from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 from vllm.logger import init_logger
 from vllm.profiler.wrapper import CudaProfilerWrapper, WorkerProfiler
 from vllm.transformers_utils.config import get_hf_text_config
-from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.mem_utils import GiB_bytes
 from vllm.v1.worker.workspace import init_workspace_manager
 
@@ -53,6 +52,7 @@ from vllm_omni.engine.stage_init_utils import set_death_signal
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.profiler import OmniTorchProfilerWrapper, create_omni_profiler
+from vllm_omni.utils.dynamic_import import load_callable
 from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
 logger = init_logger(__name__)
@@ -239,7 +239,9 @@ class DiffusionWorker:
             model_runner_cls_path = engine_runner
         else:
             model_runner_cls_path = current_omni_platform.get_diffusion_model_runner_cls()
-        model_runner_cls = resolve_obj_by_qualname(model_runner_cls_path)
+        model_runner_cls = load_callable(
+            model_runner_cls_path, context="DiffusionWorker.__init__(rank={self.rank}) diffusion_model_runner_cls"
+        )
         self.model_runner = model_runner_cls(
             vllm_config=self.vllm_config,
             od_config=self.od_config,
@@ -795,7 +797,10 @@ class WorkerProc:
     ) -> DiffusionWorker:
         """Create a worker instance. Override in subclasses for different worker types."""
         worker_cls_path = current_omni_platform.get_diffusion_worker_cls()
-        base_worker_class = resolve_obj_by_qualname(worker_cls_path)
+        base_worker_class = load_callable(
+            worker_cls_path,
+            context="WorkerProc._create_worker diffusion_worker_cls",
+        )
         wrapper = WorkerWrapperBase(
             gpu_id=gpu_id,
             od_config=od_config,
@@ -1102,7 +1107,10 @@ class WorkerWrapperBase:
 
         if self.worker_extension_cls:
             if isinstance(self.worker_extension_cls, str):
-                worker_extension_cls = resolve_obj_by_qualname(self.worker_extension_cls)
+                worker_extension_cls = load_callable(
+                    self.worker_extension_cls,
+                    context="WorkerWrapperBase._prepare_worker_class worker_extension_cls",
+                )
             else:
                 worker_extension_cls = self.worker_extension_cls
             extended_calls = []

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import importlib
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping
 from typing import Any
@@ -10,6 +9,7 @@ import torch
 from vllm.v1.request import Request, RequestStatus
 
 from vllm_omni.data_entry_keys import MetaStruct, OmniPayloadStruct, unflatten_payload
+from vllm_omni.utils.dynamic_import import load_callable
 
 from ..adapter import construct_next_stage_streaming_input_prompt
 from ..factory import OmniConnectorFactory
@@ -62,9 +62,10 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         self.custom_process_next_stage_input_func: Callable[..., OmniPayloadStruct | None] | None = None
         custom_process_next_stage_input_func = getattr(model_config, "custom_process_next_stage_input_func", None)
         if custom_process_next_stage_input_func:
-            module_path, func_name = custom_process_next_stage_input_func.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            self.custom_process_next_stage_input_func = getattr(module, func_name)
+            self.custom_process_next_stage_input_func = load_callable(
+                custom_process_next_stage_input_func,
+                context="OmniChunkTransferAdapter.__init__ custom_process_next_stage_input_func",
+            )
         # mapping for request id and chunk id
         self.put_req_chunk: dict[str, int] = defaultdict(int)
         self.get_req_chunk: dict[str, int] = defaultdict(int)

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -9,7 +9,6 @@ out of StageEngineCoreClient into reusable functions.
 from __future__ import annotations
 
 import fcntl
-import importlib
 import multiprocessing as mp
 import os
 import time
@@ -34,6 +33,7 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParam
 from vllm_omni.inputs.preprocess import OmniInputPreprocessor
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization.inc_config import OmniINCConfig
+from vllm_omni.utils.dynamic_import import load_callable
 
 logger = init_logger(__name__)
 
@@ -377,20 +377,26 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
     custom_process_input_func: Callable | None = None
     _cpif_path = getattr(stage_config, "custom_process_input_func", None)
     if _cpif_path:
-        mod_path, fn_name = _cpif_path.rsplit(".", 1)
-        custom_process_input_func = getattr(importlib.import_module(mod_path), fn_name)
+        custom_process_input_func = load_callable(
+            _cpif_path,
+            context=f"stage {stage_id} custom_process_input_func",
+        )
 
     prompt_expand_func: Callable | None = None
     _pef_path = getattr(stage_config, "prompt_expand_func", None)
     if _pef_path:
-        _mod, _fn = _pef_path.rsplit(".", 1)
-        prompt_expand_func = getattr(importlib.import_module(_mod), _fn)
+        prompt_expand_func = load_callable(
+            _pef_path,
+            context=f"stage {stage_id} prompt_expand_func",
+        )
 
     cfg_kv_collect_func: Callable | None = None
     _ckf_path = getattr(stage_config, "cfg_kv_collect_func", None)
     if _ckf_path:
-        _mod, _fn = _ckf_path.rsplit(".", 1)
-        cfg_kv_collect_func = getattr(importlib.import_module(_mod), _fn)
+        cfg_kv_collect_func = load_callable(
+            _ckf_path,
+            content=f"stage {stage_id} cfg_kv_collect_func",
+        )
 
     model_stage = getattr(engine_args, "model_stage", None)
 

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -379,7 +379,7 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
     if _cpif_path:
         custom_process_input_func = load_callable(
             _cpif_path,
-            context=f"stage {stage_id} custom_process_input_func",
+            context=f"extract_stage_metadata stage {stage_id} custom_process_input_func",
         )
 
     prompt_expand_func: Callable | None = None
@@ -387,7 +387,7 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
     if _pef_path:
         prompt_expand_func = load_callable(
             _pef_path,
-            context=f"stage {stage_id} prompt_expand_func",
+            context=f"extract_stage_metadata stage {stage_id} prompt_expand_func",
         )
 
     cfg_kv_collect_func: Callable | None = None
@@ -395,7 +395,7 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
     if _ckf_path:
         cfg_kv_collect_func = load_callable(
             _ckf_path,
-            content=f"stage {stage_id} cfg_kv_collect_func",
+            content=f"extract_stage_metadata stage {stage_id} cfg_kv_collect_func",
         )
 
     model_stage = getattr(engine_args, "model_stage", None)

--- a/vllm_omni/utils/dynamic_import.py
+++ b/vllm_omni/utils/dynamic_import.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vllm.utils.import_utils import resolve_obj_by_qualname
+
+
+def load_callable(path: str, *, context: str) -> Callable:
+    """Load a callable from a dotted path string.
+
+    This is the single approved entry point for user-configured dotted paths
+    (stage hooks, connector builders, diffusion registry functions, etc.).
+
+    Args:
+        path: Fully qualified dotted path, e.g. "my.module.my_func".
+        context: Human-readable description of what is being loaded,
+                 used in error messages.
+
+    Returns:
+        The resolved callable.
+    """
+    if not path or "." not in path:
+        raise ValueError(f"[{context}] Invalid dotted path {path!r}: expected 'package.module.callable_name'")
+    try:
+        obj = resolve_obj_by_qualname(path)
+    except ImportError as e:
+        raise ImportError(f"[{context}] Cannot import module from path {path!r}: {e}") from e
+    except AttributeError as e:
+        raise AttributeError(f"[{context}] Attribute not found in path {path!r}: {e}") from e
+
+    if not callable(obj):
+        raise TypeError(f"[{context}] {path!r} resolved to {type(obj).__name__}, expected a callable")
+    return obj

--- a/vllm_omni/utils/dynamic_import.py
+++ b/vllm_omni/utils/dynamic_import.py
@@ -23,11 +23,8 @@ def load_callable(path: str, *, context: str) -> Callable:
         raise ValueError(f"[{context}] Invalid dotted path {path!r}: expected 'package.module.callable_name'")
     try:
         obj = resolve_obj_by_qualname(path)
-    except ImportError as e:
-        raise ImportError(f"[{context}] Cannot import module from path {path!r}: {e}") from e
-    except AttributeError as e:
-        raise AttributeError(f"[{context}] Attribute not found in path {path!r}: {e}") from e
-
+    except (ImportError, AttributeError, ValueError) as e:
+        raise ValueError(f"[{context}] Failed to load {path!r}: {e}") from e
     if not callable(obj):
-        raise TypeError(f"[{context}] {path!r} resolved to {type(obj).__name__}, expected a callable")
+        raise ValueError(f"[{context}] {path!r} resolved to {type(obj).__name__}, expected a callable")
     return obj

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -28,6 +28,7 @@ from vllm_omni.data_entry_keys import OmniPayload
 from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory
 from vllm_omni.distributed.omni_connectors.utils.config import ConnectorSpec
 from vllm_omni.outputs import OmniConnectorOutput
+from vllm_omni.utils.dynamic_import import load_callable
 from vllm_omni.worker.payload_span import (
     get_tensor_span,
     merge_tensor_spans,
@@ -2196,20 +2197,20 @@ class OmniConnectorModelRunnerMixin:
                 continue
             tried.add(func_path)
             try:
-                module_path, func_name = func_path.rsplit(".", 1)
-                module = importlib.import_module(module_path)
-                func = getattr(module, func_name, None)
-                if callable(func):
-                    if not OmniConnectorModelRunnerMixin._is_connector_payload_builder(func):
-                        logger.debug(
-                            "Skipping incompatible connector payload hook %s; signature=%s",
-                            func_path,
-                            inspect.signature(func),
-                        )
-                        continue
-                    return func_path, func
-            except Exception:
+                func = load_callable(func_path, context=f"_load_connector_payload_builder {func_path!r}")
+            except ValueError:
+                # candidates may include derived probe paths (e.g. _full_payload, _batch
+                # suffixes) that are not guaranteed to exist; silently skip missing ones.
                 logger.warning("Failed to load custom func: %s", func_path, exc_info=True)
+                continue
+            if not OmniConnectorModelRunnerMixin._is_connector_payload_builder(func):
+                logger.debug(
+                    "Skipping incompatible connector payload hook %s; signature=%s",
+                    func_path,
+                    inspect.signature(func),
+                )
+                continue
+            return func_path, func
 
         return None, None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

#5198 Extract load_callable helper, unify error handling for dynamic loading.

## Changes

- Add `load_callable(path: str, *, context: str) -> Callable` and corresponding tests
- Migrate hook / connector / registry dynamic loading to use it

## Test Plan
```text
pytest -sv \
  tests/utils/test_dynamic_import.py \
  tests/ar_diffusion/test_engine_routing.py \
  tests/distributed/omni_connectors/test_chunk_transfer_adapter.py \
  tests/worker/test_omni_connector_mixin.py \
  tests/engine/test_async_omni_engine_stage_init.py
```

## Test Result
```text
...
tests/engine/test_async_omni_engine_stage_init.py::test_port_from_zmq_address_parsing --- Running test: test_port_from_zmq_address_parsing
PASSED

=========================================================== warnings summary ============================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../.venv/vllm-omni/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/mrdong/.venv/vllm-omni/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=================================================== 147 passed, 16 warnings in 3.42s ====================================================
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
