### PR TITLE
[WIP] [Bugfix] Fix MiniCPM-o duplex async scheduling 

### DIFF
--- a/tests/helpers/minicpmo_4_5_duplex.py
+++ b/tests/helpers/minicpmo_4_5_duplex.py
@@ -20,9 +20,18 @@ DEPLOY_CONFIG = modify_stage_config(
     updates={
         "base_config": get_deploy_config_path("minicpmo_4_5.yaml"),
         "stages": {
-            0: {"kv_cache_memory_bytes": 6 * 1024 * 1024 * 1024},
-            1: {"kv_cache_memory_bytes": 512 * 1024 * 1024},
-            2: {"kv_cache_memory_bytes": 256 * 1024 * 1024},
+            0: {
+                "async_scheduling": True,
+                "kv_cache_memory_bytes": 6 * 1024 * 1024 * 1024,
+            },
+            1: {
+                "async_scheduling": True,
+                "kv_cache_memory_bytes": 512 * 1024 * 1024,
+            },
+            2: {
+                "async_scheduling": False,
+                "kv_cache_memory_bytes": 256 * 1024 * 1024,
+            },
         },
     },
 )

--- a/tests/worker/test_native_duplex_hooks.py
+++ b/tests/worker/test_native_duplex_hooks.py
@@ -1698,6 +1698,60 @@ def test_minicpmo_stage0_records_bounded_model_policy_history():
     assert state.generated_tokens == [*expected_history[len(token_ids) :], *token_ids.values()]
 
 
+def test_minicpmo_stage0_async_lookahead_preserves_pending_terminator():
+    from vllm_omni.experimental.fullduplex.minicpmo45.stage0 import (
+        _MiniCPMO45Stage0SessionState,
+    )
+    from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
+        MiniCPMO45OmniForConditionalGeneration,
+    )
+
+    session_key = ("sid-async-lookahead", 0)
+    state = _MiniCPMO45Stage0SessionState(session_id=session_key[0])
+    state.pending_terminator_token = 8
+    state.last_terminator_token = 8
+    state.generated_tokens = [198]
+
+    model = MiniCPMO45OmniForConditionalGeneration.__new__(MiniCPMO45OmniForConditionalGeneration)
+    model._minicpmo45_duplex_data_plane_helper = SimpleNamespace(sessions={session_key: state})
+    model._minicpmo45_duplex_row_sessions = {0: session_key}
+    model._minicpmo45_duplex_row_payloads = {0: {"is_speech": True}}
+
+    token_ids = {
+        "unit_token_id": 1,
+        "unit_end_token_id": 2,
+        "listen_token_id": 3,
+        "speak_token_id": 4,
+        "tts_bos_token_id": 5,
+        "tts_eos_token_id": 6,
+        "tts_pad_token_id": 7,
+        "chunk_eos_token_id": 8,
+        "chunk_tts_eos_token_id": 9,
+        "turn_eos_token_id": 10,
+    }
+    logits = torch.full((1, 32), -100.0)
+    logits[0, 11] = 20.0
+    sampling_metadata = SimpleNamespace(
+        all_greedy=True,
+        output_token_ids=[[]],
+    )
+
+    sampled = model._sample_minicpmo45_native_duplex_row(
+        logits,
+        sampling_metadata,
+        row_idx=0,
+        token_ids=token_ids,
+    )
+
+    # Async scheduling may execute one decode frame after the segment
+    # terminator is sampled but before the scheduler processes it. That stale
+    # frame must not advance the Python-owned duplex policy state.
+    assert sampled == token_ids["chunk_eos_token_id"]
+    assert state.pending_terminator_token == token_ids["chunk_eos_token_id"]
+    assert state.last_terminator_token == token_ids["chunk_eos_token_id"]
+    assert state.generated_tokens == [198]
+
+
 def test_minicpmo_stage0_native_sampler_does_not_override_model_at_punctuation():
     from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
         MiniCPMO45OmniForConditionalGeneration,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -726,6 +726,18 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         top_k = int(self._sampling_metadata_value(sampling_metadata, "top_k", row_idx, 100))
         top_p = float(self._sampling_metadata_value(sampling_metadata, "top_p", row_idx, 0.8))
         state = self._minicpmo45_duplex_state_for_row(row_idx)
+        pending_terminator = getattr(state, "pending_terminator_token", None)
+        terminator_ids = {
+            token_ids.get("listen_token_id", -1),
+            token_ids.get("chunk_eos_token_id", -1),
+            token_ids.get("chunk_tts_eos_token_id", -1),
+            token_ids.get("turn_eos_token_id", -1),
+        }
+        if isinstance(pending_terminator, int) and pending_terminator >= 0 and pending_terminator in terminator_ids:
+            # Async scheduling can execute one stale decode frame before the
+            # scheduler observes the segment stop. Keep the model-owned policy
+            # state frozen until the next append consumes this terminator.
+            return int(pending_terminator)
         if chunk_eos_id >= 0 and chunk_eos_id < logits.shape[-1]:
             max_speak_tokens = int(
                 getattr(


### PR DESCRIPTION
## Purpose

MiniCPM-o 4.5 native Full-Duplex keeps the model-sampled unit terminator in
`pending_terminator_token` so the next audio append can feed
`terminator + </unit>` back into the model context.

With async scheduling enabled, the AR runner may execute one lookahead decode
frame after the terminator has been sampled but before the scheduler consumes
the segment stop. On `main`, that stale frame sampled and recorded an ordinary
token, cleared the pending terminator, and advanced the Python-owned duplex
policy history. The next unit consequently lost the previous unit boundary.
In remote reproduction this produced a truncated first response and a timeout
waiting for the second turn's `response.created`.

This change makes a stale lookahead frame return the still-unconsumed
terminator without advancing policy history. The existing Stage 0 append path
continues to inject and clear that terminator on the next real audio append.

The PR intentionally does not enable async scheduling in the default MiniCPM-o
duplex deploy YAML. Its E2E test overlay explicitly enables async scheduling
for Stage 0/1 and keeps Stage 2 synchronous, so the H100 merge job exercises
the repaired path.

Runtime reproduction:

1. Copy `vllm_omni/deploy/minicpmo_4_5_duplex.yaml` to a temporary overlay,
   make `base_config` absolute, and set the first two
   `async_scheduling` values to `true` while keeping Stage 2 `false`.
2. Start the three-stage server with that overlay:

```bash
CUDA_VISIBLE_DEVICES=2 python -m vllm_omni.entrypoints.cli.main serve \
  /path/to/MiniCPM-o-4_5 \
  --omni \
  --host 127.0.0.1 \
  --port 28939 \
  --trust-remote-code \
  --stage-init-timeout 600 \
  --deploy-config /tmp/minicpmo_4_5_duplex_async.yaml
```

3. Run the fixed response-required fixture for three sequential turns:

```bash
python tests/e2e/online_serving/minicpmo_realtime_duplex_scenarios.py \
  --url 'ws://127.0.0.1:28939/v1/realtime?duplex=1' \
  --model /path/to/MiniCPM-o-4_5 \
  --input-wav tests/assets/minicpmo_4_5/response_required_16k.wav \
  --ref-audio /path/to/MiniCPM-o-4_5/assets/HT_ref_audio.wav \
  --validation-mode response-required \
  --realtime-input \
  --turns 3
```

On unmodified `main`, the focused regression selected ordinary token `11`
instead of pending `chunk_eos` token `8`, and the three-turn E2E timed out on
the second turn.

## Test Plan

- [x] Verify the focused test fails on unmodified `main`.
- [x] Run the complete native-duplex hook test file.
- [x] Run single-session and three-turn response-required E2E on one H20.
- [x] Run two concurrent response-required sessions with resume and takeover.
- [x] Run Ruff, format check, compileall, and `git diff --check` on changed files.
- [x] Run the H100 advanced-model MiniCPM-o duplex Buildkite job.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `03c9bd9022516f9221feca5f8364e4221cb6a6dd`

## Test Result

Remote topology: one NVIDIA H20, with Thinker, Talker, and Code2Wav all on GPU 2.
Stage 0 and Stage 1 used `OmniARAsyncScheduler`; Stage 2 remained synchronous.

- H100 merge E2E: `2 passed, 1 deselected, 14 warnings in 346.03s`
- Unit tests: `58 passed, 17 warnings`
- Single session: 15 audio deltas, one `response.done`, zero errors
- Three turns: 3 `response.speak`, 3 `response.done`, 41 audio deltas,
  zero stale audio deltas, zero errors
- Two concurrent sessions: 15/7 audio deltas, both completed with transcripts,
  zero stale audio deltas, zero errors
- Resume: attachment generation advanced from 1 to 2 and the resume token rotated
- Takeover: old attachment closed and all 4 old-attachment writes were rejected
- Server log: no `ERROR`, `Traceback`, or `ValueError`
- Local and remote SHA-256 matched for both runtime-fix files

This validation establishes correctness, not a performance gain. In the
single-H20 concurrent run, the second session still waited about 19.8 seconds
for its first audio chunk.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
