### PR TITLE
[WIP][Feature][TTS] Preserve state across sentence commits

### DIFF
--- a/docs/serving/speech_api.md
+++ b/docs/serving/speech_api.md
@@ -207,10 +207,13 @@ curl -X POST http://localhost:8091/v1/audio/voices \
 
 ## Streaming Text Input (WebSocket)
 
-The `/v1/audio/speech/stream` WebSocket endpoint accepts text incrementally and generates audio per sentence as boundaries are detected.
+The `/v1/audio/speech/stream` WebSocket endpoint accepts text incrementally. It can generate
+separate requests at sentence boundaries or keep one request alive across explicit sentence commits.
 
-> Note: text input is always streamed incrementally. Audio output remains sentence-scoped:
-> use `stream_audio=false` for one binary frame per sentence, or `stream_audio=true` for one or more PCM chunks per sentence.
+> In the default `sentence` mode, audio output remains sentence-scoped: use
+> `stream_audio=false` for one binary frame per sentence, or `stream_audio=true`
+> for one or more PCM chunks per sentence. Single-request modes emit one
+> continuous PCM stream.
 
 ### WebSocket Protocol
 
@@ -220,6 +223,7 @@ Client -> Server:
 |---------|-------------|
 | `{"type": "session.config", ...}` | Session configuration (sent once, first message) |
 | `{"type": "input.text", "text": "..."}` | Text chunk |
+| `{"type": "input.commit", "commit_id": "optional-id"}` | Commit buffered text in `sentence_commit` mode |
 | `{"type": "input.done"}` | End of input, flushes remaining buffer |
 
 Server -> Client:
@@ -229,6 +233,7 @@ Server -> Client:
 | `{"type": "audio.start", "sentence_index": 0, "sentence_text": "...", "format": "pcm", "sample_rate": 24000}` | Audio generation starting for a sentence |
 | Binary frame | Raw audio bytes (one or more PCM chunks when `stream_audio=true`) |
 | `{"type": "audio.done", "sentence_index": 0, "total_bytes": 96000, "error": false}` | Audio complete for a sentence |
+| `{"type": "input.committed", "commit_id": "optional-id", "sentence_index": 0, "chars_committed": 42}` | Buffered text was accepted by the persistent request |
 | `{"type": "session.done", "total_sentences": N}` | Session complete |
 | `{"type": "error", "message": "..."}` | Non-fatal error |
 
@@ -240,8 +245,8 @@ All REST API parameters are supported, plus:
 |-----------|------|---------|-------------|
 | `stream_audio` | bool | false | Stream one or more PCM chunks per sentence over WebSocket |
 | `split_granularity` | string | "sentence" | Text splitting granularity |
-| `streaming_mode` | string | "sentence" | `"sentence"` waits for sentence boundaries before submitting to TTS; `"token_level"` feeds text incrementally into a single TTS request (see below) |
-| `streaming_drain_max_steps` | int | 100 | token_level only: max decode steps after text + EOS are fully consumed before the runtime force-finishes the request |
+| `streaming_mode` | string | "sentence" | `"sentence"` creates one request per sentence; `"token_level"` appends every text chunk to one request; `"sentence_commit"` appends explicitly committed text to one request |
+| `streaming_drain_max_steps` | int | 100 | Single-request modes only: max decode steps after text + EOS are consumed before force-finishing |
 
 ## Token-Level Streaming Text Input (WebSocket)
 
@@ -314,6 +319,37 @@ asyncio.run(main())
 
 A runnable version with incremental-feed timing is at
 `examples/online_serving/text_to_speech/qwen3_tts/token_level_streaming_client.py`.
+
+## Persistent Sentence Commits (WebSocket)
+
+`streaming_mode="sentence_commit"` gives the client explicit control over when enough text
+has accumulated to start or resume synthesis. It uses one WebSocket and one engine request
+for the full utterance, so the talker's KV cache, codec state, speaker conditioning, and
+positions survive sentence boundaries.
+
+The client buffers text with `input.text`, then sends `input.commit`. The first commit starts
+generation; later commits append text to the same request. A commit does not append EOS.
+When generation catches up with committed text, the request pauses until the next commit.
+Only `input.done` appends EOS and releases the request after audio drains.
+
+```json
+{"type": "session.config", "streaming_mode": "sentence_commit", "response_format": "pcm", "voice": "vivian"}
+{"type": "input.text", "text": "The first sentence is ready."}
+{"type": "input.commit", "commit_id": "sentence-1"}
+{"type": "input.text", "text": " The next sentence arrived later."}
+{"type": "input.commit", "commit_id": "sentence-2"}
+{"type": "input.done"}
+```
+
+Each accepted commit produces `input.committed`. The optional `commit_id` is echoed so a
+client can correlate acknowledgements. Audio is one continuous PCM stream: there is one
+`audio.start` for the first commit and one `audio.done` after `input.done`, not per commit.
+If `input.done` arrives with uncommitted buffered text, the server commits that text before
+finalizing.
+
+The mode has the same deployment opt-in and PCM/speed constraints as `token_level`. See
+`examples/online_serving/text_to_speech/qwen3_tts/sentence_commit_streaming_client.py`
+for a runnable client.
 
 ```bash
 DELETE /v1/audio/voices/{name}

--- a/docs/serving/speech_api.md
+++ b/docs/serving/speech_api.md
@@ -240,7 +240,80 @@ All REST API parameters are supported, plus:
 |-----------|------|---------|-------------|
 | `stream_audio` | bool | false | Stream one or more PCM chunks per sentence over WebSocket |
 | `split_granularity` | string | "sentence" | Text splitting granularity |
+| `streaming_mode` | string | "sentence" | `"sentence"` waits for sentence boundaries before submitting to TTS; `"token_level"` feeds text incrementally into a single TTS request (see below) |
+| `streaming_drain_max_steps` | int | 100 | token_level only: max decode steps after text + EOS are fully consumed before the runtime force-finishes the request |
 
+## Token-Level Streaming Text Input (WebSocket)
+
+The default `streaming_mode="sentence"` buffers text until a sentence boundary, then
+runs one TTS request per sentence. `streaming_mode="token_level"` instead starts a
+**single** TTS request from an initial text buffer and extends that same request with
+later text chunks via engine-level streaming updates — so audio for the beginning of an
+utterance can start before the rest of the text has arrived (e.g. while an upstream LLM is
+still producing tokens), without rebuilding the request.
+
+### Enabling the feature
+
+Token-level streaming is **off by default** and must be enabled per model at deploy time
+by setting `streaming_text_enabled: true` at the top level of the deploy YAML
+(`vllm_omni/deploy/qwen3_tts.yaml` ships with it on). It is currently supported by
+Qwen3-TTS. If a client requests `streaming_mode="token_level"` against a server that did
+not enable it, the session is rejected with an `error` frame.
+
+```yaml
+# vllm_omni/deploy/qwen3_tts.yaml
+streaming_text_enabled: true   # enable token-level streaming text input
+```
+
+### Constraints
+
+- `response_format` must be `"pcm"` (the handler forces `stream_audio=true`).
+- `speed` must be `1.0` (or omitted).
+
+### Message flow
+
+1. Client sends `session.config` with `streaming_mode: "token_level"` and `response_format: "pcm"`.
+2. Client sends one or more `input.text` chunks. The server buffers an initial ~60
+   characters, submits one TTS request, and emits `audio.start`.
+3. Audio streams back as binary PCM frames while the client keeps sending `input.text`
+   chunks; each chunk is appended to the **same** request.
+4. Client sends `input.done`; the server appends an end-of-text marker and lets the
+   request drain, then emits `audio.done` and `session.done`.
+
+### Example client
+
+```python
+import asyncio, json, websockets
+
+async def main():
+    async with websockets.connect("ws://localhost:8091/v1/audio/speech/stream") as ws:
+        await ws.send(json.dumps({
+            "type": "session.config",
+            "voice": "vivian",
+            "streaming_mode": "token_level",
+            "response_format": "pcm",
+        }))
+        # Feed text incrementally (e.g. tokens streamed from an upstream LLM).
+        for chunk in ["Hello there, ", "this is token level ", "streaming. "]:
+            await ws.send(json.dumps({"type": "input.text", "text": chunk}))
+        await ws.send(json.dumps({"type": "input.done"}))
+
+        audio = bytearray()
+        while True:
+            msg = await ws.recv()
+            if isinstance(msg, bytes):
+                audio.extend(msg)            # PCM s16le, 24 kHz mono
+            else:
+                evt = json.loads(msg)
+                if evt["type"] == "session.done":
+                    break
+        print("received", len(audio), "PCM bytes")
+
+asyncio.run(main())
+```
+
+A runnable version with incremental-feed timing is at
+`examples/online_serving/text_to_speech/qwen3_tts/token_level_streaming_client.py`.
 
 ```bash
 DELETE /v1/audio/voices/{name}

--- a/examples/online_serving/text_to_speech/qwen3_tts/sentence_commit_streaming_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/sentence_commit_streaming_client.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Persistent sentence-commit streaming client for Qwen3-TTS.
+
+Each sentence is committed as soon as it is available, while one WebSocket
+and one engine request preserve model state for the full utterance.
+"""
+
+import argparse
+import asyncio
+import json
+import wave
+
+try:
+    import websockets
+except ImportError:
+    raise SystemExit("Please install websockets: pip install websockets")
+
+
+DEFAULT_SENTENCES = [
+    "Hello there, this first sentence can begin playing immediately.",
+    " The second sentence resumes the same request without resetting the voice.",
+    " The final sentence is followed by input.done to release the session.",
+]
+
+
+def save_pcm_wav(path: str, pcm: bytes, sample_rate: int) -> None:
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+
+
+async def run(args: argparse.Namespace) -> None:
+    url = args.api_base.replace("http://", "ws://").replace("https://", "wss://").rstrip("/")
+    url += "/v1/audio/speech/stream"
+    config = {
+        "type": "session.config",
+        "voice": args.voice,
+        "streaming_mode": "sentence_commit",
+        "response_format": "pcm",
+    }
+    if args.model:
+        config["model"] = args.model
+
+    audio = bytearray()
+    sample_rate = 24000
+    async with websockets.connect(url, max_size=64 * 1024 * 1024) as ws:
+        await ws.send(json.dumps(config))
+
+        async def feed_sentences() -> None:
+            for sentence_index, sentence in enumerate(DEFAULT_SENTENCES):
+                await ws.send(json.dumps({"type": "input.text", "text": sentence}))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "input.commit",
+                            "commit_id": f"sentence-{sentence_index}",
+                        }
+                    )
+                )
+                await asyncio.sleep(args.sentence_delay)
+            await ws.send(json.dumps({"type": "input.done"}))
+
+        feeder = asyncio.create_task(feed_sentences())
+        try:
+            while True:
+                msg = await asyncio.wait_for(ws.recv(), timeout=args.timeout)
+                if isinstance(msg, bytes):
+                    audio.extend(msg)
+                    continue
+                event = json.loads(msg)
+                event_type = event.get("type")
+                if event_type == "audio.start":
+                    sample_rate = event.get("sample_rate", sample_rate)
+                elif event_type == "input.committed":
+                    print(
+                        "committed",
+                        event.get("commit_id"),
+                        f"as sentence {event.get('sentence_index')}",
+                    )
+                elif event_type == "error":
+                    print("ERROR:", event.get("message"))
+                elif event_type == "session.done":
+                    break
+        finally:
+            if not feeder.done():
+                feeder.cancel()
+
+    if audio:
+        save_pcm_wav(args.out, bytes(audio), sample_rate)
+        print(f"wrote {len(audio)} PCM bytes to {args.out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-base", default="http://localhost:8091")
+    parser.add_argument("--model", default=None)
+    parser.add_argument("--voice", default="vivian")
+    parser.add_argument("--sentence-delay", type=float, default=0.5)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--out", default="sentence_commit.wav")
+    asyncio.run(run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/text_to_speech/qwen3_tts/token_level_streaming_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/token_level_streaming_client.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Token-level streaming text input client for Qwen3-TTS.
+
+Demonstrates ``streaming_mode="token_level"`` over the WebSocket speech
+endpoint ``/v1/audio/speech/stream``: a single TTS request is started from an
+initial text buffer and extended with later ``input.text`` chunks via
+engine-level streaming, so audio for the start of an utterance begins before
+the rest of the text has been sent (e.g. while an upstream LLM is still
+producing tokens), without rebuilding the request.
+
+Server must be launched with ``streaming_text_enabled: true`` in the deploy
+YAML (``vllm_omni/deploy/qwen3_tts.yaml`` ships with it on).
+
+Usage:
+    python token_level_streaming_client.py \
+        --api-base http://localhost:8091 \
+        --voice vivian \
+        --out token_level.wav
+
+Requirements:
+    pip install websockets
+"""
+
+import argparse
+import asyncio
+import json
+import time
+import wave
+
+try:
+    import websockets
+except ImportError:
+    raise SystemExit("Please install websockets: pip install websockets")
+
+# Default text, split into small chunks to simulate an upstream LLM streaming
+# tokens. A real caller would forward tokens as they are produced.
+DEFAULT_CHUNKS = [
+    "Hello there, ",
+    "this is a token level ",
+    "streaming text input test ",
+    "for Qwen3 TTS. ",
+    "The audio starts playing ",
+    "before all the text has been sent.",
+]
+
+
+def save_pcm_wav(path: str, pcm: bytes, sample_rate: int) -> None:
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # s16le
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+
+
+async def run(args: argparse.Namespace) -> None:
+    url = args.api_base.replace("http://", "ws://").replace("https://", "wss://").rstrip("/")
+    url += "/v1/audio/speech/stream"
+
+    config = {
+        "type": "session.config",
+        "voice": args.voice,
+        "streaming_mode": "token_level",
+        "response_format": "pcm",
+    }
+    if args.model:
+        config["model"] = args.model
+
+    audio = bytearray()
+    sample_rate = 24000
+    t0 = time.perf_counter()
+    t_first_audio: float | None = None
+    t_input_done: float | None = None
+
+    async with websockets.connect(url, max_size=64 * 1024 * 1024) as ws:
+        await ws.send(json.dumps(config))
+
+        async def feed_text() -> None:
+            nonlocal t_input_done
+            for chunk in DEFAULT_CHUNKS:
+                await ws.send(json.dumps({"type": "input.text", "text": chunk}))
+                print(f"[{time.perf_counter() - t0:5.2f}s] sent input.text ({len(chunk)} chars)")
+                await asyncio.sleep(args.chunk_delay)
+            await ws.send(json.dumps({"type": "input.done"}))
+            t_input_done = time.perf_counter() - t0
+            print(f"[{t_input_done:5.2f}s] sent input.done")
+
+        feeder = asyncio.create_task(feed_text())
+        try:
+            while True:
+                msg = await asyncio.wait_for(ws.recv(), timeout=args.timeout)
+                now = time.perf_counter() - t0
+                if isinstance(msg, bytes):
+                    if t_first_audio is None:
+                        t_first_audio = now
+                        print(f"[{now:5.2f}s] first audio frame ({len(msg)} bytes)")
+                    audio.extend(msg)
+                    continue
+                evt = json.loads(msg)
+                etype = evt.get("type")
+                if etype == "audio.start":
+                    sample_rate = evt.get("sample_rate", sample_rate)
+                    print(f"[{now:5.2f}s] audio.start sample_rate={sample_rate}")
+                elif etype == "audio.done":
+                    print(f"[{now:5.2f}s] audio.done total_bytes={evt.get('total_bytes')} error={evt.get('error')}")
+                elif etype == "error":
+                    print(f"[{now:5.2f}s] ERROR: {evt.get('message')}")
+                elif etype == "session.done":
+                    print(f"[{now:5.2f}s] session.done")
+                    break
+        finally:
+            if not feeder.done():
+                feeder.cancel()
+
+    duration = len(audio) / 2 / sample_rate
+    print(f"\nreceived {len(audio)} PCM bytes ({duration:.2f}s @ {sample_rate} Hz)")
+    if t_first_audio is not None and t_input_done is not None:
+        if t_first_audio < t_input_done:
+            print(f"streaming confirmed: first audio at {t_first_audio:.2f}s, input.done at {t_input_done:.2f}s")
+    if audio:
+        save_pcm_wav(args.out, bytes(audio), sample_rate)
+        print(f"wrote {args.out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-base", default="http://localhost:8091", help="Server base URL")
+    parser.add_argument("--model", default=None, help="Optional model name to validate against the server")
+    parser.add_argument("--voice", default="vivian", help="Voice preset")
+    parser.add_argument("--chunk-delay", type=float, default=0.1, help="Seconds between input.text chunks")
+    parser.add_argument("--timeout", type=float, default=120.0, help="Per-message receive timeout")
+    parser.add_argument("--out", default="token_level.wav", help="Output WAV path")
+    asyncio.run(run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/entrypoints/openai_api/test_serving_speech_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_speech_stream.py
@@ -236,7 +236,8 @@ class TestStreamingSpeechWebSocket:
                 ws.send_json({"type": "input.done"})
                 assert ws.receive_json() == {"type": "session.done", "total_sentences": 1}
 
-    def test_token_level_requires_server_opt_in(self, mocker: MockerFixture):
+    @pytest.mark.parametrize("streaming_mode", ["token_level", "sentence_commit"])
+    def test_single_request_streaming_requires_server_opt_in(self, streaming_mode: str, mocker: MockerFixture):
         speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
         speech_service.engine_client = SimpleNamespace(
             model_config=SimpleNamespace(streaming_text_enabled=False),
@@ -251,7 +252,7 @@ class TestStreamingSpeechWebSocket:
                     {
                         "type": "session.config",
                         "voice": "Vivian",
-                        "streaming_mode": "token_level",
+                        "streaming_mode": streaming_mode,
                         "response_format": "pcm",
                     }
                 )
@@ -342,6 +343,143 @@ class TestStreamingSpeechWebSocket:
         speech_service.engine_client.abort.assert_awaited_once_with("req-token")
         error_payloads = [call.args[0] for call in websocket.send_json.await_args_list if call.args]
         assert {"type": "error", "message": "input.text buffer exceeded limit"} in error_payloads
+
+    @pytest.mark.asyncio
+    async def test_sentence_commit_reuses_one_request_and_flushes_pending_text(self, mocker: MockerFixture):
+        finish_event = asyncio.Event()
+        speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
+        speech_service.engine_client = SimpleNamespace(
+            model_config=SimpleNamespace(streaming_text_enabled=True),
+            abort=mocker.AsyncMock(),
+        )
+
+        def extend_streaming_text(_request_id, *, new_text, finished: bool):
+            if finished:
+                assert new_text == ""
+                finish_event.set()
+
+        speech_service.engine_client.extend_streaming_text = mocker.Mock(side_effect=extend_streaming_text)
+
+        async def prepare(request):
+            assert request.input == "First sentence."
+            assert request.streaming_text_input is True
+            assert request.non_streaming_mode is False
+            return "req-commit", object(), {}
+
+        async def chunks(_generator, _request_id):
+            yield b"\x01"
+            await asyncio.wait_for(finish_event.wait(), timeout=1)
+            yield b"\x02"
+
+        speech_service._prepare_speech_generation = mocker.AsyncMock(side_effect=prepare)
+        speech_service._generate_pcm_chunks = chunks
+        handler = OmniStreamingSpeechHandler(speech_service=speech_service)
+        websocket = mocker.MagicMock()
+        websocket.receive_text = mocker.AsyncMock(
+            side_effect=[
+                json.dumps({"type": "input.text", "text": "First sentence."}),
+                json.dumps({"type": "input.commit", "commit_id": "first"}),
+                json.dumps({"type": "input.text", "text": " Second sentence."}),
+                json.dumps({"type": "input.commit", "commit_id": "second"}),
+                json.dumps({"type": "input.text", "text": " Final sentence."}),
+                json.dumps({"type": "input.done"}),
+            ]
+        )
+        websocket.send_json = mocker.AsyncMock()
+        websocket.send_bytes = mocker.AsyncMock()
+        config = streaming_speech_module.StreamingSpeechSessionConfig(
+            voice="Vivian",
+            streaming_mode="sentence_commit",
+            response_format="pcm",
+        )
+
+        await handler._handle_sentence_commit_session(websocket, config)
+
+        speech_service._prepare_speech_generation.assert_awaited_once()
+        assert speech_service.engine_client.extend_streaming_text.call_args_list == [
+            mocker.call("req-commit", new_text=" Second sentence.", finished=False),
+            mocker.call("req-commit", new_text=" Final sentence.", finished=False),
+            mocker.call("req-commit", new_text="", finished=True),
+        ]
+        json_payloads = [call.args[0] for call in websocket.send_json.await_args_list]
+        assert [payload for payload in json_payloads if payload["type"] == "input.committed"] == [
+            {
+                "type": "input.committed",
+                "commit_id": "first",
+                "sentence_index": 0,
+                "chars_committed": 15,
+            },
+            {
+                "type": "input.committed",
+                "commit_id": "second",
+                "sentence_index": 1,
+                "chars_committed": 17,
+            },
+            {
+                "type": "input.committed",
+                "commit_id": None,
+                "sentence_index": 2,
+                "chars_committed": 16,
+            },
+        ]
+        assert json_payloads[-2] == {
+            "type": "audio.done",
+            "sentence_index": 0,
+            "total_bytes": 2,
+            "error": False,
+        }
+        assert json_payloads[-1] == {"type": "session.done", "total_sentences": 3}
+
+    @pytest.mark.asyncio
+    async def test_sentence_commit_rejects_empty_commit_without_ending_session(self, mocker: MockerFixture):
+        finish_event = asyncio.Event()
+        speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
+        speech_service.engine_client = SimpleNamespace(
+            model_config=SimpleNamespace(streaming_text_enabled=True),
+            abort=mocker.AsyncMock(),
+        )
+
+        def extend_streaming_text(_request_id, *, new_text, finished: bool):
+            if finished:
+                finish_event.set()
+
+        speech_service.engine_client.extend_streaming_text = mocker.Mock(side_effect=extend_streaming_text)
+        speech_service._prepare_speech_generation = mocker.AsyncMock(return_value=("req-commit", object(), {}))
+
+        async def chunks(_generator, _request_id):
+            await asyncio.wait_for(finish_event.wait(), timeout=1)
+            yield b"\x01"
+
+        speech_service._generate_pcm_chunks = chunks
+        handler = OmniStreamingSpeechHandler(speech_service=speech_service)
+        websocket = mocker.MagicMock()
+        websocket.receive_text = mocker.AsyncMock(
+            side_effect=[
+                json.dumps({"type": "input.commit", "commit_id": "empty"}),
+                json.dumps({"type": "input.text", "text": "Committed sentence."}),
+                json.dumps({"type": "input.commit", "commit_id": "valid"}),
+                json.dumps({"type": "input.done"}),
+            ]
+        )
+        websocket.send_json = mocker.AsyncMock()
+        websocket.send_bytes = mocker.AsyncMock()
+        config = streaming_speech_module.StreamingSpeechSessionConfig(
+            voice="Vivian",
+            streaming_mode="sentence_commit",
+            response_format="pcm",
+        )
+
+        await handler._handle_sentence_commit_session(websocket, config)
+
+        payloads = [call.args[0] for call in websocket.send_json.await_args_list]
+        assert {"type": "error", "message": "input.commit requires buffered text"} in payloads
+        assert {
+            "type": "input.committed",
+            "commit_id": "valid",
+            "sentence_index": 0,
+            "chars_committed": 19,
+        } in payloads
+        assert payloads[-1] == {"type": "session.done", "total_sentences": 1}
 
     def test_config_timeout_closes_session(self, mocker: MockerFixture):
         app, _ = _build_test_app(config_timeout=0.01, mocker=mocker)

--- a/tests/entrypoints/openai_api/test_serving_speech_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_speech_stream.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI, WebSocket
@@ -233,6 +235,113 @@ class TestStreamingSpeechWebSocket:
 
                 ws.send_json({"type": "input.done"})
                 assert ws.receive_json() == {"type": "session.done", "total_sentences": 1}
+
+    def test_token_level_requires_server_opt_in(self, mocker: MockerFixture):
+        speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
+        speech_service.engine_client = SimpleNamespace(
+            model_config=SimpleNamespace(streaming_text_enabled=False),
+            abort=mocker.AsyncMock(),
+        )
+        speech_service._prepare_speech_generation = mocker.AsyncMock()
+        app, _ = _build_test_app(speech_service)
+
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/audio/speech/stream") as ws:
+                ws.send_json(
+                    {
+                        "type": "session.config",
+                        "voice": "Vivian",
+                        "streaming_mode": "token_level",
+                        "response_format": "pcm",
+                    }
+                )
+
+                error = ws.receive_json()
+                assert error["type"] == "error"
+                assert "disabled" in error["message"]
+
+        speech_service._prepare_speech_generation.assert_not_awaited()
+
+    def test_token_level_sends_finished_after_audio_stream_completes(self, mocker: MockerFixture):
+        speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
+        speech_service.engine_client = SimpleNamespace(
+            model_config=SimpleNamespace(streaming_text_enabled=True),
+            abort=mocker.AsyncMock(),
+        )
+        speech_service.engine_client.extend_streaming_text = mocker.Mock()
+
+        async def prepare(request):
+            assert request.streaming_text_input is True
+            return "req-token", object(), {}
+
+        async def chunks(_generator, _request_id):
+            yield b"\x01\x02"
+
+        speech_service._prepare_speech_generation = mocker.AsyncMock(side_effect=prepare)
+        speech_service._generate_pcm_chunks = chunks
+        app, _ = _build_test_app(speech_service)
+
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/audio/speech/stream") as ws:
+                ws.send_json(
+                    {
+                        "type": "session.config",
+                        "voice": "Vivian",
+                        "streaming_mode": "token_level",
+                        "response_format": "pcm",
+                    }
+                )
+                ws.send_json({"type": "input.text", "text": "x" * 60})
+
+                assert ws.receive_json()["type"] == "audio.start"
+                assert ws.receive_bytes() == b"\x01\x02"
+                assert ws.receive_json() == {
+                    "type": "audio.done",
+                    "sentence_index": 0,
+                    "total_bytes": 2,
+                    "error": False,
+                }
+                assert ws.receive_json() == {"type": "session.done", "total_sentences": 1}
+
+        speech_service.engine_client.extend_streaming_text.assert_called_with("req-token", new_text="", finished=True)
+
+    @pytest.mark.asyncio
+    async def test_token_level_buffer_limit_reports_error_and_aborts(self, monkeypatch, mocker: MockerFixture):
+        monkeypatch.setattr(streaming_speech_module, "_MAX_BUFFER_SIZE", 61)
+        speech_service = mocker.MagicMock(spec=OmniOpenAIServingSpeech)
+        speech_service.engine_client = SimpleNamespace(
+            model_config=SimpleNamespace(streaming_text_enabled=True),
+            abort=mocker.AsyncMock(),
+        )
+        speech_service.engine_client.extend_streaming_text = mocker.Mock()
+        speech_service._prepare_speech_generation = mocker.AsyncMock(return_value=("req-token", object(), {}))
+
+        async def chunks(_generator, _request_id):
+            await asyncio.sleep(0.05)
+            yield b"\x01"
+
+        speech_service._generate_pcm_chunks = chunks
+        handler = OmniStreamingSpeechHandler(speech_service=speech_service, idle_timeout=0.01)
+        websocket = mocker.MagicMock()
+        websocket.receive_text = mocker.AsyncMock(
+            side_effect=[
+                json.dumps({"type": "input.text", "text": "x" * 60}),
+                json.dumps({"type": "input.text", "text": "y" * 2}),
+            ]
+        )
+        websocket.send_json = mocker.AsyncMock()
+        websocket.send_bytes = mocker.AsyncMock()
+        config = streaming_speech_module.StreamingSpeechSessionConfig(
+            voice="Vivian",
+            streaming_mode="token_level",
+            response_format="pcm",
+        )
+
+        await handler._handle_token_level_session(websocket, config)
+
+        speech_service.engine_client.abort.assert_awaited_once_with("req-token")
+        error_payloads = [call.args[0] for call in websocket.send_json.await_args_list if call.args]
+        assert {"type": "error", "message": "input.text buffer exceeded limit"} in error_payloads
 
     def test_config_timeout_closes_session(self, mocker: MockerFixture):
         app, _ = _build_test_app(config_timeout=0.01, mocker=mocker)

--- a/tests/model_executor/models/qwen3_tts/test_qwen3_tts_talker_preprocess.py
+++ b/tests/model_executor/models/qwen3_tts/test_qwen3_tts_talker_preprocess.py
@@ -252,6 +252,39 @@ def test_decode_compacts_long_trailing_text_after_large_offset():
     assert torch.equal(update["hidden_states"]["trailing_text"], trailing_text[65:])
 
 
+def test_streaming_text_starvation_pauses_before_decode():
+    model = _make_minimal_talker()
+
+    out_ids, out_embeds, update = model.preprocess(
+        input_ids=torch.tensor([123], dtype=torch.long),
+        input_embeds=None,
+        text=["hello"],
+        task_type=["CustomVoice"],
+        hidden_states={
+            "trailing_text": torch.empty((0, 4), dtype=torch.bfloat16),
+            "last": torch.ones((4,), dtype=torch.bfloat16),
+        },
+        meta={"streaming_text_input": True, "talker_text_offset": 0},
+        streaming_text_finished=False,
+        _omni_is_prefill=False,
+        _omni_num_computed_tokens=2,
+        _omni_prompt_len=2,
+    )
+
+    assert out_ids.tolist() == [123]
+    assert out_embeds is None
+    assert update["meta"]["streaming_wait_for_input"] is True
+    assert update["streaming_text_new_text"] is None
+
+
+def test_streaming_text_requests_bypass_decode_batch_fast_path():
+    model = _make_minimal_talker()
+
+    assert model.can_preprocess_decode_batch({"meta": {"streaming_text_input": False}})
+    assert not model.can_preprocess_decode_batch({"meta": {"streaming_text_input": True}})
+    assert not model.can_preprocess_decode_batch({"additional_information": {"meta": {"streaming_text_input": True}}})
+
+
 def test_decode_batch_preprocess_matches_decode_state_updates():
     tts_pad = torch.full((1, 4), -1.0, dtype=torch.bfloat16)
     model = _make_minimal_talker(tts_pad_embed=tts_pad)

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -121,6 +121,7 @@ class OmniModelConfig(ModelConfig):
     async_chunk: bool = False
     # Stage-1 active stream slots; 0 keeps legacy chunk-level round-robin.
     active_stream_window: int = 0
+    streaming_text_enabled: bool = False
     model_stage: str = "thinker"
     model_arch: str | None = None
     worker_type: str | None = None

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -499,6 +499,8 @@ class DeployConfig:
     async_chunk: bool = True
     # Stage-1 active stream slots; 0 preserves legacy all-stream cycling.
     active_stream_window: int = 0
+    # Enable token-level streaming text input (incremental text -> single TTS request).
+    streaming_text_enabled: bool = False
     connectors: dict[str, Any] | None = None
     edges: list[dict[str, Any]] | None = None
     stages: list[StageDeployConfig] = field(default_factory=list)
@@ -677,6 +679,7 @@ def load_deploy_config(path: str | Path) -> DeployConfig:
     kwargs: dict[str, Any] = {
         "async_chunk": raw_dict.get("async_chunk", True),
         "active_stream_window": int(raw_dict.get("active_stream_window", 0) or 0),
+        "streaming_text_enabled": bool(raw_dict.get("streaming_text_enabled", False)),
         "connectors": raw_dict.get("connectors", None),
         "edges": raw_dict.get("edges", None),
         "stages": stages,
@@ -817,6 +820,7 @@ _PIPELINE_WIDE_ENGINE_FIELDS: tuple[str, ...] = (
     "data_parallel_size",
     "pipeline_parallel_size",
     "active_stream_window",
+    "streaming_text_enabled",
     "custom_voice_dir",
 )
 

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -337,6 +337,27 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 except Exception:
                     init_logger(__name__).exception("Failed to pre-process KV extraction for %s", req_id)
 
+        # Roll back num_computed_tokens for requests that were skipped during
+        # forward (streaming text starving). schedule() already incremented
+        # num_computed_tokens before execute_model, but the model runner
+        # skipped these requests, so no token was actually computed.
+        starving_ids = getattr(model_runner_output, "streaming_starving_req_ids", None) or set()
+        for sid in starving_ids:
+            req = self.requests.get(sid)
+            if req is not None and sid in num_scheduled_tokens:
+                req.num_computed_tokens -= num_scheduled_tokens[sid]
+
+        # Force-finish requests whose streaming text input is fully drained.
+        # Same rollback as starving (forward was skipped), then mark FINISHED.
+        drained_ids = getattr(model_runner_output, "streaming_drained_req_ids", None) or set()
+        for did in drained_ids:
+            req = self.requests.get(did)
+            if req is not None:
+                if did in num_scheduled_tokens:
+                    req.num_computed_tokens -= num_scheduled_tokens[did]
+                if not req.is_finished():
+                    req.status = RequestStatus.FINISHED_STOPPED
+
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
         # the below loop can be a performance bottleneck. We should do our best
         # to avoid expensive operations inside the loop.
@@ -346,6 +367,27 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             assert num_tokens_scheduled > 0
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # Skip requests that were recovered from KV load failure
+                continue
+            if req_id in starving_ids:
+                continue
+            if req_id in drained_ids:
+                request = self.requests.get(req_id)
+                if request is not None and request.is_finished():
+                    finish_reason = request.get_finished_reason()
+                    finished = self._handle_stopped_request(request)
+                    if finished:
+                        self._free_request(request)
+                    stopped_running_reqs.add(request)
+                    outputs[request.client_index].append(
+                        EngineCoreOutput(
+                            request_id=req_id,
+                            new_token_ids=[],
+                            finish_reason=finish_reason,
+                            events=request.take_events(),
+                            trace_headers=request.trace_headers,
+                            num_cached_tokens=request.num_cached_tokens,
+                        )
+                    )
                 continue
             request = self.requests.get(req_id)
             if request is None or request.is_finished():

--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -13,6 +13,7 @@
 #     set true to disable that path in eager mode. NPU platform flips stage 0 to true where
 #     cudagraph is not yet verified.
 async_chunk: true
+streaming_text_enabled: true
 
 connectors:
   connector_of_shared_memory:

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -147,6 +147,7 @@ class OmniEngineArgs(EngineArgs):
     # Must be declared here so engine_args dict propagation does not silently
     # drop the value when constructing OmniEngineArgs from kwargs.
     active_stream_window: int = 0
+    streaming_text_enabled: bool = False
     omni_kv_config: dict | None = None
     quantization_config: Any | None = None
     force_cutlass_fp8: bool | None = None
@@ -324,6 +325,7 @@ class OmniEngineArgs(EngineArgs):
             stage_id=self.stage_id,
             async_chunk=self.async_chunk,
             active_stream_window=self.active_stream_window,
+            streaming_text_enabled=self.streaming_text_enabled,
             model_stage=self.model_stage,
             model_arch=self.model_arch,
             worker_type=self.worker_type,

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -60,6 +60,7 @@ from vllm_omni.engine.messages import (
     RegisterRemoteReplicaMessage,
     ShutdownRequestMessage,
     StageSubmissionMessage,
+    StreamingTextExtendMessage,
 )
 from vllm_omni.engine.orchestrator import Orchestrator
 from vllm_omni.engine.output_modality import FinalOutputModalityType
@@ -2272,6 +2273,17 @@ class AsyncOmniEngine:
             data_parallel_rank=data_parallel_rank,
             reasoning_ended=reasoning_ended,
             resumable=resumable,
+        )
+
+    def extend_streaming_text(self, request_id: str, *, new_text: str, finished: bool) -> None:
+        if self.request_queue is None:
+            raise RuntimeError("request_queue is not initialized")
+        self.request_queue.sync_q.put_nowait(
+            StreamingTextExtendMessage(
+                request_id=request_id,
+                new_text=new_text,
+                finished=finished,
+            )
         )
 
     def add_streaming_update(

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -44,6 +44,13 @@ class AbortRequestMessage(EngineQueueMessage, kw_only=True):
     request_ids: list[str]
 
 
+class StreamingTextExtendMessage(EngineQueueMessage, kw_only=True):
+    type: Literal["streaming_text_extend"] = "streaming_text_extend"
+    request_id: str
+    new_text: str
+    finished: bool
+
+
 class CollectiveRPCRequestMessage(EngineQueueMessage, kw_only=True):
     type: Literal["collective_rpc"] = "collective_rpc"
     rpc_id: str

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1336,8 +1336,17 @@ class Orchestrator:
         new_text = msg.new_text
         finished = msg.finished
 
+        # The client extends by the base API request id (e.g. "speech-<uuid>"),
+        # but the orchestrator tracks requests (and the worker keys its model
+        # buffer) under a per-request global/stage id that appends a suffix
+        # ("speech-<uuid>-<hex>"). Resolve the tracked id so the update lands on
+        # the right request instead of being silently dropped.
         if request_id not in self.request_states:
-            return
+            prefix = request_id + "-"
+            resolved = next((k for k in self.request_states if k.startswith(prefix)), None)
+            if resolved is None:
+                return
+            request_id = resolved
 
         state_update: dict[str, Any] = {}
         if new_text:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -51,6 +51,7 @@ from vllm_omni.engine.messages import (
     ShutdownRequestMessage,
     StageMetricsMessage,
     StageSubmissionMessage,
+    StreamingTextExtendMessage,
     UnregisterRemoteReplicaMessage,
 )
 from vllm_omni.engine.serialization import serialize_additional_information
@@ -412,6 +413,8 @@ class Orchestrator:
                 await self._handle_add_request(msg)
             elif msg_type == "streaming_update":
                 await self._handle_streaming_update(msg)
+            elif msg_type == "streaming_text_extend":
+                await self._handle_streaming_text_extend(msg)
             elif msg_type == "add_companion_request":
                 await self._handle_add_companion(msg)
             elif msg_type == "abort":
@@ -1327,6 +1330,41 @@ class Orchestrator:
             request_id=req_id,
             tx_ms=_tx_ms,
         )
+
+    async def _handle_streaming_text_extend(self, msg: StreamingTextExtendMessage) -> None:
+        request_id = msg.request_id
+        new_text = msg.new_text
+        finished = msg.finished
+
+        if request_id not in self.request_states:
+            return
+
+        state_update: dict[str, Any] = {}
+        if new_text:
+            state_update["streaming_text_new_text"] = new_text
+        if finished:
+            state_update["streaming_text_finished"] = True
+        if not state_update:
+            return
+
+        try:
+            pool = self.stage_pools[0]
+            replica_id = pool.get_bound_replica_id(request_id)
+            if replica_id is None:
+                return
+            await pool.collective_rpc(
+                replica_id,
+                "update_model_state",
+                args=(request_id, state_update),
+            )
+            logger.info(
+                "[Orchestrator] streaming_text_extend OK req=%s text_len=%d finished=%s",
+                request_id,
+                len(new_text) if new_text else 0,
+                finished,
+            )
+        except Exception as exc:
+            logger.warning("[Orchestrator] streaming_text_extend failed for req=%s: %s", request_id, exc)
 
     async def _prewarm_async_chunk_stages(
         self,

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -771,6 +771,9 @@ class AsyncOmni(EngineClient, OmniBase):
             return all(bool(item) for item in result)
         return bool(result)
 
+    def extend_streaming_text(self, request_id: str, *, new_text: str, finished: bool) -> None:
+        self.engine.extend_streaming_text(request_id, new_text=new_text, finished=finished)
+
     async def abort(self, request_id: str | Iterable[str]) -> None:
         """Abort request(s) via the Orchestrator."""
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -429,6 +429,22 @@ class BatchSpeechResponse(BaseModel):
     failed: int
 
 
+class StreamingSpeechInputCommit(BaseModel):
+    """Commit buffered text to a persistent streaming speech request."""
+
+    type: Literal["input.commit"]
+    commit_id: str | None = None
+
+
+class StreamingSpeechInputCommitted(BaseModel):
+    """Acknowledgement that a text commit was accepted by the engine."""
+
+    type: Literal["input.committed"] = "input.committed"
+    commit_id: str | None = None
+    sentence_index: int = Field(ge=0)
+    chars_committed: int = Field(ge=1)
+
+
 class StreamingSpeechSessionConfig(BaseModel):
     """Configuration sent as the first WebSocket message for streaming TTS."""
 
@@ -475,12 +491,13 @@ class StreamingSpeechSessionConfig(BaseModel):
             "'clause' also splits on CJK commas ， and semicolons ；."
         ),
     )
-    streaming_mode: Literal["sentence", "token_level"] = Field(
+    streaming_mode: Literal["sentence", "token_level", "sentence_commit"] = Field(
         default="sentence",
         description=(
             "Text input streaming mode: 'sentence' (default) waits for sentence boundaries "
             "before submitting to TTS; 'token_level' feeds text incrementally to a single "
-            "TTS request via engine-level streaming updates."
+            "TTS request; 'sentence_commit' buffers input.text messages until input.commit, "
+            "then appends each commit to one persistent TTS request."
         ),
     )
     streaming_drain_max_steps: int = Field(
@@ -488,21 +505,21 @@ class StreamingSpeechSessionConfig(BaseModel):
         ge=0,
         description=(
             "Max decode steps after text + EOS are fully consumed before "
-            "runtime force-finishes the request. Only used in token_level mode."
+            "runtime force-finishes the request. Used in token_level and sentence_commit modes."
         ),
     )
 
     @model_validator(mode="after")
     def validate_streaming_constraints(self) -> "StreamingSpeechSessionConfig":
-        if self.streaming_mode == "token_level":
+        if self.streaming_mode in ("token_level", "sentence_commit"):
             if self.response_format != "pcm":
                 raise ValueError(
-                    "token_level streaming requires response_format='pcm'. "
+                    f"{self.streaming_mode} streaming requires response_format='pcm'. "
                     f"Got response_format='{self.response_format}'."
                 )
             self.stream_audio = True
             if self.speed is not None and self.speed != 1.0:
-                raise ValueError("Speed adjustment is not supported in token_level mode.")
+                raise ValueError(f"Speed adjustment is not supported in {self.streaming_mode} mode.")
             self.speed = 1.0
         if self.stream_audio:
             if self.response_format != "pcm":

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -145,6 +145,18 @@ class OpenAICreateSpeechRequest(BaseModel):
         default=None,
         description=("Optional model-specific parameters passed directly to the model's extra_args."),
     )
+    streaming_text_input: bool = Field(
+        default=False,
+        description="Internal flag: set by token_level streaming handler to enable "
+        "incremental text embedding append in the Talker model.",
+    )
+    streaming_drain_max_steps: int = Field(
+        default=100,
+        ge=0,
+        description="Max decode steps after text input is fully drained before "
+        "runtime force-finishes the request. 0 means force-finish immediately "
+        "when text + EOS are consumed (no grace period for natural codec EOS).",
+    )
 
     @field_validator("stream_format")
     @classmethod
@@ -463,9 +475,35 @@ class StreamingSpeechSessionConfig(BaseModel):
             "'clause' also splits on CJK commas ， and semicolons ；."
         ),
     )
+    streaming_mode: Literal["sentence", "token_level"] = Field(
+        default="sentence",
+        description=(
+            "Text input streaming mode: 'sentence' (default) waits for sentence boundaries "
+            "before submitting to TTS; 'token_level' feeds text incrementally to a single "
+            "TTS request via engine-level streaming updates."
+        ),
+    )
+    streaming_drain_max_steps: int = Field(
+        default=100,
+        ge=0,
+        description=(
+            "Max decode steps after text + EOS are fully consumed before "
+            "runtime force-finishes the request. Only used in token_level mode."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_streaming_constraints(self) -> "StreamingSpeechSessionConfig":
+        if self.streaming_mode == "token_level":
+            if self.response_format != "pcm":
+                raise ValueError(
+                    "token_level streaming requires response_format='pcm'. "
+                    f"Got response_format='{self.response_format}'."
+                )
+            self.stream_audio = True
+            if self.speed is not None and self.speed != 1.0:
+                raise ValueError("Speed adjustment is not supported in token_level mode.")
+            self.speed = 1.0
         if self.stream_audio:
             if self.response_format != "pcm":
                 raise ValueError(

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -2866,6 +2866,10 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         elif params["task_type"][0] == "VoiceDesign":
             params["non_streaming_mode"] = [True]
 
+        if request.streaming_text_input:
+            params["streaming_text_input"] = [True]
+            params["streaming_drain_max_steps"] = [request.streaming_drain_max_steps]
+
         return params
 
     # ---- Voxtral TTS helpers ----

--- a/vllm_omni/entrypoints/openai/serving_speech_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_speech_stream.py
@@ -1,16 +1,19 @@
 """WebSocket handler for streaming text input TTS.
 
-Accepts text incrementally via WebSocket, buffers and splits at sentence
-boundaries, and generates audio per sentence using the existing TTS pipeline.
+Accepts text incrementally via WebSocket and supports sentence-scoped
+generation, token-level extension, or explicit sentence commits to one
+persistent TTS request.
 
 Protocol:
     Client -> Server:
         {"type": "session.config", ...}   # Session config (sent once first)
         {"type": "input.text", "text": "..."} # Text chunks
+        {"type": "input.commit", "commit_id": "..."} # Commit buffered text
         {"type": "input.done"}            # End of input
 
     Server -> Client:
         {"type": "audio.start", "sentence_index": 0, "sentence_text": "...", "format": "wav"}
+        {"type": "input.committed", "commit_id": "...", "sentence_index": 0}
         <binary frame: audio bytes>
         {"type": "audio.done", "sentence_index": 0}
         {"type": "session.done", "total_sentences": N}
@@ -27,6 +30,8 @@ from vllm.logger import init_logger
 
 from vllm_omni.entrypoints.openai.protocol.audio import (
     OpenAICreateSpeechRequest,
+    StreamingSpeechInputCommit,
+    StreamingSpeechInputCommitted,
     StreamingSpeechSessionConfig,
 )
 from vllm_omni.entrypoints.openai.serving_speech import OmniOpenAIServingSpeech
@@ -89,8 +94,8 @@ class OmniStreamingSpeechHandler:
                     await self._send_error(websocket, str(error))
                     return
 
-            # Route to token-level handler if requested.
-            if config.streaming_mode == "token_level":
+            # Single-request streaming modes require engine-level text updates.
+            if config.streaming_mode in ("token_level", "sentence_commit"):
                 server_enabled = getattr(
                     self._speech_service.engine_client.model_config,
                     "streaming_text_enabled",
@@ -99,11 +104,14 @@ class OmniStreamingSpeechHandler:
                 if not server_enabled:
                     await self._send_error(
                         websocket,
-                        "token_level streaming is disabled on this server "
+                        f"{config.streaming_mode} streaming is disabled on this server "
                         "(set streaming_text_enabled: true in stage config to enable)",
                     )
                     return
-                await self._handle_token_level_session(websocket, config)
+                if config.streaming_mode == "sentence_commit":
+                    await self._handle_sentence_commit_session(websocket, config)
+                else:
+                    await self._handle_token_level_session(websocket, config)
                 return
 
             boundary_re = SPLIT_CLAUSE if config.split_granularity == "clause" else SPLIT_SENTENCE
@@ -281,6 +289,7 @@ class OmniStreamingSpeechHandler:
             speed=config.speed,
             max_new_tokens=config.max_new_tokens,
             initial_codec_chunk_frames=config.initial_codec_chunk_frames,
+            non_streaming_mode=False,
             ref_audio=config.ref_audio,
             ref_text=config.ref_text,
             x_vector_only_mode=config.x_vector_only_mode,
@@ -438,6 +447,268 @@ class OmniStreamingSpeechHandler:
                     {
                         "type": "session.done",
                         "total_sentences": 1,
+                    }
+                )
+            except Exception:
+                pass
+
+    async def _handle_sentence_commit_session(
+        self,
+        websocket: WebSocket,
+        config: StreamingSpeechSessionConfig,
+    ) -> None:
+        """Stream committed sentences through one persistent TTS request.
+
+        ``input.text`` messages are buffered until ``input.commit``. The first
+        commit creates the request; later commits extend it without resetting
+        model state. Only ``input.done`` marks the engine request as finished.
+        """
+        response_format = config.response_format or "pcm"
+        pending_parts: list[str] = []
+        total_input_chars = 0
+        sentence_count = 0
+        input_done = False
+        first_commit: StreamingSpeechInputCommit | None = None
+        first_text = ""
+
+        async def receive_message() -> dict | None:
+            try:
+                raw = await asyncio.wait_for(
+                    websocket.receive_text(),
+                    timeout=self._idle_timeout,
+                )
+            except asyncio.TimeoutError:
+                await self._send_error(websocket, "Idle timeout")
+                return None
+            if len(raw) > _MAX_INPUT_TEXT_MESSAGE_SIZE:
+                await self._send_error(websocket, "input.text message too large")
+                return {}
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await self._send_error(websocket, "Invalid JSON message")
+                return {}
+            if not isinstance(msg, dict):
+                await self._send_error(websocket, "WebSocket messages must be JSON objects")
+                return {}
+            return msg
+
+        # Wait for the first commit before creating the engine request.
+        while first_commit is None and not input_done:
+            msg = await receive_message()
+            if msg is None:
+                return
+            if not msg:
+                continue
+            msg_type = msg.get("type")
+            if msg_type == "input.text":
+                text = msg.get("text", "")
+                if not isinstance(text, str):
+                    await self._send_error(websocket, "input.text requires a string value")
+                    continue
+                total_input_chars += len(text)
+                if total_input_chars > _MAX_BUFFER_SIZE:
+                    await self._send_error(websocket, "input.text buffer exceeded limit")
+                    return
+                pending_parts.append(text)
+            elif msg_type in ("input.commit", "input.done"):
+                text = "".join(pending_parts)
+                if not text.strip():
+                    if msg_type == "input.done":
+                        await websocket.send_json({"type": "session.done", "total_sentences": 0})
+                        return
+                    await self._send_error(websocket, "input.commit requires buffered text")
+                    continue
+                if msg_type == "input.commit":
+                    try:
+                        first_commit = StreamingSpeechInputCommit.model_validate(msg)
+                    except ValidationError as e:
+                        await self._send_error(websocket, f"Invalid input.commit: {e}")
+                        continue
+                else:
+                    first_commit = StreamingSpeechInputCommit(type="input.commit")
+                    input_done = True
+                first_text = text
+                pending_parts.clear()
+            else:
+                await self._send_error(websocket, f"Unknown message type: {msg_type}")
+
+        if first_commit is None:
+            return
+
+        initial_request = OpenAICreateSpeechRequest(
+            input=first_text,
+            model=config.model,
+            voice=config.voice,
+            task_type=config.task_type,
+            language=config.language,
+            instructions=config.instructions,
+            response_format=response_format,
+            speed=config.speed,
+            max_new_tokens=config.max_new_tokens,
+            initial_codec_chunk_frames=config.initial_codec_chunk_frames,
+            non_streaming_mode=False,
+            ref_audio=config.ref_audio,
+            ref_text=config.ref_text,
+            x_vector_only_mode=config.x_vector_only_mode,
+            speaker_embedding=config.speaker_embedding,
+            stream=True,
+            streaming_text_input=True,
+            streaming_drain_max_steps=config.streaming_drain_max_steps,
+        )
+        request_id, generator, _ = await self._speech_service._prepare_speech_generation(initial_request)
+
+        sentence_count = 1
+        await websocket.send_json(
+            StreamingSpeechInputCommitted(
+                commit_id=first_commit.commit_id,
+                sentence_index=0,
+                chars_committed=len(first_text),
+            ).model_dump()
+        )
+        start_payload: dict = {
+            "type": "audio.start",
+            "sentence_index": 0,
+            "sentence_text": first_text[:80] + ("..." if len(first_text) > 80 else ""),
+            "format": response_format,
+        }
+        if response_format == "pcm":
+            start_payload["sample_rate"] = _PCM_SAMPLE_RATE
+        await websocket.send_json(start_payload)
+
+        total_bytes = 0
+        generation_failed = False
+        finished_sent = False
+        input_error: str | None = None
+
+        def send_extend(new_text: str, *, finished: bool) -> None:
+            self._speech_service.engine_client.extend_streaming_text(
+                request_id,
+                new_text=new_text,
+                finished=finished,
+            )
+
+        def finish_text() -> None:
+            nonlocal finished_sent
+            if not finished_sent:
+                finished_sent = True
+                send_extend("", finished=True)
+
+        async def commit_pending(commit: StreamingSpeechInputCommit) -> bool:
+            nonlocal sentence_count
+            text = "".join(pending_parts)
+            if not text.strip():
+                await self._send_error(websocket, "input.commit requires buffered text")
+                return False
+            pending_parts.clear()
+            send_extend(text, finished=False)
+            await websocket.send_json(
+                StreamingSpeechInputCommitted(
+                    commit_id=commit.commit_id,
+                    sentence_index=sentence_count,
+                    chars_committed=len(text),
+                ).model_dump()
+            )
+            sentence_count += 1
+            return True
+
+        async def feed_commits() -> None:
+            nonlocal input_done, input_error, total_input_chars
+            if input_done:
+                finish_text()
+                return
+            try:
+                while True:
+                    msg = await receive_message()
+                    if msg is None:
+                        input_error = "Idle timeout"
+                        break
+                    if not msg:
+                        continue
+                    msg_type = msg.get("type")
+                    if msg_type == "input.text":
+                        text = msg.get("text", "")
+                        if not isinstance(text, str):
+                            await self._send_error(websocket, "input.text requires a string value")
+                            continue
+                        total_input_chars += len(text)
+                        if total_input_chars > _MAX_BUFFER_SIZE:
+                            input_error = "input.text buffer exceeded limit"
+                            break
+                        pending_parts.append(text)
+                    elif msg_type == "input.commit":
+                        try:
+                            commit = StreamingSpeechInputCommit.model_validate(msg)
+                        except ValidationError as e:
+                            await self._send_error(websocket, f"Invalid input.commit: {e}")
+                            continue
+                        await commit_pending(commit)
+                    elif msg_type == "input.done":
+                        input_done = True
+                        if any(part.strip() for part in pending_parts):
+                            await commit_pending(StreamingSpeechInputCommit(type="input.commit"))
+                        finish_text()
+                        break
+                    else:
+                        await self._send_error(websocket, f"Unknown message type: {msg_type}")
+            except WebSocketDisconnect:
+                raise
+            except Exception:
+                logger.debug("sentence commit feed error", exc_info=True)
+                input_error = "sentence commit streaming failed"
+
+        input_task = asyncio.create_task(feed_commits())
+        try:
+            async with aclosing(self._speech_service._generate_pcm_chunks(generator, request_id)) as stream:
+                async for chunk in stream:
+                    total_bytes += len(chunk)
+                    await websocket.send_bytes(chunk)
+            if not input_task.done():
+                input_task.cancel()
+                try:
+                    await input_task
+                except asyncio.CancelledError:
+                    pass
+            if input_error is None:
+                finish_text()
+        except WebSocketDisconnect:
+            input_task.cancel()
+            try:
+                await self._speech_service.engine_client.abort(request_id)
+            except Exception:
+                pass
+            raise
+        except Exception as e:
+            generation_failed = True
+            logger.error("Sentence-commit generation failed: %s", e)
+            await self._send_error(websocket, f"Generation failed: {e}")
+        finally:
+            if not input_task.done():
+                input_task.cancel()
+                try:
+                    await input_task
+                except (asyncio.CancelledError, WebSocketDisconnect):
+                    pass
+            if input_error is not None:
+                generation_failed = True
+                try:
+                    await self._speech_service.engine_client.abort(request_id)
+                except Exception:
+                    pass
+                await self._send_error(websocket, input_error)
+            try:
+                await websocket.send_json(
+                    {
+                        "type": "audio.done",
+                        "sentence_index": 0,
+                        "total_bytes": total_bytes,
+                        "error": generation_failed,
+                    }
+                )
+                await websocket.send_json(
+                    {
+                        "type": "session.done",
+                        "total_sentences": sentence_count,
                     }
                 )
             except Exception:

--- a/vllm_omni/entrypoints/openai/serving_speech_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_speech_stream.py
@@ -43,6 +43,7 @@ _DEFAULT_CONFIG_TIMEOUT = 10.0  # seconds
 _PCM_SAMPLE_RATE = 24000
 _MAX_CONFIG_MESSAGE_SIZE = 4 * 1024 * 1024  # allow large ref_audio payloads
 _MAX_INPUT_TEXT_MESSAGE_SIZE = 128 * 1024
+_MAX_BUFFER_SIZE = 100_000  # max accumulated text chars for token-level mode
 
 
 class OmniStreamingSpeechHandler:
@@ -87,6 +88,23 @@ class OmniStreamingSpeechHandler:
                 if error is not None:
                     await self._send_error(websocket, str(error))
                     return
+
+            # Route to token-level handler if requested.
+            if config.streaming_mode == "token_level":
+                server_enabled = getattr(
+                    self._speech_service.engine_client.model_config,
+                    "streaming_text_enabled",
+                    False,
+                )
+                if not server_enabled:
+                    await self._send_error(
+                        websocket,
+                        "token_level streaming is disabled on this server "
+                        "(set streaming_text_enabled: true in stage config to enable)",
+                    )
+                    return
+                await self._handle_token_level_session(websocket, config)
+                return
 
             boundary_re = SPLIT_CLAUSE if config.split_granularity == "clause" else SPLIT_SENTENCE
             splitter = SentenceSplitter(boundary_re=boundary_re)
@@ -199,6 +217,231 @@ class OmniStreamingSpeechHandler:
             return None
 
         return config
+
+    async def _handle_token_level_session(
+        self,
+        websocket: WebSocket,
+        config: StreamingSpeechSessionConfig,
+    ) -> None:
+        """True engine-level streaming: text arrives incrementally, audio
+        generation starts immediately and runs concurrently.
+
+        1. Collect minimum text buffer (MIN_INITIAL_CHARS)
+        2. Submit initial TTS request to the engine (audio generation starts)
+        3. Concurrently: read text from WebSocket -> extend_text messages to orchestrator
+                         stream audio from engine -> send to WebSocket
+        4. On input.done -> send text_finished signal
+        """
+        response_format = config.response_format or "pcm"
+        all_text = ""
+        input_done = False
+
+        MIN_INITIAL_CHARS = 60
+        while len(all_text) < MIN_INITIAL_CHARS:
+            try:
+                raw = await asyncio.wait_for(
+                    websocket.receive_text(),
+                    timeout=self._idle_timeout,
+                )
+            except asyncio.TimeoutError:
+                await self._send_error(websocket, "Idle timeout")
+                return
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
+            msg_type = msg.get("type")
+            if msg_type == "input.text":
+                text = msg.get("text", "")
+                if not isinstance(text, str):
+                    await self._send_error(websocket, "input.text requires a string value")
+                    continue
+                all_text += text
+                if len(all_text) > _MAX_BUFFER_SIZE:
+                    await self._send_error(websocket, "input.text buffer exceeded limit")
+                    return
+            elif msg_type == "input.done":
+                input_done = True
+                break
+
+        if not all_text.strip():
+            await websocket.send_json({"type": "session.done", "total_sentences": 0})
+            return
+
+        initial_request = OpenAICreateSpeechRequest(
+            input=all_text,
+            model=config.model,
+            voice=config.voice,
+            task_type=config.task_type,
+            language=config.language,
+            instructions=config.instructions,
+            response_format=response_format,
+            speed=config.speed,
+            max_new_tokens=config.max_new_tokens,
+            initial_codec_chunk_frames=config.initial_codec_chunk_frames,
+            ref_audio=config.ref_audio,
+            ref_text=config.ref_text,
+            x_vector_only_mode=config.x_vector_only_mode,
+            speaker_embedding=config.speaker_embedding,
+            stream=True,
+            streaming_text_input=True,
+            streaming_drain_max_steps=config.streaming_drain_max_steps,
+        )
+        request_id, generator, _ = await self._speech_service._prepare_speech_generation(
+            initial_request,
+        )
+
+        start_payload: dict = {
+            "type": "audio.start",
+            "sentence_index": 0,
+            "sentence_text": all_text[:80] + ("..." if len(all_text) > 80 else ""),
+            "format": response_format,
+        }
+        if response_format == "pcm":
+            start_payload["sample_rate"] = _PCM_SAMPLE_RATE
+        await websocket.send_json(start_payload)
+
+        total_bytes = 0
+        generation_failed = False
+
+        _extend_count = 0
+        _extend_chars_total = 0
+
+        finished_sent = False
+        input_error: str | None = None
+
+        def _send_extend(new_text: str, finished: bool) -> None:
+            nonlocal _extend_count, _extend_chars_total
+            _extend_count += 1
+            _extend_chars_total += len(new_text) if new_text else 0
+            logger.info(
+                "[WS][extend] req=%s chunk#%d text_len=%d finished=%s cumulative_chars=%d",
+                request_id,
+                _extend_count,
+                len(new_text) if new_text else 0,
+                finished,
+                _extend_chars_total,
+            )
+            self._speech_service.engine_client.extend_streaming_text(
+                request_id,
+                new_text=new_text,
+                finished=finished,
+            )
+
+        def _finish_text() -> None:
+            nonlocal finished_sent
+            if not finished_sent:
+                finished_sent = True
+                _send_extend("", finished=True)
+
+        async def feed_text() -> None:
+            nonlocal all_text, input_error
+            if input_done:
+                _finish_text()
+                return
+            try:
+                text_chars_total = len(all_text)
+                while True:
+                    try:
+                        raw = await asyncio.wait_for(
+                            websocket.receive_text(),
+                            timeout=self._idle_timeout,
+                        )
+                    except asyncio.TimeoutError:
+                        break
+                    if len(raw) > _MAX_INPUT_TEXT_MESSAGE_SIZE:
+                        input_error = "input.text message too large"
+                        break
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(msg, dict):
+                        continue
+                    msg_type = msg.get("type")
+                    if msg_type == "input.text":
+                        new_text = msg.get("text", "")
+                        if not isinstance(new_text, str):
+                            input_error = "input.text requires a string value"
+                            break
+                        if not new_text:
+                            continue
+                        text_chars_total += len(new_text)
+                        if text_chars_total > _MAX_BUFFER_SIZE:
+                            input_error = "input.text buffer exceeded limit"
+                            break
+                        _send_extend(new_text, finished=False)
+                    elif msg_type == "input.done":
+                        break
+            except WebSocketDisconnect:
+                raise
+            except Exception:
+                logger.debug("feed_text error", exc_info=True)
+                input_error = "input.text streaming failed"
+            if input_error is None:
+                _finish_text()
+
+        text_task = asyncio.create_task(feed_text())
+
+        try:
+            async with aclosing(self._speech_service._generate_pcm_chunks(generator, request_id)) as stream:
+                async for chunk in stream:
+                    total_bytes += len(chunk)
+                    await websocket.send_bytes(chunk)
+            if not text_task.done():
+                text_task.cancel()
+                try:
+                    await text_task
+                except asyncio.CancelledError:
+                    pass
+            if input_error is None:
+                _finish_text()
+        except WebSocketDisconnect:
+            text_task.cancel()
+            try:
+                await self._speech_service.engine_client.abort(request_id)
+            except Exception:
+                pass
+            raise
+        except Exception as e:
+            generation_failed = True
+            logger.error("Token-level generation failed: %s", e)
+            await self._send_error(websocket, f"Generation failed: {e}")
+        finally:
+            if not text_task.done():
+                text_task.cancel()
+                try:
+                    await text_task
+                except asyncio.CancelledError:
+                    pass
+                except WebSocketDisconnect:
+                    pass
+            if input_error is not None:
+                generation_failed = True
+                try:
+                    await self._speech_service.engine_client.abort(request_id)
+                except Exception:
+                    pass
+                await self._send_error(websocket, input_error)
+            try:
+                await websocket.send_json(
+                    {
+                        "type": "audio.done",
+                        "sentence_index": 0,
+                        "total_bytes": total_bytes,
+                        "error": generation_failed,
+                    }
+                )
+                await websocket.send_json(
+                    {
+                        "type": "session.done",
+                        "total_sentences": 1,
+                    }
+                )
+            except Exception:
+                pass
 
     async def _generate_and_send(
         self,

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -860,6 +860,20 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                 info_update["meta"]["streaming_drain_step"] = int(meta.get("streaming_drain_step", 0) or 0) + 1
         return input_ids, inputs_embeds_out, info_update
 
+    @staticmethod
+    def can_preprocess_decode_batch(info_dict: dict[str, Any]) -> bool:
+        """Return whether decode can use the non-pausing batched fast path.
+
+        Streaming-text requests must use ``preprocess`` so an empty text tail
+        can return ``None`` and pause before the model advances its state.
+        """
+        additional_information = info_dict.get("additional_information")
+        if isinstance(additional_information, dict):
+            meta = additional_information.get("meta", {})
+        else:
+            meta = info_dict.get("meta", {})
+        return not bool(meta.get("streaming_text_input"))
+
     def preprocess_decode_batch(
         self,
         *,

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -680,6 +680,16 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                     info_update.setdefault("codes", {})["ref"] = ref_code.detach().to("cpu").contiguous()
                 if ref_code_len is not None:
                     info_update["meta"]["ref_code_len"] = int(ref_code_len)
+                st_input_flag = info_dict.get("streaming_text_input")
+                if isinstance(st_input_flag, list):
+                    st_input_flag = st_input_flag[0] if st_input_flag else False
+                if st_input_flag:
+                    info_update["meta"]["streaming_text_input"] = True
+                    drain_max_raw = info_dict.get("streaming_drain_max_steps")
+                    if isinstance(drain_max_raw, list):
+                        drain_max_raw = drain_max_raw[0] if drain_max_raw else None
+                    if drain_max_raw is not None:
+                        info_update["meta"]["streaming_drain_max_steps"] = int(drain_max_raw)
                 # First prefill: source the slice offset from `_omni_num_computed_tokens`
                 # so cache-recovery (prefill replay at a later offset) lands on the right
                 # slice of the stored embeddings. Subsequent chunks below advance from
@@ -720,8 +730,71 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # (request-independent buffer) — no per-request fetch needed.
 
         tail = hs.get("trailing_text")
+        is_streaming_text = bool(meta.get("streaming_text_input"))
+        eos_injected_this_step = False
+        if is_streaming_text:
+            new_raw_text = info_dict.get("streaming_text_new_text")
+            if isinstance(new_raw_text, str) and new_raw_text:
+                tok = self._get_tokenizer()
+                raw_ids = tok(new_raw_text, return_tensors="pt", padding=False, add_special_tokens=False)["input_ids"]
+                raw_ids = raw_ids.to(device=input_ids.device)
+                raw_embeds = self.text_projection(self.text_embedding(raw_ids)).squeeze(0)
+                if isinstance(tail, torch.Tensor) and tail.ndim == 2 and tail.shape[0] > 0:
+                    tail = torch.cat([tail, raw_embeds.to(device=tail.device, dtype=tail.dtype)], dim=0)
+                else:
+                    tail = raw_embeds.to(device=input_ids.device, dtype=dtype)
+            if bool(info_dict.get("streaming_text_finished")) and not bool(meta.get("streaming_eos_appended")):
+                eos_ids = torch.tensor([[self.config.tts_eos_token_id]], device=input_ids.device, dtype=torch.long)
+                eos_embed = self.text_projection(self.text_embedding(eos_ids)).squeeze(0).to(dtype=dtype)
+                if isinstance(tail, torch.Tensor) and tail.ndim == 2 and tail.shape[0] > 0:
+                    tail = torch.cat([tail, eos_embed.to(device=tail.device, dtype=tail.dtype)], dim=0)
+                else:
+                    tail = eos_embed
+                eos_injected_this_step = True
+
         text_offset = max(0, int(meta.get("talker_text_offset", 0) or 0))
         trailing_text_update = None
+        if is_streaming_text and (not isinstance(tail, torch.Tensor) or tail.ndim != 2 or tail.shape[0] == 0):
+            if not bool(info_dict.get("streaming_text_finished")):
+                return (
+                    input_ids,
+                    None,
+                    {
+                        "hidden_states": {
+                            "trailing_text": torch.empty(
+                                (0, tts_pad_embed.shape[-1]),
+                                device=input_ids.device,
+                                dtype=dtype,
+                            )
+                        },
+                        "meta": {
+                            "streaming_wait_for_input": True,
+                        },
+                        "streaming_text_new_text": None,
+                        "streaming_text_new_ids": None,
+                    },
+                )
+            if bool(meta.get("streaming_eos_appended")):
+                drain_step = int(meta.get("streaming_drain_step", 0) or 0)
+                max_drain = int(meta.get("streaming_drain_max_steps", 100) or 100)
+                if drain_step >= max_drain:
+                    return (
+                        input_ids,
+                        None,
+                        {
+                            "hidden_states": {
+                                "trailing_text": torch.empty(
+                                    (0, tts_pad_embed.shape[-1]),
+                                    device=input_ids.device,
+                                    dtype=dtype,
+                                )
+                            },
+                            "meta": {"streaming_drain_step": drain_step},
+                            "streaming_text_drained": True,
+                            "streaming_text_new_text": None,
+                            "streaming_text_new_ids": None,
+                        },
+                    )
         if isinstance(tail, torch.Tensor) and tail.ndim == 2:
             tail_len = int(tail.shape[0])
             if text_offset < tail_len:
@@ -774,6 +847,17 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         }
         if trailing_text_update is not None:
             info_update["hidden_states"] = {"trailing_text": trailing_text_update.detach()}
+        if is_streaming_text:
+            info_update["streaming_text_new_text"] = None
+            info_update["streaming_text_new_ids"] = None
+            info_update["meta"]["streaming_text_input"] = True
+            if eos_injected_this_step:
+                info_update["meta"]["streaming_eos_appended"] = True
+            st_fin = bool(info_dict.get("streaming_text_finished"))
+            st_eos = bool(meta.get("streaming_eos_appended")) or eos_injected_this_step
+            tail_empty = trailing_text_update is not None and trailing_text_update.numel() == 0
+            if st_fin and st_eos and tail_empty:
+                info_update["meta"]["streaming_drain_step"] = int(meta.get("streaming_drain_step", 0) or 0) + 1
         return input_ids, inputs_embeds_out, info_update
 
     def preprocess_decode_batch(

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -54,6 +54,12 @@ class OmniModelRunnerOutput(ModelRunnerOutput):
     # The Scheduler can safely free the block tables for these requests.
     kv_extracted_req_ids: list[str] | None = None
     omni_connector_output: OmniConnectorOutput | None = None
+    # IDs of requests whose forward was skipped this step (text starving).
+    # Scheduler rolls back num_computed_tokens for these requests.
+    streaming_starving_req_ids: set[str] | None = None
+    # IDs of requests whose streaming text input is fully drained (finished +
+    # EOS consumed + tail empty). Scheduler force-finishes these requests.
+    streaming_drained_req_ids: set[str] | None = None
 
 
 @dataclass

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -834,7 +834,6 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     )
                 except TypeError:
                     logits = self.model.compute_logits(sample_hidden_states)
-                self._suppress_streaming_text_eos(logits)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
@@ -858,7 +857,6 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         )
                     except TypeError:
                         logits = self.model.compute_logits(sample_hidden_states)
-                    self._suppress_streaming_text_eos(logits)
 
                 model_output_broadcast_data: dict[str, Any] = {}
                 if logits is not None:
@@ -893,40 +891,6 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             self._omni_routed_experts_d2h(scheduler_output)
 
         return None
-
-    def _suppress_streaming_text_eos(self, logits: torch.Tensor | None) -> None:
-        """Mask the codec EOS for token-level streaming requests still feeding text.
-
-        While a ``streaming_text_input`` request has not been marked finished,
-        the talker must not autoregressively sample the codec EOS token: doing so
-        ends the request before the rest of the (incrementally arriving) text has
-        been synthesized. Once the client signals ``input.done``
-        (``streaming_text_finished``) the EOS is injected on the text side and the
-        request is allowed to terminate normally, so masking is dropped here.
-
-        Rows align with ``input_batch.req_ids`` for the requests sampled this
-        step (the steady-state decode case where premature EOS occurs).
-        """
-        if logits is None:
-            return
-        eos_id = getattr(self.model, "_codec_eos_token_id", -1)
-        if not (isinstance(eos_id, int) and 0 <= eos_id < logits.shape[-1]):
-            return
-        buffer = getattr(self, "model_intermediate_buffer", None)
-        if not buffer:
-            return
-        rows: list[int] = []
-        for i, req_id in enumerate(self.input_batch.req_ids):
-            if i >= logits.shape[0]:
-                break
-            buf = buffer.get(req_id)
-            if not buf:
-                continue
-            meta = buf.get("meta") or {}
-            if meta.get("streaming_text_input") and not buf.get("streaming_text_finished"):
-                rows.append(i)
-        if rows:
-            logits[rows, eos_id] = float("-inf")
 
     def _sample(
         self,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -834,6 +834,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     )
                 except TypeError:
                     logits = self.model.compute_logits(sample_hidden_states)
+                self._suppress_streaming_text_eos(logits)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
@@ -857,6 +858,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         )
                     except TypeError:
                         logits = self.model.compute_logits(sample_hidden_states)
+                    self._suppress_streaming_text_eos(logits)
 
                 model_output_broadcast_data: dict[str, Any] = {}
                 if logits is not None:
@@ -891,6 +893,40 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             self._omni_routed_experts_d2h(scheduler_output)
 
         return None
+
+    def _suppress_streaming_text_eos(self, logits: torch.Tensor | None) -> None:
+        """Mask the codec EOS for token-level streaming requests still feeding text.
+
+        While a ``streaming_text_input`` request has not been marked finished,
+        the talker must not autoregressively sample the codec EOS token: doing so
+        ends the request before the rest of the (incrementally arriving) text has
+        been synthesized. Once the client signals ``input.done``
+        (``streaming_text_finished``) the EOS is injected on the text side and the
+        request is allowed to terminate normally, so masking is dropped here.
+
+        Rows align with ``input_batch.req_ids`` for the requests sampled this
+        step (the steady-state decode case where premature EOS occurs).
+        """
+        if logits is None:
+            return
+        eos_id = getattr(self.model, "_codec_eos_token_id", -1)
+        if not (isinstance(eos_id, int) and 0 <= eos_id < logits.shape[-1]):
+            return
+        buffer = getattr(self, "model_intermediate_buffer", None)
+        if not buffer:
+            return
+        rows: list[int] = []
+        for i, req_id in enumerate(self.input_batch.req_ids):
+            if i >= logits.shape[0]:
+                break
+            buf = buffer.get(req_id)
+            if not buf:
+                continue
+            meta = buf.get("meta") or {}
+            if meta.get("streaming_text_input") and not buf.get("streaming_text_finished"):
+                rows.append(i)
+        if rows:
+            logits[rows, eos_id] = float("-inf")
 
     def _sample(
         self,

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1103,6 +1103,17 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 scheduler_output.total_num_scheduled_tokens,
             )
 
+        _skip_ids_bk = getattr(self, "_streaming_starving_req_ids", set()) | getattr(
+            self,
+            "_streaming_drained_req_ids",
+            set(),
+        )
+        if _skip_ids_bk and valid_sampled_token_ids is not None:
+            for rid in _skip_ids_bk:
+                idx = req_id_to_index_output_copy.get(rid)
+                if idx is not None and idx < len(valid_sampled_token_ids):
+                    valid_sampled_token_ids[idx] = []
+
         if propose_drafts_after_bookkeeping:
             # ngram and other speculative decoding methods use the sampled
             # tokens on the CPU, so they are run after bookkeeping.
@@ -1178,6 +1189,16 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         # OmniModelRunnerOutput.pooler_output (which is set to None below).
         # The actual multimodal wire transport uses multimodal_outputs instead.
         pooler_output: list[dict[str, object]] | None = None
+        _skip_ids = getattr(self, "_streaming_starving_req_ids", set()) | getattr(
+            self,
+            "_streaming_drained_req_ids",
+            set(),
+        )
+        if _skip_ids:
+            downstream_req_id_set -= _skip_ids
+            downstream_req_ids = [rid for rid in downstream_req_ids if rid in downstream_req_id_set]
+            needs_pooler_payload = len(downstream_req_ids) > 0
+
         if needs_pooler_payload:
             mm_cpu = None
             if self.omni_prefix_cache is not None:
@@ -1307,6 +1328,12 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             output.kv_extracted_req_ids = kv_extracted_req_ids
             output.omni_connector_output = self.get_omni_connector_output()
             output.routed_experts = routed_experts_lists
+            starving = getattr(self, "_streaming_starving_req_ids", None)
+            if starving:
+                output.streaming_starving_req_ids = starving
+            drained = getattr(self, "_streaming_drained_req_ids", None)
+            if drained:
+                output.streaming_drained_req_ids = drained
 
         if not self.use_async_scheduling:
             return output

--- a/vllm_omni/worker/gpu_ar_worker.py
+++ b/vllm_omni/worker/gpu_ar_worker.py
@@ -106,6 +106,47 @@ class GPUARWorker(OmniWorkerMixin, OmniGPUWorkerBase):
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
 
+    def update_model_state(self, req_id: str, state: dict) -> None:
+        """Update a running request's model_intermediate_buffer directly.
+
+        Called via collective_rpc from the orchestrator to inject streaming
+        text updates into the Talker model without going through the scheduler.
+
+        Special handling for streaming_text_new_text: append to existing
+        unconsumed text instead of overwriting, so rapid consecutive chunks
+        don't lose data.
+        """
+        new_text = state.get("streaming_text_new_text")
+        if isinstance(new_text, str) and new_text:
+            existing = self.model_runner.model_intermediate_buffer.get(req_id, {})
+            old_text = existing.get("streaming_text_new_text")
+            if isinstance(old_text, str) and old_text:
+                state = dict(state)
+                state["streaming_text_new_text"] = old_text + new_text
+                logger.info(
+                    "[Worker] update_model_state req=%s APPEND text old=%d new=%d total=%d",
+                    req_id,
+                    len(old_text),
+                    len(new_text),
+                    len(state["streaming_text_new_text"]),
+                )
+            else:
+                logger.info(
+                    "[Worker] update_model_state req=%s SET text len=%d",
+                    req_id,
+                    len(new_text),
+                )
+        else:
+            keys = list(state.keys())
+            logger.info("[Worker] update_model_state req=%s keys=%s", req_id, keys)
+        self.model_runner._update_intermediate_buffer(req_id, state)
+
+        if new_text or state.get("streaming_text_finished"):
+            buf = self.model_runner.model_intermediate_buffer.get(req_id)
+            if buf is not None:
+                buf["streaming_wait_for_input"] = False
+            logger.info("[Worker] cleared streaming_wait_for_input for req=%s", req_id)
+
     def handle_sleep_task(self, task: OmniSleepTask | dict) -> OmniACK:
         """
         Explicitly handle sleep commands.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1623,6 +1623,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             decode_start_offsets = []
             decode_batch_items = []
             batch_decode_preprocess = getattr(self.model, "preprocess_decode_batch", None)
+            can_preprocess_decode_batch = getattr(self.model, "can_preprocess_decode_batch", None)
 
             def flush_decode_batch() -> None:
                 nonlocal inputs_embeds
@@ -1682,7 +1683,16 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_infos["_omni_prompt_len"] = prompt_len
                 req_infos["_omni_num_computed_tokens"] = num_computed_tokens
                 req_infos["_omni_is_prefill"] = is_prefill
-                if callable(batch_decode_preprocess) and self.has_talker_mtp and span_len == 1 and not is_prefill:
+                batch_decode_allowed = not callable(can_preprocess_decode_batch) or can_preprocess_decode_batch(
+                    req_infos
+                )
+                if (
+                    callable(batch_decode_preprocess)
+                    and batch_decode_allowed
+                    and self.has_talker_mtp
+                    and span_len == 1
+                    and not is_prefill
+                ):
                     decode_batch_items.append((req_id, s, req_infos))
                     continue
 

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1348,8 +1348,15 @@ class OmniGPUModelRunner(GPUModelRunner):
                 postprocess_uses_hidden_states = getattr(self.model, "postprocess_uses_hidden_states", True)
                 postprocess_uses_multimodal_outputs = getattr(self.model, "postprocess_uses_multimodal_outputs", True)
                 postprocess_uses_req_infos = getattr(self.model, "postprocess_uses_req_infos", True)
+                _skip_ids = getattr(self, "_streaming_starving_req_ids", set()) | getattr(
+                    self,
+                    "_streaming_drained_req_ids",
+                    set(),
+                )
                 for req_index, req_id in enumerate(self.input_batch.req_ids):
                     if req_ids_filter is not None and req_id not in req_ids_filter:
+                        continue
+                    if req_id in _skip_ids:
                         continue
                     req_infos = self.model_intermediate_buffer.get(req_id, {}) if postprocess_uses_req_infos else {}
                     if postprocess_uses_hidden_states:
@@ -1479,6 +1486,8 @@ class OmniGPUModelRunner(GPUModelRunner):
         intermediate_tensors: IntermediateTensors | None = None,
     ):
         """Align with v0.14.0 preprocess and omni's additional information handling."""
+        self._streaming_starving_req_ids: set[str] = set()
+        self._streaming_drained_req_ids: set[str] = set()
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         is_first_rank = get_pp_group().is_first_rank
         is_encoder_decoder = self.model_config.is_encoder_decoder
@@ -1683,6 +1692,18 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_input_ids, req_embeds, update_dict = self.model.preprocess(
                     input_ids=input_ids[s:e], input_embeds=embed_slice, **req_infos
                 )
+
+                # Streaming text starving: model returned None embeds to signal
+                # it needs more input.  Merge the update (sets streaming_wait_for_input)
+                # and skip this request's forward pass.
+                if req_embeds is None:
+                    self._merge_additional_information_update(req_id, update_dict)
+                    if update_dict.get("streaming_text_drained"):
+                        self._streaming_drained_req_ids.add(req_id)
+                    else:
+                        self._streaming_starving_req_ids.add(req_id)
+                    continue
+
                 if inputs_embeds is None:
                     inputs_embeds = torch.empty(
                         (input_ids.shape[0], req_embeds.shape[-1]),
@@ -1714,6 +1735,14 @@ class OmniGPUModelRunner(GPUModelRunner):
             # run talker mtp decode
             if self.has_talker_mtp:
                 self._talker_mtp_forward(decode_req_ids, inputs_embeds, decode_start_offsets)
+
+        skipped_ids = self._streaming_starving_req_ids | self._streaming_drained_req_ids
+        if skipped_ids and inputs_embeds is not None:
+            for req_index, req_id in enumerate(self.input_batch.req_ids):
+                if req_id in skipped_ids:
+                    s = int(self.query_start_loc.cpu[req_index])
+                    e = s + int(num_scheduled_tokens_np[req_index])
+                    inputs_embeds[s:e].zero_()
 
         return (
             input_ids,


### PR DESCRIPTION
## Summary

- add `streaming_mode="sentence_commit"` so clients can commit completed sentences over one WebSocket and one persistent Qwen3-TTS request
- acknowledge each `input.commit`, append later commits without EOS, and finalize only on `input.done`
- route streaming-text requests through the pausing decode path so starvation does not fall through to pad-conditioned generation
- document the protocol and add a runnable sentence-commit client

## Dependency

This draft is stacked on #4417 at `ff35ae5e`. Since #4417 originates from another fork, this PR includes its commits and targets `main`; it should be rebased after #4417 lands or is refreshed.

## Test plan

- [x] Ruff format/check on changed Python files
- [x] Python compilation on changed files
- [x] Protocol-model smoke test
- [ ] Focused pytest suites (local collection blocked because `vllm` is not installed)
- [ ] Qwen3-TTS GPU validation with delayed commits and continuity checks

Local dependency setup was blocked by a full disk while populating the uv cache.