### PR TITLE
[BugFix] Hunyuan image3 ar2dit text gen fix

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
@@ -498,20 +498,24 @@ def test_build_multistage_generation_inputs_sets_ar_stop_token_ids_with_explicit
     assert getattr(diff_params, "stop_token_ids", None) is None, "Diffusion stage must not have stop_token_ids set"
 
 
-def test_build_multistage_generation_inputs_no_stop_token_ids_without_size(serving_chat):
+def test_build_multistage_generation_inputs_plain_mode_still_sets_ratio_stop_tokens(serving_chat):
     """Without height+width, ar_image_size=None -> need_ratio=True ->
     stop_token_ids is set to the ratio range (AR predicts ratio).
     This still assigns stop_token_ids, but the set is the ratio range,
     not the terminator.
 
-    Without bot_task at all, ar_stop_token_ids stays None and
-    stop_token_ids is not set on any stage.
+    Without bot_task, Hunyuan plain mode still needs ratio stop tokens
+    so generation ends after selecting the output aspect ratio.
     """
     from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 
     engine = SimpleNamespace(
         stage_configs=[
-            SimpleNamespace(stage_type="llm", is_comprehension=True),
+            SimpleNamespace(
+                stage_type="llm",
+                is_comprehension=True,
+                engine_args=SimpleNamespace(model_arch="HunyuanImage3ForCausalMM"),
+            ),
             SimpleNamespace(stage_type="diffusion", is_comprehension=False),
         ],
         default_sampling_params_list=[
@@ -521,9 +525,7 @@ def test_build_multistage_generation_inputs_no_stop_token_ids_without_size(servi
     )
     images = [Image.new("RGB", (32, 32), color="red")]
 
-    # No height/width, no bot_task -> ar_stop_token_ids=None ->
-    # stop_token_ids not set on any stage.
-    _, sampling_params_list = OmniOpenAIServingChat._build_multistage_generation_inputs(
+    engine_prompt, sampling_params_list = OmniOpenAIServingChat._build_multistage_generation_inputs(
         serving_chat,
         engine=engine,
         prompt="draw a cat",
@@ -532,9 +534,7 @@ def test_build_multistage_generation_inputs_no_stop_token_ids_without_size(servi
         gen_params=OmniDiffusionSamplingParams(),
     )
 
-    # SamplingParams defaults stop_token_ids=[], not None.
-    # The key contract: it was NOT set by resolve_stop_token_ids,
-    # so it stays as the SamplingParams default (empty list).
-    assert sampling_params_list[0].stop_token_ids == [], (
-        "Without bot_task, AR stage stop_token_ids must be the default empty list"
-    )
+    assert engine_prompt["prompt"].endswith("\n\nAssistant: ")
+    assert "bot_task" not in engine_prompt
+    assert len(sampling_params_list[0].stop_token_ids) == 37
+    assert getattr(sampling_params_list[1], "stop_token_ids", None) is None

--- a/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
+++ b/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
@@ -40,9 +40,37 @@ def test_extract_ratio_index_uses_fixed_special_token_ids():
     assert _extract_ratio_index([1, ratio_33, 2, ratio_36]) == 36
 
 
-def test_truncate_at_cot_end_strips_tail_after_recaption_marker():
-    text = _truncate_at_cot_end("body text</recaption><answer><boi><img_size_1024><img_ratio_0>")
-    assert text == "body text</recaption>"
+@pytest.mark.parametrize(
+    ("bot_task", "generated_text", "expected"),
+    [
+        (
+            "think",
+            "thought</think><answer><boi><img_size_1024><img_ratio_0>",
+            "<think>thought</think>",
+        ),
+        (
+            "recaption",
+            "caption</recaption><answer><boi><img_size_1024><img_ratio_0>",
+            "<recaption>caption</recaption>",
+        ),
+        (
+            "think_recaption",
+            "thought</think><recaption>caption</recaption><answer>",
+            "<think>thought</think><recaption>caption</recaption>",
+        ),
+        (
+            None,
+            "<answer><boi><img_size_1024><img_ratio_0>",
+            "",
+        ),
+    ],
+)
+def test_truncate_at_cot_end_matches_bot_task(
+    bot_task: str | None,
+    generated_text: str,
+    expected: str,
+):
+    assert _truncate_at_cot_end(generated_text, bot_task=bot_task) == expected
 
 
 def test_ar2diffusion_returns_one_request_payload_for_request_level_batching():
@@ -58,14 +86,14 @@ def test_ar2diffusion_returns_one_request_payload_for_request_level_batching():
 def test_ar2diffusion_uses_parent_output_when_companions_are_present():
     result = ar2diffusion(
         [
-            _source_output([100], text="parent thought"),
+            _source_output([100], text="parent thought</think><answer>"),
             _source_output([200], text="companion thought"),
         ],
-        prompt={"prompt": "edit"},
+        prompt={"prompt": "edit", "bot_task": "think"},
     )
 
     assert result is not None
-    assert result["extra"]["ar_generated_text"] == "parent thought"
+    assert result["extra"]["ar_generated_text"] == "<think>parent thought</think>"
 
 
 def test_ar2diffusion_returns_none_without_parent_output():
@@ -90,13 +118,13 @@ def test_ar2diffusion_applies_ratio_and_truncates_tail_without_tokenizer(monkeyp
     token_ids = [100, 101, end_recaption, answer, boi, size, ratio_0]
 
     result = ar2diffusion(
-        [_source_output(token_ids, text="decoded without special tokens")],
-        prompt=[{"prompt": "edit", "height": 64, "width": 64}],
+        [_source_output(token_ids, text="caption</recaption><answer>")],
+        prompt=[{"prompt": "edit", "height": 64, "width": 64, "bot_task": "recaption"}],
     )
 
     assert result is not None
     assert (result["height"], result["width"]) == (512, 2048)
-    assert result["extra"]["ar_generated_text"] == "decoded without special tokens"
+    assert result["extra"]["ar_generated_text"] == "<recaption>caption</recaption>"
     assert "ar_token_ids" not in result["extra"]
 
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1831,7 +1831,7 @@ async def generate_images(
                     status_code=generation_result.error.code if generation_result.error else 400,
                     content=generation_result.model_dump(),
                 )
-            flat_images, stage_durations, peak_memory_mb, _ = generation_result
+            flat_images, stage_durations, peak_memory_mb, cot_output = generation_result
             image_data = [ImageData(b64_json=encode_image_base64(img), revised_prompt=None) for img in flat_images]
 
             return ImageGenerationResponse(
@@ -1841,7 +1841,10 @@ async def generate_images(
                     "stage_durations": stage_durations or None,
                     "peak_memory_mb": float(peak_memory_mb) if peak_memory_mb else None,
                 },
+                cot_output=cot_output,
             )
+
+            return ImageGenerationResponse(created=int(time.time()), data=image_data, cot_output=cot_output)
 
         # Build params - pass through user values directly
         prompt: OmniTextPrompt = {"prompt": request.prompt, "modalities": ["image"]}

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3295,35 +3295,23 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         peak_memory_mb = result.peak_memory_mb
         cot_output = None
 
-        req_out = getattr(result, "request_output", None)
-        if req_out:
-            prompt_obj = getattr(req_out, "prompt", None)
-            if isinstance(prompt_obj, dict):
-                extra = prompt_obj.get("extra", {})
-                if isinstance(extra, dict):
-                    ar_text = extra.get("ar_generated_text")
-                    if isinstance(ar_text, str) and ar_text.strip():
-                        cot_output = ar_text
-
-        req_out = getattr(result, "request_output", None)
-        if req_out:
-            prompt_obj = getattr(req_out, "prompt", None)
-            if isinstance(prompt_obj, dict):
-                extra = prompt_obj.get("extra", {})
-                if isinstance(extra, dict):
-                    ar_text = extra.get("ar_generated_text")
-                    if isinstance(ar_text, str) and ar_text.strip():
-                        cot_output = ar_text
-
-        req_out = getattr(result, "request_output", None)
-        if req_out:
-            prompt_obj = getattr(req_out, "prompt", None)
-            if isinstance(prompt_obj, dict):
-                extra = prompt_obj.get("extra", {})
-                if isinstance(extra, dict):
-                    ar_text = extra.get("ar_generated_text")
-                    if isinstance(ar_text, str) and ar_text.strip():
-                        cot_output = ar_text
+        # Only return CoT text when the caller explicitly requested it
+        # (bot_task=think/recaption/think_recaption).  In plain mode
+        # (bot_task omitted or None) the AR generates only image-structure
+        # tokens (<answer><boi><img_size_*><img_ratio_*>) which are not
+        # meaningful CoT output — matching the official generate_image()
+        # contract where cot_text stays None when bot_task is None.
+        bot_task = (extra_body or {}).get("bot_task")
+        if bot_task is not None:
+            req_out = getattr(result, "request_output", None)
+            if req_out:
+                prompt_obj = getattr(req_out, "prompt", None)
+                if isinstance(prompt_obj, dict):
+                    extra_prompt = prompt_obj.get("extra", {})
+                    if isinstance(extra_prompt, dict):
+                        ar_text = extra_prompt.get("ar_generated_text")
+                        if isinstance(ar_text, str) and ar_text.strip():
+                            cot_output = ar_text
 
         return self._flatten_diffusion_images(images), stage_durations, peak_memory_mb, cot_output
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2959,7 +2959,19 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         build_kwargs: dict[str, Any] = {}
         ar_stop_token_ids: list[int] | None = None
 
-        if bot_task is not None or use_system_prompt is not None or custom_system_prompt is not None:
+        # ── HunyuanImage3 AR prompt setup ──────────────────────────
+        # TODO: Abstract to a model-agnostic interface (build_prompt /
+        # build_prompt_tokens / resolve_stop_token_ids) once a second
+        # AR+DiT model is supported.  For now the block is entered when
+        # any Hunyuan-specific param is set, OR when the pipeline stage
+        # declares HunyuanImage3ForCausalMM as its model_arch — this
+        # ensures ar_stop_token_ids is always resolved so the AR stage
+        # stops on <img_ratio_*> even when the caller omits bot_task.
+        _is_hunyuan_image_3 = any(
+            getattr(getattr(s, "engine_args", None), "model_arch", "") == "HunyuanImage3ForCausalMM"
+            for s in stage_configs
+        ) or any(value is not None for value in (bot_task, use_system_prompt, custom_system_prompt))
+        if _is_hunyuan_image_3:
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
                 build_prompt,
                 build_prompt_tokens,
@@ -2971,14 +2983,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 "sys_type": use_system_prompt,
                 "custom_system_prompt": custom_system_prompt,
                 "num_images": len(reference_images) if reference_images else 1,
+                # API requests use None as plain mode. Pass it explicitly so
+                # the prompt helper does not apply its legacy "think" default.
+                "bot_task": bot_task,
             }
 
-            if bot_task is not None:
-                build_kwargs["bot_task"] = bot_task
-            elif "bot_task" in extra_body:
-                # Explicit None from the caller is plain-mode; omitted lets
-                # each task fall back to its default trigger.
-                build_kwargs["bot_task"] = extra_body["bot_task"]
             if tokenizer is not None:
                 # Feed segment-tokenized prompt_token_ids so AR matches HF
                 # apply_chat_template byte-for-byte (engine BPE would merge

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3019,6 +3019,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             engine_prompt["prompt_token_ids"] = prompt_token_ids
         if system_prompt_type is not None:
             engine_prompt["use_system_prompt"] = system_prompt_type
+        # Forward bot_task so the stage input processor can truncate CoT
+        # text at the correct closing tag (</think> vs </recaption>).
+        if bot_task is not None:
+            engine_prompt["bot_task"] = bot_task
         # DiT's get_system_prompt(use_system_prompt, "image", system_prompt) reads
         # this; omitting it makes sys_type=custom yield an empty DiT prefix.
         if custom_system_prompt is not None:

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -32,19 +32,50 @@ from vllm_omni.inputs.data import OmniTokensPrompt
 logger = init_logger(__name__)
 
 
-def _truncate_at_cot_end(generated_text: str) -> str:
-    """Truncate AR output at first `</recaption>` (or `</think>` fallback).
+def _truncate_at_cot_end(
+    generated_text: str,
+    *,
+    bot_task: str | None = None,
+) -> str:
+    """Truncate AR output at the correct CoT closing tag and prepend the
+    opening tag (the AR consumed it as a generation trigger so the decoded
+    output starts *after* ``<think>`` / ``<recaption>``).
 
-    Mirrors upstream `HunyuanImage3ForCausalMM.generate_image` which feeds
-    DiT only the cot text up to the closing tag; the trailing
-    `<answer><boi><img_size_*><img_ratio_*>` is consumed via height/width
-    extraction and must not leak into DiT's prompt builder.
+    Mirrors upstream ``HunyuanImage3ForCausalMM.generate_image`` (line
+    3343-3358): ``bot_task="think"`` stops at ``</think>``, while
+    ``recaption`` and ``think_recaption`` stop at ``</recaption>``.
+    When ``bot_task`` is ``None`` (plain mode) the AR generates only
+    image-structure tokens — returns empty string, matching upstream
+    where ``cot_text`` stays ``None`` in this path.
     """
-    for marker in ("</recaption>", "</think>"):
-        idx = generated_text.find(marker)
+    if bot_task == "think":
+        idx = generated_text.find("</think>")
         if idx != -1:
-            return generated_text[: idx + len(marker)]
-    return generated_text
+            truncated = generated_text[: idx + len("</think>")]
+            if not truncated.startswith("<think>"):
+                truncated = "<think>" + truncated
+            return truncated
+    elif bot_task == "recaption":
+        idx = generated_text.find("</recaption>")
+        if idx != -1:
+            truncated = generated_text[: idx + len("</recaption>")]
+            if not truncated.startswith("<recaption>"):
+                truncated = "<recaption>" + truncated
+            return truncated
+    elif bot_task == "think_recaption":
+        # Emits <think>...</think><recaption>...</recaption>;
+        # stop at </recaption> so recaption conditioning reaches DiT.
+        # AR consumed <think> as the generation trigger, so prepend it.
+        idx = generated_text.find("</recaption>")
+        if idx != -1:
+            truncated = generated_text[: idx + len("</recaption>")]
+            if not truncated.startswith("<think>"):
+                truncated = "<think>" + truncated
+            return truncated
+    # bot_task is None (plain mode) or unknown: upstream keeps
+    # cot_text=None, so return empty — get_cot_sections produces no
+    # text-conditioning sections.
+    return ""
 
 
 @lru_cache(maxsize=4)
@@ -169,7 +200,10 @@ def ar2diffusion(
                 width,
             )
 
-    cot_text_for_dit = _truncate_at_cot_end(generated_text)
+    cot_text_for_dit = _truncate_at_cot_end(
+        generated_text,
+        bot_task=original_prompt.get("bot_task"),
+    )
 
     logger.info(
         "[ar2diffusion] Request 0: AR generated %d tokens, text length=%d, cot_text length=%d, target size=%dx%d (%s)",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Fix some issue in text generation when loading HunyuanImage3.0 AR + DiT.
1. Fix issue in using `/v1/images/generations` no text returned when bot_task was set.
2. Fix issue in using `/v1/images/edits` wrong text returnd. Text, not the think and recaption, still returned even if bot_task was not set.
3. Fix issue in using `/v1/images/generations` hang when bot_task was not set
4. Align text format of HunyuanImage3.0 generated text with official repo.

## Test Plan
#### Issue1:
using curl command to call `/v1/images/generations` with bot_task=think:
```python
    url = "http://127.0.0.1:8091/v1/images/generations"
    headers = {"Content-Type": "application/json"}
    payload_think = {
        "prompt": "A brown and white dog is running on the grass.",
        "size": "1024x1024",
        "n": 1,
        "response_format": "b64_json",
        "seed": 1234,
        "bot_task": "think",
    }
    response = requests.post(url, headers=headers, json=payload_think
    response.raise_for_status()

    res_data = response.json()

    # 1. 提取并打印 cot_output (考虑顶层或 data 数组中的可能性)
    cot_output = res_data.get("cot_output")
    if cot_output is None and "data" in res_data and len(res_data["data"]) > 0:
        cot_output = res_data["data"][0].get("cot_output")

    print(f"=== Chain of Thought Output ===\n{cot_output}\n")

    # 2. 提取 b64_json 数据并保存为本地 PNG 文件
    b64_image = res_data.get("b64_json")
    if not b64_image and "data" in res_data and len(res_data["data"]) > 0:
        b64_image = res_data["data"][0].get("b64_json")

    if b64_image:
        img_bytes = base64.b64decode(b64_image)
        output_path = "output.png"
        with open(output_path, "wb") as f:
            f.write(img_bytes)
        print(f"Image successfully saved to {output_path}")
    else:
        print("Error: 'b64_json' not found in response.")
```
original output:
```bash
root@node73-148:/vllm-workspace/vllm-omni# python cot_curl.py 
=== Chain of Thought Output ===
None

Image successfully saved to output.png
```
after PR fixed:
```bash
root@node73-148:/vllm-workspace/vllm-omni# python cot_curl.py 
=== Chain of Thought Output ===
<think>First, I'll diagnose the user's input. The request, 'A brown and white dog is running on the grass,' is a simple, descriptive scene. The primary goal is to elevate this into a dynamic, high-quality photograph. The thought process will therefore prioritize photographic principles like composition, subject detail, and lighting to create a sense of realism and action.

The first step is to establish a strong composition and define the action. The word 'running' is generic, so to create a more compelling shot, I need to specify the dog's direction of movement and its position within the frame. Placing the subject off-center and having it move across the frame creates a more dynamic and professional-looking composition than a simple, static portrait.

Next, I'll focus on building the character of the dog. 'Brown and white' is too vague. To make the subject believable, I need to detail the specific pattern of its coat, describing where the different colors are located. This gives the dog a unique identity. Furthermore, to convey the energy of 'running,' I must describe its physical state: the angle of its body, the position of its legs in mid-stride, and the alert posture of its ears. Adding a small detail like an open mouth suggests exertion and makes the moment feel more alive.

Then, I'll construct the environment and lighting. 'On the grass' is a flat setting. To create depth and focus attention on the dog, I'll use a classic photographic technique: a shallow depth of field. This involves describing the foreground grass in sharp detail while rendering the background as a soft, out-of-focus blur. This not only isolates the subject but also adds a professional, artistic quality. Light is essential for realism. I'll define a clear light source, like sunlight, to explain how it creates highlights on the dog's fur and casts subtle shadows on the ground, which grounds the subject in its environment and enhances its three-dimensional form.

Finally, all these elements are unified under a clear photographic style. By emphasizing concepts like 'sharp focus,' 'depth of field,' and 'natural lighting,' the goal is to guide the AI to produce not just an image of a dog, but a high-quality, dynamic action photograph that captures a fleeting moment in time.</think>

Image successfully saved to output.png
```
#### Issue2:
using curl command to call `/v1/images/edits` with no bot_task:
```python
    url_edit = "http://127.0.0.1:8091/v1/images/edits"
    form_data_no_bot = {
        "prompt": "Please refer to the image, generate a image of that dog running on grass.",
        "size": "auto",
        "n": "1",
        "seed": "1234"
    }

    image_path = "/vllm-workspace/vllm-omni/corgi.jpg"

    with open(image_path, "rb") as f:
        files = {"image": ("corgi.jpg", f, "image/jpeg")}
        response_edit = requests.post(url_edit, data=form_data_no_bot, files=files)

    response_edit.raise_for_status()

    # ----------------- 兼容 SSE / 普通 JSON 解析逻辑 -----------------
    raw_text = response_edit.text.strip()
    res_data_edit = {}

    try:
        # 尝试直接解析为普通 JSON
        res_data_edit = json.loads(raw_text)
    except json.JSONDecodeError:
        # 说明返回的是 SSE 格式 (data: {...})，按行切分提取 JSON
        cot_chunks = []
        for line in raw_text.splitlines():
            line = line.strip()
            if line.startswith("data:"):
                payload_str = line[len("data:") :].strip()
                if payload_str == "[DONE]":
                    continue
                try:
                    chunk = json.loads(payload_str)
                    # 拼接 cot_output
                    cot = chunk.get("cot_output")
                    if not cot and "data" in chunk and chunk["data"]:
                        cot = chunk["data"][0].get("cot_output")
                    if cot:
                        cot_chunks.append(cot)

                    # 保留包含 b64_json/data 的字段
                    if "b64_json" in chunk or "data" in chunk:
                        res_data_edit = chunk
                except json.JSONDecodeError:
                    pass

        if cot_chunks and "cot_output" not in res_data_edit:
            res_data_edit["cot_output"] = "".join(cot_chunks)
    # 提取并打印 cot_output
    cot_output_edit = res_data_edit.get("cot_output")
    if cot_output_edit is None and "data" in res_data_edit and len(res_data_edit["data"]) > 0:
        cot_output_edit = res_data_edit["data"][0].get("cot_output")

    print(f"=== Edits: Chain of Thought Output ===\n{cot_output_edit}\n")

    # 提取 b64_json 数据并保存为本地 PNG 文件
    b64_image_edit = res_data_edit.get("b64_json")
    if not b64_image_edit and "data" in res_data_edit and len(res_data_edit["data"]) > 0:
        b64_image_edit = res_data_edit["data"][0].get("b64_json")

    if b64_image_edit:
        img_bytes = base64.b64decode(b64_image_edit)
        output_path = "edited_output.png"
        with open(output_path, "wb") as f:
            f.write(img_bytes)
        print(f"Edited image successfully saved to {output_path}")
    else:
        print("Error: 'b64_json' not found in edits response.")
```
original output,  with all text generated even the image related token:
```bash
root@node73-148:/vllm-workspace/vllm-omni# python cot_curl.py 
=== Edits: Chain of Thought Output ===
The user wants to transform a static image of a dog into a dynamic scene where the same dog is running. The original instruction is \"Please refer to the image, generate a image of that dog running on grass.\" This requires several key changes. First, the dog's pose must change from a static, somewhat obscured view to a full-body, active running posture. This implies that the entire body of the dog, including its legs, tail, and full torso, needs to be rendered in motion. The dog's head, which is partially visible in the reference image, should be reoriented to face forward, consistent with running, while maintaining its happy expression with its tongue out. Second, the background needs to be completely replaced. The current plain white background must be swapped for a natural outdoor setting featuring green grass. This new background should be consistent with the lighting and perspective of the running dog. The rewritten instruction must therefore detail the new pose of the dog, its full visibility, its expression, and the characteristics of the new grassy environment, ensuring all elements are harmoniously integrated.</think><recaption>Transform the dog from the reference image into a full-body depiction, actively running forward on a vibrant green grass field. The dog should be shown in mid-stride, with its front paws extended and its tail wagging, maintaining its happy expression with its tongue slightly out. The background should be a natural outdoor scene with lush green grass, and the lighting should be bright and consistent with an outdoor environment.</recaption><answer><boi><img_size_1024><img_ratio_16>

Edited image successfully saved to edited_output.png
```
after PR fixed:
```bash
root@node73-148:/vllm-workspace/vllm-omni# python cot_curl.py 
=== Edits: Chain of Thought Output ===
None

Edited image successfully saved to edited_output.png
```
#### Issue3:
```bash
root@node73-148:/home/xxxxxxxxxxxx# curl -X POST http://127.0.0.1:8091/v1/images/generations   -H "Content-Type: application/json"   -d '{
    "prompt": "A brown and white dog is running on the grass.",
    "size": "1024x1024",
    "n": 1,
    "response_format": "b64_json",
    "seed": 1234
  }' > reponse.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   158    0     0    0   158      0      0 --:--:--  0:08:03 --:--:--     0^C
```
The curl command was hang for almost 10min, it should return within 1min.
After this PR fixed, the command returned in 55s, which is normal now:

```bash
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] [Overall Summary]
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] +-----------------------------+------------+
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | Field                       |      Value |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] +-----------------------------+------------+
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_requests                |          1 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_wall_time_ms            | 55,949.366 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_total_tokens            |      3,404 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_avg_time_per_request_ms | 55,949.366 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_avg_tokens_per_s        |     60.841 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | input_preprocess_time_ms    |      0.276 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_stage_0_wall_time_ms    | 34,174.540 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] | e2e_stage_1_wall_time_ms    | 21,769.876 |
(APIServer pid=167201) INFO 07-20 14:57:48 [stats.py:758] +-----------------------------+------------+
```

#### Issue4:
Now trunck ar_generated_txt with `</think>` and `</recaption>`, and add `think` and `recaption` mannually, which is aligned with offfical HunyuanImage3.0 code:
[https://github.com/Tencent-Hunyuan/HunyuanImage-3.0/blob/main/hunyuan_image_3/modeling_hunyuan_image_3.py:\[3343:3358\]](https://github.com/Tencent-Hunyuan/HunyuanImage-3.0/blob/main/hunyuan_image_3/modeling_hunyuan_image_3.py#L3343-L3358)

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
