### PR TITLE
[CI] Add MiniCPM-o async chunk streaming coverage

### DIFF
--- a/tests/e2e/offline_inference/test_minicpmo_4_5.py
+++ b/tests/e2e/offline_inference/test_minicpmo_4_5.py
@@ -2,11 +2,14 @@
 E2E offline tests for MiniCPM-o 4.5 model with multimodal input and audio / text output.
 """
 
+import copy
 import os
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 import pytest
+import torch
+from vllm.sampling_params import RequestOutputKind
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
@@ -15,9 +18,13 @@ from tests.helpers.stage_config import get_deploy_config_path
 models = ["openbmb/MiniCPM-o-4_5"]
 
 _CI_DEPLOY = get_deploy_config_path("minicpmo_4_5_batching.yaml")
+_ASYNC_CHUNK_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
 
 
 test_params = [(model, None, {"deploy_config": _CI_DEPLOY, "trust_remote_code": True}) for model in models]
+async_chunk_test_params = [
+    (model, None, {"deploy_config": _ASYNC_CHUNK_DEPLOY, "trust_remote_code": True}) for model in models
+]
 
 
 def get_question(prompt_type: str = "text") -> str:
@@ -118,3 +125,134 @@ def test_video_to_audio(omni_runner, omni_runner_handler) -> None:
     video = generate_synthetic_video(24, 24, 20)["np_array"]
     request_config = {"prompts": get_question("video"), "videos": video, "modalities": ["audio"]}
     omni_runner_handler.send_omni_request(request_config)
+
+
+def _delta_outputs(
+    omni_runner,
+    *,
+    prompt,
+    modalities,
+    audios=None,
+    images=None,
+    videos=None,
+):
+    omni_inputs = omni_runner.get_omni_inputs(
+        prompts=prompt,
+        audios=audios,
+        images=images,
+        videos=videos,
+        modalities=modalities,
+    )
+    sampling_params_list = copy.deepcopy(omni_runner.get_default_sampling_params_list())
+    for stage_id, sampling_params in enumerate(sampling_params_list):
+        if hasattr(sampling_params, "output_kind"):
+            # Audio streaming starts at the Talker. The Thinker must hand off
+            # its complete TTS span and aligned hidden states in one output.
+            sampling_params.output_kind = (
+                RequestOutputKind.FINAL_ONLY if stage_id == 0 and "audio" in modalities else RequestOutputKind.DELTA
+            )
+    return omni_runner.omni.generate(omni_inputs, sampling_params_list, use_tqdm=False)
+
+
+def _text_chunks(outputs) -> list[str]:
+    chunks = []
+    for stage_output in outputs:
+        if stage_output.final_output_type != "text":
+            continue
+        text = stage_output.request_output.outputs[0].text
+        if text:
+            chunks.append(text)
+    return chunks
+
+
+def _audio_chunks(outputs) -> list[torch.Tensor]:
+    chunks = []
+    for stage_output in outputs:
+        if stage_output.final_output_type != "audio":
+            continue
+        audio = (stage_output.multimodal_output or {}).get("audio")
+        if audio is None:
+            continue
+        values = audio if isinstance(audio, list) else [audio]
+        pieces = [torch.as_tensor(value).detach().float().cpu().reshape(-1) for value in values]
+        pieces = [piece for piece in pieces if piece.numel()]
+        if pieces:
+            chunks.append(torch.cat(pieces))
+    return chunks
+
+
+def _assert_terminal_output(outputs, output_type: str) -> None:
+    assert any(output.final_output_type == output_type and output.finished for output in outputs), (
+        f"No terminal {output_type} output received"
+    )
+
+
+def _assert_chunked_audio(outputs) -> None:
+    chunks = _audio_chunks(outputs)
+    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
+    waveform = torch.cat(chunks)
+    assert waveform.numel() > 0, "Generated audio is empty"
+    assert torch.isfinite(waveform).all(), "Generated audio contains non-finite samples"
+    assert waveform.abs().max() > 0.01, "Generated audio appears silent"
+    _assert_terminal_output(outputs, "audio")
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", async_chunk_test_params, indirect=True)
+def test_text_to_text_async_chunk_streaming(omni_runner, run_level) -> None:
+    outputs = _delta_outputs(
+        omni_runner,
+        prompt=get_question("text"),
+        modalities=["text"],
+    )
+
+    chunks = _text_chunks(outputs)
+    assert len(chunks) >= 2, f"Expected at least two text chunks, got {len(chunks)}"
+    _assert_terminal_output(outputs, "text")
+    if run_level in {"advanced_model", "full_model"}:
+        assert "beijing" in "".join(chunks).lower()
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", async_chunk_test_params, indirect=True)
+def test_text_to_audio_async_chunk_streaming(omni_runner) -> None:
+    outputs = _delta_outputs(
+        omni_runner,
+        prompt=get_question("text"),
+        modalities=["audio"],
+    )
+
+    _assert_chunked_audio(outputs)
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", async_chunk_test_params, indirect=True)
+def test_mix_to_text_audio_async_chunk_streaming(omni_runner) -> None:
+    audio = generate_synthetic_audio(5, 1, 16000)["np_array"]
+    if len(audio.shape) == 2:
+        audio = audio.squeeze()
+    outputs = _delta_outputs(
+        omni_runner,
+        prompt="What is recited in the audio? What is in this image? Describe the video briefly.",
+        audios=(audio, 16000),
+        images=generate_synthetic_image(24, 24)["np_array"],
+        videos=generate_synthetic_video(24, 24, 20)["np_array"],
+        modalities=["text", "audio"],
+    )
+
+    text_chunks = _text_chunks(outputs)
+    assert text_chunks, "Expected a final text output"
+    _assert_terminal_output(outputs, "text")
+    _assert_chunked_audio(outputs)

--- a/tests/e2e/offline_inference/test_minicpmo_4_5.py
+++ b/tests/e2e/offline_inference/test_minicpmo_4_5.py
@@ -2,28 +2,31 @@
 E2E offline tests for MiniCPM-o 4.5 model with multimodal input and audio / text output.
 """
 
-import copy
 import os
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 import pytest
-import torch
-from vllm.sampling_params import RequestOutputKind
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
+from tests.helpers.minicpmo import (
+    assert_chunked_audio,
+    assert_terminal_output,
+    extract_text_chunks,
+    generate_delta_outputs,
+)
 from tests.helpers.stage_config import get_deploy_config_path
 
 models = ["openbmb/MiniCPM-o-4_5"]
 
 _CI_DEPLOY = get_deploy_config_path("minicpmo_4_5_batching.yaml")
-_ASYNC_CHUNK_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
+_SINGLE_GPU_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
 
 
 test_params = [(model, None, {"deploy_config": _CI_DEPLOY, "trust_remote_code": True}) for model in models]
 async_chunk_test_params = [
-    (model, None, {"deploy_config": _ASYNC_CHUNK_DEPLOY, "trust_remote_code": True}) for model in models
+    (model, None, {"deploy_config": _SINGLE_GPU_DEPLOY, "trust_remote_code": True}) for model in models
 ]
 
 
@@ -127,76 +130,6 @@ def test_video_to_audio(omni_runner, omni_runner_handler) -> None:
     omni_runner_handler.send_omni_request(request_config)
 
 
-def _delta_outputs(
-    omni_runner,
-    *,
-    prompt,
-    modalities,
-    audios=None,
-    images=None,
-    videos=None,
-):
-    omni_inputs = omni_runner.get_omni_inputs(
-        prompts=prompt,
-        audios=audios,
-        images=images,
-        videos=videos,
-        modalities=modalities,
-    )
-    sampling_params_list = copy.deepcopy(omni_runner.get_default_sampling_params_list())
-    for stage_id, sampling_params in enumerate(sampling_params_list):
-        if hasattr(sampling_params, "output_kind"):
-            # Audio streaming starts at the Talker. The Thinker must hand off
-            # its complete TTS span and aligned hidden states in one output.
-            sampling_params.output_kind = (
-                RequestOutputKind.FINAL_ONLY if stage_id == 0 and "audio" in modalities else RequestOutputKind.DELTA
-            )
-    return omni_runner.omni.generate(omni_inputs, sampling_params_list, use_tqdm=False)
-
-
-def _text_chunks(outputs) -> list[str]:
-    chunks = []
-    for stage_output in outputs:
-        if stage_output.final_output_type != "text":
-            continue
-        text = stage_output.request_output.outputs[0].text
-        if text:
-            chunks.append(text)
-    return chunks
-
-
-def _audio_chunks(outputs) -> list[torch.Tensor]:
-    chunks = []
-    for stage_output in outputs:
-        if stage_output.final_output_type != "audio":
-            continue
-        audio = (stage_output.multimodal_output or {}).get("audio")
-        if audio is None:
-            continue
-        values = audio if isinstance(audio, list) else [audio]
-        pieces = [torch.as_tensor(value).detach().float().cpu().reshape(-1) for value in values]
-        pieces = [piece for piece in pieces if piece.numel()]
-        if pieces:
-            chunks.append(torch.cat(pieces))
-    return chunks
-
-
-def _assert_terminal_output(outputs, output_type: str) -> None:
-    assert any(output.final_output_type == output_type and output.finished for output in outputs), (
-        f"No terminal {output_type} output received"
-    )
-
-
-def _assert_chunked_audio(outputs) -> None:
-    chunks = _audio_chunks(outputs)
-    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
-    waveform = torch.cat(chunks)
-    assert waveform.numel() > 0, "Generated audio is empty"
-    assert torch.isfinite(waveform).all(), "Generated audio contains non-finite samples"
-    assert waveform.abs().max() > 0.01, "Generated audio appears silent"
-    _assert_terminal_output(outputs, "audio")
-
-
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.full_model
@@ -204,15 +137,15 @@ def _assert_chunked_audio(outputs) -> None:
 @hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", async_chunk_test_params, indirect=True)
 def test_text_to_text_async_chunk_streaming(omni_runner, run_level) -> None:
-    outputs = _delta_outputs(
+    outputs = generate_delta_outputs(
         omni_runner,
         prompt=get_question("text"),
         modalities=["text"],
     )
 
-    chunks = _text_chunks(outputs)
+    chunks = extract_text_chunks(outputs)
     assert len(chunks) >= 2, f"Expected at least two text chunks, got {len(chunks)}"
-    _assert_terminal_output(outputs, "text")
+    assert_terminal_output(outputs, "text")
     if run_level in {"advanced_model", "full_model"}:
         assert "beijing" in "".join(chunks).lower()
 
@@ -224,13 +157,13 @@ def test_text_to_text_async_chunk_streaming(omni_runner, run_level) -> None:
 @hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", async_chunk_test_params, indirect=True)
 def test_text_to_audio_async_chunk_streaming(omni_runner) -> None:
-    outputs = _delta_outputs(
+    outputs = generate_delta_outputs(
         omni_runner,
         prompt=get_question("text"),
         modalities=["audio"],
     )
 
-    _assert_chunked_audio(outputs)
+    assert_chunked_audio(outputs)
 
 
 @pytest.mark.core_model
@@ -243,7 +176,7 @@ def test_mix_to_text_audio_async_chunk_streaming(omni_runner) -> None:
     audio = generate_synthetic_audio(5, 1, 16000)["np_array"]
     if len(audio.shape) == 2:
         audio = audio.squeeze()
-    outputs = _delta_outputs(
+    outputs = generate_delta_outputs(
         omni_runner,
         prompt="What is recited in the audio? What is in this image? Describe the video briefly.",
         audios=(audio, 16000),
@@ -252,7 +185,7 @@ def test_mix_to_text_audio_async_chunk_streaming(omni_runner) -> None:
         modalities=["text", "audio"],
     )
 
-    text_chunks = _text_chunks(outputs)
-    assert text_chunks, "Expected a final text output"
-    _assert_terminal_output(outputs, "text")
-    _assert_chunked_audio(outputs)
+    chunks = extract_text_chunks(outputs)
+    assert chunks, "Expected a final text output"
+    assert_terminal_output(outputs, "text")
+    assert_chunked_audio(outputs)

--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -1,7 +1,8 @@
 """E2E online tests for MiniCPM-o 4.5 multimodal input and audio/text output.
 
 The batching deployment uses async chunk transfer across separate Thinker,
-Talker, and Code2Wav stages.
+Talker, and Code2Wav stages. Dedicated streaming cases below use the single-GPU
+deployment and validate incremental SSE text and audio output.
 """
 
 import os
@@ -17,6 +18,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 _MODEL = "openbmb/MiniCPM-o-4_5"
 _CI_DEPLOY = get_deploy_config_path("minicpmo_4_5_batching.yaml")
+_ASYNC_CHUNK_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
 
 test_params = [
     pytest.param(
@@ -27,6 +29,21 @@ test_params = [
             server_args=["--trust-remote-code"],
         ),
         id="default",
+    )
+]
+
+async_chunk_test_params = [
+    pytest.param(
+        OmniServerParams(
+            model=_MODEL,
+            stage_config_path=_ASYNC_CHUNK_DEPLOY,
+            use_stage_cli=True,
+            server_args=[
+                "--trust-remote-code",
+                "--async-chunk",
+            ],
+        ),
+        id="async_chunk",
     )
 ]
 
@@ -58,6 +75,26 @@ def get_prompt(prompt_type: str = "text_only") -> str:
 def get_max_batch_size(size_type="few"):
     batch_sizes = {"few": 5, "medium": 100, "large": 256}
     return batch_sizes.get(size_type, 5)
+
+
+def _assert_stream_finished(response) -> None:
+    finish_reasons = response.finish_reasons or []
+    assert finish_reasons, "Stream ended without a finish reason"
+    assert finish_reasons[-1] == "stop", f"Unexpected terminal finish reason: {finish_reasons[-1]}"
+
+
+def _assert_text_stream(response, *, min_chunks: int = 2) -> None:
+    chunks = response.text_chunks or []
+    assert len(chunks) >= min_chunks, f"Expected at least {min_chunks} text chunks, got {len(chunks)}"
+    assert response.text_content == "".join(chunks)
+    _assert_stream_finished(response)
+
+
+def _assert_audio_stream(response) -> None:
+    chunks = response.audio_data or []
+    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
+    assert response.audio_bytes is not None and len(response.audio_bytes) > 44
+    _assert_stream_finished(response)
 
 
 @pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/5437")
@@ -229,3 +266,71 @@ def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", async_chunk_test_params, indirect=True)
+def test_text_to_text_async_chunk_streaming_001(omni_server, openai_client) -> None:
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt())
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "stream": True,
+        "modalities": ["text"],
+        "key_words": {"text": ["Beijing"]},
+    }
+
+    response = openai_client.send_omni_request(request_config)[0]
+    _assert_text_stream(response)
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", async_chunk_test_params, indirect=True)
+def test_text_to_audio_async_chunk_streaming_001(omni_server, openai_client) -> None:
+    messages = dummy_messages_from_mix_data(system_prompt=get_system_prompt(), content_text=get_prompt())
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "stream": True,
+        "modalities": ["audio"],
+        "key_words": {"audio": ["Beijing"]},
+    }
+
+    response = openai_client.send_omni_request(request_config)[0]
+    _assert_audio_stream(response)
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", async_chunk_test_params, indirect=True)
+def test_mix_to_text_audio_async_chunk_streaming_001(omni_server, openai_client) -> None:
+    video_data_url = f"data:video/mp4;base64,{generate_synthetic_video(24, 24, 20)['base64']}"
+    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(24, 24)['base64']}"
+    audio_data_url = f"data:audio/wav;base64,{generate_synthetic_audio(5, 1)['base64']}"
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        video_data_url=video_data_url,
+        image_data_url=image_data_url,
+        audio_data_url=audio_data_url,
+        content_text=get_prompt("mix"),
+    )
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "stream": True,
+    }
+
+    response = openai_client.send_omni_request(request_config)[0]
+    _assert_text_stream(response, min_chunks=1)
+    _assert_audio_stream(response)

--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -11,6 +11,7 @@ import pytest
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
+from tests.helpers.minicpmo import assert_audio_stream, assert_text_stream
 from tests.helpers.runtime import OmniServerParams, dummy_messages_from_mix_data
 from tests.helpers.stage_config import get_deploy_config_path
 
@@ -18,7 +19,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 _MODEL = "openbmb/MiniCPM-o-4_5"
 _CI_DEPLOY = get_deploy_config_path("minicpmo_4_5_batching.yaml")
-_ASYNC_CHUNK_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
+_SINGLE_GPU_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
 
 test_params = [
     pytest.param(
@@ -36,7 +37,7 @@ async_chunk_test_params = [
     pytest.param(
         OmniServerParams(
             model=_MODEL,
-            stage_config_path=_ASYNC_CHUNK_DEPLOY,
+            stage_config_path=_SINGLE_GPU_DEPLOY,
             use_stage_cli=True,
             server_args=[
                 "--trust-remote-code",
@@ -75,26 +76,6 @@ def get_prompt(prompt_type: str = "text_only") -> str:
 def get_max_batch_size(size_type="few"):
     batch_sizes = {"few": 5, "medium": 100, "large": 256}
     return batch_sizes.get(size_type, 5)
-
-
-def _assert_stream_finished(response) -> None:
-    finish_reasons = response.finish_reasons or []
-    assert finish_reasons, "Stream ended without a finish reason"
-    assert finish_reasons[-1] == "stop", f"Unexpected terminal finish reason: {finish_reasons[-1]}"
-
-
-def _assert_text_stream(response, *, min_chunks: int = 2) -> None:
-    chunks = response.text_chunks or []
-    assert len(chunks) >= min_chunks, f"Expected at least {min_chunks} text chunks, got {len(chunks)}"
-    assert response.text_content == "".join(chunks)
-    _assert_stream_finished(response)
-
-
-def _assert_audio_stream(response) -> None:
-    chunks = response.audio_data or []
-    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
-    assert response.audio_bytes is not None and len(response.audio_bytes) > 44
-    _assert_stream_finished(response)
 
 
 @pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/5437")
@@ -285,7 +266,7 @@ def test_text_to_text_async_chunk_streaming_001(omni_server, openai_client) -> N
     }
 
     response = openai_client.send_omni_request(request_config)[0]
-    _assert_text_stream(response)
+    assert_text_stream(response)
 
 
 @pytest.mark.core_model
@@ -305,7 +286,7 @@ def test_text_to_audio_async_chunk_streaming_001(omni_server, openai_client) -> 
     }
 
     response = openai_client.send_omni_request(request_config)[0]
-    _assert_audio_stream(response)
+    assert_audio_stream(response)
 
 
 @pytest.mark.core_model
@@ -332,5 +313,5 @@ def test_mix_to_text_audio_async_chunk_streaming_001(omni_server, openai_client)
     }
 
     response = openai_client.send_omni_request(request_config)[0]
-    _assert_text_stream(response, min_chunks=1)
-    _assert_audio_stream(response)
+    assert_text_stream(response, min_chunks=1)
+    assert_audio_stream(response)

--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -1,8 +1,8 @@
 """E2E online tests for MiniCPM-o 4.5 multimodal input and audio/text output.
 
-The batching deployment uses async chunk transfer across separate Thinker,
-Talker, and Code2Wav stages. Dedicated streaming cases below use the single-GPU
-deployment and validate incremental SSE text and audio output.
+The existing batching cases explicitly disable async chunk to cover sequential
+stage execution. Dedicated streaming cases below use the single-GPU deployment
+with async chunk enabled and validate incremental SSE text and audio output.
 """
 
 import os
@@ -27,7 +27,10 @@ test_params = [
             model=_MODEL,
             stage_config_path=_CI_DEPLOY,
             use_stage_cli=True,
-            server_args=["--trust-remote-code"],
+            server_args=[
+                "--trust-remote-code",
+                "--no-async-chunk",
+            ],
         ),
         id="default",
     )

--- a/tests/helpers/minicpmo.py
+++ b/tests/helpers/minicpmo.py
@@ -1,0 +1,96 @@
+"""MiniCPM-o async-chunk and streaming test helpers."""
+
+import copy
+
+import torch
+from vllm.sampling_params import RequestOutputKind
+
+
+def generate_delta_outputs(
+    omni_runner,
+    *,
+    prompt,
+    modalities,
+    audios=None,
+    images=None,
+    videos=None,
+):
+    omni_inputs = omni_runner.get_omni_inputs(
+        prompts=prompt,
+        audios=audios,
+        images=images,
+        videos=videos,
+        modalities=modalities,
+    )
+    sampling_params_list = copy.deepcopy(omni_runner.get_default_sampling_params_list())
+    for stage_id, sampling_params in enumerate(sampling_params_list):
+        if hasattr(sampling_params, "output_kind"):
+            # Audio streaming starts at the Talker. The Thinker must hand off
+            # its complete TTS span and aligned hidden states in one output.
+            sampling_params.output_kind = (
+                RequestOutputKind.FINAL_ONLY if stage_id == 0 and "audio" in modalities else RequestOutputKind.DELTA
+            )
+    return omni_runner.omni.generate(omni_inputs, sampling_params_list, use_tqdm=False)
+
+
+def extract_text_chunks(outputs) -> list[str]:
+    chunks = []
+    for stage_output in outputs:
+        if stage_output.final_output_type != "text":
+            continue
+        text = stage_output.request_output.outputs[0].text
+        if text:
+            chunks.append(text)
+    return chunks
+
+
+def _audio_chunks(outputs) -> list[torch.Tensor]:
+    chunks = []
+    for stage_output in outputs:
+        if stage_output.final_output_type != "audio":
+            continue
+        audio = (stage_output.multimodal_output or {}).get("audio")
+        if audio is None:
+            continue
+        values = audio if isinstance(audio, list) else [audio]
+        pieces = [torch.as_tensor(value).detach().float().cpu().reshape(-1) for value in values]
+        pieces = [piece for piece in pieces if piece.numel()]
+        if pieces:
+            chunks.append(torch.cat(pieces))
+    return chunks
+
+
+def assert_terminal_output(outputs, output_type: str) -> None:
+    assert any(output.final_output_type == output_type and output.finished for output in outputs), (
+        f"No terminal {output_type} output received"
+    )
+
+
+def assert_chunked_audio(outputs) -> None:
+    chunks = _audio_chunks(outputs)
+    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
+    waveform = torch.cat(chunks)
+    assert waveform.numel() > 0, "Generated audio is empty"
+    assert torch.isfinite(waveform).all(), "Generated audio contains non-finite samples"
+    assert waveform.abs().max() > 0.01, "Generated audio appears silent"
+    assert_terminal_output(outputs, "audio")
+
+
+def assert_stream_finished(response) -> None:
+    finish_reasons = response.finish_reasons or []
+    assert finish_reasons, "Stream ended without a finish reason"
+    assert finish_reasons[-1] == "stop", f"Unexpected terminal finish reason: {finish_reasons[-1]}"
+
+
+def assert_text_stream(response, *, min_chunks: int = 2) -> None:
+    chunks = response.text_chunks or []
+    assert len(chunks) >= min_chunks, f"Expected at least {min_chunks} text chunks, got {len(chunks)}"
+    assert response.text_content == "".join(chunks)
+    assert_stream_finished(response)
+
+
+def assert_audio_stream(response) -> None:
+    chunks = response.audio_data or []
+    assert len(chunks) >= 2, f"Expected at least two audio chunks, got {len(chunks)}"
+    assert response.audio_bytes is not None and len(response.audio_bytes) > 44
+    assert_stream_finished(response)

--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -754,6 +754,7 @@ class OmniResponse:
     """Decoded multimodal / chat output from the OpenAI SDK or offline runner (not raw ``requests``)."""
 
     text_content: str | None = None
+    text_chunks: list[str] | None = None
     audio_data: list[str] | None = None
     audio_content: str | None = None
     audio_format: str | None = None
@@ -765,6 +766,7 @@ class OmniResponse:
     prompt_tokens: int | None = None
     cached_tokens: int | None = None
     logprobs: list | None = None
+    finish_reasons: list[str] | None = None
     #: HTTP status + error text for the error-handling path (e.g. validator
     #: rejections); populated when the OpenAI client raises an APIError.
     status_code: int | None = None
@@ -886,7 +888,9 @@ class OpenAIClientHandler:
         result = OmniResponse()
         try:
             text_content = ""
+            text_chunks = []
             audio_data = []
+            finish_reasons = []
             for chunk in chat_completion:
                 for choice in chunk.choices:
                     content = getattr(getattr(choice, "delta", None), "content", None)
@@ -894,7 +898,11 @@ class OpenAIClientHandler:
                     if modality == "audio" and content:
                         audio_data.append(content)
                     elif modality == "text" and content:
+                        text_chunks.append(content)
                         text_content += content
+                    finish_reason = getattr(choice, "finish_reason", None)
+                    if finish_reason is not None:
+                        finish_reasons.append(str(finish_reason))
                 # Usage is yielded after the last token
                 if chunk.usage:
                     result.prompt_tokens = chunk.usage.prompt_tokens
@@ -907,7 +915,9 @@ class OpenAIClientHandler:
                 merged_seg.export(wav_buf, format="wav")
                 result.audio_bytes = wav_buf.getvalue()
             result.text_content = text_content
+            result.text_chunks = text_chunks
             result.audio_data = audio_data
+            result.finish_reasons = finish_reasons
             result.e2e_latency = time.perf_counter() - wall_start
             result.success = True
         except Exception as e:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

 ## Purpose

  Add MiniCPM-o 4.5 async chunk and streaming output E2E coverage for:

  - Text → Text
  - Text → Audio
  - Mixed input → Text + Audio
  - Offline and online serving


  ## Test Plan

  - Validate offline async-chunk output.
  - Validate online SSE streaming output.
  - Check text/audio chunks, WAV output, semantic results, and stream termination.
  - Run existing async-chunk processor tests and static checks.

  vLLM Version: 0.26.0

  vLLM-Omni Commit: c6fe3477b70701d34f13e8f22231876eeb57ff65 plus the current review fix

  ## Test Result

  - Static checks: Passed
  - Processor unit tests: 12 passed
  - Test collection: 6/19
  - Offline E2E: 3 passed
  - Online E2E: 3 passed
  - All six newly added E2E cases passed.

  
**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
