### PR TITLE
[Bugfix] Disable async scheduling for Step-Audio2 tests

### DIFF
--- a/tests/e2e/offline_inference/stage_configs/step_audio2_ci.yaml
+++ b/tests/e2e/offline_inference/stage_configs/step_audio2_ci.yaml
@@ -15,6 +15,7 @@ stage_args:
       tensor_parallel_size: 1
       worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
       scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      async_scheduling: false
       max_model_len: 4096
       max_num_batched_tokens: 4096
       max_num_seqs: 1


### PR DESCRIPTION
## Purpose

### What broke

The Step-Audio2 offline and online E2E tests fail with a `KeyError` in
`vllm_omni/worker/gpu_model_runner.py` while updating cached request state.

### Reproduction

```bash
python -m pytest -s -vv --run-level advanced_model \
  tests/e2e/offline_inference/test_step_audio2_expansion.py

python -m pytest -s -vv --run-level advanced_model \
  tests/e2e/online_serving/test_step_audio2_expansion.py
```

### Root cause

The Step-Audio2 pipeline uses custom Omni schedulers that are not compatible
with vLLM asynchronous scheduling. Enabling both causes cached request token
state to become inconsistent with the scheduler output.

### Fix

Disable asynchronous scheduling for the Step-Audio2 offline stage and both
online serving stages. This only changes the Step-Audio2 CI stage
configurations; runtime implementation code is unchanged.

Fixes #5207

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 109942465fa4d8e140f9ccac3430bfd90b7cf6de

**Hardware:** 2 x NVIDIA GeForce RTX 4090 (24 GB)

## Test Result

```text
tests/e2e/offline_inference/test_step_audio2_expansion.py
2 passed, 14 warnings in 36.33s

tests/e2e/online_serving/test_step_audio2_expansion.py
3 passed, 14 warnings in 204.34s
```
