### PR TITLE
[CI][Bugfix] remove module-level skip_if_gated_repo_inaccessible in flux kontext e2e (#5250)

### DIFF
--- a/tests/e2e/online_serving/test_flux_kontext_expansion.py
+++ b/tests/e2e/online_serving/test_flux_kontext_expansion.py
@@ -5,7 +5,6 @@ and are supported by the FluxKontext model.
 
 import pytest
 
-from tests.helpers import skip_if_gated_repo_inaccessible
 from tests.helpers.mark import hardware_marks
 from tests.helpers.media import generate_synthetic_image
 from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHandler, dummy_messages_from_mix_data
@@ -15,7 +14,6 @@ pytestmark = [pytest.mark.diffusion, pytest.mark.slow]
 EDIT_PROMPT = "Transform this modern, geometrist image into a Vincent van Gogh style impressionist painting."
 NEGATIVE_PROMPT = "blurry, low quality, modern, geometrist"
 MODEL = "black-forest-labs/FLUX.1-Kontext-dev"
-skip_if_gated_repo_inaccessible(MODEL)
 PARALLEL_FEATURE_MARKS = hardware_marks(res={"cuda": "L4"}, num_cards=2)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Remove module-level `skip_if_gated_repo_inaccessible(MODEL)` from `test_flux_kontext_expansion.py`.

Calling `pytest.skip()` at import time skips the entire module and, on current pytest, raises a collection error unless `allow_module_level=True` is set. This broke Intel CI collection for the Flux Kontext e2e module.

Fixes https://github.com/vllm-project/vllm-omni/issues/5250

## Test Plan

```bash
pytest -sv tests/e2e/online_serving/test_flux_kontext_expansion.py --run-level full_model
```

Expect the module to collect normally (no `ERROR collecting ... pytest.skip outside of a test`).

**vLLM Version:** N/A (test-only change)

**vLLM-Omni Commit:** current branch HEAD

## Test Result
<img width="2542" height="102" alt="f67dafe2-8556-4c2f-b1cc-63835b3c2fe7" src="https://github.com/user-attachments/assets/03f30663-1c8e-4a4e-b09e-23a9a49799a0" />
<img width="828" height="68" alt="c8ce027c-58c5-4abf-abee-89b18e724757" src="https://github.com/user-attachments/assets/40a3b773-508a-4599-a66b-c4dfc6839317" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
