### PR TITLE
[Model] Add MiniCPM-RobotManip VLA policy pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ vLLM-Omni seamlessly supports most popular open-source models on HuggingFace, in
 - Omni-modality models (e.g. Qwen3-Omni, Cosmos3, HunyuanImage, BAGEL)
 - TTS models (e.g. Qwen3-TTS, VoxCPM2, Ming-Omni-TTS, CosyVoice3)
 - Diffusion models — image, video, and audio generation (e.g. Qwen-Image, Wan2.2, FLUX)
-- Robot-policy and action models (e.g. GR00T-N1.7, DreamZero-DROID, InternVLA-A1, Cosmos3 action policy)
+- Robot-policy and action models (e.g. GR00T-N1.7, DreamZero-DROID, InternVLA-A1, MiniCPM-RobotManip, Cosmos3 action policy)
 
 For more information, checkout the following:
 

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -25,6 +25,7 @@ th {
 | `BagelForConditionalGeneration` | BAGEL (DiT-only) | `ByteDance-Seed/BAGEL-7B-MoT` | ✅︎ | ✅︎ | | ✅︎ |
 | `InternVLAA1Pipeline` | InternVLA-A1 | `InternRobotics/InternVLA-A1-3B` | ✅︎ | ✅︎ | | |
 | `Gr00tN1d7Pipeline` | GR00T N1.7 | `nvidia/GR00T-N1.7-3B` | ✅︎ | | | |
+| `MiniCPMRobotManipPipeline` | MiniCPM-RobotManip | `openbmb/MiniCPM-RobotManip` | ✅︎ | | | |
 | `HunyuanImage3ForCausalMM` | HunyuanImage3.0 (DiT-only) | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `QwenImagePipeline` | Qwen-Image | `Qwen/Qwen-Image` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `QwenImagePipeline` | Qwen-Image-2512 | `Qwen/Qwen-Image-2512` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |

--- a/tests/diffusion/models/minicpm_robot/__init__.py
+++ b/tests/diffusion/models/minicpm_robot/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/diffusion/models/minicpm_robot/test_pipeline.py
+++ b/tests/diffusion/models/minicpm_robot/test_pipeline.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MiniCPM-RobotManip diffusion pipeline."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_omni.diffusion.models.minicpm_robot import pipeline_minicpm_robot
+from vllm_omni.diffusion.models.minicpm_robot.pipeline_minicpm_robot import (
+    MiniCPMRobotManipPipeline,
+)
+from vllm_omni.diffusion.models.minicpm_robot.policy import (
+    _format_prompt,
+    normalize_robot_obs,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class FakeMiniCPMRobotPolicy:
+    instances: list["FakeMiniCPMRobotPolicy"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.reset_calls = 0
+        self.seen_obs = None
+        self.seen_seed = None
+        self.state_dim = 80
+        self.model = SimpleNamespace(config=SimpleNamespace(action_dim=80, action_horizon=30, state_dim=80))
+        FakeMiniCPMRobotPolicy.instances.append(self)
+
+    def get_action(self, obs, *, seed=None):
+        self.seen_obs = obs
+        self.seen_seed = seed
+        return {"default": np.zeros((1, 30, 80), dtype=np.float32)}
+
+    def reset(self):
+        self.reset_calls += 1
+        return {"reset": True}
+
+
+@pytest.fixture(autouse=True)
+def fake_policy(monkeypatch):
+    FakeMiniCPMRobotPolicy.instances.clear()
+    monkeypatch.setattr(
+        pipeline_minicpm_robot,
+        "MiniCPMRobotPolicy",
+        FakeMiniCPMRobotPolicy,
+    )
+
+
+def _rgb(h=64, w=64, value=0):
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _robot_obs(**overrides):
+    obs = {
+        "images": [_rgb(value=0), _rgb(value=1)],
+        "state": np.zeros(80, dtype=np.float32),
+        "language": "pick up the black bowl",
+    }
+    obs.update(overrides)
+    return obs
+
+
+def _pipeline(**model_config_overrides):
+    model_config = {
+        "embodiment_id": 0,
+    }
+    model_config.update(model_config_overrides)
+    od_config = SimpleNamespace(
+        model="/path/to/MiniCPM-RobotManip",
+        model_config=model_config,
+    )
+    return MiniCPMRobotManipPipeline(od_config=od_config)
+
+
+# ---------------------------------------------------------------------------
+# Observation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_robot_obs_preserves_sizes_and_accepts_dict_images():
+    obs = normalize_robot_obs(
+        {
+            "images": {
+                "cam_high": _rgb(120, 160, 7),
+                "cam_low": _rgb(90, 100, 9),
+            },
+            "state": np.arange(80, dtype=np.float32),
+            "prompt": "do the task",
+        }
+    )
+
+    assert len(obs["images"]) == 2
+    assert obs["images"][0].shape == (120, 160, 3)
+    assert obs["images"][1].shape == (90, 100, 3)
+    assert all(img.dtype == np.uint8 for img in obs["images"])
+    assert obs["state"].shape == (80,)
+    assert obs["language"] == "do the task"
+
+
+def test_normalize_robot_obs_rejects_bad_state_dim():
+    with pytest.raises(ValueError, match="state"):
+        normalize_robot_obs(
+            {
+                "images": [_rgb()],
+                "state": np.zeros(7, dtype=np.float32),
+                "language": "task",
+            }
+        )
+
+
+def test_normalize_robot_obs_rejects_missing_images():
+    with pytest.raises(ValueError, match="images"):
+        normalize_robot_obs(
+            {
+                "state": np.zeros(80, dtype=np.float32),
+                "language": "task",
+            }
+        )
+
+
+def test_format_prompt_handles_braces_in_instruction():
+    text = _format_prompt(
+        "Task: {instruction}",
+        "use {gripper} carefully",
+    )
+    assert text == "Task: use {gripper} carefully"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline construction
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_initializes_policy():
+    pipeline = _pipeline()
+
+    policy = FakeMiniCPMRobotPolicy.instances[0]
+    assert policy.kwargs["model_path"] == "/path/to/MiniCPM-RobotManip"
+    assert policy.kwargs["embodiment_id"] == 0
+    assert policy.kwargs["device"] in ("cuda", "cpu")
+    assert pipeline.weights_sources == ()
+    assert pipeline.load_weights(iter(())) == set()
+
+
+def test_load_weights_rejects_non_empty_weights():
+    pipeline = _pipeline()
+    with pytest.raises(RuntimeError, match="load_weights received"):
+        pipeline.load_weights(iter([("a.b", np.array(1.0))]))
+
+
+def test_weights_sources_is_empty():
+    pipeline = _pipeline()
+    assert pipeline.weights_sources == ()
+
+
+# ---------------------------------------------------------------------------
+# Forward path
+# ---------------------------------------------------------------------------
+
+
+def test_forward_returns_default_actions_in_output():
+    pipeline = _pipeline()
+    state = np.random.randn(80).astype(np.float32)
+    req = OmniDiffusionRequest(
+        prompt="pick up the black bowl",
+        request_id="req-1",
+        sampling_params=OmniDiffusionSamplingParams(
+            seed=123,
+            extra_args={
+                "robot_obs": _robot_obs(state=state),
+            },
+        ),
+    )
+
+    output = pipeline.forward(req)
+
+    assert output.error is None
+    actions = output.output["actions"]
+    assert set(actions) == {"default"}
+    assert actions["default"].dtype == np.float32
+    assert actions["default"].shape == (1, 30, 80)
+    policy = FakeMiniCPMRobotPolicy.instances[0]
+    assert policy.seen_obs is not None
+    assert policy.seen_obs["state"].shape == (80,)
+    np.testing.assert_allclose(policy.seen_obs["state"], state)
+    assert policy.seen_obs["language"] == "pick up the black bowl"
+    assert all(img.shape == (64, 64, 3) for img in policy.seen_obs["images"])
+    assert policy.seen_seed == 123
+
+
+def test_forward_reset_calls_policy_reset():
+    pipeline = _pipeline()
+    req = OmniDiffusionRequest(
+        prompt="task",
+        request_id="req-2",
+        sampling_params=OmniDiffusionSamplingParams(
+            extra_args={
+                "robot_obs": _robot_obs(language="task"),
+                "reset": True,
+            }
+        ),
+    )
+
+    output = pipeline.forward(req)
+    assert output.error is None
+    assert FakeMiniCPMRobotPolicy.instances[0].reset_calls == 1
+
+
+def test_forward_missing_robot_obs_returns_error():
+    pipeline = _pipeline()
+    req = OmniDiffusionRequest(
+        prompt="task",
+        request_id="req-3",
+        sampling_params=OmniDiffusionSamplingParams(),
+    )
+
+    output = pipeline.forward(req)
+    assert output.error is not None
+    assert "robot_obs" in output.error
+
+
+def test_forward_non_dict_robot_obs_returns_error():
+    pipeline = _pipeline()
+    req = OmniDiffusionRequest(
+        prompt="task",
+        request_id="req-4",
+        sampling_params=OmniDiffusionSamplingParams(
+            extra_args={"robot_obs": "invalid"},
+        ),
+    )
+
+    output = pipeline.forward(req)
+    assert output.error is not None
+    assert "dict" in output.error
+
+
+def test_forward_invalid_obs_returns_error():
+    pipeline = _pipeline()
+    req = OmniDiffusionRequest(
+        prompt="task",
+        request_id="req-5",
+        sampling_params=OmniDiffusionSamplingParams(
+            extra_args={
+                "robot_obs": {
+                    "images": [],
+                    "state": np.zeros(80, dtype=np.float32),
+                    "language": "task",
+                }
+            }
+        ),
+    )
+
+    output = pipeline.forward(req)
+    assert output.error is not None
+    assert "images" in output.error
+    assert FakeMiniCPMRobotPolicy.instances[0].seen_obs is None
+
+
+def test_dummy_warmup_returns_zero_actions():
+    pipeline = _pipeline()
+    req = OmniDiffusionRequest(
+        prompt="dummy run",
+        request_id="dummy_req_id",
+        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1),
+    )
+
+    output = pipeline.forward(req)
+
+    assert output.error is None
+    actions = output.output["actions"]
+    assert set(actions) == {"default"}
+    assert actions["default"].shape == (1, 30, 80)
+    assert actions["default"].dtype == np.float32
+    assert not actions["default"].any()
+    assert FakeMiniCPMRobotPolicy.instances[0].seen_obs is None
+
+
+def test_reset_delegates_to_policy():
+    pipeline = _pipeline()
+
+    assert pipeline.reset() == {"reset": True}
+    assert FakeMiniCPMRobotPolicy.instances[0].reset_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Pipeline registration
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_is_registered_in_diffusion_registry():
+    from vllm_omni.diffusion.registry import DiffusionModelRegistry
+
+    registered = DiffusionModelRegistry.get_supported_archs()
+    assert "MiniCPMRobotManipPipeline" in registered
+
+
+def test_pipeline_is_registered_in_omni_pipelines():
+    from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
+
+    assert "MiniCPMRobotManip" in OMNI_PIPELINES
+
+
+# ---------------------------------------------------------------------------
+# Policy server config validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_policy_server_config_accepts_matching_dims():
+    pipeline = _pipeline()
+    pipeline._validate_policy_server_config(
+        {
+            "action_horizon": 30,
+            "action_dim": 80,
+            "state_dim": 80,
+        }
+    )
+
+
+def test_validate_policy_server_config_raises_on_action_horizon_mismatch():
+    pipeline = _pipeline()
+    with pytest.raises(ValueError, match="policy_server_config.action_horizon"):
+        pipeline._validate_policy_server_config(
+            {
+                "action_horizon": 99,
+                "action_dim": 80,
+                "state_dim": 80,
+            }
+        )
+
+
+def test_validate_policy_server_config_raises_on_action_dim_mismatch():
+    pipeline = _pipeline()
+    with pytest.raises(ValueError, match="policy_server_config.action_dim"):
+        pipeline._validate_policy_server_config(
+            {
+                "action_horizon": 30,
+                "action_dim": 99,
+                "state_dim": 80,
+            }
+        )
+
+
+def test_validate_policy_server_config_raises_on_state_dim_mismatch():
+    pipeline = _pipeline()
+    with pytest.raises(ValueError, match="policy_server_config.state_dim"):
+        pipeline._validate_policy_server_config(
+            {
+                "action_horizon": 30,
+                "action_dim": 80,
+                "state_dim": 99,
+            }
+        )

--- a/tests/e2e/online_serving/test_minicpm_robot_openpi.py
+++ b/tests/e2e/online_serving/test_minicpm_robot_openpi.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end online serving test for MiniCPM-RobotManip through OpenPI."""
+
+import os
+from typing import Any
+
+import numpy as np
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import OmniServerParams
+from tests.helpers.stage_config import get_deploy_config_path
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MODEL = "openbmb/MiniCPM-RobotManip"
+
+pytest.importorskip("websockets")
+pytest.importorskip("openpi_client.msgpack_numpy")
+
+test_params = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            stage_config_path=get_deploy_config_path("MiniCPMRobotManip.yaml"),
+            server_args=[
+                "--disable-log-stats",
+                "--trust-remote-code",
+            ],
+            init_timeout=600,
+            stage_init_timeout=450,
+        ),
+        id="minicpm-robot-openpi",
+    )
+]
+
+
+def _openpi_connect(host: str, port: int) -> tuple[Any, Any]:
+    import websockets.sync.client as ws_client
+    from openpi_client import msgpack_numpy
+
+    uri = f"ws://{host}:{port}/v1/realtime/robot/openpi"
+    ws = ws_client.connect(uri)
+    metadata = msgpack_numpy.unpackb(ws.recv())
+    return ws, metadata
+
+
+def _openpi_infer(ws: Any, obs: dict[str, Any]) -> dict[str, np.ndarray]:
+    from openpi_client import msgpack_numpy
+
+    payload = dict(obs)
+    payload["endpoint"] = "infer"
+    ws.send(msgpack_numpy.packb(payload))
+    response = msgpack_numpy.unpackb(ws.recv())
+    if isinstance(response, dict) and response.get("type") == "error":
+        raise RuntimeError(f"Inference failed: {response['message']}")
+    if not isinstance(response, dict):
+        raise RuntimeError(f"Expected dict, got {type(response)!r}")
+    return {str(k): np.asarray(v, dtype=np.float32) for k, v in response.items()}
+
+
+def _build_observation() -> dict[str, Any]:
+    return {
+        "images": [
+            np.zeros((448, 448, 3), dtype=np.uint8),
+            np.zeros((448, 448, 3), dtype=np.uint8),
+        ],
+        "state": np.zeros(80, dtype=np.float32),
+        "language": "pick up the black bowl",
+    }
+
+
+@pytest.mark.full_model
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+def test_minicpm_robot_openpi_infer(omni_server) -> None:
+    ws, metadata = _openpi_connect(omni_server.host, omni_server.port)
+
+    try:
+        assert isinstance(metadata, dict), f"Expected dict metadata, got {type(metadata)!r}"
+
+        actions = _openpi_infer(ws, _build_observation())
+
+        assert "default" in actions, f"Missing 'default' key in actions; got {list(actions)}"
+        assert actions["default"].dtype == np.float32
+        assert actions["default"].shape == (1, 30, 80), f"Expected (1, 30, 80), got {actions['default'].shape}"
+        assert np.isfinite(actions["default"]).all(), "Actions contain non-finite values"
+    finally:
+        ws.close()

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -77,6 +77,7 @@ EXCLUDED_MODELS = [
     "DreamZeroPipeline",
     "StableDiffusionXLPipeline",
     "Gr00tN1d7Pipeline",
+    "MiniCPMRobotManipPipeline",
     "SoulXSingerPipeline",
     "SoulXSingerSVCPipeline",
 ]

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -72,6 +72,9 @@ from vllm_omni.model_executor.models.ming_tts.pipeline import (
     MING_TTS_MOE_PIPELINE,
     MING_TTS_PIPELINE,
 )
+from vllm_omni.model_executor.models.minicpm_robot.pipeline import (
+    MINICPM_ROBOT_MANIP_PIPELINE,
+)
 from vllm_omni.model_executor.models.minicpmo_4_5.pipeline import MINICPMO_4_5_PIPELINE
 from vllm_omni.model_executor.models.moss_tts.pipeline import (
     MOSS_TTS_LOCAL_PIPELINE,
@@ -114,6 +117,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "lance": LANCE_PIPELINE,
     "dreamzero": DREAMZERO_PIPELINE,
     "Gr00tN1d7": GR00T_N1D7_PIPELINE,
+    "MiniCPMRobotManip": MINICPM_ROBOT_MANIP_PIPELINE,
     "glm_image": GLM_IMAGE_PIPELINE,
     "hunyuan_image_3_moe": HUNYUAN_IMAGE3_PIPELINE,
     "hunyuan_image3_ar": HUNYUAN_IMAGE3_AR_PIPELINE,

--- a/vllm_omni/deploy/MiniCPMRobotManip.yaml
+++ b/vllm_omni/deploy/MiniCPMRobotManip.yaml
@@ -1,0 +1,42 @@
+# MiniCPM-RobotManip deploy: single diffusion stage.
+#
+# Topology is declared in
+# vllm_omni/model_executor/models/minicpm_robot/pipeline.py.
+# This default uses one GPU with TP=1 and supports only a single
+# concurrent request (max_num_seqs: 1).
+#
+# Usage:
+#   vllm serve openbmb/MiniCPM-RobotManip --omni \
+#     --stage-configs-path vllm_omni/deploy/MiniCPMRobotManip.yaml \
+#     --trust-remote-code
+#
+# The pipeline loads the complete HF VLA model via AutoModel.from_pretrained
+# (embodiment_id=0, bfloat16).  Inference is stateless; each step expects
+# robot_obs (images, state, language) in sampling_params.extra_args.
+#
+# Optional model_config overrides:
+#   embodiment_id:   embodiment slot (default 0; 0-31)
+#   processor_path:  alternate path for AutoProcessor
+#                    (default: same as model directory)
+#   prompt_template: override the LIBERO Franka default,
+#                    e.g. for RoboTwin2 ALOHA-AgileX
+
+pipeline: MiniCPMRobotManip
+async_chunk: false
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: MiniCPMRobotManipPipeline
+    model_config:
+      embodiment_id: 0
+      # OpenPI client handshake — model-specific values for MiniCPM-RobotManip.
+      # Sent verbatim to the client; the pipeline validates consistency against
+      # the loaded model's config on startup.
+      policy_server_config:
+        image_resolution: [448, 448]
+        needs_session_id: false
+        action_horizon: 30
+        action_dim: 80
+        state_dim: 80

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -564,6 +564,10 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
         from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
 
         return "DreamZeroPipeline" if _looks_like_dreamzero(model) else None
+    if model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
+        return "Gr00tN1d7Pipeline"
+    if model_type == "minicpm_vla" or "MiniCPMV_VLA" in architectures:
+        return "MiniCPMRobotManipPipeline"
     if len(architectures) == 1:
         return architectures[0]
     return None
@@ -1160,6 +1164,10 @@ class OmniDiffusionConfig:
                     self.update_multimodal_support()
                 elif model_type == "Gr00tN1d7" or "Gr00tN1d7" in architectures:
                     self.model_class_name = "Gr00tN1d7Pipeline"
+                    self.set_tf_model_config(TransformerConfig())
+                    self.update_multimodal_support()
+                elif model_type == "minicpm_vla" or "MiniCPMV_VLA" in architectures:
+                    self.model_class_name = "MiniCPMRobotManipPipeline"
                     self.set_tf_model_config(TransformerConfig())
                     self.update_multimodal_support()
                 elif model_type == "vla":

--- a/vllm_omni/diffusion/models/minicpm_robot/__init__.py
+++ b/vllm_omni/diffusion/models/minicpm_robot/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.diffusion.models.minicpm_robot.pipeline_minicpm_robot import (
+    MiniCPMRobotManipPipeline,
+)
+
+__all__ = ["MiniCPMRobotManipPipeline"]

--- a/vllm_omni/diffusion/models/minicpm_robot/pipeline_minicpm_robot.py
+++ b/vllm_omni/diffusion/models/minicpm_robot/pipeline_minicpm_robot.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniCPM-RobotManip single-stage diffusion pipeline for vLLM-Omni."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.models.minicpm_robot.policy import (
+    MiniCPMRobotPolicy,
+    normalize_robot_obs,
+)
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+logger = init_logger(__name__)
+
+
+def _to_float32_action_dict(
+    actions: Mapping[str, Any],
+) -> dict[str, np.ndarray]:
+    converted = {str(key): np.asarray(value, dtype=np.float32) for key, value in actions.items()}
+    if not converted:
+        raise RuntimeError("MiniCPM-RobotManip policy returned an empty action dict.")
+    return converted
+
+
+class MiniCPMRobotManipPipeline(nn.Module):
+    """Thin wrapper around MiniCPM-RobotManip VLA policy.
+
+    Observations arrive through
+    ``sampling_params.extra_args["robot_obs"]``, this pipeline delegates
+    to ``MiniCPMRobotPolicy.get_action()`` and returns actions via
+    ``DiffusionOutput.output["actions"]``.
+    """
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
+        super().__init__()
+        del prefix
+        model_config = od_config.model_config
+        self.model_path = od_config.model
+        self.embodiment_id = int(model_config.get("embodiment_id", 0))
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        processor_path = model_config.get("processor_path")
+        prompt_template = model_config.get("prompt_template")
+
+        logger.info(
+            "Loading MiniCPM-RobotManip policy from %s with embodiment_id=%d",
+            self.model_path,
+            self.embodiment_id,
+        )
+        self.policy = MiniCPMRobotPolicy(
+            model_path=self.model_path,
+            device=self.device,
+            processor_path=processor_path,
+            prompt_template=prompt_template,
+            embodiment_id=self.embodiment_id,
+        )
+        self._validate_policy_server_config(model_config.get("policy_server_config"))
+
+    def _validate_policy_server_config(self, psc: Mapping[str, Any] | None) -> None:
+        """Fail fast if the deploy YAML handshake drifts from the loaded model.
+
+        ``policy_server_config`` is sent verbatim to the OpenPI client, so its
+        model-specific values must match the loaded checkpoint's config.
+        """
+        if not isinstance(psc, Mapping):
+            return
+        model_cfg = self.policy.model.config
+        expected = {
+            "action_horizon": model_cfg.action_horizon,
+            "action_dim": model_cfg.action_dim,
+            "state_dim": model_cfg.state_dim,
+        }
+        for key, expected_val in expected.items():
+            if key in psc and psc[key] != expected_val:
+                raise ValueError(f"policy_server_config.{key}={psc[key]} != loaded model's {key}={expected_val}.")
+
+    def reset(self) -> dict[str, Any]:
+        return self.policy.reset() or {}
+
+    @property
+    def weights_sources(self) -> tuple[Any, ...]:
+        return ()
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        consumed = list(weights)
+        if consumed:
+            raise RuntimeError(
+                "MiniCPMRobotManipPipeline.load_weights received "
+                f"{len(consumed)} weight tensors; "
+                "weights_sources=() should prevent this. "
+                "Weights are loaded directly by MiniCPMRobotPolicy "
+                "via AutoModel.from_pretrained()."
+            )
+        return set()
+
+    def _dummy_actions(self) -> dict[str, np.ndarray]:
+        action_dim = self.policy.model.config.action_dim
+        action_horizon = self.policy.model.config.action_horizon
+        return {
+            "default": np.zeros((1, action_horizon, action_dim), dtype=np.float32),
+        }
+
+    @torch.inference_mode()
+    def forward(self, req: DiffusionRequestBatch, **kwargs) -> DiffusionOutput:
+        del kwargs
+        extra_args = req.sampling_params.extra_args or {}
+        robot_obs = extra_args.get("robot_obs")
+        if robot_obs is None:
+            if req.request_id == DUMMY_DIFFUSION_REQUEST_ID:
+                return DiffusionOutput(output={"actions": self._dummy_actions()})
+            return DiffusionOutput(
+                error=("MiniCPMRobotManipPipeline.forward expects sampling_params.extra_args['robot_obs'].")
+            )
+        if not isinstance(robot_obs, Mapping):
+            return DiffusionOutput(error=(f"robot_obs must be a dict, got {type(robot_obs).__name__}."))
+
+        if extra_args.get("reset"):
+            self.reset()
+
+        state_dim = int(getattr(self.policy, "state_dim", 80))
+        try:
+            normalized_obs = normalize_robot_obs(robot_obs, state_dim=state_dim)
+        except (TypeError, ValueError) as exc:
+            return DiffusionOutput(error=str(exc))
+
+        seed = getattr(req.sampling_params, "seed", None)
+        actions = self.policy.get_action(normalized_obs, seed=seed)
+        if not isinstance(actions, Mapping):
+            return DiffusionOutput(
+                error=(f"MiniCPM-RobotManip policy returned {type(actions).__name__}; expected dict actions.")
+            )
+        return DiffusionOutput(output={"actions": _to_float32_action_dict(actions)})

--- a/vllm_omni/diffusion/models/minicpm_robot/policy.py
+++ b/vllm_omni/diffusion/models/minicpm_robot/policy.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniCPM-RobotManip policy for VLA inference via AutoModel.from_pretrained."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import AutoModel, AutoProcessor
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "The robot is LIBERO Franka, a simulated single-arm Franka manipulator. "
+    "Its action control method is absolute single-arm end-effector pose in the unified 80D layout "
+    "with gripper closed command, and its action FPS is 20 Hz. Task: {instruction}"
+)
+STATE_DIM = 80
+
+
+def _format_prompt(template: str, instruction: str) -> str:
+    """Apply prompt template without choking on braces in the instruction."""
+    if "{instruction}" in template:
+        return template.replace("{instruction}", instruction)
+    return f"{template}{instruction}"
+
+
+def _load_images(images: Any) -> list[np.ndarray]:
+    """Normalize camera inputs to HxWx3 uint8 arrays.
+
+    Accepts a list/tuple of images, or a dict of camera_name -> image
+    (OpenPI-style). Spatial resizing is left to the MiniCPM-V processor,
+    which infers a target size from each image's original aspect ratio.
+    """
+    if images is None:
+        raise ValueError("robot_obs['images'] is required.")
+    if isinstance(images, Mapping):
+        image_list = list(images.values())
+    elif isinstance(images, Sequence) and not isinstance(images, (str, bytes)):
+        image_list = list(images)
+    else:
+        raise ValueError(f"robot_obs['images'] must be a list or dict of images, got {type(images).__name__}.")
+    if not image_list:
+        raise ValueError("robot_obs['images'] must contain at least one image.")
+
+    loaded: list[np.ndarray] = []
+    for image in image_list:
+        if isinstance(image, (str, Path)):
+            with Image.open(image) as pil_image:
+                array = np.asarray(pil_image.convert("RGB"))
+        elif isinstance(image, Image.Image):
+            array = np.asarray(image.convert("RGB"))
+        elif isinstance(image, np.ndarray):
+            array = image
+        elif isinstance(image, torch.Tensor):
+            array = image.detach().cpu().numpy()
+        else:
+            raise TypeError(f"Unsupported image type: {type(image)!r}")
+
+        if array.ndim == 3 and array.shape[0] in (1, 3) and array.shape[-1] not in (1, 3):
+            # CHW -> HWC
+            array = np.transpose(array, (1, 2, 0))
+        if array.ndim != 3 or array.shape[-1] != 3:
+            raise ValueError(f"Expected an HxWx3 image, got shape {array.shape}")
+        if array.dtype != np.uint8:
+            max_val = float(np.max(array)) if array.size else 0.0
+            if max_val <= 1.0:
+                array = (array * 255.0).clip(0, 255).astype(np.uint8)
+            else:
+                array = np.asarray(array).clip(0, 255).astype(np.uint8)
+
+        loaded.append(np.ascontiguousarray(array))
+    return loaded
+
+
+def _prepare_state(state: Any, *, state_dim: int = STATE_DIM) -> np.ndarray:
+    if state is None:
+        raise ValueError("robot_obs['state'] is required.")
+    state_arr = np.asarray(state, dtype=np.float32).reshape(-1)
+    if state_arr.shape[0] != state_dim:
+        raise ValueError(f"robot_obs['state'] must have shape ({state_dim},), got {tuple(np.asarray(state).shape)}.")
+    return state_arr
+
+
+def normalize_robot_obs(
+    observation: Mapping[str, Any],
+    *,
+    state_dim: int = STATE_DIM,
+) -> dict[str, Any]:
+    """Validate and normalize OpenPI / adapter observations."""
+    if "images" not in observation and "video" not in observation:
+        raise ValueError("robot_obs must include 'images' (or 'video').")
+    images = observation.get("images", observation.get("video"))
+    language = observation.get("language")
+    if language is None:
+        language = observation.get("prompt", "")
+    normalized: dict[str, Any] = {
+        "images": _load_images(images),
+        "state": _prepare_state(observation.get("state"), state_dim=state_dim),
+        "language": str(language),
+    }
+    if "embodiment_id" in observation and observation["embodiment_id"] is not None:
+        normalized["embodiment_id"] = int(observation["embodiment_id"])
+    return normalized
+
+
+class MiniCPMRobotPolicy:
+    """MiniCPM-RobotManip policy backed by a complete HF VLA model.
+
+    The full ``MiniCPMV_VLA`` model (MiniCPM-V 4.6 VLM + DiT ActionHead) is
+    loaded via ``AutoModel.from_pretrained`` with ``trust_remote_code=True``.
+    Weights live in ``model.safetensors`` (3.5 GB); the pipeline does not
+    participate in vLLM's weight-loading path (``weights_sources=()``).
+
+    The prompt template can be overridden via ``model_config.prompt_template``
+    in the deploy YAML.  The default targets the LIBERO Franka embodiment.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: int | str,
+        processor_path: str | None = None,
+        prompt_template: str | None = None,
+        embodiment_id: int = 0,
+    ):
+        self.device = torch.device(device)
+        self.embodiment_id = embodiment_id
+        self.prompt_template = prompt_template or DEFAULT_PROMPT_TEMPLATE
+        self.state_dim = STATE_DIM
+
+        self.model = AutoModel.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            trust_remote_code=True,
+        )
+        self.model.eval()
+        self.model.to(device=self.device)
+        self.state_dim = int(getattr(self.model.config, "state_dim", STATE_DIM))
+
+        proc_path = processor_path or model_path
+        self.processor = AutoProcessor.from_pretrained(
+            proc_path,
+            trust_remote_code=True,
+        )
+
+    def _build_text(self, raw_instruction: str) -> str:
+        if "unified 80D layout" in raw_instruction and "Task:" in raw_instruction:
+            return raw_instruction
+        return _format_prompt(self.prompt_template, raw_instruction)
+
+    def _move_to_device(self, value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.to(self.device)
+        if isinstance(value, list):
+            return [self._move_to_device(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._move_to_device(item) for item in value)
+        if isinstance(value, Mapping):
+            return {key: self._move_to_device(item) for key, item in value.items()}
+        return value
+
+    @torch.no_grad()
+    def get_action(
+        self,
+        observation: Mapping[str, Any],
+        *,
+        seed: int | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Run a single VLA inference step.
+
+        Args:
+            observation:
+                ``{"images": <list|dict>, "state": <(state_dim,)>,
+                  "language"|"prompt": <str>}``
+            seed: Optional RNG seed for the action-head diffusion sampler.
+
+        Returns:
+            ``{"default": <np.ndarray (1, action_horizon, action_dim)>}``
+        """
+        obs = normalize_robot_obs(observation, state_dim=self.state_dim)
+        images = obs["images"]
+        robot_state = obs["state"]
+        text = self._build_text(obs["language"])
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    *[{"type": "image", "image": img} for img in images],
+                    {"type": "text", "text": text},
+                ],
+            }
+        ]
+        chat_inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+            processor_kwargs={"padding": False},
+        )
+        # Match the official HF example: move every tensor/list-of-tensors.
+        vlm_inputs = {key: self._move_to_device(value) for key, value in chat_inputs.items()}
+        if "input_ids" in vlm_inputs and isinstance(vlm_inputs["input_ids"], torch.Tensor):
+            vlm_inputs["input_ids"] = vlm_inputs["input_ids"].long()
+        if "attention_mask" in vlm_inputs and "language_attention_mask" not in vlm_inputs:
+            mask = vlm_inputs.pop("attention_mask")
+            if isinstance(mask, torch.Tensor):
+                mask = mask.long()
+            vlm_inputs["language_attention_mask"] = mask
+
+        state_t = torch.as_tensor(robot_state, device=self.device).float()
+        if state_t.ndim == 1:
+            state_t = state_t.unsqueeze(0)
+        state_t = state_t.unsqueeze(1)  # (B, state_dim) -> (B, 1, state_dim)
+        emb_id = obs.get("embodiment_id", self.embodiment_id)
+        emb_id_t = torch.tensor([int(emb_id)], dtype=torch.long, device=self.device)
+
+        if seed is not None:
+            torch.manual_seed(seed)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed_all(seed)
+
+        actions = self.model.predict_action(
+            state=state_t,
+            embodiment_id=emb_id_t,
+            **vlm_inputs,
+        )
+        return {
+            "default": actions.cpu().numpy().astype(np.float32),
+        }
+
+    def reset(self) -> dict[str, Any]:
+        """Reset policy state (markovian, no persistent state)."""
+        return {}

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -161,6 +161,11 @@ _DIFFUSION_MODELS = {
         "pipeline_gr00t",
         "Gr00tN1d7Pipeline",
     ),
+    "MiniCPMRobotManipPipeline": (
+        "minicpm_robot",
+        "pipeline_minicpm_robot",
+        "MiniCPMRobotManipPipeline",
+    ),
     "LongCatImageEditPipeline": (
         "longcat_image",
         "pipeline_longcat_image_edit",

--- a/vllm_omni/model_executor/models/minicpm_robot/__init__.py
+++ b/vllm_omni/model_executor/models/minicpm_robot/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# NOTE: Do not import model classes in this file. Importing any
+# submodule in this package triggers __init__.py execution, and
+# both the model registry and pipeline registry import submodules
+# directly -- heavy imports here would be loaded as a side effect
+# even though nothing depends on these re-exports.

--- a/vllm_omni/model_executor/models/minicpm_robot/pipeline.py
+++ b/vllm_omni/model_executor/models/minicpm_robot/pipeline.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniCPM-RobotManip single-stage VLA policy topology."""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+MINICPM_ROBOT_MANIP_PIPELINE = PipelineConfig(
+    model_type="MiniCPMRobotManip",
+    default_deploy_config_name="MiniCPMRobotManip.yaml",
+    model_arch="MiniCPMRobotManipPipeline",
+    hf_architectures=("MiniCPMV_VLA",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="diffusion",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(),
+            final_output=True,
+            final_output_type="actions",
+            model_arch="MiniCPMRobotManipPipeline",
+        ),
+    ),
+)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add support for the MiniCPM-RobotManip 1.5B VLA model, including OpenPI serving, model registration, deployment configuration, and tests.

## Test Plan

- Run CPU pipeline unit tests.
- Verify diffusion registry alignment.
- Run real-model OpenPI online serving inference.
- Run Ruff lint and format checks.

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** cfa68537

## Test Result

- Unit tests: 20 passed
- Registry alignment tests: 2 passed
- OpenPI E2E test: 1 passed on RTX 4090
- Ruff lint and format checks: passed