### PR TITLE
[MiniCPM-o 4.5] Split TTS into Talker and Token2Wav stages

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,6 +12,14 @@ Model-agnostic serving benchmarks for TTS models, including Qwen3-TTS and VoxCPM
 - **Dataset**: Seed-TTS full or text-only datasets, plus bundled smoke/design prompts under `build_dataset/`
 - **Key metrics**: TTFP (time to first audio packet), E2E latency, RTF (real-time factor), throughput (audio seconds / wall-clock second)
 
+### [MiniCPM-o 4.5](minicpmo/README.md) — Three-Stage TTS
+
+MiniCPM-o 4.5-specific smoke and profiling scripts for the Thinker -> Talker -> Token2Wav split.
+
+- **Layout**: `minicpmo/benchmark_e2e_tts.py` (text + complete WAV serving), `minicpmo/benchmark_token2wav.py` (Stage-2 decode)
+- **Key metrics**: latency p50/p95, RTF, peak GPU memory, waveform duration, finite/NaN/Inf, clipping, RMS/peak
+- **Failure handling**: request failures, timeouts, and OOM rows stay in JSON/CSV outputs
+
 ### [Diffusion](diffusion/README.md) — Image and Video Generation
 
 Online-serving benchmark for diffusion image/video models, sending requests to the configured vLLM serving endpoint (`/v1/chat/completions`, `/v1/images/generations`, or `/v1/videos`, depending on backend/task).

--- a/benchmarks/minicpmo/README.md
+++ b/benchmarks/minicpmo/README.md
@@ -1,0 +1,54 @@
+# MiniCPM-o 4.5 Benchmarks
+
+Benchmarks for the MiniCPM-o 4.5 three-stage TTS path:
+
+- `benchmark_e2e_tts.py`: OpenAI-compatible `/v1/chat/completions` text + complete WAV E2E.
+- `benchmark_token2wav.py`: isolated Stage-2 Token2Wav decode from pre-existing audio tokens.
+
+Both scripts keep failed, timeout, and OOM rows in their outputs.
+
+## E2E Text + Audio
+
+Start a server first. The default deploy config auto-loads with `--omni`; pass
+`--deploy-config` for a non-default GPU layout.
+
+```bash
+vllm serve openbmb/MiniCPM-o-4_5 --omni \
+    --deploy-config vllm_omni/deploy/minicpmo_4_5_2gpu.yaml \
+    --trust-remote-code \
+    --host 0.0.0.0 --port 8099
+```
+
+Run a short benchmark:
+
+```bash
+python benchmarks/minicpmo/benchmark_e2e_tts.py \
+    --base-url http://127.0.0.1:8099/v1 \
+    --model openbmb/MiniCPM-o-4_5 \
+    --serve-config vllm_omni/deploy/minicpmo_4_5_2gpu.yaml \
+    --requests 8 --concurrency 8 --warmup 1 \
+    --output-dir ./results/minicpmo/e2e-c8
+```
+
+Outputs:
+
+- `summary.json` / `summary.csv`: latency p50/p95, RTF, peak GPU memory, audio sanity, and null stage-timing fields when unavailable.
+- `requests.jsonl`: one row per request, including failures.
+
+## Token2Wav
+
+```bash
+python benchmarks/minicpmo/benchmark_token2wav.py \
+    --token2wav-dir /path/to/MiniCPM-o-4_5/assets/token2wav \
+    --prompt-wav /path/to/MiniCPM-o-4_5/assets/HT_ref_audio.wav \
+    --lengths 1024 2048 4096 \
+    --warmup 1 --iters 3 \
+    --output-dir ./results/minicpmo/token2wav
+```
+
+Outputs are `token2wav_fp32.json` and `token2wav_fp32.csv` by default. Add
+`--float16` only for opt-in comparison runs; PR1 does not change the default
+Token2Wav precision.
+
+Set `VLLM_OMNI_COMMIT=<sha>` when running from a copied source tree where
+`git rev-parse HEAD` is unavailable.

--- a/benchmarks/minicpmo/benchmark_e2e_tts.py
+++ b/benchmarks/minicpmo/benchmark_e2e_tts.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniCPM-o 4.5 OpenAI-compatible text+audio E2E benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import io
+import json
+import math
+import os
+import statistics
+import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import requests
+import soundfile as sf
+
+SAMPLE_RATE = 24_000
+DEFAULT_PROMPT = "Say hello, then introduce vLLM in one sentence."
+
+
+@dataclass
+class RequestResult:
+    request_id: int
+    ok: bool
+    status_code: int | None
+    latency_s: float
+    audio_present: bool
+    text_present: bool
+    audio_bytes: int
+    waveform_samples: int
+    waveform_duration_s: float
+    rtf: float
+    sample_rate: int | None
+    finite: bool
+    nan_count: int
+    inf_count: int
+    clipping_ratio: float
+    rms: float
+    peak_abs: float
+    text_chars: int
+    completion_tokens: int | None
+    prompt_tokens: int | None
+    total_tokens: int | None
+    error: str | None
+
+
+class GpuMemorySampler:
+    def __init__(self, gpu_indexes: list[int], interval_s: float) -> None:
+        self.gpu_indexes = gpu_indexes
+        self.interval_s = interval_s
+        self.samples: list[dict[int, int]] = []
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> GpuMemorySampler:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                proc = subprocess.run(
+                    [
+                        "nvidia-smi",
+                        "--query-gpu=index,memory.used",
+                        "--format=csv,noheader,nounits",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                row: dict[int, int] = {}
+                for line in proc.stdout.splitlines():
+                    if not line.strip():
+                        continue
+                    gpu_s, mem_s = [part.strip() for part in line.split(",", 1)]
+                    gpu = int(gpu_s)
+                    if gpu in self.gpu_indexes:
+                        row[gpu] = int(mem_s)
+                if row:
+                    self.samples.append(row)
+            except Exception:
+                pass
+            self._stop.wait(self.interval_s)
+
+    def peak_by_gpu(self) -> dict[str, int]:
+        peaks = {gpu: 0 for gpu in self.gpu_indexes}
+        for sample in self.samples:
+            for gpu, mem in sample.items():
+                peaks[gpu] = max(peaks.get(gpu, 0), mem)
+        return {str(gpu): mem for gpu, mem in peaks.items()}
+
+
+def _git_commit() -> str | None:
+    if commit := os.getenv("VLLM_OMNI_COMMIT"):
+        return commit
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return math.nan
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * percentile
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
+
+
+def _extract_response_payload(response: dict[str, Any]) -> tuple[str, bytes | None]:
+    text_parts: list[str] = []
+    audio_b64: str | None = None
+
+    for choice in response.get("choices", []):
+        message = choice.get("message", {})
+        content = message.get("content")
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if isinstance(item.get("text"), str):
+                    text_parts.append(item["text"])
+                audio = item.get("audio")
+                if isinstance(audio, dict) and isinstance(audio.get("data"), str):
+                    audio_b64 = audio["data"]
+
+        audio = message.get("audio")
+        if isinstance(audio, dict) and isinstance(audio.get("data"), str):
+            audio_b64 = audio["data"]
+
+    if audio_b64 and "," in audio_b64 and audio_b64.startswith("data:"):
+        audio_b64 = audio_b64.split(",", 1)[1]
+    audio_bytes = base64.b64decode(audio_b64) if audio_b64 else None
+    return "\n".join(text_parts), audio_bytes
+
+
+def _audio_stats(audio_bytes: bytes | None, latency_s: float) -> dict[str, Any]:
+    if not audio_bytes:
+        return {
+            "audio_present": False,
+            "audio_bytes": 0,
+            "waveform_samples": 0,
+            "waveform_duration_s": 0.0,
+            "rtf": math.inf,
+            "sample_rate": None,
+            "finite": False,
+            "nan_count": 0,
+            "inf_count": 0,
+            "clipping_ratio": math.nan,
+            "rms": math.nan,
+            "peak_abs": math.nan,
+        }
+
+    waveform, sample_rate = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+    wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+    finite_mask = np.isfinite(wav)
+    finite_values = wav[finite_mask]
+    abs_values = np.abs(finite_values) if finite_values.size else np.asarray([], dtype=np.float32)
+    samples = int(wav.shape[0])
+    duration_s = samples / sample_rate if sample_rate else 0.0
+    return {
+        "audio_present": True,
+        "audio_bytes": len(audio_bytes),
+        "waveform_samples": samples,
+        "waveform_duration_s": float(duration_s),
+        "rtf": latency_s / duration_s if duration_s else math.inf,
+        "sample_rate": int(sample_rate),
+        "finite": bool(finite_mask.all()),
+        "nan_count": int(np.isnan(wav).sum()),
+        "inf_count": int(np.isinf(wav).sum()),
+        "clipping_ratio": float((abs_values >= 0.999).mean()) if abs_values.size else math.nan,
+        "rms": float(np.sqrt(np.mean(np.square(finite_values)))) if finite_values.size else math.nan,
+        "peak_abs": float(abs_values.max()) if abs_values.size else math.nan,
+    }
+
+
+def _usage_field(usage: dict[str, Any], key: str) -> int | None:
+    value = usage.get(key)
+    return int(value) if isinstance(value, int | float) else None
+
+
+def _send_request(args: argparse.Namespace, request_id: int) -> RequestResult:
+    prompt = args.prompt
+    if args.unique_suffix:
+        prompt = f"{prompt}\nRequest id: {request_id}."
+
+    body: dict[str, Any] = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "modalities": ["text", "audio"],
+        "chat_template_kwargs": {"use_tts_template": True},
+        "temperature": args.temperature,
+        "seed": args.seed,
+    }
+    if args.max_tokens is not None:
+        body["max_tokens"] = args.max_tokens
+
+    url = args.base_url.rstrip("/") + "/chat/completions"
+    start = time.perf_counter()
+    status_code = None
+    error = None
+    response_json: dict[str, Any] = {}
+    try:
+        response = requests.post(url, json=body, timeout=args.timeout_s)
+        status_code = response.status_code
+        response.raise_for_status()
+        response_json = response.json()
+    except Exception as exc:
+        error = repr(exc)
+    latency_s = time.perf_counter() - start
+
+    text = ""
+    audio_bytes = None
+    if response_json:
+        try:
+            text, audio_bytes = _extract_response_payload(response_json)
+        except Exception as exc:
+            error = repr(exc)
+
+    try:
+        stats = _audio_stats(audio_bytes, latency_s)
+    except Exception as exc:
+        error = repr(exc)
+        stats = _audio_stats(None, latency_s)
+
+    usage = response_json.get("usage", {}) if response_json else {}
+    text_present = bool(text.strip())
+    ok = (
+        error is None
+        and status_code == 200
+        and text_present
+        and bool(stats["audio_present"])
+        and stats["finite"]
+        and stats["sample_rate"] == SAMPLE_RATE
+    )
+    return RequestResult(
+        request_id=request_id,
+        ok=ok,
+        status_code=status_code,
+        latency_s=latency_s,
+        text_present=text_present,
+        text_chars=len(text),
+        completion_tokens=_usage_field(usage, "completion_tokens"),
+        prompt_tokens=_usage_field(usage, "prompt_tokens"),
+        total_tokens=_usage_field(usage, "total_tokens"),
+        error=error,
+        **stats,
+    )
+
+
+def _summarize(args: argparse.Namespace, results: list[RequestResult], peak_by_gpu: dict[str, int]) -> dict[str, Any]:
+    successful = [result for result in results if result.ok]
+    latencies = [result.latency_s for result in successful]
+    rtfs = [result.rtf for result in successful]
+    durations = [result.waveform_duration_s for result in successful]
+    return {
+        "model": args.model,
+        "model_revision": args.model_revision,
+        "vllm_omni_commit": _git_commit(),
+        "serve_config": args.serve_config,
+        "base_url": args.base_url,
+        "prompt": args.prompt,
+        "prompt_chars": len(args.prompt),
+        "max_tokens": args.max_tokens,
+        "seed": args.seed,
+        "temperature": args.temperature,
+        "concurrency": args.concurrency,
+        "warmup": args.warmup,
+        "requests": args.requests,
+        "timeout_s": args.timeout_s,
+        "successes": len(successful),
+        "failures": len(results) - len(successful),
+        "failure_rate": (len(results) - len(successful)) / len(results) if results else math.nan,
+        "latency_p50_s": statistics.median(latencies) if latencies else math.nan,
+        "latency_p95_s": _percentile(latencies, 0.95),
+        "latency_mean_s": statistics.mean(latencies) if latencies else math.nan,
+        "rtf_p50": statistics.median(rtfs) if rtfs else math.nan,
+        "rtf_p95": _percentile(rtfs, 0.95),
+        "waveform_duration_s_median": statistics.median(durations) if durations else math.nan,
+        "audio_finite_all": all(result.finite for result in successful) if successful else False,
+        "nan_count_total": sum(result.nan_count for result in results),
+        "inf_count_total": sum(result.inf_count for result in results),
+        "clipping_ratio_max": max((result.clipping_ratio for result in successful), default=math.nan),
+        "rms_median": statistics.median(result.rms for result in successful) if successful else math.nan,
+        "peak_abs_max": max((result.peak_abs for result in successful), default=math.nan),
+        "peak_gpu_memory_mib_by_gpu": peak_by_gpu,
+        "stage_timing_s": {"thinker": None, "talker": None, "token2wav": None, "packaging": None},
+    }
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for warmup_id in range(args.warmup):
+        _send_request(args, -warmup_id - 1)
+
+    results: list[RequestResult] = []
+    gpu_indexes = [int(item) for item in args.gpu_indexes.split(",") if item.strip()]
+    with GpuMemorySampler(gpu_indexes, args.gpu_sample_interval_s) as sampler:
+        with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+            futures = [executor.submit(_send_request, args, i) for i in range(args.requests)]
+            for future in as_completed(futures):
+                results.append(future.result())
+    results.sort(key=lambda item: item.request_id)
+
+    rows_path = output_dir / "requests.jsonl"
+    with rows_path.open("w", encoding="utf-8") as f:
+        for result in results:
+            f.write(json.dumps(asdict(result), sort_keys=True) + "\n")
+
+    summary = _summarize(args, results, sampler.peak_by_gpu())
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    csv_path = output_dir / "summary.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=summary.keys())
+        writer.writeheader()
+        writer.writerow(summary)
+
+    return {
+        "summary": summary,
+        "summary_path": str(summary_path),
+        "rows_path": str(rows_path),
+        "csv_path": str(csv_path),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8099/v1")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default=None)
+    parser.add_argument("--serve-config", default=None)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--requests", type=int, default=3)
+    parser.add_argument("--timeout-s", type=float, default=900.0)
+    parser.add_argument("--gpu-indexes", default="0,1")
+    parser.add_argument("--gpu-sample-interval-s", type=float, default=0.25)
+    parser.add_argument("--unique-suffix", action="store_true")
+    parser.add_argument("--output-dir", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(parse_args()), indent=2, sort_keys=True))

--- a/benchmarks/minicpmo/benchmark_token2wav.py
+++ b/benchmarks/minicpmo/benchmark_token2wav.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniCPM-o 4.5 Token2Wav isolated microbenchmark.
+
+The benchmark intentionally measures only the Stage-2 Token2Wav boundary used by
+``MiniCPMO45OmniTTSForConditionalGeneration`` after audio tokens already exist.
+It uses the MiniCPM-o-flavored ``stepaudio2.Token2wav`` package and the official
+``assets/token2wav`` files from ``openbmb/MiniCPM-o-4_5``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import io
+import json
+import math
+import os
+import platform
+import statistics
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+import torch
+
+SAMPLE_RATE = 24_000
+DEFAULT_LENGTHS = (256, 512, 1024, 2048, 4096)
+MIN_TAIL = 6
+
+
+def _load_token2wav_cls():
+    try:
+        from stepaudio2 import Token2wav
+    except ImportError as exc:
+        raise RuntimeError(
+            "benchmark_token2wav.py requires the MiniCPM-o-flavored "
+            "`stepaudio2.Token2wav` entry point. Install `stepaudio2-minicpmo` "
+            "or `vllm-omni[minicpmo]`."
+        ) from exc
+    return Token2wav
+
+
+def _install_torchaudio_soundfile_shim() -> None:
+    """Make Token2wav prompt I/O work when torchcodec/ffmpeg is unavailable."""
+    try:
+        import torchaudio
+    except Exception:
+        return
+
+    if not getattr(torchaudio, "_minicpmo_soundfile_shim_installed", False):
+        orig_load = torchaudio.load
+
+        def patched_load(uri, *args: Any, **kwargs: Any):
+            try:
+                return orig_load(uri, *args, **kwargs)
+            except Exception:
+                data, sr = sf.read(uri, dtype="float32", always_2d=True)
+                wav = torch.from_numpy(np.ascontiguousarray(data.T))
+                return wav, sr
+
+        torchaudio.load = patched_load
+
+    if not getattr(torchaudio, "_minicpmo_soundfile_save_shim_installed", False):
+        orig_save = torchaudio.save
+
+        def patched_save(uri, src, sample_rate, **kwargs: Any):
+            kwargs.pop("backend", None)
+            if hasattr(uri, "write"):
+                sf.write(uri, src.detach().cpu().numpy().T, sample_rate, format="WAV")
+                return
+            return orig_save(uri, src, sample_rate, backend="soundfile", **kwargs)
+
+        torchaudio.save = patched_save
+
+    torchaudio._minicpmo_soundfile_shim_installed = True
+    torchaudio._minicpmo_soundfile_save_shim_installed = True
+
+
+@dataclass
+class IterationResult:
+    latency_s: float
+    setup_s: float
+    decode_or_concat_s: float
+    waveform_samples: int
+    waveform_duration_s: float
+    rtf: float
+    peak_allocated_mib: float
+    peak_reserved_mib: float
+    finite: bool
+    nan_count: int
+    inf_count: int
+    clipping_ratio: float
+    rms: float
+    peak_abs: float
+    mean: float
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        _call_accelerator_or_cuda("synchronize", device)
+
+
+def _reset_peak_memory(device: torch.device) -> None:
+    if device.type == "cuda":
+        _call_accelerator_or_cuda("reset_peak_memory_stats", device)
+
+
+def _peak_memory_mib(device: torch.device) -> tuple[float, float]:
+    if device.type != "cuda":
+        return 0.0, 0.0
+    return (
+        _call_accelerator_or_cuda("max_memory_allocated", device) / (1024**2),
+        _call_accelerator_or_cuda("max_memory_reserved", device) / (1024**2),
+    )
+
+
+def _call_accelerator_or_cuda(name: str, *args: Any) -> Any:
+    accelerator = getattr(torch, "accelerator", None)
+    if accelerator is not None:
+        accelerator_fn = getattr(accelerator, name, None)
+        if accelerator_fn is not None:
+            return accelerator_fn(*args)
+    cuda_fn = getattr(torch.cuda, name)
+    return cuda_fn(*args)
+
+
+def _git_commit() -> str | None:
+    if commit := os.getenv("VLLM_OMNI_COMMIT"):
+        return commit
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return math.nan
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * percentile
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
+
+
+def _waveform_stats(
+    waveform: np.ndarray,
+    elapsed_s: float,
+    peak_allocated: float,
+    peak_reserved: float,
+) -> IterationResult:
+    wav = np.asarray(waveform, dtype=np.float32).reshape(-1)
+    finite_mask = np.isfinite(wav)
+    samples = int(wav.shape[0])
+    duration_s = samples / SAMPLE_RATE if samples else 0.0
+    abs_wav = np.abs(wav[finite_mask]) if finite_mask.any() else np.asarray([], dtype=np.float32)
+    rms = float(np.sqrt(np.mean(np.square(wav[finite_mask])))) if finite_mask.any() else math.nan
+    peak_abs = float(abs_wav.max()) if abs_wav.size else math.nan
+    return IterationResult(
+        latency_s=elapsed_s,
+        setup_s=0.0,
+        decode_or_concat_s=0.0,
+        waveform_samples=samples,
+        waveform_duration_s=duration_s,
+        rtf=elapsed_s / duration_s if duration_s > 0 else math.inf,
+        peak_allocated_mib=peak_allocated,
+        peak_reserved_mib=peak_reserved,
+        finite=bool(finite_mask.all()),
+        nan_count=int(np.isnan(wav).sum()),
+        inf_count=int(np.isinf(wav).sum()),
+        clipping_ratio=float((abs_wav >= 0.999).mean()) if abs_wav.size else math.nan,
+        rms=rms,
+        peak_abs=peak_abs,
+        mean=float(np.mean(wav[finite_mask])) if finite_mask.any() else math.nan,
+    )
+
+
+def _decode_wav_bytes(wav_bytes: bytes) -> np.ndarray:
+    waveform, sr = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+    if sr != SAMPLE_RATE:
+        raise RuntimeError(f"Expected {SAMPLE_RATE} Hz output, got {sr} Hz")
+    return np.asarray(waveform, dtype=np.float32).reshape(-1)
+
+
+def _chunk_bounds(num_tokens: int, chunk_size: int) -> list[tuple[int, int]]:
+    bounds: list[tuple[int, int]] = []
+    start = 0
+    while start < num_tokens:
+        end = min(start + chunk_size, num_tokens)
+        if 0 < num_tokens - end < MIN_TAIL:
+            end = num_tokens
+        bounds.append((start, end))
+        start = end
+    return bounds
+
+
+def _prepare_seed_tokens(tokenizer: Any, prompt_wav: str, max_len: int) -> list[int]:
+    if tokenizer.cache is None:
+        tokenizer.cache = tokenizer._prepare_prompt(prompt_wav)
+    prompt_tokens = tokenizer.cache[0].detach().reshape(-1).to("cpu").tolist()
+    if not prompt_tokens:
+        raise RuntimeError("Prompt audio produced no speech tokens")
+    repeats = (max_len + len(prompt_tokens) - 1) // len(prompt_tokens)
+    return (prompt_tokens * repeats)[:max_len]
+
+
+def _measure_one_shot(
+    tokenizer: Any,
+    tokens: list[int],
+    prompt_wav: str,
+    device: torch.device,
+) -> IterationResult:
+    _reset_peak_memory(device)
+    _sync(device)
+    start = time.perf_counter()
+    wav_bytes = tokenizer(tokens, prompt_wav)
+    after_call = time.perf_counter()
+    waveform = _decode_wav_bytes(wav_bytes)
+    end = time.perf_counter()
+    _sync(device)
+    peak_allocated, peak_reserved = _peak_memory_mib(device)
+    result = _waveform_stats(waveform, end - start, peak_allocated, peak_reserved)
+    result.decode_or_concat_s = end - after_call
+    return result
+
+
+def _measure_streaming(
+    tokenizer: Any,
+    tokens: list[int],
+    prompt_wav: str,
+    device: torch.device,
+    chunk_size: int,
+) -> IterationResult:
+    _reset_peak_memory(device)
+    _sync(device)
+    start = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()):
+        stream_cache, hift_cache_dict = tokenizer.set_stream_cache(prompt_wav)
+    tokenizer.stream_cache = stream_cache
+    tokenizer.hift_cache_dict = hift_cache_dict
+    after_setup = time.perf_counter()
+    pieces: list[np.ndarray] = []
+    try:
+        bounds = _chunk_bounds(len(tokens), chunk_size)
+        for idx, (chunk_start, chunk_end) in enumerate(bounds):
+            wav_np = tokenizer.stream(
+                tokens[chunk_start:chunk_end],
+                prompt_wav,
+                last_chunk=idx == len(bounds) - 1,
+                return_waveform=True,
+            )
+            pieces.append(np.asarray(wav_np, dtype=np.float32).reshape(-1))
+        waveform = np.concatenate(pieces, axis=0) if pieces else np.asarray([], dtype=np.float32)
+    finally:
+        tokenizer.stream_cache = None
+        tokenizer.hift_cache_dict = {}
+    end = time.perf_counter()
+    _sync(device)
+    peak_allocated, peak_reserved = _peak_memory_mib(device)
+    result = _waveform_stats(waveform, end - start, peak_allocated, peak_reserved)
+    result.setup_s = after_setup - start
+    result.decode_or_concat_s = end - after_setup
+    return result
+
+
+def _summarize(results: list[IterationResult]) -> dict[str, Any]:
+    latencies = [r.latency_s for r in results]
+    rtfs = [r.rtf for r in results]
+    peak_allocated = [r.peak_allocated_mib for r in results]
+    peak_reserved = [r.peak_reserved_mib for r in results]
+    return {
+        "iterations": len(results),
+        "latency_p50_s": statistics.median(latencies),
+        "latency_p95_s": _percentile(latencies, 0.95),
+        "latency_mean_s": statistics.mean(latencies),
+        "rtf_p50": statistics.median(rtfs),
+        "rtf_p95": _percentile(rtfs, 0.95),
+        "peak_allocated_mib_max": max(peak_allocated),
+        "peak_reserved_mib_max": max(peak_reserved),
+        "waveform_duration_s_median": statistics.median(r.waveform_duration_s for r in results),
+        "finite_all": all(r.finite for r in results),
+        "nan_count_total": sum(r.nan_count for r in results),
+        "inf_count_total": sum(r.inf_count for r in results),
+        "clipping_ratio_max": max(r.clipping_ratio for r in results),
+        "rms_median": statistics.median(r.rms for r in results),
+        "peak_abs_max": max(r.peak_abs for r in results),
+    }
+
+
+def _environment(model_revision: str | None) -> dict[str, Any]:
+    return {
+        "model": "openbmb/MiniCPM-o-4_5",
+        "model_revision": model_revision,
+        "vllm_omni_commit": _git_commit(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "cuda_available": torch.cuda.is_available(),
+        "gpu": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
+        "cuda_device_count": _call_accelerator_or_cuda("device_count") if torch.cuda.is_available() else 0,
+        "pid": os.getpid(),
+    }
+
+
+def _parse_device(value: str | int) -> torch.device:
+    text = str(value)
+    if text.isdigit():
+        return torch.device("cuda", int(text))
+    return torch.device(text)
+
+
+def _result_row(
+    *,
+    precision: str,
+    mode: str,
+    length: int,
+    phase: str,
+    iteration: int,
+    result: IterationResult | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "precision": precision,
+        "mode": mode,
+        "length": length,
+        "phase": phase,
+        "iteration": iteration,
+        "ok": result is not None and error is None,
+        "error": error,
+    }
+    if result is not None:
+        row.update(asdict(result))
+        return row
+    row.update(
+        {
+            "latency_s": math.nan,
+            "setup_s": math.nan,
+            "decode_or_concat_s": math.nan,
+            "waveform_samples": 0,
+            "waveform_duration_s": 0.0,
+            "rtf": math.inf,
+            "peak_allocated_mib": math.nan,
+            "peak_reserved_mib": math.nan,
+            "finite": False,
+            "nan_count": 0,
+            "inf_count": 0,
+            "clipping_ratio": math.nan,
+            "rms": math.nan,
+            "peak_abs": math.nan,
+            "mean": math.nan,
+        }
+    )
+    return row
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    device = _parse_device(args.device)
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+    token2wav_dir = str(args.token2wav_dir)
+    prompt_wav = str(args.prompt_wav)
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _install_torchaudio_soundfile_shim()
+    token2wav_cls = _load_token2wav_cls()
+    tokenizer = token2wav_cls(token2wav_dir, float16=args.float16, n_timesteps=args.n_timesteps)
+    max_len = max(args.lengths)
+    seed_tokens = _prepare_seed_tokens(tokenizer, prompt_wav, max_len)
+
+    rows: list[dict[str, Any]] = []
+    summaries: list[dict[str, Any]] = []
+    for length in args.lengths:
+        tokens = seed_tokens[:length]
+        precision = "float16" if args.float16 else "float32"
+        for mode in args.modes:
+            measure = _measure_one_shot if mode == "one_shot" else _measure_streaming
+            warmup_failures: list[str] = []
+            for warmup_iteration in range(args.warmup):
+                try:
+                    if mode == "one_shot":
+                        measure(tokenizer, tokens, prompt_wav, device)  # type: ignore[misc]
+                    else:
+                        measure(tokenizer, tokens, prompt_wav, device, args.chunk_size)  # type: ignore[misc]
+                except Exception as exc:  # noqa: BLE001 - benchmark should record failures
+                    error = f"CUDA OOM: {exc}" if isinstance(exc, torch.cuda.OutOfMemoryError) else repr(exc)
+                    warmup_failures.append(error)
+                    rows.append(
+                        _result_row(
+                            precision=precision,
+                            mode=mode,
+                            length=length,
+                            phase="warmup",
+                            iteration=warmup_iteration,
+                            error=error,
+                        )
+                    )
+                    if isinstance(exc, torch.cuda.OutOfMemoryError):
+                        _call_accelerator_or_cuda("empty_cache")
+                    break
+
+            measured: list[IterationResult] = []
+            failures: list[str] = []
+            if not warmup_failures:
+                for iteration in range(args.iters):
+                    try:
+                        if mode == "one_shot":
+                            result = measure(tokenizer, tokens, prompt_wav, device)  # type: ignore[misc]
+                        else:
+                            result = measure(tokenizer, tokens, prompt_wav, device, args.chunk_size)  # type: ignore[misc]
+                        measured.append(result)
+                        rows.append(
+                            _result_row(
+                                precision=precision,
+                                mode=mode,
+                                length=length,
+                                phase="measure",
+                                iteration=iteration,
+                                result=result,
+                            )
+                        )
+                    except torch.cuda.OutOfMemoryError as exc:
+                        error = f"CUDA OOM: {exc}"
+                        failures.append(error)
+                        rows.append(
+                            _result_row(
+                                precision=precision,
+                                mode=mode,
+                                length=length,
+                                phase="measure",
+                                iteration=iteration,
+                                error=error,
+                            )
+                        )
+                        _call_accelerator_or_cuda("empty_cache")
+                    except Exception as exc:  # noqa: BLE001 - benchmark should record failures
+                        error = repr(exc)
+                        failures.append(error)
+                        rows.append(
+                            _result_row(
+                                precision=precision,
+                                mode=mode,
+                                length=length,
+                                phase="measure",
+                                iteration=iteration,
+                                error=error,
+                            )
+                        )
+
+            summary = {
+                "precision": precision,
+                "mode": mode,
+                "length": length,
+                "warmup_failures": warmup_failures,
+                "failures": failures,
+                "successes": len(measured),
+                "requested_iterations": args.iters,
+                "chunk_size": args.chunk_size if mode == "streaming" else None,
+                "summary": _summarize(measured) if measured else None,
+            }
+            summaries.append(summary)
+            print(json.dumps(summary, sort_keys=True), flush=True)
+
+    result_payload = {
+        "environment": _environment(args.model_revision),
+        "args": {
+            "lengths": args.lengths,
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "chunk_size": args.chunk_size,
+            "n_timesteps": args.n_timesteps,
+            "float16": args.float16,
+            "modes": args.modes,
+            "token2wav_dir": token2wav_dir,
+            "prompt_wav": prompt_wav,
+            "device": str(device),
+        },
+        "summaries": summaries,
+    }
+    json_path = output_dir / f"token2wav_{'fp16' if args.float16 else 'fp32'}.json"
+    csv_path = output_dir / f"token2wav_{'fp16' if args.float16 else 'fp32'}.csv"
+    json_path.write_text(json.dumps(result_payload, indent=2, sort_keys=True), encoding="utf-8")
+    if rows:
+        with csv_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+    return result_payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--token2wav-dir", type=Path, required=True)
+    parser.add_argument("--prompt-wav", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("benchmarks/minicpmo/results"))
+    parser.add_argument("--lengths", type=int, nargs="+", default=list(DEFAULT_LENGTHS))
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--chunk-size", type=int, default=50)
+    parser.add_argument("--n-timesteps", type=int, default=10)
+    parser.add_argument("--device", default="0", help="CUDA index (e.g. 0) or torch device string (e.g. cuda:0).")
+    parser.add_argument("--float16", action="store_true")
+    parser.add_argument("--model-revision", default=None)
+    parser.add_argument("--modes", choices=("one_shot", "streaming"), nargs="+", default=["one_shot", "streaming"])
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/examples/online_serving/minicpmo/README.md
+++ b/examples/online_serving/minicpmo/README.md
@@ -17,14 +17,14 @@ pip install 'vllm-omni[minicpmo]'
 
 The deploy config auto-loads via `--omni`; the default
 `vllm_omni/deploy/minicpmo_4_5.yaml` targets a single-GPU layout (thinker
-and talker + t2w co-located on GPU 0).  For other hardware layouts pick
+talker, and Token2Wav co-located on GPU 0). For other hardware layouts pick
 one of the deploy variants below.
 
 | deploy config | GPUs | Notes |
 |---|---|---|
-| `minicpmo_4_5.yaml` (default) | 1 | Thinker and talker+t2w co-located on GPU0. |
-| `minicpmo_4_5_2gpu.yaml` | 2 | Thinker on GPU0, talker+t2w on GPU1. |
-| `minicpmo_4_5_3gpu.yaml` | 3 | Thinker 2-way TP on GPU0/1, talker+t2w share GPU2. |
+| `minicpmo_4_5.yaml` (default) | 1 | Thinker, Talker, and Token2Wav co-located on GPU0. |
+| `minicpmo_4_5_2gpu.yaml` | 2 | Thinker on GPU0; Talker and Token2Wav on GPU1. |
+| `minicpmo_4_5_3gpu.yaml` | 3 | Thinker 2-way TP on GPU0/1; Talker and Token2Wav on GPU2. |
 | `minicpmo_4_5_8x4090.yaml` | 8 | Full 8x4090 layout. |
 
 Default (single-GPU):
@@ -46,7 +46,8 @@ vllm serve openbmb/MiniCPM-o-4_5 --omni \
 
 ### Stage-based CLI (optional)
 
-Stage 0 (thinker + API) and stage 1 (talker) can run in separate processes:
+Stage 0 (thinker + API), stage 1 (talker), and stage 2 (Token2Wav) can run in
+separate processes:
 
 ```bash
 # Stage 0
@@ -57,6 +58,11 @@ CUDA_VISIBLE_DEVICES=0 vllm serve openbmb/MiniCPM-o-4_5 --omni \
 # Stage 1 (headless)
 CUDA_VISIBLE_DEVICES=1 vllm serve openbmb/MiniCPM-o-4_5 --omni \
     --trust-remote-code --stage-id 1 --headless \
+    --omni-master-address 127.0.0.1 --omni-master-port 26000
+
+# Stage 2 (headless)
+CUDA_VISIBLE_DEVICES=1 vllm serve openbmb/MiniCPM-o-4_5 --omni \
+    --trust-remote-code --stage-id 2 --headless \
     --omni-master-address 127.0.0.1 --omni-master-port 26000
 ```
 
@@ -150,9 +156,17 @@ root; nested `extra_body` is ignored. The OpenAI Python SDK may use
 
 ## Notes
 
+- TTS trigger: the MiniCPM-specific client and demo set
+  `chat_template_kwargs.use_tts_template=true`, which appends `<|tts_bos|>` to
+  the assistant prefix.
+- Uncheck **"Generate speech output (TTS)"** to get text-only responses
+  (faster).
 - Stage 1 is capped at `max_num_seqs: 1` in the deploy YAML (talker shares
   request-0 audio metadata).
-- Output audio is base64 WAV in `message.audio.data` (24 kHz mono).
+- Output audio is base64 WAV in `message.audio.data`, produced by the stage-2
+  Token2Wav stage at 24 kHz mono.
+- Video input is forwarded as a base64 `video_url` entry; the server needs
+  decord/torchvision to decode it.
 - Offline counterpart:
   [`examples/offline_inference/minicpmo/`](../../offline_inference/minicpmo/)
 - Recipe:

--- a/examples/online_serving/minicpmo/run_gradio_demo.sh
+++ b/examples/online_serving/minicpmo/run_gradio_demo.sh
@@ -3,7 +3,7 @@
 #
 # Prereq:
 #   Start a vllm-omni OpenAI server for MiniCPM-o 4.5 on :8099 (see the
-#   8x4090 stage config under vllm_omni/model_executor/stage_configs).
+#   deploy configs under vllm_omni/deploy/).
 set -e
 
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/core/sched/test_omni_scheduling_coordinator.py
+++ b/tests/core/sched/test_omni_scheduling_coordinator.py
@@ -114,6 +114,7 @@ class TestFullPayloadCoordinatorSelection(unittest.TestCase):
             ("CovoAudioForConditionalGeneration", "code2wav"),
             ("MiMoAudioModel", "code2wav"),
             ("Qwen3TTSCode2Wav", "code2wav"),
+            ("MiniCPMO45OmniForConditionalGeneration", "token2wav"),
             ("CosyVoice3Model", "cosyvoice3_code2wav"),
             ("IndexTTS2S2MelDecoder", "indextts2_s2mel_decoder"),
             ("DyninOmniForConditionalGeneration", "token2image"),

--- a/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
@@ -1,20 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for the MiniCPM-o 4.5 stage 0 -> stage 1 bridge.
+"""Unit tests for MiniCPM-o 4.5 stage processors.
 
-Covers ``vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.llm2tts``:
+Covers ``vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni``:
 
+  - ``llm2talker`` and the backward-compatible ``llm2tts`` alias
   - empty ``source_outputs`` raises
   - latent fallback to ``hidden_states`` when ``multimodal_output`` is empty
   - both inputs missing -> raises
-  - additional_information payload carries the keys the talker expects
-    (prompt_embeds, prompt_token_ids, llm_output_token_ids, llm_output_text)
+  - additional_information carries only the Talker token/hidden slice
   - dummy talker prompt ``[BOS, PAD, EOS] = [1, 0, 2]`` (single prefill step)
   - MiniCPM-o 4.5 TTS region detection on 151703 / 151704 tokens
   - MiniCPM-o 2.6 fallback detection on 151691 / 151692 when no 4.5 markers
   - No TTS markers present -> no ``tts_token_ids`` / ``tts_hidden_states`` keys
   - prompt arg is normalized to a list and ``multi_modal_data`` is gated by
     ``requires_multimodal_data``
+  - Talker -> Token2Wav token-only and full-payload handoff
 """
 
 from __future__ import annotations
@@ -24,7 +25,12 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import llm2tts
+from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import (
+    llm2talker,
+    llm2tts,
+    talker2token2wav_full_payload,
+    talker2token2wav_token_only,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -36,7 +42,6 @@ def _make_thinker_output(
     *,
     prompt_token_ids: list[int],
     output_token_ids: list[int],
-    text: str = "",
     request_id: str = "req-0",
     latent: torch.Tensor | None = None,
     hidden_states: torch.Tensor | None = None,
@@ -46,12 +51,11 @@ def _make_thinker_output(
     The real ``llm2tts`` only reads a tight slice of fields:
       - top-level: ``request_id``, ``prompt_token_ids``, ``outputs[0]``
       - per-output: ``multimodal_output`` (dict), ``hidden_states`` (opt),
-        ``text``, ``token_ids``
+        ``token_ids``
     """
     output = SimpleNamespace(
         multimodal_output={"latent": latent} if latent is not None else {},
         token_ids=output_token_ids,
-        text=text,
     )
     if hidden_states is not None:
         output.hidden_states = hidden_states
@@ -62,7 +66,29 @@ def _make_thinker_output(
     )
 
 
+def _make_talker_output(
+    audio: torch.Tensor | None,
+    *,
+    request_id: str = "req-0",
+    finished: bool = True,
+):
+    output = SimpleNamespace(
+        multimodal_output={"codes": {"audio": audio}} if audio is not None else {},
+        cumulative_token_ids=[],
+        token_ids=[],
+    )
+    return SimpleNamespace(
+        request_id=request_id,
+        prompt_token_ids=[0],
+        outputs=[output],
+        finished=finished,
+    )
+
+
 class TestInputValidation:
+    def test_llm2tts_alias_points_to_llm2talker(self) -> None:
+        assert llm2tts is llm2talker
+
     def test_empty_source_outputs_raises(self) -> None:
         with pytest.raises(ValueError, match="source_outputs cannot be empty"):
             llm2tts([], prompt=None)
@@ -100,37 +126,12 @@ class TestBasicShape:
         # this is the agreed [BOS, PAD, EOS] minimal payload.
         assert out[0]["prompt_token_ids"] == [1, 0, 2]
 
-    def test_additional_information_carries_thinker_outputs(self) -> None:
-        prompt_ids = [10, 11, 12]
-        out_ids = [20, 21]
-        hidden = torch.randn(len(prompt_ids) + len(out_ids), _HIDDEN_DIM)
-
-        result = llm2tts(
-            [
-                _make_thinker_output(
-                    prompt_token_ids=prompt_ids,
-                    output_token_ids=out_ids,
-                    text="hello",
-                    hidden_states=hidden,
-                )
-            ],
-            prompt=None,
-        )
-        ai = result[0]["additional_information"]
-        assert ai["prompt_token_ids"] == prompt_ids
-        assert ai["llm_output_token_ids"] == out_ids
-        assert ai["llm_output_text"] == ["hello"]
-        # prompt_embeds = float32 view of the prompt-portion of hidden states.
-        assert ai["prompt_embeds"].dtype == torch.float32
-        assert ai["prompt_embeds"].shape == (len(prompt_ids), _HIDDEN_DIM)
-        assert torch.equal(ai["prompt_embeds"], hidden[: len(prompt_ids)].to(torch.float32))
-
     def test_latent_in_multimodal_output_takes_precedence(self) -> None:
         # When both ``multimodal_output["latent"]`` and ``hidden_states`` are
         # present, the latent payload must win (this is the steady-state path
         # produced by the thinker stage).
         prompt_ids = [10, 11]
-        out_ids = [20]
+        out_ids = [151703, 30, 151704]
         latent = torch.ones((len(prompt_ids) + len(out_ids), _HIDDEN_DIM))
         hidden = torch.zeros_like(latent)
 
@@ -147,7 +148,7 @@ class TestBasicShape:
         )
         ai = result[0]["additional_information"]
         # latent (ones) won over hidden_states (zeros)
-        assert torch.equal(ai["prompt_embeds"], latent[: len(prompt_ids)].to(torch.float32))
+        assert torch.equal(ai["tts_hidden_states"], latent[3:4].to(torch.float32))
 
 
 class TestTtsRegionDetection:
@@ -262,3 +263,43 @@ class TestPromptAndMultiModal:
             streaming_context=object(),
         )
         assert len(out) == 1
+
+
+class TestTalkerToToken2Wav:
+    def test_token_only_sizes_prompt_from_audio_codes(self) -> None:
+        out = talker2token2wav_token_only([_make_talker_output(torch.tensor([10, 11, 12]))])
+        assert len(out) == 1
+        assert out[0]["prompt_token_ids"] == [0, 0, 0]
+        assert out[0]["additional_information"] is None
+
+    def test_token_only_empty_audio_keeps_one_placeholder(self) -> None:
+        out = talker2token2wav_token_only([_make_talker_output(torch.empty(0, dtype=torch.long))])
+        assert len(out) == 1
+        assert out[0]["prompt_token_ids"] == [0]
+
+    def test_token_only_skips_unfinished_output(self) -> None:
+        assert talker2token2wav_token_only([_make_talker_output(torch.tensor([1]), finished=False)]) == []
+
+    def test_full_payload_valid_codes(self) -> None:
+        pooling_output = {"codes.audio": torch.tensor([101, 102, 103])}
+        request = SimpleNamespace(request_id="req-a")
+        payload = talker2token2wav_full_payload(None, pooling_output, request)
+        assert payload["codes"]["audio"].tolist() == [101, 102, 103]
+        assert payload["codes"]["audio"].dtype == torch.long
+        assert payload["meta"]["finished"].item() is True
+        assert payload["meta"]["code_flat_numel"] == 3
+        assert payload["meta"]["next_stage_prompt_len"] == 3
+
+    def test_full_payload_nested_codes(self) -> None:
+        pooling_output = {"codes": {"audio": [7, 8]}}
+        payload = talker2token2wav_full_payload(None, pooling_output, SimpleNamespace(request_id="req-b"))
+        assert payload["codes"]["audio"].tolist() == [7, 8]
+        assert payload["meta"]["next_stage_prompt_len"] == 2
+
+    def test_full_payload_missing_codes_returns_empty_finished_payload(self, caplog) -> None:
+        payload = talker2token2wav_full_payload(None, {"other": torch.tensor([1])}, SimpleNamespace(request_id="req-c"))
+        assert payload["codes"]["audio"].numel() == 0
+        assert payload["meta"]["finished"].item() is True
+        assert payload["meta"]["code_flat_numel"] == 0
+        assert payload["meta"]["next_stage_prompt_len"] == 1
+        assert "missing codes.audio" in caplog.text

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -90,8 +90,7 @@ class TestPipelineTopology:
             "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.llm2talker"
         )
         assert talker.custom_process_next_stage_input_func == (
-            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
-            "talker2token2wav_full_payload"
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.talker2token2wav_full_payload"
         )
 
     def test_token2wav_stage(self, pipeline: PipelineConfig) -> None:
@@ -105,8 +104,7 @@ class TestPipelineTopology:
         assert token2wav.engine_output_type == "audio"
         assert token2wav.hf_config_name == "tts_config"
         assert token2wav.sync_process_input_func == (
-            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
-            "talker2token2wav_token_only"
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.talker2token2wav_token_only"
         )
 
 

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -5,8 +5,9 @@
 Covers:
   - pipeline declared in the central registry
   - lazy loader returns the expected ``PipelineConfig``
-  - 2-stage topology (thinker LLM_AR + talker LLM_AR with audio output)
-  - stage 1 routes through ``llm2tts`` custom input processor
+  - 3-stage topology (thinker LLM_AR + talker LLM_AR + token2wav generation)
+  - stage 1 routes through ``llm2talker`` and emits ``codes.audio``
+  - stage 2 consumes the full-payload codec tensor and emits audio
   - ``hf_architectures`` covers both the shared ``MiniCPMO`` alias and the
     explicit 4.5 arch
   - ``hf_config_predicate`` selects MiniCPM-o 4.5 only and rejects 2.6
@@ -35,9 +36,6 @@ class TestRegistryDeclaration:
     def test_declared_in_omni_pipelines(self) -> None:
         assert _PIPELINE_KEY in OMNI_PIPELINES
 
-    def test_visible_in_central_registry(self) -> None:
-        assert _PIPELINE_KEY in OMNI_PIPELINES
-
     def test_lazy_load_returns_pipeline_config(self) -> None:
         pipeline = OMNI_PIPELINES[_PIPELINE_KEY]
         assert isinstance(pipeline, PipelineConfig)
@@ -50,9 +48,9 @@ class TestPipelineTopology:
     def pipeline(self) -> PipelineConfig:
         return OMNI_PIPELINES[_PIPELINE_KEY]
 
-    def test_two_stages(self, pipeline: PipelineConfig) -> None:
-        assert len(pipeline.stages) == 2
-        assert [s.stage_id for s in pipeline.stages] == [0, 1]
+    def test_three_stages(self, pipeline: PipelineConfig) -> None:
+        assert len(pipeline.stages) == 3
+        assert [s.stage_id for s in pipeline.stages] == [0, 1, 2]
 
     def test_topology_validates(self, pipeline: PipelineConfig) -> None:
         # ``validate`` returns a list of structural errors; empty == valid.
@@ -72,24 +70,43 @@ class TestPipelineTopology:
     def test_talker_stage(self, pipeline: PipelineConfig) -> None:
         talker = pipeline.get_stage(1)
         assert talker is not None
-        assert talker.model_stage == "tts"
+        assert talker.model_stage == "talker"
         assert talker.execution_type == StageExecutionType.LLM_AR
         # talker consumes thinker output
         assert talker.input_sources == (0,)
-        assert talker.final_output is True
-        assert talker.final_output_type == "audio"
-        assert talker.engine_output_type == "audio"
+        assert talker.final_output is False
+        assert talker.final_output_type is None
+        assert talker.engine_output_type == "latent"
         # scope KV cache / mrope sizing to talker sub-config
         assert talker.hf_config_name == "tts_config"
 
-    def test_talker_routes_through_llm2tts(self, pipeline: PipelineConfig) -> None:
+    def test_talker_routes_through_llm2talker(self, pipeline: PipelineConfig) -> None:
         talker = pipeline.get_stage(1)
         assert talker is not None
         # stage 1's custom_process_input_func is what bridges thinker
         # hidden_states + token ids into the talker; if this drifts the
         # talker silently goes through the dummy path.
         assert talker.custom_process_input_func == (
-            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.llm2tts"
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.llm2talker"
+        )
+        assert talker.custom_process_next_stage_input_func == (
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
+            "talker2token2wav_full_payload"
+        )
+
+    def test_token2wav_stage(self, pipeline: PipelineConfig) -> None:
+        token2wav = pipeline.get_stage(2)
+        assert token2wav is not None
+        assert token2wav.model_stage == "token2wav"
+        assert token2wav.execution_type == StageExecutionType.LLM_GENERATION
+        assert token2wav.input_sources == (1,)
+        assert token2wav.final_output is True
+        assert token2wav.final_output_type == "audio"
+        assert token2wav.engine_output_type == "audio"
+        assert token2wav.hf_config_name == "tts_config"
+        assert token2wav.sync_process_input_func == (
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
+            "talker2token2wav_token_only"
         )
 
 

--- a/tests/model_executor/models/minicpmo_4_5/test_tts_stage_split.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_tts_stage_split.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MiniCPM-o 4.5 Talker / Token2Wav split."""
+
+from __future__ import annotations
+
+import io
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+import torch.nn as nn
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
+    MiniCPMO45OmniForConditionalGeneration,
+)
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts import (
+    MiniCPMO45OmniTTSForConditionalGeneration,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _bare_model(stage: str = "talker", model_path: str = "/tmp/minicpmo") -> MiniCPMO45OmniTTSForConditionalGeneration:
+    model = MiniCPMO45OmniTTSForConditionalGeneration.__new__(MiniCPMO45OmniTTSForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.model_stage = stage
+    model.vllm_config = SimpleNamespace(model_config=SimpleNamespace(model=model_path))
+    model.audio_tokenizer = None
+    model._hidden_size = 4
+    return model
+
+
+def _bare_wrapper(stage: str = "talker") -> MiniCPMO45OmniForConditionalGeneration:
+    model = MiniCPMO45OmniForConditionalGeneration.__new__(MiniCPMO45OmniForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.model_stage = stage
+    model.config = SimpleNamespace(hidden_size=4)
+    return model
+
+
+class _FakeMiniCPMTTS(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(
+            text_eos_token_id=9,
+            num_audio_tokens=20,
+            hidden_size=4,
+            normalize_projected_hidden=False,
+        )
+        self.audio_bos_token_id = 8
+        self.emb_text = nn.Embedding(32, 4)
+        self.projector_semantic = nn.Linear(4, 4, bias=False)
+        self.last_generate_kwargs = None
+
+    def generate(self, **kwargs):
+        self.last_generate_kwargs = kwargs
+        return SimpleNamespace(new_ids=torch.tensor([[[5], [6], [7]]], dtype=torch.long))
+
+
+def _wav_bytes(samples: np.ndarray | None = None, sample_rate: int = 24_000) -> bytes:
+    if samples is None:
+        samples = np.zeros(240, dtype=np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, samples, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+def test_prepare_tts_inputs_and_generate_audio_tokens() -> None:
+    model = _bare_model("talker")
+    fake_tts = _FakeMiniCPMTTS().to(dtype=torch.bfloat16)
+    model.tts_obj = fake_tts
+    model._lazy_init_talker = lambda: None
+
+    tts_token_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+    tts_hidden_states = torch.ones(3, 4)
+
+    inputs_embeds, eos_token, max_new_token, num_text = model.prepare_tts_inputs(tts_token_ids, tts_hidden_states)
+    assert inputs_embeds.shape == (1, 5, 4)
+    assert eos_token.tolist() == [19]
+    assert max_new_token == 2048
+    assert num_text == 3
+
+    audio_tokens = model.generate_audio_tokens(tts_token_ids, tts_hidden_states)
+    assert audio_tokens.tolist() == [5, 6, 7]
+    assert fake_tts.last_generate_kwargs["max_new_token"] == 2048
+
+
+def test_decode_audio_tokens_uses_token2wav(monkeypatch, tmp_path) -> None:
+    model = _bare_model("token2wav", str(tmp_path))
+    model._lazy_init_token2wav = lambda: None
+    monkeypatch.setitem(sys.modules, "torchaudio", types.SimpleNamespace(save=lambda *args, **kwargs: None))
+
+    calls: list[tuple[list[int], str | None]] = []
+
+    def fake_tokenizer(tokens, prompt_wav_path):
+        calls.append((list(tokens), prompt_wav_path))
+        return _wav_bytes(np.linspace(-0.1, 0.1, 120, dtype=np.float32))
+
+    model.audio_tokenizer = fake_tokenizer
+    waveform = model.decode_audio_tokens(torch.tensor([1, 2, 3]))
+
+    assert calls == [([1, 2, 3], None)]
+    assert waveform.dtype == np.float32
+    assert waveform.shape == (120,)
+    assert np.isfinite(waveform).all()
+
+
+def test_decode_audio_tokens_fails_fast_without_tokenizer() -> None:
+    model = _bare_model("token2wav")
+    model._lazy_init_token2wav = lambda: None
+    model.audio_tokenizer = None
+
+    with pytest.raises(RuntimeError, match="Token2Wav is not initialized"):
+        model.decode_audio_tokens(torch.tensor([1], dtype=torch.long))
+
+
+def test_token2wav_forward_empty_finished_payload_returns_empty_waveform() -> None:
+    model = _bare_model("token2wav")
+    output = model.forward(
+        input_ids=torch.tensor([0], dtype=torch.long),
+        additional_information={
+            "codes": {"audio": torch.empty(0, dtype=torch.long)},
+            "meta": {"code_flat_numel": 0},
+        },
+    )
+
+    assert isinstance(output, torch.Tensor)
+    assert output.dtype == torch.float32
+    assert output.numel() == 0
+
+
+def test_token2wav_forward_missing_payload_ignores_placeholder_tokens() -> None:
+    model = _bare_model("token2wav")
+    model.decode_audio_tokens = lambda _codes: pytest.fail("placeholder input_ids must not be decoded")
+
+    output = model.forward(input_ids=torch.tensor([1, 2, 3], dtype=torch.long))
+
+    assert isinstance(output, torch.Tensor)
+    assert output.dtype == torch.float32
+    assert output.numel() == 0
+
+
+def test_wrapper_talker_missing_runtime_payload_returns_dummy_hidden() -> None:
+    model = _bare_wrapper("talker")
+    output = model.forward(
+        input_ids=torch.tensor([1, 2], dtype=torch.long),
+        positions=torch.tensor([0, 1], dtype=torch.long),
+        runtime_additional_information=[{}],
+    )
+
+    assert output.text_hidden_states.shape == (2, 4)
+    assert output.multimodal_outputs is None
+
+
+def test_wrapper_token2wav_load_weights_does_not_scan_checkpoint() -> None:
+    model = _bare_wrapper("token2wav")
+
+    class FakeToken2Wav:
+        def load_weights(self, weights):
+            assert weights == []
+            return {"assets"}
+
+    class NoIterCheckpoint:
+        def __iter__(self):
+            raise AssertionError("token2wav stage must not iterate HF checkpoint weights")
+
+    model.token2wav = FakeToken2Wav()
+
+    assert model.load_weights(NoIterCheckpoint()) == {"token2wav.assets"}
+
+
+def test_token2wav_forward_non_empty_decode_cannot_silently_return_empty() -> None:
+    model = _bare_model("token2wav")
+    model.decode_audio_tokens = lambda _codes: np.asarray([], dtype=np.float32)
+
+    with pytest.raises(RuntimeError, match="decoded empty audio"):
+        model.forward(
+            input_ids=torch.tensor([0, 0], dtype=torch.long),
+            additional_information={"codes": {"audio": torch.tensor([1, 2], dtype=torch.long)}},
+        )
+
+
+def test_package_waveform() -> None:
+    waveform = MiniCPMO45OmniTTSForConditionalGeneration.package_waveform(np.asarray([0.25, -0.25]))
+    assert isinstance(waveform, torch.Tensor)
+    assert waveform.dtype == torch.float32
+    assert waveform.tolist() == [0.25, -0.25]

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -565,6 +565,33 @@ def test_accumulate_full_payload_output_keeps_all_zero_qwen3_omni_prefill_placeh
     assert torch.equal(stored["codes.audio"], codes)
 
 
+def test_accumulate_full_payload_output_replaces_1d_minicpmo_audio_codes():
+    runner = _make_full_payload_accumulation_runner(
+        model_arch="MiniCPMO45OmniForConditionalGeneration",
+        custom_process_next_stage_input_func=(
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
+            "talker2token2wav_full_payload"
+        ),
+    )
+    request = SimpleNamespace(output_token_ids=[10, 11, 12])
+
+    OmniConnectorModelRunnerMixin.accumulate_full_payload_output(
+        runner,
+        "r1",
+        {"codes.audio": torch.tensor([10, 11], dtype=torch.long)},
+        request,
+    )
+    OmniConnectorModelRunnerMixin.accumulate_full_payload_output(
+        runner,
+        "r1",
+        {"codes.audio": torch.tensor([10, 11, 12], dtype=torch.long)},
+        request,
+    )
+
+    stored, _ = OmniConnectorModelRunnerMixin._materialize_full_payload_entry(runner._pending_full_payload_send["r1"])
+    assert stored["codes.audio"].tolist() == [10, 11, 12]
+
+
 def test_full_payload_output_accumulation_hook_matrix():
     """Producer-side gate: fires iff an explicit next-stage payload hook is loaded.
 

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -569,8 +569,7 @@ def test_accumulate_full_payload_output_replaces_1d_minicpmo_audio_codes():
     runner = _make_full_payload_accumulation_runner(
         model_arch="MiniCPMO45OmniForConditionalGeneration",
         custom_process_next_stage_input_func=(
-            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni."
-            "talker2token2wav_full_payload"
+            "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.talker2token2wav_full_payload"
         ),
     )
     request = SimpleNamespace(output_token_ids=[10, 11, 12])

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -49,6 +49,8 @@ _FULL_PAYLOAD_INPUT_STAGES: frozenset[tuple[str, str]] = frozenset(
         # qwen3_tts: Qwen3TTSTalkerForConditionalGeneration (Stage 0)
         # -> Qwen3TTSCode2Wav (Stage 1).  Stage 1 is the consumer.
         ("Qwen3TTSCode2Wav", "code2wav"),
+        # MiniCPM-o 4.5: talker (Stage 1) -> token2wav (Stage 2).
+        ("MiniCPMO45OmniForConditionalGeneration", "token2wav"),
         # cosyvoice3: cosyvoice3_talker (Stage 0) -> cosyvoice3_code2wav (Stage 1).
         ("CosyVoice3Model", "cosyvoice3_code2wav"),
         # indextts2: indextts2_talker (Stage 0) -> indextts2_s2mel_decoder

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -1,15 +1,24 @@
 # MiniCPM-o 4.5 default deploy: single-GPU layout.
 #
-# Both stages are co-located on GPU 0:
+# All stages are co-located on GPU 0:
 #   Stage 0 (thinker): multimodal understanding, ~80% mem.
-#   Stage 1 (talker) : MiniCPMTTS + in-process Token2Wav vocoder, ~10% mem
-#                      (talker LM plus the vocoder that emits the waveform).
+#   Stage 1 (talker): MiniCPMTTS audio-token generation, ~5% mem.
+#   Stage 2 (token2wav): Token2Wav final waveform decode, ~5% mem.
 #
-# Other GPU layouts: minicpmo_4_5_3gpu.yaml, minicpmo_4_5_8x4090.yaml.
+# Other GPU layouts: minicpmo_4_5_2gpu.yaml, minicpmo_4_5_3gpu.yaml,
+# minicpmo_4_5_8x4090.yaml.
 async_chunk: false
 
 trust_remote_code: true
 enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
 
 stages:
   - stage_id: 0
@@ -34,15 +43,35 @@ stages:
     # Talker only consumes runtime_additional_information[0]; any value > 1
     # makes concurrent requests share request-0's audio (mm_outputs fallback).
     max_num_seqs: 1
-    gpu_memory_utilization: 0.1
+    gpu_memory_utilization: 0.05
     enforce_eager: false
     max_num_batched_tokens: 8192
     devices: "0"
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
       top_k: -1
       max_tokens: 1
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.05
+    enforce_eager: false
+    async_scheduling: false
+    max_model_len: 16384
+    max_num_batched_tokens: 16384
+    devices: "0"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 16384
       seed: 42
       detokenize: false
 
@@ -55,5 +84,9 @@ platforms:
           cudagraph_mode: PIECEWISE
       - stage_id: 1
         max_num_batched_tokens: 8192
+        compilation_config:
+          cudagraph_mode: PIECEWISE
+      - stage_id: 2
+        max_num_batched_tokens: 16384
         compilation_config:
           cudagraph_mode: PIECEWISE

--- a/vllm_omni/deploy/minicpmo_4_5_2gpu.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_2gpu.yaml
@@ -1,13 +1,17 @@
 # MiniCPM-o 4.5 deploy: 2-GPU layout (thinker on GPU 0, talker on GPU 1).
 #
-# Stage 0 (thinker): GPU 0 — multimodal understanding, ~90% mem (thinker
+# Stage 0 (thinker): GPU 0 — multimodal understanding, ~95% mem (thinker
 #                            gets a dedicated card, so it can take more of
 #                            the GPU than the single-GPU co-located layout).
-# Stage 1 (talker) : GPU 1 — MiniCPMTTS + Token2Wav, ~75% mem
-#                            (covers both the talker LM and the in-process
-#                            Token2Wav vocoder that emits the waveform).
+# Stage 1 (talker) : GPU 1 — MiniCPMTTS audio-token generation, ~40% mem.
+# Stage 2 (token2wav): GPU 1 — Token2Wav final waveform decode, ~35% mem.
 #
-# Use this when you have two GPUs and want the talker + Token2Wav vocoder
+# Keep the single-TP thinker at a 4096-token serving ceiling on 32GB-class
+# cards: the upstream 40k context OOMs during multimodal profiling before the
+# server can accept the first request. The existing stage-0 concurrency is
+# preserved; Stage 1 remains single-seq until Talker batching is fixed.
+#
+# Use this when you have two GPUs and want Talker + Token2Wav
 # on its own card instead of sharing GPU 0 with the thinker (the default
 # single-GPU layout co-locates both and can OOM under load).
 pipeline: minicpmo_4_5
@@ -16,13 +20,22 @@ async_chunk: false
 trust_remote_code: true
 enable_prefix_caching: false
 
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+
 stages:
   - stage_id: 0
     max_num_seqs: 16
-    gpu_memory_utilization: 0.9
+    gpu_memory_utilization: 0.95
     enforce_eager: false
     tensor_parallel_size: 1
-    max_num_batched_tokens: 16384
+    max_model_len: 4096
+    max_num_batched_tokens: 4096
     devices: "0"
     limit_mm_per_prompt:
       video: 1
@@ -39,15 +52,36 @@ stages:
     # Talker only consumes runtime_additional_information[0]; any value > 1
     # makes concurrent requests share request-0's audio (mm_outputs fallback).
     max_num_seqs: 1
-    gpu_memory_utilization: 0.75
+    gpu_memory_utilization: 0.4
     enforce_eager: false
-    max_num_batched_tokens: 8192
+    max_model_len: 4096
+    max_num_batched_tokens: 4096
     devices: "1"
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
       top_k: -1
       max_tokens: 1
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.35
+    enforce_eager: false
+    async_scheduling: false
+    max_model_len: 4096
+    max_num_batched_tokens: 4096
+    devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 16384
       seed: 42
       detokenize: false
 
@@ -59,6 +93,10 @@ platforms:
         compilation_config:
           cudagraph_mode: PIECEWISE
       - stage_id: 1
-        max_num_batched_tokens: 8192
+        max_num_batched_tokens: 4096
+        compilation_config:
+          cudagraph_mode: PIECEWISE
+      - stage_id: 2
+        max_num_batched_tokens: 4096
         compilation_config:
           cudagraph_mode: PIECEWISE

--- a/vllm_omni/deploy/minicpmo_4_5_3gpu.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_3gpu.yaml
@@ -1,14 +1,21 @@
 # MiniCPM-o 4.5 deploy: 3-GPU layout (thinker TP=2 + talker on GPU 2).
 #
 # Stage 0 (thinker): GPU 0,1 — 2-way tensor parallel, ~70% mem each.
-# Stage 1 (talker) : GPU 2   — MiniCPMTTS + Token2Wav, ~75% mem
-#                              (covers both the talker LM and the in-process
-#                              Token2Wav vocoder that emits the waveform).
+# Stage 1 (talker) : GPU 2   — MiniCPMTTS audio-token generation, ~40% mem.
+# Stage 2 (token2wav): GPU 2 — Token2Wav final waveform decode, ~35% mem.
 pipeline: minicpmo_4_5
 async_chunk: false
 
 trust_remote_code: true
 enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
 
 stages:
   - stage_id: 0
@@ -33,15 +40,35 @@ stages:
     # Talker only consumes runtime_additional_information[0]; any value > 1
     # makes concurrent requests share request-0's audio (mm_outputs fallback).
     max_num_seqs: 1
-    gpu_memory_utilization: 0.75
+    gpu_memory_utilization: 0.4
     enforce_eager: false
     max_num_batched_tokens: 8192
     devices: "2"
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
       top_k: -1
       max_tokens: 1
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.35
+    enforce_eager: false
+    async_scheduling: false
+    max_model_len: 16384
+    max_num_batched_tokens: 16384
+    devices: "2"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 16384
       seed: 42
       detokenize: false
 

--- a/vllm_omni/deploy/minicpmo_4_5_8x4090.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_8x4090.yaml
@@ -4,10 +4,8 @@
 #                                  thinker weights take ~17.5 GB per card
 #                                  on 4090, leaving ~3 GB for KV cache /
 #                                  activations).
-# Stage 1 (talker) : GPU 4       — MiniCPMTTS + Token2Wav, ~90% mem
-#                                  (covers both the talker LM and the
-#                                  in-process Token2Wav vocoder that emits
-#                                  the waveform).
+# Stage 1 (talker) : GPU 4       — MiniCPMTTS audio-token generation, ~55% mem.
+# Stage 2 (token2wav): GPU 4     — Token2Wav final waveform decode, ~35% mem.
 #
 # max_model_len is pinned to 4096 because the upstream config.json
 # advertises max_position_embeddings=40960 (tuned for H20 141GB); on a
@@ -20,6 +18,14 @@ async_chunk: false
 
 trust_remote_code: true
 enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
 
 stages:
   - stage_id: 0
@@ -45,15 +51,35 @@ stages:
     # Talker only consumes runtime_additional_information[0]; any value > 1
     # makes concurrent requests share request-0's audio (mm_outputs fallback).
     max_num_seqs: 1
-    gpu_memory_utilization: 0.9
+    gpu_memory_utilization: 0.55
     enforce_eager: true
     max_num_batched_tokens: 8192
     devices: "4"
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0
       top_k: -1
       max_tokens: 1
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.35
+    enforce_eager: true
+    async_scheduling: false
+    max_model_len: 16384
+    max_num_batched_tokens: 16384
+    devices: "4"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 16384
       seed: 42
       detokenize: false
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -52,11 +52,13 @@ logger = init_logger(__name__)
 class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP, SupportsMRoPE):
     """MiniCPM-o 4.5 Omni model for conditional generation.
 
-    Two-stage pipeline:
+    Three-stage pipeline:
     - thinker (model_stage="llm"): image / video / audio encoders + 3D
       resampler + the omni LLM that emits text + hidden states.
-    - talker  (model_stage="tts"): MiniCPMTTS + the in-process Token2Wav
-      vocoder that emits the final audio waveform directly.
+    - talker  (model_stage in {"talker", "tts"}): MiniCPMTTS generates
+      discrete audio tokens.
+    - token2wav (model_stage="token2wav"): Token2Wav decodes audio tokens
+      into the final waveform.
     """
 
     @classmethod
@@ -74,49 +76,60 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         self.have_multimodal_outputs = True
         config: MiniCPMOConfig = vllm_config.model_config.hf_config
         multimodal_config = vllm_config.model_config.multimodal_config
-        # keep vllm_config for later submodule init
         self.vllm_config = vllm_config
-
-        # Store configs
         self.config = config
         self.multimodal_config = multimodal_config
 
         self.model_stage = vllm_config.model_config.model_stage
 
         if self.model_stage == "llm":
-            # Initialize thinker model (image preprocessing + vision encoder + 3D resampler)
             self.thinker = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 prefix=maybe_prefix(prefix, "thinker"),
                 hf_config=config,
-                # Registry key — must match the entries declared in
-                # vllm_omni/model_executor/models/registry.py::_OMNI_MODELS.
                 architectures=["MiniCPMO45OmniLLMForConditionalGeneration"],
             )
             self.model = self.thinker
             self.talker = None
+            self.token2wav = None
 
-        elif self.model_stage == "tts":
+        elif self.model_stage in {"tts", "talker"}:
+            if multimodal_config is not None:
+                multimodal_config.skip_mm_profiling = True
+            self.omni_pooler_payload_include_hidden = False
             self.thinker = None
-            # Initialize talker model — runs MiniCPMTTS + the in-process
-            # Token2Wav vocoder and emits the final audio waveform directly.
+            self.token2wav = None
+            # ``tts`` remains a compatibility alias for older deploy configs.
             self.talker = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 prefix=maybe_prefix(prefix, "talker"),
                 hf_config=config,
-                # Registry key — must match the entries declared in
-                # vllm_omni/model_executor/models/registry.py::_OMNI_MODELS.
                 architectures=["MiniCPMO45OmniTTSForConditionalGeneration"],
             )
-            # Initialize multimodal components if needed
             if hasattr(self.talker, "init_multi_modal"):
                 self.talker.init_multi_modal(config)
             self.model = self.talker
 
-        else:
-            raise ValueError(f"Invalid model stage: {self.model_stage}. Must be one of: 'llm', 'tts'")
+        elif self.model_stage == "token2wav":
+            if multimodal_config is not None:
+                multimodal_config.skip_mm_profiling = True
+            self.enable_update_additional_information = True
+            self.requires_raw_input_tokens = True
+            self.thinker = None
+            self.talker = None
+            self.token2wav = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "token2wav"),
+                hf_config=config,
+                architectures=["MiniCPMO45OmniTTSForConditionalGeneration"],
+            )
+            self.model = self.token2wav
 
-        # Set up intermediate tensors
+        else:
+            raise ValueError(
+                f"Invalid model stage: {self.model_stage}. Must be one of: 'llm', 'talker', 'tts', 'token2wav'"
+            )
+
         self.make_empty_intermediate_tensors = (
             (self.thinker.make_empty_intermediate_tensors)
             if self.model_stage == "llm" and self.thinker is not None
@@ -149,19 +162,23 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         *,
         thinker_device: str | torch.device | None = None,
         talker_device: str | torch.device | None = None,
+        token2wav_device: str | torch.device | None = None,
     ) -> None:
-        """Optionally move thinker / talker to different devices.
+        """Optionally move the active stage modules to explicit devices.
 
         Example:
             model.move_submodules_to_devices(
                 thinker_device='cuda:0',
                 talker_device='cuda:1',
+                token2wav_device='cuda:1',
             )
         """
         if thinker_device is not None and self.thinker is not None:
             self.thinker.to(thinker_device)
         if talker_device is not None and self.talker is not None:
             self.talker.to(talker_device)
+        if token2wav_device is not None and self.token2wav is not None:
+            self.token2wav.to(token2wav_device)
 
     def get_input_embeddings(
         self,
@@ -177,7 +194,7 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         *,
         is_multimodal=None,
     ) -> torch.Tensor:
-        if self.model_stage == "tts":
+        if self.model_stage in {"tts", "talker", "token2wav"}:
             return self.get_input_embeddings(input_ids)
         return super().embed_input_ids(input_ids, multimodal_embeddings, is_multimodal=is_multimodal)
 
@@ -210,8 +227,8 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         Workflow:
         1) Thinker (model_stage="llm"): Image / video / audio encoders +
            3D resampler + omni LLM → text + hidden states.
-        2) Talker (model_stage="tts"): MiniCPMTTS + the in-process
-           Token2Wav vocoder → audio waveform (final pipeline output).
+        2) Talker (model_stage in {"talker", "tts"}): MiniCPMTTS → audio tokens.
+        3) Token2Wav (model_stage="token2wav"): audio tokens → final waveform.
         """
         if self.model_stage == "llm":
             # Normalize to batched inputs if caller provides 1D/2D unbatched tensors
@@ -280,9 +297,8 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
                 multimodal_outputs={"latent": text_hidden_states},
             )
 
-        # Talker stage: runs MiniCPMTTS + the in-process Token2Wav vocoder and
-        # emits the final audio waveform directly.
-        if self.model_stage == "tts":
+        # Talker stage: runs MiniCPMTTS and emits audio tokens only.
+        if self.model_stage in {"tts", "talker"}:
             if input_ids is not None:
                 num_tokens = input_ids.shape[0]
                 device = input_ids.device
@@ -293,12 +309,12 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
                 num_tokens = 1
                 device = current_omni_platform.get_torch_device()
             hidden_dim = self.config.hidden_size if hasattr(self.config, "hidden_size") else 2560
+            dummy_hidden = torch.zeros(num_tokens, hidden_dim, device=device)
 
             # Profile/dummy run: both input_ids and inputs_embeds are None.
             # Note: SupportsMultiModal preprocessing converts input_ids to
             # inputs_embeds, so input_ids=None alone does NOT indicate a dummy run.
             if input_ids is None and inputs_embeds is None:
-                dummy_hidden = torch.zeros(num_tokens, hidden_dim, device=device)
                 return OmniOutput(text_hidden_states=dummy_hidden, multimodal_outputs=None)
 
             runtime_info = kwargs.get("runtime_additional_information")
@@ -306,39 +322,52 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             if runtime_info and isinstance(runtime_info, list) and len(runtime_info) > 0:
                 talker_info = runtime_info[0] if isinstance(runtime_info[0], dict) else {}
 
+            if talker_info.get("tts_token_ids") is None or talker_info.get("tts_hidden_states") is None:
+                return OmniOutput(text_hidden_states=dummy_hidden, multimodal_outputs=None)
+
             with torch.inference_mode():
-                talker_result = self.talker(
+                audio_tokens = self.talker(
                     input_ids=input_ids,
                     positions=positions,
                     inputs_embeds=inputs_embeds,
                     additional_information=talker_info,
                 )
 
-            dummy_hidden = torch.zeros(num_tokens, hidden_dim, device=device)
-
-            # Talker returns a (mel_spec, waveform_or_None) tuple. MiniCPM-o
-            # 4.5 emits only the waveform (mel_spec is always None); keep the
-            # 2-slot unpack so a future mel-emitting variant can plug in
-            # without changing the wrapper.
-            mm_out: dict = {}
-            if isinstance(talker_result, tuple) and len(talker_result) == 2:
-                _, waveform = talker_result
-                if waveform is not None:
-                    mm_out["model_outputs"] = [waveform]
+            if not isinstance(audio_tokens, torch.Tensor):
+                raise RuntimeError(f"MiniCPM-o 4.5 Talker returned {type(audio_tokens).__name__}, expected Tensor")
+            audio_tokens = audio_tokens.to(dtype=torch.long).reshape(-1)
 
             return OmniOutput(
                 text_hidden_states=dummy_hidden,
-                multimodal_outputs=mm_out if mm_out else None,
+                multimodal_outputs={"codes": {"audio": audio_tokens}},
+            )
+
+        if self.model_stage == "token2wav":
+            with torch.inference_mode():
+                waveform = self.token2wav(
+                    input_ids=input_ids,
+                    positions=positions,
+                    inputs_embeds=inputs_embeds,
+                    additional_information=additional_information,
+                    **kwargs,
+                )
+            if not isinstance(waveform, torch.Tensor):
+                raise RuntimeError(f"MiniCPM-o 4.5 Token2Wav returned {type(waveform).__name__}, expected Tensor")
+            sample_rate = int(getattr(self.token2wav, "sample_rate", 24000))
+            return OmniOutput(
+                text_hidden_states=None,
+                multimodal_outputs={
+                    "model_outputs": [waveform.reshape(1, -1)],
+                    "sr": [torch.tensor(sample_rate, dtype=torch.int32)],
+                },
             )
 
         raise ValueError(f"Unsupported model stage: {self.model_stage}")
 
     def compute_logits(self, hidden_states: torch.Tensor | OmniOutput) -> torch.Tensor | None:
-        # Handle OmniOutput type
         if isinstance(hidden_states, OmniOutput):
             hidden_states = hidden_states.text_hidden_states
 
-        # Use model for logits computation
         return self.model.compute_logits(hidden_states)
 
     def sample(
@@ -346,21 +375,20 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
     ) -> SamplerOutput | None:
-        # Use model for sampling
         return self.model.sample(logits, sampling_metadata)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load weights for the active stage of the omni model."""
+        if self.token2wav is not None:
+            loaded = self.token2wav.load_weights([])
+            return add_prefix_to_loaded_weights(loaded, "token2wav")
+
         loaded_weights = set()
         thinker_weights = []
         talker_weights = []
 
-        # MiniCPM-o checkpoint prefixes → stage mapping:
-        #   thinker: vpm, resampler, llm, apm, audio_projection_layer
-        #   talker:  tts (MiniCPMTTS); the Token2Wav vocoder weights load
-        #            separately inside the talker module from the
-        #            ``assets/token2wav`` subdirectory and do not appear
-        #            in this iterator.
+        # Token2Wav loads from assets/token2wav; the HF iterator only carries
+        # thinker and MiniCPMTTS checkpoint weights.
         for k, v in weights:
             if k.startswith(("vpm.", "resampler.", "llm.", "apm.", "audio_projection_layer.")):
                 thinker_weights.append((k, v))
@@ -369,13 +397,11 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             else:
                 logger.warning("Unknown weight prefix: %s, skipping", k)
 
-        # Load thinker weights
         if self.thinker is not None and thinker_weights:
             thinker_loaded = self.thinker.load_weights(thinker_weights)
             thinker_loaded = add_prefix_to_loaded_weights(thinker_loaded, "thinker")
             loaded_weights.update(thinker_loaded)
 
-        # Load talker weights
         if self.talker is not None and talker_weights:
             talker_loaded = self.talker.load_weights(talker_weights)
             talker_loaded = add_prefix_to_loaded_weights(talker_loaded, "talker")

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -471,8 +471,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         **kwargs,
     ):
         payload_was_provided = (
-            additional_information is not None
-            or kwargs.get("runtime_additional_information") is not None
+            additional_information is not None or kwargs.get("runtime_additional_information") is not None
         )
         if additional_information is None:
             additional_information = {}

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from:
 # https://huggingface.co/openbmb/MiniCPM-o-4_5/blob/main/modeling_minicpmo.py
-"""MiniCPM-o 4.5 Talker + Token2Wav: MiniCPMTTS with hidden_text_merge condition.
+"""MiniCPM-o 4.5 Talker / Token2Wav helpers.
 
 Pipeline:
   1. Receive thinker hidden_states + full token IDs via additional_information
   2. Extract tts_bos..tts_eos region
   3. Build condition: emb_text(tokens) + projector_semantic(hidden) (hidden_text_merge)
   4. Run MiniCPMTTS.generate() -> discrete audio tokens
-  5. Run Token2wav(tokens) -> waveform bytes -> numpy array
+  5. Run Token2wav(tokens) -> waveform bytes -> numpy array in the token2wav stage
 """
 
 import io
@@ -92,7 +92,15 @@ _install_torchaudio_soundfile_shim()
 
 
 class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
-    """MiniCPM-o 4.5 Talker: MiniCPMTTS + Token2wav in a single forward pass."""
+    """MiniCPM-o 4.5 Talker / Token2Wav implementation.
+
+    ``model_stage in {"tts", "talker"}`` runs only MiniCPMTTS.generate() and
+    returns generated audio tokens. ``model_stage="token2wav"`` decodes those
+    tokens into one complete waveform. The legacy ``generate_speech`` method
+    still composes both helpers for direct unit tests and old callers.
+    """
+
+    sample_rate = 24_000
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -101,27 +109,29 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         config: MiniCPMOConfig = vllm_config.model_config.hf_config
         self.config = config
         self.vllm_config = vllm_config
+        self.model_stage = getattr(vllm_config.model_config, "model_stage", "talker")
 
-        self.tts = None
         self.audio_tokenizer = None
-        self._assets_loaded = False
+        self._talker_assets_loaded = False
+        self._token2wav_assets_loaded = False
 
         tts_config = getattr(config, "tts_config", None)
+        if tts_config is None and any(hasattr(config, attr) for attr in ("num_audio_tokens", "audio_bos_token_id")):
+            tts_config = config
         if tts_config is not None:
             self._tts_config = tts_config
-            self._tts_bos_id = getattr(tts_config, "audio_bos_token_id", 151687)
-            self._text_eos_id = getattr(tts_config, "text_eos_token_id", 151692)
-            self._num_audio_tokens = getattr(tts_config, "num_audio_tokens", 6562)
             self._hidden_size = getattr(tts_config, "hidden_size", 768)
-            self._normalize = getattr(tts_config, "normalize_projected_hidden", True)
         else:
             self._tts_config = None
 
-    def _lazy_init_tts(self):
-        if self._assets_loaded or self._tts_config is None:
+    def _model_path(self) -> str:
+        return self.vllm_config.model_config.model
+
+    def _lazy_init_talker(self):
+        if self._talker_assets_loaded or self._tts_config is None:
             return
         try:
-            model_path = self.vllm_config.model_config.model
+            model_path = self._model_path()
 
             if model_path not in sys.path:
                 sys.path.insert(0, model_path)
@@ -166,7 +176,18 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 torch.set_default_dtype(prev_dtype)
             self.emb_text = self.tts_obj.emb_text
             self.projector_semantic = self.tts_obj.projector_semantic
+            self._talker_assets_loaded = True
+        except ImportError:
+            raise
+        except Exception:
+            logger.error("Failed to init 4.5 Talker", exc_info=True)
+            raise
 
+    def _lazy_init_token2wav(self):
+        if self._token2wav_assets_loaded:
+            return
+        try:
+            model_path = self._model_path()
             token2wav_dir = os.path.join(model_path, "assets", "token2wav")
             if os.path.isdir(token2wav_dir):
                 if not _stepaudio2_available:
@@ -184,49 +205,48 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 prev_dtype2 = torch.get_default_dtype()
                 torch.set_default_dtype(torch.float32)
                 try:
-                    # NB: this must be the MiniCPM-o-flavored Token2wav from
-                    # the `stepaudio2-minicpmo` PyPI package (or the
-                    # `minicpmo-utils[all]` umbrella), not the upstream
-                    # `stepfun-ai/Step-Audio2` repo. The MiniCPM-o variant's
-                    # __init__ accepts n_timesteps; the upstream signature is
-                    # (model_path, float16=False) and will raise
-                    # TypeError on n_timesteps. See ImportError message below
-                    # for installation guidance.
+                    # MiniCPM-o's Token2wav variant accepts n_timesteps; the
+                    # upstream Step-Audio2 package does not.
                     self.audio_tokenizer = _Token2wav(token2wav_dir, float16=False, n_timesteps=10)
                 finally:
                     torch.set_default_dtype(prev_dtype2)
-                self.tts_obj.audio_tokenizer = self.audio_tokenizer
+                if hasattr(self, "tts_obj"):
+                    self.tts_obj.audio_tokenizer = self.audio_tokenizer
                 logger.info(
                     "Loaded Token2wav from %s (backend=%s)",
                     token2wav_dir,
                     _token2wav_backend,
                 )
+            else:
+                raise FileNotFoundError(f"MiniCPM-o 4.5 token2wav assets not found: {token2wav_dir}")
             # Only mark init as complete after every step succeeds, so a
             # partial failure leaves the next call free to retry the full
             # init instead of short-circuiting back to a silent empty path.
-            self._assets_loaded = True
+            self._token2wav_assets_loaded = True
         except ImportError:
             # Surface missing dependencies directly so users can act on them
             # instead of getting a silent None waveform downstream.
             raise
         except Exception:
-            # Re-raise non-import init failures (bad token2wav assets, missing
-            # weights, OOM during Token2wav construction, etc.) so the server
-            # fails loudly at startup / first request instead of returning
-            # silent empty audio for every subsequent request.
-            logger.error("Failed to init 4.5 TTS", exc_info=True)
+            # Bad assets or OOM should fail the request/server loudly, not
+            # degrade into silent empty audio.
+            logger.error("Failed to init 4.5 Token2Wav", exc_info=True)
             raise
 
-    def generate_speech(
+    def _lazy_init_tts(self):
+        """Compatibility initializer for the old fused TTS path."""
+        self._lazy_init_talker()
+        self._lazy_init_token2wav()
+
+    def prepare_tts_inputs(
         self,
         tts_token_ids: torch.Tensor,
         tts_hidden_states: torch.Tensor,
-    ) -> np.ndarray | None:
-        """Run full 4.5 TTS pipeline using original MiniCPMTTS.generate."""
-        self._lazy_init_tts()
+    ) -> tuple[torch.Tensor, torch.Tensor, int, int]:
+        """Build MiniCPMTTS.generate inputs from thinker token/hidden slices."""
+        self._lazy_init_talker()
         if not hasattr(self, "tts_obj") or self.tts_obj is None:
-            logger.warning("generate_speech: tts_obj not initialized")
-            return None
+            raise RuntimeError("MiniCPM-o 4.5 Talker is not initialized")
 
         tts = self.tts_obj
         device = tts.emb_text.weight.device
@@ -249,7 +269,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
         inputs_embeds = torch.cat([spk_embeds, tts_embeds, text_eos, audio_bos], dim=0).unsqueeze(0)
         inputs_embeds = inputs_embeds.to(dtype=ar_dtype)
-        logger.info("generate_speech: inputs_embeds shape=%s", list(inputs_embeds.shape))
+        logger.info("prepare_tts_inputs: inputs_embeds shape=%s", list(inputs_embeds.shape))
 
         # Scale max_new_token with input text length to avoid mid-stream truncation on long
         # responses (default 2048 can only cover ~300 text tokens at ~6x audio/text ratio).
@@ -259,29 +279,52 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         max_new_token = max(2048, min(16384, num_text * 10))
 
         eos_token = torch.tensor([tts.config.num_audio_tokens - 1], dtype=torch.long, device=device)
+        return inputs_embeds, eos_token, max_new_token, num_text
+
+    def generate_audio_tokens(
+        self,
+        tts_token_ids: torch.Tensor,
+        tts_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run MiniCPMTTS.generate() and return one-dimensional audio tokens."""
+        inputs_embeds, eos_token, max_new_token, num_text = self.prepare_tts_inputs(
+            tts_token_ids,
+            tts_hidden_states,
+        )
+        tts = self.tts_obj
         outputs = tts.generate(
             inputs_embeds=inputs_embeds,
             eos_token=eos_token,
             max_new_token=max_new_token,
             show_tqdm=False,
         )
-        generated_tokens = outputs.new_ids.squeeze(-1)
+        generated_tokens = outputs.new_ids.squeeze(-1).reshape(-1).to(torch.long)
         logger.info(
-            "generate_speech: generated %d audio tokens (cap=%d, text_tokens=%d)",
-            generated_tokens.shape[-1],
+            "generate_audio_tokens: generated %d audio tokens (cap=%d, text_tokens=%d)",
+            generated_tokens.numel(),
             max_new_token,
             num_text,
         )
+        if generated_tokens.numel() == 0:
+            raise RuntimeError("MiniCPM-o 4.5 Talker generated no audio tokens")
+        return generated_tokens
 
+    def decode_audio_tokens(
+        self,
+        generated_tokens: torch.Tensor | list[int],
+        prompt_wav_path: str | None = None,
+    ) -> np.ndarray:
+        """Decode generated audio tokens with the MiniCPM-o Token2Wav assets."""
+        self._lazy_init_token2wav()
         if self.audio_tokenizer is None:
-            logger.warning("No audio_tokenizer")
-            return None
+            raise RuntimeError("MiniCPM-o 4.5 Token2Wav is not initialized")
 
         import torchaudio
 
-        model_path = self.vllm_config.model_config.model
-        default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
-        prompt_wav_path = default_ref if os.path.exists(default_ref) else None
+        if prompt_wav_path is None:
+            model_path = self._model_path()
+            default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
+            prompt_wav_path = default_ref if os.path.exists(default_ref) else None
 
         _orig_save = torchaudio.save
 
@@ -299,23 +342,28 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             # Vocoder path is float32; use the platform abstraction because
             # torch.amp.autocast validates unsupported device types even when
             # autocast is disabled.
+            device = (
+                generated_tokens.device
+                if isinstance(generated_tokens, torch.Tensor)
+                else current_omni_platform.get_torch_device()
+            )
             autocast_device = device.type if isinstance(device, torch.device) else str(device)
             with current_omni_platform.create_autocast_context(
                 device_type=autocast_device,
                 dtype=torch.float32,
                 enabled=False,
             ):
-                token_list = generated_tokens.squeeze(0).tolist()
+                if isinstance(generated_tokens, torch.Tensor):
+                    token_list = generated_tokens.detach().to("cpu", dtype=torch.long).reshape(-1).tolist()
+                else:
+                    token_list = [int(token) for token in generated_tokens]
                 num_tokens = len(token_list)
+                if num_tokens == 0:
+                    return np.asarray([], dtype=np.float32)
 
-                # For long outputs, the one-shot vocoder path
-                # (Token2wav.__call__ -> flow.inference) runs full O(N^2) self-
-                # attention over all audio tokens and OOMs on a 24GB card once
-                # N exceeds a few thousand (e.g. 4964 tokens needs ~3GiB for a
-                # single attention matmul). Switch to the chunked / streaming
-                # vocoder (set_stream_cache + stream) which truncates the flow
-                # attention caches to prompt_len + 100 steps on every chunk,
-                # keeping peak memory bounded regardless of total length.
+                # Preserve the existing long-output vocoder fallback: one-shot
+                # decode has O(N^2) attention memory, while stream() bounds the
+                # cache per chunk.
                 STREAM_THRESHOLD = int(os.environ.get("MINICPMO45_TTS_STREAM_THRESHOLD", "2500"))  # ~100s @ 25Hz
                 CHUNK_SIZE = int(os.environ.get("MINICPMO45_TTS_STREAM_CHUNK", "50"))  # ~2s per chunk
                 MIN_TAIL = 6  # must exceed flow.pre_lookahead_len (typically 3)
@@ -337,7 +385,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                         i = end
 
                     logger.info(
-                        "generate_speech: streaming vocoder, %d tokens -> %d chunks (chunk=%d)",
+                        "decode_audio_tokens: streaming vocoder, %d tokens -> %d chunks (chunk=%d)",
                         num_tokens,
                         len(boundaries),
                         CHUNK_SIZE,
@@ -368,53 +416,26 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             torch.set_default_dtype(prev_dtype)
             torchaudio.save = _orig_save
 
-        logger.info("generate_speech: waveform %d samples, sr=%d", waveform.shape[0], sr)
+        logger.info("decode_audio_tokens: waveform %d samples, sr=%d", waveform.shape[0], sr)
         return waveform
 
-    def _generate_tokens(self, inputs_embeds: torch.Tensor, max_new_token: int = 2048) -> torch.Tensor | None:
-        """Autoregressive generation of audio tokens using the TTS LlamaModel."""
-        device = inputs_embeds.device
-        eos_token = self._num_audio_tokens - 1
-        condition_length = inputs_embeds.shape[1]
-        num_vq = len(self.emb_code)
+    @staticmethod
+    def package_waveform(waveform: np.ndarray | torch.Tensor | None) -> torch.Tensor | None:
+        """Convert decoded waveform to the tensor form consumed by OmniOutput."""
+        if waveform is None:
+            return None
+        if isinstance(waveform, torch.Tensor):
+            return waveform.to(dtype=torch.float32).reshape(-1)
+        return torch.as_tensor(np.asarray(waveform, dtype=np.float32).reshape(-1), dtype=torch.float32)
 
-        new_tokens = torch.zeros(1, max_new_token, num_vq, device=device, dtype=torch.long)
-        past_key_values = None
-        finished = False
-
-        for t in range(max_new_token):
-            if t == 0:
-                emb = inputs_embeds
-                position_ids = torch.arange(condition_length, device=device).unsqueeze(0)
-            else:
-                code_emb = [self.emb_code[q](new_tokens[:, t - 1 : t, q]) for q in range(num_vq)]
-                emb = torch.stack(code_emb, -1).sum(-1)
-                position_ids = torch.tensor([[condition_length + t - 1]], device=device)
-
-            outputs = self.tts_model(
-                inputs_embeds=emb,
-                position_ids=position_ids,
-                past_key_values=past_key_values,
-                use_cache=True,
-            )
-            hidden = outputs.last_hidden_state
-            past_key_values = outputs.past_key_values
-
-            logits = torch.stack([self.head_code[q](hidden[:, -1]) for q in range(num_vq)], dim=-1)
-            logits = logits.float() / 0.8
-
-            if t < 50:
-                logits[:, eos_token, :] = -float("inf")
-
-            probs = F.softmax(logits, dim=1)
-            idx = torch.multinomial(probs.view(-1, probs.shape[1]), 1).view(1, num_vq)
-            new_tokens[:, t] = idx
-
-            if (idx == eos_token).any():
-                finished = True
-                break
-
-        return new_tokens[:, : t + 1 if finished else t, :]
+    def generate_speech(
+        self,
+        tts_token_ids: torch.Tensor,
+        tts_hidden_states: torch.Tensor,
+    ) -> np.ndarray:
+        """Run the old fused 4.5 TTS pipeline for direct callers/tests."""
+        audio_tokens = self.generate_audio_tokens(tts_token_ids, tts_hidden_states)
+        return self.decode_audio_tokens(audio_tokens)
 
     def _dummy_hidden_states(
         self,
@@ -449,28 +470,70 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         additional_information=None,
         **kwargs,
     ):
+        payload_was_provided = (
+            additional_information is not None
+            or kwargs.get("runtime_additional_information") is not None
+        )
         if additional_information is None:
             additional_information = {}
 
+        if self.model_stage == "token2wav":
+            audio_codes = self._extract_token2wav_codes(input_ids, additional_information, kwargs)
+            if audio_codes is None:
+                log = logger.warning if payload_was_provided else logger.debug
+                log("4.5 Token2Wav: missing audio token payload; returning empty waveform")
+                device = input_ids.device if isinstance(input_ids, torch.Tensor) else torch.device("cpu")
+                return torch.empty(0, dtype=torch.float32, device=device)
+            if audio_codes.numel() == 0:
+                logger.debug("4.5 Token2Wav: empty audio token payload; returning empty waveform")
+                device = input_ids.device if isinstance(input_ids, torch.Tensor) else torch.device("cpu")
+                return torch.empty(0, dtype=torch.float32, device=device)
+            logger.info("4.5 Token2Wav: decoding %d audio tokens", audio_codes.numel())
+            waveform = self.decode_audio_tokens(audio_codes)
+            packaged = self.package_waveform(waveform)
+            if packaged is None or packaged.numel() == 0:
+                raise RuntimeError("MiniCPM-o 4.5 Token2Wav decoded empty audio from non-empty tokens")
+            return packaged
+
         tts_token_ids = additional_information.get("tts_token_ids")
         tts_hidden_states = additional_information.get("tts_hidden_states")
-        tts_text = additional_information.get("llm_output_text", [""])
-        if isinstance(tts_text, list):
-            tts_text = tts_text[0] if tts_text else ""
 
         if tts_token_ids is None or tts_hidden_states is None:
             # KV cache profiling / dummy run path — no real TTS input yet.
             logger.debug("4.5 Talker: dummy forward (missing tts_token_ids/tts_hidden_states)")
             return self._dummy_hidden_states(input_ids, positions, inputs_embeds)
 
-        logger.info("4.5 Talker: generating speech for %d tokens", tts_token_ids.shape[0])
-        waveform = self.generate_speech(tts_token_ids, tts_hidden_states)
-        # Tuple layout: (mel_spec, waveform). 4.5 talker emits only waveform,
-        # so mel_spec stays None; the wrapper unpacks in this order and
-        # packages the waveform into ``multimodal_outputs["model_outputs"]``.
-        if waveform is not None:
-            return None, torch.tensor(waveform, dtype=torch.float32)
-        return None, None
+        logger.info("4.5 Talker: generating audio tokens for %d tokens", tts_token_ids.shape[0])
+        return self.generate_audio_tokens(tts_token_ids, tts_hidden_states)
+
+    def _extract_token2wav_codes(
+        self,
+        input_ids: torch.Tensor | None,
+        additional_information: dict[str, object],
+        kwargs: dict[str, object],
+    ) -> torch.Tensor | None:
+        """Resolve Token2Wav codec tokens from connector payload or input_ids."""
+        runtime_info = kwargs.get("runtime_additional_information")
+        if runtime_info is not None and isinstance(runtime_info, list) and runtime_info:
+            first = runtime_info[0]
+            if isinstance(first, dict):
+                additional_information = first
+
+        meta = additional_information.get("meta") if isinstance(additional_information, dict) else None
+        meta = meta if isinstance(meta, dict) else {}
+        if int(meta.get("code_flat_numel", -1)) == 0:
+            device = input_ids.device if isinstance(input_ids, torch.Tensor) else torch.device("cpu")
+            return torch.empty(0, dtype=torch.long, device=device)
+
+        codes = additional_information.get("codes") if isinstance(additional_information, dict) else None
+        audio_codes = codes.get("audio") if isinstance(codes, dict) else None
+        if audio_codes is None:
+            return None
+        if isinstance(audio_codes, torch.Tensor):
+            device = input_ids.device if isinstance(input_ids, torch.Tensor) else audio_codes.device
+            return audio_codes.to(device=device, dtype=torch.long).reshape(-1)
+        device = input_ids.device if isinstance(input_ids, torch.Tensor) else torch.device("cpu")
+        return torch.as_tensor(audio_codes, dtype=torch.long, device=device).reshape(-1)
 
     def compute_logits(self, hidden_states, *args, **kwargs):
         # Placeholder logits: one row per sampled request (the scheduler
@@ -490,6 +553,10 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         loaded = set()
+        if self.model_stage == "token2wav":
+            self._lazy_init_token2wav()
+            return loaded
+
         tts_weights = {}
         for k, v in weights:
             if k.startswith("tts."):
@@ -500,7 +567,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 loaded.add(k.replace("tts.", "tts_obj.", 1))
 
         if tts_weights and self._tts_config is not None:
-            self._lazy_init_tts()
+            self._lazy_init_talker()
             if hasattr(self, "tts_obj") and self.tts_obj is not None:
                 missing, unexpected = self.tts_obj.load_state_dict(tts_weights, strict=False)
                 if missing:
@@ -538,7 +605,9 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
     def get_input_embeddings(self, input_ids, multimodal_embeddings=None, **kwargs):
         if hasattr(self, "emb_text") and self.emb_text is not None:
             return self.emb_text(input_ids)
-        return torch.zeros(input_ids.shape[0], 1)
+        hidden_size = int(getattr(self, "_hidden_size", 1) or 1)
+        device = input_ids.device if isinstance(input_ids, torch.Tensor) else torch.device("cpu")
+        return torch.zeros(input_ids.shape[0], hidden_size, device=device)
 
     def embed_input_ids(self, input_ids, **kwargs):
         return self.get_input_embeddings(input_ids, **kwargs)

--- a/vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MiniCPM-o 4.5 pipeline topology (frozen).
+"""MiniCPM-o 4.5 pipeline topology.
 
 Stage 0: Thinker — multimodal understanding + text generation.
-Stage 1: Talker  — MiniCPMTTS + Token2Wav, emits the final audio waveform.
+Stage 1: Talker  — MiniCPMTTS, emits generated audio tokens.
+Stage 2: Token2Wav — decodes audio tokens into the final waveform.
 
 The thinker -> talker bridge passes the hidden states + token ids extracted
-from the thinker output through ``minicpmo_4_5_omni.llm2tts``; the talker
-runs MiniCPMTTS and the on-device Token2wav vocoder in the same process and
-returns the waveform directly as the pipeline's final audio output.
+from the thinker output through ``minicpmo_4_5_omni.llm2talker``. The
+talker -> token2wav bridge sends a complete ``codes.audio`` payload; async
+chunking remains disabled for PR1.
 """
 
 from vllm_omni.config.stage_config import (
@@ -24,15 +25,8 @@ MINICPMO_4_5_PIPELINE = PipelineConfig(
     model_type="minicpmo_4_5",
     default_deploy_config_name="minicpmo_4_5.yaml",
     model_arch="MiniCPMO45OmniForConditionalGeneration",
-    # MiniCPM-o 4.5's HF config.json reports `model_type="minicpmo"` and
-    # `architectures=["MiniCPMO"]` — both shared verbatim with older MiniCPM-o
-    # 1.0 / 2.6 checkpoints. The only field distinguishing the generations is
-    # the top-level ``version`` string, so we register both the shared
-    # ``MiniCPMO`` arch (for auto-detection) and the 4.5-specific arch (for
-    # repos that opt into the explicit name later), then pin the routing to
-    # 4.5 via ``hf_config_predicate``. Without the predicate, loading a 2.6
-    # checkpoint would also intersect ``["MiniCPMO"]`` here and get routed
-    # into the 4.5 pipeline, which would then fail at load time.
+    # MiniCPM-o 2.6 and 4.5 both advertise ``architectures=["MiniCPMO"]``.
+    # The version predicate keeps 2.6 checkpoints out of the 4.5 pipeline.
     hf_architectures=("MiniCPMO", "MiniCPMO45OmniForConditionalGeneration"),
     hf_config_predicate=lambda c: str(getattr(c, "version", "")) == "4.5",
     stages=(
@@ -50,29 +44,29 @@ MINICPMO_4_5_PIPELINE = PipelineConfig(
         ),
         StagePipelineConfig(
             stage_id=1,
-            model_stage="tts",
-            # Stage 1 shares the top-level wrapper class
-            # (``MiniCPMO45OmniForConditionalGeneration``) inherited from
-            # ``model_arch`` above. The wrapper dispatches on ``model_stage``
-            # and, for ``"tts"``, instantiates the standalone TTS submodule
-            # (``MiniCPMO45OmniTTSForConditionalGeneration``) internally.
-            # Routing through the wrapper is required so that the runner-side
-            # ``runtime_additional_information`` payload reaches the talker
-            # (the standalone TTS class only reads ``additional_information``,
-            # so wiring stage 1 directly to it would always trigger the dummy
-            # path) and so the resulting waveform is packaged as
-            # ``OmniOutput.multimodal_outputs["model_outputs"]`` instead of
-            # being returned as a bare tuple that the AR runner would mistake
-            # for hidden states. ``hf_config_name="tts_config"`` keeps KV
-            # cache / mrope sizing scoped to the talker sub-config.
+            model_stage="talker",
+            # Keep the wrapper here so runner-side runtime metadata reaches
+            # the Talker; wiring the standalone TTS module directly would hit
+            # the dummy path.
             execution_type=StageExecutionType.LLM_AR,
             input_sources=(0,),
+            hf_config_name="tts_config",
+            engine_output_type="latent",
+            custom_process_input_func=f"{_PROC}.llm2talker",
+            custom_process_next_stage_input_func=f"{_PROC}.talker2token2wav_full_payload",
+            sampling_constraints={"detokenize": False},
+        ),
+        StagePipelineConfig(
+            stage_id=2,
+            model_stage="token2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(1,),
             final_output=True,
             final_output_type="audio",
             hf_config_name="tts_config",
             engine_output_type="audio",
-            custom_process_input_func=f"{_PROC}.llm2tts",
-            sampling_constraints={"detokenize": False},
+            sync_process_input_func=f"{_PROC}.talker2token2wav_token_only",
+            sampling_constraints={"detokenize": True},
         ),
     ),
 )

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -198,8 +198,7 @@ def talker2token2wav_full_payload(
     audio = _audio_codes_from_mapping(pooling_output)
     if audio is None:
         logger.warning(
-            "talker2token2wav_full_payload: missing codes.audio (keys=%s) for req=%s; "
-            "sending empty finished payload.",
+            "talker2token2wav_full_payload: missing codes.audio (keys=%s) for req=%s; sending empty finished payload.",
             list(pooling_output.keys()),
             rid,
         )

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Stage input processor for MiniCPM-o 4.5: Thinker (LLM) -> Talker (TTS).
+"""Stage input processors for MiniCPM-o 4.5.
 
-This is the original vLLM-Omni bridge: it converts the thinker stage's
-hidden states + token ids into the talker stage's prompt payload. The
-talker model itself is adapted from openbmb/MiniCPM-o-4_5 (see the headers
-on vllm_omni/model_executor/models/minicpmo_4_5/*.py).
+Thinker -> Talker converts hidden states + token ids into the MiniCPMTTS
+conditioning payload. Talker -> Token2Wav ships the complete generated
+audio-token payload through the connector in non-async mode.
 """
 
+import logging
+from collections.abc import Mapping
 from typing import Any
 
 import torch
@@ -15,57 +16,35 @@ from vllm.inputs import TextPrompt
 
 from vllm_omni.inputs.data import OmniTokensPrompt
 
+logger = logging.getLogger(__name__)
 
-def llm2tts(
+
+def llm2talker(
     source_outputs: list[Any],
     prompt: OmniTokensPrompt | TextPrompt | dict | list | None = None,
     requires_multimodal_data: bool = False,
     streaming_context: Any | None = None,
 ):
-    """Convert thinker stage output to talker stage input for MiniCPMO Omni.
-
-    The signature matches the framework's ``custom_process_input_func`` call
-    convention used by ``StageEngineCoreClientBase.process_engine_inputs``:
-
-        (source_outputs, prompt, requires_multimodal_data, streaming_context)
-
-    ``source_outputs`` is the already-resolved list of upstream engine
-    outputs (one entry per request), so we do not need to look anything up
-    via ``stage_list[source_stage_id].engine_outputs``.
-
-    Extracts from thinker output:
-      - Full hidden states (prompt + generated) for speaker embedding extraction
-      - Prompt token IDs (for finding spk_bos/spk_eos positions)
-      - Generated token IDs (for decoding TTS text)
-
-    The talker model will:
-      1. Find <|spk_bos|>/<|spk_eos|> positions in prompt_token_ids
-      2. Extract speaker embedding from hidden states at those positions
-      3. Decode generated text and extract TTS content
-      4. Run ConditionalChatTTS pipeline
-    """
+    """Extract the thinker token/hidden slice consumed by the Talker stage."""
     del streaming_context  # not used by MiniCPM-o 4.5 turn-taking pipeline
 
     if not source_outputs:
         raise ValueError("source_outputs cannot be empty")
 
-    llm_outputs = source_outputs
-    tts_inputs = []
+    talker_inputs = []
 
     if not isinstance(prompt, list):
         prompt = [prompt]
 
     multi_modal_data = {
         llm_output.request_id: p.get("multi_modal_data", None) if isinstance(p, dict) else None
-        for llm_output, p in zip(llm_outputs, prompt)
+        for llm_output, p in zip(source_outputs, prompt)
     }
 
-    for i, llm_output in enumerate(llm_outputs):
+    for llm_output in source_outputs:
         output = llm_output.outputs[0]
         prompt_token_ids = llm_output.prompt_token_ids
         llm_output_ids = output.token_ids
-        prompt_token_ids_len = len(prompt_token_ids)
-
         latent = output.multimodal_output.get("latent", None)
         if latent is None:
             latent = output.hidden_states if hasattr(output, "hidden_states") else None
@@ -73,13 +52,6 @@ def llm2tts(
                 raise ValueError("No latent or hidden_states found in thinker output")
 
         thinker_hidden_states = latent.clone().detach()
-
-        # Split hidden states: prompt portion has speaker embedding,
-        # generated portion has the text content
-        prompt_hidden = thinker_hidden_states[:prompt_token_ids_len].to(torch.float32)
-
-        # Extract decoded text from thinker output for TTS text extraction
-        thinker_text = getattr(output, "text", "") or ""
 
         # Build full token sequence and extract TTS region
         full_token_ids = list(prompt_token_ids) + (
@@ -107,12 +79,7 @@ def llm2tts(
             tts_token_ids_slice = torch.tensor(full_token_ids[tts_bos_idx:end_idx], dtype=torch.long)
             tts_hidden_slice = full_hidden[tts_bos_idx:end_idx]
 
-        additional_information = {
-            "prompt_embeds": prompt_hidden,
-            "prompt_token_ids": list(prompt_token_ids),
-            "llm_output_token_ids": list(llm_output_ids) if not isinstance(llm_output_ids, list) else llm_output_ids,
-            "llm_output_text": [thinker_text],
-        }
+        additional_information: dict[str, Any] = {}
         if tts_token_ids_slice is not None:
             additional_information["tts_token_ids"] = tts_token_ids_slice
         if tts_hidden_slice is not None:
@@ -120,17 +87,139 @@ def llm2tts(
 
         # Minimal prompt token IDs: the talker's AR framework needs *some* tokens
         # to do a single prefill step. We use [BOS, PAD, EOS] as a dummy.
-        tts_inputs.append(
+        request_mm = multi_modal_data.get(llm_output.request_id)
+        talker_inputs.append(
             OmniTokensPrompt(
                 prompt_token_ids=[1, 0, 2],
                 additional_information=additional_information,
-                multi_modal_data=(
-                    multi_modal_data[llm_output.request_id]
-                    if requires_multimodal_data and multi_modal_data.get(llm_output.request_id) is not None
-                    else None
-                ),
+                multi_modal_data=request_mm if requires_multimodal_data and request_mm is not None else None,
                 mm_processor_kwargs=None,
             )
         )
 
-    return tts_inputs
+    return talker_inputs
+
+
+# Backward-compatible alias for old deploys / tests. The alias now points to
+# the Talker-only path; Token2Wav is a separate downstream stage.
+llm2tts = llm2talker
+
+
+def _audio_codes_from_mapping(mapping: Mapping[str, Any] | None) -> Any:
+    if not isinstance(mapping, Mapping):
+        return None
+    audio = mapping.get("codes.audio")
+    if audio is not None:
+        return audio
+    codes = mapping.get("codes")
+    if isinstance(codes, Mapping):
+        return codes.get("audio")
+    return None
+
+
+def _audio_code_len(audio: Any) -> int:
+    if audio is None:
+        return 0
+    if isinstance(audio, torch.Tensor):
+        return int(audio.numel())
+    try:
+        return int(torch.as_tensor(audio).numel())
+    except (TypeError, ValueError):
+        try:
+            return len(audio)
+        except TypeError:
+            return 1
+
+
+def _minicpmo_empty_finished_payload() -> dict[str, Any]:
+    return {
+        "codes": {"audio": torch.empty(0, dtype=torch.long)},
+        "meta": {
+            "finished": torch.tensor(True, dtype=torch.bool),
+            "code_flat_numel": 0,
+            "next_stage_prompt_len": 1,
+        },
+    }
+
+
+def talker2token2wav_token_only(
+    source_outputs: list[Any],
+    _prompt: OmniTokensPrompt | TextPrompt | None = None,
+    _requires_multimodal_data: bool = False,
+    streaming_context: Any | None = None,
+) -> list[OmniTokensPrompt]:
+    """Sync-side placeholder for the Token2Wav stage.
+
+    The actual audio token tensor is delivered by
+    ``talker2token2wav_full_payload`` through the worker connector. This
+    function only sizes the consumer prompt so the generation runner can
+    schedule the request. Empty audio payloads still get one placeholder slot
+    and are disambiguated by ``meta.code_flat_numel=0`` in the connector
+    payload.
+    """
+    del _prompt, _requires_multimodal_data, streaming_context
+
+    token2wav_inputs: list[OmniTokensPrompt] = []
+    for talker_output in source_outputs:
+        if getattr(talker_output, "finished", True) is False:
+            continue
+        output = talker_output.outputs[0]
+        mm = output.multimodal_output if hasattr(output, "multimodal_output") else None
+        audio = _audio_codes_from_mapping(mm if isinstance(mm, Mapping) else None)
+        prompt_len = max(1, _audio_code_len(audio))
+        token2wav_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=[0] * prompt_len,
+                additional_information=None,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        )
+    return token2wav_inputs
+
+
+def talker2token2wav_full_payload(
+    transfer_manager: Any,
+    pooling_output: dict[str, Any],
+    request: Any,
+) -> dict[str, Any]:
+    """Pack complete MiniCPM-o Talker audio tokens for Token2Wav."""
+    del transfer_manager
+    rid = getattr(request, "request_id", None)
+    if not isinstance(pooling_output, Mapping):
+        logger.warning(
+            "talker2token2wav_full_payload: pooling_output not a dict (type=%s) for req=%s; "
+            "sending empty finished payload.",
+            type(pooling_output).__name__,
+            rid,
+        )
+        return _minicpmo_empty_finished_payload()
+
+    audio = _audio_codes_from_mapping(pooling_output)
+    if audio is None:
+        logger.warning(
+            "talker2token2wav_full_payload: missing codes.audio (keys=%s) for req=%s; "
+            "sending empty finished payload.",
+            list(pooling_output.keys()),
+            rid,
+        )
+        return _minicpmo_empty_finished_payload()
+    if not isinstance(audio, torch.Tensor):
+        audio = torch.as_tensor(audio, dtype=torch.long)
+    audio = audio.to(dtype=torch.long).reshape(-1)
+    if audio.numel() == 0:
+        logger.warning(
+            "talker2token2wav_full_payload: empty codes.audio for req=%s; sending empty finished payload.",
+            rid,
+        )
+        return _minicpmo_empty_finished_payload()
+
+    audio_cpu = audio.detach().to("cpu").contiguous()
+    return {
+        "codes": {"audio": audio_cpu},
+        "meta": {
+            "finished": torch.tensor(True, dtype=torch.bool),
+            "code_flat_numel": int(audio_cpu.numel()),
+            "next_stage_prompt_len": int(audio_cpu.numel()),
+        },
+    }

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -315,6 +315,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             "Qwen2_5OmniForConditionalGeneration",
             "CovoAudioForConditionalGeneration",
             "MiMoAudioModel",
+            "MiniCPMO45OmniForConditionalGeneration",
             "Qwen3TTSTalkerForConditionalGeneration",
             "Qwen3TTSCode2Wav",
             "CosyVoice3Model",

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -62,6 +62,7 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
             "Qwen2_5OmniForConditionalGeneration",
             "CovoAudioForConditionalGeneration",
             "MiMoAudioModel",
+            "MiniCPMO45OmniForConditionalGeneration",
             "Qwen3TTSTalkerForConditionalGeneration",
             "Qwen3TTSCode2Wav",
             "CosyVoice3Model",


### PR DESCRIPTION
## Summary

Relates to #5184.

This PR splits the MiniCPM-o 4.5 serving TTS path from the previous fused
`llm -> tts` flow into:

```text
thinker / llm -> talker -> token2wav
```

The external OpenAI-compatible `/v1/chat/completions` behavior is preserved:
text output still comes from the thinker stage, and audio requests still return
a complete 24 kHz WAV waveform.

## Details

- Updates the MiniCPM-o 4.5 pipeline and deploy configs so Stage 1 is `talker`
  and Stage 2 is `token2wav`.
- Keeps `model_stage="tts"` as a compatibility alias for the Talker path.
- Refactors the MiniCPM-o 4.5 TTS wrapper around four explicit steps:
  prepare TTS inputs, generate audio tokens, decode audio tokens, and package
  the waveform.
- Adds Talker -> Token2Wav stage processors for scheduler sizing and full
  `codes.audio` payload handoff.
- Updates connector allowlists so the Token2Wav stage receives full payload
  inputs instead of staying in `WAITING_FOR_INPUT`.
- Adds MiniCPM-o 4.5 E2E TTS and isolated Token2Wav benchmark scripts with
  JSON/CSV output and failure-row recording.

## Scope

This PR is limited to the structural stage split and reproducible benchmark
entry points. It does not enable async chunking, change default Token2Wav
precision, add runtime tracing, tune chunk thresholds, or claim a performance
improvement.

Stage 1 still uses `max_num_seqs: 1` because the current Talker path consumes
`runtime_additional_information[0]`. Safe Talker batching should be handled in a
separate follow-up.

Missing or empty codec payloads are converted to finished empty payloads so the
downstream stage does not wait forever. Real Token2Wav init/decode failures
still fail loudly.

## Test 

GPU validation was run on a 2x RTX 5090 validation host before the final cleanup
pass:

- Text+audio E2E short benchmark at concurrency 8: 8/8 successful requests.
- Long text+audio smoke: complete 24 kHz finite waveform.
- Token2Wav benchmark: 1024 / 2048 / 4096 tokens passed in one-shot and
  streaming modes.
- 8192-token Token2Wav one-shot OOM was recorded as a failure row; 8192-token
  streaming passed.
- No `WAITING_FOR_INPUT`, serving CUDA OOM, NaN/Inf audio, or clipping was
  observed in the successful E2E runs.

