### PR TITLE
[CI] [non-CUDA] [ROCm] Fix `get_diffusion_attn_backend_cls() got an unexpected keyword argument 'allow_trtllm_default'`

### DIFF
--- a/vllm_omni/diffusion/attention/selector.py
+++ b/vllm_omni/diffusion/attention/selector.py
@@ -61,10 +61,13 @@ def _cached_get_backend_cls(
     """
     from vllm_omni.platforms import current_omni_platform
 
+    extra_kwargs = {}
+    if current_omni_platform.is_cuda():
+        extra_kwargs["allow_trtllm_default"] = allow_trtllm_default
     backend_cls_path = current_omni_platform.get_diffusion_attn_backend_cls(
         selected_backend=backend_name,
         head_size=head_size,
-        allow_trtllm_default=allow_trtllm_default,
+        **extra_kwargs,
     )
     return _load_backend_cls(backend_cls_path)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix error introduced by PR https://github.com/vllm-project/vllm-omni/pull/5283 . This error will also occur on all non-CUDA platform.

```log
2026-07-28 07:40:35 UTC
  File "/app/vllm-omni/vllm_omni/diffusion/attention/layer.py", line 85, in __init__
2026-07-28 07:40:35 UTC
    attn_backend_cls, spec = get_attn_backend_for_role(
2026-07-28 07:40:35 UTC
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-28 07:40:35 UTC
  File "/app/vllm-omni/vllm_omni/diffusion/attention/selector.py", line 146, in get_attn_backend_for_role
2026-07-28 07:40:35 UTC
    backend_cls = _cached_get_backend_cls(None, head_size, allow_trtllm_default)
2026-07-28 07:40:35 UTC
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-28 07:40:35 UTC
  File "/app/vllm-omni/vllm_omni/diffusion/attention/selector.py", line 64, in _cached_get_backend_cls
2026-07-28 07:40:35 UTC
    backend_cls_path = current_omni_platform.get_diffusion_attn_backend_cls(
2026-07-28 07:40:35 UTC
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-28 07:40:35 UTC
TypeError: RocmOmniPlatform.get_diffusion_attn_backend_cls() got an unexpected keyword argument 'allow_trtllm_default'
```

Affected test group: `mi325_1: Diffusion · Wan22 Test`

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
