### PR TITLE
Fix missing sequence_parallel_size in deploy config output

### DIFF
--- a/tests/e2e/accuracy/test_hunyuan_image3_pixel_accuracy.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3_pixel_accuracy.py
@@ -112,6 +112,7 @@ def _write_deploy_config(path: Path) -> None:
         f"the number of devices ({num_devices}): {parallel_config}"
     )
 
+    parallel_config["sequence_parallel_size"] = sequence_parallel_size
     config_text = yaml.dump(config, default_flow_style=False, sort_keys=False)
     path.write_text(config_text)
     logger.info(


### PR DESCRIPTION


## Purpose
fix [issue#5390](https://github.com/vllm-project/vllm-omni/issues/5390)
## Test Plan
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3_pixel_accuracy.py -m full_model --run-level full_model`
**vLLM Version:**
vllm：0.25.0
omni：main

## Test Result
offline
<img width="838" height="368" alt="d77739e07a3ff9832f2b9a8ef411f37e" src="https://github.com/user-attachments/assets/946d6f0a-9d3d-4ba7-810f-a0b2b96470aa" />

online
<img width="890" height="362" alt="ada37340721bca0b410a771d0cbd938a" src="https://github.com/user-attachments/assets/399c665e-f1aa-4c0c-b615-b7e7c0c9aa69" />
