### PR TITLE
[WIP] added Ascend NPU support for the MiniCPM-o 4.5 vocoder by routing it …

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -15,6 +15,20 @@ import torch.nn.functional as F
 _SILENCE_TOKEN = 4218
 
 
+def _autocast_disabled(device: torch.device):
+    """Disable an enclosing autocast region on ``device``.
+
+    ``torch.amp.autocast`` resolves the autocast dtype for ``device_type``
+    while constructing the context, which raises on accelerators that never
+    registered autocast support. Degrade to a no-op there: an enclosing region
+    can only exist on a device type torch already knows.
+    """
+    try:
+        return torch.amp.autocast(device.type, enabled=False)
+    except (RuntimeError, TypeError, ValueError):
+        return nullcontext()
+
+
 def tensor_signature(value: torch.Tensor) -> tuple[tuple[int, ...], str, str]:
     return tuple(value.shape), str(value.dtype), value.device.type
 
@@ -72,7 +86,7 @@ class BatchedToken2Wav(nn.Module):
             previous_dtype = torch.get_default_dtype()
             try:
                 torch.set_default_dtype(torch.float32)
-                with torch.amp.autocast("cuda", enabled=False):
+                with _autocast_disabled(self.speech_window.device):
                     values = self._token2wav._prepare_prompt(prompt_wav)
             finally:
                 torch.set_default_dtype(previous_dtype)

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -19,12 +19,30 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 
 from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.platforms import current_omni_platform
 
 from .batched_token2wav import (
     BatchedToken2Wav,
     BatchedToken2WavState,
     state_shape_signature,
 )
+
+
+def _resolve_token2wav_cls() -> type:
+    """Select the vocoder asset loader for the current platform.
+
+    ``stepaudio2`` hard-codes CUDA device placement, so Ascend loads the
+    in-tree adapter over ``StepAudio2Token2WavCore``, which carries the
+    vendored NPU vocoder fixes.
+    """
+    if current_omni_platform.is_npu():
+        from .minicpmo_4_5_token2wav import MiniCPMO45Token2wav
+
+        return MiniCPMO45Token2wav
+
+    from stepaudio2.token2wav import Token2wav
+
+    return Token2wav
 
 
 def _batch_error(reason: str, **details: Any) -> RuntimeError:
@@ -516,7 +534,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             pass
         if self.backend is not None:
             return {name for name, _ in self.named_parameters()}
-        from stepaudio2.token2wav import Token2wav
+        token2wav_cls = _resolve_token2wav_cls()
 
         extra = self._extra_config()
         prompt_path = Path(self._default_prompt_wav)
@@ -532,7 +550,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             # Token2wav contains fp32-only S3Tokenizer/HiFT modules, so build
             # its independent assets in their native precision.
             torch.set_default_dtype(torch.float32)
-            token2wav = Token2wav(
+            token2wav = token2wav_cls(
                 str(token2wav_path),
                 float16=use_float16,
                 n_timesteps=int(extra.get("token2wav_n_timesteps", 10)),

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py
@@ -13,6 +13,10 @@ This module exposes the same call surface MiniCPM expects
 (``__call__`` / ``set_stream_cache`` / ``stream``) while delegating the
 actual vocoder work to
 ``vllm_omni.model_executor.models.step_audio2.step_audio2_token2wav.StepAudio2Token2WavCore``.
+
+It also exposes the asset surface (``flow`` / ``hift`` / cache lengths /
+``speech_window`` / ``_prepare_prompt``) that the Stage-2 ``BatchedToken2Wav``
+driver reads instead of calling ``stream``.
 """
 
 from __future__ import annotations
@@ -81,6 +85,41 @@ class MiniCPMO45Token2wav:
         # Mutable streaming fields expected by MiniCPM's long-form path.
         self.stream_cache: Any | None = None
         self.hift_cache_dict: dict[str, torch.Tensor] = {}
+
+    @property
+    def flow(self):
+        return self._core.flow
+
+    @property
+    def hift(self):
+        return self._core.hift
+
+    @property
+    def mel_cache_len(self) -> int:
+        return self._core.mel_cache_len
+
+    @property
+    def source_cache_len(self) -> int:
+        return self._core.source_cache_len
+
+    @property
+    def speech_window(self) -> torch.Tensor:
+        """Overlap-add window, materialized on first access.
+
+        The core builds this inside its own streaming setup, but Stage-2 reads
+        it while constructing its batched driver, before any stream starts.
+        """
+        window = self._core.speech_window
+        if window is None or window.device != self._core.device:
+            window = torch.from_numpy(np.hamming(2 * self._core.source_cache_len)).to(
+                device=self._core.device, dtype=torch.float32
+            )
+            self._core.speech_window = window
+        return window
+
+    def _prepare_prompt(self, prompt_wav: str):
+        """Extract prompt speech tokens, speaker embedding, and mels."""
+        return self._core._prepare_prompt(prompt_wav)
 
     def __call__(self, generated_speech_tokens, prompt_wav) -> bytes:
         """One-shot tokens → 24 kHz WAV bytes."""


### PR DESCRIPTION
…through

the in-tree  adapter over , avoiding
the CUDA-only external  package

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
