### PR TITLE
[BugFix] Fix possible HunyuanImage3.0 model load issue

### DIFF
--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py
@@ -6,6 +6,10 @@ ratio restriction, comprehension blocking)."""
 import pytest
 import torch
 
+from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
+    _get_ratio_other_slices,
+)
+
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 # Fake token IDs for testing (avoid importing the real model).
@@ -21,6 +25,35 @@ RATIO_END = 210
 RATIO_OTHER_START = 220
 RATIO_OTHER_END = 223
 TIMESTEP = 224
+
+
+class FakeTokenizer:
+    def __init__(self, token_ids: dict[str, int]):
+        self.token_ids = token_ids
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return self.token_ids.get(token)
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "expected"),
+    [
+        ({}, []),
+        (
+            {
+                "<img_ratio_33>": 130103,
+                "<img_ratio_36>": 130106,
+            },
+            [(130103, 130107)],
+        ),
+    ],
+    ids=["base", "instruct"],
+)
+def test_get_ratio_other_slices(
+    token_ids: dict[str, int],
+    expected: list[tuple[int, int]],
+):
+    assert _get_ratio_other_slices(FakeTokenizer(token_ids)) == expected
 
 
 class FakeSamplerModel:

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -97,6 +97,14 @@ from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import LightProjecto
 logger = init_logger(__name__)
 
 
+def _get_ratio_other_slices(tokenizer: Any) -> list[tuple[int, int]]:
+    ratio_33 = tokenizer.convert_tokens_to_ids("<img_ratio_33>")
+    ratio_36 = tokenizer.convert_tokens_to_ids("<img_ratio_36>")
+    if ratio_33 is None or ratio_36 is None:
+        return []
+    return [(ratio_33, ratio_36 + 1)]
+
+
 @support_torch_compile(
     dynamic_arg_dims={
         "input_ids": 0,
@@ -1558,9 +1566,7 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         self._timestep_token_id = tokenizer.convert_tokens_to_ids("<timestep>")
         self._start_ratio_id = tokenizer.convert_tokens_to_ids("<img_ratio_0>")
         self._end_ratio_id = tokenizer.convert_tokens_to_ids("<img_ratio_32>")
-        ratio_33 = tokenizer.convert_tokens_to_ids("<img_ratio_33>")
-        ratio_36 = tokenizer.convert_tokens_to_ids("<img_ratio_36>")
-        self._ratio_other_slices = [(ratio_33, ratio_36 + 1)]
+        self._ratio_other_slices = _get_ratio_other_slices(tokenizer)
         # Build the full set of ratio token IDs for use as stop tokens.
         self._all_ratio_ids = set(range(self._start_ratio_id, self._end_ratio_id + 1))
         for s, e in self._ratio_other_slices:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
`HunyuanImage3.0` and `HunyuanImage3.0-instruct` got different image_ratio token, which lead to slight different load behavior.
The `HunyuanImage3.0` got image ratio token `{ratio_0, ratio_32}`, but `HunyuanImage3.0-instruct` got image ratio token `{ratio_0, ratio_36}`. Current code read token `{ratio_33, ratio_36}` directly from tokenizer.json which may lead to cursh when loading `HunyuanImage3.0(without instruct)`.
Error log:
```bash
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888] WorkerProc failed to start.
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888] Traceback (most recent call last):
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 855, in worker_main
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     worker = WorkerProc(*args, **kwargs)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 634, in __init__
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     self.worker.load_model()
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/worker.py", line 556, in load_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     self.model_runner.load_model()
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-omni/vllm_omni/platforms/npu/worker/npu_model_runner.py", line 42, in load_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     NPUModelRunner.load_model(self, *args, **kwargs)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 3635, in load_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     self.model: nn.Module = get_model(vllm_config=self.vllm_config)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/__init__.py", line 143, in get_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     return loader.load_model(
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/base_loader.py", line 55, in load_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     model = initialize_model(
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]             ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/utils.py", line 61, in initialize_model
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     model = model_class(vllm_config=vllm_config, prefix=prefix)
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-omni/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py", line 1569, in __init__
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]     self._ratio_other_slices = [(ratio_33, ratio_36 + 1)]
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888]                                            ~~~~~~~~~^~~
(Worker_TP0 pid=1367509) ERROR 07-21 16:00:34 [multiproc_executor.py:888] TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888] WorkerProc failed to start.
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888] Traceback (most recent call last):
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 855, in worker_main
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     worker = WorkerProc(*args, **kwargs)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 634, in __init__
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     self.worker.load_model()
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/worker.py", line 556, in load_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     self.model_runner.load_model()
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-omni/vllm_omni/platforms/npu/worker/npu_model_runner.py", line 42, in load_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     NPUModelRunner.load_model(self, *args, **kwargs)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 3635, in load_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     self.model: nn.Module = get_model(vllm_config=self.vllm_config)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/__init__.py", line 143, in get_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     return loader.load_model(
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/base_loader.py", line 55, in load_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     model = initialize_model(
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]             ^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     return func(*args, **kwargs)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm/vllm/model_executor/model_loader/utils.py", line 61, in initialize_model
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     model = model_class(vllm_config=vllm_config, prefix=prefix)
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]   File "/vllm-workspace/vllm-omni/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py", line 1569, in __init__
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]     self._ratio_other_slices = [(ratio_33, ratio_36 + 1)]
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888]                                            ~~~~~~~~~^~~
(Worker_TP1 pid=1367510) ERROR 07-21 16:00:35 [multiproc_executor.py:888] TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```
This PR fixed issue when loading `HunyuanImage3.0(without instruct)`.
Now code generate empty `self._ratio_other_slices ` if `ratio_33` or `ratio_36` is None. Which lead to no extra image ratio, it's also aligned with model inherent tokenizer bahavior and will not generate any impact on the result.
## Test Plan

1. HunyuanImage3.0
1.1 Before apply this PR, model loading failed, errors reported as above. No output image for check.
1.2 After apply this PR, model laoding successful:

```bash
(APIServer pid=34618) INFO 07-22 16:51:26 [async_omni_engine.py:326] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=34618) INFO 07-22 16:51:26 [omni_base.py:185] [AsyncOmni] AsyncOmniEngine initialized in 360.10 seconds
(APIServer pid=34618) INFO 07-22 16:51:26 [omni_base.py:205] [AsyncOmni] Initialized with 2 stages for model /new_data/Weights/HunyuanImage-3.0
[...]
(APIServer pid=34618) INFO 07-22 16:51:28 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=34618) INFO 07-22 16:51:28 [api_server.py:531] Starting vLLM API server 0 on http://0.0.0.0:8091
(APIServer pid=34618) INFO 07-22 16:51:28 [launcher.py:37] Available routes are:
(APIServer pid=34618) INFO 07-22 16:51:28 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=34618) INFO 07-22 16:51:28 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=34618) INFO 07-22 16:51:28 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
[...]
(APIServer pid=34618) INFO 07-22 16:51:28 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=34618) INFO:     Started server process [34618]
(APIServer pid=34618) INFO:     Waiting for application startup.
(APIServer pid=34618) INFO:     Application startup complete.
```
image for HunyuanImage3.0 output:
<img width="859" height="863" alt="image" src="https://github.com/user-attachments/assets/6e0f6729-e11c-442b-994b-e7211afb86a0" />
2. HunyuanImage3.0-Instruct
2.1 Before apply this PR:
```bash
(APIServer pid=690134) INFO 07-23 09:49:41 [omni_base.py:185] [AsyncOmni] AsyncOmniEngine initialized in 436.43 seconds
(APIServer pid=690134) INFO 07-23 09:49:41 [omni_base.py:205] [AsyncOmni] Initialized with 2 stages for model /new_data/HunyuanImage-3.0-Instruct/
[...]
(APIServer pid=690134) INFO 07-23 09:49:42 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=690134) INFO 07-23 09:49:42 [api_server.py:531] Starting vLLM API server 0 on http://0.0.0.0:8091
(APIServer pid=690134) INFO 07-23 09:49:42 [launcher.py:37] Available routes are:
(APIServer pid=690134) INFO 07-23 09:49:42 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=690134) INFO 07-23 09:49:42 [launcher.py:46] Route: /docs, Methods: GET, HEAD
[...]
(APIServer pid=690134) INFO 07-23 09:49:42 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=690134) INFO:     Started server process [690134]
(APIServer pid=690134) INFO:     Waiting for application startup.
(APIServer pid=690134) INFO:     Application startup complete.
```
2.2 After apply this PR:
```bash
(APIServer pid=70889) INFO 07-22 17:03:45 [omni_base.py:185] [AsyncOmni] AsyncOmniEngine initialized in 440.33 seconds
(APIServer pid=70889) INFO 07-22 17:03:45 [omni_base.py:205] [AsyncOmni] Initialized with 2 stages for model /new_data/HunyuanImage-3.0-Instruct/
(APIServer pid=70889) INFO 07-22 17:03:46 [api_server.py:827] Supported tasks: {'generate'}
[...]
(APIServer pid=70889) INFO 07-22 17:03:47 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=70889) INFO 07-22 17:03:47 [api_server.py:531] Starting vLLM API server 0 on http://0.0.0.0:8091
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:37] Available routes are:
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
[...]
(APIServer pid=70889) INFO 07-22 17:03:47 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=70889) INFO:     Started server process [70889]
(APIServer pid=70889) INFO:     Waiting for application startup.
(APIServer pid=70889) INFO:     Application startup complete.
```
2.3 image compare:

<img width="1860" height="990" alt="image" src="https://github.com/user-attachments/assets/ec4763d4-7d01-41b1-8f4c-4f2c2db7b9dd" />

It's identical by md5sum:
```bash
root@node73-148:/vllm-workspace/vllm-omni# md5sum output_instruct_unapplied.png 
1857ae3cce56bc150eeecda50262b77d  output_instruct_unapplied.png
root@node73-148:/vllm-workspace/vllm-omni# md5sum output_instruct_applied.png   
1857ae3cce56bc150eeecda50262b77d  output_instruct_applied.png
```

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
