### PR TITLE
[CI] move Krea-2 expansion to slow and skip failing README snippets

### DIFF
--- a/tests/e2e/offline_inference/test_krea2_expansion.py
+++ b/tests/e2e/offline_inference/test_krea2_expansion.py
@@ -31,7 +31,7 @@ LORA_PROMPT = f"a fox in the snow, {LORA_TRIGGER}"
 
 pytestmark = [
     pytest.mark.diffusion,
-    pytest.mark.full_model,
+    pytest.mark.slow,
 ]
 
 

--- a/tests/e2e/online_serving/test_krea2_expansion.py
+++ b/tests/e2e/online_serving/test_krea2_expansion.py
@@ -31,7 +31,7 @@ from PIL import Image
 from tests.helpers.mark import hardware_marks
 from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHandler, dummy_messages_from_mix_data
 
-pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
+pytestmark = [pytest.mark.diffusion, pytest.mark.slow]
 
 MODEL = os.environ.get("KREA2_MODEL", "krea/Krea-2-Turbo")
 # vLLM-Omni-compatible PEFT repackaging of krea/Krea-2-LoRA-darkbrush (264 modules, r=alpha=32).

--- a/tests/examples/offline_inference/test_text_to_image.py
+++ b/tests/examples/offline_inference/test_text_to_image.py
@@ -26,6 +26,9 @@ EXAMPLE_OUTPUT_SUBFOLDER = "example_offline_t2i"
 def _skip_readme_snippet(language: str, code: str, h2_title: str) -> tuple[bool, str]:
     if h2_title == "Web UI Demo":
         return True, f"README section '{h2_title}' is intentionally excluded for examples tests"
+    # Krea-2 Turbo/Raw README snippets currently fail in CI (more_cli_examples_006/007).
+    if "krea/Krea-2-Turbo" in code or "krea/Krea-2-Raw" in code:
+        return True, "Krea-2 README snippets are temporarily skipped (CI failures)"
     return False, ""
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

- Route Krea-2 expansion e2e tests from `full_model` to `slow` so they are not selected by merge/full_model CI lanes that currently fail on these workloads.
- Temporarily skip Krea-2 Turbo/Raw README CLI snippets in `test_text_to_image` (`more_cli_examples_006/007`) to unblock CI while those example paths remain broken.

## Test Plan

**vLLM Version:** N/A (test-only change)

**vLLM-Omni Commit:** `4d9913e5`

- Marker / skip-path review on:
  - `tests/e2e/offline_inference/test_krea2_expansion.py`
  - `tests/e2e/online_serving/test_krea2_expansion.py`
  - `tests/examples/offline_inference/test_text_to_image.py`
- Rely on upstream CI to confirm `full_model` / examples lanes no longer pick up the failing Krea-2 cases.

## Test Result

- Local: not re-run full Krea-2 e2e (GPU / model weight heavy).
- Pending upstream CI on this PR for confirmation.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
