### PR TITLE
[Bugfix] Fix omni video second_per_grid_ts key mismatch (#5355)

### DIFF
--- a/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
@@ -13,6 +13,7 @@ from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
     Qwen2_5OmniThinkerMultiModalProcessor,
     _coerce_use_audio_in_video_for_hf_processor,
     _filter_video_use_audio_in_video_for_uncached_items,
+    _get_video_second_per_grid_t,
     _normalize_use_audio_in_video,
 )
 from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker import (
@@ -191,6 +192,31 @@ def test_coerce_use_audio_in_video_for_hf_processor_does_not_validate_against_pa
 
     assert result["use_audio_in_video"] is False
     assert result[_PER_VIDEO_USE_AUDIO_IN_VIDEO_KEY] == [True, False]
+
+
+def test_get_video_second_per_grid_t_reads_the_omni_processor_key():
+    """Regression test for vllm-project/vllm-omni#5355.
+
+    The HF Qwen2.5-Omni / Qwen3-Omni-MoE processors compute the correct
+    per-video time step from the real sampled fps and return it as
+    ``video_second_per_grid`` (see processing_qwen3_omni_moe.py /
+    processing_qwen2_5_omni.py __call__: they set
+    ``videos_inputs["video_second_per_grid"] = temporal_patch_size / fps``
+    and merge ``videos_inputs`` into the returned BatchFeature). That is a
+    different key than ``second_per_grid_ts``, which is what the non-omni
+    Qwen2_5VLProcessor uses instead (processing_qwen2_5_vl.py). This helper
+    only checked ``second_per_grid_ts``, so for the omni models it always
+    missed the real value already sitting in ``out_mm_data`` and fell back
+    to ``default``.
+    """
+    second_per_grid_t = _get_video_second_per_grid_t(
+        out_mm_data={"video_second_per_grid": [1.0019083969465647]},
+        hf_processor_mm_kwargs={},
+        item_idx=0,
+        default=2.0,
+    )
+
+    assert second_per_grid_t == pytest.approx(1.0019083969465647)
 
 
 def test_filter_video_use_audio_in_video_for_uncached_items_aligns_partial_cache_mask():

--- a/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
@@ -374,7 +374,9 @@ def test_qwen2_5_prompt_updates_apply_audio_mask_per_video():
     assert video_update.resolve(1).content.full == [VIDEO_TOKEN_ID, VIDEO_TOKEN_ID]
 
 
-def test_qwen2_5_prompt_updates_prefer_hf_second_per_grid_ts_from_outputs():
+def test_qwen2_5_prompt_updates_prefer_hf_video_second_per_grid_from_outputs():
+    """The omni processor output (video_second_per_grid) takes priority
+    over a client-supplied second_per_grid_ts override."""
     captured = {}
     fake_self = _fake_qwen2_prompt_processor()
 
@@ -387,7 +389,7 @@ def test_qwen2_5_prompt_updates_prefer_hf_second_per_grid_ts_from_outputs():
         get_data=lambda **_kwargs: {
             "audio_feature_lengths": torch.tensor([100]),
             "video_grid_thw": torch.tensor([[1, 1, 1]]),
-            "second_per_grid_ts": torch.tensor([0.25]),
+            "video_second_per_grid": torch.tensor([0.25]),
         }
     )
     mm_items = SimpleNamespace(
@@ -534,7 +536,9 @@ def test_qwen3_processor_inherits_vllm_omni_per_video_helpers():
     )
 
 
-def test_qwen3_prompt_updates_prefer_hf_second_per_grid_ts_from_outputs():
+def test_qwen3_prompt_updates_prefer_hf_video_second_per_grid_from_outputs():
+    """The omni processor output (video_second_per_grid) takes priority
+    over a client-supplied second_per_grid_ts override."""
     captured = {}
     fake_self = _fake_qwen3_prompt_processor()
 
@@ -547,7 +551,7 @@ def test_qwen3_prompt_updates_prefer_hf_second_per_grid_ts_from_outputs():
         get_data=lambda **_kwargs: {
             "audio_feature_lengths": torch.tensor([100]),
             "video_grid_thw": torch.tensor([[1, 1, 1]]),
-            "second_per_grid_ts": torch.tensor([0.25]),
+            "video_second_per_grid": torch.tensor([0.25]),
         }
     )
     mm_items = SimpleNamespace(

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -174,12 +174,6 @@ def _get_video_second_per_grid_t(
     item_idx: int,
     default: float,
 ) -> float:
-    # The omni HF processors (Qwen2.5-Omni, Qwen3-Omni-MoE) compute this from
-    # the real sampled fps and return it as "video_second_per_grid" -- a
-    # different key than the non-omni Qwen2_5VLProcessor's
-    # "second_per_grid_ts". Check the omni key first; the legacy key and the
-    # client-supplied kwarg remain as fallbacks. See
-    # vllm-project/vllm-omni#5355.
     second_per_grid_ts = out_mm_data.get("video_second_per_grid")
     if second_per_grid_ts is None:
         second_per_grid_ts = out_mm_data.get("second_per_grid_ts")
@@ -1073,13 +1067,8 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
             elif modality == "video":
                 t, h, w = mm_feature.data["video_grid_thw"].data.tolist()
                 second_per_grid_ts = 1.0
-                # See _get_video_second_per_grid_t: the omni HF processor
-                # returns this as "video_second_per_grid", not
-                # "second_per_grid_ts". vllm-project/vllm-omni#5355.
                 if mm_feature.data.get("video_second_per_grid"):
                     second_per_grid_ts = mm_feature.data["video_second_per_grid"].data.item()
-                elif mm_feature.data.get("second_per_grid_ts"):
-                    second_per_grid_ts = mm_feature.data["second_per_grid_ts"].data.item()
                 use_audio_in_video = False
                 if mm_feature.data.get("use_audio_in_video"):
                     use_audio_in_video = bool(mm_feature.data["use_audio_in_video"].data.item())

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -176,8 +176,6 @@ def _get_video_second_per_grid_t(
 ) -> float:
     second_per_grid_ts = out_mm_data.get("video_second_per_grid")
     if second_per_grid_ts is None:
-        second_per_grid_ts = out_mm_data.get("second_per_grid_ts")
-    if second_per_grid_ts is None:
         second_per_grid_ts = hf_processor_mm_kwargs.get("second_per_grid_ts", None)
     if second_per_grid_ts is None:
         return default

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -174,7 +174,15 @@ def _get_video_second_per_grid_t(
     item_idx: int,
     default: float,
 ) -> float:
-    second_per_grid_ts = out_mm_data.get("second_per_grid_ts")
+    # The omni HF processors (Qwen2.5-Omni, Qwen3-Omni-MoE) compute this from
+    # the real sampled fps and return it as "video_second_per_grid" -- a
+    # different key than the non-omni Qwen2_5VLProcessor's
+    # "second_per_grid_ts". Check the omni key first; the legacy key and the
+    # client-supplied kwarg remain as fallbacks. See
+    # vllm-project/vllm-omni#5355.
+    second_per_grid_ts = out_mm_data.get("video_second_per_grid")
+    if second_per_grid_ts is None:
+        second_per_grid_ts = out_mm_data.get("second_per_grid_ts")
     if second_per_grid_ts is None:
         second_per_grid_ts = hf_processor_mm_kwargs.get("second_per_grid_ts", None)
     if second_per_grid_ts is None:
@@ -1065,7 +1073,12 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
             elif modality == "video":
                 t, h, w = mm_feature.data["video_grid_thw"].data.tolist()
                 second_per_grid_ts = 1.0
-                if mm_feature.data.get("second_per_grid_ts"):
+                # See _get_video_second_per_grid_t: the omni HF processor
+                # returns this as "video_second_per_grid", not
+                # "second_per_grid_ts". vllm-project/vllm-omni#5355.
+                if mm_feature.data.get("video_second_per_grid"):
+                    second_per_grid_ts = mm_feature.data["video_second_per_grid"].data.item()
+                elif mm_feature.data.get("second_per_grid_ts"):
                     second_per_grid_ts = mm_feature.data["second_per_grid_ts"].data.item()
                 use_audio_in_video = False
                 if mm_feature.data.get("use_audio_in_video"):

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -1590,13 +1590,8 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             elif modality == "video":
                 t, h, w = mm_feature.data["video_grid_thw"].data.tolist()
                 second_per_grid_ts = 2.0
-                # See _get_video_second_per_grid_t: the omni HF processor
-                # returns this as "video_second_per_grid", not
-                # "second_per_grid_ts". vllm-project/vllm-omni#5355.
                 if mm_feature.data.get("video_second_per_grid"):
                     second_per_grid_ts = mm_feature.data["video_second_per_grid"].data.item()
-                elif mm_feature.data.get("second_per_grid_ts"):
-                    second_per_grid_ts = mm_feature.data["second_per_grid_ts"].data.item()
                 use_audio_in_video = bool(
                     mm_feature.data.get("use_audio_in_video") and mm_feature.data["use_audio_in_video"].data.item()
                 )

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -1590,7 +1590,12 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             elif modality == "video":
                 t, h, w = mm_feature.data["video_grid_thw"].data.tolist()
                 second_per_grid_ts = 2.0
-                if mm_feature.data.get("second_per_grid_ts"):
+                # See _get_video_second_per_grid_t: the omni HF processor
+                # returns this as "video_second_per_grid", not
+                # "second_per_grid_ts". vllm-project/vllm-omni#5355.
+                if mm_feature.data.get("video_second_per_grid"):
+                    second_per_grid_ts = mm_feature.data["video_second_per_grid"].data.item()
+                elif mm_feature.data.get("second_per_grid_ts"):
                     second_per_grid_ts = mm_feature.data["second_per_grid_ts"].data.item()
                 use_audio_in_video = bool(
                     mm_feature.data.get("use_audio_in_video") and mm_feature.data["use_audio_in_video"].data.item()


### PR DESCRIPTION
## Purpose

Fix Qwen3-Omni (and Qwen2.5-Omni) silently using a wrong, hardcoded
`second_per_grid_ts` for audio/video interleaving and multimodal RoPE
whenever a video's sampled fps deviates from the target fps (#5355).

The HF `Qwen2.5-Omni` / `Qwen3-Omni-MoE` processors already compute the
correct per-video time step from the real sampled fps (after FRAME_FACTOR
rounding / max_frames clipping) and return it in their `BatchFeature`
output as `video_second_per_grid` -- see
`transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py` and
`qwen2_5_omni/processing_qwen2_5_omni.py`, both of which set
`videos_inputs["video_second_per_grid"] = temporal_patch_size / fps`.
vllm-omni's own code checks a different key, `second_per_grid_ts` --
the key the non-omni `Qwen2_5VLProcessor` uses instead
(`processing_qwen2_5_vl.py`) -- so it never finds the value already
sitting in `out_mm_data` and silently falls back to a hardcoded default
(`2.0` for Qwen3-Omni, `1.0` for Qwen2.5-Omni).

This PR:

- `_get_video_second_per_grid_t` (`qwen2_5_omni_thinker.py`, shared by
  both thinkers) now checks `video_second_per_grid` first, falling back
  to the client-supplied `mm_processor_kwargs` override.
- Both thinkers' `iter_mm_features` inline fallback (MRoPE position
  construction) does the same, checking only `video_second_per_grid` --
  no other key is ever produced there by the omni processors.

Backward compatibility: additive -- only adds a new, higher-priority key
check; the documented client-side workaround of manually passing
`second_per_grid_ts` via `mm_processor_kwargs` keeps working.

Note: an earlier revision of this PR also kept a `second_per_grid_ts`
fallback reading from the processor output (`out_mm_data` /
`mm_feature.data`) for extra safety. Traced through
`_get_mm_fields_config` and the installed `transformers` source and
confirmed the omni processors never emit that key there (only the
non-omni `Qwen2_5VLProcessor` does), so both occurrences were dead code
and have been removed.

Not a duplicate: no open PR references #5355; #5308 fixes an unrelated
mm-cache coupling bug (#5248) touching the same file area but a
different code path.

## Test Plan

**vLLM Version:** vllm 0.25.0

**vLLM-Omni Commit:** this branch (base `7afd3a0dc`)

- [x] Unit (CPU): `tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py`
  - `_get_video_second_per_grid_t` picks up `video_second_per_grid` from
    `out_mm_data` instead of falling back to `default`
  - the two tests that previously exercised the removed
    `out_mm_data`-based `second_per_grid_ts` fallback were updated to
    target `video_second_per_grid` instead (renamed to
    `..._prefer_hf_video_second_per_grid_from_outputs`)
- [x] Standalone repro of the issue's core numeric claim (real sampled
      fps vs. target fps, via `qwen_omni_utils.fetch_video`)

## Test Result

- Unit: **30 passed** (`test_per_video_audio_mask.py`); **86 passed**
  across the broader `qwen2_5_omni`/`qwen3_omni` test directories (one
  file could not be collected due to a missing `peft` module in the
  test environment, unrelated to this change); ruff/pre-commit clean.
- Standalone repro (synthesized test video, not the reporter's private
  data): target_fps=2.0, real sampled fps=1.9834710743801653, hardcoded
  fallback=2.0, correct value=1.0083333333333333 -- confirms the exact
  discrepancy class the issue describes.

_AI assistance: developed with Claude; I reviewed every changed line and ran the tests above._
