### PR TITLE
[CI] Relax Seed-TTS mean-WER gate to 0.5 while the drift is investigated

### DIFF
--- a/tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py
+++ b/tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py
@@ -53,7 +53,7 @@ Skip one suite, tighten gates::
 
     python tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py \\
         --skip-daily-omni \\
-        --max-seed-tts-mean-wer 0.35 \\
+        --max-seed-tts-mean-wer 0.5 \\
         --min-seed-tts-mean-sim 0.75
 """
 
@@ -340,7 +340,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--max-seed-tts-mean-wer",
         type=float,
-        default=0.35,
+        # Interim gate while the post-#4137 WER drift is investigated: main
+        # nightlies measure 0.40-0.46 against the previous 0.35 bar, so 0.35
+        # only produces a permanently red job. 0.5 (the pre-#4137 value) still
+        # fails on gross TTS breakage. Tighten back to 0.35 per the
+        # restoration criterion in
+        # https://github.com/vllm-project/vllm-omni/issues/5480 (mean WER
+        # <= 0.30 on 7 consecutive main nightlies).
+        default=0.5,
         help="If set, fail when seed_tts_content_error_mean is strictly above this value.",
     )
     p.add_argument(


### PR DESCRIPTION
## Summary

The nightly `Omni · Accuracy Test` has been red on every recent `main` run: `seed_tts_content_error_mean` measures **0.404–0.462** against the `0.35` default gate (builds 2885→2917), with 1088/1088 samples generated successfully — the gate no longer distinguishes regressions from baseline. The companion `daily_omni_accuracy` metric is flat (~0.716) across the same builds.

This restores the pre-#4137 default of **0.5** (the gate still fails on gross TTS breakage such as garbage output or dropped audio) and links the drift investigation + restoration criterion in #5480.

- Threshold history: 0.5 → 0.25 (#4137) → 0.35 (#4160), both on 2026-06-05.
- Restoration criterion (from #5480): tighten back to 0.35 once mean WER ≤ 0.30 on 7 consecutive main nightlies.

## Test

Config-only change to the benchmark CLI default; verified `python tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py --help` renders and the pytest wrapper picks up the default (no explicit flag passed in `qwen3_omni_acc_bench_core.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related issues

- Tracking issue: #5480 (WER drift investigation + restoration criterion for tightening back to 0.35).
- Related (same benchmark, different model): #5404 proposes a Seed-TTS WER gate for MiniCPM-o 4.5, and #5298 documents a MiniCPM-o streaming-TTS bug measured by Seed-TTS WER — threshold choices here should stay consistent with those efforts.
