### PR TITLE
[Perf][Diffusion] Add graphable functional collectives for Ulysses SP and enable BOOGU Image

### DIFF
--- a/benchmarks/diffusion/benchmark_boogu_graphable_sp.py
+++ b/benchmarks/diffusion/benchmark_boogu_graphable_sp.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Compare native and graphable BOOGU Ulysses SP on two CUDA GPUs.
+
+Each backend runs in a fresh process group. Alternating separately compiled
+native and functional graphs in one process measurably distorts the functional
+latency, especially for small shapes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import socket
+import statistics
+import tempfile
+import time
+from collections.abc import Callable
+from functools import partial
+
+import torch
+import torch.distributed as dist
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+from vllm_omni.diffusion.config import set_current_diffusion_config
+from vllm_omni.diffusion.data import (
+    DiffusionParallelConfig,
+    OmniDiffusionConfig,
+)
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.forward_context import (
+    get_forward_context,
+    set_forward_context,
+)
+from vllm_omni.platforms import current_omni_platform
+
+DIM = 3360
+NUM_HEADS = 28
+NUM_KV_HEADS = 7
+HEAD_DIM = 120
+CASES = ("native", "functional")
+DEFAULT_SHAPES = (
+    (1024, 1),
+    (1024, 2),
+    (1024, 4),
+    (1024, 8),
+    (1536, 1),
+    (1536, 2),
+    (1536, 4),
+    (2048, 1),
+    (2048, 2),
+)
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _parse_shape(value: str) -> tuple[int, int]:
+    try:
+        resolution, batch_size = (int(part) for part in value.lower().split("x", 1))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shape must be RESOLUTIONxBATCH, for example 1024x4") from exc
+    if resolution <= 0 or batch_size <= 0 or resolution % 16 != 0:
+        raise argparse.ArgumentTypeError("resolution and batch must be positive, and resolution must divide by 16")
+    return resolution, batch_size
+
+
+def _make_config(communication_backend: str) -> OmniDiffusionConfig:
+    return OmniDiffusionConfig(
+        model="boogu-graphable-sp-benchmark",
+        dtype=torch.bfloat16,
+        parallel_config=DiffusionParallelConfig(
+            sequence_parallel_size=2,
+            ulysses_degree=2,
+            ulysses_mode="advanced_uaa",
+            sp_communication_backend=communication_backend,
+        ),
+    )
+
+
+def _measure(
+    functions: dict[str, Callable[[], torch.Tensor]],
+    *,
+    rank: int,
+    warmup: int,
+    iterations: int,
+    repeats: int,
+) -> dict[str, object]:
+    names = tuple(functions)
+    for _ in range(warmup):
+        for name in names:
+            functions[name]()
+    torch.accelerator.synchronize()
+    dist.barrier(device_ids=[rank])
+
+    trials: dict[str, list[float]] = {name: [] for name in names}
+    for repeat in range(repeats):
+        offset = repeat % len(names)
+        order = names[offset:] + names[:offset]
+        for name in order:
+            dist.barrier(device_ids=[rank])
+            torch.accelerator.synchronize()
+            started = time.perf_counter()
+            for _ in range(iterations):
+                functions[name]()
+            torch.accelerator.synchronize()
+            elapsed = torch.tensor(
+                [(time.perf_counter() - started) * 1000.0 / iterations],
+                device=torch.device("cuda", rank),
+                dtype=torch.float64,
+            )
+            dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+            trials[name].append(float(elapsed.item()))
+
+    medians = {name: statistics.median(values) for name, values in trials.items()}
+    result = {
+        "trials_ms": trials,
+        "median_ms": medians,
+        "min_ms": {name: min(values) for name, values in trials.items()},
+        "max_ms": {name: max(values) for name, values in trials.items()},
+    }
+    if "native" in medians and "functional" in medians:
+        result["functional_vs_native_pct"] = (medians["native"] / medians["functional"] - 1.0) * 100.0
+    return result
+
+
+def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
+    world_size = 2
+    os.environ.update(
+        {
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "DIFFUSION_ATTENTION_BACKEND": "FLASH_ATTN",
+        }
+    )
+    device = torch.device(f"cuda:{rank}")
+    current_omni_platform.set_device(device)
+    init_distributed_environment(world_size=world_size, rank=rank)
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=world_size,
+        ring_degree=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+
+    try:
+        from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+            BooguImageTransformerBlock,
+        )
+
+        run_config = _make_config("functional")
+        with (
+            set_current_vllm_config(VllmConfig(device_config=DeviceConfig(device=str(device)))),
+            set_forward_context(omni_diffusion_config=run_config),
+            set_current_diffusion_config(run_config),
+            torch.inference_mode(),
+        ):
+            get_forward_context()._sp_shard_depth = 1
+            common_kwargs = {
+                "dim": DIM,
+                "num_attention_heads": NUM_HEADS,
+                "num_kv_heads": NUM_KV_HEADS,
+                "multiple_of": 256,
+                "ffn_dim_multiplier": None,
+                "norm_eps": 1e-5,
+                "modulation": False,
+            }
+            forwards: dict[
+                str,
+                Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+            ] = {}
+            reference_state = None
+            for case in args.case:
+                case_config = _make_config(case)
+                with (
+                    set_forward_context(omni_diffusion_config=case_config),
+                    set_current_diffusion_config(case_config),
+                ):
+                    get_forward_context()._sp_shard_depth = 1
+                    torch.manual_seed(args.seed)
+                    block = BooguImageTransformerBlock(
+                        **common_kwargs,
+                    ).to(device=device, dtype=torch.bfloat16)
+                block.eval()
+                if reference_state is None:
+                    reference_state = block.state_dict()
+                else:
+                    block.load_state_dict(reference_state)
+
+                def forward(
+                    hidden: torch.Tensor,
+                    rope: torch.Tensor,
+                    *,
+                    selected_block=block,
+                ) -> torch.Tensor:
+                    return selected_block(hidden, None, rope)
+
+                forwards[case] = (
+                    torch.compile(
+                        forward,
+                        dynamic=True,
+                        fullgraph=args.fullgraph,
+                    )
+                    if not args.eager
+                    else forward
+                )
+
+            results = []
+            for resolution, batch_size in args.shape:
+                global_seq_len = (resolution // 16) ** 2
+                local_seq_len = global_seq_len // world_size
+                generator = torch.Generator(device=device).manual_seed(args.seed + rank)
+                hidden_states = torch.randn(
+                    batch_size,
+                    local_seq_len,
+                    DIM,
+                    device=device,
+                    dtype=torch.bfloat16,
+                    generator=generator,
+                )
+                rotary_emb = torch.ones(
+                    batch_size,
+                    local_seq_len,
+                    HEAD_DIM // 2,
+                    device=device,
+                    dtype=torch.complex64,
+                )
+                functions = {name: partial(forward, hidden_states, rotary_emb) for name, forward in forwards.items()}
+
+                max_abs_error = None
+                if "native" in functions and "functional" in functions:
+                    with torch.inference_mode():
+                        native_output = functions["native"]()
+                        functional_output = functions["functional"]()
+                    max_abs_error = float((native_output - functional_output).abs().max().item())
+                measurement = _measure(
+                    functions,
+                    rank=rank,
+                    warmup=args.warmup,
+                    iterations=args.iterations,
+                    repeats=args.repeats,
+                )
+                result = {
+                    "resolution": resolution,
+                    "batch_size": batch_size,
+                    "global_seq_len": global_seq_len,
+                    "local_seq_len": local_seq_len,
+                    "compiled": not args.eager,
+                    "fullgraph": args.fullgraph,
+                    "cases": list(args.case),
+                    "max_abs_error": max_abs_error,
+                    **measurement,
+                }
+                results.append(result)
+                if rank == 0 and getattr(args, "_emit_results", True):
+                    print(
+                        "BOOGU_GRAPHABLE_SP_POINT=" + json.dumps(result, sort_keys=True),
+                        flush=True,
+                    )
+                del hidden_states, rotary_emb
+                torch.accelerator.empty_cache()
+
+            if rank == 0:
+                payload = json.dumps(results, sort_keys=True)
+                if getattr(args, "_emit_results", True):
+                    print(
+                        "BOOGU_GRAPHABLE_SP_RESULT=" + payload,
+                        flush=True,
+                    )
+                if args.output_json:
+                    with open(
+                        args.output_json,
+                        "w",
+                        encoding="utf-8",
+                    ) as output:
+                        output.write(payload + "\n")
+    finally:
+        destroy_distributed_env()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=_parse_shape,
+        default=None,
+        help="RESOLUTIONxBATCH; repeat for multiple points",
+    )
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--seed", type=int, default=20260726)
+    parser.add_argument("--eager", action="store_true")
+    parser.add_argument("--fullgraph", action="store_true")
+    parser.add_argument("--output-json")
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=CASES,
+        default=None,
+        help="backend to measure; repeat for an interleaved comparison",
+    )
+    args = parser.parse_args()
+    args.shape = tuple(args.shape or DEFAULT_SHAPES)
+    args.case = tuple(dict.fromkeys(args.case or CASES))
+    for name in ("warmup", "iterations", "repeats"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name} must be positive")
+    return args
+
+
+def _spawn_workers(args: argparse.Namespace) -> None:
+    torch.multiprocessing.spawn(
+        _worker,
+        args=(_find_free_port(), args),
+        nprocs=2,
+    )
+
+
+def _merge_isolated_results(
+    results_by_case: dict[str, list[dict[str, object]]],
+    cases: tuple[str, ...],
+) -> list[dict[str, object]]:
+    merged_results = []
+    for index, template in enumerate(results_by_case[cases[0]]):
+        merged = {
+            name: template[name]
+            for name in (
+                "resolution",
+                "batch_size",
+                "global_seq_len",
+                "local_seq_len",
+                "compiled",
+                "fullgraph",
+            )
+        }
+        merged.update(
+            {
+                "cases": list(cases),
+                "max_abs_error": None,
+                "trials_ms": {},
+                "median_ms": {},
+                "min_ms": {},
+                "max_ms": {},
+            }
+        )
+        for case in cases:
+            result = results_by_case[case][index]
+            if (
+                result["resolution"],
+                result["batch_size"],
+            ) != (
+                merged["resolution"],
+                merged["batch_size"],
+            ):
+                raise RuntimeError("Isolated benchmark result order differs.")
+            for metric in (
+                "trials_ms",
+                "median_ms",
+                "min_ms",
+                "max_ms",
+            ):
+                merged[metric][case] = result[metric][case]
+        medians = merged["median_ms"]
+        if "native" in medians and "functional" in medians:
+            merged["functional_vs_native_pct"] = (medians["native"] / medians["functional"] - 1.0) * 100.0
+        merged_results.append(merged)
+    return merged_results
+
+
+def _run_isolated_cases(args: argparse.Namespace) -> None:
+    """Run each backend in a fresh process group, then merge its measurements."""
+    results_by_case = {}
+    with tempfile.TemporaryDirectory(prefix="boogu_graphable_sp_") as temp_dir:
+        for case in args.case:
+            case_args = copy.copy(args)
+            case_args.case = (case,)
+            case_args.output_json = os.path.join(
+                temp_dir,
+                f"{case}.json",
+            )
+            case_args._emit_results = False
+            _spawn_workers(case_args)
+            with open(
+                case_args.output_json,
+                encoding="utf-8",
+            ) as result_file:
+                results_by_case[case] = json.load(result_file)
+
+    results = _merge_isolated_results(results_by_case, args.case)
+    for result in results:
+        print(
+            "BOOGU_GRAPHABLE_SP_POINT=" + json.dumps(result, sort_keys=True),
+            flush=True,
+        )
+    payload = json.dumps(results, sort_keys=True)
+    print("BOOGU_GRAPHABLE_SP_RESULT=" + payload, flush=True)
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as output:
+            output.write(payload + "\n")
+
+
+if __name__ == "__main__":
+    parsed_args = _parse_args()
+    if not current_omni_platform.is_cuda() or current_omni_platform.get_device_count() < 2:
+        raise RuntimeError("This benchmark requires two CUDA GPUs.")
+    if len(parsed_args.case) == 1:
+        _spawn_workers(parsed_args)
+    else:
+        _run_isolated_cases(parsed_args)

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -433,6 +433,7 @@ def test_sub_config_fields_match_rfc_scopes():
         "ring_degree",
         "allgather_degree",
         "ulysses_mode",
+        "sp_communication_backend",
         "cfg_parallel_size",
         "vae_patch_parallel_size",
         "vae_parallel_mode",
@@ -580,6 +581,24 @@ def test_diffusion_parallel_config_rejects_cfg_parallel_size_outside_current_bou
 def test_diffusion_parallel_config_rejects_allgather_with_ulysses_or_ring():
     with pytest.raises(ValidationError):
         OmniStageDiffusionParallelConfig(allgather_degree=2, ulysses_degree=2)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "ring_degree": 2,
+            "sp_communication_backend": "functional",
+        },
+        {
+            "allgather_degree": 2,
+            "sp_communication_backend": "functional",
+        },
+    ],
+)
+def test_diffusion_parallel_config_limits_functional_backend_to_ulysses(kwargs):
+    with pytest.raises(ValidationError, match="pure Ulysses"):
+        OmniStageDiffusionParallelConfig(**kwargs)
 
 
 def test_stage_realizations_use_stage_specific_parallel_config_types():

--- a/tests/diffusion/attention/test_ulysses_uaa.py
+++ b/tests/diffusion/attention/test_ulysses_uaa.py
@@ -22,6 +22,30 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 from vllm_omni.diffusion.forward_context import get_forward_context, set_forward_context
 from vllm_omni.platforms import current_omni_platform
 
+pytestmark = [
+    pytest.mark.diffusion,
+    pytest.mark.parallel,
+    pytest.mark.core_model,
+    pytest.mark.gpu,
+]
+
+
+def test_uaa_head_plan_preserves_gqa_ratio() -> None:
+    from vllm_omni.diffusion.attention.parallel.ulysses import (
+        _UlyssesHeadPlan,
+    )
+
+    plan = _UlyssesHeadPlan.build(
+        query_heads=28,
+        kv_heads=7,
+        world_size=2,
+        mode="advanced_uaa",
+    )
+
+    assert plan.padded_query_heads == 32
+    assert plan.padded_kv_heads == 8
+    assert plan.padded_query_heads // plan.padded_kv_heads == plan.query_heads // plan.kv_heads
+
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/tests/diffusion/distributed/test_comm.py
+++ b/tests/diffusion/distributed/test_comm.py
@@ -7,14 +7,27 @@ import os
 import pytest
 import torch
 
-from vllm_omni.diffusion.distributed.comm import RingComm, SeqAllToAll4D, SeqAllToAll5D
+from vllm_omni.diffusion.distributed.comm import (
+    RingComm,
+    SeqAllToAll4D,
+    SeqAllToAll5D,
+    all_to_all_4D,
+)
 from vllm_omni.diffusion.distributed.parallel_state import (
     destroy_distributed_env,
     get_sp_group,
     init_distributed_environment,
     initialize_model_parallel,
 )
+from vllm_omni.diffusion.distributed.sp_sharding import sp_gather
 from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [
+    pytest.mark.diffusion,
+    pytest.mark.parallel,
+    pytest.mark.core_model,
+    pytest.mark.gpu,
+]
 
 
 def update_environment_variables(envs_dict: dict[str, str]):
@@ -155,6 +168,125 @@ def _test_4d_identity_worker(
 
     # Cleanup distributed environment
     destroy_distributed_env()
+
+
+def test_functional_4d_is_graphable_and_matches_native():
+    """Functional 4D resharding must be equivalent and compile as one graph."""
+    if not current_omni_platform.is_cuda():
+        pytest.skip("Functional sequence-parallel collectives require CUDA/NCCL")
+    if current_omni_platform.get_device_count() < 2:
+        pytest.skip("Test requires 2 GPUs")
+
+    torch.multiprocessing.spawn(
+        _test_functional_4d_worker,
+        args=(2,),
+        nprocs=2,
+    )
+
+
+def _test_functional_4d_worker(local_rank: int, world_size: int):
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "29502",
+        }
+    )
+
+    init_distributed_environment()
+    initialize_model_parallel(ulysses_degree=world_size)
+    group = get_sp_group().ulysses_group
+    try:
+        torch.manual_seed(42 + local_rank)
+        input_tensor = torch.randn(
+            2,
+            8,
+            8,
+            32,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        expected = all_to_all_4D(
+            input_tensor,
+            scatter_idx=2,
+            gather_idx=1,
+            group=group,
+            communication_backend="native",
+            world_size=world_size,
+        )
+
+        def functional_forward(tensor: torch.Tensor) -> torch.Tensor:
+            return all_to_all_4D(
+                tensor,
+                scatter_idx=2,
+                gather_idx=1,
+                group=group,
+                communication_backend="functional",
+                world_size=world_size,
+            )
+
+        compiled_forward = torch.compile(
+            functional_forward,
+            fullgraph=True,
+            dynamic=False,
+        )
+        actual = compiled_forward(input_tensor)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+        def functional_reverse(tensor: torch.Tensor) -> torch.Tensor:
+            return all_to_all_4D(
+                tensor,
+                scatter_idx=1,
+                gather_idx=2,
+                group=group,
+                communication_backend="functional",
+                world_size=world_size,
+            )
+
+        compiled_reverse = torch.compile(
+            functional_reverse,
+            fullgraph=True,
+            dynamic=False,
+        )
+        restored = compiled_reverse(actual)
+        torch.testing.assert_close(restored, input_tensor, rtol=0, atol=0)
+
+        local_output = torch.full(
+            (1, 3, 2),
+            local_rank,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+
+        def functional_gather(tensor: torch.Tensor) -> torch.Tensor:
+            return sp_gather(
+                tensor,
+                dim=1,
+                communication_backend="functional",
+            )
+
+        compiled_gather = torch.compile(
+            functional_gather,
+            fullgraph=True,
+            dynamic=False,
+        )
+        gathered = compiled_gather(local_output)
+        expected_gather = torch.cat(
+            [torch.full_like(local_output, rank) for rank in range(world_size)],
+            dim=1,
+        )
+        torch.testing.assert_close(
+            gathered,
+            expected_gather,
+            rtol=0,
+            atol=0,
+        )
+    finally:
+        destroy_distributed_env()
 
 
 @pytest.mark.parametrize("world_size", [2, 4])

--- a/tests/diffusion/distributed/test_sp_plan_hooks.py
+++ b/tests/diffusion/distributed/test_sp_plan_hooks.py
@@ -1029,6 +1029,160 @@ class TestStrictModeSplitValidation:
 
 
 @pytest.mark.cpu
+class TestKeyedSequenceShardMetadata:
+    """Test independent sequence padding metadata used by public SP hooks."""
+
+    def test_local_prefix_and_segment_lengths(self):
+        from vllm_omni.diffusion.distributed.sp_sharding import (
+            SequenceShardMetadata,
+        )
+
+        rank_zero = SequenceShardMetadata.from_global_length(
+            5,
+            world_size=2,
+            rank=0,
+        )
+        rank_one = SequenceShardMetadata.from_global_length(
+            5,
+            world_size=2,
+            rank=1,
+        )
+
+        assert rank_zero.padded_seq_len == 6
+        assert rank_zero.local_seq_len == 3
+        assert rank_zero.local_valid_lengths([5, 2]) == [3, 2]
+        assert rank_one.local_valid_lengths([5, 2]) == [2, 0]
+        assert rank_zero.local_segment_lengths([[2, 3]]) == [[2, 1]]
+        assert rank_one.local_segment_lengths([[2, 3]]) == [[0, 2]]
+
+    def test_auto_pad_tracks_independent_groups(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from vllm_omni.diffusion.attention import selector
+        from vllm_omni.diffusion.distributed import parallel_state
+        from vllm_omni.diffusion.distributed.sp_plan import (
+            SequenceParallelConfig,
+        )
+        from vllm_omni.diffusion.forward_context import (
+            get_forward_context,
+            set_forward_context,
+        )
+        from vllm_omni.diffusion.hooks.sequence_parallel import (
+            SequenceParallelSplitHook,
+        )
+
+        class MaskBackend:
+            supports_attention_mask = True
+
+            @staticmethod
+            def get_name():
+                return "test"
+
+        monkeypatch.setattr(
+            parallel_state,
+            "get_sequence_parallel_world_size",
+            lambda: 2,
+        )
+        monkeypatch.setattr(
+            parallel_state,
+            "get_sequence_parallel_rank",
+            lambda: 1,
+        )
+        monkeypatch.setattr(
+            parallel_state,
+            "get_ring_parallel_world_size",
+            lambda: 1,
+        )
+        monkeypatch.setattr(
+            selector,
+            "get_attn_backend_for_role",
+            lambda **_: (MaskBackend(), None),
+        )
+
+        hook = SequenceParallelSplitHook(
+            {},
+            SequenceParallelConfig(ulysses_degree=2),
+        )
+        with set_forward_context():
+            image = hook._shard_with_auto_pad(
+                torch.arange(5).reshape(1, 5, 1),
+                1,
+                "image",
+            )
+            context = hook._shard_with_auto_pad(
+                torch.arange(7).reshape(1, 7, 1),
+                1,
+                "context",
+            )
+            ctx = get_forward_context()
+
+            assert image.shape[1] == 3
+            assert context.shape[1] == 4
+            assert ctx.sp_shard_metadata["image"].original_seq_len == 5
+            assert ctx.sp_shard_metadata["context"].original_seq_len == 7
+
+            with pytest.raises(ValueError, match="same global sequence length"):
+                hook._shard_with_auto_pad(
+                    torch.zeros(1, 7, 1),
+                    1,
+                    "image",
+                )
+
+    def test_gather_uses_keyed_trim_and_configured_backend(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from vllm_omni.diffusion.distributed.sp_plan import (
+            SequenceParallelConfig,
+        )
+        from vllm_omni.diffusion.distributed.sp_sharding import (
+            SequenceShardMetadata,
+        )
+        from vllm_omni.diffusion.forward_context import (
+            get_forward_context,
+            set_forward_context,
+        )
+        from vllm_omni.diffusion.hooks import sequence_parallel
+        from vllm_omni.diffusion.hooks.sequence_parallel import (
+            SequenceParallelGatherHook,
+        )
+
+        observed = {}
+
+        def fake_gather(tensor, dim, validate, communication_backend):
+            observed["backend"] = communication_backend
+            return torch.cat([tensor, tensor], dim=dim)
+
+        monkeypatch.setattr(sequence_parallel, "sp_gather", fake_gather)
+        hook = SequenceParallelGatherHook(
+            SequenceParallelOutput(
+                gather_dim=1,
+                expected_dims=3,
+                shard_group="image",
+            ),
+            SequenceParallelConfig(
+                ulysses_degree=2,
+                communication_backend="functional",
+            ),
+        )
+
+        with set_forward_context():
+            get_forward_context().sp_shard_metadata["image"] = SequenceShardMetadata.from_global_length(
+                5,
+                world_size=2,
+                rank=0,
+            )
+            output = hook.post_forward(
+                nn.Identity(),
+                torch.zeros(1, 3, 4),
+            )
+
+        assert observed["backend"] == "functional"
+        assert output.shape == (1, 5, 4)
+
+
+@pytest.mark.cpu
 class TestSequenceParallelConfig:
     """Test SequenceParallelConfig dataclass."""
 
@@ -1062,3 +1216,33 @@ class TestSequenceParallelConfig:
 
         config = SequenceParallelConfig(ulysses_degree=2, ring_degree=4)
         assert config.sequence_parallel_size == 8
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            (
+                {
+                    "ulysses_degree": 2,
+                    "ring_degree": 2,
+                    "communication_backend": "functional",
+                },
+                "pure Ulysses",
+            ),
+            (
+                {
+                    "allgather_degree": 2,
+                    "communication_backend": "functional",
+                },
+                "pure Ulysses",
+            ),
+        ],
+    )
+    def test_functional_backend_rejects_non_ulysses_modes(
+        self,
+        kwargs,
+        match,
+    ):
+        from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelConfig
+
+        with pytest.raises(ValueError, match=match):
+            SequenceParallelConfig(**kwargs)

--- a/tests/diffusion/models/boogu_image/test_boogu_image_graphable_sp.py
+++ b/tests/diffusion/models/boogu_image/test_boogu_image_graphable_sp.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.config import set_current_diffusion_config
+from vllm_omni.diffusion.data import (
+    DiffusionParallelConfig,
+    OmniDiffusionConfig,
+    TransformerConfig,
+)
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelConfig
+from vllm_omni.diffusion.forward_context import (
+    get_forward_context,
+    set_forward_context,
+)
+from vllm_omni.diffusion.hooks.sequence_parallel import apply_sequence_parallel
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.parallel, pytest.mark.core_model]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _set_dist_env(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(
+        {
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "DIFFUSION_ATTENTION_BACKEND": "TORCH_SDPA",
+        }
+    )
+
+
+def _transformer_config() -> TransformerConfig:
+    return TransformerConfig.from_dict(
+        {
+            "patch_size": 2,
+            "in_channels": 4,
+            "hidden_size": 64,
+            "num_layers": 2,
+            "num_double_stream_layers": 1,
+            "num_refiner_layers": 1,
+            "num_attention_heads": 4,
+            "num_kv_heads": 1,
+            "multiple_of": 32,
+            "norm_eps": 1e-5,
+            "axes_dim_rope": [8, 4, 4],
+            "axes_lens": [64, 32, 32],
+            "instruction_feature_configs": {
+                "instruction_feat_dim": 32,
+                "reduce_type": "mean",
+                "num_instruction_feature_layers": 1,
+            },
+            "prompt_tuning_configs": {"use_prompt_tuning": False},
+            "timestep_scale": 1.0,
+        }
+    )
+
+
+def _od_config(
+    world_size: int,
+    *,
+    communication_backend: str,
+) -> OmniDiffusionConfig:
+    return OmniDiffusionConfig(
+        model="boogu-tiny",
+        dtype=torch.float32,
+        tf_model_config=_transformer_config(),
+        parallel_config=DiffusionParallelConfig(
+            sequence_parallel_size=world_size,
+            ulysses_degree=world_size,
+            ulysses_mode="advanced_uaa",
+            sp_communication_backend=communication_backend,
+        ),
+    )
+
+
+def _checkpoint_name(name: str) -> str:
+    if ".to_out." in name:
+        name = name.replace(".to_out.", ".to_out.0.")
+    for projection in (
+        "img_to_q",
+        "img_to_k",
+        "img_to_v",
+        "instruct_to_q",
+        "instruct_to_k",
+        "instruct_to_v",
+        "instruct_out",
+        "img_out",
+    ):
+        token = f".img_instruct_attn.{projection}."
+        if token in name:
+            return name.replace(
+                token,
+                f".img_instruct_attn.processor.{projection}.",
+            )
+    return name
+
+
+def _random_checkpoint(model: torch.nn.Module) -> list[tuple[str, torch.Tensor]]:
+    generator = torch.Generator(device=next(model.parameters()).device).manual_seed(2026)
+    checkpoint = []
+    for name, param in model.named_parameters():
+        value = torch.empty_like(param).uniform_(
+            -0.02,
+            0.02,
+            generator=generator,
+        )
+        checkpoint.append((_checkpoint_name(name), value))
+    return checkpoint
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    communication_backend: str,
+    output_file: str,
+) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{rank}")
+    current_omni_platform.set_device(device)
+    _set_dist_env(rank, world_size, port)
+    init_distributed_environment(world_size=world_size, rank=rank)
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=world_size,
+        ring_degree=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+
+    try:
+        from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+            BooguImageDoubleStreamRotaryPosEmbed,
+            BooguImageTransformer2DModel,
+        )
+
+        od_config = _od_config(
+            world_size,
+            communication_backend=communication_backend,
+        )
+        with (
+            set_current_vllm_config(VllmConfig(device_config=DeviceConfig(device=str(device)))),
+            set_forward_context(omni_diffusion_config=od_config),
+            set_current_diffusion_config(od_config),
+        ):
+            source = BooguImageTransformer2DModel(od_config).to(device)
+            checkpoint = _random_checkpoint(source)
+            del source
+
+            model = BooguImageTransformer2DModel(od_config).to(device)
+            assert model.load_weights(checkpoint) == set(dict(model.named_parameters()))
+            model.eval()
+
+            if world_size > 1:
+                apply_sequence_parallel(
+                    model,
+                    SequenceParallelConfig(
+                        ulysses_degree=world_size,
+                        communication_backend=communication_backend,
+                    ),
+                    model._sp_plan,
+                )
+                get_forward_context().sp_plan_hooks_applied = True
+
+            generator = torch.Generator(device=device).manual_seed(17)
+            latents = torch.randn(
+                1,
+                4,
+                8,
+                8,
+                device=device,
+                generator=generator,
+            )
+            timestep = torch.tensor([0.5], device=device)
+            instruction = torch.randn(
+                1,
+                7,
+                32,
+                device=device,
+                generator=generator,
+            )
+            instruction_mask = torch.ones(
+                1,
+                7,
+                dtype=torch.bool,
+                device=device,
+            )
+            ref_image = [
+                [
+                    torch.randn(
+                        4,
+                        6,
+                        10,
+                        device=device,
+                        generator=generator,
+                    )
+                ]
+            ]
+            freqs_cis = BooguImageDoubleStreamRotaryPosEmbed.get_freqs_cis(
+                model.axes_dim_rope,
+                model.axes_lens,
+                theta=10000,
+            )
+
+            with torch.inference_mode():
+                t2i = model(
+                    latents,
+                    timestep,
+                    instruction,
+                    freqs_cis,
+                    instruction_mask,
+                )
+                edit = model(
+                    latents,
+                    timestep,
+                    instruction,
+                    freqs_cis,
+                    instruction_mask,
+                    ref_image_hidden_states=ref_image,
+                )
+
+            if rank == 0:
+                np.savez(
+                    output_file,
+                    t2i=t2i.cpu().numpy(),
+                    edit=edit.cpu().numpy(),
+                )
+    finally:
+        destroy_distributed_env()
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=2)
+def test_boogu_graphable_sp_matches_single_gpu() -> None:
+    if not current_omni_platform.is_cuda() or current_omni_platform.get_device_count() < 2:
+        pytest.skip("BOOGU graphable SP test requires two CUDA GPUs.")
+
+    output_files = []
+    try:
+        for _ in range(3):
+            with tempfile.NamedTemporaryFile(
+                delete=False,
+                suffix=".npz",
+            ) as handle:
+                output_files.append(handle.name)
+
+        torch.multiprocessing.spawn(
+            _worker,
+            args=(1, _find_free_port(), "native", output_files[0]),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _worker,
+            args=(2, _find_free_port(), "native", output_files[1]),
+            nprocs=2,
+        )
+        torch.multiprocessing.spawn(
+            _worker,
+            args=(2, _find_free_port(), "functional", output_files[2]),
+            nprocs=2,
+        )
+
+        with (
+            np.load(output_files[0], allow_pickle=False) as baseline,
+            np.load(output_files[1], allow_pickle=False) as native,
+            np.load(output_files[2], allow_pickle=False) as functional,
+        ):
+            for key in ("t2i", "edit"):
+                np.testing.assert_allclose(
+                    native[key],
+                    baseline[key],
+                    rtol=2e-4,
+                    atol=2e-4,
+                )
+                np.testing.assert_allclose(
+                    functional[key],
+                    baseline[key],
+                    rtol=2e-4,
+                    atol=2e-4,
+                )
+    finally:
+        for path in output_files:
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
+++ b/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
@@ -145,8 +145,7 @@ def test_constructor_weights_sources(boogu_pipeline):
     ("parallel_config", "cache_backend", "message"),
     [
         (DiffusionParallelConfig(tensor_parallel_size=2), "none", "Tensor parallelism"),
-        (DiffusionParallelConfig(ulysses_degree=2), "none", "Sequence parallelism"),
-        (DiffusionParallelConfig(ring_degree=2), "none", "Sequence parallelism"),
+        (DiffusionParallelConfig(ring_degree=2), "none", "Ulysses only"),
         (DiffusionParallelConfig(cfg_parallel_size=2), "none", "CFG parallelism"),
         (
             DiffusionParallelConfig(use_hsdp=True, hsdp_shard_size=2),
@@ -180,6 +179,55 @@ def test_constructor_rejects_unsupported_execution_modes(
 
     # Validation happens before any checkpoint component is constructed.
     mock_dependencies["mllm_wrapper"].model.to.assert_not_called()
+
+
+def test_constructor_accepts_graphable_ulysses_uaa(mock_dependencies):
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import (
+        BooguImagePipeline,
+    )
+
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(
+            params={
+                "num_attention_heads": 28,
+                "num_kv_heads": 7,
+            }
+        ),
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            ulysses_degree=2,
+            ulysses_mode="advanced_uaa",
+            sp_communication_backend="functional",
+        ),
+    )
+
+    pipeline = BooguImagePipeline(od_config=od_config)
+    assert pipeline.transformer is mock_dependencies["transformer"]
+
+
+def test_constructor_requires_uaa_for_boogu_gqa(mock_dependencies):
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import (
+        BooguImagePipeline,
+    )
+
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(
+            params={
+                "num_attention_heads": 28,
+                "num_kv_heads": 7,
+            }
+        ),
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            ulysses_degree=2,
+            ulysses_mode="strict",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="advanced_uaa"):
+        BooguImagePipeline(od_config=od_config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -204,6 +204,7 @@ class TestStageConfig:
                     "ulysses_degree": 1,
                     "ring_degree": 1,
                     "ulysses_mode": "strict",
+                    "sp_communication_backend": "native",
                     "sequence_parallel_size": 1,
                     "cfg_parallel_size": 1,
                     "vae_patch_parallel_size": 1,
@@ -218,9 +219,10 @@ class TestStageConfig:
                 "tensor_parallel_size": 8,
                 "enable_expert_parallel": True,
                 "ulysses_degree": 2,
-                "ring_degree": 4,
+                "ring_degree": 1,
                 "ulysses_mode": "advanced_uaa",
-                "sequence_parallel_size": 8,
+                "sp_communication_backend": "functional",
+                "sequence_parallel_size": 2,
                 "cfg_parallel_size": 2,
                 "vae_patch_parallel_size": 2,
                 "use_hsdp": True,
@@ -236,9 +238,10 @@ class TestStageConfig:
         assert omega_config.engine_args.parallel_config.tensor_parallel_size == 8
         assert omega_config.engine_args.parallel_config.enable_expert_parallel is True
         assert omega_config.engine_args.parallel_config.ulysses_degree == 2
-        assert omega_config.engine_args.parallel_config.ring_degree == 4
+        assert omega_config.engine_args.parallel_config.ring_degree == 1
         assert omega_config.engine_args.parallel_config.ulysses_mode == "advanced_uaa"
-        assert omega_config.engine_args.parallel_config.sequence_parallel_size == 8
+        assert omega_config.engine_args.parallel_config.sp_communication_backend == "functional"
+        assert omega_config.engine_args.parallel_config.sequence_parallel_size == 2
         assert omega_config.engine_args.parallel_config.cfg_parallel_size == 2
         assert omega_config.engine_args.parallel_config.vae_patch_parallel_size == 2
         assert omega_config.engine_args.parallel_config.use_hsdp is True
@@ -251,6 +254,7 @@ class TestStageConfig:
         assert "ulysses_degree" not in omega_config.engine_args
         assert "ring_degree" not in omega_config.engine_args
         assert "ulysses_mode" not in omega_config.engine_args
+        assert "sp_communication_backend" not in omega_config.engine_args
         assert "sequence_parallel_size" not in omega_config.engine_args
         assert "cfg_parallel_size" not in omega_config.engine_args
         assert "vae_patch_parallel_size" not in omega_config.engine_args
@@ -269,9 +273,10 @@ class TestStageConfig:
                 "tensor_parallel_size": 8,
                 "enable_expert_parallel": True,
                 "ulysses_degree": 2,
-                "ring_degree": 4,
+                "ring_degree": 1,
                 "ulysses_mode": "advanced_uaa",
-                "sequence_parallel_size": 8,
+                "sp_communication_backend": "functional",
+                "sequence_parallel_size": 2,
                 "cfg_parallel_size": 2,
                 "vae_patch_parallel_size": 2,
                 "use_hsdp": True,
@@ -287,9 +292,10 @@ class TestStageConfig:
         assert omega_config.engine_args.parallel_config.tensor_parallel_size == 8
         assert omega_config.engine_args.parallel_config.enable_expert_parallel is True
         assert omega_config.engine_args.parallel_config.ulysses_degree == 2
-        assert omega_config.engine_args.parallel_config.ring_degree == 4
+        assert omega_config.engine_args.parallel_config.ring_degree == 1
         assert omega_config.engine_args.parallel_config.ulysses_mode == "advanced_uaa"
-        assert omega_config.engine_args.parallel_config.sequence_parallel_size == 8
+        assert omega_config.engine_args.parallel_config.sp_communication_backend == "functional"
+        assert omega_config.engine_args.parallel_config.sequence_parallel_size == 2
         assert omega_config.engine_args.parallel_config.cfg_parallel_size == 2
         assert omega_config.engine_args.parallel_config.vae_patch_parallel_size == 2
         assert omega_config.engine_args.parallel_config.use_hsdp is True
@@ -302,6 +308,7 @@ class TestStageConfig:
         assert "ulysses_degree" not in omega_config.engine_args
         assert "ring_degree" not in omega_config.engine_args
         assert "ulysses_mode" not in omega_config.engine_args
+        assert "sp_communication_backend" not in omega_config.engine_args
         assert "sequence_parallel_size" not in omega_config.engine_args
         assert "cfg_parallel_size" not in omega_config.engine_args
         assert "vae_patch_parallel_size" not in omega_config.engine_args

--- a/tests/test_diffusion_config_propagation.py
+++ b/tests/test_diffusion_config_propagation.py
@@ -72,6 +72,31 @@ class TestParallelConfigPropagation:
         od = _roundtrip_diffusion_config(model="x", parallel_config=pc)
         assert od.parallel_config.mask_sp_padding is False
 
+    def test_functional_sp_backend_roundtrip(self):
+        pc = DiffusionParallelConfig(
+            ulysses_degree=2,
+            sp_communication_backend="functional",
+        )
+        od = _roundtrip_diffusion_config(model="x", parallel_config=pc)
+        assert od.parallel_config.sp_communication_backend == "functional"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {
+                "ring_degree": 2,
+                "sp_communication_backend": "functional",
+            },
+            {
+                "allgather_degree": 2,
+                "sp_communication_backend": "functional",
+            },
+        ],
+    )
+    def test_functional_sp_backend_rejects_non_ulysses_modes(self, kwargs):
+        with pytest.raises(ValueError, match="pure Ulysses"):
+            DiffusionParallelConfig(**kwargs)
+
     def test_cfg_parallel_roundtrip(self):
         pc = DiffusionParallelConfig(cfg_parallel_size=2)
         od = _roundtrip_diffusion_config(model="x", parallel_config=pc)

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -111,6 +111,7 @@ class _ParallelConfigEngineOverrides(TypedDict, total=False):
     ring_degree: int
     allgather_degree: int
     ulysses_mode: str
+    sp_communication_backend: str
     cfg_parallel_size: int
     vae_patch_parallel_size: int
     use_hsdp: bool
@@ -363,6 +364,7 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
     ring_degree: int = Field(default=1, ge=1)
     allgather_degree: int = Field(default=1, ge=1)
     ulysses_mode: str = "strict"
+    sp_communication_backend: Literal["native", "functional"] = "native"
     cfg_parallel_size: int = Field(default=1, ge=1, le=3)
     vae_patch_parallel_size: int = Field(default=1, ge=1)
     vae_parallel_mode: str = "tile"
@@ -379,6 +381,16 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
             raise ValueError("allgather_degree > 1 is mutually exclusive with ulysses_degree/ring_degree > 1")
         if self.ulysses_mode not in {"strict", "advanced_uaa"}:
             raise ValueError("ulysses_mode must be 'strict' or 'advanced_uaa'")
+        if self.sp_communication_backend not in {"native", "functional"}:
+            raise ValueError("sp_communication_backend must be 'native' or 'functional'")
+        if self.sp_communication_backend == "functional" and (
+            self.ulysses_degree <= 1 or self.ring_degree != 1 or self.allgather_degree != 1
+        ):
+            raise ValueError(
+                "sp_communication_backend='functional' currently supports pure "
+                "Ulysses only (ulysses_degree > 1, ring_degree = "
+                "allgather_degree = 1)."
+            )
         if self.vae_parallel_mode not in {"tile", "spatial_shard_height", "spatial_shard_width"}:
             raise ValueError(
                 "vae_parallel_mode must be one of {'tile', 'spatial_shard_height', 'spatial_shard_width'}, "

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -368,6 +368,7 @@ class StageDeployConfig:
     # Diffusion parallel_config deploy/runtime override fields.
     ulysses_degree: int | None = None
     ulysses_mode: str | None = None
+    sp_communication_backend: str | None = None
     ring_degree: int | None = None
     allgather_degree: int | None = None
     sequence_parallel_size: int | None = None

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -141,6 +141,8 @@ class Attention(nn.Module):
             gather_idx=gather_idx,
             use_sync=use_sync,
             causal=causal,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads or num_heads,
         )
         # Fallback strategy when SP is not active (outside sharded regions)
         self._no_parallel_strategy = NoParallelAttention()

--- a/vllm_omni/diffusion/attention/parallel/factory.py
+++ b/vllm_omni/diffusion/attention/parallel/factory.py
@@ -29,6 +29,8 @@ def build_parallel_attention_strategy(
     gather_idx: int,
     use_sync: bool,
     causal: bool = False,
+    num_heads: int | None = None,
+    num_kv_heads: int | None = None,
 ) -> ParallelAttentionStrategy:
     """Select a parallel attention strategy based on current diffusion config.
 
@@ -47,6 +49,7 @@ def build_parallel_attention_strategy(
     ulysses_degree = getattr(p, "ulysses_degree", 1)
     ring_degree = getattr(p, "ring_degree", 1)
     allgather_degree = getattr(p, "allgather_degree", 1)
+    communication_backend = getattr(p, "sp_communication_backend", "native")
 
     try:
         sp_group = get_sp_group()
@@ -77,12 +80,20 @@ def build_parallel_attention_strategy(
 
     # Ulysses (or Hybrid Ulysses+Ring)
     if ulysses_degree > 1:
+        if communication_backend == "functional" and ring_degree > 1:
+            raise ValueError(
+                "sp_communication_backend='functional' currently supports pure Ulysses only; set ring_degree=1."
+            )
         logger.debug(f"Using UlyssesParallelAttention (ulysses_degree={ulysses_degree})")
         return UlyssesParallelAttention(
             sp_group=sp_group,
             scatter_idx=scatter_idx,
             gather_idx=gather_idx,
             use_sync=use_sync,
+            mode=getattr(p, "ulysses_mode", "strict"),
+            communication_backend=communication_backend,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
         )
 
     # Pure Ring Attention

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -11,9 +11,15 @@ import torch.nn.functional as F
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.parallel.base import ParallelAttentionContext
-from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D
+from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D, all_to_all_4D
+from vllm_omni.diffusion.distributed.functional_collectives import (
+    functional_all_gather_tensor,
+    functional_all_to_all_single,
+    launch_functional_all_to_all_single,
+    wait_functional_collective,
+)
 from vllm_omni.diffusion.distributed.group_coordinator import SequenceParallelGroupCoordinator
-from vllm_omni.diffusion.forward_context import get_ulysses_mode
+from vllm_omni.platforms import current_omni_platform
 
 
 def _ceil_div(n: int, d: int) -> int:
@@ -33,6 +39,44 @@ def _positive_divisors(n: int) -> list[int]:
     return sorted(divs)
 
 
+@dataclass(frozen=True, slots=True)
+class _UlyssesHeadPlan:
+    """Head padding that preserves the original Q:KV ratio under UAA."""
+
+    query_heads: int
+    kv_heads: int
+    padded_query_heads: int
+    padded_kv_heads: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        query_heads: int,
+        kv_heads: int,
+        world_size: int,
+        mode: str,
+    ) -> _UlyssesHeadPlan:
+        if query_heads <= 0 or kv_heads <= 0:
+            raise ValueError(f"Q/KV head counts must be positive, got Q={query_heads}, KV={kv_heads}.")
+        if query_heads % kv_heads != 0:
+            raise ValueError(
+                f"Ulysses GQA requires query heads to be a multiple of KV heads, got Q={query_heads}, KV={kv_heads}."
+            )
+        if mode == "advanced_uaa":
+            padded_kv_heads = _ceil_div(kv_heads, world_size) * world_size
+            padded_query_heads = padded_kv_heads * (query_heads // kv_heads)
+        else:
+            padded_query_heads = query_heads
+            padded_kv_heads = kv_heads
+        return cls(
+            query_heads=query_heads,
+            kv_heads=kv_heads,
+            padded_query_heads=padded_query_heads,
+            padded_kv_heads=padded_kv_heads,
+        )
+
+
 @torch.compiler.disable
 def _all_gather_int(pg: dist.ProcessGroup, value: int, *, device: torch.device) -> list[int]:
     """All-gather a scalar int across pg.
@@ -49,25 +93,54 @@ def _all_gather_int(pg: dist.ProcessGroup, value: int, *, device: torch.device) 
     return [int(x.item()) for x in gathered]
 
 
+def _all_gather_2d_mask(
+    pg: dist.ProcessGroup,
+    mask: torch.Tensor,
+    *,
+    communication_backend: str,
+    world_size: int,
+) -> torch.Tensor:
+    mask = mask.contiguous()
+    if communication_backend == "functional":
+        return functional_all_gather_tensor(
+            mask,
+            gather_dim=1,
+            group=pg,
+        )
+
+    gathered = [torch.empty_like(mask) for _ in range(world_size)]
+    dist.all_gather(gathered, mask, group=pg)
+    return torch.cat(gathered, dim=1)
+
+
 def _ulysses_all_to_all_any_qkv(
     pg: dist.ProcessGroup,
     x: torch.Tensor,  # (B, S_local, H, D)
     *,
     seq_lens: list[int],
     use_sync: bool,
+    padded_head_cnt: int | None = None,
+    communication_backend: str = "native",
+    world_size: int | None = None,
 ) -> tuple[torch.Tensor, int]:
     """UAA forward all-to-all: (B, S_local, H, D) -> (B, S_global, H_local, D).
 
     Returns:
         (resharded, orig_head_cnt)
     """
-    world_size = dist.get_world_size(pg)
+    if world_size is None:
+        world_size = dist.get_world_size(pg)
     if world_size == 1:
         return x, int(x.shape[2])
 
     bsz, s_local, head_cnt, head_dim = x.shape
     orig_head_cnt = int(head_cnt)
-    padded_head_cnt = _ceil_div(orig_head_cnt, world_size) * world_size
+    if padded_head_cnt is None:
+        padded_head_cnt = _ceil_div(orig_head_cnt, world_size) * world_size
+    if padded_head_cnt < orig_head_cnt or padded_head_cnt % world_size != 0:
+        raise ValueError(
+            f"Invalid padded head count {padded_head_cnt} for original heads={orig_head_cnt}, world_size={world_size}."
+        )
     head_pad = padded_head_cnt - orig_head_cnt
     if head_pad:
         x = F.pad(x, (0, 0, 0, head_pad))
@@ -81,24 +154,87 @@ def _ulysses_all_to_all_any_qkv(
 
     input_split_sizes = [s_local] * world_size
     output_split_sizes = seq_lens
-    s_global = int(sum(output_split_sizes))
-
-    out = torch.empty((s_global, bsz, head_cnt_local, head_dim), device=x.device, dtype=x.dtype)
-    dist.all_to_all_single(
-        out,
-        x_t,
-        output_split_sizes=output_split_sizes,
-        input_split_sizes=input_split_sizes,
-        group=pg,
-    )
-    if use_sync:
-        from vllm_omni.platforms import current_omni_platform
-
-        current_omni_platform.synchronize()
+    if communication_backend == "functional":
+        out = functional_all_to_all_single(
+            x_t,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=pg,
+        )
+    else:
+        s_global = sum(output_split_sizes)
+        out = torch.empty(
+            (s_global, bsz, head_cnt_local, head_dim),
+            device=x.device,
+            dtype=x.dtype,
+        )
+        dist.all_to_all_single(
+            out,
+            x_t,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=pg,
+        )
+        if use_sync:
+            current_omni_platform.synchronize()
 
     # (S_global, B, H_local, D) -> (B, S_global, H_local, D)
     out = out.permute(1, 0, 2, 3).contiguous()
     return out, orig_head_cnt
+
+
+def _launch_functional_ulysses_all_to_all_any_qkv(
+    pg: dist.ProcessGroup,
+    x: torch.Tensor,
+    *,
+    seq_lens: list[int],
+    padded_head_cnt: int,
+    world_size: int,
+) -> tuple[torch.Tensor, int]:
+    """Launch graphable UAA Q/K/V resharding and defer its wait."""
+    if world_size == 1:
+        return x, int(x.shape[2])
+
+    batch_size, local_seq_len, head_count, head_dim = x.shape
+    original_head_count = int(head_count)
+    if padded_head_cnt < original_head_count or padded_head_cnt % world_size != 0:
+        raise ValueError(
+            f"Invalid padded head count {padded_head_cnt} for original "
+            f"heads={original_head_count}, world_size={world_size}."
+        )
+    if padded_head_cnt != original_head_count:
+        x = F.pad(
+            x,
+            (0, 0, 0, padded_head_cnt - original_head_count),
+        )
+
+    local_head_count = padded_head_cnt // world_size
+    input_tensor = (
+        x.reshape(
+            batch_size,
+            local_seq_len,
+            world_size,
+            local_head_count,
+            head_dim,
+        )
+        .permute(2, 1, 0, 3, 4)
+        .contiguous()
+        .flatten(0, 1)
+    )
+    output = launch_functional_all_to_all_single(
+        input_tensor,
+        output_split_sizes=seq_lens,
+        input_split_sizes=[local_seq_len] * world_size,
+        group=pg,
+    )
+    return output, original_head_count
+
+
+def _finish_functional_ulysses_all_to_all_any_qkv(
+    output: torch.Tensor,
+) -> torch.Tensor:
+    output = wait_functional_collective(output)
+    return output.permute(1, 0, 2, 3).contiguous()
 
 
 def _ulysses_all_to_all_any_o(
@@ -109,9 +245,12 @@ def _ulysses_all_to_all_any_o(
     local_seq_len: int,
     orig_head_cnt: int,
     use_sync: bool,
+    communication_backend: str = "native",
+    world_size: int | None = None,
 ) -> torch.Tensor:
     """UAA reverse all-to-all: (B, S_global, H_local, D) -> (B, S_local, H, D)."""
-    world_size = dist.get_world_size(pg)
+    if world_size is None:
+        world_size = dist.get_world_size(pg)
     if world_size == 1:
         return x
 
@@ -124,18 +263,28 @@ def _ulysses_all_to_all_any_o(
     input_split_sizes = seq_lens
     output_split_sizes = [s_local] * world_size
 
-    out = torch.empty((world_size * s_local, bsz, head_cnt_local, head_dim), device=x.device, dtype=x.dtype)
-    dist.all_to_all_single(
-        out,
-        x_t,
-        output_split_sizes=output_split_sizes,
-        input_split_sizes=input_split_sizes,
-        group=pg,
-    )
-    if use_sync:
-        from vllm_omni.platforms import current_omni_platform
-
-        current_omni_platform.synchronize()
+    if communication_backend == "functional":
+        out = functional_all_to_all_single(
+            x_t,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=pg,
+        )
+    else:
+        out = torch.empty(
+            (world_size * s_local, bsz, head_cnt_local, head_dim),
+            device=x.device,
+            dtype=x.dtype,
+        )
+        dist.all_to_all_single(
+            out,
+            x_t,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=pg,
+        )
+        if use_sync:
+            current_omni_platform.synchronize()
 
     # (world_size * S_local, B, H_local, D) -> (B, S_local, H, D)
     out = out.reshape(world_size, s_local, bsz, head_cnt_local, head_dim).permute(2, 1, 0, 3, 4).contiguous()
@@ -154,6 +303,8 @@ class _UlyssesCtx(ParallelAttentionContext):
     scatter_idx: int
     gather_idx: int
     use_sync: bool
+    communication_backend: str = "native"
+    world_size: int = 1
     joint_len: int = 0
     joint_strategy: str = "front"
     # UAA (Ulysses Anything Attention) metadata
@@ -181,12 +332,50 @@ class UlyssesParallelAttention:
         scatter_idx: int,
         gather_idx: int,
         use_sync: bool,
+        mode: str = "strict",
+        communication_backend: str = "native",
+        num_heads: int | None = None,
+        num_kv_heads: int | None = None,
     ) -> None:
         self._sp_group = sp_group
         self._ulysses_pg = sp_group.ulysses_group
         self._scatter_idx = scatter_idx
         self._gather_idx = gather_idx
         self._use_sync = use_sync
+        self._mode = mode
+        self._communication_backend = communication_backend
+        self._world_size = sp_group.ulysses_world_size
+        if communication_backend not in {"native", "functional"}:
+            raise ValueError(
+                f"Ulysses communication backend must be 'native' or 'functional', got {communication_backend!r}."
+            )
+        if communication_backend == "functional":
+            backend = str(dist.get_backend(self._ulysses_pg)).rsplit(".", 1)[-1].lower()
+            if not current_omni_platform.is_cuda() or backend != "nccl":
+                raise RuntimeError(
+                    "sp_communication_backend='functional' currently supports CUDA/NCCL only, "
+                    f"but platform={current_omni_platform.device_name}, "
+                    f"distributed_backend={backend}."
+                )
+            if sp_group.ring_world_size > 1:
+                raise ValueError(
+                    "sp_communication_backend='functional' currently supports pure Ulysses only; set ring_degree=1."
+                )
+        self._head_plan_value = (
+            _UlyssesHeadPlan.build(
+                query_heads=num_heads,
+                kv_heads=num_kv_heads or num_heads,
+                world_size=self._world_size,
+                mode=mode,
+            )
+            if num_heads is not None
+            else None
+        )
+
+    def _head_plan(self) -> _UlyssesHeadPlan:
+        if self._head_plan_value is None:
+            raise RuntimeError("Ulysses requires Attention Q/KV head counts at strategy construction.")
+        return self._head_plan_value
 
     @property
     def enabled(self) -> bool:
@@ -203,7 +392,8 @@ class UlyssesParallelAttention:
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None,
     ):
-        mode = get_ulysses_mode(default="strict")
+        mode = self._mode
+        head_plan = self._head_plan()
         joint_tensor_query = joint_tensor_key = joint_tensor_value = None
         joint_strategy = "front"
         joint_len = 0
@@ -226,31 +416,49 @@ class UlyssesParallelAttention:
 
             # Slice joint_query for this Ulysses rank
             # joint_query is (B, S, H, D). We split H (dim 2).
-            ulysses_world_size = self._sp_group.ulysses_world_size
+            ulysses_world_size = self._world_size
             ulysses_rank = self._sp_group.ulysses_rank
             joint_head_cnt = int(joint_tensor_query.shape[-2])
+            joint_kv_head_cnt = int(joint_tensor_key.shape[-2])
             joint_orig_head_cnt = joint_head_cnt
+            if joint_head_cnt != head_plan.query_heads or joint_kv_head_cnt != head_plan.kv_heads:
+                raise ValueError(
+                    "Joint Q/KV heads must match the Attention configuration, "
+                    f"got Q={joint_head_cnt}, KV={joint_kv_head_cnt}, "
+                    f"expected Q={head_plan.query_heads}, KV={head_plan.kv_heads}."
+                )
+            if int(joint_tensor_value.shape[-2]) != joint_kv_head_cnt:
+                raise ValueError("Joint K/V head counts must match.")
 
             if mode == "advanced_uaa":
-                padded_joint_head_cnt = _ceil_div(joint_head_cnt, ulysses_world_size) * ulysses_world_size
-                joint_head_pad = padded_joint_head_cnt - joint_head_cnt
-                if joint_head_pad:
-                    joint_tensor_query = F.pad(joint_tensor_query, (0, 0, 0, joint_head_pad))
-                    joint_tensor_key = F.pad(joint_tensor_key, (0, 0, 0, joint_head_pad))
-                    joint_tensor_value = F.pad(joint_tensor_value, (0, 0, 0, joint_head_pad))
-                joint_head_cnt = padded_joint_head_cnt
+                joint_tensor_query = F.pad(
+                    joint_tensor_query,
+                    (0, 0, 0, head_plan.padded_query_heads - joint_head_cnt),
+                )
+                joint_tensor_key = F.pad(
+                    joint_tensor_key,
+                    (0, 0, 0, head_plan.padded_kv_heads - joint_kv_head_cnt),
+                )
+                joint_tensor_value = F.pad(
+                    joint_tensor_value,
+                    (0, 0, 0, head_plan.padded_kv_heads - joint_kv_head_cnt),
+                )
+                joint_head_cnt = head_plan.padded_query_heads
+                joint_kv_head_cnt = head_plan.padded_kv_heads
             else:
-                if joint_head_cnt % ulysses_world_size != 0:
-                    supported = _positive_divisors(joint_head_cnt)
+                if joint_head_cnt % ulysses_world_size != 0 or joint_kv_head_cnt % ulysses_world_size != 0:
+                    supported = sorted(
+                        set(_positive_divisors(joint_head_cnt)) & set(_positive_divisors(joint_kv_head_cnt))
+                    )
                     raise ValueError(
-                        "Ulysses-SP strict mode requires joint head_cnt divisible by ulysses_degree. "
-                        f"joint_head_cnt={joint_head_cnt}, ulysses_degree={ulysses_world_size}. "
+                        "Ulysses-SP strict mode requires joint Q/KV heads divisible "
+                        f"by ulysses_degree. Q={joint_head_cnt}, KV={joint_kv_head_cnt}, "
+                        f"ulysses_degree={ulysses_world_size}. "
                         f"Try ulysses_degree in {supported}, or set ulysses_mode='advanced_uaa'."
                     )
 
             attn_heads_per_ulysses_rank = joint_head_cnt // ulysses_world_size
 
-            # Note: We use the same heads for Q/K/V
             joint_tensor_query = joint_tensor_query[
                 ...,
                 attn_heads_per_ulysses_rank * ulysses_rank : attn_heads_per_ulysses_rank * (ulysses_rank + 1),
@@ -266,9 +474,7 @@ class UlyssesParallelAttention:
             raise ValueError("joint_query, joint_key, and joint_value should be None or not None simultaneously.")
 
         if is_joint:
-            # Slice joint key/value heads for this ulysses rank.
-            # Using same slicing logic as query
-            attn_heads_per_ulysses_rank_kv = joint_tensor_key.shape[-2] // ulysses_world_size
+            attn_heads_per_ulysses_rank_kv = joint_kv_head_cnt // ulysses_world_size
 
             joint_tensor_key = joint_tensor_key[
                 ...,
@@ -286,7 +492,7 @@ class UlyssesParallelAttention:
                 attn_metadata.joint_key = joint_tensor_key
                 attn_metadata.joint_value = joint_tensor_value
 
-        ulysses_world_size = self._sp_group.ulysses_world_size
+        ulysses_world_size = self._world_size
         if mode == "advanced_uaa":
             if self._scatter_idx != 2 or self._gather_idx != 1:
                 raise ValueError(
@@ -294,9 +500,17 @@ class UlyssesParallelAttention:
                     f"(got scatter_idx={self._scatter_idx}, gather_idx={self._gather_idx})."
                 )
 
-            local_seq_len = int(query.shape[1])
-            seq_lens = _all_gather_int(self._ulysses_pg, local_seq_len, device=query.device)
-            s_global = int(sum(seq_lens))
+            if self._communication_backend == "functional":
+                local_seq_len = query.shape[1]
+                seq_lens = [local_seq_len] * ulysses_world_size
+            else:
+                local_seq_len = int(query.shape[1])
+                seq_lens = _all_gather_int(
+                    self._ulysses_pg,
+                    local_seq_len,
+                    device=query.device,
+                )
+            s_global = sum(seq_lens)
 
             # In hybrid Ulysses+Ring, Ring attention uses P2P send/recv with fixed-shape
             # buffers. This requires all ring ranks to have the same seq_len after the
@@ -311,11 +525,59 @@ class UlyssesParallelAttention:
                         "This typically means the input sequence was not evenly shardable across the ring. "
                         "Try setting ring_degree=1, or choose a sequence length divisible by ring_degree."
                     )
-            query, orig_head_cnt = _ulysses_all_to_all_any_qkv(
-                self._ulysses_pg, query, seq_lens=seq_lens, use_sync=self._use_sync
-            )
-            key, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, key, seq_lens=seq_lens, use_sync=self._use_sync)
-            value, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, value, seq_lens=seq_lens, use_sync=self._use_sync)
+            if self._communication_backend == "functional":
+                query_work, orig_head_cnt = _launch_functional_ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    query,
+                    seq_lens=seq_lens,
+                    padded_head_cnt=head_plan.padded_query_heads,
+                    world_size=ulysses_world_size,
+                )
+                key_work, _ = _launch_functional_ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    key,
+                    seq_lens=seq_lens,
+                    padded_head_cnt=head_plan.padded_kv_heads,
+                    world_size=ulysses_world_size,
+                )
+                value_work, _ = _launch_functional_ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    value,
+                    seq_lens=seq_lens,
+                    padded_head_cnt=head_plan.padded_kv_heads,
+                    world_size=ulysses_world_size,
+                )
+                query = _finish_functional_ulysses_all_to_all_any_qkv(query_work)
+                key = _finish_functional_ulysses_all_to_all_any_qkv(key_work)
+                value = _finish_functional_ulysses_all_to_all_any_qkv(value_work)
+            else:
+                query, orig_head_cnt = _ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    query,
+                    seq_lens=seq_lens,
+                    use_sync=self._use_sync,
+                    padded_head_cnt=head_plan.padded_query_heads,
+                    communication_backend=self._communication_backend,
+                    world_size=ulysses_world_size,
+                )
+                key, _ = _ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    key,
+                    seq_lens=seq_lens,
+                    use_sync=self._use_sync,
+                    padded_head_cnt=head_plan.padded_kv_heads,
+                    communication_backend=self._communication_backend,
+                    world_size=ulysses_world_size,
+                )
+                value, _ = _ulysses_all_to_all_any_qkv(
+                    self._ulysses_pg,
+                    value,
+                    seq_lens=seq_lens,
+                    use_sync=self._use_sync,
+                    padded_head_cnt=head_plan.padded_kv_heads,
+                    communication_backend=self._communication_backend,
+                    world_size=ulysses_world_size,
+                )
         else:
             # Strict mode: fail fast with actionable errors for head divisibility.
             for name, t in (("query", query), ("key", key), ("value", value)):
@@ -329,9 +591,53 @@ class UlyssesParallelAttention:
                     )
 
             # (bs, seq_len/P, head_cnt, head_size) -> (bs, seq_len, head_cnt/P, head_size)
-            query = SeqAllToAll4D.apply(self._ulysses_pg, query, self._scatter_idx, self._gather_idx, self._use_sync)
-            key = SeqAllToAll4D.apply(self._ulysses_pg, key, self._scatter_idx, self._gather_idx, self._use_sync)
-            value = SeqAllToAll4D.apply(self._ulysses_pg, value, self._scatter_idx, self._gather_idx, self._use_sync)
+            if self._communication_backend == "functional":
+                query = all_to_all_4D(
+                    query,
+                    scatter_idx=self._scatter_idx,
+                    gather_idx=self._gather_idx,
+                    group=self._ulysses_pg,
+                    communication_backend="functional",
+                    world_size=ulysses_world_size,
+                )
+                key = all_to_all_4D(
+                    key,
+                    scatter_idx=self._scatter_idx,
+                    gather_idx=self._gather_idx,
+                    group=self._ulysses_pg,
+                    communication_backend="functional",
+                    world_size=ulysses_world_size,
+                )
+                value = all_to_all_4D(
+                    value,
+                    scatter_idx=self._scatter_idx,
+                    gather_idx=self._gather_idx,
+                    group=self._ulysses_pg,
+                    communication_backend="functional",
+                    world_size=ulysses_world_size,
+                )
+            else:
+                query = SeqAllToAll4D.apply(
+                    self._ulysses_pg,
+                    query,
+                    self._scatter_idx,
+                    self._gather_idx,
+                    self._use_sync,
+                )
+                key = SeqAllToAll4D.apply(
+                    self._ulysses_pg,
+                    key,
+                    self._scatter_idx,
+                    self._gather_idx,
+                    self._use_sync,
+                )
+                value = SeqAllToAll4D.apply(
+                    self._ulysses_pg,
+                    value,
+                    self._scatter_idx,
+                    self._gather_idx,
+                    self._use_sync,
+                )
             seq_lens = []
             local_seq_len = 0
             orig_head_cnt = 0
@@ -359,17 +665,32 @@ class UlyssesParallelAttention:
                 key = torch.cat([key, joint_tensor_key], dim=1)
                 value = torch.cat([value, joint_tensor_value], dim=1)
 
+        if (
+            not is_joint
+            and attn_metadata is not None
+            and attn_metadata.attn_mask is not None
+            and attn_metadata.attn_mask.ndim == 2
+        ):
+            attn_metadata.attn_mask = _all_gather_2d_mask(
+                self._ulysses_pg,
+                attn_metadata.attn_mask,
+                communication_backend=self._communication_backend,
+                world_size=ulysses_world_size,
+            )
+
         ctx = _UlyssesCtx(
             name=self.name,
             ulysses_pg=self._ulysses_pg,
             scatter_idx=self._scatter_idx,
             gather_idx=self._gather_idx,
             use_sync=self._use_sync,
+            communication_backend=self._communication_backend,
+            world_size=ulysses_world_size,
             joint_len=joint_len,
             joint_strategy=joint_strategy,
             use_uaa=(mode == "advanced_uaa"),
-            uaa_seq_lens=tuple(int(x) for x in seq_lens) if mode == "advanced_uaa" else (),
-            uaa_local_seq_len=int(local_seq_len) if mode == "advanced_uaa" else 0,
+            uaa_seq_lens=tuple(seq_lens) if mode == "advanced_uaa" else (),
+            uaa_local_seq_len=local_seq_len if mode == "advanced_uaa" else 0,
             orig_head_cnt=int(orig_head_cnt) if mode == "advanced_uaa" else 0,
             joint_orig_head_cnt=int(joint_orig_head_cnt) if mode == "advanced_uaa" else 0,
         )
@@ -437,6 +758,17 @@ class UlyssesParallelAttention:
                     local_seq_len=ctx.uaa_local_seq_len,
                     orig_head_cnt=ctx.orig_head_cnt,
                     use_sync=ctx.use_sync,
+                    communication_backend=ctx.communication_backend,
+                    world_size=ctx.world_size,
+                )
+            elif ctx.communication_backend == "functional":
+                output_img = all_to_all_4D(
+                    output_img,
+                    scatter_idx=ctx.gather_idx,
+                    gather_idx=ctx.scatter_idx,
+                    group=ctx.ulysses_pg,
+                    communication_backend="functional",
+                    world_size=ctx.world_size,
                 )
             else:
                 output_img = SeqAllToAll4D.apply(
@@ -448,9 +780,20 @@ class UlyssesParallelAttention:
             # AllGather along dim 2.
             # Ensure tensor is contiguous for all_gather (slicing may create non-contiguous views)
             output_joint = output_joint.contiguous()
-            gathered_joint = [torch.zeros_like(output_joint) for _ in range(dist.get_world_size(ctx.ulysses_pg))]
-            dist.all_gather(gathered_joint, output_joint, group=ctx.ulysses_pg)
-            output_joint = torch.cat(gathered_joint, dim=2)
+            if ctx.communication_backend == "functional":
+                output_joint = functional_all_gather_tensor(
+                    output_joint,
+                    gather_dim=2,
+                    group=ctx.ulysses_pg,
+                )
+            else:
+                gathered_joint = [torch.zeros_like(output_joint) for _ in range(ctx.world_size)]
+                dist.all_gather(
+                    gathered_joint,
+                    output_joint,
+                    group=ctx.ulysses_pg,
+                )
+                output_joint = torch.cat(gathered_joint, dim=2)
             if ctx.use_uaa and ctx.joint_orig_head_cnt > 0 and output_joint.shape[2] != ctx.joint_orig_head_cnt:
                 output_joint = output_joint[:, :, : ctx.joint_orig_head_cnt, :].contiguous()
 
@@ -469,5 +812,16 @@ class UlyssesParallelAttention:
                 local_seq_len=ctx.uaa_local_seq_len,
                 orig_head_cnt=ctx.orig_head_cnt,
                 use_sync=ctx.use_sync,
+                communication_backend=ctx.communication_backend,
+                world_size=ctx.world_size,
+            )
+        if ctx.communication_backend == "functional":
+            return all_to_all_4D(
+                attn_output,
+                scatter_idx=ctx.gather_idx,
+                gather_idx=ctx.scatter_idx,
+                group=ctx.ulysses_pg,
+                communication_backend="functional",
+                world_size=ctx.world_size,
             )
         return SeqAllToAll4D.apply(ctx.ulysses_pg, attn_output, ctx.gather_idx, ctx.scatter_idx, ctx.use_sync)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -7,7 +7,7 @@ import random
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import diffusers
 import torch
@@ -183,6 +183,14 @@ class DiffusionParallelConfig:
       sequence shapes across the ring group.
     """
 
+    sp_communication_backend: Literal["native", "functional"] = "native"
+    """Communication backend used by sequence-parallel attention.
+
+    - ``"native"`` uses imperative ``torch.distributed`` collectives.
+    - ``"functional"`` uses graphable tensor collectives. It currently
+      supports CUDA/NCCL Ulysses with evenly sharded sequence inputs.
+    """
+
     cfg_parallel_size: int = 1
     """Number of Classifier Free Guidance (CFG) parallel groups."""
 
@@ -255,6 +263,16 @@ class DiffusionParallelConfig:
         assert self.ulysses_mode in {"strict", "advanced_uaa"}, (
             f"ulysses_mode must be one of {{'strict','advanced_uaa'}}, but got {self.ulysses_mode!r}."
         )
+        assert self.sp_communication_backend in {"native", "functional"}, (
+            "sp_communication_backend must be one of {'native','functional'}, "
+            f"but got {self.sp_communication_backend!r}."
+        )
+        if self.sp_communication_backend == "functional":
+            assert self.ulysses_degree > 1 and self.ring_degree == 1 and self.allgather_degree == 1, (
+                "sp_communication_backend='functional' currently supports pure "
+                "Ulysses only (ulysses_degree > 1, ring_degree = "
+                "allgather_degree = 1)."
+            )
 
         # Validate HSDP configuration
         if self.use_hsdp:

--- a/vllm_omni/diffusion/distributed/comm.py
+++ b/vllm_omni/diffusion/distributed/comm.py
@@ -8,13 +8,22 @@ import torch
 import torch.distributed as dist
 from torch import Tensor
 
+from vllm_omni.diffusion.distributed.functional_collectives import (
+    functional_all_to_all_single,
+)
 from vllm_omni.platforms import current_omni_platform
 
 __all__ = ["all_to_all_4D", "all_to_all_5D", "SeqAllToAll4D", "SeqAllToAll5D", "RingComm"]
 
 
 def all_to_all_4D(
-    input: torch.tensor, scatter_idx: int = 2, gather_idx: int = 1, group=None, use_sync: bool = False
+    input: torch.tensor,
+    scatter_idx: int = 2,
+    gather_idx: int = 1,
+    group=None,
+    use_sync: bool = False,
+    communication_backend: str = "native",
+    world_size: int | None = None,
 ) -> torch.tensor:
     """
     all-to-all for QKV
@@ -25,13 +34,17 @@ def all_to_all_4D(
         gather_idx (int): default 2
         group (torch.distributed.ProcessGroup): torch process group
         use_sync (bool): whether to synchronize after all-to-all
+        communication_backend (str): ``native`` or graphable ``functional``
+        world_size (int | None): cached group size for compile-friendly callers
 
     Returns:
         torch.tensor: resharded tensor (bs, seqlen/P, hc, hs)
     """
     assert input.dim() == 4, f"input must be 4D tensor, got {input.dim()} and shape {input.shape}"
 
-    seq_world_size = dist.get_world_size(group)
+    seq_world_size = world_size
+    if seq_world_size is None:
+        seq_world_size = dist.get_world_size(group)
 
     if scatter_idx == 2 and gather_idx == 1:
         # input (torch.tensor): a tensor sharded along dim 1 (bs, seqlen/P, hc, hs) output: (bs, seqlen, hc/P, hs)
@@ -43,14 +56,26 @@ def all_to_all_4D(
         # (bs, seqlen/P, hc, hs) -reshape-> (bs, seq_len/P, P, hc/P, hs) -transpose(0,2)-> (P, seq_len/P, bs, hc/P, hs)
         input_t = input.reshape(bs, shard_seqlen, seq_world_size, shard_hc, hs).transpose(0, 2).contiguous()
 
-        output = torch.empty_like(input_t)
         # https://pytorch.org/docs/stable/distributed.html#torch.distributed.all_to_all_single
         # (P, seq_len/P, bs, hc/P, hs) scatter seqlen -all2all-> (P, seq_len/P, bs, hc/P, hs) scatter head
 
         if seq_world_size > 1:
-            dist.all_to_all_single(output, input_t, group=group)
-            if use_sync:
-                current_omni_platform.synchronize()
+            if communication_backend == "functional":
+                output = functional_all_to_all_single(
+                    input_t,
+                    output_split_sizes=None,
+                    input_split_sizes=None,
+                    group=group,
+                )
+            elif communication_backend == "native":
+                output = torch.empty_like(input_t)
+                dist.all_to_all_single(output, input_t, group=group)
+                if use_sync:
+                    current_omni_platform.synchronize()
+            else:
+                raise ValueError(
+                    f"communication_backend must be 'native' or 'functional', got {communication_backend!r}."
+                )
         else:
             output = input_t
         # if scattering the seq-dim, transpose the heads back to the original dimension
@@ -66,8 +91,6 @@ def all_to_all_4D(
         bs, seqlen, shard_hc, hs = input.shape
         hc = shard_hc * seq_world_size
         shard_seqlen = seqlen // seq_world_size
-        seq_world_size = dist.get_world_size(group)
-
         # transpose groups of heads with the seq-len parallel dimension, so that we can scatter them!
         # (bs, seqlen, hc/P, hs) -reshape-> (bs, P, seq_len/P, hc/P, hs) -transpose(0, 3)->
         #  (hc/P, P, seqlen/P, bs, hs) -transpose(0, 1) -> (P, hc/P, seqlen/P, bs, hs)
@@ -79,13 +102,25 @@ def all_to_all_4D(
             .reshape(seq_world_size, shard_hc, shard_seqlen, bs, hs)
         )
 
-        output = torch.empty_like(input_t)
         # https://pytorch.org/docs/stable/distributed.html#torch.distributed.all_to_all_single
         # (P, bs x hc/P, seqlen/P, hs) scatter seqlen -all2all-> (P, bs x seq_len/P, hc/P, hs) scatter head
         if seq_world_size > 1:
-            dist.all_to_all_single(output, input_t, group=group)
-            if use_sync:
-                current_omni_platform.synchronize()
+            if communication_backend == "functional":
+                output = functional_all_to_all_single(
+                    input_t,
+                    output_split_sizes=None,
+                    input_split_sizes=None,
+                    group=group,
+                )
+            elif communication_backend == "native":
+                output = torch.empty_like(input_t)
+                dist.all_to_all_single(output, input_t, group=group)
+                if use_sync:
+                    current_omni_platform.synchronize()
+            else:
+                raise ValueError(
+                    f"communication_backend must be 'native' or 'functional', got {communication_backend!r}."
+                )
         else:
             output = input_t
 

--- a/vllm_omni/diffusion/distributed/functional_collectives.py
+++ b/vllm_omni/diffusion/distributed/functional_collectives.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Graphable tensor-based collectives for diffusion sequence parallelism.
+
+PyTorch's functional collectives return tensors whose dependencies can be
+captured by ``torch.compile``.  Keep the private PyTorch import isolated in
+this module so callers have one compatibility boundary and the native
+``torch.distributed`` path can remain the default fallback.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+
+def launch_functional_all_to_all_single(
+    input_tensor: torch.Tensor,
+    *,
+    output_split_sizes: list[int] | None,
+    input_split_sizes: list[int] | None,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Launch a graphable all-to-all-single without forcing materialization."""
+    import torch.distributed._functional_collectives as funcol
+
+    return funcol.all_to_all_single(
+        input_tensor,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=group,
+    )
+
+
+def wait_functional_collective(output: torch.Tensor) -> torch.Tensor:
+    """Materialize a tensor returned by a functional collective."""
+    import torch.distributed._functional_collectives as funcol
+
+    return funcol.wait_tensor(output)
+
+
+def functional_all_to_all_single(
+    input_tensor: torch.Tensor,
+    *,
+    output_split_sizes: list[int] | None,
+    input_split_sizes: list[int] | None,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Run a graphable all-to-all-single and materialize its tensor result."""
+    output = launch_functional_all_to_all_single(
+        input_tensor,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=group,
+    )
+    return wait_functional_collective(output)
+
+
+def functional_all_gather_tensor(
+    input_tensor: torch.Tensor,
+    *,
+    gather_dim: int,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Run a graphable all-gather along ``gather_dim``."""
+    import torch.distributed._functional_collectives as funcol
+
+    # funcol.all_gather_tensor handles non-zero gather dimensions through
+    # torch._utils._maybe_view_chunk_cat, which Dynamo intentionally skips.
+    # Move the gather dimension to the front and call the graphable c10d
+    # primitive directly instead.
+    input_tensor = input_tensor.movedim(gather_dim, 0).contiguous()
+    group_name = funcol._resolve_group_name(group, "")
+    group_size = funcol.c10d._get_group_size_by_name(group_name)
+    output = torch.ops._c10d_functional.all_gather_into_tensor(
+        input_tensor,
+        group_size,
+        group_name,
+    )
+    output = funcol._maybe_wrap_tensor(output)
+    output = wait_functional_collective(output)
+    return output.movedim(0, gather_dim).contiguous()

--- a/vllm_omni/diffusion/distributed/sp_plan.py
+++ b/vllm_omni/diffusion/distributed/sp_plan.py
@@ -36,7 +36,7 @@ Example:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import torch
@@ -69,6 +69,9 @@ class SequenceParallelConfig:
             sequences with limited memory/bandwidth.
         convert_to_fp32: Whether to convert output and LSE to float32 for
             numerical stability in ring attention.
+        communication_backend: Communication implementation used by attention
+            and output gathers. ``functional`` is graphable and currently
+            supports pure CUDA/NCCL Ulysses only.
 
     Note:
         ulysses_degree * ring_degree = sequence_parallel_size
@@ -79,6 +82,7 @@ class SequenceParallelConfig:
     ring_degree: int = 1
     allgather_degree: int = 1
     convert_to_fp32: bool = True
+    communication_backend: Literal["native", "functional"] = "native"
 
     # Internal state - populated by setup()
     _rank: int | None = None
@@ -93,6 +97,16 @@ class SequenceParallelConfig:
             raise ValueError("AllGather-KV is mutually exclusive with Ulysses and Ring.")
         if self.ulysses_degree == self.ring_degree == self.allgather_degree == 1:
             raise ValueError("At least one SP degree must be > 1.")
+        if self.communication_backend not in {"native", "functional"}:
+            raise ValueError("communication_backend must be 'native' or 'functional'.")
+        if self.communication_backend == "functional" and (
+            self.ulysses_degree <= 1 or self.ring_degree != 1 or self.allgather_degree != 1
+        ):
+            raise ValueError(
+                "communication_backend='functional' currently supports pure "
+                "Ulysses only (ulysses_degree > 1, ring_degree = "
+                "allgather_degree = 1)."
+            )
 
     @property
     def sequence_parallel_size(self) -> int:

--- a/vllm_omni/diffusion/distributed/sp_plan.py
+++ b/vllm_omni/diffusion/distributed/sp_plan.py
@@ -220,10 +220,13 @@ class SequenceParallelInput:
             This is useful for layers whose outputs should be split after preprocessing
             (e.g., RoPE embeddings).
         auto_pad: If True, automatically pad the tensor if its size along split_dim
-            is not divisible by world_size. Creates an attention mask to indicate
-            valid vs padding positions. The mask is stored in ForwardContext.
+            is not divisible by world_size. Padding metadata is stored in
+            ForwardContext so models can construct attention masks when needed.
             Note: Ring attention does not support attention mask, so auto_pad
             should only be used with Ulysses SP.
+        shard_group: Optional key shared by tensors representing the same global
+            sequence. Keyed groups track independent padding metadata; omitting
+            it preserves the legacy single-sequence padding behavior.
 
     Example:
         # Split hidden_states along sequence dimension (dim 1)
@@ -240,12 +243,13 @@ class SequenceParallelInput:
     expected_dims: int | None = None
     split_output: bool = False
     auto_pad: bool = False
+    shard_group: str | None = None
 
     def __repr__(self) -> str:
         return (
             f"SequenceParallelInput(split_dim={self.split_dim}, "
             f"expected_dims={self.expected_dims}, split_output={self.split_output}, "
-            f"auto_pad={self.auto_pad})"
+            f"auto_pad={self.auto_pad}, shard_group={self.shard_group!r})"
         )
 
 
@@ -262,6 +266,8 @@ class SequenceParallelOutput:
         gather_dim: The dimension along which to gather the tensor.
         expected_dims: Expected number of dimensions. If provided, validates that
             the tensor has this many dimensions before gathering.
+        shard_group: Optional key whose padding metadata determines the gathered
+            sequence length. Omitting it preserves legacy singleton trimming.
 
     Example:
         # Gather output along sequence dimension (dim 1)
@@ -270,9 +276,13 @@ class SequenceParallelOutput:
 
     gather_dim: int
     expected_dims: int | None = None
+    shard_group: str | None = None
 
     def __repr__(self) -> str:
-        return f"SequenceParallelOutput(gather_dim={self.gather_dim}, expected_dims={self.expected_dims})"
+        return (
+            f"SequenceParallelOutput(gather_dim={self.gather_dim}, "
+            f"expected_dims={self.expected_dims}, shard_group={self.shard_group!r})"
+        )
 
 
 @dataclass(frozen=True)

--- a/vllm_omni/diffusion/distributed/sp_sharding.py
+++ b/vllm_omni/diffusion/distributed/sp_sharding.py
@@ -24,6 +24,121 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 logger = init_logger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class SequenceShardMetadata:
+    """Static metadata for one globally padded sequence shard.
+
+    A shard group identifies tensors that represent the same global sequence
+    (for example, hidden states, mask, and RoPE tensors). All tensors in a
+    group are padded and split identically.
+    """
+
+    original_seq_len: int
+    padded_seq_len: int
+    world_size: int
+    rank: int
+    local_seq_len: int
+
+    def __post_init__(self) -> None:
+        if self.original_seq_len < 0:
+            raise ValueError("original_seq_len must be non-negative.")
+        if self.world_size < 1:
+            raise ValueError("world_size must be >= 1.")
+        if self.rank < 0 or self.rank >= self.world_size:
+            raise ValueError(f"rank must be in [0, {self.world_size}), got {self.rank}.")
+        if self.padded_seq_len < self.original_seq_len:
+            raise ValueError("padded_seq_len must be >= original_seq_len.")
+        if self.padded_seq_len % self.world_size != 0:
+            raise ValueError("padded_seq_len must be divisible by world_size.")
+        if self.local_seq_len != self.padded_seq_len // self.world_size:
+            raise ValueError("local_seq_len must equal padded_seq_len // world_size.")
+
+    @classmethod
+    def from_global_length(
+        cls,
+        original_seq_len: int,
+        *,
+        world_size: int,
+        rank: int,
+    ) -> SequenceShardMetadata:
+        """Build metadata for an evenly padded shard of a global sequence."""
+        if original_seq_len < 0:
+            raise ValueError("original_seq_len must be non-negative.")
+        if world_size < 1:
+            raise ValueError("world_size must be >= 1.")
+        padded_seq_len = ((original_seq_len + world_size - 1) // world_size) * world_size
+        return cls(
+            original_seq_len=original_seq_len,
+            padded_seq_len=padded_seq_len,
+            world_size=world_size,
+            rank=rank,
+            local_seq_len=padded_seq_len // world_size,
+        )
+
+    @classmethod
+    def identity(cls, seq_len: int) -> SequenceShardMetadata:
+        """Build metadata for a non-sharded sequence."""
+        return cls.from_global_length(seq_len, world_size=1, rank=0)
+
+    @property
+    def padding_size(self) -> int:
+        return self.padded_seq_len - self.original_seq_len
+
+    @property
+    def local_start(self) -> int:
+        return self.rank * self.local_seq_len
+
+    @property
+    def local_end(self) -> int:
+        return self.local_start + self.local_seq_len
+
+    def local_valid_length(self, global_valid_length: int) -> int:
+        """Return this rank's valid prefix length for a global prefix."""
+        if global_valid_length < 0 or global_valid_length > self.original_seq_len:
+            raise ValueError(
+                f"global_valid_length must be in [0, {self.original_seq_len}], "
+                f"got {global_valid_length}."
+            )
+        return max(
+            0,
+            min(global_valid_length, self.local_end) - self.local_start,
+        )
+
+    def local_valid_lengths(self, global_valid_lengths: list[int]) -> list[int]:
+        """Vectorized :meth:`local_valid_length` for batched prefix lengths."""
+        return [self.local_valid_length(int(length)) for length in global_valid_lengths]
+
+    def local_segment_lengths(
+        self,
+        global_segment_lengths: list[list[int]],
+    ) -> list[list[int]]:
+        """Intersect contiguous per-sample segments with this rank's shard."""
+        local_lengths: list[list[int]] = []
+        for sample_lengths in global_segment_lengths:
+            if any(int(length) < 0 for length in sample_lengths):
+                raise ValueError("Segment lengths must be non-negative.")
+            if sum(int(length) for length in sample_lengths) > self.original_seq_len:
+                raise ValueError(
+                    "The sum of segment lengths cannot exceed original_seq_len "
+                    f"({self.original_seq_len})."
+                )
+
+            sample_local: list[int] = []
+            segment_start = 0
+            for length in sample_lengths:
+                segment_end = segment_start + int(length)
+                sample_local.append(
+                    max(
+                        0,
+                        min(segment_end, self.local_end)
+                        - max(segment_start, self.local_start),
+                    )
+                )
+                segment_start = segment_end
+            local_lengths.append(sample_local)
+        return local_lengths
+
+
 def sp_shard(
     tensor: torch.Tensor,
     dim: int,

--- a/vllm_omni/diffusion/distributed/sp_sharding.py
+++ b/vllm_omni/diffusion/distributed/sp_sharding.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from typing import Literal
 
 import torch
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.distributed.functional_collectives import (
+    functional_all_gather_tensor,
+)
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,
@@ -95,10 +99,7 @@ class SequenceShardMetadata:
     def local_valid_length(self, global_valid_length: int) -> int:
         """Return this rank's valid prefix length for a global prefix."""
         if global_valid_length < 0 or global_valid_length > self.original_seq_len:
-            raise ValueError(
-                f"global_valid_length must be in [0, {self.original_seq_len}], "
-                f"got {global_valid_length}."
-            )
+            raise ValueError(f"global_valid_length must be in [0, {self.original_seq_len}], got {global_valid_length}.")
         return max(
             0,
             min(global_valid_length, self.local_end) - self.local_start,
@@ -119,8 +120,7 @@ class SequenceShardMetadata:
                 raise ValueError("Segment lengths must be non-negative.")
             if sum(int(length) for length in sample_lengths) > self.original_seq_len:
                 raise ValueError(
-                    "The sum of segment lengths cannot exceed original_seq_len "
-                    f"({self.original_seq_len})."
+                    f"The sum of segment lengths cannot exceed original_seq_len ({self.original_seq_len})."
                 )
 
             sample_local: list[int] = []
@@ -130,8 +130,7 @@ class SequenceShardMetadata:
                 sample_local.append(
                     max(
                         0,
-                        min(segment_end, self.local_end)
-                        - max(segment_start, self.local_start),
+                        min(segment_end, self.local_end) - max(segment_start, self.local_start),
                     )
                 )
                 segment_start = segment_end
@@ -190,6 +189,7 @@ def sp_gather(
     tensor: torch.Tensor,
     dim: int,
     validate: bool = True,
+    communication_backend: Literal["native", "functional"] = "native",
 ) -> torch.Tensor:
     """Gather a tensor along the specified dimension from all sequence parallel ranks.
 
@@ -199,6 +199,8 @@ def sp_gather(
         tensor: The local shard to gather.
         dim: The dimension along which to gather.
         validate: If True, validate tensor consistency (currently unused).
+        communication_backend: Collective implementation. ``functional`` is
+            graphable by ``torch.compile`` and currently supports CUDA/NCCL.
 
     Returns:
         The full tensor gathered from all ranks.
@@ -213,6 +215,14 @@ def sp_gather(
         return tensor
 
     sp_group = get_sp_group()
+    if communication_backend == "functional":
+        return functional_all_gather_tensor(
+            tensor,
+            gather_dim=dim,
+            group=sp_group.device_group,
+        )
+    if communication_backend != "native":
+        raise ValueError(f"communication_backend must be 'native' or 'functional', got {communication_backend!r}.")
     return sp_group.all_gather(tensor, dim=dim)
 
 

--- a/vllm_omni/diffusion/forward_context.py
+++ b/vllm_omni/diffusion/forward_context.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, overload
 
 import torch
 import vllm.ir
@@ -15,6 +15,10 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 
 if TYPE_CHECKING:
     import torch
+
+    from vllm_omni.diffusion.distributed.sp_sharding import (
+        SequenceShardMetadata,
+    )
 
 
 @dataclass
@@ -39,6 +43,9 @@ class ForwardContext:
     sp_padding_size: int = 0
     # Original sequence length before padding (for removing padding in gather)
     sp_original_seq_len: int | None = None
+    # Independent padding/sharding metadata keyed by SequenceParallelInput
+    # shard_group. The singleton fields above remain for backward compatibility.
+    sp_shard_metadata: dict[str, SequenceShardMetadata] = field(default_factory=dict)
 
     # Set by registry when _sp_plan hooks are applied.
     # When True, sp_active is determined by _sp_shard_depth (for _sp_plan hooks)
@@ -87,6 +94,42 @@ def get_forward_context() -> ForwardContext:
 
 def is_forward_context_available() -> bool:
     return _forward_context is not None
+
+
+@overload
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: int,
+) -> SequenceShardMetadata: ...
+
+
+@overload
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: None = None,
+) -> SequenceShardMetadata | None: ...
+
+
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: int | None = None,
+) -> SequenceShardMetadata | None:
+    """Get keyed SP shard metadata, optionally falling back to identity."""
+    if is_forward_context_available():
+        metadata = get_forward_context().sp_shard_metadata.get(shard_group)
+        if metadata is not None:
+            return metadata
+    if default_seq_len is None:
+        return None
+
+    from vllm_omni.diffusion.distributed.sp_sharding import (
+        SequenceShardMetadata,
+    )
+
+    return SequenceShardMetadata.identity(default_seq_len)
 
 
 def build_local_sp_padding_mask(

--- a/vllm_omni/diffusion/hooks/sequence_parallel.py
+++ b/vllm_omni/diffusion/hooks/sequence_parallel.py
@@ -50,7 +50,11 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelOutput,
     SequenceParallelPartialInput,
 )
-from vllm_omni.diffusion.distributed.sp_sharding import sp_gather, sp_shard
+from vllm_omni.diffusion.distributed.sp_sharding import (
+    SequenceShardMetadata,
+    sp_gather,
+    sp_shard,
+)
 from vllm_omni.diffusion.hooks.base import HookRegistry, ModelHook
 
 logger = init_logger(__name__)
@@ -173,6 +177,13 @@ class SequenceParallelSplitHook(ModelHook):
         self.module_forward_metadata: ModuleForwardMetadata | None = None
         # Cache for text lengths resolved from kwargs
         self._text_len_cache: dict[str, int] = {}
+        self._shard_groups = {
+            sp_input.shard_group
+            for value in metadata.values()
+            for sp_input in (value if isinstance(value, (list, tuple)) else (value,))
+            if isinstance(sp_input, SequenceParallelInput)
+            and sp_input.shard_group is not None
+        }
 
     def initialize_hook(self, module: nn.Module) -> nn.Module:
         cls = _unwrap_module(module).__class__
@@ -184,6 +195,16 @@ class SequenceParallelSplitHook(ModelHook):
         args_list = list(args)
         # Clear text length cache for this forward pass
         self._text_len_cache.clear()
+        if self._shard_groups:
+            from vllm_omni.diffusion.forward_context import (
+                get_forward_context,
+                is_forward_context_available,
+            )
+
+            if is_forward_context_available():
+                ctx = get_forward_context()
+                for shard_group in self._shard_groups:
+                    ctx.sp_shard_metadata.pop(shard_group, None)
 
         for name, spm in self.metadata.items():
             # Skip if this is a split_output entry (handled in post_forward)
@@ -353,7 +374,11 @@ class SequenceParallelSplitHook(ModelHook):
         if isinstance(sp_input, SequenceParallelInput):
             # Full split with optional auto-padding
             if sp_input.auto_pad:
-                return self._shard_with_auto_pad(x, sp_input.split_dim)
+                return self._shard_with_auto_pad(
+                    x,
+                    sp_input.split_dim,
+                    sp_input.shard_group,
+                )
             _maybe_validate_strict_divisibility(dim=sp_input.split_dim, seq_len=x.size(sp_input.split_dim))
             return sp_shard(x, sp_input.split_dim, validate=False)
         elif isinstance(sp_input, SequenceParallelPartialInput):
@@ -374,7 +399,12 @@ class SequenceParallelSplitHook(ModelHook):
         else:
             raise ValueError(f"Unsupported input config type: {type(sp_input).__name__}")
 
-    def _shard_with_auto_pad(self, x: torch.Tensor, dim: int) -> torch.Tensor:
+    def _shard_with_auto_pad(
+        self,
+        x: torch.Tensor,
+        dim: int,
+        shard_group: str | None,
+    ) -> torch.Tensor:
         """Shard tensor with automatic padding and attention mask creation.
 
         When sequence length is not divisible by SP world size, this method:
@@ -395,10 +425,28 @@ class SequenceParallelSplitHook(ModelHook):
             return x
 
         seq_len = x.size(dim)
+        rank = get_sequence_parallel_rank()
+        shard_metadata = SequenceShardMetadata.from_global_length(
+            seq_len,
+            world_size=world_size,
+            rank=rank,
+        )
         remainder = seq_len % world_size
 
+        if is_forward_context_available():
+            ctx = get_forward_context()
+            if shard_group is not None:
+                existing = ctx.sp_shard_metadata.get(shard_group)
+                if existing is not None and existing != shard_metadata:
+                    raise ValueError(
+                        f"All tensors in shard_group={shard_group!r} must have "
+                        "the same global sequence length and shard layout, but "
+                        f"got {existing} and {shard_metadata}."
+                    )
+                ctx.sp_shard_metadata[shard_group] = shard_metadata
+
         if remainder == 0:
-            # No padding needed
+            # Keyed groups record metadata even when no padding is necessary.
             return sp_shard(x, dim, validate=False)
 
         # Check backend compatibility
@@ -429,8 +477,8 @@ class SequenceParallelSplitHook(ModelHook):
             )
 
         # Calculate padding
-        pad_size = world_size - remainder
-        padded_seq_len = seq_len + pad_size
+        pad_size = shard_metadata.padding_size
+        padded_seq_len = shard_metadata.padded_seq_len
 
         # Pad the tensor
         pad_shape = list(x.shape)
@@ -452,7 +500,6 @@ class SequenceParallelSplitHook(ModelHook):
                 )
 
         # Shard the padded tensor
-        rank = get_sequence_parallel_rank()
         return x_padded.chunk(world_size, dim=dim)[rank]
 
 
@@ -496,12 +543,6 @@ class SequenceParallelGatherHook(ModelHook):
         if len(output) != len(self.metadata):
             raise ValueError(f"Expected {len(self.metadata)} outputs, got {len(output)}.")
 
-        # Check if padding was applied during split
-        original_seq_len = None
-        if is_forward_context_available():
-            ctx = get_forward_context()
-            original_seq_len = ctx.sp_original_seq_len
-
         actually_gathered = False
 
         for i, spm in enumerate(self.metadata):
@@ -519,6 +560,19 @@ class SequenceParallelGatherHook(ModelHook):
             gathered = sp_gather(x, spm.gather_dim, validate=False)
 
             # Remove padding if it was applied
+            original_seq_len = None
+            if is_forward_context_available():
+                ctx = get_forward_context()
+                if spm.shard_group is None:
+                    original_seq_len = ctx.sp_original_seq_len
+                else:
+                    shard_metadata = ctx.sp_shard_metadata.get(spm.shard_group)
+                    if shard_metadata is None:
+                        raise RuntimeError(
+                            f"No SP shard metadata was registered for "
+                            f"shard_group={spm.shard_group!r}."
+                        )
+                    original_seq_len = shard_metadata.original_seq_len
             if original_seq_len is not None and gathered.size(spm.gather_dim) > original_seq_len:
                 gathered = gathered.narrow(spm.gather_dim, 0, original_seq_len)
                 logger.debug(f"Removed padding: gathered shape {gathered.shape} (original_seq_len={original_seq_len})")

--- a/vllm_omni/diffusion/hooks/sequence_parallel.py
+++ b/vllm_omni/diffusion/hooks/sequence_parallel.py
@@ -181,8 +181,7 @@ class SequenceParallelSplitHook(ModelHook):
             sp_input.shard_group
             for value in metadata.values()
             for sp_input in (value if isinstance(value, (list, tuple)) else (value,))
-            if isinstance(sp_input, SequenceParallelInput)
-            and sp_input.shard_group is not None
+            if isinstance(sp_input, SequenceParallelInput) and sp_input.shard_group is not None
         }
 
     def initialize_hook(self, module: nn.Module) -> nn.Module:
@@ -557,7 +556,12 @@ class SequenceParallelGatherHook(ModelHook):
                 continue
 
             # Gather from all ranks
-            gathered = sp_gather(x, spm.gather_dim, validate=False)
+            gathered = sp_gather(
+                x,
+                spm.gather_dim,
+                validate=False,
+                communication_backend=self.config.communication_backend,
+            )
 
             # Remove padding if it was applied
             original_seq_len = None
@@ -568,10 +572,7 @@ class SequenceParallelGatherHook(ModelHook):
                 else:
                     shard_metadata = ctx.sp_shard_metadata.get(spm.shard_group)
                     if shard_metadata is None:
-                        raise RuntimeError(
-                            f"No SP shard metadata was registered for "
-                            f"shard_group={spm.shard_group!r}."
-                        )
+                        raise RuntimeError(f"No SP shard metadata was registered for shard_group={spm.shard_group!r}.")
                     original_seq_len = shard_metadata.original_seq_len
             if original_seq_len is not None and gathered.size(spm.gather_dim) > original_seq_len:
                 gathered = gathered.narrow(spm.gather_dim, 0, original_seq_len)

--- a/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
+++ b/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
@@ -34,6 +34,11 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.sp_plan import (
+    SequenceParallelInput,
+    SequenceParallelOutput,
+)
+from vllm_omni.diffusion.forward_context import get_sp_shard_metadata
 
 logger = init_logger(__name__)
 
@@ -341,12 +346,16 @@ def _concat_instruction_image_features(
     assert len(img_tensors) == len(instruct_tensors)
 
     batch_size = img_tensors[0].shape[0]
-    max_seq_len = max(seq_lengths)
+    joint_capacity = instruct_tensors[0].shape[1] + img_tensors[0].shape[1]
 
     concatenated_list = []
     for img_tensor, instruct_tensor in zip(img_tensors, instruct_tensors):
         feature_dim = img_tensor.shape[-1]
-        concatenated = img_tensor.new_zeros(batch_size, max_seq_len, feature_dim)
+        concatenated = img_tensor.new_zeros(
+            batch_size,
+            joint_capacity,
+            feature_dim,
+        )
         for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
             concatenated[i, :encoder_seq_len] = instruct_tensor[i, :encoder_seq_len]
             concatenated[i, encoder_seq_len:seq_len] = img_tensor[i, : seq_len - encoder_seq_len]
@@ -359,16 +368,24 @@ def _split_instruction_image_features(
     hidden_states: torch.Tensor,
     encoder_seq_lengths: list[int],
     seq_lengths: list[int],
+    *,
+    instruct_capacity: int,
+    img_capacity: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Unpack a joint sequence back into (instruction, image) streams."""
     batch_size = hidden_states.shape[0]
     feature_dim = hidden_states.shape[-1]
 
-    max_instruct_len = max(encoder_seq_lengths)
-    max_img_len = max(seq_len - encoder_seq_len for seq_len, encoder_seq_len in zip(seq_lengths, encoder_seq_lengths))
-
-    instruct_hidden_states = hidden_states.new_zeros(batch_size, max_instruct_len, feature_dim)
-    img_hidden_states = hidden_states.new_zeros(batch_size, max_img_len, feature_dim)
+    instruct_hidden_states = hidden_states.new_zeros(
+        batch_size,
+        instruct_capacity,
+        feature_dim,
+    )
+    img_hidden_states = hidden_states.new_zeros(
+        batch_size,
+        img_capacity,
+        feature_dim,
+    )
 
     for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
         img_len = seq_len - encoder_seq_len
@@ -529,7 +546,11 @@ class BooguImageJointAttention(nn.Module):
         attn_output = attn_output.flatten(2, 3).to(dtype)
 
         instruct_attn_out, img_attn_out = _split_instruction_image_features(
-            attn_output, encoder_seq_lengths, seq_lengths
+            attn_output,
+            encoder_seq_lengths,
+            seq_lengths,
+            instruct_capacity=instruct_hidden_states.shape[1],
+            img_capacity=img_hidden_states.shape[1],
         )
         instruct_projected, _ = self.instruct_out(instruct_attn_out)
         img_projected, _ = self.img_out(img_attn_out)
@@ -800,6 +821,20 @@ def _cal_preprocessed_instruction_feat_dim(instruction_feature_configs: dict) ->
         raise ValueError(f"Invalid reduce_type: {reduce_type}")
 
 
+class _BooguImageSPBoundary(nn.Module):
+    """Identity module used by framework SP split hooks."""
+
+    def forward(self, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        return tensors
+
+
+class _BooguImageSPGather(nn.Module):
+    """Identity module used by the framework SP gather hook."""
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
+
+
 class BooguImageTransformer2DModel(nn.Module):
     """Boogu-Image transformer with mixed stream topology.
 
@@ -817,6 +852,38 @@ class BooguImageTransformer2DModel(nn.Module):
         "BooguImageSingleStreamTransformerBlock",
     ]
     _layerwise_offload_blocks_attrs = ["single_stream_layers", "double_stream_layers"]
+    _sp_plan = {
+        "sp_shard_boundary": {
+            index: SequenceParallelInput(
+                split_dim=1,
+                expected_dims=dims,
+                split_output=True,
+                auto_pad=True,
+                shard_group=shard_group,
+            )
+            for index, (dims, shard_group) in enumerate(
+                zip(
+                    (3, 3, 3, 2, 2, 2, 3, 3, 3),
+                    (
+                        "image",
+                        "reference",
+                        "context",
+                        "image",
+                        "reference",
+                        "context",
+                        "image",
+                        "reference",
+                        "context",
+                    ),
+                )
+            )
+        },
+        "sp_gather_boundary": SequenceParallelOutput(
+            gather_dim=1,
+            expected_dims=3,
+            shard_group="image",
+        ),
+    }
 
     def __init__(self, od_config: OmniDiffusionConfig) -> None:
         super().__init__()
@@ -878,6 +945,8 @@ class BooguImageTransformer2DModel(nn.Module):
             axes_lens=axes_lens,
             patch_size=patch_size,
         )
+        self.sp_shard_boundary = _BooguImageSPBoundary()
+        self.sp_gather_boundary = _BooguImageSPGather()
 
         self.x_embedder = nn.Linear(
             in_features=patch_size * patch_size * in_channels,
@@ -1112,6 +1181,7 @@ class BooguImageTransformer2DModel(nn.Module):
         l_effective_ref_img_len,
         l_effective_img_len,
         temb,
+        preserve_ref_shard_capacity: bool = False,
     ):
         """Embed image patches and run the refiner blocks.
 
@@ -1121,9 +1191,7 @@ class BooguImageTransformer2DModel(nn.Module):
         avoiding a degenerate zero-length attention.
         """
         batch_size = len(hidden_states)
-        max_combined_img_len = max(
-            img_len + sum(ref_img_len) for img_len, ref_img_len in zip(l_effective_img_len, l_effective_ref_img_len)
-        )
+        max_combined_img_len = hidden_states.shape[1] + ref_image_hidden_states.shape[1]
 
         hidden_states = self.x_embedder(hidden_states)
         ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states)
@@ -1142,6 +1210,14 @@ class BooguImageTransformer2DModel(nn.Module):
         flat_l_effective_ref_img_len = list(itertools.chain(*l_effective_ref_img_len))
         num_ref_images = len(flat_l_effective_ref_img_len)
         max_ref_img_len = max(flat_l_effective_ref_img_len)
+        if preserve_ref_shard_capacity:
+            # Functional collectives require the same sequence extent on every
+            # rank. Keep the packed per-reference batch at the local padded
+            # capacity instead of shrinking it to a rank-local effective max.
+            max_ref_img_len = max(
+                max_ref_img_len,
+                padded_ref_img_mask.shape[1],
+            )
 
         if max_ref_img_len > 0:
             batch_ref_img_mask = ref_image_hidden_states.new_zeros(num_ref_images, max_ref_img_len, dtype=torch.bool)
@@ -1168,8 +1244,17 @@ class BooguImageTransformer2DModel(nn.Module):
                     idx += 1
 
             for layer in self.ref_image_refiner:
+                ref_attention_mask = (
+                    batch_ref_img_mask
+                    if preserve_ref_shard_capacity
+                    or any(length != max_ref_img_len for length in flat_l_effective_ref_img_len)
+                    else None
+                )
                 batch_ref_image_hidden_states = layer(
-                    batch_ref_image_hidden_states, batch_ref_img_mask, batch_ref_img_rotary_emb, batch_temb
+                    batch_ref_image_hidden_states,
+                    ref_attention_mask,
+                    batch_ref_img_rotary_emb,
+                    batch_temb,
                 )
 
             # Restore reference-image sequence layout.
@@ -1189,6 +1274,75 @@ class BooguImageTransformer2DModel(nn.Module):
             combined_img_hidden_states[i, sum(ref_img_len) : sum(ref_img_len) + img_len] = hidden_states[i, :img_len]
 
         return combined_img_hidden_states
+
+    @staticmethod
+    def _mask_or_none(
+        mask: torch.Tensor,
+        effective_lengths: list[int],
+        *,
+        required: bool = False,
+    ) -> torch.Tensor | None:
+        return mask if required or any(int(length) != mask.shape[1] for length in effective_lengths) else None
+
+    @staticmethod
+    def _pack_local_rotary(
+        context_rotary_emb: torch.Tensor,
+        ref_img_rotary_emb: torch.Tensor,
+        noise_rotary_emb: torch.Tensor,
+        encoder_seq_lengths: list[int],
+        ref_img_seq_lengths: list[list[int]],
+        img_seq_lengths: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int], list[int]]:
+        batch_size = context_rotary_emb.shape[0]
+        rotary_dim = context_rotary_emb.shape[-1]
+        combined_img_seq_lengths = [
+            sum(ref_lengths) + img_length
+            for ref_lengths, img_length in zip(
+                ref_img_seq_lengths,
+                img_seq_lengths,
+            )
+        ]
+        seq_lengths = [
+            context_length + combined_length
+            for context_length, combined_length in zip(
+                encoder_seq_lengths,
+                combined_img_seq_lengths,
+            )
+        ]
+        combined_img_capacity = ref_img_rotary_emb.shape[1] + noise_rotary_emb.shape[1]
+        combined_img_rotary_emb = context_rotary_emb.new_zeros(
+            batch_size,
+            combined_img_capacity,
+            rotary_dim,
+        )
+        rotary_emb = context_rotary_emb.new_zeros(
+            batch_size,
+            context_rotary_emb.shape[1] + combined_img_capacity,
+            rotary_dim,
+        )
+
+        for i, (context_length, ref_lengths, img_length) in enumerate(
+            zip(
+                encoder_seq_lengths,
+                ref_img_seq_lengths,
+                img_seq_lengths,
+            )
+        ):
+            ref_length = sum(ref_lengths)
+            combined_length = ref_length + img_length
+            combined_img_rotary_emb[i, :ref_length] = ref_img_rotary_emb[i, :ref_length]
+            combined_img_rotary_emb[i, ref_length:combined_length] = noise_rotary_emb[i, :img_length]
+            rotary_emb[i, :context_length] = context_rotary_emb[i, :context_length]
+            rotary_emb[i, context_length : context_length + combined_length] = combined_img_rotary_emb[
+                i, :combined_length
+            ]
+
+        return (
+            rotary_emb,
+            combined_img_rotary_emb,
+            seq_lengths,
+            combined_img_seq_lengths,
+        )
 
     def forward(
         self,
@@ -1237,11 +1391,11 @@ class BooguImageTransformer2DModel(nn.Module):
             context_rotary_emb,
             ref_img_rotary_emb,
             noise_rotary_emb,
-            rotary_emb,
-            encoder_seq_lengths,
-            seq_lengths,
-            combined_img_rotary_emb,
-            combined_img_seq_lengths,
+            _,
+            global_encoder_seq_lengths,
+            _,
+            _,
+            _,
         ) = self.rope_embedder(
             freqs_cis,
             instruction_attention_mask,
@@ -1252,38 +1406,141 @@ class BooguImageTransformer2DModel(nn.Module):
             device,
         )
 
+        (
+            hidden_states,
+            ref_image_hidden_states,
+            instruction_hidden_states,
+            img_mask,
+            ref_img_mask,
+            instruction_attention_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            context_rotary_emb,
+        ) = self.sp_shard_boundary(
+            hidden_states,
+            ref_image_hidden_states,
+            instruction_hidden_states,
+            img_mask,
+            ref_img_mask,
+            instruction_attention_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            context_rotary_emb,
+        )
+
+        image_shard = get_sp_shard_metadata(
+            "image",
+            default_seq_len=img_mask.shape[1],
+        )
+        reference_shard = get_sp_shard_metadata(
+            "reference",
+            default_seq_len=ref_img_mask.shape[1],
+        )
+        context_shard = get_sp_shard_metadata(
+            "context",
+            default_seq_len=instruction_attention_mask.shape[1],
+        )
+
+        context_mask_required = context_shard.padding_size > 0 or any(
+            length != context_shard.original_seq_len for length in global_encoder_seq_lengths
+        )
+        noise_mask_required = image_shard.padding_size > 0 or any(
+            length != image_shard.original_seq_len for length in l_effective_img_len
+        )
+        ref_mask_required = reference_shard.padding_size > 0 or any(
+            sum(lengths) != reference_shard.original_seq_len for lengths in l_effective_ref_img_len
+        )
+
+        global_img_lengths = list(l_effective_img_len)
+        local_img_lengths = image_shard.local_valid_lengths(
+            global_img_lengths,
+        )
+        local_ref_lengths = reference_shard.local_segment_lengths(
+            l_effective_ref_img_len,
+        )
+        local_encoder_lengths = context_shard.local_valid_lengths(
+            global_encoder_seq_lengths,
+        )
+        (
+            rotary_emb,
+            combined_img_rotary_emb,
+            seq_lengths,
+            combined_img_seq_lengths,
+        ) = self._pack_local_rotary(
+            context_rotary_emb,
+            ref_img_rotary_emb,
+            noise_rotary_emb,
+            local_encoder_lengths,
+            local_ref_lengths,
+            local_img_lengths,
+        )
+
+        context_attention_mask = self._mask_or_none(
+            instruction_attention_mask,
+            local_encoder_lengths,
+            required=context_mask_required,
+        )
+        noise_attention_mask = self._mask_or_none(
+            img_mask,
+            local_img_lengths,
+            required=noise_mask_required,
+        )
+
         # Context refinement.
         for layer in self.context_refiner:
-            instruction_hidden_states = layer(instruction_hidden_states, instruction_attention_mask, context_rotary_emb)
+            instruction_hidden_states = layer(
+                instruction_hidden_states,
+                context_attention_mask,
+                context_rotary_emb,
+            )
 
         # Image patch embedding and refinement.
         combined_img_hidden_states = self.img_patch_embed_and_refine(
             hidden_states,
             ref_image_hidden_states,
-            img_mask,
+            noise_attention_mask,
             ref_img_mask,
             noise_rotary_emb,
             ref_img_rotary_emb,
-            l_effective_ref_img_len,
-            l_effective_img_len,
+            local_ref_lengths,
+            local_img_lengths,
             temb,
+            preserve_ref_shard_capacity=reference_shard.world_size > 1,
         )
 
         instruct_hidden_states = instruction_hidden_states
         img_hidden_states = combined_img_hidden_states
 
         # Joint mask for [instruct + image].
-        max_seq_len = max(seq_lengths)
-        joint_attention_mask = hidden_states.new_zeros(batch_size, max_seq_len, dtype=torch.bool)
+        max_seq_len = rotary_emb.shape[1]
+        joint_attention_mask = hidden_states.new_zeros(
+            batch_size,
+            max_seq_len,
+            dtype=torch.bool,
+        )
         for i, seq_len in enumerate(seq_lengths):
             joint_attention_mask[i, :seq_len] = True
+        joint_attention_mask = self._mask_or_none(
+            joint_attention_mask,
+            seq_lengths,
+            required=(context_mask_required or noise_mask_required or ref_mask_required),
+        )
 
         # Dual-stream (double-stream) stage.
         if self.num_double_stream_layers > 0:
-            max_img_len = max(combined_img_seq_lengths)
-            img_attention_mask = hidden_states.new_zeros(batch_size, max_img_len, dtype=torch.bool)
+            max_img_len = combined_img_rotary_emb.shape[1]
+            img_attention_mask = hidden_states.new_zeros(
+                batch_size,
+                max_img_len,
+                dtype=torch.bool,
+            )
             for i, img_seq_len in enumerate(combined_img_seq_lengths):
                 img_attention_mask[i, :img_seq_len] = True
+            img_attention_mask = self._mask_or_none(
+                img_attention_mask,
+                combined_img_seq_lengths,
+                required=noise_mask_required or ref_mask_required,
+            )
 
             for layer in self.double_stream_layers:
                 img_hidden_states, instruct_hidden_states = layer(
@@ -1294,13 +1551,17 @@ class BooguImageTransformer2DModel(nn.Module):
                     combined_img_rotary_emb,
                     rotary_emb,
                     temb,
-                    encoder_seq_lengths,
+                    local_encoder_lengths,
                     seq_lengths,
                 )
 
         # Fuse streams to joint sequence.
-        joint_hidden_states = hidden_states.new_zeros(batch_size, max(seq_lengths), self.hidden_size)
-        for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
+        joint_hidden_states = hidden_states.new_zeros(
+            batch_size,
+            rotary_emb.shape[1],
+            self.hidden_size,
+        )
+        for i, (encoder_seq_len, seq_len) in enumerate(zip(local_encoder_lengths, seq_lengths)):
             joint_hidden_states[i, :encoder_seq_len] = instruct_hidden_states[i, :encoder_seq_len]
             joint_hidden_states[i, encoder_seq_len:seq_len] = img_hidden_states[i, : seq_len - encoder_seq_len]
 
@@ -1312,12 +1573,23 @@ class BooguImageTransformer2DModel(nn.Module):
         # Output projection.
         hidden_states = self.norm_out(hidden_states, temb)
 
+        # Extract this rank's noise-image shard and gather it once.
+        local_img_output = hidden_states.new_zeros(
+            batch_size,
+            img_mask.shape[1],
+            hidden_states.shape[-1],
+        )
+        for i, (img_len, seq_len) in enumerate(zip(local_img_lengths, seq_lengths)):
+            local_img_output[i, :img_len] = hidden_states[i, seq_len - img_len : seq_len]
+
+        image_tokens = self.sp_gather_boundary(local_img_output)
+
         # Reshape back to image format.
         p = self.patch_size
         output = []
-        for i, (img_size, img_len, seq_len) in enumerate(zip(img_sizes, l_effective_img_len, seq_lengths)):
+        for i, (img_size, img_len) in enumerate(zip(img_sizes, global_img_lengths)):
             height, width = img_size
-            img_tokens = hidden_states[i][seq_len - img_len : seq_len]
+            img_tokens = image_tokens[i, :img_len]
             img_output = rearrange(
                 img_tokens,
                 "(h w) (p1 p2 c) -> c (h p1) (w p2)",

--- a/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
+++ b/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
@@ -285,7 +285,28 @@ class BooguImagePipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery
         if parallel_config.tensor_parallel_size > 1:
             raise NotImplementedError("Tensor parallelism is not supported by BooguImagePipeline.")
         if (parallel_config.sequence_parallel_size or 1) > 1:
-            raise NotImplementedError("Sequence parallelism is not supported by BooguImagePipeline.")
+            if parallel_config.ring_degree > 1 or getattr(parallel_config, "allgather_degree", 1) > 1:
+                raise NotImplementedError(
+                    "BooguImagePipeline currently supports sequence parallelism through Ulysses only."
+                )
+            if parallel_config.ulysses_mode == "strict":
+                num_heads = self.od_config.tf_model_config.get(
+                    "num_attention_heads",
+                    24,
+                )
+                num_kv_heads = self.od_config.tf_model_config.get(
+                    "num_kv_heads",
+                    8,
+                )
+                if (
+                    num_heads % parallel_config.ulysses_degree != 0
+                    or num_kv_heads % parallel_config.ulysses_degree != 0
+                ):
+                    raise ValueError(
+                        "BooguImagePipeline GQA heads are not divisible by the "
+                        "configured Ulysses degree; set "
+                        "parallel_config.ulysses_mode='advanced_uaa'."
+                    )
         if parallel_config.cfg_parallel_size > 1:
             raise NotImplementedError("CFG parallelism is not supported by BooguImagePipeline.")
         if parallel_config.use_hsdp:

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -469,12 +469,14 @@ def _apply_sequence_parallel_if_enabled(model, od_config: OmniDiffusionConfig) -
             if allgather_degree > 1:
                 sp_config = SequenceParallelConfig(
                     allgather_degree=allgather_degree,
+                    communication_backend=od_config.parallel_config.sp_communication_backend,
                 )
                 mode = "allgather_kv"
             else:
                 sp_config = SequenceParallelConfig(
                     ulysses_degree=od_config.parallel_config.ulysses_degree,
                     ring_degree=od_config.parallel_config.ring_degree,
+                    communication_backend=od_config.parallel_config.sp_communication_backend,
                 )
                 # Apply hooks according to the plan
                 mode = (

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -458,6 +458,7 @@ class OrchestratorArgs:
     diffusers_call_kwargs: str = "{}"
     ulysses_degree: int | None = None
     ulysses_mode: str = "strict"
+    sp_communication_backend: str = "native"
     ring_degree: int | None = None
     allgather_degree: int | None = None
     diffusion_quantization_config: str | None = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -935,6 +935,7 @@ class AsyncOmniEngine:
             ring_degree = normalized_kwargs.get("ring_degree") or 1
             allgather_degree = normalized_kwargs.get("allgather_degree") or 1
             ulysses_mode = normalized_kwargs.get("ulysses_mode") or "strict"
+            sp_communication_backend = normalized_kwargs.get("sp_communication_backend") or "native"
             sequence_parallel_size = normalized_kwargs.get("sequence_parallel_size")
             pipeline_parallel_size = normalized_kwargs.get("pipeline_parallel_size") or 1
             data_parallel_size = normalized_kwargs.get("data_parallel_size") or 1
@@ -960,6 +961,7 @@ class AsyncOmniEngine:
                 ring_degree=ring_degree,
                 allgather_degree=allgather_degree,
                 ulysses_mode=ulysses_mode,
+                sp_communication_backend=sp_communication_backend,
                 cfg_parallel_size=cfg_parallel_size,
                 vae_patch_parallel_size=vae_patch_parallel_size,
                 vae_parallel_mode=vae_parallel_mode,


### PR DESCRIPTION
## Purpose

This PR adds an opt-in functional-collective backend for pure Ulysses sequence
parallelism on CUDA/NCCL. BOOGU Image is the first model fully validated with
this backend, enabling SP2 inference without model-specific communication code.

The new backend keeps the following communication operations visible to
`torch.compile`:

- Q/K/V and output all-to-all;
- attention-mask and joint-output all-gather;
- the final SP output gather.

In `advanced_uaa` mode, it also uses the public equal-rank padding contract.
This avoids the native path's per-attention sequence-length collective and host
scalar materialization, while allowing the Q/K/V A2As to be submitted before
their waits.

The implementation is reusable by other DiTs built on the shared Ulysses
attention and SP-plan hooks. Both `strict` and `advanced_uaa` support the
functional backend, though `advanced_uaa` is expected to benefit the most.
Actual performance will still vary by model and input shape.

The public switch is:

```yaml
parallel_config:
  sequence_parallel_size: 2
  ulysses_degree: 2
  ring_degree: 1
  ulysses_mode: advanced_uaa
  sp_communication_backend: functional
```

`native` remains the default. For now, `functional` is limited to CUDA/NCCL and
pure Ulysses (`ulysses_degree > 1`, `ring_degree = 1`,
`allgather_degree = 1`). This PR does not change ring attention, hybrid USP,
AllGather-KV, or non-CUDA backends.

The implementation is split by responsibility:

- `functional_collectives.py` isolates PyTorch functional-collective APIs and
  their materialization boundary.
- `comm.py` owns the 4D sequence/head layout transformation and dispatches
  native or functional transport.
- `UlyssesParallelAttention` applies the selected backend consistently to
  Q/K/V and output A2A plus mask/joint-output gathers.
- SP plan hooks use the configured backend for the final output gather.
- Keyed `SequenceShardMetadata` allows public SP hooks to pad, shard, gather,
  and trim image, reference-image, and context sequences independently.
- The BOOGU adapter only declares its SP boundaries and uses public shard
  metadata for model-specific sequence packing.

BOOGU itself contains no functional-collective calls or distributed
rank/world-size calculations, and its original Q/K/V projection order remains
unchanged.

## Test Plan

### Configuration and hook tests

```bash
pytest -q \
  tests/config/test_omni_config.py \
  tests/test_config_factory.py \
  tests/test_diffusion_config_propagation.py \
  tests/diffusion/attention/test_ulysses_uaa.py \
  tests/diffusion/distributed/test_sp_plan_hooks.py \
  tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
```

These tests cover configuration propagation, unsupported-topology validation,
keyed shard metadata, independent sequence padding and trimming, output-gather
backend selection, BOOGU SP validation, and GQA UAA padding.

### Two-GPU CUDA correctness

```bash
pytest -q \
  tests/diffusion/distributed/test_comm.py \
  tests/diffusion/models/boogu_image/test_boogu_image_graphable_sp.py
```

The distributed tests verify:

- native/functional forward and reverse 4D A2A equivalence;
- functional all-gather along a non-zero sequence dimension;
- `torch.compile(fullgraph=True)` capture;
- single-GPU vs SP2 native vs SP2 functional BOOGU outputs for text-to-image
  and image-edit inputs.

### Performance benchmark

```bash
python benchmarks/diffusion/benchmark_boogu_graphable_sp.py \
  --case native \
  --case functional \
  --warmup 20 \
  --iterations 50 \
  --repeats 7
```

Each backend runs in a fresh process group so separately compiled collective
graphs do not interfere with one another. The reported latency is the median
of the maximum latency across ranks.

### End-to-end generation

The full `Boogu-Image-0.1-Base` checkpoint was tested against a single-GPU SP1
baseline and two SP2 configurations: `sp_communication_backend=native` and
`sp_communication_backend=functional`. All other settings were identical:

- SP1 native, or SP2 with `advanced_uaa`;
- one visible GPU for SP1 and two visible GPUs for SP2;
- BF16, FlashAttention, regional `torch.compile(dynamic=True)`;
- 1024 x 1024, batch size 1, guidance scale 4.0, empty negative prompt;
- one explicit 1024 x 1024, 4-step warmup request after the framework startup
  warmup;
- formal generation with 50 denoising steps and seed 42;
- prompt:

<details>
<summary>Prompt used for E2E validation</summary>

> 一幅国风琉金风格的山水画作，展现了桂林山水在金光普照下的壮丽景象。远山层叠，江水如镜，山峰边缘勾勒着发光的金色线条。画面采用石青石绿岩彩与鎏金质感相结合，局部有厚涂油画笔触，空中飘浮着金色粒子，营造出梦幻朦胧而又磅礴大气的意境。

</details>

**vLLM Version:** `0.24.0`

**vLLM-Omni Commit:** `ca19e6efe3f59d966a53804fb3539e0ab8b342c2`

Additional environment:

- Python `3.12.3`
- PyTorch `2.11.0+cu130`
- CUDA `13.0`
- NVIDIA driver `570.148.08`
- 2 x GPUs exposed as NVIDIA H800, 81,559 MiB each

## Test Result

### Correctness and graph capture

- Functional forward/reverse A2A and non-zero-dimension all-gather match the
  native rank order.
- Functional collectives and a production-size BOOGU block compile with
  `fullgraph=True`.
- The tiny-model BOOGU T2I/edit test matches the single-GPU reference with
  `rtol=2e-4, atol=2e-4`.
- Compiled native/functional production-block validation observed
  `max_abs_error=0` at all nine benchmark shapes.

### Compiled BOOGU block performance

Benchmark configuration: BOOGU Base transformer block, hidden size 3360,
28 query heads, 7 KV heads, head dimension 120, BF16, FlashAttention, SP2,
`advanced_uaa`, and `torch.compile(dynamic=True)`.

Gain is defined as `native latency / functional latency - 1`.

| Resolution | Batch | Native compiled (ms) | Functional compiled (ms) | Gain |
|---:|---:|---:|---:|---:|
| 1024² | 1 | 2.645 | 2.072 | +27.69% |
| 1024² | 2 | 4.682 | 3.865 | +21.14% |
| 1024² | 4 | 8.958 | 7.593 | +17.98% |
| 1024² | 8 | 16.895 | 14.514 | +16.41% |
| 1536² | 1 | 5.288 | 4.697 | +12.57% |
| 1536² | 2 | 10.658 | 9.186 | +16.03% |
| 1536² | 4 | 20.530 | 17.900 | +14.69% |
| 2048² | 1 | 10.315 | 9.548 | +8.03% |
| 2048² | 2 | 20.722 | 18.427 | +12.46% |

The geometric-mean gain across all nine shapes is **16.21%**. At 1024²/BS1,
functional latency is **2.072 ms**; a separate `fullgraph=True` measurement
recorded **2.069 ms**.

BOOGU is a strong fit for this optimization because its 28 query heads and 7
KV heads require `advanced_uaa` at SP2. On every attention call, the native
path gathers rank-local sequence lengths and materializes device scalars on the
host. The functional path instead relies on the public equal-rank padding
contract, keeps collectives graphable, and submits the Q/K/V A2As before
waiting on them.

Models whose head counts support strict Ulysses do not incur the same
per-layer host overhead, so BOOGU's gains should not be treated as
representative of every DiT.

### End-to-end 1024² / 50-step validation

| SP | Backend | Formal request latency | Reduction vs SP1 | 
|---:|---|---:|---|
| 1 | Native | 14.477 s | Baseline | 
| 2 | Native | 12.562 s | 13.2% | 
| 2 | Functional | 9.394 s | 35.1% | 

The SP1 baseline was repeated in two fresh single-GPU processes. The runs took
14.471 s and 14.483 s (14.477 s median), and both produced the same full
SHA256. Against that median, SP2 functional is approximately **1.54x faster**.
It also reduces latency by **25.2%** compared with the reported SP2 native run.

These single-request E2E timings complement the repeated block benchmark; they
are not the primary performance claim. A repeated SP2 native A/A run took
12.334 s and produced the same full SHA256 as the first SP2 native run.

After 50 BF16 denoising steps, the native and functional outputs are not
bitwise identical, but they preserve the same composition and prompt
semantics:

| Metric on original 1024² RGB outputs | Result |
|---|---:|
| SSIM | 0.97965 |
| PSNR | 37.89 dB |
| Mean absolute pixel error | 1.420 / 255 |
| RMSE | 3.253 / 255 |
| Components with absolute error <= 2 | 86.51% |
| Components with absolute error <= 4 | 94.28% |
| Components with absolute error <= 8 | 98.05% |

The embedded previews below are resized JPEGs. Metrics were calculated from
the original 1024 x 1024 PNG outputs.

| Native SP1 | Native SP2 | Functional SP2 |
|---|---|---|
| <img width="512" height="512" alt="IMG_4165 2" src="https://github.com/user-attachments/assets/cc88c11f-5646-49c7-b878-73ab51dc0ca6" /> | <img width="512" height="512" alt="IMG_4166 2" src="https://github.com/user-attachments/assets/c007a39f-d2a2-46f0-988a-595ddefd8c37" /> | <img width="512" height="512" alt="IMG_4167 2" src="https://github.com/user-attachments/assets/e47dd27b-c25c-45b4-8041-02266929f1b1" /> |


