### PR TITLE
[Docs] Fix broken relative links in online serving docs

### DIFF
--- a/docs/contributing/ci/test_examples/l4_performance_tests.inc.md
+++ b/docs/contributing/ci/test_examples/l4_performance_tests.inc.md
@@ -148,7 +148,7 @@ pytest -sv tests/dfx/perf/scripts/run_diffusion_benchmark.py --assert-baseline \
   --test-config-file tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
 ```
 
-See also [Markers for Tests](./tests_markers.md) for registered hardware markers (`H100`, `L4`, `cuda`, `distributed_cuda`, …).
+See also [Markers for Tests](../tests_markers.md) for registered hardware markers (`H100`, `L4`, `cuda`, `distributed_cuda`, …).
 
 **`server_params` Configuration**
 

--- a/docs/user_guide/examples/online_serving/diffusers_pipeline_adapter.md
+++ b/docs/user_guide/examples/online_serving/diffusers_pipeline_adapter.md
@@ -99,7 +99,7 @@ a native vLLM-Omni pipeline for those cases.
 ### Attention Backends
 
 The diffusers backend converts
-[vLLM-Omni standard of attention backend setting](../../../docs/user_guide/diffusion/attention_backends.md)
+[vLLM-Omni standard of attention backend setting](../../diffusion/attention_backends.md)
 to [diffusers standard](https://huggingface.co/docs/diffusers/optimization/attention_backends#available-backends).
 
 Specifically for `FLASH_ATTN`, it will first attempt to use FlashAttention-3 and then FlashAttention-2.

--- a/docs/user_guide/examples/online_serving/image_to_image.md
+++ b/docs/user_guide/examples/online_serving/image_to_image.md
@@ -208,7 +208,7 @@ Wrap generation parameters inside `extra_body` in the request JSON:
     ```
 
     For details on how generation parameters are handled across different clients, see the
-    [Chat Completions API guide](../../../../serving/chat_completions_api.md).
+    [Chat Completions API guide](../../../serving/chat_completions_api.md).
 
 ### Layered Image Generation (Qwen-Image-Layered)
 
@@ -361,8 +361,8 @@ Provide multiple images in `content` (order matters):
 
 When using `/v1/chat/completions`, pass these inside `extra_body` in the curl
 JSON, or via the `extra_body` keyword argument in the OpenAI Python SDK (see the
-[Chat Completions API guide](../../../../serving/chat_completions_api.md)).
-When using the dedicated [`/v1/images/edits`](../../../../serving/image_edit_api.md)
+[Chat Completions API guide](../../../serving/chat_completions_api.md)).
+When using the dedicated [`/v1/images/edits`](../../../serving/image_edit_api.md)
 endpoint, pass the supported generation controls as top-level form fields
 directly. For image dimensions and count, use `size` and `n` rather than
 `height`, `width`, or `num_outputs_per_prompt`.

--- a/docs/user_guide/examples/online_serving/text_to_image.md
+++ b/docs/user_guide/examples/online_serving/text_to_image.md
@@ -216,7 +216,7 @@ Wrap generation parameters inside `extra_body` in the request JSON:
     ```
 
     For details on how generation parameters are handled across different clients, see the
-    [Chat Completions API guide](../../../../serving/chat_completions_api.md).
+    [Chat Completions API guide](../../../serving/chat_completions_api.md).
 
 ### Multimodal Input (Text + Structured Content)
 
@@ -237,8 +237,8 @@ Wrap generation parameters inside `extra_body` in the request JSON:
 
 When using `/v1/chat/completions`, pass these inside `extra_body` in the curl
 JSON, or via the `extra_body` keyword argument in the OpenAI Python SDK (see the
-[Chat Completions API guide](../../../../serving/chat_completions_api.md)).
-When using the dedicated [`/v1/images/generations`](../../../../serving/image_generation_api.md)
+[Chat Completions API guide](../../../serving/chat_completions_api.md)).
+When using the dedicated [`/v1/images/generations`](../../../serving/image_generation_api.md)
 endpoint, pass the supported generation controls as top-level JSON fields
 directly. For image dimensions and count, use `size` and `n` rather than
 `height`, `width`, or `num_outputs_per_prompt`.


### PR DESCRIPTION
## Summary

Several markdown files use incorrect relative link depths, causing broken cross-references in the rendered docs:

- `text_to_image.md` and `image_to_image.md` use `../../../../serving/` (4 levels up, resolves outside `docs/`) instead of `../../../serving/` (3 levels up, correctly resolves to `docs/serving/`)
- `diffusers_pipeline_adapter.md` links to `../../../docs/user_guide/diffusion/attention_backends.md` which includes a redundant `docs/` segment; corrected to `../../diffusion/attention_backends.md`
- `l4_performance_tests.inc.md` links to `./tests_markers.md` (same directory) instead of `../tests_markers.md` (parent directory where the file actually lives)

## Changes

- `docs/user_guide/examples/online_serving/text_to_image.md`: fix 3 links from `../../../../serving/` to `../../../serving/`
- `docs/user_guide/examples/online_serving/image_to_image.md`: fix 3 links from `../../../../serving/` to `../../../serving/`
- `docs/user_guide/examples/online_serving/diffusers_pipeline_adapter.md`: fix link from `../../../docs/user_guide/diffusion/attention_backends.md` to `../../diffusion/attention_backends.md`
- `docs/contributing/ci/test_examples/l4_performance_tests.inc.md`: fix link from `./tests_markers.md` to `../tests_markers.md`

## Testing

Link targets verified to exist at the corrected relative paths.