### PR TITLE
[Feature] Add LTX-2.3 keyframe interpolation (FLF2V / FMLF) one-stage pipeline

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -43,6 +43,7 @@ th {
 | `Wan22VACEPipeline` | Wan2.2-VACE | `Pyros13/Wan2.2-VACE-Fun-A14B-Diffusers` | ✅︎ |   |   |   |
 | `LTX2Pipeline` | LTX-2 / LTX-2.3 one-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `LTX2DistilledPipeline` | LTX-2 distilled two-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled` | ✅︎ | ✅︎ | | |
+| `LTX2ConditionPipeline` | LTX-2 / LTX-2.3 keyframe interpolation (FLF2V / FMLF) | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `LingBotVideoPipeline` | LingBot-Video dense and MoE T2V | `robbyant/lingbot-video-dense-1.3b`, `robbyant/lingbot-video-moe-30b-a3b` | ✅︎ | | | |
 | `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `HeliosPipeline`, `HeliosPyramidPipeline` | Helios | `BestWishYsh/Helios-Base`, `BestWishYsh/Helios-Mid`, `BestWishYsh/Helios-Distilled` | ✅︎ | ✅︎ | ✅︎ | |

--- a/tests/diffusion/models/ltx2/test_ltx2_condition.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_condition.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for LTX-2 / LTX-2.3 multi-anchor frame conditioning (FLF2V / FMLF)."""
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.ltx2.ltx2_components import LTX2_COMPONENT_PROFILE
+from vllm_omni.diffusion.models.ltx2.ltx2_condition import (
+    LTX2VideoCondition,
+    LTXMultiAnchorConditioningMixin,
+    apply_first_frame_conditioning,
+    preprocess_conditions,
+)
+from vllm_omni.diffusion.models.ltx2.ltx2_runtime import LTXRuntime
+from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import LTX2ConditionPipeline, LTX2Pipeline
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_condition_pipeline_composes_multi_anchor_mixin_over_ltx2():
+    assert issubclass(LTX2ConditionPipeline, LTXMultiAnchorConditioningMixin)
+    assert issubclass(LTX2ConditionPipeline, LTX2Pipeline)
+    assert issubclass(LTX2ConditionPipeline, LTXRuntime)
+
+
+def test_condition_pipeline_inherits_runtime_contract():
+    assert LTX2ConditionPipeline.pipeline_kind == "one_stage"
+    assert LTX2ConditionPipeline.component_profile is LTX2_COMPONENT_PROFILE
+    # Anchors resolve from the first request only -> batching disabled.
+    assert LTX2ConditionPipeline.supports_request_batch is False
+    assert LTX2ConditionPipeline.support_image_input is True
+    assert LTX2ConditionPipeline.unified_text_image_entry is True
+
+
+def test_condition_pipeline_overrides_conditioning_hooks():
+    for hook in (
+        "_prepare_video_latents_stage",
+        "_step_video_latents_i2v",
+        "_denoise_timestep_kwargs",
+        "_prepare_denoise_context_for_cfg",
+        "_video_guidance_model_sigma",
+        "_unpack_and_denormalize_stage",
+        "forward",
+    ):
+        assert getattr(LTX2ConditionPipeline, hook) is getattr(LTXMultiAnchorConditioningMixin, hook)
+
+
+def test_condition_pipeline_registered():
+    from vllm_omni.diffusion.registry import _DIFFUSION_MODELS, _DIFFUSION_POST_PROCESS_FUNCS
+
+    assert _DIFFUSION_MODELS["LTX2ConditionPipeline"] == ("ltx2", "pipeline_ltx2", "LTX2ConditionPipeline")
+    assert _DIFFUSION_POST_PROCESS_FUNCS["LTX2ConditionPipeline"] == "get_ltx2_post_process_func"
+
+
+class _StubVideoProcessor:
+    def preprocess_video(self, frames, height, width):
+        return torch.zeros(1, 3, 1, height, width)
+
+
+def _cond(index=0, strength=1.0):
+    return LTX2VideoCondition(frames=object(), index=index, strength=strength)
+
+
+def test_preprocess_conditions_rejects_empty():
+    with pytest.raises(ValueError, match="at least one condition"):
+        preprocess_conditions([], _StubVideoProcessor(), 64, 64, 8, device="cpu", dtype=torch.float32)
+
+
+@pytest.mark.parametrize("strength", [-0.1, 1.1])
+def test_preprocess_conditions_rejects_out_of_range_strength(strength):
+    with pytest.raises(ValueError, match="strength"):
+        preprocess_conditions(
+            [_cond(strength=strength)], _StubVideoProcessor(), 64, 64, 8, device="cpu", dtype=torch.float32
+        )
+
+
+def test_preprocess_conditions_rejects_out_of_range_index():
+    with pytest.raises(ValueError, match="outside the valid range"):
+        preprocess_conditions([_cond(index=8)], _StubVideoProcessor(), 64, 64, 8, device="cpu", dtype=torch.float32)
+
+
+def test_preprocess_conditions_resolves_negative_index():
+    _, strengths, indices, pixel_frames = preprocess_conditions(
+        [_cond(index=-1, strength=0.5)], _StubVideoProcessor(), 64, 64, 8, device="cpu", dtype=torch.float32
+    )
+    assert indices == [7]
+    assert strengths == [0.5]
+    assert pixel_frames == [1]
+
+
+def test_apply_first_frame_conditioning_pins_frame_zero_and_skips_keyframes():
+    latent_height, latent_width = 2, 2
+    tokens_per_frame = latent_height * latent_width
+    num_frames = 2
+    latents = torch.zeros(1, num_frames * tokens_per_frame, 4)
+    conditioning_mask = torch.zeros(1, num_frames * tokens_per_frame)
+    frame0 = torch.full((1, tokens_per_frame, 4), 5.0)
+    keyframe = torch.full((1, tokens_per_frame, 4), 9.0)
+
+    out, mask, clean = apply_first_frame_conditioning(
+        latents,
+        conditioning_mask,
+        [frame0, keyframe],
+        [1.0, 1.0],
+        [0, 1],  # index 0 applied in place; index 1 is a keyframe -> skipped here
+        latent_height=latent_height,
+        latent_width=latent_width,
+    )
+
+    assert torch.all(out[:, :tokens_per_frame] == 5.0)
+    assert torch.all(mask[:, :tokens_per_frame] == 1.0)
+    assert torch.all(clean[:, :tokens_per_frame] == 5.0)
+    # The non-zero (keyframe) index is NOT overwritten in place; it is appended separately.
+    assert torch.all(out[:, tokens_per_frame:] == 0.0)
+    assert torch.all(mask[:, tokens_per_frame:] == 0.0)
+
+
+def test_prepare_keyframe_coords_places_anchor_at_pixel_frame():
+    pipe = object.__new__(LTX2ConditionPipeline)
+    pipe.transformer_spatial_patch_size = 1
+    pipe.transformer_temporal_patch_size = 1
+    pipe.vae_spatial_compression_ratio = 32
+    pipe.vae_temporal_compression_ratio = 8
+
+    # latent_idx=2 -> pixel_frame_idx = (2 - 1) * 8 + 1 = 9
+    coords = pipe._prepare_keyframe_coords(
+        keyframe_latent_num_frames=1,
+        keyframe_latent_height=1,
+        keyframe_latent_width=1,
+        pixel_frame_idx=9,
+        num_pixel_frames=1,
+        fps=24.0,
+        device=torch.device("cpu"),
+    )
+
+    assert coords.shape[0] == 1
+    assert coords.shape[1] == 3
+    assert coords.shape[-1] == 2
+    torch.testing.assert_close(coords[0, 0, 0, 0], torch.tensor(9.0 / 24.0))
+    torch.testing.assert_close(coords[0, 0, 0, 1], torch.tensor(10.0 / 24.0))

--- a/vllm_omni/diffusion/models/ltx2/__init__.py
+++ b/vllm_omni/diffusion/models/ltx2/__init__.py
@@ -6,8 +6,10 @@ from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     get_ltx2_post_process_func,
     load_transformer_config,
 )
+from vllm_omni.diffusion.models.ltx2.ltx2_condition import LTX2VideoCondition
 from vllm_omni.diffusion.models.ltx2.ltx2_transformer import LTX2VideoTransformer3DModel
 from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import (
+    LTX2ConditionPipeline,
     LTX2I2VDMD2Pipeline,
     LTX2Pipeline,
     LTX2T2VDMD2Pipeline,
@@ -19,6 +21,8 @@ __all__ = [
     "LTX2T2VDMD2Pipeline",
     "LTX2I2VDMD2Pipeline",
     "LTX2DistilledPipeline",
+    "LTX2ConditionPipeline",
+    "LTX2VideoCondition",
     "get_ltx2_post_process_func",
     "load_transformer_config",
     "create_transformer_from_config",

--- a/vllm_omni/diffusion/models/ltx2/ltx2_condition.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_condition.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Multi-anchor frame conditioning for LTX-2 / LTX-2.3 (FLF2V / FMLF).
+
+Keyframe-interpolation building blocks for ``LTX2ConditionPipeline``. Mirrors the
+Diffusers ``LTX2ConditionPipeline`` (``diffusers/pipelines/ltx2``):
+
+* First-frame anchors (``latent_idx == 0``) overwrite the base latent timeline
+  in place (``apply_first_frame_conditioning``).
+* Non-first-frame anchors (``latent_idx > 0``) are appended as extra *keyframe
+  tokens* with their own RoPE coordinates (``_prepare_keyframe_coords``), so a
+  middle/last anchor is positioned at its own pixel-frame index. The sequence
+  grows by those tokens for the denoise loop and is trimmed before VAE decode.
+
+Re-expressed on the unified ``LTXRuntime``: conditioning is a mixin over
+``LTX2Pipeline`` mirroring ``LTXI2VConditioningMixin``. The anchor pinning runs
+through the ``_step_video_latents_i2v`` hook (which the shared step adapter calls
+whenever a conditioning mask is present), so no shared runtime file is modified.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import PIL.Image
+import torch
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import retrieve_latents
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
+
+from . import ltx2_latents as latent_ops
+from .ltx2_guidance import euler_step_from_velocity
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+    from .ltx2_conditioning import LTXPromptContext
+    from .ltx2_denoise import LTXDenoiseContext, LTXForwardContext
+    from .ltx2_request import LTXRequestInputs
+
+
+@dataclass
+class LTX2VideoCondition:
+    """A single frame-conditioning item for LTX-2 / LTX-2.3 video generation.
+
+    Ports the Diffusers ``LTX2VideoCondition`` dataclass. Used by
+    ``LTX2ConditionPipeline`` for FLF2V (first-last-frame) and FMLF
+    (first-middle-last-frame) workflows.
+
+    Attributes:
+        frames: The image (or video) to condition on. PIL, list-of-PIL, numpy
+            array, or ``torch.Tensor`` -- anything ``VideoProcessor`` handles.
+        index: The frame index at which the condition is applied. May be
+            negative (``-1`` = last frame).
+        strength: Conditioning strength in ``[0, 1]``. ``1.0`` = fully applied.
+    """
+
+    frames: PIL.Image.Image | list[PIL.Image.Image] | np.ndarray | torch.Tensor
+    index: int = 0
+    strength: float = 1.0
+
+
+@dataclass
+class _KeyframeExtras:
+    """Appended keyframe tokens for non-first-frame anchors (``latent_idx > 0``)."""
+
+    tokens: torch.Tensor  # (B, num_keyframe_tokens, C)
+    coords: torch.Tensor  # (B, 3, num_keyframe_tokens, 2) -- to append to video_coords
+    mask: torch.Tensor  # (B, num_keyframe_tokens) -- conditioning strength per token
+
+
+def preprocess_conditions(
+    conditions: list[LTX2VideoCondition],
+    video_processor: VideoProcessor,
+    height: int,
+    width: int,
+    latent_num_frames: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[list[torch.Tensor], list[float], list[int], list[int]]:
+    """Validate and preprocess a list of :class:`LTX2VideoCondition` items.
+
+    Returns parallel lists ``(frames_tensors, strengths, indices, pixel_frames)``.
+    ``pixel_frames`` is the number of pixel-space frames per condition (1 for a
+    single image), used to compute keyframe RoPE coordinates. Negative ``index``
+    values are resolved against ``latent_num_frames``.
+
+    Raises ``ValueError`` for empty input, out-of-range indices, or strengths
+    outside ``[0, 1]``.
+    """
+    if not conditions:
+        raise ValueError("LTX2ConditionPipeline requires at least one condition.")
+
+    frames_tensors: list[torch.Tensor] = []
+    strengths: list[float] = []
+    indices: list[int] = []
+    pixel_frames: list[int] = []
+    for cond in conditions:
+        if not 0.0 <= cond.strength <= 1.0:
+            raise ValueError(f"Condition strength must be in [0, 1], got {cond.strength}.")
+        resolved = cond.index if cond.index >= 0 else latent_num_frames + cond.index
+        if not 0 <= resolved < latent_num_frames:
+            raise ValueError(
+                f"Condition index {cond.index} resolves to {resolved}, "
+                f"outside the valid range [0, {latent_num_frames})."
+            )
+        frames_tensor = video_processor.preprocess_video(cond.frames, height=height, width=width).to(
+            device=device, dtype=dtype
+        )
+        frames_tensors.append(frames_tensor)
+        strengths.append(float(cond.strength))
+        indices.append(resolved)
+        pixel_frames.append(int(frames_tensor.shape[2]))
+    return frames_tensors, strengths, indices, pixel_frames
+
+
+def encode_condition_latents(
+    pipeline: Any,
+    condition_frames: list[torch.Tensor],
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    generator: torch.Generator | None,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """VAE-encode, normalize each condition tensor; return ``(latents_5d, latents_packed)``.
+
+    The unpacked 5D latents are kept for keyframe coordinate dimensions; the
+    packed 3D latents feed both first-frame replacement and keyframe append.
+    """
+    latents_5d: list[torch.Tensor] = []
+    latents_packed: list[torch.Tensor] = []
+    for condition_tensor in condition_frames:
+        condition_latent = retrieve_latents(
+            pipeline.vae.encode(condition_tensor.to(dtype=pipeline.vae.dtype)),
+            generator=generator,
+            sample_mode="argmax",
+        )
+        condition_latent = latent_ops.normalize_latents(
+            condition_latent, pipeline.vae.latents_mean, pipeline.vae.latents_std
+        ).to(device=device, dtype=dtype)
+        packed = latent_ops.pack_latents(
+            condition_latent,
+            pipeline.transformer_spatial_patch_size,
+            pipeline.transformer_temporal_patch_size,
+        )
+        latents_5d.append(condition_latent)
+        latents_packed.append(packed)
+    return latents_5d, latents_packed
+
+
+def apply_first_frame_conditioning(
+    latents: torch.Tensor,
+    conditioning_mask: torch.Tensor,
+    condition_latents: list[torch.Tensor],
+    condition_strengths: list[float],
+    condition_indices: list[int],
+    *,
+    latent_height: int,
+    latent_width: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Overwrite ``latents`` / ``conditioning_mask`` in place at the first-frame
+    positions and build the parallel ``clean_latents`` tensor.
+
+    Only conditions with ``latent_idx == 0`` are applied here (matching Diffusers'
+    ``apply_first_frame_conditioning``); non-first-frame anchors are appended as
+    keyframe tokens instead and are skipped. ``conditioning_mask`` is ``(B, N)``.
+    """
+    clean_latents = torch.zeros_like(latents)
+    for cond, strength, latent_idx in zip(condition_latents, condition_strengths, condition_indices, strict=True):
+        if latent_idx != 0:
+            continue
+        num_cond_tokens = cond.size(1)
+        start_token_idx = latent_idx * latent_height * latent_width
+        end_token_idx = start_token_idx + num_cond_tokens
+        latents[:, start_token_idx:end_token_idx] = cond
+        conditioning_mask[:, start_token_idx:end_token_idx] = strength
+        clean_latents[:, start_token_idx:end_token_idx] = cond
+    return latents, conditioning_mask, clean_latents
+
+
+class LTXMultiAnchorConditioningMixin:
+    """Multi-anchor frame conditioning (FLF2V / FMLF) for LTX-2 / LTX-2.3.
+
+    Sibling to ``LTXI2VConditioningMixin``: whereas I2V pins only the first
+    frame, this mixin pins an arbitrary set of anchor frame indices, each with
+    its own strength. Applied via MRO on top of ``LTX2Pipeline`` so it reuses the
+    prompt connector, x0-space CFG, and audio branch unchanged.
+
+    First-frame anchors overwrite the base timeline; non-first anchors are
+    appended as keyframe tokens (with their own RoPE coordinates) for the denoise
+    loop and trimmed before VAE decode. The anchor pinning runs through
+    ``_step_video_latents_i2v`` (the conditioning-step hook the shared step
+    adapter calls whenever a conditioning mask is present) as an x0-space blend
+    toward the clean anchor latents. Transient per-request state is stashed on
+    ``self`` for the duration of ``forward`` and cleared in its ``finally``. When
+    no conditions are present the pipeline degrades to the pure T2V path.
+    """
+
+    support_image_input = True
+    unified_text_image_entry = True
+    # Conditions are resolved from the first request only; disable request batching
+    # so a batch cannot silently apply one item's anchors to every output.
+    supports_request_batch = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.video_processor = VideoProcessor(
+            vae_scale_factor=self.vae_spatial_compression_ratio,
+            resample="bilinear",
+        )
+
+    @staticmethod
+    def _resolve_conditions_from_request(
+        req: DiffusionRequestBatch,
+    ) -> list[LTX2VideoCondition] | None:
+        """Read condition anchors from the request's ``multi_modal_data``.
+
+        The OpenAI-compatible serving layer stashes a list of objects exposing
+        ``.data`` (PIL image), ``.index`` (int), and ``.strength`` (float) under
+        ``prompt["multi_modal_data"]["conditions"]``. Duck-typed here so the
+        pipeline does not depend on serving types.
+        """
+        if not req.prompts:
+            return None
+        first = req.prompts[0]
+        if isinstance(first, str):
+            return None
+        multi_modal_data = first.get("multi_modal_data") or {}
+        raw_conditions = multi_modal_data.get("conditions")
+        if not raw_conditions:
+            return None
+        resolved: list[LTX2VideoCondition] = []
+        for anchor in raw_conditions:
+            if isinstance(anchor, LTX2VideoCondition):
+                resolved.append(anchor)
+                continue
+            resolved.append(
+                LTX2VideoCondition(
+                    frames=anchor.data,
+                    index=int(anchor.index),
+                    strength=float(anchor.strength),
+                )
+            )
+        return resolved or None
+
+    def _prepare_keyframe_coords(
+        self,
+        keyframe_latent_num_frames: int,
+        keyframe_latent_height: int,
+        keyframe_latent_width: int,
+        pixel_frame_idx: int,
+        num_pixel_frames: int,
+        fps: float,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """RoPE coordinates for a keyframe condition appended as extra tokens.
+
+        Ports Diffusers' ``_prepare_keyframe_coords``: latent coords are scaled to
+        pixel space *without* the first-frame causal fix, the temporal axis is
+        offset by ``pixel_frame_idx``, single-frame keyframes are clamped to a
+        one-timestep extent, and time is divided by ``fps``. Output shape
+        ``[1, 3, num_patches, 2]`` matches the base ``prepare_video_coords``
+        layout so it can be concatenated onto it.
+        """
+        patch_size = self.transformer_spatial_patch_size
+        patch_size_t = self.transformer_temporal_patch_size
+        scale_factors = (
+            self.vae_temporal_compression_ratio,
+            self.vae_spatial_compression_ratio,
+            self.vae_spatial_compression_ratio,
+        )
+
+        grid_f = torch.arange(
+            start=0, end=keyframe_latent_num_frames, step=patch_size_t, dtype=torch.float32, device=device
+        )
+        grid_h = torch.arange(start=0, end=keyframe_latent_height, step=patch_size, dtype=torch.float32, device=device)
+        grid_w = torch.arange(start=0, end=keyframe_latent_width, step=patch_size, dtype=torch.float32, device=device)
+        grid = torch.stack(torch.meshgrid(grid_f, grid_h, grid_w, indexing="ij"), dim=0)
+
+        patch_size_delta = torch.tensor((patch_size_t, patch_size, patch_size), dtype=grid.dtype, device=device)
+        patch_ends = grid + patch_size_delta.view(3, 1, 1, 1)
+
+        latent_coords = torch.stack([grid, patch_ends], dim=-1).flatten(1, 3).unsqueeze(0)  # [1, 3, num_patches, 2]
+
+        scale_tensor = torch.tensor(scale_factors, device=device, dtype=latent_coords.dtype)
+        broadcast_shape = [1] * latent_coords.ndim
+        broadcast_shape[1] = -1
+        pixel_coords = latent_coords * scale_tensor.view(*broadcast_shape)
+
+        # No causal fix: place the keyframe at `pixel_frame_idx` directly.
+        pixel_coords[:, 0, :, :] = pixel_coords[:, 0, :, :] + pixel_frame_idx
+        if num_pixel_frames == 1:
+            # Single-pixel-frame keyframe: clamp temporal extent to [idx, idx + 1).
+            pixel_coords[:, 0, :, 1:] = pixel_coords[:, 0, :, :1] + 1
+        pixel_coords[:, 0, :, :] = pixel_coords[:, 0, :, :] / fps
+        return pixel_coords
+
+    def _prepare_condition_latents(
+        self,
+        conditions: list[LTX2VideoCondition],
+        batch_size: int,
+        num_channels_latents: int,
+        height: int,
+        width: int,
+        num_frames: int,
+        frame_rate: float,
+        noise_scale: float,
+        dtype: torch.dtype | None,
+        device: torch.device | None,
+        generator: torch.Generator | list[torch.Generator] | None,
+        latents: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, _KeyframeExtras | None]:
+        """Build the base ``(latents, conditioning_mask, clean_latents)`` plus the
+        appended keyframe extras (or ``None`` if all anchors are first-frame).
+
+        ``conditioning_mask`` is packed ``(B, N)``. First-frame anchors are
+        overwritten in place; non-first anchors become keyframe tokens with their
+        own coordinates. Caller-provided ``latents`` are renoised SDEdit-style
+        (deferred two-stage Stage 2); otherwise the base state is Gaussian noise
+        at non-anchor tokens.
+        """
+        latent_height = height // self.vae_spatial_compression_ratio
+        latent_width = width // self.vae_spatial_compression_ratio
+        latent_num_frames = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
+
+        shape = (batch_size, num_channels_latents, latent_num_frames, latent_height, latent_width)
+        mask_shape = (batch_size, 1, latent_num_frames, latent_height, latent_width)
+
+        latents_supplied = latents is not None
+        if latents_supplied:
+            latents = latent_ops.normalize_latents(
+                latents, self.vae.latents_mean, self.vae.latents_std, self.vae.config.scaling_factor
+            )
+        else:
+            latents = torch.zeros(shape, device=device, dtype=dtype)
+
+        conditioning_mask = latents.new_zeros(mask_shape)
+        latents = latent_ops.pack_latents(
+            latents, self.transformer_spatial_patch_size, self.transformer_temporal_patch_size
+        )
+        conditioning_mask = latent_ops.pack_latents(
+            conditioning_mask, self.transformer_spatial_patch_size, self.transformer_temporal_patch_size
+        ).squeeze(-1)  # (B, N)
+
+        if isinstance(generator, list):
+            generator = generator[0]
+
+        condition_frames, strengths, indices, pixel_frames = preprocess_conditions(
+            conditions, self.video_processor, height, width, latent_num_frames, device=device, dtype=dtype
+        )
+        latents_5d, latents_packed = encode_condition_latents(
+            self, condition_frames, device=device, dtype=dtype, generator=generator
+        )
+
+        # First-frame anchors (latent_idx == 0): in-place overwrite.
+        latents, conditioning_mask, clean_latents = apply_first_frame_conditioning(
+            latents,
+            conditioning_mask,
+            latents_packed,
+            strengths,
+            indices,
+            latent_height=latent_height,
+            latent_width=latent_width,
+        )
+
+        # Non-first-frame anchors (latent_idx > 0): build appended keyframe tokens.
+        frame_scale_factor = self.vae_temporal_compression_ratio
+        kf_tokens, kf_coords, kf_mask = [], [], []
+        for cond_5d, cond_packed, strength, latent_idx, num_pixel_frames in zip(
+            latents_5d, latents_packed, strengths, indices, pixel_frames, strict=True
+        ):
+            if latent_idx == 0:
+                continue
+            _, _, kf_latent_frames, kf_latent_height, kf_latent_width = cond_5d.shape
+            pixel_frame_idx = (latent_idx - 1) * frame_scale_factor + 1
+            coords = self._prepare_keyframe_coords(
+                kf_latent_frames,
+                kf_latent_height,
+                kf_latent_width,
+                pixel_frame_idx,
+                num_pixel_frames,
+                frame_rate,
+                device,
+            )
+            kf_tokens.append(cond_packed)
+            kf_coords.append(coords)
+            kf_mask.append(cond_packed.new_full((cond_packed.shape[0], cond_packed.shape[1]), float(strength)))
+
+        keyframe: _KeyframeExtras | None = None
+        if kf_tokens:
+            keyframe = _KeyframeExtras(
+                tokens=torch.cat(kf_tokens, dim=1),
+                coords=torch.cat(kf_coords, dim=2),
+                mask=torch.cat(kf_mask, dim=1),
+            )
+
+        noise = randn_tensor(latents.shape, generator=generator, device=latents.device, dtype=latents.dtype)
+        effective_scale = noise_scale if latents_supplied else 1.0
+        base_scaled = (effective_scale * (1.0 - conditioning_mask)).unsqueeze(-1)
+        latents = base_scaled * noise + (1.0 - base_scaled) * latents
+
+        # Renoise keyframe tokens with the same formula (strength=1 keeps them clean).
+        if keyframe is not None:
+            kf_scaled = (effective_scale * (1.0 - keyframe.mask)).unsqueeze(-1)
+            kf_noise = randn_tensor(
+                keyframe.tokens.shape, generator=generator, device=keyframe.tokens.device, dtype=keyframe.tokens.dtype
+            )
+            keyframe.tokens = kf_scaled * kf_noise + (1.0 - kf_scaled) * keyframe.tokens
+
+        return latents, conditioning_mask, clean_latents, keyframe
+
+    def _prepare_video_latents_stage(
+        self,
+        request_inputs: LTXRequestInputs,
+        prompt_context: LTXPromptContext,
+        *,
+        device: torch.device,
+        noise_scale: float,
+        image: Any | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        conditions = getattr(self, "_pending_conditions", None)
+        if not conditions:
+            return super()._prepare_video_latents_stage(
+                request_inputs, prompt_context, device=device, noise_scale=noise_scale, image=image
+            )
+
+        latents, conditioning_mask, clean_latents, keyframe = self._prepare_condition_latents(
+            conditions,
+            prompt_context.batch_size * request_inputs.num_videos_per_prompt,
+            self.transformer.config.in_channels,
+            request_inputs.height,
+            request_inputs.width,
+            request_inputs.num_frames,
+            request_inputs.frame_rate,
+            noise_scale,
+            prompt_context.positive_connector_prompt_embeds.dtype,
+            device,
+            request_inputs.generator,
+            request_inputs.latents,
+        )
+
+        # The step hook operates on the *extended* sequence (base + keyframe
+        # tokens); build the full mask + clean latents for it here.
+        if keyframe is not None:
+            full_mask = torch.cat([conditioning_mask, keyframe.mask], dim=1)
+            full_clean = torch.cat([clean_latents, keyframe.tokens], dim=1)
+        else:
+            full_mask, full_clean = conditioning_mask, clean_latents
+
+        self._pending_keyframe = keyframe
+        self._pending_num_keyframe_tokens = keyframe.tokens.shape[1] if keyframe is not None else 0
+        self._pending_conditioning_mask = full_mask
+        self._pending_clean_latents = full_clean
+        return latents, conditioning_mask
+
+    def _step_video_latents_i2v(
+        self,
+        noise_pred_video: torch.Tensor,
+        latents: torch.Tensor,
+        step_index: int,
+        latent_num_frames: int,
+        latent_height: int,
+        latent_width: int,
+    ) -> torch.Tensor:
+        # Pin every conditioned token (first-frame slots + appended keyframe
+        # tokens) via an x0-space blend, then take the Euler step. Operates on the
+        # packed sequence directly so it is agnostic to the appended keyframes.
+        mask = getattr(self, "_pending_conditioning_mask", None)
+        clean = getattr(self, "_pending_clean_latents", None)
+        if mask is None or clean is None:
+            return super()._step_video_latents_i2v(
+                noise_pred_video, latents, step_index, latent_num_frames, latent_height, latent_width
+            )
+        bsz = latents.size(0)
+        if mask.shape[0] != bsz:
+            mask = mask[:bsz]
+            clean = clean[:bsz]
+        sigma = self.scheduler.sigmas[step_index].to(latents.dtype)
+        mask_3d = mask.unsqueeze(-1)
+        x0 = latents - noise_pred_video * sigma
+        x0_blended = x0 * (1 - mask_3d) + clean * mask_3d
+        velocity_corr = (latents - x0_blended) / sigma
+        return euler_step_from_velocity(latents, velocity_corr, self.scheduler.sigmas, step_index)
+
+    def _prepare_denoise_context_for_cfg(
+        self,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+    ) -> LTXDenoiseContext:
+        # Extend the sequence with keyframe tokens/coords/mask *before* the base
+        # CFG prep duplicates video_coords, so the extras get duplicated too.
+        keyframe = getattr(self, "_pending_keyframe", None)
+        if keyframe is not None:
+            denoise_ctx.latents = torch.cat([denoise_ctx.latents, keyframe.tokens], dim=1)
+            denoise_ctx.video_coords = torch.cat([denoise_ctx.video_coords, keyframe.coords], dim=2)
+            if denoise_ctx.conditioning_mask is not None:
+                denoise_ctx.conditioning_mask = torch.cat([denoise_ctx.conditioning_mask, keyframe.mask], dim=1)
+
+        denoise_ctx = super()._prepare_denoise_context_for_cfg(forward_ctx, denoise_ctx)
+        if denoise_ctx.conditioning_mask is None:
+            return denoise_ctx
+
+        mask_batch = denoise_ctx.conditioning_mask.shape[0]
+        model_batch = denoise_ctx.video_coords.shape[0]
+        if model_batch % mask_batch != 0:
+            raise ValueError(
+                f"Condition mask batch must divide the Transformer input batch, but got {mask_batch} and {model_batch}."
+            )
+        repeats = model_batch // mask_batch
+        denoise_ctx.conditioning_mask_for_model = (
+            denoise_ctx.conditioning_mask if repeats == 1 else torch.cat([denoise_ctx.conditioning_mask] * repeats)
+        )
+        return denoise_ctx
+
+    def _denoise_timestep_kwargs(
+        self,
+        ts: torch.Tensor,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+        *,
+        video_token_count: int,
+        audio_token_count: int,
+    ) -> dict[str, torch.Tensor]:
+        kwargs = super()._denoise_timestep_kwargs(
+            ts, forward_ctx, denoise_ctx, video_token_count=video_token_count, audio_token_count=audio_token_count
+        )
+        conditioning_mask = (
+            denoise_ctx.conditioning_mask if forward_ctx.cfg_parallel_ready else denoise_ctx.conditioning_mask_for_model
+        )
+        if conditioning_mask is None:
+            return kwargs
+        kwargs.update(timestep=ts.reshape(-1, 1) * (1 - conditioning_mask))
+        return kwargs
+
+    def _video_guidance_model_sigma(
+        self,
+        sigma: torch.Tensor,
+        denoise_ctx: LTXDenoiseContext,
+    ) -> torch.Tensor:
+        if denoise_ctx.conditioning_mask is None:
+            return super()._video_guidance_model_sigma(sigma, denoise_ctx)
+        # Conditioned tokens are evaluated at timestep zero, so velocity-to-x0
+        # guidance must use that same per-token sigma.
+        return sigma.reshape(-1, 1, 1) * (1 - denoise_ctx.conditioning_mask).unsqueeze(-1)
+
+    def _unpack_and_denormalize_stage(
+        self,
+        forward_ctx: LTXForwardContext,
+        latents: torch.Tensor,
+        audio_latents: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Trim appended keyframe tokens before the base grid is unpacked.
+        num_keyframe_tokens = getattr(self, "_pending_num_keyframe_tokens", 0)
+        if num_keyframe_tokens:
+            latents = latents[:, : latents.shape[1] - num_keyframe_tokens]
+        return super()._unpack_and_denormalize_stage(forward_ctx, latents, audio_latents)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        req: DiffusionRequestBatch,
+        conditions: list[LTX2VideoCondition] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Multi-anchor conditional forward.
+
+        ``conditions=None`` triggers the request-side resolver (serving path); an
+        explicit empty list opts out. Falls back to pure T2V when no conditions
+        resolve.
+        """
+        if conditions is None:
+            conditions = self._resolve_conditions_from_request(req)
+        try:
+            self._pending_conditions = conditions or None
+            self._pending_keyframe = None
+            self._pending_num_keyframe_tokens = 0
+            self._pending_conditioning_mask = None
+            self._pending_clean_latents = None
+            return super().forward(req, **kwargs)
+        finally:
+            self._pending_conditions = None
+            self._pending_keyframe = None
+            self._pending_num_keyframe_tokens = 0
+            self._pending_conditioning_mask = None
+            self._pending_clean_latents = None

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -14,6 +14,7 @@ from .ltx2_components import LTX2_COMPONENT_PROFILE
 from .ltx2_components import (
     get_ltx2_post_process_func as get_ltx2_post_process_func,  # noqa: F401
 )
+from .ltx2_condition import LTXMultiAnchorConditioningMixin
 from .ltx2_conditioning import LTXI2VConditioningMixin
 from .ltx2_recipes import (
     LTX2_ONE_STAGE_RECIPE,
@@ -34,6 +35,15 @@ class LTX2Pipeline(LTXI2VConditioningMixin, LTXRuntime):
     _vae_modules: ClassVar[list[str]] = list(component_profile.vae_modules)
     _resident_modules: ClassVar[list[str]] = list(component_profile.resident_modules)
     supports_request_batch = True
+
+
+class LTX2ConditionPipeline(LTXMultiAnchorConditioningMixin, LTX2Pipeline):
+    """LTX-2 / LTX-2.3 one-stage multi-anchor frame conditioning entry (FLF2V / FMLF).
+
+    Keyframe interpolation: anchor a set of frames (first-last, first-middle-last,
+    ...) at given indices and strengths. Degrades to pure T2V when no conditions
+    are supplied. See :mod:`.ltx2_condition`.
+    """
 
 
 class LTX2T2VDMD2Pipeline(DMD2PipelineMixin, LTX2Pipeline):

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -86,6 +86,11 @@ _DIFFUSION_MODELS = {
         "pipeline_ltx2",
         "LTX2I2VDMD2Pipeline",
     ),
+    "LTX2ConditionPipeline": (
+        "ltx2",
+        "pipeline_ltx2",
+        "LTX2ConditionPipeline",
+    ),
     "StableAudioPipeline": (
         "stable_audio",
         "pipeline_stable_audio",
@@ -502,6 +507,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "LTX2DistilledPipeline": "get_ltx2_post_process_func",
     "LTX2T2VDMD2Pipeline": "get_ltx2_post_process_func",
     "LTX2I2VDMD2Pipeline": "get_ltx2_post_process_func",
+    "LTX2ConditionPipeline": "get_ltx2_post_process_func",
     "StableAudioPipeline": "get_stable_audio_post_process_func",
     "SoulXSingerPipeline": "get_soulxsinger_post_process_func",
     "SoulXSingerSVCPipeline": "get_soulxsinger_post_process_func",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -132,6 +132,7 @@ from vllm_omni.entrypoints.openai.serving_speech_stream import OmniStreamingSpee
 from vllm_omni.entrypoints.openai.serving_video import (
     OmniOpenAIServingVideo,
     ReferenceAudio,
+    ReferenceConditionAnchor,
     ReferenceImage,
     ReferenceVideo,
 )
@@ -144,7 +145,7 @@ from vllm_omni.entrypoints.openai.stage_params import (
 from vllm_omni.entrypoints.openai.storage import STORAGE_MANAGER, FileStorageHandle
 from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
-from vllm_omni.entrypoints.openai.video_api_utils import decode_audio_url, decode_input_reference
+from vllm_omni.entrypoints.openai.video_api_utils import decode_audio_url, decode_image_url, decode_input_reference
 from vllm_omni.entrypoints.openpi.serving import ServingRealtimeRobotOpenPI
 from vllm_omni.errors import OmniClientError
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
@@ -2839,6 +2840,7 @@ async def _run_video_generation_job(
     reference_image: ReferenceImage | None = None,
     reference_video: ReferenceVideo | None = None,
     reference_audio: ReferenceAudio | None = None,
+    reference_conditions: list[ReferenceConditionAnchor] | None = None,
     app_state: Any | None = None,
 ) -> None:
     job = await VIDEO_STORE.get(video_id)
@@ -2855,6 +2857,7 @@ async def _run_video_generation_job(
             reference_image=reference_image,
             reference_video=reference_video,
             reference_audio=reference_audio,
+            reference_conditions=reference_conditions,
         )
 
         save_context = await STORAGE_MANAGER.save(video_bytes, video_id)
@@ -2950,6 +2953,7 @@ async def _parse_video_form(
     frame_interpolation_model_path: str | None = Form(default=None),
     lora: str | None = Form(default=None),
     extra_params: str | None = Form(default=None),
+    conditions: str | None = Form(default=None),
 ) -> tuple[
     VideoGenerationRequest,
     "OmniOpenAIServingVideo",
@@ -2957,6 +2961,7 @@ async def _parse_video_form(
     ReferenceImage | None,
     ReferenceVideo | None,
     ReferenceAudio | None,
+    list[ReferenceConditionAnchor] | None,
 ]:
     """FastAPI dependency that parses video form data, validates inputs,
     resolves the handler, and decodes any reference image.
@@ -3006,6 +3011,7 @@ async def _parse_video_form(
         "frame_interpolation_model_path": frame_interpolation_model_path,
         "lora": _parse_form_json(lora, expected_type=dict),
         "extra_params": _parse_form_json(extra_params, expected_type=dict),
+        "conditions": _parse_form_json(conditions, expected_type=list),
     }
     request_data = {k: v for k, v in request_data.items() if v is not None}
     request = VideoGenerationRequest(**request_data)
@@ -3068,7 +3074,29 @@ async def _parse_video_form(
             raise HTTPException(400, detail=str(exc)) from exc
         reference_audio = ReferenceAudio(path=audio_path)
 
-    return request, handler, effective_model_name, reference_image, reference_video, reference_audio
+    reference_conditions: list[ReferenceConditionAnchor] | None = None
+    if request.conditions:
+        try:
+            reference_conditions = [
+                ReferenceConditionAnchor(
+                    data=await decode_image_url(anchor.image_url),
+                    index=anchor.index,
+                    strength=anchor.strength,
+                )
+                for anchor in request.conditions
+            ]
+        except (InvalidInputReferenceError, ValueError) as exc:
+            raise HTTPException(400, detail=str(exc) or "Invalid condition anchor.") from exc
+
+    return (
+        request,
+        handler,
+        effective_model_name,
+        reference_image,
+        reference_video,
+        reference_audio,
+        reference_conditions,
+    )
 
 
 @router.post(
@@ -3089,6 +3117,7 @@ async def create_video(
         ReferenceImage | None,
         ReferenceVideo | None,
         ReferenceAudio | None,
+        list[ReferenceConditionAnchor] | None,
     ] = Depends(_parse_video_form),
 ) -> VideoResponse:
     """Create an asynchronous video generation job.
@@ -3096,7 +3125,15 @@ async def create_video(
     Accepts multipart form-data (see ``_parse_video_form`` for parameters),
     persists a queued job record, and starts generation in the background.
     """
-    request, handler, effective_model_name, reference_image, reference_video, reference_audio = ctx
+    (
+        request,
+        handler,
+        effective_model_name,
+        reference_image,
+        reference_video,
+        reference_audio,
+        reference_conditions,
+    ) = ctx
     ref = video_response_from_request(effective_model_name, request)
     await VIDEO_STORE.upsert(ref.id, ref)
     task = asyncio.create_task(
@@ -3107,6 +3144,7 @@ async def create_video(
             reference_image,
             reference_video,
             reference_audio,
+            reference_conditions=reference_conditions,
             app_state=raw_request.app.state,
         )
     )
@@ -3132,6 +3170,7 @@ async def create_video_sync(
         ReferenceImage | None,
         ReferenceVideo | None,
         ReferenceAudio | None,
+        list[ReferenceConditionAnchor] | None,
     ] = Depends(_parse_video_form),
 ) -> Response:
     """Synchronous video generation endpoint.
@@ -3143,7 +3182,15 @@ async def create_video_sync(
     Metadata is returned via response headers ``X-Request-Id``,
     ``X-Model``, and ``X-Inference-Time-S``.
     """
-    request, handler, effective_model_name, reference_image, reference_video, reference_audio = ctx
+    (
+        request,
+        handler,
+        effective_model_name,
+        reference_image,
+        reference_video,
+        reference_audio,
+        reference_conditions,
+    ) = ctx
     request_id = f"video_sync-{random_uuid()}"
     raw_request.state.request_metadata = RequestResponseMetadata(request_id=request_id)
     started_at = time.perf_counter()
@@ -3155,6 +3202,7 @@ async def create_video_sync(
                 reference_image=reference_image,
                 reference_video=reference_video,
                 reference_audio=reference_audio,
+                reference_conditions=reference_conditions,
             ),
             timeout=VIDEO_SYNC_TIMEOUT_S,
         )

--- a/vllm_omni/entrypoints/openai/protocol/videos.py
+++ b/vllm_omni/entrypoints/openai/protocol/videos.py
@@ -94,6 +94,33 @@ class UrlAudioReference(BaseModel):
 AudioReference = UrlAudioReference
 
 
+class VideoConditionAnchor(BaseModel):
+    """One anchor in a multi-anchor frame conditioning request (FLF2V / FMLF).
+
+    Used by pipelines that accept a list of frames anchored at specific latent
+    indices (e.g. ``LTX2ConditionPipeline``). Mirrors the ``ImageReference``
+    convention: ``image_url`` accepts ``data:`` URLs (base64) and
+    ``http(s)://`` URLs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    image_url: str = Field(
+        ...,
+        description="Image source for this anchor. Accepts a data: URL (base64) or http(s):// URL.",
+    )
+    index: int = Field(
+        ...,
+        description="Latent frame index for this anchor. Negative values resolve from the end (-1 = last).",
+    )
+    strength: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="Per-anchor conditioning strength (1.0 = hard pin, 0.0 = no-op).",
+    )
+
+
 class VideoGenerationRequest(BaseModel):
     """
     OpenAI-style video generation request.
@@ -127,6 +154,17 @@ class VideoGenerationRequest(BaseModel):
     audio_reference: AudioReference | None = Field(
         default=None,
         description="Optional audio reference for speech-to-video. Provide audio_url (http(s) or data URL).",
+    )
+
+    conditions: list[VideoConditionAnchor] | None = Field(
+        default=None,
+        description=(
+            "Multi-anchor frame conditioning (FLF2V / FMLF). Each entry pins the latent at `index` "
+            "to the image at `image_url` with `strength`. Consumed by pipelines that support "
+            "multi-anchor conditioning (e.g., `LTX2ConditionPipeline`). Anchors are resized to the "
+            "output resolution, so keep base64 `data:` images small (or use an http(s) URL) to stay "
+            "under the multipart request size limit."
+        ),
     )
 
     # Video params block for extensibility

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -60,6 +60,19 @@ class ReferenceAudio:
 
 
 @dataclass
+class ReferenceConditionAnchor:
+    """One decoded anchor for multi-anchor frame conditioning (FLF2V / FMLF).
+
+    Carries the decoded PIL image together with the per-anchor latent ``index``
+    and ``strength`` from the HTTP request, ready for the pipeline to consume.
+    """
+
+    data: Image.Image
+    index: int
+    strength: float
+
+
+@dataclass
 class VideoGenerationArtifacts:
     """Normalized outputs and profiler metadata extracted from one request."""
 
@@ -118,6 +131,7 @@ class OmniOpenAIServingVideo:
         reference_image: ReferenceImage | None = None,
         reference_video: ReferenceVideo | None = None,
         reference_audio: ReferenceAudio | None = None,
+        reference_conditions: list[ReferenceConditionAnchor] | None = None,
     ) -> VideoGenerationArtifacts:
         """Run the generation pipeline and extract video/audio/profiler outputs."""
         prompt: OmniTextPrompt = OmniTextPrompt(prompt=request.prompt, modalities=["video"])
@@ -140,6 +154,18 @@ class OmniOpenAIServingVideo:
             target_size = (vp.width, vp.height)
             if input_image.size != target_size:
                 input_image = input_image.resize(target_size, Image.Resampling.LANCZOS)
+        if reference_conditions and vp.width is not None and vp.height is not None:
+            target_size = (vp.width, vp.height)
+            reference_conditions = [
+                ReferenceConditionAnchor(
+                    data=anchor.data.resize(target_size, Image.Resampling.LANCZOS)
+                    if anchor.data.size != target_size
+                    else anchor.data,
+                    index=anchor.index,
+                    strength=anchor.strength,
+                )
+                for anchor in reference_conditions
+            ]
         multi_modal_data: dict[str, Any] = {}
         if input_image is not None:
             multi_modal_data["image"] = input_image
@@ -147,6 +173,8 @@ class OmniOpenAIServingVideo:
             multi_modal_data["video"] = input_video
         if reference_audio is not None:
             multi_modal_data["audio"] = reference_audio.path
+        if reference_conditions:
+            multi_modal_data["conditions"] = reference_conditions
         if multi_modal_data:
             prompt["multi_modal_data"] = multi_modal_data
         if vp.width is not None and vp.height is not None:
@@ -259,6 +287,7 @@ class OmniOpenAIServingVideo:
         reference_image: ReferenceImage | None = None,
         reference_video: ReferenceVideo | None = None,
         reference_audio: ReferenceAudio | None = None,
+        reference_conditions: list[ReferenceConditionAnchor] | None = None,
     ) -> VideoGenerationResponse:
         artifacts = await self._run_and_extract(
             request,
@@ -266,6 +295,7 @@ class OmniOpenAIServingVideo:
             reference_image=reference_image,
             reference_video=reference_video,
             reference_audio=reference_audio,
+            reference_conditions=reference_conditions,
         )
 
         video_codec_options = {"preset": "ultrafast", "threads": "0"}
@@ -308,6 +338,7 @@ class OmniOpenAIServingVideo:
         reference_image: ReferenceImage | None = None,
         reference_video: ReferenceVideo | None = None,
         reference_audio: ReferenceAudio | None = None,
+        reference_conditions: list[ReferenceConditionAnchor] | None = None,
     ) -> tuple[bytes, dict[str, float], float, VideoAction | None]:
         """Generate a video and return raw MP4 bytes, bypassing base64 encoding."""
         artifacts = await self._run_and_extract(
@@ -316,6 +347,7 @@ class OmniOpenAIServingVideo:
             reference_image=reference_image,
             reference_video=reference_video,
             reference_audio=reference_audio,
+            reference_conditions=reference_conditions,
         )
         if len(artifacts.videos) > 1:
             logger.warning(


### PR DESCRIPTION
## What

Adds `LTX23ConditionPipeline`, a one-stage multi-anchor **keyframe-interpolation**
pipeline for LTX-2.3 (FLF2V / FMLF), built on the unified `LTXPipelineRuntime`
from #5147. Anchors pin arbitrary frame indices (each with its own strength) and
the model interpolates the motion between them under text + audio conditioning.

Addresses the *keyframe interpolation* item of #4985.

## How

- **`LTXMultiAnchorConditioningMixin`** — sibling to `LTXI2VConditioningMixin`.
  Where I2V pins only frame 0, this generalizes to a set of anchor indices,
  reusing the existing `conditioning_mask` / video-audio-scheduler / timestep
  hooks. **No shared runtime file is modified.**
- **`LTX23ConditionPipeline(LTXMultiAnchorConditioningMixin, LTX23Pipeline)`** —
  thin MRO composition; inherits x0 guidance, component profile and denoise loop.
  Degrades to pure T2V when no conditions are supplied.
- **`ConditionVideoAudioScheduler`** — applies the x0-space anchor blend during
  the loop; the mask and clean latents are captured at construction, so no
  mutable per-step pipeline state is introduced.
- Everything lives in a self-contained new module `ltx2_condition.py`.

## Files

- `vllm_omni/diffusion/models/ltx2/ltx2_condition.py` (new)
- `vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py`, `__init__.py`,
  `vllm_omni/diffusion/registry.py` (register + export)
- `tests/diffusion/models/ltx2/test_ltx2_condition.py` (new)
- `docs/models/supported_models.md`

## Testing

- **Unit + structural (CI, `core_model`/`cpu`, no GPU):** MRO / guidance / hook /
  registry contracts, condition validation, `apply_visual_conditioning` token
  pinning.
- **Forward-path (CI, CPU):** condition resolution from `multi_modal_data`,
  pure-T2V fallback when no conditions, and the anchor timestep-masking hook
  (`timestep = t·(1 − mask)`, audio unmasked).
- **End-to-end (manual, H100 / Modal):** FLF2V & FMLF requests generate coherent
  video + audio with anchors correctly pinned at first / middle / last frames.
- **Deferred to follow-up:** a checked-in GPU accuracy/similarity E2E test (needs
  weights + GPU CI), in the spirit of `tests/e2e/accuracy/test_ltx2_3_video_similarity.py`.

## Scope / follow-ups

- **One-stage only.** The two-stage condition variant is intentionally held until
  the Standard / Full-distilled recipe layer lands, so it builds on that rather
  than the legacy `LTX2TwoStagesPipeline` path.
- **HTTP serving** for `conditions` (request schema → `multi_modal_data["conditions"]`)
  is a **follow-up PR**. The pipeline reads conditions defensively, so it is
  independently mergeable. Two open contract questions for the serving layer:
  1. Should multi-anchor input flow through the same `multi_modal_data` path as
     I2V, or do you want a dedicated anchor schema?
  2. Any objection to a public `LTX23ConditionPipeline` class as the entry point,
     mirroring `LTX23ImageToVideoPipeline`?

---

cc @mglyn — following up on #4985, where you noted keyframe interpolation would be
welcome once it can build on the shared pipeline framework. This is that work,
re-expressed on the merged `LTXPipelineRuntime`. Happy to adjust the entry-point
and request-schema contract per your answer to the two questions above.
