### PR TITLE
[Refactor] Migrate replica-DP Wan2.2 example to --deploy-config

### DIFF
--- a/examples/online_serving/replica_data_parallel/README.md
+++ b/examples/online_serving/replica_data_parallel/README.md
@@ -12,7 +12,7 @@ This example uses `Wan-AI/Wan2.2-TI2V-5B-Diffusers` with one GPU per replica.
 
 | File | Purpose |
 |------|---------|
-| `wan2_2_ti2v_dp.yaml` | Diffusion stage config; `runtime.num_replicas` + `runtime.devices` drive the fan-out. |
+| `wan2_2_ti2v_dp.yaml` | Deploy config; `num_replicas` + `devices` drive the fan-out. |
 | `run_server.sh` | Substitutes `NUM_REPLICAS` / `DEVICES` into the config and serves. |
 | `bench_replica_dp.py` | Replica-agnostic load driver; reports throughput, latency, and a per-input isolation check. |
 
@@ -82,10 +82,9 @@ output under `N>=2` concurrency must match its own single-replica baseline.
 - `runtime.num_replicas: N` fans out `N` replicas; `runtime.devices` assigns their
   GPUs. With `tensor_parallel_size = 1`, list one GPU per replica
   (`num_replicas * tensor_parallel_size` entries, pool mode).
-- Replica fan-out here comes from the stage config, not a CLI flag. (The headless /
+- Replica fan-out here comes from the deploy config, not a CLI flag. (The headless /
   multi-runtime launch path uses the process-local `--omni-dp-size-local`, which
   requires `--stage-id`.)
-- This recipe serves via `--stage-configs-path`. Expressing replica-DP under the
-  newer `--deploy-config` schema is part of the ongoing serving-config alignment
-  (see the diffusion parallelism guide and the `#4707` discussion); `num_replicas`
-  is accepted by both paths.
+- This recipe serves via `--deploy-config`. Replica fan-out comes from the deploy
+  config's `num_replicas` / `devices`; stage topology comes from the registered
+  `WanPipeline`.

--- a/examples/online_serving/replica_data_parallel/run_server.sh
+++ b/examples/online_serving/replica_data_parallel/run_server.sh
@@ -30,4 +30,4 @@ echo "Serving ${MODEL}: num_replicas=${NUM_REPLICAS} devices=${DEVICES} (config 
 vllm serve "$MODEL" --omni \
     --host "$HOST" \
     --port "$PORT" \
-    --stage-configs-path "$CFG"
+    --deploy-config "$CFG"

--- a/examples/online_serving/replica_data_parallel/wan2_2_ti2v_dp.yaml
+++ b/examples/online_serving/replica_data_parallel/wan2_2_ti2v_dp.yaml
@@ -8,36 +8,20 @@
 # run_server.sh substitutes __NUM_REPLICAS__ / __DEVICES__ from env before serving.
 # For tensor_parallel_size = 1, `devices` lists one GPU per replica (pool mode):
 # num_replicas=4 -> devices "0,1,2,3".
+#
+# Stage topology (diffusion DiT, video output) comes from the registered
+# WanPipeline, which auto-detects TI2V-5B mode from model_index.json; this file
+# carries deployment knobs only.
+trust_remote_code: true
+distributed_executor_backend: mp
 
-stage_args:
+stages:
   - stage_id: 0
-    stage_type: diffusion
-    runtime:
-      num_replicas: __NUM_REPLICAS__
-      devices: "__DEVICES__"
-      max_batch_size: 1
-    engine_args:
-      model_stage: dit
-      # `model_class_name` takes the diffusion registry KEY (WanPipeline), which
-      # resolves to the Wan22Pipeline class. Wan2.2 TI2V-5B is served by the base
-      # WanPipeline, which auto-detects TI2V-5B mode from model_index.json.
-      model_class_name: WanPipeline
-      max_num_seqs: 1
-      enforce_eager: true
-      trust_remote_code: true
-      distributed_executor_backend: "mp"
-      vae_use_tiling: true
-      parallel_config:
-        tensor_parallel_size: 1
-
-    final_output: true
-    final_output_type: video
-    is_comprehension: false
+    num_replicas: __NUM_REPLICAS__
+    devices: "__DEVICES__"
+    max_num_seqs: 1
+    tensor_parallel_size: 1
+    enforce_eager: true
+    vae_use_tiling: true
     default_sampling_params:
       seed: 42
-
-runtime:
-  enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1


### PR DESCRIPTION
Part of #5266.

## What this does

The replica data-parallel recipe was the last Wan example still on the legacy `stage_args` YAML. Stage topology (diffusion DiT, video output) already comes from the registered `WanPipeline`, so the config only needs deployment knobs:

```yaml
trust_remote_code: true
distributed_executor_backend: mp

stages:
  - stage_id: 0
    num_replicas: __NUM_REPLICAS__
    devices: "__DEVICES__"
    max_num_seqs: 1
    tensor_parallel_size: 1
    enforce_eager: true
    vae_use_tiling: true
    default_sampling_params:
      seed: 42
```

`run_server.sh` now serves with `--deploy-config` instead of `--stage-configs-path`; README updated to match. Behavior is unchanged — `num_replicas` / `devices` still drive the fan-out.

This is the mechanical one of the five stragglers in #5266. The other four (Qwen3-Omni thinking, Step-Audio2 CI x2, Voxtral XPU) each need a new `PipelineConfig` entry because their topology fields are registry-only, and are left to their owners.

## Test Plan

Verified the migrated config resolves under the deploy schema with every knob preserved:

```
num_replicas=4 devices='0,1,2,3' tp=1 max_num_seqs=1 eager=True seed={'seed': 42}
```

```bash
NUM_REPLICAS=4 DEVICES=0,1,2,3 examples/online_serving/replica_data_parallel/run_server.sh
python examples/online_serving/replica_data_parallel/bench_replica_dp.py
```
