### PR TITLE
[Model][MiniCPM-o 4.5] Resolve Hugging Face model ID to local cache path in TTS

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_hf_model_path.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_hf_model_path.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for HF model-ID resolution and path caching in MiniCPM-o 4.5 TTS."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts import (
+    MiniCPMO45OmniTTSForConditionalGeneration,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_hf_model_id_path_caching(mocker, tmp_path):
+    """Verify HF model-ID path is resolved via download_weights_from_hf_specific
+    once during _lazy_init_tts, cached in self._model_path, and reused in generate_speech.
+    """
+    resolved_path = str(tmp_path / "resolved_hf_model")
+    assets_dir = tmp_path / "resolved_hf_model" / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    ref_audio_file = assets_dir / "HT_ref_audio.wav"
+    ref_audio_file.write_bytes(b"dummy wav content")
+
+    mock_download = mocker.patch(
+        "vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts.download_weights_from_hf_specific",
+        return_value=resolved_path,
+    )
+
+    # Mock dynamic class loading
+    fake_tts_class = mocker.MagicMock()
+    mocker.patch(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        return_value=fake_tts_class,
+    )
+
+    # Build fake vllm_config with HF model ID
+    model_id = "openbmb/MiniCPM-o-4_5"
+    tts_cfg = SimpleNamespace(
+        audio_bos_token_id=151687,
+        text_eos_token_id=151692,
+        num_audio_tokens=6562,
+        hidden_size=768,
+        normalize_projected_hidden=True,
+        top_p=0.8,
+        top_k=100,
+        repetition_penalty=1.02,
+        attn_implementation="sdpa",
+    )
+    hf_config = SimpleNamespace(tts_config=tts_cfg)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            model=model_id,
+            hf_config=hf_config,
+        )
+    )
+
+    tts_model = MiniCPMO45OmniTTSForConditionalGeneration(vllm_config=vllm_config)
+
+    # 1. Trigger lazy init
+    tts_model._lazy_init_tts()
+
+    # Verify download_weights_from_hf_specific was called with HF model ID and cached
+    mock_download.assert_called_once_with(model_id, None, ["*"])
+    assert tts_model._model_path == resolved_path
+    assert tts_model._assets_loaded is True
+
+    # 2. Mock TTS object generate method and audio tokenizer for generate_speech
+    fake_tts_obj = mocker.MagicMock()
+    fake_tts_obj.emb_text.weight.device = torch.device("cpu")
+    fake_tts_obj.emb_text.side_effect = lambda t: torch.zeros(t.shape[0], 768)
+    fake_tts_obj.projector_semantic.side_effect = lambda h, **kw: torch.zeros(h.shape[0], 768)
+    fake_tts_obj.config = tts_cfg
+    fake_tts_obj.audio_bos_token_id = 151687
+
+    fake_output = SimpleNamespace(new_ids=torch.tensor([[[100]]]))
+    fake_tts_obj.generate.return_value = fake_output
+
+    tts_model.tts_obj = fake_tts_obj
+    fake_tokenizer = mocker.MagicMock(return_value=b"dummy_wav_bytes")
+    tts_model.audio_tokenizer = fake_tokenizer
+
+    # Mock sf.read to return fake numpy audio
+    mocker.patch(
+        "soundfile.read",
+        return_value=(torch.zeros(16000).numpy(), 24000),
+    )
+
+    # Call generate_speech
+    tts_token_ids = torch.tensor([1, 2, 3])
+    tts_hidden_states = torch.zeros(3, 768)
+    waveform = tts_model.generate_speech(tts_token_ids, tts_hidden_states)
+
+    # Verify download_weights_from_hf_specific was NOT called a second time
+    assert mock_download.call_count == 1
+    assert waveform is not None

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -91,6 +91,29 @@ def _install_torchaudio_soundfile_shim() -> None:
 _install_torchaudio_soundfile_shim()
 
 
+def _resolve_model_path(model_path: str) -> str:
+    """Resolve a Hugging Face model ID to a local cache path.
+
+    If ``model_path`` is already a local directory, return it as-is.
+    Otherwise, use huggingface_hub to resolve the model ID to the cached
+    snapshot directory. This is necessary because downstream code treats
+    ``model_path`` as a filesystem path (e.g. joining with ``assets/...``).
+    """
+    if os.path.isdir(model_path):
+        return model_path
+    try:
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(model_path, local_files_only=True)
+    except Exception:
+        logger.warning(
+            "Could not resolve model path %s to local HF cache; "
+            "using as-is (sub-assets may fail to load).",
+            model_path,
+        )
+        return model_path
+
+
 class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
     """MiniCPM-o 4.5 Talker: MiniCPMTTS + Token2wav in a single forward pass."""
 
@@ -121,7 +144,8 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         if self._assets_loaded or self._tts_config is None:
             return
         try:
-            model_path = self.vllm_config.model_config.model
+            model_path = _resolve_model_path(self.vllm_config.model_config.model)
+
 
             if model_path not in sys.path:
                 sys.path.insert(0, model_path)
@@ -279,7 +303,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
         import torchaudio
 
-        model_path = self.vllm_config.model_config.model
+        model_path = _resolve_model_path(self.vllm_config.model_config.model)
         default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
         prompt_wav_path = default_ref if os.path.exists(default_ref) else None
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -124,10 +124,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         if self._assets_loaded or self._tts_config is None:
             return
         try:
-            model_path = download_weights_from_hf_specific(
-                self.vllm_config.model_config.model, None, ["*"]
-            )
-
+            model_path = download_weights_from_hf_specific(self.vllm_config.model_config.model, None, ["*"])
 
             if model_path not in sys.path:
                 sys.path.insert(0, model_path)
@@ -285,9 +282,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
         import torchaudio
 
-        model_path = download_weights_from_hf_specific(
-            self.vllm_config.model_config.model, None, ["*"]
-        )
+        model_path = download_weights_from_hf_specific(self.vllm_config.model_config.model, None, ["*"])
         default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
         prompt_wav_path = default_ref if os.path.exists(default_ref) else None
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -108,6 +108,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         self.tts = None
         self.audio_tokenizer = None
         self._assets_loaded = False
+        self._model_path = None
 
         tts_config = getattr(config, "tts_config", None)
         if tts_config is not None:
@@ -125,6 +126,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             return
         try:
             model_path = download_weights_from_hf_specific(self.vllm_config.model_config.model, None, ["*"])
+            self._model_path = model_path
 
             if model_path not in sys.path:
                 sys.path.insert(0, model_path)
@@ -282,7 +284,9 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
         import torchaudio
 
-        model_path = download_weights_from_hf_specific(self.vllm_config.model_config.model, None, ["*"])
+        model_path = self._model_path or download_weights_from_hf_specific(
+            self.vllm_config.model_config.model, None, ["*"]
+        )
         default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
         prompt_wav_path = default_ref if os.path.exists(default_ref) else None
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -26,6 +26,9 @@ import torch.nn.functional as F
 from vllm.config import VllmConfig
 from vllm.model_executor.models.interfaces import SupportsPP
 
+from vllm_omni.model_executor.model_loader.weight_utils import (
+    download_weights_from_hf_specific,
+)
 from vllm_omni.platforms import current_omni_platform
 
 # Preserve the established external vocoder on CUDA. Ascend uses the in-tree
@@ -91,29 +94,6 @@ def _install_torchaudio_soundfile_shim() -> None:
 _install_torchaudio_soundfile_shim()
 
 
-def _resolve_model_path(model_path: str) -> str:
-    """Resolve a Hugging Face model ID to a local cache path.
-
-    If ``model_path`` is already a local directory, return it as-is.
-    Otherwise, use huggingface_hub to resolve the model ID to the cached
-    snapshot directory. This is necessary because downstream code treats
-    ``model_path`` as a filesystem path (e.g. joining with ``assets/...``).
-    """
-    if os.path.isdir(model_path):
-        return model_path
-    try:
-        from huggingface_hub import snapshot_download
-
-        return snapshot_download(model_path, local_files_only=True)
-    except Exception:
-        logger.warning(
-            "Could not resolve model path %s to local HF cache; "
-            "using as-is (sub-assets may fail to load).",
-            model_path,
-        )
-        return model_path
-
-
 class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
     """MiniCPM-o 4.5 Talker: MiniCPMTTS + Token2wav in a single forward pass."""
 
@@ -144,7 +124,9 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         if self._assets_loaded or self._tts_config is None:
             return
         try:
-            model_path = _resolve_model_path(self.vllm_config.model_config.model)
+            model_path = download_weights_from_hf_specific(
+                self.vllm_config.model_config.model, None, ["*"]
+            )
 
 
             if model_path not in sys.path:
@@ -303,7 +285,9 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
         import torchaudio
 
-        model_path = _resolve_model_path(self.vllm_config.model_config.model)
+        model_path = download_weights_from_hf_specific(
+            self.vllm_config.model_config.model, None, ["*"]
+        )
         default_ref = os.path.join(model_path, "assets", "HT_ref_audio.wav")
         prompt_wav_path = default_ref if os.path.exists(default_ref) else None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

When `vllm_config.model_config.model` is passed as a Hugging Face repository ID (e.g., `"openbmb/MiniCPM-o-4_5"`), downstream code in `minicpmo_4_5_omni_tts.py` attempts to join filesystem paths directly against `model_path` (e.g., `os.path.join(model_path, "assets", ...)`). This causes file resolution failures (`FileNotFoundError`) for sub-assets such as `assets/token2wav` and `assets/HT_ref_audio.wav`.

This PR addresses the path resolution issue by leveraging `download_weights_from_hf_specific` from `vllm_omni.model_executor.model_loader.weight_utils` in both `_lazy_init_tts()` and `generate_speech()`:
- Resolves Hugging Face repository IDs to their cached local snapshot directories cleanly.
- Preserves existing behavior when `model_path` is already a local directory.
- Follows existing codebase conventions for weight and asset download utilities and fixes pre-commit formatting issues.

## Test Plan

- Initialize and run MiniCPM-o 4.5 TTS with HF model ID `openbmb/MiniCPM-o-4_5`.
- Verify `_lazy_init_tts()` correctly resolves `model_path` to the HF snapshot cache directory and loads `token2wav` assets cleanly.
- Verify `generate_speech()` correctly locates `HT_ref_audio.wav` and synthesizes speech without file path errors.
- Run `pre-commit` hooks to ensure code style and formatting compliance.

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** cfa745eb

## Test Result

- TTS dynamic modules and Token2wav vocoder initialized cleanly from local HF cache.
- Confirmed audio generation runs smoothly with no `FileNotFoundError` or path resolution warnings.
- All pre-commit check hooks passed cleanly.
