### PR TITLE
[Bugfix] Select the AR-Diffusion engine in the DreamZero CFG-parallel deploy config

### DIFF
--- a/tests/dreamzero/test_deploy_configs.py
+++ b/tests/dreamzero/test_deploy_configs.py
@@ -15,21 +15,23 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
-import vllm_omni
+from tests.helpers.stage_config import get_deploy_config_path
 from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
 from vllm_omni.experimental.ar_diffusion.engine import ARDiffusionEngine
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
-DEPLOY_DIR = Path(vllm_omni.__file__).parent / "deploy"
+# Discover siblings of a known config so a future dreamzero*.yaml is covered
+# without editing this test.
+DEPLOY_DIR = Path(get_deploy_config_path("dreamzero.yaml")).parent
 
 
 def _dreamzero_stages() -> list[tuple[str, int, dict]]:
     stages = []
-    for config_path in sorted(DEPLOY_DIR.glob("dreamzero*.yaml")):
-        config = yaml.safe_load(config_path.read_text())
+    for name in sorted(path.name for path in DEPLOY_DIR.glob("dreamzero*.yaml")):
+        config = yaml.safe_load(Path(get_deploy_config_path(name)).read_text())
         for index, stage in enumerate(config.get("stages") or []):
-            stages.append((config_path.name, index, stage))
+            stages.append((name, index, stage))
     return stages
 
 

--- a/tests/dreamzero/test_deploy_configs.py
+++ b/tests/dreamzero/test_deploy_configs.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Every shipped DreamZero deploy config must select the AR-Diffusion engine.
+
+``DreamZeroPipeline.__init__`` rejects any other engine, so a config missing
+``engine_backend`` fails at worker startup rather than at request time. That
+only surfaces in slow multi-GPU e2e serving tests (see issue #5046), so assert
+it here on CPU instead.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+import vllm_omni
+from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+from vllm_omni.experimental.ar_diffusion.engine import ARDiffusionEngine
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+DEPLOY_DIR = Path(vllm_omni.__file__).parent / "deploy"
+
+
+def _dreamzero_stages() -> list[tuple[str, int, dict]]:
+    stages = []
+    for config_path in sorted(DEPLOY_DIR.glob("dreamzero*.yaml")):
+        config = yaml.safe_load(config_path.read_text())
+        for index, stage in enumerate(config.get("stages") or []):
+            stages.append((config_path.name, index, stage))
+    return stages
+
+
+def test_dreamzero_deploy_configs_exist() -> None:
+    assert _dreamzero_stages(), f"no DreamZero deploy configs found under {DEPLOY_DIR}"
+
+
+@pytest.mark.parametrize(
+    ("config_name", "stage_index", "stage"),
+    _dreamzero_stages(),
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_dreamzero_stage_selects_ar_diffusion_engine(config_name: str, stage_index: int, stage: dict) -> None:
+    backend = stage.get("engine_backend")
+    assert backend, (
+        f"{config_name} stage {stage_index} does not set engine_backend; "
+        "DreamZeroPipeline requires the AR-Diffusion engine"
+    )
+    # Resolving also proves the import path is real, not just a lookalike string.
+    engine_class = DiffusionEngine.resolve_engine_class(SimpleNamespace(engine_backend=backend))
+    assert issubclass(engine_class, ARDiffusionEngine), (
+        f"{config_name} stage {stage_index} resolves to {engine_class.__name__}, not an AR-Diffusion engine"
+    )

--- a/vllm_omni/deploy/dreamzero_tp1_cfg2.yaml
+++ b/vllm_omni/deploy/dreamzero_tp1_cfg2.yaml
@@ -11,6 +11,8 @@ stages:
     max_num_seqs: 1
     enforce_eager: false
     model_class_name: DreamZeroPipeline
+    # DreamZero runs on the AR-Diffusion engine (engine-level paged KV cache).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
     parallel_config:
       tensor_parallel_size: 1
       cfg_parallel_size: 2


### PR DESCRIPTION
## Purpose

Fixes #5046.

`DreamZeroPipeline` requires the AR-Diffusion engine and raises at construction when `engine_backend` resolves to anything else. #4534 added `engine_backend` to `vllm_omni/deploy/dreamzero.yaml` but not to `vllm_omni/deploy/dreamzero_tp1_cfg2.yaml`, and nothing else injects it (`OmniDiffusionConfig.engine_backend` defaults to `"default"`). Every launch through the CFG-parallel config therefore died during worker startup:

```
ValueError: DreamZeroPipeline requires the AR-Diffusion engine; set engine_backend:
vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine in the deploy config
(got engine_backend='default').
```

Both workers died, the executor got `EOFError` on `reader.recv()`, and stage init tore the server down — the rest of the traceback in the issue is that cascade.

This is not CI-only: `examples/online_serving/dreamzero/run_server.sh` defaults to the same config, so the documented multi-GPU serving path was broken too.

Two changes:

1. Add the missing `engine_backend` to `dreamzero_tp1_cfg2.yaml`, matching `dreamzero.yaml`. No other change is needed — CFG parallelism is already handled by the capability, which collapses the negative branch onto `local_index=0` when `cfg_world >= 2`.
2. Add `tests/dreamzero/test_deploy_configs.py`, a CPU test asserting every shipped `dreamzero*.yaml` stage selects an AR-Diffusion engine. It resolves the import path through `DiffusionEngine.resolve_engine_class` rather than string-matching, so a stale or typo'd path fails too. Previously only an H100x2 `slow`-marked e2e test covered this, which is why it surfaced weekly rather than in PR CI.

## Test Plan

- `pytest tests/dreamzero/test_deploy_configs.py`
- Negative control: temporarily remove the new `engine_backend` line and confirm only the `dreamzero_tp1_cfg2.yaml` case fails.
- `pre-commit run --files vllm_omni/deploy/dreamzero_tp1_cfg2.yaml tests/dreamzero/test_deploy_configs.py`

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 84bbd57e

## Test Result

```
tests/dreamzero/test_deploy_configs.py::test_dreamzero_deploy_configs_exist PASSED
tests/dreamzero/test_deploy_configs.py::test_dreamzero_stage_selects_ar_diffusion_engine[dreamzero.yaml-0-stage0] PASSED
tests/dreamzero/test_deploy_configs.py::test_dreamzero_stage_selects_ar_diffusion_engine[dreamzero_tp1_cfg2.yaml-0-stage1] PASSED
3 passed in 9.96s
```

Negative control, with the fix reverted:

```
FAILED tests/dreamzero/test_deploy_configs.py::test_dreamzero_stage_selects_ar_diffusion_engine[dreamzero_tp1_cfg2.yaml-0-stage1]
1 failed, 2 passed
```

pre-commit: all hooks passed.

Not run: the weekly `test_dreamzero_openpi_online` e2e test, which needs 2x H100. The new test covers the config-level regression, not the full serving path — worth confirming the weekly job goes green after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)