### PR TITLE
[CI] Skip known-failing tests and filter NPU ready TTS by npu mark

### DIFF
--- a/.buildkite/npu/test-npu-ready.yml
+++ b/.buildkite/npu/test-npu-ready.yml
@@ -31,4 +31,4 @@ steps:
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
           HF_TOKEN: "${HF_TOKEN}"
         commands:
-          - pytest -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model' --run-level 'core_model'
+          - pytest -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model and npu' --run-level 'core_model'

--- a/tests/core/sched/test_omni_ar_scheduler_logprobs.py
+++ b/tests/core/sched/test_omni_ar_scheduler_logprobs.py
@@ -104,6 +104,7 @@ class _RequestQueue(list):
                 self.remove(request)
 
 
+@pytest.mark.skip(reason="#issue 5484")
 def test_invalid_logprobs_finish_only_the_affected_scheduler_request() -> None:
     """A bad runner response must not bring down unrelated batch requests."""
     bad = _Request("bad")

--- a/tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py
+++ b/tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py
@@ -228,6 +228,7 @@ def _resolve_deploy_config(config_path: str, run_level: str) -> str:
 
 
 @pytest.mark.advanced_model
+@pytest.mark.skip(reason="#issue 5475")
 @pytest.mark.diffusion
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 def test_bagel_img2img_shared_memory_connector(run_level):

--- a/tests/e2e/online_serving/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/online_serving/test_qwen3_tts_customvoice.py
@@ -12,7 +12,6 @@ import os
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 import pytest
-from vllm.platforms import current_platform
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniServerParams
@@ -21,6 +20,7 @@ from tests.helpers.stage_config import (
     get_deploy_config_stage,
     modify_stage_config,
 )
+from vllm_omni.platforms import current_omni_platform
 
 MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
 
@@ -71,7 +71,6 @@ default_tts_server_params = [
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.tts
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA Graph startup test requires CUDA")
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", default_tts_server_params, indirect=True)
 def test_default_cuda_graph_startup(omni_server) -> None:
@@ -93,7 +92,11 @@ def test_default_cuda_graph_startup(omni_server) -> None:
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.skipif(
+    current_omni_platform.is_npu(),
+    reason="#issue 5479",
+)
+@hardware_test(res={"cuda": "L4", "npu": "A3"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
 def test_text_to_audio_001(omni_server, openai_client) -> None:
     """
@@ -119,7 +122,11 @@ def test_text_to_audio_001(omni_server, openai_client) -> None:
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.skipif(
+    current_omni_platform.is_npu(),
+    reason="#issue 5479",
+)
+@hardware_test(res={"cuda": "L4", "npu": "A3"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
 def test_text_to_audio_002(omni_server, openai_client) -> None:
     """


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Temporarily stabilize CI by skipping known-failing tests and tightening NPU ready TTS selection:

- Skip `test_invalid_logprobs_finish_only_the_affected_scheduler_request` until [#5484](https://github.com/vllm-project/vllm-omni/issues/5484) is fixed.
- Skip `test_bagel_img2img_shared_memory_connector` until [#5475](https://github.com/vllm-project/vllm-omni/issues/5475) is fixed.
- On NPU, skip Qwen3-TTS CustomVoice online serving cases `test_text_to_audio_001` / `test_text_to_audio_002` until [#5479](https://github.com/vllm-project/vllm-omni/issues/5479) is fixed (server exits before ready).
- Mark those TTS cases with `npu: A3` and change NPU ready pytest filter to `core_model and npu`, so CUDA-only cases (e.g. cudagraph startup) are not selected on Ascend ready CI.

## Test Plan

**vLLM Version:** unchanged (rebase onto current `main`)

**vLLM-Omni Commit:** this PR branch (`skip`)

- Rely on CI marker selection / skip behavior (no new functional tests).
- Local / CI-like collection checks:

```bash
# NPU ready-style collection for TTS customvoice
pytest -q --collect-only tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model and npu' --run-level 'core_model'

# Confirm skipped unit/e2e cases still collect as skipped
pytest -q --collect-only tests/core/sched/test_omni_ar_scheduler_logprobs.py::test_invalid_logprobs_finish_only_the_affected_scheduler_request
pytest -q --collect-only tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py::test_bagel_img2img_shared_memory_connector
```

## Test Result

- Pending upstream CI (Buildkite NPU ready / CUDA ready & merge as applicable).
- Expected: previously ERROR'ing NPU TTS cases are skipped; logprobs / bagel cases are skipped until linked issues are resolved.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
