### PR TITLE
[Feature] Allow headless stages to recover from failures

### DIFF
--- a/vllm_omni/distributed/omni_coordinator/omni_coord_client_for_stage.py
+++ b/vllm_omni/distributed/omni_coordinator/omni_coord_client_for_stage.py
@@ -224,7 +224,7 @@ class OmniCoordClientForStage:
                 pass  # Socket may already be broken, proceed with close
 
             # Close DEALER socket and terminate this client's context.
-            self._socket.close(0)
+            self._socket.close(linger=1000)
             try:
                 self._ctx.term()
             except zmq.ZMQError:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -245,7 +245,6 @@ class AsyncOmniEngine:
         stage0_args = getattr(self.stage_configs[0], "engine_args", None) if self.num_stages > 0 else None
         self.async_chunk = bool(getattr(stage0_args, "async_chunk", False))
         self.stage_pools: list[StagePool] = []
-        self.stage_clients: list[StageClient] = []  # logical-stage view for external readers
         self.input_processor: InputProcessor | None = None
         self.prompt_expand_func: Any | None = None
         self.supported_tasks: tuple[str, ...] = ("generate",)
@@ -336,9 +335,6 @@ class AsyncOmniEngine:
 
         self.num_stages = len(self.stage_configs)
         self.stage_pools = self._runtime.stage_pools
-        self.stage_clients = [
-            cast(StageClient, pool.stage_client) for pool in self.stage_pools if pool.stage_client is not None
-        ]
         self.stage_vllm_configs = [pool.stage_vllm_config for pool in self.stage_pools]
         self.output_processors = [pool.output_processor for pool in self.stage_pools]
         self.input_processor = (
@@ -370,6 +366,11 @@ class AsyncOmniEngine:
         if any(meta.final_output_type == "audio" for meta in self.stage_metadata):
             supported_tasks.add("speech")
         self.supported_tasks = tuple(supported_tasks) if supported_tasks else ("generate",)
+
+    @property
+    def stage_clients(self) -> list[StageClient]:
+        """# logical-stage view for external readers."""
+        return [cast(StageClient, pool.stage_client) for pool in self.stage_pools if pool.stage_client is not None]
 
     def _bootstrap_orchestrator(
         self,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -958,6 +958,15 @@ class Orchestrator:
                         except asyncio.CancelledError:
                             raise
                         except EngineDeadError as e:
+                            if pool.clients[replica_id] is None:
+                                logger.info(
+                                    "[Orchestrator] Stage-%s replica-%s poll failed after the replica"
+                                    " was already detached, ignoring stale error: %s",
+                                    stage_id,
+                                    replica_id,
+                                    e,
+                                )
+                                continue
                             logger.error(
                                 "[Orchestrator] Stage-%s replica-%s is dead: %s",
                                 stage_id,

--- a/vllm_omni/engine/stage_engine_core_proc.py
+++ b/vllm_omni/engine/stage_engine_core_proc.py
@@ -173,6 +173,9 @@ class StageEngineCoreProc(EngineCoreProc):
             signal_callback = SignalCallback(wakeup_engine)
 
             def signal_handler(signum: int, frame: Any) -> None:
+                # Ignore a repeat signal once shutdown is already underway.
+                if engine_core.shutdown_state != EngineShutdownState.RUNNING:
+                    return
                 engine_core.shutdown_state = EngineShutdownState.REQUESTED
                 signal_callback.trigger()
                 raise SystemExit(_signal_exit_code(signum))
@@ -193,8 +196,6 @@ class StageEngineCoreProc(EngineCoreProc):
                 engine_core._send_engine_dead()
             raise
         finally:
-            signal.signal(signal.SIGTERM, signal.SIG_DFL)
-            signal.signal(signal.SIGINT, signal.SIG_DFL)
             if signal_callback is not None:
                 signal_callback.stop()
             if coord_client is not None:
@@ -202,3 +203,6 @@ class StageEngineCoreProc(EngineCoreProc):
                     coord_client.close()
             if engine_core is not None:
                 engine_core.shutdown()
+            # Reset handlers only after cleanup finishes, not before.
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
## Purpose

Right now if you deploy vllm-omni using the stage cli deployment mode (stage 0 + API server + orchestrator, and multiple headless workers for other stages), the failure of a single worker stage would bring down the entire deployment. This PR allows for individual stages to restart/recover on their own. The fixes included are:

Commit 1 and 2: Fix shutdown notification, so instead of the orchestrator waiting for 30s before finding out the worker stages are dead, make sure the stage shutdown notification is actually delivered.
Commit 3: Prevent a crash in the orchestrator polling a already detached (properly shutdown) stage.
Commit 4: Make sure the orchestrator do make use of the newly registered replacement stage replicas.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 3ccb86269dcfa266260426ad150253d377d02717

```
vllm serve --omni Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice --omni-master-address 127.0.0.1 --omni-master-port 9999 --stage-id 0
vllm serve --omni Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice --omni-master-address 127.0.0.1 --omni-master-port 9999 --stage-id 1 --headless
# send a request
# kill stage 1
# restart stage 1
# send another request
# both requests should succeed
# without the fix: the second request fails/hangs, even if the replacement replica is ready
```

## Test Result

PASSED