### PR TITLE
[Benchmark] Support setting env to load paraformer-zh from disk

### DIFF
--- a/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
@@ -36,7 +36,8 @@ Enable with ``SEED_TTS_WER_EVAL=1`` or ``--seed-tts-wer-eval``. Install optional
     pip install 'vllm-omni[dev]'
 
 Env: ``SEED_TTS_EVAL_DEVICE`` (e.g. ``cuda:0``, ``cpu``); ``SEED_TTS_HF_WHISPER_MODEL``
-defaults to ``openai/whisper-large-v3`` (override for debugging only). Set
+defaults to ``openai/whisper-large-v3`` (override for debugging only);
+``SEED_TTS_PARAFORMER_MODEL`` defaults to ``paraformer-zh``. Set
 ``SEED_TTS_WER_SAVE_AUDIO_DIR`` to save the captured 24 kHz mono WAV used by
 WER evaluation for each synthesized utterance.
 Streaming PCM is decoded using ``VLLM_OMNI_BENCH_AUDIO_SAMPLE_RATE`` /
@@ -425,15 +426,16 @@ def _ensure_zh_asr() -> None:
         from funasr import AutoModel
 
         _device = _get_eval_device()
+        mid = os.environ.get("SEED_TTS_PARAFORMER_MODEL", PARAFORMER_MODEL_ID).strip() or PARAFORMER_MODEL_ID
         logger.warning(
             "Loading Seed-TTS eval Paraformer %r on %s (one-time, seed-tts-eval protocol)...",
             PARAFORMER_MODEL_ID,
             _device,
         )
         try:
-            _zh_paraformer = AutoModel(model=PARAFORMER_MODEL_ID, device=_device)
+            _zh_paraformer = AutoModel(model=mid, device=_device)
         except TypeError:
-            _zh_paraformer = AutoModel(model=PARAFORMER_MODEL_ID)
+            _zh_paraformer = AutoModel(model=mid)
 
 
 def _transcribe_en_f32_16k(wav_f32: np.ndarray) -> str:

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -120,7 +120,7 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
         "--backend openai-audio-speech or openai-chat-omni). Scoring follows "
         "zhaochenyang20/seed-tts-eval (Whisper-large-v3 / Paraformer-zh + jiwer). "
         "Sets SEED_TTS_WER_EVAL=1. Install: pip install 'vllm-omni[dev]'. "
-        "Optional: SEED_TTS_EVAL_DEVICE, SEED_TTS_HF_WHISPER_MODEL.",
+        "Optional: SEED_TTS_EVAL_DEVICE, SEED_TTS_HF_WHISPER_MODEL, SEED_TTS_PARAFORMER_MODEL.",
     )
     g.add_argument(
         "--seed-tts-wer-save-items",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Env ` SEED_TTS_PARAFORMER_MODEL` has been added for TTS benchmark (zh WER), enabling the Paraformer-zh model to be loaded from a specific local path (or an alternative model ID). This is useful for offline devices.

## Test Plan

vLLM Version: v0.23.0

vLLM-Ascend Commit: 4885d8e7b7f4bf03a0b6c895428fc4fdcdfd6f23

vLLM-Omni Commit: 65bc737fd4375aca26c890941a02cdf88dcc3e14

```
export SEED_TTS_PARAFORMER_MODEL='/home/x50058110/tts-aclg/paraformer-zh'

vllm bench serve --omni --host 127.0.0.1 --port 8091 --model /home/x50058110/tts-aclg/Qwen3-TTS-12Hz-1.7B-Base --endpoint /v1/audio/speech --backend openai-audio-speech --request-rate inf --num-prompts 200 --max-concurrency 8 --no-oversample --num-warmups 0 --seed 42 --percentile-metrics e2el,audio_ttfp,audio_rtf,audio_duration --save-result --save-detailed --result-dir results/qwen3_tts_pg_audio --result-filename qwen_omni_acc_seed_tts_baseline_1784723073.json --dataset-name seed-tts --dataset-path /home/x50058110/tts-aclg/seedtts_testset --seed-tts-locale zh --seed-tts-wer-eval --extra-body {} --seed-tts-wer-save-items
```

## Test Result

Testing confirms that the results meet expectations.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
