### PR TITLE
[CI/Bugfix] Fix empty vllm_omni stub breaking stage CLI imports after Docker cache (#5338)

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -15,10 +15,10 @@ WORKDIR ${APP_DIR}
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-# Create a vllm_omni dir so that we can install the python package
-# without failing to write the version files; we'll copy over it
-# after installing
-RUN mkdir -p vllm_omni
+# Placeholder package tree so editable install can register APP_DIR.
+# The final stage COPY --link fills this directory with the real sources;
+# the editable .pth / egg-link keeps resolving imports there — no PYTHONPATH.
+RUN mkdir -p vllm_omni && touch vllm_omni/__init__.py
 
 # Install system dependencies
 RUN apt-get update && \
@@ -32,7 +32,11 @@ RUN apt-get update && \
 COPY pyproject.toml setup.py ./
 COPY requirements/ requirements/
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
-RUN uv pip install --system ".[dev]"
+# Editable install: deps + project metadata are cached in this layer, while
+# the package itself is linked to APP_DIR (populated later by COPY --link).
+# Do NOT use a non-editable install here — that copies an empty stub into
+# site-packages and breaks ``import vllm_omni.entrypoints``.
+RUN uv pip install --system -e ".[dev]"
 
 # The final stage just copies the working dir on top of the
 # dependencies image. This uses --link so that we can skip
@@ -40,17 +44,10 @@ RUN uv pip install --system ".[dev]"
 #
 # IMPORTANT: Do not make any modifications that depend on the
 # file system after the --link copy, otherwise we'd need to pull
-# the heavy base image to build it. This is the reason we copy
-# link & update the pythonpath to point at the copied code instead
-# of running a new pip install on it.
+# the heavy base image to build it. Editable install above already
+# registered APP_DIR, so we must not re-pip-install after COPY.
 FROM deps
 ARG APP_DIR=/workspace/vllm-omni
-# Add APP_DIR to the pythonpath, since the entrypoint stub
-# that was installed in the earlier step must point at the copied code.
-#
-# NOTE: this will probably warn about undefined vars, but is expected.
-# See: https://github.com/docker/buildx/issues/2751
-ENV PYTHONPATH=${APP_DIR}${PYTHONPATH:+:${PYTHONPATH}}
 WORKDIR ${APP_DIR}
 
 COPY --link . .

--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -638,7 +638,10 @@ class OmniServerStageCli(OmniServer):
         proc = subprocess.Popen(
             cmd,
             env=env,
-            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            # Must be repo root (not tests/): after Docker deps-cache installs an empty
+            # vllm_omni stub into site-packages, cwd on sys.path[0] is what makes
+            # ``python -m vllm_omni.entrypoints...`` resolve the real package.
+            cwd=_omni_subprocess_cwd(),
             stdout=log_fh,
             stderr=subprocess.STDOUT,
         )


### PR DESCRIPTION
﻿<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix CI failures after [#5133](https://github.com/vllm-project/vllm-omni/commit/7d5376f21534482d383c8bab085f5a2ca801b37f) (`Optimize Docker Caching`) where stage CLI subprocesses crash with:

```text
ModuleNotFoundError: No module named 'vllm_omni.entrypoints'
```

Root cause:
1. The deps stage did a **non-editable** `uv pip install ".[dev]"` against an empty `vllm_omni/` stub, so site-packages got a broken empty package.
2. The final image relied on `PYTHONPATH` + `COPY --link` instead of a real install.
3. `OmniServerStageCli` set subprocess `cwd` to `tests/` (not repo root), so `python -m vllm_omni.entrypoints.cli.main` resolved the empty stub and failed (seen in `test_qwen3_omni_realtime_websocket`).

This PR:
- Switches the CI image deps install to **editable** (`uv pip install -e ".[dev]"`) so site-packages links to `APP_DIR`; after `COPY --link` the real sources are used — **no `PYTHONPATH`**, and the deps-layer cache design from #5133 is preserved.
- Fixes stage CLI `cwd` to `_omni_subprocess_cwd()` (repo root), matching `OmniServer`.

Fixes #5338

## Test Plan

**vLLM Version:** (CI image pin) see `docker/Dockerfile.ci` `VLLM_BASE_TAG`

**vLLM-Omni Commit:** this PR HEAD

- Rebuild CI image with updated `Dockerfile.ci` (cache key will rotate once because Dockerfile changed; subsequent builds keep deps caching).
- Regression (stage CLI import path — the failing job):

```bash
pytest -sv tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py -m "advanced_model and cuda" --run-level advanced_model
```

## Test Result
<img width="2288" height="92" alt="79921b1e-7eea-43f5-8837-aea4dc77dc67" src="https://github.com/user-attachments/assets/dd0bcd4c-6539-4db5-8457-5365074cf20b" />

- Pending Buildkite after image rebuild (paste logs when available).
- Local Docker image rebuild / GPU e2e not run in this environment.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
