### PR TITLE
[Frontend] Add tool/function calling support to /v1/realtime for Qwen3-Omni

### DIFF
--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -208,6 +208,37 @@ WEATHER_TOOL = {
 }
 
 
+# Two cities in one utterance, to make the model request two calls in one turn.
+TOOL_CALLING_TWO_CITY_PHRASE_TEXT = "What is the weather like in Boston and in Denver right now?"
+
+# Distinct results per city, so the final reply shows each result reached the call
+# that asked for it rather than both being collapsed into one <tool_response>.
+_TOOL_RESULT_BY_CITY = {
+    "boston": "sunny and 72 degrees",
+    "denver": "snowing and 28 degrees",
+}
+
+
+def _tool_result_for(arguments: str) -> str:
+    """Answer a get_weather call based on the city it asked about."""
+    city = (json.loads(arguments).get("city") or "").lower()
+    for key, result in _TOOL_RESULT_BY_CITY.items():
+        if key in city:
+            return result
+    raise AssertionError(f"Tool call asked about an unexpected city: {arguments!r}")
+
+
+def _two_city_tool_calling_pcm16_input() -> bytes:
+    syn = generate_synthetic_audio(
+        10,
+        1,
+        sample_rate=16000,
+        phrase_text=TOOL_CALLING_TWO_CITY_PHRASE_TEXT,
+    )
+    wav_bytes = base64.b64decode(syn["base64"])
+    return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
+
+
 def _tool_calling_pcm16_input() -> bytes:
     syn = generate_synthetic_audio(
         10,
@@ -233,8 +264,10 @@ async def _run_realtime_tool_call_roundtrip(
     bytes_per_ms = 16000 * 2 // 1000
     chunk_bytes = max(bytes_per_ms * chunk_ms, 2)
 
-    tool_call_name: str | None = None
-    tool_call_args = ""
+    # Keyed by call_id: with parallel calls the added/delta/done events for the
+    # two calls interleave, so per-call state cannot be a single accumulator.
+    calls: dict[str, dict[str, str]] = {}
+    call_order: list[str] = []
     final_text_chunks: list[str] = []
     final_text = ""
     saw_final_audio_delta = False
@@ -259,13 +292,16 @@ async def _run_realtime_tool_call_roundtrip(
             if event_type in ("session.created", "transcription.delta"):
                 continue
             if event_type == "response.output_item.added":
-                tool_call_name = event["item"]["name"]
+                call_id = event["item"]["call_id"]
+                calls[call_id] = {"name": event["item"]["name"], "arguments": ""}
+                call_order.append(call_id)
                 continue
             if event_type == "response.function_call_arguments.delta":
-                tool_call_args += event["delta"]
+                calls[event["call_id"]]["arguments"] += event["delta"]
                 continue
             if event_type == "response.function_call_arguments.done":
-                # Answer the tool call so generation resumes with a real result.
+                # Answer with a result keyed to the requested city, so a parallel
+                # pair can be checked for having each result matched to its call.
                 await ws.send(
                     json.dumps(
                         {
@@ -273,7 +309,7 @@ async def _run_realtime_tool_call_roundtrip(
                             "item": {
                                 "type": "function_call_output",
                                 "call_id": event["call_id"],
-                                "output": "sunny and 72 degrees",
+                                "output": _tool_result_for(event["arguments"]),
                             },
                         }
                     )
@@ -292,9 +328,14 @@ async def _run_realtime_tool_call_roundtrip(
                 raise AssertionError(f"WebSocket error: {event}")
             raise AssertionError(f"Unexpected WebSocket event: {event}")
 
+    ordered = [calls[cid] for cid in call_order]
     return {
-        "tool_call_name": tool_call_name,
-        "tool_call_arguments": tool_call_args,
+        # Single-call view, kept for the one-city test.
+        "tool_call_name": ordered[0]["name"] if ordered else None,
+        "tool_call_arguments": ordered[0]["arguments"] if ordered else "",
+        # Full view, in the order the model requested the calls.
+        "calls": ordered,
+        "call_ids": list(call_order),
         "final_text": final_text,
         "saw_final_audio_delta": saw_final_audio_delta,
     }
@@ -310,6 +351,25 @@ def _assert_tool_call_roundtrip(result: dict) -> None:
     assert "boston" in parsed_args["city"].lower()
     assert result["final_text"], "Expected a spoken final reply after the tool result was submitted"
     assert "72" in result["final_text"], f"Expected the mocked tool result to reach the final reply: {result}"
+    assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
+
+
+def _assert_two_call_roundtrip(result: dict) -> None:
+    """Both results must reach the reply, which requires each `role="tool"` message
+    to be its own `<tool_response>` block - joining them into one leaves the model
+    unable to tell which result answered which call."""
+    calls = result["calls"]
+    assert len(calls) == 2, f"Expected two parallel tool calls, got {len(calls)}: {calls}"
+    assert len(set(result["call_ids"])) == 2, f"Expected distinct call_ids: {result['call_ids']}"
+    assert {c["name"] for c in calls} == {"get_weather"}, calls
+
+    cities = [json.loads(c["arguments"])["city"].lower() for c in calls]
+    assert any("boston" in c for c in cities), cities
+    assert any("denver" in c for c in cities), cities
+
+    final = result["final_text"].lower()
+    assert "72" in final, f"Boston's result did not reach the reply: {result['final_text']!r}"
+    assert "28" in final, f"Denver's result did not reach the reply: {result['final_text']!r}"
     assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
 
 
@@ -432,3 +492,30 @@ class TestQwen3OmniRealtimeWebSocket:
         )
 
         _assert_tool_call_roundtrip(result)
+
+    @pytest.mark.advanced_model
+    @pytest.mark.omni
+    @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+    @pytest.mark.parametrize("omni_server", realtime_sync_server_params, indirect=True)
+    def test_two_call_tool_round_trip(self, omni_server) -> None:
+        """Merge CI: one utterance naming two cities -> the model requests two
+        `get_weather` calls -> the test client answers each with a distinct result
+        -> both results reach the spoken reply.
+
+        This is the case that fails when parallel results are joined into a single
+        `role="tool"` message: the template then emits one `<tool_response>` holding
+        both outputs, and the model cannot tell which result answered which call.
+        Same `async_chunk`-off requirement as the single-call test above.
+        """
+        pcm16 = _two_city_tool_calling_pcm16_input()
+
+        result = asyncio.run(
+            _run_realtime_tool_call_roundtrip(
+                omni_server.host,
+                omni_server.port,
+                omni_server.model,
+                pcm16,
+            )
+        )
+
+        _assert_two_call_roundtrip(result)

--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -189,6 +189,130 @@ def _synthetic_pcm16_input() -> bytes:
     return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
 
 
+# Distinct cache entry from REALTIME_SYNTH_PHRASE_TEXT above - must actually ask
+# something the weather tool below plausibly answers, so the model has a real
+# reason to call it (not just prompted to via `tools=`).
+TOOL_CALLING_PHRASE_TEXT = "What is the weather like in Boston right now?"
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def _tool_calling_pcm16_input() -> bytes:
+    syn = generate_synthetic_audio(
+        10,
+        1,
+        sample_rate=16000,
+        phrase_text=TOOL_CALLING_PHRASE_TEXT,
+    )
+    wav_bytes = base64.b64decode(syn["base64"])
+    return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
+
+
+async def _run_realtime_tool_call_roundtrip(
+    host: str,
+    port: int,
+    model: str,
+    pcm16: bytes,
+    *,
+    chunk_ms: int = 200,
+) -> dict:
+    """Drive one full tool-calling exchange: model calls a tool, test client
+    answers it, generation resumes and speaks the final reply."""
+    uri = f"ws://{host}:{port}/v1/realtime"
+    bytes_per_ms = 16000 * 2 // 1000
+    chunk_bytes = max(bytes_per_ms * chunk_ms, 2)
+
+    tool_call_name: str | None = None
+    tool_call_args = ""
+    final_text_chunks: list[str] = []
+    final_text = ""
+    saw_final_audio_delta = False
+
+    async with websockets.connect(uri, max_size=64 * 1024 * 1024) as ws:
+        await ws.send(json.dumps({"type": "session.update", "model": model, "tools": [WEATHER_TOOL]}))
+        await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": False}))
+        for i in range(0, len(pcm16), chunk_bytes):
+            chunk = pcm16[i : i + chunk_bytes]
+            await ws.send(
+                json.dumps({"type": "input_audio_buffer.append", "audio": base64.b64encode(chunk).decode("utf-8")})
+            )
+        await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": True}))
+
+        while True:
+            message = await asyncio.wait_for(ws.recv(), timeout=600)
+            if isinstance(message, bytes):
+                continue
+            event = json.loads(message)
+            event_type = event.get("type")
+
+            if event_type in ("session.created", "transcription.delta"):
+                continue
+            if event_type == "response.output_item.added":
+                tool_call_name = event["item"]["name"]
+                continue
+            if event_type == "response.function_call_arguments.delta":
+                tool_call_args += event["delta"]
+                continue
+            if event_type == "response.function_call_arguments.done":
+                # Answer the tool call so generation resumes with a real result.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "conversation.item.create",
+                            "item": {
+                                "type": "function_call_output",
+                                "call_id": event["call_id"],
+                                "output": "sunny and 72 degrees",
+                            },
+                        }
+                    )
+                )
+                continue
+            if event_type == "response.audio.delta":
+                saw_final_audio_delta = True
+                continue
+            if event_type == "transcription.done":
+                final_text_chunks.append(event.get("text", ""))
+                final_text = event.get("text", "") or "".join(final_text_chunks)
+                continue
+            if event_type == "response.audio.done":
+                break
+            if event_type == "error":
+                raise AssertionError(f"WebSocket error: {event}")
+            raise AssertionError(f"Unexpected WebSocket event: {event}")
+
+    return {
+        "tool_call_name": tool_call_name,
+        "tool_call_arguments": tool_call_args,
+        "final_text": final_text,
+        "saw_final_audio_delta": saw_final_audio_delta,
+    }
+
+
+def _assert_tool_call_roundtrip(result: dict) -> None:
+    assert result["tool_call_name"] == "get_weather", (
+        f"Expected the model to call get_weather, got {result['tool_call_name']!r} "
+        f"(final_text={result['final_text']!r})"
+    )
+    parsed_args = json.loads(result["tool_call_arguments"])  # must be valid JSON, not e.g. '{"city": "Boston"}}\\n'
+    assert "city" in parsed_args
+    assert "boston" in parsed_args["city"].lower()
+    assert result["final_text"], "Expected a spoken final reply after the tool result was submitted"
+    assert "72" in result["final_text"], f"Expected the mocked tool result to reach the final reply: {result}"
+    assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
+
+
 def _assert_realtime_smoke(result: dict) -> None:
     out_pcm = result["output_pcm"]
     assert result["delta_events"] >= 1
@@ -281,3 +405,30 @@ class TestQwen3OmniRealtimeWebSocket:
 
         _assert_realtime_smoke(result)
         _assert_realtime_accuracy(result)
+
+    @pytest.mark.advanced_model
+    @pytest.mark.omni
+    @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+    @pytest.mark.parametrize("omni_server", realtime_sync_server_params, indirect=True)
+    def test_tool_calling_round_trip(self, omni_server) -> None:
+        """Merge CI: session.update.tools -> model calls get_weather -> test
+        client submits a function_call_output -> generation resumes and
+        speaks a final reply that incorporates the (mocked) tool result.
+
+        Requires async_chunk off (same server config as the non-async_chunk
+        streaming test above) - the realtime endpoint's generation loop only
+        sees one complete thinker turn to scan for a <tool_call> block when
+        async_chunk is disabled.
+        """
+        pcm16 = _tool_calling_pcm16_input()
+
+        result = asyncio.run(
+            _run_realtime_tool_call_roundtrip(
+                omni_server.host,
+                omni_server.port,
+                omni_server.model,
+                pcm16,
+            )
+        )
+
+        _assert_tool_call_roundtrip(result)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -210,3 +210,52 @@ class TestRenderTokenPromptReattachesAudio:
 
         assert conn._turn_prompt["prompt_token_ids"] == [10, 11]
         assert conn._turn_prompt["multi_modal_data"] is audio
+
+
+class TestCloseAssistantTurnBeforeToolResult:
+    """Regression test for a real bug: the tool-result suffix opens with
+    `<|im_start|>user`, but the raw generated token ids stop at the tool call
+    without the `<|im_end|>` the chat template would emit. Splicing them
+    directly produced `</tool_call><|im_start|>user`, leaving the assistant turn
+    open. The thinker answered that malformed conversation by re-emitting the
+    same tool call, looping until something bounded it - while the reference HF
+    path (apply_chat_template, which closes the turn) answered the identical
+    prompt correctly. Verified against a live Qwen3-Omni realtime session:
+    tool results that previously looped 8+ times now answer in one round, with
+    wording matching the reference implementation."""
+
+    class _Tok:
+        unk_token_id = 0
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            assert token == "<|im_end|>"
+            return 151645
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert text == "\n"
+            return [198]
+
+    def test_appends_terminator_and_newline(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 2, 3])
+        assert out == [1, 2, 3, 151645, 198]
+
+    def test_adds_only_newline_when_terminator_present(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 2, 151645])
+        assert out == [1, 2, 151645, 198]
+
+    def test_is_idempotent_when_already_closed(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 151645, 198])
+        assert out == [1, 151645, 198]
+
+    def test_does_not_mutate_caller_list(self) -> None:
+        original = [1, 2, 3]
+        RealtimeConnection._close_assistant_turn(self._Tok(), original)
+        assert original == [1, 2, 3]
+
+    def test_unknown_terminator_leaves_splice_untouched(self) -> None:
+        class _Bad(self._Tok().__class__):
+            def convert_tokens_to_ids(self, token: str) -> int:
+                return 0  # == unk_token_id
+
+        out = RealtimeConnection._close_assistant_turn(_Bad(), [1, 2, 3])
+        assert out == [1, 2, 3]

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 
 import numpy as np
 import pytest
 import torch
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -20,6 +22,15 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 @pytest.fixture
 def realtime_conn() -> RealtimeConnection:
     return RealtimeConnection.__new__(RealtimeConnection)
+
+
+@pytest.fixture
+def tool_call_conn() -> RealtimeConnection:
+    conn = RealtimeConnection.__new__(RealtimeConnection)
+    conn._tools = None
+    conn._tool_result_queue = asyncio.Queue()
+    conn._pending_tool_calls = {}
+    return conn
 
 
 class TestRealtimeConnectionTensorAndPcm:
@@ -84,3 +95,54 @@ class TestAsyncOmniStreamingParamsValidation:
         p = SamplingParams(n=1, stop=["\n"], output_kind=RequestOutputKind.DELTA)
         with pytest.raises(ValueError, match="Input streaming"):
             AsyncOmni._validate_streaming_input_sampling_params(p)
+
+
+class TestRealtimeConnectionToolCallEventRouting:
+    """handle_event's tool-calling additions (session.update.tools capture,
+    conversation.item.create routing) - see realtime_tool_calls.py for the
+    <tool_call> text parser these events feed."""
+
+    def _patch_base_handle_event(self, mocker):
+        return mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+
+    def test_session_update_captures_tools_and_delegates_to_base(self, tool_call_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        event = {"type": "session.update", "model": "qwen3-omni", "tools": tools}
+
+        asyncio.run(tool_call_conn.handle_event(event))
+
+        assert tool_call_conn._tools == tools
+        base_handle_event.assert_awaited_once_with(event)
+
+    def test_session_update_without_tools_leaves_existing_tools_untouched(self, tool_call_conn, mocker) -> None:
+        self._patch_base_handle_event(mocker)
+        tool_call_conn._tools = [{"type": "function", "function": {"name": "existing"}}]
+
+        asyncio.run(tool_call_conn.handle_event({"type": "session.update", "model": "qwen3-omni"}))
+
+        assert tool_call_conn._tools == [{"type": "function", "function": {"name": "existing"}}]
+
+    def test_conversation_item_create_function_call_output_is_queued(self, tool_call_conn) -> None:
+        item = {"type": "function_call_output", "call_id": "call_1", "output": "sunny and 72"}
+
+        asyncio.run(tool_call_conn.handle_event({"type": "conversation.item.create", "item": item}))
+
+        assert tool_call_conn._tool_result_queue.qsize() == 1
+        assert tool_call_conn._tool_result_queue.get_nowait() == item
+
+    def test_conversation_item_create_unsupported_item_type_sends_error(self, tool_call_conn, mocker) -> None:
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+
+        asyncio.run(tool_call_conn.handle_event({"type": "conversation.item.create", "item": {"type": "not_a_thing"}}))
+
+        send_error.assert_awaited_once()
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_unrelated_event_types_still_delegate_to_base(self, tool_call_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        event = {"type": "input_audio_buffer.commit", "final": True}
+
+        asyncio.run(tool_call_conn.handle_event(event))
+
+        base_handle_event.assert_awaited_once_with(event)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
+from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -146,3 +147,66 @@ class TestRealtimeConnectionToolCallEventRouting:
         asyncio.run(tool_call_conn.handle_event(event))
 
         base_handle_event.assert_awaited_once_with(event)
+
+
+class TestRenderTokenPromptReattachesAudio:
+    """Regression test for a real bug: the tool-call continuation re-submitted
+    the engine's POST-expansion `output.prompt_token_ids` as a bare
+    TokensPrompt. Those ids still contain the expanded `<|audio_pad|>` run for
+    the user's spoken turn, but with no `multi_modal_data` the audio encoder
+    output is gone - so the thinker saw placeholder tokens backed by nothing,
+    lost the question entirely, and "answered" by emitting further tool calls
+    for unrelated cities/items (and even fabricating tool results) instead of
+    replying, never terminating. Fixed by splicing onto the PRE-expansion
+    prompt and re-attaching its audio on every continuation."""
+
+    def _conn(self, mocker):
+        conn = RealtimeConnection.__new__(RealtimeConnection)
+        conn.serving = mocker.Mock()
+        conn.serving.model_config.is_encoder_decoder = False
+        conn.serving.renderer.render_cmpl_async = mocker.AsyncMock(side_effect=lambda prompts: [dict(prompts[0])])
+        return conn
+
+    @staticmethod
+    def _first(gen):
+        async def _run():
+            return await anext(gen)
+
+        return asyncio.run(_run())
+
+    def test_audio_is_reattached_to_continuation_prompt(self, mocker) -> None:
+        conn = self._conn(mocker)
+        audio = {"audio": np.zeros(16000, dtype=np.float32)}
+
+        result = self._first(conn._render_token_prompt([1, 2, 3], audio))
+
+        assert result.prompt["multi_modal_data"] is audio
+
+    def test_no_multi_modal_data_is_a_noop(self, mocker) -> None:
+        conn = self._conn(mocker)
+
+        result = self._first(conn._render_token_prompt([1, 2, 3]))
+
+        assert "multi_modal_data" not in result.prompt
+
+    def test_turn_prompt_capture_keeps_unexpanded_ids_and_audio(self, mocker) -> None:
+        """_buffer_realtime_audio_with_tools must stash the pre-render prompt so
+        the continuation has something audio-bearing to splice onto."""
+        conn = self._conn(mocker)
+        conn._tools = None
+        conn._turn_prompt = None
+        audio = {"audio": np.zeros(8000, dtype=np.float32)}
+        prompt = TokensPrompt(prompt_token_ids=[10, 11], multi_modal_data=audio)
+
+        async def _fake_buffer(*_args, **_kwargs):
+            yield prompt
+
+        conn.serving.model_cls.buffer_realtime_audio = _fake_buffer
+
+        async def _drain():
+            return [x async for x in conn._buffer_realtime_audio_with_tools(None, None)]
+
+        asyncio.run(_drain())
+
+        assert conn._turn_prompt["prompt_token_ids"] == [10, 11]
+        assert conn._turn_prompt["multi_modal_data"] is audio

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from dataclasses import dataclass, field
 
 import numpy as np
 import pytest
@@ -25,6 +26,18 @@ def realtime_conn() -> RealtimeConnection:
     return RealtimeConnection.__new__(RealtimeConnection)
 
 
+@dataclass
+class _FakeModelConfig:
+    """Only the field `_async_chunk_enabled` reads."""
+
+    async_chunk: bool = False
+
+
+@dataclass
+class _FakeServing:
+    model_config: _FakeModelConfig = field(default_factory=_FakeModelConfig)
+
+
 @pytest.fixture
 def tool_call_conn() -> RealtimeConnection:
     conn = RealtimeConnection.__new__(RealtimeConnection)
@@ -32,6 +45,9 @@ def tool_call_conn() -> RealtimeConnection:
     conn._tool_result_queue = asyncio.Queue()
     conn._pending_tool_calls = {}
     conn._tool_rounds = 0
+    # Tool calling is only supported with async_chunk off, so that is the default
+    # here; tests that care about the other mode set it explicitly.
+    conn.serving = _FakeServing()
     return conn
 
 
@@ -323,3 +339,166 @@ class TestToolResultWaitReleasesOnDisconnect:
         asyncio.run(asyncio.wait_for(tool_call_conn._await_tool_results_and_continue([1], [2]), timeout=5))
 
         run_generation.assert_not_awaited()
+
+
+class TestParallelToolResultsRenderSeparateBlocks:
+    """Review #5555: joining parallel tool results into one `role="tool"` message
+    produced a single `<tool_response>` holding both outputs, so the model could
+    not associate each result with its call. The chat template emits one
+    `<tool_response>` per tool message (grouping consecutive tool messages under
+    one user turn), so each result must be its own message, in call order.
+    """
+
+    @staticmethod
+    def _capture_suffix(conn, mocker, pending: dict[int, _PendingToolCall]) -> list[dict[str, str]]:
+        """Drive `_await_tool_results_and_continue` and return the message list
+        handed to the chat template."""
+        conn._is_connected = True
+        conn._tool_rounds = 0
+        conn._turn_prompt = None
+        conn._pending_tool_calls = pending
+        conn.serving = mocker.Mock()
+        mocker.patch.object(conn, "_run_generation", new_callable=mocker.AsyncMock)
+        mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.cached_tokenizer_from_config",
+            return_value=mocker.Mock(
+                encode=lambda text, add_special_tokens=True: [9],
+                convert_tokens_to_ids=lambda token: 151645,
+                unk_token_id=0,
+            ),
+        )
+        mocker.patch("vllm_omni.entrypoints.openai.realtime_connection.cached_processor_from_config")
+        apply_tmpl = mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.safe_apply_chat_template",
+            return_value="<|im_start|>user\nr<|im_end|>\n<|im_start|>assistant\n",
+        )
+        asyncio.run(conn._await_tool_results_and_continue([1, 2], [3]))
+        return apply_tmpl.call_args.args[2]
+
+    def test_two_results_become_two_tool_messages_in_call_order(self, tool_call_conn, mocker) -> None:
+        pending = {
+            0: _PendingToolCall(call_id="call_a", name="get_weather"),
+            1: _PendingToolCall(call_id="call_b", name="get_weather"),
+        }
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "sunny 72"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_b", "output": "rainy 55"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert messages == [
+            {"role": "tool", "content": "sunny 72"},
+            {"role": "tool", "content": "rainy 55"},
+        ]
+
+    def test_call_order_is_kept_when_results_arrive_reversed(self, tool_call_conn, mocker) -> None:
+        """Arrival order is the client's choice; call order is the model's."""
+        pending = {
+            0: _PendingToolCall(call_id="call_a", name="get_weather"),
+            1: _PendingToolCall(call_id="call_b", name="get_weather"),
+        }
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_b", "output": "rainy 55"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "sunny 72"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert [m["content"] for m in messages] == ["sunny 72", "rainy 55"]
+
+    def test_duplicate_result_for_one_call_does_not_desync_the_wait(self, tool_call_conn, mocker) -> None:
+        pending = {0: _PendingToolCall(call_id="call_a", name="get_weather")}
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "first"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "second"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert messages == [{"role": "tool", "content": "first"}]
+
+
+class TestToolResultValidation:
+    """Review #5555: any dict with `type="function_call_output"` was enqueued, so a
+    missing/non-string `call_id` or a non-string `output` was accepted and the turn
+    then waited for a result that could never match - with nothing reported to the
+    client. Shape problems are protocol errors."""
+
+    @staticmethod
+    def _create(item: dict) -> dict:
+        return {"type": "conversation.item.create", "item": item}
+
+    def _run(self, conn, mocker, item: dict):
+        send_error = mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+        asyncio.run(conn.handle_event(self._create(item)))
+        return send_error
+
+    def test_missing_call_id_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(tool_call_conn, mocker, {"type": "function_call_output", "output": "x"})
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_non_string_call_id_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(tool_call_conn, mocker, {"type": "function_call_output", "call_id": 7, "output": "x"})
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_non_string_output_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(
+            tool_call_conn, mocker, {"type": "function_call_output", "call_id": "call_a", "output": {"a": 1}}
+        )
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_well_formed_result_is_enqueued(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(
+            tool_call_conn, mocker, {"type": "function_call_output", "call_id": "call_a", "output": "sunny"}
+        )
+        send_error.assert_not_awaited()
+        assert tool_call_conn._tool_result_queue.qsize() == 1
+
+    def test_unknown_call_id_is_reported_to_the_client(self, tool_call_conn, mocker) -> None:
+        """Previously only logged, so a client typo produced silence."""
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = 0
+        tool_call_conn._pending_tool_calls = {0: _PendingToolCall(call_id="call_a", name="get_weather")}
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_TYPO", "output": "sunny"})
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        async def _drive() -> None:
+            task = asyncio.ensure_future(tool_call_conn._await_tool_results_and_continue([1], [2]))
+            for _ in range(40):
+                await asyncio.sleep(0.02)
+                if send_error.await_count:
+                    break
+            tool_call_conn._is_connected = False
+            await asyncio.wait_for(task, timeout=5)
+
+        asyncio.run(_drive())
+
+        assert send_error.await_args.args[1] == "unknown_tool_call_id"
+
+
+class TestToolsRejectedUnderAsyncChunk:
+    """Review #5555: with async_chunk on, the buffer yields one TokensPrompt per
+    segment, so a tool-call continuation reattached only the final segment and lost
+    the start of the utterance. Aggregating the audio would not be enough - the
+    generation loop also never sees one complete thinker turn to scan for a
+    <tool_call> block - so tools are refused outright instead."""
+
+    def _session_update(self, conn, mocker, async_chunk: bool):
+        conn.serving = _FakeServing(_FakeModelConfig(async_chunk=async_chunk))
+        send_error = mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        base = mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        asyncio.run(conn.handle_event({"type": "session.update", "model": "m", "tools": tools}))
+        return send_error, base
+
+    def test_tools_rejected_when_async_chunk_enabled(self, tool_call_conn, mocker) -> None:
+        send_error, base = self._session_update(tool_call_conn, mocker, async_chunk=True)
+        assert send_error.await_args.args[1] == "tools_require_no_async_chunk"
+        assert tool_call_conn._tools is None
+        base.assert_awaited_once()
+
+    def test_tools_accepted_when_async_chunk_disabled(self, tool_call_conn, mocker) -> None:
+        send_error, _ = self._session_update(tool_call_conn, mocker, async_chunk=False)
+        send_error.assert_not_awaited()
+        assert tool_call_conn._tools == [{"type": "function", "function": {"name": "get_weather"}}]

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -15,7 +15,7 @@ from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
-from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection
+from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection, _PendingToolCall
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -31,6 +31,7 @@ def tool_call_conn() -> RealtimeConnection:
     conn._tools = None
     conn._tool_result_queue = asyncio.Queue()
     conn._pending_tool_calls = {}
+    conn._tool_rounds = 0
     return conn
 
 
@@ -259,3 +260,66 @@ class TestCloseAssistantTurnBeforeToolResult:
 
         out = RealtimeConnection._close_assistant_turn(_Bad(), [1, 2, 3])
         assert out == [1, 2, 3]
+
+
+class TestToolChainIsBounded:
+    """A model that keeps re-emitting tool calls instead of answering must not
+    recurse without bound: `_await_tool_results_and_continue` re-enters
+    `_run_generation`, so an unbounded chain grows the stack and holds every
+    round's result generator open. Observed during bring-up when the spliced
+    prompt was malformed (see TestCloseAssistantTurnBeforeToolResult)."""
+
+    def test_exceeding_max_rounds_reports_error_and_stops(self, tool_call_conn, mocker) -> None:
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = RealtimeConnection.MAX_TOOL_ROUNDS
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        asyncio.run(tool_call_conn._await_tool_results_and_continue([1, 2], [3]))
+
+        send_error.assert_awaited_once()
+        assert send_error.await_args.args[1] == "tool_call_loop"
+        run_generation.assert_not_awaited()
+
+    def test_rounds_below_the_cap_still_continue(self, tool_call_conn, mocker) -> None:
+        """The cap must not fire early: with no pending calls the wait loop is
+        skipped and generation continues."""
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = 0
+        tool_call_conn._turn_prompt = None
+        mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.cached_tokenizer_from_config",
+            return_value=mocker.Mock(
+                encode=lambda text, add_special_tokens=True: [9],
+                convert_tokens_to_ids=lambda token: 151645,
+                unk_token_id=0,
+            ),
+        )
+        mocker.patch("vllm_omni.entrypoints.openai.realtime_connection.cached_processor_from_config")
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.safe_apply_chat_template",
+            return_value="<|im_start|>user\nresult<|im_end|>\n<|im_start|>assistant\n",
+        )
+        tool_call_conn.serving = mocker.Mock()
+
+        asyncio.run(tool_call_conn._await_tool_results_and_continue([1, 2], [3]))
+
+        run_generation.assert_awaited_once()
+
+
+class TestToolResultWaitReleasesOnDisconnect:
+    """A client that vanishes mid-tool-call must not park the generation task
+    forever. The wait is bounded so `_is_connected` is re-checked instead of
+    blocking indefinitely on an empty queue."""
+
+    def test_wait_returns_when_client_disconnects(self, tool_call_conn, mocker) -> None:
+        tool_call_conn._is_connected = False  # client already gone
+        tool_call_conn._pending_tool_calls = {0: _PendingToolCall(call_id="call_x", name="get_weather")}
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        # Returns rather than hanging on the empty queue.
+        asyncio.run(asyncio.wait_for(tool_call_conn._await_tool_results_and_continue([1], [2]), timeout=5))
+
+        run_generation.assert_not_awaited()

--- a/tests/entrypoints/test_realtime_tool_calls.py
+++ b/tests/entrypoints/test_realtime_tool_calls.py
@@ -7,12 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_omni.entrypoints.openai.realtime_tool_calls import (
-    ToolCallStreamState,
-    extract_complete_tool_calls,
-    extract_deltas,
-    strip_tool_calls,
-)
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -118,45 +113,3 @@ class TestExtractDeltasToolCallLifecycle:
                 args_by_index[d.index] += d.arguments_delta
         assert args_by_index[0] == '{"city": "Boston"}'
         assert args_by_index[1] == '{"tz": "EST"}'
-
-
-class TestExtractCompleteToolCalls:
-    def test_single_complete_call(self) -> None:
-        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
-        calls = extract_complete_tool_calls(text)
-        assert calls == [{"name": "get_weather", "arguments": {"city": "Boston"}}]
-
-    def test_no_tool_call_returns_empty(self) -> None:
-        assert extract_complete_tool_calls("just some regular text") == []
-
-    def test_incomplete_block_ignored(self) -> None:
-        text = '<tool_call>\n{"name": "get_weather", "arguments": {'
-        assert extract_complete_tool_calls(text) == []
-
-    def test_malformed_json_skipped_not_raised(self) -> None:
-        text = "<tool_call>\nnot json at all\n</tool_call>"
-        assert extract_complete_tool_calls(text) == []
-
-    def test_multiple_calls_all_parsed(self) -> None:
-        text = (
-            '<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
-            '<tool_call>\n{"name": "b", "arguments": {"x": 1}}\n</tool_call>'
-        )
-        calls = extract_complete_tool_calls(text)
-        assert [c["name"] for c in calls] == ["a", "b"]
-
-
-class TestStripToolCalls:
-    def test_removes_tool_call_block(self) -> None:
-        text = 'Sure.<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
-        assert strip_tool_calls(text) == "Sure."
-
-    def test_no_tool_call_returns_stripped_text(self) -> None:
-        assert strip_tool_calls("  plain text  ") == "plain text"
-
-    def test_multiple_tool_calls_all_removed(self) -> None:
-        text = (
-            'Before<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
-            'Middle<tool_call>\n{"name": "b", "arguments": {}}\n</tool_call>After'
-        )
-        assert strip_tool_calls(text) == "BeforeMiddleAfter"

--- a/tests/entrypoints/test_realtime_tool_calls.py
+++ b/tests/entrypoints/test_realtime_tool_calls.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the self-contained <tool_call> parser used by the
+/v1/realtime tool-calling extension (see realtime_tool_calls.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_omni.entrypoints.openai.realtime_tool_calls import (
+    ToolCallStreamState,
+    extract_complete_tool_calls,
+    extract_deltas,
+    strip_tool_calls,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestExtractDeltasPlainContent:
+    def test_plain_text_no_tool_call_streams_as_content(self) -> None:
+        state = ToolCallStreamState()
+        content, deltas = extract_deltas("Hello", state)
+        assert content == "Hello"
+        assert deltas == []
+        assert not state.has_tool_calls()
+
+    def test_content_only_advances_incrementally(self) -> None:
+        state = ToolCallStreamState()
+        first, _ = extract_deltas("Hello", state)
+        second, _ = extract_deltas("Hello, world", state)
+        assert first == "Hello"
+        assert second == ", world"
+
+    def test_withholds_partial_start_tag_suffix(self) -> None:
+        state = ToolCallStreamState()
+        content, deltas = extract_deltas("Sure thing<tool_c", state)
+        # "<tool_c" could still turn into "<tool_call>"; must not be sent as content yet.
+        assert content == "Sure thing"
+        assert deltas == []
+
+
+class TestExtractDeltasToolCallLifecycle:
+    def test_name_delta_emitted_once_available(self) -> None:
+        state = ToolCallStreamState()
+        text = '<tool_call>\n{"name": "get_weather", "arguments": '
+        _, deltas = extract_deltas(text, state)
+        assert len(deltas) == 1
+        assert deltas[0].index == 0
+        assert deltas[0].name == "get_weather"
+        assert deltas[0].arguments_delta == ""
+        assert state.has_tool_calls()
+
+    def test_name_not_emitted_twice(self) -> None:
+        state = ToolCallStreamState()
+        extract_deltas('<tool_call>\n{"name": "get_weather", "arguments": {}', state)
+        _, deltas = extract_deltas('<tool_call>\n{"name": "get_weather", "arguments": {}}', state)
+        assert all(d.name is None for d in deltas)
+
+    def test_arguments_stream_incrementally_as_suffix_diff(self) -> None:
+        state = ToolCallStreamState()
+        chunks = [
+            '<tool_call>\n{"name": "get_weather", "arguments": {"',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city":',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}',
+        ]
+        collected_args = ""
+        for chunk in chunks:
+            _, deltas = extract_deltas(chunk, state)
+            for d in deltas:
+                collected_args += d.arguments_delta
+        assert collected_args == '{"city": "Boston"}'
+
+    def test_full_block_including_trailing_outer_brace_and_newline(self) -> None:
+        """Regression: the outer {"name":..., "arguments":...} object's own
+        closing brace and the newline before </tool_call> must never leak
+        into the arguments value, even when they arrive in the same chunk
+        as the arguments value's own closing brace."""
+        state = ToolCallStreamState()
+        full_text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+        _, deltas = extract_deltas(full_text, state)
+        args_deltas = [d.arguments_delta for d in deltas if d.arguments_delta]
+        combined = "".join(args_deltas)
+        assert combined == '{"city": "Boston"}'
+        import json
+
+        json.loads(combined)  # must be valid JSON, not '{"city": "Boston"}}\n'
+
+    def test_nested_object_in_arguments_not_truncated_early(self) -> None:
+        state = ToolCallStreamState()
+        full_text = (
+            '<tool_call>\n{"name": "book_flight", '
+            '"arguments": {"from": "BOS", "to": "SFO", "options": {"nonstop": true}}}\n</tool_call>'
+        )
+        _, deltas = extract_deltas(full_text, state)
+        combined = "".join(d.arguments_delta for d in deltas if d.arguments_delta)
+        assert combined == '{"from": "BOS", "to": "SFO", "options": {"nonstop": true}}'
+
+    def test_content_before_tool_call_is_still_streamed(self) -> None:
+        state = ToolCallStreamState()
+        text = 'One moment<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+        content, _ = extract_deltas(text, state)
+        assert content == "One moment"
+
+    def test_multiple_tool_calls_tracked_by_independent_index(self) -> None:
+        state = ToolCallStreamState()
+        text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+            '<tool_call>\n{"name": "get_time", "arguments": {"tz": "EST"}}\n</tool_call>'
+        )
+        _, deltas = extract_deltas(text, state)
+        names = {d.index: d.name for d in deltas if d.name is not None}
+        assert names == {0: "get_weather", 1: "get_time"}
+        args_by_index: dict[int, str] = {0: "", 1: ""}
+        for d in deltas:
+            if d.arguments_delta:
+                args_by_index[d.index] += d.arguments_delta
+        assert args_by_index[0] == '{"city": "Boston"}'
+        assert args_by_index[1] == '{"tz": "EST"}'
+
+
+class TestExtractCompleteToolCalls:
+    def test_single_complete_call(self) -> None:
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+        calls = extract_complete_tool_calls(text)
+        assert calls == [{"name": "get_weather", "arguments": {"city": "Boston"}}]
+
+    def test_no_tool_call_returns_empty(self) -> None:
+        assert extract_complete_tool_calls("just some regular text") == []
+
+    def test_incomplete_block_ignored(self) -> None:
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {'
+        assert extract_complete_tool_calls(text) == []
+
+    def test_malformed_json_skipped_not_raised(self) -> None:
+        text = "<tool_call>\nnot json at all\n</tool_call>"
+        assert extract_complete_tool_calls(text) == []
+
+    def test_multiple_calls_all_parsed(self) -> None:
+        text = (
+            '<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
+            '<tool_call>\n{"name": "b", "arguments": {"x": 1}}\n</tool_call>'
+        )
+        calls = extract_complete_tool_calls(text)
+        assert [c["name"] for c in calls] == ["a", "b"]
+
+
+class TestStripToolCalls:
+    def test_removes_tool_call_block(self) -> None:
+        text = 'Sure.<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+        assert strip_tool_calls(text) == "Sure."
+
+    def test_no_tool_call_returns_stripped_text(self) -> None:
+        assert strip_tool_calls("  plain text  ") == "plain text"
+
+    def test_multiple_tool_calls_all_removed(self) -> None:
+        text = (
+            'Before<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
+            'Middle<tool_call>\n{"name": "b", "arguments": {}}\n</tool_call>After'
+        )
+        assert strip_tool_calls(text) == "BeforeMiddleAfter"

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -58,6 +58,13 @@ class RealtimeConnection(VllmRealtimeConnection):
         self.engine = cast(AsyncOmni, self.serving.engine_client)
         self._realtime_audio_ref: np.ndarray | None = None
         self._tools: list[dict[str, Any]] | None = None
+        # The current turn's prompt as handed to the engine BEFORE multimodal
+        # expansion: un-expanded `prompt_token_ids` (one `<|audio_pad|>`) plus the
+        # audio in `multi_modal_data`. Tool-call continuations rebuild from this
+        # rather than from the engine's post-expansion `output.prompt_token_ids`,
+        # because those contain the expanded audio placeholder run with no way to
+        # re-attach the audio - see _await_tool_results_and_continue.
+        self._turn_prompt: dict[str, Any] | None = None
         # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
         self._pending_tool_calls: dict[int, dict[str, Any]] = {}
         self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -109,10 +116,25 @@ class RealtimeConnection(VllmRealtimeConnection):
             audio_stream, input_stream, self.serving.model_config, tools=self._tools
         )
         async for prompt in stream_input_iter:
+            # Remember the pre-expansion prompt so tool-call continuations can
+            # re-anchor on the user's audio (see self._turn_prompt).
+            if isinstance(prompt, dict):
+                self._turn_prompt = dict(prompt)
             yield await self._render_prompt(prompt)
 
-    async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
-        yield await self._render_prompt(TokensPrompt(prompt_token_ids=prompt_token_ids))
+    async def _render_token_prompt(
+        self,
+        prompt_token_ids: list[int],
+        multi_modal_data: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[StreamingInput, None]:
+        token_prompt = TokensPrompt(prompt_token_ids=prompt_token_ids)
+        # Tool-call continuation: re-attach the turn's audio. Without it the
+        # `<|audio_pad|>` placeholder still sits in the token ids but has no
+        # encoder output behind it, so the thinker cannot see what the user asked
+        # and free-associates unrelated tool calls instead of answering.
+        if multi_modal_data:
+            token_prompt["multi_modal_data"] = multi_modal_data
+        yield await self._render_prompt(token_prompt)
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:
@@ -397,12 +419,27 @@ class RealtimeConnection(VllmRealtimeConnection):
             add_generation_prompt=True,
             tokenize=False,
         )
-        continuation_token_ids = (
-            list(prior_prompt_token_ids) + list(assistant_token_ids) + tokenizer.encode(suffix_text)
-        )
+        # Splice onto the turn's PRE-expansion prompt, not the engine's
+        # post-expansion `output.prompt_token_ids`. The latter carries the expanded
+        # `<|audio_pad|>` run, and re-submitting it as a bare TokensPrompt drops the
+        # audio itself: the thinker then sees placeholder tokens with no encoder
+        # output, loses the user's question entirely, and answers by inventing
+        # further tool calls (unrelated cities/items) instead of replying. Falling
+        # back to `prior_prompt_token_ids` only matters for a continuation that never
+        # went through buffer_realtime_audio (no audio to lose in that case).
+        base_prompt = self._turn_prompt or {}
+        base_token_ids = list(base_prompt.get("prompt_token_ids") or prior_prompt_token_ids)
+        multi_modal_data = base_prompt.get("multi_modal_data")
+        continuation_token_ids = base_token_ids + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+
+        # Advance the base so a chained tool call next round splices onto this
+        # turn's full history while the audio stays attached exactly once, at the
+        # front, still un-expanded.
+        if self._turn_prompt is not None:
+            self._turn_prompt = {**base_prompt, "prompt_token_ids": continuation_token_ids}
 
         input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
-        await self._run_generation(self._render_token_prompt(continuation_token_ids), input_stream)
+        await self._run_generation(self._render_token_prompt(continuation_token_ids, multi_modal_data), input_stream)
 
     async def send_json(self, payload: dict):
         try:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator, Mapping
+from dataclasses import dataclass
 from typing import Any, cast
 from uuid import uuid4
 
@@ -20,10 +21,25 @@ from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
-from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallDelta, ToolCallStreamState, extract_deltas
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
+
+# How long to block on a client tool result before re-checking the connection.
+# Only bounds the wait between liveness checks, not the total wait: a tool may
+# legitimately take a long time, but a client that has gone away must not leave
+# the generation task parked forever.
+_TOOL_RESULT_POLL_S = 0.5
+
+
+@dataclass
+class _PendingToolCall:
+    """A tool call being accumulated from the model's streamed output."""
+
+    call_id: str
+    name: str
+    arguments: str = ""
 
 
 class RealtimeConnection(VllmRealtimeConnection):
@@ -46,12 +62,20 @@ class RealtimeConnection(VllmRealtimeConnection):
       - generation then continues automatically with the tool result appended,
         streaming the model's actual spoken reply as normal.
 
-    No audio is synthesized/forwarded for a turn that turns out to be a tool
-    call - the underlying 3-stage pipeline (thinker->talker->code2wav) still
-    runs end to end for it (there is no clean lower-level hook to skip talker/
-    code2wav without changing the shared orchestrator - see PR description),
-    but the resulting audio bytes are simply not sent to the client.
+    Audio for a tool-call turn is not forwarded to the client once the
+    `<tool_call>` tag has been parsed - the underlying 3-stage pipeline
+    (thinker->talker->code2wav) still synthesizes it (there is no clean
+    lower-level hook to skip talker/code2wav without changing the shared
+    orchestrator - see PR description), the bytes are just dropped. Any audio
+    that arrived before the tag was recognized has already been sent; in
+    practice the tag appears in the thinker's text well ahead of the
+    corresponding synthesized audio.
+
+    A chain of tool calls is bounded by MAX_TOOL_ROUNDS.
     """
+
+    # Upper bound on consecutive tool-call rounds within one user turn.
+    MAX_TOOL_ROUNDS = 8
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,9 +89,11 @@ class RealtimeConnection(VllmRealtimeConnection):
         # because those contain the expanded audio placeholder run with no way to
         # re-attach the audio - see _await_tool_results_and_continue.
         self._turn_prompt: dict[str, Any] | None = None
-        # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
-        self._pending_tool_calls: dict[int, dict[str, Any]] = {}
+        # parser-assigned index (per generation) -> the call being accumulated
+        self._pending_tool_calls: dict[int, _PendingToolCall] = {}
         self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        # Consecutive tool-call rounds in this turn, bounded by MAX_TOOL_ROUNDS.
+        self._tool_rounds = 0
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")
@@ -89,6 +115,13 @@ class RealtimeConnection(VllmRealtimeConnection):
         if self.generation_task is not None and not self.generation_task.done():
             logger.warning("Generation already in progress, ignoring commit")
             return
+
+        # New user turn: reset the tool-round budget and discard any tool result
+        # left over from a previous turn, which would otherwise be consumed as if
+        # it answered one of this turn's calls.
+        self._tool_rounds = 0
+        while not self._tool_result_queue.empty():
+            self._tool_result_queue.get_nowait()
 
         audio_stream = self.audio_stream_generator()
         input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
@@ -219,26 +252,26 @@ class RealtimeConnection(VllmRealtimeConnection):
         pcm16 = (clipped * 32767.0).astype(np.int16)
         return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
-    async def _emit_tool_call_deltas(self, tool_deltas: list) -> None:
+    async def _emit_tool_call_deltas(self, tool_deltas: list[ToolCallDelta]) -> None:
         for delta in tool_deltas:
             if delta.name is not None:
-                call_id = f"call_{uuid4().hex[:24]}"
-                self._pending_tool_calls[delta.index] = {"call_id": call_id, "name": delta.name, "arguments": ""}
+                call = _PendingToolCall(call_id=f"call_{uuid4().hex[:24]}", name=delta.name)
+                self._pending_tool_calls[delta.index] = call
                 await self.send_json(
                     {
                         "type": "response.output_item.added",
-                        "item": {"type": "function_call", "name": delta.name, "call_id": call_id},
+                        "item": {"type": "function_call", "name": call.name, "call_id": call.call_id},
                     }
                 )
             if delta.arguments_delta:
-                info = self._pending_tool_calls.get(delta.index)
-                if info is None:
+                call = self._pending_tool_calls.get(delta.index)
+                if call is None:
                     continue  # shouldn't happen: name delta always precedes argument deltas for the same index
-                info["arguments"] += delta.arguments_delta
+                call.arguments += delta.arguments_delta
                 await self.send_json(
                     {
                         "type": "response.function_call_arguments.delta",
-                        "call_id": info["call_id"],
+                        "call_id": call.call_id,
                         "delta": delta.arguments_delta,
                     }
                 )
@@ -325,12 +358,12 @@ class RealtimeConnection(VllmRealtimeConnection):
                     break
 
             if tool_state.has_tool_calls():
-                for idx, info in self._pending_tool_calls.items():
+                for call in self._pending_tool_calls.values():
                     await self.send_json(
                         {
                             "type": "response.function_call_arguments.done",
-                            "call_id": info["call_id"],
-                            "arguments": info["arguments"],
+                            "call_id": call.call_id,
+                            "arguments": call.arguments,
                         }
                     )
                 if self._is_connected:
@@ -406,13 +439,31 @@ class RealtimeConnection(VllmRealtimeConnection):
         own generated tool-call tokens + a freshly-rendered tool-result turn)
         and continue generation - which streams the model's actual spoken
         reply as a normal `_run_generation` call, recursing again if the
-        model chains into another tool call."""
+        model chains into another tool call (bounded by MAX_TOOL_ROUNDS)."""
+        self._tool_rounds += 1
+        if self._tool_rounds > self.MAX_TOOL_ROUNDS:
+            # A model that keeps re-emitting tool calls instead of answering
+            # would otherwise recurse without bound. Observed during bring-up
+            # when the spliced prompt was malformed (see _close_assistant_turn).
+            logger.warning("tool-call chain exceeded %d rounds; abandoning turn", self.MAX_TOOL_ROUNDS)
+            if self._is_connected:
+                await self.send_error(
+                    f"Tool-call chain exceeded {self.MAX_TOOL_ROUNDS} rounds without a final response",
+                    "tool_call_loop",
+                )
+            return
+
         pending = dict(self._pending_tool_calls)
-        call_id_to_index = {info["call_id"]: idx for idx, info in pending.items()}
+        call_id_to_index = {call.call_id: idx for idx, call in pending.items()}
         results_by_index: dict[int, str] = {}
 
         while len(results_by_index) < len(pending) and self._is_connected:
-            item = await self._tool_result_queue.get()
+            # Bounded wait so a client that disappears mid-tool-call cannot park
+            # this task forever; a slow-but-live client is unaffected.
+            try:
+                item = await asyncio.wait_for(self._tool_result_queue.get(), timeout=_TOOL_RESULT_POLL_S)
+            except TimeoutError:
+                continue
             call_id = item.get("call_id")
             idx = call_id_to_index.get(call_id)
             if idx is None:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -72,6 +72,20 @@ class RealtimeConnection(VllmRealtimeConnection):
     corresponding synthesized audio.
 
     A chain of tool calls is bounded by MAX_TOOL_ROUNDS.
+
+    Scope and limitations of the tool-calling path:
+
+    - **Non-duplex only.** This is the half-duplex `/v1/realtime` path. The
+      full-duplex runtime under `experimental/fullduplex/` has no tool-calling
+      support and shares no code with this.
+    - **Requires `async_chunk` disabled.** `session.update` with `tools` is
+      rejected when the server runs in async-chunk mode; see
+      `_async_chunk_enabled` for why aggregating instead would not be enough.
+    - **Waits on client liveness.** Once the model has requested a tool, the turn
+      blocks until a `function_call_output` arrives for every pending call. There
+      is deliberately no deadline, because a slow tool is indistinguishable from
+      an absent one; a client that disconnects releases the wait, and malformed
+      or unknown results are reported back rather than silently dropped.
     """
 
     # Upper bound on consecutive tool-call rounds within one user turn.
@@ -100,16 +114,67 @@ class RealtimeConnection(VllmRealtimeConnection):
         if event_type == "session.update":
             tools = event.get("tools")
             if tools is not None:
-                self._tools = tools
+                if self._async_chunk_enabled():
+                    # Refuse rather than half-work. Two independent things break
+                    # under async_chunk: the buffer yields one TokensPrompt per
+                    # segment, so a tool-call continuation would reattach only the
+                    # final segment's audio and lose the start of the utterance;
+                    # and the generation loop never sees one complete thinker turn
+                    # to scan for a <tool_call> block. Aggregating the audio would
+                    # fix only the first, leaving the feature looking supported
+                    # while still broken -- so the limitation is explicit instead.
+                    await self.send_error(
+                        "Tool calling on /v1/realtime requires async_chunk to be disabled "
+                        "(serve with --no-async-chunk); tools were not applied.",
+                        "tools_require_no_async_chunk",
+                    )
+                else:
+                    self._tools = tools
             await super().handle_event(event)
         elif event_type == "conversation.item.create":
             item = event.get("item") or {}
             if item.get("type") == "function_call_output":
-                self._tool_result_queue.put_nowait(item)
+                await self._enqueue_tool_result(item)
             else:
                 await self.send_error(f"Unsupported conversation.item type: {item.get('type')!r}", "unsupported_item")
         else:
             await super().handle_event(event)
+
+    def _async_chunk_enabled(self) -> bool:
+        """Whether the server runs in async-chunk mode.
+
+        Read off ``model_config`` the same way ``serving_speech.py`` does
+        (``:3232``, ``:3569``).
+        """
+        return bool(getattr(self.serving.model_config, "async_chunk", False))
+
+    async def _enqueue_tool_result(self, item: dict) -> None:
+        """Validate a `function_call_output` before it can influence generation.
+
+        Without this, any dict carrying the right `type` was accepted: a missing
+        or non-string `call_id` never matched a pending call, and `output` was
+        coerced with `str()`. A client typo therefore left generation waiting
+        with nothing reported back. Shape errors are protocol errors, so they are
+        rejected here rather than discovered later.
+
+        (Kept as explicit checks for now; supersede with pydantic tool-event
+        models when those land.)
+        """
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            await self.send_error(
+                "function_call_output requires a non-empty string 'call_id'",
+                "invalid_function_call_output",
+            )
+            return
+        output = item.get("output")
+        if not isinstance(output, str):
+            await self.send_error(
+                f"function_call_output 'output' must be a string, got {type(output).__name__}",
+                "invalid_function_call_output",
+            )
+            return
+        self._tool_result_queue.put_nowait(item)
 
     async def start_generation(self):
         if self.generation_task is not None and not self.generation_task.done():
@@ -467,9 +532,17 @@ class RealtimeConnection(VllmRealtimeConnection):
             call_id = item.get("call_id")
             idx = call_id_to_index.get(call_id)
             if idx is None:
+                # Tell the client: silently dropping this would leave the turn
+                # waiting for a result that is never going to match. Keep waiting
+                # afterwards, since the correct result may still arrive.
                 logger.warning("received function_call_output for unknown call_id=%s", call_id)
+                await self.send_error(
+                    f"No pending tool call with call_id={call_id!r}; expected one of {sorted(call_id_to_index)}",
+                    "unknown_tool_call_id",
+                )
                 continue
-            results_by_index[idx] = str(item.get("output", ""))
+            # `output` is validated as a string at ingress (_enqueue_tool_result).
+            results_by_index[idx] = item["output"]
 
         if not self._is_connected:
             return
@@ -481,16 +554,27 @@ class RealtimeConnection(VllmRealtimeConnection):
         # for why relying on safe_apply_chat_template's own auto-resolution
         # is unsafe for this checkpoint.
         processor = cached_processor_from_config(model_config)
-        # Multiple tool calls in one turn -> one combined tool-role message,
-        # matching how Qwen's own chat template batches consecutive tool
-        # results under a single <|im_start|>user block. No `tools=` here:
-        # this is a continuation of a conversation that already has the
-        # tools system preamble in its token history, not a fresh turn.
-        combined_result_text = "\n".join(results_by_index[i] for i in sorted(results_by_index))
+        # One `role="tool"` message PER result, in call order. The chat template
+        # emits one <tool_response> block per tool message and groups consecutive
+        # tool messages under a single <|im_start|>user turn, so passing separate
+        # messages is what lets the model associate each result with its call.
+        # Joining the results instead produces a single <tool_response> holding
+        # both outputs, which breaks parallel calls.
+        #
+        # `sorted()` on the parser-assigned index is call order: extract_deltas
+        # appends `tool_call_starts` in the order <tool_call> appears in the
+        # generated text, so this is stable regardless of the order in which the
+        # client returns the results.
+        #
+        # No `tools=` here: this continues a conversation whose token history
+        # already carries the tools system preamble; it is not a fresh turn.
+        tool_messages: list[dict[str, str]] = [
+            {"role": "tool", "content": results_by_index[i]} for i in sorted(results_by_index)
+        ]
         suffix_text = safe_apply_chat_template(
             model_config,
             tokenizer,
-            [{"role": "tool", "content": combined_result_text}],
+            tool_messages,
             chat_template=processor.chat_template,
             add_generation_prompt=True,
             tokenize=False,

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -370,6 +370,31 @@ class RealtimeConnection(VllmRealtimeConnection):
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
 
+    @staticmethod
+    def _close_assistant_turn(tokenizer, assistant_token_ids: list[int]) -> list[int]:
+        """Terminate the model's tool-call turn with `<|im_end|>\\n` before a
+        tool-result turn is appended.
+
+        The tool-result suffix opens with `<|im_start|>user`, but the raw generated
+        token ids stop at the tool call without the closing `<|im_end|>` that the
+        chat template would emit. Splicing them directly yields
+        `</tool_call><|im_start|>user`, leaving the assistant turn open - a
+        malformed conversation the thinker responds to by re-emitting the same tool
+        call instead of answering, looping until something bounds it. The reference
+        HF path answers the identical prompt because `apply_chat_template` closes
+        the turn. Idempotent: only the missing pieces are added.
+        """
+        ids = list(assistant_token_ids)
+        im_end_id = tokenizer.convert_tokens_to_ids("<|im_end|>")
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if im_end_id in (None, getattr(tokenizer, "unk_token_id", None)):
+            return ids  # unexpected tokenizer; leave the splice untouched
+        if im_end_id not in ids[-2:]:
+            ids.append(im_end_id)
+        if newline_ids and ids[-len(newline_ids) :] != newline_ids:
+            ids.extend(newline_ids)
+        return ids
+
     async def _await_tool_results_and_continue(
         self,
         prior_prompt_token_ids: list[int],
@@ -430,7 +455,9 @@ class RealtimeConnection(VllmRealtimeConnection):
         base_prompt = self._turn_prompt or {}
         base_token_ids = list(base_prompt.get("prompt_token_ids") or prior_prompt_token_ids)
         multi_modal_data = base_prompt.get("multi_modal_data")
-        continuation_token_ids = base_token_ids + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+        continuation_token_ids = (
+            base_token_ids + self._close_assistant_turn(tokenizer, assistant_token_ids) + tokenizer.encode(suffix_text)
+        )
 
         # Advance the base so a chained tool call next round splices onto this
         # turn's full history while the audio stays attached exactly once, at the

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -4,35 +4,117 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator, Mapping
-from typing import cast
+from typing import Any, cast
 from uuid import uuid4
 
 import numpy as np
+from vllm.engine.protocol import StreamingInput
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.entrypoints.speech_to_text.realtime.protocol import TranscriptionDelta, TranscriptionDone
+from vllm.inputs import TokensPrompt
 from vllm.logger import init_logger
+from vllm.renderers.hf import safe_apply_chat_template
+from vllm.renderers.inputs.preprocess import parse_model_prompt
+from vllm.tokenizers import cached_tokenizer_from_config
+from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
 
 
 class RealtimeConnection(VllmRealtimeConnection):
-    """Omni realtime connection with audio-only server events.
+    """Omni realtime connection with audio-only server events, plus
+    OpenAI-Realtime-shaped tool/function calling.
 
-    Reuses upstream vLLM websocket/session lifecycle and only customizes
-    generation output handling to emit audio deltas.
+    Reuses upstream vLLM websocket/session lifecycle and customizes
+    generation output handling to emit audio deltas and tool-call events.
+
+    Tool-calling protocol (mirrors OpenAI's Realtime API event shapes):
+      - client -> server: `session.update` gains an optional `tools` field
+        (list of OpenAI-style tool/function definitions).
+      - server -> client, once the model starts a tool call:
+        `response.output_item.added` (item.type="function_call", name, call_id)
+        `response.function_call_arguments.delta` (call_id, delta)
+        `response.function_call_arguments.done` (call_id, arguments)
+      - client -> server, once the tool has run:
+        `conversation.item.create` with
+        `item = {"type": "function_call_output", "call_id": ..., "output": "..."}`
+      - generation then continues automatically with the tool result appended,
+        streaming the model's actual spoken reply as normal.
+
+    No audio is synthesized/forwarded for a turn that turns out to be a tool
+    call - the underlying 3-stage pipeline (thinker->talker->code2wav) still
+    runs end to end for it (there is no clean lower-level hook to skip talker/
+    code2wav without changing the shared orchestrator - see PR description),
+    but the resulting audio bytes are simply not sent to the client.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.engine = cast(AsyncOmni, self.serving.engine_client)
         self._realtime_audio_ref: np.ndarray | None = None
+        self._tools: list[dict[str, Any]] | None = None
+        # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
+        self._pending_tool_calls: dict[int, dict[str, Any]] = {}
+        self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def handle_event(self, event: dict):
+        event_type = event.get("type")
+        if event_type == "session.update":
+            tools = event.get("tools")
+            if tools is not None:
+                self._tools = tools
+            await super().handle_event(event)
+        elif event_type == "conversation.item.create":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call_output":
+                self._tool_result_queue.put_nowait(item)
+            else:
+                await self.send_error(f"Unsupported conversation.item type: {item.get('type')!r}", "unsupported_item")
+        else:
+            await super().handle_event(event)
 
     async def start_generation(self):
-        await super().start_generation()
+        if self.generation_task is not None and not self.generation_task.done():
+            logger.warning("Generation already in progress, ignoring commit")
+            return
+
+        audio_stream = self.audio_stream_generator()
+        input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
+        streaming_input_gen = self._buffer_realtime_audio_with_tools(audio_stream, input_stream)
+        self.generation_task = asyncio.create_task(self._run_generation(streaming_input_gen, input_stream))
+
+    async def _buffer_realtime_audio_with_tools(
+        self,
+        audio_stream: AsyncGenerator[np.ndarray, None],
+        input_stream: asyncio.Queue[list[int]],
+    ) -> AsyncGenerator[StreamingInput, None]:
+        """Equivalent to `OpenAIServingRealtime.transcribe_realtime`, but
+        threads `self._tools` through to the model's `buffer_realtime_audio`.
+        The base class's `transcribe_realtime` has a fixed
+        (audio_stream, input_stream, model_config) call signature with no
+        seam for extra per-connection state like tools, so this reimplements
+        its (short) body directly rather than patching upstream vLLM."""
+        model_config = self.serving.model_config
+        renderer = self.serving.renderer
+        stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
+            audio_stream, input_stream, model_config, tools=self._tools
+        )
+        async for prompt in stream_input_iter:
+            parsed_prompt = parse_model_prompt(model_config, prompt)
+            (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
+            yield StreamingInput(prompt=engine_input)
+
+    async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
+        model_config = self.serving.model_config
+        renderer = self.serving.renderer
+        parsed_prompt = parse_model_prompt(model_config, TokensPrompt(prompt_token_ids=prompt_token_ids))
+        (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
+        yield StreamingInput(prompt=engine_input)
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:
@@ -117,6 +199,30 @@ class RealtimeConnection(VllmRealtimeConnection):
         pcm16 = (clipped * 32767.0).astype(np.int16)
         return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
+    async def _emit_tool_call_deltas(self, tool_deltas: list) -> None:
+        for delta in tool_deltas:
+            if delta.name is not None:
+                call_id = f"call_{uuid4().hex[:24]}"
+                self._pending_tool_calls[delta.index] = {"call_id": call_id, "name": delta.name, "arguments": ""}
+                await self.send_json(
+                    {
+                        "type": "response.output_item.added",
+                        "item": {"type": "function_call", "name": delta.name, "call_id": call_id},
+                    }
+                )
+            if delta.arguments_delta:
+                info = self._pending_tool_calls.get(delta.index)
+                if info is None:
+                    continue  # shouldn't happen: name delta always precedes argument deltas for the same index
+                info["arguments"] += delta.arguments_delta
+                await self.send_json(
+                    {
+                        "type": "response.function_call_arguments.delta",
+                        "call_id": info["call_id"],
+                        "delta": delta.arguments_delta,
+                    }
+                )
+
     async def _run_generation(
         self,
         streaming_input_gen: AsyncGenerator,
@@ -129,6 +235,11 @@ class RealtimeConnection(VllmRealtimeConnection):
         prompt_token_ids_len = 0
         completion_tokens_len = 0
         self._realtime_audio_ref = None
+
+        request_prompt_token_ids: list[int] = []
+        assistant_token_ids: list[int] = []
+        tool_state = ToolCallStreamState()
+        self._pending_tool_calls = {}
 
         # Coerce cumulative outputs to delta outputs; this ensures
         # we don't emit redundant MM data & drain after emitting.
@@ -153,35 +264,58 @@ class RealtimeConnection(VllmRealtimeConnection):
                     new_token_ids = list(first_output.token_ids)
                     if new_token_ids:
                         input_stream.put_nowait(new_token_ids)
+                        assistant_token_ids.extend(new_token_ids)
 
                     if output.prompt_token_ids:
                         prompt_token_ids_len = max(
                             prompt_token_ids_len,
                             len(output.prompt_token_ids),
                         )
+                        if not request_prompt_token_ids:
+                            request_prompt_token_ids = list(output.prompt_token_ids)
 
                     delta_text = first_output.text or ""
                     full_text += delta_text
                     completion_tokens_len += len(new_token_ids)
 
                     if delta_text:
-                        await self.send(TranscriptionDelta(delta=delta_text))
+                        content_delta, tool_deltas = extract_deltas(full_text, tool_state)
+                        if content_delta:
+                            await self.send(TranscriptionDelta(delta=content_delta))
+                        if tool_deltas:
+                            await self._emit_tool_call_deltas(tool_deltas)
 
                 audio_chunks, sample_rate = self._extract_audio_chunks(output)
-
-                for chunk in audio_chunks:
-                    sent_audio = True
-                    await self.send_json(
-                        {
-                            "type": "response.audio.delta",
-                            "audio": self._pcm16_b64(chunk),
-                            "format": "pcm16",
-                            "sample_rate_hz": sample_rate,
-                        }
-                    )
+                if audio_chunks and not tool_state.has_tool_calls():
+                    for chunk in audio_chunks:
+                        sent_audio = True
+                        await self.send_json(
+                            {
+                                "type": "response.audio.delta",
+                                "audio": self._pcm16_b64(chunk),
+                                "format": "pcm16",
+                                "sample_rate_hz": sample_rate,
+                            }
+                        )
+                # else: a tool-call turn - the pipeline still synthesizes audio for the
+                # raw <tool_call> text (no cheap hook to skip talker/code2wav for just
+                # this turn), we just don't forward it to the client.
 
                 if not self._is_connected:
                     break
+
+            if tool_state.has_tool_calls():
+                for idx, info in self._pending_tool_calls.items():
+                    await self.send_json(
+                        {
+                            "type": "response.function_call_arguments.done",
+                            "call_id": info["call_id"],
+                            "arguments": info["arguments"],
+                        }
+                    )
+                if self._is_connected:
+                    await self._await_tool_results_and_continue(request_prompt_token_ids, assistant_token_ids)
+                return
 
             usage = UsageInfo(
                 prompt_tokens=prompt_token_ids_len,
@@ -208,13 +342,69 @@ class RealtimeConnection(VllmRealtimeConnection):
                 except Exception:
                     logger.exception("Failed to close realtime result generator")
             # Always send terminal event so clients don't hang forever.
-            if self._is_connected and not audio_done_sent:
+            if self._is_connected and not audio_done_sent and not tool_state.has_tool_calls():
                 try:
                     await self.send_json({"type": "response.audio.done", "has_audio": sent_audio})
                 except Exception:
                     logger.exception("Failed to send response.audio.done")
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
+
+    async def _await_tool_results_and_continue(
+        self,
+        prior_prompt_token_ids: list[int],
+        assistant_token_ids: list[int],
+    ) -> None:
+        """Block until the client has submitted a `function_call_output` for
+        every pending tool call from the turn that just finished, then splice
+        the results onto the raw token sequence (prior prompt + the model's
+        own generated tool-call tokens + a freshly-rendered tool-result turn)
+        and continue generation - which streams the model's actual spoken
+        reply as a normal `_run_generation` call, recursing again if the
+        model chains into another tool call."""
+        pending = dict(self._pending_tool_calls)
+        call_id_to_index = {info["call_id"]: idx for idx, info in pending.items()}
+        results_by_index: dict[int, str] = {}
+
+        while len(results_by_index) < len(pending) and self._is_connected:
+            item = await self._tool_result_queue.get()
+            call_id = item.get("call_id")
+            idx = call_id_to_index.get(call_id)
+            if idx is None:
+                logger.warning("received function_call_output for unknown call_id=%s", call_id)
+                continue
+            results_by_index[idx] = str(item.get("output", ""))
+
+        if not self._is_connected:
+            return
+
+        model_config = self.serving.model_config
+        tokenizer = cached_tokenizer_from_config(model_config)
+        # Pass the processor's chat_template explicitly - see the matching
+        # comment in Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio
+        # for why relying on safe_apply_chat_template's own auto-resolution
+        # is unsafe for this checkpoint.
+        processor = cached_processor_from_config(model_config)
+        # Multiple tool calls in one turn -> one combined tool-role message,
+        # matching how Qwen's own chat template batches consecutive tool
+        # results under a single <|im_start|>user block. No `tools=` here:
+        # this is a continuation of a conversation that already has the
+        # tools system preamble in its token history, not a fresh turn.
+        combined_result_text = "\n".join(results_by_index[i] for i in sorted(results_by_index))
+        suffix_text = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            [{"role": "tool", "content": combined_result_text}],
+            chat_template=processor.chat_template,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        continuation_token_ids = (
+            list(prior_prompt_token_ids) + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+        )
+
+        input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
+        await self._run_generation(self._render_token_prompt(continuation_token_ids), input_stream)
 
     async def send_json(self, payload: dict):
         try:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -12,7 +12,7 @@ from vllm.engine.protocol import StreamingInput
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.entrypoints.speech_to_text.realtime.protocol import TranscriptionDelta, TranscriptionDone
-from vllm.inputs import TokensPrompt
+from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.renderers.hf import safe_apply_chat_template
 from vllm.renderers.inputs.preprocess import parse_model_prompt
@@ -88,6 +88,12 @@ class RealtimeConnection(VllmRealtimeConnection):
         streaming_input_gen = self._buffer_realtime_audio_with_tools(audio_stream, input_stream)
         self.generation_task = asyncio.create_task(self._run_generation(streaming_input_gen, input_stream))
 
+    async def _render_prompt(self, prompt: PromptType) -> StreamingInput:
+        model_config = self.serving.model_config
+        parsed_prompt = parse_model_prompt(model_config, prompt)
+        (engine_input,) = await self.serving.renderer.render_cmpl_async([parsed_prompt])
+        return StreamingInput(prompt=engine_input)
+
     async def _buffer_realtime_audio_with_tools(
         self,
         audio_stream: AsyncGenerator[np.ndarray, None],
@@ -99,22 +105,14 @@ class RealtimeConnection(VllmRealtimeConnection):
         (audio_stream, input_stream, model_config) call signature with no
         seam for extra per-connection state like tools, so this reimplements
         its (short) body directly rather than patching upstream vLLM."""
-        model_config = self.serving.model_config
-        renderer = self.serving.renderer
         stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
-            audio_stream, input_stream, model_config, tools=self._tools
+            audio_stream, input_stream, self.serving.model_config, tools=self._tools
         )
         async for prompt in stream_input_iter:
-            parsed_prompt = parse_model_prompt(model_config, prompt)
-            (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
-            yield StreamingInput(prompt=engine_input)
+            yield await self._render_prompt(prompt)
 
     async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
-        model_config = self.serving.model_config
-        renderer = self.serving.renderer
-        parsed_prompt = parse_model_prompt(model_config, TokensPrompt(prompt_token_ids=prompt_token_ids))
-        (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
-        yield StreamingInput(prompt=engine_input)
+        yield await self._render_prompt(TokensPrompt(prompt_token_ids=prompt_token_ids))
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -29,6 +29,7 @@ tool-parser internals that may change across versions.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 
@@ -36,6 +37,7 @@ _TOOL_CALL_START = "<tool_call>"
 _TOOL_CALL_END = "</tool_call>"
 _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
 _ARGS_KEY_RE = re.compile(r'"arguments"\s*:\s*')
+_JSON_DECODER = json.JSONDecoder()
 
 
 @dataclass
@@ -77,36 +79,25 @@ def _partial_tag_overlap(text: str, tag: str) -> int:
 
 def _json_value_end(text: str) -> int | None:
     """If `text` starts (after optional leading whitespace) with a complete
-    JSON object or array, return the index just past its matching closing
-    bracket. Returns None if `text` doesn't start with '{'/'[' or the value
-    isn't complete yet. Used to find exactly where an "arguments" value ends
+    JSON object or array, return the index just past its closing bracket.
+    Returns None if `text` doesn't start with '{'/'[' or the value isn't
+    complete yet. Used to find exactly where an "arguments" value ends
     without assuming anything about what (if anything) follows it - argument
-    values can themselves contain nested objects/arrays."""
+    values can themselves contain nested objects/arrays.
+
+    `raw_decode` is exactly this primitive: it parses one JSON value from the
+    start of the string and reports where it stopped, ignoring trailing text,
+    and raises on an incomplete value (the normal case mid-stream)."""
     stripped = text.lstrip()
+    # Restrict to object/array: `raw_decode` would also accept a bare scalar,
+    # but "arguments" is always a JSON object per the tool-call format.
     if not stripped or stripped[0] not in "{[":
         return None
-    offset = len(text) - len(stripped)
-    depth = 0
-    in_string = False
-    escape = False
-    for i, ch in enumerate(stripped):
-        if in_string:
-            if escape:
-                escape = False
-            elif ch == "\\":
-                escape = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-        elif ch in "{[":
-            depth += 1
-        elif ch in "}]":
-            depth -= 1
-            if depth == 0:
-                return offset + i + 1
-    return None
+    try:
+        _, end = _JSON_DECODER.raw_decode(stripped)
+    except ValueError:
+        return None
+    return (len(text) - len(stripped)) + end
 
 
 def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, list[ToolCallDelta]]:

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -29,7 +29,6 @@ tool-parser internals that may change across versions.
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 
@@ -172,36 +171,3 @@ def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, 
             state.streamed_args[i] = args_str
 
     return content_delta, tool_deltas
-
-
-def extract_complete_tool_calls(text: str) -> list[dict]:
-    """Non-streaming: parse all complete <tool_call> blocks out of finished
-    text, returning [{"name": ..., "arguments": {...}}, ...]. Malformed
-    blocks are skipped rather than raising."""
-    calls: list[dict] = []
-    pos = 0
-    while True:
-        start = text.find(_TOOL_CALL_START, pos)
-        if start == -1:
-            break
-        end = text.find(_TOOL_CALL_END, start)
-        if end == -1:
-            break
-        body = text[start + len(_TOOL_CALL_START) : end].strip()
-        try:
-            calls.append(json.loads(body))
-        except json.JSONDecodeError:
-            pass
-        pos = end + len(_TOOL_CALL_END)
-    return calls
-
-
-def strip_tool_calls(text: str) -> str:
-    """Remove <tool_call>...</tool_call> blocks, returning whatever plain
-    spoken content (if any) surrounds them."""
-    return re.sub(
-        re.escape(_TOOL_CALL_START) + r".*?" + re.escape(_TOOL_CALL_END),
-        "",
-        text,
-        flags=re.DOTALL,
-    ).strip()

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Self-contained <tool_call> XML-tag parser for vLLM-Omni's /v1/realtime endpoint.
+
+Qwen's own chat template (see the model's chat_template.json) instructs the
+model to emit tool calls as:
+
+    <tool_call>
+    {"name": <function-name>, "arguments": <args-json-object>}
+    </tool_call>
+
+This is the same wire format vLLM's `Hermes2ProToolParser`
+(vllm/tool_parsers/hermes_tool_parser.py) already parses for
+/v1/chat/completions, and the algorithm below (regex name extraction,
+length-based suffix diff for streaming arguments, partial-tag-overlap
+withholding) intentionally mirrors that parser's approach.
+
+We do not import that class directly: `ToolParser.extract_tool_calls*`
+methods are typed against `ChatCompletionRequest | ResponsesRequest` and read
+`request.tools`/`request.tool_choice` from it, and for Qwen3 specifically
+tool-call parsing has moved to vLLM's structured-output/guided-decoding
+engine rather than a plain text parser (see `vllm/tool_parsers/
+qwen3_engine_tool_parser.py`) - neither shape fits this self-hosted,
+websocket-driven streaming loop without either duck-typing a fake request
+object or pulling in the structured-output engine. A small, self-contained
+parser is easier to review and keeps this feature independent of vLLM
+tool-parser internals that may change across versions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+_TOOL_CALL_START = "<tool_call>"
+_TOOL_CALL_END = "</tool_call>"
+_NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
+_ARGS_KEY_RE = re.compile(r'"arguments"\s*:\s*')
+
+
+@dataclass
+class ToolCallDelta:
+    """One incremental piece of a tool call. `name` is set at most once per
+    index (the first time it becomes available); `arguments_delta` is the new
+    tail of the arguments JSON text since the last delta for this index."""
+
+    index: int
+    name: str | None = None
+    arguments_delta: str = ""
+
+
+@dataclass
+class ToolCallStreamState:
+    """Tracks incremental parsing progress across repeated calls with the
+    growing `current_text` of a single generation."""
+
+    sent_content_idx: int = 0
+    tool_call_starts: list[int] = field(default_factory=list)
+    names_sent: list[bool] = field(default_factory=list)
+    streamed_args: list[str] = field(default_factory=list)
+
+    def has_tool_calls(self) -> bool:
+        return bool(self.tool_call_starts)
+
+
+def _partial_tag_overlap(text: str, tag: str) -> int:
+    """Length of the longest suffix of `text` that is a proper prefix of
+    `tag` - e.g. text ending in "...</tool_c" against tag "</tool_call>"
+    returns 5, so callers can withhold that suffix until it's known whether
+    it's about to become part of the tag."""
+    max_overlap = min(len(text), len(tag) - 1)
+    for size in range(max_overlap, 0, -1):
+        if text.endswith(tag[:size]):
+            return size
+    return 0
+
+
+def _json_value_end(text: str) -> int | None:
+    """If `text` starts (after optional leading whitespace) with a complete
+    JSON object or array, return the index just past its matching closing
+    bracket. Returns None if `text` doesn't start with '{'/'[' or the value
+    isn't complete yet. Used to find exactly where an "arguments" value ends
+    without assuming anything about what (if anything) follows it - argument
+    values can themselves contain nested objects/arrays."""
+    stripped = text.lstrip()
+    if not stripped or stripped[0] not in "{[":
+        return None
+    offset = len(text) - len(stripped)
+    depth = 0
+    in_string = False
+    escape = False
+    for i, ch in enumerate(stripped):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+            if depth == 0:
+                return offset + i + 1
+    return None
+
+
+def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, list[ToolCallDelta]]:
+    """Given the full accumulated generation text so far, return
+    (new plain-content substring, new tool-call deltas) since the last call
+    with this `state`. Mutates `state` in place."""
+    tool_deltas: list[ToolCallDelta] = []
+
+    search_from = state.tool_call_starts[-1] + len(_TOOL_CALL_START) if state.tool_call_starts else 0
+    while (idx := current_text.find(_TOOL_CALL_START, search_from)) != -1:
+        state.tool_call_starts.append(idx)
+        state.names_sent.append(False)
+        state.streamed_args.append("")
+        search_from = idx + len(_TOOL_CALL_START)
+
+    if state.tool_call_starts:
+        content_end = state.tool_call_starts[0]
+    else:
+        content_end = len(current_text) - _partial_tag_overlap(current_text, _TOOL_CALL_START)
+    content_delta = ""
+    if content_end > state.sent_content_idx:
+        content_delta = current_text[state.sent_content_idx : content_end]
+        state.sent_content_idx = content_end
+
+    for i, start in enumerate(state.tool_call_starts):
+        block_start = start + len(_TOOL_CALL_START)
+        end_idx = current_text.find(_TOOL_CALL_END, block_start)
+        if end_idx == -1:
+            raw = current_text[block_start:]
+            overlap = _partial_tag_overlap(raw, _TOOL_CALL_END)
+            if overlap:
+                raw = raw[: len(raw) - overlap]
+        else:
+            raw = current_text[block_start:end_idx]
+
+        if not state.names_sent[i]:
+            name_match = _NAME_RE.search(raw)
+            if name_match is None:
+                continue  # don't parse ahead to arguments until a name is available
+            tool_deltas.append(ToolCallDelta(index=i, name=name_match.group(1)))
+            state.names_sent[i] = True
+
+        args_match = _ARGS_KEY_RE.search(raw)
+        if args_match is None:
+            continue
+        tail = raw[args_match.end() :]
+        # Find the exact end of the arguments JSON value via bracket-depth
+        # matching, rather than assuming "the last '}' in the block is the
+        # outer object's, not the value's" - that assumption breaks whenever
+        # the trailing "}\n" (closing the outer {"name":..., "arguments":...}
+        # object, before </tool_call>) arrives in the same chunk as the
+        # arguments value's own closing brace: naively stripping one trailing
+        # '}' either over- or under-trims depending on exact token boundaries,
+        # and (worse) can desync the running length-based diff against
+        # state.streamed_args so the final delta silently never gets sent,
+        # leaving invalid trailing "}\n" baked into the accumulated arguments.
+        value_end = _json_value_end(tail)
+        args_str = tail[:value_end] if value_end is not None else tail
+        new_args = args_str[len(state.streamed_args[i]) :]
+        if new_args:
+            tool_deltas.append(ToolCallDelta(index=i, arguments_delta=new_args))
+            state.streamed_args[i] = args_str
+
+    return content_delta, tool_deltas
+
+
+def extract_complete_tool_calls(text: str) -> list[dict]:
+    """Non-streaming: parse all complete <tool_call> blocks out of finished
+    text, returning [{"name": ..., "arguments": {...}}, ...]. Malformed
+    blocks are skipped rather than raising."""
+    calls: list[dict] = []
+    pos = 0
+    while True:
+        start = text.find(_TOOL_CALL_START, pos)
+        if start == -1:
+            break
+        end = text.find(_TOOL_CALL_END, start)
+        if end == -1:
+            break
+        body = text[start + len(_TOOL_CALL_START) : end].strip()
+        try:
+            calls.append(json.loads(body))
+        except json.JSONDecodeError:
+            pass
+        pos = end + len(_TOOL_CALL_END)
+    return calls
+
+
+def strip_tool_calls(text: str) -> str:
+    """Remove <tool_call>...</tool_call> blocks, returning whatever plain
+    spoken content (if any) surrounds them."""
+    return re.sub(
+        re.escape(_TOOL_CALL_START) + r".*?" + re.escape(_TOOL_CALL_END),
+        "",
+        text,
+        flags=re.DOTALL,
+    ).strip()

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -227,6 +227,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
         model_config: ModelConfig,
+        tools: list[dict[str, Any]] | None = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -241,7 +242,45 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
         audio_placeholder = Qwen3OmniMoeThinkerForConditionalGeneration.get_placeholder_str("audio", 0)
-        prompt_template = f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
+        if tools:
+            # Render through the model's own chat template with `tools=` so the
+            # thinker gets the <tools>...</tools> system preamble and the
+            # <tool_call></tool_call> output instructions it was trained on
+            # (see chat_template.json) - this is the same tool-calling format
+            # /v1/chat/completions already supports for this checkpoint, just
+            # never previously wired into the realtime audio-in path. When
+            # `tools` is empty this renders byte-identical to the plain
+            # f-string below, so that path is untouched to keep this change
+            # scoped to the new capability.
+            #
+            # tokenizer.apply_chat_template() alone raises here: the tokenizer
+            # object itself has no .chat_template set. safe_apply_chat_template
+            # is the same helper vLLM's own /v1/chat/completions path uses to
+            # resolve the template from model_config before calling
+            # apply_chat_template - but its own auto-resolution
+            # (resolve_chat_template in vllm/renderers/hf.py) explicitly skips
+            # the AutoProcessor-based lookup whenever `tools` is given (its
+            # 2nd-priority path is gated on `tools is None`), and for this
+            # multimodal checkpoint the chat_template genuinely lives on the
+            # processor, not the raw tokenizer - so with tools set it falls
+            # through silently to vLLM's generic (non-tool-aware) fallback
+            # template instead of erroring. Passing the processor's own
+            # chat_template explicitly bypasses that broken auto-resolution
+            # (resolve_chat_template's 1st priority: an explicit template
+            # always wins and still respects `tools` when applying it).
+            from vllm.renderers.hf import safe_apply_chat_template
+
+            prompt_template = safe_apply_chat_template(
+                model_config,
+                tokenizer,
+                [{"role": "user", "content": audio_placeholder}],
+                tools=tools,
+                chat_template=processor.chat_template,
+                add_generation_prompt=True,
+                tokenize=False,
+            )
+        else:
+            prompt_template = f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
 
         prompt_token_ids = tokenizer.encode(prompt_template)
 


### PR DESCRIPTION
## Summary

Fixes #5522.

`/v1/realtime` had no wire mechanism for tools at all - no field on `session.update`, no function-call events in either direction - so a self-hosted Qwen3-Omni realtime session could never be given tools, even though the same checkpoint supports tool-calling fine via `/v1/chat/completions`. This adds it, mirroring OpenAI's Realtime API event shapes:

- `session.update` gains an optional `tools` field.
- `buffer_realtime_audio()` renders through the model's own chat template with `tools=` when present, so the thinker gets the `<tools>...</tools>` system preamble and `<tool_call>` output format it was already trained on (same format `/v1/chat/completions` uses). No-op when `tools` is empty - verified byte-identical rendering to the prior hardcoded prompt string.
- New `realtime_tool_calls.py`: a small, self-contained `<tool_call>` XML-tag parser (streaming name/arguments diffing via bracket-depth JSON matching, not naive string trimming).
- New server events: `response.output_item.added`, `response.function_call_arguments.delta`, `response.function_call_arguments.done`.
- New client event: `conversation.item.create` with a `function_call_output` item submits a tool result, which splices onto the raw token sequence and continues generation - producing the model's actual spoken reply, recursing if it chains another tool call.

This PR is part of a 3-PR split of a broader `/v1/realtime` spec-conformance audit (#5558): this one covers tool-calling, #TBD covers voice/speaker selection, #TBD covers `instructions` (system prompt). Split into independent PRs so each can be reviewed/merged on its own.

## A real vLLM template-resolution bug found along the way

`safe_apply_chat_template`'s own auto-resolution (`resolve_chat_template` in `vllm/renderers/hf.py`) explicitly skips the AutoProcessor-based template lookup whenever `tools` is passed (that path is gated on `tools is None`). For this multimodal checkpoint the tool-aware chat template genuinely lives on the processor, not the raw tokenizer, so with `tools` set it silently fell through to vLLM's generic non-tool-aware fallback template - no crash, no error, just a plausible-looking wrong answer. Worked around here by passing the processor's `chat_template` explicitly (`resolve_chat_template`'s 1st priority always wins and still respects `tools` when applying it). Happy to also raise this separately against vLLM proper if maintainers think it's worth a dedicated fix upstream there.

## Known limitation (by design, not an oversight)

Audio is not forwarded to the client for a turn that turns out to be a tool call, but the 3-stage pipeline (thinker→talker→code2wav) still runs end-to-end for it under the hood. Properly skipping talker/code2wav for a tool-call segment would require teaching the shared orchestrator (`engine/orchestrator.py`, used by every model in the repo) a new "finish successfully after stage 0 only" capability - a much larger, riskier change for a first PR. This trades a small amount of wasted compute on an already lighter-loaded GPU (talker/code2wav run on a separate GPU from the thinker in the standard 2-GPU deploy config) for a change contained entirely to this feature's own files. Happy to discuss tackling proper pipeline-level gating as a follow-up if there's interest.

## Robustness bounds

Two limits on the tool-call loop, both with unit tests:

- **`MAX_TOOL_ROUNDS = 8`.** `_await_tool_results_and_continue` re-enters `_run_generation`, so a model that keeps re-emitting tool calls instead of answering would recurse without bound -- growing the stack and holding each round's result generator open, since every round is awaited inside the outer `try`. Exceeding the cap emits an `error` event with code `tool_call_loop` and abandons the turn. This is the failure mode hit during bring-up when the spliced prompt was malformed (see `_close_assistant_turn`).
- **The tool-result wait releases when the client goes away.** It previously checked `_is_connected` only at the top of the loop and then blocked in `Queue.get()` indefinitely, so a client that vanished mid-tool-call parked the generation task forever. The wait is now bounded so liveness is re-checked; a slow-but-live client is unaffected.

A new user turn also resets the round budget and drains any stale `function_call_output`, so a late result from a previous turn can't be consumed as if it answered one of this turn's calls.

## Test plan

- [x] New L1 unit tests for the `<tool_call>` parser (`tests/entrypoints/test_realtime_tool_calls.py`) - 10 tests, all passing, including a regression test for a streaming-diff edge case that left invalid trailing `}\n` in the accumulated arguments JSON.
- [x] New L1 unit tests for `handle_event`'s tool-call event routing (`tests/entrypoints/test_realtime_connection_helpers.py`) - 5 tests, all passing, using `mocker`/`AsyncMock` per repo convention.
- [x] New L3 online e2e test (`tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py::test_tool_calling_round_trip`) following the exact pattern of its two neighbors in the same file. **Run green through the real `omni_server` fixture**: `pytest -sv '...::test_tool_calling_round_trip[sync]' --run-level advanced_model` -> `1 passed in 156.66s`, on 2x H100 with real weights.
- [x] Manually verified end-to-end on real GPUs against `Qwen3-Omni-30B-A3B-Instruct`: full tool-call round trip (model calls `get_weather`, streams valid incremental JSON arguments, client submits a result, generation resumes and speaks the final answer incorporating it) and the no-tools path confirmed byte-for-byte unchanged from before this PR.
- [x] All 25 tests across both new/changed test files actually executed (not just collected) against the real `vllm`/`vllm_omni` install inside the serving container, all passing.
- No CI YAML changes needed - `tests/entrypoints/` is already swept unconditionally by `test-ready.yml` (L1) and `test-merge.yml` (L3 H100/L4), so both new test files are picked up automatically.

**Note on the new L3 test**: now verified end to end through the `omni_server` fixture (`--run-level advanced_model`, 2x H100, real `Qwen3-Omni-30B-A3B-Instruct` weights): the model emits a `get_weather` call, the client submits a `function_call_output`, and generation resumes and speaks a final reply incorporating the result. Note the test needs `espeak-ng` + `pyttsx3` to synthesize its input audio; the CI images install both (`docker/Dockerfile.ci`), a plain serving image does not.
