### PR TITLE
[Kernel] Refresh FlashInfer attention; Add quantized attention support (Blackwell QK16/V8)

### DIFF
--- a/docs/user_guide/diffusion/attention_backends.md
+++ b/docs/user_guide/diffusion/attention_backends.md
@@ -17,7 +17,7 @@ The full set of backends and their platform defaults is in the **Backend Options
 | `TRTLLM_ATTN` | FlashInfer's trtllm-gen FMHA (TensorRT-LLM's generated kernels, vendored by FlashInfer). BF16, GQA native, `head_dim=128`. Datacenter Blackwell only (sm_100 / sm_103). Supports **Skip-Softmax** sparse attention and **SAGE** quantized attention — see below. Requires `flashinfer`. |
 | `FLASH_ATTN` | Wraps FlashAttention 2. Default on Hopper / Ada / Ampere when `flash-attn` is installed. |
 | `CUDNN_ATTN` | Pins `sdpa_kernel([CUDNN_ATTENTION])`. Default on Blackwell (sm_10x / sm_12x) with cuDNN ≥ 9.5. Wins on mask-heavy DiTs (HunyuanVideo-1.5: 2× e2e vs SDPA). |
-| `FLASHINFER_ATTN` | Calls FlashInfer's dense `single_prefill_with_kv_cache` directly with `custom_mask` for non-causal masked attention. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer`. |
+| `FLASHINFER_ATTN` | Uses FlashInfer's batch-prefill wrapper for regular attention. Supports mixed Q/K and V input dtypes and SageAttention for Blackwell through backend-specific configuration. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer`; quantized configurations may require a future FlashInfer version. |
 | `TORCH_SDPA` | PyTorch `scaled_dot_product_attention` with the default backend dispatcher. Most conservative; always available. |
 | `SAGE_ATTN` | SageAttention 2.2 — INT8-quantized attention with FP16 accumulation. Lossy but typically visually indistinguishable on diffusion outputs. Requires `sageattention`. |
 | `SAGE_ATTN_3` | Requires `sageattn3` from `SageAttention/sageattention3_blackwell`. CUDA only, intended for Blackwell GPUs, with GQA/MQA requests falling back to PyTorch SDPA. |
@@ -96,6 +96,48 @@ config = OmniDiffusionConfig(
 ```
 
 A plain dict is also accepted and normalized to `AttentionConfig`.
+
+#### FlashInfer QK16/V8 quantized attention
+
+`FLASHINFER_ATTN` accepts backend-specific quantization options through `AttentionSpec.extra`. For QK16/V8:
+
+```python
+config = OmniDiffusionConfig(
+    diffusion_attention_config=AttentionConfig(
+        default=AttentionSpec(
+            backend="FLASHINFER_ATTN",
+            extra={
+                "dtype_qk": "bfloat16",
+                "dtype_vo": "float8_e4m3fn",
+            },
+        ),
+    ),
+    ...,
+)
+```
+
+`dtype_qk` configures the Q and K input dtypes. `dtype_vo` configures only the V input dtype.
+
+#### FlashInfer SageAttention for Blackwell:
+
+```python
+config = OmniDiffusionConfig(
+    diffusion_attention_config=AttentionConfig(
+        default=AttentionSpec(
+            backend="FLASHINFER_ATTN",
+            extra={
+                "dtype_qk": "int8",
+                "dtype_vo": "float8_e4m3fn",
+                "sage_q_block_size": 1,
+                "sage_k_block_size": 16,
+            },
+        ),
+    ),
+    ...,
+)
+```
+
+SageAttention for Blackwell requires an B200/GB200 GPU, head dimension 128, and future FlashInfer APIs.
 
 ## Platform Defaults
 

--- a/docs/user_guide/diffusion/attention_backends.md
+++ b/docs/user_guide/diffusion/attention_backends.md
@@ -17,7 +17,7 @@ The full set of backends and their platform defaults is in the **Backend Options
 | `TRTLLM_ATTN` | FlashInfer's trtllm-gen FMHA (TensorRT-LLM's generated kernels, vendored by FlashInfer). BF16, GQA native, `head_dim=128`. Datacenter Blackwell only (sm_100 / sm_103). Supports **Skip-Softmax** sparse attention and **SAGE** quantized attention — see below. Requires `flashinfer`. |
 | `FLASH_ATTN` | Wraps FlashAttention 2. Default on Hopper / Ada / Ampere when `flash-attn` is installed. |
 | `CUDNN_ATTN` | Pins `sdpa_kernel([CUDNN_ATTENTION])`. Default on Blackwell (sm_10x / sm_12x) with cuDNN ≥ 9.5. Wins on mask-heavy DiTs (HunyuanVideo-1.5: 2× e2e vs SDPA). |
-| `FLASHINFER_ATTN` | Uses FlashInfer's batch-prefill wrapper for regular attention. Supports mixed Q/K and V input dtypes and SageAttention for Blackwell through backend-specific configuration. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer`; quantized configurations may require a future FlashInfer version. |
+| `FLASHINFER_ATTN` | Uses FlashInfer's batch-prefill wrapper and supports mixed Q/K and V input dtypes through backend-specific configuration. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer` newer than 0.6.15 for mixed-dtype configurations. |
 | `TORCH_SDPA` | PyTorch `scaled_dot_product_attention` with the default backend dispatcher. Most conservative; always available. |
 | `SAGE_ATTN` | SageAttention 2.2 — INT8-quantized attention with FP16 accumulation. Lossy but typically visually indistinguishable on diffusion outputs. Requires `sageattention`. |
 | `SAGE_ATTN_3` | Requires `sageattn3` from `SageAttention/sageattention3_blackwell`. CUDA only, intended for Blackwell GPUs, with GQA/MQA requests falling back to PyTorch SDPA. |
@@ -116,28 +116,7 @@ config = OmniDiffusionConfig(
 )
 ```
 
-`dtype_qk` configures the Q and K input dtypes. `dtype_vo` configures only the V input dtype.
-
-#### FlashInfer SageAttention for Blackwell:
-
-```python
-config = OmniDiffusionConfig(
-    diffusion_attention_config=AttentionConfig(
-        default=AttentionSpec(
-            backend="FLASHINFER_ATTN",
-            extra={
-                "dtype_qk": "int8",
-                "dtype_vo": "float8_e4m3fn",
-                "sage_q_block_size": 1,
-                "sage_k_block_size": 16,
-            },
-        ),
-    ),
-    ...,
-)
-```
-
-SageAttention for Blackwell requires an B200/GB200 GPU, head dimension 128, and future FlashInfer APIs.
+`dtype_qk` configures the Q and K input dtypes. `dtype_vo` configures the V input dtype.
 
 ## Platform Defaults
 

--- a/docs/user_guide/diffusion/attention_backends.md
+++ b/docs/user_guide/diffusion/attention_backends.md
@@ -17,7 +17,7 @@ The full set of backends and their platform defaults is in the **Backend Options
 | `TRTLLM_ATTN` | FlashInfer's trtllm-gen FMHA (TensorRT-LLM's generated kernels, vendored by FlashInfer). BF16, GQA native, `head_dim=128`. Datacenter Blackwell only (sm_100 / sm_103). Supports **Skip-Softmax** sparse attention and **SAGE** quantized attention — see below. Requires `flashinfer`. |
 | `FLASH_ATTN` | Wraps FlashAttention 2. Default on Hopper / Ada / Ampere when `flash-attn` is installed. |
 | `CUDNN_ATTN` | Pins `sdpa_kernel([CUDNN_ATTENTION])`. Default on Blackwell (sm_10x / sm_12x) with cuDNN ≥ 9.5. Wins on mask-heavy DiTs (HunyuanVideo-1.5: 2× e2e vs SDPA). |
-| `FLASHINFER_ATTN` | Uses FlashInfer's batch-prefill wrapper and supports mixed Q/K and V input dtypes through backend-specific configuration. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer` newer than 0.6.15 for mixed-dtype configurations. |
+| `FLASHINFER_ATTN` | Uses FlashInfer's batch-prefill wrapper and supports mixed Q/K and V input dtypes through backend-specific configuration. Used as Blackwell fallback when cuDNN is unavailable. Requires `flashinfer` >= 0.6.16rc1 for mixed-dtype configurations. |
 | `TORCH_SDPA` | PyTorch `scaled_dot_product_attention` with the default backend dispatcher. Most conservative; always available. |
 | `SAGE_ATTN` | SageAttention 2.2 — INT8-quantized attention with FP16 accumulation. Lossy but typically visually indistinguishable on diffusion outputs. Requires `sageattention`. |
 | `SAGE_ATTN_3` | Requires `sageattn3` from `SageAttention/sageattention3_blackwell`. CUDA only, intended for Blackwell GPUs, with GQA/MQA requests falling back to PyTorch SDPA. |
@@ -82,7 +82,7 @@ one is `TRTLLM_ATTN`'s Skip-Softmax (see [below](#trtllm_attn-backend-and-skip-s
 When constructing `OmniDiffusionConfig` directly:
 
 ```python
-from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec, OmniDiffusionConfig
+from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec, AttnQuantSpec, OmniDiffusionConfig
 
 config = OmniDiffusionConfig(
     diffusion_attention_config=AttentionConfig(
@@ -99,17 +99,17 @@ A plain dict is also accepted and normalized to `AttentionConfig`.
 
 #### FlashInfer QK16/V8 quantized attention
 
-`FLASHINFER_ATTN` accepts backend-specific quantization options through `AttentionSpec.extra`. For QK16/V8:
+`FLASHINFER_ATTN` accepts quantization options through `AttentionSpec.quant`. For QK16/V8:
 
 ```python
 config = OmniDiffusionConfig(
     diffusion_attention_config=AttentionConfig(
         default=AttentionSpec(
             backend="FLASHINFER_ATTN",
-            extra={
-                "dtype_qk": "bfloat16",
-                "dtype_vo": "float8_e4m3fn",
-            },
+            quant=AttnQuantSpec(
+                dtype_qk="bfloat16",
+                dtype_vo="fp8_e4m3",
+            ),
         ),
     ),
     ...,

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -354,11 +354,18 @@ class TestOmniDiffusionConfigAttentionParsing:
     def test_dict_diffusion_attention_config(self):
         config = OmniDiffusionConfig(
             diffusion_attention_config={
-                "default": {"backend": "FLASH_ATTN"},
+                "default": {
+                    "backend": "FLASHINFER_ATTN",
+                    "extra": {"dtype_qk": torch.bfloat16, "dtype_vo": torch.float8_e4m3fn},
+                },
                 "per_role": {"self": "SPARSE_BLOCK"},
             }
         )
-        assert config.diffusion_attention_config.default.backend == "FLASH_ATTN"
+        assert config.diffusion_attention_config.default.backend == "FLASHINFER_ATTN"
+        assert config.diffusion_attention_config.default.extra == {
+            "dtype_qk": torch.bfloat16,
+            "dtype_vo": torch.float8_e4m3fn,
+        }
         assert config.diffusion_attention_config.per_role["self"].backend == "SPARSE_BLOCK"
 
     def test_no_diffusion_attention_config_defaults_to_empty(self):

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -354,18 +354,11 @@ class TestOmniDiffusionConfigAttentionParsing:
     def test_dict_diffusion_attention_config(self):
         config = OmniDiffusionConfig(
             diffusion_attention_config={
-                "default": {
-                    "backend": "FLASHINFER_ATTN",
-                    "extra": {"dtype_qk": torch.bfloat16, "dtype_vo": torch.float8_e4m3fn},
-                },
+                "default": {"backend": "FLASH_ATTN"},
                 "per_role": {"self": "SPARSE_BLOCK"},
             }
         )
-        assert config.diffusion_attention_config.default.backend == "FLASHINFER_ATTN"
-        assert config.diffusion_attention_config.default.extra == {
-            "dtype_qk": torch.bfloat16,
-            "dtype_vo": torch.float8_e4m3fn,
-        }
+        assert config.diffusion_attention_config.default.backend == "FLASH_ATTN"
         assert config.diffusion_attention_config.per_role["self"].backend == "SPARSE_BLOCK"
 
     def test_no_diffusion_attention_config_defaults_to_empty(self):

--- a/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
@@ -90,14 +90,15 @@ class FlashInferAttentionImpl(AttentionImpl):
         self.softmax_scale = softmax_scale
         self.device = torch.device("cuda", torch.accelerator.current_device_index())
         backend_kwargs = backend_kwargs or {}
-        self.dtype_qk = self._check_dtype(backend_kwargs.get("dtype_qk"), "dtype_qk", self._QK_DTYPES)
-        self.dtype_vo = self._check_dtype(backend_kwargs.get("dtype_vo"), "dtype_vo", self._VO_DTYPES)
-        requested_backend = backend_kwargs.get("flashinfer_backend", "auto")
+        quant = backend_kwargs.get("quant") or {}
+        self.dtype_qk = self._check_dtype(quant.get("dtype_qk"), "dtype_qk", self._QK_DTYPES)
+        self.dtype_vo = self._check_dtype(quant.get("dtype_vo"), "dtype_vo", self._VO_DTYPES)
+        requested_backend = quant.get("flashinfer_backend", "auto")
 
         if not HAS_FLASHINFER:
             raise ImportError("FLASHINFER_ATTN backend requires flashinfer")
 
-        self._check_future_flashinfer_version()
+        self._check_flashinfer_version()
 
         self.flashinfer_backend = self._select_backend(requested_backend, self.device)
         workspace_size = 0 if self.flashinfer_backend == "cute-dsl" else 128 * 1024 * 1024
@@ -128,7 +129,7 @@ class FlashInferAttentionImpl(AttentionImpl):
             self.device,
         )
 
-    def _check_future_flashinfer_version(self) -> None:
+    def _check_flashinfer_version(self) -> None:
         if self.dtype_qk == self.dtype_vo:
             return
         try:
@@ -136,15 +137,11 @@ class FlashInferAttentionImpl(AttentionImpl):
         except (AttributeError, InvalidVersion):
             return
         if flashinfer_version <= Version("0.6.15"):
-            error_msg = (
-                f"FlashInfer {flashinfer_version} may be too old for reliable mixed "
+            raise RuntimeError(
+                f"FlashInfer {flashinfer_version} is too old for reliable mixed "
                 f"QK/V dtype attention (Q/K={self.dtype_qk}, V={self.dtype_vo}); "
-                "install flashinfer > 0.6.15 or build from later than 41155ec2."
+                "install flashinfer >= 0.6.16rc1."
             )
-            if flashinfer_version == Version("0.6.15"):
-                logger.warning_once(error_msg)
-            else:
-                raise RuntimeError(error_msg)
 
     @staticmethod
     def _select_backend(requested_backend: str, device: torch.device) -> str:
@@ -167,7 +164,7 @@ class FlashInferAttentionImpl(AttentionImpl):
         if dtype is None:
             return None
         if isinstance(dtype, str):
-            dtype = getattr(torch, dtype)  # "bfloat16" -> torch.bfloat16
+            dtype = torch.float8_e4m3fn if dtype == "fp8_e4m3" else getattr(torch, dtype)
         if dtype not in allowed:
             choices = ", ".join(sorted(str(item) for item in allowed))
             raise ValueError(f"Unsupported {option_name}={dtype}; expected one of: {choices}")

--- a/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
@@ -13,11 +13,25 @@ from vllm_omni.diffusion.attention.backends.abstract import (
 logger = init_logger(__name__)
 
 try:
-    from flashinfer.prefill import single_prefill_with_kv_cache
+    from flashinfer.prefill import (
+        # Templated single prefill
+        single_prefill_with_kv_cache,
+    )
+    from flashinfer.prefill import (
+        # TRTLLM-optimized kernels for DeepSeek and DiT models
+        trtllm_ragged_attention_deepseek as _trtllm_ragged_attention_deepseek,
+    )
+    from flashinfer.prefill import (
+        trtllm_sage_attention_quantize as _trtllm_sage_attention_quantize,
+    )
+
+    trtllm_ragged_attention_deepseek = torch.compiler.disable(_trtllm_ragged_attention_deepseek)
+    trtllm_sage_attention_quantize = torch.compiler.disable(_trtllm_sage_attention_quantize)
 
     HAS_FLASHINFER = True
 except Exception as e:
     HAS_FLASHINFER = False
+    trtllm_ragged_attention_deepseek, trtllm_sage_attention_quantize = None, None
     logger.warning(
         "FlashInfer is unavailable; FLASHINFER_ATTN backend will not work. Reason: %s",
         e,
@@ -29,10 +43,8 @@ class FlashInferAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_attention_mask(cls) -> bool:
-        # FlashInfer single_prefill_with_kv_cache accepts a ``custom_mask`` kwarg
-        # (2D boolean, ``True`` = keep) for non-causal attention. See reviewer
-        # comment on #3079 and the flashinfer docs:
-        #   https://docs.flashinfer.ai/generated/flashinfer.prefill.single_prefill_with_kv_cache.html
+        # The single-prefill path accepts a boolean custom mask; the direct
+        # quantized path falls back to SDPA when a nontrivial mask is present.
         return True
 
     @staticmethod
@@ -52,6 +64,9 @@ class FlashInferAttentionBackend(AttentionBackend):
 
 
 class FlashInferAttentionImpl(AttentionImpl):
+    _QK_DTYPES = {torch.float16, torch.bfloat16, torch.int8}
+    _VO_DTYPES = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
+
     def __init__(
         self,
         num_heads: int,
@@ -60,10 +75,69 @@ class FlashInferAttentionImpl(AttentionImpl):
         causal: bool = False,
         num_kv_heads: int | None = None,
         prefix: str = "",
+        backend_kwargs: dict | None = None,
         **extra_impl_args,
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
+        self.device = torch.device("cuda", torch.accelerator.current_device_index())
+        backend_kwargs = backend_kwargs or {}
+        self.dtype_qk = self._check_dtype(backend_kwargs.get("dtype_qk"), "dtype_qk", self._QK_DTYPES)
+        self.dtype_vo = self._check_dtype(backend_kwargs.get("dtype_vo"), "dtype_vo", self._VO_DTYPES)
+        self.sage_q_block_size = backend_kwargs.get("sage_q_block_size")
+        self.sage_k_block_size = backend_kwargs.get("sage_k_block_size")
+        self.is_sage = self.sage_q_block_size or self.sage_k_block_size
+        requested_backend = backend_kwargs.get("flashinfer_backend", "auto")
+
+        if not HAS_FLASHINFER:
+            raise ImportError("FLASHINFER_ATTN backend requires flashinfer")
+
+        sm_major, _ = torch.cuda.get_device_capability(self.device)
+        self.use_trtllm_ragged = head_size == 128 and sm_major == 10
+        self._workspace: torch.Tensor | None = None
+        if self.use_trtllm_ragged:
+            if requested_backend == "auto":
+                self.flashinfer_backend = "trtllm-gen" if self.is_sage else "cute-dsl"
+            else:
+                self.flashinfer_backend = requested_backend
+            if self.flashinfer_backend == "trtllm-gen":
+                self._workspace = torch.zeros(256 * 1024 * 1024, device=self.device, dtype=torch.uint8)
+
+            if self.is_sage and self.dtype_vo != torch.float8_e4m3fn:
+                raise ValueError("SageAttention requires QK in {FP8, INT8}, V in {FP8}.")
+            if self.dtype_qk or self.dtype_vo:
+                logger.info_once(
+                    "FLASHINFER_ATTN dtype override: Q/K=%s, V=%s.",
+                    self.dtype_qk,
+                    self.dtype_vo,
+                )
+        else:
+            self.flashinfer_backend = requested_backend
+            if self.dtype_qk or self.dtype_vo or self.is_sage:
+                raise ValueError(f"Quantization options are not supported for {head_size=} on cc={sm_major}")
+
+        logger.info_once(
+            "FLASHINFER_ATTN initialized path=%s backend=%s on %s.",
+            "trtllm-ragged" if self.use_trtllm_ragged else "single-prefill",
+            self.flashinfer_backend,
+            self.device,
+        )
+
+    @classmethod
+    def _check_dtype(
+        cls,
+        dtype: torch.dtype | str | None,
+        option_name: str,
+        allowed: set[torch.dtype],
+    ) -> torch.dtype | None:
+        if dtype is None:
+            return None
+        if isinstance(dtype, str):
+            dtype = getattr(torch, dtype) # "bfloat16" -> torch.bfloat16
+        if dtype not in allowed:
+            choices = ", ".join(sorted(str(item) for item in allowed))
+            raise ValueError(f"Unsupported {option_name}={dtype}; expected one of: {choices}")
+        return dtype
 
     @staticmethod
     def _pack_mask_for_flashinfer(
@@ -128,6 +202,108 @@ class FlashInferAttentionImpl(AttentionImpl):
         )
         return impl.forward_cuda(query, key, value, attn_metadata)
 
+    def _run_single_prefill(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        custom_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        outputs = []
+        for batch_idx in range(query.shape[0]):
+            kwargs = {
+                "causal": self.causal,
+                "sm_scale": self.softmax_scale,
+                "backend": self.flashinfer_backend,
+            }
+            if custom_mask is not None:
+                kwargs["custom_mask"] = custom_mask if custom_mask.dim() == 2 else custom_mask[batch_idx]
+            outputs.append(
+                single_prefill_with_kv_cache(
+                    query[batch_idx],
+                    key[batch_idx],
+                    value[batch_idx],
+                    **kwargs,
+                )
+            )
+        return torch.stack(outputs, dim=0)
+
+    def _run_trtllm_ragged(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, qo_len, num_q_heads, head_dim = query.shape
+        kv_len = key.shape[1]
+        num_kv_heads = key.shape[2]
+        q = query.reshape(batch_size * qo_len, num_q_heads, head_dim)
+        k = key.reshape(batch_size * kv_len, num_kv_heads, key.shape[3])
+        v = value.reshape(batch_size * kv_len, num_kv_heads, value.shape[3])
+
+        sage_attn_sfs = (None, None, None, None)
+        sage_block_sizes = (0, 0, 0, 0)
+        if self.is_sage:
+            q, k, v, q_sf, k_sf, v_sf = trtllm_sage_attention_quantize(
+                q,
+                k,
+                v,
+                q_block_size=self.sage_q_block_size,
+                k_block_size=self.sage_k_block_size,
+                qk_quant_dtype=self.dtype_qk,
+            )
+            sage_attn_sfs = (q_sf, k_sf, None, v_sf)
+            sage_block_sizes = (
+                self.sage_q_block_size,
+                self.sage_k_block_size,
+                0,
+                1,
+            )
+        elif self.dtype_qk is not None:
+            q = q.to(self.dtype_qk)
+            k = k.to(self.dtype_qk)
+            v = v.to(self.dtype_vo)
+
+        qo_indptr = torch.arange(
+            0,
+            (batch_size + 1) * qo_len,
+            qo_len,
+            device=query.device,
+            dtype=torch.int32,
+        )
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * kv_len,
+            kv_len,
+            device=query.device,
+            dtype=torch.int32,
+        )
+        seq_lens = torch.full((batch_size,), kv_len, device=query.device, dtype=torch.int32)
+        out = trtllm_ragged_attention_deepseek(
+            query=q,
+            key=k,
+            value=v,
+            workspace_buffer=self._workspace,
+            seq_lens=seq_lens,
+            max_q_len=qo_len,
+            max_kv_len=kv_len,
+            bmm1_scale=self.softmax_scale,
+            bmm2_scale=1.0,
+            o_sf_scale=-1.0,
+            batch_size=batch_size,
+            window_left=-1,
+            cum_seq_lens_q=qo_indptr,
+            cum_seq_lens_kv=kv_indptr,
+            enable_pdl=False,
+            is_causal=self.causal,
+            return_lse=False,
+            sage_attn_sfs=sage_attn_sfs,
+            num_elts_per_sage_attn_blk=sage_block_sizes,
+            backend=self.flashinfer_backend,
+        )
+        out = out.reshape(batch_size, qo_len, num_q_heads, value.shape[3])
+        return out.to(query.dtype) if out.dtype != query.dtype else out
+
     def forward_cuda(
         self,
         query: torch.Tensor,
@@ -135,18 +311,7 @@ class FlashInferAttentionImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        if not HAS_FLASHINFER:
-            raise ImportError(
-                "FLASHINFER_ATTN backend requires flashinfer. "
-                "Install it or set DIFFUSION_ATTENTION_BACKEND to another backend."
-            )
-
-        # Try the custom_mask path; if the mask can't be packed into the
-        # (qo_len, kv_len) layout FlashInfer expects, fall back to SDPA
-        # instead of risking an illegal-memory-access crash in the kernel.
-        # Input layout is (B, S, H, D); FlashInfer dense prefill takes (S, H, D).
         batch_size = query.shape[0]
-
         custom_mask = None
         if attn_metadata is not None and attn_metadata.attn_mask is not None:
             try:
@@ -156,28 +321,16 @@ class FlashInferAttentionImpl(AttentionImpl):
                     qo_len=query.shape[1],
                     kv_len=key.shape[1],
                 )
-            except ValueError as e:
-                logger.debug("Falling back to SDPA for mask path: %s", e)
+            except ValueError as error:
+                logger.debug("Falling back to SDPA for mask path: %s", error)
                 return self._sdpa_fallback(query, key, value, attn_metadata)
-            # FlashInfer cannot combine causal masking with a custom_mask; rather
-            # than silently dropping the explicit mask (diverging from SDPA), let
-            # SDPA handle the causal+mask case correctly.
             if custom_mask is not None and self.causal:
-                logger.debug("causal=True with explicit attn_mask; deferring to SDPA")
                 return self._sdpa_fallback(query, key, value, attn_metadata)
 
-        outputs = []
-        for b in range(batch_size):
-            kwargs: dict = {
-                "sm_scale": self.softmax_scale,
-                "causal": self.causal,
-                "return_lse": False,
-            }
+        if self.use_trtllm_ragged:
             if custom_mask is not None:
-                kwargs["custom_mask"] = custom_mask if custom_mask.dim() == 2 else custom_mask[b]
-            out = single_prefill_with_kv_cache(query[b], key[b], value[b], **kwargs)
-            outputs.append(out)
+                logger.debug("TRT-LLM ragged attention has no custom-mask input; deferring to SDPA")
+                return self._sdpa_fallback(query, key, value, attn_metadata)
+            return self._run_trtllm_ragged(query, key, value)
 
-        if batch_size == 1:
-            return outputs[0].unsqueeze(0)
-        return torch.stack(outputs, dim=0)
+        return self._run_single_prefill(query, key, value, custom_mask)

--- a/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
+
 import torch
+from packaging.version import InvalidVersion, Version
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.attention.backends.abstract import (
@@ -13,7 +16,8 @@ from vllm_omni.diffusion.attention.backends.abstract import (
 logger = init_logger(__name__)
 
 try:
-    from flashinfer.prefill import single_prefill_with_kv_cache
+    import flashinfer
+    from flashinfer.prefill import BatchPrefillWithRaggedKVCacheWrapper
 
     HAS_FLASHINFER = True
 except Exception as e:
@@ -24,7 +28,6 @@ except Exception as e:
     )
 
 try:
-    # New API: TRTLLM-optimized kernels for DeepSeek and DiT models
     from flashinfer.prefill import (
         trtllm_ragged_attention_deepseek as _trtllm_ragged_attention_deepseek,
     )
@@ -34,14 +37,11 @@ try:
 
     trtllm_ragged_attention_deepseek = torch.compiler.disable(_trtllm_ragged_attention_deepseek)
     trtllm_sage_attention_quantize = torch.compiler.disable(_trtllm_sage_attention_quantize)
-
-    HAS_TRTLLM_RUGGED = True
+    HAS_FLASHINFER_FUTURE = True
+    FLASHINFER_FUTURE_IMPORT_ERROR: Exception | None = None
 except Exception as e:
-    HAS_TRTLLM_RUGGED = False
-    logger.warning(
-        "TRTLLM-optimized kernels are unavailable. Reason: %s",
-        e,
-    )
+    HAS_FLASHINFER_FUTURE = False
+    FLASHINFER_FUTURE_IMPORT_ERROR = e
 
 
 class FlashInferAttentionBackend(AttentionBackend):
@@ -49,8 +49,8 @@ class FlashInferAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_attention_mask(cls) -> bool:
-        # The single-prefill path accepts a boolean custom mask; the direct
-        # quantized path falls back to SDPA when a nontrivial mask is present.
+        # Non-CuTe batch-prefill backends accept boolean custom masks. CuTe-DSL
+        # and SageAttention fall back to SDPA for nontrivial masks.
         return True
 
     @staticmethod
@@ -73,6 +73,24 @@ class FlashInferAttentionImpl(AttentionImpl):
     _QK_DTYPES = {torch.float16, torch.bfloat16, torch.int8}
     _VO_DTYPES = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
 
+    @dataclass(frozen=True)
+    class _WrapperPlanKey:
+        batch_size: int
+        qo_len: int
+        kv_len: int
+        num_q_heads: int
+        num_kv_heads: int
+        head_dim_qk: int
+        head_dim_k: int
+        head_dim_vo: int
+        q_dtype: torch.dtype
+        k_dtype: torch.dtype
+        v_dtype: torch.dtype
+        o_dtype: torch.dtype
+        causal: bool
+        softmax_scale: float
+        has_custom_mask: bool
+
     def __init__(
         self,
         num_heads: int,
@@ -92,42 +110,100 @@ class FlashInferAttentionImpl(AttentionImpl):
         self.dtype_vo = self._check_dtype(backend_kwargs.get("dtype_vo"), "dtype_vo", self._VO_DTYPES)
         self.sage_q_block_size = backend_kwargs.get("sage_q_block_size")
         self.sage_k_block_size = backend_kwargs.get("sage_k_block_size")
-        self.is_sage = self.sage_q_block_size or self.sage_k_block_size
         requested_backend = backend_kwargs.get("flashinfer_backend", "auto")
+
+        # SageAttention config for non-causal layers
+        if bool(self.sage_q_block_size or self.sage_k_block_size):
+            self.is_sage = not causal
+            if causal:
+                self.dtype_qk = None
+                self.dtype_vo = None
+        else:
+            self.is_sage = False
 
         if not HAS_FLASHINFER:
             raise ImportError("FLASHINFER_ATTN backend requires flashinfer")
+        if self.is_sage and not HAS_FLASHINFER_FUTURE:
+            raise ImportError(
+                "SageAttention requires a newer version of FlashInfer"
+            ) from FLASHINFER_FUTURE_IMPORT_ERROR
+
+        self._check_future_flashinfer_version()
 
         sm_major, _ = torch.cuda.get_device_capability(self.device)
-        self.use_trtllm_ragged = sm_major == 10 and head_size == 128 and HAS_TRTLLM_RUGGED
-        self._workspace: torch.Tensor | None = None
-        if self.use_trtllm_ragged:
-            if requested_backend == "auto":
-                self.flashinfer_backend = "trtllm-gen" if self.is_sage else "cute-dsl"
-            else:
-                self.flashinfer_backend = requested_backend
-            if self.flashinfer_backend == "trtllm-gen":
-                self._workspace = torch.zeros(256 * 1024 * 1024, device=self.device, dtype=torch.uint8)
+        self._wrapper: BatchPrefillWithRaggedKVCacheWrapper | None = None
+        self._qo_indptr: torch.Tensor | None = None
+        self._kv_indptr: torch.Tensor | None = None
+        self._plan_key: FlashInferAttentionImpl._WrapperPlanKey | None = None
 
-            if self.is_sage and self.dtype_vo != torch.float8_e4m3fn:
-                raise ValueError("SageAttention requires QK in {FP8, INT8}, V in {FP8}.")
-            if self.dtype_qk or self.dtype_vo:
-                logger.info_once(
-                    "FLASHINFER_ATTN dtype override: Q/K=%s, V=%s.",
-                    self.dtype_qk,
-                    self.dtype_vo,
+        if self.is_sage:
+            if sm_major != 10 or head_size != 128:
+                raise ValueError(
+                    f"SageAttention requires head_size=128 on SM10x; got head_size={head_size}, cc={sm_major}."
                 )
+            if self.dtype_vo != torch.float8_e4m3fn:
+                raise ValueError("SageAttention requires QK in {FP8, INT8}, V in {FP8}.")
+            self.flashinfer_backend = "trtllm-gen" if requested_backend == "auto" else requested_backend
+            if self.flashinfer_backend != "trtllm-gen":
+                raise ValueError("SageAttention requires flashinfer_backend='trtllm-gen'.")
+            self._workspace = torch.empty(
+                256 * 1024 * 1024,
+                device=self.device,
+                dtype=torch.uint8,
+            )
         else:
-            self.flashinfer_backend = requested_backend
-            if self.dtype_qk or self.dtype_vo or self.is_sage:
-                raise ValueError(f"Quantization options are not supported for {head_size=} on cc={sm_major}")
+            self.flashinfer_backend = self._select_backend(requested_backend, self.device)
+            workspace_size = 0 if self.flashinfer_backend == "cute-dsl" else 128 * 1024 * 1024
+            self._workspace = torch.empty(
+                workspace_size,
+                device=self.device,
+                dtype=torch.uint8,
+            )
+            self._wrapper = BatchPrefillWithRaggedKVCacheWrapper(
+                self._workspace,
+                kv_layout="NHD",
+                backend=self.flashinfer_backend,
+            )
+
+        if self.dtype_qk is not None or self.dtype_vo is not None:
+            logger.info_once(
+                "FLASHINFER_ATTN dtype override: Q/K=%s, V=%s.",
+                self.dtype_qk,
+                self.dtype_vo,
+            )
 
         logger.info_once(
-            "FLASHINFER_ATTN initialized path=%s backend=%s on %s.",
-            "trtllm-ragged" if self.use_trtllm_ragged else "single-prefill",
+            "FLASHINFER_ATTN initialized backend=%s on %s.",
             self.flashinfer_backend,
             self.device,
         )
+
+    def _check_future_flashinfer_version(self) -> None:
+        if self.dtype_qk == self.dtype_vo:
+            return
+        try:
+            flashinfer_version = Version(flashinfer.__version__)
+        except (AttributeError, InvalidVersion):
+            return
+        if flashinfer_version <= Version("0.6.15"):
+            logger.warning_once(
+                "FlashInfer %s is too old for reliable mixed QK/V dtype "
+                "attention (Q/K=%s, V=%s); use a version newer than 0.6.15.",
+                flashinfer_version,
+                self.dtype_qk,
+                self.dtype_vo,
+            )
+
+    @staticmethod
+    def _select_backend(requested_backend: str, device: torch.device) -> str:
+        if requested_backend != "auto":
+            return requested_backend
+        major, _minor = torch.cuda.get_device_capability(device)
+        if major >= 10:
+            return "cute-dsl"
+        if major >= 9:
+            return "fa3"
+        return "fa2"
 
     @classmethod
     def _check_dtype(
@@ -208,33 +284,129 @@ class FlashInferAttentionImpl(AttentionImpl):
         )
         return impl.forward_cuda(query, key, value, attn_metadata)
 
-    def _run_single_prefill(
+    @torch.compiler.disable
+    def _plan_wrapper(
+        self,
+        key: _WrapperPlanKey,
+        flat_mask: torch.Tensor | None,
+    ) -> None:
+        assert self._wrapper is not None
+        self._wrapper.plan(
+            self._qo_indptr,
+            self._kv_indptr,
+            key.num_q_heads,
+            key.num_kv_heads,
+            key.head_dim_qk,
+            head_dim_vo=key.head_dim_vo,
+            custom_mask=flat_mask,
+            causal=key.causal,
+            sm_scale=key.softmax_scale,
+            q_data_type=key.q_dtype,
+            # FlashInfer versions newer than 0.6.15 can dispatch K and V with
+            # independent runtime dtypes even though plan() names this K/V.
+            kv_data_type=key.k_dtype,
+            o_data_type=key.o_dtype,
+        )
+
+    @torch.compiler.disable
+    def _make_indptr(self, batch_size: int, sequence_length: int) -> torch.Tensor:
+        return (
+            torch.arange(
+                batch_size + 1,
+                device=self.device,
+                dtype=torch.int32,
+            )
+            * sequence_length
+        )
+
+    def _ensure_plan(
+        self,
+        key: _WrapperPlanKey,
+        flat_mask: torch.Tensor | None,
+    ) -> None:
+        key_changed = key != self._plan_key
+        if not key_changed and flat_mask is None:
+            return
+
+        if key_changed:
+            self._qo_indptr = self._make_indptr(key.batch_size, key.qo_len)
+            self._kv_indptr = self._make_indptr(key.batch_size, key.kv_len)
+
+        # A custom mask's contents may change without its shape changing, so
+        # copy/re-plan it for every masked invocation.
+        self._plan_wrapper(key, flat_mask)
+        self._plan_key = key
+
+    def _run_batch_prefill(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         custom_mask: torch.Tensor | None,
     ) -> torch.Tensor:
-        outputs = []
-        for batch_idx in range(query.shape[0]):
-            kwargs = {
-                "causal": self.causal,
-                "sm_scale": self.softmax_scale,
-                "backend": self.flashinfer_backend,
-            }
-            if custom_mask is not None:
-                kwargs["custom_mask"] = custom_mask if custom_mask.dim() == 2 else custom_mask[batch_idx]
-            outputs.append(
-                single_prefill_with_kv_cache(
-                    query[batch_idx],
-                    key[batch_idx],
-                    value[batch_idx],
-                    **kwargs,
-                )
+        if query.device != self.device or key.device != self.device or value.device != self.device:
+            raise ValueError(
+                "FLASHINFER_ATTN inputs must remain on the layer initialization "
+                f"device {self.device}; got Q={query.device}, K={key.device}, "
+                f"V={value.device}"
             )
-        return torch.stack(outputs, dim=0)
 
-    def _run_trtllm_ragged(
+        batch_size, qo_len, num_q_heads, head_dim_qk = query.shape
+        kv_len = key.shape[1]
+        num_kv_heads = key.shape[2]
+        head_dim_k = key.shape[3]
+        head_dim_vo = value.shape[3]
+
+        q = query.reshape(batch_size * qo_len, num_q_heads, head_dim_qk)
+        k = key.reshape(batch_size * kv_len, num_kv_heads, head_dim_k)
+        v = value.reshape(batch_size * kv_len, num_kv_heads, head_dim_vo)
+        if self.dtype_qk is not None:
+            q = q.to(self.dtype_qk)
+            k = k.to(self.dtype_qk)
+        if self.dtype_vo is not None:
+            v = v.to(self.dtype_vo)
+
+        flat_mask = None
+        if custom_mask is not None:
+            if custom_mask.dim() == 2:
+                custom_mask = custom_mask.unsqueeze(0).expand(batch_size, -1, -1)
+            flat_mask = custom_mask.contiguous().view(-1)
+
+        self._ensure_plan(
+            FlashInferAttentionImpl._WrapperPlanKey(
+                batch_size=batch_size,
+                qo_len=qo_len,
+                kv_len=kv_len,
+                num_q_heads=num_q_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim_qk=head_dim_qk,
+                head_dim_k=head_dim_k,
+                head_dim_vo=head_dim_vo,
+                q_dtype=q.dtype,
+                k_dtype=k.dtype,
+                v_dtype=v.dtype,
+                o_dtype=query.dtype,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                has_custom_mask=flat_mask is not None,
+            ),
+            flat_mask,
+        )
+        out = self._run_wrapper(q, k, v)
+        out = out.reshape(batch_size, qo_len, num_q_heads, head_dim_vo)
+        return out.to(query.dtype) if out.dtype != query.dtype else out
+
+    @torch.compiler.disable
+    def _run_wrapper(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self._wrapper is not None
+        return self._wrapper.run(query, key, value)
+
+    def _run_trtllm_sage_attn(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
@@ -247,28 +419,21 @@ class FlashInferAttentionImpl(AttentionImpl):
         k = key.reshape(batch_size * kv_len, num_kv_heads, key.shape[3])
         v = value.reshape(batch_size * kv_len, num_kv_heads, value.shape[3])
 
-        sage_attn_sfs = (None, None, None, None)
-        sage_block_sizes = (0, 0, 0, 0)
-        if self.is_sage:
-            q, k, v, q_sf, k_sf, v_sf = trtllm_sage_attention_quantize(
-                q,
-                k,
-                v,
-                q_block_size=self.sage_q_block_size,
-                k_block_size=self.sage_k_block_size,
-                qk_quant_dtype=self.dtype_qk,
-            )
-            sage_attn_sfs = (q_sf, k_sf, None, v_sf)
-            sage_block_sizes = (
-                self.sage_q_block_size,
-                self.sage_k_block_size,
-                0,
-                1,
-            )
-        elif self.dtype_qk is not None:
-            q = q.to(self.dtype_qk)
-            k = k.to(self.dtype_qk)
-            v = v.to(self.dtype_vo)
+        q, k, v, q_sf, k_sf, v_sf = trtllm_sage_attention_quantize(
+            q,
+            k,
+            v,
+            q_block_size=self.sage_q_block_size,
+            k_block_size=self.sage_k_block_size,
+            qk_quant_dtype=self.dtype_qk,
+        )
+        sage_attn_sfs = (q_sf, k_sf, None, v_sf)
+        sage_block_sizes = (
+            self.sage_q_block_size,
+            self.sage_k_block_size,
+            0,
+            1,
+        )
 
         qo_indptr = torch.arange(
             0,
@@ -333,10 +498,14 @@ class FlashInferAttentionImpl(AttentionImpl):
             if custom_mask is not None and self.causal:
                 return self._sdpa_fallback(query, key, value, attn_metadata)
 
-        if self.use_trtllm_ragged:
+        if self.is_sage:
             if custom_mask is not None:
-                logger.debug("TRT-LLM ragged attention has no custom-mask input; deferring to SDPA")
+                logger.debug("SageAttention has no custom-mask input; deferring to SDPA")
                 return self._sdpa_fallback(query, key, value, attn_metadata)
-            return self._run_trtllm_ragged(query, key, value)
+            return self._run_trtllm_sage_attn(query, key, value)
 
-        return self._run_single_prefill(query, key, value, custom_mask)
+        if custom_mask is not None and self.flashinfer_backend == "cute-dsl":
+            logger.debug("CuTe DSL does not support custom masks; deferring to SDPA")
+            return self._sdpa_fallback(query, key, value, attn_metadata)
+
+        return self._run_batch_prefill(query, key, value, custom_mask)

--- a/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
@@ -13,12 +13,19 @@ from vllm_omni.diffusion.attention.backends.abstract import (
 logger = init_logger(__name__)
 
 try:
-    from flashinfer.prefill import (
-        # Templated single prefill
-        single_prefill_with_kv_cache,
+    from flashinfer.prefill import single_prefill_with_kv_cache
+
+    HAS_FLASHINFER = True
+except Exception as e:
+    HAS_FLASHINFER = False
+    logger.warning(
+        "FlashInfer is unavailable; FLASHINFER_ATTN backend will not work. Reason: %s",
+        e,
     )
+
+try:
+    # New API: TRTLLM-optimized kernels for DeepSeek and DiT models
     from flashinfer.prefill import (
-        # TRTLLM-optimized kernels for DeepSeek and DiT models
         trtllm_ragged_attention_deepseek as _trtllm_ragged_attention_deepseek,
     )
     from flashinfer.prefill import (
@@ -28,12 +35,11 @@ try:
     trtllm_ragged_attention_deepseek = torch.compiler.disable(_trtllm_ragged_attention_deepseek)
     trtllm_sage_attention_quantize = torch.compiler.disable(_trtllm_sage_attention_quantize)
 
-    HAS_FLASHINFER = True
+    HAS_TRTLLM_RUGGED = True
 except Exception as e:
-    HAS_FLASHINFER = False
-    trtllm_ragged_attention_deepseek, trtllm_sage_attention_quantize = None, None
+    HAS_TRTLLM_RUGGED = False
     logger.warning(
-        "FlashInfer is unavailable; FLASHINFER_ATTN backend will not work. Reason: %s",
+        "TRTLLM-optimized kernels are unavailable. Reason: %s",
         e,
     )
 
@@ -93,7 +99,7 @@ class FlashInferAttentionImpl(AttentionImpl):
             raise ImportError("FLASHINFER_ATTN backend requires flashinfer")
 
         sm_major, _ = torch.cuda.get_device_capability(self.device)
-        self.use_trtllm_ragged = head_size == 128 and sm_major == 10
+        self.use_trtllm_ragged = sm_major == 10 and head_size == 128 and HAS_TRTLLM_RUGGED
         self._workspace: torch.Tensor | None = None
         if self.use_trtllm_ragged:
             if requested_backend == "auto":
@@ -133,7 +139,7 @@ class FlashInferAttentionImpl(AttentionImpl):
         if dtype is None:
             return None
         if isinstance(dtype, str):
-            dtype = getattr(torch, dtype) # "bfloat16" -> torch.bfloat16
+            dtype = getattr(torch, dtype)  # "bfloat16" -> torch.bfloat16
         if dtype not in allowed:
             choices = ", ".join(sorted(str(item) for item in allowed))
             raise ValueError(f"Unsupported {option_name}={dtype}; expected one of: {choices}")

--- a/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flashinfer_attn.py
@@ -27,22 +27,6 @@ except Exception as e:
         e,
     )
 
-try:
-    from flashinfer.prefill import (
-        trtllm_ragged_attention_deepseek as _trtllm_ragged_attention_deepseek,
-    )
-    from flashinfer.prefill import (
-        trtllm_sage_attention_quantize as _trtllm_sage_attention_quantize,
-    )
-
-    trtllm_ragged_attention_deepseek = torch.compiler.disable(_trtllm_ragged_attention_deepseek)
-    trtllm_sage_attention_quantize = torch.compiler.disable(_trtllm_sage_attention_quantize)
-    HAS_FLASHINFER_FUTURE = True
-    FLASHINFER_FUTURE_IMPORT_ERROR: Exception | None = None
-except Exception as e:
-    HAS_FLASHINFER_FUTURE = False
-    FLASHINFER_FUTURE_IMPORT_ERROR = e
-
 
 class FlashInferAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -50,7 +34,7 @@ class FlashInferAttentionBackend(AttentionBackend):
     @classmethod
     def supports_attention_mask(cls) -> bool:
         # Non-CuTe batch-prefill backends accept boolean custom masks. CuTe-DSL
-        # and SageAttention fall back to SDPA for nontrivial masks.
+        # falls back to SDPA for nontrivial masks.
         return True
 
     @staticmethod
@@ -70,7 +54,7 @@ class FlashInferAttentionBackend(AttentionBackend):
 
 
 class FlashInferAttentionImpl(AttentionImpl):
-    _QK_DTYPES = {torch.float16, torch.bfloat16, torch.int8}
+    _QK_DTYPES = {torch.float16, torch.bfloat16}
     _VO_DTYPES = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
 
     @dataclass(frozen=True)
@@ -108,62 +92,28 @@ class FlashInferAttentionImpl(AttentionImpl):
         backend_kwargs = backend_kwargs or {}
         self.dtype_qk = self._check_dtype(backend_kwargs.get("dtype_qk"), "dtype_qk", self._QK_DTYPES)
         self.dtype_vo = self._check_dtype(backend_kwargs.get("dtype_vo"), "dtype_vo", self._VO_DTYPES)
-        self.sage_q_block_size = backend_kwargs.get("sage_q_block_size")
-        self.sage_k_block_size = backend_kwargs.get("sage_k_block_size")
         requested_backend = backend_kwargs.get("flashinfer_backend", "auto")
-
-        # SageAttention config for non-causal layers
-        if bool(self.sage_q_block_size or self.sage_k_block_size):
-            self.is_sage = not causal
-            if causal:
-                self.dtype_qk = None
-                self.dtype_vo = None
-        else:
-            self.is_sage = False
 
         if not HAS_FLASHINFER:
             raise ImportError("FLASHINFER_ATTN backend requires flashinfer")
-        if self.is_sage and not HAS_FLASHINFER_FUTURE:
-            raise ImportError(
-                "SageAttention requires a newer version of FlashInfer"
-            ) from FLASHINFER_FUTURE_IMPORT_ERROR
 
         self._check_future_flashinfer_version()
 
-        sm_major, _ = torch.cuda.get_device_capability(self.device)
-        self._wrapper: BatchPrefillWithRaggedKVCacheWrapper | None = None
+        self.flashinfer_backend = self._select_backend(requested_backend, self.device)
+        workspace_size = 0 if self.flashinfer_backend == "cute-dsl" else 128 * 1024 * 1024
+        self._workspace = torch.empty(
+            workspace_size,
+            device=self.device,
+            dtype=torch.uint8,
+        )
+        self._wrapper = BatchPrefillWithRaggedKVCacheWrapper(
+            self._workspace,
+            kv_layout="NHD",
+            backend=self.flashinfer_backend,
+        )
         self._qo_indptr: torch.Tensor | None = None
         self._kv_indptr: torch.Tensor | None = None
         self._plan_key: FlashInferAttentionImpl._WrapperPlanKey | None = None
-
-        if self.is_sage:
-            if sm_major != 10 or head_size != 128:
-                raise ValueError(
-                    f"SageAttention requires head_size=128 on SM10x; got head_size={head_size}, cc={sm_major}."
-                )
-            if self.dtype_vo != torch.float8_e4m3fn:
-                raise ValueError("SageAttention requires QK in {FP8, INT8}, V in {FP8}.")
-            self.flashinfer_backend = "trtllm-gen" if requested_backend == "auto" else requested_backend
-            if self.flashinfer_backend != "trtllm-gen":
-                raise ValueError("SageAttention requires flashinfer_backend='trtllm-gen'.")
-            self._workspace = torch.empty(
-                256 * 1024 * 1024,
-                device=self.device,
-                dtype=torch.uint8,
-            )
-        else:
-            self.flashinfer_backend = self._select_backend(requested_backend, self.device)
-            workspace_size = 0 if self.flashinfer_backend == "cute-dsl" else 128 * 1024 * 1024
-            self._workspace = torch.empty(
-                workspace_size,
-                device=self.device,
-                dtype=torch.uint8,
-            )
-            self._wrapper = BatchPrefillWithRaggedKVCacheWrapper(
-                self._workspace,
-                kv_layout="NHD",
-                backend=self.flashinfer_backend,
-            )
 
         if self.dtype_qk is not None or self.dtype_vo is not None:
             logger.info_once(
@@ -186,13 +136,15 @@ class FlashInferAttentionImpl(AttentionImpl):
         except (AttributeError, InvalidVersion):
             return
         if flashinfer_version <= Version("0.6.15"):
-            logger.warning_once(
-                "FlashInfer %s is too old for reliable mixed QK/V dtype "
-                "attention (Q/K=%s, V=%s); use a version newer than 0.6.15.",
-                flashinfer_version,
-                self.dtype_qk,
-                self.dtype_vo,
+            error_msg = (
+                f"FlashInfer {flashinfer_version} may be too old for reliable mixed "
+                f"QK/V dtype attention (Q/K={self.dtype_qk}, V={self.dtype_vo}); "
+                "install flashinfer > 0.6.15 or build from later than 41155ec2."
             )
+            if flashinfer_version == Version("0.6.15"):
+                logger.warning_once(error_msg)
+            else:
+                raise RuntimeError(error_msg)
 
     @staticmethod
     def _select_backend(requested_backend: str, device: torch.device) -> str:
@@ -290,7 +242,6 @@ class FlashInferAttentionImpl(AttentionImpl):
         key: _WrapperPlanKey,
         flat_mask: torch.Tensor | None,
     ) -> None:
-        assert self._wrapper is not None
         self._wrapper.plan(
             self._qo_indptr,
             self._kv_indptr,
@@ -403,77 +354,7 @@ class FlashInferAttentionImpl(AttentionImpl):
         key: torch.Tensor,
         value: torch.Tensor,
     ) -> torch.Tensor:
-        assert self._wrapper is not None
         return self._wrapper.run(query, key, value)
-
-    def _run_trtllm_sage_attn(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-    ) -> torch.Tensor:
-        batch_size, qo_len, num_q_heads, head_dim = query.shape
-        kv_len = key.shape[1]
-        num_kv_heads = key.shape[2]
-        q = query.reshape(batch_size * qo_len, num_q_heads, head_dim)
-        k = key.reshape(batch_size * kv_len, num_kv_heads, key.shape[3])
-        v = value.reshape(batch_size * kv_len, num_kv_heads, value.shape[3])
-
-        q, k, v, q_sf, k_sf, v_sf = trtllm_sage_attention_quantize(
-            q,
-            k,
-            v,
-            q_block_size=self.sage_q_block_size,
-            k_block_size=self.sage_k_block_size,
-            qk_quant_dtype=self.dtype_qk,
-        )
-        sage_attn_sfs = (q_sf, k_sf, None, v_sf)
-        sage_block_sizes = (
-            self.sage_q_block_size,
-            self.sage_k_block_size,
-            0,
-            1,
-        )
-
-        qo_indptr = torch.arange(
-            0,
-            (batch_size + 1) * qo_len,
-            qo_len,
-            device=query.device,
-            dtype=torch.int32,
-        )
-        kv_indptr = torch.arange(
-            0,
-            (batch_size + 1) * kv_len,
-            kv_len,
-            device=query.device,
-            dtype=torch.int32,
-        )
-        seq_lens = torch.full((batch_size,), kv_len, device=query.device, dtype=torch.int32)
-        out = trtllm_ragged_attention_deepseek(
-            query=q,
-            key=k,
-            value=v,
-            workspace_buffer=self._workspace,
-            seq_lens=seq_lens,
-            max_q_len=qo_len,
-            max_kv_len=kv_len,
-            bmm1_scale=self.softmax_scale,
-            bmm2_scale=1.0,
-            o_sf_scale=-1.0,
-            batch_size=batch_size,
-            window_left=-1,
-            cum_seq_lens_q=qo_indptr,
-            cum_seq_lens_kv=kv_indptr,
-            enable_pdl=False,
-            is_causal=self.causal,
-            return_lse=False,
-            sage_attn_sfs=sage_attn_sfs,
-            num_elts_per_sage_attn_blk=sage_block_sizes,
-            backend=self.flashinfer_backend,
-        )
-        out = out.reshape(batch_size, qo_len, num_q_heads, value.shape[3])
-        return out.to(query.dtype) if out.dtype != query.dtype else out
 
     def forward_cuda(
         self,
@@ -497,12 +378,6 @@ class FlashInferAttentionImpl(AttentionImpl):
                 return self._sdpa_fallback(query, key, value, attn_metadata)
             if custom_mask is not None and self.causal:
                 return self._sdpa_fallback(query, key, value, attn_metadata)
-
-        if self.is_sage:
-            if custom_mask is not None:
-                logger.debug("SageAttention has no custom-mask input; deferring to SDPA")
-                return self._sdpa_fallback(query, key, value, attn_metadata)
-            return self._run_trtllm_sage_attn(query, key, value)
 
         if custom_mask is not None and self.flashinfer_backend == "cute-dsl":
             logger.debug("CuTe DSL does not support custom masks; deferring to SDPA")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Refresh the FlashInfer diffusion attention integration and add support for attention quantization schemas that are implemented in a top-of-tree FlashInfer version.

This PR:

- removes the `single_prefill_with_kv_cache` code path;
- routes regular FlashInfer attention through `BatchPrefillWithRaggedKVCacheWrapper`;
- supports mixed Q/K and V dtype schemas such as QK16/V8;
- caches the ragged-attention plan and indptr tensors until the relevant shape, dtype, mask, or causality parameters change;
- preserves Torch compilation around input conversion so quantization casts can fuse with preceding operations.

### Configuration

The options are supplied through `diffusion_attention_config` under the backend-specific `extra` mapping.

QK16/V8 example:

```python
diffusion_attention_config=AttentionConfig(
    default=AttentionSpec(
        backend="FLASHINFER_ATTN",
        quant=AttnQuantSpec(
            dtype_qk="bfloat16",
            dtype_vo="fp8_e4m3",
            flashinfer_backend="auto",
        ),
    ),
)
```

`dtype_qk` configures the Q and K input dtypes. `dtype_vo` configures the V input dtype.

Compatible calls select the regular FlashInfer backend, including CuTe-DSL on supported Blackwell GPUs.

### FlashInfer compatibility

- The regular FlashInfer path uses `BatchPrefillWithRaggedKVCacheWrapper`.
- Mixed Q/K and V dtype support requires a future FlashInfer version built from top-of-tree, at or after commit `41155ec2`.

## Test Plan

- Run Ruff check and format check on the modified backend.
- Compile the modified Python module.
- Smoke-test BF16 and QK16/V8 in eager mode and with `torch.compile`.
- Smoke-test custom-mask dispatch and fallback behavior.
- Run end-to-end Cosmos3-Nano and Cosmos3-Super video generation.
- Compare QK16/V8 quality against Torch SDPA using LPIPS.
- Measure DiT execution time with CUDA events.

**vLLM Version:** `0.25.0`

**vLLM-Omni Commit:** `4ce23c3362344638cad56d889a5996b6d7ef3069`

**FlashInfer Upgraded to:** `d0889c7c95619d48a957353c379cb724ec8e3fb5`

## Test Result

- Ruff check: passed.
- Ruff format check: passed.
- Python compilation: passed.
- Eager and `torch.compile` attention smoke tests: passed.
- Custom-mask dispatch smoke tests: passed.
- End-to-end Cosmos3-Nano and Cosmos3-Super generation: passed.
- QK16/V8 LPIPS comparison against Torch SDPA: passed.

### Performance

CUDA-event DiT time, 1280×720, 35 denoising steps, seed 42:

| Model / GPU | Frames | Torch SDPA | QK16/V8 |
|---|---:|---:|---:|
| Cosmos3-Nano, B200 | 93 | 68.11 s | 31.94 s (2.13×) |
| Cosmos3-Nano, B300 | 93 | 63.16 s | 27.02 s (2.34×) |
| Cosmos3-Super, B200 | 193 | 921.54 s | 360.91 s (2.55×) |
| Cosmos3-Super, B300 | 193 | 876.56 s | 289.44 s (3.03×) |

### Accuracy

For Cosmos3-Nano I2V at 1280×720 and 93 frames, LPIPS was computed against Torch SDPA over output frames 0–23:

| Configuration | LPIPS | Naked eyes of @xrq-phys |
|---|---:|---:|
| QK16/V8 | 0.051496 | Quality as good as ref |

Lower is better.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)

