### PR TITLE
[CI] skip test_audio_in_video_default_loader_sampling_regression (#5248)

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -411,6 +411,7 @@ def test_audio_in_video_002(omni_server, openai_client) -> None:
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
 
 
+@pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/5248")
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_audio_in_video_default_loader_sampling_regression(omni_server, openai_client) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Skip flaky nightly e2e regression `test_audio_in_video_default_loader_sampling_regression` (`[default]` and `[async_chunk]`) while #5248 is investigated.

The second request in the test (default video loader sampling after an explicit `media_io_kwargs.video.fps`) fails with `openai.BadRequestError: 400` from `Qwen3OmniMoeProcessor` instead of the historical `StopIteration` regression.

Related: https://github.com/vllm-project/vllm-omni/issues/5248

## Test Plan

```bash
pytest tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_audio_in_video_default_loader_sampling_regression -v
```

Expect both parametrized cases to report **SKIPPED** with reason linking to #5248.

**vLLM Version:** N/A (test-only change)

**vLLM-Omni Commit:** current branch HEAD

## Test Result

- Pending CI (Buildkite nightly / e2e job that previously failed on this test).
- Locally: pytest should collect the test as skipped without starting the omni server fixture for execution.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
