### PR TITLE
[CI/Test] Skip realtime async_chunk WebSocket case blocked by #3907 (#5363)

### DIFF
--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -234,6 +234,12 @@ class TestQwen3OmniRealtimeWebSocket:
     @pytest.mark.omni
     @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
     @pytest.mark.parametrize("omni_server", realtime_async_chunk_server_params, indirect=True)
+    @pytest.mark.skip(
+        reason=(
+            "/v1/realtime rejects async_chunk since #3907 (server closes with 1000 after "
+            "unsupported error); tracked in #5363"
+        )
+    )
     def test_streaming_audio_input_pcm_output_async_chunk(self, omni_server) -> None:
         """Merge CI: async_chunk on, paced upload, full accuracy check."""
         pcm16 = _synthetic_pcm16_input()


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Skip Merge CI case `test_streaming_audio_input_pcm_output_async_chunk` after [#3907](https://github.com/vllm-project/vllm-omni/pull/3907): `/v1/realtime` now rejects servers with `async_chunk` enabled (accept → unsupported error → close 1000). The client then fails with `websockets.exceptions.ConnectionClosedOK` on the first `session.update`.

This unblocks Merge CI while product behavior and a longer-term fix (restore async_chunk realtime, or drop the scenario) are decided.

Related: [#5363](https://github.com/vllm-project/vllm-omni/issues/5363)

## Test Plan

**vLLM Version:** (CI image pin) see `docker/Dockerfile.ci` `VLLM_BASE_TAG`

**vLLM-Omni Commit:** this PR HEAD

- Confirm the async_chunk case is skipped and the sync realtime case is unchanged:

```bash
pytest -sv tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py -k "async_chunk or test_streaming_audio_input_pcm_output" -m "advanced_model and cuda" --run-level advanced_model
```

- No new product code; skip only. Full H100 e2e not required for this CI unblock.

## Test Result

- Not run locally (no H100 in this environment). Pending Buildkite Merge CI for the Qwen3-Omni realtime WebSocket job.
- Expected: `test_streaming_audio_input_pcm_output_async_chunk` → skipped; `test_streaming_audio_input_pcm_output` still collected/run as before.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
