### PR TITLE
[Bugfix][Step-Audio2] Align audio feature lengths with encoder outputs

### DIFF
--- a/tests/model_executor/models/step_audio2/test_step_audio2_thinker.py
+++ b/tests/model_executor/models/step_audio2/test_step_audio2_thinker.py
@@ -44,11 +44,29 @@ def test_audio_preprocessing():
     assert mel.shape[0] == 128, f"Expected 128 mel bins, got {mel.shape[0]}"
 
     mels = [mel, mel]
-    padded_mels, _mel_lens = padding_mels(mels)
+    padded_mels, mel_lens = padding_mels(mels)
 
     assert padded_mels.ndim == 3, f"Expected 3D tensor, got {padded_mels.ndim}D"
     assert padded_mels.shape[0] == 2, f"Expected batch size 2, got {padded_mels.shape[0]}"
     assert padded_mels.shape[1] == 128, f"Expected 128 mel bins, got {padded_mels.shape[1]}"
+    assert mel_lens.tolist() == [mel.shape[1], mel.shape[1]]
+
+
+def test_padding_mels_keeps_short_tail_boundary_frames():
+    """Match the Step-Audio2 reference length convention for a tiny audio tail."""
+    from vllm_omni.model_executor.models.step_audio2.step_audio2_thinker import (
+        log_mel_spectrogram,
+        padding_mels,
+    )
+
+    full_chunk = torch.zeros(128, 2502)
+    short_tail = log_mel_spectrogram(np.zeros(1, dtype=np.float32))
+
+    padded_mels, mel_lens = padding_mels([full_chunk, short_tail])
+
+    assert short_tail.shape == (128, 3)
+    assert padded_mels.shape == (2, 128, 2502)
+    assert mel_lens.tolist() == [2502, 3]
 
 
 def test_feature_length_calculation():
@@ -58,10 +76,22 @@ def test_feature_length_calculation():
     )
 
     assert calculate_audio_feature_length(1000) == 125
-
     assert calculate_audio_feature_length(100) > 0
+    assert calculate_audio_feature_length(3) == 1
+    assert calculate_audio_feature_length(2) == 0
 
-    assert calculate_audio_feature_length(1) >= 1
+
+def test_feature_lengths_for_full_chunks_and_short_tail():
+    """A non-empty tail must add one placeholder and one model embedding."""
+    from vllm_omni.model_executor.models.step_audio2.step_audio2_thinker import (
+        calculate_audio_feature_length,
+    )
+
+    mel_lens = [2502] * 10 + [3]
+    feature_lens = [calculate_audio_feature_length(length) for length in mel_lens]
+
+    assert feature_lens == [313] * 10 + [1]
+    assert sum(feature_lens) == 3131
 
 
 def test_token_config_constants():
@@ -122,6 +152,14 @@ def test_audio_encoder_output_shape():
     assert adapted.ndim == 3
     assert adapted.shape[0] == batch_size
     assert adapted.shape[2] == 4096
+
+    short_tail = torch.randn(1, n_mels, 3)
+    short_encoded, short_encoded_lens = encoder(short_tail, torch.tensor([3], dtype=torch.int32))
+    short_adapted = adapter(short_encoded)
+    short_feature_lens = (short_encoded_lens - 1) // 2 + 1
+
+    assert short_feature_lens.tolist() == [1]
+    assert short_adapted.shape[1] >= short_feature_lens.item()
 
 
 def test_token_separation():

--- a/vllm_omni/model_executor/models/step_audio2/step_audio2_thinker.py
+++ b/vllm_omni/model_executor/models/step_audio2/step_audio2_thinker.py
@@ -117,7 +117,14 @@ def padding_mels(data: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         padded_feats: Padded tensor of shape (batch, n_mels, max_T)
         feats_lengths: Lengths of each sequence
     """
-    feats_lengths = torch.tensor([s.size(1) - 2 for s in data], dtype=torch.int32)
+    # Keep the full mel length, including the two boundary frames produced by
+    # Step-Audio2's 479-sample right padding.  The Step-Audio2 reference
+    # implementation uses this same length for prompt expansion and encoder
+    # masking.  Dropping the boundary frames here makes very short, non-empty
+    # audio inconsistent:
+    # prompt expansion produces one placeholder while the encoder produces no
+    # embeddings.
+    feats_lengths = torch.tensor([s.size(1) for s in data], dtype=torch.int32)
     feats = [s.t() for s in data]
     padded_feats = pad_sequence(feats, batch_first=True, padding_value=0)
     return padded_feats.transpose(1, 2), feats_lengths
@@ -344,11 +351,11 @@ def calculate_audio_feature_length(mel_length: int) -> int:
         >>> calculate_audio_feature_length(1000)
         125
     """
-    encoder_output_len = (mel_length + 1) // 4
+    encoder_output_len = (mel_length + 1) // 2 // 2
 
     adapter_output_len = (encoder_output_len - 1) // 2 + 1
 
-    return max(1, adapter_output_len)
+    return adapter_output_len
 
 
 class StepAudio2Processor(ProcessorMixin):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Background

Step-Audio2 applies 479 samples of right padding before computing the log-mel spectrogram. As a result, even a very short non-empty audio tail can produce three mel frames.

However, `padding_mels` previously reported each mel length as `T - 2`, excluding the two boundary frames. For a one-sample audio tail:

- The actual mel length is `3`.
- The reported mel length becomes `1`.
- Prompt expansion forces at least one audio placeholder.
- The model encoder calculates zero valid audio embeddings from the reported length.

This causes the number of multimodal embeddings to differ from the number of placeholders. A real request containing ten 25-second chunks followed by a very short tail produced:

```text
3130 multimodal embeddings
3131 audio placeholders
```

The request then failed while merging multimodal embeddings into the language-model inputs.

## Purpose

Ensure that Step-Audio2 uses the same audio-length convention for prompt expansion, encoder masking, and adapter output slicing.

In particular, a non-empty three-frame audio tail should produce exactly one placeholder and one embedding instead of one placeholder and zero embeddings.

## Changes

- Preserve the full mel-spectrogram length in `padding_mels`, including the two boundary frames introduced by Step-Audio2's right padding.
- Calculate the encoder output length using the same two-stage downsampling formula as the model:

  ```python
  (mel_length + 1) // 2 // 2
  ```

- Remove the forced minimum of one feature from `calculate_audio_feature_length`, so the helper reports the actual encoder and adapter output length.
- Add regression coverage for:
  - A one-sample audio tail producing three mel frames.
  - The boundary mappings `3 -> 1` and `2 -> 0`.
  - Ten full 25-second chunks plus a short tail producing:

    ```text
    [313] * 10 + [1] = 3131
    ```

  - The encoder and adapter producing one valid embedding for a three-frame input.

## Test Plan

Run the targeted Step-Audio2 unit tests:

```bash
pytest -q tests/model_executor/models/step_audio2/test_step_audio2_thinker.py
```

Run end-to-end ASR requests covering:

1. A standalone 10 ms audio input.
2. Ten 25-second audio chunks followed by a 10 ms tail.
3. A real speech sample followed by a 10 ms tail to verify that ASR quality is preserved.

**vLLM Version:** `0.25.0`

**vLLM-Omni Commit:** `253740c4124d361ea91471f5bed85a4ca80ad359`

## Test Result

### Short-tail boundary test

Command:

```bash
curl --noproxy '*' -sS \
  -X POST 'http://127.0.0.1:8188/v1/chat/completions' \
  -H 'Content-Type: application/json' \
  --data-binary @step_audio_10ms_request.json \
  -w '\nHTTP %{http_code}\n'
```

The request contains a 10 ms, 16 kHz audio input. It produces three mel frames and one audio embedding.

Result:

```text
HTTP 200
finish_reason: stop
prompt_tokens: 32
completion_tokens: 1
```

The previous `0 multimodal tokens to 1 placeholders` error no longer occurs.

### Original failure regression test

Command:

```bash
curl --noproxy '*' -sS \
  -X POST 'http://127.0.0.1:8188/v1/chat/completions' \
  -H 'Content-Type: application/json' \
  --data-binary @step_audio_10x25s_plus_tail_request.json \
  -w '\nHTTP %{http_code}\n'
```

The request contains ten 25-second audio chunks followed by a 10 ms tail.

Expected feature lengths:

```text
[313] * 10 + [1] = 3131
```

Result:

```text
HTTP 200
prompt_tokens: 3162
completion_tokens: 16
finish_reason: length
```

The previous `3130 multimodal tokens to 3131 placeholders` error no longer occurs.

### ASR correctness regression test

Command:

```bash
curl --noproxy '*' -sS \
  -X POST 'http://127.0.0.1:8188/v1/chat/completions' \
  -H 'Content-Type: application/json' \
  --data-binary @step_audio_mary_had_lamb_with_tail_request.json \
  -w '\nHTTP %{http_code}\n'
```

The request contains the vLLM `mary_had_lamb.ogg` sample followed by a 10 ms audio tail.

Result:

```text
HTTP 200
prompt_tokens: 263
completion_tokens: 46
finish_reason: stop
```

Transcription:

```text
The first words I spoke in the original kornograph, a little piece of
practical poetry: Mary had a little lamb, its fleece was white as snow,
and everywhere that Mary went, the lamb was sure to go.
```

The spoken content was transcribed correctly apart from one minor word substitution, and the 10 ms tail did not introduce additional text.

```