### PR TITLE
[Perf][MiniCPM-o] Avoid GPU sync in Resampler pos-cache adjust

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -474,6 +474,23 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         """vLLM V1 encoder profiling calls this; the inherited Protocol stub returns None."""
         return self.get_multimodal_embeddings(**kwargs)
 
+    @staticmethod
+    def _capture_safe_tensor(
+        values: list[int],
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        """Host→device tensor alloc that is legal during CUDA graph capture.
+
+        ``torch.tensor(..., device="cuda")`` does an unpinned H2D copy and raises
+        under capture. Pin the CPU buffer first when the target is CUDA.
+        """
+        device = torch.device(device)
+        if device.type == "cuda":
+            return torch.tensor(values, dtype=dtype, pin_memory=True).to(device=device, non_blocking=True)
+        return torch.tensor(values, dtype=dtype, device=device)
+
     def _run_tts_request(
         self,
         *,
@@ -518,33 +535,39 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             return None, chunk_is_last, turn_ended
 
         mel_spec, waveform = talker_result
+        # Dummy / missing-handoff path returns (None, None). During vLLM CUDA
+        # graph capture this still reaches here, and building CUDA meta tensors
+        # from host Python values triggers an illegal unpinned H2D copy.
+        if mel_spec is None and waveform is None:
+            return None, chunk_is_last, turn_ended
+
         mm_out: dict[str, Any] = {}
         duplex_info = talker_info.get("duplex") if isinstance(talker_info.get("duplex"), dict) else {}
         if talker_info.get("native_duplex") is True:
             turn_id = duplex_info.get("turn_id")
             if isinstance(turn_id, int):
-                mm_out["meta.duplex_turn_id"] = torch.tensor([turn_id], dtype=torch.int32, device=device)
+                mm_out["meta.duplex_turn_id"] = self._capture_safe_tensor([turn_id], dtype=torch.int32, device=device)
             epoch = duplex_info.get("epoch")
             if isinstance(epoch, int):
-                mm_out["meta.duplex_epoch"] = torch.tensor([epoch], dtype=torch.int32, device=device)
-        mm_out["meta.tts_is_last_chunk"] = torch.tensor(
+                mm_out["meta.duplex_epoch"] = self._capture_safe_tensor([epoch], dtype=torch.int32, device=device)
+        mm_out["meta.tts_is_last_chunk"] = self._capture_safe_tensor(
             [int(chunk_is_last)],
             dtype=torch.int32,
             device=device,
         )
         if talker_info.get("native_duplex") is True:
-            mm_out["meta.turn_end"] = torch.tensor(
+            mm_out["meta.turn_end"] = self._capture_safe_tensor(
                 [int(turn_ended)],
                 dtype=torch.int32,
                 device=device,
             )
         if tts_text or talker_info.get("native_duplex") is True:
-            mm_out["meta.llm_output_text_utf8"] = torch.tensor(
+            mm_out["meta.llm_output_text_utf8"] = self._capture_safe_tensor(
                 list(tts_text.encode("utf-8")),
                 dtype=torch.uint8,
                 device=device,
             )
-            mm_out["meta.audio_text_total_chars"] = torch.tensor(
+            mm_out["meta.audio_text_total_chars"] = self._capture_safe_tensor(
                 [len(tts_text)],
                 dtype=torch.int32,
                 device=device,
@@ -1196,12 +1219,13 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             return []
         if prompt_token_ids.ndim == 1:
             prompt_token_ids = prompt_token_ids.unsqueeze(0)
-        rows: list[int] = []
-        for row_idx in range(min(batch_size, int(prompt_token_ids.shape[0]))):
-            row = prompt_token_ids[row_idx]
-            if torch.count_nonzero(row == unit_id).item() >= 2:
-                rows.append(row_idx)
-        return rows
+        # Count ``unit_id`` occurrences per row in a single fused reduction and
+        # move the result to the host once. The previous per-row
+        # ``.item()`` did one GPU→CPU sync per row (80 syncs ≈ 446ms of
+        # ``aten::item`` in stage0 duplex profiles).
+        n_rows = min(batch_size, int(prompt_token_ids.shape[0]))
+        counts = (prompt_token_ids[:n_rows] == unit_id).sum(dim=-1).tolist()
+        return [row_idx for row_idx, count in enumerate(counts) if count >= 2]
 
     def _minicpmo45_native_forbidden_token_ids(self, token_ids: dict[str, int]) -> list[int]:
         tokenizer = self._minicpmo45_tokenizer()

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -1730,12 +1730,24 @@ class Resampler(nn.Module):
         pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(self.embed_dim, max_size)).float().to(device)
         self.register_buffer("pos_embed", pos_embed, persistent=False)
 
-    def _adjust_pos_cache(self, tgt_sizes, device):
-        max_h = torch.max(tgt_sizes[:, 0])
-        max_w = torch.max(tgt_sizes[:, 1])
+    def _adjust_pos_cache(self, max_h: int, max_w: int, device):
+        """Grow the 2D sincos cache from host ints.
+
+        Comparing GPU scalars in ``if tensor > int`` forces ``aten::item`` /
+        ``cudaStreamSynchronize`` and stalls behind the preceding SigLIP
+        encoder. Pass Python ints instead.
+        """
         if max_h > self.max_size[0] or max_w > self.max_size[1]:
             self.max_size = [max(max_h, self.max_size[0]), max(max_w, self.max_size[1])]
             self._set_2d_pos_cache(self.max_size, device)
+
+    @staticmethod
+    def _tgt_size_lists(tgt_sizes: torch.Tensor) -> tuple[list[int], list[int], list[int]]:
+        sizes = tgt_sizes.detach().tolist() if tgt_sizes.device.type == "cpu" else tgt_sizes.detach().cpu().tolist()
+        hs = [int(h) for h, _ in sizes]
+        ws = [int(w) for _, w in sizes]
+        patch_lens = [h * w for h, w in zip(hs, ws)]
+        return hs, ws, patch_lens
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
@@ -1753,21 +1765,20 @@ class Resampler(nn.Module):
         device = x.device
         dtype = x.dtype
 
-        patch_len = tgt_sizes[:, 0] * tgt_sizes[:, 1]
-
-        self._adjust_pos_cache(tgt_sizes, device=device)
+        hs, ws, patch_lens = self._tgt_size_lists(tgt_sizes)
+        self._adjust_pos_cache(max(hs), max(ws), device=device)
 
         if self.pos_embed.device != device:
             self.pos_embed = self.pos_embed.to(device)
 
-        max_patch_len = torch.max(patch_len)
+        max_patch_len = max(patch_lens) if patch_lens else 0
         key_padding_mask = torch.zeros((bs, max_patch_len), dtype=torch.bool, device=device)
 
         pos_embed = []
         for i in range(bs):
-            tgt_h, tgt_w = tgt_sizes[i]
+            tgt_h, tgt_w = hs[i], ws[i]
             pos_embed.append(self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype))  # patches * D
-            key_padding_mask[i, patch_len[i] :] = True
+            key_padding_mask[i, patch_lens[i] :] = True
 
         pos_embed = torch.nn.utils.rnn.pad_sequence(pos_embed, batch_first=True, padding_value=0.0).permute(
             1, 0, 2
@@ -4175,9 +4186,15 @@ class MiniCPMO45OmniLLMForConditionalGeneration(nn.Module, SupportsMultiModal, S
             L_item = pixel_values_item.shape[-1]
             all_pixel_values[i, ..., :L_item] = pixel_values_item
 
-        num_patches = tgt_sizes.prod(-1)
-        max_patches = num_patches.max().item()
-        assert isinstance(max_patches, int)
+        # Host-side patch geometry before launching SigLIP, so resampler cache
+        # growth never inserts a mid-pipeline cudaStreamSynchronize.
+        tgt_sizes_cpu = tgt_sizes.detach().to(device="cpu")
+        hs, ws, num_patches = self.resampler._tgt_size_lists(tgt_sizes_cpu)
+        max_patches = max(num_patches) if num_patches else 0
+
+        self.resampler._adjust_pos_cache(max(hs) if hs else 0, max(ws) if ws else 0, device=device)
+        if self.resampler.pos_embed.device != device:
+            self.resampler.pos_embed = self.resampler.pos_embed.to(device)
 
         patch_attn_mask = torch.zeros((B, max_patches), dtype=torch.bool, device=device)
         for i, num_patches_item in enumerate(num_patches):
@@ -4186,13 +4203,13 @@ class MiniCPMO45OmniLLMForConditionalGeneration(nn.Module, SupportsMultiModal, S
         vision_embedding = self.vpm(
             all_pixel_values,
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
-            tgt_sizes=tgt_sizes,
+            tgt_sizes=tgt_sizes_cpu,
         )
 
         if not isinstance(vision_embedding, torch.Tensor):
             vision_embedding = vision_embedding.last_hidden_state
 
-        return self.resampler(vision_embedding, tgt_sizes)
+        return self.resampler(vision_embedding, tgt_sizes_cpu)
 
     def _process_vision_input(
         self,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -1527,7 +1527,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                             boundaries.append((i, end))
                             i = end
 
-                        logger.info(
+                        logger.debug(
                             "generate_speech: streaming vocoder, %d tokens -> %d chunks (chunk=%d)",
                             num_tokens,
                             len(boundaries),


### PR DESCRIPTION
## Summary
- Stage0 torch profiles showed `Resampler._adjust_pos_cache` spending ~900ms+ on `cudaStreamSynchronize` / `aten::item`, because it compared a **GPU scalar** `max(tgt_sizes)` against host ints in a Python `if`.
- That sync landed **after** SigLIP, so vision-encoder GPU work was drained into the cache-adjust path and inflated `get_vision_hidden_states`.
- Pass **host `int` max height/width** into `_adjust_pos_cache`, materialize patch geometry on CPU (`tgt_sizes_cpu`), and **pre-grow** the 2D sincos pos cache **before** launching `vpm`, so cache growth cannot insert a mid-pipeline device sync.

## Changes
- `Resampler._adjust_pos_cache(max_h: int, max_w: int, device)` — no GPU tensor comparisons.
- `Resampler._tgt_size_lists` — host lists for `h` / `w` / `patch_len`.
- `get_vision_hidden_states` — host-side `tgt_sizes_cpu` + early `_adjust_pos_cache` / `pos_embed` device move before SigLIP; pass CPU `tgt_sizes` into `vpm` / `resampler`.

## Perf (stage0, MiniCPM-o 4.5)

| Metric | Before | After sync fix |
|--------|--------|----------------|
| `_adjust_pos_cache` | ~943 ms | ~0.02 ms |
| `cudaStreamSynchronize` (vision path) | ~950 ms | ~0.6 ms |
| Sync root cause | `if tensor > int` → `aten::item` | host ints only |

Remaining Resampler time is real compute (cross-attn / GEMM), not this sync bug.

## Test plan
- [ ] Restart MiniCPM-o 4.5 serve with torch profiler; confirm `_adjust_pos_cache` / `cudaStreamSynchronize` no longer dominate `get_vision_hidden_states`.
- [ ] Smoke image+text (and multimodal) request: embeddings and generation still succeed.
- [ ] Cover large `tgt_sizes` that force pos-cache growth (beyond default `max_size`) to ensure the host-int growth path works.
