### PR TITLE
[HuyuanImage3] Skip redundant hidden state D2H- #5346

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1602,6 +1602,10 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
                 self._size_token_id,
             ]
 
+        # AR→Diffusion pooler only needs the generated tokens; skip the
+        # per-step blocking hidden_states[:n].to("cpu") copy.
+        self.omni_pooler_payload_include_hidden = False
+
         self._sampler: Sampler | None = None
         self._eos_token_id: int = tokenizer.eos_token_id
         # Lazily built on first sample() call so we can pick up logits.device


### PR DESCRIPTION
The AR→Diffusion inter-stage pooler only needs the generated text tokens from stage 0 to feed into stage 1 (DiT). Hidden states are not consumed by the downstream diffusion stage, so copying them to CPU each step via hidden_states[:n].to('cpu') is pure overhead.

Setting omni_pooler_payload_include_hidden = False tells GPUARModelRunner to skip this per-step blocking D2H copy, consistent with qwen3-tts-talker, qwen3-omni, and moss-tts.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
