### PR TITLE
[Bugfix][Core] Honor --stage-configs-path when resolving pipeline config

### DIFF
--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -21,6 +21,7 @@ from vllm_omni.entrypoints.utils import (
     filter_stages,
     load_and_resolve_stage_configs,
     load_stage_configs_from_yaml,
+    resolve_deploy_config_path,
     resolve_model_config_path,
 )
 
@@ -413,6 +414,66 @@ class TestLoadAndResolveStageConfigs:
         assert filtered[0].runtime.requires_multimodal_data is True
         assert filtered[0].final_output is False
         assert filtered[0].final_output_type is None
+
+
+class TestResolveDeployConfigPath:
+    """``--stage-configs-path`` and ``--deploy-config`` must resolve alike.
+
+    ``load_and_resolve_stage_configs`` promotes a new-format YAML given via
+    ``--stage-configs-path`` to ``deploy_config_path`` (see
+    ``test_stage_configs_path_promotes_new_deploy_yaml_without_expanding_replicas``).
+    Callers that read the deploy YAML before stage resolution runs must apply
+    the same promotion, or everything they read from it silently defaults.
+    """
+
+    NEW_FORMAT = 'stages:\n  - stage_id: 0\n    devices: "0"\n'
+    LEGACY_FORMAT = "stage_args:\n  - stage_id: 0\n"
+
+    def _write(self, tmp_path, name, text):
+        path = tmp_path / name
+        path.write_text(text, encoding="utf-8")
+        return str(path)
+
+    def test_promotes_new_format_stage_configs_path(self, tmp_path):
+        path = self._write(tmp_path, "deploy.yaml", self.NEW_FORMAT)
+        assert resolve_deploy_config_path(None, path) == path
+
+    def test_legacy_stage_args_yaml_is_not_a_deploy_config(self, tmp_path):
+        path = self._write(tmp_path, "legacy.yaml", self.LEGACY_FORMAT)
+        assert resolve_deploy_config_path(None, path) is None
+
+    def test_explicit_deploy_config_wins(self, tmp_path):
+        deploy = self._write(tmp_path, "deploy.yaml", self.NEW_FORMAT)
+        legacy = self._write(tmp_path, "legacy.yaml", self.LEGACY_FORMAT)
+        assert resolve_deploy_config_path(deploy, legacy) == deploy
+
+    @pytest.mark.parametrize("stage_configs_path", [None, "/nonexistent/deploy.yaml"])
+    def test_missing_input_yields_none_without_raising(self, stage_configs_path):
+        # load_and_resolve_stage_configs re-reads the file and owns the error;
+        # resolving a pipeline must not pre-empt its diagnostics.
+        assert resolve_deploy_config_path(None, stage_configs_path) is None
+
+    def test_unreadable_yaml_yields_none_without_raising(self, tmp_path):
+        path = self._write(tmp_path, "broken.yaml", "stages: [unclosed\n")
+        assert resolve_deploy_config_path(None, path) is None
+
+    def test_agrees_with_the_promotion_load_and_resolve_performs(self, tmp_path, mocker: MockerFixture):
+        """Pin the two call sites together so they cannot drift apart again."""
+        path = self._write(tmp_path, "deploy.yaml", self.NEW_FORMAT)
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.load_stage_configs_from_model",
+            return_value=([create_config({"stage_id": 0, "engine_args": {"model": "dummy"}})], None),
+        )
+
+        config_path, _, _ = load_and_resolve_stage_configs(
+            model="dummy-model",
+            stage_configs_path=path,
+            kwargs={},
+            trust_remote_code=False,
+        )
+
+        assert config_path == path
+        assert resolve_deploy_config_path(None, path) == config_path
 
 
 class TestLoadStageConfigsFromYaml:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -71,6 +71,7 @@ from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import (
     load_and_resolve_stage_configs,
     parse_stage_overrides,
+    resolve_deploy_config_path,
 )
 from vllm_omni.inputs.data import OmniInteractionPrompt, OmniSamplingParams
 from vllm_omni.metrics.prometheus import OmniRequestCounter
@@ -211,8 +212,14 @@ class AsyncOmniEngine:
 
         # Stage resolution pops deploy_config, so get pipeline-wide settings
         # beforehand. The stage CLI exposes the same deploy YAML through
-        # stage_configs_path.
-        deploy_config_path = kwargs.get("deploy_config") or kwargs.get("stage_configs_path")
+        # stage_configs_path. Share the promotion rule with
+        # ``load_and_resolve_stage_configs`` so the two cannot disagree about
+        # which file is this run's deploy YAML, and so a legacy ``stage_args``
+        # YAML or a bad path is not mistaken for one here.
+        deploy_config_path = resolve_deploy_config_path(
+            kwargs.get("deploy_config"),
+            kwargs.get("stage_configs_path"),
+        )
         pipeline_config = StageConfigFactory.get_pipeline_config(
             model=model,
             trust_remote_code=bool(trust_remote_code),

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -554,6 +554,40 @@ def parse_stage_overrides(value: Any) -> dict[str, dict[str, Any]] | None:
     return value
 
 
+def _is_new_format_deploy_yaml(path: str) -> bool:
+    """Whether *path* holds a new-format deploy YAML (``stages``, not ``stage_args``)."""
+    with open(path, encoding="utf-8") as f:
+        peek = yaml.safe_load(f) or {}
+    return isinstance(peek, dict) and "stages" in peek and "stage_args" not in peek
+
+
+def resolve_deploy_config_path(
+    deploy_config_path: str | None,
+    stage_configs_path: str | None,
+) -> str | None:
+    """Return this run's deploy YAML, honouring the legacy ``--stage-configs-path``.
+
+    For a new-format YAML the two flags are the same input:
+    :func:`load_and_resolve_stage_configs` promotes ``--stage-configs-path`` to
+    ``deploy_config_path`` before loading anything. Callers that need the deploy
+    YAML *before* stage resolution runs (pipeline lookup, duplex session config)
+    must apply the same promotion, or every setting they read from that file
+    silently falls back to its default.
+
+    A missing or unreadable path yields ``None`` rather than raising, because
+    :func:`load_and_resolve_stage_configs` re-reads the file and owns those
+    diagnostics.
+    """
+    if deploy_config_path is not None:
+        return deploy_config_path
+    if not stage_configs_path or not os.path.exists(stage_configs_path):
+        return None
+    try:
+        return stage_configs_path if _is_new_format_deploy_yaml(stage_configs_path) else None
+    except (OSError, yaml.YAMLError):
+        return None
+
+
 def load_and_resolve_stage_configs(
     model: str,
     stage_configs_path: str | None,
@@ -601,9 +635,7 @@ def load_and_resolve_stage_configs(
                 "Legacy `stage_configs/` yamls were replaced by `vllm_omni/deploy/<model>.yaml`; "
                 "use --deploy-config. See docs/configuration/stage_configs.md."
             )
-        with open(stage_configs_path, encoding="utf-8") as f:
-            _peek = yaml.safe_load(f) or {}
-        if "stages" in _peek and "stage_args" not in _peek:
+        if _is_new_format_deploy_yaml(stage_configs_path):
             deploy_config_path = stage_configs_path
             stage_configs_path = None
         else:


### PR DESCRIPTION
## Purpose

Fixes #5539.

`--stage-configs-path` and `--deploy-config` are the same input once the YAML is
in the new (`stages`) format: `load_and_resolve_stage_configs()` promotes the
former to `deploy_config_path` before loading anything, and
`test_stage_configs_path_promotes_new_deploy_yaml_without_expanding_replicas`
pins that. `AsyncOmniEngine.__init__()` runs before the promotion and reads only
`kwargs.get("deploy_config")`, so with `--stage-configs-path` it resolves
pipeline-level settings against `None` while stage resolution uses the file.

Five settings silently fall back:

- `endpoint_restrictions`
- `duplex_runtime_extension`
- `duplex_serving_adapter`
- `duplex_control_enabled`
- `duplex_session_config`, gated directly on `deploy_config_path is not None`

The first four come from `get_pipeline_config()`, so a YAML with `pipeline:
<name>` gets the auto-detected pipeline's settings instead of the selected one.
41 in-tree deploy YAMLs set `pipeline:`. `duplex_session_config` is dropped
entirely, which loses all 9 values `minicpmo_4_5_duplex.yaml` tunes.

This adds `resolve_deploy_config_path()` next to
`load_and_resolve_stage_configs()` and has both sites go through the same
`_is_new_format_deploy_yaml()` peek, so the two cannot drift again. The engine
call site uses it.

Behaviour outside that promotion is unchanged. An explicit `--deploy-config`
still wins, a legacy `stage_args` YAML is still not a deploy config, and a
missing or unparseable path returns `None` instead of raising so
`load_and_resolve_stage_configs()` keeps producing its own `FileNotFoundError`
and YAML diagnostics.

## Test Plan

Six unit tests plus one drift guard in
`tests/entrypoints/test_utils.py`, which is already marked `core_model` and
`cpu`, so the existing L1 lane picks them up with no Buildkite changes:

- a new-format YAML given as `stage_configs_path` resolves to itself
- a legacy `stage_args` YAML does not
- an explicit `deploy_config` wins over `stage_configs_path`
- `None` and a nonexistent path return `None` without raising
- an unparseable YAML returns `None` without raising
- `resolve_deploy_config_path()` returns exactly the path
  `load_and_resolve_stage_configs()` promotes to, which is the invariant that
  broke

```bash
pytest -sv tests/entrypoints/test_utils.py -m 'core_model and cpu'
```

Repro for the original behaviour, no accelerator needed. This prints the values
that a `--stage-configs-path` launch never reaches on `main`:

```bash
python -c "
from vllm_omni.config.stage_config import load_deploy_config
d = load_deploy_config('vllm_omni/deploy/minicpmo_4_5_duplex.yaml')
print('pipeline override           :', d.pipeline)
print('duplex_session.max_sessions :', d.duplex_session.max_sessions)
print('duplex_session.idle_ttl_s   :', d.duplex_session.idle_ttl_s)
"
```

**vLLM Version:** v0.26.0

**vLLM-Omni Commit:** f6e59c329b01c43750a425893cde55b0aacf25cc

## Test Result

Replaying both resolution rules against one launch
(`--stage-configs-path minicpmo_4_5_duplex.yaml`), on `main`:

```text
rule A  load_and_resolve_stage_configs -> '.../minicpmo_4_5_duplex.yaml'
rule B  AsyncOmniEngine.__init__       -> None
        (expression: kwargs.get("deploy_config"))
AGREE? NO
```

With this branch:

```text
rule A  load_and_resolve_stage_configs -> '.../minicpmo_4_5_duplex.yaml'
rule B  AsyncOmniEngine.__init__       -> '.../minicpmo_4_5_duplex.yaml'
AGREE? yes
```

The new tests plus the pre-existing promotion test:

```text
8 passed
```

`ruff check`, `ruff format --check` and `tools/pre_commit/check_test_marks.py`
are clean on all three changed files.

I do not have a CUDA box, and `vllm` is not installable on this machine, so
those runs were done in a CPU sandbox that executes the verbatim source of
`load_and_resolve_stage_configs`, `resolve_deploy_config_path` and
`_is_new_format_deploy_yaml` from this branch, and from `main` for the "before"
numbers, with stubbed collaborators. The test functions are the ones in this PR,
unmodified, and the promotion test is taken from `main` so the change cannot
rewrite its own baseline (it passes on both refs). Rule B is lifted out of
`AsyncOmniEngine.__init__` by AST at each ref rather than retyped. The full
`tests/entrypoints/` suite needs CI.
