### PR TITLE
[Perf][MiniCPM-o 4.5] Accelerate the three-stage inference pipeline

### DIFF
--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -463,11 +463,12 @@ def test_fifo_promotion(build_adapter):
     adapter.process_pending_chunks(waiting_queue, running_queue)
 
     assert list(adapter._active_streams) == ["req-1", "req-2"]
-    assert waiting_queue == reqs[2:]
+    assert waiting_queue == []
     assert reqs[0].status == RequestStatus.WAITING_FOR_CHUNK
     assert reqs[1].status == RequestStatus.WAITING_FOR_CHUNK
     assert reqs[2].status == RequestStatus.WAITING
 
+    adapter.restore_queues(waiting_queue, running_queue)
     adapter.finished_requests.add("req-1")
     # Eviction is deferred to postprocess_scheduler_output in the runtime path
     # (commit c4d95fd9 — otherwise the terminal chunk deadlocks at c=8 K=2).
@@ -479,6 +480,36 @@ def test_fifo_promotion(build_adapter):
     # Promotion + chunk processing happen in the same call, so req-3 is
     # already WAITING_FOR_CHUNK by the time we check.
     assert reqs[2].status == RequestStatus.WAITING_FOR_CHUNK
+
+
+def test_non_active_waiting_request_is_hidden_from_scheduler(build_adapter):
+    adapter, _ = build_adapter(stage_id=2, max_num_seqs=1, active_stream_window=1)
+    active = _req("active", RequestStatus.WAITING)
+    non_active = _req("non-active", RequestStatus.WAITING)
+    non_active.prompt_token_ids = [0] * 2556
+    waiting_queue = DummyWaitingQueue([active, non_active])
+    running_queue = []
+    scheduler_requests = {
+        active.request_id: active,
+        non_active.request_id: non_active,
+    }
+
+    adapter.process_pending_chunks(
+        waiting_queue,
+        running_queue,
+        scheduler_requests=scheduler_requests,
+    )
+
+    assert waiting_queue == []
+    assert non_active.status == RequestStatus.WAITING
+
+    adapter.restore_queues(
+        waiting_queue,
+        running_queue,
+        scheduler_requests=scheduler_requests,
+    )
+
+    assert waiting_queue == [active, non_active]
 
 
 def test_legacy_k0(build_adapter):
@@ -509,8 +540,9 @@ def test_finished_releases_slot(build_adapter):
 
     adapter.process_pending_chunks(waiting_queue, running_queue)
     assert list(adapter._active_streams) == ["req-1"]
-    assert waiting_queue == [req_2]
+    assert waiting_queue == []
 
+    adapter.restore_queues(waiting_queue, running_queue)
     adapter.finished_requests.add("req-1")
     # Eviction is deferred to postprocess_scheduler_output in the runtime path
     # (commit c4d95fd9). Simulate it so promotion can pick up the freed slot.

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -1,3 +1,4 @@
+import math
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -69,6 +70,20 @@ class _FakeEstimator(nn.Module):
         cnn_out.copy_(marker.reshape(1, -1, 1, 1).expand_as(cnn_out))
         att_out.copy_(marker.reshape(1, -1, 1, 1, 1).expand_as(att_out))
         return inputs[:, 1:2]
+
+
+class _FakeTimestepEmbedder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.frequency_embedding_size = 8
+        self.scale = 1000
+        self.mlp = nn.Identity()
+
+    def forward(self, time):
+        half = self.frequency_embedding_size // 2
+        frequencies = torch.exp(-math.log(10000) * torch.arange(0, half) / half).to(time.device)
+        args = (time * self.scale)[:, None] * frequencies[None]
+        return torch.cat((torch.cos(args), torch.sin(args)), dim=-1)
 
 
 class _FakeDecoder(nn.Module):
@@ -210,6 +225,65 @@ def test_adapter_runs_true_batch_cfg_and_splits_request_caches():
     assert cache0.data_ptr() != cache1.data_ptr()
     assert cache0[0, 0, 0, 0, 0].item() == 10
     assert cache1[0, 0, 0, 0, 0].item() == 20
+
+
+def test_initial_state_template_is_cached_per_prompt_and_batch_without_aliasing():
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(token2wav, enable_initial_state_cache=True)
+    prompt = adapter.prepare_prompt("shared", "/fake/prompt.wav")
+
+    first = adapter.setup_batch_cached("shared", "/fake/prompt.wav", prompt, 2)
+    second = adapter.setup_batch_cached("shared", "/fake/prompt.wav", prompt, 2)
+    singleton = adapter.setup_batch_cached("shared", "/fake/prompt.wav", prompt, 1)
+
+    # The expensive prompt-conditioned Flow initialization runs once per exact
+    # batch shape, while every request receives private cache storage.
+    assert token2wav.flow.encoder.calls == [2, 1]
+    assert torch.equal(
+        first[0].flow_cache["estimator_att_cache"],
+        second[0].flow_cache["estimator_att_cache"],
+    )
+    assert (
+        first[0].flow_cache["estimator_att_cache"].data_ptr() != second[0].flow_cache["estimator_att_cache"].data_ptr()
+    )
+    assert (
+        first[0].flow_cache["estimator_att_cache"].data_ptr() != first[1].flow_cache["estimator_att_cache"].data_ptr()
+    )
+    assert len(singleton) == 1
+
+
+def test_graph_safe_timestep_embedding_matches_original() -> None:
+    token2wav = _FakeToken2Wav()
+    token2wav.flow.decoder.estimator.t_embedder = _FakeTimestepEmbedder()
+    adapter = BatchedToken2Wav(token2wav)
+    time = torch.tensor([0.0, 0.25, 0.75], dtype=torch.float32)
+
+    expected = token2wav.flow.decoder.estimator.t_embedder(time)
+    actual = adapter._embed_time(token2wav.flow.decoder.estimator, time)
+
+    assert torch.equal(actual, expected)
+
+
+def test_cfm_cuda_graph_option_falls_back_to_eager_on_cpu() -> None:
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(
+        token2wav,
+        enable_cfm_cuda_graph=True,
+        cfm_cuda_graph_max_batch_size=2,
+    )
+    prompt = adapter.prepare_prompt("shared", "/fake/prompt.wav")
+    states = adapter.setup_batch(prompt, 1)
+
+    audios, _ = adapter.decode_batch(
+        torch.tensor([[10, 11]]),
+        prompt,
+        states,
+        last_chunk=False,
+    )
+
+    assert len(audios) == 1
+    assert adapter._cfm_graph_max_batch_size == 2
+    assert adapter._cfm_graph_entry is None
 
 
 def test_estimator_cache_stack_split_round_trip_preserves_cfg_rows():

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -24,6 +24,7 @@ from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
 from vllm_omni.config.stage_config import (
     PipelineConfig,
     StageExecutionType,
+    _apply_platform_overrides,
     load_deploy_config,
     merge_pipeline_deploy,
 )
@@ -166,12 +167,20 @@ class TestDeployTopology:
                 0.15,
                 0.15,
             ]
+            assert stages[0].yaml_engine_args["compilation_config"]["compile_mm_encoder"] is True
         elif filename in {"minicpmo_4_5_batching.yaml", "minicpmo_4_5_2gpu.yaml"}:
             assert [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages] == [
                 0.9,
                 0.55,
                 0.35,
             ]
+
+    def test_npu_override_does_not_inherit_cuda_encoder_compile(self) -> None:
+        deploy = load_deploy_config(_DEPLOY_DIR / "minicpmo_4_5.yaml")
+        deploy = _apply_platform_overrides(deploy, platform="npu")
+        stages = merge_pipeline_deploy(OMNI_PIPELINES[deploy.pipeline], deploy)
+
+        assert stages[0].yaml_engine_args["compilation_config"] == {"cudagraph_mode": "PIECEWISE"}
 
     def test_pipeline_exposes_no_full_payload_or_token_placeholder_hooks(self) -> None:
         pipeline = OMNI_PIPELINES[_PIPELINE_KEY]

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -131,6 +131,9 @@ class TestPipelineTopology:
         assert code2wav.engine_output_type == "audio"
         assert code2wav.model_arch == "MiniCPMO45Code2Wav"
         assert code2wav.sync_process_input_func is None
+        assert code2wav.scheduler_cls == (
+            "vllm_omni.model_executor.models.minicpmo_4_5.scheduler.MiniCPMO45Code2WavScheduler"
+        )
 
 
 class TestDeployTopology:

--- a/tests/model_executor/models/minicpmo_4_5/test_scheduler.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_scheduler.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+import vllm_omni  # noqa: F401 - apply vLLM request patches before scheduler import
+from vllm_omni.model_executor.models.minicpmo_4_5.scheduler import (
+    MiniCPMO45Code2WavScheduler,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _AdapterStub:
+    def __init__(self, *, ready: int, pending: int) -> None:
+        self._finished_load_reqs = {f"ready-{index}" for index in range(ready)}
+        self._pending_load_reqs = deque(f"pending-{index}" for index in range(pending))
+
+
+class _FakeClock:
+    def __init__(
+        self,
+        adapter: _AdapterStub,
+        *,
+        release_after_s: float | None = None,
+        additional_ready: int = 0,
+    ) -> None:
+        self.adapter = adapter
+        self.release_after_s = release_after_s
+        self.additional_ready = additional_ready
+        self.now = 10.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        self.sleeps.append(duration)
+        self.now += duration
+        if self.release_after_s is not None and sum(self.sleeps) >= self.release_after_s:
+            while self.adapter._pending_load_reqs:
+                request_id = self.adapter._pending_load_reqs.popleft()
+                self.adapter._finished_load_reqs.add(request_id)
+            for index in range(self.additional_ready):
+                self.adapter._finished_load_reqs.add(f"released-{index}")
+            self.release_after_s = None
+
+
+def _make_scheduler(*, wait_ms: float, ready: int, pending: int) -> MiniCPMO45Code2WavScheduler:
+    scheduler = MiniCPMO45Code2WavScheduler.__new__(MiniCPMO45Code2WavScheduler)
+    scheduler._code2wav_batch_wait_s = wait_ms / 1000.0
+    scheduler.chunk_transfer_adapter = _AdapterStub(ready=ready, pending=pending)
+    scheduler.max_num_running_reqs = 4
+    scheduler.requests = {f"request-{index}": object() for index in range(min(4, ready + pending))}
+    return scheduler
+
+
+def test_disabled_wait_returns_without_sleeping(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduler = _make_scheduler(wait_ms=0.0, ready=1, pending=3)
+    clock = _FakeClock(scheduler.chunk_transfer_adapter)
+    monkeypatch.setattr("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.time", clock)
+
+    scheduler._wait_for_ready_chunk_batch()
+
+    assert clock.sleeps == []
+
+
+def test_single_request_returns_without_sleeping(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduler = _make_scheduler(wait_ms=2.0, ready=1, pending=0)
+    clock = _FakeClock(scheduler.chunk_transfer_adapter)
+    monkeypatch.setattr("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.time", clock)
+
+    scheduler._wait_for_ready_chunk_batch()
+
+    assert clock.sleeps == []
+
+
+def test_wait_exits_when_pending_cohort_becomes_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduler = _make_scheduler(wait_ms=2.0, ready=1, pending=3)
+    clock = _FakeClock(scheduler.chunk_transfer_adapter, release_after_s=0.0006)
+    monkeypatch.setattr("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.time", clock)
+
+    scheduler._wait_for_ready_chunk_batch()
+
+    assert len(scheduler.chunk_transfer_adapter._finished_load_reqs) == 4
+    assert 0.0006 <= sum(clock.sleeps) < 0.002
+
+
+def test_wait_uses_live_scheduler_cohort_when_recv_queue_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = _make_scheduler(wait_ms=2.0, ready=1, pending=0)
+    scheduler.requests = {f"request-{index}": object() for index in range(4)}
+    clock = _FakeClock(
+        scheduler.chunk_transfer_adapter,
+        release_after_s=0.0006,
+        additional_ready=3,
+    )
+    monkeypatch.setattr("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.time", clock)
+
+    scheduler._wait_for_ready_chunk_batch()
+
+    assert len(scheduler.chunk_transfer_adapter._finished_load_reqs) == 4
+    assert 0.0006 <= sum(clock.sleeps) < 0.002
+
+
+def test_wait_falls_back_at_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduler = _make_scheduler(wait_ms=1.0, ready=1, pending=3)
+    clock = _FakeClock(scheduler.chunk_transfer_adapter)
+    monkeypatch.setattr("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.time", clock)
+
+    scheduler._wait_for_ready_chunk_batch()
+
+    assert len(scheduler.chunk_transfer_adapter._finished_load_reqs) == 1
+    assert sum(clock.sleeps) == pytest.approx(0.001)
+
+
+def test_wait_config_rejects_negative_values() -> None:
+    model_config = SimpleNamespace(
+        stage_connector_config={
+            "extra": {
+                "code2wav_batch_wait_ms": -0.1,
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="code2wav_batch_wait_ms must be non-negative"):
+        MiniCPMO45Code2WavScheduler._batch_wait_seconds(model_config)
+
+
+def test_wait_config_reads_connector_extra() -> None:
+    model_config = SimpleNamespace(
+        stage_connector_config={
+            "extra": {
+                "code2wav_batch_wait_ms": 1.5,
+            }
+        }
+    )
+
+    assert MiniCPMO45Code2WavScheduler._batch_wait_seconds(model_config) == pytest.approx(0.0015)

--- a/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
@@ -81,13 +81,42 @@ def test_audio_token_limit_scales_with_condition_length(
     assert _max_audio_tokens(condition_tokens) == expected
 
 
+def test_talker_reuses_device_stop_logit_rows() -> None:
+    talker = _make_talker()
+    hidden = torch.ones(2, 2)
+    infos = [None, {"audio_state": {"finished": True}}]
+
+    first = talker.make_omni_output(
+        hidden,
+        model_intermediate_buffer=infos,
+        request_token_spans=[(0, 1), (1, 2)],
+    )
+    cached_rows = talker._stop_logit_rows
+    first_logits = talker.compute_logits(first.text_hidden_states)
+    second = talker.make_omni_output(
+        hidden,
+        model_intermediate_buffer=infos,
+        request_token_spans=[(0, 1), (1, 2)],
+    )
+
+    assert talker._stop_logit_rows is cached_rows
+    torch.testing.assert_close(
+        cached_rows,
+        torch.tensor([[0.0, float("-inf")], [float("-inf"), 0.0]]),
+        rtol=0,
+        atol=0,
+    )
+    assert first_logits.argmax(dim=-1).tolist() == [0, 1]
+    assert talker.compute_logits(second.text_hidden_states).argmax(dim=-1).tolist() == [0, 1]
+
+
 def test_talker_emits_request_aligned_codec_deltas_after_compaction(mocker) -> None:
     talker = _make_talker()
-    seen: list[tuple[str, list[float], list[int]]] = []
+    seen: list[tuple[str, list[float], list[int], int]] = []
 
     def sample(hidden, history, request_id, step):
         assert step == 0
-        seen.append((request_id, hidden.reshape(-1).tolist(), history.tolist()))
+        seen.append((request_id, hidden.reshape(-1).tolist(), history.tolist(), step))
         return torch.tensor(2 if request_id == "req-a" else 3)
 
     mocker.patch.object(talker, "_sample_audio_code", side_effect=sample)
@@ -103,8 +132,8 @@ def test_talker_emits_request_aligned_codec_deltas_after_compaction(mocker) -> N
     )
 
     assert seen == [
-        ("req-a", [2.0, 0.0], [1]),
-        ("req-b", [3.0, 0.0], []),
+        ("req-a", [2.0, 0.0], [1], 0),
+        ("req-b", [3.0, 0.0], [], 0),
     ]
     assert infos[0]["audio_codes"]["accumulated"].tolist() == [1, 2]
     assert infos[1]["audio_codes"]["accumulated"].tolist() == [3]
@@ -142,6 +171,7 @@ def test_incomplete_prefill_emits_no_code_and_does_not_advance_state(mocker) -> 
 
     sample.assert_called_once()
     assert sample.call_args.args[2] == "req-decode"
+    assert sample.call_args.args[3] == 4
     assert infos[0]["audio_state"]["step"] == 0
     assert infos[0]["audio_codes"]["accumulated"].numel() == 0
     assert infos[1]["audio_state"]["step"] == 5

--- a/tests/model_executor/models/minicpmo_4_5/test_vision_attention_backend.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_vision_attention_backend.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MiniCPM-o 4.5 vision attention backend selection."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
+    SiglipEncoderLayer,
+    SiglipVisionTransformer,
+    _resolve_vision_attention_implementation,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_siglip_declares_transformers_5_flash_attention_support() -> None:
+    assert SiglipVisionTransformer._supports_flash_attn is True
+
+
+def _vision_config(attention_implementation: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        _attn_implementation=attention_implementation,
+        attention_dropout=0.0,
+        hidden_act="gelu",
+        hidden_size=32,
+        intermediate_size=64,
+        layer_norm_eps=1e-6,
+        num_attention_heads=4,
+    )
+
+
+def test_siglip_declares_sdpa_support() -> None:
+    assert SiglipVisionTransformer._supports_sdpa is True
+
+
+def test_siglip_encoder_selects_sdpa_attention() -> None:
+    layer = SiglipEncoderLayer(_vision_config("sdpa"))
+
+    assert type(layer.self_attn).__name__ == "SiglipSdpaAttention"
+
+
+def test_siglip_sdpa_matches_eager_attention() -> None:
+    torch.manual_seed(7)
+    eager = SiglipEncoderLayer(_vision_config("eager")).eval()
+    sdpa = SiglipEncoderLayer(_vision_config("sdpa")).eval()
+    sdpa.load_state_dict(eager.state_dict())
+    hidden_states = torch.randn(2, 5, 32)
+    attention_mask = torch.zeros(2, 1, 5, 5)
+    attention_mask[1, :, :, -1] = torch.finfo(torch.float32).min
+
+    eager_output = eager(hidden_states, attention_mask)[0]
+    sdpa_output = sdpa(hidden_states, attention_mask)[0]
+
+    torch.testing.assert_close(sdpa_output, eager_output, rtol=1e-5, atol=1e-6)
+
+
+def test_explicit_vision_flash_attention_override_is_preserved() -> None:
+    vision_config = SimpleNamespace(_attn_implementation="flash_attention_2")
+    model_config = SimpleNamespace(_attn_implementation="eager")
+
+    assert _resolve_vision_attention_implementation(vision_config, model_config) == "flash_attention_2"
+
+
+def test_legacy_model_attention_override_is_used_without_vision_override() -> None:
+    vision_config = SimpleNamespace(_attn_implementation="eager")
+    model_config = SimpleNamespace(_attn_implementation="flash_attention_2")
+
+    assert _resolve_vision_attention_implementation(vision_config, model_config) == "flash_attention_2"
+
+
+def test_vision_attention_defaults_to_eager() -> None:
+    assert _resolve_vision_attention_implementation(SimpleNamespace(), SimpleNamespace()) == "eager"

--- a/tests/model_executor/models/minicpmo_4_5/test_vision_attention_backend.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_vision_attention_backend.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
     SiglipEncoderLayer,
@@ -34,6 +35,10 @@ def _vision_config(attention_implementation: str) -> SimpleNamespace:
 
 def test_siglip_declares_sdpa_support() -> None:
     assert SiglipVisionTransformer._supports_sdpa is True
+
+
+def test_siglip_encoder_layer_supports_regional_compile() -> None:
+    assert TorchCompileWithNoGuardsWrapper in SiglipEncoderLayer.__bases__
 
 
 def test_siglip_encoder_selects_sdpa_attention() -> None:

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -21,6 +21,8 @@ stages:
     gpu_memory_utilization: 0.65
     enforce_eager: false
     tensor_parallel_size: 1
+    compilation_config:
+      compile_mm_encoder: true
     max_num_batched_tokens: 16384
     devices: "0"
     limit_mm_per_prompt:

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -87,6 +87,10 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         # ("Cannot register new removed request after self.removed has
         #   been read").
         self._held_non_active: deque[Any] = deque()
+        # Keep non-active waiting requests out of the scheduler for this tick.
+        # Generation stages prewarm with non-empty placeholder prompts, which
+        # are invalid until the first upstream chunk supplies metadata.
+        self._held_non_active_waiting: deque[Any] = deque()
         self.requests_num_chunks_sent: dict[str, int] = defaultdict(int)
         self._pending_streaming_prefills: dict[str, dict] = {}
 
@@ -478,6 +482,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if scheduler_requests is not None:
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_waiting_requests, scheduler_requests)
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_running_requests, scheduler_requests)
+            self._purge_untracked_chunk_requests(self._held_non_active_waiting, scheduler_requests)
 
         if self._active_window <= 0:
             self._process_chunk_queue_legacy(
@@ -637,6 +642,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if scheduler_requests is not None:
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_waiting_requests, scheduler_requests)
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_running_requests, scheduler_requests)
+            self._purge_untracked_chunk_requests(self._held_non_active_waiting, scheduler_requests)
         # Add request waiting for chunk to the waiting and running queue
         for request in self.waiting_for_chunk_waiting_requests:
             if scheduler_requests is None or request.request_id in scheduler_requests:
@@ -655,6 +661,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if self._held_non_active:
             running_queue.extend(self._held_non_active)
             self._held_non_active = deque()
+
+        for request in self._held_non_active_waiting:
+            if scheduler_requests is None or request.request_id in scheduler_requests:
+                waiting_queue.add_request(request)
+        self._held_non_active_waiting = deque()
 
     def postprocess_scheduler_output(
         self,
@@ -718,6 +729,9 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         queue_snapshot = list(queue)
         for request in queue_snapshot:
             if not self._ensure_active_stream(request):
+                if target_status == RequestStatus.WAITING:
+                    queue.remove(request)
+                    self._held_non_active_waiting.append(request)
                 continue
             if request.status != RequestStatus.WAITING_FOR_CHUNK:
                 if request.request_id in self.requests_with_ready_chunks:
@@ -781,6 +795,9 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         )
         self._held_non_active = deque(
             request for request in self._held_non_active if request.request_id not in request_ids
+        )
+        self._held_non_active_waiting = deque(
+            request for request in self._held_non_active_waiting if request.request_id not in request_ids
         )
 
         for req_id in request_ids:

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import logging
+import math
+from collections import OrderedDict
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 _SILENCE_TOKEN = 4218
+logger = logging.getLogger(__name__)
 
 
 def tensor_signature(value: torch.Tensor) -> tuple[tuple[int, ...], str, str]:
@@ -38,6 +42,15 @@ class BatchedToken2WavState:
     hift_cache: dict[str, torch.Tensor]
 
 
+@dataclass(frozen=True)
+class _CfmGraphEntry:
+    key: tuple[Any, ...]
+    graph: Any
+    stream: Any
+    static_inputs: tuple[torch.Tensor, ...]
+    outputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+
 class BatchedToken2Wav(nn.Module):
     """Drive Token2wav's modules with dynamically-sized, request-owned caches.
 
@@ -46,7 +59,15 @@ class BatchedToken2Wav(nn.Module):
     asset loader and prompt feature extractor.
     """
 
-    def __init__(self, token2wav: Any):
+    def __init__(
+        self,
+        token2wav: Any,
+        *,
+        enable_cfm_cuda_graph: bool = False,
+        cfm_cuda_graph_capture_after: int = 2,
+        cfm_cuda_graph_max_batch_size: int = 2,
+        enable_initial_state_cache: bool = False,
+    ):
         super().__init__()
         self._token2wav = token2wav
         self.flow = token2wav.flow
@@ -60,7 +81,30 @@ class BatchedToken2Wav(nn.Module):
             token2wav.speech_window.detach().clone(),
             persistent=False,
         )
+        timestep_embedder = getattr(self.flow.decoder.estimator, "t_embedder", None)
+        frequency_embedding_size = getattr(timestep_embedder, "frequency_embedding_size", None)
+        if frequency_embedding_size is None:
+            timestep_frequencies = None
+        else:
+            half = int(frequency_embedding_size) // 2
+            timestep_frequencies = torch.exp(-math.log(10000) * torch.arange(0, half) / half).to(
+                device=self.flow.decoder.rand_noise.device
+            )
+        self.register_buffer(
+            "_timestep_frequencies",
+            timestep_frequencies,
+            persistent=False,
+        )
+        self._cfm_cuda_graph_enabled = bool(enable_cfm_cuda_graph)
+        self._cfm_graph_capture_after = max(2, int(cfm_cuda_graph_capture_after))
+        self._cfm_graph_max_batch_size = max(1, int(cfm_cuda_graph_max_batch_size))
+        self._cfm_graph_seen: dict[tuple[Any, ...], int] = {}
+        self._cfm_graph_entry: _CfmGraphEntry | None = None
+        self._initial_state_cache_enabled = bool(enable_initial_state_cache)
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
+        self._initial_state_templates: OrderedDict[tuple[str, str, int], tuple[BatchedToken2WavState, ...]] = (
+            OrderedDict()
+        )
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -155,7 +199,7 @@ class BatchedToken2Wav(nn.Module):
         cnn_cache: torch.Tensor | None,
         att_cache: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        time_embedding = estimator.t_embedder(time).unsqueeze(1)
+        time_embedding = self._embed_time(estimator, time).unsqueeze(1)
         width = int(x.shape[-1])
         speaker_features = speakers.unsqueeze(-1).expand(-1, -1, width)
         estimator_input = torch.cat((x, mu, speaker_features, cond), dim=1)
@@ -172,6 +216,17 @@ class BatchedToken2Wav(nn.Module):
             att_out,
         )
         return result, cnn_out, att_out
+
+    def _embed_time(self, estimator: nn.Module, time: torch.Tensor) -> torch.Tensor:
+        frequencies = self._timestep_frequencies
+        embedder = estimator.t_embedder
+        if frequencies is None:
+            return embedder(time)
+        args = (time * embedder.scale)[:, None] * frequencies[None]
+        embedding = torch.cat((torch.cos(args), torch.sin(args)), dim=-1)
+        if int(embedder.frequency_embedding_size) % 2:
+            embedding = torch.cat((embedding, torch.zeros_like(embedding[:, :1])), dim=-1)
+        return embedder.mlp(embedding)
 
     def _decode_cfm(
         self,
@@ -231,6 +286,121 @@ class BatchedToken2Wav(nn.Module):
             next_cnn.append(step_cnn)
             next_att.append(step_att)
         return x, torch.stack(next_cnn), torch.stack(next_att)
+
+    @staticmethod
+    def _cfm_graph_key(values: tuple[torch.Tensor, ...]) -> tuple[Any, ...]:
+        return tuple(
+            (
+                tuple(value.shape),
+                tuple(value.stride()),
+                str(value.dtype),
+                value.device.type,
+                value.device.index,
+            )
+            for value in values
+        )
+
+    def _capture_cfm_graph(
+        self,
+        key: tuple[Any, ...],
+        inputs: tuple[torch.Tensor, ...],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        static_inputs = tuple(value.clone() for value in inputs)
+        static_mu, static_speakers, static_cond, static_cnn, static_att = static_inputs
+
+        caller_stream = torch.cuda.current_stream()
+        graph_stream = torch.cuda.Stream()
+        graph_stream.wait_stream(caller_stream)
+        with torch.cuda.stream(graph_stream):
+            for _ in range(3):
+                self._decode_cfm(
+                    static_mu,
+                    static_speakers,
+                    static_cond,
+                    cnn_cache=static_cnn,
+                    att_cache=static_att,
+                )
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=graph_stream):
+            outputs = self._decode_cfm(
+                static_mu,
+                static_speakers,
+                static_cond,
+                cnn_cache=static_cnn,
+                att_cache=static_att,
+            )
+        caller_stream.wait_stream(graph_stream)
+        self._cfm_graph_entry = _CfmGraphEntry(
+            key=key,
+            graph=graph,
+            stream=graph_stream,
+            static_inputs=static_inputs,
+            outputs=outputs,
+        )
+        logger.info(
+            "Captured MiniCPM-o exact-shape CFM CUDA Graph: batch=%d key=%s",
+            int(static_mu.shape[0]),
+            key,
+        )
+        return outputs
+
+    def _decode_cfm_maybe_graphed(
+        self,
+        mu: torch.Tensor,
+        speakers: torch.Tensor,
+        cond: torch.Tensor,
+        *,
+        cnn_cache: torch.Tensor,
+        att_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if (
+            not self._cfm_cuda_graph_enabled
+            or mu.device.type != "cuda"
+            or int(mu.shape[0]) > self._cfm_graph_max_batch_size
+        ):
+            return self._decode_cfm(
+                mu,
+                speakers,
+                cond,
+                cnn_cache=cnn_cache,
+                att_cache=att_cache,
+            )
+
+        inputs = (mu, speakers, cond, cnn_cache, att_cache)
+        key = self._cfm_graph_key(inputs)
+        entry = self._cfm_graph_entry
+        if entry is not None and entry.key == key:
+            for static_input, value in zip(entry.static_inputs, inputs, strict=True):
+                static_input.copy_(value)
+            caller_stream = torch.cuda.current_stream()
+            entry.stream.wait_stream(caller_stream)
+            with torch.cuda.stream(entry.stream):
+                entry.graph.replay()
+            caller_stream.wait_stream(entry.stream)
+            return entry.outputs
+        if entry is not None:
+            return self._decode_cfm(
+                mu,
+                speakers,
+                cond,
+                cnn_cache=cnn_cache,
+                att_cache=att_cache,
+            )
+
+        seen = self._cfm_graph_seen.get(key, 0) + 1
+        if len(self._cfm_graph_seen) >= 8 and key not in self._cfm_graph_seen:
+            self._cfm_graph_seen.clear()
+        self._cfm_graph_seen[key] = seen
+        if seen < self._cfm_graph_capture_after:
+            return self._decode_cfm(
+                mu,
+                speakers,
+                cond,
+                cnn_cache=cnn_cache,
+                att_cache=att_cache,
+            )
+        return self._capture_cfm_graph(key, inputs)
 
     @staticmethod
     def _split_flow_cache(cache: dict[str, torch.Tensor], batch_size: int) -> list[dict[str, torch.Tensor]]:
@@ -315,6 +485,33 @@ class BatchedToken2Wav(nn.Module):
         ]
 
     @staticmethod
+    def _clone_state(state: BatchedToken2WavState) -> BatchedToken2WavState:
+        return BatchedToken2WavState(
+            flow_cache={name: value.clone() for name, value in state.flow_cache.items()},
+            hift_cache={name: value.clone() for name, value in state.hift_cache.items()},
+        )
+
+    def setup_batch_cached(
+        self,
+        prompt_cache_id: str,
+        prompt_wav: str,
+        features: PromptFeatures,
+        batch_size: int,
+    ) -> list[BatchedToken2WavState]:
+        if not self._initial_state_cache_enabled:
+            return self.setup_batch(features, batch_size)
+        cache_key = (prompt_cache_id, prompt_wav, batch_size)
+        templates = self._initial_state_templates.get(cache_key)
+        if templates is None:
+            templates = tuple(self.setup_batch(features, batch_size))
+            self._initial_state_templates[cache_key] = templates
+            if len(self._initial_state_templates) > 4:
+                self._initial_state_templates.popitem(last=False)
+        else:
+            self._initial_state_templates.move_to_end(cache_key)
+        return [self._clone_state(state) for state in templates]
+
+    @staticmethod
     def _fade_in_out(
         speech: torch.Tensor,
         previous: torch.Tensor,
@@ -347,7 +544,7 @@ class BatchedToken2Wav(nn.Module):
             )
             projected_speakers = self.flow.spk_embed_affine_layer(F.normalize(speakers, dim=1))
             cond = torch.zeros_like(hidden).transpose(1, 2).contiguous()
-            chunk_mel, estimator_cnn, estimator_att = self._decode_cfm(
+            chunk_mel, estimator_cnn, estimator_att = self._decode_cfm_maybe_graphed(
                 hidden.transpose(1, 2).contiguous(),
                 projected_speakers,
                 cond,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -111,6 +111,10 @@ class MiniCPMO45Code2Wav(nn.Module):
                 Path(self.model_path) / "assets" / "HT_ref_audio.wav",
             )
         )
+        self._enable_cfm_cuda_graph = bool(extra.get("token2wav_cfm_cuda_graph", False))
+        self._cfm_cuda_graph_capture_after = int(extra.get("token2wav_cfm_cuda_graph_capture_after", 2))
+        self._cfm_cuda_graph_max_batch_size = int(extra.get("token2wav_cfm_cuda_graph_max_batch_size", 2))
+        self._enable_initial_state_cache = bool(extra.get("token2wav_initial_state_cache", False))
 
     def _extra_config(self) -> dict[str, Any]:
         model_config = getattr(self.vllm_config, "model_config", None)
@@ -425,7 +429,12 @@ class MiniCPMO45Code2Wav(nn.Module):
                     bucket[0].prompt_wav,
                 )
                 if bucket[0].previous is None:
-                    states = self.backend.setup_batch(features, batch_size)
+                    states = self.backend.setup_batch_cached(
+                        bucket[0].prompt_cache_id,
+                        bucket[0].prompt_wav,
+                        features,
+                        batch_size,
+                    )
                 else:
                     states = [item.previous.token2wav for item in bucket if item.previous is not None]
                 tokens = torch.stack([item.tokens for item in bucket], dim=0)
@@ -539,7 +548,13 @@ class MiniCPMO45Code2Wav(nn.Module):
             )
         finally:
             torch.set_default_dtype(previous_dtype)
-        self.backend = BatchedToken2Wav(token2wav)
+        self.backend = BatchedToken2Wav(
+            token2wav,
+            enable_cfm_cuda_graph=self._enable_cfm_cuda_graph,
+            cfm_cuda_graph_capture_after=self._cfm_cuda_graph_capture_after,
+            cfm_cuda_graph_max_batch_size=self._cfm_cuda_graph_max_batch_size,
+            enable_initial_state_cache=self._enable_initial_state_cache,
+        )
         # Token2wav loads flow.pt and hift.pt inside its constructor instead of
         # from the parent MiniCPM checkpoint iterator. Report those registered
         # parameters as initialized so vLLM's strict loader audit does not

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -402,6 +402,18 @@ class MiniCPMOConfig(Qwen2Config):
         super().__init__(**kwargs)
 
 
+def _resolve_vision_attention_implementation(vision_config, model_config) -> str:
+    vision_implementation = getattr(vision_config, "_attn_implementation", None)
+    if vision_implementation not in (None, "eager"):
+        return vision_implementation
+
+    model_implementation = getattr(model_config, "_attn_implementation", None)
+    if model_implementation is not None:
+        return model_implementation
+
+    return vision_implementation or "eager"
+
+
 # ============== Image Processing Classes ==============
 
 
@@ -1107,6 +1119,41 @@ class SiglipAttention(nn.Module):
         return attn_output, attn_weights
 
 
+class SiglipSdpaAttention(SiglipAttention):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        output_attentions: bool | None = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if output_attentions:
+            return super().forward(
+                hidden_states,
+                attention_mask=attention_mask,
+                output_attentions=output_attentions,
+            )
+
+        batch_size, q_len, _ = hidden_states.size()
+        query_states = self.q_proj(hidden_states).view(batch_size, q_len, self.num_heads, self.head_dim)
+        key_states = self.k_proj(hidden_states).view(batch_size, q_len, self.num_heads, self.head_dim)
+        value_states = self.v_proj(hidden_states).view(batch_size, q_len, self.num_heads, self.head_dim)
+
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        value_states = value_states.transpose(1, 2)
+        attn_output = nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=attention_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+            scale=self.scale,
+        )
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(batch_size, q_len, self.embed_dim)
+        return self.out_proj(attn_output), None
+
+
 class SiglipFlashAttention2(SiglipAttention):
     """
     Llama flash attention module. This module inherits from `LlamaAttention` as the weights of the module stays
@@ -1316,7 +1363,12 @@ class SiglipEncoderLayer(nn.Module):
         super().__init__()
         self.embed_dim = config.hidden_size
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
-        self.self_attn = SiglipAttention(config) if not self._use_flash_attention_2 else SiglipFlashAttention2(config)
+        if self._use_flash_attention_2:
+            self.self_attn = SiglipFlashAttention2(config)
+        elif config._attn_implementation == "sdpa":
+            self.self_attn = SiglipSdpaAttention(config)
+        else:
+            self.self_attn = SiglipAttention(config)
         self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
         self.mlp = SiglipMLP(config)
         self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
@@ -1519,7 +1571,9 @@ class SiglipEncoder(nn.Module):
 class SiglipVisionTransformer(SiglipPreTrainedModel):
     config_class = SiglipVisionConfig
     main_input_name = "pixel_values"
+    _supports_flash_attn = True
     _supports_flash_attn_2 = True
+    _supports_sdpa = True
     _no_split_modules = []
 
     def __init__(self, config: SiglipVisionConfig):
@@ -3833,11 +3887,10 @@ class MiniCPMO45OmniLLMForConditionalGeneration(nn.Module, SupportsMultiModal, S
 
         # Initialize vision encoder (SigLIP)
         if multimodal_config.get_limit_per_prompt("image"):
-            # Set attention implementation
-            if hasattr(vllm_config, "model_config") and hasattr(vllm_config.model_config, "_attn_implementation"):
-                config.vision_config._attn_implementation = vllm_config.model_config._attn_implementation
-            else:
-                config.vision_config._attn_implementation = "eager"
+            config.vision_config._attn_implementation = _resolve_vision_attention_implementation(
+                config.vision_config,
+                vllm_config.model_config,
+            )
 
             self.vpm = SiglipVisionTransformer(config.vision_config)
             # Drop last layer if configured

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -80,6 +80,10 @@ from transformers.utils import (
     replace_return_docstrings,
     requires_backends,
 )
+from vllm.compilation.decorators import (
+    should_torch_compile_mm_encoder,
+    support_torch_compile,
+)
 from vllm.config import VllmConfig
 from vllm.config.multimodal import (
     AudioDummyOptions,
@@ -1358,6 +1362,11 @@ class SiglipMLP(nn.Module):
 
 
 # Copied from transformers.models.clip.modeling_clip.CLIPEncoderLayer with CLIP->Siglip
+@support_torch_compile(
+    dynamic_arg_dims={"hidden_states": [0, 1]},
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class SiglipEncoderLayer(nn.Module):
     def __init__(self, config: SiglipVisionConfig):
         super().__init__()

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -134,6 +134,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         self.config = config
         self.vllm_config = vllm_config
         self._batch_stop_logits: torch.Tensor | None = None
+        self._stop_logit_rows: torch.Tensor | None = None
         self._request_generators: dict[str, torch.Generator] = {}
         self._request_audio_states: dict[str, dict[str, Any]] = {}
         self._deferred_cleanup_ids: set[str] = set()
@@ -354,6 +355,18 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             generator=self._request_generator(request_id, probabilities.device),
         ).reshape(())
 
+    def _get_stop_logit_rows(self, hidden: torch.Tensor) -> torch.Tensor:
+        rows = getattr(self, "_stop_logit_rows", None)
+        if rows is None or rows.device != hidden.device or rows.dtype != hidden.dtype:
+            rows = hidden.new_tensor(
+                [
+                    [0.0, float("-inf")],
+                    [float("-inf"), 0.0],
+                ]
+            )
+            self._stop_logit_rows = rows
+        return rows
+
     def make_omni_output(
         self,
         model_outputs: torch.Tensor | OmniOutput,
@@ -374,20 +387,21 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 f"MiniCPM-o continuous Talker received {len(sample_eligible)} sampling flags for {len(infos)} requests"
             )
 
+        empty_delta = hidden.new_empty((0, 1), dtype=torch.long)
+        continue_row, finished_row = self._get_stop_logit_rows(hidden).unbind(0)
         stop_rows: list[torch.Tensor] = []
         codec_deltas: list[torch.Tensor] = []
         terminal_flags: list[torch.Tensor] = []
-        empty_delta = hidden.new_empty((0, 1), dtype=torch.long)
         for index, info in enumerate(infos):
             if not isinstance(info, dict):
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(continue_row)
                 codec_deltas.append(empty_delta)
                 terminal_flags.append(torch.tensor(False, dtype=torch.bool))
                 continue
             start, end = spans[index]
             end = min(int(end), int(hidden.shape[0]))
             if int(start) >= end:
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(continue_row)
                 codec_deltas.append(empty_delta)
                 terminal_flags.append(torch.tensor(False, dtype=torch.bool))
                 continue
@@ -401,7 +415,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 state = dict(info.get("audio_state", {}) or {})
                 request_states[request_id] = state
             if state.get("finished"):
-                stop_rows.append(hidden.new_tensor([float("-inf"), 0.0]))
+                stop_rows.append(finished_row)
                 codec_deltas.append(empty_delta)
                 terminal_flags.append(torch.tensor(False, dtype=torch.bool))
                 continue
@@ -409,7 +423,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 # vLLM computes a logit row for incomplete chunked prefills but
                 # discards its sampled token. Advancing codec/RNG state here
                 # would make output depend on prefill chunking and compaction.
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(continue_row)
                 codec_deltas.append(empty_delta)
                 terminal_flags.append(torch.tensor(False, dtype=torch.bool))
                 continue
@@ -423,7 +437,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             step = int(state.get("step", 0))
             sampled = self._sample_audio_code(hidden[end - 1 : end], codes, request_id, step)
             is_eos = int(sampled.item()) == self._num_audio_tokens - 1
-            state["step"] = int(state.get("step", 0)) + 1
+            state["step"] = step + 1
             reached_limit = int(state["step"]) >= int(state.get("max_tokens", 2048))
             finished = is_eos or reached_limit
             state["finished"] = finished
@@ -440,7 +454,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             }
             codec_deltas.append(delta)
             terminal_flags.append(torch.tensor(finished, dtype=torch.bool))
-            stop_rows.append(hidden.new_tensor([float("-inf"), 0.0] if finished else [0.0, float("-inf")]))
+            stop_rows.append(finished_row if finished else continue_row)
 
         self._batch_stop_logits = torch.stack(stop_rows, dim=0) if stop_rows else hidden.new_empty((0, 2))
         # Lists are deliberate: the runner routes element i to request i,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py
@@ -73,6 +73,7 @@ MINICPMO_4_5_PIPELINE = PipelineConfig(
             engine_output_type="audio",
             model_arch="MiniCPMO45Code2Wav",
             sampling_constraints={"detokenize": True},
+            scheduler_cls=("vllm_omni.model_executor.models.minicpmo_4_5.scheduler.MiniCPMO45Code2WavScheduler"),
         ),
     ),
 )

--- a/vllm_omni/model_executor/models/minicpmo_4_5/scheduler.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/scheduler.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from vllm.v1.core.sched.output import SchedulerOutput
+
+from vllm_omni.core.sched.omni_generation_scheduler import (
+    OmniGenerationScheduler,
+)
+
+
+class MiniCPMO45Code2WavScheduler(OmniGenerationScheduler):
+    """Briefly coalesce same-wave codec chunks before Code2Wav scheduling."""
+
+    _POLL_INTERVAL_S = 0.0001
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._code2wav_batch_wait_s = self._batch_wait_seconds(self.vllm_config.model_config)
+
+    @staticmethod
+    def _batch_wait_seconds(model_config: Any) -> float:
+        connector = getattr(model_config, "stage_connector_config", None)
+        if isinstance(connector, Mapping):
+            extra = connector.get("extra", connector)
+        else:
+            extra = getattr(connector, "extra", None)
+        if not isinstance(extra, Mapping):
+            extra = {}
+        wait_ms = float(extra.get("code2wav_batch_wait_ms", 0.0) or 0.0)
+        if wait_ms < 0:
+            raise ValueError("MiniCPM-o Code2Wav code2wav_batch_wait_ms must be non-negative")
+        return wait_ms / 1000.0
+
+    def _ready_and_target_chunk_counts(self) -> tuple[int, int]:
+        adapter = self.chunk_transfer_adapter
+        if adapter is None:
+            return 0, 0
+        ready = len(adapter._finished_load_reqs)
+        target = min(self.max_num_running_reqs, len(self.requests))
+        return ready, target
+
+    def _wait_for_ready_chunk_batch(self) -> None:
+        if self._code2wav_batch_wait_s <= 0:
+            return
+
+        ready, target = self._ready_and_target_chunk_counts()
+        if ready <= 0 or target <= 1 or ready >= target:
+            return
+
+        deadline = time.monotonic() + self._code2wav_batch_wait_s
+        while ready < target:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(self._POLL_INTERVAL_S, remaining))
+            ready, target = self._ready_and_target_chunk_counts()
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        self._wait_for_ready_chunk_batch()
+        return super().schedule(throttle_prefills)


### PR DESCRIPTION
## Purpose

Build on #5228 to reduce MiniCPM-o 4.5 end-to-end latency and improve throughput when Thinker, Talker, and Code2Wav share one physical H20.

This PR:

- adds a PyTorch SDPA path for SigLIP and preserves explicit vision-attention overrides;
- regionally compiles each SigLIP encoder layer and enables it in the single-H20 deploy;
- adds opt-in, exact-shape B1/B2 CUDA Graph replay for the full 10-step CFM path, including graph-safe timestep embeddings;
- adds an opt-in request-isolated Token2Wav initial-state template cache;
- adds bounded Code2Wav chunk coalescing and keeps inactive prewarmed streams out of the active scheduler window;
- caches Talker continue/stop logit rows to avoid repeated per-step tensor construction;
- adds focused coverage for attention parity, encoder compile, platform config isolation, graph fallback, cache isolation, scheduling, Talker batching, and connector behavior.

The Code2Wav and Talker performance knobs remain opt-in. Their checked-in defaults stay `code2wav_batch_wait_ms=0`, `token2wav_cfm_cuda_graph=false`, and `token2wav_initial_state_cache=false`. The single-H20 deploy now enables `compile_mm_encoder`; the NPU platform override replaces that CUDA compilation config with `cudagraph_mode=PIECEWISE` and does not inherit encoder compile.

The cumulative benchmark additionally used existing deploy overrides for Stage-0/Stage-1 FlashInfer, `active_stream_window=4`, and SigLIP SDPA. Those overrides are not hardcoded by this source diff.

No quality-oriented setting was reduced: CFM stays at 10 steps, and CFG, precision, codec sampling, output length, frame count, and 25-token audio chunking are unchanged.

Related: #5069, #5228.

## Test Plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `git diff --check`
- [x] Remote focused tests on exact commit `6051e87f`: 32 passed
- [x] Single-H20 Daily-Omni c=1/c=4 matched benchmark with warmup and three measured rounds
- [x] Daily-Omni accuracy unchanged in the matched compile A/B
- [ ] Run the full 1,197-request Daily-Omni suite before moving this Draft PR to ready for review

**vLLM Version:** 0.25.0 (`torch==2.11.0+cu128`, `transformers==5.8.0`, CUDA driver 580.82.07)

**vLLM-Omni Commit:** benchmark prototype based on exact #5228 head `f2a216917940a85c44801ccf555a7807426a475d`; clean PR commit `6051e87ff326820aebb52555abe0d17b845a6ee3`

## Test Result

Hardware/topology: one NVIDIA H20 96 GB; all three stages colocated on the same physical GPU.

Workload: the same 20-request Daily-Omni subset and seed for every round. One c=4, 8-request warmup preceded three measured rounds at c=1 and c=4. Values are medians. All rounds completed 20/20 requests without HTTP or evaluation parse failures.

### Cumulative result against #5228

| Metric | #5228 c=1 | Cumulative c=1 | #5228 c=4 | Cumulative c=4 |
|---|---:|---:|---:|---:|
| Request throughput | 0.332613 req/s | 0.752709 req/s (2.26x) | 0.376805 req/s | 1.080269 req/s (2.87x) |
| Audio throughput | 0.798272 audio-s/s | 1.801986 audio-s/s (2.26x) | 0.899621 audio-s/s | 2.547274 audio-s/s (2.83x) |
| Median TTFT | 2259.67 ms | 834.47 ms (-63.1%) | 8990.77 ms | 2972.61 ms (-66.9%) |
| Median audio TTFP | 2665.08 ms | 1063.90 ms (-60.1%) | 9936.30 ms | 3259.31 ms (-67.2%) |
| Median audio RTF | 1.26697 | 0.55277 (-56.4%) | 4.58565 | 1.59431 (-65.2%) |
| Daily-Omni accuracy | 13/20 | 13/20 | 13/20 | 13/20 |
| Median audio duration | 2.28 s | 2.28 s | 2.28 s | 2.28 s |

These are stacked end-to-end results for the cumulative configuration, not attribution to any single optimization. The clean `main` port has been revalidated with the focused test suite; the cumulative benchmark was collected on the corresponding prototype based on the exact #5228 head.

### SigLIP regional compile attribution

The only variable in this matched A/B was `compile_mm_encoder`. Both sides included the same experimental Vision host-metadata fast path, so the relative deltas isolate encoder compile; the metadata fast path itself is not included in commit `6051e87f`.

| Metric | c=1 change | c=4 change |
|---|---:|---:|
| Request throughput | +2.08% | +0.74% |
| Audio throughput | +3.28% | +1.33% |
| Total time | -2.03% | -0.74% |
| Median TTFT | -3.07% | -2.56% |
| Median audio TTFP | -2.37% | -3.09% |
| Median audio RTF | -3.40% | -3.16% |
| Daily-Omni accuracy | 65% to 65% | 65% to 65% |

Post-warmup profiling attributes the gain to SigLIP encoder fusion:

- Stage-0 accelerator time: `2834.9 ms -> 2737.1 ms` (`-3.45%`);
- layout/direct-copy time: `73.4 ms -> 22.4 ms`;
- residual add and LayerNorm fuse into a Triton kernel;
- the initial AOT compile takes about 9 seconds once, after which all encoder layers reuse the cache;
- no graph-break or recompilation error was observed.

<!-- markdownlint-disable -->
**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
