### PR TITLE
[Core] Release robot session KV state when the session ends

### DIFF
--- a/tests/ar_diffusion/test_pipeline_bridge.py
+++ b/tests/ar_diffusion/test_pipeline_bridge.py
@@ -11,6 +11,10 @@ from vllm_omni.experimental.ar_diffusion.kv_cache import (
 )
 from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
 
+# Required by the check-test-ci-coverage hook once this file is touched; these
+# tests are CPU-only and cheap, so they belong in the per-PR level.
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 BLOCK = 16
 N_HEADS = 4
 HEAD_DIM = 64
@@ -220,3 +224,58 @@ def test_failed_forward_tears_down_session(monkeypatch):
     assert runner.pipeline._ar_diffusion_kv_state is None
     # close() freed the session's resident blocks.
     assert kv.manager.block_pool.get_num_free_blocks() > free_before_failure
+
+
+def test_session_churn_does_not_exhaust_pool(monkeypatch):
+    """A client reconnecting under a fresh session_id must not strand pool blocks.
+
+    Nothing tells the worker that a session ended, so its blocks are released
+    only by eviction. The count cap alone cannot bound the pool — the pool floor
+    is one session's window, so it holds far fewer sessions than the cap — and
+    session-id churn used to exhaust it permanently.
+    """
+    from collections import OrderedDict
+    from types import SimpleNamespace
+
+    from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+    from vllm_omni.experimental.ar_diffusion.runner import ARDiffusionModelRunner
+
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=4)
+    kv = ARDiffusionKVCache(
+        cfg,
+        num_layers=1,
+        num_kv_heads=N_HEADS,
+        head_size=HEAD_DIM,
+        dtype=torch.float32,
+        block_size=BLOCK,
+        max_model_len=4096,
+        available_bytes=1 << 24,
+        device=torch.device("cpu"),
+    )
+
+    runner = object.__new__(ARDiffusionModelRunner)
+    runner.kv_cache = kv
+    runner._ar_diffusion_states = OrderedDict()
+    runner._max_ar_diffusion_states = 64  # the shipped cap
+    runner.pipeline = SimpleNamespace(_states={}, _ar_diffusion_kv_state=None)
+    runner.device = None
+    runner._perf_e2e_times = []
+
+    def fill_window(self, req, kv_prefetch_jobs=None):
+        # A real forward leaves the session holding its resident window blocks.
+        _prepare_and_commit(self.pipeline._ar_diffusion_kv_state, False, 2)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(DiffusionModelRunner, "execute_model", fill_window)
+
+    n_sessions = 4 * kv.num_blocks  # far more sessions than the pool can hold
+    for i in range(n_sessions):
+        req = SimpleNamespace(
+            request_id=f"r{i}",
+            sampling_params=SimpleNamespace(extra_args={"session_id": f"s{i}"}),
+        )
+        ARDiffusionModelRunner.execute_model(runner, req)
+
+    # The pool bounded the live sessions; the count cap never had to fire.
+    assert len(runner._ar_diffusion_states) < n_sessions
+    assert len(runner._ar_diffusion_states) < runner._max_ar_diffusion_states

--- a/tests/ar_diffusion/test_pipeline_bridge.py
+++ b/tests/ar_diffusion/test_pipeline_bridge.py
@@ -226,6 +226,35 @@ def test_failed_forward_tears_down_session(monkeypatch):
     assert kv.manager.block_pool.get_num_free_blocks() > free_before_failure
 
 
+def test_end_session_frees_blocks_without_waiting_for_eviction():
+    """The serving layer knows when a session is over; releasing it then returns
+    the blocks immediately instead of leaving them for the next admission to
+    evict under pool pressure."""
+    from collections import OrderedDict
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.ar_diffusion.runner import ARDiffusionModelRunner
+
+    kv, st = make_state(num_layers=1, window_chunks=4)
+    _prepare_and_commit(st, False, 2)  # session owns pool blocks
+    held = kv.num_free_blocks
+
+    runner = object.__new__(ARDiffusionModelRunner)
+    runner.kv_cache = kv
+    runner._ar_diffusion_states = OrderedDict({"s1": st})
+    runner.pipeline = SimpleNamespace(_states={"s1": object()})
+
+    assert runner.end_session("s1") is True
+    assert "s1" not in runner._ar_diffusion_states
+    assert "s1" not in runner.pipeline._states
+    assert kv.num_free_blocks > held
+
+    # Unknown or already-released sessions are a no-op, so the serving layer can
+    # call this on every teardown path without tracking what is still live.
+    assert runner.end_session("s1") is False
+    assert runner.end_session("never-seen") is False
+
+
 def test_session_churn_does_not_exhaust_pool(monkeypatch):
     """A client reconnecting under a fresh session_id must not strand pool blocks.
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -391,6 +391,17 @@ class DiffusionWorker:
         """Generate output for the given requests."""
         return self.execute_model(request, self.od_config)
 
+    def ar_diffusion_end_session(self, session_id: str) -> bool:
+        """Release a finished robot session's session-scoped KV state (worker RPC).
+
+        A no-op for runners that keep no per-session state, so the serving layer can
+        call it unconditionally without knowing which pipeline is loaded.
+        """
+        end_session = getattr(self.model_runner, "end_session", None)
+        if not callable(end_session):
+            return False
+        return bool(end_session(session_id))
+
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         """Start or stop profiling for this GPU worker.
 

--- a/vllm_omni/entrypoints/openpi/connection.py
+++ b/vllm_omni/entrypoints/openpi/connection.py
@@ -220,8 +220,11 @@ class RobotRealtimeConnection:
                     endpoint = obs.pop("endpoint", "infer")
 
                     if endpoint == "reset":
+                        ended = self._current_session_id
                         self.reset()
                         self.serving.reset(obs)
+                        if ended is not None:
+                            await self.serving.end_session(ended)
                         await self.websocket.send_bytes(_pack({"status": "reset successful"}))
                     else:
                         session_id = str(obs.get("session_id") or self._current_session_id or "default")
@@ -232,6 +235,11 @@ class RobotRealtimeConnection:
                                     self._current_session_id,
                                     session_id,
                                 )
+                                # A client that rolls its session id without
+                                # reconnecting (the DROID eval loop does this per
+                                # episode) would otherwise strand the old
+                                # session's state for the life of the connection.
+                                await self.serving.end_session(self._current_session_id)
                             self._current_session_id = session_id
                             self._call_count = 0
 
@@ -253,3 +261,10 @@ class RobotRealtimeConnection:
             pass
         except Exception:
             logger.exception("Connection error")
+        finally:
+            # Last resort: the connection is gone, so whatever session it left
+            # behind has no owner. Eviction would reclaim it eventually, but only
+            # once the pool is already under pressure.
+            if self._current_session_id is not None:
+                ended, self._current_session_id = self._current_session_id, None
+                await self.serving.end_session(ended)

--- a/vllm_omni/entrypoints/openpi/serving.py
+++ b/vllm_omni/entrypoints/openpi/serving.py
@@ -119,6 +119,19 @@ class ServingRealtimeRobotOpenPI:
     def reset(self, obs: dict) -> None:
         """Compatibility hook; per-connection state lives in RobotRealtimeConnection."""
 
+    async def end_session(self, session_id: str) -> None:
+        """Release the engine-side state a finished session still owns.
+
+        Best effort: cleanup runs on paths that are already ending (disconnect,
+        session switch, `reset`), so a failure here must not surface to the client
+        or break the connection loop. Engines that keep no session state answer
+        False and the call is a no-op.
+        """
+        try:
+            await self.engine_client.collective_rpc("ar_diffusion_end_session", args=(session_id,))
+        except Exception:
+            logger.debug("Failed to release robot session %s", session_id, exc_info=True)
+
     async def infer(self, obs: dict, *, session_id: str, reset: bool) -> ActionOutput:
         """raw obs → engine → actions."""
         # Build request, run inference through AsyncOmni

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -447,6 +447,21 @@ class ARDiffusionKVCache:
         base = self.managed_num_blocks + branch_offset + start
         return list(range(base, base + count))
 
+    @property
+    def num_free_blocks(self) -> int:
+        """Managed blocks currently free in the pool."""
+        return self.manager.block_pool.get_num_free_blocks()
+
+    @property
+    def blocks_per_session(self) -> int:
+        """Managed blocks one session's rollout can hold on this rank.
+
+        Mirrors the pool floor in ``__init__`` (resident window + in-flight chunk
+        per local branch), so callers can tell whether admitting another session
+        can be served rather than discovering it mid-forward.
+        """
+        return self.local_branches * (self.config.window_chunks + self.num_frame_per_block)
+
     def key_cache(self, layer_idx: int) -> torch.Tensor:
         return self._kv_pools[layer_idx][0]
 

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -76,6 +76,25 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         # by the ar_diffusion_perf_stats worker RPC for the perf-compare summary.
         self._perf_e2e_times: list[float] = []
 
+    def end_session(self, session_id: str) -> bool:
+        """Release a finished session's KV pool blocks.
+
+        Sessions are otherwise dropped only by eviction, which reclaims them once
+        the pool is under pressure rather than when they actually end. The serving
+        layer knows the real end of life — a client disconnecting, switching
+        session id, or sending `reset` — and calls this out of band so the blocks
+        go back immediately. Returns whether a session was live under this id.
+        """
+        state = self._ar_diffusion_states.pop(session_id, None)
+        states = getattr(self.pipeline, "_states", None)
+        if states is not None:
+            states.pop(session_id, None)
+        if state is None:
+            return False
+        state.close()
+        logger.debug("AR-Diffusion ended session=%s; freed pool blocks", session_id)
+        return True
+
     def build_kv_cache(
         self,
         *,

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -247,6 +247,24 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         session_id = str(extra_args.get("session_id") or "default")
         state = self._ar_diffusion_states.get(session_id)
         if state is None:
+            # Make room before admitting the session. Sessions are only dropped by
+            # the count cap below, but a session's blocks are released solely by
+            # eviction: the OpenPI connection has no way to tell the worker that a
+            # client disconnected, so an ended session keeps its blocks until it is
+            # evicted. The pool holds far fewer than `_max_ar_diffusion_states`
+            # sessions (its floor is one session's window), so the count cap is
+            # unreachable and session-id churn exhausts the pool — permanently,
+            # since every later request then fails to allocate. Evict by capacity
+            # too, so the bound the count cap was meant to provide actually holds.
+            while self._ar_diffusion_states and kv.num_free_blocks < kv.blocks_per_session:
+                old_id, old_state = self._ar_diffusion_states.popitem(last=False)
+                old_state.close()
+                logger.debug(
+                    "AR-Diffusion evicted session=%s (pool capacity); free=%d needs=%d",
+                    old_id,
+                    kv.num_free_blocks,
+                    kv.blocks_per_session,
+                )
             pos = kv.begin_request(f"bde__{session_id}")
             neg = kv.begin_request(f"bde__{session_id}__neg")
             state = ARDiffusionKVState(kv, pos, neg, num_layers=kv.num_layers)


### PR DESCRIPTION
## Purpose

Follow-up to #5296 (issue #5295). **Draft: stacked on #5296, and opened to ask for a direction rather
than to merge as-is** — see the question at the end.

#5296 stops the server from bricking, but it reclaims a session's KV blocks only when the pool is
already under pressure. Nothing tells the worker that a session actually ended, so a finished session
keeps its blocks until some later admission evicts it.

`AsyncOmni.collective_rpc` already reaches worker methods (it is how `ar_diffusion_perf_stats` reads
and clears runner state), so no new plumbing is needed. This adds
`DiffusionWorker.ar_diffusion_end_session(session_id)` — a no-op for runners without session-scoped
state — and calls it from the three points where the serving layer knows a session is over:

| Path | Why |
|---|---|
| session id changes mid-connection | the DROID eval loop's actual pattern, see below |
| `endpoint: "reset"` | `RobotRealtimeServing.reset` is currently empty, while the client's own docstring says it sends this "so the server can clear any request/session-side state" |
| websocket disconnect | `handle_connection` had no `finally` |

The session-switch path is the one that matters in practice.
`examples/online_serving/dreamzero/droid_sim_eval_client.py` creates its `OpenPIWebsocketClientPolicy`
once and calls `close()` only after the whole benchmark; its per-episode `reset()` rolls a fresh
`uuid4()` session id over the *same* connection. So a disconnect-only cleanup would never fire between
episodes.

## Test Plan

**vLLM Version:** 0.11.1rc4.dev7201+gee0da84ab

**vLLM-Omni Commit:** branched from f18924c1. Runtime verification ran on v0.24.0 + #4941 + both
patches, since main needs a newer vLLM than the box has; the files touched here are identical on both.

1. Unit: `pytest tests/ar_diffusion/`, plus `test_end_session_frees_blocks_without_waiting_for_eviction`.
2. End to end: `GEAR-Dreams/DreamZero-DROID` on 1x GB10, 8 episodes over **one** websocket connection
   with a fresh session id per episode (the sim-eval pattern), comparing #5296 alone against #5296 +
   this change.

## Test Result

```
$ pytest tests/ar_diffusion/ -q
85 passed, 22 warnings in 42.24s
```

8 episodes, one connection, session id rolled per episode:

| | #5296 only | #5296 + this |
|---|---:|---:|
| session releases | 0 | 8 |
| capacity evictions | 8 | **0** |
| pool exhaustions | 0 | 0 |

Both serve all 8 episodes — that is #5296 doing its job. The difference is that without this change
every admission runs into a full pool and evicts the previous session, so the pool is at its limit
continuously; with it the blocks come back when the episode ends and admission never hits pressure.
Steady-state latency is unchanged (~13.9 s/episode on this box, which is the eager + SDPA reference
path, not a tuned number).

## Question for reviewers

@hsliuustc0106 you assigned me #5295, so before polishing this: is this the shape you want?

Specifically, session lifecycle is being designed in #4480 / #4487, and this puts a small amount of
lifecycle knowledge in the OpenPI connection layer. Options as I see them:

1. Land #5296 alone as the crash fix and let the session manager from #4480 handle release later.
2. Land both — #5296 as the invariant that the pool can always admit a session, this as the timely
   release — and let the future session manager replace the worker-side method.
3. Something else you have in mind for where end-of-session should be signalled from.

I am happy to take whichever, including the larger change if you would rather have the control path
generalized now instead of a DreamZero-specific RPC name.
