### PR TITLE
[BugFix] Resolve the issue where the image generation subprocess fails to exit…… (#4526)

### DIFF
--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -57,6 +57,10 @@ class _ExecutorShutdownCleaner:
                     logger.warning("Terminating diffusion worker %s after timeout", proc.name)
                     proc.terminate()
                     proc.join(5)
+                if proc.is_alive():  # The worker did not response proc.terminate()
+                    logger.warning("Terminating diffusion worker %s still alive", proc.name)
+                    proc.kill()
+                    proc.join(5)
 
 
 class MultiprocDiffusionExecutor(DiffusionExecutor):


### PR DESCRIPTION
Resolve the issue where the image generation subprocess fails to exit (#4526)
## Purpose
Fixes #4526.

This PR fixes an abnormal shutdown issue in the vLLM-Omni image generation / diffusion worker path.

Before this change, when `SIGTERM` was sent directly to one image generation worker subprocess during active text-to-image inference, the target worker did not exit immediately. In the reproduced case, `DiffusionWorker-0` remained alive with a small amount of GPU memory still occupied, while the other image generation worker subprocesses kept 100% GPU utilization and stayed blocked in distributed execution. The whole service could only exit after waiting for the NCCL watchdog timeout, which took about 10 minutes, or  printing "[rank1]:[W723 16:36:48.555477787 ProcessGroupNCCL.cpp:1826] [PG ID 0 PG GUID 0 Rank 1] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Broken pipe", which took about more time.

The root cause is that an externally terminated worker could enter the Python shutdown / distributed cleanup path instead of failing fast. During active inference, this could leave the remaining ranks waiting in NCCL collectives and prevent the parent process from immediately recovering the full worker group.

This PR separates the abnormal external worker termination path from the normal graceful shutdown path.

After this change:

+ A worker subprocess that receives external `SIGTERM` exits immediately.
+ The parent process can observe the worker failure and tear down the image generation worker group.
+ The service can be shutdown within one minute.
+ No stale image generation subprocess remains after shutdown.
+ GPU resources are fully released.

For normal service termination, users should send `SIGTERM` to the parent process of the image generation worker subprocesses rather than directly killing an individual worker. The parent process will let the current batch of image generation tasks finish and then shut down the worker group gracefully.

## Test Plan
Manual reproduction test for #4526.

Test machine:

+ GPU: 4 x NVIDIA A100 80G
+ Model: HunyuanImage-3.0-Instruct
+ Tensor / diffusion workers: 4 GPUs

### 1. Start vLLM-Omni with HunyuanImage-3.0-Instruct on 4 GPUs
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -u -m vllm_omni.entrypoints.cli.main serve \
  /data/HunyuanImage-3.0-Instruct \
  --host 127.0.0.1 \
  --port 33547 \
  --omni \
  --trust-remote-code \
  --disable-log-stats \
  --stage-init-timeout 600 \
  --init-timeout 900 \
  --stage-configs-path /app/vllm-omni/vllm_omni/deploy/hunyuan_image3_dit.yaml
```

### 2. Run text-to-image requests
```bash
python -u vllm-omni/benchmarks/diffusion/diffusion_benchmark_serving.py \
  --host 127.0.0.1 \
  --port 33547 \
  --model /data/HunyuanImage-3.0-Instruct \
  --endpoint /v1/images/generations \
  --dataset random \
  --task t2i \
  --num-prompts 10 \
  --request-rate 0.3 \
  --max-concurrency 8 \
  --width 512 \
  --height 512 \
  --num-inference-steps 4 \
  --seed 42
```

### 3. Send SIGTERM to one image generation worker subprocess
While requests are running, find one diffusion worker subprocess and send `SIGTERM` to it:

```bash
ps -ef | grep -E "DiffusionWorker|image|vllm_omni" | grep -v grep

kill -15 <DiffusionWorker-0 PID>
```

### 4. Verify process and GPU resource cleanup
```bash
ps -ef | grep -E "DiffusionWorker|image|vllm_omni" | grep -v grep

nvidia-smi
```

### 5. Verify graceful parent-process shutdown
Send `SIGTERM` to the parent process of the image generation worker subprocesses and verify that the service finishes the current image generation batch, then exits cleanly without stale worker subprocesses.

```bash
kill -15 <parent PID>
```

**vLLM Version:**

 0.23.1rc1.dev1400+g27ffbfde8  (main)

**vLLM-Omni Commit:**

 0.25.0rc2.dev92+g925adafb0.d20260723  (main)

## Test Result
### Before this PR
When `SIGTERM` was sent directly to `DiffusionWorker-0` during active image generation on a 4 x A100 80G machine:

+ `DiffusionWorker-0` did not exit immediately.
+ `DiffusionWorker-0` remained alive with a small amount of GPU memory still occupied.
+ Other image generation worker subprocesses kept 100% GPU utilization.
+ The remaining worker subprocesses were blocked in distributed execution / NCCL collectives.
+ The full shutdown delay was more than 10 minutes.
+ GPU resources were not released along.
+ Stale subprocesses and GPU resource residue could be observed during the hang.

### After this PR
When `SIGTERM` is sent directly to `DiffusionWorker-0` during active image generation on the same 4 x A100 80G machine:

+ The terminated worker exits immediately.
+ The whole process group exits in about 1 minute.
+ No stale worker subprocess remains.
+ `nvidia-smi` shows that GPU resources are fully released.
+ No long-running low-memory residual worker process is observed.

### Graceful shutdown behavior
When `SIGTERM` is sent to the parent process instead of directly to an individual worker subprocess:

+ The parent process waits for the current batch of text-to-image tasks to finish.
+ The image generation worker group exits gracefully.
+ No stale subprocess remains.
+ GPU resources are fully released.

Therefore, users who want to stop the service should send `SIGTERM` to the parent process. Directly sending `SIGTERM` to an individual worker subprocess is treated as an abnormal worker failure and now triggers fail-fast worker-group cleanup.
