### PR TITLE
[Feature] Tool/function calling for the realtime API

### DIFF
--- a/examples/online_serving/qwen3_omni/openai_realtime_client.py
+++ b/examples/online_serving/qwen3_omni/openai_realtime_client.py
@@ -81,6 +81,9 @@ async def run_client(
     delta_dump_dir: Path | None,
     request_idx: int = 1,
     total_requests: int = 1,
+    tools: list[dict] | None = None,
+    tool_choice: str = "auto",
+    tool_output: str | None = None,
 ) -> None:
     log_prefix = f"[req {request_idx:02d}/{total_requests:02d}] " if total_requests > 1 else ""
     pcm16 = _read_wav_pcm16(input_wav)
@@ -92,20 +95,18 @@ async def run_client(
     delta_index = 0
     text_chunks: list[str] = []
     final_text: str = ""
+    tool_calls: list[dict] = []
 
     if delta_dump_dir is not None:
         delta_dump_dir.mkdir(parents=True, exist_ok=True)
 
     async with websockets.connect(url, max_size=64 * 1024 * 1024) as ws:
-        # 1) Validate model.
-        await ws.send(
-            json.dumps(
-                {
-                    "type": "session.update",
-                    "model": model,
-                }
-            )
-        )
+        # 1) Validate model, and declare tools if the caller asked for them.
+        session_update: dict = {"type": "session.update", "model": model}
+        if tools:
+            session_update["tools"] = tools
+            session_update["tool_choice"] = tool_choice
+        await ws.send(json.dumps(session_update))
 
         # 2) Start generation once (non-final commit).
         await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": False}))
@@ -176,11 +177,45 @@ async def run_client(
                     print(f"{log_prefix}text usage: {usage}")
                 continue
 
+            if event_type == "response.function_call_arguments.delta":
+                print(
+                    f"{log_prefix}function call (delta): {event.get('name')} "
+                    f"call_id={event.get('call_id')} arguments+={event.get('delta')}"
+                )
+                continue
+
+            if event_type == "response.function_call_arguments.done":
+                print(
+                    f"{log_prefix}function call: {event.get('name')}"
+                    f"({event.get('arguments')}) call_id={event.get('call_id')}"
+                )
+                tool_calls.append(event)
+                continue
+
             if event_type == "response.audio.done":
                 break
 
             if event_type == "error":
                 raise RuntimeError(f"Server error: {event}")
+
+        # 6) Return a tool result, if the model asked for one and the caller
+        #    supplied a canned output. The result becomes context for the next
+        #    turn, so send audio again to hear the model use it.
+        if tool_calls and tool_output is not None:
+            for call in tool_calls:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "conversation.item.create",
+                            "item": {
+                                "type": "function_call_output",
+                                "call_id": call.get("call_id"),
+                                "output": tool_output,
+                            },
+                        }
+                    )
+                )
+                print(f"{log_prefix}sent tool result for call_id={call.get('call_id')}: {tool_output}")
 
         all_pcm16 = b"".join(incremental_pcm_parts)
         if not all_pcm16:
@@ -215,6 +250,9 @@ async def run_clients_concurrent(
     delta_dump_dir: Path | None,
     num_requests: int,
     concurrency: int,
+    tools: list[dict] | None = None,
+    tool_choice: str = "auto",
+    tool_output: str | None = None,
 ) -> None:
     sem = asyncio.Semaphore(concurrency)
 
@@ -237,6 +275,9 @@ async def run_clients_concurrent(
                     delta_dump_dir=per_delta_dir,
                     request_idx=index,
                     total_requests=num_requests,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    tool_output=tool_output,
                 )
                 return index, True, None
             except Exception as exc:
@@ -290,7 +331,32 @@ def main() -> None:
         default=1,
         help="Maximum number of concurrent websocket requests",
     )
+    parser.add_argument(
+        "--tools",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON file with a list of tool definitions (same shape as the "
+            "chat completions `tools` field). Declared on session.update, so the model "
+            "can answer with a function call instead of speaking."
+        ),
+    )
+    parser.add_argument(
+        "--tool-choice",
+        default="auto",
+        help="tool_choice for session.update: none | auto | required (default: auto)",
+    )
+    parser.add_argument(
+        "--tool-output",
+        default=None,
+        help=(
+            "Canned tool result (a JSON string) returned via conversation.item.create "
+            "for every function call the model makes"
+        ),
+    )
     args = parser.parse_args()
+
+    tools = json.loads(args.tools.read_text(encoding="utf-8")) if args.tools is not None else None
 
     if args.num_requests <= 0:
         raise ValueError("--num-requests must be >= 1")
@@ -309,6 +375,9 @@ def main() -> None:
                 chunk_ms=args.chunk_ms,
                 send_delay_ms=args.send_delay_ms,
                 delta_dump_dir=args.delta_dump_dir,
+                tools=tools,
+                tool_choice=args.tool_choice,
+                tool_output=args.tool_output,
             )
         )
     else:
@@ -324,6 +393,9 @@ def main() -> None:
                 delta_dump_dir=args.delta_dump_dir,
                 num_requests=args.num_requests,
                 concurrency=concurrency,
+                tools=tools,
+                tool_choice=args.tool_choice,
+                tool_output=args.tool_output,
             )
         )
 

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -4,15 +4,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 
 import numpy as np
 import pytest
 import torch
+from vllm.entrypoints.openai.engine.protocol import FunctionCall, ToolCall
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection
+from vllm_omni.entrypoints.openai.realtime_protocol import OmniSessionUpdate
+from vllm_omni.entrypoints.openai.realtime_tool_format import render_tool_preamble
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni import (
+    build_realtime_prompt_token_ids,
+    drain_realtime_prompt_context,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -84,3 +92,210 @@ class TestAsyncOmniStreamingParamsValidation:
         p = SamplingParams(n=1, stop=["\n"], output_kind=RequestOutputKind.DELTA)
         with pytest.raises(ValueError, match="Input streaming"):
             AsyncOmni._validate_streaming_input_sampling_params(p)
+
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Look up the weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+class _FakeTokenizer:
+    """Encodes to one id per character, which is enough to assert that a rendered
+    turn reaches the prompt and in which order."""
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        return [ord(ch) % 1000 for ch in text]
+
+
+@pytest.fixture
+def tool_conn() -> RealtimeConnection:
+    conn = RealtimeConnection.__new__(RealtimeConnection)
+    conn.connection_id = "ws-test"
+    conn._tools = None
+    conn._tool_choice = "auto"
+    conn._pending_context_tokens = []
+    conn._pending_tool_calls = {}
+    conn._tokenizer = _FakeTokenizer()
+    conn._tool_parser = None
+    return conn
+
+
+class TestRealtimeToolConfiguration:
+    def test_no_tools_by_default(self, tool_conn: RealtimeConnection) -> None:
+        assert tool_conn.tools_enabled is False
+
+    def test_session_update_with_tools_enables_and_stages_preamble(self, tool_conn: RealtimeConnection) -> None:
+        tool_conn._configure_tools({"type": "session.update", "model": "m", "tools": [_WEATHER_TOOL]})
+        assert tool_conn.tools_enabled is True
+        # The tool definitions must be staged for the next prompt, otherwise the
+        # model never learns the tools exist.
+        assert tool_conn._pending_context_tokens
+
+    def test_preamble_declares_tool_in_qwen_format(self, tool_conn: RealtimeConnection) -> None:
+        update = OmniSessionUpdate(type="session.update", model="m", tools=[_WEATHER_TOOL])
+        preamble = render_tool_preamble(update.tools)
+        assert "<|im_start|>system" in preamble
+        assert "<tools>" in preamble and "</tools>" in preamble
+        assert "get_weather" in preamble
+        # The parser recognizes calls by this tag, so the instruction must name it.
+        assert "<tool_call>" in preamble
+
+    def test_tool_choice_none_disables_tools(self, tool_conn: RealtimeConnection) -> None:
+        tool_conn._configure_tools(
+            {"type": "session.update", "model": "m", "tools": [_WEATHER_TOOL], "tool_choice": "none"}
+        )
+        assert tool_conn.tools_enabled is False
+        assert tool_conn._pending_context_tokens == []
+
+    def test_session_update_without_tools_keeps_tools_disabled(self, tool_conn: RealtimeConnection) -> None:
+        tool_conn._configure_tools({"type": "session.update", "model": "m"})
+        assert tool_conn.tools_enabled is False
+        assert tool_conn._pending_context_tokens == []
+
+
+class TestRealtimeToolResults:
+    @pytest.mark.asyncio
+    async def test_tool_result_is_staged_as_context(self, tool_conn: RealtimeConnection) -> None:
+        tool_conn._pending_tool_calls = {"call_1": "get_weather"}
+        await tool_conn._handle_conversation_item_create(
+            {
+                "type": "conversation.item.create",
+                "item": {"type": "function_call_output", "call_id": "call_1", "output": '{"temp_c": 21}'},
+            }
+        )
+        assert tool_conn._pending_context_tokens
+        # The call is settled, so a duplicate result would be flagged as unknown.
+        assert "call_1" not in tool_conn._pending_tool_calls
+
+    @pytest.mark.asyncio
+    async def test_unknown_call_id_is_tolerated(self, tool_conn: RealtimeConnection) -> None:
+        # A late or duplicated result must not break the session.
+        await tool_conn._handle_conversation_item_create(
+            {
+                "type": "conversation.item.create",
+                "item": {"type": "function_call_output", "call_id": "nope", "output": "{}"},
+            }
+        )
+        assert tool_conn._pending_context_tokens
+
+
+class TestRealtimeToolCallEmission:
+    @pytest.mark.asyncio
+    async def test_emits_delta_and_done_and_tracks_call_id(self, tool_conn: RealtimeConnection) -> None:
+        sent: list[dict] = []
+
+        async def fake_send_json(payload: dict) -> None:
+            sent.append(payload)
+
+        tool_conn.send_json = fake_send_json  # type: ignore[method-assign]
+        call = ToolCall(id="call_1", function=FunctionCall(name="get_weather", arguments='{"city": "Berlin"}'))
+
+        await tool_conn._emit_tool_calls([call])
+
+        types = [event["type"] for event in sent]
+        assert types == [
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+        ]
+        assert sent[-1]["call_id"] == "call_1"
+        assert sent[-1]["name"] == "get_weather"
+        assert sent[-1]["arguments"] == '{"city": "Berlin"}'
+        # Needed so the tool result the client sends back can be rendered.
+        assert tool_conn._pending_tool_calls["call_1"] == "get_weather"
+        # The model's own call is kept as context for the follow-up turn.
+        assert tool_conn._pending_context_tokens
+
+    def test_extract_returns_nothing_when_tools_disabled(self, tool_conn: RealtimeConnection) -> None:
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+        tool_calls, spoken = tool_conn._extract_tool_calls(text)
+        assert tool_calls == []
+        assert spoken == text
+
+
+class TestRealtimeToolPromptFormat:
+    """Pins the rendered turns to what the model's own chat template emits.
+
+    These strings were taken from Qwen3-Omni's ``chat_template.json``; if they
+    drift the model stops recognizing the tool protocol, and it fails silently
+    (the model just talks instead of calling), so assert them exactly.
+    """
+
+    def test_preamble_matches_chat_template_output(self, tool_conn: RealtimeConnection) -> None:
+        update = OmniSessionUpdate(type="session.update", model="m", tools=[_WEATHER_TOOL])
+        rendered = render_tool_preamble(update.tools)
+        assert rendered.startswith("<|im_start|>system\n\n\n# Tools\n\n")
+        assert "You may call one or more functions to assist with the user query." in rendered
+        assert "You are provided with function signatures within <tools></tools> XML tags:\n<tools>\n" in rendered
+        assert (
+            "\n</tools>\n\nFor each function call, return a json object with function name "
+            'and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": '
+            '<function-name>, "arguments": <args-json-object>}\n</tool_call><|im_end|>' in rendered
+        )
+
+    def test_tool_result_matches_chat_template_output(self, tool_conn: RealtimeConnection) -> None:
+        from vllm_omni.entrypoints.openai.realtime_tool_format import TOOL_RESULT_TEMPLATE
+
+        assert TOOL_RESULT_TEMPLATE.format(output='{"temp_c": 21}') == (
+            '<|im_start|>user\n<tool_response>\n{"temp_c": 21}\n</tool_response><|im_end|>\n'
+        )
+
+    def test_assistant_tool_call_embeds_arguments_as_json_object(self, tool_conn: RealtimeConnection) -> None:
+        from vllm_omni.entrypoints.openai.realtime_tool_format import ASSISTANT_TOOL_CALL_TEMPLATE
+
+        rendered = ASSISTANT_TOOL_CALL_TEMPLATE.format(name="get_weather", arguments='{"city": "Berlin"}')
+        # The chat template emits a string-valued arguments field verbatim, so the
+        # arguments must appear as a JSON object and not as an escaped string.
+        assert rendered == (
+            '<|im_start|>assistant\n<tool_call>\n{"name": "get_weather", '
+            '"arguments": {"city": "Berlin"}}\n</tool_call><|im_end|>\n'
+        )
+        assert "\\" not in rendered
+
+
+class TestRealtimePromptContext:
+    """``buffer_realtime_audio`` prefixes each segment prompt with whatever the
+    connection staged on the context channel."""
+
+    def test_context_is_prepended(self) -> None:
+        assert build_realtime_prompt_token_ids([1, 2, 3], [10, 11]) == [1, 2, 3, 10, 11]
+
+    def test_empty_context_returns_the_prompt_itself(self) -> None:
+        # A session that configures no tools must see the exact prompt it saw
+        # before, so return the same object rather than a copy.
+        prompt_token_ids = [10, 11]
+        assert build_realtime_prompt_token_ids([], prompt_token_ids) is prompt_token_ids
+
+    def test_drain_collects_everything_queued(self) -> None:
+        queue: asyncio.Queue[list[int]] = asyncio.Queue()
+        queue.put_nowait([1, 2])
+        queue.put_nowait([3])
+        collected: list[int] = []
+        drain_realtime_prompt_context(queue, collected)
+        assert collected == [1, 2, 3]
+        assert queue.empty()
+
+    def test_drain_accumulates_across_calls(self) -> None:
+        # Later turns (a tool result, then the next one) append to the context
+        # already in place instead of replacing it.
+        queue: asyncio.Queue[list[int]] = asyncio.Queue()
+        collected: list[int] = []
+        queue.put_nowait([1])
+        drain_realtime_prompt_context(queue, collected)
+        queue.put_nowait([2])
+        drain_realtime_prompt_context(queue, collected)
+        assert collected == [1, 2]
+
+    def test_drain_on_empty_queue_is_a_noop(self) -> None:
+        queue: asyncio.Queue[list[int]] = asyncio.Queue()
+        collected: list[int] = []
+        drain_realtime_prompt_context(queue, collected)
+        assert collected == []

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -4,26 +4,49 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator, Mapping
-from typing import cast
+from typing import Any, cast
 from uuid import uuid4
 
 import numpy as np
-from vllm.entrypoints.openai.engine.protocol import UsageInfo
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest, ChatCompletionToolsParam
+from vllm.entrypoints.openai.engine.protocol import ToolCall, UsageInfo
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.entrypoints.speech_to_text.realtime.protocol import TranscriptionDelta, TranscriptionDone
 from vllm.logger import init_logger
+from vllm.tokenizers import cached_tokenizer_from_config
+from vllm.tool_parsers import ToolParserManager
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.entrypoints.openai.realtime_protocol import (
+    ConversationItemCreate,
+    OmniSessionUpdate,
+    ResponseFunctionCallArgumentsDelta,
+    ResponseFunctionCallArgumentsDone,
+)
+from vllm_omni.entrypoints.openai.realtime_tool_format import (
+    render_assistant_tool_call,
+    render_tool_preamble,
+    render_tool_result,
+)
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
+
+# Fallback only: the tool parser is normally taken from the one the server already
+# resolved for /v1/chat/completions (see _get_tool_parser), so a --tool-call-parser
+# choice applies to realtime too. hermes covers the Qwen family, which is what
+# this realtime path serves today.
+_DEFAULT_TOOL_PARSER = "hermes"
 
 
 class RealtimeConnection(VllmRealtimeConnection):
     """Omni realtime connection with audio-only server events.
 
-    Reuses upstream vLLM websocket/session lifecycle and only customizes
-    generation output handling to emit audio deltas.
+    Reuses upstream vLLM websocket/session lifecycle and customizes generation
+    output handling to emit audio deltas, plus tool/function calling: upstream's
+    realtime protocol has no wire mechanism for tools, so ``session.update``
+    accepts tool definitions here and function calls are surfaced using the
+    OpenAI realtime event shapes.
     """
 
     def __init__(self, *args, **kwargs):
@@ -31,8 +54,148 @@ class RealtimeConnection(VllmRealtimeConnection):
         self.engine = cast(AsyncOmni, self.serving.engine_client)
         self._realtime_audio_ref: np.ndarray | None = None
 
+        # Tool-calling session state.
+        self._tools: list[ChatCompletionToolsParam] | None = None
+        self._tool_choice: Any = "auto"
+        # Rendered turns waiting to be prepended to the next prompt. They travel
+        # over ``input_stream``, the context channel upstream already threads from
+        # the connection down into ``buffer_realtime_audio``.
+        self._pending_context_tokens: list[int] = []
+        # call_id -> function name, so a tool result coming back from the client
+        # can be rendered even though the wire event only carries the call id.
+        self._pending_tool_calls: dict[str, str] = {}
+        self._tokenizer = None
+        self._tool_parser = None
+
     async def start_generation(self):
         await super().start_generation()
+
+    # ==================== tool calling ====================
+
+    @property
+    def tools_enabled(self) -> bool:
+        return bool(self._tools)
+
+    def _get_tokenizer(self):
+        if self._tokenizer is None:
+            self._tokenizer = cached_tokenizer_from_config(self.serving.model_config)
+        return self._tokenizer
+
+    def _get_tool_parser(self):
+        """Reuse whatever tool parser the server resolved for chat completions.
+
+        That keeps a ``--tool-call-parser`` choice (and the model-family special
+        cases that come with it) consistent between /v1/chat/completions and
+        realtime, instead of pinning one syntax here.
+        """
+        if self._tool_parser is None:
+            serving_chat = getattr(getattr(self.websocket, "app", None), "state", None)
+            serving_chat = getattr(serving_chat, "openai_serving_chat", None)
+            parser_cls = getattr(getattr(serving_chat, "parser_cls", None), "tool_parser_cls", None)
+            if parser_cls is None:
+                parser_cls = ToolParserManager.get_tool_parser(_DEFAULT_TOOL_PARSER)
+            self._tool_parser = parser_cls(self._get_tokenizer())
+        return self._tool_parser
+
+    def _stage_context(self, text: str) -> None:
+        """Queue a rendered turn to be prepended to the next prompt."""
+        if not text:
+            return
+        self._pending_context_tokens.extend(self._get_tokenizer().encode(text, add_special_tokens=False))
+
+    def _configure_tools(self, event: dict) -> None:
+        """Read tool configuration out of a ``session.update`` event."""
+        session_update = OmniSessionUpdate(**event)
+        self._tool_choice = session_update.tool_choice
+        if not session_update.tools or self._tool_choice == "none":
+            self._tools = None
+            return
+
+        self._tools = session_update.tools
+        self._pending_tool_calls.clear()
+        self._stage_context(render_tool_preamble(self._tools))
+        logger.debug(
+            "Realtime session %s configured with %d tool(s)",
+            self.connection_id,
+            len(self._tools),
+        )
+
+    async def _handle_conversation_item_create(self, event: dict) -> None:
+        """Accept a tool result and stage it as context for the next turn."""
+        item = ConversationItemCreate(**event).item
+        if item.call_id not in self._pending_tool_calls:
+            logger.warning(
+                "Realtime session %s: tool result for unknown call_id %s",
+                self.connection_id,
+                item.call_id,
+            )
+        self._pending_tool_calls.pop(item.call_id, None)
+        self._stage_context(render_tool_result(item.output))
+
+    def _tool_request(self) -> ChatCompletionRequest:
+        """Minimal request object, required by the tool parser's API."""
+        return ChatCompletionRequest(
+            model=self.serving.model_config.served_model_name or "",
+            messages=[],
+            tools=self._tools,
+            tool_choice=self._tool_choice,
+        )
+
+    def _extract_tool_calls(self, text: str) -> tuple[list[ToolCall], str]:
+        """Split generated text into tool calls and the remaining spoken content."""
+        if not text or not self.tools_enabled:
+            return [], text
+        try:
+            extracted = self._get_tool_parser().extract_tool_calls(text, self._tool_request())
+        except Exception:
+            logger.exception("Realtime session %s: tool call extraction failed", self.connection_id)
+            return [], text
+        if not extracted.tools_called:
+            return [], text
+        return list(extracted.tool_calls), getattr(extracted, "content", None) or ""
+
+    async def _emit_tool_calls(self, tool_calls: list[ToolCall]) -> None:
+        """Send the OpenAI realtime function-call events for each call."""
+        for tool_call in tool_calls:
+            call_id = tool_call.id
+            name = tool_call.function.name
+            arguments = tool_call.function.arguments or "{}"
+            self._pending_tool_calls[call_id] = name
+            item_id = f"item-{uuid4()}"
+            await self.send_json(
+                ResponseFunctionCallArgumentsDelta(
+                    item_id=item_id,
+                    call_id=call_id,
+                    name=name,
+                    delta=arguments,
+                ).model_dump()
+            )
+            await self.send_json(
+                ResponseFunctionCallArgumentsDone(
+                    item_id=item_id,
+                    call_id=call_id,
+                    name=name,
+                    arguments=arguments,
+                ).model_dump()
+            )
+            # Keep the model's own call in context so the tool result the client
+            # sends back has something to attach to.
+            self._stage_context(render_assistant_tool_call(name, arguments))
+
+    async def handle_event(self, event: dict):
+        """Route events, adding the tool-related ones on top of upstream's."""
+        event_type = event.get("type")
+        if event_type == "session.update":
+            await super().handle_event(event)
+            if self._is_model_validated:
+                self._configure_tools(event)
+            return
+        if event_type == "conversation.item.create":
+            await self._handle_conversation_item_create(event)
+            return
+        await super().handle_event(event)
+
+    # ==================== audio helpers ====================
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:
@@ -129,6 +292,14 @@ class RealtimeConnection(VllmRealtimeConnection):
         prompt_token_ids_len = 0
         completion_tokens_len = 0
         self._realtime_audio_ref = None
+        tools_enabled = self.tools_enabled
+
+        # Hand any staged context (tool definitions, a tool result, the model's
+        # own previous tool call) to ``buffer_realtime_audio`` before the engine
+        # starts consuming the prompt generator.
+        if self._pending_context_tokens:
+            input_stream.put_nowait(list(self._pending_context_tokens))
+            self._pending_context_tokens.clear()
 
         # Coerce cumulative outputs to delta outputs; this ensures
         # we don't emit redundant MM data & drain after emitting.
@@ -151,7 +322,10 @@ class RealtimeConnection(VllmRealtimeConnection):
                 if stage_id == 0 and output.outputs:
                     first_output = output.outputs[0]
                     new_token_ids = list(first_output.token_ids)
-                    if new_token_ids:
+                    # With tools configured the connection owns the context: it
+                    # stages properly rendered turns instead of echoing raw
+                    # output tokens, so the two do not fight over the channel.
+                    if new_token_ids and not tools_enabled:
                         input_stream.put_nowait(new_token_ids)
 
                     if output.prompt_token_ids:
@@ -164,7 +338,11 @@ class RealtimeConnection(VllmRealtimeConnection):
                     full_text += delta_text
                     completion_tokens_len += len(new_token_ids)
 
-                    if delta_text:
+                    # With tools configured the text is held back until the turn
+                    # ends: a tool call is only recognizable once its
+                    # <tool_call>...</tool_call> block is complete, and streaming
+                    # that raw markup as transcription would be wrong.
+                    if delta_text and not tools_enabled:
                         await self.send(TranscriptionDelta(delta=delta_text))
 
                 audio_chunks, sample_rate = self._extract_audio_chunks(output)
@@ -183,12 +361,20 @@ class RealtimeConnection(VllmRealtimeConnection):
                 if not self._is_connected:
                     break
 
+            spoken_text = full_text
+            if tools_enabled:
+                tool_calls, spoken_text = self._extract_tool_calls(full_text)
+                if spoken_text:
+                    await self.send(TranscriptionDelta(delta=spoken_text))
+                if tool_calls:
+                    await self._emit_tool_calls(tool_calls)
+
             usage = UsageInfo(
                 prompt_tokens=prompt_token_ids_len,
                 completion_tokens=completion_tokens_len,
                 total_tokens=prompt_token_ids_len + completion_tokens_len,
             )
-            await self.send(TranscriptionDone(text=full_text, usage=usage))
+            await self.send(TranscriptionDone(text=spoken_text, usage=usage))
 
             if sent_audio:
                 await self.send_json({"type": "response.audio.done", "has_audio": True})

--- a/vllm_omni/entrypoints/openai/realtime_protocol.py
+++ b/vllm_omni/entrypoints/openai/realtime_protocol.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Omni extensions to the realtime websocket protocol.
+
+Upstream's realtime protocol (``vllm/entrypoints/speech_to_text/realtime/protocol.py``)
+is transcription-oriented: ``session.update`` carries only ``model``, and there is no
+wire mechanism for tools at all. The events below add tool/function calling using the
+shapes of the OpenAI realtime API, so clients that already speak it (LiveKit Agents and
+similar) work without changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
+from vllm.utils import random_uuid
+
+# Client -> Server events
+
+
+class OmniSessionUpdate(OpenAIBaseModel):
+    """``session.update`` extended with tool configuration.
+
+    Upstream only reads ``model``; the extra fields are ignored by the base
+    implementation, so a client that sends them against a build without this
+    support degrades to plain speech-to-speech instead of failing.
+    """
+
+    type: Literal["session.update"] = "session.update"
+    model: str | None = None
+    tools: list[ChatCompletionToolsParam] | None = None
+    tool_choice: Literal["none", "auto", "required"] | dict[str, Any] = "auto"
+
+
+class FunctionCallOutputItem(OpenAIBaseModel):
+    """The result of a tool call, produced by the client."""
+
+    type: Literal["function_call_output"] = "function_call_output"
+    call_id: str
+    output: str
+
+
+class ConversationItemCreate(OpenAIBaseModel):
+    """``conversation.item.create`` carrying a tool result."""
+
+    type: Literal["conversation.item.create"] = "conversation.item.create"
+    item: FunctionCallOutputItem
+
+
+# Server -> Client events
+
+
+class ResponseFunctionCallArgumentsDelta(OpenAIBaseModel):
+    """Incremental arguments for a function call the model is requesting."""
+
+    type: Literal["response.function_call_arguments.delta"] = "response.function_call_arguments.delta"
+    item_id: str = Field(default_factory=lambda: f"item-{random_uuid()}")
+    call_id: str
+    name: str | None = None
+    delta: str
+
+
+class ResponseFunctionCallArgumentsDone(OpenAIBaseModel):
+    """Terminal event for one function call, with the complete arguments."""
+
+    type: Literal["response.function_call_arguments.done"] = "response.function_call_arguments.done"
+    item_id: str = Field(default_factory=lambda: f"item-{random_uuid()}")
+    call_id: str
+    name: str
+    arguments: str

--- a/vllm_omni/entrypoints/openai/realtime_tool_format.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_format.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Prompt formatting for realtime tool calling.
+
+The realtime prompt built by ``buffer_realtime_audio`` has no system turn, so a
+tool-calling session has to render the tool definitions -- and later the tool
+results -- itself and feed them in as prompt context.
+
+**These templates are Qwen-family specific.** They reproduce, turn for turn,
+what the model's own chat template emits for tools (verified against
+Qwen3-Omni's ``chat_template.json``): the tool block is a system turn, a tool
+result is a user turn wrapped in ``<tool_response>``, and a tool call is an
+assistant turn wrapped in ``<tool_call>`` -- which is also the shape the
+``hermes`` tool parser reads back out of generated text.
+
+They are rendered here rather than through ``tokenizer.apply_chat_template`` so
+that the prompt stays deterministic and unit-testable, and does not depend on
+whether a given checkpoint ships a tools-aware chat template. Supporting another
+model family means adding its variants alongside these.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+TOOL_PREAMBLE_TEMPLATE = """<|im_start|>system
+
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{tool_signatures}
+</tools>
+
+For each function call, return a json object with function name and arguments \
+within <tool_call></tool_call> XML tags:
+<tool_call>
+{{"name": <function-name>, "arguments": <args-json-object>}}
+</tool_call><|im_end|>
+"""
+
+TOOL_RESULT_TEMPLATE = """<|im_start|>user
+<tool_response>
+{output}
+</tool_response><|im_end|>
+"""
+
+ASSISTANT_TOOL_CALL_TEMPLATE = """<|im_start|>assistant
+<tool_call>
+{{"name": "{name}", "arguments": {arguments}}}
+</tool_call><|im_end|>
+"""
+
+
+def render_tool_preamble(tools: Sequence[Any]) -> str:
+    """Render the system turn that declares the available tools."""
+    signatures = "\n".join(json.dumps(tool.model_dump(exclude_none=True), ensure_ascii=False) for tool in tools)
+    return TOOL_PREAMBLE_TEMPLATE.format(tool_signatures=signatures)
+
+
+def render_tool_result(output: str) -> str:
+    """Render the user turn carrying a tool result."""
+    return TOOL_RESULT_TEMPLATE.format(output=output)
+
+
+def render_assistant_tool_call(name: str, arguments: str) -> str:
+    """Render the assistant turn for a call the model made.
+
+    ``arguments`` is embedded as the JSON object it already is: the chat template
+    emits a string-valued arguments field verbatim rather than quoting it.
+    """
+    return ASSISTANT_TOOL_CALL_TEMPLATE.format(name=name, arguments=arguments)

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -73,6 +73,33 @@ TALKER_CODEC_THINK_EOS_ID = 4205  # Think mode end
 logger = init_logger(__name__)
 
 
+def drain_realtime_prompt_context(input_stream: "asyncio.Queue[list[int]]", context_token_ids: list[int]) -> None:
+    """Move everything queued on the realtime context channel into ``context_token_ids``.
+
+    ``input_stream`` is the channel upstream threads from the realtime connection
+    into ``buffer_realtime_audio`` ("context token IDs ... for autoregressive
+    multi-turn processing"). The connection uses it to hand over already-rendered
+    turns -- today the tool definitions and tool results of a tool-calling session,
+    which have nowhere else to go because the realtime prompt has no system turn.
+    """
+    while True:
+        try:
+            context_token_ids.extend(input_stream.get_nowait())
+        except asyncio.QueueEmpty:
+            return
+
+
+def build_realtime_prompt_token_ids(context_token_ids: list[int], prompt_token_ids: list[int]) -> list[int]:
+    """Prefix the per-segment prompt with any context the connection staged.
+
+    With an empty channel this returns the prompt unchanged, so a session that
+    configures no tools behaves exactly as before.
+    """
+    if not context_token_ids:
+        return prompt_token_ids
+    return [*context_token_ids, *prompt_token_ids]
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3OmniMoeThinkerMultiModalProcessor,
     info=Qwen3OmniMoeThinkerProcessingInfo,
@@ -245,6 +272,11 @@ class Qwen3OmniMoeForConditionalGeneration(
 
         prompt_token_ids = tokenizer.encode(prompt_template)
 
+        # Context handed over by the realtime connection (tool definitions, tool
+        # results) is prepended to every segment prompt; an empty channel leaves
+        # the prompt untouched.
+        context_token_ids: list[int] = []
+
         # In non-async-chunk (full-payload) mode the engine treats each
         # streaming TokensPrompt as a fresh decode, so mid-stream segment
         # yields cause the thinker to emit duplicate responses and the
@@ -257,15 +289,17 @@ class Qwen3OmniMoeForConditionalGeneration(
 
             if async_chunk:
                 while (segment := buffer.read_audio()) is not None:
+                    drain_realtime_prompt_context(input_stream, context_token_ids)
                     yield TokensPrompt(
-                        prompt_token_ids=prompt_token_ids,
+                        prompt_token_ids=build_realtime_prompt_token_ids(context_token_ids, prompt_token_ids),
                         multi_modal_data={"audio": segment},
                     )
 
         remaining = buffer.flush()
         if remaining is not None and len(remaining) > 0:
+            drain_realtime_prompt_context(input_stream, context_token_ids)
             yield TokensPrompt(
-                prompt_token_ids=prompt_token_ids,
+                prompt_token_ids=build_realtime_prompt_token_ids(context_token_ids, prompt_token_ids),
                 multi_modal_data={"audio": remaining},
             )
 


### PR DESCRIPTION
# [Feature] Tool/function calling for the realtime API

## Purpose

Fixes #5522.

`/v1/realtime` has no wire mechanism for tools, so a session can never be told which tools exist. The model then declines verbally ("I can't provide real-time weather updates...") instead of calling anything, even though the same checkpoint does tool calling fine over `/v1/chat/completions`.

There are two layers to the gap:

1. **No wire fields or events.** Upstream's realtime protocol (`vllm/entrypoints/speech_to_text/realtime/protocol.py`) declares only `type` and `model` on `session.update`, and its only server events are `transcription.delta` / `transcription.done`. There is no way to send tool definitions, no server event for a requested call, and no client event to return a result.
2. **No place in the prompt for tool definitions.** The realtime prompt is assembled per audio segment `buffer_realtime_audio`, which builds a fixed single-turn prompt with **no system turn** — and Qwen declares tools in the system turn. So even with the wire fields in place the definitions would have nowhere to go. Upstream does thread a context channel down to the model for this kind of thing (`input_stream`, documented as "context token IDs ... for autoregressive multi-turn processing"), but no model consumes it.

This PR closes both, using the event shapes of the OpenAI realtime API so clients that already speak it (LiveKit Agents and similar) work unchanged.

## What changed

**`vllm_omni/entrypoints/openai/realtime_protocol.py`** (new) — omni-side events:

- `session.update` gains `tools` and `tool_choice`.
- `conversation.item.create` carrying a `function_call_output` item (tool result).
- `response.function_call_arguments.delta` / `.done` (server -> client).

**`vllm_omni/entrypoints/openai/realtime_tool_format.py`** (new) — renders the three turns a tool-calling session needs. These reproduce, turn for turn, what the model's own chat template emits (verified against Qwen3-Omni's `chat_template.json`): tool definitions are a system turn, a tool result is a user turn wrapped in `<tool_response>`, a call is an assistant turn wrapped `<tool_call>` — the same shape the tool parser reads back out. Rendering them directly keeps the prompt deterministic and unit-testable, and independent of whether a checkpoint ships a tools-aware chat template. **The templates are Qwen-family specific and the module says so**; another family means adding its variants alongside.

**`vllm_omni/entrypoints/openai/realtime_connection.py`** — wiring only:

- `handle_event` handles `session.update` (tool config) and `conversation.item.create` (tool result), delegating everything else upstream.
- Rendered turns are staged and handed to the model over `input_stream` before the engine starts consuming the prompt generator.
- At the end of a turn the generated text goes through the tool parser; calls are emitted as function-call events and the model's own call is kept as context so the returned result has something to attach to.
- The parser is **the one the server already resolved for `/v1/chat/completions`**, so a `--tool-call-parser` choice applies to realtime too; `hermes` is only the fallback when none is configured.

**`vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py`** — two small helpers plus their calls in `buffer_realtime_audio`, so staged context is prepended to each segment prompt.

**`examples/online_serving/qwen3_omni/openai_realtime_client.py`** — `--tools` (a JSON file of tool definitions), `--tool-choice` and `--tool-output` (a canned result returned via `conversation.item.create`), plus printing of the two function-call events. This is what produced the end-to-end output below.

## Behaviour when no tools are configured

Unchanged, and deliberately so: every new code path is behind `tools_enabled`.
The context channel stays empty, so `buffer_realtime_audio` returns the same prompt object it did before; text deltas still stream per chunk; the raw-output echo into `input_stream` is untouched.

## Test Plan

```bash
pytest tests/entrypoints/test_realtime_connection_helpers.py -v
```

The file gains 17 tests (10 -> 27) covering: tool configuration from `session.update`, `tool_choice: none` disabling tools, tool results being staged (including an unknown `call_id` being tolerated), the emitted event pair and its `call_id` / name / arguments, the parser not firing when tools are off, the prompt-context drain and prefixing, and — most importantly — the rendered turns matching the chat template exactly.

Additionally verified against the real checkpoint's tokenizer and the `hermes` parser (`Qwen/Qwen3-Omni-30B-A3B-Instruct`): a bare `<tool_call>` block is extracted as a call, `"Let me check that." + <tool_call>` splits into spoken text plus a call, and ordinary speech is not mistaken for a call.

## Test Result

```
27 passed
```

Rendered-turn checks against `chat_template.json` — these caught two real bugs while developing (arguments were being escaped as a string instead of embedded as a JSON object, and the system turn was missing two newlines), both of which would have shown up only as "the model never calls tools":

```
OK   preamble phrase '# Tools'
OK   preamble phrase 'You may call one or more functions to ...'
OK   preamble phrase 'You are provided with function signatu...'
OK   preamble phrase 'For each function call, return a json ...'
OK   tool result exact
OK   tool call exact
OK   arguments not escaped
```

Parser behaviour against the real tokenizer:

```
pure call     : OK -> {"city": "Berlin"}
speech + call : OK -> spoken part: 'Let me check that.'
plain speech  : OK (not treated as a tool call)
```

### End to end against `Qwen/Qwen3-Omni-30B-A3B-Instruct`

Server (2 GPUs, stage 0 / stages 1-2):

```bash
vllm-omni serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
    --omni --no-async-chunk --port 8091 --trust-remote-code
```

Tool definition used below (`weather_tool.json` / `legal_tool.json` have the same
shape as the chat completions `tools` field):

```json
[{"type": "function",
  "function": {"name": "search_legal_advice",
               "description": "Search legal guidance for a situation involving Chinese law, such as detention, fighting, or police procedures. Call this whenever the user describes a legal situation and needs guidance.",
               "parameters": {"type": "object",
                              "properties": {"situation": {"type": "string"},
                                             "jurisdiction": {"type": "string"}},
                              "required": ["situation"]}}}]
```

Client, with and without tools (the `--tools` / `--tool-choice` / `--tool-output`
flags are the ones this PR adds to the example):

```bash
# control: no tools declared
python examples/online_serving/qwen3_omni/openai_realtime_client.py \
    --url ws://localhost:8091/v1/realtime \
    --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
    --input-wav tests/assets/minicpmo_4_5/response_required_16k.wav \
    --output-wav /tmp/rt_notools.wav

# tools declared
python examples/online_serving/qwen3_omni/openai_realtime_client.py \
    --url ws://localhost:8091/v1/realtime \
    --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
    --input-wav tests/assets/minicpmo_4_5/response_required_16k.wav \
    --output-wav /tmp/rt_tools.wav \
    --tools legal_tool.json --tool-choice auto \
    --tool-output '{"summary": "Detention for fighting is handled under public security administration law; consult a lawyer."}'
```

**Tool definitions reach the prompt.** Same audio, same everything, only
`session.update` differs:

| run | `prompt_tokens` |
| --- | --- |
| without `tools` | 81 |
| with one tool declared | 246 |

The 165-token difference is exactly the tokenized length of the rendered tool
preamble for that tool, so the definitions land in the prompt verbatim.

**The model calls the tool.** With a tool whose description matched what the
speaker was asking about, the model stopped answering in prose and issued a call
instead, extracting the argument from the audio itself:

```
function call (delta): search_legal_advice call_id=chatcmpl-tool-ad8f0347a911fa0d
                       arguments+={"situation": "打架进局子", "jurisdiction": "China"}
function call:         search_legal_advice({"situation": "打架进局子", "jurisdiction": "China"})
Final transcription:   ''
sent tool result for call_id=chatcmpl-tool-ad8f0347a911fa0d
```

Note the empty transcription: the `<tool_call>` markup is consumed by the parser
rather than streamed to the client as speech-to-text. Returning the result via
`conversation.item.create` is accepted and staged for the next turn.

**Control run.** The same tool declared for unrelated audio produced no call and
the usual text plus audio deltas, i.e. `tool_choice: auto` is left to the model.

## Known limitations / follow-ups

- **Text is held back until the turn ends when tools are configured.** A call is only recognizable once its `<tool_call>...</tool_call>` block is complete, and streaming that raw markup as transcription would be wrong. Audio deltas are unaffected, so the voice path still streams. Switching to the parser's streaming interface (`extract_tool_calls_streaming`) would restore incremental text for tool sessions; happy to do that here if you would rather have it now.
- **Scope is the non-duplex `/v1/realtime` path.** The `?duplex=1` full-duplex runtime is a separate implementation; wiring the same capability there is a natural follow-up.
- **Prompt context is consumed by Qwen3-Omni's `buffer_realtime_audio`.** It is currently the only model in this repo implementing `SupportsRealtime`, so this covers the endpoint as it stands; another speech-to-speech model adding realtime support would call the same two helpers. The alternative — draining the channel one level up, in the serving layer, so every realtime model gets it automatically — was prototyped but needs replacing the serving class at its construction site and copying upstream's `transcribe_realtime` body (which then drifts). Say the word if you prefer that trade.
- **`tool_choice` is honoured for `none` but not enforced for `required`.** `none` disables tools outright, and `auto` leaves the decision to the model (verified above). `required` is accepted and passed to the tool parser, but nothing in the prompt forces a call, so the model may still answer in prose.  Enforcing it would mean either encoding the constraint in the preamble or driving structured outputs; happy to add whichever you prefer.
- **The model may vocalize a call it is also emitting as text.** With `tool_choice: auto` the checkpoint decides; if that turns out noisy in practice, suppressing audio for a turn that produced a call would be the fix.
