### PR TITLE
[Model][Diffusion] Enable BOOGU Image sequence parallelism

### DIFF
--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -53,6 +53,7 @@ steps:
           - vllm_omni/diffusion/models/
         commands:
           - timeout 20m pytest -sv tests/diffusion/distributed -m 'core_model and cuda' --run-level "core_model"
+          - timeout 10m pytest -sv tests/diffusion/attention/test_ulysses_uaa.py -m 'core_model and cuda' --run-level "core_model"
         mirror_hardwares: l4_4
 
       - label: "Diffusion · Model Test"

--- a/tests/diffusion/attention/test_ulysses_uaa.py
+++ b/tests/diffusion/attention/test_ulysses_uaa.py
@@ -11,6 +11,8 @@ import numpy as np
 import pytest
 import torch
 
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.config import set_current_diffusion_config
 from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
@@ -21,6 +23,97 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 )
 from vllm_omni.diffusion.forward_context import get_forward_context, set_forward_context
 from vllm_omni.platforms import current_omni_platform
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_uaa_equal_rank_contract_skips_length_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_omni.diffusion.attention.parallel import ulysses
+    from vllm_omni.diffusion.forward_context import set_forward_context
+
+    class FakeGroup:
+        ulysses_group = object()
+        ulysses_world_size = 2
+        ulysses_rank = 0
+        ring_world_size = 1
+
+    observed = []
+
+    def fake_all_to_all(pg, tensor, **kwargs):
+        observed.append((kwargs["seq_lens"], kwargs["padded_head_cnt"]))
+        return tensor, tensor.shape[2]
+
+    monkeypatch.setattr(ulysses, "_ulysses_all_to_all_any_qkv", fake_all_to_all)
+    monkeypatch.setattr(ulysses, "get_ulysses_mode", lambda **kwargs: "advanced_uaa")
+    monkeypatch.setattr(
+        ulysses,
+        "_all_gather_int",
+        lambda *args, **kwargs: pytest.fail("length gather must be skipped"),
+    )
+    strategy = ulysses.UlyssesParallelAttention(
+        FakeGroup(),
+        scatter_idx=2,
+        gather_idx=1,
+        use_sync=False,
+    )
+
+    with set_forward_context():
+        get_forward_context()._sp_equal_rank_seq_len_stack.append(True)
+        strategy.pre_attention(
+            torch.zeros(1, 3, 28, 4),
+            torch.zeros(1, 3, 7, 4),
+            torch.zeros(1, 3, 7, 4),
+            None,
+        )
+
+    assert observed == [([3, 3], 32), ([3, 3], 8), ([3, 3], 8)]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_uaa_without_contract_keeps_dynamic_length_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_omni.diffusion.attention.parallel import ulysses
+    from vllm_omni.diffusion.forward_context import set_forward_context
+
+    class FakeGroup:
+        ulysses_group = object()
+        ulysses_world_size = 2
+        ulysses_rank = 0
+        ring_world_size = 1
+
+    observed = []
+    monkeypatch.setattr(
+        ulysses,
+        "_all_gather_int",
+        lambda *args, **kwargs: [3, 4],
+    )
+    monkeypatch.setattr(ulysses, "get_ulysses_mode", lambda **kwargs: "advanced_uaa")
+
+    def fake_all_to_all(pg, tensor, **kwargs):
+        observed.append(kwargs["seq_lens"])
+        return tensor, tensor.shape[2]
+
+    monkeypatch.setattr(ulysses, "_ulysses_all_to_all_any_qkv", fake_all_to_all)
+    strategy = ulysses.UlyssesParallelAttention(
+        FakeGroup(),
+        scatter_idx=2,
+        gather_idx=1,
+        use_sync=False,
+    )
+
+    with set_forward_context():
+        strategy.pre_attention(
+            torch.zeros(1, 3, 28, 4),
+            torch.zeros(1, 3, 7, 4),
+            torch.zeros(1, 3, 7, 4),
+            None,
+        )
+
+    assert observed == [[3, 4], [3, 4], [3, 4]]
 
 
 def _find_free_port() -> int:
@@ -50,6 +143,7 @@ def _run_attention_case(
     ring_degree: int = 1,
     split_sizes: list[int] | None = None,
     sdp_kernel_mode: str = "math",
+    mask_layout: str | None = None,
 ) -> None:
     device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
     current_omni_platform.set_device(device)
@@ -92,9 +186,11 @@ def _run_attention_case(
             q_full = torch.from_numpy(payload["q"]).to(device=device)
             k_full = torch.from_numpy(payload["k"]).to(device=device)
             v_full = torch.from_numpy(payload["v"]).to(device=device)
+            mask_full = torch.from_numpy(payload["mask"]).to(device=device) if "mask" in payload else None
 
         if world_size == 1:
             q, k, v = q_full, k_full, v_full
+            mask = mask_full
         else:
             if split_sizes is None:
                 # NOTE: torch.chunk may return fewer than `world_size` chunks for some
@@ -114,6 +210,25 @@ def _run_attention_case(
                 q = torch.split(q_full, split_sizes, dim=1)[local_rank].contiguous()
                 k = torch.split(k_full, split_sizes, dim=1)[local_rank].contiguous()
                 v = torch.split(v_full, split_sizes, dim=1)[local_rank].contiguous()
+            if mask_full is None:
+                mask = None
+            elif mask_layout == "global":
+                mask = mask_full
+            elif mask_layout == "local":
+                if split_sizes is None:
+                    mask = torch.tensor_split(
+                        mask_full,
+                        world_size,
+                        dim=1,
+                    )[local_rank].contiguous()
+                else:
+                    mask = torch.split(
+                        mask_full,
+                        split_sizes,
+                        dim=1,
+                    )[local_rank].contiguous()
+            else:
+                raise ValueError("mask_layout must be 'global' or 'local' when a mask is provided.")
             # The Attention layer only enables SP communication when ForwardContext.sp_active is True.
             # In production this is managed by SequenceParallelSplitHook/GatherHook, but here we
             # shard manually for testing.
@@ -127,7 +242,8 @@ def _run_attention_case(
             raise ValueError(f"Invalid sdp_kernel_mode: {sdp_kernel_mode!r}")
 
         with sdp_ctx:
-            out_local = attn(q, k, v).contiguous()
+            attn_metadata = AttentionMetadata(attn_mask=mask) if mask is not None else None
+            out_local = attn(q, k, v, attn_metadata).contiguous()
 
         if world_size == 1:
             out_full = out_local
@@ -220,6 +336,99 @@ def test_ulysses_uaa_matches_baseline(sp_world_size: int, seq_len: int, num_head
         sp_t = torch.from_numpy(sp)
         assert baseline_t.shape == sp_t.shape
         torch.testing.assert_close(sp_t, baseline_t, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+@pytest.mark.core_model
+@pytest.mark.parametrize("mask_layout", ["global", "local"])
+@hardware_test(res={"cuda": "L4"}, num_cards=2)
+def test_ulysses_uaa_2d_mask_layout_matches_baseline(
+    mask_layout: str,
+) -> None:
+    world_size = 2
+    batch_size = 2
+    seq_len = 5
+    split_sizes = [2, 3]
+    num_heads = 3
+    head_size = 8
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npy") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npy") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(0)
+        q = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
+        k = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
+        v = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
+        mask = torch.tensor(
+            [
+                [True, True, True, True, False],
+                [True, True, True, False, False],
+            ],
+            dtype=torch.bool,
+        )
+        np.savez(
+            input_file,
+            q=q.numpy(),
+            k=k.numpy(),
+            v=v.numpy(),
+            mask=mask.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_attention_case,
+            args=(
+                1,
+                base_port,
+                input_file,
+                baseline_file,
+                num_heads,
+                head_size,
+                1,
+                "strict",
+                1,
+                None,
+                "math",
+                "global",
+            ),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_attention_case,
+            args=(
+                world_size,
+                sp_port,
+                input_file,
+                sp_file,
+                num_heads,
+                head_size,
+                world_size,
+                "advanced_uaa",
+                1,
+                split_sizes,
+                "math",
+                mask_layout,
+            ),
+            nprocs=world_size,
+        )
+
+        baseline = torch.from_numpy(np.load(baseline_file, allow_pickle=False))
+        sp = torch.from_numpy(np.load(sp_file, allow_pickle=False))
+        torch.testing.assert_close(sp, baseline, atol=1e-5, rtol=1e-5)
     finally:
         for path in (input_file, baseline_file, sp_file):
             try:

--- a/tests/diffusion/distributed/test_boogu_image_sp.py
+++ b/tests/diffusion/distributed/test_boogu_image_sp.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.config import set_current_diffusion_config
+from vllm_omni.diffusion.data import (
+    DiffusionParallelConfig,
+    OmniDiffusionConfig,
+    TransformerConfig,
+)
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelConfig
+from vllm_omni.diffusion.forward_context import (
+    get_forward_context,
+    set_forward_context,
+)
+from vllm_omni.diffusion.hooks.sequence_parallel import apply_sequence_parallel
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.diffusion,
+    pytest.mark.parallel,
+]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _set_dist_env(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(
+        {
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "DIFFUSION_ATTENTION_BACKEND": "TORCH_SDPA",
+        }
+    )
+
+
+def _transformer_config() -> TransformerConfig:
+    return TransformerConfig.from_dict(
+        {
+            "patch_size": 2,
+            "in_channels": 4,
+            "hidden_size": 64,
+            "num_layers": 2,
+            "num_double_stream_layers": 1,
+            "num_refiner_layers": 1,
+            "num_attention_heads": 4,
+            "num_kv_heads": 1,
+            "multiple_of": 32,
+            "norm_eps": 1e-5,
+            "axes_dim_rope": [8, 4, 4],
+            "axes_lens": [64, 32, 32],
+            "instruction_feature_configs": {
+                "instruction_feat_dim": 32,
+                "reduce_type": "mean",
+                "num_instruction_feature_layers": 1,
+            },
+            "prompt_tuning_configs": {"use_prompt_tuning": False},
+            "timestep_scale": 1.0,
+        }
+    )
+
+
+def _od_config(world_size: int) -> OmniDiffusionConfig:
+    return OmniDiffusionConfig(
+        model="boogu-tiny",
+        dtype=torch.float32,
+        tf_model_config=_transformer_config(),
+        parallel_config=DiffusionParallelConfig(
+            sequence_parallel_size=world_size,
+            ulysses_degree=world_size,
+            ulysses_mode="advanced_uaa",
+        ),
+    )
+
+
+def _checkpoint_name(name: str) -> str:
+    if ".to_out." in name:
+        name = name.replace(".to_out.", ".to_out.0.")
+    for projection in (
+        "img_to_q",
+        "img_to_k",
+        "img_to_v",
+        "instruct_to_q",
+        "instruct_to_k",
+        "instruct_to_v",
+        "instruct_out",
+        "img_out",
+    ):
+        token = f".img_instruct_attn.{projection}."
+        if token in name:
+            return name.replace(
+                token,
+                f".img_instruct_attn.processor.{projection}.",
+            )
+    return name
+
+
+def _random_checkpoint(model: torch.nn.Module) -> list[tuple[str, torch.Tensor]]:
+    generator = torch.Generator(device=next(model.parameters()).device).manual_seed(2026)
+    return [
+        (
+            _checkpoint_name(name),
+            torch.empty_like(param).uniform_(
+                -0.02,
+                0.02,
+                generator=generator,
+            ),
+        )
+        for name, param in model.named_parameters()
+    ]
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    output_file: str,
+) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{rank}")
+    current_omni_platform.set_device(device)
+    _set_dist_env(rank, world_size, port)
+    init_distributed_environment(world_size=world_size, rank=rank)
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=world_size,
+        ring_degree=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+
+    try:
+        from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+            BooguImageDoubleStreamRotaryPosEmbed,
+            BooguImageTransformer2DModel,
+        )
+
+        od_config = _od_config(world_size)
+        with (
+            set_current_vllm_config(VllmConfig(device_config=DeviceConfig(device=str(device)))),
+            set_forward_context(omni_diffusion_config=od_config),
+            set_current_diffusion_config(od_config),
+        ):
+            source = BooguImageTransformer2DModel(od_config).to(device)
+            checkpoint = _random_checkpoint(source)
+            del source
+
+            model = BooguImageTransformer2DModel(od_config).to(device)
+            assert model.load_weights(checkpoint) == set(dict(model.named_parameters()))
+            model.eval()
+
+            if world_size > 1:
+                apply_sequence_parallel(
+                    model,
+                    SequenceParallelConfig(ulysses_degree=world_size),
+                    model._sp_plan,
+                )
+                get_forward_context().sp_plan_hooks_applied = True
+
+            generator = torch.Generator(device=device).manual_seed(17)
+            latents = torch.randn(
+                1,
+                4,
+                8,
+                8,
+                device=device,
+                generator=generator,
+            )
+            timestep = torch.tensor([0.5], device=device)
+            instruction = torch.randn(
+                1,
+                7,
+                32,
+                device=device,
+                generator=generator,
+            )
+            instruction_mask = torch.ones(
+                1,
+                7,
+                dtype=torch.bool,
+                device=device,
+            )
+            ref_image = [
+                [
+                    torch.randn(
+                        4,
+                        6,
+                        10,
+                        device=device,
+                        generator=generator,
+                    )
+                ]
+            ]
+            freqs_cis = BooguImageDoubleStreamRotaryPosEmbed.get_freqs_cis(
+                model.axes_dim_rope,
+                model.axes_lens,
+                theta=10000,
+            )
+
+            with torch.inference_mode():
+                t2i = model(
+                    latents,
+                    timestep,
+                    instruction,
+                    freqs_cis,
+                    instruction_mask,
+                )
+                edit = model(
+                    latents,
+                    timestep,
+                    instruction,
+                    freqs_cis,
+                    instruction_mask,
+                    ref_image_hidden_states=ref_image,
+                )
+
+            if rank == 0:
+                np.savez(
+                    output_file,
+                    t2i=t2i.cpu().numpy(),
+                    edit=edit.cpu().numpy(),
+                )
+    finally:
+        destroy_distributed_env()
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=2)
+def test_boogu_sp_matches_single_gpu() -> None:
+    if not current_omni_platform.is_cuda() or current_omni_platform.get_device_count() < 2:
+        pytest.skip("BOOGU SP test requires two CUDA GPUs.")
+
+    output_files = []
+    try:
+        for _ in range(2):
+            with tempfile.NamedTemporaryFile(
+                delete=False,
+                suffix=".npz",
+            ) as handle:
+                output_files.append(handle.name)
+
+        torch.multiprocessing.spawn(
+            _worker,
+            args=(1, _find_free_port(), output_files[0]),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _worker,
+            args=(2, _find_free_port(), output_files[1]),
+            nprocs=2,
+        )
+
+        with (
+            np.load(output_files[0], allow_pickle=False) as baseline,
+            np.load(output_files[1], allow_pickle=False) as sp_output,
+        ):
+            for key in ("t2i", "edit"):
+                np.testing.assert_allclose(
+                    sp_output[key],
+                    baseline[key],
+                    rtol=2e-4,
+                    atol=2e-4,
+                )
+    finally:
+        for path in output_files:
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/tests/diffusion/distributed/test_sp_plan_hooks.py
+++ b/tests/diffusion/distributed/test_sp_plan_hooks.py
@@ -114,6 +114,47 @@ class TestSequenceParallelPlanValidation:
         with pytest.raises(ValueError, match="split_output=True"):
             validate_sp_plan(plan)
 
+    def test_keyed_metadata_requires_auto_pad(self):
+        plan = {
+            "prepare": {
+                0: SequenceParallelInput(
+                    split_dim=1,
+                    split_output=True,
+                    shard_group="image",
+                ),
+            },
+            "output": SequenceParallelOutput(
+                gather_dim=1,
+                shard_group="image",
+            ),
+        }
+
+        with pytest.raises(ValueError, match="requires auto_pad=True"):
+            validate_sp_plan(plan)
+
+    def test_shard_group_is_scoped_to_one_split_boundary(self):
+        plan = {
+            "prepare_image": {
+                0: SequenceParallelInput(
+                    split_dim=1,
+                    split_output=True,
+                    auto_pad=True,
+                    shard_group="image",
+                ),
+            },
+            "prepare_rope": {
+                0: SequenceParallelInput(
+                    split_dim=1,
+                    split_output=True,
+                    auto_pad=True,
+                    shard_group="image",
+                ),
+            },
+        }
+
+        with pytest.raises(ValueError, match="multiple split boundaries"):
+            validate_sp_plan(plan)
+
 
 @pytest.mark.cpu
 class TestGetSpPlanFromModel:
@@ -1026,6 +1067,160 @@ class TestStrictModeSplitValidation:
         with set_forward_context(omni_diffusion_config=od_config):
             with pytest.raises(ValueError, match=r"strict mode.*sequence_parallel_size"):
                 hook._prepare_sp_input(x, metadata["x"], (), {})
+
+
+@pytest.mark.cpu
+class TestKeyedSequenceShardMetadata:
+    def test_local_prefix_and_segment_lengths(self):
+        from vllm_omni.diffusion.distributed.sp_sharding import (
+            SequenceShardMetadata,
+        )
+
+        rank_zero = SequenceShardMetadata.from_global_length(
+            5,
+            world_size=2,
+            rank=0,
+        )
+        rank_one = SequenceShardMetadata.from_global_length(
+            5,
+            world_size=2,
+            rank=1,
+        )
+
+        assert rank_zero.padded_seq_len == 6
+        assert rank_zero.local_valid_lengths([5, 2]) == [3, 2]
+        assert rank_one.local_valid_lengths([5, 2]) == [2, 0]
+        assert rank_zero.local_segment_lengths([[2, 3]]) == [[2, 1]]
+        assert rank_one.local_segment_lengths([[2, 3]]) == [[0, 2]]
+
+    def test_auto_pad_registers_equal_rank_contract(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from vllm_omni.diffusion.attention import selector
+        from vllm_omni.diffusion.distributed import parallel_state
+        from vllm_omni.diffusion.distributed.sp_plan import (
+            SequenceParallelConfig,
+        )
+        from vllm_omni.diffusion.forward_context import (
+            get_forward_context,
+            set_forward_context,
+        )
+        from vllm_omni.diffusion.hooks.sequence_parallel import (
+            SequenceParallelSplitHook,
+        )
+
+        class MaskBackend:
+            supports_attention_mask = True
+
+            @staticmethod
+            def get_name():
+                return "test"
+
+        monkeypatch.setattr(
+            parallel_state,
+            "get_sequence_parallel_world_size",
+            lambda: 2,
+        )
+        monkeypatch.setattr(
+            parallel_state,
+            "get_sequence_parallel_rank",
+            lambda: 1,
+        )
+        monkeypatch.setattr(
+            parallel_state,
+            "get_ring_parallel_world_size",
+            lambda: 1,
+        )
+        monkeypatch.setattr(
+            selector,
+            "get_attn_backend_for_role",
+            lambda **_: (MaskBackend(), None),
+        )
+
+        hook = SequenceParallelSplitHook(
+            {
+                0: SequenceParallelInput(
+                    split_dim=1,
+                    expected_dims=3,
+                    split_output=True,
+                    auto_pad=True,
+                    shard_group="image",
+                )
+            },
+            SequenceParallelConfig(ulysses_degree=2),
+        )
+        hook.initialize_hook(nn.Identity())
+
+        with set_forward_context():
+            hook.pre_forward(nn.Identity())
+            shard = hook.post_forward(
+                nn.Identity(),
+                torch.arange(5).reshape(1, 5, 1),
+            )
+            ctx = get_forward_context()
+
+            assert shard.shape[1] == 3
+            assert ctx.sp_rank_local_seq_lens_equal
+            assert ctx.sp_shard_metadata["image"].original_seq_len == 5
+
+    def test_gather_trims_keyed_padding_and_closes_contract(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from vllm_omni.diffusion.distributed.sp_plan import (
+            SequenceParallelConfig,
+        )
+        from vllm_omni.diffusion.distributed.sp_sharding import (
+            SequenceShardMetadata,
+        )
+        from vllm_omni.diffusion.forward_context import (
+            get_forward_context,
+            set_forward_context,
+        )
+        from vllm_omni.diffusion.hooks import sequence_parallel
+        from vllm_omni.diffusion.hooks.sequence_parallel import (
+            SequenceParallelGatherHook,
+        )
+
+        monkeypatch.setattr(
+            sequence_parallel,
+            "sp_gather",
+            lambda tensor, dim, validate: torch.cat([tensor, tensor], dim=dim),
+        )
+        hook = SequenceParallelGatherHook(
+            SequenceParallelOutput(
+                gather_dim=1,
+                expected_dims=3,
+                shard_group="image",
+            ),
+            SequenceParallelConfig(ulysses_degree=2),
+        )
+
+        with set_forward_context():
+            ctx = get_forward_context()
+            ctx.sp_shard_metadata["image"] = SequenceShardMetadata.from_global_length(
+                5,
+                world_size=2,
+                rank=0,
+            )
+            ctx.sp_shard_metadata["context"] = SequenceShardMetadata.from_global_length(
+                7,
+                world_size=2,
+                rank=0,
+            )
+            ctx._sp_shard_depth = 3
+            ctx._sp_equal_rank_seq_len_stack.extend([True, True, True])
+            output = hook.post_forward(
+                nn.Identity(),
+                torch.zeros(1, 3, 4),
+            )
+
+            assert output.shape == (1, 5, 4)
+            assert not ctx.sp_rank_local_seq_lens_equal
+            assert ctx._sp_equal_rank_seq_len_stack == []
+            assert ctx.sp_shard_metadata == {}
+            assert ctx._sp_shard_depth == 0
 
 
 @pytest.mark.cpu

--- a/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
+++ b/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
@@ -145,8 +145,7 @@ def test_constructor_weights_sources(boogu_pipeline):
     ("parallel_config", "cache_backend", "message"),
     [
         (DiffusionParallelConfig(tensor_parallel_size=2), "none", "Tensor parallelism"),
-        (DiffusionParallelConfig(ulysses_degree=2), "none", "Sequence parallelism"),
-        (DiffusionParallelConfig(ring_degree=2), "none", "Sequence parallelism"),
+        (DiffusionParallelConfig(ring_degree=2), "none", "Ulysses only"),
         (DiffusionParallelConfig(cfg_parallel_size=2), "none", "CFG parallelism"),
         (
             DiffusionParallelConfig(use_hsdp=True, hsdp_shard_size=2),
@@ -179,6 +178,96 @@ def test_constructor_rejects_unsupported_execution_modes(
         BooguImagePipeline(od_config=od_config)
 
     # Validation happens before any checkpoint component is constructed.
+    mock_dependencies["mllm_wrapper"].model.to.assert_not_called()
+
+
+def test_constructor_accepts_ulysses_uaa(
+    mock_dependencies,
+    monkeypatch,
+):
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import (
+        BooguImagePipeline,
+    )
+
+    monkeypatch.setattr(
+        f"{_MODULE}.current_omni_platform.is_cuda",
+        lambda: True,
+    )
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(
+            params={
+                "num_attention_heads": 28,
+                "num_kv_heads": 7,
+            }
+        ),
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            ulysses_degree=2,
+            ulysses_mode="advanced_uaa",
+        ),
+    )
+
+    pipeline = BooguImagePipeline(od_config=od_config)
+    assert pipeline.transformer is mock_dependencies["transformer"]
+
+
+def test_constructor_requires_uaa_for_boogu_gqa(
+    mock_dependencies,
+    monkeypatch,
+):
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import (
+        BooguImagePipeline,
+    )
+
+    monkeypatch.setattr(
+        f"{_MODULE}.current_omni_platform.is_cuda",
+        lambda: True,
+    )
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(
+            params={
+                "num_attention_heads": 28,
+                "num_kv_heads": 7,
+            }
+        ),
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            ulysses_degree=2,
+            ulysses_mode="strict",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="advanced_uaa"):
+        BooguImagePipeline(od_config=od_config)
+
+
+def test_constructor_rejects_non_cuda_sequence_parallelism(
+    mock_dependencies,
+    monkeypatch,
+):
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import (
+        BooguImagePipeline,
+    )
+
+    monkeypatch.setattr(
+        f"{_MODULE}.current_omni_platform.is_cuda",
+        lambda: False,
+    )
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(params={}),
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            ulysses_degree=2,
+            ulysses_mode="advanced_uaa",
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="requires CUDA"):
+        BooguImagePipeline(od_config=od_config)
+
     mock_dependencies["mllm_wrapper"].model.to.assert_not_called()
 
 

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -13,7 +13,7 @@ from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.parallel.base import ParallelAttentionContext
 from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D
 from vllm_omni.diffusion.distributed.group_coordinator import SequenceParallelGroupCoordinator
-from vllm_omni.diffusion.forward_context import get_ulysses_mode
+from vllm_omni.diffusion.forward_context import get_forward_context, get_ulysses_mode
 
 
 def _ceil_div(n: int, d: int) -> int:
@@ -55,6 +55,7 @@ def _ulysses_all_to_all_any_qkv(
     *,
     seq_lens: list[int],
     use_sync: bool,
+    padded_head_cnt: int | None = None,
 ) -> tuple[torch.Tensor, int]:
     """UAA forward all-to-all: (B, S_local, H, D) -> (B, S_global, H_local, D).
 
@@ -67,7 +68,12 @@ def _ulysses_all_to_all_any_qkv(
 
     bsz, s_local, head_cnt, head_dim = x.shape
     orig_head_cnt = int(head_cnt)
-    padded_head_cnt = _ceil_div(orig_head_cnt, world_size) * world_size
+    if padded_head_cnt is None:
+        padded_head_cnt = _ceil_div(orig_head_cnt, world_size) * world_size
+    if padded_head_cnt < orig_head_cnt or padded_head_cnt % world_size != 0:
+        raise ValueError(
+            f"Invalid padded head count {padded_head_cnt} for original heads={orig_head_cnt}, world_size={world_size}."
+        )
     head_pad = padded_head_cnt - orig_head_cnt
     if head_pad:
         x = F.pad(x, (0, 0, 0, head_pad))
@@ -81,7 +87,7 @@ def _ulysses_all_to_all_any_qkv(
 
     input_split_sizes = [s_local] * world_size
     output_split_sizes = seq_lens
-    s_global = int(sum(output_split_sizes))
+    s_global = sum(output_split_sizes)
 
     out = torch.empty((s_global, bsz, head_cnt_local, head_dim), device=x.device, dtype=x.dtype)
     dist.all_to_all_single(
@@ -116,7 +122,7 @@ def _ulysses_all_to_all_any_o(
         return x
 
     bsz, s_global, head_cnt_local, head_dim = x.shape
-    s_local = int(local_seq_len)
+    s_local = local_seq_len
 
     # (B, S_global, H_local, D) -> (S_global, B, H_local, D)
     x_t = x.permute(1, 0, 2, 3).contiguous()
@@ -204,6 +210,7 @@ class UlyssesParallelAttention:
         attn_metadata: AttentionMetadata | None,
     ):
         mode = get_ulysses_mode(default="strict")
+        input_local_seq_len = query.shape[1]
         joint_tensor_query = joint_tensor_key = joint_tensor_value = None
         joint_strategy = "front"
         joint_len = 0
@@ -294,9 +301,20 @@ class UlyssesParallelAttention:
                     f"(got scatter_idx={self._scatter_idx}, gather_idx={self._gather_idx})."
                 )
 
-            local_seq_len = int(query.shape[1])
-            seq_lens = _all_gather_int(self._ulysses_pg, local_seq_len, device=query.device)
-            s_global = int(sum(seq_lens))
+            rank_seq_lens_equal = get_forward_context().sp_rank_local_seq_lens_equal
+            if rank_seq_lens_equal:
+                # auto_pad guarantees equal extents; keep the shape symbolic to
+                # avoid the host sync and graph break of a length all-gather.
+                local_seq_len = query.shape[1]
+                seq_lens = [local_seq_len] * ulysses_world_size
+            else:
+                local_seq_len = int(query.shape[1])
+                seq_lens = _all_gather_int(
+                    self._ulysses_pg,
+                    local_seq_len,
+                    device=query.device,
+                )
+            s_global = sum(seq_lens)
 
             # In hybrid Ulysses+Ring, Ring attention uses P2P send/recv with fixed-shape
             # buffers. This requires all ring ranks to have the same seq_len after the
@@ -311,12 +329,48 @@ class UlyssesParallelAttention:
                         "This typically means the input sequence was not evenly shardable across the ring. "
                         "Try setting ring_degree=1, or choose a sequence length divisible by ring_degree."
                     )
+
+            query_head_cnt = int(query.shape[2])
+            kv_head_cnt = int(key.shape[2])
+            value_head_cnt = int(value.shape[2])
+            if (
+                query_head_cnt <= 0
+                or kv_head_cnt <= 0
+                or value_head_cnt != kv_head_cnt
+                or query_head_cnt % kv_head_cnt != 0
+            ):
+                raise ValueError(
+                    "Ulysses GQA requires equal K/V head counts and query heads "
+                    f"to be a multiple of KV heads, got Q={query_head_cnt}, "
+                    f"K={kv_head_cnt}, V={value_head_cnt}."
+                )
+            # Pad KV first, then derive Q capacity to preserve the GQA ratio.
+            padded_kv_head_cnt = _ceil_div(kv_head_cnt, ulysses_world_size) * ulysses_world_size
+            padded_query_head_cnt = padded_kv_head_cnt * (query_head_cnt // kv_head_cnt)
+
             query, orig_head_cnt = _ulysses_all_to_all_any_qkv(
-                self._ulysses_pg, query, seq_lens=seq_lens, use_sync=self._use_sync
+                self._ulysses_pg,
+                query,
+                seq_lens=seq_lens,
+                use_sync=self._use_sync,
+                padded_head_cnt=padded_query_head_cnt,
             )
-            key, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, key, seq_lens=seq_lens, use_sync=self._use_sync)
-            value, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, value, seq_lens=seq_lens, use_sync=self._use_sync)
+            key, _ = _ulysses_all_to_all_any_qkv(
+                self._ulysses_pg,
+                key,
+                seq_lens=seq_lens,
+                use_sync=self._use_sync,
+                padded_head_cnt=padded_kv_head_cnt,
+            )
+            value, _ = _ulysses_all_to_all_any_qkv(
+                self._ulysses_pg,
+                value,
+                seq_lens=seq_lens,
+                use_sync=self._use_sync,
+                padded_head_cnt=padded_kv_head_cnt,
+            )
         else:
+            rank_seq_lens_equal = True
             # Strict mode: fail fast with actionable errors for head divisibility.
             for name, t in (("query", query), ("key", key), ("value", value)):
                 head_cnt = int(t.shape[2])
@@ -359,6 +413,56 @@ class UlyssesParallelAttention:
                 key = torch.cat([key, joint_tensor_key], dim=1)
                 value = torch.cat([value, joint_tensor_value], dim=1)
 
+        if (
+            not is_joint
+            and attn_metadata is not None
+            and attn_metadata.attn_mask is not None
+            and attn_metadata.attn_mask.ndim == 2
+        ):
+            mask = attn_metadata.attn_mask
+            if mask.shape[1] == query.shape[1]:
+                # Some existing adapters (for example ERNIE-Image) keep the
+                # already-padded global mask replicated while sharding Q/K/V.
+                pass
+            elif mask.shape[1] == input_local_seq_len:
+                local_mask = mask.contiguous()
+                if rank_seq_lens_equal:
+                    gathered_masks = [torch.empty_like(local_mask) for _ in range(ulysses_world_size)]
+                    dist.all_gather(gathered_masks, local_mask, group=self._ulysses_pg)
+                else:
+                    local_seq_len_int = int(local_mask.shape[1])
+                    ulysses_rank = self._sp_group.ulysses_rank
+                    if local_seq_len_int != seq_lens[ulysses_rank]:
+                        raise ValueError(
+                            "The rank-local attention mask length must match the "
+                            "rank-local query length, but got "
+                            f"mask_len={local_seq_len_int}, "
+                            f"query_len={seq_lens[ulysses_rank]}."
+                        )
+                    max_seq_len = max(seq_lens)
+                    padded_mask = F.pad(
+                        local_mask,
+                        (0, max_seq_len - local_seq_len_int),
+                    ).contiguous()
+                    padded_masks = [torch.empty_like(padded_mask) for _ in range(ulysses_world_size)]
+                    dist.all_gather(padded_masks, padded_mask, group=self._ulysses_pg)
+                    gathered_masks = [
+                        rank_mask[:, :rank_seq_len]
+                        for rank_mask, rank_seq_len in zip(
+                            padded_masks,
+                            seq_lens,
+                            strict=True,
+                        )
+                    ]
+                attn_metadata.attn_mask = torch.cat(gathered_masks, dim=1)
+            else:
+                raise ValueError(
+                    "A 2D Ulysses attention mask must describe either the "
+                    "rank-local or global sequence, but got "
+                    f"mask_len={mask.shape[1]}, local_query_len={input_local_seq_len}, "
+                    f"global_query_len={query.shape[1]}."
+                )
+
         ctx = _UlyssesCtx(
             name=self.name,
             ulysses_pg=self._ulysses_pg,
@@ -368,8 +472,8 @@ class UlyssesParallelAttention:
             joint_len=joint_len,
             joint_strategy=joint_strategy,
             use_uaa=(mode == "advanced_uaa"),
-            uaa_seq_lens=tuple(int(x) for x in seq_lens) if mode == "advanced_uaa" else (),
-            uaa_local_seq_len=int(local_seq_len) if mode == "advanced_uaa" else 0,
+            uaa_seq_lens=tuple(seq_lens) if mode == "advanced_uaa" else (),
+            uaa_local_seq_len=local_seq_len if mode == "advanced_uaa" else 0,
             orig_head_cnt=int(orig_head_cnt) if mode == "advanced_uaa" else 0,
             joint_orig_head_cnt=int(joint_orig_head_cnt) if mode == "advanced_uaa" else 0,
         )

--- a/vllm_omni/diffusion/distributed/sp_plan.py
+++ b/vllm_omni/diffusion/distributed/sp_plan.py
@@ -220,10 +220,13 @@ class SequenceParallelInput:
             This is useful for layers whose outputs should be split after preprocessing
             (e.g., RoPE embeddings).
         auto_pad: If True, automatically pad the tensor if its size along split_dim
-            is not divisible by world_size. Creates an attention mask to indicate
-            valid vs padding positions. The mask is stored in ForwardContext.
+            is not divisible by world_size. Padding metadata is stored in
+            ForwardContext so models can construct attention masks when needed.
             Note: Ring attention does not support attention mask, so auto_pad
             should only be used with Ulysses SP.
+        shard_group: Optional key shared by tensors representing the same global
+            sequence. Keyed groups track independent padding metadata; omitting
+            it preserves the legacy single-sequence padding behavior.
 
     Example:
         # Split hidden_states along sequence dimension (dim 1)
@@ -240,12 +243,13 @@ class SequenceParallelInput:
     expected_dims: int | None = None
     split_output: bool = False
     auto_pad: bool = False
+    shard_group: str | None = None
 
     def __repr__(self) -> str:
         return (
             f"SequenceParallelInput(split_dim={self.split_dim}, "
             f"expected_dims={self.expected_dims}, split_output={self.split_output}, "
-            f"auto_pad={self.auto_pad})"
+            f"auto_pad={self.auto_pad}, shard_group={self.shard_group!r})"
         )
 
 
@@ -262,6 +266,8 @@ class SequenceParallelOutput:
         gather_dim: The dimension along which to gather the tensor.
         expected_dims: Expected number of dimensions. If provided, validates that
             the tensor has this many dimensions before gathering.
+        shard_group: Optional key whose padding metadata determines the gathered
+            sequence length. Omitting it preserves legacy singleton trimming.
 
     Example:
         # Gather output along sequence dimension (dim 1)
@@ -270,9 +276,13 @@ class SequenceParallelOutput:
 
     gather_dim: int
     expected_dims: int | None = None
+    shard_group: str | None = None
 
     def __repr__(self) -> str:
-        return f"SequenceParallelOutput(gather_dim={self.gather_dim}, expected_dims={self.expected_dims})"
+        return (
+            f"SequenceParallelOutput(gather_dim={self.gather_dim}, "
+            f"expected_dims={self.expected_dims}, shard_group={self.shard_group!r})"
+        )
 
 
 @dataclass(frozen=True)
@@ -396,17 +406,62 @@ def validate_sp_plan(plan: SequenceParallelModelPlan) -> None:
     if not isinstance(plan, dict):
         raise ValueError(f"_sp_plan must be a dict, got {type(plan).__name__}")
 
+    shard_group_owners: dict[str, str] = {}
+    gather_group_owners: dict[str, str] = {}
+    gathered_groups: set[str] = set()
+
+    def _validate_input(
+        sp_input: AnySequenceParallelInput,
+        *,
+        module_id: str,
+    ) -> None:
+        if not isinstance(sp_input, SequenceParallelInput) or sp_input.shard_group is None:
+            return
+        if not sp_input.auto_pad:
+            raise ValueError(
+                f"SequenceParallelInput for module {module_id!r} declares "
+                f"shard_group={sp_input.shard_group!r}, but keyed shard "
+                "metadata currently requires auto_pad=True."
+            )
+        owner = shard_group_owners.setdefault(sp_input.shard_group, module_id)
+        if owner != module_id:
+            raise ValueError(
+                f"shard_group={sp_input.shard_group!r} is used by multiple "
+                f"split boundaries ({owner!r} and {module_id!r}). Use a unique "
+                "name for each boundary."
+            )
+
+    def _validate_output(
+        sp_output: SequenceParallelOutput,
+        *,
+        module_id: str,
+    ) -> None:
+        if sp_output.shard_group is None:
+            return
+        owner = gather_group_owners.setdefault(sp_output.shard_group, module_id)
+        if owner != module_id:
+            raise ValueError(
+                f"shard_group={sp_output.shard_group!r} is gathered by multiple "
+                f"boundaries ({owner!r} and {module_id!r})."
+            )
+        gathered_groups.add(sp_output.shard_group)
+
     for module_id, module_plan in plan.items():
         if not isinstance(module_id, str):
             raise ValueError(f"_sp_plan keys must be strings, got {type(module_id).__name__}")
 
         # Check if it's an output specification (SequenceParallelOutput or list/tuple thereof)
         if isinstance(module_plan, SequenceParallelOutput):
+            _validate_output(module_plan, module_id=module_id)
             continue
         if isinstance(module_plan, (list, tuple)):
             if all(isinstance(x, SequenceParallelOutput) for x in module_plan):
+                for sp_output in module_plan:
+                    _validate_output(sp_output, module_id=module_id)
                 continue
             if _is_valid_input_config_list(module_plan):
+                for sp_input in module_plan:
+                    _validate_input(sp_input, module_id=module_id)
                 # List of inputs for a specific parameter (when output is tuple)
                 continue
 
@@ -428,8 +483,10 @@ def validate_sp_plan(plan: SequenceParallelModelPlan) -> None:
                             f"Integer keys (output indices) require split_output=True, "
                             f"got split_output=False for module '{module_id}'[{key}]"
                         )
+                    _validate_input(value, module_id=module_id)
                 elif _is_valid_input_config_list(value):
-                    pass  # Valid list of input configs
+                    for sp_input in value:
+                        _validate_input(sp_input, module_id=module_id)
                 else:
                     raise ValueError(
                         f"Input spec values must be SequenceParallelInput/PartialInput or list thereof, "
@@ -440,6 +497,13 @@ def validate_sp_plan(plan: SequenceParallelModelPlan) -> None:
                 f"_sp_plan values must be dict (input spec) or SequenceParallelOutput, "
                 f"got {type(module_plan).__name__} for module '{module_id}'"
             )
+
+    missing_groups = gathered_groups.difference(shard_group_owners)
+    if missing_groups:
+        raise ValueError(
+            "SequenceParallelOutput references shard_group values with no "
+            f"matching auto-padded input: {sorted(missing_groups)}."
+        )
 
 
 def get_sp_plan_from_model(model: nn.Module) -> SequenceParallelModelPlan | None:

--- a/vllm_omni/diffusion/distributed/sp_sharding.py
+++ b/vllm_omni/diffusion/distributed/sp_sharding.py
@@ -24,6 +24,116 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 logger = init_logger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class SequenceShardMetadata:
+    """Static metadata for one globally padded sequence shard.
+
+    A shard group identifies tensors that represent the same global sequence
+    (for example, hidden states, mask, and RoPE tensors). All tensors in a
+    group are padded and split identically.
+    """
+
+    original_seq_len: int
+    padded_seq_len: int
+    world_size: int
+    rank: int
+    local_seq_len: int
+
+    def __post_init__(self) -> None:
+        if self.original_seq_len < 0:
+            raise ValueError("original_seq_len must be non-negative.")
+        if self.world_size < 1:
+            raise ValueError("world_size must be >= 1.")
+        if self.rank < 0 or self.rank >= self.world_size:
+            raise ValueError(f"rank must be in [0, {self.world_size}), got {self.rank}.")
+        if self.padded_seq_len < self.original_seq_len:
+            raise ValueError("padded_seq_len must be >= original_seq_len.")
+        if self.padded_seq_len % self.world_size != 0:
+            raise ValueError("padded_seq_len must be divisible by world_size.")
+        if self.local_seq_len != self.padded_seq_len // self.world_size:
+            raise ValueError("local_seq_len must equal padded_seq_len // world_size.")
+
+    @classmethod
+    def from_global_length(
+        cls,
+        original_seq_len: int,
+        *,
+        world_size: int,
+        rank: int,
+    ) -> SequenceShardMetadata:
+        """Build metadata for an evenly padded shard of a global sequence."""
+        if original_seq_len < 0:
+            raise ValueError("original_seq_len must be non-negative.")
+        if world_size < 1:
+            raise ValueError("world_size must be >= 1.")
+        padded_seq_len = ((original_seq_len + world_size - 1) // world_size) * world_size
+        return cls(
+            original_seq_len=original_seq_len,
+            padded_seq_len=padded_seq_len,
+            world_size=world_size,
+            rank=rank,
+            local_seq_len=padded_seq_len // world_size,
+        )
+
+    @classmethod
+    def identity(cls, seq_len: int) -> SequenceShardMetadata:
+        """Build metadata for a non-sharded sequence."""
+        return cls.from_global_length(seq_len, world_size=1, rank=0)
+
+    @property
+    def padding_size(self) -> int:
+        return self.padded_seq_len - self.original_seq_len
+
+    @property
+    def local_start(self) -> int:
+        return self.rank * self.local_seq_len
+
+    @property
+    def local_end(self) -> int:
+        return self.local_start + self.local_seq_len
+
+    def local_valid_length(self, global_valid_length: int) -> int:
+        """Return this rank's valid prefix length for a global prefix."""
+        if global_valid_length < 0 or global_valid_length > self.original_seq_len:
+            raise ValueError(f"global_valid_length must be in [0, {self.original_seq_len}], got {global_valid_length}.")
+        return max(
+            0,
+            min(global_valid_length, self.local_end) - self.local_start,
+        )
+
+    def local_valid_lengths(self, global_valid_lengths: list[int]) -> list[int]:
+        """Vectorized :meth:`local_valid_length` for batched prefix lengths."""
+        return [self.local_valid_length(int(length)) for length in global_valid_lengths]
+
+    def local_segment_lengths(
+        self,
+        global_segment_lengths: list[list[int]],
+    ) -> list[list[int]]:
+        """Intersect contiguous per-sample segments with this rank's shard."""
+        local_lengths: list[list[int]] = []
+        for sample_lengths in global_segment_lengths:
+            if any(int(length) < 0 for length in sample_lengths):
+                raise ValueError("Segment lengths must be non-negative.")
+            if sum(int(length) for length in sample_lengths) > self.original_seq_len:
+                raise ValueError(
+                    f"The sum of segment lengths cannot exceed original_seq_len ({self.original_seq_len})."
+                )
+
+            sample_local: list[int] = []
+            segment_start = 0
+            for length in sample_lengths:
+                segment_end = segment_start + int(length)
+                sample_local.append(
+                    max(
+                        0,
+                        min(segment_end, self.local_end) - max(segment_start, self.local_start),
+                    )
+                )
+                segment_start = segment_end
+            local_lengths.append(sample_local)
+        return local_lengths
+
+
 def sp_shard(
     tensor: torch.Tensor,
     dim: int,

--- a/vllm_omni/diffusion/forward_context.py
+++ b/vllm_omni/diffusion/forward_context.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, overload
 
 import torch
 import vllm.ir
@@ -15,6 +15,10 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 
 if TYPE_CHECKING:
     import torch
+
+    from vllm_omni.diffusion.distributed.sp_sharding import (
+        SequenceShardMetadata,
+    )
 
 
 @dataclass
@@ -39,6 +43,9 @@ class ForwardContext:
     sp_padding_size: int = 0
     # Original sequence length before padding (for removing padding in gather)
     sp_original_seq_len: int | None = None
+    # Independent padding/sharding metadata keyed by SequenceParallelInput
+    # shard_group. The singleton fields above remain for backward compatibility.
+    sp_shard_metadata: dict[str, SequenceShardMetadata] = field(default_factory=dict)
 
     # Set by registry when _sp_plan hooks are applied.
     # When True, sp_active is determined by _sp_shard_depth (for _sp_plan hooks)
@@ -48,6 +55,10 @@ class ForwardContext:
     # Tracks the depth of SP sharding - incremented on shard, decremented on gather
     # Used by attention layers to determine if SP communication should be enabled
     _sp_shard_depth: int = 0
+    # Each active SP split boundary records whether it guarantees identical
+    # rank-local sequence extents. Auto-padded boundaries provide this contract,
+    # allowing attention collectives to avoid a runtime length all-gather.
+    _sp_equal_rank_seq_len_stack: list[bool] = field(default_factory=list)
 
     @property
     def sp_active(self) -> bool:
@@ -70,6 +81,15 @@ class ForwardContext:
         sp_size = self.omni_diffusion_config.parallel_config.sequence_parallel_size
         return sp_size is not None and sp_size > 1
 
+    @property
+    def sp_rank_local_seq_lens_equal(self) -> bool:
+        """Whether active SP boundaries guarantee equal local sequence sizes.
+
+        The guarantee is deliberately scoped to framework-managed SP regions.
+        Callers that shard tensors manually retain the dynamic length exchange.
+        """
+        return bool(self._sp_equal_rank_seq_len_stack) and all(self._sp_equal_rank_seq_len_stack)
+
     def __post_init__(self):
         pass
 
@@ -87,6 +107,42 @@ def get_forward_context() -> ForwardContext:
 
 def is_forward_context_available() -> bool:
     return _forward_context is not None
+
+
+@overload
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: int,
+) -> SequenceShardMetadata: ...
+
+
+@overload
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: None = None,
+) -> SequenceShardMetadata | None: ...
+
+
+def get_sp_shard_metadata(
+    shard_group: str,
+    *,
+    default_seq_len: int | None = None,
+) -> SequenceShardMetadata | None:
+    """Get keyed SP shard metadata, optionally falling back to identity."""
+    if is_forward_context_available():
+        metadata = get_forward_context().sp_shard_metadata.get(shard_group)
+        if metadata is not None:
+            return metadata
+    if default_seq_len is None:
+        return None
+
+    from vllm_omni.diffusion.distributed.sp_sharding import (
+        SequenceShardMetadata,
+    )
+
+    return SequenceShardMetadata.identity(default_seq_len)
 
 
 def build_local_sp_padding_mask(

--- a/vllm_omni/diffusion/hooks/sequence_parallel.py
+++ b/vllm_omni/diffusion/hooks/sequence_parallel.py
@@ -50,7 +50,11 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelOutput,
     SequenceParallelPartialInput,
 )
-from vllm_omni.diffusion.distributed.sp_sharding import sp_gather, sp_shard
+from vllm_omni.diffusion.distributed.sp_sharding import (
+    SequenceShardMetadata,
+    sp_gather,
+    sp_shard,
+)
 from vllm_omni.diffusion.hooks.base import HookRegistry, ModelHook
 
 logger = init_logger(__name__)
@@ -173,6 +177,12 @@ class SequenceParallelSplitHook(ModelHook):
         self.module_forward_metadata: ModuleForwardMetadata | None = None
         # Cache for text lengths resolved from kwargs
         self._text_len_cache: dict[str, int] = {}
+        self._shard_groups = {
+            sp_input.shard_group
+            for value in metadata.values()
+            for sp_input in (value if isinstance(value, (list, tuple)) else (value,))
+            if isinstance(sp_input, SequenceParallelInput) and sp_input.shard_group is not None
+        }
 
     def initialize_hook(self, module: nn.Module) -> nn.Module:
         cls = _unwrap_module(module).__class__
@@ -184,6 +194,16 @@ class SequenceParallelSplitHook(ModelHook):
         args_list = list(args)
         # Clear text length cache for this forward pass
         self._text_len_cache.clear()
+        if self._shard_groups:
+            from vllm_omni.diffusion.forward_context import (
+                get_forward_context,
+                is_forward_context_available,
+            )
+
+            if is_forward_context_available():
+                ctx = get_forward_context()
+                for shard_group in self._shard_groups:
+                    ctx.sp_shard_metadata.pop(shard_group, None)
 
         for name, spm in self.metadata.items():
             # Skip if this is a split_output entry (handled in post_forward)
@@ -247,6 +267,7 @@ class SequenceParallelSplitHook(ModelHook):
 
         output_list = [output] if is_tensor else list(output)
         actually_sharded = False
+        equal_rank_seq_lens = True
 
         for index, spm in self.metadata.items():
             if not isinstance(index, int):
@@ -260,10 +281,13 @@ class SequenceParallelSplitHook(ModelHook):
             output_list[index] = self._prepare_sp_input(original, spm, self._last_args, self._last_kwargs)
             if output_list[index] is not original:
                 actually_sharded = True
+                equal_rank_seq_lens &= isinstance(spm, SequenceParallelInput) and spm.auto_pad
 
         # Mark SP as active only if at least one tensor was actually sharded
         if actually_sharded and is_forward_context_available():
-            get_forward_context()._sp_shard_depth += 1
+            ctx = get_forward_context()
+            ctx._sp_shard_depth += 1
+            ctx._sp_equal_rank_seq_len_stack.append(equal_rank_seq_lens)
 
         return output_list[0] if is_tensor else type(output)(output_list)
 
@@ -353,7 +377,11 @@ class SequenceParallelSplitHook(ModelHook):
         if isinstance(sp_input, SequenceParallelInput):
             # Full split with optional auto-padding
             if sp_input.auto_pad:
-                return self._shard_with_auto_pad(x, sp_input.split_dim)
+                return self._shard_with_auto_pad(
+                    x,
+                    sp_input.split_dim,
+                    sp_input.shard_group,
+                )
             _maybe_validate_strict_divisibility(dim=sp_input.split_dim, seq_len=x.size(sp_input.split_dim))
             return sp_shard(x, sp_input.split_dim, validate=False)
         elif isinstance(sp_input, SequenceParallelPartialInput):
@@ -374,13 +402,16 @@ class SequenceParallelSplitHook(ModelHook):
         else:
             raise ValueError(f"Unsupported input config type: {type(sp_input).__name__}")
 
-    def _shard_with_auto_pad(self, x: torch.Tensor, dim: int) -> torch.Tensor:
-        """Shard tensor with automatic padding and attention mask creation.
+    def _shard_with_auto_pad(
+        self,
+        x: torch.Tensor,
+        dim: int,
+        shard_group: str | None,
+    ) -> torch.Tensor:
+        """Pad and shard a tensor while recording its sequence layout.
 
-        When sequence length is not divisible by SP world size, this method:
-        1. Pads the tensor to make it divisible
-        2. Creates an attention mask indicating valid vs padding positions
-        3. Stores the mask and padding info in ForwardContext
+        Models use the recorded metadata to build masks. Legacy singleton
+        padding fields are also populated for backward compatibility.
         """
         from vllm_omni.diffusion.attention.selector import get_attn_backend_for_role
         from vllm_omni.diffusion.distributed.parallel_state import (
@@ -395,10 +426,28 @@ class SequenceParallelSplitHook(ModelHook):
             return x
 
         seq_len = x.size(dim)
+        rank = get_sequence_parallel_rank()
+        shard_metadata = SequenceShardMetadata.from_global_length(
+            seq_len,
+            world_size=world_size,
+            rank=rank,
+        )
         remainder = seq_len % world_size
 
+        if is_forward_context_available():
+            ctx = get_forward_context()
+            if shard_group is not None:
+                existing = ctx.sp_shard_metadata.get(shard_group)
+                if existing is not None and existing != shard_metadata:
+                    raise ValueError(
+                        f"All tensors in shard_group={shard_group!r} must have "
+                        "the same global sequence length and shard layout, but "
+                        f"got {existing} and {shard_metadata}."
+                    )
+                ctx.sp_shard_metadata[shard_group] = shard_metadata
+
         if remainder == 0:
-            # No padding needed
+            # Keyed groups record metadata even when no padding is necessary.
             return sp_shard(x, dim, validate=False)
 
         # Check backend compatibility
@@ -429,8 +478,8 @@ class SequenceParallelSplitHook(ModelHook):
             )
 
         # Calculate padding
-        pad_size = world_size - remainder
-        padded_seq_len = seq_len + pad_size
+        pad_size = shard_metadata.padding_size
+        padded_seq_len = shard_metadata.padded_seq_len
 
         # Pad the tensor
         pad_shape = list(x.shape)
@@ -452,7 +501,6 @@ class SequenceParallelSplitHook(ModelHook):
                 )
 
         # Shard the padded tensor
-        rank = get_sequence_parallel_rank()
         return x_padded.chunk(world_size, dim=dim)[rank]
 
 
@@ -496,12 +544,6 @@ class SequenceParallelGatherHook(ModelHook):
         if len(output) != len(self.metadata):
             raise ValueError(f"Expected {len(self.metadata)} outputs, got {len(output)}.")
 
-        # Check if padding was applied during split
-        original_seq_len = None
-        if is_forward_context_available():
-            ctx = get_forward_context()
-            original_seq_len = ctx.sp_original_seq_len
-
         actually_gathered = False
 
         for i, spm in enumerate(self.metadata):
@@ -519,6 +561,16 @@ class SequenceParallelGatherHook(ModelHook):
             gathered = sp_gather(x, spm.gather_dim, validate=False)
 
             # Remove padding if it was applied
+            original_seq_len = None
+            if is_forward_context_available():
+                ctx = get_forward_context()
+                if spm.shard_group is None:
+                    original_seq_len = ctx.sp_original_seq_len
+                else:
+                    shard_metadata = ctx.sp_shard_metadata.get(spm.shard_group)
+                    if shard_metadata is None:
+                        raise RuntimeError(f"No SP shard metadata was registered for shard_group={spm.shard_group!r}.")
+                    original_seq_len = shard_metadata.original_seq_len
             if original_seq_len is not None and gathered.size(spm.gather_dim) > original_seq_len:
                 gathered = gathered.narrow(spm.gather_dim, 0, original_seq_len)
                 logger.debug(f"Removed padding: gathered shape {gathered.shape} (original_seq_len={original_seq_len})")
@@ -529,7 +581,13 @@ class SequenceParallelGatherHook(ModelHook):
         # Mark SP as inactive only if at least one tensor was actually gathered
         if actually_gathered and is_forward_context_available():
             ctx = get_forward_context()
-            ctx._sp_shard_depth = max(0, ctx._sp_shard_depth - 1)
+            # A gather boundary closes the framework-managed SP region. There
+            # may be multiple preprocessing split hooks before one final
+            # gather, so decrementing a single entry can leak SP-active state
+            # and an equal-rank contract into later attention calls.
+            ctx._sp_shard_depth = 0
+            ctx._sp_equal_rank_seq_len_stack.clear()
+            ctx.sp_shard_metadata.clear()
 
         return output[0] if is_tensor else type(output)(output)
 

--- a/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
+++ b/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
@@ -34,6 +34,11 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.sp_plan import (
+    SequenceParallelInput,
+    SequenceParallelOutput,
+)
+from vllm_omni.diffusion.forward_context import get_sp_shard_metadata
 
 logger = init_logger(__name__)
 
@@ -341,12 +346,16 @@ def _concat_instruction_image_features(
     assert len(img_tensors) == len(instruct_tensors)
 
     batch_size = img_tensors[0].shape[0]
-    max_seq_len = max(seq_lengths)
+    joint_capacity = instruct_tensors[0].shape[1] + img_tensors[0].shape[1]
 
     concatenated_list = []
     for img_tensor, instruct_tensor in zip(img_tensors, instruct_tensors):
         feature_dim = img_tensor.shape[-1]
-        concatenated = img_tensor.new_zeros(batch_size, max_seq_len, feature_dim)
+        concatenated = img_tensor.new_zeros(
+            batch_size,
+            joint_capacity,
+            feature_dim,
+        )
         for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
             concatenated[i, :encoder_seq_len] = instruct_tensor[i, :encoder_seq_len]
             concatenated[i, encoder_seq_len:seq_len] = img_tensor[i, : seq_len - encoder_seq_len]
@@ -359,16 +368,24 @@ def _split_instruction_image_features(
     hidden_states: torch.Tensor,
     encoder_seq_lengths: list[int],
     seq_lengths: list[int],
+    *,
+    instruct_capacity: int,
+    img_capacity: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Unpack a joint sequence back into (instruction, image) streams."""
     batch_size = hidden_states.shape[0]
     feature_dim = hidden_states.shape[-1]
 
-    max_instruct_len = max(encoder_seq_lengths)
-    max_img_len = max(seq_len - encoder_seq_len for seq_len, encoder_seq_len in zip(seq_lengths, encoder_seq_lengths))
-
-    instruct_hidden_states = hidden_states.new_zeros(batch_size, max_instruct_len, feature_dim)
-    img_hidden_states = hidden_states.new_zeros(batch_size, max_img_len, feature_dim)
+    instruct_hidden_states = hidden_states.new_zeros(
+        batch_size,
+        instruct_capacity,
+        feature_dim,
+    )
+    img_hidden_states = hidden_states.new_zeros(
+        batch_size,
+        img_capacity,
+        feature_dim,
+    )
 
     for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
         img_len = seq_len - encoder_seq_len
@@ -529,7 +546,11 @@ class BooguImageJointAttention(nn.Module):
         attn_output = attn_output.flatten(2, 3).to(dtype)
 
         instruct_attn_out, img_attn_out = _split_instruction_image_features(
-            attn_output, encoder_seq_lengths, seq_lengths
+            attn_output,
+            encoder_seq_lengths,
+            seq_lengths,
+            instruct_capacity=instruct_hidden_states.shape[1],
+            img_capacity=img_hidden_states.shape[1],
         )
         instruct_projected, _ = self.instruct_out(instruct_attn_out)
         img_projected, _ = self.img_out(img_attn_out)
@@ -800,6 +821,20 @@ def _cal_preprocessed_instruction_feat_dim(instruction_feature_configs: dict) ->
         raise ValueError(f"Invalid reduce_type: {reduce_type}")
 
 
+class _BooguImageSPBoundary(nn.Module):
+    """Identity module used by framework SP split hooks."""
+
+    def forward(self, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        return tensors
+
+
+class _BooguImageSPGather(nn.Module):
+    """Identity module used by the framework SP gather hook."""
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
+
+
 class BooguImageTransformer2DModel(nn.Module):
     """Boogu-Image transformer with mixed stream topology.
 
@@ -817,6 +852,40 @@ class BooguImageTransformer2DModel(nn.Module):
         "BooguImageSingleStreamTransformerBlock",
     ]
     _layerwise_offload_blocks_attrs = ["single_stream_layers", "double_stream_layers"]
+    # Boundary outputs are hidden states, masks, and RoPE; each triplet is in
+    # image/reference/context order so tensors sharing a sequence reuse metadata.
+    _sp_plan = {
+        "sp_shard_boundary": {
+            index: SequenceParallelInput(
+                split_dim=1,
+                expected_dims=dims,
+                split_output=True,
+                auto_pad=True,
+                shard_group=shard_group,
+            )
+            for index, (dims, shard_group) in enumerate(
+                zip(
+                    (3, 3, 3, 2, 2, 2, 3, 3, 3),
+                    (
+                        "image",
+                        "reference",
+                        "context",
+                        "image",
+                        "reference",
+                        "context",
+                        "image",
+                        "reference",
+                        "context",
+                    ),
+                )
+            )
+        },
+        "sp_gather_boundary": SequenceParallelOutput(
+            gather_dim=1,
+            expected_dims=3,
+            shard_group="image",
+        ),
+    }
 
     def __init__(self, od_config: OmniDiffusionConfig) -> None:
         super().__init__()
@@ -878,6 +947,8 @@ class BooguImageTransformer2DModel(nn.Module):
             axes_lens=axes_lens,
             patch_size=patch_size,
         )
+        self.sp_shard_boundary = _BooguImageSPBoundary()
+        self.sp_gather_boundary = _BooguImageSPGather()
 
         self.x_embedder = nn.Linear(
             in_features=patch_size * patch_size * in_channels,
@@ -1112,6 +1183,7 @@ class BooguImageTransformer2DModel(nn.Module):
         l_effective_ref_img_len,
         l_effective_img_len,
         temb,
+        preserve_equal_rank_capacity: bool = False,
     ):
         """Embed image patches and run the refiner blocks.
 
@@ -1121,9 +1193,7 @@ class BooguImageTransformer2DModel(nn.Module):
         avoiding a degenerate zero-length attention.
         """
         batch_size = len(hidden_states)
-        max_combined_img_len = max(
-            img_len + sum(ref_img_len) for img_len, ref_img_len in zip(l_effective_img_len, l_effective_ref_img_len)
-        )
+        max_combined_img_len = hidden_states.shape[1] + ref_image_hidden_states.shape[1]
 
         hidden_states = self.x_embedder(hidden_states)
         ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states)
@@ -1142,6 +1212,13 @@ class BooguImageTransformer2DModel(nn.Module):
         flat_l_effective_ref_img_len = list(itertools.chain(*l_effective_ref_img_len))
         num_ref_images = len(flat_l_effective_ref_img_len)
         max_ref_img_len = max(flat_l_effective_ref_img_len)
+        if preserve_equal_rank_capacity:
+            # Keep the packed reference batch at the padded local capacity so
+            # every SP rank retains the equal-length contract.
+            max_ref_img_len = max(
+                max_ref_img_len,
+                padded_ref_img_mask.shape[1],
+            )
 
         if max_ref_img_len > 0:
             batch_ref_img_mask = ref_image_hidden_states.new_zeros(num_ref_images, max_ref_img_len, dtype=torch.bool)
@@ -1168,8 +1245,17 @@ class BooguImageTransformer2DModel(nn.Module):
                     idx += 1
 
             for layer in self.ref_image_refiner:
+                ref_attention_mask = (
+                    batch_ref_img_mask
+                    if preserve_equal_rank_capacity
+                    or any(length != max_ref_img_len for length in flat_l_effective_ref_img_len)
+                    else None
+                )
                 batch_ref_image_hidden_states = layer(
-                    batch_ref_image_hidden_states, batch_ref_img_mask, batch_ref_img_rotary_emb, batch_temb
+                    batch_ref_image_hidden_states,
+                    ref_attention_mask,
+                    batch_ref_img_rotary_emb,
+                    batch_temb,
                 )
 
             # Restore reference-image sequence layout.
@@ -1189,6 +1275,80 @@ class BooguImageTransformer2DModel(nn.Module):
             combined_img_hidden_states[i, sum(ref_img_len) : sum(ref_img_len) + img_len] = hidden_states[i, :img_len]
 
         return combined_img_hidden_states
+
+    @staticmethod
+    def _mask_or_none(
+        mask: torch.Tensor,
+        effective_lengths: list[int],
+        *,
+        required: bool = False,
+    ) -> torch.Tensor | None:
+        """Drop all-valid masks unless an external mask contract requires one."""
+        return mask if required or any(int(length) != mask.shape[1] for length in effective_lengths) else None
+
+    @staticmethod
+    def _pack_local_rotary(
+        context_rotary_emb: torch.Tensor,
+        ref_img_rotary_emb: torch.Tensor,
+        noise_rotary_emb: torch.Tensor,
+        encoder_seq_lengths: list[int],
+        ref_img_seq_lengths: list[list[int]],
+        img_seq_lengths: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int], list[int]]:
+        """Pack local RoPE as [context, references, noise].
+
+        Capacities stay equal across ranks; returned lengths exclude padding.
+        """
+        batch_size = context_rotary_emb.shape[0]
+        rotary_dim = context_rotary_emb.shape[-1]
+        combined_img_seq_lengths = [
+            sum(ref_lengths) + img_length
+            for ref_lengths, img_length in zip(
+                ref_img_seq_lengths,
+                img_seq_lengths,
+            )
+        ]
+        seq_lengths = [
+            context_length + combined_length
+            for context_length, combined_length in zip(
+                encoder_seq_lengths,
+                combined_img_seq_lengths,
+            )
+        ]
+        combined_img_capacity = ref_img_rotary_emb.shape[1] + noise_rotary_emb.shape[1]
+        combined_img_rotary_emb = context_rotary_emb.new_zeros(
+            batch_size,
+            combined_img_capacity,
+            rotary_dim,
+        )
+        rotary_emb = context_rotary_emb.new_zeros(
+            batch_size,
+            context_rotary_emb.shape[1] + combined_img_capacity,
+            rotary_dim,
+        )
+
+        for i, (context_length, ref_lengths, img_length) in enumerate(
+            zip(
+                encoder_seq_lengths,
+                ref_img_seq_lengths,
+                img_seq_lengths,
+            )
+        ):
+            ref_length = sum(ref_lengths)
+            combined_length = ref_length + img_length
+            combined_img_rotary_emb[i, :ref_length] = ref_img_rotary_emb[i, :ref_length]
+            combined_img_rotary_emb[i, ref_length:combined_length] = noise_rotary_emb[i, :img_length]
+            rotary_emb[i, :context_length] = context_rotary_emb[i, :context_length]
+            rotary_emb[i, context_length : context_length + combined_length] = combined_img_rotary_emb[
+                i, :combined_length
+            ]
+
+        return (
+            rotary_emb,
+            combined_img_rotary_emb,
+            seq_lengths,
+            combined_img_seq_lengths,
+        )
 
     def forward(
         self,
@@ -1237,11 +1397,11 @@ class BooguImageTransformer2DModel(nn.Module):
             context_rotary_emb,
             ref_img_rotary_emb,
             noise_rotary_emb,
-            rotary_emb,
-            encoder_seq_lengths,
-            seq_lengths,
-            combined_img_rotary_emb,
-            combined_img_seq_lengths,
+            _,
+            global_encoder_seq_lengths,
+            _,
+            _,
+            _,
         ) = self.rope_embedder(
             freqs_cis,
             instruction_attention_mask,
@@ -1252,38 +1412,139 @@ class BooguImageTransformer2DModel(nn.Module):
             device,
         )
 
+        (
+            hidden_states,
+            ref_image_hidden_states,
+            instruction_hidden_states,
+            img_mask,
+            ref_img_mask,
+            instruction_attention_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            context_rotary_emb,
+        ) = self.sp_shard_boundary(
+            hidden_states,
+            ref_image_hidden_states,
+            instruction_hidden_states,
+            img_mask,
+            ref_img_mask,
+            instruction_attention_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            context_rotary_emb,
+        )
+
+        image_shard = get_sp_shard_metadata(
+            "image",
+            default_seq_len=img_mask.shape[1],
+        )
+        reference_shard = get_sp_shard_metadata(
+            "reference",
+            default_seq_len=ref_img_mask.shape[1],
+        )
+        context_shard = get_sp_shard_metadata(
+            "context",
+            default_seq_len=instruction_attention_mask.shape[1],
+        )
+
+        context_mask_required = context_shard.padding_size > 0 or any(
+            length != context_shard.original_seq_len for length in global_encoder_seq_lengths
+        )
+        noise_mask_required = image_shard.padding_size > 0 or any(
+            length != image_shard.original_seq_len for length in l_effective_img_len
+        )
+        ref_mask_required = reference_shard.padding_size > 0 or any(
+            sum(lengths) != reference_shard.original_seq_len for lengths in l_effective_ref_img_len
+        )
+
+        global_img_lengths = list(l_effective_img_len)
+        local_img_lengths = image_shard.local_valid_lengths(
+            global_img_lengths,
+        )
+        local_ref_lengths = reference_shard.local_segment_lengths(
+            l_effective_ref_img_len,
+        )
+        local_encoder_lengths = context_shard.local_valid_lengths(
+            global_encoder_seq_lengths,
+        )
+        (
+            rotary_emb,
+            combined_img_rotary_emb,
+            seq_lengths,
+            combined_img_seq_lengths,
+        ) = self._pack_local_rotary(
+            context_rotary_emb,
+            ref_img_rotary_emb,
+            noise_rotary_emb,
+            local_encoder_lengths,
+            local_ref_lengths,
+            local_img_lengths,
+        )
+
+        context_attention_mask = self._mask_or_none(
+            instruction_attention_mask,
+            local_encoder_lengths,
+            required=context_mask_required,
+        )
+        noise_attention_mask = self._mask_or_none(
+            img_mask,
+            local_img_lengths,
+            required=noise_mask_required,
+        )
+
         # Context refinement.
         for layer in self.context_refiner:
-            instruction_hidden_states = layer(instruction_hidden_states, instruction_attention_mask, context_rotary_emb)
+            instruction_hidden_states = layer(
+                instruction_hidden_states,
+                context_attention_mask,
+                context_rotary_emb,
+            )
 
         # Image patch embedding and refinement.
         combined_img_hidden_states = self.img_patch_embed_and_refine(
             hidden_states,
             ref_image_hidden_states,
-            img_mask,
+            noise_attention_mask,
             ref_img_mask,
             noise_rotary_emb,
             ref_img_rotary_emb,
-            l_effective_ref_img_len,
-            l_effective_img_len,
+            local_ref_lengths,
+            local_img_lengths,
             temb,
+            preserve_equal_rank_capacity=reference_shard.world_size > 1,
         )
 
         instruct_hidden_states = instruction_hidden_states
         img_hidden_states = combined_img_hidden_states
 
         # Joint mask for [instruct + image].
-        max_seq_len = max(seq_lengths)
-        joint_attention_mask = hidden_states.new_zeros(batch_size, max_seq_len, dtype=torch.bool)
+        joint_attention_mask = hidden_states.new_zeros(
+            batch_size,
+            rotary_emb.shape[1],
+            dtype=torch.bool,
+        )
         for i, seq_len in enumerate(seq_lengths):
             joint_attention_mask[i, :seq_len] = True
+        joint_attention_mask = self._mask_or_none(
+            joint_attention_mask,
+            seq_lengths,
+            required=(context_mask_required or noise_mask_required or ref_mask_required),
+        )
 
         # Dual-stream (double-stream) stage.
         if self.num_double_stream_layers > 0:
-            max_img_len = max(combined_img_seq_lengths)
-            img_attention_mask = hidden_states.new_zeros(batch_size, max_img_len, dtype=torch.bool)
+            img_attention_mask = hidden_states.new_zeros(
+                batch_size,
+                combined_img_rotary_emb.shape[1],
+                dtype=torch.bool,
+            )
             for i, img_seq_len in enumerate(combined_img_seq_lengths):
                 img_attention_mask[i, :img_seq_len] = True
+            img_attention_mask = self._mask_or_none(
+                img_attention_mask,
+                combined_img_seq_lengths,
+                required=noise_mask_required or ref_mask_required,
+            )
 
             for layer in self.double_stream_layers:
                 img_hidden_states, instruct_hidden_states = layer(
@@ -1294,13 +1555,17 @@ class BooguImageTransformer2DModel(nn.Module):
                     combined_img_rotary_emb,
                     rotary_emb,
                     temb,
-                    encoder_seq_lengths,
+                    local_encoder_lengths,
                     seq_lengths,
                 )
 
         # Fuse streams to joint sequence.
-        joint_hidden_states = hidden_states.new_zeros(batch_size, max(seq_lengths), self.hidden_size)
-        for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):
+        joint_hidden_states = hidden_states.new_zeros(
+            batch_size,
+            rotary_emb.shape[1],
+            self.hidden_size,
+        )
+        for i, (encoder_seq_len, seq_len) in enumerate(zip(local_encoder_lengths, seq_lengths)):
             joint_hidden_states[i, :encoder_seq_len] = instruct_hidden_states[i, :encoder_seq_len]
             joint_hidden_states[i, encoder_seq_len:seq_len] = img_hidden_states[i, : seq_len - encoder_seq_len]
 
@@ -1312,12 +1577,23 @@ class BooguImageTransformer2DModel(nn.Module):
         # Output projection.
         hidden_states = self.norm_out(hidden_states, temb)
 
+        # Extract this rank's noise-image shard and gather it once.
+        local_img_output = hidden_states.new_zeros(
+            batch_size,
+            img_mask.shape[1],
+            hidden_states.shape[-1],
+        )
+        for i, (img_len, seq_len) in enumerate(zip(local_img_lengths, seq_lengths)):
+            local_img_output[i, :img_len] = hidden_states[i, seq_len - img_len : seq_len]
+
+        image_tokens = self.sp_gather_boundary(local_img_output)
+
         # Reshape back to image format.
         p = self.patch_size
         output = []
-        for i, (img_size, img_len, seq_len) in enumerate(zip(img_sizes, l_effective_img_len, seq_lengths)):
+        for i, (img_size, img_len) in enumerate(zip(img_sizes, global_img_lengths)):
             height, width = img_size
-            img_tokens = hidden_states[i][seq_len - img_len : seq_len]
+            img_tokens = image_tokens[i, :img_len]
             img_output = rearrange(
                 img_tokens,
                 "(h w) (p1 p2 c) -> c (h p1) (w p2)",

--- a/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
+++ b/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
@@ -52,6 +52,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -285,7 +286,30 @@ class BooguImagePipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery
         if parallel_config.tensor_parallel_size > 1:
             raise NotImplementedError("Tensor parallelism is not supported by BooguImagePipeline.")
         if (parallel_config.sequence_parallel_size or 1) > 1:
-            raise NotImplementedError("Sequence parallelism is not supported by BooguImagePipeline.")
+            if parallel_config.ring_degree > 1 or getattr(parallel_config, "allgather_degree", 1) > 1:
+                raise NotImplementedError(
+                    "BooguImagePipeline currently supports sequence parallelism through Ulysses only."
+                )
+            if not current_omni_platform.is_cuda():
+                raise NotImplementedError("BooguImagePipeline sequence parallelism currently requires CUDA.")
+            if parallel_config.ulysses_mode == "strict":
+                num_heads = self.od_config.tf_model_config.get(
+                    "num_attention_heads",
+                    24,
+                )
+                num_kv_heads = self.od_config.tf_model_config.get(
+                    "num_kv_heads",
+                    8,
+                )
+                if (
+                    num_heads % parallel_config.ulysses_degree != 0
+                    or num_kv_heads % parallel_config.ulysses_degree != 0
+                ):
+                    raise ValueError(
+                        "BooguImagePipeline GQA heads are not divisible by the "
+                        "configured Ulysses degree; set "
+                        "parallel_config.ulysses_mode='advanced_uaa'."
+                    )
         if parallel_config.cfg_parallel_size > 1:
             raise NotImplementedError("CFG parallelism is not supported by BooguImagePipeline.")
         if parallel_config.use_hsdp:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

BOOGU Image does not currently support sequence-parallel inference. Its Base
checkpoint uses 28 query heads and 7 KV heads, so SP2 requires
`advanced_uaa` and GQA-aware head padding.

The existing UAA implementation exchanges rank-local sequence lengths inside
every attention call. BOOGU inputs, however, are already padded and evenly
sharded by the framework SP hooks. Repeating the length all-gather introduces
a host synchronization point and interrupts regional `torch.compile`.

This PR:

- adds keyed shard metadata for models with multiple independent sequences;
- records an equal-rank sequence-length contract for framework `auto_pad`
  regions;
- lets native UAA skip its runtime length exchange only while that contract is
  active;
- accepts both global and rank-local 2D masks without changing existing model
  contracts;
- enables BOOGU Image SP2 through its declarative `_sp_plan` and
  model-specific sequence packing.

There is no new user-facing communication-backend option. UAA continues to use
the existing sequential native collectives, and manually sharded or unequal
rank-local sequences retain the original dynamic-length fallback.

## Implementation

### Common SP layer

- `SequenceParallelInput.shard_group` and
  `SequenceParallelOutput.shard_group` associate hidden states, masks, and RoPE
  tensors that represent the same global sequence.
- `SequenceShardMetadata` describes the original length, padded length, local
  range, and valid local prefix/segments for each group.
- An active split boundary made entirely of `auto_pad` inputs establishes the
  equal-rank contract in `ForwardContext`; its matching gather boundary removes
  the complete contract and keyed metadata for that SP region.
- `UlyssesParallelAttention` derives `seq_lens` from the local symbolic shape
  while the contract is active. Otherwise it keeps `_all_gather_int`.
- UAA head planning pads BOOGU's 28 Q / 7 KV heads to 32 / 8 at SP2,
  preserving the 4:1 GQA ratio.
- Non-joint 2D masks are classified by sequence extent: an already-global mask
  is reused, while a local mask is gathered. Uneven local masks are padded for
  the collective and sliced back according to the gathered sequence lengths.
- SP plan validation rejects keyed metadata without `auto_pad` and rejects a
  key reused across different split/gather boundaries.

Removing the host scalar exchange is sufficient for PyTorch to capture the
existing native sequential collectives. Explicit Q/K/V `Work` batching was
tested separately and was slower, so it is not part of this PR.

The speedup comes from removing `_all_gather_int` from every BOOGU attention
layer. That fallback materializes rank-local sequence lengths on the host and
creates a regional `torch.compile` break. Framework `auto_pad` has already
established equal rank-local extents, so reusing its contract keeps the
projection, native collectives, and attention inside the compiled region.

### BOOGU adapter

BOOGU declares `image`, `reference`, and `context` shard groups at one split
boundary and gathers only the final noise-image tokens. The transformer uses
the public shard metadata to:

- compute per-rank valid context/image prefixes and reference-image segments;
- repack local RoPE and attention masks;
- preserve padded local capacities through the refiner and joint-stream
  stages;
- trim the gathered image sequence back to its original length.

The adapter contains no process-group calls, rank/world-size queries, or
communication-backend branches.

## Limitations

- BOOGU SP currently supports pure Ulysses only.
- BOOGU Base requires `ulysses_mode=advanced_uaa` at SP2 because 7 KV heads are
  not divisible by 2.
- CUDA/NCCL is the supported and validated platform for this change; the BOOGU
  pipeline fails fast when SP is requested on another backend. Ring, hybrid
  USP, and AllGather-KV are outside this PR.

## Test Plan

### CPU and configuration tests

```bash
pytest -q \
  tests/diffusion/distributed/test_sp_plan_hooks.py \
  tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py \
  tests/diffusion/attention/test_ulysses_uaa.py::test_uaa_equal_rank_contract_skips_length_gather \
  tests/diffusion/attention/test_ulysses_uaa.py::test_uaa_without_contract_keeps_dynamic_length_gather
```

These tests cover keyed metadata, independent auto-padding, equal-rank
contract lifetime, keyed output trimming, BOOGU topology validation, and the
required UAA mode.

### UAA regression

```bash
pytest -q -s tests/diffusion/attention/test_ulysses_uaa.py
```

This verifies GQA-ratio padding, the equal-rank fast path, the unequal-length
fallback, and SP attention correctness against the single-GPU reference.

### Two-GPU BOOGU correctness

```bash
pytest -q -s \
  tests/diffusion/distributed/test_boogu_image_sp.py
```

The tiny BOOGU model compares SP1 and SP2 for both text-to-image and
reference-image edit inputs with `rtol=2e-4, atol=2e-4`.

### Performance protocol

Performance validation used isolated out-of-tree harnesses so this PR does not
add model-specific one-off scripts to the public benchmark package. The base
and PR worktrees used the same model, prompt, seeds, warmup, timing, and
software environment.

The production-size BOOGU block benchmark uses:

- BF16, FlashAttention, SP2, `advanced_uaa`;
- hidden size 3360, 28 Q heads, 7 KV heads, head dimension 120;
- `torch.compile(dynamic=True)`;
- 20 warmup iterations;
- 50 timed iterations per repeat, 7 repeats;
- the median of maximum-rank latency.

The full checkpoint test uses:

- `/workspace/local-models/Boogu-Image-0.1-Base`;
- 1024 x 1024, batch size 1, guidance scale 4.0;
- one explicit 4-step warmup request;
- three 50-step formal requests, seed 42;
- the median latency, with min/max reported;
- the prompt below.

<details>
<summary>Prompt used for E2E validation</summary>

> 一幅国风琉金风格的山水画作，展现了桂林山水在金光普照下的壮丽景象。远山层叠，江水如镜，山峰边缘勾勒着发光的金色线条。画面采用石青石绿岩彩与鎏金质感相结合，局部有厚涂油画笔触，空中飘浮着金色粒子，营造出梦幻朦胧而又磅礴大气的意境。

</details>

**vLLM Version:** `0.24.0`

**vLLM-Omni Base Commit:** `e043818abfc060903a188bde01b9ce648e634054`

Test environment:

- Python `3.12.3`
- PyTorch `2.11.0+cu130`
- CUDA `13.0`
- NVIDIA driver `570.148.08`
- 2 x GPUs exposed as NVIDIA L20Y, 81,559 MiB each (H800-class Pod)

## Test Result

### Automated correctness

- SP hooks, validation, and BOOGU pipeline: **106 passed**
- UAA regression: **6 passed, 3 skipped** (four-GPU cases skipped on the
  two-GPU Pod)
- Tiny BOOGU SP1/SP2 T2I and edit comparison: **1 passed**
- Global-mask and uneven local-mask UAA comparisons: **2 passed**
- Ruff 0.14.10 lint/format, Python compilation, test marker check, and
  `git diff --check`: passed

### Compiled BOOGU block performance

The baseline is native UAA with the per-attention runtime length gather. The
optimized column is this PR's native equal-rank path. Gain is
`baseline / optimized - 1`.

Values are median `[min, max]` across seven repeats.

| Resolution | Batch | Runtime length gather (ms) | Equal-rank contract (ms) | Gain |
|---:|---:|---:|---:|---:|
| 1024² | 1 | 2.822 [2.710, 2.877] | 2.024 [2.014, 2.034] | +39.43% |
| 1024² | 2 | 4.798 [4.788, 4.835] | 3.760 [3.756, 3.784] | +27.59% |
| 1024² | 4 | 9.089 [9.073, 9.111] | 7.475 [7.471, 7.515] | +21.59% |
| 1024² | 8 | 17.226 [17.213, 17.244] | 14.318 [14.305, 14.363] | +20.32% |
| 1536² | 1 | 5.361 [5.349, 5.368] | 4.600 [4.597, 4.613] | +16.55% |
| 1536² | 2 | 10.843 [10.834, 10.858] | 9.050 [9.049, 9.056] | +19.82% |
| 1536² | 4 | 20.901 [20.886, 20.989] | 17.637 [17.635, 17.640] | +18.51% |
| 2048² | 1 | 10.395 [10.383, 10.412] | 9.356 [9.345, 9.411] | +11.11% |
| 2048² | 2 | 21.039 [21.027, 21.061] | 18.196 [18.187, 18.206] | +15.63% |

The geometric-mean block speedup is **20.94%**. A separate optimized-only run
measured 1.995 ms at 1024²/BS1, confirming that the mask compatibility fix did
not regress the approximately 2.0 ms hot path.

### End-to-end 1024² / 50 steps

Values are median `[min, max]` across three formal requests after one explicit
4-step warmup request.

| Configuration | Latency | Reduction vs SP1 | RGB pixel SHA256 |
|---|---:|---:|---|
| Main SP1 | 15.138 s [15.069, 15.179] | baseline | `c4649a1e9b3f0073cef5e7fa7410af3acab8c4fd3d8cb496c5eb00a182e3e9d0` |
| This PR: SP2 equal-rank native | **9.033 s [9.015, 9.044]** | **40.33%** | `a17f7b9dd9dbaca0986dfaa00b1821f088c429763bc6dbb97ed9d583b36e6427` |

The optimized SP2 path is **1.68x** faster than main SP1. All three repetitions
within each configuration produced the same RGB pixel hash. The SHA256 values
above are computed from the uncompressed `uint8` RGB arrays before saving the
display JPEGs.

The 1024 x 1024 outputs were also inspected locally using the same checkpoint,
prompt, guidance, step count, and seed. Minor BF16 distributed-order
differences are expected; composition and prompt semantics were preserved.
Generated images are intentionally not included in the source diff.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
