### PR TITLE
[Bugfix][Quant] Skip quack FP8 GEMM when scales are unpopulated

### DIFF
--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -98,6 +98,29 @@ def quack_scaled_fp8_mm(
     return out
 
 
+_valid_scale_ptrs: set[tuple[int, int]] = set()
+
+
+def _scales_valid(scale_a: torch.Tensor, scale_b: torch.Tensor) -> bool:
+    """True when both per-tensor scales are finite and positive.
+
+    vLLM initializes a per-tensor FP8 scale to ``finfo(float32).min`` and fills it at
+    weight-load time, so a call made before that (the dummy profiling forward) would
+    make ``alpha = scale_a * scale_b`` overflow to ``+inf`` and return an all-inf tile.
+    Cache only positive results: a buffer still holding the sentinel is re-checked and
+    picks up the fast path once the real scale is written.
+    """
+    key = (scale_a.data_ptr(), scale_b.data_ptr())
+    if key in _valid_scale_ptrs:
+        return True
+    ok = bool(
+        torch.isfinite(scale_a).all() and torch.isfinite(scale_b).all() and (scale_a > 0).all() and (scale_b > 0).all()
+    )
+    if ok:
+        _valid_scale_ptrs.add(key)
+    return ok
+
+
 def install_quack_fp8_patch() -> None:
     if not quack_enabled():
         return
@@ -115,6 +138,10 @@ def install_quack_fp8_patch() -> None:
         return
 
     def apply_scaled_mm(self, *, A, B, out_dtype, As, Bs, bias, output_shape):  # noqa: N803
+        # An unpopulated scale makes alpha overflow to +inf; hand those calls to
+        # FlashInfer, whose bmm_fp8 tolerates them.
+        if As.numel() != 1 or Bs.numel() != 1 or not _scales_valid(As, Bs):
+            return original(self, A=A, B=B, out_dtype=out_dtype, As=As, Bs=Bs, bias=bias, output_shape=output_shape)
         try:
             out = quack_scaled_fp8_mm(A, B, As, Bs, out_dtype, bias)
             if out is not None:


### PR DESCRIPTION
Fixes #5263.

## Problem

On datacenter Blackwell, `Wan2.2-T2V-A14B` + ModelOpt FP8 produces **100% NaN video**, silently — no exception, no warning.

vLLM initializes a per-tensor FP8 scale to `finfo(float32).min` (`-3.4e38`) and fills it at weight-load time. Calls issued before that (the dummy profiling forward) still carry the sentinel, so in `quack_scaled_fp8_mm`:

```python
alpha = scale_a.reshape(1).float() * scale_b.reshape(1).float()
# (-3.4e38) * (-3.4e38)  ->  +inf
```

The GEMM returns an all-`inf` tile, which becomes NaN in downstream norm/attention.

**This is not a defect in quack.** With sentinel scales, quack's CuteDSL GEMM and `torch._scaled_mm` return *identical* all-inf output; with valid scales both are correct (rel-err 0.002–0.003). FlashInfer's `bmm_fp8` masks the bad scale, which is why the stock path never surfaced it and why it only appeared once quack became the Blackwell default (#4241).

It is also **model-specific**: only Wan2.2 A14B issues a quantized linear while the scale is still the sentinel, so #4241's HunyuanVideo-1.5 validation was sound.

## Fix

Check the scales once per buffer and route unpopulated ones to FlashInfer. Only *positive* results are cached (keyed by `data_ptr`), so a buffer still holding the sentinel is re-checked and picks up the fast path once the real scale is written — one device sync per layer, then none.

quack remains the Blackwell default; this changes nothing else.

## Validation (B300, 480x832x33f, ModelOpt FP8)

| model | before | after |
|---|---|---|
| **Wan2.2 A14B** | **100% NaN** | **0% NaN**, 0.888 s/step (BF16 0.946) |
| HunyuanVideo-1.5 | 0% NaN | 0% NaN |
| Cosmos 3 Nano | 0% NaN | 0% NaN, **bit-identical output** |

Unaffected models are byte-for-byte unchanged, confirming the guard only fires on the sentinel path.

Related: #4241 (introduced the quack default), #4817 (arch gate), #5153 (`inference_mode`/`compile` fix — different bug).
