### PR TITLE
[BugFix] Fix MOSS-TTS codec v1/v2 detection and align vendored tokenizer with upstream

### DIFF
--- a/vllm_omni/model_executor/models/moss_tts/audio_tokenizer.py
+++ b/vllm_omni/model_executor/models/moss_tts/audio_tokenizer.py
@@ -354,12 +354,9 @@ class _ProjectedTransformer(nn.Module):
     ) -> None:
         super().__init__()
         self.downsample_ratio: int = 1
-        # Upstream always materializes a learned Linear here regardless of
-        # whether input_dimension == d_model — substituting Identity when
-        # the dims happen to match silently drops a trained projection.
-        self.in_proj = nn.Linear(input_dimension, d_model, bias=False)
+        self.in_proj = nn.Linear(input_dimension, d_model, bias=False) if input_dimension != d_model else nn.Identity()
         self.transformer = _Transformer(d_model=d_model, **kwargs)
-        self.out_proj = nn.Linear(d_model, output_dimension, bias=False)
+        self.out_proj = nn.Linear(d_model, output_dimension, bias=False) if output_dimension != d_model else nn.Identity()
 
     def forward(self, x: torch.Tensor, lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         x = self.in_proj(x.transpose(1, 2))  # (B, D, T) → (B, T, d_model)

--- a/vllm_omni/model_executor/models/moss_tts/audio_tokenizer.py
+++ b/vllm_omni/model_executor/models/moss_tts/audio_tokenizer.py
@@ -356,7 +356,11 @@ class _ProjectedTransformer(nn.Module):
         self.downsample_ratio: int = 1
         self.in_proj = nn.Linear(input_dimension, d_model, bias=False) if input_dimension != d_model else nn.Identity()
         self.transformer = _Transformer(d_model=d_model, **kwargs)
-        self.out_proj = nn.Linear(d_model, output_dimension, bias=False) if output_dimension != d_model else nn.Identity()
+        self.out_proj = (
+            nn.Linear(d_model, output_dimension, bias=False)
+            if output_dimension != d_model
+            else nn.Identity()
+        )
 
     def forward(self, x: torch.Tensor, lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         x = self.in_proj(x.transpose(1, 2))  # (B, D, T) → (B, T, d_model)

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
@@ -793,18 +793,30 @@ class MossTTSCodecDecoder(nn.Module):
         return {f"_codec.{name}" for name, _ in codec.named_parameters()}
 
     def _build_codec(self, codec_path: str) -> tuple[Any, nn.Module]:
-        try:
-            codec_cfg = MossAudioTokenizerV2Config.from_pretrained(codec_path)
-            codec = MossAudioTokenizerV2Model(codec_cfg)
-            logger.info("Using vendored MOSS Audio Tokenizer v2 classes from %s", codec_path)
-            return codec_cfg, codec
-        except Exception:
-            logger.exception(
-                "Failed to instantiate vendored MOSS Audio Tokenizer v2; falling back to legacy vendored codec."
-            )
+        import json
+        import os
+        config_file = os.path.join(codec_path, "config.json")
+        is_v1 = True
+        if os.path.exists(config_file):
+            with open(config_file) as f:
+                raw_cfg = json.load(f)
+            if raw_cfg.get("number_channels", 1) >= 2:
+                is_v1 = False
+
+        if not is_v1:
+            try:
+                codec_cfg = MossAudioTokenizerV2Config.from_pretrained(codec_path)
+                codec = MossAudioTokenizerV2Model(codec_cfg)
+                logger.info("Using vendored MOSS Audio Tokenizer v2 classes from %s", codec_path)
+                return codec_cfg, codec
+            except Exception:
+                logger.exception(
+                    "Failed to instantiate vendored MOSS Audio Tokenizer v2; falling back to legacy vendored codec."
+                )
 
         codec_cfg = MossAudioTokenizerConfig.from_pretrained(codec_path)
         codec = MossAudioTokenizerModel(codec_cfg)
+        logger.info("Using vendored MOSS Audio Tokenizer v1 classes from %s", codec_path)
         return codec_cfg, codec
 
     def _configure_decoder_cudagraph(self, device: torch.device) -> None:

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_codec.py
@@ -793,17 +793,10 @@ class MossTTSCodecDecoder(nn.Module):
         return {f"_codec.{name}" for name, _ in codec.named_parameters()}
 
     def _build_codec(self, codec_path: str) -> tuple[Any, nn.Module]:
-        import json
-        import os
-        config_file = os.path.join(codec_path, "config.json")
-        is_v1 = True
-        if os.path.exists(config_file):
-            with open(config_file) as f:
-                raw_cfg = json.load(f)
-            if raw_cfg.get("number_channels", 1) >= 2:
-                is_v1 = False
+        config_dict, _ = MossAudioTokenizerV2Config.get_config_dict(codec_path)
+        is_v2 = config_dict.get("number_channels", 1) >= 2
 
-        if not is_v1:
+        if is_v2:
             try:
                 codec_cfg = MossAudioTokenizerV2Config.from_pretrained(codec_path)
                 codec = MossAudioTokenizerV2Model(codec_cfg)
@@ -811,7 +804,8 @@ class MossTTSCodecDecoder(nn.Module):
                 return codec_cfg, codec
             except Exception:
                 logger.exception(
-                    "Failed to instantiate vendored MOSS Audio Tokenizer v2; falling back to legacy vendored codec."
+                    "Failed to instantiate vendored MOSS Audio Tokenizer v2; "
+                    "falling back to legacy vendored codec."
                 )
 
         codec_cfg = MossAudioTokenizerConfig.from_pretrained(codec_path)


### PR DESCRIPTION
## Summary
- Fix MOSS-TTS codec v1/v2 version detection to prevent v2 model classes from incorrectly loading v1 checkpoints (6 missing weight params)
- Align vendored `_ProjectedTransformer` `in_proj`/`out_proj` with upstream checkpoint structure (use `nn.Identity()` when dimensions match)

## Problem
When deploying MOSS-TTS (Delay variant) with the MOSS-Audio-Tokenizer v1 checkpoint, two issues prevent the codec (Stage 1) from loading correctly:

1. **`_build_codec()` tries v2 model class first for v1 checkpoints**: The v2 config class (`MossAudioTokenizerV2Config`) successfully parses v1 checkpoint configs because both share `model_type = "moss-audio-tokenizer"`. When `number_channels` is absent from the v1 config, the v2 default of 2 causes `channel_interleave_factor=2`, which makes the frame rate validation pass coincidentally. The v2 model is then constructed with a different module structure, leading to 6 missing weight parameters (`decoder.0.output_proj.weight`, `encoder.3.input_proj.weight`, etc.).

2. **Vendored `_ProjectedTransformer` always creates `nn.Linear` for projections**: The upstream checkpoint uses `nn.Identity()` when `input_dimension == d_model` or `output_dimension == d_model`. The vendored v1 class always materializes `nn.Linear`, creating parameters that don't exist in the checkpoint.

## Changes
| File | Change |
|---|---|
| `modeling_moss_tts_codec.py` | Read `config.json` to check `number_channels` before attempting v2 instantiation; skip v2 for v1 checkpoints (`number_channels < 2`) |
| `audio_tokenizer.py` | Use `nn.Identity()` for `in_proj`/`out_proj` when dimensions match, consistent with upstream |

## Testing
- Verified MOSS-TTS (Delay) model loads and generates correct audio on Ascend 910B NPU
- Verified MOSS-TTS-Local-Transformer-v1.5 model loads and generates correct audio on Ascend 910B NPU
- Audio quality matches expected output (no precision issues)
