### PR TITLE
[Bugfix] Fix UnboundLocalError on finished in update_from_output (#5399)

### DIFF
--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -179,6 +179,47 @@ def test_stage0_streaming_update_keeps_all_computed_tokens_without_placeholder()
     assert sched._new_prompt_len_snapshot[session.request_id] == 2
 
 
+def test_non_stopping_step_with_chunk_transfer_adapter_does_not_crash() -> None:
+    """Regression test for vllm-project/vllm-omni#5399.
+
+    #5383 added ``finished`` as a third disjunct to the
+    chunk_transfer_adapter save_async gate, but ``finished`` is only ever
+    assigned inside the ``if stopped:`` branch -- unlike its neighbors
+    ``stopped``/``is_segment_finished``, which both get a safe top-of-loop
+    default. Any ordinary (non-terminal) decode step with a
+    chunk_transfer_adapter configured and no inter_stage_output this step
+    raised UnboundLocalError instead of treating ``finished`` as False,
+    killing the whole EngineCore.
+    """
+    session = _make_request()
+    session.status = RequestStatus.RUNNING
+
+    sched = MagicMock()
+    sched.requests = {session.request_id: session}
+    sched.perf_metrics = None
+    sched.structured_output_manager.should_advance.return_value = False
+    sched._process_kv_transfer_trigger.return_value = False
+    sched.chunk_transfer_adapter = SimpleNamespace()  # configured, i.e. not None
+
+    scheduler_output = MagicMock(spec=SchedulerOutput)
+    scheduler_output.num_scheduled_tokens = {session.request_id: 1}
+    scheduler_output.scheduled_spec_decode_tokens = {}
+    scheduler_output.num_invalid_spec_tokens = 0
+
+    model_runner_output = MagicMock(spec=ModelRunnerOutput)
+    model_runner_output.sampled_token_ids = [[]]  # no tokens generated this step
+    model_runner_output.logprobs = None
+    model_runner_output.prompt_logprobs_dict = {}
+    model_runner_output.pooler_output = None
+    model_runner_output.num_nans_in_logits = None
+    model_runner_output.kv_connector_output = None
+    model_runner_output.cudagraph_stats = None
+    model_runner_output.req_id_to_index = {session.request_id: 0}
+    model_runner_output.routed_experts = None
+
+    OmniARScheduler.update_from_output(sched, scheduler_output, model_runner_output)
+
+
 def test_explicit_streaming_payload_replaces_placeholder_prompt() -> None:
     sched = _make_scheduler(stage_id=1)
     sched.chunk_transfer_adapter = SimpleNamespace(

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -384,11 +384,6 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             stopped = False
             is_segment_finished = False
-            # Only set inside the `if stopped:` branch below; give it the
-            # same safe default as its neighbors above, otherwise the
-            # chunk_transfer_adapter gate further down raises
-            # UnboundLocalError on any non-terminal step. See
-            # vllm-project/vllm-omni#5399.
             finished = False
             new_logprobs = None
             new_token_ids = generated_token_ids

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -384,6 +384,12 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             stopped = False
             is_segment_finished = False
+            # Only set inside the `if stopped:` branch below; give it the
+            # same safe default as its neighbors above, otherwise the
+            # chunk_transfer_adapter gate further down raises
+            # UnboundLocalError on any non-terminal step. See
+            # vllm-project/vllm-omni#5399.
+            finished = False
             new_logprobs = None
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None


### PR DESCRIPTION
## Purpose

Fix an `UnboundLocalError` on `finished` in `OmniARScheduler.
update_from_output()` that crashes the whole Stage-0 `EngineCore` (and the
API server along with it) on an ordinary decode step (#5399).

#5383 (merged the same day, `e043818abf`) added `finished` as a third
disjunct to the `chunk_transfer_adapter` `save_async` gate:

```python
if self.chunk_transfer_adapter is not None and (
    inter_stage_output is not None or is_segment_finished or finished
):
```

`finished` is only ever assigned inside the `if stopped:` branch earlier in
the same per-request loop (`finished = self._handle_stopped_request(request)`).
Its neighbors `stopped` and `is_segment_finished` both get a safe
top-of-loop default (`stopped = False` / `is_segment_finished = False`);
`finished` never got the same treatment. So any ordinary decode step where
the request has **not** stopped yet (`stopped=False`, the common case), the
stage has a `chunk_transfer_adapter` configured, and there is no
`inter_stage_output` this step raises `UnboundLocalError` instead of
short-circuiting to `False`.

This PR:

- Gives `finished` the same top-of-loop default as its neighbors,
  `finished = False`.

Backward compatibility: additive -- purely fixes a crash, no behavior change
for any code path that was working before.

Not a duplicate: no open PR references #5399.

## Test Plan

**vLLM Version:** vllm 0.25.0

**vLLM-Omni Commit:** this branch (base `7afd3a0dc`)

- [x] E2E (1x RTX PRO 6000 Blackwell, `Qwen/Qwen3-Omni-30B-A3B-Instruct`):
      a `use_audio_in_video=True` request against a synthesized video+audio
      clip needing multiple prefill steps
  - reproduced the crash twice from a fresh server boot before writing the fix
  - re-ran the identical request against a fresh server boot with this fix
    applied to confirm the crash is gone
- [x] Unit (CPU): `tests/core/sched/test_omni_ar_scheduler_streaming.py`
  - a non-stopping decode step (`stopped=False`) with
    `chunk_transfer_adapter` configured and no `inter_stage_output` no
    longer raises `UnboundLocalError`

## Test Result

- E2E without the fix: `UnboundLocalError: cannot access local variable
  'finished' where it is not associated with a value` at
  `omni_ar_scheduler.py:500`, Stage-0 `EngineCore` dies, API server exits;
  reproduced identically on two separate fresh server boots.
- E2E with the fix: the same request completes normally with a streamed text
  response, no traceback in the server log, `/health` still returns 200
  afterward.
- Unit: **8 passed** (`test_omni_ar_scheduler_streaming.py`), **74 passed**
  across `tests/core/sched/`; ruff/pre-commit clean.

_AI assistance: developed with Claude; I reviewed every changed line and ran the tests above._
