### PR TITLE
[Core] Remove dead async_chunk paths from OmniConnectorModelRunnerMixin

### DIFF
--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -141,7 +141,7 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
 
         sender.shutdown_omni_connectors()
 
-    def test_send_chunk_does_not_retry_real_type_error(self):
+    def test_build_custom_process_payload_does_not_retry_real_type_error(self):
         connector = MockConnector(stage_id=0)
 
         sender = MixinHost()
@@ -159,11 +159,16 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
             return {"data": is_finished + "tail"}
 
         sender._custom_process_func = broken_process
+        sender._custom_process_supports_is_finished = sender._custom_process_supports_is_finished_kwarg()
 
         request = _make_request("req-1", "ext-req-1")
         request.is_finished = lambda: True
-        ok = sender.send_chunk(request, pooling_output={"value": 42})
-        self.assertFalse(ok)
+        payload = sender._build_custom_process_payload(
+            request_id="ext-req-1",
+            request=request,
+            pooling_output={"value": 42},
+        )
+        self.assertIsNone(payload)
         self.assertEqual(seen["calls"], 1)
 
         sender.shutdown_omni_connectors()
@@ -312,9 +317,6 @@ class TestMixinNoConnector(unittest.TestCase):
 
         sent = host.send_full_payload_outputs(None, {"req-1": {}})
         self.assertEqual(sent, [])
-
-        ok = host.send_chunk(_make_request("req-1"), pooling_output={})
-        self.assertFalse(ok)
 
         output = host.get_omni_connector_output()
         self.assertIsInstance(output, OmniConnectorOutput)
@@ -747,37 +749,6 @@ class TestCleanupFinishedRequest(unittest.TestCase):
         self.assertNotIn(req_id, host._request_ids_mapping)
         self.assertNotIn(ext_id, host._put_req_chunk)
 
-        host.shutdown_omni_connectors()
-
-
-class TestSendChunkCachesMapping(unittest.TestCase):
-    """Test that send_chunk caches internal→external req ID mapping."""
-
-    def test_send_chunk_populates_request_ids_mapping(self):
-        """send_chunk should cache the internal→external mapping."""
-        host = MixinHost()
-        host.init_omni_connectors(
-            model_config=_make_model_config(stage_id=0, async_chunk=True),
-        )
-        host._omni_connector = MockConnector(stage_id=0)
-        host._stage_id = 0
-        host._async_chunk = True
-
-        def mock_process(transfer_manager, pooling_output, request):
-            return {"data": "test", "finished": False}
-
-        host._custom_process_func = mock_process
-
-        request = _make_request("internal-1", "external-1")
-        host.send_chunk(request, pooling_output={"v": 1})
-
-        # The mapping should be cached
-        self.assertEqual(
-            host._request_ids_mapping.get("internal-1"),
-            "external-1",
-        )
-
-        time.sleep(0.1)
         host.shutdown_omni_connectors()
 
 

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -3,8 +3,8 @@
 """Unified data-plane communication mixin for Model Runners.
 
 All connector.put()/get() calls are consolidated here. Background I/O
-threads handle async_chunk and full_payload_mode transfers; KV cache is delegated to
-the existing OmniKVTransferManager (to be absorbed later).
+threads handle full-payload transfers; KV cache is delegated to the existing
+OmniKVTransferManager (to be absorbed later).
 
 The mixin reports transfer results via OmniConnectorOutput so that the
 Scheduler can make scheduling decisions without ever touching a connector.
@@ -70,9 +70,9 @@ def should_accumulate_full_payload_output(model_config, custom_process_func) -> 
 class OmniConnectorModelRunnerMixin:
     """Unified data-plane communication mixin for Model Runners.
 
-    Provides three transfer modes through a single pair of bg I/O threads:
-      - **full_payload_mode**: ``recv_full_payload_inputs`` / ``send_full_payload_outputs``
-      - **Streaming (async_chunk)**: ``recv_chunk`` / ``send_chunk``
+    Provides full-payload transfer through a single pair of bg I/O threads:
+      - ``register_chunk_recv`` + ``recv_full_payload_inputs`` on receive
+      - ``accumulate_full_payload_output`` + ``send_full_payload_outputs`` / ``flush_full_payload_outputs`` on send.
       - **KV cache**: ``send_kv_cache`` / ``recv_kv_cache`` (delegates to
         the existing ``OmniKVTransferManager``)
 
@@ -141,7 +141,7 @@ class OmniConnectorModelRunnerMixin:
         self._cached_ic: dict[str, int] = {}
         self._request_ids_mapping: dict[str, str] = {}
 
-        # -- async I/O state (shared by chunk + full_payload_mode) --
+        # -- background I/O state for full-payload transfers --
         self._pending_load_reqs: dict[str, Any] = {}
         self._finished_load_reqs: set[str] = set()
         self._pending_save_reqs: dict[str, deque] = {}
@@ -170,7 +170,7 @@ class OmniConnectorModelRunnerMixin:
         # Prevents re-registration after the finish sentinel has been received.
         self._chunk_stream_completed: set[str] = set()
 
-        # -- full_payload_mode: accumulate latest pooler_output per request,
+        # -- Full-payload output: accumulate latest pooler_output per request,
         #    send only when the request finishes (next-cycle flush) --
         self._pending_full_payload_send: dict[str, tuple[Any, ...]] = {}
 
@@ -234,14 +234,13 @@ class OmniConnectorModelRunnerMixin:
         Call this when a request is freed from the model runner to prevent
         memory leaks in the mixin's tracking dicts/sets.
 
-        Two senders use different keys: ``send_chunk`` keys per-request
-        state under the EXTERNAL id (after mapping resolution), while
-        ``send_full_payload_outputs`` keys under the INTERNAL id. To cover
-        both modes (and forward compat with id-rename scenarios) we attempt
-        cleanup against both keys; the entry that doesn't exist for the
-        active mode is a no-op pop.  Only the key that actually has pending
-        saves is added to ``_deferred_send_cleanup`` so the bg save's
-        decrement path drains it without leaving orphans.
+        ``send_full_payload_outputs`` keys per-request send state under the
+        INTERNAL id, while ``register_chunk_recv`` may have cached an
+        internal->external id mapping on the recv side. To cover both (and
+        forward compat with id-rename scenarios) we attempt cleanup against
+        both keys; the entry that doesn't exist is a no-op pop.  Only the key
+        that actually has pending saves is added to ``_deferred_send_cleanup``
+        so the bg save's decrement path drains it without leaving orphans.
         """
         # Force-flush any pending full-payload accumulator entry before
         # cleanup proceeds.  Without this, finished requests with no
@@ -650,11 +649,11 @@ class OmniConnectorModelRunnerMixin:
                 self._chunk_stream_completed.add(req_id)
 
     # ------------------------------------------------------------------ #
-    #  full_payload_mode (recv_full_payload_inputs / send_full_payload_outputs)
+    #  Full-payload transfer (recv_full_payload_inputs / send_full_payload_outputs)
     # ------------------------------------------------------------------ #
 
     def recv_full_payload_inputs(self, scheduler_output: Any) -> dict[str, Any] | None:
-        """Check for incoming full_payload_mode stage inputs (non-blocking).
+        """Check for incoming full-payload stage inputs (non-blocking).
 
         Returns a dict mapping ``request_id -> engine_inputs`` for data
         that has arrived, or ``None`` if nothing is ready.  Stores full
@@ -821,7 +820,7 @@ class OmniConnectorModelRunnerMixin:
         pooler_output: Any,
         request: Any,
     ) -> None:
-        """Accumulate pooler_output for a request across steps (full_payload_mode).
+        """Accumulate pooler_output for a request across steps for full-payload transfer.
 
         Per-token tensors (2-D+, matching trailing dims) are concatenated
         along dim-0.  Scalar / global tensors (1-D or 0-D) are replaced
@@ -993,15 +992,15 @@ class OmniConnectorModelRunnerMixin:
         return sent_ids
 
     # ------------------------------------------------------------------ #
-    #  Streaming chunk mode  (recv_chunk / send_chunk)
+    #  Payload receive registration
     # ------------------------------------------------------------------ #
 
     def register_chunk_recv(self, request: Any) -> None:
-        """Register a request for async chunk retrieval by the bg thread.
+        """Register a request for background payload retrieval.
 
         Stage-0 has no upstream producer so this is a no-op there.
         Skips requests whose batch data has already been received to
-        prevent the bg thread from polling for non-existent chunks.
+        prevent the bg thread from polling for unavailable payloads.
         """
         if self._stage_id == 0:
             return
@@ -1947,10 +1946,11 @@ class OmniConnectorModelRunnerMixin:
         """Load the connector payload builder for the downstream stage.
 
         Preferred source is ``custom_process_next_stage_input_func``. Some
-        full_payload_mode configs (async_chunk=false) only expose the next-stage prompt builder via
-        ``custom_process_input_func`` (for example ``thinker2talker``), while the
-        connector payload builder lives beside it as ``thinker2talker_full_payload``.
-        In that case, derive the full_payload_mode builder path automatically.
+        stages only expose the next-stage prompt builder via
+        ``custom_process_input_func`` (for example ``thinker2talker``), while
+        the connector payload builder lives beside it as
+        ``thinker2talker_full_payload``. In that case, derive the connector
+        payload builder path automatically.
         """
         candidates: list[str] = []
 

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -564,36 +564,6 @@ class OmniConnectorModelRunnerMixin:
             return None
         return connector.get(from_stage, to_stage, connector_get_key)
 
-    def _recv_full_payload_result(
-        self,
-        connector: OmniConnectorBase,
-        from_stage: str,
-        to_stage: str,
-        connector_get_key: str,
-    ) -> Any:
-        """Receive one full-payload transfer on the local leader rank only."""
-        return self._recv_ordinary_stage_result(
-            connector,
-            from_stage,
-            to_stage,
-            connector_get_key,
-        )
-
-    def _recv_async_chunk_result(
-        self,
-        connector: OmniConnectorBase,
-        from_stage: str,
-        to_stage: str,
-        connector_get_key: str,
-    ) -> Any:
-        """Receive one ordinary async chunk on the local leader rank only."""
-        return self._recv_ordinary_stage_result(
-            connector,
-            from_stage,
-            to_stage,
-            connector_get_key,
-        )
-
     @staticmethod
     def _snapshot_payload(payload: Any) -> Any:
         if isinstance(payload, dict):
@@ -1049,103 +1019,6 @@ class OmniConnectorModelRunnerMixin:
                 return
             self._pending_load_reqs[request_id] = request
         self._work_available.set()
-
-    def recv_chunk(self) -> dict[str, Any]:
-        """Collect chunks received by the bg thread since last call.
-
-        Returns a dict ``{request_id: chunk_payload}`` for newly arrived
-        chunks.  Empty dict when nothing is ready.
-
-        This method reads from ``_finished_load_reqs`` without clearing
-        it -- ``get_omni_connector_output()`` is the sole consumer that
-        drains and resets ``_finished_load_reqs`` at the end of each
-        ``execute_model`` cycle.
-
-        Returns **shallow copies** of the cached payloads so that the
-        caller can read them without racing against the background recv
-        thread, which may concurrently mutate the live cache entries via
-        ``dict.update()``.
-        """
-        with self._lock:
-            finished = set(self._finished_load_reqs)
-            if not finished:
-                return {}
-            # Snapshot the payloads under the lock to avoid racing with
-            # _poll_single_request which does existing.update(payload_data)
-            # on the same dict objects.
-            result = {}
-            for rid in finished:
-                payload = self._local_stage_payload_cache.get(rid)
-                result[rid] = dict(payload) if isinstance(payload, dict) else payload
-
-        self._chunk_ready_req_ids.update(finished)
-        return result
-
-    def send_chunk(
-        self,
-        request: Any,
-        pooling_output: Any | None = None,
-    ) -> bool:
-        """Derive and enqueue one chunk for async sending.
-
-        Payload extraction runs in the caller thread (via
-        ``custom_process_stage_input_func``); the actual
-        ``connector.put()`` is done by the background save thread.
-        Non-KV data is identical across TP ranks; only rank 0 sends.
-        """
-        if self._omni_connector is None:
-            logger.warning("[Stage-%s] send_chunk: connector is None", self._stage_id)
-            return False
-        if not self.is_data_transfer_rank():
-            return True
-        raw_req_id = getattr(request, "request_id", None) or getattr(request, "req_id", None)
-        request_id = self._resolve_external_req_id(request, raw_req_id)
-        # Cache the internal→external mapping so that finish sentinels can
-        # resolve the external ID even after the request is freed.
-        if raw_req_id and raw_req_id != request_id:
-            self._request_ids_mapping.setdefault(raw_req_id, request_id)
-        chunk_id = self._put_req_chunk[request_id]
-
-        payload_data = self._build_custom_process_payload(
-            request_id=request_id,
-            request=request,
-            pooling_output=pooling_output,
-        )
-        if payload_data is None:
-            if chunk_id == 0:
-                logger.warning(
-                    "[Stage-%s] send_chunk: payload is None for req=%s chunk=%s (process_func=%s)",
-                    self._stage_id,
-                    request_id,
-                    chunk_id,
-                    self._custom_process_func,
-                )
-            return False
-
-        self._put_req_chunk[request_id] += 1
-        next_stage_id = self._next_stage_id
-        connector_put_key = f"{request_id}_{self._stage_id}_{chunk_id}"
-
-        if chunk_id == 0:
-            logger.debug(
-                "[Stage-%s] send_chunk: first chunk enqueued, req=%s key=%s",
-                self._stage_id,
-                request_id,
-                connector_put_key,
-            )
-
-        task = {
-            "stage_id": self._stage_id,
-            "next_stage_id": next_stage_id,
-            "put_key": connector_put_key,
-            "data": payload_data,
-            "request_id": request_id,
-        }
-        with self._lock:
-            self._pending_save_reqs.setdefault(request_id, deque()).append(task)
-            self._pending_save_counts[request_id] += 1
-        self._work_available.set()
-        return True
 
     # ------------------------------------------------------------------ #
     #  KV cache  (delegates to OmniKVTransferManager)
@@ -1723,20 +1596,12 @@ class OmniConnectorModelRunnerMixin:
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
         connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
-        if self._async_chunk:
-            result = self._recv_async_chunk_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
-        else:
-            result = self._recv_full_payload_result(
-                connector,
-                str(target_stage_id),
-                str(self._stage_id),
-                connector_get_key,
-            )
+        result = self._recv_ordinary_stage_result(
+            connector,
+            str(target_stage_id),
+            str(self._stage_id),
+            connector_get_key,
+        )
 
         if result is None:
             return False


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Removes dead async_chunk code paths from `OmniConnectorModelRunnerMixin` as data now flows through the full_payload path regardless of `async_chunk`. Async chunk paths use `OmniChunkTransferAdapter` instead, meaning that the connector mixin code is dead. The flag only gates secondary behavior (payload-consumability checks, client/inter-stage key partitioning, and TP fanout).

### Removed

- `send_chunk` / `recv_chunk`
- `recv_async_chunk_result`
- `recv_full_payload_result` (see note below)

Since `recv_full_payload_result` only delegates to `recv_ordinary_stage_result` and there is less distinction between async and full payload paths, its sole caller now uses `recv_ordinary_stage_result` and `recv_full_payload_result` has been removed.

## Test Plan

```bash
pytest \
    tests/worker/test_omni_connector_mixin.py \
    tests/worker/test_gpu_ar_model_runner.py \
    tests/worker/test_gpu_generation_model_runner.py \
    tests/worker/test_omni_gpu_model_runner.py \
    tests/core/sched/test_omni_scheduling_coordinator.py \
    tests/config/test_omni_config.py \
    tests/test_config_factory.py \
    tests/test_arg_utils.py \
    tests/model_executor/stage_input_processors/test_step_audio2_async_chunk.py \
    tests/model_executor/stage_input_processors/test_fish_speech_async_chunk.py \
    tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py \
    tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py \
    tests/model_executor/stage_input_processors/test_qwen3_tts_async_chunk.py \
    tests/model_executor/stage_input_processors/test_glm_tts_async_chunk.py \
    tests/model_executor/models/step_audio2/test_step_audio2_token2wav_async_chunk.py \
    tests/model_executor/models/qwen3_omni/test_qwen3_omni_code2wav_streaming.py \
    tests/model_executor/models/qwen3_tts/test_qwen3_tts_code2wav.py \
    tests/engine/test_orchestrator.py \
    tests/engine/test_async_omni_engine_stage_init.py \
    tests/engine/test_single_stage_mode.py \
    tests/engine/test_orchestrator_stage_input_bridge.py \
    tests/engine/test_orchestrator_kv_sender_info.py \
    -q
```

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** f5c11790

## Test Result

682 passed, 2 skipped.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)


