### PR TITLE
[Bugfix] Fix Orchestrator shutdown deadlock with membership watcher

### DIFF
--- a/tests/engine/test_membership_controller.py
+++ b/tests/engine/test_membership_controller.py
@@ -111,18 +111,18 @@ async def test_watch_replica_list_unregisters_disappeared_replicas(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_closes_hub_then_cancels_watcher(monkeypatch):
+async def test_shutdown_closes_hub_and_watcher_exits_on_its_own(monkeypatch):
     pool = FakePool(stage_id=0)
     hub = FakeHub()
     controller = _controller(monkeypatch, pool, hub)
-    watcher = asyncio.create_task(asyncio.sleep(10))
-    controller._watcher_task = watcher
+    watcher = controller.start()
 
     controller.shutdown()
-    await asyncio.sleep(0)
+    await asyncio.wait_for(watcher, timeout=1)
 
     assert hub.closed is True
-    assert watcher.cancelled()
+    assert watcher.done()
+    assert not watcher.cancelled()
 
 
 @pytest.mark.asyncio

--- a/vllm_omni/engine/membership_controller.py
+++ b/vllm_omni/engine/membership_controller.py
@@ -101,8 +101,6 @@ class MembershipController:
         if self._hub is not None:
             self._hub.close()
             self._hub = None
-        if self._watcher_task is not None and not self._watcher_task.done():
-            self._watcher_task.cancel()
 
     async def drain_tasks(self, timeout: float = 10.0) -> None:
         """Wait for in-flight membership tasks to complete."""

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -611,6 +611,9 @@ class Orchestrator:
             elif isinstance(msg, ShutdownRequestMessage):
                 logger.info("[Orchestrator] Received shutdown signal")
                 self._shutdown_event.set()
+                if self._membership is not None:
+                    # Avoids a deadlock with membership_watcher.
+                    self._membership.shutdown()
                 # Pre-mark stage clients as shutting down to prevent
                 # proc_monitor daemon threads from flagging normal
                 # process exit as EngineDeadError during teardown.
@@ -1018,6 +1021,9 @@ class Orchestrator:
                                 close_duplex_sessions=True,
                             )
                             self._shutdown_event.set()
+                            if self._membership is not None:
+                                # Avoids a deadlock with membership_watcher.
+                                self._membership.shutdown()
                             raise
                         except Exception:
                             if self._shutdown_event.is_set():


### PR DESCRIPTION
## Purpose

run()'s finally block calls MembershipController.shutdown() to stop membership_watcher, but that block is only reached after asyncio.gather() on all tasks (including the watcher) returns. Since the watcher only stops once shutdown() runs, this is circular and hangs forever in distributed/--head deployments. Call shutdown() at the two points where shutdown is actually decided instead of only in finally.

shutdown() also no longer forcibly cancels the watcher task: doing so while it's still a member of the active gather() raises CancelledError through it. Setting the shutdown event and closing the hub is enough; the watcher notices the event and exits on its own.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 663bc0ee99b41fb478147e9e34388dc550e65bf9

```
vllm serve --omni Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice --omni-master-address 127.0.0.1 --omni-master-port 9999 --stage-id 0
vllm serve --omni Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice --omni-master-address 127.0.0.1 --omni-master-port 9999 --stage-id 1 --headless
# after server ready, kill stage 1
# stage 0 should gracefully exit on its own
# without the fix: stage 0 deadlocks
```

No new tests are added as this is supposed to be caught by the online serving tests using the headless path, yet the workaround in OmniServerStageCli's teardown (_kill_process_tree in tests/helpers/runtime.py:344-441) does parent.terminate() (SIGTERM) then parent.wait(timeout=15), hiding this deadlock.

## Test Result

PASSED