### PR TITLE
[CI][MiniCPM-o] Prefer standard omni serve over stage CLI in e2e/reli…

### DIFF
--- a/tests/dfx/reliability/invalid_param_test/test_invalid_minicpmo_4_5_omni.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_minicpmo_4_5_omni.py
@@ -21,7 +21,7 @@ _MINICPMO_SERVER = [
         OmniServerParams(
             model="openbmb/MiniCPM-o-4_5",
             stage_config_path=_MINICPMO_DEPLOY,
-            use_stage_cli=True,
+            use_stage_cli=False,
             server_args=["--trust-remote-code"],
         ),
         id="minicpmo_4_5",

--- a/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
@@ -30,7 +30,7 @@ test_params = [
         OmniServerParams(
             model=_MODEL,
             stage_config_path=_CI_DEPLOY,
-            use_stage_cli=True,
+            use_stage_cli=False,
             server_args=["--trust-remote-code", "--no-async-chunk"],
         ),
         id="default",
@@ -39,7 +39,7 @@ test_params = [
         OmniServerParams(
             model=_MODEL,
             stage_config_path=_CI_DEPLOY,
-            use_stage_cli=True,
+            use_stage_cli=False,
             server_args=["--trust-remote-code", "--async-chunk"],
         ),
         id="async_chunk",


### PR DESCRIPTION
### Summary
Switch MiniCPM-o 4.5 expansion and invalid-param online tests from use_stage_cli=True (OmniServerStageCli) to use_stage_cli=False (standard OmniServer / vllm serve --omni).
Keep the same deploy YAML via --stage-configs-path, so stage topology and sampling config stay unchanged while CI exercises the same entrypoint as production serving.
Avoid the stage-CLI launch path, which can diverge from the AsyncOmniEngine transfer-config / connector init path used by normal omni serve.
