### PR TITLE
[Core][Model] Add BAGEL KV-gather context parallelism

### DIFF
--- a/docs/design/feature/sequence_parallel.md
+++ b/docs/design/feature/sequence_parallel.md
@@ -45,6 +45,58 @@ from vllm_omni.diffusion.distributed.sp_sharding import sp_shard, sp_gather
 | `sp_shard()` | Manual tensor sharding | Splits tensor across SP workers |
 | `sp_gather()` | Manual tensor gathering | Gathers sharded tensors from all workers |
 
+### KV-Gather Context Parallel
+
+KV-Gather CP is a third attention communication strategy under the SP
+umbrella, alongside Ulysses and Ring:
+
+- Ulysses exchanges Q/K/V with All-to-All and reverses the exchange for output.
+- Ring keeps Q local and circulates K/V blocks.
+- KV-Gather CP keeps Q local and All-Gathers K/V once per attention layer.
+
+Ring attention uses online softmax to merge successive K/V blocks while those
+blocks circulate; its running maximum, exponential sum, and output accumulator
+remain on the rank that owns Q. KV-Gather starts from the same local-Q
+decomposition but materializes full K/V with one collective, then invokes a
+regular attention backend. Every local query sees the same global K/V in both
+strategies, although different reduction orders need not be bitwise identical.
+
+For GQA models such as BAGEL (`Hq=28`, `Hkv=4`), CP removes Q and output
+communication from the attention strategy and communicates only the smaller
+K/V tensors. The tradeoff is that every rank stores full-sequence K/V.
+
+Let `P` be the parallel degree and `R = Hq / Hkv`. For equal sequence shards,
+the per-rank communication-volume ratio to Ulysses is:
+
+```text
+V_CP / V_Ulysses = P / (R + 1)
+```
+
+This counts the K/V All-Gather for CP and the Q/K/V forward plus output reverse
+All-to-All for Ulysses, while ignoring collective implementation overhead. For
+BAGEL CP4, `P=4` and `R=7`, so KV-Gather communicates half as many bytes as
+Ulysses. CP communicates less when `P < R+1`.
+
+The BAGEL fast path splits the generation-expert projection and schedules it
+as K projection → asynchronous K All-Gather → V projection → asynchronous V
+All-Gather → Q projection. K communication overlaps V/Q projection and V
+communication overlaps Q projection. Communication leaves the critical path
+only when those compute windows cover the collective latency. Prompt prefill
+continues to use the frozen text expert and is not part of this denoising-only
+overlap.
+
+The initial BAGEL CP path uses SDPA for numerical alignment. Although dense
+FlashAttention accepts asymmetric Q/K lengths, its small reduction-order
+differences compound across the denoise trajectory. A CP-specific stable Flash
+kernel remains follow-up work.
+
+The first implementation uses `context_parallel_degree`, requires equal
+unmasked sequence shards, and is mutually exclusive with Ulysses/Ring. Full K/V
+must fit on every rank, and quantized QKV implementations need independent
+projection slices to use the overlap fast path. Its communication group is the
+existing outer SP `device_group`; it does not create a duplicate CP process
+group.
+
 ---
 
 ## UAA Mode (Experimental)

--- a/docs/user_guide/diffusion/parallelism/sequence_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/sequence_parallel.md
@@ -23,6 +23,7 @@ See supported models list in [Diffusion Features - Supported Models](../../diffu
 - **DeepSpeed Ulysses Sequence Parallel (Ulysses-SP)** ([paper](https://arxiv.org/pdf/2309.14509)): Uses all-to-all communication for subset of attention heads per device
 - **Ring-Attention** ([paper](https://arxiv.org/abs/2310.01889)): Uses ring-based P2P communication with sharded sequence dimension throughout
 - **Hybrid Ulysses + Ring**: Combines both for larger scale parallelism (`ulysses_degree × ring_degree`)
+- **KV-Gather Context Parallel (CP)**: Keeps Q sequence-sharded and all-gathers only K/V. This is especially useful for GQA denoisers where K/V have substantially fewer heads than Q.
 
 ---
 
@@ -84,6 +85,28 @@ omni = Omni(
     parallel_config=DiffusionParallelConfig(ulysses_degree=2, ring_degree=2)  # 4 GPUs total
 )
 ```
+
+**KV-Gather Context Parallel** (BAGEL first):
+
+```python
+omni = Omni(
+    model="ByteDance-Seed/BAGEL-7B-MoT",
+    parallel_config=DiffusionParallelConfig(context_parallel_degree=4),
+)
+```
+
+CP trades replicated full-sequence K/V memory for lower communication volume. In
+the first implementation it is mutually exclusive with Ulysses and Ring. For
+parallel degree `P` and GQA head ratio `R = Hq / Hkv`, its per-rank
+communication volume relative to Ulysses is `P / (R + 1)` (ignoring collective
+implementation overhead). BAGEL has `R=7`, so CP4 communicates half as many
+bytes as Ulysses-SP 4.
+
+The BAGEL fast path launches asynchronous K/V All-Gathers between independent
+K, V, and Q projections. The communication can be fully hidden when the V/Q
+projection window covers the collective latency. Full K/V must fit on each
+rank, sequence shards must be equal and unmasked, and quantized QKV projections
+must expose independent projection slices to use this overlap path.
 
 ---
 
@@ -153,6 +176,15 @@ vllm serve Qwen/Qwen-Image --omni --port 8091 --ring 2
 vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2 --ring 2
 ```
 
+**KV-Gather Context Parallel:**
+
+```bash
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 --cp 4
+```
+
+`VLLM_OMNI_CP_DEGREE=4` supplies the CP default when neither YAML nor CLI sets
+`context_parallel_degree`.
+
 ---
 
 ## Configuration Parameters
@@ -163,10 +195,12 @@ In `DiffusionParallelConfig`:
 |-----------|------|---------|-------------|
 | `ulysses_degree` | int | 1 | Number of GPUs for Ulysses-SP. Uses all-to-all communication. |
 | `ring_degree` | int | 1 | Number of GPUs for Ring-Attention. Uses P2P ring communication. |
+| `context_parallel_degree` | int | 1 | Number of GPUs for KV-Gather CP. Q remains local; K/V are all-gathered. |
 | `ulysses_mode` | str | `"default"` | Ulysses attention mode. Set to `"advanced_uaa"` to handle arbitrary sequence lengths and head counts without padding. |
 
 **Notes:**
-- Total sequence parallel size equals to `ulysses_degree × ring_degree`
+- Total sequence parallel size is `ulysses_degree × ring_degree × context_parallel_degree`
+- CP > 1 currently requires `ulysses_degree=1` and `ring_degree=1`
 - Degrees must evenly divide the sequence length for optimal performance (or use `ulysses_mode="advanced_uaa"` for Ulysses-SP)
 
 

--- a/tests/diffusion/attention/test_context_parallel.py
+++ b/tests/diffusion/attention/test_context_parallel.py
@@ -1,0 +1,200 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.parallel.context_parallel import ContextParallelAttention
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.diffusion.layers.mot.mot_qkv_parallel_linear import MoTQKVParallelLinear
+from vllm_omni.diffusion.models.bagel.bagel_transformer import Bagel
+
+
+class _CompletedWork:
+    def wait(self) -> None:
+        return None
+
+
+def test_context_parallel_gathers_only_kv(monkeypatch: pytest.MonkeyPatch) -> None:
+    gathered_inputs: list[torch.Tensor] = []
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+
+    def _all_gather_into_tensor(output, tensor, *, group, async_op):
+        del group
+        assert async_op
+        gathered_inputs.append(tensor.clone())
+        output[: tensor.shape[0]].copy_(tensor)
+        output[tensor.shape[0] :].copy_(tensor + 10)
+        return _CompletedWork()
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", _all_gather_into_tensor)
+    strategy = ContextParallelAttention(SimpleNamespace(device_group=object()))
+    query = torch.randn(1, 2, 28, 8)
+    key = torch.randn(1, 2, 4, 8)
+    value = torch.randn(1, 2, 4, 8)
+    joint_query = torch.randn(1, 1, 28, 8)
+    joint_key = torch.randn(1, 3, 4, 8)
+    joint_value = torch.randn(1, 3, 4, 8)
+
+    out_q, out_k, out_v, _, _ = strategy.pre_attention(
+        query,
+        key,
+        value,
+        AttentionMetadata(
+            joint_query=joint_query,
+            joint_key=joint_key,
+            joint_value=joint_value,
+        ),
+    )
+
+    assert len(gathered_inputs) == 2
+    assert torch.equal(gathered_inputs[0], key)
+    assert torch.equal(gathered_inputs[1], value)
+    assert torch.equal(out_q[:, 1:], query)
+    assert out_k.shape == (1, 7, 4, 8)
+    assert out_v.shape == (1, 7, 4, 8)
+    assert torch.equal(out_k[:, :3], joint_key)
+    assert torch.equal(out_k[:, 3:5], key)
+    assert torch.equal(out_k[:, 5:], key + 10)
+
+
+def test_context_parallel_config_env_fallback_and_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_OMNI_CP_DEGREE", "4")
+    from_env = DiffusionParallelConfig()
+    explicit = DiffusionParallelConfig(context_parallel_degree=2)
+
+    assert from_env.context_parallel_degree == 4
+    assert from_env.sequence_parallel_size == 4
+    assert explicit.context_parallel_degree == 2
+    assert explicit.sequence_parallel_size == 2
+
+
+def test_context_parallel_rejects_ulysses_or_ring() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        DiffusionParallelConfig(context_parallel_degree=2, ulysses_degree=2)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        DiffusionParallelConfig(context_parallel_degree=2, ring_degree=2)
+
+
+def test_gen_component_projection_uses_separate_weight_slices() -> None:
+    layer = MoTQKVParallelLinear.__new__(MoTQKVParallelLinear)
+    torch.nn.Module.__init__(layer)
+    layer.gen_exp = torch.nn.Module()
+    layer.gen_exp.weight = torch.nn.Parameter(torch.arange(16, dtype=torch.float32).reshape(4, 4))
+    layer.gen_exp.bias = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    layer.output_partition_sizes = [2, 1, 1]
+    inputs = torch.ones(3, 4)
+
+    q = layer.forward_gen_component(inputs, "q")
+    k = layer.forward_gen_component(inputs, "k")
+    v = layer.forward_gen_component(inputs, "v")
+
+    expected = torch.nn.functional.linear(inputs, layer.gen_exp.weight, layer.gen_exp.bias)
+    assert torch.equal(q, expected[:, :2])
+    assert torch.equal(k, expected[:, 2:3])
+    assert torch.equal(v, expected[:, 3:])
+
+
+def test_context_parallel_global_cfg_renorm_uses_all_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
+    local_v = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    local_cfg = torch.tensor([[0.5, 1.0], [1.5, 2.0]])
+    remote_v = torch.tensor([[5.0, 6.0], [7.0, 8.0]])
+    remote_cfg = torch.tensor([[2.5, 3.0], [3.5, 4.0]])
+    text_scale = 2.0
+    remote_guided = remote_cfg + text_scale * (remote_v - remote_cfg)
+
+    def _all_reduce(tensor, *, op, group) -> None:
+        assert op == torch.distributed.ReduceOp.SUM
+        assert group is process_group
+        tensor.add_(
+            torch.stack(
+                (
+                    remote_v.square().sum(),
+                    remote_guided.square().sum(),
+                )
+            )
+        )
+
+    process_group = object()
+    monkeypatch.setattr(torch.distributed, "all_reduce", _all_reduce)
+    actual = Bagel._combine_cfg(
+        local_v,
+        local_cfg,
+        None,
+        text_scale,
+        1.0,
+        "global",
+        0.0,
+        global_norm_group=process_group,
+    )
+    expected = Bagel._combine_cfg(
+        torch.cat((local_v, remote_v)),
+        torch.cat((local_cfg, remote_cfg)),
+        None,
+        text_scale,
+        1.0,
+        "global",
+        0.0,
+    )[: local_v.shape[0]]
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_persistent_context_parallel_gathers_only_final_latent() -> None:
+    calls = {"forward": 0, "gather": 0}
+    model = SimpleNamespace()
+
+    def _split_vae_for_sp(x_t, vae_position_ids, *args):
+        del args
+        local_size = x_t.shape[0] // 2
+        return (
+            x_t[:local_size],
+            vae_position_ids[:local_size],
+            torch.arange(local_size),
+            torch.empty(0, dtype=torch.long),
+            torch.tensor([local_size]),
+            torch.arange(local_size),
+        )
+
+    def _forward_single_branch_local(local_x_t, *args):
+        del args
+        calls["forward"] += 1
+        return torch.ones_like(local_x_t)
+
+    def _gather_vae_for_sp(local_x_t):
+        calls["gather"] += 1
+        return torch.cat((local_x_t, local_x_t))
+
+    model._split_vae_for_sp = _split_vae_for_sp
+    model._forward_single_branch_local = _forward_single_branch_local
+    model._gather_vae_for_sp = _gather_vae_for_sp
+
+    result, trajectories, trajectory_timesteps, log_probs = Bagel._generate_image_context_parallel(
+        model,
+        x_t=torch.zeros(4, 2),
+        timesteps=torch.tensor([1.0, 0.5, 0.0]),
+        dts=torch.ones(3),
+        packed_text_ids=torch.empty(0, dtype=torch.long),
+        packed_text_indexes=torch.empty(0, dtype=torch.long),
+        packed_vae_position_ids=torch.arange(4),
+        packed_vae_token_indexes=torch.arange(4),
+        packed_seqlens=torch.tensor([6]),
+        packed_position_ids=torch.arange(4),
+        past_key_values=object(),
+        cfg_interval=(0.0, 1.0),
+        cfg_text_scale=1.0,
+        cfg_text_packed_position_ids=None,
+        cfg_text_past_key_values=None,
+        cfg_img_scale=1.0,
+        cfg_img_packed_position_ids=None,
+        cfg_img_past_key_values=None,
+        cfg_renorm_type="global",
+        cfg_renorm_min=0.0,
+    )
+
+    assert calls == {"forward": 3, "gather": 1}
+    assert len(result) == 1
+    assert torch.equal(result[0], torch.full((4, 2), -3.0))
+    assert trajectories is trajectory_timesteps is log_probs is None

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -236,6 +236,29 @@ def test_serve_cli_accepts_ulysses_mode():
     assert parallel_config.ulysses_mode == "advanced_uaa"
 
 
+def test_serve_cli_accepts_context_parallel_degree():
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    OmniServeCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "ByteDance-Seed/BAGEL-7B-MoT",
+            "--omni",
+            "--cp",
+            "4",
+        ]
+    )
+
+    explicit_kwargs = args.get_explicit_kwargs_dict()
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(explicit_kwargs)[0]
+    parallel_config = stage_cfg["engine_args"]["parallel_config"]
+
+    assert parallel_config.context_parallel_degree == 4
+    assert parallel_config.sequence_parallel_size == 4
+
+
 def test_serve_cli_accepts_diffusion_pipeline_profiler_flag():
     """Ensure diffusion serve CLI exposes the profiler switch."""
     parser = TrackingArgumentParser()

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -11,6 +11,7 @@ later PRs cut consumers over to these classes.
 from __future__ import annotations
 
 import copy
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -109,6 +110,7 @@ class _ParallelConfigEngineOverrides(TypedDict, total=False):
     sequence_parallel_size: int
     ulysses_degree: int
     ring_degree: int
+    context_parallel_degree: int
     ulysses_mode: str
     cfg_parallel_size: int
     vae_patch_parallel_size: int
@@ -360,6 +362,10 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
     sequence_parallel_size: int = Field(default=1, ge=1, init=False)
     ulysses_degree: int = Field(default=1, ge=1)
     ring_degree: int = Field(default=1, ge=1)
+    context_parallel_degree: int = Field(
+        default_factory=lambda: int(os.environ.get("VLLM_OMNI_CP_DEGREE", "1")),
+        ge=1,
+    )
     ulysses_mode: str = "strict"
     cfg_parallel_size: int = Field(default=1, ge=1, le=3)
     vae_patch_parallel_size: int = Field(default=1, ge=1)
@@ -370,7 +376,9 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
     hsdp_replicate_size: int = Field(default=1, ge=1)
 
     def __post_init__(self) -> None:
-        self.sequence_parallel_size = self.ulysses_degree * self.ring_degree
+        self.sequence_parallel_size = self.ulysses_degree * self.ring_degree * self.context_parallel_degree
+        if self.context_parallel_degree > 1 and (self.ulysses_degree > 1 or self.ring_degree > 1):
+            raise ValueError("context_parallel_degree > 1 is mutually exclusive with Ulysses and Ring")
         if self.ulysses_mode not in {"strict", "advanced_uaa"}:
             raise ValueError("ulysses_mode must be 'strict' or 'advanced_uaa'")
         if self.vae_parallel_mode not in {"tile", "spatial_shard_height", "spatial_shard_width"}:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -149,14 +149,19 @@ def _apply_diffusion_parallel_runtime_overrides(
             continue
         if parallel_config_dict is None:
             parallel_config_dict = {}
-        if key in ("ulysses_degree", "ring_degree"):
+        if key in ("ulysses_degree", "ring_degree", "context_parallel_degree"):
             degree_overridden = True
         parallel_config_dict[key] = runtime_overrides.pop(key)
 
     if parallel_config_dict is not None and degree_overridden and not sequence_parallel_explicit:
         ulysses_degree = parallel_config_dict.get("ulysses_degree") or 1
         ring_degree = parallel_config_dict.get("ring_degree") or 1
-        parallel_config_dict["sequence_parallel_size"] = ulysses_degree * ring_degree
+        context_parallel_degree = parallel_config_dict.get("context_parallel_degree")
+        if context_parallel_degree is None:
+            from vllm_omni.diffusion import envs
+
+            context_parallel_degree = envs.VLLM_OMNI_CP_DEGREE
+        parallel_config_dict["sequence_parallel_size"] = ulysses_degree * ring_degree * context_parallel_degree
 
     if parallel_config_dict is not None:
         engine_args["parallel_config"] = parallel_config_dict
@@ -357,6 +362,7 @@ class StageDeployConfig:
     ulysses_degree: int | None = None
     ulysses_mode: str | None = None
     ring_degree: int | None = None
+    context_parallel_degree: int | None = None
     sequence_parallel_size: int | None = None
     cfg_parallel_size: int | None = None
     vae_patch_parallel_size: int | None = None

--- a/vllm_omni/deploy/bagel_cp4.yaml
+++ b/vllm_omni/deploy/bagel_cp4.yaml
@@ -1,0 +1,28 @@
+# BAGEL-7B-MoT single-stage KV-Gather Context Parallel example.
+pipeline: bagel_single_stage
+async_chunk: false
+
+stages:
+  - stage_id: 0
+    max_num_batched_tokens: 32768
+    max_num_seqs: 1
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "0,1,2,3"
+    parallel_config:
+      pipeline_parallel_size: 1
+      data_parallel_size: 1
+      tensor_parallel_size: 1
+      enable_expert_parallel: false
+      sequence_parallel_size: 4
+      ulysses_degree: 1
+      ring_degree: 1
+      context_parallel_degree: 4
+      cfg_parallel_size: 1
+      vae_patch_parallel_size: 1
+      use_hsdp: false
+      hsdp_shard_size: -1
+      hsdp_replicate_size: 1
+    default_sampling_params:
+      seed: 52

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -272,6 +272,11 @@ class Attention(nn.Module):
         # 2. Kernel Execution (Computation)
         if self.use_ring and strategy is not self._no_parallel_strategy:
             out = self._run_ring_attention(query, key, value, attn_metadata)
+        elif strategy.name == "context_parallel":
+            # BAGEL's denoise trajectory is highly sensitive to the small
+            # reduction-order differences of asymmetric-Q/K FlashAttention.
+            # SDPA preserves alignment with the established UP reference.
+            out = self.sdpa_fallback.forward(query, key, value, attn_metadata)
         else:
             out = self._run_local_attention(query, key, value, attn_metadata)
 

--- a/vllm_omni/diffusion/attention/parallel/context_parallel.py
+++ b/vllm_omni/diffusion/attention/parallel/context_parallel.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.parallel.base import ParallelAttentionContext
+from vllm_omni.diffusion.distributed.group_coordinator import SequenceParallelGroupCoordinator
+
+
+@dataclass(slots=True)
+class AsyncSequenceAllGather:
+    """An asynchronous all-gather whose result is concatenated on sequence."""
+
+    output: torch.Tensor
+    work: dist.Work
+    batch_size: int
+    local_seq_len: int
+
+    def wait(self) -> torch.Tensor:
+        self.work.wait()
+        world_size = self.output.shape[0] // self.batch_size
+        return (
+            self.output.view(
+                world_size,
+                self.batch_size,
+                self.local_seq_len,
+                *self.output.shape[2:],
+            )
+            .permute(1, 0, 2, *range(3, self.output.ndim + 1))
+            .reshape(
+                self.batch_size,
+                world_size * self.local_seq_len,
+                *self.output.shape[2:],
+            )
+            .contiguous()
+        )
+
+
+def async_all_gather_sequence(
+    tensor: torch.Tensor,
+    group: dist.ProcessGroup,
+) -> AsyncSequenceAllGather:
+    """Start an equal-shape all-gather for a ``(B, S_local, ...)`` tensor."""
+    if tensor.ndim < 2:
+        raise ValueError(f"Context-parallel all-gather expects at least 2 dimensions, got {tensor.shape}.")
+    tensor = tensor.contiguous()
+    world_size = dist.get_world_size(group)
+    output = torch.empty(
+        (world_size * tensor.shape[0], *tensor.shape[1:]),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    work = dist.all_gather_into_tensor(output, tensor, group=group, async_op=True)
+    return AsyncSequenceAllGather(
+        output=output,
+        work=work,
+        batch_size=int(tensor.shape[0]),
+        local_seq_len=int(tensor.shape[1]),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ContextParallelCtx(ParallelAttentionContext):
+    joint_len: int = 0
+    joint_strategy: str = "front"
+
+
+class ContextParallelAttention:
+    """KV-gather context parallelism.
+
+    Q remains sequence-local. K/V are all-gathered over the outer SP group,
+    after which the regular local attention backend computes local-Q outputs.
+    """
+
+    def __init__(self, sp_group: SequenceParallelGroupCoordinator) -> None:
+        self._sp_group = sp_group
+        self._group = sp_group.device_group
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    @property
+    def name(self) -> str:
+        return "context_parallel"
+
+    def pre_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None,
+    ):
+        if attn_metadata is not None and (
+            attn_metadata.attn_mask is not None or attn_metadata.joint_attn_mask is not None
+        ):
+            raise ValueError("KV-gather context parallelism currently requires equal, unmasked sequence shards.")
+
+        extra = attn_metadata.extra if attn_metadata is not None else {}
+        kv_already_gathered = bool(extra.get("context_parallel_kv_gathered", False))
+        if not kv_already_gathered:
+            key_handle = async_all_gather_sequence(key, self._group)
+            value_handle = async_all_gather_sequence(value, self._group)
+            key = key_handle.wait()
+            value = value_handle.wait()
+
+        joint_query = joint_key = joint_value = None
+        joint_strategy = "front"
+        if attn_metadata is not None:
+            joint_query = attn_metadata.joint_query
+            joint_key = attn_metadata.joint_key
+            joint_value = attn_metadata.joint_value
+            joint_strategy = attn_metadata.joint_strategy
+
+        joint_len = 0
+        joint_values = (joint_query, joint_key, joint_value)
+        if any(x is not None for x in joint_values):
+            if not all(x is not None for x in joint_values):
+                raise ValueError("joint_query, joint_key, and joint_value must be provided together.")
+            if joint_strategy not in {"front", "rear"}:
+                raise ValueError(f"Unsupported joint_strategy={joint_strategy!r}.")
+            joint_len = int(joint_query.shape[1])
+            if joint_strategy == "front":
+                query = torch.cat([joint_query, query], dim=1)
+                key = torch.cat([joint_key, key], dim=1)
+                value = torch.cat([joint_value, value], dim=1)
+            else:
+                query = torch.cat([query, joint_query], dim=1)
+                key = torch.cat([key, joint_key], dim=1)
+                value = torch.cat([value, joint_value], dim=1)
+
+        ctx = _ContextParallelCtx(
+            name=self.name,
+            joint_len=joint_len,
+            joint_strategy=joint_strategy,
+        )
+        return query, key, value, attn_metadata, ctx
+
+    def post_attention(
+        self,
+        attn_output: torch.Tensor,
+        ctx: ParallelAttentionContext | None,
+    ) -> torch.Tensor:
+        return attn_output

--- a/vllm_omni/diffusion/attention/parallel/factory.py
+++ b/vllm_omni/diffusion/attention/parallel/factory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.attention.parallel.base import NoParallelAttention, ParallelAttentionStrategy
+from vllm_omni.diffusion.attention.parallel.context_parallel import ContextParallelAttention
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
 from vllm_omni.diffusion.attention.parallel.ulysses import UlyssesParallelAttention
 from vllm_omni.diffusion.distributed.parallel_state import get_sequence_parallel_world_size, get_sp_group
@@ -36,6 +37,7 @@ def build_parallel_attention_strategy(
 
     ulysses_degree = getattr(p, "ulysses_degree", 1)
     ring_degree = getattr(p, "ring_degree", 1)
+    context_parallel_degree = getattr(p, "context_parallel_degree", 1)
 
     try:
         sp_group = get_sp_group()
@@ -44,12 +46,20 @@ def build_parallel_attention_strategy(
             return NoParallelAttention()
     except Exception as e:
         # Log warning if SP is configured but group is not available
-        if ulysses_degree > 1 or ring_degree > 1:
+        if ulysses_degree > 1 or ring_degree > 1 or context_parallel_degree > 1:
             logger.warning(
-                f"SP configured (ulysses={ulysses_degree}, ring={ring_degree}) but SP group not available: {e}. "
+                f"SP configured (ulysses={ulysses_degree}, ring={ring_degree}, "
+                f"context_parallel={context_parallel_degree}) but SP group not available: {e}. "
                 f"Falling back to NoParallelAttention. This may cause incorrect results."
             )
         return NoParallelAttention()
+
+    if context_parallel_degree > 1:
+        logger.debug(
+            "Using ContextParallelAttention (context_parallel_degree=%d)",
+            context_parallel_degree,
+        )
+        return ContextParallelAttention(sp_group=sp_group)
 
     # Ulysses (or Hybrid Ulysses+Ring)
     if ulysses_degree > 1:

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _default_context_parallel_degree() -> int:
+    from vllm_omni.diffusion import envs
+
+    return envs.VLLM_OMNI_CP_DEGREE
+
+
 def normalize_omni_diffusion_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize legacy diffusion kwargs before config construction."""
     normalized = dict(kwargs)
@@ -156,13 +162,19 @@ class DiffusionParallelConfig:
     """Enable expert parallelism for MoE layers (TP is still used for non-MoE layers)."""
 
     sequence_parallel_size: int | None = None
-    """Number of sequence parallel groups. sequence_parallel_size = ring_degree * ulysses_degree"""
+    """Total SP degree: Ulysses degree × Ring degree × Context Parallel degree."""
 
     ulysses_degree: int = 1
     """Number of GPUs used for ulysses sequence parallelism."""
 
     ring_degree: int = 1
     """Number of GPUs used for ring sequence parallelism."""
+
+    context_parallel_degree: int = field(default_factory=_default_context_parallel_degree)
+    """Number of GPUs used for KV-gather context parallelism.
+
+    The first implementation is mutually exclusive with Ulysses and Ring.
+    """
 
     ulysses_mode: str = "strict"
     """Ulysses sequence-parallel mode.
@@ -225,6 +237,7 @@ class DiffusionParallelConfig:
         assert self.sequence_parallel_size > 0, "Sequence parallel size must be > 0"
         assert self.ulysses_degree > 0, "Ulysses degree must be > 0"
         assert self.ring_degree > 0, "Ring degree must be > 0"
+        assert self.context_parallel_degree > 0, "Context parallel degree must be > 0"
         assert self.cfg_parallel_size > 0, "CFG parallel size must be > 0"
         assert self.cfg_parallel_size in [1, 2, 3], (
             f"CFG parallel size must be 1, 2, or 3, but got {self.cfg_parallel_size}"
@@ -234,10 +247,16 @@ class DiffusionParallelConfig:
             "vae_parallel_mode must be one of {'tile', 'spatial_shard_height', 'spatial_shard_width'}, "
             f"but got {self.vae_parallel_mode!r}."
         )
-        assert self.sequence_parallel_size == self.ulysses_degree * self.ring_degree, (
-            "Sequence parallel size must be equal to the product of ulysses degree and ring degree,"
-            f" but got {self.sequence_parallel_size} != {self.ulysses_degree} * {self.ring_degree}"
+        assert self.sequence_parallel_size == (self.ulysses_degree * self.ring_degree * self.context_parallel_degree), (
+            "Sequence parallel size must equal ulysses_degree * ring_degree * context_parallel_degree, "
+            f"but got {self.sequence_parallel_size} != {self.ulysses_degree} * "
+            f"{self.ring_degree} * {self.context_parallel_degree}"
         )
+        if self.context_parallel_degree > 1 and (self.ulysses_degree > 1 or self.ring_degree > 1):
+            raise ValueError(
+                "KV-gather context parallelism is mutually exclusive with Ulysses and Ring in the first "
+                "implementation. Set ulysses_degree=1 and ring_degree=1 when context_parallel_degree > 1."
+            )
         assert self.ulysses_mode in {"strict", "advanced_uaa"}, (
             f"ulysses_mode must be one of {{'strict','advanced_uaa'}}, but got {self.ulysses_mode!r}."
         )
@@ -250,7 +269,7 @@ class DiffusionParallelConfig:
 
     def __post_init__(self) -> None:
         if self.sequence_parallel_size is None:
-            self.sequence_parallel_size = self.ulysses_degree * self.ring_degree
+            self.sequence_parallel_size = self.ulysses_degree * self.ring_degree * self.context_parallel_degree
 
         # Calculate world_size from other parallelism dimensions
         other_parallel_world_size = (
@@ -259,6 +278,7 @@ class DiffusionParallelConfig:
             * self.tensor_parallel_size
             * self.ulysses_degree
             * self.ring_degree
+            * self.context_parallel_degree
             * self.cfg_parallel_size
         )
 

--- a/vllm_omni/diffusion/distributed/group_coordinator.py
+++ b/vllm_omni/diffusion/distributed/group_coordinator.py
@@ -1012,8 +1012,11 @@ class SequenceParallelGroupCoordinator(GroupCoordinator):
             )
         self.ulysses_group = ulysses_group
         self.ring_group = ring_group
+        self.context_parallel_degree = int(kwargs.get("context_parallel_degree", 1))
 
         self.ulysses_world_size = torch.distributed.get_world_size(self.ulysses_group)
         self.ulysses_rank = torch.distributed.get_rank(self.ulysses_group)
         self.ring_world_size = torch.distributed.get_world_size(self.ring_group)
         self.ring_rank = torch.distributed.get_rank(self.ring_group)
+        self.context_parallel_world_size = self.world_size if self.context_parallel_degree > 1 else 1
+        self.context_parallel_rank = self.rank_in_group if self.context_parallel_degree > 1 else 0

--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -303,6 +303,14 @@ def get_ring_parallel_rank():
     return get_sp_group().ring_rank
 
 
+def get_context_parallel_world_size():
+    return get_sp_group().context_parallel_world_size
+
+
+def get_context_parallel_rank():
+    return get_sp_group().context_parallel_rank
+
+
 def get_expert_parallel_group_ranks() -> list[list[int]]:
     assert vllm_parallel_state._EP is not None, "expert parallel group is not initialized"
     assert _EXPERT_PARALLEL_GROUP_RANKS is not None, "expert parallel group ranks are not initialized"
@@ -694,6 +702,7 @@ def initialize_model_parallel(
     sequence_parallel_size: int | None = None,
     ulysses_degree: int = 1,
     ring_degree: int = 1,
+    context_parallel_degree: int = 1,
     tensor_parallel_size: int = 1,
     pipeline_parallel_size: int = 1,
     fully_shard_degree: int = 1,
@@ -710,7 +719,7 @@ def initialize_model_parallel(
         data_parallel_size: number of data parallelism groups.
         cfg_parallel_size: number of GPUs used for Classifier Free Guidance (CFG) parallelism.
         sequence_parallel_size: number of GPUs used for sequence parallelism.
-            sequence_parallel_size = ulysses_degree * ring_degree
+            sequence_parallel_size = ulysses_degree * ring_degree * context_parallel_degree
         ulysses_degree: number of GPUs used for ulysses sequence parallelism.
         ring_degree: number of GPUs used for ring sequence parallelism.
         tensor_parallel_size: number of GPUs used for tensor parallelism.
@@ -749,16 +758,20 @@ def initialize_model_parallel(
     world_size: int = torch.distributed.get_world_size()
     backend = backend or torch.distributed.get_backend(get_world_group().device_group)
 
+    if context_parallel_degree > 1 and (ulysses_degree > 1 or ring_degree > 1):
+        raise ValueError("context_parallel_degree > 1 is mutually exclusive with Ulysses and Ring.")
+
     if sequence_parallel_size is None:
-        sequence_parallel_size = ring_degree * ulysses_degree
+        sequence_parallel_size = ring_degree * ulysses_degree * context_parallel_degree
         logger.info(
-            f"sequence_parallel_size is not provided, using ring_degree * ulysses_degree = {sequence_parallel_size}"
+            "sequence_parallel_size is not provided, using ring_degree * ulysses_degree * "
+            f"context_parallel_degree = {sequence_parallel_size}"
         )
 
-    if sequence_parallel_size != ring_degree * ulysses_degree:
+    if sequence_parallel_size != ring_degree * ulysses_degree * context_parallel_degree:
         raise ValueError(
-            "sequence_parallel_size is not equal to ring_degree * ulysses_degree,"
-            f" but got {sequence_parallel_size} != {ring_degree} * {ulysses_degree}"
+            "sequence_parallel_size is not equal to ring_degree * ulysses_degree * context_parallel_degree, "
+            f"but got {sequence_parallel_size} != {ring_degree} * {ulysses_degree} * {context_parallel_degree}"
         )
 
     dit_parallel_size = (
@@ -835,12 +848,14 @@ def initialize_model_parallel(
 
     global _SP
     assert _SP is None, "sequence parallel group is already initialized"
+    subgroup_ulysses_degree = 1 if context_parallel_degree > 1 else ulysses_degree
+    subgroup_ring_degree = 1 if context_parallel_degree > 1 else ring_degree
     ulysses_pg, ring_pg = set_seq_parallel_pg(
-        sp_ulysses_degree=ulysses_degree,
-        sp_ring_degree=ring_degree,
+        sp_ulysses_degree=subgroup_ulysses_degree,
+        sp_ring_degree=subgroup_ring_degree,
         rank=get_world_group().rank_in_group,
         world_size=dit_parallel_size,
-        sp_group_ranks=sp_group_ranks,
+        sp_group_ranks=None if context_parallel_degree > 1 else sp_group_ranks,
     )
     _SP = init_model_parallel_group(
         group_ranks=sp_group_ranks,
@@ -849,6 +864,7 @@ def initialize_model_parallel(
         parallel_mode="sequence",
         ulysses_group=ulysses_pg,
         ring_group=ring_pg,
+        context_parallel_degree=context_parallel_degree,
     )
     if use_moe_parallel_mapping:
         # Diffusion normally uses its own SP group. Map it to vLLM PCP only for

--- a/vllm_omni/diffusion/distributed/sp_plan.py
+++ b/vllm_omni/diffusion/distributed/sp_plan.py
@@ -9,6 +9,9 @@ This module provides:
 2. SequenceParallelInput/Output: Type definitions for _sp_plan declarations
 3. Validation utilities for _sp_plan
 
+KV-gather context parallelism extends SequenceParallelConfig with
+context_parallel_degree while preserving the existing Ulysses/Ring interface.
+
 A _sp_plan is a dictionary that specifies how to shard/gather tensors at
 different points in a model's forward pass. This allows automatic handling
 of sequence parallelism without modifying the model's forward() method.
@@ -67,16 +70,20 @@ class SequenceParallelConfig:
         ring_degree: Number of devices for Ring attention. Sequence is split
             across devices, with K/V passed in a ring topology. Best for long
             sequences with limited memory/bandwidth.
+        context_parallel_degree: Number of devices for KV-gather context
+            parallelism. Q stays sequence-sharded while K/V are all-gathered.
+            The first implementation is mutually exclusive with Ulysses/Ring.
         convert_to_fp32: Whether to convert output and LSE to float32 for
             numerical stability in ring attention.
 
     Note:
-        ulysses_degree * ring_degree = sequence_parallel_size
+        ulysses_degree * ring_degree * context_parallel_degree = sequence_parallel_size
         vLLM-Omni supports hybrid Ulysses-Ring attention (both > 1).
     """
 
     ulysses_degree: int = 1
     ring_degree: int = 1
+    context_parallel_degree: int = 1
     convert_to_fp32: bool = True
 
     # Internal state - populated by setup()
@@ -85,18 +92,18 @@ class SequenceParallelConfig:
     _device: torch.device | None = None
 
     def __post_init__(self) -> None:
-        if self.ulysses_degree < 1 or self.ring_degree < 1:
-            raise ValueError("`ulysses_degree` and `ring_degree` must be >= 1.")
+        if self.ulysses_degree < 1 or self.ring_degree < 1 or self.context_parallel_degree < 1:
+            raise ValueError("SP degrees must be >= 1.")
 
-        if self.ulysses_degree == 1 and self.ring_degree == 1:
-            raise ValueError(
-                "At least one of `ulysses_degree` or `ring_degree` must be > 1 to use sequence parallelism."
-            )
+        if self.ulysses_degree == 1 and self.ring_degree == 1 and self.context_parallel_degree == 1:
+            raise ValueError("At least one SP degree must be > 1 to use sequence parallelism.")
+        if self.context_parallel_degree > 1 and (self.ulysses_degree > 1 or self.ring_degree > 1):
+            raise ValueError("KV-gather context parallelism is mutually exclusive with Ulysses and Ring.")
 
     @property
     def sequence_parallel_size(self) -> int:
         """Total sequence parallel world size."""
-        return self.ulysses_degree * self.ring_degree
+        return self.ulysses_degree * self.ring_degree * self.context_parallel_degree
 
     def get_world_size(self) -> int:
         """Get the sequence parallel world size from parallel state.
@@ -164,6 +171,16 @@ class SequenceParallelConfig:
 
         return get_ring_parallel_rank()
 
+    def get_context_parallel_world_size(self) -> int:
+        from vllm_omni.diffusion.distributed.parallel_state import get_context_parallel_world_size
+
+        return get_context_parallel_world_size()
+
+    def get_context_parallel_rank(self) -> int:
+        from vllm_omni.diffusion.distributed.parallel_state import get_context_parallel_rank
+
+        return get_context_parallel_rank()
+
     def setup(self, rank: int, world_size: int, device: torch.device) -> None:
         """Initialize the config with runtime parallel state.
 
@@ -178,13 +195,14 @@ class SequenceParallelConfig:
         self._world_size = world_size
         self._device = device
 
-        expected_sp_size = self.ulysses_degree * self.ring_degree
+        expected_sp_size = self.ulysses_degree * self.ring_degree * self.context_parallel_degree
         actual_sp_size = self.get_world_size()
 
         if expected_sp_size != actual_sp_size:
             raise ValueError(
                 f"Configuration mismatch: ulysses_degree ({self.ulysses_degree}) * "
-                f"ring_degree ({self.ring_degree}) = {expected_sp_size}, but "
+                f"ring_degree ({self.ring_degree}) * context_parallel_degree "
+                f"({self.context_parallel_degree}) = {expected_sp_size}, but "
                 f"actual sequence parallel world size is {actual_sp_size}."
             )
 

--- a/vllm_omni/diffusion/envs.py
+++ b/vllm_omni/diffusion/envs.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     MASTER_PORT: int | None = None
     CUDA_HOME: str | None = None
     LOCAL_RANK: int = 0
+    VLLM_OMNI_CP_DEGREE: int = 1
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # ================== Runtime Env Vars ==================
@@ -25,6 +26,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
+    # Default degree for KV-gather context parallelism. Explicit CLI/YAML
+    # configuration is passed to DiffusionParallelConfig and therefore wins.
+    "VLLM_OMNI_CP_DEGREE": lambda: int(os.environ.get("VLLM_OMNI_CP_DEGREE", "1")),
 }
 
 

--- a/vllm_omni/diffusion/layers/mot/mot_layernorm.py
+++ b/vllm_omni/diffusion/layers/mot/mot_layernorm.py
@@ -85,6 +85,12 @@ class MoTRMSNorm(CustomOp):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+    def forward_gen(self, x: torch.Tensor) -> torch.Tensor:
+        """Normalize generation-only tokens without MoT routing overhead."""
+        if x.is_cuda:
+            return ir.ops.rms_norm(x, self.gen_weight.data, self.variance_epsilon)
+        return self._rms_norm_native(x, self.gen_weight)
+
     def _rms_norm_native(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         orig_dtype = x.dtype
         x = x.float()

--- a/vllm_omni/diffusion/layers/mot/mot_qkv_parallel_linear.py
+++ b/vllm_omni/diffusion/layers/mot/mot_qkv_parallel_linear.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 from vllm.distributed import (
     tensor_model_parallel_all_gather,
@@ -125,6 +126,31 @@ class MoTQKVParallelLinear(QKVParallelLinear):
     # ==================================================================
     #  Forward
     # ==================================================================
+    @property
+    def supports_separate_gen_projection(self) -> bool:
+        weight = self.gen_exp.weight
+        return weight.dtype.is_floating_point and weight.dtype.itemsize >= 2
+
+    def forward_gen_component(self, input_: torch.Tensor, component: str) -> torch.Tensor:
+        """Project one generation-expert Q/K/V component.
+
+        KV-gather context parallelism uses this to overlap K/V collectives with
+        later projections. Quantized packed weights keep using the fused path.
+        """
+        if not self.supports_separate_gen_projection:
+            raise NotImplementedError(
+                "Separate generation Q/K/V projection currently supports BF16/FP16/FP32 weights only."
+            )
+        component_to_index = {"q": 0, "k": 1, "v": 2}
+        if component not in component_to_index:
+            raise ValueError(f"Unknown QKV component {component!r}.")
+        index = component_to_index[component]
+        start = sum(self.output_partition_sizes[:index])
+        end = start + self.output_partition_sizes[index]
+        weight = self.gen_exp.weight[start:end]
+        bias = self.gen_exp.bias[start:end] if self.gen_exp.bias is not None else None
+        return F.linear(input_, weight, bias)
+
     def forward(
         self,
         input_: torch.Tensor,

--- a/vllm_omni/diffusion/layers/mot/mot_row_parallel_linear.py
+++ b/vllm_omni/diffusion/layers/mot/mot_row_parallel_linear.py
@@ -119,6 +119,24 @@ class MoTRowParallelLinear(RowParallelLinear):
     # ==================================================================
     #  Forward
     # ==================================================================
+    def forward_gen(self, input_: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        """Generation-only projection without token routing."""
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            split_input = split_tensor_along_last_dim(input_, num_partitions=self.tp_size)
+            input_parallel = split_input[self.tp_rank].contiguous()
+
+        bias = None if (self.tp_rank > 0 or self.skip_bias_add) else self.gen_exp.bias
+        output_parallel = self.quant_method.apply(self.gen_exp, input_parallel, bias)
+        if self.reduce_results and self.tp_size > 1:
+            output = tensor_model_parallel_all_reduce(output_parallel)
+        else:
+            output = output_parallel
+        if not self.return_bias:
+            return output
+        return output, self.gen_exp.bias if self.skip_bias_add else None
+
     def forward(
         self,
         input_: torch.Tensor,

--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -37,6 +37,7 @@ from vllm.transformers_utils.configs.bagel import BagelConfig
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata as DiffusionAttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention as DiffusionAttention
+from vllm_omni.diffusion.attention.parallel.context_parallel import async_all_gather_sequence
 from vllm_omni.diffusion.cache.cache_dit_backend import BagelCachedAdapter, CacheDiTAdapterConfig
 from vllm_omni.diffusion.data import DiffusionParallelConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
@@ -499,6 +500,90 @@ class PackedAttentionMoT(nn.Module):
             return False
         return get_forward_context().sp_active
 
+    def _is_context_parallel_active(self) -> bool:
+        return (
+            self._is_sp_active()
+            and self.parallel_config is not None
+            and self.parallel_config.context_parallel_degree > 1
+        )
+
+    def _forward_gen_context_parallel(
+        self,
+        packed_query_sequence: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        past_key_values: NaiveCache | None,
+        packed_vae_token_indexes: torch.Tensor,
+        packed_text_indexes: torch.Tensor,
+    ) -> tuple[torch.Tensor, NaiveCache | None]:
+        """Generation-only CP path with K→V→Q projection/communication overlap."""
+        text_hidden = packed_query_sequence[packed_text_indexes].to(torch.bfloat16)
+        vae_hidden = packed_query_sequence[packed_vae_token_indexes].to(torch.bfloat16)
+        cos, sin = [x[..., : self.head_dim // 2] for x in packed_query_position_embeddings]
+        text_cos, text_sin = cos[packed_text_indexes], sin[packed_text_indexes]
+        vae_cos, vae_sin = cos[packed_vae_token_indexes], sin[packed_vae_token_indexes]
+
+        vae_k = self.qkv_proj.forward_gen_component(vae_hidden, "k")
+        vae_k = vae_k.view(-1, self.num_kv_heads, self.head_dim)
+        vae_k = self.k_norm.forward_gen(vae_k.to(torch.float32))
+        vae_k = self.rotary_op(vae_k.to(vae_cos.dtype).unsqueeze(0), vae_cos, vae_sin).squeeze(0).to(torch.bfloat16)
+        cp_group = get_sp_group().device_group
+        key_gather = async_all_gather_sequence(vae_k.unsqueeze(0), cp_group)
+
+        vae_v = self.qkv_proj.forward_gen_component(vae_hidden, "v")
+        vae_v = vae_v.view(-1, self.num_kv_heads, self.head_dim).to(torch.bfloat16)
+        value_gather = async_all_gather_sequence(vae_v.unsqueeze(0), cp_group)
+
+        vae_q = self.qkv_proj.forward_gen_component(vae_hidden, "q")
+        vae_q = vae_q.view(-1, self.num_heads, self.head_dim)
+        vae_q = self.q_norm.forward_gen(vae_q.to(torch.float32))
+        vae_q = self.rotary_op(vae_q.to(vae_cos.dtype).unsqueeze(0), vae_cos, vae_sin).squeeze(0).to(torch.bfloat16)
+
+        # The two replicated image-marker tokens stay on the frozen text expert.
+        text_qkv, _ = self.qkv_proj(text_hidden)
+        text_q, text_k, text_v = text_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        text_q = self.q_norm(text_q.view(-1, self.num_heads, self.head_dim).to(torch.float32))
+        text_k = self.k_norm(text_k.view(-1, self.num_kv_heads, self.head_dim).to(torch.float32))
+        text_v = text_v.view(-1, self.num_kv_heads, self.head_dim)
+        text_q = (
+            self.rotary_op(text_q.to(text_cos.dtype).unsqueeze(0), text_cos, text_sin).squeeze(0).to(torch.bfloat16)
+        )
+        text_k = (
+            self.rotary_op(text_k.to(text_cos.dtype).unsqueeze(0), text_cos, text_sin).squeeze(0).to(torch.bfloat16)
+        )
+        text_v = text_v.to(torch.bfloat16)
+
+        vae_k_global = key_gather.wait()
+        vae_v_global = value_gather.wait()
+        if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
+            ctx_k = torch.cat([past_key_values.key_cache[self.layer_idx], text_k], dim=0)
+            ctx_v = torch.cat([past_key_values.value_cache[self.layer_idx], text_v], dim=0)
+        else:
+            ctx_k, ctx_v = text_k, text_v
+
+        attn_out = self.attn_noncausal(
+            vae_q.unsqueeze(0),
+            vae_k_global,
+            vae_v_global,
+            DiffusionAttentionMetadata(
+                joint_query=text_q.unsqueeze(0),
+                joint_key=ctx_k.unsqueeze(0),
+                joint_value=ctx_v.unsqueeze(0),
+                joint_strategy="front",
+                extra={"context_parallel_kv_gathered": True},
+            ),
+        ).squeeze(0)
+
+        text_len = text_q.shape[0]
+        text_attn = attn_out[:text_len].reshape(text_len, self.q_size)
+        vae_attn = attn_out[text_len:].reshape(-1, self.q_size)
+        text_out, _ = self.o_proj(text_attn)
+        vae_out, _ = self.o_proj.forward_gen(vae_attn)
+
+        full_output = text_out.new_zeros((packed_query_sequence.shape[0], self.hidden_size))
+        full_output[packed_text_indexes] = text_out
+        full_output[packed_vae_token_indexes] = vae_out
+        return full_output, past_key_values
+
     def _forward_gen(
         self,
         packed_query_sequence: torch.Tensor,
@@ -527,6 +612,19 @@ class PackedAttentionMoT(nn.Module):
         Currently we shouldn't need it in the model, and it would be ideal to handle
         packing/batching etc in a more model agnostic way.
         """
+        if (
+            self._is_context_parallel_active()
+            and not update_past_key_values
+            and self.qkv_proj.supports_separate_gen_projection
+        ):
+            return self._forward_gen_context_parallel(
+                packed_query_sequence=packed_query_sequence,
+                packed_query_position_embeddings=packed_query_position_embeddings,
+                past_key_values=past_key_values,
+                packed_vae_token_indexes=packed_vae_token_indexes,
+                packed_text_indexes=packed_text_indexes,
+            )
+
         text_indices = packed_text_indexes
         vae_indices = packed_vae_token_indexes
 
@@ -632,7 +730,6 @@ class PackedAttentionMoT(nn.Module):
         vae_attn = attn_out[:, text_per_branch:].reshape(-1, self.q_size)
         text_len = text_attn.shape[0]
 
-        # MoT output projection over local [text, vae] order.
         local_packed = torch.cat([text_attn, vae_attn], dim=0)
         local_text_idx = torch.arange(text_len, device=local_packed.device)
         local_vae_idx = torch.arange(text_len, text_len + vae_attn.shape[0], device=local_packed.device)
@@ -1329,6 +1426,15 @@ class Bagel(CFGParallelMixin, nn.Module):
         sp_size = self._sp_size
         sp_rank = get_sequence_parallel_rank()
         num_vae = x_t.shape[0]
+        if (
+            self.parallel_config is not None
+            and self.parallel_config.context_parallel_degree > 1
+            and num_vae % self.parallel_config.context_parallel_degree != 0
+        ):
+            raise ValueError(
+                f"BAGEL context parallelism requires VAE token count ({num_vae}) to be divisible by "
+                f"context_parallel_degree ({self.parallel_config.context_parallel_degree})."
+            )
         assert num_vae % sp_size == 0, f"VAE token count {num_vae} not divisible by SP size {sp_size}"
         chunk = num_vae // sp_size
         start = sp_rank * chunk
@@ -1778,6 +1884,122 @@ class Bagel(CFGParallelMixin, nn.Module):
         output_device = generated_sequence[0].device
         return torch.stack([i.to(output_device) for i in generated_sequence], dim=0)
 
+    def _generate_image_context_parallel(
+        self,
+        x_t: torch.Tensor,
+        timesteps: torch.Tensor,
+        dts: torch.Tensor,
+        packed_text_ids: torch.Tensor,
+        packed_text_indexes: torch.Tensor,
+        packed_vae_position_ids: torch.Tensor,
+        packed_vae_token_indexes: torch.Tensor,
+        packed_seqlens: torch.Tensor,
+        packed_position_ids: torch.Tensor,
+        past_key_values: NaiveCache,
+        cfg_interval: tuple[float, float],
+        cfg_text_scale: float,
+        cfg_text_packed_position_ids: torch.Tensor | None,
+        cfg_text_past_key_values: NaiveCache | None,
+        cfg_img_scale: float,
+        cfg_img_packed_position_ids: torch.Tensor | None,
+        cfg_img_past_key_values: NaiveCache | None,
+        cfg_renorm_type: str,
+        cfg_renorm_min: float,
+    ):
+        """Denoise with a persistent local sequence shard.
+
+        Attention gathers K/V per layer. MLP, CFG combination, and Euler updates
+        remain sequence-local. The latent is gathered only once for VAE decode.
+        """
+
+        def split_branch(position_ids: torch.Tensor):
+            return self._split_vae_for_sp(
+                x_t,
+                packed_vae_position_ids,
+                packed_vae_token_indexes,
+                packed_text_indexes,
+                packed_seqlens,
+                position_ids,
+            )
+
+        (
+            local_x_t,
+            local_vae_pos_ids,
+            local_vae_indexes,
+            local_text_indexes,
+            local_seqlens,
+            local_position_ids,
+        ) = split_branch(packed_position_ids)
+
+        cfg_text_position_ids = None
+        if cfg_text_scale > 1.0:
+            if cfg_text_packed_position_ids is None or cfg_text_past_key_values is None:
+                raise ValueError("Text CFG inputs are required when cfg_text_scale > 1.")
+            cfg_text_position_ids = split_branch(cfg_text_packed_position_ids)[-1]
+
+        cfg_img_position_ids = None
+        if cfg_img_scale > 1.0:
+            if cfg_img_packed_position_ids is None or cfg_img_past_key_values is None:
+                raise ValueError("Image CFG inputs are required when cfg_img_scale > 1.")
+            cfg_img_position_ids = split_branch(cfg_img_packed_position_ids)[-1]
+
+        for i, t_value in enumerate(timesteps.tolist()):
+            local_timestep = timesteps[i].expand(local_x_t.shape[0])
+            v_t = self._forward_single_branch_local(
+                local_x_t,
+                local_timestep,
+                local_vae_pos_ids,
+                local_vae_indexes,
+                local_text_indexes,
+                local_seqlens,
+                local_position_ids,
+                packed_text_ids,
+                past_key_values,
+            )
+
+            in_cfg_window = t_value > cfg_interval[0] and t_value <= cfg_interval[1]
+            cfg_text_scale_i = cfg_text_scale if in_cfg_window else 1.0
+            cfg_img_scale_i = cfg_img_scale if in_cfg_window else 1.0
+            if cfg_text_scale_i > 1.0:
+                cfg_text_v_t = self._forward_single_branch_local(
+                    local_x_t,
+                    local_timestep,
+                    local_vae_pos_ids,
+                    local_vae_indexes,
+                    local_text_indexes,
+                    local_seqlens,
+                    cfg_text_position_ids,
+                    packed_text_ids,
+                    cfg_text_past_key_values,
+                )
+                cfg_img_v_t = None
+                if cfg_img_scale_i > 1.0:
+                    cfg_img_v_t = self._forward_single_branch_local(
+                        local_x_t,
+                        local_timestep,
+                        local_vae_pos_ids,
+                        local_vae_indexes,
+                        local_text_indexes,
+                        local_seqlens,
+                        cfg_img_position_ids,
+                        packed_text_ids,
+                        cfg_img_past_key_values,
+                    )
+                v_t = self._combine_cfg(
+                    v_t,
+                    cfg_text_v_t,
+                    cfg_img_v_t,
+                    cfg_text_scale_i,
+                    cfg_img_scale_i,
+                    cfg_renorm_type,
+                    cfg_renorm_min,
+                    global_norm_group=get_sp_group().device_group,
+                )
+            local_x_t = local_x_t - v_t.to(local_x_t.device) * dts[i]
+
+        full_x_t = self._gather_vae_for_sp(local_x_t)
+        return full_x_t.split((packed_seqlens - 2).tolist()), None, None, None
+
     def generate_image(
         self,
         packed_text_ids: torch.LongTensor,
@@ -1866,6 +2088,36 @@ class Bagel(CFGParallelMixin, nn.Module):
                 return_trajectory_latents=return_trajectory_latents,
                 scheduler=scheduler,
                 scheduler_kwargs=scheduler_kwargs,
+            )
+
+        use_persistent_cp = (
+            self.parallel_config is not None
+            and self.parallel_config.context_parallel_degree > 1
+            and scheduler is None
+            and not return_trajectory_latents
+            and frame_condition_token_indexes is None
+        )
+        if use_persistent_cp:
+            return self._generate_image_context_parallel(
+                x_t=x_t,
+                timesteps=timesteps,
+                dts=dts,
+                packed_text_ids=packed_text_ids,
+                packed_text_indexes=packed_text_indexes,
+                packed_vae_position_ids=packed_vae_position_ids,
+                packed_vae_token_indexes=packed_vae_token_indexes,
+                packed_seqlens=packed_seqlens,
+                packed_position_ids=packed_position_ids,
+                past_key_values=past_key_values,
+                cfg_interval=cfg_interval,
+                cfg_text_scale=cfg_text_scale,
+                cfg_text_packed_position_ids=cfg_text_packed_position_ids,
+                cfg_text_past_key_values=cfg_text_past_key_values,
+                cfg_img_scale=cfg_img_scale,
+                cfg_img_packed_position_ids=cfg_img_packed_position_ids,
+                cfg_img_past_key_values=cfg_img_past_key_values,
+                cfg_renorm_type=cfg_renorm_type,
+                cfg_renorm_min=cfg_renorm_min,
             )
 
         # ── SP + CFG: sequential single-branch forwards ──
@@ -2184,6 +2436,7 @@ class Bagel(CFGParallelMixin, nn.Module):
         cfg_img_scale: float,
         cfg_renorm_type: str,
         cfg_renorm_min: float,
+        global_norm_group: dist.ProcessGroup | None = None,
     ) -> torch.Tensor:
         """Combine 3-branch CFG predictions with renormalization.
 
@@ -2195,6 +2448,7 @@ class Bagel(CFGParallelMixin, nn.Module):
             cfg_img_scale: image guidance scale
             cfg_renorm_type: "text_channel", "global", or "channel"
             cfg_renorm_min: minimum renormalization scale
+            global_norm_group: process group used to aggregate sharded global norms
         """
         if cfg_renorm_type == "text_channel":
             v_t_text_ = cfg_text_v_t + cfg_text_scale * (v_t - cfg_text_v_t)
@@ -2216,8 +2470,18 @@ class Bagel(CFGParallelMixin, nn.Module):
 
             # NOTE norm is computed over all dimensions, thus currently only supports batch_size = 1 with navit
             if cfg_renorm_type == "global":
-                norm_v_t = torch.norm(v_t)
-                norm_v_t_ = torch.norm(v_t_)
+                if global_norm_group is None:
+                    norm_v_t = torch.norm(v_t)
+                    norm_v_t_ = torch.norm(v_t_)
+                else:
+                    norm_squares = torch.stack(
+                        (
+                            v_t.float().square().sum(),
+                            v_t_.float().square().sum(),
+                        )
+                    )
+                    dist.all_reduce(norm_squares, op=dist.ReduceOp.SUM, group=global_norm_group)
+                    norm_v_t, norm_v_t_ = norm_squares.sqrt().unbind()
             elif cfg_renorm_type == "channel":
                 norm_v_t = torch.norm(v_t, dim=-1, keepdim=True)
                 norm_v_t_ = torch.norm(v_t_, dim=-1, keepdim=True)
@@ -2267,6 +2531,50 @@ class Bagel(CFGParallelMixin, nn.Module):
             true_cfg_scale["cfg_renorm_min"],
         )
 
+    def _forward_single_branch_local(
+        self,
+        local_x_t: torch.Tensor,
+        timestep: torch.Tensor,
+        local_vae_pos_ids: torch.Tensor,
+        local_vae_indexes: torch.Tensor,
+        local_text_indexes: torch.Tensor,
+        local_seqlens: torch.Tensor,
+        local_position_ids: torch.Tensor,
+        packed_text_ids: torch.Tensor,
+        past_key_values: NaiveCache,
+    ) -> torch.Tensor:
+        """Run all transformer blocks while keeping the sequence shard local."""
+        packed_text_embedding = self.language_model.forward(
+            packed_text_ids=packed_text_ids,
+            return_embeddings_only=True,
+        ).packed_query_sequence
+        packed_sequence = packed_text_embedding.new_zeros((int(local_seqlens.sum()), self.hidden_size))
+        packed_sequence[local_text_indexes] = packed_text_embedding
+
+        packed_pos_embed = self.latent_pos_embed(local_vae_pos_ids)
+        packed_timestep_embeds = self.time_embedder(timestep)
+        x_t_emb = self.vae2llm(local_x_t) + packed_timestep_embeds + packed_pos_embed
+        if x_t_emb.dtype != packed_sequence.dtype:
+            x_t_emb = x_t_emb.to(packed_sequence.dtype)
+        packed_sequence[local_vae_indexes] = x_t_emb
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs["mode"] = "gen"
+            extra_inputs["packed_vae_token_indexes"] = local_vae_indexes
+            extra_inputs["packed_text_indexes"] = local_text_indexes
+
+        output = self.language_model.forward(
+            packed_query_sequence=packed_sequence,
+            query_lens=local_seqlens,
+            packed_query_position_ids=local_position_ids,
+            past_key_values=past_key_values,
+            update_past_key_values=False,
+            is_causal=False,
+            **extra_inputs,
+        )
+        return self.llm2vae(output.packed_query_sequence)[local_vae_indexes]
+
     def forward_single_branch(
         self,
         x_t: torch.Tensor,
@@ -2305,40 +2613,17 @@ class Bagel(CFGParallelMixin, nn.Module):
                 packed_position_ids,
             )
 
-            packed_text_embedding = self.language_model.forward(
+            local_v_t = self._forward_single_branch_local(
+                local_x_t=local_x_t,
+                timestep=timestep[: local_x_t.shape[0]],
+                local_vae_pos_ids=local_vae_pos_ids,
+                local_vae_indexes=local_vae_indexes,
+                local_text_indexes=local_text_indexes,
+                local_seqlens=local_seqlens,
+                local_position_ids=local_position_ids,
                 packed_text_ids=packed_text_ids,
-                return_embeddings_only=True,
-            ).packed_query_sequence
-            packed_sequence = packed_text_embedding.new_zeros((int(local_seqlens.sum()), self.hidden_size))
-            packed_sequence[local_text_indexes] = packed_text_embedding
-
-            # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
-            packed_pos_embed = self.latent_pos_embed(local_vae_pos_ids)
-            local_timestep = timestep[: local_x_t.shape[0]]
-            packed_timestep_embeds = self.time_embedder(local_timestep)
-            x_t_emb = self.vae2llm(local_x_t) + packed_timestep_embeds + packed_pos_embed
-            if x_t_emb.dtype != packed_sequence.dtype:
-                x_t_emb = x_t_emb.to(packed_sequence.dtype)
-            packed_sequence[local_vae_indexes] = x_t_emb
-
-            extra_inputs = {}
-            if self.use_moe:
-                extra_inputs["mode"] = "gen"
-                extra_inputs["packed_vae_token_indexes"] = local_vae_indexes
-                extra_inputs["packed_text_indexes"] = local_text_indexes
-
-            output = self.language_model.forward(
-                packed_query_sequence=packed_sequence,
-                query_lens=local_seqlens,
-                packed_query_position_ids=local_position_ids,
                 past_key_values=past_key_values,
-                update_past_key_values=False,
-                is_causal=False,
-                **extra_inputs,
             )
-
-            local_v_t = self.llm2vae(output.packed_query_sequence)
-            local_v_t = local_v_t[local_vae_indexes]
             return self._gather_vae_for_sp(local_v_t)
 
         # Original non-SP path

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -468,17 +468,22 @@ def _apply_sequence_parallel_if_enabled(model, od_config: OmniDiffusionConfig) -
             sp_config = SequenceParallelConfig(
                 ulysses_degree=od_config.parallel_config.ulysses_degree,
                 ring_degree=od_config.parallel_config.ring_degree,
+                context_parallel_degree=od_config.parallel_config.context_parallel_degree,
             )
 
             # Apply hooks according to the plan
-            mode = (
-                "hybrid"
-                if sp_config.ulysses_degree > 1 and sp_config.ring_degree > 1
-                else ("ulysses" if sp_config.ulysses_degree > 1 else "ring")
-            )
+            if sp_config.context_parallel_degree > 1:
+                mode = "context_parallel"
+            elif sp_config.ulysses_degree > 1 and sp_config.ring_degree > 1:
+                mode = "hybrid"
+            elif sp_config.ulysses_degree > 1:
+                mode = "ulysses"
+            else:
+                mode = "ring"
             logger.info(
                 f"Applying sequence parallelism to {transformer.__class__.__name__} ({attr}) "
-                f"(sp_size={sp_size}, mode={mode}, ulysses={sp_config.ulysses_degree}, ring={sp_config.ring_degree})"
+                f"(sp_size={sp_size}, mode={mode}, ulysses={sp_config.ulysses_degree}, "
+                f"ring={sp_config.ring_degree}, context_parallel={sp_config.context_parallel_degree})"
             )
             apply_sequence_parallel(transformer, sp_config, plan)
             applied_count += 1

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -315,6 +315,7 @@ class DiffusionWorker:
                 sequence_parallel_size=parallel_config.sequence_parallel_size,
                 ulysses_degree=parallel_config.ulysses_degree,
                 ring_degree=parallel_config.ring_degree,
+                context_parallel_degree=parallel_config.context_parallel_degree,
                 tensor_parallel_size=parallel_config.tensor_parallel_size,
                 pipeline_parallel_size=parallel_config.pipeline_parallel_size,
                 fully_shard_degree=parallel_config.hsdp_shard_size if parallel_config.use_hsdp else 1,

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -459,6 +459,7 @@ class OrchestratorArgs:
     ulysses_degree: int | None = None
     ulysses_mode: str = "strict"
     ring_degree: int | None = None
+    context_parallel_degree: int | None = None
     diffusion_quantization_config: str | None = None
     use_hsdp: bool = False
     hsdp_shard_size: int = -1

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -968,6 +968,11 @@ class AsyncOmniEngine:
         if parallel_config is None:
             ulysses_degree = normalized_kwargs.get("ulysses_degree") or 1
             ring_degree = normalized_kwargs.get("ring_degree") or 1
+            context_parallel_degree = normalized_kwargs.get("context_parallel_degree")
+            if context_parallel_degree is None:
+                from vllm_omni.diffusion import envs
+
+                context_parallel_degree = envs.VLLM_OMNI_CP_DEGREE
             ulysses_mode = normalized_kwargs.get("ulysses_mode") or "strict"
             sequence_parallel_size = normalized_kwargs.get("sequence_parallel_size")
             pipeline_parallel_size = normalized_kwargs.get("pipeline_parallel_size") or 1
@@ -982,7 +987,7 @@ class AsyncOmniEngine:
             hsdp_shard_size = normalized_kwargs.get("hsdp_shard_size", -1)
             hsdp_replicate_size = normalized_kwargs.get("hsdp_replicate_size", 1)
             if sequence_parallel_size is None:
-                sequence_parallel_size = ulysses_degree * ring_degree
+                sequence_parallel_size = ulysses_degree * ring_degree * context_parallel_degree
 
             parallel_config = DiffusionParallelConfig(
                 pipeline_parallel_size=pipeline_parallel_size,
@@ -992,6 +997,7 @@ class AsyncOmniEngine:
                 sequence_parallel_size=sequence_parallel_size,
                 ulysses_degree=ulysses_degree,
                 ring_degree=ring_degree,
+                context_parallel_degree=context_parallel_degree,
                 ulysses_mode=ulysses_mode,
                 cfg_parallel_size=cfg_parallel_size,
                 vae_patch_parallel_size=vae_patch_parallel_size,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -474,6 +474,16 @@ class OmniServeCommand(CLISubcommand):
             "Equivalent to setting DiffusionParallelConfig.ring_degree.",
         )
         omni_config_group.add_argument(
+            "--cp",
+            "--context-parallel-degree",
+            dest="context_parallel_degree",
+            type=int,
+            default=None,
+            help="KV-gather Context Parallelism degree for diffusion models. "
+            "Q remains sequence-local while K/V are all-gathered. "
+            "Equivalent to setting DiffusionParallelConfig.context_parallel_degree.",
+        )
+        omni_config_group.add_argument(
             "--diffusion-quantization-config",
             type=json.loads,
             default=None,


### PR DESCRIPTION
## Purpose

RFC: #5314

Add KV-Gather Context Parallelism (CP) for BAGEL:

- keep Q and attention output sequence-local while All-Gathering only K/V;
- split the BAGEL generation-expert Q/K/V projection so asynchronous K/V
  All-Gathers overlap the remaining projections;
- keep latent tokens sharded across transformer blocks, CFG branches, and
  denoising steps, with one final gather before VAE decode;
- expose `context_parallel_degree` through deploy config, environment, and
  `--cp` / `--context-parallel-degree`;
- preserve global CFG renormalization semantics by All-Reducing squared norms
  across CP ranks.

For parallel degree `P` and GQA ratio `R = Hq / Hkv`, the per-rank
communication-volume ratio to Ulysses is `P / (R + 1)`. BAGEL has `R=7`, so CP4
communicates half as many bytes as Ulysses-SP 4, at the cost of materializing
full K/V on every rank.

The initial implementation requires equal unmasked sequence shards and is
mutually exclusive with Ulysses/Ring. It uses SDPA for BAGEL CP numerical
alignment and falls back to the existing path for trajectory collection,
custom SDE schedulers, and Lance frame conditioning.

## Test Plan

**vLLM Version:** locally built vLLM 0.25, PyTorch 2.11.0+cu129

**vLLM-Omni Commit:** `22a6604d`

- Unit-test KV-only gather, configuration validation, split Q/K/V projections,
  distributed global CFG renormalization, and one-final-gather behavior.
- Run CLI/config regression tests.
- Run Ruff and `git diff --check`.
- Run fixed BAGEL CP4 online CFG generation on four NVIDIA H20 GPUs:
  1024x1024, 50 steps, seed 52.

## Test Result

```text
tests/diffusion/attention/test_context_parallel.py
6 passed

tests/entrypoints/test_async_omni_diffusion_config.py
-k "context_parallel or ulysses_mode"
3 passed, 18 deselected

ruff
All checks passed

git diff --check
passed

BAGEL CP4 online CFG hardware regression
wall time: 20.40 s
output: visually valid and aligned with prior fixed-seed references
```

The previously collected CP4 trace confirms per-layer K/V All-Gather and no
per-denoising-step velocity All-Gather; only final latent reconstruction remains
outside attention.
