### PR TITLE
[Bugfix][CI] Recognize local_model in check-test-ci-coverage hook

### DIFF
--- a/tools/pre_commit/check_test_marks.py
+++ b/tools/pre_commit/check_test_marks.py
@@ -4,8 +4,9 @@
 """Run a pre-commit hook that fails if test files are modified or added
 that (probably) never run in the CI. For now, this means that every tests file
 needs to have a CI level marker (e.g., core_model, advanced_model, full_model,
-etc) and hardware mark / helper so that we ensure mutated tests will actually
-be selected as long as there are pytest commands pointing at the right paths.
+local_model, slow, etc) and hardware mark / helper so that we ensure mutated
+tests will actually be selected as long as there are pytest commands pointing
+at the right paths.
 """
 
 import os
@@ -13,7 +14,7 @@ import re
 import sys
 
 # CI level markers
-LEVEL_MARKERS = ("core_model", "advanced_model", "full_model", "slow")
+LEVEL_MARKERS = ("core_model", "advanced_model", "full_model", "local_model", "slow")
 
 # Hardware markers. These are platforms and resources that CI filters on.
 # NOTE: If new hardware marks are added to pyproject.toml etc, we need


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes #5274.

The `check-test-ci-coverage` pre-commit hook (`tools/pre_commit/check_test_marks.py`) did not treat `local_model` as a valid CI level marker, even though `local_model` is registered in `pyproject.toml` and used by local-weight accuracy tests (e.g. `tests/e2e/accuracy/test_hunyuan_image3.py`).

This caused local commits touching those files to fail pre-commit with a misleading `[Level]` error.

Add `local_model` to `LEVEL_MARKERS` so the hook stays aligned with pytest marker registration and docs.

## Test Plan

```bash
python tools/pre_commit/check_test_marks.py tests/e2e/accuracy/test_hunyuan_image3.py
```

## Test Result

```text
$ python tools/pre_commit/check_test_marks.py tests/e2e/accuracy/test_hunyuan_image3.py
(exit 0)
```

Before this change, the same command failed with:

```text
The following files are missing marks:
  - tests/e2e/accuracy/test_hunyuan_image3.py [Level]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
