### PR TITLE
ci: fix flashinfer-cubin 0.6.14 install by adding flashinfer.ai extra index

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -40,9 +40,12 @@ RUN VLLM_WHEEL_URL=$(python3 -c "import urllib.request,re; \
 
 RUN uv pip install --system ".[dev]"
 
+# flashinfer-cubin is not published on PyPI since 0.6.14 — only on the
+# flashinfer.ai index (see vLLM ba47bb5be / PR #47669, requirements/cuda.txt).
 RUN uv pip install --system --upgrade \
         "flashinfer-python==0.6.14" \
-        "flashinfer-cubin==0.6.14"
+        "flashinfer-cubin==0.6.14" \
+        --extra-index-url https://flashinfer.ai/whl/
 
 RUN uv pip install --system --upgrade \
     "flashinfer-jit-cache==0.6.14" \


### PR DESCRIPTION
## Problem

Nightly align image builds fail at the flashinfer install layer of `docker/Dockerfile.ci` (first surfaced in [build 2803](https://buildkite.com/vllm/vllm-omni-rebase/builds/2803)):

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of flashinfer-cubin==0.6.14 ...
```

`flashinfer-cubin` stopped publishing to PyPI at 0.6.14 — its latest PyPI release is 0.6.13. The 2026-07-18 pin sync (8508bf5c) copied upstream's 0.6.14 version bump but not the index change that came with it: upstream vLLM (ba47bb5be, vllm-project/vllm#47669, now on `releases/v0.26.0`) installs cubin via `--extra-index-url https://flashinfer.ai/whl/`, where the 0.6.14 wheel exists.

The July 18–20 nightlies never reached the image step (they failed earlier at Load pipeline), which is why this only surfaced on 7/21.

## Fix

Add `--extra-index-url https://flashinfer.ai/whl/` to the cubin/python install layer, matching upstream. Pins stay at 0.6.14.

## Verification

`uv pip install --dry-run "flashinfer-python==0.6.14" "flashinfer-cubin==0.6.14" --extra-index-url https://flashinfer.ai/whl/` resolves both (cubin from flashinfer.ai, python from PyPI). The `flashinfer-jit-cache==0.6.14` layer below already uses the cu130 index and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)