### PR TITLE
RFC #4590: disaggregated diffusion execution (encode/denoise/decode)

### DIFF
--- a/tests/diffusion/disaggregated/conftest.py
+++ b/tests/diffusion/disaggregated/conftest.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test fixtures for RFC #4590 disaggregated diffusion.
+
+The torch-free foundation modules (``stage_roles``, ``stage_payload``, and the
+generic ``diffusion`` transition processor) are loaded directly by file path so
+these unit tests run without importing the full ``vllm_omni`` package or torch —
+useful on machines without the GPU runtime. Tests that require torch/vllm are
+marked ``needs_runtime`` and skipped when those deps are absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# This file lives at <repo>/tests/diffusion/disaggregated/conftest.py, so the
+# vllm_omni package root is <repo>/vllm_omni.
+VLLM_OMNI_ROOT = Path(__file__).resolve().parents[3] / "vllm_omni"
+
+
+def _load_module_by_path(mod_name: str, rel_path: str):
+    """Load a single module file by path, bypassing package __init__ imports."""
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    path = VLLM_OMNI_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def stage_roles():
+    return _load_module_by_path("_rfc4590_stage_roles", "diffusion/stage_roles.py")
+
+
+@pytest.fixture(scope="session")
+def stage_payload():
+    # Register under the REAL dotted name so interface.py's lazy ``_transport()``
+    # (which checks ``sys.modules["vllm_omni.diffusion.stage_payload"]``) resolves
+    # the torch-free leaf without importing the ``vllm_omni`` package (torch).
+    return _load_module_by_path("vllm_omni.diffusion.stage_payload", "diffusion/stage_payload.py")
+
+
+@pytest.fixture(scope="session")
+def diffusion_processor():
+    return _load_module_by_path(
+        "_rfc4590_diffusion_processor",
+        "model_executor/stage_input_processors/diffusion.py",
+    )
+
+
+@pytest.fixture(scope="session")
+def interface_mod():
+    # interface.py imports torch only under TYPE_CHECKING, so it loads torch-free.
+    # Pre-register the stage_payload leaf under its real dotted name so interface's
+    # lazy ``_transport()`` resolves it without importing the vllm_omni package.
+    _load_module_by_path("vllm_omni.diffusion.stage_payload", "diffusion/stage_payload.py")
+    return _load_module_by_path("_rfc4590_interface", "diffusion/models/interface.py")
+
+
+# A fabricated base whose (module, name) == ("torch", "Tensor") so the payload
+# module's duck-typed ``_is_tensor`` check accepts instances without importing
+# torch. Defined at class-creation time (reassigning __bases__ later is fragile).
+_TorchTensorBase = type("Tensor", (), {})
+_TorchTensorBase.__module__ = "torch"
+
+
+class FakeTensor(_TorchTensorBase):
+    """Minimal torch.Tensor stand-in for torch-free payload tests.
+
+    Records detach/cpu/contiguous/clone calls so sanitize behavior is
+    observable, and reports a ``data_ptr`` so the alias-avoiding clone path in
+    :func:`sanitize_transport_tensor` can be exercised.
+    """
+
+    def __init__(self, shape=(2, 3), dtype="float32", data_ptr=1000):
+        self.shape = shape
+        self.dtype = dtype
+        self._data_ptr = data_ptr
+        self.calls: list[str] = []
+
+    def detach(self):
+        self.calls.append("detach")
+        return self
+
+    def cpu(self):
+        self.calls.append("cpu")
+        return self
+
+    def contiguous(self):
+        self.calls.append("contiguous")
+        return self
+
+    def clone(self):
+        self.calls.append("clone")
+        return FakeTensor(self.shape, self.dtype, data_ptr=self._data_ptr + 1)
+
+    def data_ptr(self):
+        return self._data_ptr
+
+
+@pytest.fixture
+def fake_tensor_cls():
+    return FakeTensor

--- a/tests/diffusion/disaggregated/test_dreamzero_disaggregated.py
+++ b/tests/diffusion/disaggregated/test_dreamzero_disaggregated.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DreamZero disaggregated-execution tests (#4948 DiffusionV2Atoms).
+
+Two tiers, both ``needs_runtime`` (torch + vllm_omni + AR-Diffusion engine):
+
+* ``test_component_spec_*`` and ``test_carrier_*`` need only torch (no GPU / no
+  checkpoint) — they validate the component ownership table and the StagePayload
+  round-trip of the DreamZero carrier.
+* ``test_numerical_equivalence`` needs the real DreamZero checkpoint + XPU. It is
+  additionally gated on the ``DREAMZERO_MODEL_PATH`` env var and skipped when
+  unset. Manual command (on the gnr XPU node, inside vllm-omni-xpu):
+
+    DREAMZERO_MODEL_PATH=/models/DreamZero-DROID \\
+      pytest tests/diffusion/disaggregated/test_dreamzero_disaggregated.py \\
+      -m needs_runtime -k numerical_equivalence -s
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+try:
+    import torch
+
+    from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import DreamZeroPipeline
+    from vllm_omni.diffusion.models.dreamzero.state_dreamzero import DreamZeroStageCarrier
+    from vllm_omni.diffusion.stage_roles import DECODE, DENOISE, ENCODE
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+except Exception as exc:  # pragma: no cover - import-environment dependent
+    pytest.skip(f"vllm_omni runtime unavailable: {exc}", allow_module_level=True)
+
+pytestmark = pytest.mark.needs_runtime
+
+
+# --- capability flags (regression guard) -----------------------------------
+
+
+def test_dreamzero_declares_disaggregated_capability():
+    """DreamZero must declare the collapsed DiffusionV2Atoms disaggregation contract.
+
+    ``supports_disaggregated_execution(pipeline)`` gates on the explicit
+    ``supports_disaggregated_execution`` flag AND the full ``DiffusionV2Atoms``
+    method surface (a @runtime_checkable Protocol). Missing either would make the
+    runner reject DreamZero's encode/denoise/decode stages at startup. DreamZero
+    stays OFF the single-process step runner (``supports_step_execution`` False).
+    """
+    from vllm_omni.diffusion.models.interface import DiffusionV2Atoms
+
+    assert DreamZeroPipeline.supports_disaggregated_execution is True
+    assert DreamZeroPipeline.supports_step_execution is False
+    # Protocol structural check (all DiffusionV2Atoms methods + the
+    # supports_step_execution ClassVar are present on the class).
+    assert issubclass(DreamZeroPipeline, DiffusionV2Atoms)
+
+
+# --- component ownership (torch only, no checkpoint) -----------------------
+
+
+def test_component_spec_encode_owns_encoders_not_dit():
+    spec = DreamZeroPipeline.required_components_for_stage(ENCODE)
+    assert spec.tokenizer and spec.text_encoder and spec.image_encoder and spec.vae_encoder
+    assert not spec.dit and not spec.vae_decoder
+
+
+def test_component_spec_denoise_owns_dit_not_encoders_or_vae_decoder():
+    spec = DreamZeroPipeline.required_components_for_stage(DENOISE)
+    assert spec.dit and spec.scheduler and spec.action_modules
+    assert not spec.text_encoder and not spec.image_encoder and not spec.vae_decoder and not spec.vae_encoder
+
+
+def test_component_spec_decode_owns_vae_decoder_not_dit():
+    spec = DreamZeroPipeline.required_components_for_stage(DECODE)
+    assert spec.vae_decoder
+    assert not spec.dit and not spec.text_encoder and not spec.image_encoder
+
+
+def test_component_spec_monolithic_owns_everything():
+    spec = DreamZeroPipeline.required_components_for_stage("diffusion")
+    assert all(
+        (spec.tokenizer, spec.text_encoder, spec.image_encoder, spec.vae_encoder,
+         spec.dit, spec.scheduler, spec.vae_decoder, spec.action_modules)
+    )
+
+
+# --- carrier payload round-trip (torch only, no checkpoint) ----------------
+
+
+def _make_encode_state_with_carrier():
+    state = DiffusionRequestState(request_id="req-1", sampling=OmniDiffusionSamplingParams(seed=0))
+    carrier = DreamZeroStageCarrier(
+        session_id="sess-A",
+        embodiment_name="roboarena",
+        transform_embodiment="roboarena",
+        reset_reason="session",
+        do_true_cfg=True,
+        current_start_frame=0,
+        height=180,
+        width=320,
+        seq_len=352,
+        frame_seqlen=88,
+        num_inference_steps=4,
+        sigma_shift=5.0,
+        prompt_embeds=torch.zeros(1, 512, 4096, dtype=torch.bfloat16),
+        clip_feas=torch.zeros(1, 257, 1280, dtype=torch.bfloat16),
+        ys=torch.zeros(1, 20, 4, 22, 40, dtype=torch.bfloat16),
+        image_latent=torch.zeros(1, 1, 16, 22, 40, dtype=torch.bfloat16),
+        noise_obs=torch.zeros(1, 4, 16, 22, 40, dtype=torch.bfloat16),
+        noise_action=torch.zeros(1, 16, 32, dtype=torch.bfloat16),
+        embodiment_id=torch.zeros(1, dtype=torch.long),
+        state_for_postprocess=torch.zeros(1, 1, 64, dtype=torch.float32),
+    )
+    state.extra[DreamZeroPipeline._CARRIER_KEY] = carrier
+    return state, carrier
+
+
+def test_pack_encode_to_dit_payload_shape_dtype():
+    from vllm_omni.diffusion.models.interface import StageBoundary
+
+    # pack_stage_state is an instance method but only touches state.extra + the
+    # field-name ClassVars; bind it unbound to avoid constructing the
+    # (checkpoint-heavy) pipeline.
+    state, _ = _make_encode_state_with_carrier()
+    payload = DreamZeroPipeline.pack_stage_state(_StubPipeline(), state, StageBoundary.ENCODE_TO_DIT)
+    payload.validate()
+    assert payload.boundary is StageBoundary.ENCODE_TO_DIT
+    # session_id is PUBLIC so the transition processor / AR runner can read it.
+    assert payload.scalar_fields["session_id"] == "sess-A"
+    # model-private scalars ride in private_scalar_fields
+    assert payload.private_scalar_fields["do_true_cfg"] is True
+    assert payload.private_scalar_fields["num_inference_steps"] == 4
+    # model-private tensors ride in private_tensor_fields, dtype/shape preserved
+    assert payload.private_tensor_fields["prompt_embeds"].shape == (1, 512, 4096)
+    assert payload.private_tensor_fields["prompt_embeds"].dtype == torch.bfloat16
+    assert payload.private_tensor_fields["noise_obs"].shape == (1, 4, 16, 22, 40)
+    # KV / scheduler objects never appear anywhere
+    assert "scheduler" not in payload.private_scalar_fields
+    assert "session_id" not in payload.private_scalar_fields
+
+
+def test_unpack_mutates_state_and_reconstructs_carrier():
+    from vllm_omni.diffusion.models.interface import StageBoundary
+
+    state, carrier = _make_encode_state_with_carrier()
+    payload = DreamZeroPipeline.pack_stage_state(_StubPipeline(), state, StageBoundary.ENCODE_TO_DIT)
+    # unpack MUTATES a runner-created target state (does not build a fresh one).
+    target = DiffusionRequestState(request_id="req-1", sampling=OmniDiffusionSamplingParams(seed=1))
+    returned = DreamZeroPipeline.unpack_stage_state(_StubPipeline(), payload, target)
+    assert returned is target  # mutate-in-place, not a fresh state
+    restored = target.extra[DreamZeroPipeline._CARRIER_KEY]
+    assert restored.session_id == "sess-A"
+    assert restored.num_inference_steps == 4
+    assert restored.sigma_shift == 5.0
+    assert restored.current_start_frame == 0
+    assert torch.equal(restored.prompt_embeds, carrier.prompt_embeds)
+    assert restored.prompt_embeds.dtype == torch.bfloat16
+
+
+class _StubPipeline:
+    """Bare object exposing just what pack/unpack touch (no checkpoint load)."""
+
+    _CARRIER_KEY = DreamZeroPipeline._CARRIER_KEY
+    _PAYLOAD_TENSOR_FIELDS = DreamZeroPipeline._PAYLOAD_TENSOR_FIELDS
+    _PAYLOAD_SCALAR_FIELDS = DreamZeroPipeline._PAYLOAD_SCALAR_FIELDS
+
+
+# --- numerical equivalence (needs GPU + checkpoint) ------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DREAMZERO_MODEL_PATH"),
+    reason="DREAMZERO_MODEL_PATH unset; full GPU equivalence test requires the checkpoint.",
+)
+def test_numerical_equivalence():
+    """Golden-equivalence: monolithic forward vs encode->denoise->decode phases.
+
+    Intended check (wire on the node): build one DreamZeroPipeline, run a
+    deterministic single forward through the monolithic path, then re-run the
+    SAME inputs through ``_run_encode_phase`` -> ``_run_denoise_phase`` ->
+    ``_run_decode_phase`` on a fresh session and compare the action + video
+    outputs. Because both paths call the identical phase methods on identical
+    inputs, outputs must match within tight fp tolerance (exact for
+    integer/metadata, torch.allclose for float tensors).
+
+    This requires a concrete ``robot_obs`` fixture and an ARDiffusionKVState
+    attach that mirror the dreamzero-vllm-omni test harness; those are provided
+    on the XPU node (see skill: dreamzero-vllm-omni-test), not pinned here.
+    """
+    pytest.skip(
+        "Provide a robot_obs fixture + ARDiffusionKVState attach to run the full "
+        "equivalence comparison on the node (see skill: dreamzero-vllm-omni-test). "
+        f"DREAMZERO_MODEL_PATH={os.environ.get('DREAMZERO_MODEL_PATH')!r}."
+    )

--- a/tests/diffusion/disaggregated/test_payload_key_sync.py
+++ b/tests/diffusion/disaggregated/test_payload_key_sync.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Guard: every consumer of the cross-stage payload keys agrees with the canonical source.
+
+The canonical definitions of ``STAGE_PAYLOAD_OUTPUT_KEY`` / ``STAGE_PAYLOAD_PROMPT_KEY``
+live in ``vllm_omni.diffusion.stage_payload`` (the torch-free transport leaf). The
+torch-heavy consumers (``diffusion/worker/diffusion_model_runner.py`` and
+``experimental/ar_diffusion/runner.py``) import them directly, so they cannot drift.
+
+The generic transition processor (``model_executor/stage_input_processors/diffusion.py``)
+is the one exception: it is loaded by file path in the torch-free foundation tests
+(see ``conftest.py``), so it cannot ``from vllm_omni...`` import at module scope without
+pulling in the package ``__init__`` (and torch). It therefore re-declares the two keys as
+literals. This test parses both source files (no torch import) and asserts the processor's
+literals still equal the canonical constants, so that one hand-copy cannot drift.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+VLLM_OMNI_ROOT = Path(__file__).resolve().parents[3] / "vllm_omni"
+
+_CANONICAL = VLLM_OMNI_ROOT / "diffusion" / "stage_payload.py"
+_PROCESSOR = VLLM_OMNI_ROOT / "model_executor" / "stage_input_processors" / "diffusion.py"
+
+_KEY_NAMES = {"STAGE_PAYLOAD_OUTPUT_KEY", "STAGE_PAYLOAD_PROMPT_KEY"}
+
+
+def _module_string_constants(path: Path, names: set[str]) -> dict[str, str]:
+    """Extract top-level ``NAME = "literal"`` assignments for the given names."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id in names and isinstance(node.value, ast.Constant):
+                found[target.id] = node.value.value
+    return found
+
+
+def test_processor_literals_match_canonical_source():
+    canonical = _module_string_constants(_CANONICAL, _KEY_NAMES)
+    processor = _module_string_constants(_PROCESSOR, _KEY_NAMES)
+    assert canonical == {
+        "STAGE_PAYLOAD_OUTPUT_KEY": "__diffusion_stage_payload__",
+        "STAGE_PAYLOAD_PROMPT_KEY": "diffusion_stage_payload",
+    }, f"canonical stage_payload keys changed unexpectedly: {canonical}"
+    assert processor == canonical, f"payload key drift: processor={processor} canonical={canonical}"
+
+
+def test_torch_heavy_consumers_do_not_redeclare_the_keys():
+    """The runner and AR-Diffusion runner must import the keys, not re-declare them.
+
+    A local re-declaration would reintroduce exactly the drift this single-source-of-truth
+    refactor removed, so assert those two files carry no top-level literal copy.
+    """
+    for rel in (
+        Path("diffusion") / "worker" / "diffusion_model_runner.py",
+        Path("experimental") / "ar_diffusion" / "runner.py",
+    ):
+        redeclared = _module_string_constants(VLLM_OMNI_ROOT / rel, _KEY_NAMES)
+        assert redeclared == {}, f"{rel} re-declares payload keys instead of importing them: {redeclared}"

--- a/tests/diffusion/disaggregated/test_pipeline_capability.py
+++ b/tests/diffusion/disaggregated/test_pipeline_capability.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pipeline capability-detection tests (#4948 DiffusionV2Atoms).
+
+Torch-free: interface.py imports torch only under TYPE_CHECKING, so the
+capability helpers can be exercised directly. These lock the collapsed contract:
+``supports_step_execution`` and ``supports_disaggregated_execution`` both require
+the full :class:`DiffusionV2Atoms` method surface AND an explicit opt-in flag —
+so a pipeline that satisfies the atom surface is still not treated as
+step/disaggregated unless it carries the corresponding flag.
+"""
+
+from __future__ import annotations
+
+
+class _V2Atoms:
+    """A full DiffusionV2Atoms method surface.
+
+    ``DiffusionV2Atoms`` is a ``@runtime_checkable`` Protocol, so ``isinstance``
+    requires every declared member to be *present* — including the
+    ``supports_step_execution`` ClassVar (presence, not truthiness). Pipelines
+    opt into step vs disaggregated behavior via the two ``supports_*`` flags
+    below, both of which are read by the capability helpers.
+    """
+
+    supports_step_execution = False
+
+    def init_state(self, s): ...
+    def check_inputs(self, s): ...
+    def encode(self, s): ...
+    def prepare(self, s): ...
+    def diffuse(self, s): ...
+    def decode(self, s): ...
+    def postprocess(self, s): ...
+    def pack_stage_state(self, s, b): ...
+    def unpack_stage_state(self, p, s): ...
+    def build_step_batch(self, states, *, cached_batch=None): ...
+    def build_step_attention_metadata(self, b): ...
+    def denoise_step(self, b): ...
+    def step_scheduler(self, s, n): ...
+
+    @classmethod
+    def required_components_for_stage(cls, model_stage): ...
+
+
+def test_step_only_pipeline_is_not_disaggregated(interface_mod):
+    class StepOnly(_V2Atoms):
+        supports_step_execution = True
+        # No supports_disaggregated_execution flag.
+
+    assert interface_mod.supports_step_execution(StepOnly()) is True
+    assert interface_mod.supports_disaggregated_execution(StepOnly()) is False
+
+
+def test_disaggregated_requires_flag_and_atoms(interface_mod):
+    class WithFlag(_V2Atoms):
+        supports_disaggregated_execution = True
+
+    class FlagOff(_V2Atoms):
+        supports_disaggregated_execution = False  # explicit opt-out honored
+
+    class NoAtoms:
+        supports_disaggregated_execution = True  # flag set, but no atom methods
+
+    assert interface_mod.supports_disaggregated_execution(WithFlag()) is True
+    assert interface_mod.supports_disaggregated_execution(FlagOff()) is False
+    assert interface_mod.supports_disaggregated_execution(NoAtoms()) is False
+
+
+def test_monolithic_pipeline_needs_no_capability(interface_mod):
+    class Monolithic:
+        def forward(self, batch): ...
+
+    assert interface_mod.supports_disaggregated_execution(Monolithic()) is False
+    assert interface_mod.supports_step_execution(Monolithic()) is False

--- a/tests/diffusion/disaggregated/test_runner_stages.py
+++ b/tests/diffusion/disaggregated/test_runner_stages.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Behavioral runner tests for disaggregated stages (#4948 DiffusionV2Atoms).
+
+These import the real ``DiffusionModelRunner`` and drive it with fake pipelines
+and lightweight tensors, so they require torch + the vllm_omni runtime. They are
+marked ``needs_runtime`` and skipped where those deps are unavailable (e.g. the
+Windows dev host); run them on the XPU node inside the vllm-omni-xpu container:
+
+    pytest tests/diffusion/disaggregated/test_runner_stages.py -m needs_runtime
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+# The full runner path needs torch + the vllm_omni runtime. Any failure to
+# import them (absent, or a broken partial install as on the Windows dev host)
+# skips the whole module rather than erroring collection.
+try:
+    import torch
+
+    from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.models.interface import StageBoundary, StagePayload
+    from vllm_omni.diffusion.request import OmniDiffusionRequest
+    from vllm_omni.diffusion.stage_roles import DECODE, DENOISE, ENCODE, StageComponentSpec
+    from vllm_omni.diffusion.worker.diffusion_model_runner import (
+        STAGE_PAYLOAD_OUTPUT_KEY,
+        STAGE_PAYLOAD_PROMPT_KEY,
+        DiffusionModelRunner,
+    )
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+except Exception as exc:  # ImportError, or torch DLL load failure
+    pytest.skip(f"vllm_omni runtime unavailable: {exc}", allow_module_level=True)
+
+pytestmark = pytest.mark.needs_runtime
+
+_CARRIER_KEY = "fake_carrier"
+
+
+class FakeDisaggregatedPipeline:
+    """Minimal pipeline implementing the DiffusionV2Atoms disaggregation contract.
+
+    Records which atoms ran so tests can assert a stage never crosses into
+    another stage's work (no DiT on encode/decode, no encode on denoise, etc.).
+    Everything is stashed on a private carrier on ``state.extra`` and marshalled
+    through pack/unpack_stage_state, mirroring the DreamZero shape.
+    """
+
+    supports_disaggregated_execution = True
+    supports_step_execution = False
+
+    def __init__(self):
+        self.calls: list[str] = []
+        self.enable_diffusion_pipeline_profiler = False
+
+    # --- DiffusionV2Atoms (encode chain) ---
+    def init_state(self, state):
+        self.calls.append("init_state")
+        state.extra.pop(_CARRIER_KEY, None)
+        return state
+
+    def check_inputs(self, state):
+        self.calls.append("check_inputs")
+        return state
+
+    def encode(self, state):
+        self.calls.append("encode")
+        state.extra[_CARRIER_KEY] = {"prompt_embeds": torch.zeros(1, 4)}
+        return state
+
+    def prepare(self, state):
+        self.calls.append("prepare")
+        return state
+
+    # --- denoise (whole-request atom) ---
+    def diffuse(self, state):
+        self.calls.append("diffuse")
+        carrier = state.extra[_CARRIER_KEY]
+        carrier["latents"] = torch.ones(1, 16)
+        return state
+
+    # --- decode chain ---
+    def decode(self, state):
+        self.calls.append("decode")
+        return state
+
+    def postprocess(self, state):
+        self.calls.append("postprocess")
+        return DiffusionOutput(output={"image": torch.zeros(3, 8, 8)})
+
+    # --- payload marshalling ---
+    def pack_stage_state(self, state, boundary):
+        self.calls.append(f"pack:{boundary.value}")
+        carrier = state.extra.get(_CARRIER_KEY, {})
+        return StagePayload.create(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields={"session_id": "sess"},
+            private_tensor_fields={k: v for k, v in carrier.items() if v is not None},
+        )
+
+    def unpack_stage_state(self, payload, state):
+        self.calls.append("unpack")
+        state.extra[_CARRIER_KEY] = dict(payload.private_tensor_fields)
+        return state
+
+    # --- step-only stubs (unused: request-mode pipeline) ---
+    def build_step_batch(self, states, *, cached_batch=None):
+        raise NotImplementedError
+
+    def build_step_attention_metadata(self, input_batch):
+        return None
+
+    def denoise_step(self, input_batch):
+        raise NotImplementedError
+
+    def step_scheduler(self, state, noise_pred):
+        raise NotImplementedError
+
+    @classmethod
+    def required_components_for_stage(cls, model_stage):
+        if model_stage == ENCODE:
+            return StageComponentSpec(tokenizer=True, text_encoder=True, vae_encoder=True)
+        if model_stage == DENOISE:
+            return StageComponentSpec(dit=True, scheduler=True)
+        if model_stage == DECODE:
+            return StageComponentSpec(vae_decoder=True)
+        return StageComponentSpec()
+
+
+def _make_runner(model_stage):
+    runner = object.__new__(DiffusionModelRunner)
+    runner.od_config = types.SimpleNamespace(
+        model_stage=model_stage,
+        model_class_name="FakeDisaggregatedPipeline",
+        parallel_config=types.SimpleNamespace(use_hsdp=False),
+        stage_id=0,
+    )
+    runner.device = torch.device("cpu")
+    runner.vllm_config = None
+    runner.pipeline = FakeDisaggregatedPipeline()
+    runner.state_cache = {}
+    return runner
+
+
+def _request(prompt):
+    return OmniDiffusionRequest(
+        prompt=prompt,
+        sampling_params=OmniDiffusionSamplingParams(seed=0),
+        request_id="req-1",
+    )
+
+
+def _encode_payload():
+    return StagePayload.create(
+        request_id="req-1",
+        boundary=StageBoundary.ENCODE_TO_DIT,
+        scalar_fields={"session_id": "sess"},
+        private_tensor_fields={"prompt_embeds": torch.zeros(1, 4)},
+    )
+
+
+def _denoise_payload():
+    return StagePayload.create(
+        request_id="req-1",
+        boundary=StageBoundary.DIT_TO_DECODE,
+        scalar_fields={"session_id": "sess"},
+        private_tensor_fields={"latents": torch.ones(1, 16)},
+    )
+
+
+def test_encode_stage_runs_only_encode_atoms():
+    runner = _make_runner(ENCODE)
+    out = runner.execute_encode_stage(_request({"prompt": "hi"}))
+    calls = runner.pipeline.calls
+    assert calls[:4] == ["init_state", "check_inputs", "encode", "prepare"]
+    assert "diffuse" not in calls and "decode" not in calls
+    payload = out.custom_output[STAGE_PAYLOAD_OUTPUT_KEY]
+    assert payload.boundary is StageBoundary.ENCODE_TO_DIT
+    # state released
+    assert "req-1" not in runner.state_cache
+
+
+def test_denoise_stage_unpacks_payload_and_does_not_encode():
+    runner = _make_runner(DENOISE)
+    req = _request({"prompt": "", "extra": {STAGE_PAYLOAD_PROMPT_KEY: _encode_payload()}})
+    out = runner.execute_denoise_stage(req)
+    calls = runner.pipeline.calls
+    assert "unpack" in calls and "diffuse" in calls
+    assert "check_inputs" not in calls and "encode" not in calls
+    payload = out.custom_output[STAGE_PAYLOAD_OUTPUT_KEY]
+    assert payload.boundary is StageBoundary.DIT_TO_DECODE
+
+
+def test_decode_stage_runs_only_decode():
+    runner = _make_runner(DECODE)
+    req = _request({"prompt": "", "extra": {STAGE_PAYLOAD_PROMPT_KEY: _denoise_payload()}})
+    out = runner.execute_decode_stage(req)
+    calls = runner.pipeline.calls
+    assert "unpack" in calls and "decode" in calls and "postprocess" in calls
+    assert "diffuse" not in calls
+    assert out.output is not None and "image" in out.output
+
+
+def test_denoise_rejects_wrong_boundary():
+    runner = _make_runner(DENOISE)
+    # A DIT_TO_DECODE payload arriving at the denoise stage must be rejected.
+    req = _request({"prompt": "", "extra": {STAGE_PAYLOAD_PROMPT_KEY: _denoise_payload()}})
+    with pytest.raises(Exception, match="boundary"):
+        runner.execute_denoise_stage(req)
+
+
+def test_missing_payload_raises_actionable_error():
+    runner = _make_runner(DENOISE)
+    req = _request({"prompt": "no payload here"})
+    with pytest.raises(Exception, match="without a StagePayload"):
+        runner.execute_denoise_stage(req)

--- a/tests/diffusion/disaggregated/test_stage_dispatch.py
+++ b/tests/diffusion/disaggregated/test_stage_dispatch.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Torch-free tests for the runner's stage-dispatch decision table (RFC #4590 §4).
+
+The runner's ``execute_model`` routes on ``resolve_execution_path(model_stage)``,
+which is a pure function kept in ``stage_roles`` precisely so the routing is
+testable without importing the torch-heavy runner. A ``FakeRunner`` mirrors the
+runner's dispatch structure over that same shared function to lock the routing
+contract; the full behavioral runner tests (real pipeline mutations, payload
+export/import, cleanup) live in ``test_runner_stages.py`` under ``needs_runtime``.
+"""
+
+from __future__ import annotations
+
+
+class FakeRunner:
+    """Mirrors DiffusionModelRunner.execute_model dispatch using the shared table.
+
+    Records which stage path each role selects so the routing contract can be
+    asserted without torch. Kept structurally identical to the real dispatch so
+    a divergence in the table surfaces here.
+    """
+
+    def __init__(self, roles_mod, model_stage):
+        self._roles = roles_mod
+        self._model_stage = model_stage
+        self.calls: list[str] = []
+
+    @property
+    def model_stage(self):
+        return self._roles.normalize_stage_role(self._model_stage)
+
+    def execute_model(self, req=None):
+        roles = self._roles
+        path = roles.resolve_execution_path(self.model_stage)
+        if path == roles.EXECUTION_PATH_ENCODE:
+            return self._encode()
+        if path == roles.EXECUTION_PATH_DENOISE:
+            return self._denoise()
+        if path == roles.EXECUTION_PATH_DECODE:
+            return self._decode()
+        if path == roles.EXECUTION_PATH_MODEL_DEFINED:
+            return self._model_defined()
+        return self._monolithic()
+
+    def _encode(self):
+        self.calls.append("encode")
+
+    def _denoise(self):
+        self.calls.append("denoise")
+
+    def _decode(self):
+        self.calls.append("decode")
+
+    def _monolithic(self):
+        self.calls.append("monolithic")
+
+    def _model_defined(self):
+        self.calls.append("model_defined")
+
+
+def test_resolve_execution_path_table(stage_roles):
+    r = stage_roles
+    assert r.resolve_execution_path(None) == r.EXECUTION_PATH_MONOLITHIC
+    assert r.resolve_execution_path("") == r.EXECUTION_PATH_MONOLITHIC
+    assert r.resolve_execution_path("diffusion") == r.EXECUTION_PATH_MONOLITHIC
+    assert r.resolve_execution_path("encode") == r.EXECUTION_PATH_ENCODE
+    assert r.resolve_execution_path("denoise") == r.EXECUTION_PATH_DENOISE
+    assert r.resolve_execution_path("decode") == r.EXECUTION_PATH_DECODE
+    assert r.resolve_execution_path("kv_update") == r.EXECUTION_PATH_MODEL_DEFINED
+
+
+def test_encode_role_calls_only_encode(stage_roles):
+    runner = FakeRunner(stage_roles, "encode")
+    runner.execute_model()
+    assert runner.calls == ["encode"]
+    assert "denoise" not in runner.calls and "decode" not in runner.calls
+
+
+def test_denoise_role_calls_only_denoise(stage_roles):
+    runner = FakeRunner(stage_roles, "denoise")
+    runner.execute_model()
+    assert runner.calls == ["denoise"]
+
+
+def test_decode_role_calls_only_decode(stage_roles):
+    runner = FakeRunner(stage_roles, "decode")
+    runner.execute_model()
+    assert runner.calls == ["decode"]
+
+
+def test_monolithic_role_unchanged(stage_roles):
+    for role in (None, "", "diffusion"):
+        runner = FakeRunner(stage_roles, role)
+        runner.execute_model()
+        assert runner.calls == ["monolithic"]
+
+
+def test_custom_role_uses_model_defined(stage_roles):
+    runner = FakeRunner(stage_roles, "kv_update")
+    runner.execute_model()
+    assert runner.calls == ["model_defined"]

--- a/tests/diffusion/disaggregated/test_stage_payload.py
+++ b/tests/diffusion/disaggregated/test_stage_payload.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the StagePayload transport envelope (#4948 DiffusionV2Atoms).
+
+``StagePayload`` (in ``interface.py``) is the four-dict envelope; its transport
+safety (tensor sanitization, non-transportable-value rejection) is delegated to
+the torch-free helpers in ``stage_payload.py``. Both modules load torch-free by
+file path (see conftest); the ``interface_mod`` fixture pre-registers the
+``stage_payload`` leaf under its real dotted name so ``StagePayload``'s lazy
+``_transport()`` resolves without importing torch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_create_valid_payload(interface_mod):
+    p = interface_mod.StagePayload.create(
+        request_id="req-1",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        scalar_fields={"session_id": "s0"},
+        private_scalar_fields={"num_steps": 4, "cfg": 1.5, "shape": [1, 16, 4]},
+    )
+    assert p.payload_version == interface_mod.STAGE_PAYLOAD_SCHEMA_VERSION
+    assert p.request_id == "req-1"
+    assert p.boundary is interface_mod.StageBoundary.ENCODE_TO_DIT
+    assert p.scalar_fields["session_id"] == "s0"
+    assert p.private_scalar_fields["num_steps"] == 4
+
+
+def test_payload_version_validation(interface_mod):
+    p = interface_mod.StagePayload(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        payload_version=999,
+    )
+    with pytest.raises(Exception, match="payload_version"):
+        p.validate()
+
+
+def test_empty_request_id_rejected(interface_mod):
+    with pytest.raises(Exception, match="request_id"):
+        interface_mod.StagePayload.create(
+            request_id="",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        )
+
+
+def test_boundary_must_be_enum(interface_mod):
+    p = interface_mod.StagePayload(request_id="r", boundary="encode_to_dit")
+    with pytest.raises(Exception, match="boundary"):
+        p.validate()
+
+
+def test_expect_boundary(interface_mod):
+    p = interface_mod.StagePayload.create(
+        request_id="keep-me",
+        boundary=interface_mod.StageBoundary.DIT_TO_DECODE,
+    )
+    p.expect_boundary(interface_mod.StageBoundary.DIT_TO_DECODE)
+    assert p.request_id == "keep-me"
+    with pytest.raises(Exception, match="expected"):
+        p.expect_boundary(interface_mod.StageBoundary.ENCODE_TO_DIT)
+
+
+def test_boundary_from_roles(interface_mod):
+    SB = interface_mod.StageBoundary
+    assert interface_mod.boundary_from_roles("encode", "denoise") is SB.ENCODE_TO_DIT
+    assert interface_mod.boundary_from_roles("denoise", "decode") is SB.DIT_TO_DECODE
+    with pytest.raises(Exception):
+        interface_mod.boundary_from_roles("encode", "decode")
+
+
+def test_roundtrip_to_from_dict(interface_mod, fake_tensor_cls):
+    p = interface_mod.StagePayload.create(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        scalar_fields={"session_id": "s0"},
+        private_tensor_fields={"prompt_embeds": fake_tensor_cls()},
+        private_scalar_fields={"steps": 4},
+    )
+    d = p.to_dict()
+    assert d["boundary"] == "encode_to_dit"  # enum flattens to its str value
+    p2 = interface_mod.StagePayload.from_dict(d)
+    assert p2.boundary is interface_mod.StageBoundary.ENCODE_TO_DIT
+    assert p2.scalar_fields["session_id"] == "s0"
+    assert p2.private_scalar_fields["steps"] == 4
+    assert "prompt_embeds" in p2.private_tensor_fields
+
+
+def test_tensor_dtype_shape_preserved(interface_mod, fake_tensor_cls):
+    t = fake_tensor_cls(shape=(1, 16, 4, 22, 40), dtype="bfloat16")
+    p = interface_mod.StagePayload.create(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        private_tensor_fields={"latents": t},
+    )
+    out = p.private_tensor_fields["latents"]
+    assert out.shape == (1, 16, 4, 22, 40)
+    assert out.dtype == "bfloat16"
+
+
+def test_sanitize_detaches_and_moves_to_host(stage_payload, fake_tensor_cls):
+    t = fake_tensor_cls(data_ptr=500)
+    # sanitize path: detach -> cpu -> contiguous; clone only if ptr unchanged.
+    out = stage_payload.sanitize_transport_tensor(t)
+    assert "detach" in t.calls and "cpu" in t.calls and "contiguous" in t.calls
+    # data_ptr is unchanged in the fake, so a clone must have been forced.
+    assert out is not t
+
+
+def test_non_tensor_in_tensor_fields_rejected(interface_mod):
+    with pytest.raises(Exception, match="tensor"):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_tensor_fields={"bad": [1, 2, 3]},
+        )
+
+
+def test_tensor_in_scalar_fields_rejected(interface_mod, fake_tensor_cls):
+    with pytest.raises(Exception, match="tensor"):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_scalar_fields={"latents": fake_tensor_cls()},
+        )
+
+
+def test_scheduler_object_in_scalar_fields_rejected(interface_mod):
+    class FlowUniPCMultistepScheduler:  # name matches the non-transportable guard
+        pass
+
+    with pytest.raises(Exception, match="scheduler"):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_scalar_fields={"sched": FlowUniPCMultistepScheduler()},
+        )
+
+
+def test_callable_in_scalar_fields_rejected(interface_mod):
+    with pytest.raises(Exception):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_scalar_fields={"fn": lambda x: x},
+        )
+
+
+def test_generator_like_object_rejected(interface_mod):
+    class _FakeTorchGenerator:
+        pass
+
+    _FakeTorchGenerator.__module__ = "torch"
+    _FakeTorchGenerator.__name__ = "Generator"
+
+    with pytest.raises(Exception, match="Generator"):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_scalar_fields={"gen": _FakeTorchGenerator()},
+        )
+
+
+def test_process_local_state_object_rejected(interface_mod):
+    class DreamZeroState:
+        pass
+
+    with pytest.raises(Exception, match="process-local"):
+        interface_mod.StagePayload.create(
+            request_id="r",
+            boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+            private_scalar_fields={"state": DreamZeroState()},
+        )
+
+
+def test_nested_scalar_fields_allowed(interface_mod):
+    p = interface_mod.StagePayload.create(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        private_scalar_fields={"nested": {"a": [1, 2, {"b": None, "c": b"bytes"}], "d": True}},
+    )
+    assert p.private_scalar_fields["nested"]["d"] is True
+
+
+def test_require_tensors(interface_mod, fake_tensor_cls):
+    p = interface_mod.StagePayload.create(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        private_tensor_fields={"latents": fake_tensor_cls()},
+    )
+    p.require_tensors("latents")
+    with pytest.raises(Exception, match="missing required"):
+        p.require_tensors("latents", "prompt_embeds")
+
+
+def test_summary_has_no_tensor_contents(interface_mod, fake_tensor_cls):
+    p = interface_mod.StagePayload.create(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        private_tensor_fields={"latents": fake_tensor_cls(shape=(1, 16), dtype="bfloat16")},
+        scalar_fields={"session_id": "s0"},
+    )
+    s = p.summary()
+    assert "latents" in s and "(1, 16)" in s and "session_id" in s

--- a/tests/diffusion/disaggregated/test_stage_roles.py
+++ b/tests/diffusion/disaggregated/test_stage_roles.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for stage-role vocabulary, component spec, and topology validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+
+@dataclass
+class _Stage:
+    """Duck-typed stand-in for StagePipelineConfig used by topology validation."""
+
+    stage_id: int
+    model_stage: str
+    input_sources: tuple
+    final_output: bool = False
+
+
+# --- role vocabulary -------------------------------------------------------
+
+
+def test_normalize_role(stage_roles):
+    assert stage_roles.normalize_stage_role(None) == "diffusion"
+    assert stage_roles.normalize_stage_role("") == "diffusion"
+    assert stage_roles.normalize_stage_role("  ") == "diffusion"
+    assert stage_roles.normalize_stage_role("encode") == "encode"
+    assert stage_roles.normalize_stage_role(" Denoise ") == "Denoise"
+
+
+def test_role_predicates(stage_roles):
+    assert stage_roles.is_monolithic_role(None)
+    assert stage_roles.is_monolithic_role("diffusion")
+    assert not stage_roles.is_monolithic_role("encode")
+
+    assert stage_roles.is_disaggregated_role("encode")
+    assert stage_roles.is_disaggregated_role("denoise")
+    assert stage_roles.is_disaggregated_role("decode")
+    assert not stage_roles.is_disaggregated_role("diffusion")
+    assert not stage_roles.is_disaggregated_role("custom_role")
+
+    assert stage_roles.is_known_role("decode")
+    assert not stage_roles.is_known_role("custom_role")
+
+
+# --- component spec --------------------------------------------------------
+
+
+def test_component_spec_enabled_and_requires(stage_roles):
+    spec = stage_roles.StageComponentSpec(tokenizer=True, text_encoder=True, dit=False)
+    assert spec.requires("tokenizer")
+    assert not spec.requires("dit")
+    assert not spec.requires("nonexistent")
+    assert "tokenizer" in spec.enabled_components()
+    assert "dit" not in spec.enabled_components()
+
+
+def test_component_spec_union(stage_roles):
+    a = stage_roles.StageComponentSpec(tokenizer=True, text_encoder=True)
+    b = stage_roles.StageComponentSpec(dit=True, scheduler=True)
+    u = a.union(b)
+    assert u.tokenizer and u.text_encoder and u.dit and u.scheduler
+    assert not u.vae_decoder
+
+
+def test_all_components_spec(stage_roles):
+    assert stage_roles.ALL_COMPONENTS.tokenizer
+    assert stage_roles.ALL_COMPONENTS.vae_decoder
+    assert stage_roles.ALL_COMPONENTS.dit
+    assert len(stage_roles.ALL_COMPONENTS.enabled_components()) == 8
+
+
+def test_component_spec_describe(stage_roles):
+    assert stage_roles.StageComponentSpec().describe() == "none"
+    assert "tokenizer" in stage_roles.StageComponentSpec(tokenizer=True).describe()
+
+
+# --- topology validation ---------------------------------------------------
+
+
+def _linear_topology():
+    return [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (0,)),
+        _Stage(2, "decode", (1,), final_output=True),
+    ]
+
+
+def test_valid_linear_topology(stage_roles):
+    assert stage_roles.validate_linear_diffusion_topology(_linear_topology()) == []
+
+
+def test_empty_topology(stage_roles):
+    errs = stage_roles.validate_linear_diffusion_topology([])
+    assert errs and "no stages" in errs[0]
+
+
+def test_duplicate_stage_ids(stage_roles):
+    stages = [_Stage(0, "encode", ()), _Stage(0, "denoise", (0,), final_output=True)]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("Duplicate stage id" in e for e in errs)
+
+
+def test_denoise_without_upstream(stage_roles):
+    stages = [_Stage(1, "denoise", ()), _Stage(2, "decode", (1,), final_output=True)]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("Denoise stage 1 has no upstream source" in e for e in errs)
+
+
+def test_decode_without_denoise_source(stage_roles):
+    # decode points at an encode stage, not a denoise stage
+    stages = [_Stage(0, "encode", ()), _Stage(2, "decode", (0,), final_output=True)]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("no upstream denoise source" in e for e in errs)
+
+
+def test_nonexistent_input_source(stage_roles):
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (9,)),
+        _Stage(2, "decode", (1,), final_output=True),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("non-existent input source 9" in e for e in errs)
+
+
+def test_self_reference(stage_roles):
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (1,)),
+        _Stage(2, "decode", (1,), final_output=True),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("references itself" in e for e in errs)
+
+
+def test_multiple_final_outputs(stage_roles):
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (0,), final_output=True),
+        _Stage(2, "decode", (1,), final_output=True),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("exactly one final_output" in e for e in errs)
+
+
+def test_final_output_not_on_decode(stage_roles):
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (0,), final_output=True),
+        _Stage(2, "decode", (1,)),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("final_output must be placed on the decode stage" in e for e in errs)
+
+
+def test_denoise_multiple_upstream(stage_roles):
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(3, "encode", ()),
+        _Stage(1, "denoise", (0, 3)),
+        _Stage(2, "decode", (1,), final_output=True),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    assert any("upstream sources; the linear" in e for e in errs)
+
+
+def test_monolithic_single_stage_valid(stage_roles):
+    stages = [_Stage(0, "diffusion", (), final_output=True)]
+    # single monolithic stage: no disaggregated adjacency requirements
+    assert stage_roles.validate_linear_diffusion_topology(stages) == []
+
+
+def test_custom_role_accepted(stage_roles):
+    # unknown roles participate only in id/reference checks
+    stages = [
+        _Stage(0, "encode", ()),
+        _Stage(1, "denoise", (0,)),
+        _Stage(2, "decode", (1,)),
+        _Stage(3, "kv_update", (1,), final_output=False),
+        _Stage(4, "custom_final", (2,), final_output=True),
+    ]
+    errs = stage_roles.validate_linear_diffusion_topology(stages)
+    # final on a custom (non-decode) stage while a decode stage exists -> error,
+    # but the custom kv_update role itself must not produce a role error.
+    assert not any("kv_update" in e for e in errs)

--- a/tests/diffusion/disaggregated/test_stage_transition_processor.py
+++ b/tests/diffusion/disaggregated/test_stage_transition_processor.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the generic diffusion->diffusion transition processor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _FakeDiffusionOutput:
+    """Stand-in for DiffusionOutput carrying a payload in custom_output."""
+
+    custom_output: dict[str, Any] = field(default_factory=dict)
+
+
+def _make_payload(interface_mod, **overrides):
+    kwargs = dict(
+        request_id="req-7",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        scalar_fields={"session_id": "sess-A"},
+    )
+    kwargs.update(overrides)
+    return interface_mod.StagePayload.create(**kwargs)
+
+
+def test_transition_moves_payload_into_prompt_extra(diffusion_processor, interface_mod):
+    payload = _make_payload(interface_mod)
+    src = _FakeDiffusionOutput(custom_output={diffusion_processor.STAGE_PAYLOAD_OUTPUT_KEY: payload})
+
+    prompt = diffusion_processor.diffusion_stage_transition([src], {"prompt": "hi"}, False)
+
+    assert prompt is not None
+    assert prompt["extra"][diffusion_processor.STAGE_PAYLOAD_PROMPT_KEY] is payload
+    # session id mirrored to prompt for the denoise runner (from public scalar_fields)
+    assert prompt["session_id"] == "sess-A"
+
+
+def test_transition_returns_none_when_no_outputs(diffusion_processor):
+    assert diffusion_processor.diffusion_stage_transition([], None, False) is None
+
+
+def test_transition_returns_none_when_no_payload(diffusion_processor):
+    src = _FakeDiffusionOutput(custom_output={})
+    assert diffusion_processor.diffusion_stage_transition([src], None, False) is None
+
+
+def test_transition_accepts_bare_payload(diffusion_processor, interface_mod):
+    payload = _make_payload(interface_mod, boundary=interface_mod.StageBoundary.DIT_TO_DECODE)
+    prompt = diffusion_processor.diffusion_stage_transition([payload], None, False)
+    assert prompt["extra"][diffusion_processor.STAGE_PAYLOAD_PROMPT_KEY] is payload
+
+
+def test_transition_passthrough_fields(diffusion_processor, interface_mod):
+    payload = _make_payload(interface_mod)
+    src = _FakeDiffusionOutput(custom_output={diffusion_processor.STAGE_PAYLOAD_OUTPUT_KEY: payload})
+    prompt = diffusion_processor.diffusion_stage_transition(
+        [src],
+        {"prompt": "p", "seed": 42, "num_inference_steps": 4, "guidance_scale": 1.5},
+        False,
+    )
+    assert prompt["seed"] == 42
+    assert prompt["num_inference_steps"] == 4
+    assert prompt["guidance_scale"] == 1.5
+
+
+def test_transition_accepts_sampling_params_kwarg(diffusion_processor, interface_mod):
+    # Orchestrator probes the signature and passes sampling_params=...; the
+    # generic processor must accept it without error.
+    payload = _make_payload(interface_mod)
+    src = _FakeDiffusionOutput(custom_output={diffusion_processor.STAGE_PAYLOAD_OUTPUT_KEY: payload})
+    prompt = diffusion_processor.diffusion_stage_transition(
+        [src], None, True, sampling_params=object()
+    )
+    assert prompt is not None
+
+
+def test_transition_rejects_invalid_payload(diffusion_processor, interface_mod):
+    # A payload with a bad payload_version fails validate() -> None routed.
+    bad = interface_mod.StagePayload(
+        request_id="r",
+        boundary=interface_mod.StageBoundary.ENCODE_TO_DIT,
+        payload_version=999,
+    )
+    src = _FakeDiffusionOutput(custom_output={diffusion_processor.STAGE_PAYLOAD_OUTPUT_KEY: bad})
+    assert diffusion_processor.diffusion_stage_transition([src], None, False) is None

--- a/tests/diffusion/disaggregated/test_topology_config.py
+++ b/tests/diffusion/disaggregated/test_topology_config.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Config/topology resolution tests for the DreamZero disaggregated pipeline.
+
+These import the real config + registry (vllm/transformers), so they are marked
+``needs_runtime`` and skipped where those deps are unavailable. Run on the node:
+
+    pytest tests/diffusion/disaggregated/test_topology_config.py -m needs_runtime
+
+The torch-free topology *validation rules* are covered separately in
+test_stage_roles.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
+    from vllm_omni.config.stage_config import StageExecutionType
+    from vllm_omni.model_executor.models.dreamzero.pipeline import (
+        DREAMZERO_DISAGGREGATED_PIPELINE,
+        DREAMZERO_PIPELINE,
+        GENERIC_DIFFUSION_PROCESSOR,
+    )
+except Exception as exc:  # pragma: no cover - import-environment dependent
+    pytest.skip(f"vllm_omni config runtime unavailable: {exc}", allow_module_level=True)
+
+pytestmark = pytest.mark.needs_runtime
+
+
+def test_single_stage_dreamzero_still_registered():
+    assert OMNI_PIPELINES["dreamzero"] is DREAMZERO_PIPELINE
+    assert len(DREAMZERO_PIPELINE.stages) == 1
+    assert DREAMZERO_PIPELINE.stages[0].model_stage == "diffusion"
+    assert DREAMZERO_PIPELINE.stages[0].final_output
+
+
+def test_disaggregated_pipeline_registered():
+    assert OMNI_PIPELINES["dreamzero_disaggregated"] is DREAMZERO_DISAGGREGATED_PIPELINE
+
+
+def test_disaggregated_topology_roles_and_sources():
+    stages = DREAMZERO_DISAGGREGATED_PIPELINE.stages
+    assert [s.model_stage for s in stages] == ["encode", "denoise", "decode"]
+    assert [tuple(s.input_sources) for s in stages] == [(), (0,), (1,)]
+    assert [s.final_output for s in stages] == [False, False, True]
+    assert stages[2].final_output_type == "image"
+    for s in stages:
+        assert s.execution_type == StageExecutionType.DIFFUSION
+
+
+def test_disaggregated_uses_generic_processor():
+    encode, denoise, decode = DREAMZERO_DISAGGREGATED_PIPELINE.stages
+    assert encode.custom_process_next_stage_input_func == GENERIC_DIFFUSION_PROCESSOR
+    assert denoise.custom_process_input_func == GENERIC_DIFFUSION_PROCESSOR
+    assert denoise.custom_process_next_stage_input_func == GENERIC_DIFFUSION_PROCESSOR
+    assert decode.custom_process_input_func == GENERIC_DIFFUSION_PROCESSOR
+    # encode has no consumer hook; decode has no producer hook
+    assert encode.custom_process_input_func is None
+    assert decode.custom_process_next_stage_input_func is None
+
+
+def test_disaggregated_topology_validates_clean():
+    assert DREAMZERO_DISAGGREGATED_PIPELINE.validate() == []
+
+
+def test_single_stage_topology_validates_clean():
+    assert DREAMZERO_PIPELINE.validate() == []
+
+
+def test_invalid_disaggregated_topology_fails_validation():
+    from vllm_omni.config.stage_config import PipelineConfig, StagePipelineConfig
+
+    # decode points at the encode stage (no denoise source) -> must error
+    bad = PipelineConfig(
+        model_type="dreamzero_bad",
+        model_arch="DreamZeroPipeline",
+        stages=(
+            StagePipelineConfig(
+                stage_id=0,
+                model_stage="encode",
+                execution_type=StageExecutionType.DIFFUSION,
+                input_sources=(),
+            ),
+            StagePipelineConfig(
+                stage_id=2,
+                model_stage="decode",
+                execution_type=StageExecutionType.DIFFUSION,
+                input_sources=(0,),
+                final_output=True,
+            ),
+        ),
+    )
+    errors = bad.validate()
+    assert any("no upstream denoise source" in e for e in errors)

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 
 from vllm_omni.config.stage_config import (
     _DEPLOY_DIR,
+    _EXECUTION_TYPE_TO_STAGE_WORKER,
     _STAGE_DEPLOY_FIELDS,
     PIPELINE_WIDE_ENGINE_FIELDS,
     DeployConfig,
@@ -38,11 +39,11 @@ from vllm_omni.config.stage_config import (
     load_deploy_config,
 )
 
-_EXECUTION_TYPE_TO_STAGE_WORKER: dict[StageExecutionType, tuple[StageType, str | None]] = {
-    StageExecutionType.LLM_AR: (StageType.LLM, "ar"),
-    StageExecutionType.LLM_GENERATION: (StageType.LLM, "generation"),
-    StageExecutionType.DIFFUSION: (StageType.DIFFUSION, None),
-}
+# ``_EXECUTION_TYPE_TO_STAGE_WORKER`` (the execution-type -> (stage_type,
+# worker_type) mapping) is the single source of truth in ``stage_config`` and is
+# imported above. This module's ``_resolve_execution_mode`` looks it up directly
+# (no fallback), while ``stage_config._resolve_execution_mode`` uses ``.get()``
+# with a legacy default -- the two lookups differ on purpose.
 
 _PIPELINE_DEPLOY_CLI_FIELDS = PIPELINE_WIDE_ENGINE_FIELDS
 

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -41,7 +41,10 @@ from vllm_omni.model_executor.models.bagel.pipeline import (
 )
 from vllm_omni.model_executor.models.cosyvoice3.pipeline import COSYVOICE3_PIPELINE
 from vllm_omni.model_executor.models.covo_audio.pipeline import COVO_AUDIO_PIPELINE
-from vllm_omni.model_executor.models.dreamzero.pipeline import DREAMZERO_PIPELINE
+from vllm_omni.model_executor.models.dreamzero.pipeline import (
+    DREAMZERO_DISAGGREGATED_PIPELINE,
+    DREAMZERO_PIPELINE,
+)
 from vllm_omni.model_executor.models.dynin_omni.pipeline import DYNIN_OMNI_PIPELINE
 from vllm_omni.model_executor.models.fish_speech.pipeline import FISH_SPEECH_PIPELINE
 from vllm_omni.model_executor.models.glm_image.pipeline import GLM_IMAGE_PIPELINE
@@ -117,6 +120,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "bagel_single_stage": BAGEL_SINGLE_STAGE_PIPELINE,
     "lance": LANCE_PIPELINE,
     "dreamzero": DREAMZERO_PIPELINE,
+    "dreamzero_disaggregated": DREAMZERO_DISAGGREGATED_PIPELINE,
     "Gr00tN1d7": GR00T_N1D7_PIPELINE,
     "glm_image": GLM_IMAGE_PIPELINE,
     "hunyuan_image_3_moe": HUNYUAN_IMAGE3_PIPELINE,

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -299,6 +299,25 @@ class PipelineConfig:
                     errors.append(f"Stage {stage.stage_id} references itself")
         if not any(not s.input_sources for s in self.stages):
             errors.append("No entry point (stage with empty input_sources)")
+
+        # RFC #4590: apply the disaggregated-diffusion topology rules when any
+        # stage declares a disaggregated role (encode/denoise/decode). This
+        # catches denoise-without-encode-source, decode-without-denoise-source,
+        # bad final-output placement, and unmergeable multi-source consumers.
+        #
+        # validate_linear_diffusion_topology re-checks duplicate ids and source
+        # references that the generic block above already covers. That overlap is
+        # intentional, not redundant: the diffusion validator is duck-typed and
+        # lives in the torch-free stage_roles leaf so it can validate lightweight
+        # test doubles standalone, so it cannot assume this method ran first. The
+        # duplicate messages are harmless (callers surface the error list as-is).
+        from vllm_omni.diffusion.stage_roles import (
+            DISAGGREGATED_ROLES,
+            validate_linear_diffusion_topology,
+        )
+
+        if any(s.model_stage in DISAGGREGATED_ROLES for s in self.stages):
+            errors.extend(validate_linear_diffusion_topology(self.stages))
         return errors
 
 
@@ -754,6 +773,9 @@ _PIPELINE_WIDE_ENGINE_FIELDS: tuple[str, ...] = (
     "active_stream_window",
     "custom_voice_dir",
 )
+# Public alias for the same tuple: internal call sites use the underscored name,
+# while other packages (config.__init__ __all__, omni_config) import this public
+# one. Same object — kept as an alias only to preserve the public import path.
 PIPELINE_WIDE_ENGINE_FIELDS = _PIPELINE_WIDE_ENGINE_FIELDS
 
 
@@ -771,6 +793,12 @@ def _build_engine_args(
     ``engine_extras`` can still carry a stage-specific ``dtype``).
     """
     engine_args: dict[str, Any] = {"model_arch": ps.model_arch or pipeline.model_arch}
+    # The asymmetry here is deliberate: model_arch falls back to the pipeline
+    # value, but model_class_name is derived only from a stage-level model_arch.
+    # A diffusion stage that omits its own model_arch (relying on the pipeline
+    # fallback) intentionally does NOT auto-set model_class_name, leaving the
+    # loader to resolve the class by other means. Do not add the pipeline
+    # fallback to this branch without checking the diffusion loader.
     if ps.execution_type == StageExecutionType.DIFFUSION and ps.model_arch:
         engine_args.setdefault("model_class_name", ps.model_arch)
     if ps.engine_output_type:

--- a/vllm_omni/deploy/dreamzero_disaggregated.yaml
+++ b/vllm_omni/deploy/dreamzero_disaggregated.yaml
@@ -1,0 +1,78 @@
+# DreamZero-DROID disaggregated deploy (RFC #4590): encode -> denoise -> decode.
+#
+# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py
+# (DREAMZERO_DISAGGREGATED_PIPELINE). Each stage runs as a native diffusion stage
+# distinguished by model_stage; the generic diffusion transition processor moves
+# the typed DiffusionStagePayload between them.
+#
+# Stage ownership (see StageComponentSpec in
+# DreamZeroPipeline.required_components_for_stage):
+#   stage 0 (encode):  tokenizer + text/image encoders + VAE encoder
+#   stage 1 (denoise): CausalWan DiT + schedulers + action head + AR-Diffusion KV
+#   stage 2 (decode):  VAE decoder + video/action postprocess
+#
+# Engine backends:
+#   - The denoise stage REQUIRES the AR-Diffusion engine (session-scoped paged KV).
+#   - Encode/decode own no KV, so they use the standard diffusion engine.
+#
+# Device ids below are repository-standard examples (one GPU per stage). Override
+# per site; do not treat these as production placement.
+
+pipeline: dreamzero_disaggregated
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  # ---- Stage 0: ENCODE (standard diffusion engine, one device) ----
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 1: DENOISE (AR-Diffusion engine; configurable TP/SP/HSDP) ----
+  - stage_id: 1
+    devices: "1"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    # DreamZero denoise runs on the AR-Diffusion engine (engine-level paged KV).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 1
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 2: DECODE (standard diffusion engine, one device) ----
+  - stage_id: 2
+    devices: "2"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise.yaml
+++ b/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise.yaml
@@ -1,0 +1,83 @@
+# DreamZero-DROID disaggregated deploy (RFC #4590): encode -> denoise -> decode.
+# Variant: TP=4 applied specifically to the DENOISE stage, to test whether
+# splitting encode/decode off the DiT stage (per required_components_for_stage)
+# relieves the per-device memory pressure seen with the monolithic dreamzero_tp4.yaml
+# (which builds tokenizer + UMT5 + image encoder + VAE encoder + DiT + VAE decoder,
+# fully replicated, on every one of the 4 TP ranks).
+#
+# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py
+# (DREAMZERO_DISAGGREGATED_PIPELINE). Each stage runs as a native diffusion stage
+# distinguished by model_stage; the generic diffusion transition processor moves
+# the typed DiffusionStagePayload between them.
+#
+# Stage ownership (see StageComponentSpec in
+# DreamZeroPipeline.required_components_for_stage):
+#   stage 0 (encode):  tokenizer + text/image encoders + VAE encoder   (1 device)
+#   stage 1 (denoise): CausalWan DiT + schedulers + action head + AR-Diffusion KV (TP=4, 4 devices)
+#   stage 2 (decode):  VAE decoder + video/action postprocess          (1 device)
+#
+# Engine backends:
+#   - The denoise stage REQUIRES the AR-Diffusion engine (session-scoped paged KV).
+#   - Encode/decode own no KV, so they use the standard diffusion engine.
+#
+# Device placement: 6 devices total (0=encode, 1-4=denoise TP4, 5=decode), to
+# avoid overlapping encode/decode with the TP=4 denoise device set on an 8-GPU node.
+
+pipeline: dreamzero_disaggregated
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  # ---- Stage 0: ENCODE (standard diffusion engine, one device) ----
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 1: DENOISE (AR-Diffusion engine; TP=4) ----
+  - stage_id: 1
+    devices: "1,2,3,4"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    # DreamZero denoise runs on the AR-Diffusion engine (engine-level paged KV).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 4
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 2: DECODE (standard diffusion engine, one device) ----
+  - stage_id: 2
+    devices: "5"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise_cfgoff.yaml
+++ b/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise_cfgoff.yaml
@@ -1,0 +1,86 @@
+# DreamZero-DROID disaggregated deploy (RFC #4590): encode -> denoise -> decode.
+# Variant: TP=4 on DENOISE, CFG OFF (cfg_scale=1.0 disables true classifier-free
+# guidance -> single branch per forward instead of 2, halving the AR-Diffusion
+# KV pool vs dreamzero_disaggregated_tp4denoise.yaml). denoise_steps=16 (default).
+#
+# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py
+# (DREAMZERO_DISAGGREGATED_PIPELINE). Each stage runs as a native diffusion stage
+# distinguished by model_stage; the generic diffusion transition processor moves
+# the typed DiffusionStagePayload between them.
+#
+# Stage ownership (see StageComponentSpec in
+# DreamZeroPipeline.required_components_for_stage):
+#   stage 0 (encode):  tokenizer + text/image encoders + VAE encoder   (1 device)
+#   stage 1 (denoise): CausalWan DiT + schedulers + action head + AR-Diffusion KV (TP=4, 4 devices)
+#   stage 2 (decode):  VAE decoder + video/action postprocess          (1 device)
+#
+# Engine backends:
+#   - The denoise stage REQUIRES the AR-Diffusion engine (session-scoped paged KV).
+#   - Encode/decode own no KV, so they use the standard diffusion engine.
+#
+# Device placement: 6 devices total (0=encode, 1-4=denoise TP4, 5=decode).
+
+pipeline: dreamzero_disaggregated
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  # ---- Stage 0: ENCODE (standard diffusion engine, one device) ----
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 1: DENOISE (AR-Diffusion engine; TP=4; CFG off) ----
+  - stage_id: 1
+    devices: "1,2,3,4"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    # DreamZero denoise runs on the AR-Diffusion engine (engine-level paged KV).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 4
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 2: DECODE (standard diffusion engine, one device) ----
+  - stage_id: 2
+    devices: "5"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise_cfgoff_inductor.yaml
+++ b/vllm_omni/deploy/dreamzero_disaggregated_tp4denoise_cfgoff_inductor.yaml
@@ -1,0 +1,100 @@
+# DreamZero-DROID disaggregated deploy (RFC #4590): encode -> denoise -> decode.
+# Variant: TP=4 on DENOISE, CFG OFF, torch.compile/inductor ON for denoise
+# (enforce_eager=false). Validated end-to-end on gnr17409 2026-07-14: with the
+# encoder off the DiT's TP ranks, denoise fits resident WITHOUT layerwise offload
+# (peak ~17.9 GiB/card of 22.71 GiB), producing warm generation ~34s vs ~94s for
+# the equivalent monolithic (undisaggregated) run that requires offload. See
+# docs/dreamzero-tp4-disaggregation-results.md for the full before/after numbers.
+#
+# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py
+# (DREAMZERO_DISAGGREGATED_PIPELINE). Each stage runs as a native diffusion stage
+# distinguished by model_stage; the generic diffusion transition processor moves
+# the typed DiffusionStagePayload between them.
+#
+# Stage ownership (see StageComponentSpec in
+# DreamZeroPipeline.required_components_for_stage):
+#   stage 0 (encode):  tokenizer + text/image encoders + VAE encoder   (1 device)
+#   stage 1 (denoise): CausalWan DiT + schedulers + action head + AR-Diffusion KV (TP=4, 4 devices)
+#   stage 2 (decode):  VAE decoder + video/action postprocess          (1 device)
+#
+# Engine backends:
+#   - The denoise stage REQUIRES the AR-Diffusion engine (session-scoped paged KV).
+#   - Encode/decode own no KV, so they use the standard diffusion engine.
+#
+# Device placement: 6 devices total (0=encode, 1-4=denoise TP4, 5=decode). The
+# `devices:` values below are per-container indices — map them to physical cards
+# with ZE_AFFINITY_MASK at container-launch time (e.g. ZE_AFFINITY_MASK=1,4,5,6,7,0
+# puts denoise on physical cards 4,5,6,7, matching the validated run).
+#
+# ar_diffusion_kv_config.warmup_cudagraph is disabled on the denoise stage: its
+# synthetic warm-up rollout was observed to spike device memory past the per-card
+# ceiling (UR_RESULT_ERROR_OUT_OF_RESOURCES -> DEVICE_LOST) without offload headroom;
+# it already falls back to lazy capture on failure, so disabling it only removes
+# the spike.
+
+pipeline: dreamzero_disaggregated
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  # ---- Stage 0: ENCODE (standard diffusion engine, one device) ----
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 1: DENOISE (AR-Diffusion engine; TP=4; CFG off; inductor on) ----
+  - stage_id: 1
+    devices: "1,2,3,4"
+    max_num_seqs: 1
+    enforce_eager: false
+    model_class_name: DreamZeroPipeline
+    # DreamZero denoise runs on the AR-Diffusion engine (engine-level paged KV).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 4
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      ar_diffusion_kv_config:
+        warmup_cudagraph: false
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+
+  # ---- Stage 2: DECODE (standard diffusion engine, one device) ----
+  - stage_id: 2
+    devices: "5"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    model_config:
+      default_robot_embodiment: roboarena
+      cfg_scale: 1.0
+      num_inference_steps: 16
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -578,6 +578,14 @@ class OmniDiffusionConfig:
 
     model_class_name: str | None = None
 
+    # Disaggregated-diffusion stage role (RFC #4590). One of
+    # ``encode`` / ``denoise`` / ``decode`` for a disaggregated stage, or
+    # ``diffusion`` / ``None`` for the monolithic single-worker fallback. This
+    # is the single per-worker copy of ``StagePipelineConfig.model_stage``;
+    # ``build_diffusion_config`` sets it from the stage metadata so the runner
+    # can pick its execution path and the loader can gate component construction.
+    model_stage: str | None = None
+
     dtype: torch.dtype = torch.bfloat16
 
     model_config: dict[str, Any] = field(default_factory=dict)

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -289,8 +289,10 @@ class DiffusionEngine:
         logger.debug("Generation completed successfully.")
 
         if output.output is None:
-            logger.warning("Output is None, returning empty OmniRequestOutput")
-            return format_empty_diffusion_outputs(request, finished=output.finished)
+            logger.debug("Output is None, returning empty OmniRequestOutput (custom_output=%s)", bool(output.custom_output))
+            return format_empty_diffusion_outputs(
+                request, finished=output.finished, custom_output=output.custom_output
+            )
 
         # When CPU offload is enabled, move output to CPU before
         # post-processing to avoid device OOM — model weights may still

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -12,9 +12,10 @@ import copy
 import json
 import logging
 import os
-import re as re_module
+import re
 from collections import OrderedDict
 from collections.abc import Iterable
+from typing import ClassVar
 
 import numpy as np
 import torch
@@ -37,7 +38,10 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.dreamzero.causal_wan_model import CausalWanModel
 from vllm_omni.diffusion.models.dreamzero.image_encoder import DreamZeroImageEncoder
-from vllm_omni.diffusion.models.dreamzero.state_dreamzero import DreamZeroState
+from vllm_omni.diffusion.models.dreamzero.state_dreamzero import (
+    DreamZeroStageCarrier,
+    DreamZeroState,
+)
 from vllm_omni.diffusion.models.dreamzero.transform import (
     DEFAULT_EMBODIMENT,
     ensure_transforms_loaded,
@@ -51,11 +55,44 @@ from vllm_omni.diffusion.models.dreamzero.utils import (
     DEFAULT_SEED,
     DEFAULT_SIGMA_SHIFT,
 )
+from vllm_omni.diffusion.models.interface import StageBoundary, StagePayload
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.stage_payload import StagePayloadError
+from vllm_omni.diffusion.stage_roles import (
+    ALL_COMPONENTS,
+    DECODE,
+    DENOISE,
+    ENCODE,
+    MONOLITHIC,
+    StageComponentSpec,
+    normalize_stage_role,
+)
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 logger = logging.getLogger(__name__)
 MAX_DREAMZERO_SESSIONS = 64
+
+
+def _wan_vae_latents_mean_std() -> tuple[list[float], list[float]]:
+    """Wan 2.1 VAE (16-channel) latent normalization constants.
+
+    Mirrors ``AutoencoderKLWan.config.latents_mean`` / ``latents_std``. Used only
+    to build DreamZero's ``vae_latents_mean`` / ``vae_latents_inv_std`` buffers on
+    the disaggregated *denoise* stage, which skips constructing the VAE module
+    (and therefore cannot read ``self.vae.config``). Encode/decode stages and the
+    monolithic path read these directly from the constructed VAE, so this helper
+    is a stage-partial-loading fallback, not a second source of truth for them.
+    """
+    latents_mean = [
+        -0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508,
+        0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921,
+    ]
+    latents_std = [
+        2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743,
+        3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.9160,
+    ]
+    return latents_mean, latents_std
 
 
 class VideoActionScheduler:
@@ -101,6 +138,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     _ar_diffusion_kv_state = None  # set by the runner before each forward
 
+    # DreamZero requires a real robot_obs (raw camera frames) for every
+    # request; the engine's synthetic dummy-warmup request has no robot_obs
+    # and would fail check_inputs/encode on every role (encode, denoise,
+    # decode -- not just the monolithic path, which special-cases it in
+    # forward()). Skip the warmup entirely rather than special-case each
+    # disaggregated atom.
+    dummy_run_num_frames = 0
+
     def _kv_get(self, state, is_negative, seq_len=None, update_kv_cache=False):
         return self._ar_diffusion_kv_state.get_kv_caches(
             is_negative,
@@ -120,6 +165,26 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
     def _kv_get_cross(self, state, is_negative):
         """Cross-attn cache from the engine pool (text k/v + I2V image k_img/v_img)."""
         return self._ar_diffusion_kv_state.get_cross_kv_caches(is_negative)
+
+    @staticmethod
+    def _layerwise_offload_hook(block):
+        """Return the layerwise-offload hook attached to a DiT block, or None.
+
+        When layerwise CPU offload is active each block carries a HookRegistry
+        with a LayerwiseOffloadHook; the hook materializes/frees the block's
+        weights around its forward(). Code paths that use block weights outside
+        forward() (e.g. eager cross-attn KV population) must onload/offload via
+        this hook. Returns None when offload is not enabled.
+        """
+        registry = getattr(block, "_hook_registry", None)
+        if registry is None:
+            return None
+        try:
+            from vllm_omni.diffusion.offloader.layerwise_backend import LayerwiseOffloadHook
+
+            return registry._hooks.get(LayerwiseOffloadHook._HOOK_NAME)
+        except Exception:
+            return None
 
     def _kv_populate_cross(self, context: torch.Tensor, clip_feature, is_negative: bool) -> None:
         """Eagerly project cross-attn K/V for all layers into the AR-Diffusion pool.
@@ -144,17 +209,31 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         projected = self.transformer.text_embedding(context) if need_text else None
         img_ctx = self.transformer.img_emb(clip_feature) if need_img else None
         for i, block in enumerate(self.transformer.blocks):
-            ca = block.cross_attn
-            n, d = ca.tp_num_heads, ca.head_dim
-            k = v = None
-            if projected is not None:
-                k = ca.norm_k(ca.k(projected)).unflatten(2, (n, d))
-                v = ca.v(projected).unflatten(2, (n, d))
-            k_img = v_img = None
-            if img_ctx is not None:
-                k_img = ca.norm_k_img(ca.k_img(img_ctx)).unflatten(2, (n, d))
-                v_img = ca.v_img(img_ctx).unflatten(2, (n, d))
-            s.kv_cache.write_cross_kv(i, is_negative, k, v, k_img, v_img)
+            # Layerwise-offload compatibility: this eager cross-KV precompute reaches
+            # into block.cross_attn.{k,v,...} WITHOUT calling block.forward(), so the
+            # offload pre_forward/post_forward hooks (which materialize block weights
+            # on device and free them after) never fire and the projection weights
+            # stay as CPU/empty placeholders -> "mat1 on xpu, weight on cpu" addmm
+            # error. Mirror the hook's self-heal path: materialize this block before
+            # use and offload it after. No-op when offload is disabled (no hook).
+            _off_hook = self._layerwise_offload_hook(block)
+            if _off_hook is not None and not _off_hook.is_materialized and _off_hook._prev_hook is not None:
+                _off_hook._prev_hook.prefetch_layer(non_blocking=False)
+            try:
+                ca = block.cross_attn
+                n, d = ca.tp_num_heads, ca.head_dim
+                k = v = None
+                if projected is not None:
+                    k = ca.norm_k(ca.k(projected)).unflatten(2, (n, d))
+                    v = ca.v(projected).unflatten(2, (n, d))
+                k_img = v_img = None
+                if img_ctx is not None:
+                    k_img = ca.norm_k_img(ca.k_img(img_ctx)).unflatten(2, (n, d))
+                    v_img = ca.v_img(img_ctx).unflatten(2, (n, d))
+                s.kv_cache.write_cross_kv(i, is_negative, k, v, k_img, v_img)
+            finally:
+                if _off_hook is not None:
+                    _off_hook.offload_layer()
         if need_text:
             s._cross_text_populated[is_negative] = True
         if need_img:
@@ -177,9 +256,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         ``clear_video_latents=False`` also marks a window ("inference") reset: the
         prompt is unchanged, so the pool keeps the text cross-attn K/V and only the
         image half repopulates on the restart forward.
+
+        On the encode worker ``_ar_diffusion_kv_state`` is unset (encode owns no
+        pool), so the engine-side reset is a no-op there; only the model-local
+        state resets.
         """
         state.reset(clear_video_latents=clear_video_latents)
-        self._ar_diffusion_kv_state.reset(keep_cross_text=not clear_video_latents)
+        if self._ar_diffusion_kv_state is not None:
+            self._ar_diffusion_kv_state.reset(keep_cross_text=not clear_video_latents)
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         """Initialize pipeline components.
@@ -203,17 +287,23 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         """
         super().__init__()
 
-        # DreamZero is engine-only: every KV access in forward() routes through
-        # the AR-Diffusion engine's pool-backed state. Fail fast here — a stale
-        # or programmatic config that leaves engine_backend="default" would
-        # otherwise only crash mid-forward on the first KV access.
-        engine_backend = str(getattr(od_config, "engine_backend", "") or "")
-        if "ar_diffusion" not in engine_backend.lower().replace("-", "_"):
-            raise ValueError(
-                "DreamZeroPipeline requires the AR-Diffusion engine; set "
-                "engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine "
-                f"in the deploy config (got engine_backend={engine_backend!r})."
-            )
+        # DreamZero's DiT-owning roles (denoise, and monolithic which owns
+        # everything) are engine-only: every KV access in forward() routes
+        # through the AR-Diffusion engine's pool-backed state. Fail fast here
+        # — a stale or programmatic config that leaves engine_backend="default"
+        # would otherwise only crash mid-forward on the first KV access.
+        # Encode/decode own no DiT/KV (see required_components_for_stage) and
+        # run on the standard diffusion engine, so they are exempt.
+        model_stage_role = normalize_stage_role(getattr(od_config, "model_stage", None))
+        if model_stage_role in (DENOISE, MONOLITHIC):
+            engine_backend = str(getattr(od_config, "engine_backend", "") or "")
+            if "ar_diffusion" not in engine_backend.lower().replace("-", "_"):
+                raise ValueError(
+                    "DreamZeroPipeline requires the AR-Diffusion engine for the "
+                    f"{model_stage_role!r} role; set "
+                    "engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine "
+                    f"in the deploy config (got engine_backend={engine_backend!r})."
+                )
 
         model_path = od_config.model
         model_config = od_config.model_config
@@ -232,70 +322,124 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         ah_config = action_head_cfg["config"]
         diffusion_model_cfg = ah_config["diffusion_model_cfg"]
 
-        # ---- Tokenizer ----
-        tokenizer_source = od_config.model_paths.get("tokenizer", "google/umt5-xxl")
-        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_source)
-
-        # Instantiate from config; weights load through `load_weights()`.
-        umt5_config = UMT5Config(
-            d_model=4096,
-            d_ff=10240,
-            num_heads=64,
-            num_layers=24,
-            vocab_size=256384,
-            relative_attention_num_buckets=32,
-            relative_attention_max_distance=128,
-            dense_act_fn="gelu_new",
-            feed_forward_proj="gated-gelu",
-            is_encoder_decoder=False,
+        # ---- Stage-specific partial construction (RFC #4590 §8) ----
+        # Build only the components this stage's role needs. The monolithic role
+        # (diffusion / None) builds everything, so single-stage DreamZero is
+        # unchanged. Weight loading self-gates: load_weights only fills params
+        # present on constructed submodules. Components skipped are set to None
+        # and guarded at their use sites (setup_compile, the phase methods).
+        self._model_stage = model_stage_role
+        self._component_spec = self.required_components_for_stage(self._model_stage)
+        spec = self._component_spec
+        logger.info(
+            "DreamZeroPipeline building for stage role %r: components=%s",
+            self._model_stage,
+            spec.describe(),
         )
-        self.text_encoder = UMT5EncoderModel(umt5_config)
 
-        self.image_encoder = DreamZeroImageEncoder()
+        # ---- Tokenizer ----
+        self.tokenizer = None
+        if spec.tokenizer:
+            tokenizer_source = od_config.model_paths.get("tokenizer", "google/umt5-xxl")
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_source)
 
-        # Build a compatible VAE module, then fill it through `load_weights()`.
-        vae_source = od_config.model_paths.get("vae")
-        if vae_source:
-            self.vae = DistributedAutoencoderKLWan.from_pretrained(
-                vae_source,
-                torch_dtype=torch.float32,
+        # ---- Text encoder (UMT5) ----
+        # Instantiate from config; weights load through `load_weights()`.
+        self.text_encoder = None
+        if spec.text_encoder:
+            umt5_config = UMT5Config(
+                d_model=4096,
+                d_ff=10240,
+                num_heads=64,
+                num_layers=24,
+                vocab_size=256384,
+                relative_attention_num_buckets=32,
+                relative_attention_max_distance=128,
+                dense_act_fn="gelu_new",
+                feed_forward_proj="gated-gelu",
+                is_encoder_decoder=False,
             )
-        elif local_files_only and os.path.isdir(os.path.join(model_path, "vae")):
-            self.vae = DistributedAutoencoderKLWan.from_pretrained(
-                model_path,
-                subfolder="vae",
-                torch_dtype=torch.float32,
-            )
+            self.text_encoder = UMT5EncoderModel(umt5_config)
+
+        # ---- Image encoder (CLIP) ----
+        self.image_encoder = None
+        if spec.image_encoder:
+            self.image_encoder = DreamZeroImageEncoder()
+
+        # ---- VAE ----
+        # The diffusers AutoencoderKLWan constructor is monolithic (encoder +
+        # decoder in one __init__), so any stage needing EITHER half builds the
+        # full module (audit option 3). The denoise stage needs NEITHER half, so
+        # it skips the VAE entirely and derives the latents_mean/std buffers from
+        # the Wan VAE default config constants instead of the module.
+        self.vae = None
+        needs_vae = spec.vae_encoder or spec.vae_decoder
+        if needs_vae:
+            vae_source = od_config.model_paths.get("vae")
+            if vae_source:
+                self.vae = DistributedAutoencoderKLWan.from_pretrained(
+                    vae_source,
+                    torch_dtype=torch.float32,
+                )
+            elif local_files_only and os.path.isdir(os.path.join(model_path, "vae")):
+                self.vae = DistributedAutoencoderKLWan.from_pretrained(
+                    model_path,
+                    subfolder="vae",
+                    torch_dtype=torch.float32,
+                )
+            else:
+                self.vae = DistributedAutoencoderKLWan()
+                self.vae.init_distributed()
+            if not (
+                getattr(od_config, "enable_cpu_offload", False)
+                or getattr(od_config, "enable_layerwise_offload", False)
+            ):
+                self.vae = self.vae.to(device=get_local_device(), dtype=od_config.dtype)
+            latents_mean = self.vae.config.latents_mean
+            latents_std = self.vae.config.latents_std
         else:
-            self.vae = DistributedAutoencoderKLWan()
-            self.vae.init_distributed()
-        if not (
-            getattr(od_config, "enable_cpu_offload", False) or getattr(od_config, "enable_layerwise_offload", False)
-        ):
-            self.vae = self.vae.to(device=get_local_device(), dtype=od_config.dtype)
+            # Wan 2.1 VAE latent normalization constants (16 channels). Needed by
+            # encode/decode math; carried here so the denoise stage's buffers
+            # exist even without the VAE module (they are simply unused there).
+            latents_mean, latents_std = _wan_vae_latents_mean_std()
         self.register_buffer(
             "vae_latents_mean",
-            torch.tensor(self.vae.config.latents_mean, dtype=torch.float32).view(1, -1, 1, 1, 1),
+            torch.tensor(latents_mean, dtype=torch.float32).view(1, -1, 1, 1, 1),
             persistent=False,
         )
         self.register_buffer(
             "vae_latents_inv_std",
-            (1.0 / torch.tensor(self.vae.config.latents_std, dtype=torch.float32)).view(1, -1, 1, 1, 1),
+            (1.0 / torch.tensor(latents_std, dtype=torch.float32)).view(1, -1, 1, 1, 1),
             persistent=False,
         )
 
-        # Filter out keys not accepted by `CausalWanModel.__init__`.
-        transformer_kwargs = {k: v for k, v in diffusion_model_cfg.items() if k not in ("_convert_", "_target_")}
-        transformer_kwargs["action_dim"] = ah_config["action_dim"]
-        transformer_kwargs["max_state_dim"] = ah_config["max_state_dim"]
-        transformer_kwargs["num_frame_per_block"] = ah_config["num_frame_per_block"]
-        self.transformer = CausalWanModel(**transformer_kwargs)
+        # ---- Transformer (CausalWan DiT) + action head ----
+        self.transformer = None
+        if spec.dit:
+            # Filter out keys not accepted by `CausalWanModel.__init__`.
+            transformer_kwargs = {k: v for k, v in diffusion_model_cfg.items() if k not in ("_convert_", "_target_")}
+            transformer_kwargs["action_dim"] = ah_config["action_dim"]
+            transformer_kwargs["max_state_dim"] = ah_config["max_state_dim"]
+            transformer_kwargs["num_frame_per_block"] = ah_config["num_frame_per_block"]
+            self.transformer = CausalWanModel(**transformer_kwargs)
 
-        self.scheduler = FlowUniPCMultistepScheduler(
-            num_train_timesteps=1000,
-            shift=1,
-            use_dynamic_shifting=False,
-        )
+        # ---- Diffusion scheduler ----
+        self.scheduler = None
+        if spec.scheduler:
+            self.scheduler = FlowUniPCMultistepScheduler(
+                num_train_timesteps=1000,
+                shift=1,
+                use_dynamic_shifting=False,
+            )
+
+        # Config-derived scalars the encode phase needs WITHOUT the DiT built
+        # (the encode stage skips constructing self.transformer). These mirror
+        # CausalWanModel's own derivations so the encode stage produces the same
+        # action-noise shape and reset decision as the monolithic path.
+        self._action_dim: int = ah_config["action_dim"]
+        _max_chunk_size = int(diffusion_model_cfg.get("max_chunk_size", -1))
+        _nfpb = int(ah_config["num_frame_per_block"])
+        self._local_attn_size: int = _max_chunk_size * _nfpb + 1 if _max_chunk_size != -1 else -1
 
         self._states: OrderedDict[str, DreamZeroState] = OrderedDict()
         self._max_session_states = MAX_DREAMZERO_SESSIONS
@@ -492,23 +636,30 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             "DreamZero: torch.compile text/image/VAE encode + per-block DiT (encoders reduce-overhead, DiT default)."
         )
 
-        try:
-            self.text_encoder.forward = torch.compile(self.text_encoder.forward, **compile_ro)
-        except Exception as exc:
-            logger.warning("DreamZero: text_encoder compile failed (%s); skipping.", exc)
+        if self.text_encoder is not None:
+            try:
+                self.text_encoder.forward = torch.compile(self.text_encoder.forward, **compile_ro)
+            except Exception as exc:
+                logger.warning("DreamZero: text_encoder compile failed (%s); skipping.", exc)
 
-        try:
-            self.image_encoder.model.visual.forward = torch.compile(
-                self.image_encoder.model.visual.forward,
-                **compile_ro,
-            )
-        except Exception as exc:
-            logger.warning("DreamZero: image_encoder compile failed (%s); skipping.", exc)
+        if self.image_encoder is not None:
+            try:
+                self.image_encoder.model.visual.forward = torch.compile(
+                    self.image_encoder.model.visual.forward,
+                    **compile_ro,
+                )
+            except Exception as exc:
+                logger.warning("DreamZero: image_encoder compile failed (%s); skipping.", exc)
 
-        try:
-            self.vae._encode = torch.compile(self.vae._encode, **compile_ro)
-        except Exception as exc:
-            logger.warning("DreamZero: vae._encode compile failed (%s); skipping.", exc)
+        if self.vae is not None:
+            try:
+                self.vae._encode = torch.compile(self.vae._encode, **compile_ro)
+            except Exception as exc:
+                logger.warning("DreamZero: vae._encode compile failed (%s); skipping.", exc)
+
+        if self.transformer is None:
+            self.warmup_compile()
+            return
 
         compiled_blocks = 0
         for block in self.transformer.blocks:
@@ -576,8 +727,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                     dtype=self.vae.dtype,
                     device=device,
                 )
-                mean = self.vae_latents_mean.to(device=device, dtype=self.vae.dtype)
-                inv_std = self.vae_latents_inv_std.to(device=device, dtype=self.vae.dtype)
+                mean, inv_std = self._vae_latents_mean_inv_std(device=device, dtype=self.vae.dtype)
                 dummy_latent_denorm = dummy_latent / inv_std + mean
                 self._cudagraph_mark_step_begin()
                 self.vae.decode(dummy_latent_denorm, return_dict=False)
@@ -755,11 +905,24 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         )
         return out, self._vae_clone_feat_map(self.vae._enc_feat_map)
 
+    def _vae_latents_mean_inv_std(
+        self, *, device: torch.device, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return the (mean, inv_std) VAE-latent normalization buffers on a target device/dtype.
+
+        Single accessor for the ``vae_latents_mean`` / ``vae_latents_inv_std``
+        registered buffers so the (de)normalization sites don't each hand-cast
+        both buffers.
+        """
+        return (
+            self.vae_latents_mean.to(device=device, dtype=dtype),
+            self.vae_latents_inv_std.to(device=device, dtype=dtype),
+        )
+
     def _vae_quantize_encoder_out(self, encoder_out: torch.Tensor) -> torch.Tensor:
         enc = self.vae.quant_conv(encoder_out)
         mu, _ = enc.chunk(2, dim=1)
-        mean = self.vae_latents_mean.to(device=mu.device, dtype=mu.dtype)
-        inv_std = self.vae_latents_inv_std.to(device=mu.device, dtype=mu.dtype)
+        mean, inv_std = self._vae_latents_mean_inv_std(device=mu.device, dtype=mu.dtype)
         return (mu - mean) * inv_std
 
     def _vae_stream_seed(self, state: DreamZeroState, first_frame: torch.Tensor) -> None:
@@ -850,8 +1013,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         self._cudagraph_mark_step_begin()
         hidden = self.vae._encode(videos.to(dtype=self.vae.dtype))
         mu, _ = hidden.chunk(2, dim=1)
-        mean = self.vae_latents_mean.to(device=mu.device, dtype=mu.dtype)
-        inv_std = self.vae_latents_inv_std.to(device=mu.device, dtype=mu.dtype)
+        mean, inv_std = self._vae_latents_mean_inv_std(device=mu.device, dtype=mu.dtype)
         mu = (mu - mean) * inv_std
         return mu.to(dtype=input_dtype)
 
@@ -860,8 +1022,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         vae_dtype = self.vae.dtype
         vae_device = next(self.vae.parameters()).device
         latents = video_latents.to(device=vae_device, dtype=vae_dtype)
-        mean = self.vae_latents_mean.to(device=vae_device, dtype=vae_dtype)
-        inv_std = self.vae_latents_inv_std.to(device=vae_device, dtype=vae_dtype)
+        mean, inv_std = self._vae_latents_mean_inv_std(device=vae_device, dtype=vae_dtype)
         latents = latents / inv_std + mean
         with torch.no_grad():
             self._cudagraph_mark_step_begin()
@@ -1009,7 +1170,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 cfg_normalize=False,
             )
 
-    def diffuse(
+    def _run_dit_loop(
         self,
         video_latents: torch.Tensor,
         action_latents: torch.Tensor,
@@ -1023,6 +1184,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Denoising loop with CFG parallel support.
+
+        Internal per-chunk DiT loop over video+action latents. Renamed from the
+        former ``diffuse`` to avoid colliding with the ``DiffusionV2Atoms.diffuse``
+        whole-request denoise atom (see :meth:`diffuse`).
 
         For each timestep:
           1. Build positive_kwargs / negative_kwargs
@@ -1163,7 +1328,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     @torch.no_grad()
     def forward(self, req: DiffusionRequestBatch, **kwargs) -> DiffusionOutput:
-        """Full inference step. Called by DiffusionEngine.step()."""
+        """Full inference step. Called by DiffusionEngine.step().
+
+        Golden reference path (RFC #4590 §3): composes the SAME three phase
+        methods the disaggregated encode/denoise/decode stages call, on one
+        shared session state and one carrier, in one process. Because the atoms
+        reuse these exact methods, the disaggregated path is numerically
+        equivalent to this monolithic forward by construction.
+        """
         extra_args = req.sampling_params.extra_args or {}
         robot_obs = extra_args.get("robot_obs")
         if robot_obs is None:
@@ -1184,7 +1356,74 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         session_id = str(extra_args.get("session_id") or "default")
         state = self._get_or_create_state(session_id)
         self.state = state
+
+        # Optional phase timing (DZ_PHASE_TIMING=1): logs per-forward stage costs
+        # (text encode / obs VAE encode / KV prefill / denoise) at INFO. Each mark
+        # synchronizes CUDA, so leave it off for timed benchmark runs.
+        _pt = None
+        if os.environ.get("DZ_PHASE_TIMING"):
+            import time as _time
+
+            torch.accelerator.synchronize()
+            _pt = {"time": _time, "t0": _time.perf_counter(), "marks": []}
+
+        def _pt_mark(name: str) -> None:
+            if _pt is not None:
+                torch.accelerator.synchronize()
+                _pt["marks"].append((name, _pt["time"].perf_counter()))
+
+        # ---- Phase 1: encode (conditions + latents/timesteps params) ----
+        carrier = self._run_encode_phase(robot_obs, state, session_id, explicit_reset=extra_args.get("reset", False))
+        _pt_mark("text_encode")
+        _pt_mark("obs_vae_encode")
+
+        # ---- Phase 2: denoise (KV prefill + DiT loop; owns AR-Diffusion KV) ----
+        self._run_denoise_phase(carrier, state)
+        _pt_mark("prefill_kv")
+        if _pt is not None:
+            _pt_mark("diffuse")
+            prev_t = _pt["t0"]
+            parts = []
+            for name, t in _pt["marks"]:
+                parts.append(f"{name}={1000 * (t - prev_t):.1f}ms")
+                prev_t = t
+            logger.info(
+                "DZ_PHASE_TIMING csf=%s total=%.1fms %s",
+                state.current_start_frame,
+                1000 * (prev_t - _pt["t0"]),
+                " ".join(parts),
+            )
+
+        # ---- Phase 3: decode (action denorm + video export) ----
+        return self._run_decode_phase(carrier)
+
+    # -----------------------------------------------------------------------
+    # Disaggregated phase methods (RFC #4590). forward() composes all three;
+    # the disaggregated stages call them one per worker. They share the SAME
+    # math helpers (_encode_text / _encode_image / _prefill_kv_cache / diffuse /
+    # _denormalize_action / decode) — no duplication of the numerical path.
+    # -----------------------------------------------------------------------
+
+    def _run_encode_phase(
+        self,
+        robot_obs: dict,
+        state: DreamZeroState,
+        session_id: str,
+        *,
+        explicit_reset: bool = False,
+    ) -> DreamZeroStageCarrier:
+        """Encode conditions + prepare initial latents/timestep params.
+
+        Runs on the encode stage (and as forward()'s first phase). Produces every
+        stable condition the denoise stage consumes, plus the deterministic
+        initial noise, WITHOUT touching the AR-Diffusion KV pool or the DiT. The
+        engine-KV reset is DECIDED here (from the encode-session state) and
+        recorded on the carrier so the denoise worker can apply the same reset.
+        """
         transform, unified_obs = self._transform_robot_obs(robot_obs)
+        # Capture the exact key get_transform() was selected by, so the decode
+        # phase reselects the identical transform even across a process boundary.
+        transform_embodiment = robot_obs.get("embodiment", self.default_robot_embodiment)
         device = get_local_device()
 
         # ---- Step 1: Extract inputs from unified observation ----
@@ -1236,21 +1475,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         text_tokens = text_inputs["input_ids"].to(device)
         attention_mask = text_inputs["attention_mask"].to(device)
 
-        # Explicit reset from OpenPI serving is carried by `extra_args["reset"]`
-        # on the next inference request after websocket reset/session switch.
-        if extra_args.get("reset", False):
-            self._kv_reset(state)
+        # Decide reset (see original forward). The reset is APPLIED to model-local
+        # state here; the engine-KV window reset is applied on the denoise worker
+        # (which owns the pool) via the reason recorded on the carrier.
+        if explicit_reset:
+            reset_reason = "session"
         else:
-            # Auto-reset based on model state (before accumulation). Both a "session"
-            # reset and an "inference" (window-boundary) reset clear the model-local
-            # KV window, so route both through _kv_reset to drop the AR-Diffusion pool window
-            # too and stay parity-exact; "inference" keeps the accumulated video
-            # latents (reset_inference_state == reset(clear_video_latents=False)).
-            reset_reason = state.reset_reason(text_tokens, 0, self.transformer.local_attn_size)
-            if reset_reason == "session":
-                self._kv_reset(state)
-            elif reset_reason == "inference":
-                self._kv_reset(state, clear_video_latents=False)
+            reset_reason = state.reset_reason(text_tokens, 0, self._local_attn_size)
+        self._apply_model_local_reset(state, reset_reason)
         state.language = text_tokens
 
         # Frame accumulation: stitched single frame -> multi-frame video
@@ -1259,21 +1491,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
         videos = self._preprocess_video(videos)  # -> [B,C,T,H,W] bf16
         _, _, num_frames_raw, height, width = videos.shape
-
-        # Optional phase timing (DZ_PHASE_TIMING=1): logs per-forward stage costs
-        # (text encode / obs VAE encode / KV prefill / denoise) at INFO. Each mark
-        # synchronizes CUDA, so leave it off for timed benchmark runs.
-        _pt = None
-        if os.environ.get("DZ_PHASE_TIMING"):
-            import time as _time
-
-            torch.accelerator.synchronize()
-            _pt = {"time": _time, "t0": _time.perf_counter(), "marks": []}
-
-        def _pt_mark(name: str) -> None:
-            if _pt is not None:
-                torch.accelerator.synchronize()
-                _pt["marks"].append((name, _pt["time"].perf_counter()))
 
         # Prompt embeds are constant within a session (a prompt change triggers a
         # "session" reset above, which clears this cache alongside state.language).
@@ -1298,8 +1515,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 )
             negative_prompt_embeds = self._negative_prompt_embeds_cache
 
-        _pt_mark("text_encode")
-
         # Extract first/last frame for CLIP + VAE encoding
         if num_frames_raw == 4 or num_frames_raw == 9:
             image = videos[:, :, -1:].transpose(1, 2)
@@ -1317,19 +1532,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             state.clip_feas = clip_feas.to(dtype=image.dtype)
             state.ys = ys.to(dtype=image.dtype)
 
-            # Eager cross-attn population (AR-Diffusion only): cache text + image-token K/V
-            # into the pool now that the image is encoded (clip_feas available).
-            # Runs on the first forward of a session and after each window-boundary
-            # reset (current_start_frame returns to 0); the populate guards (text/img halves) gate re-entry.
-            self._kv_populate_cross(prompt_embeds, state.clip_feas, is_negative=False)
-            if negative_prompt_embeds is not None:
-                self._kv_populate_cross(negative_prompt_embeds, state.clip_feas, is_negative=True)
-
         if state.current_start_frame != 0:
             latent_dtype = videos.dtype
             with torch.no_grad():
                 image = self._encode_observation_latents(state, videos, latent_dtype=latent_dtype)
-        _pt_mark("obs_vae_encode")
 
         batch_size = image.shape[0]
         generator = torch.Generator(device=device).manual_seed(self.seed)
@@ -1347,7 +1553,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         noise_action = torch.randn(
             batch_size,
             self.action_horizon,
-            self.transformer.action_dim,
+            self._action_dim,
             device=device,
             dtype=torch.bfloat16,
             generator=generator,
@@ -1361,28 +1567,88 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         noise_obs = noise_obs.transpose(1, 2)
 
         do_true_cfg = self.cfg_scale > 1.0 and negative_prompt_embeds is not None
+
+        return DreamZeroStageCarrier(
+            session_id=session_id,
+            embodiment_name=embodiment_name,
+            transform_embodiment=str(transform_embodiment),
+            reset_reason=reset_reason,
+            explicit_reset=explicit_reset,
+            do_true_cfg=do_true_cfg,
+            current_start_frame=state.current_start_frame,
+            height=height,
+            width=width,
+            seq_len=seq_len,
+            frame_seqlen=frame_seqlen,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            clip_feas=state.clip_feas,
+            ys=state.ys,
+            image_latent=image,
+            state_features=state_features,
+            embodiment_id=embodiment_id,
+            noise_obs=noise_obs,
+            noise_action=noise_action,
+            num_inference_steps=self.num_inference_steps,
+            sigma_shift=self.sigma_shift,
+            state_for_postprocess=state_for_postprocess,
+        )
+
+    def _apply_model_local_reset(self, state: DreamZeroState, reset_reason: str | None) -> None:
+        """Apply the model-local + engine-KV reset for the decided reason.
+
+        On the monolithic and denoise workers ``_ar_diffusion_kv_state`` is set,
+        so this drops the pool window too (parity with the original forward). On
+        the encode worker (no KV state attached) only the model-local reset runs;
+        the engine reset is a no-op there because encode owns no pool.
+        """
+        if reset_reason == "session":
+            self._kv_reset(state)
+        elif reset_reason == "inference":
+            self._kv_reset(state, clear_video_latents=False)
+
+    def _run_denoise_phase(self, carrier: DreamZeroStageCarrier, state: DreamZeroState) -> None:
+        """KV prefill + DiT denoise loop. Owns the AR-Diffusion KV/session state.
+
+        Consumes the encode carrier's stable conditions read-only, populates the
+        cross-attn KV, prefills, runs ``diffuse``, and writes ``video_out`` /
+        ``action_out`` back onto the carrier. This is the ONLY phase that touches
+        the DiT or the AR-Diffusion pool (RFC §9.1).
+        """
+        prompt_embeds = carrier.prompt_embeds
+        negative_prompt_embeds = carrier.negative_prompt_embeds
+
+        # Eager cross-attn population (AR-Diffusion only): cache text + image-token
+        # K/V into the pool now that conditions are available. Runs on the first
+        # forward of a session and after each window-boundary reset (csf == 0).
+        if carrier.current_start_frame == 0:
+            self._kv_populate_cross(prompt_embeds, carrier.clip_feas, is_negative=False)
+            if negative_prompt_embeds is not None:
+                self._kv_populate_cross(negative_prompt_embeds, carrier.clip_feas, is_negative=True)
+
+        device = get_local_device()
+        image = carrier.image_latent
         self._prefill_kv_cache(
             image,
             prompt_embeds,
             negative_prompt_embeds,
-            frame_seqlen,
-            seq_len,
-            do_true_cfg,
+            carrier.frame_seqlen,
+            carrier.seq_len,
+            carrier.do_true_cfg,
             state,
         )
-        _pt_mark("prefill_kv")
 
         sample_scheduler = copy.deepcopy(self.scheduler)
         sample_scheduler_action = copy.deepcopy(self.scheduler)
         sample_scheduler.set_timesteps(
-            self.num_inference_steps,
+            carrier.num_inference_steps,
             device=device,
-            shift=self.sigma_shift,
+            shift=carrier.sigma_shift,
         )
         sample_scheduler_action.set_timesteps(
-            self.num_inference_steps,
+            carrier.num_inference_steps,
             device=device,
-            shift=self.sigma_shift,
+            shift=carrier.sigma_shift,
         )
 
         if self.decouple_inference_noise:
@@ -1398,33 +1664,20 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             sample_scheduler_action,
         )
 
-        video_out, action_out = self.diffuse(
-            video_latents=noise_obs,
-            action_latents=noise_action,
+        video_out, action_out = self._run_dit_loop(
+            video_latents=carrier.noise_obs,
+            action_latents=carrier.noise_action,
             timesteps_video=sample_scheduler.timesteps,
             timesteps_action=sample_scheduler_action.timesteps,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
             video_action_scheduler=video_action_scheduler,
-            do_true_cfg=do_true_cfg,
+            do_true_cfg=carrier.do_true_cfg,
             state=state,
-            seq_len=seq_len,
-            state_features=state_features,
-            embodiment_id=embodiment_id,
+            seq_len=carrier.seq_len,
+            state_features=carrier.state_features,
+            embodiment_id=carrier.embodiment_id,
         )
-        if _pt is not None:
-            _pt_mark("diffuse")
-            prev_t = _pt["t0"]
-            parts = []
-            for name, t in _pt["marks"]:
-                parts.append(f"{name}={1000 * (t - prev_t):.1f}ms")
-                prev_t = t
-            logger.info(
-                "DZ_PHASE_TIMING csf=%s total=%.1fms %s",
-                state.current_start_frame,
-                1000 * (prev_t - _pt["t0"]),
-                " ".join(parts),
-            )
 
         if state.current_start_frame == 1:
             video_out = torch.cat([image, video_out], dim=1)
@@ -1432,17 +1685,28 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
         state.append_video_latents(video_out)
 
+        carrier.video_out = video_out
+        carrier.action_out = action_out
+
+    def _run_decode_phase(self, carrier: DreamZeroStageCarrier) -> DiffusionOutput:
+        """Action denormalization + video export. Owns no DiT / KV / scheduler."""
+        # Reselect the identical transform the encode phase used (by the same key
+        # passed to get_transform), not by the derived embodiment_name.
+        transform = get_transform(carrier.transform_embodiment or carrier.embodiment_name)
+        video_out = carrier.video_out
+        action_out = carrier.action_out
+
         # q99 denorm: [-1,1] → real values
-        action_out = self._denormalize_action(action_out.float(), embodiment_name)
+        action_out = self._denormalize_action(action_out.float(), carrier.embodiment_name)
 
         # Relative -> absolute: only for relative_action_keys (joint_position only)
         # gripper_position is NOT relative, so don't add state back to it
-        if self.relative_action and state_for_postprocess is not None:
+        if self.relative_action and carrier.state_for_postprocess is not None:
             n_relative = self.relative_action_dim  # 7 for DROID (joint only)
             # Use original state precision for post-denorm absolute recovery.
             # Upstream adds obs state after `eval_transform.unapply()`
             # the bf16 denoising path.
-            last_state = state_for_postprocess[:, 0, :n_relative]  # (B, n_relative)
+            last_state = carrier.state_for_postprocess[:, 0, :n_relative]  # (B, n_relative)
             action_out[..., :n_relative] = (
                 action_out[..., :n_relative] + last_state.unsqueeze(1)  # broadcast over horizon
             )
@@ -1462,6 +1726,286 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         )
 
     # -----------------------------------------------------------------------
+    # Disaggregated diffusion protocol (DiffusionV2Atoms — #4948 contract)
+    # -----------------------------------------------------------------------
+
+    #: DreamZero supports the three-stage encode/denoise/decode topology. The
+    #: runner selects the path from ``od_config.model_stage``; the pipeline
+    #: marshals its private carrier through :class:`StagePayload` here. This flag
+    #: (plus the DiffusionV2Atoms method surface) is what
+    #: ``supports_disaggregated_execution(pipeline)`` gates on.
+    supports_disaggregated_execution: bool = True
+
+    #: DreamZero runs only as a request-mode / disaggregated pipeline (it drives
+    #: the whole-request ``diffuse`` atom with model-owned AR-Diffusion KV, not
+    #: the single-process step loop). Kept ``False`` so the worker never routes
+    #: it to the single-process DiffusionModelRunnerV2 step runner.
+    supports_step_execution: bool = False
+
+    #: Key under which the DreamZero carrier lives on DiffusionRequestState.extra.
+    _CARRIER_KEY = "dreamzero_carrier"
+
+    #: Carrier fields packed into a StagePayload per stage boundary. Everything
+    #: DreamZero carries is model-private, so tensors go in
+    #: ``private_tensor_fields`` and scalars in ``private_scalar_fields``; only
+    #: ``session_id`` is public (the transition processor + AR runner read it to
+    #: attach the right AR-Diffusion KV session without decoding private schema).
+    _PAYLOAD_TENSOR_FIELDS: ClassVar[dict[StageBoundary, tuple[str, ...]]] = {
+        StageBoundary.ENCODE_TO_DIT: (
+            "prompt_embeds",
+            "negative_prompt_embeds",
+            "clip_feas",
+            "ys",
+            "image_latent",
+            "state_features",
+            "embodiment_id",
+            "noise_obs",
+            "noise_action",
+            "state_for_postprocess",
+        ),
+        StageBoundary.DIT_TO_DECODE: ("video_out", "action_out", "state_for_postprocess"),
+    }
+    _PAYLOAD_SCALAR_FIELDS: ClassVar[tuple[str, ...]] = (
+        "embodiment_name",
+        "transform_embodiment",
+        "reset_reason",
+        "explicit_reset",
+        "do_true_cfg",
+        "current_start_frame",
+        "height",
+        "width",
+        "seq_len",
+        "frame_seqlen",
+        "num_inference_steps",
+        "sigma_shift",
+    )
+
+    @classmethod
+    def required_components_for_stage(cls, model_stage: str) -> StageComponentSpec:
+        """Declare which components each DreamZero stage must construct/load.
+
+        Derived from the real data dependencies of the phase methods:
+        encode owns the tokenizer/text+image encoders and the VAE ENCODER;
+        denoise owns the CausalWan DiT + schedulers (+ action head, part of the
+        transformer); decode owns the VAE DECODER for video export. The action
+        norm stats / transforms are lightweight metadata built in __init__ for
+        every stage, so they are not gated here.
+        """
+        role = normalize_stage_role(model_stage)
+        if role == ENCODE:
+            return StageComponentSpec(
+                tokenizer=True,
+                text_encoder=True,
+                image_encoder=True,
+                vae_encoder=True,
+            )
+        if role == DENOISE:
+            return StageComponentSpec(
+                dit=True,
+                scheduler=True,
+                action_modules=True,
+            )
+        if role == DECODE:
+            return StageComponentSpec(vae_decoder=True)
+        # Monolithic / unknown: everything. Reuse the shared all-True singleton so
+        # this stays in step with StageComponentSpec if a component is ever added.
+        return ALL_COMPONENTS
+
+    # -- DiffusionV2Atoms state-based atoms ----------------------------------
+    # The runner drives these explicitly (encode: init_state -> check_inputs ->
+    # encode -> prepare; denoise: unpack -> diffuse; decode: unpack -> decode ->
+    # postprocess). Each stores/reads the DreamZero carrier on state.extra so the
+    # generic DiffusionRequestState never grows model-private fields.
+
+    def init_state(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Initialize a fresh request state before encode (clear stale carrier)."""
+        state.extra.pop(self._CARRIER_KEY, None)
+        state.extra.pop("decoded_output", None)
+        return state
+
+    def check_inputs(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Validate that a raw request carries a robot observation."""
+        extra_args = getattr(state.sampling, "extra_args", None) or {}
+        if extra_args.get("robot_obs") is None:
+            raise ValueError(
+                f"DreamZero request {state.request_id!r} has no robot_obs in sampling_params.extra_args."
+            )
+        return state
+
+    def encode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Run the encode phase and stash the DreamZero carrier on state.extra."""
+        extra_args = getattr(state.sampling, "extra_args", None) or {}
+        robot_obs = extra_args["robot_obs"]
+        session_id = str(extra_args.get("session_id") or state.request_id or "default")
+        # Encode owns no AR-Diffusion KV: resolve a model-local session state only.
+        dz_state = self._get_or_create_state(session_id)
+        self.state = dz_state
+        carrier = self._run_encode_phase(
+            robot_obs,
+            dz_state,
+            session_id,
+            explicit_reset=bool(extra_args.get("reset", False)),
+        )
+        state.extra[self._CARRIER_KEY] = carrier
+        return state
+
+    def prepare(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """No-op atom: the encode phase already prepared initial noise + schedule.
+
+        DreamZero's timestep schedule is rebuilt on the denoise worker from the
+        carried ``num_inference_steps`` / ``sigma_shift`` (the scheduler object
+        is process-local and never transported), and the initial noise is carried
+        explicitly. Kept as a distinct atom for protocol symmetry.
+        """
+        return state
+
+    def diffuse(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Whole-request denoise atom: run the DiT loop on the restored carrier.
+
+        Called by the runner's denoise stage. The AR-Diffusion KV/session state
+        was attached to the pipeline by ARDiffusionModelRunner before this call.
+        DreamZero runs the entire per-request denoise here (its dual video+action
+        DiT loop with model-owned KV), so it does NOT implement the single-step
+        ``denoise_step`` / ``step_scheduler`` contract.
+        """
+        carrier = state.extra.get(self._CARRIER_KEY)
+        if carrier is None:
+            raise StagePayloadError(
+                f"DreamZero denoise for {state.request_id!r} has no carrier on state.extra "
+                f"[{self._CARRIER_KEY!r}] — unpack_stage_state must run first."
+            )
+        dz_state = self._get_or_create_state(carrier.session_id)
+        self.state = dz_state
+        if self._ar_diffusion_kv_state is None:
+            raise StagePayloadError(
+                f"DreamZero denoise for session {carrier.session_id!r} has no AR-Diffusion KV state; "
+                "the denoise stage must run on the AR-Diffusion engine."
+            )
+        # Apply the same engine-KV window reset the encode worker decided. On the
+        # denoise worker the KV state is attached, so this drops the pool window.
+        if carrier.current_start_frame == 0:
+            self._apply_model_local_reset(dz_state, carrier.reset_reason)
+        # Realign the model-local window position + conditions with the encode
+        # carrier (the denoise DreamZeroState is a fresh per-session shadow).
+        dz_state.current_start_frame = carrier.current_start_frame
+        dz_state.clip_feas = carrier.clip_feas
+        dz_state.ys = carrier.ys
+        if dz_state.prompt_embeds is None:
+            dz_state.prompt_embeds = carrier.prompt_embeds
+        self._run_denoise_phase(carrier, dz_state)
+        return state
+
+    def decode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """No-op atom: DreamZero's decode work happens in :meth:`postprocess`
+        (action denorm + video export from the carrier); kept for symmetry."""
+        return state
+
+    def postprocess(self, state: DiffusionRequestState) -> DiffusionOutput:
+        """Run the decode phase from the restored carrier -> user-visible output."""
+        carrier = state.extra.get(self._CARRIER_KEY)
+        if carrier is None:
+            raise StagePayloadError(
+                f"DreamZero decode for {state.request_id!r} has no carrier on state.extra."
+            )
+        return self._run_decode_phase(carrier)
+
+    # -- step-only atoms (unused: DreamZero is request-mode / disaggregated) --
+    # DreamZero's dual video+action denoise with model-owned AR-Diffusion KV does
+    # not fit the single-tensor step contract; it overrides ``diffuse`` instead.
+    # These stubs exist so ``isinstance(pipeline, DiffusionV2Atoms)`` holds while
+    # making the request-mode-only intent explicit.
+
+    def build_step_batch(self, states, *, cached_batch=None):
+        raise NotImplementedError("DreamZero does not support single-process step batching.")
+
+    def build_step_attention_metadata(self, input_batch):
+        return None
+
+    def denoise_step(self, input_batch):
+        raise NotImplementedError("DreamZero runs a whole-request denoise via diffuse(); no per-step denoise_step.")
+
+    def step_scheduler(self, state, noise_pred):
+        raise NotImplementedError("DreamZero advances its scheduler inside diffuse(); no per-step step_scheduler.")
+
+    # -- payload marshalling (StagePayload) ----------------------------------
+
+    def pack_stage_state(self, state: DiffusionRequestState, boundary: StageBoundary) -> StagePayload:
+        """Pack the DreamZero carrier into a transportable :class:`StagePayload`.
+
+        The carrier is entirely model-private, so its tensors go in
+        ``private_tensor_fields`` and its scalars in ``private_scalar_fields``
+        (both sanitized/validated by ``StagePayload.create``). Only ``session_id``
+        is exposed in the public ``scalar_fields`` so the generic transition
+        processor and the AR-Diffusion runner can attach the right KV session
+        without decoding model-private schema. The AR-Diffusion KV / scheduler /
+        DreamZeroState are NEVER packed — only stable data.
+        """
+        carrier = state.extra.get(self._CARRIER_KEY)
+        if carrier is None:
+            raise StagePayloadError(
+                f"DreamZero pack for {state.request_id!r} (boundary={boundary}) "
+                f"has no carrier on state.extra[{self._CARRIER_KEY!r}]."
+            )
+        tensor_names = self._PAYLOAD_TENSOR_FIELDS.get(boundary)
+        if tensor_names is None:
+            raise StagePayloadError(f"DreamZero has no pack for stage boundary {boundary!r}.")
+
+        private_tensor_fields = {}
+        for name in tensor_names:
+            value = getattr(carrier, name, None)
+            if value is not None:
+                private_tensor_fields[name] = value
+
+        private_scalar_fields = {name: getattr(carrier, name) for name in self._PAYLOAD_SCALAR_FIELDS}
+
+        return StagePayload.create(
+            request_id=state.request_id,
+            boundary=boundary,
+            scalar_fields={"session_id": carrier.session_id},
+            private_tensor_fields=private_tensor_fields,
+            private_scalar_fields=private_scalar_fields,
+        )
+
+    def unpack_stage_state(self, payload: StagePayload, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Apply a received :class:`StagePayload` to the existing request state.
+
+        Mutates the runner-created ``state`` in place (the runner already built it
+        from the incoming request, preserving request-level sampling/generator
+        plumbing): rebuilds the DreamZero carrier from the payload's scalar/tensor
+        dicts and stashes it on ``state.extra``. The live AR-Diffusion session is
+        acquired separately by the denoise runner via the normal engine mechanism
+        (keyed by the transported ``session_id``) — never from the payload.
+        """
+        payload.validate()
+        meta = payload.private_scalar_fields
+        device = get_local_device()
+
+        def _to_device(t):
+            return t.to(device=device) if isinstance(t, torch.Tensor) else t
+
+        carrier = DreamZeroStageCarrier(
+            session_id=str(payload.scalar_fields.get("session_id", "default")),
+            embodiment_name=str(meta.get("embodiment_name", "")),
+            transform_embodiment=str(meta.get("transform_embodiment", "")),
+            reset_reason=meta.get("reset_reason"),
+            explicit_reset=bool(meta.get("explicit_reset", False)),
+            do_true_cfg=bool(meta.get("do_true_cfg", False)),
+            current_start_frame=int(meta.get("current_start_frame", 0)),
+            height=int(meta.get("height", 0)),
+            width=int(meta.get("width", 0)),
+            seq_len=int(meta.get("seq_len", 0)),
+            frame_seqlen=int(meta.get("frame_seqlen", 0)),
+            num_inference_steps=int(meta.get("num_inference_steps", 0)),
+            sigma_shift=float(meta.get("sigma_shift", 1.0)),
+        )
+        for name, tensor in payload.private_tensor_fields.items():
+            if hasattr(carrier, name):
+                setattr(carrier, name, _to_device(tensor))
+
+        state.extra[self._CARRIER_KEY] = carrier
+        return state
+
+    # -----------------------------------------------------------------------
     # Action denormalization
     # -----------------------------------------------------------------------
 
@@ -1475,16 +2019,24 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         return self._parse_action_norm_stats(metadata)
 
     @staticmethod
-    def _parse_action_norm_stats(metadata: dict) -> dict[str, dict[str, torch.Tensor]]:
+    def _parse_norm_stats(metadata: dict, stats_kind: str) -> dict[str, dict[str, torch.Tensor]]:
+        """Parse per-embodiment q01/q99 normalization stats of one kind.
+
+        ``stats_kind`` selects the ``statistics`` sub-block ("action" or
+        "state"); the joint_position + gripper_position q01/q99 vectors are
+        concatenated into per-embodiment tensors. Shared by the action and state
+        parsers, which differ only in that key.
+
+        Returns: {embodiment_name: {"q01": Tensor(dim,), "q99": Tensor(dim,)}}
+        """
         result = {}
         for emb_name, emb_data in metadata.items():
-            action_stats = emb_data.get("statistics", {}).get("action", {})
+            stats = emb_data.get("statistics", {}).get(stats_kind, {})
             q01_parts, q99_parts = [], []
-            # Concatenate joint_position + gripper_position stats
             for key in ["joint_position", "gripper_position"]:
-                if key in action_stats:
-                    q01_parts.extend(action_stats[key]["q01"])
-                    q99_parts.extend(action_stats[key]["q99"])
+                if key in stats:
+                    q01_parts.extend(stats[key]["q01"])
+                    q99_parts.extend(stats[key]["q99"])
             if q01_parts:
                 result[emb_name] = {
                     "q01": torch.tensor(q01_parts, dtype=torch.float32),
@@ -1493,22 +2045,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         return result
 
     @staticmethod
+    def _parse_action_norm_stats(metadata: dict) -> dict[str, dict[str, torch.Tensor]]:
+        """Load per-embodiment action normalization stats from metadata.json."""
+        return DreamZeroPipeline._parse_norm_stats(metadata, "action")
+
+    @staticmethod
     def _parse_state_norm_stats(metadata: dict) -> dict[str, dict[str, torch.Tensor]]:
         """Load per-embodiment state normalization stats from metadata.json."""
-        result = {}
-        for emb_name, emb_data in metadata.items():
-            state_stats = emb_data.get("statistics", {}).get("state", {})
-            q01_parts, q99_parts = [], []
-            for key in ["joint_position", "gripper_position"]:
-                if key in state_stats:
-                    q01_parts.extend(state_stats[key]["q01"])
-                    q99_parts.extend(state_stats[key]["q99"])
-            if q01_parts:
-                result[emb_name] = {
-                    "q01": torch.tensor(q01_parts, dtype=torch.float32),
-                    "q99": torch.tensor(q99_parts, dtype=torch.float32),
-                }
-        return result
+        return DreamZeroPipeline._parse_norm_stats(metadata, "state")
 
     def _normalize_state(
         self,
@@ -1645,7 +2189,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         if subkey == "norm.weight":
             return "encoder.final_layer_norm.weight"
 
-        m = re_module.match(r"blocks\.(\d+)\.(.*)", subkey)
+        m = re.match(r"blocks\.(\d+)\.(.*)", subkey)
         if not m:
             return None
         block_idx = m.group(1)
@@ -1721,7 +2265,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             "time_conv.bias": "time_conv.bias",
         }
 
-        m = re_module.match(r"encoder\.middle\.(\d+)\.(.*)", rest)
+        m = re.match(r"encoder\.middle\.(\d+)\.(.*)", rest)
         if m:
             idx = int(m.group(1))
             tail = m.group(2)
@@ -1732,7 +2276,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 return f"encoder.mid_block.attentions.0.{tail}"
             return None
 
-        m = re_module.match(r"decoder\.middle\.(\d+)\.(.*)", rest)
+        m = re.match(r"decoder\.middle\.(\d+)\.(.*)", rest)
         if m:
             idx = int(m.group(1))
             tail = m.group(2)
@@ -1743,7 +2287,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 return f"decoder.mid_block.attentions.0.{tail}"
             return None
 
-        m = re_module.match(r"encoder\.downsamples\.(\d+)\.(.*)", rest)
+        m = re.match(r"encoder\.downsamples\.(\d+)\.(.*)", rest)
         if m:
             idx = int(m.group(1))
             tail = m.group(2)
@@ -1751,7 +2295,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 return f"encoder.down_blocks.{idx}.{block_leaf_map[tail]}"
             return None
 
-        m = re_module.match(r"decoder\.upsamples\.(\d+)\.(.*)", rest)
+        m = re.match(r"decoder\.upsamples\.(\d+)\.(.*)", rest)
         if m:
             idx = int(m.group(1))
             tail = m.group(2)

--- a/vllm_omni/diffusion/models/dreamzero/state_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/state_dreamzero.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import logging
 from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
 
 import numpy as np
 import torch
@@ -17,6 +19,76 @@ logger = logging.getLogger(__name__)
 FRAMES_PER_CHUNK = 4
 
 
+@dataclass
+class DreamZeroStageCarrier:
+    """DreamZero-private inter-phase carrier for disaggregated execution (RFC #4590).
+
+    ``forward()`` is refactored into three phase methods
+    (``_run_encode_phase`` / ``_run_denoise_phase`` / ``_run_decode_phase``) that
+    read and write this carrier. In the monolithic path all three run in one
+    process on one carrier, so the composition is byte-identical to the original
+    forward. In the disaggregated path each phase runs in its own worker and the
+    carrier's stable fields are marshalled through a ``StagePayload`` by the
+    pipeline's ``pack_stage_state`` / ``unpack_stage_state`` hooks.
+
+    This is model-private state (kept out of the generic ``DiffusionRequestState``
+    per RFC §2.3): it is stored on ``DiffusionRequestState.extra`` and interpreted
+    only by DreamZero. The AR-Diffusion KV / live session objects are NEVER placed
+    here — they stay on the denoise worker.
+    """
+
+    # -- identity / control (crosses every boundary) --
+    session_id: str = "default"
+    embodiment_name: str = ""
+    # The exact key passed to get_transform() at encode time, so decode selects
+    # the identical transform (preserves monolithic-forward behavior exactly).
+    transform_embodiment: str = ""
+    # Reset decision computed at encode from the encode-session state; the
+    # denoise worker applies the SAME reset to its engine KV window.
+    reset_reason: str | None = None
+    explicit_reset: bool = False
+    do_true_cfg: bool = False
+    # Window position at the start of this forward. Both encode and denoise track
+    # csf on their own DreamZeroState; it is carried so the denoise worker aligns
+    # its KV window with the conditions the encode worker produced.
+    current_start_frame: int = 0
+
+    # -- geometry (encode -> denoise) --
+    height: int = 0
+    width: int = 0
+    seq_len: int = 0
+    frame_seqlen: int = 0
+
+    # -- encoded conditions (encode -> denoise), stable/read-only during denoise --
+    prompt_embeds: torch.Tensor | None = None
+    negative_prompt_embeds: torch.Tensor | None = None
+    clip_feas: torch.Tensor | None = None
+    ys: torch.Tensor | None = None
+    image_latent: torch.Tensor | None = None
+    state_features: torch.Tensor | None = None
+    embodiment_id: torch.Tensor | None = None
+
+    # -- initial noise (encode -> denoise). Carried explicitly so the denoise
+    #    worker uses exactly the encode-seeded noise (deterministic parity). --
+    noise_obs: torch.Tensor | None = None
+    noise_action: torch.Tensor | None = None
+
+    # -- timestep schedule params (encode -> denoise) --
+    num_inference_steps: int = 0
+    sigma_shift: float = 1.0
+
+    # -- postprocess inputs (encode -> ... -> decode) --
+    # Raw padded observation state for relative->absolute action recovery.
+    state_for_postprocess: torch.Tensor | None = None
+
+    # -- denoise outputs (denoise -> decode) --
+    video_out: torch.Tensor | None = None
+    action_out: torch.Tensor | None = None
+
+    # -- opaque extras for forward-compat --
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
 class DreamZeroState:
     """Pipeline persistent state across forward() calls.
 
@@ -24,7 +96,7 @@ class DreamZeroState:
         - Created once in DreamZeroPipeline.__init__()
         - Mutated every forward() call (frame append, KV cache grow)
         - reset() on new session / language change
-        - reset_inference_state() on local_attn_size exceeded (KV only)
+        - reset(clear_video_latents=False) on local_attn_size exceeded (KV only)
     """
 
     def __init__(self) -> None:
@@ -98,7 +170,7 @@ class DreamZeroState:
         self.video_latents_across_time = []
 
     # ------------------------------------------------------------------
-    # Reset / should_reset
+    # Reset / reset_reason
     # ------------------------------------------------------------------
 
     def reset(self, *, clear_video_latents: bool = True) -> None:
@@ -134,10 +206,6 @@ class DreamZeroState:
         self.vae_encoder_out: torch.Tensor | None = None
         self.vae_pending_body_frames: torch.Tensor | None = None
 
-    def reset_inference_state(self) -> None:
-        """Reset KV/frame state after local attention rolls without dropping video latents."""
-        self.reset(clear_video_latents=False)
-
     def reset_reason(
         self,
         text_tokens: torch.Tensor | None,
@@ -169,7 +237,3 @@ class DreamZeroState:
             return "inference"
 
         return None
-
-    def should_reset(self, text_tokens: torch.Tensor | None, num_video_frames: int, local_attn_size: int) -> bool:
-        """Determine if state should be reset before this forward()."""
-        return self.reset_reason(text_tokens, num_video_frames, local_attn_size) is not None

--- a/vllm_omni/diffusion/models/interface.py
+++ b/vllm_omni/diffusion/models/interface.py
@@ -1,8 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Diffusion pipeline capability protocols and their feature-probe helpers.
+
+Home of the ``runtime_checkable`` protocols the diffusion runtime uses to decide
+what a loaded pipeline can do, plus the ``supports_*`` helpers that isinstance-probe
+them: input/output modality markers, :class:`DiffusionV2Atoms` (the state-based
+step/disaggregation atom contract — encode/denoise/decode atoms plus the
+``pack_stage_state`` / ``unpack_stage_state`` payload hooks and
+``required_components_for_stage``), and :class:`SupportsComponentDiscovery`
+(submodule locations for offload/HSDP).
+
+:class:`StagePayload` is the transport envelope handed from one diffusion stage
+to the next; its transport safety (tensor sanitization, non-transportable-value
+rejection) is delegated to the torch-free helpers in
+:mod:`vllm_omni.diffusion.stage_payload`. Kept torch-free at module scope (torch
+imports are TYPE_CHECKING-only) so capability checks stay importable without the
+model runtime.
+"""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -12,12 +30,43 @@ from typing import (
     runtime_checkable,
 )
 
+# NOTE: the transport helpers live in the torch-free leaf
+# ``vllm_omni.diffusion.stage_payload``. They are imported LAZILY inside the
+# StagePayload methods (via ``_transport()``), NOT at module scope: a module-scope
+# ``from vllm_omni.diffusion.stage_payload import ...`` is an absolute import that
+# would trigger ``vllm_omni/__init__`` (which imports torch), breaking the
+# torch-free by-path load the disaggregated test suite relies on. The schema
+# version is duplicated as a module constant below and asserted equal to the leaf's
+# in tests, so this module needs no import-time dependency on the leaf.
+#: Bump in lockstep with ``stage_payload.DIFFUSION_STAGE_PAYLOAD_SCHEMA_VERSION``.
+STAGE_PAYLOAD_SCHEMA_VERSION = 1
+
 if TYPE_CHECKING:
     import torch
 
     from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.stage_roles import StageComponentSpec
     from vllm_omni.diffusion.worker.input_batch import InputBatch
     from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+
+def _transport():
+    """Lazily resolve the torch-free transport helpers from the stage_payload leaf.
+
+    Deferred to call time so importing this capability module never triggers the
+    ``vllm_omni`` package ``__init__`` (torch). Checks ``sys.modules`` first so a
+    by-path, torch-free load (the disaggregated tests, which register the leaf
+    under its real dotted name) resolves without importing the package; falls
+    back to a normal import at real runtime.
+    """
+    import sys
+
+    mod = sys.modules.get("vllm_omni.diffusion.stage_payload")
+    if mod is not None:
+        return mod
+    from vllm_omni.diffusion import stage_payload
+
+    return stage_payload
 
 
 @runtime_checkable
@@ -42,32 +91,301 @@ class SupportAudioOutput(Protocol):
     support_audio_output: ClassVar[bool] = True
 
 
-@runtime_checkable
-class SupportsStepExecution(Protocol):
-    """State-driven step-level execution protocol for diffusion pipelines.
+class StageBoundary(str, Enum):
+    ENCODE_TO_DIT = "encode_to_dit"
+    DIT_TO_DECODE = "dit_to_decode"
 
-    Pipelines should split request-level ``forward()`` into:
-    ``prepare_encode()`` (one-time request setup), ``denoise_step()``
-    (one denoise forward), ``step_scheduler()`` (one scheduler update),
-    and ``post_decode()`` (final decode).
+
+def boundary_from_roles(source_stage: str, target_stage: str) -> StageBoundary:
+    """Map a disaggregated (source_stage, target_stage) transition to a boundary.
+
+    ``encode -> denoise`` is :attr:`StageBoundary.ENCODE_TO_DIT`;
+    ``denoise -> decode`` is :attr:`StageBoundary.DIT_TO_DECODE`. Torch-free;
+    the role strings are the ones in :mod:`vllm_omni.diffusion.stage_roles`.
     """
+    if source_stage == "encode" and target_stage == "denoise":
+        return StageBoundary.ENCODE_TO_DIT
+    if source_stage == "denoise" and target_stage == "decode":
+        return StageBoundary.DIT_TO_DECODE
+    raise _transport().StagePayloadError(
+        f"No stage boundary for transition {source_stage!r}->{target_stage!r}."
+    )
+
+
+@dataclass
+class StagePayload:
+    """Transport envelope handed from one diffusion stage to the next.
+
+    The #4948 four-dict envelope, carrying the *data* one stage produces for the
+    next while a mutable runner-local ``DiffusionRequestState`` never crosses a
+    process boundary. Public ``*_fields`` are runner-visible; ``private_*_fields``
+    are model-private and only the owning pipeline interprets them. Both tensor
+    dicts are sanitized to host memory at export; both scalar dicts are validated
+    against the transportable allow-list. Transport safety is delegated to the
+    torch-free helpers in :mod:`vllm_omni.diffusion.stage_payload`.
+    """
+
+    request_id: str
+    boundary: StageBoundary
+    scalar_fields: dict[str, object] = field(default_factory=dict)
+    tensor_fields: dict[str, torch.Tensor] = field(default_factory=dict)
+    private_scalar_fields: dict[str, object] = field(default_factory=dict)
+    private_tensor_fields: dict[str, torch.Tensor] = field(default_factory=dict)
+    payload_version: int = STAGE_PAYLOAD_SCHEMA_VERSION
+
+    # -- construction --------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        request_id: str,
+        boundary: StageBoundary,
+        scalar_fields: dict[str, object] | None = None,
+        tensor_fields: dict[str, "torch.Tensor"] | None = None,
+        private_scalar_fields: dict[str, object] | None = None,
+        private_tensor_fields: dict[str, "torch.Tensor"] | None = None,
+        sanitize: bool = True,
+        validate: bool = True,
+    ) -> StagePayload:
+        """Build a payload, sanitizing both tensor dicts and validating.
+
+        ``sanitize=True`` (default) routes every tensor through
+        :func:`~vllm_omni.diffusion.stage_payload.sanitize_transport_tensor` so
+        callers don't scatter ``.detach().cpu()`` through model code.
+        ``validate=True`` runs the full transportability check before returning.
+        """
+
+        transport = _transport()
+
+        def _prep(tensors: dict[str, "torch.Tensor"] | None, label: str) -> dict[str, "torch.Tensor"]:
+            prepared: dict[str, "torch.Tensor"] = {}
+            for name, tensor in (tensors or {}).items():
+                if not transport._is_tensor(tensor):
+                    raise transport.NonTransportableValueError(
+                        f"{label}[{name!r}] is {type(tensor).__name__}, expected a torch.Tensor. "
+                        "Small non-tensor values belong in a scalar dict."
+                    )
+                prepared[name] = transport.sanitize_transport_tensor(tensor) if sanitize else tensor
+            return prepared
+
+        payload = cls(
+            request_id=request_id,
+            boundary=boundary,
+            scalar_fields=dict(scalar_fields or {}),
+            tensor_fields=_prep(tensor_fields, "tensor_fields"),
+            private_scalar_fields=dict(private_scalar_fields or {}),
+            private_tensor_fields=_prep(private_tensor_fields, "private_tensor_fields"),
+        )
+        if validate:
+            payload.validate()
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StagePayload:
+        """Rehydrate a payload flattened to a plain dict by cross-process transport.
+
+        Inter-stage IPC (msgpack) does not preserve dataclass identity, so a
+        payload sent through ``custom_output`` arrives on the receiving stage as
+        a plain ``dict``. The runner's ``_extract_incoming_payload`` and the
+        generic transition processor reconstruct the real type via this method
+        before validation. ``boundary`` round-trips as its string value.
+        """
+        return cls(
+            request_id=data["request_id"],
+            boundary=StageBoundary(data["boundary"]),
+            scalar_fields=dict(data.get("scalar_fields") or {}),
+            tensor_fields=dict(data.get("tensor_fields") or {}),
+            private_scalar_fields=dict(data.get("private_scalar_fields") or {}),
+            private_tensor_fields=dict(data.get("private_tensor_fields") or {}),
+            payload_version=data.get("payload_version", STAGE_PAYLOAD_SCHEMA_VERSION),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten to a plain, transportable dict (``boundary`` as its str value)."""
+        return {
+            "request_id": self.request_id,
+            "boundary": self.boundary.value,
+            "scalar_fields": dict(self.scalar_fields),
+            "tensor_fields": dict(self.tensor_fields),
+            "private_scalar_fields": dict(self.private_scalar_fields),
+            "private_tensor_fields": dict(self.private_tensor_fields),
+            "payload_version": self.payload_version,
+        }
+
+    # -- validation ----------------------------------------------------------
+
+    def validate(self) -> None:
+        """Raise :class:`StagePayloadError` if the envelope is not transportable."""
+        transport = _transport()
+        error = transport.StagePayloadError
+        if not isinstance(self.request_id, str) or not self.request_id:
+            raise error("StagePayload.request_id must be a non-empty string.")
+        if not isinstance(self.boundary, StageBoundary):
+            raise error(f"StagePayload.boundary must be a StageBoundary, got {self.boundary!r}.")
+        if self.payload_version != STAGE_PAYLOAD_SCHEMA_VERSION:
+            raise error(
+                f"Unsupported StagePayload payload_version {self.payload_version}; "
+                f"this build understands version {STAGE_PAYLOAD_SCHEMA_VERSION}."
+            )
+        for label, tensors in (("tensor_fields", self.tensor_fields), ("private_tensor_fields", self.private_tensor_fields)):
+            if not isinstance(tensors, dict):
+                raise error(f"StagePayload.{label} must be a dict[str, Tensor].")
+            for name, tensor in tensors.items():
+                if not isinstance(name, str):
+                    raise error(f"{label} key {name!r} must be a string.")
+                if not transport._is_tensor(tensor):
+                    raise transport.NonTransportableValueError(
+                        f"{label}[{name!r}] is {type(tensor).__name__}, expected a torch.Tensor."
+                    )
+        for label, scalars in (("scalar_fields", self.scalar_fields), ("private_scalar_fields", self.private_scalar_fields)):
+            if not isinstance(scalars, dict):
+                raise error(f"StagePayload.{label} must be a dict.")
+            for key, value in scalars.items():
+                if not isinstance(key, str):
+                    raise error(f"{label} key {key!r} must be a string.")
+                transport.validate_transport_scalar(value, path=f"{label}[{key!r}]")
+
+    def sanitize(self) -> StagePayload:
+        """Return a copy with both tensor dicts moved to host memory."""
+        return StagePayload.create(
+            request_id=self.request_id,
+            boundary=self.boundary,
+            scalar_fields=self.scalar_fields,
+            tensor_fields=self.tensor_fields,
+            private_scalar_fields=self.private_scalar_fields,
+            private_tensor_fields=self.private_tensor_fields,
+            sanitize=True,
+            validate=False,
+        )
+
+    # -- convenience ---------------------------------------------------------
+
+    def require_tensors(self, *names: str, private: bool = True) -> None:
+        """Raise if any of ``names`` is missing from the (private) tensor dict."""
+        source = self.private_tensor_fields if private else self.tensor_fields
+        missing = [n for n in names if n not in source]
+        if missing:
+            which = "private_tensor_fields" if private else "tensor_fields"
+            raise _transport().StagePayloadError(
+                f"Payload {self.boundary.value!r} for request {self.request_id!r} is missing "
+                f"required {which}: {missing}. Present: {sorted(source)}."
+            )
+
+    def expect_boundary(self, boundary: StageBoundary) -> None:
+        """Raise if the payload's boundary does not match ``boundary``."""
+        if self.boundary != boundary:
+            raise _transport().StagePayloadError(
+                f"Payload for request {self.request_id!r} has boundary {self.boundary!r}, "
+                f"expected {boundary!r}."
+            )
+
+    def summary(self) -> str:
+        """One-line, tensor-content-free description for debug logging."""
+
+        def _desc(tensors: dict[str, "torch.Tensor"]) -> str:
+            return ", ".join(
+                f"{name}{tuple(t.shape)}:{str(t.dtype).replace('torch.', '')}" for name, t in tensors.items()
+            )
+
+        return (
+            f"StagePayload(req={self.request_id} boundary={self.boundary.value} "
+            f"v{self.payload_version} tensors=[{_desc(self.tensor_fields)}] "
+            f"private_tensors=[{_desc(self.private_tensor_fields)}] "
+            f"scalar_keys={sorted(self.scalar_fields)} private_scalar_keys={sorted(self.private_scalar_fields)})"
+        )
+
+
+@runtime_checkable
+class DiffusionV2Atoms(Protocol):
+    """State-based diffusion atoms shared by request mode and step mode."""
 
     supports_step_execution: ClassVar[bool] = True
 
-    def prepare_encode(self, state: DiffusionRequestState, **kwargs: Any) -> DiffusionRequestState:
-        """Prepare request-level inputs and return initialized state."""
+    def init_state(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Initialize pipeline-private fields on a newly created request state."""
         ...
 
-    def denoise_step(self, input_batch: InputBatch, **kwargs: Any) -> torch.Tensor | None:
-        """Run one denoise forward on the runner-assembled batch."""
+    def check_inputs(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Validate request inputs before model work begins."""
         ...
 
-    def step_scheduler(self, state: DiffusionRequestState, noise_pred: torch.Tensor, **kwargs: Any) -> None:
-        """Run one scheduler step."""
+    def encode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Run text/input encoders and populate encoded prompt fields."""
         ...
 
-    def post_decode(self, state: DiffusionRequestState, **kwargs: Any) -> DiffusionOutput:
-        """Decode output after denoise loop or at a partial chunk boundary."""
+    def prepare(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Prepare model-specific denoise state after encode."""
+        ...
+
+    def diffuse(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Run the full diffusion loop for request-mode/golden-path execution."""
+        ...
+
+    def decode(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        """Decode raw latent state into the model output representation."""
+        ...
+
+    def postprocess(self, state: DiffusionRequestState) -> DiffusionOutput:
+        """Apply model-specific output post-processing and return final output."""
+        ...
+
+    def pack_stage_state(
+        self,
+        state: DiffusionRequestState,
+        boundary: StageBoundary,
+    ) -> StagePayload:
+        """Pack state for a stage boundary without exposing model-private schema to the runner."""
+        ...
+
+    def unpack_stage_state(
+        self,
+        payload: StagePayload,
+        state: DiffusionRequestState,
+    ) -> DiffusionRequestState:
+        """Apply a received stage payload to an existing request state."""
+        ...
+
+    def build_step_batch(
+        self,
+        states: list[DiffusionRequestState],
+        *,
+        cached_batch: InputBatch | None = None,
+    ) -> InputBatch:
+        """Build the runner-visible step batch for one scheduler tick."""
+        ...
+
+    def build_step_attention_metadata(
+        self,
+        input_batch: InputBatch,
+    ) -> object | None:
+        """Build optional forward-context attention metadata for the step batch."""
+        ...
+
+    def denoise_step(
+        self,
+        input_batch: InputBatch,
+    ) -> torch.Tensor | None:
+        """Run one DiT denoise step on the runner-assembled batch."""
+        ...
+
+    def step_scheduler(
+        self,
+        state: DiffusionRequestState,
+        noise_pred: torch.Tensor,
+    ) -> DiffusionRequestState:
+        """Apply one scheduler step to a request-local state."""
+        ...
+
+    @classmethod
+    def required_components_for_stage(cls, model_stage: str) -> StageComponentSpec:
+        """Declare which components a given disaggregated stage role must build.
+
+        Queried before module construction so a stage process loads only the
+        components its role owns (see
+        :class:`~vllm_omni.diffusion.stage_roles.StageComponentSpec`). Monolithic
+        pipelines return the all-components spec.
+        """
         ...
 
 
@@ -97,6 +415,25 @@ class SupportsComponentDiscovery(Protocol):
 
 
 def supports_step_execution(pipeline: object) -> bool:
-    """Return whether `pipeline` implements :class:`SupportsStepExecution`."""
+    """Return whether `pipeline` implements the v2 step atom contract."""
 
-    return isinstance(pipeline, SupportsStepExecution)
+    return getattr(pipeline, "supports_step_execution", False) is True and isinstance(
+        pipeline,
+        DiffusionV2Atoms,
+    )
+
+
+def supports_disaggregated_execution(pipeline: object) -> bool:
+    """Return whether `pipeline` can be driven as a disaggregated stage.
+
+    Uses an explicit ``supports_disaggregated_execution`` flag plus the full
+    :class:`DiffusionV2Atoms` contract (the collapsed RFC #4590 + #4948 surface —
+    the encode/denoise/decode atoms, ``pack_stage_state`` / ``unpack_stage_state``
+    payload hooks, and ``required_components_for_stage``). ``isinstance`` against
+    the runtime-checkable Protocol validates the hooks are present; the flag lets
+    a step-only pipeline opt out even though it satisfies the same atom surface.
+    """
+
+    if not bool(getattr(pipeline, "supports_disaggregated_execution", False)):
+        return False
+    return isinstance(pipeline, DiffusionV2Atoms)

--- a/vllm_omni/diffusion/models/step_mixin.py
+++ b/vllm_omni/diffusion/models/step_mixin.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import torch
+
+    from vllm_omni.diffusion.worker.input_batch import InputBatch
+    from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+
+class DiffusionV2AtomDefaultsMixin:
+    """Default hooks shared by step/disaggregated diffusion pipelines."""
+
+    supports_step_execution: ClassVar[bool] = True
+
+    def init_state(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        state.extra.pop("decoded_output", None)
+        self._guidance_scale = 1.0
+        self._attention_kwargs = {}
+        self._current_timestep = None
+        self._interrupt = False
+        return state
+
+    # TODO: build varlen attention metadata here when step batching
+    # starts using packed varlen attention.
+    def build_step_attention_metadata(
+        self,
+        input_batch: InputBatch,
+    ) -> object | None:
+        return None
+
+    # TODO: keep this hook for future varlen/cudagraph batching and
+    # disaggregated DiT batch layouts.
+    def build_step_batch(
+        self,
+        states: list[DiffusionRequestState],
+        *,
+        cached_batch: InputBatch | None = None,
+    ) -> InputBatch:
+        from vllm_omni.diffusion.worker.input_batch import InputBatch
+
+        return InputBatch.make_batch(states, cached_batch=cached_batch)
+
+    def diffuse(self, state: DiffusionRequestState) -> DiffusionRequestState:
+        while not state.denoise_completed:
+            if self.interrupt:
+                break
+            input_batch = self.build_step_batch([state])
+            noise_pred = self.denoise_step(input_batch)
+            if noise_pred is None:
+                if self.interrupt:
+                    break
+                raise RuntimeError("denoise_step returned None without pipeline interrupt.")
+            self.step_scheduler(state, noise_pred)
+        return state
+
+    def _new_request_scheduler(self) -> object:
+        scheduler = deepcopy(getattr(self, "scheduler"))
+        scheduler.set_begin_index(0)
+        return scheduler
+
+
+class DiffusionV2CFGStepMixin(DiffusionV2AtomDefaultsMixin):
+    """Default one-step CFG denoise/scheduler hooks.
+
+    Pipelines using this mixin keep model-specific tensor schema in
+    ``_build_denoise_kwargs``.
+    """
+
+    def denoise_step(
+        self,
+        input_batch: InputBatch,
+    ) -> torch.Tensor | None:
+        if self.interrupt:
+            return None
+
+        t = input_batch.timesteps
+        self._current_timestep = t
+        self.transformer.do_true_cfg = input_batch.do_true_cfg
+        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
+            latents=input_batch.latents,
+            timestep=t,
+            guidance=input_batch.guidance,
+            prompt_embeds=input_batch.prompt_embeds,
+            prompt_embeds_mask=input_batch.prompt_embeds_mask,
+            img_shapes=input_batch.img_shapes,
+            txt_seq_lens=input_batch.txt_seq_lens,
+            do_true_cfg=input_batch.do_true_cfg,
+            negative_prompt_embeds=input_batch.negative_prompt_embeds,
+            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
+            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
+            image_latents=input_batch.image_latents,
+        )
+        return self.predict_noise_maybe_with_cfg(
+            input_batch.do_true_cfg,
+            input_batch.true_cfg_scale,
+            positive_kwargs,
+            negative_kwargs,
+            input_batch.cfg_normalize,
+            output_slice,
+        )
+
+    def step_scheduler(
+        self,
+        state: DiffusionRequestState,
+        noise_pred: torch.Tensor,
+    ) -> DiffusionRequestState:
+        if self.interrupt:
+            return state
+        t = state.current_timestep
+        state.latents = self.scheduler_step_maybe_with_cfg(
+            noise_pred,
+            t,
+            state.latents,
+            state.do_true_cfg,
+            per_request_scheduler=state.scheduler,
+        )
+        state.step_index += 1
+        return state

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -114,7 +114,17 @@ def format_empty_diffusion_outputs(
     request: OmniDiffusionRequest,
     *,
     finished: bool = True,
+    custom_output: dict[str, Any] | None = None,
 ) -> list[OmniRequestOutput]:
+    """Format a stage output with no user-visible payload (``output.output is None``).
+
+    Disaggregated encode/denoise stages intentionally have no image/action
+    output of their own -- they hand off a :class:`StagePayload` via
+    ``custom_output`` instead (see ``_intermediate_output`` in
+    ``diffusion_model_runner.py``). ``custom_output`` must be forwarded here so
+    the generic stage-transition processor can find that payload downstream;
+    dropping it would silently break every disaggregated pipeline.
+    """
     return [
         OmniRequestOutput.from_diffusion(
             request_id=request.request_id,
@@ -123,6 +133,7 @@ def format_empty_diffusion_outputs(
             metrics={},
             latents=None,
             finished=finished,
+            custom_output=custom_output,
         )
     ]
 

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -352,6 +352,40 @@ def _prepare_diffusion_quant_config(
     configure_quant_config(quant_config, model_class)
 
 
+def _log_stage_component_plan(od_config: OmniDiffusionConfig, model_class: type) -> None:
+    """Validate + log the component plan for a disaggregated diffusion stage.
+
+    Model-agnostic: it consults the pipeline class's declared
+    ``required_components_for_stage`` (part of the disaggregated protocol) and
+    logs which components this stage role intends to build. Raises early if a
+    disaggregated role is requested but the class does not declare the
+    capability. A no-op for the monolithic role / non-disaggregated pipelines.
+    """
+    from vllm_omni.diffusion.stage_roles import is_disaggregated_role, normalize_stage_role
+
+    role = normalize_stage_role(getattr(od_config, "model_stage", None))
+    if not is_disaggregated_role(role):
+        return
+
+    spec_fn = getattr(model_class, "required_components_for_stage", None)
+    if not callable(spec_fn) or not getattr(model_class, "supports_disaggregated_execution", False):
+        raise ValueError(
+            f"Stage role {role!r} requested for {od_config.model_class_name}, but that "
+            "pipeline does not declare disaggregated execution support "
+            "(missing supports_disaggregated_execution / required_components_for_stage)."
+        )
+    try:
+        spec = spec_fn(role)
+        logger.info(
+            "Diffusion stage loader: model=%s role=%s will construct components: %s",
+            od_config.model_class_name,
+            role,
+            spec.describe(),
+        )
+    except Exception as exc:  # pragma: no cover - logging must not block load
+        logger.warning("Failed to resolve component spec for role %s: %s", role, exc)
+
+
 def initialize_model(
     od_config: OmniDiffusionConfig,
 ) -> nn.Module:
@@ -375,6 +409,14 @@ def initialize_model(
     model_class = DiffusionModelRegistry._try_load_model_cls(od_config.model_class_name)
     if model_class is not None:
         _prepare_diffusion_quant_config(od_config, model_class)
+        # Stage-specific partial construction (RFC #4590 §8). For a disaggregated
+        # stage, query the pipeline class's component spec *before* construction
+        # and log which components this role will build. The actual skip happens
+        # inside the pipeline __init__ (it reads od_config.model_stage), because
+        # the constructor is the only place components are built; this generic
+        # hook validates + records intent and stays model-agnostic (no hard-coded
+        # pipeline class names). Monolithic stages are unaffected.
+        _log_stage_component_plan(od_config, model_class)
         with set_current_diffusion_config(od_config):
             model = model_class(od_config=od_config)
 

--- a/vllm_omni/diffusion/stage_payload.py
+++ b/vllm_omni/diffusion/stage_payload.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Torch-free transport helpers for disaggregated diffusion stage payloads.
+
+RFC #4590 §2.3 requires a small typed envelope that carries the *data* one
+diffusion stage produces for the next, kept strictly separate from the mutable
+runner-local ``DiffusionRequestState``. A ``DiffusionRequestState`` must never
+cross a process boundary; a stage payload may.
+
+The envelope type itself is now
+:class:`~vllm_omni.diffusion.models.interface.StagePayload` (the #4948
+``DiffusionV2Atoms`` contract). This module remains the **torch-free transport
+leaf** every stage layer imports, and is the single source of truth for:
+
+* the two payload-key constants (:data:`STAGE_PAYLOAD_OUTPUT_KEY` /
+  :data:`STAGE_PAYLOAD_PROMPT_KEY`) and the schema version;
+* tensor sanitization at the export boundary
+  (:func:`sanitize_transport_tensor`: detach -> host -> contiguous -> clone);
+* rejection of non-transportable values — modules, generators, CUDA streams,
+  schedulers, process-local cache objects, device pointers
+  (:func:`_looks_non_transportable`, :func:`validate_transport_scalar`).
+
+``StagePayload`` (in ``interface.py``, which stays torch-free) calls these free
+functions so the transport safety lives here without pulling torch into the
+capability-probe module. The first implementation uses the existing host-based
+(msgpack over ZMQ, or in-process) stage transport; host-to-device movement
+happens once at the *restore* boundary inside the owning pipeline.
+"""
+
+from __future__ import annotations
+
+import numbers
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+
+#: Bump when the envelope's wire shape changes incompatibly. Consumers reject
+#: payloads whose ``schema_version`` they do not understand.
+DIFFUSION_STAGE_PAYLOAD_SCHEMA_VERSION = 1
+
+#: The two channels a :class:`StagePayload` travels between stages, kept
+#: here (the torch-free transport leaf every stage layer already imports) as the
+#: single source of truth so the runner, the generic transition processor, and
+#: the AR-Diffusion runner cannot drift:
+#:
+#: * :data:`STAGE_PAYLOAD_OUTPUT_KEY` — key under which the *producer* stage's
+#:   ``DiffusionOutput.custom_output`` carries the outgoing payload.
+#: * :data:`STAGE_PAYLOAD_PROMPT_KEY` — key under which the *consumer* stage's
+#:   request prompt ``extra`` dict carries the incoming payload.
+STAGE_PAYLOAD_OUTPUT_KEY = "__diffusion_stage_payload__"
+STAGE_PAYLOAD_PROMPT_KEY = "diffusion_stage_payload"
+
+#: Metadata values are restricted to these plain, transportable Python types
+#: (recursively for containers). Everything else is rejected at validation.
+#: ``bytes`` is allowed for opaque model-private blobs; numpy scalars/arrays are
+#: allowed because the existing msgpack transport already supports them.
+_ALLOWED_METADATA_SCALARS = (str, bool, bytes, numbers.Number, type(None))
+
+
+class StagePayloadError(ValueError):
+    """Raised when a stage payload fails validation."""
+
+
+class NonTransportableValueError(StagePayloadError):
+    """Raised when payload metadata/tensors contain a non-transportable value.
+
+    The message names the offending key path and type so the failure points at
+    the model code that packed it, not at the generic transport layer.
+    """
+
+
+def _is_tensor(value: Any) -> bool:
+    """Duck-typed torch.Tensor check that does not import torch eagerly."""
+    cls = type(value)
+    # torch.Tensor instances report a module of "torch"; checking the MRO names
+    # avoids importing torch in environments (config-only tools, tests) that do
+    # not have it while still recognizing real tensors at runtime.
+    return any(base.__module__ == "torch" and base.__name__ == "Tensor" for base in cls.__mro__)
+
+
+def _looks_non_transportable(value: Any) -> str | None:
+    """Return a reason string if ``value`` is clearly non-transportable.
+
+    Catches the specific hazards RFC #4590 §2.3 enumerates: live modules,
+    generators, CUDA streams, schedulers, and other process-local objects. This
+    is a *positive* guard against obviously-unsafe types; the metadata validator
+    additionally enforces an allow-list, so novel unsafe types are still caught.
+    """
+    cls = type(value)
+    module = cls.__module__ or ""
+    name = cls.__name__
+
+    if callable(value) and (module or name):
+        # Functions, methods, lambdas, and class objects are not data.
+        if module == "builtins" and name in ("function", "builtin_function_or_method"):
+            return "callable"
+        if cls.__name__ in ("function", "method", "builtin_function_or_method", "type"):
+            return "callable"
+
+    # torch process-local objects.
+    if module.startswith("torch"):
+        if name in ("Generator", "Stream", "Event", "device", "dtype"):
+            return f"torch.{name}"
+        if "Module" in name or name.endswith("Module"):
+            return f"torch module ({name})"
+
+    # Diffusion scheduler instances and runner-local state objects.
+    lowered = name.lower()
+    if "scheduler" in lowered:
+        return f"scheduler object ({name})"
+    if name in ("DiffusionRequestState", "DreamZeroState", "ARDiffusionKVState", "ARDiffusionKVCache"):
+        return f"process-local state object ({name})"
+    if hasattr(value, "__next__") and hasattr(value, "__iter__") and name == "generator":
+        return "generator"
+
+    return None
+
+
+def sanitize_transport_tensor(tensor: "torch.Tensor") -> "torch.Tensor":
+    """Return a host-resident, detached, contiguous copy of ``tensor``.
+
+    This is the single explicit device->host transport boundary (RFC #4590 §7):
+
+    * ``detach()`` drops autograd linkage;
+    * ``.cpu()`` performs the one device-to-host move;
+    * ``.contiguous()`` makes the buffer serialization-safe;
+    * ``.clone()`` guarantees the exported tensor never aliases a buffer the
+      producer may reuse (a stage-boundary copy is acceptable for the first
+      correctness implementation).
+
+    dtype and shape are preserved exactly.
+    """
+    detached = tensor.detach()
+    host = detached.cpu()
+    contiguous = host.contiguous()
+    # clone() only when .cpu()/.contiguous() returned a view onto live memory.
+    if contiguous.data_ptr() == tensor.data_ptr():
+        contiguous = contiguous.clone()
+    return contiguous
+
+
+def validate_transport_scalar(value: Any, *, path: str) -> None:
+    """Raise :class:`NonTransportableValueError` if ``value`` is not transportable.
+
+    Recursively enforces the metadata/scalar allow-list a stage payload carries
+    across a process boundary: allow-listed scalars (str/bool/bytes/number/None),
+    nested list/tuple/dict of those, and numpy arrays/scalars; everything else —
+    tensors (which must ride the dedicated tensor channels), schedulers,
+    generators, torch modules, and other process-local objects — is rejected.
+
+    Extracted from the former ``DiffusionStagePayload._validate_metadata_value``
+    so :class:`~vllm_omni.diffusion.models.interface.StagePayload` can reuse it
+    without importing torch (this module is the torch-free transport leaf).
+    """
+    # Tensors do not belong in the scalar channels — they must be transported
+    # via the dedicated tensor dicts so a future connector can back them with
+    # handles without rewriting scalar packing.
+    if _is_tensor(value):
+        raise NonTransportableValueError(
+            f"{path} is a torch.Tensor; tensors must be placed in a payload tensor dict, not a scalar dict."
+        )
+    reason = _looks_non_transportable(value)
+    if reason is not None:
+        raise NonTransportableValueError(f"{path} is non-transportable ({reason}).")
+
+    if isinstance(value, _ALLOWED_METADATA_SCALARS):
+        return
+    if isinstance(value, (list, tuple)):
+        for i, item in enumerate(value):
+            validate_transport_scalar(item, path=f"{path}[{i}]")
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise StagePayloadError(f"{path} has non-string key {k!r}.")
+            validate_transport_scalar(v, path=f"{path}[{k!r}]")
+        return
+    # numpy arrays/scalars are transportable via the existing msgpack codec.
+    module = type(value).__module__ or ""
+    if module.startswith("numpy"):
+        return
+    raise NonTransportableValueError(
+        f"{path} has non-transportable type {type(value).__name__}. Allowed: "
+        "str/bool/bytes/number/None, nested list/tuple/dict of those, numpy arrays, "
+        "or a torch.Tensor placed in a payload tensor dict."
+    )

--- a/vllm_omni/diffusion/stage_roles.py
+++ b/vllm_omni/diffusion/stage_roles.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Diffusion stage-role vocabulary, component ownership, and topology rules.
+
+RFC #4590 (generic disaggregated diffusion execution) represents all three
+disaggregated stages as ``StageExecutionType.DIFFUSION`` and distinguishes their
+role through ``StagePipelineConfig.model_stage``:
+
+* ``encode``  — validate / text-image-VAE encode / prepare latents+timesteps.
+* ``denoise`` — DiT / scheduler loop / AR-Diffusion KV (session state lives here).
+* ``decode``  — VAE decode / postprocess / final user-visible output.
+
+The historical single-worker value ``diffusion`` (and the empty / ``None`` role)
+denotes the monolithic fallback: one worker owns the whole ``forward()``.
+
+This module is intentionally free of ``torch`` and of any heavy intra-package
+import so that role resolution, component ownership, and topology validation can
+be reasoned about (and unit-tested) without the model runtime. Keep it a leaf.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, fields
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Role vocabulary
+# ---------------------------------------------------------------------------
+
+#: The disaggregated diffusion stage roles, in their canonical linear order.
+ENCODE = "encode"
+DENOISE = "denoise"
+DECODE = "decode"
+
+#: The monolithic single-worker role (one worker owns the whole ``forward()``).
+#: Kept for backward compatibility with every existing diffusion deployment.
+MONOLITHIC = "diffusion"
+
+#: Roles that mean "run a portion of the diffusion model as its own stage".
+DISAGGREGATED_ROLES: frozenset[str] = frozenset({ENCODE, DENOISE, DECODE})
+
+#: Every role this module understands. Unknown roles are not rejected outright
+#: (a model may declare support for a custom role), but they never take the
+#: built-in encode/denoise/decode execution paths.
+KNOWN_ROLES: frozenset[str] = DISAGGREGATED_ROLES | {MONOLITHIC}
+
+#: Canonical linear order for the first-cut ``encode -> denoise -> decode`` path.
+LINEAR_ROLE_ORDER: tuple[str, ...] = (ENCODE, DENOISE, DECODE)
+
+
+def normalize_stage_role(model_stage: str | None) -> str:
+    """Return a canonical role string for a raw ``model_stage`` value.
+
+    ``None`` and the empty string collapse to :data:`MONOLITHIC`; every other
+    value is returned verbatim after stripping surrounding whitespace (case is
+    preserved) so unknown roles stay intact for model-declared extensions rather
+    than being silently rewritten. Role matching against the built-in constants
+    is therefore case-sensitive.
+    """
+    if model_stage is None:
+        return MONOLITHIC
+    role = str(model_stage).strip()
+    if not role:
+        return MONOLITHIC
+    return role
+
+
+def is_monolithic_role(model_stage: str | None) -> bool:
+    """True when the stage owns the whole ``forward()`` (legacy behavior)."""
+    return normalize_stage_role(model_stage) == MONOLITHIC
+
+
+def is_disaggregated_role(model_stage: str | None) -> bool:
+    """True when the stage is one of the built-in encode/denoise/decode roles."""
+    return normalize_stage_role(model_stage) in DISAGGREGATED_ROLES
+
+
+def is_known_role(model_stage: str | None) -> bool:
+    """True when the role is one this framework has a built-in path for."""
+    return normalize_stage_role(model_stage) in KNOWN_ROLES
+
+
+#: Names of the runner execution path a role selects. Pure mapping, kept here so
+#: the runner's dispatch decision is testable without importing the torch-heavy
+#: runner module. The runner mirrors this table in ``execute_model``.
+EXECUTION_PATH_MONOLITHIC = "monolithic"
+EXECUTION_PATH_ENCODE = "encode_stage"
+EXECUTION_PATH_DENOISE = "denoise_stage"
+EXECUTION_PATH_DECODE = "decode_stage"
+EXECUTION_PATH_MODEL_DEFINED = "model_defined_stage"
+
+
+def resolve_execution_path(model_stage: str | None) -> str:
+    """Return which runner path a stage role selects (see EXECUTION_PATH_*).
+
+    * ``diffusion`` / ``None`` / empty -> monolithic (unchanged legacy path).
+    * ``encode`` / ``denoise`` / ``decode`` -> the matching disaggregated path.
+    * any other declared role -> the model-defined-stage hook.
+    """
+    role = normalize_stage_role(model_stage)
+    if role == MONOLITHIC:
+        return EXECUTION_PATH_MONOLITHIC
+    if role == ENCODE:
+        return EXECUTION_PATH_ENCODE
+    if role == DENOISE:
+        return EXECUTION_PATH_DENOISE
+    if role == DECODE:
+        return EXECUTION_PATH_DECODE
+    return EXECUTION_PATH_MODEL_DEFINED
+
+
+# ---------------------------------------------------------------------------
+# Component ownership
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StageComponentSpec:
+    """Which pipeline components a stage must construct and load.
+
+    Queried *before* expensive module construction so a stage worker builds and
+    loads only the weights its role needs (RFC #4590 §8). A component the spec
+    marks ``False`` is skipped at build time; weight loading then self-gates
+    because the loader only fills parameters that actually exist on the module.
+
+    The fields are deliberately generic (not DreamZero-specific): a pipeline
+    maps its own submodules onto these coarse buckets. ``action_modules`` covers
+    robotics/action heads; models without one simply leave it ``False``.
+    """
+
+    tokenizer: bool = False
+    text_encoder: bool = False
+    image_encoder: bool = False
+    vae_encoder: bool = False
+    dit: bool = False
+    scheduler: bool = False
+    vae_decoder: bool = False
+    action_modules: bool = False
+
+    def enabled_components(self) -> tuple[str, ...]:
+        """Return the names of the components this spec requires, in order."""
+        return tuple(f.name for f in fields(self) if getattr(self, f.name))
+
+    def requires(self, component: str) -> bool:
+        """Return whether ``component`` is required (unknown names -> False)."""
+        return bool(getattr(self, component, False))
+
+    def union(self, other: StageComponentSpec) -> StageComponentSpec:
+        """Return a spec requiring every component either spec requires (per-field OR).
+
+        Useful for composing a superset spec from per-stage specs (e.g. a
+        "build everything" spec for a monolithic worker). The built-in monolithic
+        path instead returns the :data:`ALL_COMPONENTS` singleton directly.
+        """
+        return StageComponentSpec(
+            **{f.name: (getattr(self, f.name) or getattr(other, f.name)) for f in fields(self)}
+        )
+
+    def describe(self) -> str:
+        """Human-readable component list for startup logging."""
+        enabled = self.enabled_components()
+        return "+".join(enabled) if enabled else "none"
+
+
+#: Spec for the monolithic fallback: build everything. Used when a pipeline does
+#: not declare disaggregated support or the role is ``diffusion``/``None``.
+ALL_COMPONENTS = StageComponentSpec(
+    tokenizer=True,
+    text_encoder=True,
+    image_encoder=True,
+    vae_encoder=True,
+    dit=True,
+    scheduler=True,
+    vae_decoder=True,
+    action_modules=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Topology validation
+# ---------------------------------------------------------------------------
+
+
+class DiffusionTopologyError(ValueError):
+    """Raised when a disaggregated diffusion topology is structurally invalid."""
+
+
+def _stage_role(stage: Any) -> str:
+    return normalize_stage_role(getattr(stage, "model_stage", None))
+
+
+def validate_linear_diffusion_topology(stages: Iterable[Any]) -> list[str]:
+    """Validate a linear ``encode -> denoise -> decode`` diffusion topology.
+
+    ``stages`` is any iterable of stage-like objects exposing ``stage_id``,
+    ``model_stage``, ``input_sources`` (iterable of upstream stage ids) and
+    ``final_output`` (bool). Returns a list of human-readable error strings;
+    empty means valid. This is duck-typed on purpose so it validates both
+    ``StagePipelineConfig`` objects and lightweight test doubles, and stays
+    free of any config-package import.
+
+    Rules enforced (RFC #4590 §5):
+
+    * unique stage ids;
+    * every ``input_sources`` entry references an existing stage (no self-ref);
+    * a ``denoise`` stage has at least one ``encode`` (or upstream ``denoise``)
+      source;
+    * a ``decode`` stage has at least one ``denoise`` source;
+    * exactly one stage is marked ``final_output`` and (when a decode stage is
+      present) it is the decode stage;
+    * a linear path admits a single upstream source per consumer stage.
+
+    Stages whose role is not one of encode/denoise/decode are accepted (a model
+    may declare a custom role) but do not participate in the role-adjacency
+    checks beyond id/reference validation.
+    """
+    stage_list = list(stages)
+    errors: list[str] = []
+    if not stage_list:
+        return ["Diffusion topology has no stages."]
+
+    by_id: dict[int, Any] = {}
+    for stage in stage_list:
+        sid = getattr(stage, "stage_id", None)
+        if sid in by_id:
+            errors.append(f"Duplicate stage id {sid}.")
+        by_id[sid] = stage
+
+    disaggregated = [s for s in stage_list if _stage_role(s) in DISAGGREGATED_ROLES]
+
+    for stage in stage_list:
+        sid = getattr(stage, "stage_id", None)
+        role = _stage_role(stage)
+        sources = list(getattr(stage, "input_sources", ()) or ())
+
+        for src in sources:
+            if src == sid:
+                errors.append(f"Stage {sid} references itself as an input source.")
+            elif src not in by_id:
+                errors.append(f"Stage {sid} references non-existent input source {src}.")
+
+        if role == ENCODE and sources:
+            errors.append(f"Encode stage {sid} must be an entry point (input_sources must be empty).")
+
+        if role == DENOISE:
+            if not sources:
+                errors.append(f"Denoise stage {sid} has no upstream source; expected an encode stage.")
+            else:
+                upstream_roles = {_stage_role(by_id[s]) for s in sources if s in by_id}
+                if not (upstream_roles & {ENCODE, DENOISE}):
+                    errors.append(
+                        f"Denoise stage {sid} has no upstream encode/denoise source (got roles {sorted(upstream_roles)})."
+                    )
+                if len(sources) > 1:
+                    errors.append(
+                        f"Denoise stage {sid} has {len(sources)} upstream sources; the linear "
+                        "diffusion processor merges exactly one."
+                    )
+
+        if role == DECODE:
+            if not sources:
+                errors.append(f"Decode stage {sid} has no upstream source; expected a denoise stage.")
+            else:
+                upstream_roles = {_stage_role(by_id[s]) for s in sources if s in by_id}
+                if DENOISE not in upstream_roles:
+                    errors.append(
+                        f"Decode stage {sid} has no upstream denoise source (got roles {sorted(upstream_roles)})."
+                    )
+                if len(sources) > 1:
+                    errors.append(
+                        f"Decode stage {sid} has {len(sources)} upstream sources; the linear "
+                        "diffusion processor merges exactly one."
+                    )
+
+    # Final-output placement: exactly one stage owns the user-visible result and,
+    # when the topology is disaggregated, it must be the decode stage.
+    final_stages = [s for s in stage_list if getattr(s, "final_output", False)]
+    if len(final_stages) != 1:
+        errors.append(f"Expected exactly one final_output stage, found {len(final_stages)}.")
+    elif disaggregated:
+        decode_stages = [s for s in stage_list if _stage_role(s) == DECODE]
+        if decode_stages and _stage_role(final_stages[0]) != DECODE:
+            errors.append(
+                f"final_output must be placed on the decode stage, not the "
+                f"{_stage_role(final_stages[0])!r} stage {getattr(final_stages[0], 'stage_id', None)}."
+            )
+
+    return errors

--- a/vllm_omni/diffusion/worker/__init__.py
+++ b/vllm_omni/diffusion/worker/__init__.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+    from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
     from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker, WorkerProc
 
 __all__ = [
     "DiffusionModelRunner",
+    "DiffusionModelRunnerV2",
     "DiffusionWorker",
     "WorkerProc",
 ]
@@ -22,6 +24,10 @@ def __getattr__(name: str) -> Any:
         from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
 
         return DiffusionModelRunner
+    if name == "DiffusionModelRunnerV2":
+        from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
+
+        return DiffusionModelRunnerV2
     if name in {"DiffusionWorker", "WorkerProc"}:
         from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker, WorkerProc
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -32,12 +32,31 @@ from vllm_omni.diffusion.compile import regionally_compile
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.forward_context import set_forward_context
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import supports_step_execution
+from vllm_omni.diffusion.models.interface import (
+    StageBoundary,
+    StagePayload,
+    supports_disaggregated_execution,
+    supports_step_execution,
+)
 from vllm_omni.diffusion.offloader import get_offload_backend
 from vllm_omni.diffusion.registry import _NO_CACHE_ACCELERATION
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
-from vllm_omni.diffusion.worker.input_batch import InputBatch, scatter_latents
+from vllm_omni.diffusion.stage_payload import (
+    STAGE_PAYLOAD_OUTPUT_KEY,
+    STAGE_PAYLOAD_PROMPT_KEY,
+    StagePayloadError,
+)
+from vllm_omni.diffusion.stage_roles import (
+    EXECUTION_PATH_DECODE,
+    EXECUTION_PATH_DENOISE,
+    EXECUTION_PATH_ENCODE,
+    EXECUTION_PATH_MODEL_DEFINED,
+    EXECUTION_PATH_MONOLITHIC,
+    is_disaggregated_role,
+    normalize_stage_role,
+    resolve_execution_path,
+)
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.diffusion.worker.utils import (
     BatchRunnerOutput,
@@ -143,6 +162,41 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
     def target_device(self) -> torch.device | None:
         return getattr(self.pipeline, "device", None)
 
+    # ------------------------------------------------------------------
+    # Disaggregated-diffusion stage role (RFC #4590)
+    # ------------------------------------------------------------------
+
+    @property
+    def model_stage(self) -> str:
+        """Canonical stage role for this runner (``diffusion`` when unset).
+
+        ``diffusion`` (or ``None``/empty) means the monolithic single-worker
+        fallback: this runner owns the whole ``forward()`` and its execution
+        path is unchanged from before RFC #4590.
+        """
+        return normalize_stage_role(getattr(self.od_config, "model_stage", None))
+
+    @property
+    def is_disaggregated_stage(self) -> bool:
+        """True when this runner is an encode/denoise/decode stage."""
+        return is_disaggregated_role(getattr(self.od_config, "model_stage", None))
+
+    def supports_disaggregated_mode(self) -> bool:
+        """Return whether the loaded pipeline can run as a disaggregated stage."""
+        return self.pipeline is not None and supports_disaggregated_execution(self.pipeline)
+
+    def _require_disaggregated_pipeline(self) -> None:
+        """Raise a clear startup error if a disaggregated role lacks capability."""
+        if not self.supports_disaggregated_mode():
+            raise ValueError(
+                "Stage requested disaggregated role "
+                f"{self.model_stage!r} but pipeline "
+                f"{type(self.pipeline).__name__ if self.pipeline else self.od_config.model_class_name} "
+                "does not implement the DiffusionV2Atoms disaggregation contract "
+                "(supports_disaggregated_execution flag + pack_stage_state / "
+                "unpack_stage_state / required_components_for_stage)."
+            )
+
     def _compile_transformer(self, attr_name: str) -> None:
         """Compile a transformer attribute on the pipeline with torch.compile."""
         model = getattr(self.pipeline, attr_name, None)
@@ -220,7 +274,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if getattr(self.od_config, "step_execution", False) and not self.supports_step_mode():
             raise ValueError(
                 "step_execution=True requires a pipeline implementing "
-                "prepare_encode(), denoise_step(), step_scheduler(), and post_decode(); "
+                "DiffusionV2Atoms; "
                 f"{self.od_config.model_class_name} does not support that contract."
             )
         if self.od_config.streaming_output and not self.supports_step_mode():
@@ -228,6 +282,14 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 "streaming_output=True requires step execution support; "
                 f"{self.od_config.model_class_name} does not support that contract."
             )
+
+        # Disaggregated-diffusion capability check (RFC #4590): a stage that
+        # declares an encode/denoise/decode role requires a pipeline that
+        # implements the disaggregated protocol. Fail fast at startup rather
+        # than mid-forward.
+        if self.is_disaggregated_stage:
+            self._require_disaggregated_pipeline()
+        self._log_stage_startup()
 
         # Apply CPU offloading
         self.offload_backend = get_offload_backend(self.od_config, device=self.device)
@@ -361,14 +423,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if use_prefetch and self._kv_prefetch_enabled and kv_prefetch_jobs is not None:
             self.kv_transfer_manager.start_prefetch(kv_prefetch_jobs, self.target_device)
 
-        if req.sampling_params.generator is None and req.sampling_params.seed is not None:
-            if req.sampling_params.generator_device is not None:
-                gen_device = req.sampling_params.generator_device
-            elif self.device.type == "cpu":
-                gen_device = "cpu"
-            else:
-                gen_device = self.device
-            req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(req.sampling_params.seed)
+        self._seed_generator(req.sampling_params)
 
     def _refresh_cache_for_requests(
         self,
@@ -499,8 +554,6 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         self,
         state: DiffusionRequestState,
         output: DiffusionOutput,
-        *,
-        is_primary: bool,
     ) -> None:
         merge_stage_durations(
             state,
@@ -510,13 +563,24 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
 
     def execute_model(self, req: OmniDiffusionRequest, kv_prefetch_jobs: dict | None = None) -> DiffusionOutput:
         """
-        Execute a forward pass for the given requests.
+        Execute a forward pass for the given request.
+
+        Dispatches on the stage role (RFC #4590):
+
+        * ``diffusion`` / unset  -> the existing monolithic single-request path
+          (unchanged behavior).
+        * ``encode``             -> :meth:`execute_encode_stage`.
+        * ``denoise``            -> :meth:`execute_denoise_stage`.
+        * ``decode``             -> :meth:`execute_decode_stage`.
+        * any other declared role -> :meth:`execute_model_defined_stage`.
 
         Args:
-            req: A diffusion request containing a list of prompts to process.
+            req: A diffusion request containing a prompt to process.
 
         Returns:
-            DiffusionOutput with generated results.
+            DiffusionOutput with generated results (encode/denoise stages return
+            an intermediate output carrying a StagePayload; decode and
+            monolithic stages return the user-visible result).
 
         Note:
             We use torch.no_grad() for HSDP because HSDP2's fully_shard requires access
@@ -524,6 +588,25 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             not track. For non-HSDP inference, we use torch.inference_mode() for better
             performance.
         """
+        role = self.model_stage
+        path = resolve_execution_path(role)
+        if path == EXECUTION_PATH_ENCODE:
+            return self.execute_encode_stage(req)
+        if path == EXECUTION_PATH_DENOISE:
+            return self.execute_denoise_stage(req)
+        if path == EXECUTION_PATH_DECODE:
+            return self.execute_decode_stage(req)
+        if path == EXECUTION_PATH_MODEL_DEFINED:
+            # A model-declared custom role (not one of the built-in three).
+            return self.execute_model_defined_stage(role, req)
+
+        assert path == EXECUTION_PATH_MONOLITHIC
+        return self._execute_monolithic(req, kv_prefetch_jobs=kv_prefetch_jobs)
+
+    def _execute_monolithic(
+        self, req: OmniDiffusionRequest, kv_prefetch_jobs: dict | None = None
+    ) -> DiffusionOutput:
+        """The original monolithic single-request path (unchanged)."""
         runner_output = self._execute_request_list(
             [req],
             od_config=self.od_config,
@@ -535,6 +618,252 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         output = runner_output.runner_outputs[0].result
         assert output is not None
         return output
+
+    def execute_model_defined_stage(self, role: str, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Hook for model-declared custom stage roles.
+
+        The base runner has no built-in path for roles outside
+        encode/denoise/decode. A pipeline that declares support for a custom
+        role should subclass the runner (or override this) to handle it. Raising
+        here keeps unknown roles from silently taking the monolithic path.
+        """
+        raise ValueError(
+            f"Stage role {role!r} has no built-in execution path and pipeline "
+            f"{type(self.pipeline).__name__ if self.pipeline else self.od_config.model_class_name} "
+            "does not override execute_model_defined_stage()."
+        )
+
+    # ------------------------------------------------------------------
+    # Disaggregated-stage execution (RFC #4590)
+    # ------------------------------------------------------------------
+
+    def _log_stage_startup(self) -> None:
+        """Log stage role, capability, and (when known) loaded components."""
+        components = "n/a"
+        if self.supports_disaggregated_mode():
+            try:
+                spec = type(self.pipeline).required_components_for_stage(self.model_stage)
+                components = spec.describe()
+            except Exception:  # pragma: no cover - logging must not fail startup
+                components = "unknown"
+        logger.info(
+            "Diffusion stage startup: pipeline=%s stage_id=%s model_stage=%s "
+            "disaggregated_capable=%s components=%s",
+            type(self.pipeline).__name__ if self.pipeline else self.od_config.model_class_name,
+            getattr(self.od_config, "stage_id", 0),
+            self.model_stage,
+            self.supports_disaggregated_mode(),
+            components,
+        )
+
+    def _grad_context(self):
+        """Return the grad context used by all forward paths (HSDP-aware)."""
+        use_hsdp = self.od_config.parallel_config.use_hsdp
+        return torch.no_grad() if use_hsdp else torch.inference_mode()
+
+    def _create_state_from_request(self, req: OmniDiffusionRequest) -> DiffusionRequestState:
+        """Build a fresh runner-local state from a raw request (encode stage)."""
+        state = DiffusionRequestState(
+            request_id=req.request_id,
+            sampling=copy.deepcopy(req.sampling_params),
+            prompt=req.prompt,
+            kv_sender_info=req.kv_sender_info,
+        )
+        self._initialize_generator(state)
+        return state
+
+    def _seed_generator(self, sampling: Any) -> None:
+        """Seed a sampling-params RNG generator in place from its ``seed``.
+
+        Single source of truth for the per-request generator-device ladder used
+        by every forward path (monolithic request setup, disaggregated encode
+        state creation, and stepwise batch admission): honor an explicit
+        ``generator_device``, else fall back to CPU on a CPU runner or this
+        runner's device otherwise. A no-op when the generator is already set or
+        no seed was provided.
+        """
+        if sampling.generator is None and sampling.seed is not None:
+            if sampling.generator_device is not None:
+                gen_device = sampling.generator_device
+            elif self.device.type == "cpu":
+                gen_device = "cpu"
+            else:
+                gen_device = self.device
+            sampling.generator = torch.Generator(device=gen_device).manual_seed(sampling.seed)
+
+    def _initialize_generator(self, state: DiffusionRequestState) -> None:
+        """Seed the per-request RNG generator exactly like the stepwise path."""
+        self._seed_generator(state.sampling)
+
+    def _extract_incoming_payload(self, req: OmniDiffusionRequest) -> StagePayload:
+        """Pull the upstream StagePayload out of a request prompt.
+
+        The generic transition processor places it in the prompt's ``extra``
+        sub-dict under :data:`STAGE_PAYLOAD_PROMPT_KEY`. Raise a clear,
+        request-scoped error if it is missing or malformed.
+
+        The request crosses the out-of-process (multiproc) stage boundary via
+        msgpack, which does not preserve dataclass identity: the payload
+        arrives here as a plain ``dict`` rather than a ``StagePayload``
+        instance. Rehydrate it before validating.
+        """
+        prompt = req.prompt
+        extra = None
+        if isinstance(prompt, dict):
+            extra = prompt.get("extra")
+        elif hasattr(prompt, "extra"):
+            extra = getattr(prompt, "extra")
+        payload = extra.get(STAGE_PAYLOAD_PROMPT_KEY) if isinstance(extra, dict) else None
+        if payload is None:
+            raise StagePayloadError(
+                f"Request {req.request_id!r} reached stage {self.model_stage!r} without a "
+                f"StagePayload in prompt['extra'][{STAGE_PAYLOAD_PROMPT_KEY!r}]; "
+                f"pipeline={type(self.pipeline).__name__}."
+            )
+        if isinstance(payload, dict) and not isinstance(payload, StagePayload):
+            payload = StagePayload.from_dict(payload)
+        if not isinstance(payload, StagePayload):
+            raise StagePayloadError(
+                f"Request {req.request_id!r} stage {self.model_stage!r}: payload is "
+                f"{type(payload).__name__}, expected StagePayload."
+            )
+        payload.validate()
+        return payload
+
+    def _intermediate_output(
+        self,
+        state: DiffusionRequestState,
+        payload: StagePayload,
+    ) -> DiffusionOutput:
+        """Wrap an exported payload as an intermediate (non-final) stage output.
+
+        The payload rides in ``custom_output`` under
+        :data:`STAGE_PAYLOAD_OUTPUT_KEY`; the generic transition processor reads
+        it there. ``to_cpu=True`` guarantees the receiving process never touches
+        a live device tensor (payload tensors are already host-resident, but
+        stage_durations and any stray tensors are normalized here too).
+        """
+        output = DiffusionOutput(
+            output=None,
+            custom_output={STAGE_PAYLOAD_OUTPUT_KEY: payload},
+            finished=True,
+            to_cpu=True,
+        )
+        attach_stage_durations(state, output)
+        output.peak_memory_mb = max(output.peak_memory_mb, state.peak_memory_mb)
+        return output
+
+    def _reset_peak_memory(self) -> bool:
+        """Reset peak-memory stats on the primary rank; return is_primary."""
+        is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+        if is_primary and current_omni_platform.is_available():
+            current_omni_platform.reset_peak_memory_stats()
+        return is_primary
+
+    def execute_encode_stage(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Encode stage: validate + encode conditions + prepare latents/timesteps.
+
+        Produces an intermediate output carrying an encode->denoise payload. Does
+        NOT run the DiT, advance the scheduler, or decode. Runner-local state is
+        released once the payload is handed off (the payload is self-contained).
+        """
+        self._require_disaggregated_pipeline()
+        with self._grad_context():
+            is_primary = self._reset_peak_memory()
+            clear_pipeline_stage_durations(self.pipeline)
+            state = self._create_state_from_request(req)
+            try:
+                # Run under the diffusion forward context for parity with the
+                # monolithic/denoise/decode paths (encoders may consult it).
+                # Drive the DiffusionV2Atoms encode chain explicitly:
+                # init_state -> check_inputs -> encode -> prepare.
+                with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
+                    with record_function("pipeline_encode_stage"):
+                        state = self.pipeline.init_state(state)
+                        state = self.pipeline.check_inputs(state)
+                        state = self.pipeline.encode(state)
+                        state = self.pipeline.prepare(state)
+                merge_stage_durations(state, consume_pipeline_stage_durations(self.pipeline))
+                payload = self.pipeline.pack_stage_state(state, StageBoundary.ENCODE_TO_DIT)
+            finally:
+                # Encode owns no persistent state; drop any cache entry eagerly.
+                self.state_cache.pop(req.request_id, None)
+            if is_primary:
+                state.peak_memory_mb = max(state.peak_memory_mb, self._sample_peak_memory_mb())
+            logger.debug("encode stage: request %s payload exported (%s)", req.request_id, payload.summary())
+            return self._intermediate_output(state, payload)
+
+    def execute_denoise_stage(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Denoise stage: restore state from payload, run the DiT denoise loop.
+
+        Creates a fresh runner-local state from the request (so request-level
+        sampling/generator/session plumbing is preserved), unpacks the incoming
+        stage payload into it (``unpack_stage_state`` mutates the existing state —
+        it never fabricates one), runs the pipeline's whole-request ``diffuse``
+        atom, and packs a denoise->decode payload. Any live session/KV state the
+        denoise stage owns (AR-Diffusion KV) is attached by the runner subclass
+        before this call — never via the payload. Never re-runs encode.
+        """
+        self._require_disaggregated_pipeline()
+        with self._grad_context():
+            is_primary = self._reset_peak_memory()
+            clear_pipeline_stage_durations(self.pipeline)
+            payload = self._extract_incoming_payload(req)
+            payload.expect_boundary(StageBoundary.ENCODE_TO_DIT)
+            state = self._create_state_from_request(req)
+            state = self.pipeline.unpack_stage_state(payload, state)
+            self.state_cache[req.request_id] = state
+            try:
+                with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
+                    with record_function("pipeline_denoise_stage"):
+                        state = self.pipeline.diffuse(state)
+                out_payload = self.pipeline.pack_stage_state(state, StageBoundary.DIT_TO_DECODE)
+                merge_stage_durations(state, consume_pipeline_stage_durations(self.pipeline))
+            finally:
+                # For the first (non-streaming) implementation the whole request
+                # denoises in one call, so its state is releasable now. Streaming
+                # session retention is handled by the pipeline via its own session
+                # map, not this cache.
+                self.state_cache.pop(req.request_id, None)
+            if is_primary:
+                state.peak_memory_mb = max(state.peak_memory_mb, self._sample_peak_memory_mb())
+            logger.debug("denoise stage: request %s payload exported (%s)", req.request_id, out_payload.summary())
+            return self._intermediate_output(state, out_payload)
+
+    def execute_decode_stage(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Decode stage: restore decode state, run VAE/postprocess, return output.
+
+        Restores only what decode needs, runs decode + postprocess, and returns
+        the normal user-visible ``DiffusionOutput``. Never instantiates or runs
+        the DiT, advances a scheduler, or re-runs encoders.
+        """
+        self._require_disaggregated_pipeline()
+        with self._grad_context():
+            is_primary = self._reset_peak_memory()
+            clear_pipeline_stage_durations(self.pipeline)
+            payload = self._extract_incoming_payload(req)
+            payload.expect_boundary(StageBoundary.DIT_TO_DECODE)
+            state = self._create_state_from_request(req)
+            state = self.pipeline.unpack_stage_state(payload, state)
+            self.state_cache[req.request_id] = state
+            try:
+                with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
+                    with record_function("pipeline_decode_stage"):
+                        state = self.pipeline.decode(state)
+                        output = self.pipeline.postprocess(state)
+                if output is None:
+                    raise RuntimeError(
+                        f"Decode stage produced no output for request {req.request_id!r}."
+                    )
+                self._attach_stepwise_metrics(state, output)
+            finally:
+                self.state_cache.pop(req.request_id, None)
+            if is_primary:
+                peak = self._sample_peak_memory_mb()
+                state.peak_memory_mb = max(state.peak_memory_mb, peak)
+                output.peak_memory_mb = max(output.peak_memory_mb, state.peak_memory_mb)
+            logger.debug("decode stage: request %s produced final output", req.request_id)
+            return output
 
     def execute_model_batch(
         self,
@@ -563,240 +892,3 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
     def supports_step_mode(self) -> bool:
         """Return whether current pipeline supports step execution."""
         return self.pipeline is not None and supports_step_execution(self.pipeline)
-
-    def _update_states(
-        self, scheduler_output: DiffusionSchedulerOutput
-    ) -> tuple[list[DiffusionRequestState], list[str]]:
-        """Step-before update: cleanup finished requests and get/create one running state."""
-        for request_id in scheduler_output.finished_req_ids:
-            self.state_cache.pop(request_id, None)
-
-        resolved: list[DiffusionRequestState] = []
-        new_request_ids: list[str] = []
-        try:
-            # process new requests
-            for sched_new_req in scheduler_output.scheduled_new_reqs:
-                request_id = sched_new_req.request_id
-                new_request_ids.append(request_id)
-                if request_id in self.state_cache:
-                    raise ValueError(f"Received duplicate new-request payload for cached request {request_id}.")
-                new_state = DiffusionRequestState(
-                    request_id=request_id,
-                    sampling=copy.deepcopy(sched_new_req.req.sampling_params),
-                    prompt=sched_new_req.req.prompt,
-                    kv_sender_info=sched_new_req.req.kv_sender_info,
-                )
-                state_req = copy.copy(sched_new_req.req)
-                state_req.sampling_params = new_state.sampling
-                self.kv_transfer_manager.receive_multi_kv_cache_distributed(
-                    state_req,
-                    cfg_kv_collect_func=getattr(self.od_config, "cfg_kv_collect_func", None),
-                    target_device=self.target_device,
-                )
-                self.state_cache[request_id] = new_state
-                resolved.append(new_state)
-
-            # process cached requests
-            for request_id in scheduler_output.scheduled_cached_reqs.request_ids:
-                state = self.state_cache.get(request_id)
-                if state is None:
-                    raise ValueError(f"Missing cached state for request {request_id}.")
-                resolved.append(state)
-        except Exception:
-            for request_id in new_request_ids:
-                self.state_cache.pop(request_id, None)
-            raise
-
-        return resolved, new_request_ids
-
-    def _prepare_batch_inputs(self, states: list[DiffusionRequestState], new_request_ids: list[str]) -> InputBatch:
-        # process new reqs
-        for state in states:
-            if state.request_id in new_request_ids:
-                # set generator
-                if state.sampling.generator is None and state.sampling.seed is not None:
-                    if state.sampling.generator_device is not None:
-                        gen_device = state.sampling.generator_device
-                    elif self.device.type == "cpu":
-                        gen_device = "cpu"
-                    else:
-                        gen_device = self.device
-                    state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
-                clear_pipeline_stage_durations(self.pipeline)
-                # encode
-                self.pipeline.prepare_encode(state)
-                merge_stage_durations(
-                    state,
-                    consume_pipeline_stage_durations(self.pipeline),
-                )
-
-        input_batch = InputBatch.make_batch(
-            states,
-            cached_batch=getattr(self, "input_batch", None),
-        )
-        self.input_batch = input_batch
-        return input_batch
-
-    def _update_states_after(
-        self,
-        states: list[DiffusionRequestState],
-        input_batch: InputBatch,
-        interrupted: bool = False,
-    ):
-        """Step-after update: clear cached state for completed request."""
-        gathered_latents = torch.cat([state.latents for state in states], dim=0)
-        if (
-            input_batch.latents.size() == gathered_latents.size()
-            and input_batch.latents.dtype == gathered_latents.dtype
-            and input_batch.latents.device == gathered_latents.device
-        ):
-            input_batch.latents.copy_(gathered_latents)
-        else:
-            input_batch.latents = gathered_latents.clone()
-
-        self.input_batch = input_batch
-        scatter_latents(states, input_batch)
-
-        for state in states:
-            if interrupted or state.request_denoise_completed:
-                self.state_cache.pop(state.request_id, None)
-
-    def _prepare_attn_metadata(self, input_batch: InputBatch) -> Any:
-        model_state = getattr(self, "model_state", None)
-        if model_state is None:
-            return {}
-        prepare_attn = getattr(model_state, "prepare_attn", None)
-        if not callable(prepare_attn):
-            return {}
-        return prepare_attn(input_batch)
-
-    def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
-        """Execute one step for one scheduled request and return runner output."""
-        assert self.pipeline is not None, "Model not loaded. Call load_model() first."
-        if not self.supports_step_mode():
-            raise ValueError("Current pipeline does not support step execution.")
-        # Stepwise mode only supports the basic state-driven denoise path for now.
-        # Request-mode extras such as cache backends, editing inputs, and
-        # similar features are not supported here yet.
-        if self.od_config.cache_backend not in (None, "none"):
-            raise ValueError("Step mode does not support cache_backend yet.")
-
-        use_hsdp = self.od_config.parallel_config.use_hsdp
-        grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
-        with grad_context:
-            had_active_states = bool(self.state_cache)
-            states, new_request_ids = self._update_states(scheduler_output)
-            is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
-            if new_request_ids and not had_active_states and is_primary and current_omni_platform.is_available():
-                current_omni_platform.reset_peak_memory_stats()
-            input_batch = self._prepare_batch_inputs(states, new_request_ids)
-            attn_metadata = self._prepare_attn_metadata(input_batch)
-
-            with set_forward_context(
-                vllm_config=self.vllm_config,
-                omni_diffusion_config=self.od_config,
-                attn_metadata=attn_metadata,
-            ):
-                clear_pipeline_stage_durations(self.pipeline)
-                noise_pred = self.pipeline.denoise_step(input_batch, states=states)
-                denoise_stage_durations = consume_pipeline_stage_durations(self.pipeline)
-                for state in states:
-                    merge_stage_durations(
-                        state,
-                        denoise_stage_durations,
-                    )
-
-                runner_output_list = []
-                pipeline_interrupted = getattr(self.pipeline, "interrupt", False)
-                if noise_pred is None and pipeline_interrupted:
-                    for state in states:
-                        runner_output_list.append(
-                            RunnerOutput(
-                                request_id=state.request_id,
-                                step_index=state.step_index,
-                                finished=True,
-                                result=DiffusionOutput(error="stepwise denoise interrupted"),
-                            )
-                        )
-
-                else:
-                    offset = 0
-                    for req in states:
-                        row_num = req.latents.shape[0]
-                        try:
-                            self.pipeline.step_scheduler(
-                                req, noise_pred[offset : offset + row_num] if noise_pred is not None else None
-                            )
-                            if self.od_config.streaming_output:
-                                should_decode = req.chunk_denoise_completed
-                            else:
-                                should_decode = req.denoise_completed
-
-                            if should_decode:
-                                clear_pipeline_stage_durations(self.pipeline)
-                                result = self.pipeline.post_decode(req)
-                                if result is not None:
-                                    self._attach_stepwise_metrics(
-                                        req,
-                                        result,
-                                        is_primary=is_primary,
-                                    )
-                            else:
-                                result = None
-                            # finished should be computed after post_decode() advanced chunk_index
-                            finished = (
-                                req.request_denoise_completed
-                                if self.od_config.streaming_output
-                                else req.denoise_completed
-                            )
-                            runner_output_list.append(
-                                RunnerOutput(
-                                    request_id=req.request_id,
-                                    step_index=req.step_index,
-                                    finished=finished,
-                                    result=result,
-                                )
-                            )
-                            offset = offset + row_num
-                        except Exception as per_req_exc:
-                            offset = offset + row_num
-                            logger.error(
-                                "Stepwise per-request error for %s: %s",
-                                req.request_id,
-                                per_req_exc,
-                                exc_info=True,
-                            )
-                            runner_output_list.append(
-                                RunnerOutput(
-                                    request_id=req.request_id,
-                                    step_index=req.step_index,
-                                    finished=True,
-                                    result=DiffusionOutput(error=str(per_req_exc)),
-                                )
-                            )
-
-                    if noise_pred is not None and offset != noise_pred.shape[0]:
-                        raise ValueError(
-                            f"Stepwise noise_pred consumed {offset} rows, "
-                            f"but batched noise_pred has {noise_pred.shape[0]} rows."
-                        )
-
-                if is_primary:
-                    batch_peak_memory_mb = self._sample_peak_memory_mb()
-                    states_by_id = {state.request_id: state for state in states}
-                    for state in states:
-                        state.peak_memory_mb = max(state.peak_memory_mb, batch_peak_memory_mb)
-                    for runner_output in runner_output_list:
-                        if runner_output.result is None:
-                            continue
-                        state = states_by_id.get(runner_output.request_id)
-                        if state is None:
-                            continue
-                        runner_output.result.peak_memory_mb = max(
-                            runner_output.result.peak_memory_mb,
-                            state.peak_memory_mb,
-                        )
-
-                self._update_states_after(states, input_batch, pipeline_interrupted)
-
-                return BatchRunnerOutput.from_list(runner_output_list)

--- a/vllm_omni/diffusion/worker/diffusion_model_runner_v2.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner_v2.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Stepwise diffusion runner using state-based pipeline atoms."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from torch.profiler import record_function
+
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.forward_context import set_forward_context
+from vllm_omni.diffusion.models.interface import StagePayload, supports_step_execution
+from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
+from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.input_batch import InputBatch
+from vllm_omni.diffusion.worker.utils import (
+    BatchRunnerOutput,
+    DiffusionRequestState,
+    RunnerOutput,
+    attach_stage_durations,
+    clear_pipeline_stage_durations,
+    consume_pipeline_stage_durations,
+    merge_stage_durations,
+)
+from vllm_omni.platforms import current_omni_platform
+
+
+@dataclass
+class _StepRequestView:
+    request_id: str
+    prompt: object
+    sampling_params: object
+    kv_sender_info: dict | None
+
+
+class DiffusionModelRunnerV2(DiffusionModelRunner):
+    """Runner-side execution for diffusion v2 atoms.
+
+    The runner owns state cache, batching, step loop, scatter/gather, metrics,
+    and local stage execution. The pipeline owns model math and state atoms.
+    """
+
+    def supports_step_mode(self) -> bool:
+        return self.pipeline is not None and supports_step_execution(self.pipeline)
+
+    def run_encode_stage(
+        self,
+        state: DiffusionRequestState,
+        payload: StagePayload | None = None,
+    ) -> DiffusionRequestState:
+        """Build a DiT-ready state from local request data or a received payload."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_encode_stage"):
+            state = self.pipeline.init_state(state)
+            if payload is None:
+                state = self.pipeline.check_inputs(state)
+                state = self.pipeline.encode(state)
+            else:
+                state = self.pipeline.unpack_stage_state(payload, state)
+            state = self.pipeline.prepare(state)
+        merge_stage_durations(
+            state,
+            consume_pipeline_stage_durations(self.pipeline),
+        )
+        return state
+
+    def _update_states(
+        self, scheduler_output: DiffusionSchedulerOutput
+    ) -> tuple[list[DiffusionRequestState], list[str]]:
+        """Step-before update: cleanup finished requests and resolve running states."""
+        for request_id in scheduler_output.finished_req_ids:
+            self.state_cache.pop(request_id, None)
+
+        resolved: list[DiffusionRequestState] = []
+        new_request_ids: list[str] = []
+        for sched_new_req in scheduler_output.scheduled_new_reqs:
+            request_id = sched_new_req.request_id
+            new_request_ids.append(request_id)
+            if request_id in self.state_cache:
+                raise ValueError(f"Received duplicate new-request payload for cached request {request_id}.")
+            req = sched_new_req.req
+            sampling = deepcopy(req.sampling_params)
+            new_state = DiffusionRequestState(
+                request_id=request_id,
+                sampling=sampling,
+                prompt=getattr(req, "prompt", None),
+                kv_sender_info=getattr(req, "kv_sender_info", None),
+            )
+            state_req = _StepRequestView(
+                request_id=request_id,
+                prompt=new_state.prompt,
+                sampling_params=sampling,
+                kv_sender_info=new_state.kv_sender_info,
+            )
+            self.kv_transfer_manager.receive_multi_kv_cache_distributed(
+                state_req,
+                cfg_kv_collect_func=getattr(self.od_config, "cfg_kv_collect_func", None),
+                target_device=self.target_device,
+            )
+            self.state_cache[request_id] = new_state
+            resolved.append(new_state)
+
+        for request_id in scheduler_output.scheduled_cached_reqs.request_ids:
+            state = self.state_cache.get(request_id)
+            if state is None:
+                raise ValueError(f"Missing cached state for request {request_id}.")
+            resolved.append(state)
+
+        return resolved, new_request_ids
+
+    def _prepare_generator(self, state: DiffusionRequestState) -> None:
+        if state.sampling.generator is not None or state.sampling.seed is None:
+            return
+        if state.sampling.generator_device is not None:
+            gen_device = state.sampling.generator_device
+        elif self.device.type == "cpu":
+            gen_device = "cpu"
+        else:
+            gen_device = self.device
+        state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
+
+    def _prepare_batch_inputs(self, states: list[DiffusionRequestState], new_request_ids: list[str]) -> InputBatch:
+        for state_index, state in enumerate(states):
+            if state.request_id not in new_request_ids:
+                continue
+            self._prepare_generator(state)
+            prepared_state = self.run_encode_stage(state)
+            if prepared_state.request_id != state.request_id:
+                raise ValueError("Pipeline atom changed request_id during encode stage.")
+            states[state_index] = prepared_state
+            self.state_cache[prepared_state.request_id] = prepared_state
+
+        input_batch = self.pipeline.build_step_batch(
+            states,
+            cached_batch=getattr(self, "input_batch", None),
+        )
+        self.input_batch = input_batch
+        return input_batch
+
+    def _update_states_after(
+        self,
+        states: list[DiffusionRequestState],
+        input_batch: InputBatch,
+        interrupted: bool = False,
+    ) -> None:
+        self.input_batch = input_batch
+
+        for state in states:
+            if interrupted or state.request_denoise_completed:
+                self.state_cache.pop(state.request_id, None)
+
+    def run_denoise_stage(
+        self,
+        input_batch: InputBatch,
+    ) -> tuple[dict[str, RunnerOutput], bool]:
+        """Run one DiT denoise step and request-local scheduler updates."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_denoise_stage"):
+            noise_pred = self.pipeline.denoise_step(input_batch)
+
+        stage_results: dict[str, DiffusionOutput] = {}
+        if noise_pred is None and getattr(self.pipeline, "interrupt", False):
+            for state in input_batch.states:
+                stage_results[state.request_id] = DiffusionOutput(error="stepwise denoise interrupted")
+            pipeline_interrupted = True
+        elif noise_pred is None:
+            raise RuntimeError("denoise_step returned None without pipeline interrupt.")
+        else:
+            pipeline_interrupted = False
+            offset = 0
+            for state in input_batch.states:
+                if state.latents is None:
+                    raise ValueError(f"Request {state.request_id} has no latents for denoise scheduling.")
+                row_num = state.latents.shape[0]
+                step_noise_pred = noise_pred[offset : offset + row_num]
+                updated_state = self.pipeline.step_scheduler(state, step_noise_pred)
+                if updated_state is not state:
+                    raise RuntimeError("step_scheduler must update the existing DiffusionRequestState.")
+                offset += row_num
+
+            if offset != noise_pred.shape[0]:
+                raise ValueError(
+                    f"Stepwise noise_pred consumed {offset} rows, "
+                    f"but batched noise_pred has {noise_pred.shape[0]} rows."
+                )
+
+        denoise_stage_durations = consume_pipeline_stage_durations(self.pipeline)
+        for state in input_batch.states:
+            merge_stage_durations(state, denoise_stage_durations)
+
+        states_by_id = {state.request_id: state for state in input_batch.states}
+        stage_outputs: dict[str, RunnerOutput] = {}
+        for request_id, result in stage_results.items():
+            state = states_by_id.get(request_id)
+            if state is not None:
+                attach_stage_durations(state, result)
+            stage_outputs[request_id] = RunnerOutput(
+                request_id=request_id,
+                step_index=state.step_index if state is not None else 0,
+                finished=True,
+                result=result,
+            )
+        return stage_outputs, pipeline_interrupted
+
+    def run_decode_stage(
+        self,
+        state: DiffusionRequestState,
+        payload: StagePayload | None = None,
+    ) -> DiffusionOutput:
+        """Decode final/chunk latents through pipeline atoms."""
+        clear_pipeline_stage_durations(self.pipeline)
+        with record_function("pipeline_decode_stage"):
+            if payload is not None:
+                state = self.pipeline.unpack_stage_state(payload, state)
+            updated_state = self.pipeline.decode(state)
+            if updated_state is not state:
+                raise RuntimeError("decode must update the existing DiffusionRequestState.")
+            result = self.pipeline.postprocess(state)
+        merge_stage_durations(
+            state,
+            consume_pipeline_stage_durations(self.pipeline),
+        )
+        attach_stage_durations(state, result)
+        return result
+
+    def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
+        """Execute one scheduled diffusion step batch."""
+        assert self.pipeline is not None, "Model not loaded. Call load_model() first."
+        if not self.supports_step_mode():
+            raise ValueError("Current pipeline does not support step execution.")
+        if self.od_config.cache_backend not in (None, "none"):
+            raise ValueError("Step mode does not support cache_backend yet.")
+
+        use_hsdp = self.od_config.parallel_config.use_hsdp
+        grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
+        with grad_context:
+            had_active_states = bool(self.state_cache)
+            states, new_request_ids = self._update_states(scheduler_output)
+            if not states:
+                return BatchRunnerOutput.from_list([])
+            is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+            if new_request_ids and not had_active_states and is_primary and current_omni_platform.is_available():
+                current_omni_platform.reset_peak_memory_stats()
+            input_batch = self._prepare_batch_inputs(states, new_request_ids)
+            attn_metadata = self.pipeline.build_step_attention_metadata(input_batch)
+
+            with set_forward_context(
+                vllm_config=self.vllm_config,
+                omni_diffusion_config=self.od_config,
+                attn_metadata=attn_metadata,
+            ):
+                denoise_outputs, pipeline_interrupted = self.run_denoise_stage(input_batch)
+                runner_output_list: list[RunnerOutput] = []
+                for state in states:
+                    denoise_output = denoise_outputs.get(state.request_id)
+                    if denoise_output is not None:
+                        runner_output_list.append(denoise_output)
+                        continue
+
+                    should_decode = (
+                        state.chunk_denoise_completed if self.od_config.streaming_output else state.denoise_completed
+                    )
+
+                    result = self.run_decode_stage(state) if should_decode else None
+                    finished = (
+                        state.request_denoise_completed if self.od_config.streaming_output else state.denoise_completed
+                    )
+                    runner_output_list.append(
+                        RunnerOutput(
+                            request_id=state.request_id,
+                            step_index=state.step_index,
+                            finished=finished,
+                            result=result,
+                        )
+                    )
+
+                if is_primary:
+                    batch_peak_memory_mb = self._sample_peak_memory_mb()
+                    states_by_id = {state.request_id: state for state in states}
+                    for state in states:
+                        state.peak_memory_mb = max(state.peak_memory_mb, batch_peak_memory_mb)
+                    for runner_output in runner_output_list:
+                        if runner_output.result is None:
+                            continue
+                        state = states_by_id.get(runner_output.request_id)
+                        if state is None:
+                            continue
+                        runner_output.result.peak_memory_mb = max(
+                            runner_output.result.peak_memory_mb,
+                            state.peak_memory_mb,
+                        )
+
+                self._update_states_after(states, input_batch, pipeline_interrupted)
+                return BatchRunnerOutput.from_list(runner_output_list)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -48,6 +48,7 @@ from vllm_omni.diffusion.registry import get_diffusion_ir_op_priority_func
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.diffusion_model_runner_v2 import DiffusionModelRunnerV2
 from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput
 from vllm_omni.engine.stage_init_utils import set_death_signal
 from vllm_omni.lora.request import LoRARequest
@@ -240,6 +241,11 @@ class DiffusionWorker:
         else:
             model_runner_cls_path = current_omni_platform.get_diffusion_model_runner_cls()
         model_runner_cls = resolve_obj_by_qualname(model_runner_cls_path)
+        needs_step_runner = bool(
+            getattr(self.od_config, "step_execution", False) or getattr(self.od_config, "streaming_output", False)
+        )
+        if needs_step_runner and model_runner_cls is DiffusionModelRunner:
+            model_runner_cls = DiffusionModelRunnerV2
         self.model_runner = model_runner_cls(
             vllm_config=self.vllm_config,
             od_config=self.od_config,
@@ -324,7 +330,7 @@ class DiffusionWorker:
             init_workspace_manager(self.device)
 
     def _create_profiler(self) -> WorkerProfiler | None:
-        profiler_config = self.od_config.profiler_config
+        profiler_config = getattr(self.od_config, "profiler_config", None)
         profiler_type = getattr(profiler_config, "profiler", None)
         if profiler_type == "torch":
             return create_omni_profiler(

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -465,7 +465,9 @@ def _prepare_image_latents(
     *,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
-    image_latents = [getattr(state.sampling, "image_latent", None) for state in states]
+    image_latents = [
+        state.extra.get("image_latents", getattr(state.sampling, "image_latent", None)) for state in states
+    ]
     if all(image_latent is None for image_latent in image_latents):
         return None
     if any(image_latent is None for image_latent in image_latents):

--- a/vllm_omni/diffusion/worker/utils.py
+++ b/vllm_omni/diffusion/worker/utils.py
@@ -55,10 +55,10 @@ class DiffusionRequestState:
     """Per-request mutable state across all pipeline stages.
 
     Owned by Runner and passed through all step-execution stages:
-    ``prepare_encode()`` initializes/updates fields, ``denoise_step()`` and
-    ``step_scheduler()`` mutate per-step fields, and ``post_decode()``
-    consumes final latents. This state object is also the cache unit for
-    future continuous batching.
+    ``prepare`` initializes request state, ``denoise_step`` and
+    ``step_scheduler`` mutate per-step fields, and ``decode`` consumes
+    final/chunk latents. This state object is also the cache unit for future
+    continuous batching.
 
     This dataclass keeps only the minimal cross-model state required by the
     step-execution contract. Pipeline-specific state should be stored in
@@ -78,7 +78,7 @@ class DiffusionRequestState:
     prompt: OmniPromptType | None = None
     kv_sender_info: dict | None = None
 
-    # ── Encoded prompts (set once by prepare_encode) ──
+    # ── Encoded prompts (set once by encode) ──
     prompt_embeds: torch.Tensor | None = None
     prompt_embeds_mask: torch.Tensor | None = None
     negative_prompt_embeds: torch.Tensor | None = None
@@ -87,7 +87,7 @@ class DiffusionRequestState:
     # ── Latent state (mutated every step by step_scheduler) ──
     latents: torch.Tensor | None = None
 
-    # ── Timestep schedule (set once by prepare_encode) ──
+    # ── Timestep schedule (set once by prepare) ──
     timesteps: torch.Tensor | list[torch.Tensor] | None = None
     step_index: int = 0
 
@@ -97,14 +97,14 @@ class DiffusionRequestState:
     total_chunks: int = 1
     chunk_num_steps: int | None = None
 
-    # ── Per-request scheduler instance (set once by prepare_encode) ──
+    # ── Per-request scheduler instance (set once by prepare) ──
     scheduler: Any | None = None
 
-    # ── CFG config (set once by prepare_encode) ──
+    # ── CFG config (set once by prepare) ──
     do_true_cfg: bool = False
     guidance: torch.Tensor | None = None
 
-    # ── Spatial / sequence metadata (set once by prepare_encode) ──
+    # ── Spatial / sequence metadata (set once by prepare) ──
     img_shapes: list | None = None
     txt_seq_lens: list[int] | None = None
     negative_txt_seq_lens: list[int] | None = None

--- a/vllm_omni/docs/design/feature/diffusion_disaggregated_execution.md
+++ b/vllm_omni/docs/design/feature/diffusion_disaggregated_execution.md
@@ -1,0 +1,320 @@
+# Disaggregated Diffusion Execution (RFC #4590)
+
+## Motivation
+
+A diffusion request classically runs as one monolithic `forward()` on one worker:
+validate → encode → denoise loop → decode → output. That couples three phases
+with very different resource profiles onto one process and one device group. The
+encode phase is encoder-bound (text/image/VAE encoders), the denoise phase is
+DiT/attention-bound and owns the session KV, and the decode phase is VAE-decode
+bound. Co-locating them wastes capacity: the DiT sits idle during encode/decode,
+and encoders/VAE weights occupy memory on the DiT device throughout the rollout.
+
+RFC #4590 lets a diffusion model run its encode, denoise, and decode phases as
+**three independent native diffusion stages**, each with its own process,
+devices, parallel config, component set, scheduling, and failure handling — while
+preserving every existing execution mode unchanged.
+
+## Execution modes (all preserved)
+
+1. **Monolithic** — one worker owns `validate → encode → denoise → decode`
+   (`model_stage` = `diffusion` / unset). Unchanged.
+2. **Single-worker step execution** — `prepare_encode` once, runner-managed
+   `denoise_step` loop, `post_decode` (the `SupportsStepExecution` contract).
+   Unchanged.
+3. **Native three-stage disaggregation** — `encode → denoise → decode`, each a
+   normal diffusion stage on the existing stage engine/runtime. New.
+
+The three disaggregated stages reuse the native diffusion stage runtime — there
+is no second execution stack for encoders or VAE submodules.
+
+## Architecture
+
+```
+Raw Request
+    |
+    v
++-----------------------+
+| Encode DiffusionStage |
+| tokenizer             |
+| text/image/VAE encode |
+| latent preparation    |
++-----------+-----------+
+            |
+            | DiffusionStagePayload  (encode -> denoise)
+            v
++-----------------------+
+| Denoise DiffusionStage|
+| DiT / CausalWan       |
+| scheduler loop        |
+| AR-Diffusion KV       |
++-----------+-----------+
+            |
+            | DiffusionStagePayload  (denoise -> decode)
+            v
++-----------------------+
+| Decode DiffusionStage |
+| VAE decode            |
+| action/video output   |
+| postprocess           |
++-----------+-----------+
+            |
+            v
+       Final Output
+```
+
+Every box is a `StageExecutionType.DIFFUSION` stage. The role is carried by
+`StagePipelineConfig.model_stage` ∈ {`encode`, `denoise`, `decode`} (or
+`diffusion` for the monolithic fallback). The **execution type** answers *which
+engine family runs this stage*; the **model stage** answers *which portion of the
+diffusion model this worker owns*. No `StageType.ENCODE/DENOISE/DECODE` and no
+per-phase execution types were added.
+
+### Runner vs pipeline responsibilities
+
+| Concern | Owner |
+|---|---|
+| stage dispatch, request-state cache, scheduling, batching, scatter/gather, cleanup, profiling aggregation, envelope validation, local/remote integration | **generic runner** (`DiffusionModelRunner`) |
+| input validation, text/image/video encoding, latent & timestep prep, model-input construction, denoise math, scheduler advancement, decode, postprocess, state↔payload conversion | **model pipeline** |
+
+The generic runner never interprets model-private fields (DreamZero image
+conditioning, prompt-embedding layout, VAE stream state, action tensors,
+CFG-private metadata, cross-attention cache, model scheduler internals). There is
+**no** `if model_name == "dreamzero": …` in the runner. The stage-role dispatch is
+a pure table (`stage_roles.resolve_execution_path`), mirrored in
+`DiffusionModelRunner.execute_model`.
+
+### State vs payload
+
+`DiffusionRequestState` is **mutable runner-local state** and never crosses a
+process boundary. Inter-stage data travels as a typed, versioned
+`DiffusionStagePayload` (`vllm_omni/diffusion/stage_payload.py`):
+
+```python
+@dataclass(frozen=True)
+class DiffusionStagePayload:
+    schema_version: int
+    request_id: str
+    source_stage: str
+    target_stage: str
+    payload_type: str
+    tensors: dict[str, torch.Tensor]   # the only place tensors live
+    metadata: dict[str, Any]           # small, transportable, model-private
+```
+
+Invariants (enforced by `validate()`):
+
+* request identity, source/target stages, and `payload_type` are explicit;
+* the schema is versioned; consumers reject unknown versions;
+* tensors are separate from metadata; the envelope never grows a per-model field;
+* modules, generators, CUDA streams, schedulers, and process-local state objects
+  are rejected early (`NonTransportableValueError`);
+* model-specific keys are interpreted only by the owning pipeline;
+* tensors can later be backed by connector handles without changing the envelope.
+
+Tensors are moved to host memory, detached, made contiguous, and cloned at the
+**export** boundary (`sanitize_transport_tensor`); device movement happens once at
+the **restore** boundary inside the pipeline. `.cpu()`/`.to(device)` are not
+scattered through model code.
+
+### Pipeline capability protocol
+
+`vllm_omni/diffusion/models/interface.py` adds:
+
+* `SupportsDisaggregatedDiffusionExecution` (runtime-checkable) —
+  `export_stage_payload`, `import_stage_payload`,
+  `required_components_for_stage`, plus the `supports_disaggregated_execution`
+  flag. `supports_disaggregated_execution(pipeline)` is the capability helper,
+  paralleling the existing `supports_step_execution`.
+* `SupportsDiffusionAtoms` (additive) — finer atoms `check_inputs`,
+  `encode_conditions`, `prepare_latents_and_timesteps`, `decode_latents`,
+  `postprocess_outputs`. The runner prefers these via `run_encode_atoms` /
+  `run_decode_atoms` and falls back to the four-method step contract
+  (`prepare_encode` / `post_decode`) when absent — so existing step pipelines are
+  untouched.
+
+A stage that requests `encode`/`denoise`/`decode` on a pipeline lacking the
+disaggregated capability fails at **startup** (`load_model`), not mid-forward.
+
+## Runner stage dispatch
+
+`DiffusionModelRunner.execute_model(req)` dispatches on `self.model_stage`:
+
+```python
+role = self.model_stage
+path = resolve_execution_path(role)          # pure, shared table
+if path == EXECUTION_PATH_ENCODE:   return self.execute_encode_stage(req)
+if path == EXECUTION_PATH_DENOISE:  return self.execute_denoise_stage(req)
+if path == EXECUTION_PATH_DECODE:   return self.execute_decode_stage(req)
+if path == EXECUTION_PATH_MODEL_DEFINED: return self.execute_model_defined_stage(role, req)
+return self._execute_monolithic(req, kv_prefetch_jobs=kv_prefetch_jobs)   # unchanged
+```
+
+* **Encode stage** — creates runner-local state from the raw request, initializes
+  the generator, runs the encode atoms, exports an `encode → denoise` payload,
+  returns an *intermediate* output (payload in `custom_output`), and releases the
+  state. It never runs the DiT, advances the scheduler, or decodes.
+* **Denoise stage** — restores state from the payload via `import_stage_payload`
+  (which attaches live session/KV through the normal engine mechanism, *never*
+  from the payload), caches it, runs the model's `run_denoise`, exports a
+  `denoise → decode` payload. It never re-runs encode for a payload-origin
+  request — the origin is explicit (payload vs raw), not inferred from a
+  new-request id set.
+* **Decode stage** — restores decode state, runs `decode_latents` +
+  `postprocess_outputs`, returns the user-visible `DiffusionOutput`. It never
+  instantiates or runs the DiT or a scheduler.
+
+The historical "new request ⇒ run `prepare_encode`" coupling (`state.request_id in
+new_request_ids` in the stepwise path) is *not* used by the disaggregated denoise
+path; state origin is carried explicitly by which stage method runs.
+
+## Lifecycle
+
+```
+encode:   raw request -> state -> encode atoms -> export(encode->denoise) -> release state
+denoise:  payload -> import (attach session KV) -> cache -> run_denoise -> export(denoise->decode) -> release
+decode:   payload -> import -> decode_latents + postprocess -> DiffusionOutput -> release
+```
+
+For non-streaming requests the decode boundary is normal denoise completion. For
+streaming/chunk requests, a chunk decode boundary is distinct from request
+completion; emitting a decode payload does not destroy denoise session state.
+Exported latents are cloned at the boundary so they never alias a buffer the
+denoise worker reuses.
+
+## Partial component loading
+
+`initialize_model` (the single construction point) queries the pipeline class's
+`required_components_for_stage(model_stage)` and logs the plan before
+construction; the pipeline `__init__` reads `od_config.model_stage` and builds
+only the required components (others are `None`, guarded at use sites). Weight
+loading self-gates: the loader only fills parameters that exist on constructed
+submodules, and the strict-load check derives its expectation from
+`named_parameters()`, so a skipped component drops out of both sets automatically
+— no loader change needed.
+
+`StageComponentSpec` (in `stage_roles.py`) is the generic, model-agnostic
+component vocabulary: `tokenizer`, `text_encoder`, `image_encoder`,
+`vae_encoder`, `dit`, `scheduler`, `vae_decoder`, `action_modules`.
+
+### DreamZero component ownership
+
+| Stage | Components |
+|---|---|
+| encode | tokenizer, text encoder, image encoder, VAE **encoder** |
+| denoise | CausalWan DiT, schedulers, action head, AR-Diffusion KV |
+| decode | VAE **decoder**, video/action postprocess |
+
+DreamZero's VAE (`DistributedAutoencoderKLWan`) has a monolithic constructor
+(encoder + decoder together), so a stage needing *either* half builds the full
+module; the denoise stage needs *neither* and skips it entirely, deriving the
+`vae_latents_mean/inv_std` buffers from the Wan-VAE constants instead of the
+module.
+
+## DreamZero stage ownership & session/KV
+
+**Critical invariant:** AR-Diffusion session/KV state lives **only** on the
+denoise stage. The encode `DiffusionStagePayload` carries stable data
+(encoded text/image conditions, `ys`/`clip_feas`, initial latents+noise, timestep
+schedule params, embodiment/state metadata, session id, CFG metadata, shape
+metadata). The live paged KV, the `FlowUniPCMultistepScheduler`, and the
+`DreamZeroState` are **never** serialized. The denoise worker
+(`ARDiffusionModelRunner`) acquires/creates the session by the transported
+`session_id` through the normal engine mechanism; encode/decode stages attach no
+KV and route straight to the base runner.
+
+DreamZero's `forward()` was refactored into three phase methods
+(`_run_encode_phase` / `_run_denoise_phase` / `_run_decode_phase`) that share the
+existing math helpers. `forward()` now composes all three on one carrier and one
+session state — so the monolithic golden path and the disaggregated path run the
+**same** code, making numerical equivalence structural rather than coincidental.
+The DreamZero-private inter-phase carrier (`DreamZeroStageCarrier`) lives on
+`DiffusionRequestState.extra` (model-private), never on the generic state fields.
+
+## Generic stage transition
+
+`vllm_omni/model_executor/stage_input_processors/diffusion.py::diffusion_stage_transition`
+is the one model-agnostic adapter. It extracts the typed payload from the upstream
+`DiffusionOutput.custom_output`, validates identity/transition/version (never the
+model-private tensor keys), and places it in the downstream request prompt's
+`extra` dict — the channel the diffusion pipeline reads. It also mirrors the
+`session_id` for the denoise runner. The payload rides in channels already part of
+the msgpack transport contract, so it works in both inline (single-process) and
+out-of-process (ZMQ) stage clients without a new serializer.
+
+## Config & topology
+
+* `model_stage` now reaches the worker: added as a field on `OmniDiffusionConfig`
+  and wired in `build_diffusion_config` from the stage metadata (previously it was
+  dropped at `from_kwargs` and reached only the head-side client).
+* `PipelineConfig.validate()` applies the disaggregated linear-topology rules
+  (`stage_roles.validate_linear_diffusion_topology`) whenever any stage declares a
+  disaggregated role: unique ids, valid `input_sources`, denoise-has-encode-source,
+  decode-has-denoise-source, single final-output on the decode stage, single
+  upstream per consumer. Unknown/custom roles are accepted (a model may declare
+  support) and take the `execute_model_defined_stage` hook.
+* Topologies:
+  * `dreamzero` (`DREAMZERO_PIPELINE`) — the original single monolithic stage
+    (default, unchanged).
+  * `dreamzero_disaggregated` (`DREAMZERO_DISAGGREGATED_PIPELINE`) — the three
+    `encode → denoise → decode` stages wired with the generic processor.
+
+### Example deploy configuration
+
+`vllm_omni/deploy/dreamzero_disaggregated.yaml` places one GPU per stage
+(repository-standard example ids), keeps the AR-Diffusion engine on the denoise
+stage, and uses the standard diffusion engine for encode/decode (they own no KV).
+Per-stage `devices` and `parallel_config` are independent. Do not treat the
+example device ids as production placement.
+
+## Transport limitations of the first implementation
+
+* Uses the existing host-based stage transport (msgpack over ZMQ for
+  out-of-process, by-reference inline). No cross-node GPU tensor-transfer
+  manager, no zero-copy GPU↔GPU transfer — the payload is structured so tensors
+  can later be backed by connector handles without changing runner semantics.
+* A stage-boundary clone is taken for correctness (localized, documented).
+* No KV-update sub-stage; no decode/KV-update overlap; no DAG scheduling beyond the
+  linear `encode → denoise → decode` path; no multi-encoder/multi-decoder pools.
+
+## Backward compatibility
+
+Monolithic diffusion, request-batch forward, step execution, existing stage config
+parsing, output formats, profiling fields, cancellation/interruption, prompt-embed
+cache, and offload behavior are all preserved. Stagewise behavior is selected
+*only* by stage topology / `model_stage`; it is never globally enabled. The
+original single-stage DreamZero deploy is untouched and remains the default.
+
+## Non-goals
+
+Cross-node GPU transfer manager, zero-copy GPU↔GPU payloads, generalized DAG
+scheduling, multiple parallel encoders/decoders, fused encode/decode pools, a
+KV-update sub-stage, decode/KV overlap, autoscaling/replication policy, migrating
+every diffusion model, and a session-memory-manager rewrite.
+
+## Manual validation commands
+
+Torch-free foundation unit tests (no GPU, no vllm runtime):
+
+```bash
+python -m pytest tests/diffusion/disaggregated/ -q
+```
+
+Full runtime tests (on the gnr XPU node, inside the vllm-omni-xpu container):
+
+```bash
+# runner stage behavior, DreamZero atoms/payload round-trip, config topology
+pytest tests/diffusion/disaggregated/ -m needs_runtime
+
+# numerical equivalence (monolithic forward vs encode->denoise->decode)
+DREAMZERO_MODEL_PATH=/models/DreamZero-DROID \
+  pytest tests/diffusion/disaggregated/test_dreamzero_disaggregated.py \
+  -m needs_runtime -k numerical_equivalence -s
+```
+
+Serving the disaggregated topology:
+
+```bash
+# denoise stage requires the AR-Diffusion engine (set in the deploy YAML)
+vllm-omni serve --deploy-config vllm_omni/deploy/dreamzero_disaggregated.yaml
+```

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -1093,6 +1093,17 @@ def build_diffusion_config(
     od_config.num_gpus = num_devices_per_stage
     if metadata.cfg_kv_collect_func is not None:
         od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
+
+    # Wire the stage role through to the worker/runner (RFC #4590). engine_args
+    # may already carry it (StageConfig.to_omegaconf writes model_stage), but the
+    # authoritative source is the stage metadata; set it explicitly so the runner
+    # can select encode/denoise/decode and the loader can gate components. This is
+    # the narrowest wiring point — model_stage previously reached only the
+    # head-side client, never the worker's od_config.
+    # ``model_stage`` is a required StageMetadata field (None only for the
+    # monolithic/legacy case), so read it directly rather than defensively.
+    if metadata.model_stage is not None:
+        od_config.model_stage = metadata.model_stage
     return od_config
 
 

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
@@ -153,7 +153,7 @@ class ARDiffusionKVState:
     def reset(self, *, keep_cross_text: bool = False) -> None:
         """Drop this session's KV — mirrors the model-local ``state.reset()``.
 
-        DreamZero resets at the attention-window boundary (``should_reset``); the
+        DreamZero resets at the attention-window boundary (``reset_reason``); the
         model starts a fresh sliding window, so AR-Diffusion must free the resident pool
         blocks and start a fresh adapter for each branch. The ``ARDiffusionKVState``
         object (and thus ``pipeline._ar_diffusion_kv_state``) is preserved across the reset

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -25,7 +25,10 @@ from vllm.logger import init_logger
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import MAX_DREAMZERO_SESSIONS
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.stage_payload import STAGE_PAYLOAD_PROMPT_KEY
+from vllm_omni.diffusion.stage_roles import DECODE, DENOISE, ENCODE
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.platforms import current_omni_platform
 from vllm_omni.experimental.ar_diffusion.kv_cache.config import ARDiffusionKVConfig
 from vllm_omni.experimental.ar_diffusion.kv_cache.manager import ARDiffusionKVCache
 from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
@@ -139,9 +142,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
 
     def _infer_frame_seqlen(self) -> int:
         """frame_seqlen = (H//8)*(W//8)//4 from the configured image_resolution."""
-        mc = getattr(self.od_config, "model_config", None) or {}
-        psc = (mc.get("policy_server_config") if isinstance(mc, dict) else None) or {}
-        res = psc.get("image_resolution", [180, 320])
+        res = self._image_resolution()
         h, w = int(res[0]), int(res[1])
         return (h // 8) * (w // 8) // 4
 
@@ -167,8 +168,8 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         # The loaded transformer is the source of truth for frame_seqlen (it derives
         # max_attention_size from it). The deploy-config inference is only a
         # cross-check — warn on drift rather than silently sizing chunks wrong.
-        frame_seqlen = int(getattr(t, "frame_seqlen", 0)) or self._infer_frame_seqlen()
         inferred = self._infer_frame_seqlen()
+        frame_seqlen = int(getattr(t, "frame_seqlen", 0)) or inferred
         if frame_seqlen != inferred:
             logger.warning(
                 "AR-Diffusion frame_seqlen mismatch: transformer=%d deploy-config=%d; using transformer",
@@ -196,7 +197,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         self.ar_diffusion_kv_config = dataclasses.replace(
             self.ar_diffusion_kv_config, chunk_size=chunk_size, window_chunks=window_chunks
         )
-        free_bytes = torch.cuda.mem_get_info(self.device)[0]
+        free_bytes = current_omni_platform.get_free_memory(self.device)
         # Under CFG-parallel each rank executes exactly ONE branch (rank0 pos,
         # rank1 neg; the other branch's lazy contexts never allocate on this
         # rank), so its pool only needs one branch's capacity. A single-process
@@ -234,17 +235,51 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             num_frame_per_block=num_frame_per_block,
         )
 
+    def _resolve_session_id(self, req: OmniDiffusionRequest) -> str:
+        """Resolve the AR-Diffusion session id for this request.
+
+        Monolithic path: ``sampling_params.extra_args["session_id"]``. Denoise
+        stage: the transition processor mirrors the encode payload's public
+        ``scalar_fields["session_id"]`` into both ``extra_args["session_id"]`` and
+        the prompt, so reading extra_args covers both. Falls back to the payload's
+        public ``scalar_fields`` directly if extra_args did not carry it (handling
+        both a live ``StagePayload`` and a msgpack-flattened plain dict).
+        """
+        extra_args = req.sampling_params.extra_args or {}
+        session_id = extra_args.get("session_id")
+        if session_id is None and self.model_stage == DENOISE:
+            prompt = req.prompt
+            extra = prompt.get("extra") if isinstance(prompt, dict) else getattr(prompt, "extra", None)
+            payload = extra.get(STAGE_PAYLOAD_PROMPT_KEY) if isinstance(extra, dict) else None
+            if payload is not None:
+                scalar_fields = payload.get("scalar_fields") if isinstance(payload, dict) else getattr(
+                    payload, "scalar_fields", {}
+                )
+                session_id = (scalar_fields or {}).get("session_id")
+        return str(session_id or "default")
+
     def execute_model(self, req: OmniDiffusionRequest, kv_prefetch_jobs: dict | None = None) -> DiffusionOutput:
         # KV disabled -> base behavior, unchanged.
         if self.kv_cache is None:
+            return super().execute_model(req, kv_prefetch_jobs=kv_prefetch_jobs)
+
+        # Disaggregated encode/decode stages own NO AR-Diffusion KV: they run
+        # conditions encode / VAE decode only. Route them straight to the base
+        # runner's role dispatch without touching the session pool (RFC #4590
+        # §9.1: KV/session state lives exclusively on the denoise stage). The
+        # denoise stage (and the monolithic path) keep the session attach below.
+        role = self.model_stage
+        if role in (ENCODE, DECODE):
             return super().execute_model(req, kv_prefetch_jobs=kv_prefetch_jobs)
 
         kv = self.kv_cache
         # DreamZero KV is session-scoped (the model state persists across a
         # session's forwards), so the AR-Diffusion KV state is keyed by session_id and
         # reused — matching how pipeline.forward resolves the model-local state.
-        extra_args = req.sampling_params.extra_args or {}
-        session_id = str(extra_args.get("session_id") or "default")
+        # For the denoise stage the session id arrives in the payload metadata
+        # (mirrored to extra_args by the transition processor); for the
+        # monolithic path it is the request's own extra_args["session_id"].
+        session_id = self._resolve_session_id(req)
         state = self._ar_diffusion_states.get(session_id)
         if state is None:
             pos = kv.begin_request(f"bde__{session_id}")
@@ -363,7 +398,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
                 n_frames = 1 if i == 0 else 4  # client convention: 1-frame prefill, 4-frame chunks
                 obs = self._synth_robot_obs(h, w, n_frames)
                 sp = OmniDiffusionSamplingParams(extra_args={"reset": i == 0, "session_id": sid, "robot_obs": obs})
-                req = OmniDiffusionRequest(prompts=["warmup"], sampling_params=sp, request_id=f"ardiffusion-warmup-{i}")
+                req = OmniDiffusionRequest(prompt="warmup", sampling_params=sp, request_id=f"ardiffusion-warmup-{i}")
                 self.execute_model(req)
                 # Stop once the resident window is full — the remaining shapes are
                 # already captured (the window caps/resets through the same set).

--- a/vllm_omni/model_executor/models/dreamzero/pipeline.py
+++ b/vllm_omni/model_executor/models/dreamzero/pipeline.py
@@ -1,11 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""DreamZero single-stage diffusion topology."""
+"""DreamZero diffusion topologies.
+
+Two registered topologies:
+
+* ``DREAMZERO_PIPELINE`` (``model_type="dreamzero"``) — the original single
+  monolithic diffusion stage. Unchanged; the default for compatibility.
+* ``DREAMZERO_DISAGGREGATED_PIPELINE`` (``model_type="dreamzero_disaggregated"``)
+  — the three-stage encode -> denoise -> decode topology. All three stages run
+  as native ``StageExecutionType.DIFFUSION`` stages distinguished by
+  ``model_stage``. The generic diffusion transition processor moves the typed
+  ``StagePayload`` between them.
+"""
 
 from vllm_omni.config.stage_config import (
     PipelineConfig,
     StageExecutionType,
     StagePipelineConfig,
+)
+
+#: Dotted path to the generic diffusion -> diffusion transition processor. One
+#: model-agnostic adapter for every disaggregated diffusion model (RFC #4590 §6).
+#: Re-exported from the processor module (its single source of truth) so this
+#: topology and the function it names cannot drift.
+from vllm_omni.model_executor.stage_input_processors.diffusion import (  # noqa: E402
+    GENERIC_DIFFUSION_PROCESSOR,
 )
 
 DREAMZERO_PIPELINE = PipelineConfig(
@@ -21,6 +40,46 @@ DREAMZERO_PIPELINE = PipelineConfig(
             final_output=True,
             final_output_type="image",
             model_arch="DreamZeroPipeline",
+        ),
+    ),
+)
+
+DREAMZERO_DISAGGREGATED_PIPELINE = PipelineConfig(
+    model_type="dreamzero_disaggregated",
+    model_arch="DreamZeroPipeline",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="encode",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(),
+            final_output=False,
+            model_arch="DreamZeroPipeline",
+            # Producer hook: pack the encode->denoise payload for stage 1.
+            custom_process_next_stage_input_func=GENERIC_DIFFUSION_PROCESSOR,
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="denoise",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(0,),
+            final_output=False,
+            model_arch="DreamZeroPipeline",
+            # Consumer hook: unpack the encode->denoise payload into the request.
+            custom_process_input_func=GENERIC_DIFFUSION_PROCESSOR,
+            # Producer hook: pack the denoise->decode payload for stage 2.
+            custom_process_next_stage_input_func=GENERIC_DIFFUSION_PROCESSOR,
+        ),
+        StagePipelineConfig(
+            stage_id=2,
+            model_stage="decode",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="image",
+            model_arch="DreamZeroPipeline",
+            # Consumer hook: unpack the denoise->decode payload into the request.
+            custom_process_input_func=GENERIC_DIFFUSION_PROCESSOR,
         ),
     ),
 )

--- a/vllm_omni/model_executor/stage_input_processors/diffusion.py
+++ b/vllm_omni/model_executor/stage_input_processors/diffusion.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Generic diffusion -> diffusion stage transition processor.
+
+One model-agnostic adapter moves a :class:`StagePayload` from an upstream
+diffusion stage's output into the downstream diffusion stage's request, for every
+disaggregated diffusion model. It does *not* decode model-specific tensor keys;
+the payload round-trips opaquely through the owning pipeline's
+``pack_stage_state`` / ``unpack_stage_state`` hooks (the DiffusionV2Atoms
+contract).
+
+Wiring: set a stage's ``custom_process_input_func`` to
+``vllm_omni.model_executor.stage_input_processors.diffusion.diffusion_stage_transition``.
+The orchestrator calls it as
+``fn(source_outputs, prompt, requires_multimodal_data, sampling_params=...)`` and
+uses the returned prompt dict as the downstream ``OmniDiffusionRequest.prompt``.
+
+The payload rides in the upstream ``DiffusionOutput.custom_output`` under
+:data:`STAGE_PAYLOAD_OUTPUT_KEY`, and is re-emitted into the downstream prompt's
+``extra`` sub-dict under :data:`STAGE_PAYLOAD_PROMPT_KEY` (the channel the
+diffusion pipeline reads for cross-stage data). Both the upstream
+``DiffusionOutput.custom_output`` and the prompt ``extra`` dict are already
+part of the msgpack transport contract; msgpack does not preserve dataclass
+identity across the out-of-process (multiproc) stage client, so
+``_unwrap_stage_payload`` rehydrates the payload via ``StagePayload.from_dict``
+when it arrives as a plain dict.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Canonical dotted path to :func:`diffusion_stage_transition`, co-located with
+#: the function it names so a pipeline wiring the generic processor references one
+#: source of truth instead of hand-copying the string. Declared as a literal (not
+#: derived from ``__name__``) because the torch-free foundation tests load this
+#: module by file path under a synthetic name (see conftest.py), which would make
+#: any ``__name__``-derived path wrong.
+GENERIC_DIFFUSION_PROCESSOR = (
+    "vllm_omni.model_executor.stage_input_processors.diffusion.diffusion_stage_transition"
+)
+
+# STAGE_PAYLOAD_*_KEY: canonical definitions live in
+# ``vllm_omni.diffusion.stage_payload`` (the torch-free transport leaf). They are
+# re-declared here as literals — not imported — on purpose: this processor is
+# loaded by file path in the torch-free foundation tests (see
+# tests/diffusion/disaggregated/conftest.py), and a top-level ``from vllm_omni...``
+# import would trigger the package ``__init__`` (and torch). ``test_payload_key_sync``
+# asserts these literals stay equal to the canonical constants so the copies cannot drift.
+
+#: Key under which a stage's ``DiffusionOutput.custom_output`` carries the
+#: outgoing :class:`StagePayload`.
+STAGE_PAYLOAD_OUTPUT_KEY = "__diffusion_stage_payload__"
+
+#: Key under which the downstream request prompt's ``extra`` dict carries the
+#: incoming :class:`StagePayload`.
+STAGE_PAYLOAD_PROMPT_KEY = "diffusion_stage_payload"
+
+
+def _is_stage_payload(value: Any) -> bool:
+    """Duck-typed StagePayload check (no hard import of the class).
+
+    Recognizes a payload by its distinctive attribute surface so the processor
+    stays importable even in minimal environments; falls back to an ``isinstance``
+    check against the real class when it is importable.
+    """
+    if all(
+        hasattr(value, attr)
+        for attr in ("request_id", "boundary", "tensor_fields", "scalar_fields", "payload_version")
+    ):
+        return True
+    try:
+        from vllm_omni.diffusion.models.interface import StagePayload
+
+        return isinstance(value, StagePayload)
+    except Exception:  # pragma: no cover - import-environment dependent
+        return False
+
+
+def _rehydrate_stage_payload(payload_dict: dict[str, Any]) -> Any:
+    """Rebuild a :class:`StagePayload` from a msgpack-flattened plain dict."""
+    from vllm_omni.diffusion.models.interface import StagePayload
+
+    return StagePayload.from_dict(payload_dict)
+
+
+def _unwrap_stage_payload(source_output: Any) -> Any | None:
+    """Extract a :class:`StagePayload` from an upstream stage output.
+
+    Accepts either a ``DiffusionOutput``-like object exposing ``custom_output``,
+    a mapping, or an object that already *is* a payload. Returns ``None`` when
+    no payload is present so the caller can route a terminal error.
+
+    The out-of-process (multiproc) stage client round-trips ``custom_output``
+    through msgpack, which does not preserve dataclass identity: the payload
+    arrives here as a plain ``dict`` with the same keys as
+    :class:`StagePayload`'s fields rather than the dataclass itself. Rehydrate it
+    via :meth:`StagePayload.from_dict` before returning so :meth:`validate`
+    (called by the caller) works on both paths.
+    """
+    if _is_stage_payload(source_output):
+        return source_output
+
+    custom_output = getattr(source_output, "custom_output", None)
+    if custom_output is None and isinstance(source_output, dict):
+        custom_output = source_output.get("custom_output", source_output)
+    if isinstance(custom_output, dict):
+        payload = custom_output.get(STAGE_PAYLOAD_OUTPUT_KEY)
+        if payload is not None:
+            if _is_stage_payload(payload):
+                return payload
+            if isinstance(payload, dict):
+                return _rehydrate_stage_payload(payload)
+            return payload
+    return None
+
+
+def _passthrough_prompt_fields(prompt: Any, target: dict[str, Any]) -> None:
+    """Copy request-level knobs from the original prompt onto ``target``.
+
+    Preserves sampling-relevant fields the downstream stage may still need
+    (seed, steps, guidance, negative prompt, session id, resolution). Model
+    semantics are NOT interpreted here — these are the same generic passthrough
+    keys the existing AR->diffusion processors forward.
+    """
+    if isinstance(prompt, list):
+        prompt = prompt[0] if prompt else {}
+    if hasattr(prompt, "_asdict"):
+        prompt = prompt._asdict()
+    elif not isinstance(prompt, dict) and hasattr(prompt, "__dict__"):
+        prompt = vars(prompt)
+    if not isinstance(prompt, dict):
+        return
+    for key in (
+        "seed",
+        "num_inference_steps",
+        "guidance_scale",
+        "negative_prompt",
+        "session_id",
+        "height",
+        "width",
+    ):
+        if key in prompt and key not in target:
+            target[key] = prompt[key]
+
+
+def diffusion_stage_transition(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+    *,
+    sampling_params: Any = None,
+    **_ignored: Any,
+) -> dict[str, Any] | None:
+    """Move the upstream diffusion payload into the downstream request prompt.
+
+    Args:
+        source_outputs: Upstream stage outputs; ``source_outputs[0]`` carries
+            the :class:`StagePayload` in its ``custom_output``.
+        prompt: The original request prompt (for request-level passthrough).
+        requires_multimodal_data: Honored generically — unused here because the
+            payload already carries every conditioning tensor the model packed.
+        sampling_params: The downstream stage's sampling params (accepted so the
+            orchestrator's signature probe passes it; also mirrored so the
+            pipeline's import hook can recover a session id from ``extra_args``).
+
+    Returns:
+        A diffusion prompt dict carrying the payload in ``extra``, or ``None``
+        when no payload is present (the orchestrator routes a terminal error).
+    """
+    del requires_multimodal_data  # payload is self-contained; kept for contract parity
+
+    if not source_outputs:
+        logger.warning("[diffusion_stage_transition] no source outputs; routing terminal error")
+        return None
+
+    payload = _unwrap_stage_payload(source_outputs[0])
+    if payload is None:
+        logger.warning(
+            "[diffusion_stage_transition] upstream output carries no %s; routing terminal error",
+            STAGE_PAYLOAD_OUTPUT_KEY,
+        )
+        return None
+
+    # Validate the envelope at the transition boundary. The processor stays
+    # model-agnostic: it checks identity/transition/versioning only, never the
+    # model-private tensor keys or metadata.
+    try:
+        payload.validate()
+    except Exception as exc:  # StagePayloadError and subclasses
+        logger.error("[diffusion_stage_transition] invalid stage payload: %s", exc)
+        return None
+
+    diffusion_prompt: dict[str, Any] = {
+        "prompt": "",
+        "extra": {STAGE_PAYLOAD_PROMPT_KEY: payload},
+    }
+
+    # Mirror the session id into extra_args so the AR-Diffusion denoise runner
+    # (which keys session state by extra_args["session_id"]) attaches the right
+    # live session — this is generic session-id plumbing, not model semantics.
+    # session_id rides in the PUBLIC ``scalar_fields`` so the processor never
+    # decodes model-private schema.
+    session_id = payload.scalar_fields.get("session_id")
+    if session_id is not None:
+        diffusion_prompt["session_id"] = session_id
+
+    _passthrough_prompt_fields(prompt, diffusion_prompt)
+
+    logger.debug(
+        "[diffusion_stage_transition] req=%s boundary=%s tensors=%d private_tensors=%d",
+        payload.request_id,
+        getattr(payload.boundary, "value", payload.boundary),
+        len(payload.tensor_fields),
+        len(payload.private_tensor_fields),
+    )
+    return diffusion_prompt


### PR DESCRIPTION
Adds staged/disaggregated execution for diffusion pipelines so a model's encode, denoise, and decode phases can run as independent processes/stages that hand off a typed payload between them, instead of replicating the full encoder stack on every tensor-parallel card. DreamZero (DROID) is the reference model, validated end-to-end on Intel XPU with TP=4 denoise.

Core additions
- StagePayload / DiffusionStagePayload: typed inter-stage handoff carried via custom_output, plus a generic stage-transition input processor (model_executor/stage_input_processors/diffusion.py).
- stage_roles (ENCODE/DENOISE/DECODE) and per-stage component ownership so each stage only loads the weights it needs.
- diffusion_model_runner_v2 + step_mixin: role-dispatched stage execution on the base runner; AR-Diffusion runner routes encode/decode straight through and keeps session-scoped KV exclusively on the denoise stage.
- Deploy configs for the disaggregated topology (TP4 denoise; cfg-off; inductor variants) and a design doc under docs/design/feature.
- Tests under tests/diffusion/disaggregated covering payload sync, stage dispatch/roles, runner stages, topology config, and the DreamZero pipeline.

Integration with current upstream
- diffusion_engine None-output path now forwards custom_output to format_empty_diffusion_outputs so the StagePayload handoff survives; dropping it silently breaks every disaggregated pipeline.
- ar_diffusion/runner execute_model keeps upstream's kv_prefetch_jobs parameter.

Code changes only; profiling harnesses and test-result bundles are intentionally excluded.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
