### PR TITLE
[BugFix] Fix 'GPUARWorker' attribute error

### DIFF
--- a/vllm_omni/worker/base.py
+++ b/vllm_omni/worker/base.py
@@ -120,6 +120,7 @@ class OmniGPUWorkerBase(GPUWorker):
             self.model_runner.profile_run()
 
         self.non_torch_memory = profile_result.non_torch_increase
+        self.total_consumed = profile_result.total_consumed
         self.peak_activation_memory = profile_result.torch_peak_increase
 
         process_memory = (


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
vllm-omni[main] + vllm[main] run model with AR + DiT failed.
## Test Plan
Failed to launch vllm-omni[main] + vllm[main] with AR+DiT model, which reports error:
```bash
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183] StageEngineCoreProc failed to start.
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183] Traceback (most recent call last):
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/engine/stage_engine_core_proc.py", line 134, in run_stage_core
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     engine_core = StageEngineCoreProc(
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]                   ^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     return func(*args, **kwargs)
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]            ^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/engine/core.py", line 1070, in __init__
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     super().__init__(
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/engine/core.py", line 141, in __init__
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     kv_cache_config = self._initialize_kv_caches(vllm_config)
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     return func(*args, **kwargs)
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]            ^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/engine/core.py", line 329, in _initialize_kv_caches
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     self.model_executor.initialize_from_config(kv_cache_configs)
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/abstract.py", line 124, in initialize_from_config
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     compilation_times: list[CompilationTimes] = self.collective_rpc(
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]                                                 ^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 416, in collective_rpc
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     return future if non_block else future.result()
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]                                     ^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 91, in result
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     return super().result()
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]            ^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     return self.__get_result()
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]            ^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     raise self._exception
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 95, in _wait_for_response
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     response = self.aggregate(self.get_response())
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]                               ^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 405, in get_response
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183]     raise RuntimeError(
(StageEngineCoreProc_stage0_replica0 pid=1962982) ERROR 07-28 10:36:52 [stage_engine_core_proc.py:183] RuntimeError: Worker failed with error ''GPUARWorker' object has no attribute 'total_consumed'', please check the stack trace above for the root cause
```

It was because vllm-omni:OmniGPUWorkerBase did not initialize value:total_consumed, which was accessed in vllm. This PR fix it.
After this PR:
```bash
(APIServer pid=2020868) INFO 07-28 11:15:47 [omni_base.py:210] [AsyncOmni] Initialized with 2 stages for model /data/HunyuanImage-3.0-Instruct/
(APIServer pid=2020868) INFO 07-28 11:15:47 [api_server.py:823] Supported tasks: {'generate'}
(APIServer pid=2020868) WARNING 07-28 11:15:47 [model.py:1602] Default vLLM sampling parameters have been 
[...]
(APIServer pid=2020868) INFO 07-28 11:15:49 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=2020868) INFO 07-28 11:15:49 [api_server.py:539] Starting vLLM API server 0 on http://0.0.0.0:8080
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:37] Available routes are:
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
[...]
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/video/chat/stream, Endpoint: streaming_video_chat
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/realtime/video, Endpoint: streaming_video_output
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/realtime, Endpoint: realtime_websocket
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=2020868) INFO 07-28 11:15:49 [launcher.py:57] Route: /v1/duplex, Endpoint: duplex_websocket
(APIServer pid=2020868) INFO:     Started server process [2020868]
(APIServer pid=2020868) INFO:     Waiting for application startup.
(APIServer pid=2020868) INFO:     Application startup complete.
```
we launch omni successfully.
**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
