### PR TITLE
[Diffusion] Add official LTX ordinary and distilled two-stage pipelines

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -432,9 +432,14 @@ steps:
         commands:
           - pytest -s -v tests/e2e/accuracy/hunyuanvideo15_t2v/test_hunyuanvideo15_t2v_video_similarity.py -m full_model --run-level full_model
           - pytest -s -v tests/e2e/accuracy/hunyuanvideo15_i2v/test_hunyuanvideo15_i2v_video_similarity.py -m full_model --run-level full_model
-          - pytest -s -v 'tests/e2e/accuracy/ltx/test_ltx_official_similarity.py::test_ltx_one_stage_matches_official[ltx2_3_i2v]' -m full_model --run-level full_model
           - pytest -s -v tests/e2e/accuracy/test_video_streaming_output_similarity.py -m full_model --run-level full_model
         mirror_hardwares: h100_2
+
+      - label: ":full_moon: Diffusion X2V · LTX Accuracy Test"
+        timeout_in_minutes: 180
+        commands:
+          - pytest -s -v 'tests/e2e/accuracy/ltx/test_ltx_official_similarity.py::test_ltx_matches_official[ltx2_3_i2v]' -m full_model --run-level full_model
+        mirror_hardwares: h100_1
 
       - label: ":full_moon: Diffusion X2V · Perf Test"
         key: nightly-diffusion-x2v-performance

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -42,7 +42,7 @@ th {
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.2-VACE | `Pyros13/Wan2.2-VACE-Fun-A14B-Diffusers` | ✅︎ |   |   |   |
 | `LTX2Pipeline` | LTX-2 / LTX-2.3 one-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
-| `LTX2TwoStagePipeline` | LTX-2 / LTX-2.3 ordinary two-stage T2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` + matching Lightricks LoRA and upsampler | ✅︎ | ✅︎ | | |
+| `LTX2TwoStagePipeline` | LTX-2 / LTX-2.3 ordinary two-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` + matching Lightricks LoRA and upsampler | ✅︎ | ✅︎ | | |
 | `LTX2DistilledPipeline` | LTX-2 distilled two-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled` | ✅︎ | ✅︎ | | |
 | `LingBotVideoPipeline` | LingBot-Video dense and MoE T2V | `robbyant/lingbot-video-dense-1.3b`, `robbyant/lingbot-video-moe-30b-a3b` | ✅︎ | | | |
 | `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -42,6 +42,7 @@ th {
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.2-VACE | `Pyros13/Wan2.2-VACE-Fun-A14B-Diffusers` | ✅︎ |   |   |   |
 | `LTX2Pipeline` | LTX-2 / LTX-2.3 one-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
+| `LTX2TwoStagePipeline` | LTX-2 / LTX-2.3 ordinary two-stage T2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` + matching Lightricks LoRA and upsampler | ✅︎ | ✅︎ | | |
 | `LTX2DistilledPipeline` | LTX-2 distilled two-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled` | ✅︎ | ✅︎ | | |
 | `LingBotVideoPipeline` | LingBot-Video dense and MoE T2V | `robbyant/lingbot-video-dense-1.3b`, `robbyant/lingbot-video-moe-30b-a3b` | ✅︎ | | | |
 | `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -7,10 +7,10 @@
 | Model | Checkpoint | Task | `--model-class-name` | Batching |
 |---|---|---|---|---|
 | LTX-2 | `Lightricks/LTX-2` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
-| LTX-2 | `Lightricks/LTX-2` | Ordinary two-stage T2V | `LTX2TwoStagePipeline` | No |
+| LTX-2 | `Lightricks/LTX-2` | Ordinary two-stage T2V/I2V | `LTX2TwoStagePipeline` | No |
 | LTX-2 distilled | `rootonchair/LTX-2-19b-distilled` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
 | LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
-| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Ordinary two-stage T2V | `LTX2TwoStagePipeline` | No |
+| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Ordinary two-stage T2V/I2V | `LTX2TwoStagePipeline` | No |
 
 `LTX2Pipeline` is the unified one-stage entry. Checkpoint metadata selects the
 LTX-2 or LTX-2.3 profile; omitting an image selects T2V, while one initial
@@ -24,7 +24,8 @@ distilled mode is selected explicitly rather than inferred from the checkpoint
 name or metadata; always pass `--model-class-name LTX2DistilledPipeline`.
 
 `LTX2TwoStagePipeline` runs the regular checkpoint at half resolution, then
-upsamples and refines with the matching distilled LoRA. It needs these sidecar
+upsamples and refines with the matching distilled LoRA. Omit `image` for T2V
+or provide one initial image for I2V. It needs these sidecar
 files from `Lightricks/LTX-2` or `Lightricks/LTX-2.3` respectively:
 
 | Model | Distilled LoRA | Spatial upsampler |
@@ -132,8 +133,7 @@ vllm serve diffusers/LTX-2.3-Diffusers --omni \
   --model-class-name LTX2TwoStagePipeline --stage-init-timeout 600
 ```
 
-The one-stage and distilled entries handle both T2V and I2V; ordinary
-two-stage currently exposes T2V only. A T2V request using the selected
+All three entries handle both T2V and I2V. A T2V request using the selected
 recipe's default guidance is:
 
 ```bash
@@ -147,7 +147,7 @@ curl -X POST http://localhost:8000/v1/videos/sync \
   -o ltx_t2v.mp4
 ```
 
-For I2V on the one-stage or distilled entry, provide exactly one initial image:
+For I2V on any entry, provide exactly one initial image:
 
 ```bash
 curl -X POST http://localhost:8000/v1/videos/sync \
@@ -271,7 +271,7 @@ noted below.
 | Argument | Type/default | Meaning and constraints |
 |---|---|---|
 | `req` | `DiffusionRequestBatch`, required | Only positional argument; contains prompts and per-request sampling parameters. |
-| `image` | image or batch, `None` | One-stage and distilled only. Direct value wins over request images; no image selects T2V. I2V accepts one image per prompt, and a batch cannot mix T2V/I2V. |
+| `image` | image or batch, `None` | Supported by all entries. Direct value wins over request images; no image selects T2V. I2V accepts one image per prompt, and a batch cannot mix T2V/I2V. |
 | `prompt` | string or list, `None` | Positive-text fallback; request prompts win. Mutually exclusive with `prompt_embeds`. |
 | `negative_prompt` | string or list, `None` | Fallback after request values and before the recipe default; mutually exclusive with negative embeddings. |
 | `height` | `int`, `None` | Request → direct value → recipe default; divisible by 32 one-stage or 64 two-stage. |

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -40,6 +40,55 @@ files from `Lightricks/LTX-2` or `Lightricks/LTX-2.3` respectively:
 The runtime searches the model root, `VLLM_OMNI_LTX_ARTIFACTS_DIR`, then the
 matching Lightricks Hub repository.
 
+## Diffusion Feature Matrix
+
+The table is pipeline-specific. A model-level LTX support mark elsewhere in
+the documentation does not imply that every multi-stage entry supports that
+feature.
+
+| Diffusion feature | `LTX2Pipeline` | `LTX2TwoStagePipeline` | `LTX2DistilledPipeline` |
+|---|:---:|:---:|:---:|
+| T2V / I2V | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
+| Request-level batching | ✅ | ❌ | ❌ |
+| Custom sigma schedule | ✅ | ❌ | ❌ |
+| Request video/audio latents | ✅ | ❌ | ❌ |
+| CFG | ✅ | ⚠️ Stage 1 | — positive-only |
+| STG | ✅ | ⚠️ Stage 1 | — positive-only |
+| Cross-modality guidance / rescale | ✅ | ⚠️ Stage 1 | — positive-only |
+| Tensor parallel | ✅ | ✅ | ✅ |
+| Ulysses sequence parallel | ✅ | ✅ | ✅ |
+| Ring sequence parallel | ⚠️ | ⚠️ | ⚠️ |
+| CFG parallel | ⚠️ CFG-only | ⚠️ Stage 1, CFG-only | — |
+| HSDP | ✅ | ✅ | ✅ |
+| Pipeline parallel | ❌ | ❌ | ❌ |
+| Expert parallel | — | — | — |
+| Module-wise CPU offload | ✅ | ✅ | ✅ |
+| Layerwise CPU offload | ✅ | ✅ | ✅ |
+| VAE patch parallel decode | ✅ | ✅ | ✅ |
+| Quantization | ⚠️ | ⚠️ | ⚠️ |
+| Internal distilled LoRA | — | ✅ dynamic/resident | — merged weights |
+| Cache-DiT | ✅ | ❌ | ❌ |
+| TeaCache | ❌ | ❌ | ❌ |
+| Step execution | ❌ | ❌ | ❌ |
+
+Legend: ✅ supported; ⚠️ supported with the restriction shown below; ❌
+explicitly unsupported; — not applicable.
+
+- Ring SP requires the logical audio latent length to be divisible by the SP
+  size because it cannot consume the key-padding mask; otherwise use pure
+  Ulysses.
+- CFG parallel supports only a two-branch CFG plan. Disable STG and modality
+  guidance and set both rescale fields to `0.0`.
+- Quantization support depends on the checkpoint format and LoRA strategy.
+  Dynamic phase LoRA can reuse an online-quantized base. Resident phase LoRA
+  requires an unquantized checkpoint so the adapter can be merged before
+  online quantization; serialized quantized checkpoints are rejected.
+- Cache-DiT is deliberately limited to `LTX2Pipeline`. Multi-stage entries
+  need phase-aware cache enable/refresh across different denoise schedules and,
+  in resident mode, different Transformer instances. They fail at startup when
+  `cache_backend="cache_dit"` is requested instead of silently running an
+  uncached or stale-cache Stage 2.
+
 ## API Migration
 
 Only `req` may be passed positionally to `LTX2Pipeline`; every optional

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -100,7 +100,9 @@ The distilled recipe fixes both sigma schedules; `num_inference_steps` must be
 Ordinary two-stage defaults to a `1536 × 1024` final output. Stage 1 uses the
 selected one-stage recipe at half resolution; Stage 2 uses the fixed
 three-step positive-only schedule. All two-stage pipelines reject custom sigma
-schedules and request-provided video/audio latents.
+schedules and request-provided video/audio latents. Online Transformer
+quantization is applied to both DiTs after merging the Stage 2 LoRA into full
+checkpoint tensors; already-quantized base checkpoints are unsupported.
 
 ## Serving
 

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -4,14 +4,19 @@
 
 ## Pipelines
 
-| Model | Checkpoint | Task | `--model-class-name` | Batching |
-|---|---|---|---|---|
-| LTX-2 | `Lightricks/LTX-2` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
-| LTX-2 | `Lightricks/LTX-2` | Ordinary two-stage T2V/I2V | `LTX2TwoStagePipeline` | No |
-| LTX-2 distilled | `rootonchair/LTX-2-19b-distilled` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
-| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
-| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Ordinary two-stage T2V/I2V | `LTX2TwoStagePipeline` | No |
-| LTX-2.3 distilled | `diffusers/LTX-2.3-Distilled-Diffusers` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
+| `--model-class-name` | Task | Required checkpoint repositories |
+|---|---|---|
+| `LTX2Pipeline` | LTX-2 one-stage T2V/I2V | `Lightricks/LTX-2` |
+| `LTX2TwoStagePipeline` | LTX-2 ordinary two-stage T2V/I2V | `Lightricks/LTX-2` |
+| `LTX2DistilledPipeline` | LTX-2 full-distilled two-stage T2V/I2V | `rootonchair/LTX-2-19b-distilled` |
+| `LTX2Pipeline` | LTX-2.3 one-stage T2V/I2V | `diffusers/LTX-2.3-Diffusers` |
+| `LTX2TwoStagePipeline` | LTX-2.3 ordinary two-stage T2V/I2V | `diffusers/LTX-2.3-Diffusers`<br>`Lightricks/LTX-2.3` |
+| `LTX2DistilledPipeline` | LTX-2.3 full-distilled two-stage T2V/I2V | `diffusers/LTX-2.3-Distilled-Diffusers`<br>`Lightricks/LTX-2.3` |
+
+The table lists repositories as download units. Each full pipeline repository
+supplies the Transformer, text encoder, connectors, video/audio VAEs, vocoder,
+scheduler, and tokenizer. Where a second repository is listed, it supplies the
+matching LoRA and/or spatial upsampler sidecars.
 
 `LTX2Pipeline` is the unified one-stage entry. Checkpoint metadata selects the
 LTX-2 or LTX-2.3 profile; omitting an image selects T2V, while one initial
@@ -29,13 +34,8 @@ component profile; LTX-2.3 uses its BWE vocoder and matching x2 upsampler.
 
 `LTX2TwoStagePipeline` runs the regular checkpoint at half resolution, then
 upsamples and refines with the matching distilled LoRA. Omit `image` for T2V
-or provide one initial image for I2V. It needs these sidecar
-files from `Lightricks/LTX-2` or `Lightricks/LTX-2.3` respectively:
-
-| Model | Distilled LoRA | Spatial upsampler |
-|---|---|---|
-| LTX-2 | `ltx-2-19b-distilled-lora-384.safetensors` | `ltx-2-spatial-upscaler-x2-1.0.safetensors` |
-| LTX-2.3 | `ltx-2.3-22b-distilled-lora-384-1.1.safetensors` | `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` |
+or provide one initial image for I2V. All required sidecars and their source
+repositories are listed in the table above.
 
 To use predownloaded sidecars, set `VLLM_OMNI_LTX_ARTIFACTS_DIR` to one
 directory containing the applicable files under the exact names shown above.

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -11,6 +11,7 @@
 | LTX-2 distilled | `rootonchair/LTX-2-19b-distilled` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
 | LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
 | LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Ordinary two-stage T2V/I2V | `LTX2TwoStagePipeline` | No |
+| LTX-2.3 distilled | `diffusers/LTX-2.3-Distilled-Diffusers` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
 
 `LTX2Pipeline` is the unified one-stage entry. Checkpoint metadata selects the
 LTX-2 or LTX-2.3 profile; omitting an image selects T2V, while one initial
@@ -22,6 +23,9 @@ the raw `Lightricks/LTX-2.3` safetensors repository is not directly loadable.
 or provide one initial image for I2V. As in the official LTX pipelines,
 distilled mode is selected explicitly rather than inferred from the checkpoint
 name or metadata; always pass `--model-class-name LTX2DistilledPipeline`.
+Both stages use the full merged distilled Transformer and never load the
+standalone distilled LoRA. Checkpoint metadata selects the LTX-2 or LTX-2.3
+component profile; LTX-2.3 uses its BWE vocoder and matching x2 upsampler.
 
 `LTX2TwoStagePipeline` runs the regular checkpoint at half resolution, then
 upsamples and refines with the matching distilled LoRA. Omit `image` for T2V
@@ -123,6 +127,15 @@ Start the distilled checkpoint with its two-stage entry:
 
 ```bash
 vllm serve rootonchair/LTX-2-19b-distilled --omni \
+  --model-class-name LTX2DistilledPipeline --stage-init-timeout 600
+```
+
+For LTX-2.3 full-distilled, use the componentized distilled checkpoint. If it
+does not include `latent_upsampler/`, the runtime resolves the official v1.1
+x2 upsampler from `Lightricks/LTX-2.3`:
+
+```bash
+vllm serve diffusers/LTX-2.3-Distilled-Diffusers --omni \
   --model-class-name LTX2DistilledPipeline --stage-init-timeout 600
 ```
 
@@ -366,6 +379,7 @@ bundled offline CLI do not currently expose `sigmas`.
 - <https://huggingface.co/Lightricks/LTX-2>
 - <https://huggingface.co/Lightricks/LTX-2.3>
 - <https://huggingface.co/diffusers/LTX-2.3-Diffusers>
+- <https://huggingface.co/diffusers/LTX-2.3-Distilled-Diffusers>
 - [Online video generation](../../docs/user_guide/examples/online_serving/text_to_video.md)
 - [Request batching](../../docs/user_guide/diffusion/request_batching.md)
 - [T2V offline example](../../examples/offline_inference/text_to_video/text_to_video.md)

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -101,9 +101,11 @@ The distilled recipe fixes both sigma schedules; `num_inference_steps` must be
 Ordinary two-stage defaults to a `1536 × 1024` final output. Stage 1 uses the
 selected one-stage recipe at half resolution; Stage 2 uses the fixed
 three-step positive-only schedule. All two-stage pipelines reject custom sigma
-schedules and request-provided video/audio latents. Online Transformer
-quantization is applied to both DiTs after merging the Stage 2 LoRA into full
-checkpoint tensors; already-quantized base checkpoints are unsupported.
+schedules and request-provided video/audio latents. Ordinary two-stage uses one
+DiT with a dynamic Stage 2 LoRA by default. Set
+`VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE=resident` before startup to create a second
+DiT with the Stage 2 LoRA pre-merged; this resident override requires an
+unquantized base checkpoint.
 
 ## Serving
 
@@ -355,8 +357,9 @@ bundled offline CLI do not currently expose `sigmas`.
   request parameter.
 - For benchmarks, use `tests/dfx/perf/tests/test_ltx2_vllm_omni.json` with
   `tests/dfx/perf/scripts/run_diffusion_benchmark.py`.
-- Ordinary two-stage keeps a base DiT and a second DiT with the Stage 2 LoRA
-  merged; account for two Transformer copies when sizing GPU or host offload.
+- Ordinary two-stage keeps one base DiT plus the Stage 2 LoRA by default. The
+  `resident` override keeps two Transformer copies and should be sized
+  accordingly.
 
 ## References
 

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -409,6 +409,11 @@ bundled offline CLI do not currently expose `sigmas`.
   `--max-num-seqs 1`.
 - `--cfg-parallel-size` shards the complete LTX guidance plan, including STG,
   modality guidance, and rescale-compatible prediction gathering.
+- LTX sequence parallelism may append internal zero-padding to the audio
+  latent sequence. Pure Ulysses masks those tokens and keeps request RNG
+  invariant across SP sizes. Ring SP cannot consume that key-padding mask, so
+  requests whose logical audio length is not divisible by the SP size fail
+  with an actionable error; use `ring_degree=1` or a divisible request shape.
 
 ## Operational Notes
 

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -7,8 +7,10 @@
 | Model | Checkpoint | Task | `--model-class-name` | Batching |
 |---|---|---|---|---|
 | LTX-2 | `Lightricks/LTX-2` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
+| LTX-2 | `Lightricks/LTX-2` | Ordinary two-stage T2V | `LTX2TwoStagePipeline` | No |
 | LTX-2 distilled | `rootonchair/LTX-2-19b-distilled` | Two-stage T2V/I2V | `LTX2DistilledPipeline` | No |
 | LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | One-stage T2V/I2V | `LTX2Pipeline` | Yes |
+| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Ordinary two-stage T2V | `LTX2TwoStagePipeline` | No |
 
 `LTX2Pipeline` is the unified one-stage entry. Checkpoint metadata selects the
 LTX-2 or LTX-2.3 profile; omitting an image selects T2V, while one initial
@@ -20,6 +22,18 @@ the raw `Lightricks/LTX-2.3` safetensors repository is not directly loadable.
 or provide one initial image for I2V. As in the official LTX pipelines,
 distilled mode is selected explicitly rather than inferred from the checkpoint
 name or metadata; always pass `--model-class-name LTX2DistilledPipeline`.
+
+`LTX2TwoStagePipeline` runs the regular checkpoint at half resolution, then
+upsamples and refines with the matching distilled LoRA. It needs these sidecar
+files from `Lightricks/LTX-2` or `Lightricks/LTX-2.3` respectively:
+
+| Model | Distilled LoRA | Spatial upsampler |
+|---|---|---|
+| LTX-2 | `ltx-2-19b-distilled-lora-384.safetensors` | `ltx-2-spatial-upscaler-x2-1.0.safetensors` |
+| LTX-2.3 | `ltx-2.3-22b-distilled-lora-384-1.1.safetensors` | `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` |
+
+The runtime searches the model root, `VLLM_OMNI_LTX_ARTIFACTS_DIR`, then the
+matching Lightricks Hub repository.
 
 ## API Migration
 
@@ -83,6 +97,11 @@ divisible by 64. Both one- and two-stage requests require `num_frames = 8k+1`.
 The distilled recipe fixes both sigma schedules; `num_inference_steps` must be
 `8` when supplied.
 
+Ordinary two-stage defaults to a `1536 × 1024` final output. Stage 1 uses the
+selected one-stage recipe at half resolution; Stage 2 uses the fixed
+three-step positive-only schedule. All two-stage pipelines reject custom sigma
+schedules and request-provided video/audio latents.
+
 ## Serving
 
 Start either checkpoint:
@@ -102,8 +121,18 @@ vllm serve rootonchair/LTX-2-19b-distilled --omni \
   --model-class-name LTX2DistilledPipeline --stage-init-timeout 600
 ```
 
-The same server handles T2V and I2V. A T2V request using the selected recipe's
-default guidance is:
+Start an ordinary two-stage pipeline and optionally point it at predownloaded
+sidecars:
+
+```bash
+VLLM_OMNI_LTX_ARTIFACTS_DIR=/data/models/LTX-2.3-sidecars \
+vllm serve diffusers/LTX-2.3-Diffusers --omni \
+  --model-class-name LTX2TwoStagePipeline --stage-init-timeout 600
+```
+
+The one-stage and distilled entries handle both T2V and I2V; ordinary
+two-stage currently exposes T2V only. A T2V request using the selected
+recipe's default guidance is:
 
 ```bash
 curl -X POST http://localhost:8000/v1/videos/sync \
@@ -116,7 +145,7 @@ curl -X POST http://localhost:8000/v1/videos/sync \
   -o ltx_t2v.mp4
 ```
 
-For I2V, provide exactly one initial image:
+For I2V on the one-stage or distilled entry, provide exactly one initial image:
 
 ```bash
 curl -X POST http://localhost:8000/v1/videos/sync \
@@ -135,8 +164,9 @@ together with `input_reference`.
 
 ## Guidance
 
-LTX supports independent video/audio CFG, spatio-temporal guidance (STG),
-cross-modality guidance, and rescaling:
+One-stage and ordinary two-stage Stage 1 support independent video/audio CFG,
+spatio-temporal guidance (STG), cross-modality guidance, and rescaling. Both
+distilled stages and ordinary Stage 2 use fixed positive-only guidance.
 
 | Parameter | Default | Effect | Alias |
 |---|---:|---|---|
@@ -239,17 +269,17 @@ noted below.
 | Argument | Type/default | Meaning and constraints |
 |---|---|---|
 | `req` | `DiffusionRequestBatch`, required | Only positional argument; contains prompts and per-request sampling parameters. |
-| `image` | image or batch, `None` | Direct value wins over request images; no image selects T2V. I2V accepts one image per prompt, and a batch cannot mix T2V/I2V. |
+| `image` | image or batch, `None` | One-stage and distilled only. Direct value wins over request images; no image selects T2V. I2V accepts one image per prompt, and a batch cannot mix T2V/I2V. |
 | `prompt` | string or list, `None` | Positive-text fallback; request prompts win. Mutually exclusive with `prompt_embeds`. |
 | `negative_prompt` | string or list, `None` | Fallback after request values and before the recipe default; mutually exclusive with negative embeddings. |
-| `height` | `int`, `None` | Request → direct value → recipe default; divisible by 32 one-stage or 64 distilled. |
+| `height` | `int`, `None` | Request → direct value → recipe default; divisible by 32 one-stage or 64 two-stage. |
 | `width` | `int`, `None` | Same precedence and alignment as `height`. |
 | `num_frames` | `int`, `None` | Request → direct value → recipe default; must be `8k+1` and also determines audio duration with `frame_rate`. |
 | `frame_rate` | `float`, `None` | Request `frame_rate` → request `fps` → direct value → recipe default. |
-| `num_inference_steps` | `int`, `None` | Request → direct value → recipe default; minimum 2 one-stage, fixed at 8 for distilled Stage 1. Custom one-stage `sigmas` determine actual steps. |
+| `num_inference_steps` | `int`, `None` | Request → direct value → recipe default; controls one-stage or ordinary Stage 1, and is fixed at 8 for distilled Stage 1. Custom one-stage `sigmas` determine actual steps. |
 | `sigmas` | list of float, `None` | One-stage only. Request values win; every request in a fused batch must use the same schedule. |
 | `timesteps` | list of int, `None` | Compatibility slot; LTX accepts only `None`. Use `sigmas`. |
-| `guidance_scale` | `float`, `None` | One-stage common video/audio CFG fallback; an explicit request value wins. Distilled two-stage uses fixed positive-only guidance. |
+| `guidance_scale` | `float`, `None` | One-stage and ordinary Stage 1 common video/audio CFG fallback; distilled two-stage uses fixed positive-only guidance. |
 | `guidance_rescale` | `float`, `None` | Accepts only `None` or `0.0`; use the modality rescale fields. |
 | `noise_scale` | `float`, `0.0` | Compatibility slot; LTX accepts only `0.0`. |
 | `num_videos_per_prompt` | `int`, `1` | Output-count fallback; positive request `num_outputs_per_prompt` wins. |
@@ -273,13 +303,13 @@ request prompt payload; LTX guidance fields live in sampling `extra_args`.
 
 ### Recipe-Specific Request Capabilities
 
-| Override | One-stage | Distilled two-stage |
-|---|---|---|
-| Guidance | Supported | Fixed positive-only |
-| Negative prompt/embeddings | Supported | Rejected |
-| `num_inference_steps` | Supported | Fixed at 8 for Stage 1; Stage 2 uses 3 |
-| Custom `sigmas` | Supported | Rejected; both phases use fixed schedules |
-| Video/audio latents | Supported | Rejected |
+| Override | One-stage | Ordinary two-stage | Distilled two-stage |
+|---|---|---|---|
+| Guidance | Supported | Stage 1 only; Stage 2 is positive-only | Fixed positive-only |
+| Negative prompt/embeddings | Supported | Supported by Stage 1 | Rejected |
+| `num_inference_steps` | Supported | Controls Stage 1; Stage 2 uses 3 | Fixed at 8 for Stage 1; Stage 2 uses 3 |
+| Custom `sigmas` | Supported | Rejected | Rejected; both phases use fixed schedules |
+| Video/audio latents | Supported | Rejected | Rejected |
 
 These capability checks apply equally to direct `forward` keywords and
 values in `OmniDiffusionSamplingParams`; unsupported values fail instead of
@@ -323,8 +353,8 @@ bundled offline CLI do not currently expose `sigmas`.
   request parameter.
 - For benchmarks, use `tests/dfx/perf/tests/test_ltx2_vllm_omni.json` with
   `tests/dfx/perf/scripts/run_diffusion_benchmark.py`.
-- Current two-stage support is limited to the distilled checkpoint; official
-  LTX two-stage/HQ execution remains out of scope.
+- Ordinary two-stage keeps a base DiT and a second DiT with the Stage 2 LoRA
+  merged; account for two Transformer copies when sizing GPU or host offload.
 
 ## References
 

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -37,8 +37,12 @@ files from `Lightricks/LTX-2` or `Lightricks/LTX-2.3` respectively:
 | LTX-2 | `ltx-2-19b-distilled-lora-384.safetensors` | `ltx-2-spatial-upscaler-x2-1.0.safetensors` |
 | LTX-2.3 | `ltx-2.3-22b-distilled-lora-384-1.1.safetensors` | `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` |
 
-The runtime searches the model root, `VLLM_OMNI_LTX_ARTIFACTS_DIR`, then the
-matching Lightricks Hub repository.
+To use predownloaded sidecars, set `VLLM_OMNI_LTX_ARTIFACTS_DIR` to one
+directory containing the applicable files under the exact names shown above.
+The variable is an authoritative directory override: startup fails if a
+required file is missing. When it is unset, the runtime searches the model
+root and then the matching Lightricks Hub repository. Per-component
+`model_paths` overrides are not used by LTX.
 
 ## Diffusion Feature Matrix
 

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -255,6 +255,7 @@ class TestMaskedAttentionFallback:
             attention=SimpleNamespace(forward=run("native")),
             sdpa_fallback=SimpleNamespace(forward=run("sdpa")),
             backend_pref=backend_name,
+            _assert_piecewise_compatible=lambda _metadata: None,
         )
         return layer, calls
 

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -229,6 +229,102 @@ class TestAttentionMetadataExtra:
         assert meta.extra == {"foo": "bar"}
 
 
+class TestMaskedAttentionFallback:
+    @staticmethod
+    def _fake_layer(backend_name: str, supports_mask: bool):
+        calls: list[str] = []
+
+        class Backend:
+            @staticmethod
+            def get_name():
+                return backend_name
+
+            @staticmethod
+            def supports_attention_mask():
+                return supports_mask
+
+        def run(name):
+            def forward(query, _key, _value, _metadata):
+                calls.append(name)
+                return torch.zeros_like(query)
+
+            return forward
+
+        layer = SimpleNamespace(
+            attn_backend=Backend,
+            attention=SimpleNamespace(forward=run("native")),
+            sdpa_fallback=SimpleNamespace(forward=run("sdpa")),
+            backend_pref=backend_name,
+        )
+        return layer, calls
+
+    def test_flash_cross_attention_key_mask_uses_sdpa(self):
+        layer, calls = self._fake_layer("FLASH_ATTN", supports_mask=True)
+        query = torch.zeros(1, 3, 2, 4, dtype=torch.bfloat16)
+        key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+
+        Attention._run_local_attention(
+            layer,
+            query,
+            key,
+            value,
+            AttentionMetadata(attn_mask=torch.tensor([[True, True, True, False]])),
+        )
+
+        assert calls == ["sdpa"]
+
+    def test_flash_self_attention_padding_mask_keeps_native_varlen(self):
+        layer, calls = self._fake_layer("FLASH_ATTN", supports_mask=True)
+        query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+
+        Attention._run_local_attention(
+            layer,
+            query,
+            key,
+            value,
+            AttentionMetadata(attn_mask=torch.tensor([[True, True, True, False]])),
+        )
+
+        assert calls == ["native"]
+
+    def test_backend_without_mask_support_uses_sdpa(self):
+        layer, calls = self._fake_layer("SAGE_ATTN", supports_mask=False)
+        query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+
+        Attention._run_local_attention(
+            layer,
+            query,
+            key,
+            value,
+            AttentionMetadata(attn_mask=torch.ones(1, 4, dtype=torch.bool)),
+        )
+
+        assert calls == ["sdpa"]
+
+
+def test_ulysses_validates_2d_padding_mask_against_key_length(monkeypatch):
+    from vllm_omni.diffusion.attention.parallel import ulysses as ulysses_module
+
+    parallel = object.__new__(ulysses_module.UlyssesParallelAttention)
+    parallel._sp_group = SimpleNamespace(ulysses_world_size=1, ulysses_rank=0, ring_world_size=1)
+    parallel._ulysses_pg = None
+    parallel._scatter_idx = 2
+    parallel._gather_idx = 1
+    parallel._use_sync = False
+    monkeypatch.setattr(
+        ulysses_module.SeqAllToAll4D,
+        "apply",
+        staticmethod(lambda _group, tensor, _scatter, _gather, _sync: tensor),
+    )
+    query = torch.zeros(1, 3, 1, 4)
+    key = value = torch.zeros(1, 4, 1, 4)
+    metadata = AttentionMetadata(attn_mask=torch.tensor([[True, True, True, False]]))
+
+    _, _, _, actual_metadata, _ = parallel.pre_attention(query, key, value, metadata)
+
+    torch.testing.assert_close(actual_metadata.attn_mask, metadata.attn_mask)
+
+
 class TestBuildAttentionConfig:
     def test_env_sets_default_when_no_higher_priority_input(self, monkeypatch):
         monkeypatch.setenv("DIFFUSION_ATTENTION_BACKEND", "TORCH_SDPA")

--- a/tests/diffusion/attention/test_ulysses_uaa.py
+++ b/tests/diffusion/attention/test_ulysses_uaa.py
@@ -158,15 +158,22 @@ def _run_attention_case(
 
 
 @pytest.mark.parametrize(
-    "sp_world_size,seq_len,num_heads",
+    "sp_world_size,query_seq_len,key_value_seq_len,num_heads",
     [
-        (2, 6, 3),  # head_cnt not divisible by P=2
-        (2, 5, 4),  # seq_len not divisible by P=2
-        (4, 9, 30),  # Z-Image-like: head_cnt not divisible by P=4
-        (4, 10, 8),  # seq_len not divisible by P=4
+        (2, 6, 6, 3),  # head_cnt not divisible by P=2
+        (2, 5, 5, 4),  # seq_len not divisible by P=2
+        (4, 9, 9, 30),  # Z-Image-like: head_cnt not divisible by P=4
+        (4, 10, 10, 8),  # seq_len not divisible by P=4
+        (2, 5, 4, 4),  # cross-attention: Q and K/V have different lengths
+        (4, 9, 6, 30),  # cross-attention with uneven sequence and head shards
     ],
 )
-def test_ulysses_uaa_matches_baseline(sp_world_size: int, seq_len: int, num_heads: int) -> None:
+def test_ulysses_uaa_matches_baseline(
+    sp_world_size: int,
+    query_seq_len: int,
+    key_value_seq_len: int,
+    num_heads: int,
+) -> None:
     if current_omni_platform.get_device_count() < sp_world_size:
         pytest.skip(f"Test requires {sp_world_size} GPUs")
 
@@ -187,9 +194,9 @@ def test_ulysses_uaa_matches_baseline(sp_world_size: int, seq_len: int, num_head
 
     try:
         torch.manual_seed(0)
-        q = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
-        k = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
-        v = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=torch.float32)
+        q = torch.randn(batch_size, query_seq_len, num_heads, head_size, dtype=torch.float32)
+        k = torch.randn(batch_size, key_value_seq_len, num_heads, head_size, dtype=torch.float32)
+        v = torch.randn(batch_size, key_value_seq_len, num_heads, head_size, dtype=torch.float32)
         np.savez(input_file, q=q.numpy(), k=k.numpy(), v=v.numpy())
 
         # Baseline (no SP)

--- a/tests/diffusion/models/ltx2/test_ltx2_latents.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_latents.py
@@ -23,7 +23,7 @@ def _make_pipeline(pipeline_cls, sequence_parallel_size: int = 1):
     return pipeline
 
 
-def test_prepare_video_latents_samples_directly_in_packed_token_space():
+def test_prepare_video_latents_matches_official_values_and_token_major_layout():
     pipeline = _make_pipeline(LTX2Pipeline)
     pipeline.vae_spatial_compression_ratio = 8
     pipeline.vae_temporal_compression_ratio = 8
@@ -44,6 +44,7 @@ def test_prepare_video_latents_samples_directly_in_packed_token_space():
     )
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.stride()[1:] == (1, actual.shape[1])
 
 
 def test_prepare_audio_latents_samples_directly_in_packed_token_space():

--- a/tests/diffusion/models/ltx2/test_ltx2_latents.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_latents.py
@@ -81,6 +81,42 @@ def test_prepare_audio_latents_pads_generated_dummy_length_for_sp():
     assert original_num_frames == 1
     assert padded_num_frames == 2
     assert latents.shape == (1, 2, 128)
+    torch.testing.assert_close(latents[:, 1:], torch.zeros_like(latents[:, 1:]))
+
+
+def test_prepare_audio_latents_request_rng_is_invariant_to_sp_padding():
+    pipeline_sp1 = _make_pipeline(LTX2Pipeline, sequence_parallel_size=1)
+    pipeline_sp4 = _make_pipeline(LTX2Pipeline, sequence_parallel_size=4)
+    generator_sp1 = torch.Generator().manual_seed(42)
+    generator_sp4 = torch.Generator().manual_seed(42)
+
+    latents_sp1, _, _ = pipeline_sp1.prepare_audio_latents(
+        batch_size=1,
+        num_channels_latents=2,
+        num_mel_bins=8,
+        audio_latent_length=3,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        generator=generator_sp1,
+    )
+    latents_sp4, _, _ = pipeline_sp4.prepare_audio_latents(
+        batch_size=1,
+        num_channels_latents=2,
+        num_mel_bins=8,
+        audio_latent_length=3,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        generator=generator_sp4,
+    )
+
+    torch.testing.assert_close(latents_sp4[:, :3], latents_sp1, rtol=0, atol=0)
+    torch.testing.assert_close(latents_sp4[:, 3:], torch.zeros_like(latents_sp4[:, 3:]))
+    torch.testing.assert_close(
+        torch.randn(8, generator=generator_sp4),
+        torch.randn(8, generator=generator_sp1),
+        rtol=0,
+        atol=0,
+    )
 
 
 def test_prepare_audio_latents_pads_packed_sequence_dim_for_provided_latents():
@@ -137,7 +173,9 @@ def test_prepare_audio_latents_accepts_already_padded_4d_latents_for_sp():
     assert original_num_frames == 10
     assert padded_num_frames == 12
     assert padded.shape == (1, 12, 8)
-    torch.testing.assert_close(padded, latent_ops.pack_audio_latents(latents))
+    packed = latent_ops.pack_audio_latents(latents)
+    torch.testing.assert_close(padded[:, :10], packed[:, :10])
+    torch.testing.assert_close(padded[:, 10:], torch.zeros_like(padded[:, 10:]))
 
 
 def test_resolve_audio_latent_length_preserves_legacy_4d_shape_inference():

--- a/tests/diffusion/models/ltx2/test_ltx2_parallel.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_parallel.py
@@ -199,6 +199,7 @@ class TestCFGParallelHelpers:
             ),
             attention_kwargs=None,
             audio_scheduler=SimpleNamespace(sigmas=torch.stack([audio_sigma])),
+            original_audio_num_frames=state.audio.shape[1],
         )
 
         actual_video, actual_audio = executor.predict_parallel_guidance(

--- a/tests/diffusion/models/ltx2/test_ltx2_parallel.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_parallel.py
@@ -5,11 +5,25 @@
 
 from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_velocity_from_x0_uses_official_host_scalar_sigma():
+    from vllm_omni.diffusion.models.ltx2.ltx2_guidance import velocity_from_x0
+
+    sigma = MagicMock()
+    sigma.to.return_value.item.return_value = 0.5
+
+    actual = velocity_from_x0(torch.tensor([1.0]), torch.tensor([0.0]), sigma)
+
+    sigma.to.assert_called_once_with(torch.float32)
+    sigma.to.return_value.item.assert_called_once_with()
+    torch.testing.assert_close(actual, torch.tensor([2.0]))
 
 
 class TestCFGParallelHelpers:

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -11,9 +11,15 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from safetensors.torch import save_file
 
 from vllm_omni.diffusion.data import DiffusionOutput
-from vllm_omni.diffusion.models.ltx2 import ltx2_components
+from vllm_omni.diffusion.models.ltx2 import ltx2_components, ltx2_phase_adapter
+from vllm_omni.diffusion.models.ltx2.ltx2_adapter_parser import (
+    AdapterTarget,
+    AdapterTensorSource,
+    LTXAdapterParser,
+)
 from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     LTX2_COMPONENT_PROFILE,
     LTX2_DISTILLED_COMPONENT_PROFILE,
@@ -44,6 +50,7 @@ from vllm_omni.diffusion.models.ltx2.ltx2_lora import (
     _LTXLoRAEntry,
     _transformer_config_to_dict,
 )
+from vllm_omni.diffusion.models.ltx2.ltx2_phase_adapter import LTXPhaseAdapterRuntime
 from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_ONE_STAGE_RECIPE,
@@ -70,6 +77,54 @@ from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import (
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _LoRAAttention(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.to_qkv = torch.nn.Identity()
+        self.to_out = torch.nn.Identity()
+
+
+class _LoRABlock(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attn1 = _LoRAAttention()
+
+
+class _LoRATransformer(torch.nn.Module):
+    stacked_params_mapping = (
+        (".attn1.to_qkv", ".attn1.to_q", "q"),
+        (".attn1.to_qkv", ".attn1.to_k", "k"),
+        (".attn1.to_qkv", ".attn1.to_v", "v"),
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj_in = torch.nn.Linear(4, 6, bias=False)
+        self.transformer_blocks = torch.nn.ModuleList([_LoRABlock()])
+
+
+def test_ltx_adapter_parser_maps_official_and_packed_module_names(tmp_path):
+    adapter_path = tmp_path / "distilled.safetensors"
+    save_file(
+        {
+            "diffusion_model.text_embedding_projection.aggregate_embed.lora_A.weight": torch.randn(2, 4),
+            "diffusion_model.patchify_proj.lora_A.weight": torch.randn(2, 4),
+            "diffusion_model.patchify_proj.lora_B.weight": torch.randn(6, 2),
+            "diffusion_model.transformer_blocks.0.attn1.to_q.lora_A.weight": torch.randn(2, 4),
+            "diffusion_model.transformer_blocks.0.attn1.to_q.lora_B.weight": torch.randn(4, 2),
+        },
+        adapter_path,
+    )
+
+    manifest = LTXAdapterParser(_LoRATransformer()).parse(str(adapter_path))
+
+    targets = {(entry.source_module, entry.module, entry.slice) for entry in manifest.targets}
+    assert targets == {
+        ("proj_in", "proj_in", None),
+        ("transformer_blocks.0.attn1.to_q", "transformer_blocks.0.attn1.to_qkv", "q"),
+    }
 
 
 def _make_ltx_request_pipe(cls):
@@ -210,7 +265,7 @@ def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, 
     monkeypatch.setattr(LTXRuntime, "setup_diffusion_pipeline_profiler", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.resolve_ltx_artifact",
-        lambda *_args: "/tmp/adapter.safetensors",
+        lambda *_args, **_kwargs: "/tmp/adapter.safetensors",
     )
     monkeypatch.setattr(
         "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.LTXResidentLoRAController",
@@ -1071,10 +1126,10 @@ def test_ltx_official_two_stage_recipes_only_vary_by_model_defaults(recipe, step
 def test_ltx_two_stage_entries_select_the_official_transformer_phases():
     phase_switches = []
     ordinary_pipeline = object.__new__(LTX2TwoStagePipeline)
-    ordinary_pipeline._phase_lora_controller = SimpleNamespace(enter=phase_switches.append)
+    ordinary_pipeline._phase_adapter = SimpleNamespace(set_active=phase_switches.append)
     for phase in LTX2_TWO_STAGE_RECIPE.phases:
         ordinary_pipeline._enter_phase(phase)
-    assert phase_switches == ["base", "distilled_lora"]
+    assert phase_switches == [None, "ltx_distilled"]
 
     distilled_pipeline = object.__new__(LTX2DistilledPipeline)
     for phase in LTX2_DISTILLED_TWO_STAGE_RECIPE.phases:
@@ -1140,14 +1195,14 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
         )
     ]
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_lora_entries",
+        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_resident_lora_entries",
         lambda *args: lora_entries,
     )
 
     controller = LTXResidentLoRAController(pipe, "unused.safetensors")
     assert created_configs == [({"num_layers": 1, "cross_attn_mod": True}, quant_config)]
 
-    pipe._phase_lora_controller = controller
+    pipe._resident_lora_controller = controller
     base_weight = torch.eye(2)
     loaded = pipe.load_weights(
         [
@@ -1174,6 +1229,145 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
     assert controller.transformer is pipe.transformer_2
 
 
+def test_ltx_phase_adapter_keeps_one_transformer_and_switches_a_fixed_slot(tmp_path):
+    class _TinyTransformer(torch.nn.Module):
+        stacked_params_mapping = ()
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = torch.nn.Linear(2, 2, bias=False)
+
+    adapter_path = tmp_path / "distilled.safetensors"
+    save_file(
+        {
+            "diffusion_model.proj.lora_A.weight": torch.tensor([[1.0, 2.0]]),
+            "diffusion_model.proj.lora_B.weight": torch.tensor([[3.0], [4.0]]),
+        },
+        adapter_path,
+    )
+    transformer = _TinyTransformer()
+    runtime = LTXPhaseAdapterRuntime(
+        transformer,
+        LTXAdapterParser(transformer).parse(str(adapter_path)),
+        dtype=torch.float32,
+    )
+    runtime.install_structure()
+
+    assert runtime.base_parameter_name("proj.weight") == "proj.base_layer.weight"
+    assert {name for name, _ in transformer.named_parameters()} == {"proj.base_layer.weight"}
+    with torch.no_grad():
+        transformer.proj.base_layer.weight.copy_(torch.eye(2))
+    runtime.finalize_adapter_data()
+
+    x = torch.tensor([[1.0, 1.0]])
+    runtime.set_active(None)
+    torch.testing.assert_close(transformer.proj(x), torch.tensor([[1.0, 1.0]]))
+    runtime.set_active("ltx_distilled")
+    torch.testing.assert_close(transformer.proj(x), torch.tensor([[10.0, 13.0]]))
+
+
+@pytest.mark.parametrize(
+    ("layer_factory", "target_slice", "expected_a", "expected_b", "expected_output"),
+    [
+        (
+            lambda: type(
+                "FakeColumn",
+                (torch.nn.Module,),
+                {
+                    "input_size": 4,
+                    "output_size": 4,
+                    "output_size_per_partition": 2,
+                    "tp_rank": 1,
+                    "gather_output": False,
+                    "forward": lambda self, x: x.new_zeros((*x.shape[:-1], 2)),
+                },
+            )(),
+            None,
+            torch.tensor([[1.0, 10.0, 100.0, 1000.0]]),
+            torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+            torch.tensor([[12963.0, 17284.0]]),
+        ),
+        (
+            lambda: type(
+                "FakeRow",
+                (torch.nn.Module,),
+                {
+                    "input_size": 4,
+                    "output_size": 2,
+                    "input_size_per_partition": 2,
+                    "tp_rank": 1,
+                    "reduce_results": False,
+                    "forward": lambda self, x: x.new_zeros((*x.shape[:-1], 2)),
+                },
+            )(),
+            None,
+            torch.tensor([[1.0, 10.0, 100.0, 1000.0]]),
+            torch.tensor([[2.0], [3.0]]),
+            torch.tensor([[8600.0, 12900.0]]),
+        ),
+        (
+            lambda: type(
+                "FakeQKV",
+                (torch.nn.Module,),
+                {
+                    "input_size": 4,
+                    "head_size": 2,
+                    "v_head_size": 2,
+                    "total_num_heads": 2,
+                    "total_num_kv_heads": 2,
+                    "num_heads": 1,
+                    "num_kv_heads": 1,
+                    "num_kv_head_replicas": 1,
+                    "tp_rank": 1,
+                    "forward": lambda self, x: x.new_zeros((*x.shape[:-1], 6)),
+                },
+            )(),
+            "k",
+            torch.tensor([[1.0, 10.0, 100.0, 1000.0]]),
+            torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+            torch.tensor([[0.0, 0.0, 12963.0, 17284.0, 0.0, 0.0]]),
+        ),
+    ],
+)
+def test_ltx_phase_adapter_uses_local_tp_lora_slices(
+    monkeypatch,
+    layer_factory,
+    target_slice,
+    expected_a,
+    expected_b,
+    expected_output,
+):
+    layer = layer_factory()
+    layer.register_buffer("device_anchor", torch.empty(0))
+    layer_type = type(layer)
+    if target_slice == "k":
+        monkeypatch.setattr(ltx2_phase_adapter, "QKVParallelLinear", layer_type)
+    elif "Column" in layer_type.__name__:
+        monkeypatch.setattr(ltx2_phase_adapter, "ColumnParallelLinear", layer_type)
+    else:
+        monkeypatch.setattr(ltx2_phase_adapter, "RowParallelLinear", layer_type)
+
+    target = AdapterTarget(
+        source_module="target",
+        module="target",
+        slice=target_slice,
+        rank=1,
+        a_source=AdapterTensorSource(path="unused", key="a", shape=tuple(expected_a.shape)),
+        b_source=AdapterTensorSource(path="unused", key="b", shape=tuple(expected_b.shape)),
+    )
+    wrapper = ltx2_phase_adapter._PhaseAdapterLinear(
+        layer,
+        [target],
+        adapter_name="ltx_distilled",
+        adapter_dtype=torch.float32,
+    )
+    wrapper.load_target(target, expected_a, expected_b)
+    wrapper.set_active("ltx_distilled")
+    torch.testing.assert_close(wrapper(torch.tensor([[1.0, 2.0, 3.0, 4.0]])), expected_output)
+    expected_local_a_width = getattr(layer, "input_size_per_partition", layer.input_size)
+    assert wrapper.adapters["ltx_distilled"][0].lora_a.shape[-1] == expected_local_a_width
+
+
 def test_ltx_resident_lora_rejects_serialized_quantized_checkpoint():
     pipe = SimpleNamespace(
         transformer=SimpleNamespace(config={}),
@@ -1196,7 +1390,7 @@ def test_ltx_resident_lora_requires_every_adapter_target(monkeypatch):
     controller.adapter_path = "unused.safetensors"
     controller._merged = False
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_lora_entries",
+        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_resident_lora_entries",
         lambda *args: [
             _LTXLoRAEntry(
                 module_name="missing",

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -17,7 +17,9 @@ from vllm_omni.diffusion.models.ltx2 import ltx2_components
 from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     LTX2_COMPONENT_PROFILE,
     LTX2_DISTILLED_COMPONENT_PROFILE,
+    LTX2_TWO_STAGE_COMPONENT_PROFILE,
     LTX23_COMPONENT_PROFILE,
+    LTX23_TWO_STAGE_COMPONENT_PROFILE,
     _install_connector_attention,
     detect_ltx_model_version,
 )
@@ -40,7 +42,9 @@ from vllm_omni.diffusion.models.ltx2.ltx2_latents import LTXAVState
 from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_ONE_STAGE_RECIPE,
+    LTX2_TWO_STAGE_RECIPE,
     LTX23_ONE_STAGE_RECIPE,
+    LTX23_TWO_STAGE_RECIPE,
     LTX_DEFAULT_NEGATIVE_PROMPT,
     LTX_POSITIVE_ONLY_RECIPE,
 )
@@ -51,7 +55,10 @@ from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import (
     LTX2Pipeline,
     LTX2T2VDMD2Pipeline,
 )
-from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import LTX2DistilledPipeline
+from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import (
+    LTX2DistilledPipeline,
+    LTX2TwoStagePipeline,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -104,9 +111,12 @@ def test_ltx_public_entries_share_runtime_and_keep_recipe_boundaries():
     )
 
     assert issubclass(LTX2Pipeline, LTXRuntime)
+    assert issubclass(LTX2TwoStagePipeline, LTXRuntime)
     assert issubclass(LTX2DistilledPipeline, LTXRuntime)
     assert LTX2Pipeline.component_profile is LTX2_COMPONENT_PROFILE
     assert LTX2Pipeline.pipeline_recipe is LTX2_ONE_STAGE_RECIPE
+    assert LTX2TwoStagePipeline.component_profile is LTX2_TWO_STAGE_COMPONENT_PROFILE
+    assert LTX2TwoStagePipeline.pipeline_recipe is LTX2_TWO_STAGE_RECIPE
     assert LTX2DistilledPipeline.component_profile is LTX2_DISTILLED_COMPONENT_PROFILE
     assert LTX2_COMPONENT_PROFILE.video_vae_cls is DistributedAutoencoderKLLTX2Video
     assert LTX23_COMPONENT_PROFILE.video_vae_cls is DistributedAutoencoderKLLTX2Video
@@ -144,11 +154,46 @@ def test_ltx23_checkpoint_selects_version_specific_one_stage_profile(tmp_path, m
     assert pipe.reports_stage_durations
 
 
+def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, monkeypatch):
+    from vllm_omni.diffusion.models.ltx2 import ltx2_runtime
+
+    (tmp_path / "model_index.json").write_text(json.dumps({"vocoder": ["ltx2", "LTX2VocoderWithBWE"]}))
+
+    def stub_components(pipe, od_config):
+        pipe.od_config = od_config
+        pipe.vae_spatial_compression_ratio = 32
+
+    monkeypatch.setattr(ltx2_runtime, "initialize_pipeline_components", stub_components)
+    monkeypatch.setattr(LTXRuntime, "setup_diffusion_pipeline_profiler", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.resolve_ltx_artifact",
+        lambda *_args: "/tmp/adapter.safetensors",
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.LTXResidentLoRAController",
+        lambda *_args: SimpleNamespace(),
+    )
+
+    pipe = LTX2TwoStagePipeline(
+        od_config=SimpleNamespace(
+            model=str(tmp_path),
+            enable_diffusion_pipeline_profiler=False,
+            lora_path=None,
+        )
+    )
+
+    assert pipe.model_version == "2.3"
+    assert pipe.component_profile is LTX23_TWO_STAGE_COMPONENT_PROFILE
+    assert pipe.pipeline_recipe is LTX23_TWO_STAGE_RECIPE
+
+
 def test_ltx_one_stage_entry_exposes_batch_image_and_distributed_decode_contracts():
     assert LTX2Pipeline.supports_request_batch
     assert LTX2Pipeline.support_image_input
     assert LTX2Pipeline.unified_text_image_entry
     assert LTX2Pipeline.distributed_video_decode
+    assert not LTX2TwoStagePipeline.supports_request_batch
+    assert not LTX2TwoStagePipeline.support_image_input
     assert not LTX2DistilledPipeline.supports_request_batch
     assert LTX2DistilledPipeline.support_image_input
     assert LTX2DistilledPipeline.unified_text_image_entry
@@ -1477,6 +1522,11 @@ class TestRegistryIntegration:
         from vllm_omni.diffusion.registry import _DIFFUSION_MODELS
 
         assert _DIFFUSION_MODELS["LTX2Pipeline"] == ("ltx2", "pipeline_ltx2", "LTX2Pipeline")
+        assert _DIFFUSION_MODELS["LTX2TwoStagePipeline"] == (
+            "ltx2",
+            "pipeline_ltx2_two_stage",
+            "LTX2TwoStagePipeline",
+        )
         assert _DIFFUSION_MODELS["LTX2DistilledPipeline"] == (
             "ltx2",
             "pipeline_ltx2_two_stage",
@@ -1488,6 +1538,9 @@ class TestRegistryIntegration:
             "LTX23ImageToVideoPipeline",
             "LTX2TwoStagesPipeline",
             "LTX2ImageToVideoTwoStagesPipeline",
+            "LTX2ImageToVideoTwoStagePipeline",
+            "LTX23TwoStagePipeline",
+            "LTX23ImageToVideoTwoStagePipeline",
         }
         assert removed_entries.isdisjoint(_DIFFUSION_MODELS)
 
@@ -1497,6 +1550,7 @@ class TestRegistryIntegration:
 
         expected = [
             "LTX2Pipeline",
+            "LTX2TwoStagePipeline",
             "LTX2DistilledPipeline",
             "LTX2T2VDMD2Pipeline",
             "LTX2I2VDMD2Pipeline",
@@ -1509,6 +1563,7 @@ class TestRegistryIntegration:
         "model_class_name",
         [
             "LTX2Pipeline",
+            "LTX2TwoStagePipeline",
             "LTX2DistilledPipeline",
             "LTX2T2VDMD2Pipeline",
             "LTX2I2VDMD2Pipeline",

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -1567,11 +1567,25 @@ def test_ltx_phase_adapter_uses_local_tp_lora_slices(
     assert wrapper.adapters["ltx_distilled"][0].lora_a.shape[-1] == expected_local_a_width
 
 
-def test_ltx_resident_lora_rejects_serialized_quantized_checkpoint():
+@pytest.mark.parametrize(
+    "serialized_flag",
+    [
+        "is_checkpoint_quantized",
+        "is_checkpoint_serialized",
+        "is_checkpoint_fp8_serialized",
+        "is_checkpoint_nvfp4_serialized",
+        "is_checkpoint_mxfp4_serialized",
+        "is_checkpoint_mxfp8_serialized",
+        "is_checkpoint_int8_serialized",
+        "is_checkpoint_torchao_serialized",
+        "is_checkpoint_future_serialized",
+    ],
+)
+def test_ltx_resident_lora_rejects_serialized_quantized_checkpoint(serialized_flag):
     pipe = SimpleNamespace(
         transformer=SimpleNamespace(config={}),
         od_config=SimpleNamespace(
-            quantization_config=SimpleNamespace(is_checkpoint_fp8_serialized=True),
+            quantization_config=SimpleNamespace(**{serialized_flag: True}),
         ),
     )
 

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -1283,6 +1283,8 @@ def test_ltx_official_two_stage_recipes_only_vary_by_model_defaults(recipe, step
     assert stage2.guidance == LTXGuidanceSpec.positive_only()
     assert stage2.num_inference_steps == 3
     assert stage2.sigmas == (0.909375, 0.725, 0.421875, 0.0)
+    # Official Stage 2 refines video only; its audio result is discarded.
+    assert (recipe.video_output_phase, recipe.audio_output_phase) == (1, 0)
 
 
 def test_ltx_two_stage_entries_select_the_official_adapter_slots():

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -1057,7 +1057,7 @@ def test_ltx_resident_lora_copies_mapping_and_namespace_configs(config):
     assert copied is not config
 
 
-def test_ltx_resident_lora_keeps_two_offloadable_transformers(monkeypatch):
+def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch):
     from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
     from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 
@@ -1071,7 +1071,8 @@ def test_ltx_resident_lora_keeps_two_offloadable_transformers(monkeypatch):
     torch.nn.Module.__init__(pipe)
     pipe.transformer = _TinyTransformer()
     pipe._transformer_init_config = {"num_layers": 1, "cross_attn_mod": True}
-    pipe.od_config = SimpleNamespace(quantization_config=None, dtype=torch.float32)
+    quant_config = SimpleNamespace(is_checkpoint_fp8_serialized=False)
+    pipe.od_config = SimpleNamespace(quantization_config=quant_config, dtype=torch.float32)
     pipe.device = torch.device("cpu")
     pipe.weights_sources = [
         DiffusersPipelineLoader.ComponentSource(
@@ -1082,44 +1083,95 @@ def test_ltx_resident_lora_keeps_two_offloadable_transformers(monkeypatch):
         )
     ]
     created_configs = []
+
+    def create_transformer(config, quant_config=None):
+        created_configs.append((config, quant_config))
+        return _TinyTransformer()
+
     monkeypatch.setattr(
         "vllm_omni.diffusion.models.ltx2.ltx2_lora.create_transformer_from_config",
-        lambda config: (created_configs.append(config), _TinyTransformer())[1],
+        create_transformer,
+    )
+    lora_entries = [
+        _LTXLoRAEntry(
+            module_name="proj",
+            target_name="proj",
+            shard_id=None,
+            lora_a=torch.tensor([[1.0, 2.0]]),
+            lora_b=torch.tensor([[3.0], [4.0]]),
+        )
+    ]
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_lora_entries",
+        lambda *args: lora_entries,
     )
 
-    with torch.no_grad():
-        pipe.transformer.proj.weight.copy_(torch.eye(2))
     controller = LTXResidentLoRAController(pipe, "unused.safetensors")
-    assert created_configs == [{"num_layers": 1, "cross_attn_mod": True}]
-    with torch.no_grad():
-        pipe.transformer_2.proj.weight.copy_(pipe.transformer.proj.weight)
+    assert created_configs == [({"num_layers": 1, "cross_attn_mod": True}, quant_config)]
 
-    controller._merge_entries(
+    pipe._phase_lora_controller = controller
+    base_weight = torch.eye(2)
+    loaded = pipe.load_weights(
         [
-            _LTXLoRAEntry(
-                module_name="proj",
-                target_name="proj",
-                shard_id=None,
-                lora_a=torch.tensor([[1.0, 2.0]]),
-                lora_b=torch.tensor([[3.0], [4.0]]),
-            )
+            ("transformer.proj.weight", base_weight),
+            ("transformer_2.proj.weight", base_weight),
         ]
     )
-    controller._merged = True
 
-    modules = ModuleDiscovery.discover(pipe)
-    assert modules.dit_names == ["transformer", "transformer_2"]
-    assert pipe.weights_sources[1].prefix == "transformer_2."
-    torch.testing.assert_close(pipe.transformer.proj.weight, torch.eye(2))
+    assert loaded == {"transformer.proj.weight", "transformer_2.proj.weight"}
+    torch.testing.assert_close(pipe.transformer.proj.weight, base_weight)
     torch.testing.assert_close(
         pipe.transformer_2.proj.weight,
         torch.tensor([[4.0, 6.0], [4.0, 9.0]]),
     )
+    assert controller._merged
+
+    modules = ModuleDiscovery.discover(pipe)
+    assert modules.dit_names == ["transformer", "transformer_2"]
+    assert pipe.weights_sources[1].prefix == "transformer_2."
 
     controller.enter("base")
     assert controller.transformer is pipe.transformer
     controller.enter("distilled_lora")
     assert controller.transformer is pipe.transformer_2
+
+
+def test_ltx_resident_lora_rejects_serialized_quantized_checkpoint():
+    pipe = SimpleNamespace(
+        transformer=SimpleNamespace(config={}),
+        od_config=SimpleNamespace(
+            quantization_config=SimpleNamespace(is_checkpoint_fp8_serialized=True),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="serialized quantized checkpoints"):
+        LTXResidentLoRAController(pipe, "unused.safetensors")
+
+
+def test_ltx_resident_lora_requires_every_adapter_target(monkeypatch):
+    controller = object.__new__(LTXResidentLoRAController)
+    controller.pipeline = SimpleNamespace(
+        transformer_2=SimpleNamespace(),
+        od_config=SimpleNamespace(dtype=torch.float32),
+        device=torch.device("cpu"),
+    )
+    controller.adapter_path = "unused.safetensors"
+    controller._merged = False
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_lora_entries",
+        lambda *args: [
+            _LTXLoRAEntry(
+                module_name="missing",
+                target_name="missing",
+                shard_id=None,
+                lora_a=torch.eye(2),
+                lora_b=torch.eye(2),
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="missing LoRA target weights"):
+        list(controller.merge_stage2_weights([("transformer_2.proj.weight", torch.eye(2))]))
 
 
 class TestLTXRequestParsing:

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -53,7 +53,11 @@ from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX_DEFAULT_NEGATIVE_PROMPT,
     LTX_POSITIVE_ONLY_RECIPE,
 )
-from vllm_omni.diffusion.models.ltx2.ltx2_request import LTXRequestInputs, validate_pipeline_request
+from vllm_omni.diffusion.models.ltx2.ltx2_request import (
+    LTXRequestInputs,
+    validate_ltx_checkpoint,
+    validate_pipeline_request,
+)
 from vllm_omni.diffusion.models.ltx2.ltx2_runtime import LTXRuntime
 from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import (
     LTX2I2VDMD2Pipeline,
@@ -123,6 +127,9 @@ def test_ltx_public_entries_share_runtime_and_keep_recipe_boundaries():
     assert LTX2TwoStagePipeline.component_profile is LTX2_TWO_STAGE_COMPONENT_PROFILE
     assert LTX2TwoStagePipeline.pipeline_recipe is LTX2_TWO_STAGE_RECIPE
     assert LTX2DistilledPipeline.component_profile is LTX2_DISTILLED_COMPONENT_PROFILE
+    assert LTX2_DISTILLED_COMPONENT_PROFILE.checkpoint_kind == "distilled"
+    assert LTX2_TWO_STAGE_COMPONENT_PROFILE.checkpoint_kind == "regular"
+    assert LTX23_TWO_STAGE_COMPONENT_PROFILE.checkpoint_kind == "regular"
     assert LTX2_COMPONENT_PROFILE.video_vae_cls is DistributedAutoencoderKLLTX2Video
     assert LTX23_COMPONENT_PROFILE.video_vae_cls is DistributedAutoencoderKLLTX2Video
 
@@ -136,6 +143,37 @@ def test_ltx_checkpoint_version_detection_uses_metadata(tmp_path):
 
     (tmp_path / "model_index.json").write_text(json.dumps({"vocoder": ["ltx2", "LTX2Vocoder"]}))
     assert detect_ltx_model_version(str(tmp_path)) == "2"
+
+
+@pytest.mark.parametrize(
+    ("expected_kind", "scheduler_config"),
+    [
+        ("regular", {"use_dynamic_shifting": True, "shift_terminal": 0.1}),
+        ("distilled", {"use_dynamic_shifting": False, "shift_terminal": None}),
+    ],
+)
+def test_ltx_checkpoint_validation_accepts_matching_scheduler_metadata(expected_kind, scheduler_config):
+    validate_ltx_checkpoint(
+        scheduler_config,
+        expected_kind=expected_kind,
+        pipeline_name="TestLTXPipeline",
+    )
+
+
+@pytest.mark.parametrize(
+    ("expected_kind", "scheduler_config", "error"),
+    [
+        ("regular", {"use_dynamic_shifting": False, "shift_terminal": None}, "regular non-distilled"),
+        ("distilled", {"use_dynamic_shifting": True, "shift_terminal": 0.1}, "merged distilled"),
+    ],
+)
+def test_ltx_checkpoint_validation_rejects_mismatched_scheduler_metadata(expected_kind, scheduler_config, error):
+    with pytest.raises(ValueError, match=error):
+        validate_ltx_checkpoint(
+            scheduler_config,
+            expected_kind=expected_kind,
+            pipeline_name="TestLTXPipeline",
+        )
 
 
 def test_ltx23_checkpoint_selects_version_specific_one_stage_profile(tmp_path, monkeypatch):

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     LTX23_TWO_STAGE_COMPONENT_PROFILE,
     _install_connector_attention,
     detect_ltx_model_version,
+    resolve_ltx_artifact,
     resolve_ltx_component_profile,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_conditioning import LTXI2VConditioningMixin
@@ -203,6 +204,30 @@ def test_ltx_checkpoint_version_detection_uses_metadata(tmp_path):
 
     (tmp_path / "model_index.json").write_text(json.dumps({"vocoder": ["ltx2", "LTX2Vocoder"]}))
     assert detect_ltx_model_version(str(tmp_path)) == "2"
+
+
+def test_ltx_artifact_directory_is_an_authoritative_override(tmp_path, monkeypatch):
+    artifacts_dir = tmp_path / "sidecars"
+    artifacts_dir.mkdir()
+    filename = "ltx-sidecar.safetensors"
+    expected = artifacts_dir / filename
+    expected.write_bytes(b"sidecar")
+    monkeypatch.setenv("VLLM_OMNI_LTX_ARTIFACTS_DIR", str(artifacts_dir))
+    monkeypatch.setattr(ltx2_components, "hf_hub_download", lambda **_kwargs: pytest.fail("unexpected Hub lookup"))
+
+    assert resolve_ltx_artifact(str(tmp_path / "model"), "Lightricks/test", filename) == str(expected)
+
+    with pytest.raises(FileNotFoundError, match="does not contain required LTX artifact"):
+        resolve_ltx_artifact(str(tmp_path / "model"), "Lightricks/test", "missing.safetensors")
+
+
+def test_ltx_artifact_falls_back_to_model_root_without_override(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_LTX_ARTIFACTS_DIR", raising=False)
+    filename = "ltx-sidecar.safetensors"
+    expected = tmp_path / filename
+    expected.write_bytes(b"sidecar")
+
+    assert resolve_ltx_artifact(str(tmp_path), "Lightricks/test", filename) == str(expected)
 
 
 @pytest.mark.parametrize(
@@ -1268,7 +1293,6 @@ def _make_phase_weight_factory_pipeline():
         transformer=object(),
         od_config=SimpleNamespace(
             model="unused",
-            model_paths={"distilled_lora": "/models/distilled.safetensors"},
             lora_path=None,
             dtype=torch.float32,
         ),

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -25,9 +25,11 @@ from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     LTX2_DISTILLED_COMPONENT_PROFILE,
     LTX2_TWO_STAGE_COMPONENT_PROFILE,
     LTX23_COMPONENT_PROFILE,
+    LTX23_DISTILLED_COMPONENT_PROFILE,
     LTX23_TWO_STAGE_COMPONENT_PROFILE,
     _install_connector_attention,
     detect_ltx_model_version,
+    resolve_ltx_component_profile,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_conditioning import LTXI2VConditioningMixin
 from vllm_omni.diffusion.models.ltx2.ltx2_denoise import (
@@ -55,10 +57,12 @@ from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_ONE_STAGE_RECIPE,
     LTX2_TWO_STAGE_RECIPE,
+    LTX23_DISTILLED_TWO_STAGE_RECIPE,
     LTX23_ONE_STAGE_RECIPE,
     LTX23_TWO_STAGE_RECIPE,
     LTX_DEFAULT_NEGATIVE_PROMPT,
     LTX_POSITIVE_ONLY_RECIPE,
+    resolve_ltx_pipeline_recipe,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_request import (
     LTXRequestInputs,
@@ -183,6 +187,7 @@ def test_ltx_public_entries_share_runtime_and_keep_recipe_boundaries():
     assert LTX2TwoStagePipeline.pipeline_recipe is LTX2_TWO_STAGE_RECIPE
     assert LTX2DistilledPipeline.component_profile is LTX2_DISTILLED_COMPONENT_PROFILE
     assert LTX2_DISTILLED_COMPONENT_PROFILE.checkpoint_kind == "distilled"
+    assert LTX23_DISTILLED_COMPONENT_PROFILE.checkpoint_kind == "distilled"
     assert LTX2_TWO_STAGE_COMPONENT_PROFILE.checkpoint_kind == "regular"
     assert LTX23_TWO_STAGE_COMPONENT_PROFILE.checkpoint_kind == "regular"
     assert LTX2_COMPONENT_PROFILE.video_vae_cls is DistributedAutoencoderKLLTX2Video
@@ -284,6 +289,33 @@ def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, 
     assert pipe.model_version == "2.3"
     assert pipe.component_profile is LTX23_TWO_STAGE_COMPONENT_PROFILE
     assert pipe.pipeline_recipe is LTX23_TWO_STAGE_RECIPE
+
+
+def test_ltx23_checkpoint_selects_full_distilled_profile_and_recipe(tmp_path, monkeypatch):
+    from vllm_omni.diffusion.models.ltx2 import ltx2_runtime
+
+    (tmp_path / "model_index.json").write_text(json.dumps({"vocoder": ["ltx2", "LTX2VocoderWithBWE"]}))
+
+    def stub_components(pipe, od_config):
+        pipe.od_config = od_config
+        pipe.vae_spatial_compression_ratio = 32
+
+    monkeypatch.setattr(ltx2_runtime, "initialize_pipeline_components", stub_components)
+    monkeypatch.setattr(LTXRuntime, "setup_diffusion_pipeline_profiler", lambda *_args, **_kwargs: None)
+
+    pipe = LTX2DistilledPipeline(
+        od_config=SimpleNamespace(
+            model=str(tmp_path),
+            enable_diffusion_pipeline_profiler=False,
+        )
+    )
+
+    assert pipe.model_version == "2.3"
+    assert pipe.component_profile is LTX23_DISTILLED_COMPONENT_PROFILE
+    assert pipe.pipeline_recipe is LTX23_DISTILLED_TWO_STAGE_RECIPE
+    assert pipe._phase_weights is None
+    assert pipe.preserve_sp_padded_audio_duration
+    assert pipe.reports_stage_durations
 
 
 def test_ltx_entries_expose_batch_image_and_distributed_decode_contracts():
@@ -916,6 +948,19 @@ def test_ltx2_distilled_two_stage_recipe_is_fixed_positive_only():
     assert not LTX2_DISTILLED_TWO_STAGE_RECIPE.allow_negative_prompt
     assert LTX2_DISTILLED_TWO_STAGE_RECIPE.fixed_num_inference_steps
     assert (LTX2_DISTILLED_TWO_STAGE_RECIPE.height, LTX2_DISTILLED_TWO_STAGE_RECIPE.width) == (1024, 1536)
+
+
+def test_ltx23_full_distilled_route_uses_merged_weights_without_lora():
+    assert resolve_ltx_component_profile("distilled_two_stage", "2.3") is LTX23_DISTILLED_COMPONENT_PROFILE
+    assert resolve_ltx_pipeline_recipe("distilled_two_stage", "2.3") is LTX23_DISTILLED_TWO_STAGE_RECIPE
+    assert LTX23_DISTILLED_TWO_STAGE_RECIPE == LTX2_DISTILLED_TWO_STAGE_RECIPE
+    assert LTX23_DISTILLED_TWO_STAGE_RECIPE is not LTX2_DISTILLED_TWO_STAGE_RECIPE
+    assert all(phase.adapter_slot is None for phase in LTX23_DISTILLED_TWO_STAGE_RECIPE.phases)
+    assert LTX23_DISTILLED_COMPONENT_PROFILE.distilled_lora_filename is None
+    assert LTX23_DISTILLED_COMPONENT_PROFILE.vocoder_cls is LTX23_COMPONENT_PROFILE.vocoder_cls
+    assert LTX23_DISTILLED_COMPONENT_PROFILE.latent_upsampler_filename == (
+        "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1971,6 +2016,7 @@ class TestPipelineComponents:
 
     def test_distilled_profile_keeps_upsampler_in_managed_resident_components(self):
         assert LTX2_DISTILLED_COMPONENT_PROFILE.resident_modules == ("vocoder", "latent_upsampler")
+        assert LTX23_DISTILLED_COMPONENT_PROFILE.resident_modules == ("vocoder", "latent_upsampler")
 
 
 class TestLTX23DecodeConditioning:

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -632,6 +632,32 @@ def test_ltx_guidance_rescale_handles_zero_variance_prediction():
     torch.testing.assert_close(actual, torch.zeros_like(cond))
 
 
+def test_ltx_audio_guidance_rescale_ignores_sp_padding_tokens():
+    logical_cond = torch.tensor([[[1.0, 2.0], [3.0, 5.0]]])
+    logical_uncond = torch.tensor([[[0.5, -1.0], [2.0, 1.0]]])
+    guidance = LTXModalityGuidance(cfg_scale=3.0, rescale_scale=1.0)
+    expected = combine_guided_x0(
+        cond=logical_cond,
+        uncond_text=logical_uncond,
+        uncond_perturbed=0.0,
+        uncond_modality=0.0,
+        guidance=guidance,
+    )
+    padded_cond = torch.cat([logical_cond, torch.tensor([[[1000.0, -1000.0]]])], dim=1)
+    padded_uncond = torch.cat([logical_uncond, torch.tensor([[[-500.0, 500.0]]])], dim=1)
+
+    actual = combine_guided_x0(
+        cond=padded_cond,
+        uncond_text=padded_uncond,
+        uncond_perturbed=0.0,
+        uncond_modality=0.0,
+        guidance=guidance,
+        rescale_token_count=2,
+    )
+
+    torch.testing.assert_close(actual[:, :2], expected)
+
+
 def test_ltx_guidance_builds_per_sample_stg_and_modality_masks():
     plan = LTXGuidancePlan.build(LTX23_ONE_STAGE_RECIPE.request_guidance)
     perturbations = build_perturbation_kwargs(plan, batch_size=2, reference=torch.ones(8, 1, 1))

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -14,7 +14,7 @@ import torch
 from safetensors.torch import save_file
 
 from vllm_omni.diffusion.data import DiffusionOutput
-from vllm_omni.diffusion.models.ltx2 import ltx2_components, ltx2_phase_adapter
+from vllm_omni.diffusion.models.ltx2 import ltx2_components, ltx2_phase_adapter, ltx2_phase_weights
 from vllm_omni.diffusion.models.ltx2.ltx2_adapter_parser import (
     AdapterTarget,
     AdapterTensorSource,
@@ -45,12 +45,12 @@ from vllm_omni.diffusion.models.ltx2.ltx2_guidance import (
     combine_guided_x0,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_latents import LTXAVState
-from vllm_omni.diffusion.models.ltx2.ltx2_lora import (
+from vllm_omni.diffusion.models.ltx2.ltx2_phase_adapter import LTXPhaseAdapterRuntime
+from vllm_omni.diffusion.models.ltx2.ltx2_phase_weights import (
     LTXResidentLoRAController,
     _LTXLoRAEntry,
     _transformer_config_to_dict,
 )
-from vllm_omni.diffusion.models.ltx2.ltx2_phase_adapter import LTXPhaseAdapterRuntime
 from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_ONE_STAGE_RECIPE,
@@ -264,11 +264,11 @@ def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, 
     monkeypatch.setattr(ltx2_runtime, "initialize_pipeline_components", stub_components)
     monkeypatch.setattr(LTXRuntime, "setup_diffusion_pipeline_profiler", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.resolve_ltx_artifact",
+        "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights.resolve_ltx_artifact",
         lambda *_args, **_kwargs: "/tmp/adapter.safetensors",
     )
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage.LTXResidentLoRAController",
+        "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights.LTXResidentLoRAController",
         lambda *_args: SimpleNamespace(),
     )
 
@@ -295,6 +295,18 @@ def test_ltx_one_stage_entry_exposes_batch_image_and_distributed_decode_contract
     assert not LTX2DistilledPipeline.supports_request_batch
     assert LTX2DistilledPipeline.support_image_input
     assert LTX2DistilledPipeline.unified_text_image_entry
+
+
+def test_ltx_two_stage_rejects_request_embedded_images():
+    pipe = object.__new__(LTX2TwoStagePipeline)
+    request_inputs = SimpleNamespace(latents=None)
+    object.__setattr__(pipe, "_resolve_request_inputs", lambda *_args, **_kwargs: request_inputs)
+    req = SimpleNamespace(
+        prompts=[{"prompt": "image conditioned", "multi_modal_data": {"image": torch.zeros(3, 8, 8)}}]
+    )
+
+    with pytest.raises(ValueError, match="does not support `image` input"):
+        pipe._forward_request(req)
 
 
 def test_ltx_dmd2_entries_retain_their_task_boundaries():
@@ -693,6 +705,13 @@ def test_ltx2_distilled_pipeline_shares_recipe_runtime():
     assert issubclass(LTX2DistilledPipeline, LTX2Pipeline)
     assert LTX2DistilledPipeline._run_recipe is LTXRuntime._run_recipe
     assert "_forward_request" not in LTX2DistilledPipeline.__dict__
+
+
+def test_ltx_two_stage_entry_is_a_thin_pipeline_variant():
+    assert "_run_recipe" not in LTX2TwoStagePipeline.__dict__
+    assert "_forward_request" not in LTX2TwoStagePipeline.__dict__
+    assert "load_weights" not in LTX2TwoStagePipeline.__dict__
+    assert issubclass(LTX2TwoStagePipeline, LTX2Pipeline)
 
 
 def test_ltx_variants_share_denoise_loop_and_i2v_conditioning():
@@ -1113,20 +1132,20 @@ def test_ltx_official_two_stage_recipes_only_vary_by_model_defaults(recipe, step
     assert (recipe.width, recipe.height) == (1536, 1024)
     assert recipe.num_inference_steps == steps
     assert stage1.spatial_downscale == 2
-    assert stage1.transformer_phase == "base"
+    assert stage1.adapter_slot is None
     assert stage1.guidance.video.stg_blocks == (stg_block,)
     assert stage1.guidance.audio.stg_blocks == (stg_block,)
     assert stage2.input_transform == "spatial_upsample"
-    assert stage2.transformer_phase == "distilled_lora"
+    assert stage2.adapter_slot == "ltx_distilled"
     assert stage2.guidance == LTXGuidanceSpec.positive_only()
     assert stage2.num_inference_steps == 3
     assert stage2.sigmas == (0.909375, 0.725, 0.421875, 0.0)
 
 
-def test_ltx_two_stage_entries_select_the_official_transformer_phases():
+def test_ltx_two_stage_entries_select_the_official_adapter_slots():
     phase_switches = []
     ordinary_pipeline = object.__new__(LTX2TwoStagePipeline)
-    ordinary_pipeline._phase_adapter = SimpleNamespace(set_active=phase_switches.append)
+    ordinary_pipeline._phase_weights = SimpleNamespace(activate=phase_switches.append)
     for phase in LTX2_TWO_STAGE_RECIPE.phases:
         ordinary_pipeline._enter_phase(phase)
     assert phase_switches == [None, "ltx_distilled"]
@@ -1148,6 +1167,59 @@ def test_ltx_resident_lora_copies_mapping_and_namespace_configs(config):
 
     assert copied == {"num_layers": 2, "cross_attn_mod": True}
     assert copied is not config
+
+
+def _make_phase_weight_factory_pipeline(mode: str):
+    return SimpleNamespace(
+        pipeline_recipe=LTX2_TWO_STAGE_RECIPE,
+        component_profile=LTX23_TWO_STAGE_COMPONENT_PROFILE,
+        transformer=object(),
+        od_config=SimpleNamespace(
+            model="unused",
+            model_config={"ltx_two_stage_lora_mode": mode},
+            model_paths={"distilled_lora": "/models/distilled.safetensors"},
+            lora_path=None,
+            dtype=torch.float32,
+        ),
+    )
+
+
+def test_ltx_phase_weight_factory_selects_resident_mode(monkeypatch):
+    pipeline = _make_phase_weight_factory_pipeline("resident")
+    resident = object()
+    monkeypatch.setattr(ltx2_phase_weights, "resolve_ltx_artifact", lambda *_args, **_kwargs: "adapter")
+    monkeypatch.setattr(ltx2_phase_weights, "LTXResidentLoRAController", lambda pipe, path: resident)
+
+    assert ltx2_phase_weights.build_ltx_phase_weights(pipeline) is resident
+
+
+def test_ltx_phase_weight_factory_selects_dynamic_mode(monkeypatch):
+    pipeline = _make_phase_weight_factory_pipeline("dynamic")
+    manifest = object()
+    installed = []
+
+    monkeypatch.setattr(ltx2_phase_weights, "resolve_ltx_artifact", lambda *_args, **_kwargs: "adapter")
+    monkeypatch.setattr(
+        ltx2_phase_weights,
+        "LTXAdapterParser",
+        lambda transformer: SimpleNamespace(parse=lambda path, name: manifest),
+    )
+
+    class DynamicRuntime:
+        def __init__(self, transformer, parsed_manifest, *, dtype):
+            assert transformer is pipeline.transformer
+            assert parsed_manifest is manifest
+            assert dtype is torch.float32
+
+        def install_structure(self):
+            installed.append(True)
+
+    monkeypatch.setattr(ltx2_phase_weights, "LTXPhaseAdapterRuntime", DynamicRuntime)
+
+    runtime = ltx2_phase_weights.build_ltx_phase_weights(pipeline)
+
+    assert isinstance(runtime, DynamicRuntime)
+    assert installed == [True]
 
 
 def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch):
@@ -1182,7 +1254,7 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
         return _TinyTransformer()
 
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.ltx2_lora.create_transformer_from_config",
+        "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights.create_transformer_from_config",
         create_transformer,
     )
     lora_entries = [
@@ -1195,14 +1267,14 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
         )
     ]
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_resident_lora_entries",
+        "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights._load_resident_lora_entries",
         lambda *args: lora_entries,
     )
 
     controller = LTXResidentLoRAController(pipe, "unused.safetensors")
     assert created_configs == [({"num_layers": 1, "cross_attn_mod": True}, quant_config)]
 
-    pipe._resident_lora_controller = controller
+    pipe._phase_weights = controller
     base_weight = torch.eye(2)
     loaded = pipe.load_weights(
         [
@@ -1223,9 +1295,9 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
     assert modules.dit_names == ["transformer", "transformer_2"]
     assert pipe.weights_sources[1].prefix == "transformer_2."
 
-    controller.enter("base")
+    controller.activate(None)
     assert controller.transformer is pipe.transformer
-    controller.enter("distilled_lora")
+    controller.activate("ltx_distilled")
     assert controller.transformer is pipe.transformer_2
 
 
@@ -1257,12 +1329,12 @@ def test_ltx_phase_adapter_keeps_one_transformer_and_switches_a_fixed_slot(tmp_p
     assert {name for name, _ in transformer.named_parameters()} == {"proj.base_layer.weight"}
     with torch.no_grad():
         transformer.proj.base_layer.weight.copy_(torch.eye(2))
-    runtime.finalize_adapter_data()
+    runtime.finalize()
 
     x = torch.tensor([[1.0, 1.0]])
-    runtime.set_active(None)
+    runtime.activate(None)
     torch.testing.assert_close(transformer.proj(x), torch.tensor([[1.0, 1.0]]))
-    runtime.set_active("ltx_distilled")
+    runtime.activate("ltx_distilled")
     torch.testing.assert_close(transformer.proj(x), torch.tensor([[10.0, 13.0]]))
 
 
@@ -1390,7 +1462,7 @@ def test_ltx_resident_lora_requires_every_adapter_target(monkeypatch):
     controller.adapter_path = "unused.safetensors"
     controller._merged = False
     monkeypatch.setattr(
-        "vllm_omni.diffusion.models.ltx2.ltx2_lora._load_resident_lora_entries",
+        "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights._load_resident_lora_entries",
         lambda *args: [
             _LTXLoRAEntry(
                 module_name="missing",
@@ -1403,7 +1475,7 @@ def test_ltx_resident_lora_requires_every_adapter_target(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="missing LoRA target weights"):
-        list(controller.merge_stage2_weights([("transformer_2.proj.weight", torch.eye(2))]))
+        list(controller.prepare_weights([("transformer_2.proj.weight", torch.eye(2))]))
 
 
 class TestLTXRequestParsing:

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -271,6 +271,7 @@ def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, 
         "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights.LTXResidentLoRAController",
         lambda *_args: SimpleNamespace(),
     )
+    monkeypatch.setenv("VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE", "resident")
 
     pipe = LTX2TwoStagePipeline(
         od_config=SimpleNamespace(
@@ -1174,14 +1175,13 @@ def test_ltx_resident_lora_copies_mapping_and_namespace_configs(config):
     assert copied is not config
 
 
-def _make_phase_weight_factory_pipeline(mode: str):
+def _make_phase_weight_factory_pipeline():
     return SimpleNamespace(
         pipeline_recipe=LTX2_TWO_STAGE_RECIPE,
         component_profile=LTX23_TWO_STAGE_COMPONENT_PROFILE,
         transformer=object(),
         od_config=SimpleNamespace(
             model="unused",
-            model_config={"ltx_two_stage_lora_mode": mode},
             model_paths={"distilled_lora": "/models/distilled.safetensors"},
             lora_path=None,
             dtype=torch.float32,
@@ -1190,19 +1190,25 @@ def _make_phase_weight_factory_pipeline(mode: str):
 
 
 def test_ltx_phase_weight_factory_selects_resident_mode(monkeypatch):
-    pipeline = _make_phase_weight_factory_pipeline("resident")
+    pipeline = _make_phase_weight_factory_pipeline()
     resident = object()
+    monkeypatch.setenv("VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE", " ReSiDeNt ")
     monkeypatch.setattr(ltx2_phase_weights, "resolve_ltx_artifact", lambda *_args, **_kwargs: "adapter")
     monkeypatch.setattr(ltx2_phase_weights, "LTXResidentLoRAController", lambda pipe, path: resident)
 
     assert ltx2_phase_weights.build_ltx_phase_weights(pipeline) is resident
 
 
-def test_ltx_phase_weight_factory_selects_dynamic_mode(monkeypatch):
-    pipeline = _make_phase_weight_factory_pipeline("dynamic")
+@pytest.mark.parametrize("mode", [None, " DyNaMiC "])
+def test_ltx_phase_weight_factory_selects_dynamic_mode(monkeypatch, mode):
+    pipeline = _make_phase_weight_factory_pipeline()
     manifest = object()
     installed = []
 
+    if mode is None:
+        monkeypatch.delenv("VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE", mode)
     monkeypatch.setattr(ltx2_phase_weights, "resolve_ltx_artifact", lambda *_args, **_kwargs: "adapter")
     monkeypatch.setattr(
         ltx2_phase_weights,
@@ -1225,6 +1231,14 @@ def test_ltx_phase_weight_factory_selects_dynamic_mode(monkeypatch):
 
     assert isinstance(runtime, DynamicRuntime)
     assert installed == [True]
+
+
+def test_ltx_phase_weight_factory_rejects_invalid_environment_mode(monkeypatch):
+    pipeline = _make_phase_weight_factory_pipeline()
+    monkeypatch.setenv("VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE", "auto")
+
+    with pytest.raises(ValueError, match="VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE"):
+        ltx2_phase_weights.build_ltx_phase_weights(pipeline)
 
 
 def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch):

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -39,6 +39,11 @@ from vllm_omni.diffusion.models.ltx2.ltx2_guidance import (
     combine_guided_x0,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_latents import LTXAVState
+from vllm_omni.diffusion.models.ltx2.ltx2_lora import (
+    LTXResidentLoRAController,
+    _LTXLoRAEntry,
+    _transformer_config_to_dict,
+)
 from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_ONE_STAGE_RECIPE,
@@ -1001,6 +1006,120 @@ def test_ltx_custom_sigmas_bypass_scheduler_shifting():
     torch.testing.assert_close(pipeline.scheduler.sigmas, expected)
     torch.testing.assert_close(audio_scheduler.sigmas, expected)
     torch.testing.assert_close(timesteps, expected[:-1] * scheduler.config.num_train_timesteps)
+
+
+@pytest.mark.parametrize(
+    ("recipe", "steps", "stg_block"),
+    [
+        (LTX2_TWO_STAGE_RECIPE, 40, 29),
+        (LTX23_TWO_STAGE_RECIPE, 30, 28),
+    ],
+)
+def test_ltx_official_two_stage_recipes_only_vary_by_model_defaults(recipe, steps, stg_block):
+    stage1, stage2 = recipe.phases
+    assert (recipe.width, recipe.height) == (1536, 1024)
+    assert recipe.num_inference_steps == steps
+    assert stage1.spatial_downscale == 2
+    assert stage1.transformer_phase == "base"
+    assert stage1.guidance.video.stg_blocks == (stg_block,)
+    assert stage1.guidance.audio.stg_blocks == (stg_block,)
+    assert stage2.input_transform == "spatial_upsample"
+    assert stage2.transformer_phase == "distilled_lora"
+    assert stage2.guidance == LTXGuidanceSpec.positive_only()
+    assert stage2.num_inference_steps == 3
+    assert stage2.sigmas == (0.909375, 0.725, 0.421875, 0.0)
+
+
+def test_ltx_two_stage_entries_select_the_official_transformer_phases():
+    phase_switches = []
+    ordinary_pipeline = object.__new__(LTX2TwoStagePipeline)
+    ordinary_pipeline._phase_lora_controller = SimpleNamespace(enter=phase_switches.append)
+    for phase in LTX2_TWO_STAGE_RECIPE.phases:
+        ordinary_pipeline._enter_phase(phase)
+    assert phase_switches == ["base", "distilled_lora"]
+
+    distilled_pipeline = object.__new__(LTX2DistilledPipeline)
+    for phase in LTX2_DISTILLED_TWO_STAGE_RECIPE.phases:
+        distilled_pipeline._enter_phase(phase)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"num_layers": 2, "cross_attn_mod": True},
+        SimpleNamespace(num_layers=2, cross_attn_mod=True),
+    ],
+)
+def test_ltx_resident_lora_copies_mapping_and_namespace_configs(config):
+    copied = _transformer_config_to_dict(config)
+
+    assert copied == {"num_layers": 2, "cross_attn_mod": True}
+    assert copied is not config
+
+
+def test_ltx_resident_lora_keeps_two_offloadable_transformers(monkeypatch):
+    from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+    from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
+
+    class _TinyTransformer(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = SimpleNamespace(num_layers=1)
+            self.proj = torch.nn.Linear(2, 2, bias=False)
+
+    pipe = object.__new__(LTX2TwoStagePipeline)
+    torch.nn.Module.__init__(pipe)
+    pipe.transformer = _TinyTransformer()
+    pipe._transformer_init_config = {"num_layers": 1, "cross_attn_mod": True}
+    pipe.od_config = SimpleNamespace(quantization_config=None, dtype=torch.float32)
+    pipe.device = torch.device("cpu")
+    pipe.weights_sources = [
+        DiffusersPipelineLoader.ComponentSource(
+            model_or_path="unused",
+            subfolder="transformer",
+            revision=None,
+            prefix="transformer.",
+        )
+    ]
+    created_configs = []
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.ltx2.ltx2_lora.create_transformer_from_config",
+        lambda config: (created_configs.append(config), _TinyTransformer())[1],
+    )
+
+    with torch.no_grad():
+        pipe.transformer.proj.weight.copy_(torch.eye(2))
+    controller = LTXResidentLoRAController(pipe, "unused.safetensors")
+    assert created_configs == [{"num_layers": 1, "cross_attn_mod": True}]
+    with torch.no_grad():
+        pipe.transformer_2.proj.weight.copy_(pipe.transformer.proj.weight)
+
+    controller._merge_entries(
+        [
+            _LTXLoRAEntry(
+                module_name="proj",
+                target_name="proj",
+                shard_id=None,
+                lora_a=torch.tensor([[1.0, 2.0]]),
+                lora_b=torch.tensor([[3.0], [4.0]]),
+            )
+        ]
+    )
+    controller._merged = True
+
+    modules = ModuleDiscovery.discover(pipe)
+    assert modules.dit_names == ["transformer", "transformer_2"]
+    assert pipe.weights_sources[1].prefix == "transformer_2."
+    torch.testing.assert_close(pipe.transformer.proj.weight, torch.eye(2))
+    torch.testing.assert_close(
+        pipe.transformer_2.proj.weight,
+        torch.tensor([[4.0, 6.0], [4.0, 9.0]]),
+    )
+
+    controller.enter("base")
+    assert controller.transformer is pipe.transformer
+    controller.enter("distilled_lora")
+    assert controller.transformer is pipe.transformer_2
 
 
 class TestLTXRequestParsing:

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -988,7 +988,8 @@ def test_ltx_two_stage_executes_declarative_i2v_phase_plan(pipeline_cls):
     if pipeline_cls is LTX2TwoStagePipeline:
         assert activated_slots == [None, "ltx_distilled"]
     torch.testing.assert_close(output.output[0], torch.full((1, 128, 1, 2, 2), 3.0))
-    torch.testing.assert_close(output.output[1], torch.full((1, 8, 1, 2), 4.0))
+    expected_audio = 2.0 if pipeline_cls is LTX2TwoStagePipeline else 4.0
+    torch.testing.assert_close(output.output[1], torch.full((1, 8, 1, 2), expected_audio))
 
 
 @pytest.mark.parametrize("pipeline_cls", [LTX2TwoStagePipeline, LTX2DistilledPipeline])

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -44,6 +44,7 @@ from vllm_omni.diffusion.models.ltx2.ltx2_guidance import (
     LTXGuidancePlan,
     LTXGuidanceSpec,
     LTXModalityGuidance,
+    _repeat_batch,
     build_perturbation_kwargs,
     combine_guided_x0,
 )
@@ -580,6 +581,15 @@ def test_ltx_guidance_uses_official_close_to_disabled_semantics():
     )
 
     assert LTXGuidancePlan.build(LTXGuidanceSpec(video=guidance)).names == ("cond",)
+
+
+def test_ltx_positive_only_guidance_preserves_token_major_layout():
+    tensor = torch.arange(24).view(1, 3, 8).transpose(1, 2).contiguous().transpose(1, 2)
+
+    repeated = _repeat_batch(tensor, 1)
+
+    assert repeated is tensor
+    assert repeated.stride() == tensor.stride()
 
 
 def test_ltx_guidance_rescale_is_invariant_to_request_batching():

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -285,28 +285,26 @@ def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, 
     assert pipe.pipeline_recipe is LTX23_TWO_STAGE_RECIPE
 
 
-def test_ltx_one_stage_entry_exposes_batch_image_and_distributed_decode_contracts():
+def test_ltx_entries_expose_batch_image_and_distributed_decode_contracts():
     assert LTX2Pipeline.supports_request_batch
     assert LTX2Pipeline.support_image_input
     assert LTX2Pipeline.unified_text_image_entry
     assert LTX2Pipeline.distributed_video_decode
     assert not LTX2TwoStagePipeline.supports_request_batch
-    assert not LTX2TwoStagePipeline.support_image_input
+    assert LTX2TwoStagePipeline.support_image_input
+    assert LTX2TwoStagePipeline.unified_text_image_entry
     assert not LTX2DistilledPipeline.supports_request_batch
     assert LTX2DistilledPipeline.support_image_input
     assert LTX2DistilledPipeline.unified_text_image_entry
 
 
-def test_ltx_two_stage_rejects_request_embedded_images():
+def test_ltx_two_stage_resolves_request_embedded_images():
     pipe = object.__new__(LTX2TwoStagePipeline)
     request_inputs = SimpleNamespace(latents=None)
-    object.__setattr__(pipe, "_resolve_request_inputs", lambda *_args, **_kwargs: request_inputs)
-    req = SimpleNamespace(
-        prompts=[{"prompt": "image conditioned", "multi_modal_data": {"image": torch.zeros(3, 8, 8)}}]
-    )
+    image = torch.zeros(3, 8, 8)
+    req = SimpleNamespace(prompts=[{"prompt": "image conditioned", "multi_modal_data": {"image": image}}])
 
-    with pytest.raises(ValueError, match="does not support `image` input"):
-        pipe._forward_request(req)
+    assert pipe._resolve_request_image(req, None, request_inputs) is image
 
 
 def test_ltx_dmd2_entries_retain_their_task_boundaries():
@@ -756,7 +754,8 @@ def test_denoise_executor_owns_progress_and_interrupt():
     torch.testing.assert_close(state.audio, torch.tensor(11.0))
 
 
-def test_ltx2_distilled_two_stage_executes_declarative_phase_plan():
+@pytest.mark.parametrize("pipeline_cls", [LTX2TwoStagePipeline, LTX2DistilledPipeline])
+def test_ltx_two_stage_executes_declarative_i2v_phase_plan(pipeline_cls):
     request_inputs = LTXRequestInputs(
         prompt="prompt",
         negative_prompt="",
@@ -833,12 +832,15 @@ def test_ltx2_distilled_two_stage_executes_declarative_phase_plan():
             return latents.repeat_interleave(2, dim=-2).repeat_interleave(2, dim=-1)
 
     prompt_context_sentinel = prompt_context
-    pipeline = object.__new__(LTX2DistilledPipeline)
+    pipeline = object.__new__(pipeline_cls)
     torch.nn.Module.__init__(pipeline)
     pipeline.device = torch.device("cpu")
     pipeline.vae_spatial_compression_ratio = 32
     pipeline.vae_temporal_compression_ratio = 8
     pipeline.latent_upsampler = FakeUpsampler()
+    activated_slots = []
+    if pipeline_cls is LTX2TwoStagePipeline:
+        pipeline._phase_weights = SimpleNamespace(activate=activated_slots.append)
     object.__setattr__(pipeline, "_resolve_request_inputs", resolve_request_inputs)
     object.__setattr__(pipeline, "run_phase", run_phase)
     object.__setattr__(pipeline, "decode_phase", decode_phase)
@@ -848,14 +850,17 @@ def test_ltx2_distilled_two_stage_executes_declarative_phase_plan():
 
     assert len(phase_calls) == 2
     assert phase_calls[1][2] is prompt_context_sentinel
+    if pipeline_cls is LTX2TwoStagePipeline:
+        assert activated_slots == [None, "ltx_distilled"]
     torch.testing.assert_close(output.output[0], torch.full((1, 128, 1, 2, 2), 3.0))
     torch.testing.assert_close(output.output[1], torch.full((1, 8, 1, 2), 4.0))
 
 
-def test_ltx2_distilled_stage2_reapplies_final_resolution_i2v_conditioning():
+@pytest.mark.parametrize("pipeline_cls", [LTX2TwoStagePipeline, LTX2DistilledPipeline])
+def test_ltx_two_stage_stage2_reapplies_final_resolution_i2v_conditioning(pipeline_cls):
     from vllm_omni.diffusion.models.ltx2 import ltx2_latents
 
-    pipeline = object.__new__(LTX2DistilledPipeline)
+    pipeline = object.__new__(pipeline_cls)
     torch.nn.Module.__init__(pipeline)
     pipeline.vae_spatial_compression_ratio = 32
     pipeline.vae_temporal_compression_ratio = 8

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -1323,9 +1323,7 @@ def test_ltx_resident_lora_premerges_full_weights_for_shared_loader(monkeypatch)
     )
     lora_entries = [
         _LTXLoRAEntry(
-            module_name="proj",
-            target_name="proj",
-            shard_id=None,
+            source_module="proj",
             lora_a=torch.tensor([[1.0, 2.0]]),
             lora_b=torch.tensor([[3.0], [4.0]]),
         )
@@ -1529,9 +1527,7 @@ def test_ltx_resident_lora_requires_every_adapter_target(monkeypatch):
         "vllm_omni.diffusion.models.ltx2.ltx2_phase_weights._load_resident_lora_entries",
         lambda *args: [
             _LTXLoRAEntry(
-                module_name="missing",
-                target_name="missing",
-                shard_id=None,
+                source_module="missing",
                 lora_a=torch.eye(2),
                 lora_b=torch.eye(2),
             )

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -257,6 +257,47 @@ def test_ltx23_checkpoint_selects_version_specific_one_stage_profile(tmp_path, m
     assert pipe.reports_stage_durations
 
 
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        LTX2_TWO_STAGE_RECIPE,
+        LTX23_TWO_STAGE_RECIPE,
+        LTX2_DISTILLED_TWO_STAGE_RECIPE,
+        LTX23_DISTILLED_TWO_STAGE_RECIPE,
+    ],
+)
+def test_ltx_multistage_recipes_declare_cache_dit_unsupported(recipe):
+    assert not recipe.supports_cache_dit
+
+
+@pytest.mark.parametrize("recipe", [LTX2_ONE_STAGE_RECIPE, LTX23_ONE_STAGE_RECIPE, LTX_POSITIVE_ONLY_RECIPE])
+def test_ltx_one_stage_recipes_declare_cache_dit_supported(recipe):
+    assert recipe.supports_cache_dit
+
+
+def test_ltx_multistage_rejects_cache_dit_before_component_initialization(tmp_path, monkeypatch):
+    from vllm_omni.diffusion.models.ltx2 import ltx2_runtime
+
+    (tmp_path / "model_index.json").write_text(json.dumps({"vocoder": ["ltx2", "LTX2Vocoder"]}))
+    initialized = False
+
+    def stub_components(*_args, **_kwargs):
+        nonlocal initialized
+        initialized = True
+
+    monkeypatch.setattr(ltx2_runtime, "initialize_pipeline_components", stub_components)
+
+    with pytest.raises(ValueError, match="only one-stage LTX recipes"):
+        LTX2TwoStagePipeline(
+            od_config=SimpleNamespace(
+                model=str(tmp_path),
+                cache_backend="cache_dit",
+            )
+        )
+
+    assert not initialized
+
+
 def test_ltx23_checkpoint_selects_version_specific_two_stage_profiles(tmp_path, monkeypatch):
     from vllm_omni.diffusion.models.ltx2 import ltx2_runtime
 

--- a/tests/diffusion/models/ltx2/test_ltx2_transformer.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_transformer.py
@@ -7,10 +7,12 @@ import pytest
 import torch
 from torch import nn
 
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
 from vllm_omni.diffusion.models.ltx2.ltx2_transformer import (
     LTX2AudioVideoAttnProcessor,
     LTX2VideoTransformer3DModel,
+    _LTX2ParallelAttention,
     _make_rms_norm,
 )
 
@@ -92,3 +94,63 @@ def test_ltx_sp_keeps_cross_attention_key_padding_mask(monkeypatch):
     )
 
     torch.testing.assert_close(actual, key_padding_mask)
+
+
+def _fake_ltx_parallel_attention(*, is_cross_attention: bool):
+    calls = []
+
+    class Backend:
+        @staticmethod
+        def get_name():
+            return "FLASH_ATTN"
+
+        @staticmethod
+        def supports_attention_mask():
+            return True
+
+    def run(name):
+        def forward(query, _key, _value, _metadata):
+            calls.append(name)
+            return torch.zeros_like(query)
+
+        return forward
+
+    layer = object.__new__(_LTX2ParallelAttention)
+    nn.Module.__init__(layer)
+    layer.is_cross_attention = is_cross_attention
+    layer.attn_backend = Backend
+    layer.attention = SimpleNamespace(forward=run("native"))
+    layer.sdpa_fallback = SimpleNamespace(forward=run("sdpa"))
+    layer.backend_pref = "FLASH_ATTN"
+    return layer, calls
+
+
+@pytest.mark.parametrize(("query_length", "key_length"), [(4, 4), (3, 4)])
+def test_ltx_masked_cross_attention_uses_sdpa(query_length, key_length):
+    layer, calls = _fake_ltx_parallel_attention(is_cross_attention=True)
+    query = torch.zeros(1, query_length, 2, 4, dtype=torch.bfloat16)
+    key = value = torch.zeros(1, key_length, 2, 4, dtype=torch.bfloat16)
+    metadata = AttentionMetadata(attn_mask=torch.tensor([[True] * (key_length - 1) + [False]]))
+
+    layer._run_local_attention(query, key, value, metadata)
+
+    assert calls == ["sdpa"]
+
+
+def test_ltx_masked_self_attention_keeps_native_backend():
+    layer, calls = _fake_ltx_parallel_attention(is_cross_attention=False)
+    query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+    metadata = AttentionMetadata(attn_mask=torch.tensor([[True, True, True, False]]))
+
+    layer._run_local_attention(query, key, value, metadata)
+
+    assert calls == ["native"]
+
+
+def test_ltx_unmasked_cross_attention_keeps_native_backend():
+    layer, calls = _fake_ltx_parallel_attention(is_cross_attention=True)
+    query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+
+    layer._run_local_attention(query, key, value, None)
+
+    assert calls == ["native"]

--- a/tests/diffusion/models/ltx2/test_ltx2_transformer.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_transformer.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 from torch import nn
 
 from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
-from vllm_omni.diffusion.models.ltx2.ltx2_transformer import LTX2VideoTransformer3DModel, _make_rms_norm
+from vllm_omni.diffusion.models.ltx2.ltx2_transformer import (
+    LTX2AudioVideoAttnProcessor,
+    LTX2VideoTransformer3DModel,
+    _make_rms_norm,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -66,3 +73,22 @@ def test_ltx_sp_plan_shards_video_and_audio_timesteps_together(rope_type):
     assert video_timestep.expected_dims == audio_timestep.expected_dims == 2
     assert not video_timestep.split_output
     assert not audio_timestep.split_output
+
+
+def test_ltx_sp_keeps_cross_attention_key_padding_mask(monkeypatch):
+    monkeypatch.setattr(LTX2AudioVideoAttnProcessor, "_is_sp_enabled", staticmethod(lambda: True))
+    processor = LTX2AudioVideoAttnProcessor()
+    hidden_states = torch.zeros(1, 3, 4)
+    encoder_hidden_states = torch.zeros(1, 4, 4)
+    key_padding_mask = torch.tensor([[True, True, True, False]])
+
+    actual = processor._prepare_attention_mask(
+        SimpleNamespace(),
+        hidden_states,
+        encoder_hidden_states,
+        key_padding_mask,
+        batch_size=1,
+        sequence_length=4,
+    )
+
+    torch.testing.assert_close(actual, key_padding_mask)

--- a/tests/e2e/accuracy/ltx/run_ltx_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx_reference.py
@@ -20,6 +20,11 @@ from PIL import Image
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", choices=("official", "omni"), required=True)
+    parser.add_argument(
+        "--pipeline-kind",
+        choices=("one_stage", "distilled", "two_stage"),
+        default="one_stage",
+    )
     parser.add_argument("--request", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--model")
@@ -27,6 +32,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--official-root", type=Path)
     parser.add_argument("--checkpoint", type=Path)
     parser.add_argument("--gemma-root", type=Path)
+    parser.add_argument("--spatial-upsampler", type=Path)
+    parser.add_argument("--distilled-lora", type=Path)
     parser.add_argument("--enable-layerwise-offload", action="store_true")
     return parser.parse_args()
 
@@ -91,9 +98,13 @@ def _configure_official_sdpa(pipeline: Any) -> None:
         attention=attention,
         masked_attention=attention,
     )
-    owners_and_attributes = (
-        (pipeline.stage, "_transformer_builder"),
+    owners_and_attributes = [
         (pipeline.prompt_encoder, "_embeddings_processor_builder"),
+    ]
+    owners_and_attributes.extend(
+        (stage, "_transformer_builder")
+        for name in ("stage", "stage_1", "stage_2")
+        if (stage := getattr(pipeline, name, None)) is not None
     )
     for owner, attribute in owners_and_attributes:
         builder = getattr(owner, attribute)
@@ -102,6 +113,12 @@ def _configure_official_sdpa(pipeline: Any) -> None:
             attribute,
             builder.with_module_ops((*builder.module_ops, module_op)),
         )
+
+
+def _require_path(path: Path | None, description: str) -> str:
+    if path is None or not path.is_file():
+        raise ValueError(f"Official {description} is required and must exist: {path}")
+    return str(path)
 
 
 @torch.inference_mode()
@@ -113,16 +130,54 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
     torch.backends.cuda.enable_cudnn_sdp(False)
 
     from ltx_core.components.guiders import MultiModalGuiderParams
+    from ltx_core.loader import LTXV_LORA_COMFY_RENAMING_MAP, LoraPathStrengthAndSDOps
+    from ltx_pipelines.distilled import DistilledPipeline
     from ltx_pipelines.ti2vid_one_stage import TI2VidOneStagePipeline
+    from ltx_pipelines.ti2vid_two_stages import TI2VidTwoStagesPipeline
     from ltx_pipelines.utils.args import ImageConditioningInput
     from ltx_pipelines.utils.types import OffloadMode
 
-    pipeline = TI2VidOneStagePipeline(
-        checkpoint_path=str(args.checkpoint),
-        gemma_root=str(args.gemma_root),
-        loras=(),
-        offload_mode=OffloadMode.CPU if args.enable_layerwise_offload else OffloadMode.NONE,
-    )
+    if request.get("pipeline_kind", "one_stage") != args.pipeline_kind:
+        raise ValueError(
+            f"Request pipeline kind {request.get('pipeline_kind')!r} does not match {args.pipeline_kind!r}"
+        )
+    checkpoint = _require_path(args.checkpoint, "checkpoint")
+    gemma_root = str(args.gemma_root)
+    if not Path(gemma_root).is_dir():
+        raise ValueError(f"Official Gemma root is required and must be a directory: {gemma_root}")
+    offload_mode = OffloadMode.CPU if args.enable_layerwise_offload else OffloadMode.NONE
+    pipeline: Any
+    if args.pipeline_kind == "one_stage":
+        pipeline = TI2VidOneStagePipeline(
+            checkpoint_path=checkpoint,
+            gemma_root=gemma_root,
+            loras=(),
+            offload_mode=offload_mode,
+        )
+    elif args.pipeline_kind == "distilled":
+        pipeline = DistilledPipeline(
+            distilled_checkpoint_path=checkpoint,
+            spatial_upsampler_path=_require_path(args.spatial_upsampler, "spatial upsampler"),
+            gemma_root=gemma_root,
+            loras=(),
+            offload_mode=offload_mode,
+        )
+    else:
+        distilled_lora = [
+            LoraPathStrengthAndSDOps(
+                path=_require_path(args.distilled_lora, "distilled LoRA"),
+                strength=1.0,
+                sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
+            )
+        ]
+        pipeline = TI2VidTwoStagesPipeline(
+            checkpoint_path=checkpoint,
+            distilled_lora=distilled_lora,
+            spatial_upsampler_path=_require_path(args.spatial_upsampler, "spatial upsampler"),
+            gemma_root=gemma_root,
+            loras=(),
+            offload_mode=offload_mode,
+        )
     _configure_official_sdpa(pipeline)
     image_path = request.get("image")
     images = (
@@ -140,34 +195,45 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
             )
         ]
     )
-    video, audio = pipeline(
-        prompt=request["prompt"],
-        negative_prompt=request["negative_prompt"],
-        seed=request["seed"],
-        height=request["height"],
-        width=request["width"],
-        num_frames=request["num_frames"],
-        frame_rate=request["fps"],
-        num_inference_steps=request["num_inference_steps"],
-        video_guider_params=MultiModalGuiderParams(
-            cfg_scale=request["video_cfg_scale"],
-            stg_scale=request["video_stg_scale"],
-            rescale_scale=request["video_rescale_scale"],
-            modality_scale=request["video_modality_scale"],
-            skip_step=0,
-            stg_blocks=request["video_stg_blocks"],
-        ),
-        audio_guider_params=MultiModalGuiderParams(
-            cfg_scale=request["audio_cfg_scale"],
-            stg_scale=request["audio_stg_scale"],
-            rescale_scale=request["audio_rescale_scale"],
-            modality_scale=request["audio_modality_scale"],
-            skip_step=0,
-            stg_blocks=request["audio_stg_blocks"],
-        ),
-        images=images,
-        max_batch_size=4,
-    )
+    if args.pipeline_kind == "distilled":
+        video, audio = pipeline(
+            prompt=request["prompt"],
+            seed=request["seed"],
+            height=request["height"],
+            width=request["width"],
+            num_frames=request["num_frames"],
+            frame_rate=request["fps"],
+            images=images,
+        )
+    else:
+        video, audio = pipeline(
+            prompt=request["prompt"],
+            negative_prompt=request["negative_prompt"],
+            seed=request["seed"],
+            height=request["height"],
+            width=request["width"],
+            num_frames=request["num_frames"],
+            frame_rate=request["fps"],
+            num_inference_steps=request["num_inference_steps"],
+            video_guider_params=MultiModalGuiderParams(
+                cfg_scale=request["video_cfg_scale"],
+                stg_scale=request["video_stg_scale"],
+                rescale_scale=request["video_rescale_scale"],
+                modality_scale=request["video_modality_scale"],
+                skip_step=0,
+                stg_blocks=request["video_stg_blocks"],
+            ),
+            audio_guider_params=MultiModalGuiderParams(
+                cfg_scale=request["audio_cfg_scale"],
+                stg_scale=request["audio_stg_scale"],
+                rescale_scale=request["audio_rescale_scale"],
+                modality_scale=request["audio_modality_scale"],
+                skip_step=0,
+                stg_blocks=request["audio_stg_blocks"],
+            ),
+            images=images,
+            max_batch_size=4,
+        )
     video_tensor = torch.cat([chunk.detach().cpu() for chunk in video], dim=0)
     _save_outputs(
         args.output_dir,
@@ -179,6 +245,7 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
             "attention_backend": "torch_sdpa",
             "official_revision": os.environ.get("VLLM_TEST_LTX_OFFICIAL_REVISION"),
             "checkpoint": str(args.checkpoint),
+            "pipeline_kind": args.pipeline_kind,
         },
     )
 
@@ -253,6 +320,10 @@ def _canonical_video(video: Any) -> torch.Tensor:
 def _run_omni(args: argparse.Namespace, request: dict[str, Any]) -> None:
     if args.model is None or args.model_class_name is None:
         raise ValueError("Omni backend requires --model and --model-class-name")
+    if request.get("pipeline_kind", "one_stage") != args.pipeline_kind:
+        raise ValueError(
+            f"Request pipeline kind {request.get('pipeline_kind')!r} does not match {args.pipeline_kind!r}"
+        )
 
     attention_config = {"default": {"backend": "TORCH_SDPA"}}
 
@@ -273,7 +344,8 @@ def _run_omni(args: argparse.Namespace, request: dict[str, Any]) -> None:
         parallel_config=DiffusionParallelConfig(),
     )
     try:
-        model_class_name = get_model_class_name(omni)
+        detected_model_class_name = get_model_class_name(omni)
+        model_class_name = args.model_class_name
         sampling_params = OmniDiffusionSamplingParams(
             height=request["height"],
             width=request["width"],
@@ -289,10 +361,9 @@ def _run_omni(args: argparse.Namespace, request: dict[str, Any]) -> None:
             key: value for key, value in request.items() if key.startswith("video_") or key.startswith("audio_")
         }
         apply_declared_extra_args(sampling_params, get_extra_body_params(model_class_name), guidance)
-        prompt: dict[str, Any] = {
-            "prompt": request["prompt"],
-            "negative_prompt": request["negative_prompt"],
-        }
+        prompt: dict[str, Any] = {"prompt": request["prompt"]}
+        if request.get("negative_prompt"):
+            prompt["negative_prompt"] = request["negative_prompt"]
         image_path = request.get("image")
         if image_path is not None:
             with Image.open(str(image_path)) as source_image:
@@ -312,6 +383,8 @@ def _run_omni(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 "attention_backend": "torch_sdpa",
                 "model": args.model,
                 "model_class_name": model_class_name,
+                "model_config_class_name": detected_model_class_name,
+                "pipeline_kind": args.pipeline_kind,
             },
         )
     finally:

--- a/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
@@ -3,10 +3,11 @@
 
 """E2E accuracy guard against a pinned Lightricks LTX pipeline revision.
 
-The comparison runs both runtimes through PyTorch SDPA and uses
-``max_batch_size=4`` in the official reference to match Omni's fused guidance
-batch. Video and audio guidance use the official non-HQ one-stage defaults;
-only the generation shape and step count are reduced for CI runtime.
+The original reduced one-stage guards remain unchanged. Additional cases cover
+text-to-video and image-to-video for one-stage, full-distilled two-stage,
+ordinary two-stage with resident weights matching official fused arithmetic,
+and dedicated dynamic-LoRA two-stage variants. Select an individual case with
+its pytest parameter node ID. Both runtimes use PyTorch SDPA.
 """
 
 from __future__ import annotations
@@ -17,8 +18,9 @@ import shutil
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import pytest
@@ -53,72 +55,376 @@ NEGATIVE_PROMPT = (
 
 # Both runtimes use PyTorch SDPA with the current Torch dispatch defaults.
 ATTENTION_BACKEND = "torch_sdpa"
-VIDEO_SSIM_MEAN_THRESHOLD = 0.95
-VIDEO_SSIM_MIN_THRESHOLD = 0.90
-VIDEO_PSNR_MEAN_THRESHOLD = 30.0
-AUDIO_RELATIVE_L2_THRESHOLD = 0.2
-AUDIO_COSINE_THRESHOLD = 0.95
+
+
+@dataclass(frozen=True)
+class LTXArtifact:
+    repo_id: str
+    filename: str
+    revision: str
+    env: str
+    repo_type: Literal["model", "dataset"] = "model"
+
+
+@dataclass(frozen=True)
+class LTXAccuracyThresholds:
+    video_ssim_mean: float
+    video_ssim_min: float
+    video_psnr_mean_db: float
+    # Zero disables gating for waveform-sensitive audio that is not expected
+    # to align with the official output.
+    audio_relative_l2: float
+    audio_cosine_similarity: float
 
 
 @dataclass(frozen=True)
 class LTXAccuracyCase:
     name: str
+    pipeline_kind: Literal["one_stage", "distilled", "two_stage"]
     model_id: str
     model_revision: str
     model_env: str
     model_class_name: str
-    checkpoint_repo: str
-    checkpoint_filename: str
-    checkpoint_revision: str
-    checkpoint_env: str
-    stg_block: int
+    checkpoint: LTXArtifact
+    width: int
+    height: int
+    num_frames: int
+    num_inference_steps: int
+    seed: int
+    stg_block: int | None
+    thresholds: LTXAccuracyThresholds
     prompt: str = PROMPT
-    image_repo: str | None = None
-    image_filename: str | None = None
-    image_revision: str | None = None
+    gemma_model_id: str | None = None
+    gemma_model_revision: str | None = None
+    gemma_model_env: str | None = None
+    image: LTXArtifact | None = None
+    spatial_upsampler: LTXArtifact | None = None
+    distilled_lora: LTXArtifact | None = None
+    two_stage_lora_mode: Literal["dynamic", "resident"] | None = None
 
 
-CASES = (
+LTX2_REVISION = "47da56e2ad66ce4125a9922b4a8826bf407f9d0a"
+LTX23_REVISION = "4229404625088d21c4f112eb640fb04a0900ee25"
+LTX2_CHECKPOINT = LTXArtifact(
+    repo_id="Lightricks/LTX-2",
+    filename="ltx-2-19b-dev.safetensors",
+    revision=LTX2_REVISION,
+    env="VLLM_TEST_LTX2_OFFICIAL_CHECKPOINT",
+)
+LTX2_DISTILLED_CHECKPOINT = replace(
+    LTX2_CHECKPOINT,
+    filename="ltx-2-19b-distilled.safetensors",
+    env="VLLM_TEST_LTX2_DISTILLED_OFFICIAL_CHECKPOINT",
+)
+LTX2_UPSAMPLER = replace(
+    LTX2_CHECKPOINT,
+    filename="ltx-2-spatial-upscaler-x2-1.0.safetensors",
+    env="VLLM_TEST_LTX2_UPSAMPLER",
+)
+LTX2_DISTILLED_LORA = replace(
+    LTX2_CHECKPOINT,
+    filename="ltx-2-19b-distilled-lora-384.safetensors",
+    env="VLLM_TEST_LTX2_DISTILLED_LORA",
+)
+LTX23_CHECKPOINT = LTXArtifact(
+    repo_id="Lightricks/LTX-2.3",
+    filename="ltx-2.3-22b-dev.safetensors",
+    revision=LTX23_REVISION,
+    env="VLLM_TEST_LTX23_OFFICIAL_CHECKPOINT",
+)
+LTX23_DISTILLED_CHECKPOINT = replace(
+    LTX23_CHECKPOINT,
+    # The pinned Diffusers checkpoint contains the original merged distilled
+    # Transformer. Keep the reference Transformer on the same version; the
+    # spatial upsampler is versioned independently and remains on 1.1 below.
+    filename="ltx-2.3-22b-distilled.safetensors",
+    env="VLLM_TEST_LTX23_DISTILLED_OFFICIAL_CHECKPOINT",
+)
+LTX23_UPSAMPLER = replace(
+    LTX23_CHECKPOINT,
+    filename="ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
+    env="VLLM_TEST_LTX23_UPSAMPLER",
+)
+LTX23_DISTILLED_LORA = replace(
+    LTX23_CHECKPOINT,
+    filename="ltx-2.3-22b-distilled-lora-384-1.1.safetensors",
+    env="VLLM_TEST_LTX23_DISTILLED_LORA",
+)
+I2V_IMAGE = LTXArtifact(
+    repo_id="huggingface/documentation-images",
+    filename="diffusers/svd/rocket.png",
+    revision="645d8364f0c7a101180b364811b5a11a362e4010",
+    env="VLLM_TEST_LTX_I2V_IMAGE",
+    repo_type="dataset",
+)
+
+
+LEGACY_CASES = (
     LTXAccuracyCase(
         name="ltx2",
+        pipeline_kind="one_stage",
         model_id="Lightricks/LTX-2",
-        model_revision="47da56e2ad66ce4125a9922b4a8826bf407f9d0a",
+        model_revision=LTX2_REVISION,
         model_env="VLLM_TEST_LTX2_MODEL",
         model_class_name="LTX2Pipeline",
-        checkpoint_repo="Lightricks/LTX-2",
-        checkpoint_filename="ltx-2-19b-dev.safetensors",
-        checkpoint_revision="47da56e2ad66ce4125a9922b4a8826bf407f9d0a",
-        checkpoint_env="VLLM_TEST_LTX2_OFFICIAL_CHECKPOINT",
+        checkpoint=LTX2_CHECKPOINT,
+        width=512,
+        height=384,
+        num_frames=25,
+        num_inference_steps=20,
+        seed=42,
         stg_block=29,
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
     ),
     LTXAccuracyCase(
         name="ltx2_3",
+        pipeline_kind="one_stage",
         model_id="diffusers/LTX-2.3-Diffusers",
         model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
         model_env="VLLM_TEST_LTX23_MODEL",
         model_class_name="LTX2Pipeline",
-        checkpoint_repo="Lightricks/LTX-2.3",
-        checkpoint_filename="ltx-2.3-22b-dev.safetensors",
-        checkpoint_revision="4229404625088d21c4f112eb640fb04a0900ee25",
-        checkpoint_env="VLLM_TEST_LTX23_OFFICIAL_CHECKPOINT",
+        checkpoint=LTX23_CHECKPOINT,
+        width=512,
+        height=384,
+        num_frames=25,
+        num_inference_steps=20,
+        seed=42,
         stg_block=28,
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
     ),
     LTXAccuracyCase(
         name="ltx2_3_i2v",
+        pipeline_kind="one_stage",
         model_id="diffusers/LTX-2.3-Diffusers",
         model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
         model_env="VLLM_TEST_LTX23_MODEL",
         model_class_name="LTX2Pipeline",
-        checkpoint_repo="Lightricks/LTX-2.3",
-        checkpoint_filename="ltx-2.3-22b-dev.safetensors",
-        checkpoint_revision="4229404625088d21c4f112eb640fb04a0900ee25",
-        checkpoint_env="VLLM_TEST_LTX23_OFFICIAL_CHECKPOINT",
+        checkpoint=LTX23_CHECKPOINT,
+        width=512,
+        height=384,
+        num_frames=25,
+        num_inference_steps=20,
+        seed=42,
         stg_block=28,
-        image_repo="huggingface/documentation-images",
-        image_filename="diffusers/svd/rocket.png",
-        image_revision="645d8364f0c7a101180b364811b5a11a362e4010",
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+        image=I2V_IMAGE,
     ),
 )
+
+
+_DEFAULT_CONFIG_CASES = (
+    LTXAccuracyCase(
+        name="ltx2_one_stage",
+        pipeline_kind="one_stage",
+        model_id="Lightricks/LTX-2",
+        model_revision=LTX2_REVISION,
+        model_env="VLLM_TEST_LTX2_MODEL",
+        model_class_name="LTX2Pipeline",
+        checkpoint=LTX2_CHECKPOINT,
+        width=768,
+        height=512,
+        num_frames=121,
+        num_inference_steps=40,
+        seed=10,
+        stg_block=29,
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+    LTXAccuracyCase(
+        name="ltx23_one_stage",
+        pipeline_kind="one_stage",
+        model_id="diffusers/LTX-2.3-Diffusers",
+        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
+        model_env="VLLM_TEST_LTX23_MODEL",
+        model_class_name="LTX2Pipeline",
+        checkpoint=LTX23_CHECKPOINT,
+        width=768,
+        height=512,
+        num_frames=121,
+        num_inference_steps=30,
+        seed=10,
+        stg_block=28,
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+    LTXAccuracyCase(
+        name="ltx2_distilled",
+        pipeline_kind="distilled",
+        model_id="rootonchair/LTX-2-19b-distilled",
+        model_revision="388e2846f54aae51687498ffb6b27c7c2c9ce9e5",
+        model_env="VLLM_TEST_LTX2_DISTILLED_MODEL",
+        model_class_name="LTX2DistilledPipeline",
+        checkpoint=LTX2_DISTILLED_CHECKPOINT,
+        spatial_upsampler=LTX2_UPSAMPLER,
+        width=1536,
+        height=1024,
+        num_frames=121,
+        num_inference_steps=8,
+        seed=10,
+        stg_block=None,
+        gemma_model_id="Lightricks/LTX-2",
+        gemma_model_revision=LTX2_REVISION,
+        gemma_model_env="VLLM_TEST_LTX2_MODEL",
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+    LTXAccuracyCase(
+        name="ltx23_distilled",
+        pipeline_kind="distilled",
+        model_id="diffusers/LTX-2.3-Distilled-Diffusers",
+        model_revision="432e0d3c2d1769aaa4d295f9243f7062bf6b47ee",
+        model_env="VLLM_TEST_LTX23_DISTILLED_MODEL",
+        model_class_name="LTX2DistilledPipeline",
+        checkpoint=LTX23_DISTILLED_CHECKPOINT,
+        spatial_upsampler=LTX23_UPSAMPLER,
+        width=1536,
+        height=1024,
+        num_frames=121,
+        num_inference_steps=8,
+        seed=10,
+        stg_block=None,
+        gemma_model_id="diffusers/LTX-2.3-Diffusers",
+        gemma_model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
+        gemma_model_env="VLLM_TEST_LTX23_MODEL",
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+    LTXAccuracyCase(
+        name="ltx2_two_stage",
+        pipeline_kind="two_stage",
+        model_id="Lightricks/LTX-2",
+        model_revision=LTX2_REVISION,
+        model_env="VLLM_TEST_LTX2_MODEL",
+        model_class_name="LTX2TwoStagePipeline",
+        checkpoint=LTX2_CHECKPOINT,
+        spatial_upsampler=LTX2_UPSAMPLER,
+        distilled_lora=LTX2_DISTILLED_LORA,
+        width=1536,
+        height=1024,
+        num_frames=121,
+        num_inference_steps=40,
+        seed=10,
+        stg_block=29,
+        two_stage_lora_mode="resident",
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+    LTXAccuracyCase(
+        name="ltx23_two_stage",
+        pipeline_kind="two_stage",
+        model_id="diffusers/LTX-2.3-Diffusers",
+        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
+        model_env="VLLM_TEST_LTX23_MODEL",
+        model_class_name="LTX2TwoStagePipeline",
+        checkpoint=LTX23_CHECKPOINT,
+        spatial_upsampler=LTX23_UPSAMPLER,
+        distilled_lora=LTX23_DISTILLED_LORA,
+        width=1536,
+        height=1024,
+        num_frames=121,
+        num_inference_steps=30,
+        seed=10,
+        stg_block=28,
+        # Official execution fuses the phase LoRA into the Transformer and
+        # unloads it after use. Omni resident mode keeps equivalent pre-fused
+        # phase weights in memory to preserve the bf16 arithmetic; dynamic mode
+        # avoids weight mutation but is not expected to be bitwise-equivalent.
+        two_stage_lora_mode="resident",
+        thresholds=LTXAccuracyThresholds(
+            video_ssim_mean=0.95,
+            video_ssim_min=0.90,
+            video_psnr_mean_db=30.0,
+            audio_relative_l2=0.20,
+            audio_cosine_similarity=0.95,
+        ),
+    ),
+)
+
+
+def _dynamic_lora_case(base_name: str, thresholds: LTXAccuracyThresholds) -> LTXAccuracyCase:
+    base_case = next(case for case in _DEFAULT_CONFIG_CASES if case.name == base_name)
+    return replace(
+        base_case,
+        name=f"{base_case.name}_dynamic",
+        two_stage_lora_mode="dynamic",
+        thresholds=thresholds,
+    )
+
+
+_DYNAMIC_LORA_TWO_STAGE_CASES = (
+    _dynamic_lora_case(
+        "ltx2_two_stage",
+        LTXAccuracyThresholds(
+            video_ssim_mean=0.80,
+            video_ssim_min=0.60,
+            video_psnr_mean_db=15.0,
+            audio_relative_l2=1.0,
+            audio_cosine_similarity=0.0,
+        ),
+    ),
+    _dynamic_lora_case(
+        "ltx23_two_stage",
+        LTXAccuracyThresholds(
+            video_ssim_mean=0.80,
+            video_ssim_min=0.60,
+            video_psnr_mean_db=15.0,
+            audio_relative_l2=1.0,
+            audio_cosine_similarity=0.0,
+        ),
+    ),
+)
+
+
+DEFAULT_CONFIG_CASES = tuple(
+    replace(case, name=f"{case.name}_{task}", image=I2V_IMAGE if task == "i2v" else None)
+    for case in (*_DEFAULT_CONFIG_CASES, *_DYNAMIC_LORA_TWO_STAGE_CASES)
+    for task in ("t2v", "i2v")
+)
+
+CASES = (*LEGACY_CASES, *DEFAULT_CONFIG_CASES)
 
 
 def _run(command: list[str], *, env: dict[str, str], timeout: int = 1800) -> None:
@@ -209,6 +515,7 @@ def _resolve_model(case: LTXAccuracyCase) -> Path:
                 "model_index.json",
                 "audio_vae/*",
                 "connectors/*",
+                "latent_upsampler/*",
                 "processor/*",
                 "scheduler/*",
                 "text_encoder/config.json",
@@ -223,74 +530,82 @@ def _resolve_model(case: LTXAccuracyCase) -> Path:
     )
 
 
-def _resolve_gemma_root(model: Path) -> Path:
+def _resolve_gemma_root(case: LTXAccuracyCase, model: Path) -> Path:
     configured_root = os.environ.get("VLLM_TEST_LTX_GEMMA_ROOT")
     if configured_root:
         root = Path(configured_root)
         assert root.is_dir(), f"Gemma root not found: {root}"
         return root
+    if case.gemma_model_id is not None:
+        configured_model = os.environ.get(case.gemma_model_env or "")
+        if configured_model and Path(configured_model).is_dir():
+            return Path(configured_model)
+        return Path(
+            snapshot_download(
+                repo_id=case.gemma_model_id,
+                revision=case.gemma_model_revision,
+                allow_patterns=[
+                    "processor/*",
+                    "text_encoder/*",
+                    "tokenizer/*",
+                ],
+            )
+        )
     return model
 
 
-def _resolve_checkpoint(case: LTXAccuracyCase, model: Path) -> Path:
-    configured_checkpoint = os.environ.get(case.checkpoint_env)
-    if configured_checkpoint:
-        checkpoint = Path(configured_checkpoint)
-        assert checkpoint.is_file(), f"Official checkpoint not found: {checkpoint}"
-        return checkpoint
-    model_checkpoint = model / case.checkpoint_filename
-    if model_checkpoint.is_file():
-        return model_checkpoint
+def _resolve_artifact(artifact: LTXArtifact, model: Path | None = None) -> Path:
+    configured_path = os.environ.get(artifact.env)
+    if configured_path:
+        path = Path(configured_path)
+        assert path.is_file(), f"Configured LTX artifact not found: {path}"
+        return path
+    if model is not None:
+        model_path = model / artifact.filename
+        if model_path.is_file():
+            return model_path
     return Path(
         hf_hub_download(
-            repo_id=case.checkpoint_repo,
-            filename=case.checkpoint_filename,
-            revision=case.checkpoint_revision,
+            repo_id=artifact.repo_id,
+            repo_type=None if artifact.repo_type == "model" else artifact.repo_type,
+            filename=artifact.filename,
+            revision=artifact.revision,
         )
     )
 
 
 def _resolve_image(case: LTXAccuracyCase) -> Path | None:
-    if case.image_filename is None:
+    if case.image is None:
         return None
-    if case.image_repo is None or case.image_revision is None:
-        raise ValueError(f"Incomplete image source for LTX accuracy case {case.name!r}.")
-    configured_image = os.environ.get("VLLM_TEST_LTX_I2V_IMAGE")
-    if configured_image:
-        image = Path(configured_image)
-        assert image.is_file(), f"LTX I2V conditioning image not found: {image}"
-        return image
-    return Path(
-        hf_hub_download(
-            repo_id=case.image_repo,
-            repo_type="dataset",
-            filename=case.image_filename,
-            revision=case.image_revision,
-        )
-    )
+    return _resolve_artifact(case.image)
 
 
 def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
     request: dict[str, object] = {
+        "pipeline_kind": case.pipeline_kind,
         "prompt": case.prompt,
-        "negative_prompt": NEGATIVE_PROMPT,
-        "width": 512,
-        "height": 384,
-        "num_frames": 25,
+        "negative_prompt": "" if case.pipeline_kind == "distilled" else NEGATIVE_PROMPT,
+        "width": case.width,
+        "height": case.height,
+        "num_frames": case.num_frames,
         "fps": 24,
-        "num_inference_steps": 20,
-        "seed": 42,
-        "video_cfg_scale": 3.0,
-        "audio_cfg_scale": 7.0,
-        "video_stg_scale": 1.0,
-        "audio_stg_scale": 1.0,
-        "video_modality_scale": 3.0,
-        "audio_modality_scale": 3.0,
-        "video_rescale_scale": 0.7,
-        "audio_rescale_scale": 0.7,
-        "video_stg_blocks": [case.stg_block],
-        "audio_stg_blocks": [case.stg_block],
+        "num_inference_steps": case.num_inference_steps,
+        "seed": case.seed,
     }
+    if case.pipeline_kind != "distilled":
+        assert case.stg_block is not None
+        request.update(
+            video_cfg_scale=3.0,
+            audio_cfg_scale=7.0,
+            video_stg_scale=1.0,
+            audio_stg_scale=1.0,
+            video_modality_scale=3.0,
+            audio_modality_scale=3.0,
+            video_rescale_scale=0.7,
+            audio_rescale_scale=0.7,
+            video_stg_blocks=[case.stg_block],
+            audio_stg_blocks=[case.stg_block],
+        )
     if image is not None:
         request["image"] = str(image.resolve())
     return request
@@ -299,20 +614,30 @@ def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
 def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, float]:
     assert reference.shape == prediction.shape
     assert reference.ndim == 4 and reference.shape[-1] == 3
+    device = torch.device("cpu")
+    ssim = StructuralSimilarityIndexMeasure(data_range=1.0).to(device)
+    psnr = PeakSignalNoiseRatio(data_range=1.0).to(device)
     ssim_scores: list[float] = []
     psnr_scores: list[float] = []
-    for reference_frame, prediction_frame in zip(reference, prediction, strict=True):
-        reference_tensor = torch.from_numpy(reference_frame).permute(2, 0, 1).unsqueeze(0)
-        prediction_tensor = torch.from_numpy(prediction_frame).permute(2, 0, 1).unsqueeze(0)
-        ssim_scores.append(float(StructuralSimilarityIndexMeasure(data_range=1.0)(prediction_tensor, reference_tensor)))
-        psnr_scores.append(float(PeakSignalNoiseRatio(data_range=1.0)(prediction_tensor, reference_tensor)))
-    difference = np.abs(reference.astype(np.float64) - prediction.astype(np.float64))
+    max_abs = 0.0
+    absolute_error_sum = 0.0
+    with torch.inference_mode():
+        for reference_frame, prediction_frame in zip(reference, prediction, strict=True):
+            reference_tensor = torch.from_numpy(reference_frame).permute(2, 0, 1).unsqueeze(0).to(device)
+            prediction_tensor = torch.from_numpy(prediction_frame).permute(2, 0, 1).unsqueeze(0).to(device)
+            ssim_scores.append(float(ssim(prediction_tensor, reference_tensor)))
+            psnr_scores.append(float(psnr(prediction_tensor, reference_tensor)))
+            ssim.reset()
+            psnr.reset()
+            difference = np.abs(reference_frame.astype(np.float64) - prediction_frame.astype(np.float64))
+            max_abs = max(max_abs, float(difference.max()))
+            absolute_error_sum += float(difference.sum())
     return {
         "ssim_mean": float(np.mean(ssim_scores)),
         "ssim_min": float(np.min(ssim_scores)),
         "psnr_mean_db": float(np.mean(psnr_scores)),
-        "max_abs": float(difference.max()),
-        "mean_abs": float(difference.mean()),
+        "max_abs": max_abs,
+        "mean_abs": absolute_error_sum / reference.size,
     }
 
 
@@ -343,13 +668,19 @@ def _audio_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, f
 @pytest.mark.benchmark
 @pytest.mark.diffusion
 @hardware_test(res={"cuda": "H100"}, num_cards=1)
-def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact_root: Path) -> None:
+def test_ltx_matches_official(case: LTXAccuracyCase, accuracy_artifact_root: Path) -> None:
     """Compare official and Omni raw AV outputs from the same E2E request."""
+    configured_artifact_root = os.environ.get("VLLM_TEST_LTX_ARTIFACT_ROOT")
+    if configured_artifact_root:
+        accuracy_artifact_root = Path(configured_artifact_root)
+        accuracy_artifact_root.mkdir(parents=True, exist_ok=True)
     output_root = reset_artifact_dir(accuracy_artifact_root / "ltx_official" / case.name)
     official_root, official_revision = _official_source(accuracy_artifact_root / "ltx_official")
     model = _resolve_model(case)
-    gemma_root = _resolve_gemma_root(model)
-    checkpoint = _resolve_checkpoint(case, model)
+    gemma_root = _resolve_gemma_root(case, model)
+    checkpoint = _resolve_artifact(case.checkpoint, model)
+    spatial_upsampler = _resolve_artifact(case.spatial_upsampler, model) if case.spatial_upsampler is not None else None
+    distilled_lora = _resolve_artifact(case.distilled_lora, model) if case.distilled_lora is not None else None
     image = _resolve_image(case)
     request_path = output_root / "request.json"
     request_path.write_text(json.dumps(_request(case, image), indent=2) + "\n")
@@ -359,12 +690,21 @@ def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact
         str(runner),
         "--request",
         str(request_path),
+        "--pipeline-kind",
+        case.pipeline_kind,
     ]
     if os.environ.get("VLLM_TEST_LTX_ENABLE_LAYERWISE_OFFLOAD", "").lower() in {"1", "true", "yes", "on"}:
         runner_args.append("--enable-layerwise-offload")
     env = os.environ.copy()
     env["VLLM_TEST_LTX_OFFICIAL_REVISION"] = official_revision
     env["PYTHONUNBUFFERED"] = "1"
+    sidecars = [path for path in (spatial_upsampler, distilled_lora) if path is not None]
+    if sidecars:
+        sidecar_root = output_root / "sidecars"
+        sidecar_root.mkdir()
+        for path in sidecars:
+            (sidecar_root / path.name).symlink_to(path.resolve())
+        env["VLLM_OMNI_LTX_ARTIFACTS_DIR"] = str(sidecar_root)
     repository_root = Path(__file__).resolve().parents[4]
     existing_pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (
@@ -372,10 +712,9 @@ def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact
     )
 
     official_output = output_root / "official"
-    _run(
-        _official_runner_prefix()
-        + runner_args
-        + [
+    official_args = _official_runner_prefix() + runner_args
+    official_args.extend(
+        [
             "--backend",
             "official",
             "--output-dir",
@@ -386,11 +725,18 @@ def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact
             str(checkpoint),
             "--gemma-root",
             str(gemma_root),
-        ],
-        env=env,
+        ]
     )
+    if spatial_upsampler is not None:
+        official_args.extend(["--spatial-upsampler", str(spatial_upsampler)])
+    if distilled_lora is not None:
+        official_args.extend(["--distilled-lora", str(distilled_lora)])
+    _run(official_args, env=env)
 
     omni_output = output_root / "omni"
+    omni_env = env.copy()
+    if case.two_stage_lora_mode is not None:
+        omni_env["VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE"] = case.two_stage_lora_mode
     _run(
         [sys.executable]
         + runner_args
@@ -404,7 +750,7 @@ def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact
             "--model-class-name",
             case.model_class_name,
         ],
-        env=env,
+        env=omni_env,
     )
 
     official_metadata = json.loads((official_output / "metadata.json").read_text())
@@ -423,18 +769,27 @@ def test_ltx_one_stage_matches_official(case: LTXAccuracyCase, accuracy_artifact
     result = {
         "case": case.name,
         "task": "i2v" if image is not None else "t2v",
+        "pipeline_kind": case.pipeline_kind,
+        "model_class_name": case.model_class_name,
         "attention_backend": ATTENTION_BACKEND,
         "official_revision": official_revision,
         "model_revision": case.model_revision,
-        "checkpoint_revision": case.checkpoint_revision,
+        "checkpoint_revision": case.checkpoint.revision,
+        "spatial_upsampler_revision": (case.spatial_upsampler.revision if case.spatial_upsampler is not None else None),
+        "distilled_lora_revision": case.distilled_lora.revision if case.distilled_lora is not None else None,
+        "two_stage_lora_mode": case.two_stage_lora_mode,
+        "thresholds": asdict(case.thresholds),
+        "request": _request(case, image),
         "video": video_metrics,
         "audio": audio_metrics,
     }
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    assert video_metrics["ssim_mean"] >= VIDEO_SSIM_MEAN_THRESHOLD
-    assert video_metrics["ssim_min"] >= VIDEO_SSIM_MIN_THRESHOLD
-    assert video_metrics["psnr_mean_db"] >= VIDEO_PSNR_MEAN_THRESHOLD
-    assert audio_metrics["relative_l2"] <= AUDIO_RELATIVE_L2_THRESHOLD
-    assert audio_metrics["cosine_similarity"] >= AUDIO_COSINE_THRESHOLD
+    assert video_metrics["ssim_mean"] >= case.thresholds.video_ssim_mean
+    assert video_metrics["ssim_min"] >= case.thresholds.video_ssim_min
+    assert video_metrics["psnr_mean_db"] >= case.thresholds.video_psnr_mean_db
+    if case.thresholds.audio_relative_l2 > 0:
+        assert audio_metrics["relative_l2"] <= case.thresholds.audio_relative_l2
+    if case.thresholds.audio_cosine_similarity > 0:
+        assert audio_metrics["cosine_similarity"] >= case.thresholds.audio_cosine_similarity

--- a/tests/model_extras/test_model_extras.py
+++ b/tests/model_extras/test_model_extras.py
@@ -205,10 +205,13 @@ def test_ltx_extra_registry_declares_official_guidance_params() -> None:
         }
     )
 
-    assert get_extra_body_params("LTX2Pipeline") == expected
-    assert get_extra_output_params("LTX2Pipeline") == frozenset()
-    assert get_extra_body_params("LTX2DistilledPipeline") == expected
-    assert get_extra_output_params("LTX2DistilledPipeline") == frozenset()
+    for pipeline_name in (
+        "LTX2Pipeline",
+        "LTX2TwoStagePipeline",
+        "LTX2DistilledPipeline",
+    ):
+        assert get_extra_body_params(pipeline_name) == expected
+        assert get_extra_output_params(pipeline_name) == frozenset()
 
 
 @pytest.mark.core_model

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -30,6 +30,7 @@ EXCLUDED_MODELS = [
     "OvisImagePipeline",
     "WanPipeline",
     "WanVACEPipeline",
+    "LTX2TwoStagePipeline",
     "LTX2DistilledPipeline",
     "LTX2T2VDMD2Pipeline",
     "LTX2I2VDMD2Pipeline",

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -299,6 +299,20 @@ class Attention(nn.Module):
             )
             return self.sdpa_fallback.forward(query, key, value, attn_metadata)
 
+        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+        if attention_mask is not None:
+            backend_name = self.attn_backend.get_name().upper()
+            backend_ignores_mask = not self.attn_backend.supports_attention_mask()
+            # FlashAttention's varlen helper applies one 2D padding mask to
+            # both Q and K. A key-only cross-attention mask therefore needs
+            # SDPA when Q and K lengths differ. Non-2D masks also cannot use
+            # that varlen path.
+            flash_mask_needs_sdpa = backend_name.startswith("FLASH_ATTN") and (
+                attention_mask.ndim != 2 or query.shape[1] != key.shape[1]
+            )
+            if backend_ignores_mask or flash_mask_needs_sdpa:
+                return self.sdpa_fallback.forward(query, key, value, attn_metadata)
+
         # Fallback to standard attention
         return self.attention.forward(query, key, value, attn_metadata)
 

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -387,13 +387,13 @@ class UlyssesParallelAttention:
                 else:
                     if attn_metadata.attn_mask is None:
                         attn_metadata.attn_mask = torch.ones(
-                            [query.shape[0], query.shape[1] - attn_metadata.joint_attn_mask.shape[1]],
+                            [key.shape[0], key.shape[1] - attn_metadata.joint_attn_mask.shape[1]],
                             dtype=torch.bool,
                             device=query.device,
                         )
                     elif attn_metadata.joint_attn_mask is None:
                         attn_metadata.joint_attn_mask = torch.ones(
-                            [query.shape[0], query.shape[1] - attn_metadata.attn_mask.shape[1]],
+                            [key.shape[0], key.shape[1] - attn_metadata.attn_mask.shape[1]],
                             dtype=torch.bool,
                             device=query.device,
                         )
@@ -404,9 +404,10 @@ class UlyssesParallelAttention:
                     )
 
             if attn_metadata.attn_mask is not None:
-                # the final attn_mask is ready, the length should be aligedn with query length
-                assert attn_metadata.attn_mask.shape[1] == query.shape[1], (
-                    f"attn_mask length: {attn_metadata.attn_mask.shape[1]} != query length: {query.shape[1]}"
+                # A 2D attention mask is a key-padding mask. Q and K lengths
+                # may differ for cross-attention.
+                assert attn_metadata.attn_mask.shape[1] == key.shape[1], (
+                    f"attn_mask length: {attn_metadata.attn_mask.shape[1]} != key length: {key.shape[1]}"
                 )
                 attn_metadata.attn_mask = attn_metadata.attn_mask.bool().contiguous()
         return query, key, value, attn_metadata, ctx

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -34,19 +34,30 @@ def _positive_divisors(n: int) -> list[int]:
 
 
 @torch.compiler.disable
-def _all_gather_int(pg: dist.ProcessGroup, value: int, *, device: torch.device) -> list[int]:
-    """All-gather a scalar int across pg.
+def _all_gather_ints(
+    pg: dist.ProcessGroup,
+    values: tuple[int, ...],
+    *,
+    device: torch.device,
+) -> list[tuple[int, ...]]:
+    """All-gather a fixed-size tuple of ints across pg.
 
     Note: we use a device tensor so this works for NCCL subgroups (e.g. Ulysses/Ring).
     """
     world_size = dist.get_world_size(pg)
     if world_size == 1:
-        return [int(value)]
+        return [tuple(int(value) for value in values)]
 
-    t = torch.tensor([int(value)], dtype=torch.int64, device=device)
+    t = torch.tensor(values, dtype=torch.int64, device=device)
     gathered = [torch.empty_like(t) for _ in range(world_size)]
     dist.all_gather(gathered, t, group=pg)
-    return [int(x.item()) for x in gathered]
+    return [tuple(int(value) for value in x.tolist()) for x in gathered]
+
+
+@torch.compiler.disable
+def _all_gather_int(pg: dist.ProcessGroup, value: int, *, device: torch.device) -> list[int]:
+    """All-gather a scalar int across pg."""
+    return [rank_values[0] for rank_values in _all_gather_ints(pg, (value,), device=device)]
 
 
 def _ulysses_all_to_all_any_qkv(
@@ -158,8 +169,8 @@ class _UlyssesCtx(ParallelAttentionContext):
     joint_strategy: str = "front"
     # UAA (Ulysses Anything Attention) metadata
     use_uaa: bool = False
-    uaa_seq_lens: tuple[int, ...] = ()
-    uaa_local_seq_len: int = 0
+    uaa_query_seq_lens: tuple[int, ...] = ()
+    uaa_query_local_seq_len: int = 0
     orig_head_cnt: int = 0
     joint_orig_head_cnt: int = 0
 
@@ -294,28 +305,58 @@ class UlyssesParallelAttention:
                     f"(got scatter_idx={self._scatter_idx}, gather_idx={self._gather_idx})."
                 )
 
-            local_seq_len = int(query.shape[1])
-            seq_lens = _all_gather_int(self._ulysses_pg, local_seq_len, device=query.device)
-            s_global = int(sum(seq_lens))
+            query_local_seq_len = int(query.shape[1])
+            key_local_seq_len = int(key.shape[1])
+            value_local_seq_len = int(value.shape[1])
+            qkv_seq_lens_by_rank = _all_gather_ints(
+                self._ulysses_pg,
+                (query_local_seq_len, key_local_seq_len, value_local_seq_len),
+                device=query.device,
+            )
+            query_seq_lens = [seq_lens[0] for seq_lens in qkv_seq_lens_by_rank]
+            key_seq_lens = [seq_lens[1] for seq_lens in qkv_seq_lens_by_rank]
+            value_seq_lens = [seq_lens[2] for seq_lens in qkv_seq_lens_by_rank]
+            if key_seq_lens != value_seq_lens:
+                raise ValueError(
+                    "Ulysses attention requires matching key/value sequence lengths on every rank, "
+                    f"but got key={key_seq_lens} and value={value_seq_lens}."
+                )
+
+            query_global_seq_len = int(sum(query_seq_lens))
+            key_global_seq_len = int(sum(key_seq_lens))
+            value_global_seq_len = int(sum(value_seq_lens))
 
             # In hybrid Ulysses+Ring, Ring attention uses P2P send/recv with fixed-shape
-            # buffers. This requires all ring ranks to have the same seq_len after the
-            # Ulysses all-to-all (i.e. per-ring-rank S_global must match).
+            # buffers. This requires all ring ranks to have the same Q, K, and V
+            # sequence lengths after the Ulysses all-to-all.
             if self._sp_group.ring_world_size > 1:
-                ring_s_globals = _all_gather_int(self._sp_group.ring_group, s_global, device=query.device)
-                if len(set(ring_s_globals)) != 1:
+                ring_qkv_seq_lens = _all_gather_ints(
+                    self._sp_group.ring_group,
+                    (query_global_seq_len, key_global_seq_len, value_global_seq_len),
+                    device=query.device,
+                )
+                ring_query_seq_lens = [seq_lens[0] for seq_lens in ring_qkv_seq_lens]
+                ring_key_seq_lens = [seq_lens[1] for seq_lens in ring_qkv_seq_lens]
+                ring_value_seq_lens = [seq_lens[2] for seq_lens in ring_qkv_seq_lens]
+                if any(
+                    len(set(seq_lens)) != 1
+                    for seq_lens in (ring_query_seq_lens, ring_key_seq_lens, ring_value_seq_lens)
+                ):
                     raise ValueError(
                         "ulysses_mode='advanced_uaa' with hybrid Ulysses+Ring requires the "
-                        "post-Ulysses seq_len to be equal across ring ranks, but got "
-                        f"{ring_s_globals} (ring_degree={self._sp_group.ring_world_size}). "
+                        "post-Ulysses Q/K/V seq_len to be equal across ring ranks, but got "
+                        f"query={ring_query_seq_lens}, key={ring_key_seq_lens}, "
+                        f"value={ring_value_seq_lens} (ring_degree={self._sp_group.ring_world_size}). "
                         "This typically means the input sequence was not evenly shardable across the ring. "
                         "Try setting ring_degree=1, or choose a sequence length divisible by ring_degree."
                     )
             query, orig_head_cnt = _ulysses_all_to_all_any_qkv(
-                self._ulysses_pg, query, seq_lens=seq_lens, use_sync=self._use_sync
+                self._ulysses_pg, query, seq_lens=query_seq_lens, use_sync=self._use_sync
             )
-            key, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, key, seq_lens=seq_lens, use_sync=self._use_sync)
-            value, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, value, seq_lens=seq_lens, use_sync=self._use_sync)
+            key, _ = _ulysses_all_to_all_any_qkv(self._ulysses_pg, key, seq_lens=key_seq_lens, use_sync=self._use_sync)
+            value, _ = _ulysses_all_to_all_any_qkv(
+                self._ulysses_pg, value, seq_lens=value_seq_lens, use_sync=self._use_sync
+            )
         else:
             # Strict mode: fail fast with actionable errors for head divisibility.
             for name, t in (("query", query), ("key", key), ("value", value)):
@@ -332,8 +373,8 @@ class UlyssesParallelAttention:
             query = SeqAllToAll4D.apply(self._ulysses_pg, query, self._scatter_idx, self._gather_idx, self._use_sync)
             key = SeqAllToAll4D.apply(self._ulysses_pg, key, self._scatter_idx, self._gather_idx, self._use_sync)
             value = SeqAllToAll4D.apply(self._ulysses_pg, value, self._scatter_idx, self._gather_idx, self._use_sync)
-            seq_lens = []
-            local_seq_len = 0
+            query_seq_lens = []
+            query_local_seq_len = 0
             orig_head_cnt = 0
 
         if is_joint:
@@ -368,8 +409,8 @@ class UlyssesParallelAttention:
             joint_len=joint_len,
             joint_strategy=joint_strategy,
             use_uaa=(mode == "advanced_uaa"),
-            uaa_seq_lens=tuple(int(x) for x in seq_lens) if mode == "advanced_uaa" else (),
-            uaa_local_seq_len=int(local_seq_len) if mode == "advanced_uaa" else 0,
+            uaa_query_seq_lens=tuple(int(x) for x in query_seq_lens) if mode == "advanced_uaa" else (),
+            uaa_query_local_seq_len=int(query_local_seq_len) if mode == "advanced_uaa" else 0,
             orig_head_cnt=int(orig_head_cnt) if mode == "advanced_uaa" else 0,
             joint_orig_head_cnt=int(joint_orig_head_cnt) if mode == "advanced_uaa" else 0,
         )
@@ -434,8 +475,8 @@ class UlyssesParallelAttention:
                 output_img = _ulysses_all_to_all_any_o(
                     ctx.ulysses_pg,
                     output_img,
-                    seq_lens=list(ctx.uaa_seq_lens),
-                    local_seq_len=ctx.uaa_local_seq_len,
+                    seq_lens=list(ctx.uaa_query_seq_lens),
+                    local_seq_len=ctx.uaa_query_local_seq_len,
                     orig_head_cnt=ctx.orig_head_cnt,
                     use_sync=ctx.use_sync,
                 )
@@ -466,8 +507,8 @@ class UlyssesParallelAttention:
             return _ulysses_all_to_all_any_o(
                 ctx.ulysses_pg,
                 attn_output,
-                seq_lens=list(ctx.uaa_seq_lens),
-                local_seq_len=ctx.uaa_local_seq_len,
+                seq_lens=list(ctx.uaa_query_seq_lens),
+                local_seq_len=ctx.uaa_query_local_seq_len,
                 orig_head_cnt=ctx.orig_head_cnt,
                 use_sync=ctx.use_sync,
             )

--- a/vllm_omni/diffusion/models/ltx2/__init__.py
+++ b/vllm_omni/diffusion/models/ltx2/__init__.py
@@ -12,12 +12,16 @@ from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import (
     LTX2Pipeline,
     LTX2T2VDMD2Pipeline,
 )
-from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import LTX2DistilledPipeline
+from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import (
+    LTX2DistilledPipeline,
+    LTX2TwoStagePipeline,
+)
 
 __all__ = [
     "LTX2Pipeline",
     "LTX2T2VDMD2Pipeline",
     "LTX2I2VDMD2Pipeline",
+    "LTX2TwoStagePipeline",
     "LTX2DistilledPipeline",
     "get_ltx2_post_process_func",
     "load_transformer_config",

--- a/vllm_omni/diffusion/models/ltx2/ltx2_adapter_parser.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_adapter_parser.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Parse official LTX distilled adapters without materializing their tensors.
+
+The official LTX adapters are raw safetensors files rather than PEFT
+checkpoints.  This module is deliberately LTX-specific: it translates the
+official names into the locally constructed Diffusers transformer names and
+describes the resulting adapter targets.  Applying those targets is the job
+of :mod:`ltx2_phase_adapter`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from safetensors import safe_open
+
+_IGNORED_OFFICIAL_LORA_MODULES = {"text_embedding_projection.aggregate_embed"}
+_OFFICIAL_TO_DIFFUSERS_PREFIXES = (
+    ("audio_prompt_adaln_single.", "audio_prompt_adaln."),
+    ("prompt_adaln_single.", "prompt_adaln."),
+    ("audio_adaln_single.", "audio_time_embed."),
+    ("adaln_single.", "time_embed."),
+    ("audio_patchify_proj", "audio_proj_in"),
+    ("patchify_proj", "proj_in"),
+    ("av_ca_video_scale_shift_adaln_single.", "av_cross_attn_video_scale_shift."),
+    ("av_ca_audio_scale_shift_adaln_single.", "av_cross_attn_audio_scale_shift."),
+    ("av_ca_a2v_gate_adaln_single.", "av_cross_attn_video_a2v_gate."),
+    ("av_ca_v2a_gate_adaln_single.", "av_cross_attn_audio_v2a_gate."),
+)
+
+
+@dataclass(frozen=True)
+class AdapterTensorSource:
+    """One tensor in an official raw adapter file."""
+
+    path: str
+    key: str
+    shape: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class AdapterTarget:
+    """One A/B pair mapped onto a local transformer linear layer."""
+
+    # ``source_module`` remains useful to the resident merge path, which
+    # intercepts original checkpoint names before LTX fuses Q/K/V.
+    source_module: str
+    module: str
+    slice: str | None
+    rank: int
+    a_source: AdapterTensorSource
+    b_source: AdapterTensorSource
+
+
+@dataclass(frozen=True)
+class AdapterManifest:
+    """Tensor-free description of an adapter slot."""
+
+    name: str
+    targets: tuple[AdapterTarget, ...]
+
+
+def _to_diffusers_module_name(name: str) -> str:
+    for official_prefix, diffusers_prefix in _OFFICIAL_TO_DIFFUSERS_PREFIXES:
+        if name.startswith(official_prefix):
+            return diffusers_prefix + name[len(official_prefix) :]
+    return name
+
+
+def _resolve_lora_target(transformer: nn.Module, module_name: str) -> tuple[str, str | int | None] | None:
+    modules = dict(transformer.named_modules())
+    if module_name in modules:
+        return module_name, None
+    for packed_suffix, sub_suffix, shard_id in getattr(transformer, "stacked_params_mapping", ()):
+        if sub_suffix in module_name:
+            packed_name = module_name.replace(sub_suffix, packed_suffix)
+            if packed_name in modules:
+                return packed_name, shard_id
+    return None
+
+
+class LTXAdapterParser:
+    """Translate one official LTX raw adapter file into an ``AdapterManifest``."""
+
+    def __init__(self, transformer: nn.Module) -> None:
+        self.transformer = transformer
+
+    def parse(self, path: str, *, name: str = "ltx_distilled") -> AdapterManifest:
+        path = str(Path(path))
+        targets: list[AdapterTarget] = []
+        unresolved: list[str] = []
+        seen: set[tuple[str, str | int | None]] = set()
+
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            tensor_names = set(handle.keys())
+            official_names = sorted(
+                tensor_name.removeprefix("diffusion_model.").rsplit(".lora_", 1)[0]
+                for tensor_name in tensor_names
+                if tensor_name.endswith(".lora_A.weight")
+            )
+            for official_name in official_names:
+                if official_name in _IGNORED_OFFICIAL_LORA_MODULES:
+                    continue
+                key_prefix = f"diffusion_model.{official_name}"
+                key_a = f"{key_prefix}.lora_A.weight"
+                key_b = f"{key_prefix}.lora_B.weight"
+                if key_b not in tensor_names:
+                    raise ValueError(f"Missing paired LoRA tensor {key_b!r} in {path}.")
+
+                a_shape = tuple(handle.get_slice(key_a).get_shape())
+                b_shape = tuple(handle.get_slice(key_b).get_shape())
+                if len(a_shape) != 2 or len(b_shape) != 2 or b_shape[1] != a_shape[0]:
+                    raise ValueError(
+                        f"Invalid LoRA pair for {official_name}: A={a_shape}, B={b_shape}."
+                    )
+
+                source_module = _to_diffusers_module_name(official_name)
+                resolved = _resolve_lora_target(self.transformer, source_module)
+                if resolved is None:
+                    unresolved.append(official_name)
+                    continue
+                module, shard_id = resolved
+                target_id = (module, shard_id)
+                if target_id in seen:
+                    raise ValueError(
+                        f"Official LTX LoRA contains duplicate target {module!r}, slice {shard_id!r}."
+                    )
+                seen.add(target_id)
+                targets.append(
+                    AdapterTarget(
+                        source_module=source_module,
+                        module=module,
+                        slice=shard_id,
+                        rank=a_shape[0],
+                        a_source=AdapterTensorSource(path=path, key=key_a, shape=a_shape),
+                        b_source=AdapterTensorSource(path=path, key=key_b, shape=b_shape),
+                    )
+                )
+
+        if unresolved:
+            raise ValueError(f"Official LTX LoRA contains unmapped modules: {unresolved}.")
+        if not targets:
+            raise ValueError(f"No Transformer LoRA tensors were found in {path}.")
+        return AdapterManifest(name=name, targets=tuple(targets))
+
+
+def iter_adapter_tensors(manifest: AdapterManifest) -> Iterator[tuple[AdapterTarget, torch.Tensor, torch.Tensor]]:
+    """Stream adapter pairs in manifest order without a full checkpoint copy."""
+
+    paths = {target.a_source.path for target in manifest.targets} | {
+        target.b_source.path for target in manifest.targets
+    }
+    if len(paths) != 1:
+        raise ValueError("An LTX adapter manifest must reference exactly one safetensors file.")
+    path = next(iter(paths))
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        for target in manifest.targets:
+            yield (
+                target,
+                handle.get_tensor(target.a_source.key),
+                handle.get_tensor(target.b_source.key),
+            )

--- a/vllm_omni/diffusion/models/ltx2/ltx2_adapter_parser.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_adapter_parser.py
@@ -116,9 +116,7 @@ class LTXAdapterParser:
                 a_shape = tuple(handle.get_slice(key_a).get_shape())
                 b_shape = tuple(handle.get_slice(key_b).get_shape())
                 if len(a_shape) != 2 or len(b_shape) != 2 or b_shape[1] != a_shape[0]:
-                    raise ValueError(
-                        f"Invalid LoRA pair for {official_name}: A={a_shape}, B={b_shape}."
-                    )
+                    raise ValueError(f"Invalid LoRA pair for {official_name}: A={a_shape}, B={b_shape}.")
 
                 source_module = _to_diffusers_module_name(official_name)
                 resolved = _resolve_lora_target(self.transformer, source_module)
@@ -128,9 +126,7 @@ class LTXAdapterParser:
                 module, shard_id = resolved
                 target_id = (module, shard_id)
                 if target_id in seen:
-                    raise ValueError(
-                        f"Official LTX LoRA contains duplicate target {module!r}, slice {shard_id!r}."
-                    )
+                    raise ValueError(f"Official LTX LoRA contains duplicate target {module!r}, slice {shard_id!r}.")
                 seen.add(target_id)
                 targets.append(
                     AdapterTarget(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
+from .ltx2_request import LTXCheckpointKind, validate_ltx_checkpoint
 from .ltx2_transformer import (
     LTX2VideoTransformer3DModel,
     apply_interleaved_rotary_emb,
@@ -78,6 +79,7 @@ class LTXComponentProfile:
     artifact_repo_id: str | None = None
     latent_upsampler_filename: str | None = None
     distilled_lora_filename: str | None = None
+    checkpoint_kind: LTXCheckpointKind | None = None
 
 
 LTX2_COMPONENT_PROFILE = LTXComponentProfile(
@@ -108,6 +110,7 @@ LTX2_DISTILLED_COMPONENT_PROFILE = LTXComponentProfile(
     resident_modules=("vocoder", "latent_upsampler"),
     video_vae_cls=DistributedAutoencoderKLLTX2Video,
     latent_upsampler_cls=LTX2LatentUpsamplerModel,
+    checkpoint_kind="distilled",
 )
 
 LTX2_TWO_STAGE_COMPONENT_PROFILE = replace(
@@ -118,6 +121,7 @@ LTX2_TWO_STAGE_COMPONENT_PROFILE = replace(
     artifact_repo_id="Lightricks/LTX-2",
     latent_upsampler_filename="ltx-2-spatial-upscaler-x2-1.0.safetensors",
     distilled_lora_filename="ltx-2-19b-distilled-lora-384.safetensors",
+    checkpoint_kind="regular",
 )
 
 LTX23_TWO_STAGE_COMPONENT_PROFILE = replace(
@@ -128,6 +132,7 @@ LTX23_TWO_STAGE_COMPONENT_PROFILE = replace(
     artifact_repo_id="Lightricks/LTX-2.3",
     latent_upsampler_filename="ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
     distilled_lora_filename="ltx-2.3-22b-distilled-lora-384-1.1.safetensors",
+    checkpoint_kind="regular",
 )
 
 
@@ -519,6 +524,11 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
         model,
         subfolder="scheduler",
         local_files_only=local_files_only,
+    )
+    validate_ltx_checkpoint(
+        pipeline.scheduler.config,
+        expected_kind=profile.checkpoint_kind,
+        pipeline_name=type(pipeline).__name__,
     )
 
     pipeline.vae_spatial_compression_ratio = pipeline.vae.spatial_compression_ratio

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -162,21 +162,19 @@ def resolve_ltx_artifact(
     model: str,
     repo_id: str,
     filename: str,
-    *,
-    explicit_path: str | None = None,
 ) -> str:
-    """Resolve an official LTX sidecar from an explicit local path or the Hub."""
-    if explicit_path is not None:
-        candidate = Path(explicit_path)
-        if candidate.is_file():
-            return str(candidate)
-        raise FileNotFoundError(f"Configured LTX artifact {filename!r} does not exist: {candidate}")
-
-    candidates = [Path(model) / filename]
+    """Resolve an official LTX sidecar from one artifact directory or the Hub."""
     artifacts_dir = os.getenv(_LTX_ARTIFACTS_DIR_ENV)
     if artifacts_dir:
-        candidates.append(Path(artifacts_dir) / filename)
+        candidate = Path(artifacts_dir) / filename
+        if candidate.is_file():
+            return str(candidate)
+        raise FileNotFoundError(
+            f"{_LTX_ARTIFACTS_DIR_ENV}={artifacts_dir!r} does not contain required LTX artifact "
+            f"{filename!r}: {candidate}"
+        )
 
+    candidates = [Path(model) / filename]
     for candidate in candidates:
         if candidate.is_file():
             return str(candidate)
@@ -436,8 +434,6 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
     pipeline.device = get_local_device()
     dtype = getattr(od_config, "dtype", torch.bfloat16)
     model = od_config.model
-    model_paths = getattr(od_config, "model_paths", {}) or {}
-    explicit_upsampler_path = model_paths.get("latent_upsampler")
     local_files_only = os.path.exists(model)
 
     pipeline.weights_sources = [
@@ -507,14 +503,13 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
 
     if profile.latent_upsampler_cls is not None:
         upsampler_config = os.path.join(model, "latent_upsampler", "config.json")
-        if explicit_upsampler_path is not None:
-            if profile.latent_upsampler_filename is None or profile.artifact_repo_id is None:
-                raise FileNotFoundError(f"LTX latent upsampler component not configured for {profile.name}.")
+        if os.getenv(_LTX_ARTIFACTS_DIR_ENV) and profile.latent_upsampler_filename is not None:
+            if profile.artifact_repo_id is None:
+                raise FileNotFoundError(f"LTX latent upsampler artifact repository not configured for {profile.name}.")
             upsampler_path = resolve_ltx_artifact(
                 model,
                 profile.artifact_repo_id,
                 profile.latent_upsampler_filename,
-                explicit_path=explicit_upsampler_path,
             )
             pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
         elif os.path.isfile(upsampler_config) or not local_files_only:
@@ -533,7 +528,6 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
                     model,
                     profile.artifact_repo_id,
                     profile.latent_upsampler_filename,
-                    explicit_path=explicit_upsampler_path,
                 )
                 pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
         else:
@@ -543,7 +537,6 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
                 model,
                 profile.artifact_repo_id,
                 profile.latent_upsampler_filename,
-                explicit_path=explicit_upsampler_path,
             )
             pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -113,6 +113,16 @@ LTX2_DISTILLED_COMPONENT_PROFILE = LTXComponentProfile(
     checkpoint_kind="distilled",
 )
 
+LTX23_DISTILLED_COMPONENT_PROFILE = replace(
+    LTX23_COMPONENT_PROFILE,
+    name="ltx2_3_distilled",
+    resident_modules=(*LTX23_COMPONENT_PROFILE.resident_modules, "latent_upsampler"),
+    latent_upsampler_cls=LTX2LatentUpsamplerModel,
+    artifact_repo_id="Lightricks/LTX-2.3",
+    latent_upsampler_filename="ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
+    checkpoint_kind="distilled",
+)
+
 LTX2_TWO_STAGE_COMPONENT_PROFILE = replace(
     LTX2_COMPONENT_PROFILE,
     name="ltx2_two_stage",
@@ -142,6 +152,7 @@ _COMPONENT_PROFILES: dict[tuple[str, str], LTXComponentProfile] = {
     ("two_stage", "2"): LTX2_TWO_STAGE_COMPONENT_PROFILE,
     ("two_stage", "2.3"): LTX23_TWO_STAGE_COMPONENT_PROFILE,
     ("distilled_two_stage", "2"): LTX2_DISTILLED_COMPONENT_PROFILE,
+    ("distilled_two_stage", "2.3"): LTX23_DISTILLED_COMPONENT_PROFILE,
     ("dmd2", "2"): LTX2_COMPONENT_PROFILE,
     ("dmd2", "2.3"): LTX23_COMPONENT_PROFILE,
 }

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -147,8 +147,20 @@ _COMPONENT_PROFILES: dict[tuple[str, str], LTXComponentProfile] = {
 }
 
 
-def resolve_ltx_artifact(model: str, repo_id: str, filename: str) -> str:
-    """Resolve an official LTX sidecar from a local path or the Hub."""
+def resolve_ltx_artifact(
+    model: str,
+    repo_id: str,
+    filename: str,
+    *,
+    explicit_path: str | None = None,
+) -> str:
+    """Resolve an official LTX sidecar from an explicit local path or the Hub."""
+    if explicit_path is not None:
+        candidate = Path(explicit_path)
+        if candidate.is_file():
+            return str(candidate)
+        raise FileNotFoundError(f"Configured LTX artifact {filename!r} does not exist: {candidate}")
+
     candidates = [Path(model) / filename]
     artifacts_dir = os.getenv(_LTX_ARTIFACTS_DIR_ENV)
     if artifacts_dir:
@@ -413,6 +425,8 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
     pipeline.device = get_local_device()
     dtype = getattr(od_config, "dtype", torch.bfloat16)
     model = od_config.model
+    model_paths = getattr(od_config, "model_paths", {}) or {}
+    explicit_upsampler_path = model_paths.get("latent_upsampler")
     local_files_only = os.path.exists(model)
 
     pipeline.weights_sources = [
@@ -482,7 +496,17 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
 
     if profile.latent_upsampler_cls is not None:
         upsampler_config = os.path.join(model, "latent_upsampler", "config.json")
-        if os.path.isfile(upsampler_config) or not local_files_only:
+        if explicit_upsampler_path is not None:
+            if profile.latent_upsampler_filename is None or profile.artifact_repo_id is None:
+                raise FileNotFoundError(f"LTX latent upsampler component not configured for {profile.name}.")
+            upsampler_path = resolve_ltx_artifact(
+                model,
+                profile.artifact_repo_id,
+                profile.latent_upsampler_filename,
+                explicit_path=explicit_upsampler_path,
+            )
+            pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
+        elif os.path.isfile(upsampler_config) or not local_files_only:
             try:
                 pipeline.latent_upsampler = _load_component(
                     profile.latent_upsampler_cls,
@@ -498,6 +522,7 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
                     model,
                     profile.artifact_repo_id,
                     profile.latent_upsampler_filename,
+                    explicit_path=explicit_upsampler_path,
                 )
                 pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
         else:
@@ -507,6 +532,7 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
                 model,
                 profile.artifact_repo_id,
                 profile.latent_upsampler_filename,
+                explicit_path=explicit_upsampler_path,
             )
             pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -506,6 +506,12 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
             pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
 
     transformer_config = load_transformer_config(model, "transformer", local_files_only)
+    # Keep the complete checkpoint config for pipelines that construct another
+    # Transformer after the shared components have been initialized.  The
+    # runtime Transformer's ``config`` is a SimpleNamespace containing only
+    # the fields needed during inference, so it cannot faithfully recreate an
+    # LTX-2.3 Transformer on its own.
+    pipeline._transformer_init_config = dict(transformer_config)
     quant_config = getattr(od_config, "quantization_config", None)
     pipeline.transformer = create_transformer_from_config(transformer_config, quant_config=quant_config)
     _place_aux_components(pipeline)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -9,7 +9,8 @@ import inspect
 import json
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -19,6 +20,8 @@ from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
 from diffusers.pipelines.ltx2.vocoder import LTX2Vocoder
 from diffusers.video_processor import VideoProcessor
 from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+from safetensors.torch import load_file
 from transformers import AutoTokenizer, Gemma3ForConditionalGeneration
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
@@ -55,6 +58,7 @@ _LTX_COMPONENT_SUBFOLDERS = (
     "scheduler",
     "latent_upsampler",
 )
+_LTX_ARTIFACTS_DIR_ENV = "VLLM_OMNI_LTX_ARTIFACTS_DIR"
 logger = logging.getLogger(__name__)
 
 
@@ -70,6 +74,10 @@ class LTXComponentProfile:
     video_vae_cls: type = AutoencoderKLLTX2Video
     vocoder_cls: type = LTX2Vocoder
     vocoder_fallback_cls: type | None = None
+    latent_upsampler_cls: type | None = None
+    artifact_repo_id: str | None = None
+    latent_upsampler_filename: str | None = None
+    distilled_lora_filename: str | None = None
 
 
 LTX2_COMPONENT_PROFILE = LTXComponentProfile(
@@ -99,16 +107,92 @@ LTX2_DISTILLED_COMPONENT_PROFILE = LTXComponentProfile(
     vae_modules=("vae", "audio_vae"),
     resident_modules=("vocoder", "latent_upsampler"),
     video_vae_cls=DistributedAutoencoderKLLTX2Video,
+    latent_upsampler_cls=LTX2LatentUpsamplerModel,
+)
+
+LTX2_TWO_STAGE_COMPONENT_PROFILE = replace(
+    LTX2_COMPONENT_PROFILE,
+    name="ltx2_two_stage",
+    resident_modules=(*LTX2_COMPONENT_PROFILE.resident_modules, "latent_upsampler"),
+    latent_upsampler_cls=LTX2LatentUpsamplerModel,
+    artifact_repo_id="Lightricks/LTX-2",
+    latent_upsampler_filename="ltx-2-spatial-upscaler-x2-1.0.safetensors",
+    distilled_lora_filename="ltx-2-19b-distilled-lora-384.safetensors",
+)
+
+LTX23_TWO_STAGE_COMPONENT_PROFILE = replace(
+    LTX23_COMPONENT_PROFILE,
+    name="ltx2_3_two_stage",
+    resident_modules=(*LTX23_COMPONENT_PROFILE.resident_modules, "latent_upsampler"),
+    latent_upsampler_cls=LTX2LatentUpsamplerModel,
+    artifact_repo_id="Lightricks/LTX-2.3",
+    latent_upsampler_filename="ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
+    distilled_lora_filename="ltx-2.3-22b-distilled-lora-384-1.1.safetensors",
 )
 
 
 _COMPONENT_PROFILES: dict[tuple[str, str], LTXComponentProfile] = {
     ("one_stage", "2"): LTX2_COMPONENT_PROFILE,
     ("one_stage", "2.3"): LTX23_COMPONENT_PROFILE,
+    ("two_stage", "2"): LTX2_TWO_STAGE_COMPONENT_PROFILE,
+    ("two_stage", "2.3"): LTX23_TWO_STAGE_COMPONENT_PROFILE,
     ("distilled_two_stage", "2"): LTX2_DISTILLED_COMPONENT_PROFILE,
     ("dmd2", "2"): LTX2_COMPONENT_PROFILE,
     ("dmd2", "2.3"): LTX23_COMPONENT_PROFILE,
 }
+
+
+def resolve_ltx_artifact(model: str, repo_id: str, filename: str) -> str:
+    """Resolve an official LTX sidecar from a local path or the Hub."""
+    candidates = [Path(model) / filename]
+    artifacts_dir = os.getenv(_LTX_ARTIFACTS_DIR_ENV)
+    if artifacts_dir:
+        candidates.append(Path(artifacts_dir) / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+
+    try:
+        return hf_hub_download(repo_id=repo_id, filename=filename)
+    except Exception as exc:
+        searched = ", ".join(str(path) for path in candidates)
+        raise FileNotFoundError(
+            f"Unable to resolve LTX artifact {filename!r}. Searched {searched}; "
+            f"place the file in the model root, set {_LTX_ARTIFACTS_DIR_ENV}, or make {repo_id} available."
+        ) from exc
+
+
+def _load_ltx_latent_upsampler_single_file(path: str, dtype: torch.dtype) -> LTX2LatentUpsamplerModel:
+    """Load an official single-file upsampler into the Diffusers module."""
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        metadata = handle.metadata() or {}
+    raw_config = json.loads(metadata.get("config", "{}"))
+    config = {
+        "in_channels": raw_config.get("in_channels", 128),
+        "mid_channels": raw_config.get("mid_channels", 1024),
+        "num_blocks_per_stage": raw_config.get("num_blocks_per_stage", 4),
+        "dims": raw_config.get("dims", 3),
+        "spatial_upsample": raw_config.get("spatial_upsample", True),
+        "temporal_upsample": raw_config.get("temporal_upsample", False),
+        "rational_spatial_scale": raw_config.get("spatial_scale", 2.0),
+        "use_rational_resampler": raw_config.get("rational_resampler", False),
+    }
+    with torch.device("cpu"):
+        upsampler = LTX2LatentUpsamplerModel(**config).to(dtype=dtype)
+
+    state_dict = load_file(path, device="cpu")
+    if "upsampler.0.weight" in state_dict and hasattr(upsampler.upsampler, "conv"):
+        state_dict["upsampler.conv.weight"] = state_dict.pop("upsampler.0.weight")
+        state_dict["upsampler.conv.bias"] = state_dict.pop("upsampler.0.bias")
+    missing, unexpected = upsampler.load_state_dict(state_dict, strict=False)
+    unresolved_missing = set(missing) - {"upsampler.blur_down.kernel"}
+    if unresolved_missing or unexpected:
+        raise ValueError(
+            f"Invalid LTX latent upsampler {path}: missing={sorted(unresolved_missing)}, "
+            f"unexpected={sorted(unexpected)}."
+        )
+    return upsampler
 
 
 def resolve_ltx_component_profile(pipeline_kind: str, model_version: str) -> LTXComponentProfile:
@@ -391,17 +475,35 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
             dtype=dtype,
         )
 
-    if "latent_upsampler" in profile.resident_modules:
-        # BlurDownsample constructs an integer kernel that must be initialized
-        # on CPU; component placement is handled uniformly after construction.
-        with torch.device("cpu"):
-            pipeline.latent_upsampler = _load_component(
-                LTX2LatentUpsamplerModel,
+    if profile.latent_upsampler_cls is not None:
+        upsampler_config = os.path.join(model, "latent_upsampler", "config.json")
+        if os.path.isfile(upsampler_config) or not local_files_only:
+            try:
+                pipeline.latent_upsampler = _load_component(
+                    profile.latent_upsampler_cls,
+                    model,
+                    "latent_upsampler",
+                    local_files_only=local_files_only,
+                    dtype=dtype,
+                )
+            except (OSError, ValueError):
+                if profile.latent_upsampler_filename is None or profile.artifact_repo_id is None:
+                    raise
+                upsampler_path = resolve_ltx_artifact(
+                    model,
+                    profile.artifact_repo_id,
+                    profile.latent_upsampler_filename,
+                )
+                pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
+        else:
+            if profile.latent_upsampler_filename is None or profile.artifact_repo_id is None:
+                raise FileNotFoundError(f"LTX latent upsampler component not found under {model}.")
+            upsampler_path = resolve_ltx_artifact(
                 model,
-                "latent_upsampler",
-                local_files_only=local_files_only,
-                dtype=dtype,
+                profile.artifact_repo_id,
+                profile.latent_upsampler_filename,
             )
+            pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
 
     transformer_config = load_transformer_config(model, "transformer", local_files_only)
     quant_config = getattr(od_config, "quantization_config", None)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
@@ -62,6 +62,7 @@ class LTXDenoiseContext:
     audio_latents: torch.Tensor
     video_coords: torch.Tensor
     audio_coords: torch.Tensor
+    audio_attention_mask: torch.Tensor | None = None
     conditioning_mask: torch.Tensor | None = None
     conditioning_mask_for_model: torch.Tensor | None = None
 
@@ -332,6 +333,7 @@ def build_transformer_kwargs(
         # with a learned register, making all output context tokens valid.
         "encoder_attention_mask": None,
         "audio_encoder_attention_mask": None,
+        "audio_attention_mask": denoise_ctx.audio_attention_mask,
         "num_frames": forward_ctx.latent_num_frames,
         "height": forward_ctx.latent_height,
         "width": forward_ctx.latent_width,
@@ -443,11 +445,25 @@ class LTXPhaseExecutor:
             video_audio_step_adapter=video_audio_step_adapter,
         )
         video_coords, audio_coords = prepare_rope_coords_stage(pipeline, forward_ctx, latents, audio_latents)
+        ring_degree = getattr(pipeline.od_config.parallel_config, "ring_degree", 1) or 1
+        if padded_audio_num_frames > original_audio_num_frames and ring_degree > 1:
+            raise ValueError(
+                "LTX audio padding requires an attention mask, which Ring sequence parallelism does not support. "
+                "Use Ulysses-only SP or choose a request whose audio latent length is divisible by the SP size."
+            )
         denoise_ctx = LTXDenoiseContext(
             latents=latents,
             audio_latents=audio_latents,
             video_coords=video_coords,
             audio_coords=audio_coords,
+            audio_attention_mask=(
+                torch.arange(padded_audio_num_frames, device=audio_latents.device)
+                .lt(original_audio_num_frames)
+                .unsqueeze(0)
+                .expand(audio_latents.shape[0], -1)
+                if padded_audio_num_frames > original_audio_num_frames
+                else None
+            ),
             conditioning_mask=conditioning_mask,
         )
         denoise_ctx = pipeline._prepare_denoise_context_for_guidance(forward_ctx, denoise_ctx)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
@@ -68,7 +68,7 @@ class LTXDenoiseContext:
 
 @dataclass
 class LTXPhaseResult:
-    """Denoised, unpacked AV latents and the context used to produce them."""
+    """Denoised AV latents and the context used to produce them."""
 
     forward_context: LTXForwardContext
     video: torch.Tensor
@@ -284,7 +284,8 @@ def prepare_rope_coords_stage(
     latents: torch.Tensor,
     audio_latents: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    video_coords = pipeline.transformer.rope.prepare_video_coords(
+    transformer = pipeline.denoise_transformer
+    video_coords = transformer.rope.prepare_video_coords(
         latents.shape[0],
         forward_ctx.latent_num_frames,
         forward_ctx.latent_height,
@@ -292,7 +293,7 @@ def prepare_rope_coords_stage(
         latents.device,
         fps=forward_ctx.request_inputs.frame_rate,
     )
-    audio_coords = pipeline.transformer.audio_rope.prepare_audio_coords(
+    audio_coords = transformer.audio_rope.prepare_audio_coords(
         audio_latents.shape[0],
         forward_ctx.padded_audio_num_frames,
         audio_latents.device,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -126,7 +126,10 @@ def x0_from_velocity(sample: torch.Tensor, velocity: torch.Tensor, sigma: torch.
 
 def velocity_from_x0(sample: torch.Tensor, x0: torch.Tensor, sigma: torch.Tensor) -> torch.Tensor:
     """Convert x0 back to velocity using the official fp32 arithmetic order."""
-    sigma = sigma.to(torch.float32)
+    # Official LTX converts the scalar scheduler sigma to a host value before
+    # division. A CUDA scalar tensor selects different kernel arithmetic and
+    # can cross bf16 rounding boundaries late in the denoise trajectory.
+    sigma = sigma.to(torch.float32).item()
     return ((sample.to(torch.float32) - x0.to(torch.float32)) / sigma).to(sample.dtype)
 
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -148,6 +148,7 @@ def combine_guided_x0(
     uncond_perturbed: torch.Tensor | float,
     uncond_modality: torch.Tensor | float,
     guidance: LTXModalityGuidance,
+    rescale_token_count: int | None = None,
 ) -> torch.Tensor:
     dtype = cond.dtype
     cond = cond.float()
@@ -163,9 +164,18 @@ def combine_guided_x0(
         # uses its full-tensor standard deviation. In Omni, dimension 0 may
         # instead contain independently scheduled requests. Reduce each item
         # separately so its result cannot depend on unrelated co-batched work.
-        reduce_dims = tuple(range(1, pred.ndim))
-        cond_std = cond.std(dim=reduce_dims, keepdim=True)
-        pred_std = pred.std(dim=reduce_dims, keepdim=True)
+        stats_cond = cond
+        stats_pred = pred
+        if rescale_token_count is not None:
+            if cond.ndim < 2 or not 0 < rescale_token_count <= cond.shape[1]:
+                raise ValueError(
+                    f"Guidance rescale token count must be in [1, {cond.shape[1]}], got {rescale_token_count}."
+                )
+            stats_cond = cond[:, :rescale_token_count]
+            stats_pred = pred[:, :rescale_token_count]
+        reduce_dims = tuple(range(1, stats_pred.ndim))
+        cond_std = stats_cond.std(dim=reduce_dims, keepdim=True)
+        pred_std = stats_pred.std(dim=reduce_dims, keepdim=True)
         eps = torch.finfo(pred.dtype).eps
         factor = cond_std / pred_std.clamp_min(eps)
         factor = torch.where(pred_std > eps, factor, torch.ones_like(factor))
@@ -278,6 +288,11 @@ class LTXGuidanceExecutor:
         if model_pass_count > 1:
             denoise_ctx.video_coords = _repeat_batch(denoise_ctx.video_coords, model_pass_count)
             denoise_ctx.audio_coords = _repeat_batch(denoise_ctx.audio_coords, model_pass_count)
+            if denoise_ctx.audio_attention_mask is not None:
+                denoise_ctx.audio_attention_mask = _repeat_batch(
+                    denoise_ctx.audio_attention_mask,
+                    model_pass_count,
+                )
         return denoise_ctx
 
     @staticmethod
@@ -322,6 +337,7 @@ class LTXGuidanceExecutor:
         guidance: LTXModalityGuidance,
         *,
         model_sigma: torch.Tensor | None = None,
+        rescale_token_count: int | None = None,
     ) -> torch.Tensor:
         model_sigma = sigma if model_sigma is None else model_sigma
         # Official guidance reduces contiguous BSC tensors. The fused
@@ -334,6 +350,7 @@ class LTXGuidanceExecutor:
             uncond_perturbed=x0.get("ptb", 0.0),
             uncond_modality=x0.get("mod", 0.0),
             guidance=guidance,
+            rescale_token_count=rescale_token_count,
         )
         return velocity_from_x0(sample, guided, sigma)
 
@@ -434,6 +451,7 @@ class LTXGuidanceExecutor:
                 audio_splits,
                 forward_ctx.audio_scheduler.sigmas[index],
                 plan.spec.audio,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
             ),
         )
 
@@ -509,6 +527,7 @@ class LTXGuidanceExecutor:
                 audio_splits,
                 forward_ctx.audio_scheduler.sigmas[index],
                 plan.spec.audio,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
             ),
         )
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -489,7 +489,7 @@ class LTXGuidanceExecutor:
             attention_kwargs=attention_kwargs,
         )
         with pipeline._transformer_cache_context("guided"):
-            video_velocity, audio_velocity = pipeline.transformer(**kwargs)
+            video_velocity, audio_velocity = pipeline.denoise_transformer(**kwargs)
         video_splits = dict(zip(plan.names, video_velocity.chunk(pass_count), strict=True))
         audio_splits = dict(zip(plan.names, audio_velocity.chunk(pass_count), strict=True))
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -188,6 +188,8 @@ def combine_guided_x0(
 
 
 def _repeat_batch(tensor: torch.Tensor, repeats: int) -> torch.Tensor:
+    if repeats == 1:
+        return tensor
     return tensor.repeat((repeats,) + (1,) * (tensor.ndim - 1))
 
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
@@ -117,7 +117,9 @@ def create_noised_state(
         device=latents.device,
         dtype=latents.dtype,
     )
-    return noise_scale * noise + (1 - noise_scale) * latents
+    if isinstance(noise_scale, torch.Tensor):
+        noise_scale = noise_scale.float()
+    return torch.lerp(latents.float(), noise.float(), noise_scale).to(latents.dtype)
 
 
 def pack_audio_latents(latents: torch.Tensor) -> torch.Tensor:

--- a/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
@@ -137,6 +137,16 @@ def unpad_audio_latents(latents: torch.Tensor, num_frames: int) -> torch.Tensor:
     return latents[:, :num_frames]
 
 
+def clear_audio_padding(latents: torch.Tensor, num_frames: int) -> torch.Tensor:
+    """Keep Omni's SP-only audio padding outside the sampler state."""
+    if not 0 < num_frames <= latents.shape[1]:
+        raise ValueError(f"Audio frame count must be in [1, {latents.shape[1]}], got {num_frames}.")
+    if num_frames == latents.shape[1]:
+        return latents
+    padding = latents.new_zeros(latents.shape[0], latents.shape[1] - num_frames, latents.shape[2])
+    return torch.cat([latents[:, :num_frames], padding], dim=1)
+
+
 def get_sp_padded_audio_latent_length(audio_latent_length: int, sp_size: int) -> int:
     if sp_size > 1:
         audio_latent_length += (sp_size - (audio_latent_length % sp_size)) % sp_size
@@ -228,6 +238,16 @@ def prepare_audio_latents(
     sp_size = getattr(pipeline.od_config.parallel_config, "sequence_parallel_size", 1) or 1
     padded_latent_length = get_sp_padded_audio_latent_length(original_latent_length, int(sp_size))
 
+    def pad_logical_latents(logical_latents: torch.Tensor) -> torch.Tensor:
+        if padded_latent_length == original_latent_length:
+            return logical_latents
+        padding = logical_latents.new_zeros(
+            logical_latents.shape[0],
+            padded_latent_length - original_latent_length,
+            logical_latents.shape[2],
+        )
+        return torch.cat([logical_latents, padding], dim=1)
+
     if latents is not None:
         if latents.ndim == 4:
             latents = pack_audio_latents(latents)
@@ -239,29 +259,24 @@ def prepare_audio_latents(
                 pipeline.audio_vae.latents_mean,
                 pipeline.audio_vae.latents_std,
             )
-        latents = create_noised_state(latents, noise_scale, generator)
 
         if latents.shape[1] not in {original_latent_length, padded_latent_length}:
             raise ValueError(
                 "Provided `audio_latents` has incompatible audio frame count "
                 f"{latents.shape[1]}; expected {original_latent_length} or {padded_latent_length}."
             )
-        if latents.shape[1] == original_latent_length and padded_latent_length > original_latent_length:
-            padding = torch.zeros(
-                latents.shape[0],
-                padded_latent_length - original_latent_length,
-                latents.shape[2],
-                dtype=latents.dtype,
-                device=latents.device,
-            )
-            latents = torch.cat([latents, padding], dim=1)
+        # Padding is an Omni implementation detail, not part of the official
+        # audio state. Draw request RNG only for logical tokens so later phases
+        # remain seed-invariant across SP degrees, then append deterministic 0s.
+        latents = create_noised_state(latents[:, :original_latent_length], noise_scale, generator)
+        latents = pad_logical_latents(latents)
         return latents.to(device=device, dtype=dtype), original_latent_length, padded_latent_length
 
-    shape = (batch_size, padded_latent_length, num_channels_latents * latent_mel_bins)
+    shape = (batch_size, original_latent_length, num_channels_latents * latent_mel_bins)
     if isinstance(generator, list) and len(generator) != batch_size:
         raise ValueError(
             f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
             f" size of {batch_size}. Make sure the batch size matches the length of the generators."
         )
-    latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    latents = pad_logical_latents(randn_tensor(shape, generator=generator, device=device, dtype=dtype))
     return latents, original_latent_length, padded_latent_length

--- a/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
@@ -217,7 +217,12 @@ def prepare_video_latents(
             f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
             f" size of {batch_size}. Make sure the batch size matches the length of the generators."
         )
-    return randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    # Official LTX samples the 5D video latent first and then patchifies it,
+    # leaving token-major storage behind the [B, tokens, channels] view.  The
+    # logical values are unchanged, but preserving that layout is important:
+    # CUDA selects a different bf16 GEMM path for a contiguous token tensor.
+    return latents.transpose(1, 2).contiguous().transpose(1, 2)
 
 
 def prepare_audio_latents(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Resident stage-2 LoRA weights for official LTX two-stage pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+import torch
+import torch.nn as nn
+from safetensors import safe_open
+from vllm.logger import init_logger
+
+from .ltx2_components import create_transformer_from_config
+
+logger = init_logger(__name__)
+
+_IGNORED_OFFICIAL_LORA_MODULES = {"text_embedding_projection.aggregate_embed"}
+_OFFICIAL_TO_DIFFUSERS_PREFIXES = (
+    ("audio_prompt_adaln_single.", "audio_prompt_adaln."),
+    ("prompt_adaln_single.", "prompt_adaln."),
+    ("audio_adaln_single.", "audio_time_embed."),
+    ("adaln_single.", "time_embed."),
+    ("audio_patchify_proj", "audio_proj_in"),
+    ("patchify_proj", "proj_in"),
+    ("av_ca_video_scale_shift_adaln_single.", "av_cross_attn_video_scale_shift."),
+    ("av_ca_audio_scale_shift_adaln_single.", "av_cross_attn_audio_scale_shift."),
+    ("av_ca_a2v_gate_adaln_single.", "av_cross_attn_video_a2v_gate."),
+    ("av_ca_v2a_gate_adaln_single.", "av_cross_attn_audio_v2a_gate."),
+)
+
+
+@dataclass(frozen=True)
+class _LTXLoRAEntry:
+    module_name: str
+    target_name: str
+    shard_id: str | int | None
+    lora_a: torch.Tensor
+    lora_b: torch.Tensor
+
+
+def _to_diffusers_module_name(name: str) -> str:
+    for official_prefix, diffusers_prefix in _OFFICIAL_TO_DIFFUSERS_PREFIXES:
+        if name.startswith(official_prefix):
+            return diffusers_prefix + name[len(official_prefix) :]
+    return name
+
+
+def _resolve_lora_target(transformer: nn.Module, module_name: str) -> tuple[str, str | int | None] | None:
+    modules = dict(transformer.named_modules())
+    if module_name in modules:
+        return module_name, None
+    for packed_suffix, sub_suffix, shard_id in getattr(transformer, "stacked_params_mapping", ()):
+        if sub_suffix in module_name:
+            packed_name = module_name.replace(sub_suffix, packed_suffix)
+            if packed_name in modules:
+                return packed_name, shard_id
+    return None
+
+
+def _load_lora_entries(transformer: nn.Module, path: str, dtype: torch.dtype) -> list[_LTXLoRAEntry]:
+    entries: list[_LTXLoRAEntry] = []
+    unresolved: list[str] = []
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        tensor_names = set(handle.keys())
+        module_names = sorted(
+            name.removeprefix("diffusion_model.").rsplit(".lora_", 1)[0]
+            for name in tensor_names
+            if name.endswith(".lora_A.weight")
+        )
+        for official_name in module_names:
+            if official_name in _IGNORED_OFFICIAL_LORA_MODULES:
+                continue
+            key_prefix = f"diffusion_model.{official_name}"
+            key_a = f"{key_prefix}.lora_A.weight"
+            key_b = f"{key_prefix}.lora_B.weight"
+            if key_b not in tensor_names:
+                raise ValueError(f"Missing paired LoRA tensor {key_b!r} in {path}.")
+
+            module_name = _to_diffusers_module_name(official_name)
+            target = _resolve_lora_target(transformer, module_name)
+            if target is None:
+                unresolved.append(official_name)
+                continue
+
+            lora_a = handle.get_tensor(key_a).to(dtype=dtype)
+            lora_b = handle.get_tensor(key_b).to(dtype=dtype)
+            if lora_b.shape[1] != lora_a.shape[0]:
+                raise ValueError(
+                    f"Invalid LoRA pair for {official_name}: A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)}."
+                )
+            entries.append(
+                _LTXLoRAEntry(
+                    module_name=module_name,
+                    target_name=target[0],
+                    shard_id=target[1],
+                    lora_a=lora_a,
+                    lora_b=lora_b,
+                )
+            )
+
+    if unresolved:
+        raise ValueError(f"Official LTX LoRA contains unmapped modules: {unresolved}.")
+    if not entries:
+        raise ValueError(f"No Transformer LoRA tensors were loaded from {path}.")
+    return entries
+
+
+class LTXResidentLoRAController:
+    """Keep base and stage-2 LoRA weights as two offloadable DiT modules."""
+
+    def __init__(self, pipeline: Any, adapter_path: str) -> None:
+        self.pipeline = pipeline
+        self.adapter_path = adapter_path
+        self.active_transformer_name = "transformer"
+        self._merged = False
+
+        if getattr(pipeline.od_config, "quantization_config", None) is not None:
+            raise ValueError("LTX resident LoRA mode does not support quantized Transformer weights yet.")
+
+        transformer_config = dict(pipeline.transformer.config)
+        pipeline.transformer_2 = create_transformer_from_config(transformer_config)
+        source = next(
+            (source for source in pipeline.weights_sources if source.prefix == "transformer."),
+            None,
+        )
+        if source is None:
+            raise RuntimeError("LTX resident LoRA mode requires a transformer weight source.")
+        pipeline.weights_sources.append(replace(source, prefix="transformer_2."))
+        pipeline._dit_modules = ["transformer", "transformer_2"]
+        logger.info("Using resident LTX stage-2 LoRA weights")
+
+    @property
+    def transformer(self) -> nn.Module:
+        return getattr(self.pipeline, self.active_transformer_name)
+
+    def after_weights_loaded(self) -> None:
+        if self._merged:
+            return
+        entries = _load_lora_entries(
+            self.pipeline.transformer_2,
+            self.adapter_path,
+            self.pipeline.od_config.dtype,
+        )
+        self._merge_entries(entries)
+        self._merged = True
+
+    @torch.no_grad()
+    def _merge_entries(self, entries: list[_LTXLoRAEntry]) -> None:
+        grouped: dict[str, list[_LTXLoRAEntry]] = {}
+        for entry in entries:
+            grouped.setdefault(entry.target_name, []).append(entry)
+
+        modules = dict(self.pipeline.transformer_2.named_modules())
+        fusion_device = torch.device(self.pipeline.device)
+        if fusion_device.type == "cuda" and not torch.cuda.is_available():
+            fusion_device = torch.device("cpu")
+
+        for target_name, target_entries in grouped.items():
+            module = modules.get(target_name)
+            weight = getattr(module, "weight", None)
+            if not isinstance(weight, torch.Tensor):
+                raise TypeError(f"Expected a weight tensor at transformer_2.{target_name}.")
+            if not weight.is_floating_point():
+                raise TypeError(f"Cannot merge LTX LoRA into non-floating weight transformer_2.{target_name}.")
+
+            weight_loader = getattr(weight, "weight_loader", None)
+            if weight_loader is None:
+                if len(target_entries) != 1 or target_entries[0].shard_id is not None:
+                    raise ValueError(f"Cannot merge packed LoRA shards into transformer_2.{target_name}.")
+                delta = self._compute_delta(target_entries[0], fusion_device, weight.dtype)
+                weight.add_(delta.to(device=weight.device, dtype=weight.dtype))
+                continue
+
+            base_weight = weight.detach().clone()
+            weight.zero_()
+            try:
+                for entry in target_entries:
+                    delta = self._compute_delta(entry, fusion_device, weight.dtype)
+                    if entry.shard_id is None:
+                        weight_loader(weight, delta)
+                    else:
+                        weight_loader(weight, delta, entry.shard_id)
+                weight.add_(base_weight)
+            except Exception:
+                weight.copy_(base_weight)
+                raise
+
+    @staticmethod
+    def _compute_delta(entry: _LTXLoRAEntry, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        lora_a = entry.lora_a.to(device=device, dtype=dtype)
+        lora_b = entry.lora_b.to(device=device, dtype=dtype)
+        return torch.matmul(lora_b, lora_a)
+
+    def enter(self, transformer_phase: str) -> None:
+        if not self._merged:
+            raise RuntimeError("LTX resident LoRA weights have not been finalized.")
+        if transformer_phase == "base":
+            self.active_transformer_name = "transformer"
+        elif transformer_phase == "distilled_lora":
+            self.active_transformer_name = "transformer_2"
+        else:
+            raise ValueError(f"Unsupported LTX Transformer phase: {transformer_phase!r}.")

--- a/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -50,6 +50,26 @@ def _transformer_config_to_dict(config: Any) -> dict[str, Any]:
     if isinstance(attributes, dict):
         return dict(attributes)
     raise TypeError(f"Unsupported LTX Transformer config type: {type(config).__name__}.")
+
+
+def _uses_serialized_quantization(quant_config: Any) -> bool:
+    """Whether Transformer weights are already quantized in the checkpoint."""
+    if quant_config is None:
+        return False
+    if hasattr(quant_config, "resolve"):
+        quant_config = quant_config.resolve("transformer")
+    if quant_config is None:
+        return False
+    serialized_flags = (
+        "is_checkpoint_quantized",
+        "is_checkpoint_fp8_serialized",
+        "is_checkpoint_nvfp4_serialized",
+        "is_checkpoint_mxfp8_serialized",
+        "is_checkpoint_torchao_serialized",
+    )
+    return getattr(quant_config, "data_type", None) == "mx_fp" or any(
+        bool(getattr(quant_config, name, False)) for name in serialized_flags
+    )
 
 
 def _to_diffusers_module_name(name: str) -> str:
@@ -128,13 +148,17 @@ class LTXResidentLoRAController:
         self.active_transformer_name = "transformer"
         self._merged = False
 
-        if getattr(pipeline.od_config, "quantization_config", None) is not None:
-            raise ValueError("LTX resident LoRA mode does not support quantized Transformer weights yet.")
+        quant_config = getattr(pipeline.od_config, "quantization_config", None)
+        if _uses_serialized_quantization(quant_config):
+            raise ValueError(
+                "LTX resident LoRA mode requires an unquantized base checkpoint so the stage-2 adapter can be "
+                "merged before quantization; serialized quantized checkpoints are not supported."
+            )
 
         transformer_config = _transformer_config_to_dict(
             getattr(pipeline, "_transformer_init_config", pipeline.transformer.config)
         )
-        pipeline.transformer_2 = create_transformer_from_config(transformer_config)
+        pipeline.transformer_2 = create_transformer_from_config(transformer_config, quant_config=quant_config)
         source = next(
             (source for source in pipeline.weights_sources if source.prefix == "transformer."),
             None,
@@ -149,57 +173,53 @@ class LTXResidentLoRAController:
     def transformer(self) -> nn.Module:
         return getattr(self.pipeline, self.active_transformer_name)
 
-    def after_weights_loaded(self) -> None:
+    @torch.no_grad()
+    def merge_stage2_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Merge LoRA into full stage-2 tensors before the standard loader."""
         if self._merged:
-            return
+            raise RuntimeError("LTX resident LoRA weights have already been merged.")
+
         entries = _load_lora_entries(
             self.pipeline.transformer_2,
             self.adapter_path,
             self.pipeline.od_config.dtype,
         )
-        self._merge_entries(entries)
-        self._merged = True
-
-    @torch.no_grad()
-    def _merge_entries(self, entries: list[_LTXLoRAEntry]) -> None:
-        grouped: dict[str, list[_LTXLoRAEntry]] = {}
+        entries_by_module: dict[str, _LTXLoRAEntry] = {}
         for entry in entries:
-            grouped.setdefault(entry.target_name, []).append(entry)
+            if entry.module_name in entries_by_module:
+                raise ValueError(f"Official LTX LoRA contains duplicate module {entry.module_name!r}.")
+            entries_by_module[entry.module_name] = entry
 
-        modules = dict(self.pipeline.transformer_2.named_modules())
         fusion_device = torch.device(self.pipeline.device)
         if fusion_device.type == "cuda" and not torch.cuda.is_available():
             fusion_device = torch.device("cpu")
+        merged_modules: set[str] = set()
+        stage2_prefix = "transformer_2."
+        weight_suffix = ".weight"
 
-        for target_name, target_entries in grouped.items():
-            module = modules.get(target_name)
-            weight = getattr(module, "weight", None)
-            if not isinstance(weight, torch.Tensor):
-                raise TypeError(f"Expected a weight tensor at transformer_2.{target_name}.")
-            if not weight.is_floating_point():
-                raise TypeError(f"Cannot merge LTX LoRA into non-floating weight transformer_2.{target_name}.")
+        for name, weight in weights:
+            module_name = None
+            if name.startswith(stage2_prefix) and name.endswith(weight_suffix):
+                module_name = name[len(stage2_prefix) : -len(weight_suffix)]
+            entry = entries_by_module.get(module_name) if module_name is not None else None
+            if entry is not None:
+                delta = self._compute_delta(entry, fusion_device, weight.dtype)
+                if delta.shape != weight.shape:
+                    raise ValueError(
+                        f"Cannot match LoRA delta {tuple(delta.shape)} to checkpoint tensor "
+                        f"{name} {tuple(weight.shape)}."
+                    )
+                weight = weight.to(device=fusion_device) + delta
+                merged_modules.add(entry.module_name)
+            yield name, weight
 
-            weight_loader = getattr(weight, "weight_loader", None)
-            if weight_loader is None:
-                if len(target_entries) != 1 or target_entries[0].shard_id is not None:
-                    raise ValueError(f"Cannot merge packed LoRA shards into transformer_2.{target_name}.")
-                delta = self._compute_delta(target_entries[0], fusion_device, weight.dtype)
-                weight.add_(delta.to(device=weight.device, dtype=weight.dtype))
-                continue
-
-            base_weight = weight.detach().clone()
-            weight.zero_()
-            try:
-                for entry in target_entries:
-                    delta = self._compute_delta(entry, fusion_device, weight.dtype)
-                    if entry.shard_id is None:
-                        weight_loader(weight, delta)
-                    else:
-                        weight_loader(weight, delta, entry.shard_id)
-                weight.add_(base_weight)
-            except Exception:
-                weight.copy_(base_weight)
-                raise
+        missing = set(entries_by_module) - merged_modules
+        if missing:
+            raise ValueError(f"LTX stage-2 checkpoint is missing LoRA target weights: {sorted(missing)}.")
+        self._merged = True
 
     @staticmethod
     def _compute_delta(entry: _LTXLoRAEntry, device: torch.device, dtype: torch.dtype) -> torch.Tensor:

--- a/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -39,6 +40,16 @@ class _LTXLoRAEntry:
     shard_id: str | int | None
     lora_a: torch.Tensor
     lora_b: torch.Tensor
+
+
+def _transformer_config_to_dict(config: Any) -> dict[str, Any]:
+    """Copy a Diffusers-style mapping or namespace Transformer config."""
+    if isinstance(config, Mapping):
+        return dict(config)
+    attributes = getattr(config, "__dict__", None)
+    if isinstance(attributes, dict):
+        return dict(attributes)
+    raise TypeError(f"Unsupported LTX Transformer config type: {type(config).__name__}.")
 
 
 def _to_diffusers_module_name(name: str) -> str:
@@ -120,7 +131,9 @@ class LTXResidentLoRAController:
         if getattr(pipeline.od_config, "quantization_config", None) is not None:
             raise ValueError("LTX resident LoRA mode does not support quantized Transformer weights yet.")
 
-        transformer_config = dict(pipeline.transformer.config)
+        transformer_config = _transformer_config_to_dict(
+            getattr(pipeline, "_transformer_init_config", pipeline.transformer.config)
+        )
         pipeline.transformer_2 = create_transformer_from_config(transformer_config)
         source = next(
             (source for source in pipeline.weights_sources if source.prefix == "transformer."),

--- a/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_lora.py
@@ -11,27 +11,12 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from safetensors import safe_open
 from vllm.logger import init_logger
 
+from .ltx2_adapter_parser import LTXAdapterParser, iter_adapter_tensors
 from .ltx2_components import create_transformer_from_config
 
 logger = init_logger(__name__)
-
-_IGNORED_OFFICIAL_LORA_MODULES = {"text_embedding_projection.aggregate_embed"}
-_OFFICIAL_TO_DIFFUSERS_PREFIXES = (
-    ("audio_prompt_adaln_single.", "audio_prompt_adaln."),
-    ("prompt_adaln_single.", "prompt_adaln."),
-    ("audio_adaln_single.", "audio_time_embed."),
-    ("adaln_single.", "time_embed."),
-    ("audio_patchify_proj", "audio_proj_in"),
-    ("patchify_proj", "proj_in"),
-    ("av_ca_video_scale_shift_adaln_single.", "av_cross_attn_video_scale_shift."),
-    ("av_ca_audio_scale_shift_adaln_single.", "av_cross_attn_audio_scale_shift."),
-    ("av_ca_a2v_gate_adaln_single.", "av_cross_attn_video_a2v_gate."),
-    ("av_ca_v2a_gate_adaln_single.", "av_cross_attn_audio_v2a_gate."),
-)
-
 
 @dataclass(frozen=True)
 class _LTXLoRAEntry:
@@ -72,71 +57,19 @@ def _uses_serialized_quantization(quant_config: Any) -> bool:
     )
 
 
-def _to_diffusers_module_name(name: str) -> str:
-    for official_prefix, diffusers_prefix in _OFFICIAL_TO_DIFFUSERS_PREFIXES:
-        if name.startswith(official_prefix):
-            return diffusers_prefix + name[len(official_prefix) :]
-    return name
-
-
-def _resolve_lora_target(transformer: nn.Module, module_name: str) -> tuple[str, str | int | None] | None:
-    modules = dict(transformer.named_modules())
-    if module_name in modules:
-        return module_name, None
-    for packed_suffix, sub_suffix, shard_id in getattr(transformer, "stacked_params_mapping", ()):
-        if sub_suffix in module_name:
-            packed_name = module_name.replace(sub_suffix, packed_suffix)
-            if packed_name in modules:
-                return packed_name, shard_id
-    return None
-
-
-def _load_lora_entries(transformer: nn.Module, path: str, dtype: torch.dtype) -> list[_LTXLoRAEntry]:
-    entries: list[_LTXLoRAEntry] = []
-    unresolved: list[str] = []
-    with safe_open(path, framework="pt", device="cpu") as handle:
-        tensor_names = set(handle.keys())
-        module_names = sorted(
-            name.removeprefix("diffusion_model.").rsplit(".lora_", 1)[0]
-            for name in tensor_names
-            if name.endswith(".lora_A.weight")
+def _load_resident_lora_entries(transformer: nn.Module, path: str, dtype: torch.dtype) -> list[_LTXLoRAEntry]:
+    """Materialize parser output only for the resident pre-merge path."""
+    manifest = LTXAdapterParser(transformer).parse(path)
+    return [
+        _LTXLoRAEntry(
+            module_name=target.source_module,
+            target_name=target.module,
+            shard_id=target.slice,
+            lora_a=lora_a.to(dtype=dtype),
+            lora_b=lora_b.to(dtype=dtype),
         )
-        for official_name in module_names:
-            if official_name in _IGNORED_OFFICIAL_LORA_MODULES:
-                continue
-            key_prefix = f"diffusion_model.{official_name}"
-            key_a = f"{key_prefix}.lora_A.weight"
-            key_b = f"{key_prefix}.lora_B.weight"
-            if key_b not in tensor_names:
-                raise ValueError(f"Missing paired LoRA tensor {key_b!r} in {path}.")
-
-            module_name = _to_diffusers_module_name(official_name)
-            target = _resolve_lora_target(transformer, module_name)
-            if target is None:
-                unresolved.append(official_name)
-                continue
-
-            lora_a = handle.get_tensor(key_a).to(dtype=dtype)
-            lora_b = handle.get_tensor(key_b).to(dtype=dtype)
-            if lora_b.shape[1] != lora_a.shape[0]:
-                raise ValueError(
-                    f"Invalid LoRA pair for {official_name}: A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)}."
-                )
-            entries.append(
-                _LTXLoRAEntry(
-                    module_name=module_name,
-                    target_name=target[0],
-                    shard_id=target[1],
-                    lora_a=lora_a,
-                    lora_b=lora_b,
-                )
-            )
-
-    if unresolved:
-        raise ValueError(f"Official LTX LoRA contains unmapped modules: {unresolved}.")
-    if not entries:
-        raise ValueError(f"No Transformer LoRA tensors were loaded from {path}.")
-    return entries
+        for target, lora_a, lora_b in iter_adapter_tensors(manifest)
+    ]
 
 
 class LTXResidentLoRAController:
@@ -182,7 +115,7 @@ class LTXResidentLoRAController:
         if self._merged:
             raise RuntimeError("LTX resident LoRA weights have already been merged.")
 
-        entries = _load_lora_entries(
+        entries = _load_resident_lora_entries(
             self.pipeline.transformer_2,
             self.adapter_path,
             self.pipeline.od_config.dtype,
@@ -236,3 +169,12 @@ class LTXResidentLoRAController:
             self.active_transformer_name = "transformer_2"
         else:
             raise ValueError(f"Unsupported LTX Transformer phase: {transformer_phase!r}.")
+
+    def set_active(self, adapter_name: str | None) -> None:
+        """Match the fixed-slot API used by the dynamic phase adapter."""
+        if adapter_name is None:
+            self.enter("base")
+        elif adapter_name == "ltx_distilled":
+            self.enter("distilled_lora")
+        else:
+            raise ValueError(f"Unknown LTX phase adapter slot {adapter_name!r}.")

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Runtime for a fixed LTX two-stage adapter slot.
+
+This module intentionally knows nothing about official LTX safetensors names.
+It receives an :class:`AdapterManifest` and makes the existing LTX transformer
+linears adapter-capable while retaining their original quantization and tensor
+parallel implementations.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelLinear, RowParallelLinear
+
+from .ltx2_adapter_parser import AdapterManifest, AdapterTarget, iter_adapter_tensors
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _AdapterLayout:
+    """Rank-local storage and execution layout for one LoRA pair."""
+
+    kind: str
+    input_size: int
+    output_size: int
+    a_input_start: int
+    a_input_size: int
+    b_output_start: int
+    b_output_size: int
+    output_start: int
+    reduce_results: bool = False
+
+
+def _module_device(module: nn.Module) -> torch.device:
+    for tensor in (*module.parameters(), *module.buffers()):
+        if tensor.device.type != "meta":
+            return tensor.device
+    raise RuntimeError(f"Cannot materialize an LTX phase adapter for meta module {module._get_name()}.")
+
+
+def _build_layout(layer: nn.Module, target: AdapterTarget) -> _AdapterLayout:
+    if isinstance(layer, QKVParallelLinear):
+        if target.slice not in {"q", "k", "v"}:
+            raise ValueError(
+                f"LTX packed QKV target {target.module!r} requires a q/k/v adapter slice, got {target.slice!r}."
+            )
+        q_local = layer.num_heads * layer.head_size
+        k_local = layer.num_kv_heads * layer.head_size
+        v_local = layer.num_kv_heads * layer.v_head_size
+        if target.slice == "q":
+            output_size = layer.total_num_heads * layer.head_size
+            b_output_start = layer.tp_rank * q_local
+            b_output_size = q_local
+            output_start = 0
+        elif target.slice == "k":
+            output_size = layer.total_num_kv_heads * layer.head_size
+            shard_rank = layer.tp_rank // layer.num_kv_head_replicas
+            b_output_start = shard_rank * k_local
+            b_output_size = k_local
+            output_start = q_local
+        else:
+            output_size = layer.total_num_kv_heads * layer.v_head_size
+            shard_rank = layer.tp_rank // layer.num_kv_head_replicas
+            b_output_start = shard_rank * v_local
+            b_output_size = v_local
+            output_start = q_local + k_local
+        return _AdapterLayout(
+            kind="qkv",
+            input_size=layer.input_size,
+            output_size=output_size,
+            a_input_start=0,
+            a_input_size=layer.input_size,
+            b_output_start=b_output_start,
+            b_output_size=b_output_size,
+            output_start=output_start,
+        )
+
+    if isinstance(layer, ColumnParallelLinear):
+        if layer.gather_output:
+            raise ValueError(
+                f"LTX phase adapter does not support gathered ColumnParallelLinear target {target.module!r}."
+            )
+        return _AdapterLayout(
+            kind="column",
+            input_size=layer.input_size,
+            output_size=layer.output_size,
+            a_input_start=0,
+            a_input_size=layer.input_size,
+            b_output_start=layer.tp_rank * layer.output_size_per_partition,
+            b_output_size=layer.output_size_per_partition,
+            output_start=0,
+        )
+
+    if isinstance(layer, RowParallelLinear):
+        return _AdapterLayout(
+            kind="row",
+            input_size=layer.input_size,
+            output_size=layer.output_size,
+            a_input_start=layer.tp_rank * layer.input_size_per_partition,
+            a_input_size=layer.input_size_per_partition,
+            b_output_start=0,
+            b_output_size=layer.output_size,
+            output_start=0,
+            reduce_results=layer.reduce_results,
+        )
+
+    if isinstance(layer, nn.Linear):
+        return _AdapterLayout(
+            kind="replicated",
+            input_size=layer.in_features,
+            output_size=layer.out_features,
+            a_input_start=0,
+            a_input_size=layer.in_features,
+            b_output_start=0,
+            b_output_size=layer.out_features,
+            output_start=0,
+        )
+
+    raise TypeError(
+        f"LTX phase adapter target {target.module!r} has unsupported layer type {type(layer).__name__}."
+    )
+
+
+class _AdapterPiece(nn.Module):
+    """One rank-local A/B pair stored as non-persistent buffers."""
+
+    def __init__(self, target: AdapterTarget, layout: _AdapterLayout) -> None:
+        super().__init__()
+        self.target = target
+        self.layout = layout
+        # The fixed graph is installed before base checkpoint loading.  The
+        # empty buffers are replaced only after the base layer's quant/TP layout
+        # has settled and before offload/compile snapshots are taken.
+        self.register_buffer("lora_a", torch.empty(0), persistent=False)
+        self.register_buffer("lora_b", torch.empty(0), persistent=False)
+
+    def load(self, lora_a: torch.Tensor, lora_b: torch.Tensor, *, device: torch.device, dtype: torch.dtype) -> None:
+        if tuple(lora_a.shape) != self.target.a_source.shape or tuple(lora_b.shape) != self.target.b_source.shape:
+            raise ValueError(
+                f"LTX adapter source shape changed for {self.target.source_module!r}: "
+                f"A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)}."
+            )
+        if lora_a.ndim != 2 or lora_b.ndim != 2:
+            raise ValueError(f"LTX adapter target {self.target.source_module!r} must use rank-2 A/B tensors.")
+        if lora_a.shape[0] != self.target.rank or lora_b.shape[1] != self.target.rank:
+            raise ValueError(
+                f"LTX adapter rank mismatch for {self.target.source_module!r}: "
+                f"expected {self.target.rank}, got A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)}."
+            )
+        if lora_a.shape[1] != self.layout.input_size or lora_b.shape[0] != self.layout.output_size:
+            raise ValueError(
+                f"LTX adapter shape does not match {self.target.module!r}: "
+                f"expected A=({self.target.rank}, {self.layout.input_size}), "
+                f"B=({self.layout.output_size}, {self.target.rank}); "
+                f"got A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)}."
+            )
+
+        local_a = lora_a.narrow(1, self.layout.a_input_start, self.layout.a_input_size)
+        local_b = lora_b.narrow(0, self.layout.b_output_start, self.layout.b_output_size)
+        self.lora_a = local_a.to(device=device, dtype=dtype)
+        self.lora_b = local_b.to(device=device, dtype=dtype)
+
+    def delta(self, input_: torch.Tensor) -> torch.Tensor:
+        if self.lora_a.numel() == 0 or self.lora_b.numel() == 0:
+            raise RuntimeError(f"LTX phase adapter target {self.target.module!r} was not materialized.")
+        if self.layout.kind == "row" and input_.shape[-1] != self.layout.a_input_size:
+            input_ = input_.narrow(-1, self.layout.a_input_start, self.layout.a_input_size)
+        input_ = input_.to(dtype=self.lora_a.dtype)
+        delta = F.linear(F.linear(input_, self.lora_a), self.lora_b)
+        if self.layout.kind == "row" and self.layout.reduce_results:
+            delta = tensor_model_parallel_all_reduce(delta)
+        return delta
+
+
+class _PhaseAdapterLinear(nn.Module):
+    """Delegate the base linear unchanged and add an enabled adapter slot."""
+
+    def __init__(
+        self,
+        base_layer: nn.Module,
+        targets: Iterable[AdapterTarget],
+        *,
+        adapter_name: str,
+        adapter_dtype: torch.dtype,
+    ) -> None:
+        super().__init__()
+        self.base_layer = base_layer
+        self.adapter_dtype = adapter_dtype
+        pieces = [_AdapterPiece(target, _build_layout(base_layer, target)) for target in targets]
+        self.adapters = nn.ModuleDict({adapter_name: nn.ModuleList(pieces)})
+        self._pieces_by_target = {piece.target: piece for piece in pieces}
+        self._active_adapter: str | None = None
+
+    def load_target(self, target: AdapterTarget, lora_a: torch.Tensor, lora_b: torch.Tensor) -> None:
+        try:
+            piece = self._pieces_by_target[target]
+        except KeyError as exc:
+            raise ValueError(f"Adapter target {target.module!r} is not installed on this layer.") from exc
+        piece.load(lora_a, lora_b, device=_module_device(self.base_layer), dtype=self.adapter_dtype)
+
+    def set_active(self, adapter_name: str | None) -> None:
+        if adapter_name is not None and adapter_name not in self.adapters:
+            raise ValueError(f"Unknown LTX phase adapter slot {adapter_name!r}.")
+        self._active_adapter = adapter_name
+
+    def _add_adapter_delta(self, input_: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        adapter_name = self._active_adapter
+        if adapter_name is None:
+            return output
+        if output.requires_grad:
+            output = output.clone()
+        for piece in self.adapters[adapter_name]:
+            delta = piece.delta(input_).to(dtype=output.dtype)
+            start = piece.layout.output_start
+            output[..., start : start + piece.layout.b_output_size].add_(delta)
+        return output
+
+    def forward(self, input_: torch.Tensor):
+        output = self.base_layer(input_)
+        if self._active_adapter is None:
+            return output
+        if isinstance(output, tuple):
+            return (self._add_adapter_delta(input_, output[0]), *output[1:])
+        return self._add_adapter_delta(input_, output)
+
+
+class LTXPhaseAdapterRuntime:
+    """Install and operate one fixed phase adapter on an existing transformer."""
+
+    def __init__(self, transformer: nn.Module, manifest: AdapterManifest, *, dtype: torch.dtype) -> None:
+        self.transformer = transformer
+        self.manifest = manifest
+        self.dtype = dtype
+        self._wrappers: dict[str, _PhaseAdapterLinear] = {}
+        self._target_names: tuple[str, ...] = ()
+        self._installed = False
+        self._materialized = False
+
+    def install_structure(self) -> None:
+        """Replace target linears before base checkpoint loading begins."""
+        if self._installed:
+            raise RuntimeError("LTX phase adapter structure is already installed.")
+        grouped: dict[str, list[AdapterTarget]] = defaultdict(list)
+        for target in self.manifest.targets:
+            grouped[target.module].append(target)
+
+        original_layers = {name: self.transformer.get_submodule(name) for name in grouped}
+        for name, targets in grouped.items():
+            wrapper = _PhaseAdapterLinear(
+                original_layers[name],
+                targets,
+                adapter_name=self.manifest.name,
+                adapter_dtype=self.dtype,
+            )
+            parent_name, _, child_name = name.rpartition(".")
+            parent = self.transformer.get_submodule(parent_name) if parent_name else self.transformer
+            if child_name not in parent._modules:
+                raise ValueError(f"LTX phase adapter target {name!r} is no longer a direct module child.")
+            parent._modules[child_name] = wrapper
+            self._wrappers[name] = wrapper
+
+        self._target_names = tuple(sorted(self._wrappers, key=len, reverse=True))
+        # LTX's custom loader receives the original checkpoint names.  Keep the
+        # adaptation local to that loader rather than changing AutoWeightsLoader.
+        self.transformer._phase_adapter_parameter_name = self.base_parameter_name
+        self._installed = True
+        logger.info("Installed %d LTX phase-adapter linears for slot %s", len(self._wrappers), self.manifest.name)
+
+    def base_parameter_name(self, name: str) -> str:
+        for target_name in self._target_names:
+            prefix = f"{target_name}."
+            if name.startswith(prefix):
+                return f"{target_name}.base_layer.{name[len(prefix) :]}"
+        return name
+
+    def finalize_adapter_data(self) -> None:
+        """Stream rank-local A/B buffers after base weight processing completes."""
+        if not self._installed:
+            raise RuntimeError("LTX phase adapter structure must be installed before materialization.")
+        if self._materialized:
+            return
+        loaded: set[AdapterTarget] = set()
+        for target, lora_a, lora_b in iter_adapter_tensors(self.manifest):
+            self._wrappers[target.module].load_target(target, lora_a, lora_b)
+            loaded.add(target)
+        missing = set(self.manifest.targets) - loaded
+        if missing:
+            missing_modules = sorted(target.module for target in missing)
+            raise RuntimeError(f"LTX phase adapter did not load targets: {missing_modules}.")
+        self._materialized = True
+        logger.info("Materialized %d LTX phase-adapter tensor pairs for slot %s", len(loaded), self.manifest.name)
+
+    def set_active(self, adapter_name: str | None) -> None:
+        if adapter_name is not None:
+            if adapter_name != self.manifest.name:
+                raise ValueError(f"Unknown LTX phase adapter slot {adapter_name!r}.")
+            if not self._materialized:
+                raise RuntimeError("LTX phase adapter data must be materialized before activation.")
+        for wrapper in self._wrappers.values():
+            wrapper.set_active(adapter_name)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Runtime for a fixed LTX two-stage adapter slot.
+"""Runtime for a fixed LTX refinement-phase adapter slot.
 
 This module intentionally knows nothing about official LTX safetensors names.
 It receives an :class:`AdapterManifest` and makes the existing LTX transformer
@@ -127,9 +127,7 @@ def _build_layout(layer: nn.Module, target: AdapterTarget) -> _AdapterLayout:
             output_start=0,
         )
 
-    raise TypeError(
-        f"LTX phase adapter target {target.module!r} has unsupported layer type {type(layer).__name__}."
-    )
+    raise TypeError(f"LTX phase adapter target {target.module!r} has unsupported layer type {type(layer).__name__}.")
 
 
 class _AdapterPiece(nn.Module):
@@ -284,7 +282,14 @@ class LTXPhaseAdapterRuntime:
                 return f"{target_name}.base_layer.{name[len(prefix) :]}"
         return name
 
-    def finalize_adapter_data(self) -> None:
+    def prepare_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Keep base weights on the transformer's standard loading path."""
+        return weights
+
+    def finalize(self) -> None:
         """Stream rank-local A/B buffers after base weight processing completes."""
         if not self._installed:
             raise RuntimeError("LTX phase adapter structure must be installed before materialization.")
@@ -301,11 +306,11 @@ class LTXPhaseAdapterRuntime:
         self._materialized = True
         logger.info("Materialized %d LTX phase-adapter tensor pairs for slot %s", len(loaded), self.manifest.name)
 
-    def set_active(self, adapter_name: str | None) -> None:
-        if adapter_name is not None:
-            if adapter_name != self.manifest.name:
-                raise ValueError(f"Unknown LTX phase adapter slot {adapter_name!r}.")
+    def activate(self, adapter_slot: str | None) -> None:
+        if adapter_slot is not None:
+            if adapter_slot != self.manifest.name:
+                raise ValueError(f"Unknown LTX phase adapter slot {adapter_slot!r}.")
             if not self._materialized:
                 raise RuntimeError("LTX phase adapter data must be materialized before activation.")
         for wrapper in self._wrappers.values():
-            wrapper.set_active(adapter_name)
+            wrapper.set_active(adapter_slot)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
@@ -1,22 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Resident stage-2 LoRA weights for official LTX two-stage pipelines."""
+"""Phase-specific Transformer weights for LTX pipeline recipes."""
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Protocol
 
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
 
 from .ltx2_adapter_parser import LTXAdapterParser, iter_adapter_tensors
-from .ltx2_components import create_transformer_from_config
+from .ltx2_components import create_transformer_from_config, resolve_ltx_artifact
+from .ltx2_phase_adapter import LTXPhaseAdapterRuntime
 
 logger = init_logger(__name__)
+
+
+class LTXPhaseWeights(Protocol):
+    """Common lifecycle for resident and dynamic phase-specific weights."""
+
+    @property
+    def transformer(self) -> nn.Module: ...
+
+    def prepare_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]: ...
+
+    def finalize(self) -> None: ...
+
+    def activate(self, adapter_slot: str | None) -> None: ...
+
 
 @dataclass(frozen=True)
 class _LTXLoRAEntry:
@@ -73,7 +91,7 @@ def _load_resident_lora_entries(transformer: nn.Module, path: str, dtype: torch.
 
 
 class LTXResidentLoRAController:
-    """Keep base and stage-2 LoRA weights as two offloadable DiT modules."""
+    """Keep base and refinement weights as two offloadable DiT modules."""
 
     def __init__(self, pipeline: Any, adapter_path: str) -> None:
         self.pipeline = pipeline
@@ -84,7 +102,7 @@ class LTXResidentLoRAController:
         quant_config = getattr(pipeline.od_config, "quantization_config", None)
         if _uses_serialized_quantization(quant_config):
             raise ValueError(
-                "LTX resident LoRA mode requires an unquantized base checkpoint so the stage-2 adapter can be "
+                "LTX resident LoRA mode requires an unquantized base checkpoint so the refinement adapter can be "
                 "merged before quantization; serialized quantized checkpoints are not supported."
             )
 
@@ -100,18 +118,18 @@ class LTXResidentLoRAController:
             raise RuntimeError("LTX resident LoRA mode requires a transformer weight source.")
         pipeline.weights_sources.append(replace(source, prefix="transformer_2."))
         pipeline._dit_modules = ["transformer", "transformer_2"]
-        logger.info("Using resident LTX stage-2 LoRA weights")
+        logger.info("Using resident LTX refinement-phase LoRA weights")
 
     @property
     def transformer(self) -> nn.Module:
         return getattr(self.pipeline, self.active_transformer_name)
 
     @torch.no_grad()
-    def merge_stage2_weights(
+    def prepare_weights(
         self,
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> Iterable[tuple[str, torch.Tensor]]:
-        """Merge LoRA into full stage-2 tensors before the standard loader."""
+        """Merge LoRA into full refinement tensors before the standard loader."""
         if self._merged:
             raise RuntimeError("LTX resident LoRA weights have already been merged.")
 
@@ -130,13 +148,13 @@ class LTXResidentLoRAController:
         if fusion_device.type == "cuda" and not torch.cuda.is_available():
             fusion_device = torch.device("cpu")
         merged_modules: set[str] = set()
-        stage2_prefix = "transformer_2."
+        refinement_prefix = "transformer_2."
         weight_suffix = ".weight"
 
         for name, weight in weights:
             module_name = None
-            if name.startswith(stage2_prefix) and name.endswith(weight_suffix):
-                module_name = name[len(stage2_prefix) : -len(weight_suffix)]
+            if name.startswith(refinement_prefix) and name.endswith(weight_suffix):
+                module_name = name[len(refinement_prefix) : -len(weight_suffix)]
             entry = entries_by_module.get(module_name) if module_name is not None else None
             if entry is not None:
                 delta = self._compute_delta(entry, fusion_device, weight.dtype)
@@ -151,7 +169,7 @@ class LTXResidentLoRAController:
 
         missing = set(entries_by_module) - merged_modules
         if missing:
-            raise ValueError(f"LTX stage-2 checkpoint is missing LoRA target weights: {sorted(missing)}.")
+            raise ValueError(f"LTX refinement checkpoint is missing LoRA target weights: {sorted(missing)}.")
         self._merged = True
 
     @staticmethod
@@ -160,21 +178,53 @@ class LTXResidentLoRAController:
         lora_b = entry.lora_b.to(device=device, dtype=dtype)
         return torch.matmul(lora_b, lora_a)
 
-    def enter(self, transformer_phase: str) -> None:
+    def finalize(self) -> None:
         if not self._merged:
             raise RuntimeError("LTX resident LoRA weights have not been finalized.")
-        if transformer_phase == "base":
+
+    def activate(self, adapter_slot: str | None) -> None:
+        self.finalize()
+        if adapter_slot is None:
             self.active_transformer_name = "transformer"
-        elif transformer_phase == "distilled_lora":
+        elif adapter_slot == "ltx_distilled":
             self.active_transformer_name = "transformer_2"
         else:
-            raise ValueError(f"Unsupported LTX Transformer phase: {transformer_phase!r}.")
+            raise ValueError(f"Unknown LTX phase adapter slot {adapter_slot!r}.")
 
-    def set_active(self, adapter_name: str | None) -> None:
-        """Match the fixed-slot API used by the dynamic phase adapter."""
-        if adapter_name is None:
-            self.enter("base")
-        elif adapter_name == "ltx_distilled":
-            self.enter("distilled_lora")
-        else:
-            raise ValueError(f"Unknown LTX phase adapter slot {adapter_name!r}.")
+
+def build_ltx_phase_weights(pipeline: Any) -> LTXPhaseWeights | None:
+    """Build the fixed phase-weight strategy required by a pipeline recipe."""
+    adapter_slots = {phase.adapter_slot for phase in pipeline.pipeline_recipe.phases if phase.adapter_slot is not None}
+    if not adapter_slots:
+        return None
+    if adapter_slots != {"ltx_distilled"}:
+        raise ValueError(f"Unsupported LTX phase adapter slots: {sorted(adapter_slots)}.")
+
+    profile = pipeline.component_profile
+    if profile.distilled_lora_filename is None or profile.artifact_repo_id is None:
+        raise ValueError(f"{profile.name} does not declare the required distilled adapter artifact.")
+    if getattr(pipeline.od_config, "lora_path", None) is not None:
+        raise ValueError(
+            f"{pipeline.__class__.__name__} reserves LoRA execution for its phase adapter; "
+            "request or static LoRA composition is not supported yet."
+        )
+
+    model_config = getattr(pipeline.od_config, "model_config", {}) or {}
+    mode = model_config.get("ltx_two_stage_lora_mode", "resident")
+    if mode not in {"resident", "dynamic"}:
+        raise ValueError(f"model_config.ltx_two_stage_lora_mode must be either 'resident' or 'dynamic', got {mode!r}.")
+    model_paths = getattr(pipeline.od_config, "model_paths", {}) or {}
+    adapter_path = resolve_ltx_artifact(
+        pipeline.od_config.model,
+        profile.artifact_repo_id,
+        profile.distilled_lora_filename,
+        explicit_path=model_paths.get("distilled_lora"),
+    )
+
+    if mode == "resident":
+        return LTXResidentLoRAController(pipeline, adapter_path)
+
+    manifest = LTXAdapterParser(pipeline.transformer).parse(adapter_path, name="ltx_distilled")
+    runtime = LTXPhaseAdapterRuntime(pipeline.transformer, manifest, dtype=pipeline.od_config.dtype)
+    runtime.install_structure()
+    return runtime

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
@@ -41,9 +41,7 @@ class LTXPhaseWeights(Protocol):
 
 @dataclass(frozen=True)
 class _LTXLoRAEntry:
-    module_name: str
-    target_name: str
-    shard_id: str | int | None
+    source_module: str
     lora_a: torch.Tensor
     lora_b: torch.Tensor
 
@@ -90,9 +88,7 @@ def _load_resident_lora_entries(transformer: nn.Module, path: str, dtype: torch.
     manifest = LTXAdapterParser(transformer).parse(path)
     return [
         _LTXLoRAEntry(
-            module_name=target.source_module,
-            target_name=target.module,
-            shard_id=target.slice,
+            source_module=target.source_module,
             lora_a=lora_a.to(dtype=dtype),
             lora_b=lora_b.to(dtype=dtype),
         )
@@ -150,9 +146,9 @@ class LTXResidentLoRAController:
         )
         entries_by_module: dict[str, _LTXLoRAEntry] = {}
         for entry in entries:
-            if entry.module_name in entries_by_module:
-                raise ValueError(f"Official LTX LoRA contains duplicate module {entry.module_name!r}.")
-            entries_by_module[entry.module_name] = entry
+            if entry.source_module in entries_by_module:
+                raise ValueError(f"Official LTX LoRA contains duplicate module {entry.source_module!r}.")
+            entries_by_module[entry.source_module] = entry
 
         fusion_device = torch.device(self.pipeline.device)
         if fusion_device.type == "cuda" and not torch.cuda.is_available():
@@ -174,7 +170,7 @@ class LTXResidentLoRAController:
                         f"{name} {tuple(weight.shape)}."
                     )
                 weight = weight.to(device=fusion_device) + delta
-                merged_modules.add(entry.module_name)
+                merged_modules.add(entry.source_module)
             yield name, weight
 
         missing = set(entries_by_module) - merged_modules

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
@@ -64,15 +64,20 @@ def _uses_serialized_quantization(quant_config: Any) -> bool:
         quant_config = quant_config.resolve("transformer")
     if quant_config is None:
         return False
-    serialized_flags = (
-        "is_checkpoint_quantized",
-        "is_checkpoint_fp8_serialized",
-        "is_checkpoint_nvfp4_serialized",
-        "is_checkpoint_mxfp8_serialized",
-        "is_checkpoint_torchao_serialized",
-    )
-    return getattr(quant_config, "data_type", None) == "mx_fp" or any(
-        bool(getattr(quant_config, name, False)) for name in serialized_flags
+    if getattr(quant_config, "data_type", None) == "mx_fp" or bool(
+        getattr(quant_config, "is_checkpoint_quantized", False)
+    ):
+        return True
+
+    # Quantization backends do not share one serialized-checkpoint flag:
+    # examples include is_checkpoint_int8_serialized,
+    # is_checkpoint_mxfp4_serialized, and is_checkpoint_serialized. Match the
+    # naming contract instead of maintaining a format list that becomes stale
+    # whenever another offline format is added.
+    return any(
+        bool(getattr(quant_config, name))
+        for name in dir(quant_config)
+        if name == "is_checkpoint_serialized" or (name.startswith("is_checkpoint_") and name.endswith("_serialized"))
     )
 
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
@@ -18,6 +19,8 @@ from .ltx2_components import create_transformer_from_config, resolve_ltx_artifac
 from .ltx2_phase_adapter import LTXPhaseAdapterRuntime
 
 logger = init_logger(__name__)
+
+_LTX_TWO_STAGE_LORA_MODE_ENV = "VLLM_OMNI_LTX_TWO_STAGE_LORA_MODE"
 
 
 class LTXPhaseWeights(Protocol):
@@ -73,6 +76,13 @@ def _uses_serialized_quantization(quant_config: Any) -> bool:
     return getattr(quant_config, "data_type", None) == "mx_fp" or any(
         bool(getattr(quant_config, name, False)) for name in serialized_flags
     )
+
+
+def _resolve_two_stage_lora_mode() -> str:
+    mode = os.getenv(_LTX_TWO_STAGE_LORA_MODE_ENV, "dynamic").strip().lower()
+    if mode not in {"resident", "dynamic"}:
+        raise ValueError(f"{_LTX_TWO_STAGE_LORA_MODE_ENV} must be either 'resident' or 'dynamic', got {mode!r}.")
+    return mode
 
 
 def _load_resident_lora_entries(transformer: nn.Module, path: str, dtype: torch.dtype) -> list[_LTXLoRAEntry]:
@@ -209,10 +219,7 @@ def build_ltx_phase_weights(pipeline: Any) -> LTXPhaseWeights | None:
             "request or static LoRA composition is not supported yet."
         )
 
-    model_config = getattr(pipeline.od_config, "model_config", {}) or {}
-    mode = model_config.get("ltx_two_stage_lora_mode", "resident")
-    if mode not in {"resident", "dynamic"}:
-        raise ValueError(f"model_config.ltx_two_stage_lora_mode must be either 'resident' or 'dynamic', got {mode!r}.")
+    mode = _resolve_two_stage_lora_mode()
     model_paths = getattr(pipeline.od_config, "model_paths", {}) or {}
     adapter_path = resolve_ltx_artifact(
         pipeline.od_config.model,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_weights.py
@@ -216,12 +216,10 @@ def build_ltx_phase_weights(pipeline: Any) -> LTXPhaseWeights | None:
         )
 
     mode = _resolve_two_stage_lora_mode()
-    model_paths = getattr(pipeline.od_config, "model_paths", {}) or {}
     adapter_path = resolve_ltx_artifact(
         pipeline.od_config.model,
         profile.artifact_repo_id,
         profile.distilled_lora_filename,
-        explicit_path=model_paths.get("distilled_lora"),
     )
 
     if mode == "resident":

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -36,7 +36,7 @@ class LTXPhaseRecipe:
     sigmas: tuple[float, ...] | None = None
     noise_scale: float = 0.0
     input_transform: Literal["initial", "spatial_upsample"] = "initial"
-    transformer_phase: str = "base"
+    adapter_slot: str | None = None
     allow_guidance_override: bool = True
     use_official_sigma_schedule: bool = True
 
@@ -173,7 +173,6 @@ def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipeli
                 guidance=one_stage_recipe.request_guidance,
                 spatial_downscale=2,
                 noise_scale=1.0,
-                transformer_phase="base",
             ),
             LTXPhaseRecipe(
                 name="refine",
@@ -181,7 +180,7 @@ def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipeli
                 sigmas=LTX_STAGE_2_DISTILLED_SIGMAS,
                 noise_scale=LTX_STAGE_2_DISTILLED_SIGMAS[0],
                 input_transform="spatial_upsample",
-                transformer_phase="distilled_lora",
+                adapter_slot="ltx_distilled",
                 allow_guidance_override=False,
                 use_official_sigma_schedule=False,
             ),

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -196,7 +196,9 @@ def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipeli
             ),
         ),
         video_output_phase=1,
-        audio_output_phase=1,
+        # The official second stage refines video only and deliberately
+        # discards its audio result. Decode the full-context Stage-1 audio.
+        audio_output_phase=0,
         allow_request_sigmas=False,
         allow_request_latents=False,
     )

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -36,6 +36,7 @@ class LTXPhaseRecipe:
     sigmas: tuple[float, ...] | None = None
     noise_scale: float = 0.0
     input_transform: Literal["initial", "spatial_upsample"] = "initial"
+    transformer_phase: str = "base"
     allow_guidance_override: bool = True
     use_official_sigma_schedule: bool = True
 
@@ -158,9 +159,49 @@ LTX2_DISTILLED_TWO_STAGE_RECIPE = LTXPipelineRecipe(
 )
 
 
+def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipelineRecipe:
+    return LTXPipelineRecipe(
+        height=one_stage_recipe.height * 2,
+        width=one_stage_recipe.width * 2,
+        num_frames=one_stage_recipe.num_frames,
+        frame_rate=one_stage_recipe.frame_rate,
+        num_inference_steps=one_stage_recipe.num_inference_steps,
+        negative_prompt=one_stage_recipe.negative_prompt,
+        phases=(
+            LTXPhaseRecipe(
+                name="generate_lowres",
+                guidance=one_stage_recipe.request_guidance,
+                spatial_downscale=2,
+                noise_scale=1.0,
+                transformer_phase="base",
+            ),
+            LTXPhaseRecipe(
+                name="refine",
+                guidance=LTXGuidanceSpec.positive_only(),
+                sigmas=LTX_STAGE_2_DISTILLED_SIGMAS,
+                noise_scale=LTX_STAGE_2_DISTILLED_SIGMAS[0],
+                input_transform="spatial_upsample",
+                transformer_phase="distilled_lora",
+                allow_guidance_override=False,
+                use_official_sigma_schedule=False,
+            ),
+        ),
+        video_output_phase=1,
+        audio_output_phase=1,
+        allow_request_sigmas=False,
+        allow_request_latents=False,
+    )
+
+
+LTX2_TWO_STAGE_RECIPE = _official_two_stage_recipe(LTX2_ONE_STAGE_RECIPE)
+LTX23_TWO_STAGE_RECIPE = _official_two_stage_recipe(LTX23_ONE_STAGE_RECIPE)
+
+
 _PIPELINE_RECIPES: dict[tuple[str, str], LTXPipelineRecipe] = {
     ("one_stage", "2"): LTX2_ONE_STAGE_RECIPE,
     ("one_stage", "2.3"): LTX23_ONE_STAGE_RECIPE,
+    ("two_stage", "2"): LTX2_TWO_STAGE_RECIPE,
+    ("two_stage", "2.3"): LTX23_TWO_STAGE_RECIPE,
     ("distilled_two_stage", "2"): LTX2_DISTILLED_TWO_STAGE_RECIPE,
     ("dmd2", "2"): LTX_POSITIVE_ONLY_RECIPE,
     ("dmd2", "2.3"): LTX_POSITIVE_ONLY_RECIPE,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -68,6 +68,7 @@ class LTXPipelineRecipe:
     allow_request_latents: bool = True
     allow_negative_prompt: bool = True
     fixed_num_inference_steps: bool = False
+    supports_cache_dit: bool = False
 
     def __post_init__(self) -> None:
         if not self.phases:
@@ -108,13 +109,16 @@ def _official_guidance(stg_block: int) -> LTXGuidanceSpec:
 
 
 LTX2_ONE_STAGE_RECIPE = LTXPipelineRecipe(
+    supports_cache_dit=True,
     phases=(LTXPhaseRecipe(name="generate", guidance=_official_guidance(29)),),
 )
 LTX23_ONE_STAGE_RECIPE = LTXPipelineRecipe(
+    supports_cache_dit=True,
     num_inference_steps=30,
     phases=(LTXPhaseRecipe(name="generate", guidance=_official_guidance(28)),),
 )
 LTX_POSITIVE_ONLY_RECIPE = LTXPipelineRecipe(
+    supports_cache_dit=True,
     phases=(
         LTXPhaseRecipe(
             name="generate",

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -3,7 +3,7 @@
 
 """Declarative execution recipes for the LTX model family."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 from .ltx2_guidance import LTXGuidanceSpec, LTXModalityGuidance
@@ -158,6 +158,12 @@ LTX2_DISTILLED_TWO_STAGE_RECIPE = LTXPipelineRecipe(
     fixed_num_inference_steps=True,
 )
 
+# LTX-2.3 full-distilled uses the same official fixed 8 + 3 sigma schedules
+# and request contract. Its distinct component profile selects the 22B merged
+# distilled Transformer, BWE vocoder, and matching spatial upsampler; no
+# distilled LoRA is loaded for either phase.
+LTX23_DISTILLED_TWO_STAGE_RECIPE = replace(LTX2_DISTILLED_TWO_STAGE_RECIPE)
+
 
 def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipelineRecipe:
     return LTXPipelineRecipe(
@@ -202,6 +208,7 @@ _PIPELINE_RECIPES: dict[tuple[str, str], LTXPipelineRecipe] = {
     ("two_stage", "2"): LTX2_TWO_STAGE_RECIPE,
     ("two_stage", "2.3"): LTX23_TWO_STAGE_RECIPE,
     ("distilled_two_stage", "2"): LTX2_DISTILLED_TWO_STAGE_RECIPE,
+    ("distilled_two_stage", "2.3"): LTX23_DISTILLED_TWO_STAGE_RECIPE,
     ("dmd2", "2"): LTX_POSITIVE_ONLY_RECIPE,
     ("dmd2", "2.3"): LTX_POSITIVE_ONLY_RECIPE,
 }

--- a/vllm_omni/diffusion/models/ltx2/ltx2_request.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_request.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Literal
 
 import torch
 
@@ -47,6 +48,34 @@ class LTXRequestInputs:
     def guidance_scale(self) -> float:
         """Compatibility view for callers that only understand video CFG."""
         return self.guidance.video.cfg_scale
+
+
+LTXCheckpointKind = Literal["distilled", "regular"]
+
+
+def validate_ltx_checkpoint(
+    scheduler_config: Mapping[str, Any],
+    *,
+    expected_kind: LTXCheckpointKind | None,
+    pipeline_name: str,
+) -> None:
+    """Ensure scheduler metadata matches the checkpoint required by a profile."""
+    if expected_kind is None:
+        return
+
+    if expected_kind == "distilled":
+        if scheduler_config.get("use_dynamic_shifting", True) or scheduler_config.get("shift_terminal") is not None:
+            raise ValueError(
+                f"{pipeline_name} requires a merged distilled LTX2 checkpoint; "
+                "the loaded scheduler metadata describes a non-distilled checkpoint."
+            )
+        return
+
+    if not scheduler_config.get("use_dynamic_shifting", False) or scheduler_config.get("shift_terminal") is None:
+        raise ValueError(
+            f"{pipeline_name} requires a regular non-distilled LTX checkpoint; "
+            "the loaded scheduler metadata describes a distilled checkpoint."
+        )
 
 
 def validate_pipeline_request(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -214,6 +214,13 @@ class LTXRuntime(
             pipeline_name=self.__class__.__name__,
             request_sigmas=request_sigmas,
         )
+        phase_lora_controller = getattr(self, "_phase_lora_controller", None)
+        if phase_lora_controller is not None and any(
+            getattr(sampling, "lora_request", None) is not None for sampling in req.sampling_params_list
+        ):
+            raise ValueError(
+                f"{self.__class__.__name__} cannot compose a request LoRA with its internal stage-2 adapter."
+            )
         return self._run_recipe(req, request_inputs, request_sigmas=request_sigmas, image=image)
 
     def _run_recipe(
@@ -331,15 +338,22 @@ class LTXRuntime(
     def interrupt(self):
         return self._interrupt
 
+    @property
+    def denoise_transformer(self) -> nn.Module:
+        controller = getattr(self, "_phase_lora_controller", None)
+        if controller is not None:
+            return controller.transformer
+        return self.transformer
+
     def _transformer_cache_context(self, context_name: str):
-        cache_context = getattr(self.transformer, "cache_context", None)
+        cache_context = getattr(self.denoise_transformer, "cache_context", None)
         if callable(cache_context):
             return cache_context(context_name)
         return nullcontext()
 
     def predict_noise(self, **kwargs):
         with self._transformer_cache_context("cond_uncond"):
-            noise_pred_video, noise_pred_audio = self.transformer(**kwargs)
+            noise_pred_video, noise_pred_audio = self.denoise_transformer(**kwargs)
         return noise_pred_video.float(), noise_pred_audio.float()
 
     def combine_cfg_noise(
@@ -510,7 +524,7 @@ class LTXRuntime(
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         latents = self.prepare_latents(
             batch_size=prompt_context.batch_size * request_inputs.num_videos_per_prompt,
-            num_channels_latents=self.transformer.config.in_channels,
+            num_channels_latents=self.denoise_transformer.config.in_channels,
             height=request_inputs.height,
             width=request_inputs.width,
             num_frames=request_inputs.num_frames,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -728,6 +728,7 @@ class LTXRuntime(
             noise_pred_audio,
             timestep,
         )
+        audio = latent_ops.clear_audio_padding(audio, forward_ctx.original_audio_num_frames)
         return latent_ops.LTXAVState(video=video, audio=audio)
 
     def _unpack_and_denormalize_stage(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -214,8 +214,8 @@ class LTXRuntime(
             pipeline_name=self.__class__.__name__,
             request_sigmas=request_sigmas,
         )
-        phase_lora_controller = getattr(self, "_phase_lora_controller", None)
-        if phase_lora_controller is not None and any(
+        phase_adapter = getattr(self, "_phase_adapter", None)
+        if phase_adapter is not None and any(
             getattr(sampling, "lora_request", None) is not None for sampling in req.sampling_params_list
         ):
             raise ValueError(
@@ -340,9 +340,9 @@ class LTXRuntime(
 
     @property
     def denoise_transformer(self) -> nn.Module:
-        controller = getattr(self, "_phase_lora_controller", None)
-        if controller is not None:
-            return controller.transformer
+        phase_adapter = getattr(self, "_phase_adapter", None)
+        if phase_adapter is not None:
+            return phase_adapter.transformer
         return self.transformer
 
     def _transformer_cache_context(self, context_name: str):

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -47,6 +47,7 @@ from .ltx2_guidance import (
     LTXGuidanceExecutor,
     LTXGuidancePlan,
 )
+from .ltx2_phase_weights import LTXPhaseWeights, build_ltx_phase_weights
 from .ltx2_recipes import (
     LTXPhaseRecipe,
     LTXPipelineRecipe,
@@ -150,6 +151,7 @@ class LTXRuntime(
         super().__init__()
         self._guidance_plan = LTXGuidancePlan.build(self.pipeline_recipe.request_guidance)
         initialize_pipeline_components(self, od_config)
+        self._phase_weights: LTXPhaseWeights | None = build_ltx_phase_weights(self)
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
@@ -205,6 +207,8 @@ class LTXRuntime(
             max_sequence_length=max_sequence_length,
         )
         image = self._resolve_request_image(req, image, request_inputs)
+        if image is not None and not self.support_image_input:
+            raise ValueError(f"{self.__class__.__name__} does not support `image` input.")
         request_sigmas = self._resolve_request_sigmas(req, sigmas)
         validate_pipeline_request(
             request_inputs,
@@ -214,12 +218,12 @@ class LTXRuntime(
             pipeline_name=self.__class__.__name__,
             request_sigmas=request_sigmas,
         )
-        phase_adapter = getattr(self, "_phase_adapter", None)
-        if phase_adapter is not None and any(
+        phase_weights = getattr(self, "_phase_weights", None)
+        if phase_weights is not None and any(
             getattr(sampling, "lora_request", None) is not None for sampling in req.sampling_params_list
         ):
             raise ValueError(
-                f"{self.__class__.__name__} cannot compose a request LoRA with its internal stage-2 adapter."
+                f"{self.__class__.__name__} cannot compose a request LoRA with its internal phase adapter."
             )
         return self._run_recipe(req, request_inputs, request_sigmas=request_sigmas, image=image)
 
@@ -265,8 +269,20 @@ class LTXRuntime(
         return self.decode_phase(output_phase)
 
     def _enter_phase(self, phase: LTXPhaseRecipe) -> None:
-        """Hook for a future phase-weight strategy."""
         self._active_phase_name = phase.name
+        phase_weights = getattr(self, "_phase_weights", None)
+        if phase_weights is None:
+            if phase.adapter_slot is not None:
+                raise RuntimeError(f"LTX phase {phase.name!r} requires adapter slot {phase.adapter_slot!r}.")
+            return
+        phase_weights.activate(phase.adapter_slot)
+
+    def eval(self):
+        result = super().eval()
+        phase_weights = getattr(self, "_phase_weights", None)
+        if phase_weights is not None:
+            phase_weights.finalize()
+        return result
 
     def prepare_latents(
         self,
@@ -340,9 +356,9 @@ class LTXRuntime(
 
     @property
     def denoise_transformer(self) -> nn.Module:
-        phase_adapter = getattr(self, "_phase_adapter", None)
-        if phase_adapter is not None:
-            return phase_adapter.transformer
+        phase_weights = getattr(self, "_phase_weights", None)
+        if phase_weights is not None:
+            return phase_weights.transformer
         return self.transformer
 
     def _transformer_cache_context(self, context_name: str):
@@ -865,4 +881,7 @@ class LTXRuntime(
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        phase_weights = getattr(self, "_phase_weights", None)
+        if phase_weights is not None:
+            weights = phase_weights.prepare_weights(weights)
         return AutoWeightsLoader(self).load_weights(weights)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -141,6 +141,12 @@ class LTXRuntime(
         self.model_version = detect_ltx_model_version(od_config.model)
         self.component_profile = resolve_ltx_component_profile(self.pipeline_kind, self.model_version)
         self.pipeline_recipe = resolve_ltx_pipeline_recipe(self.pipeline_kind, self.model_version)
+        if getattr(od_config, "cache_backend", "none") == "cache_dit" and not self.pipeline_recipe.supports_cache_dit:
+            raise ValueError(
+                f"{self.__class__.__name__} does not support cache_backend='cache_dit'. "
+                "Cache-DiT currently supports only one-stage LTX recipes; multi-stage recipes require "
+                "phase-aware cache enable and refresh."
+            )
         self._dit_modules = list(self.component_profile.dit_modules)
         self._encoder_modules = list(self.component_profile.encoder_modules)
         self._vae_modules = list(self.component_profile.vae_modules)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -2106,6 +2106,7 @@ class LTX2VideoTransformer3DModel(nn.Module):
             Set of parameter names that were successfully loaded.
         """
         params_dict = dict(self.named_parameters())
+        phase_adapter_parameter_name = getattr(self, "_phase_adapter_parameter_name", None)
         tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank() if tp_size > 1 else 0
         loaded_params: set[str] = set()
@@ -2130,6 +2131,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 if weight_name not in name:
                     continue
                 packed_name = name.replace(weight_name, param_name)
+                if callable(phase_adapter_parameter_name):
+                    packed_name = phase_adapter_parameter_name(packed_name)
                 if packed_name not in params_dict:
                     continue
                 name = packed_name
@@ -2138,6 +2141,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                if callable(phase_adapter_parameter_name):
+                    name = phase_adapter_parameter_name(name)
                 if name not in params_dict:
                     logger.warning(
                         "Skipping transformer weight %s -- not found in model "

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -396,10 +396,9 @@ class LTX2AudioVideoAttnProcessor:
             return None
 
         if self._is_sp_enabled():
-            # In SP, Ulysses expects a 2D padding mask that matches query length.
-            # For cross-attention, encoder sequence length != query length, so drop the mask.
-            if encoder_hidden_states is not None and encoder_hidden_states.shape[1] != hidden_states.shape[1]:
-                return None
+            # Ulysses consumes a replicated 2D key-padding mask after Q/K/V
+            # all-to-all. This also supports cross-attention where Q and K have
+            # different sequence lengths.
             return to_ltx_padding_mask(attention_mask)
 
         attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
@@ -1836,6 +1835,7 @@ class LTX2VideoTransformer3DModel(nn.Module):
         audio_sigma: torch.Tensor | None = None,
         encoder_attention_mask: torch.Tensor | None = None,
         audio_encoder_attention_mask: torch.Tensor | None = None,
+        audio_attention_mask: torch.Tensor | None = None,
         num_frames: int | None = None,
         height: int | None = None,
         width: int | None = None,
@@ -1869,6 +1869,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)`.
             audio_encoder_attention_mask (`torch.Tensor`, *optional*):
                 Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)` for audio modeling.
+            audio_attention_mask (`torch.Tensor`, *optional*):
+                Optional audio-token key padding mask shared by audio self-attention and audio-to-video attention.
             num_frames (`int`, *optional*):
                 The number of latent video frames. Used if calculating the video coordinates for RoPE.
             height (`int`, *optional*):
@@ -2052,6 +2054,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 "ca_audio_rotary_emb": audio_cross_attn_rotary_emb,
                 "encoder_attention_mask": encoder_attention_mask,
                 "audio_encoder_attention_mask": audio_encoder_attention_mask,
+                "audio_self_attention_mask": audio_attention_mask,
+                "a2v_cross_attention_mask": audio_attention_mask,
                 "video_self_attention_perturbation_mask": perturbation_mask_for("video_self_attention", block_idx),
                 "audio_self_attention_perturbation_mask": perturbation_mask_for("audio_self_attention", block_idx),
                 "a2v_cross_attention_perturbation_mask": perturbation_mask_for("a2v_cross_attention", block_idx),

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -355,6 +355,23 @@ def to_ltx_padding_mask(attention_mask: torch.Tensor) -> torch.Tensor:
     return attention_mask
 
 
+class _LTX2ParallelAttention(Attention):
+    """Preserve LTX SP collectives while keeping masked cross-attention key-only."""
+
+    def __init__(self, *args, is_cross_attention: bool, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.is_cross_attention = is_cross_attention
+
+    def _run_local_attention(self, query, key, value, attn_metadata):
+        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+        if self.is_cross_attention and attention_mask is not None:
+            # A 2D LTX cross-attention mask describes K/V padding only. Flash
+            # varlen applies one mask to Q and K when their lengths happen to
+            # match, so use mask-aware SDPA after the SP redistribution.
+            return self.sdpa_fallback.forward(query, key, value, attn_metadata)
+        return super()._run_local_attention(query, key, value, attn_metadata)
+
+
 class LTX2AudioVideoAttnProcessor:
     r"""
     Processor for implementing attention (SDPA is used by default if you're using PyTorch 2.0) for the LTX-2.0 model.
@@ -581,6 +598,7 @@ class LTX2Attention(torch.nn.Module):
         disable_kv_quant: bool = False,
     ):
         super().__init__()
+        is_cross_attention = cross_attention_dim is not None
         # LTX-2 uses "rms_norm_across_heads", LTX-2.3 uses "rms_norm" -- both
         # map to the same RMSNorm implementation applied across Q/K heads.
         if qk_norm not in ("rms_norm_across_heads", "rms_norm"):
@@ -695,7 +713,7 @@ class LTX2Attention(torch.nn.Module):
                 torch.nn.Dropout(dropout) if dropout > 0 else torch.nn.Identity(),
             ]
         )
-        self.attn = Attention(
+        self.attn = _LTX2ParallelAttention(
             num_heads=self.query_num_heads,
             head_size=dim_head,
             num_kv_heads=self.kv_num_heads,
@@ -703,6 +721,7 @@ class LTX2Attention(torch.nn.Module):
             causal=False,
             prefix=prefix,
             disable_kv_quant=disable_kv_quant,
+            is_cross_attention=is_cross_attention,
         )
 
         # LTX-2.3: per-head gated attention

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -1498,6 +1498,14 @@ class LTX2VideoTransformer3DModel(nn.Module):
     _layerwise_offload_blocks_attrs = ["transformer_blocks"]
     _hsdp_shard_conditions = [is_transformer_block_module]
     _sp_plan: dict[str, Any] | None = None
+    stacked_params_mapping = (
+        (".attn1.to_qkv", ".attn1.to_q", "q"),
+        (".attn1.to_qkv", ".attn1.to_k", "k"),
+        (".attn1.to_qkv", ".attn1.to_v", "v"),
+        (".audio_attn1.to_qkv", ".audio_attn1.to_q", "q"),
+        (".audio_attn1.to_qkv", ".audio_attn1.to_k", "k"),
+        (".audio_attn1.to_qkv", ".audio_attn1.to_v", "v"),
+    )
     packed_modules_mapping = {
         "to_qkv": ["to_q", "to_k", "to_v"],
     }
@@ -2097,15 +2105,6 @@ class LTX2VideoTransformer3DModel(nn.Module):
         Returns:
             Set of parameter names that were successfully loaded.
         """
-        stacked_params_mapping = [
-            (".attn1.to_qkv", ".attn1.to_q", "q"),
-            (".attn1.to_qkv", ".attn1.to_k", "k"),
-            (".attn1.to_qkv", ".attn1.to_v", "v"),
-            (".audio_attn1.to_qkv", ".audio_attn1.to_q", "q"),
-            (".audio_attn1.to_qkv", ".audio_attn1.to_k", "k"),
-            (".audio_attn1.to_qkv", ".audio_attn1.to_v", "v"),
-        ]
-
         params_dict = dict(self.named_parameters())
         tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank() if tp_size > 1 else 0
@@ -2127,7 +2126,7 @@ class LTX2VideoTransformer3DModel(nn.Module):
             return weight
 
         for name, loaded_weight in weights:
-            for param_name, weight_name, shard_id in stacked_params_mapping:
+            for param_name, weight_name, shard_id in self.stacked_params_mapping:
                 if weight_name not in name:
                     continue
                 packed_name = name.replace(weight_name, param_name)

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -52,9 +52,8 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
         self._phase_lora_controller = LTXResidentLoRAController(self, adapter_path)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loaded = super().load_weights(weights)
-        self._phase_lora_controller.after_weights_loaded()
-        return loaded
+        weights = self._phase_lora_controller.merge_stage2_weights(weights)
+        return super().load_weights(weights)
 
     def _enter_phase(self, phase: LTXPhaseRecipe) -> None:
         self._phase_lora_controller.enter(phase.transformer_phase)

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 import torch
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 
+from .ltx2_adapter_parser import LTXAdapterParser
 from .ltx2_components import (
     LTX2_DISTILLED_COMPONENT_PROFILE,
     LTX2_TWO_STAGE_COMPONENT_PROFILE,
@@ -17,6 +18,7 @@ from .ltx2_components import (
     get_ltx2_post_process_func as get_ltx2_post_process_func,  # noqa: F401
 )
 from .ltx2_lora import LTXResidentLoRAController
+from .ltx2_phase_adapter import LTXPhaseAdapterRuntime
 from .ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_TWO_STAGE_RECIPE,
@@ -36,6 +38,8 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
+        self._phase_adapter: LTXResidentLoRAController | LTXPhaseAdapterRuntime | None = None
+        self._resident_lora_controller: LTXResidentLoRAController | None = None
         profile = self.component_profile
         if getattr(od_config, "lora_path", None) is not None:
             raise ValueError(
@@ -44,19 +48,50 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
             )
         if profile.artifact_repo_id is None or profile.distilled_lora_filename is None:
             raise ValueError(f"{profile.name} does not declare a stage-2 adapter.")
+        model_config = getattr(od_config, "model_config", {}) or {}
+        lora_mode = model_config.get("ltx_two_stage_lora_mode", "resident")
+        if lora_mode not in {"resident", "dynamic"}:
+            raise ValueError(
+                "model_config.ltx_two_stage_lora_mode must be either 'resident' or 'dynamic', "
+                f"got {lora_mode!r}."
+            )
+        model_paths = getattr(od_config, "model_paths", {}) or {}
         adapter_path = resolve_ltx_artifact(
             od_config.model,
             profile.artifact_repo_id,
             profile.distilled_lora_filename,
+            explicit_path=model_paths.get("distilled_lora"),
         )
-        self._phase_lora_controller = LTXResidentLoRAController(self, adapter_path)
+        if lora_mode == "resident":
+            self._resident_lora_controller = LTXResidentLoRAController(self, adapter_path)
+            self._phase_adapter = self._resident_lora_controller
+        else:
+            manifest = LTXAdapterParser(self.transformer).parse(adapter_path, name="ltx_distilled")
+            self._phase_adapter = LTXPhaseAdapterRuntime(self.transformer, manifest, dtype=od_config.dtype)
+            self._phase_adapter.install_structure()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        weights = self._phase_lora_controller.merge_stage2_weights(weights)
+        if self._resident_lora_controller is not None:
+            weights = self._resident_lora_controller.merge_stage2_weights(weights)
         return super().load_weights(weights)
 
+    def eval(self):
+        """Materialize dynamic adapter buffers after loading the base weights."""
+        result = super().eval()
+        if isinstance(self._phase_adapter, LTXPhaseAdapterRuntime):
+            self._phase_adapter.finalize_adapter_data()
+        return result
+
     def _enter_phase(self, phase: LTXPhaseRecipe) -> None:
-        self._phase_lora_controller.enter(phase.transformer_phase)
+        adapter = self._phase_adapter
+        if adapter is None:
+            raise RuntimeError(f"Transformer phase {phase.transformer_phase!r} requires a stage adapter controller.")
+        if phase.transformer_phase == "base":
+            adapter.set_active(None)
+        elif phase.transformer_phase == "distilled_lora":
+            adapter.set_active("ltx_distilled")
+        else:
+            raise ValueError(f"Unsupported LTX Transformer phase: {phase.transformer_phase!r}.")
 
 
 class LTX2DistilledPipeline(LTX2Pipeline):

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -1,16 +1,63 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Distilled two-stage entry points for the LTX model family."""
+"""Two-stage entry points for the LTX model family."""
 
+from collections.abc import Iterable
+
+import torch
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 
-from .ltx2_components import LTX2_DISTILLED_COMPONENT_PROFILE
+from .ltx2_components import (
+    LTX2_DISTILLED_COMPONENT_PROFILE,
+    LTX2_TWO_STAGE_COMPONENT_PROFILE,
+    resolve_ltx_artifact,
+)
 from .ltx2_components import (
     get_ltx2_post_process_func as get_ltx2_post_process_func,  # noqa: F401
 )
-from .ltx2_recipes import LTX2_DISTILLED_TWO_STAGE_RECIPE
+from .ltx2_lora import LTXResidentLoRAController
+from .ltx2_recipes import (
+    LTX2_DISTILLED_TWO_STAGE_RECIPE,
+    LTX2_TWO_STAGE_RECIPE,
+    LTXPhaseRecipe,
+)
 from .pipeline_ltx2 import LTX2Pipeline
+
+
+class LTX2TwoStagePipeline(LTX2Pipeline):
+    """Regular checkpoint with low-resolution generation and LoRA refinement."""
+
+    pipeline_kind = "two_stage"
+    component_profile = LTX2_TWO_STAGE_COMPONENT_PROFILE
+    pipeline_recipe = LTX2_TWO_STAGE_RECIPE
+    supports_request_batch = False
+    support_image_input = False
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__(od_config=od_config, prefix=prefix)
+        profile = self.component_profile
+        if getattr(od_config, "lora_path", None) is not None:
+            raise ValueError(
+                f"{self.__class__.__name__} reserves LoRA execution for its stage-2 distilled adapter; "
+                "request or static LoRA composition is not supported yet."
+            )
+        if profile.artifact_repo_id is None or profile.distilled_lora_filename is None:
+            raise ValueError(f"{profile.name} does not declare a stage-2 adapter.")
+        adapter_path = resolve_ltx_artifact(
+            od_config.model,
+            profile.artifact_repo_id,
+            profile.distilled_lora_filename,
+        )
+        self._phase_lora_controller = LTXResidentLoRAController(self, adapter_path)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loaded = super().load_weights(weights)
+        self._phase_lora_controller.after_weights_loaded()
+        return loaded
+
+    def _enter_phase(self, phase: LTXPhaseRecipe) -> None:
+        self._phase_lora_controller.enter(phase.transformer_phase)
 
 
 class LTX2DistilledPipeline(LTX2Pipeline):

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -27,7 +27,7 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
 
 
 class LTX2DistilledPipeline(LTX2Pipeline):
-    """Unified LTX-2 distilled two-stage T2V/I2V entry."""
+    """Unified LTX-2/LTX-2.3 full-distilled two-stage T2V/I2V entry."""
 
     pipeline_kind = "distilled_two_stage"
     component_profile = LTX2_DISTILLED_COMPONENT_PROFILE

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -3,26 +3,16 @@
 
 """Two-stage entry points for the LTX model family."""
 
-from collections.abc import Iterable
-
-import torch
-from vllm_omni.diffusion.data import OmniDiffusionConfig
-
-from .ltx2_adapter_parser import LTXAdapterParser
 from .ltx2_components import (
     LTX2_DISTILLED_COMPONENT_PROFILE,
     LTX2_TWO_STAGE_COMPONENT_PROFILE,
-    resolve_ltx_artifact,
 )
 from .ltx2_components import (
     get_ltx2_post_process_func as get_ltx2_post_process_func,  # noqa: F401
 )
-from .ltx2_lora import LTXResidentLoRAController
-from .ltx2_phase_adapter import LTXPhaseAdapterRuntime
 from .ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_TWO_STAGE_RECIPE,
-    LTXPhaseRecipe,
 )
 from .pipeline_ltx2 import LTX2Pipeline
 
@@ -36,63 +26,6 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
     supports_request_batch = False
     support_image_input = False
 
-    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
-        super().__init__(od_config=od_config, prefix=prefix)
-        self._phase_adapter: LTXResidentLoRAController | LTXPhaseAdapterRuntime | None = None
-        self._resident_lora_controller: LTXResidentLoRAController | None = None
-        profile = self.component_profile
-        if getattr(od_config, "lora_path", None) is not None:
-            raise ValueError(
-                f"{self.__class__.__name__} reserves LoRA execution for its stage-2 distilled adapter; "
-                "request or static LoRA composition is not supported yet."
-            )
-        if profile.artifact_repo_id is None or profile.distilled_lora_filename is None:
-            raise ValueError(f"{profile.name} does not declare a stage-2 adapter.")
-        model_config = getattr(od_config, "model_config", {}) or {}
-        lora_mode = model_config.get("ltx_two_stage_lora_mode", "resident")
-        if lora_mode not in {"resident", "dynamic"}:
-            raise ValueError(
-                "model_config.ltx_two_stage_lora_mode must be either 'resident' or 'dynamic', "
-                f"got {lora_mode!r}."
-            )
-        model_paths = getattr(od_config, "model_paths", {}) or {}
-        adapter_path = resolve_ltx_artifact(
-            od_config.model,
-            profile.artifact_repo_id,
-            profile.distilled_lora_filename,
-            explicit_path=model_paths.get("distilled_lora"),
-        )
-        if lora_mode == "resident":
-            self._resident_lora_controller = LTXResidentLoRAController(self, adapter_path)
-            self._phase_adapter = self._resident_lora_controller
-        else:
-            manifest = LTXAdapterParser(self.transformer).parse(adapter_path, name="ltx_distilled")
-            self._phase_adapter = LTXPhaseAdapterRuntime(self.transformer, manifest, dtype=od_config.dtype)
-            self._phase_adapter.install_structure()
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        if self._resident_lora_controller is not None:
-            weights = self._resident_lora_controller.merge_stage2_weights(weights)
-        return super().load_weights(weights)
-
-    def eval(self):
-        """Materialize dynamic adapter buffers after loading the base weights."""
-        result = super().eval()
-        if isinstance(self._phase_adapter, LTXPhaseAdapterRuntime):
-            self._phase_adapter.finalize_adapter_data()
-        return result
-
-    def _enter_phase(self, phase: LTXPhaseRecipe) -> None:
-        adapter = self._phase_adapter
-        if adapter is None:
-            raise RuntimeError(f"Transformer phase {phase.transformer_phase!r} requires a stage adapter controller.")
-        if phase.transformer_phase == "base":
-            adapter.set_active(None)
-        elif phase.transformer_phase == "distilled_lora":
-            adapter.set_active("ltx_distilled")
-        else:
-            raise ValueError(f"Unsupported LTX Transformer phase: {phase.transformer_phase!r}.")
-
 
 class LTX2DistilledPipeline(LTX2Pipeline):
     """Unified LTX-2 distilled two-stage T2V/I2V entry."""
@@ -103,6 +36,3 @@ class LTX2DistilledPipeline(LTX2Pipeline):
     supports_request_batch = False
     support_image_input = True
     unified_text_image_entry = True
-
-    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
-        super().__init__(od_config=od_config, prefix=prefix)

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -24,7 +24,6 @@ class LTX2TwoStagePipeline(LTX2Pipeline):
     component_profile = LTX2_TWO_STAGE_COMPONENT_PROFILE
     pipeline_recipe = LTX2_TWO_STAGE_RECIPE
     supports_request_batch = False
-    support_image_input = False
 
 
 class LTX2DistilledPipeline(LTX2Pipeline):

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -71,6 +71,11 @@ _DIFFUSION_MODELS = {
         "pipeline_ltx2",
         "LTX2Pipeline",
     ),
+    "LTX2TwoStagePipeline": (
+        "ltx2",
+        "pipeline_ltx2_two_stage",
+        "LTX2TwoStagePipeline",
+    ),
     "LTX2DistilledPipeline": (
         "ltx2",
         "pipeline_ltx2_two_stage",
@@ -499,6 +504,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "WanPipeline": "get_wan22_post_process_func",
     "WanVACEPipeline": "get_wan22_vace_post_process_func",
     "LTX2Pipeline": "get_ltx2_post_process_func",
+    "LTX2TwoStagePipeline": "get_ltx2_post_process_func",
     "LTX2DistilledPipeline": "get_ltx2_post_process_func",
     "LTX2T2VDMD2Pipeline": "get_ltx2_post_process_func",
     "LTX2I2VDMD2Pipeline": "get_ltx2_post_process_func",

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -231,6 +231,7 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
         }
         for model_class_name in (
             "LTX2Pipeline",
+            "LTX2TwoStagePipeline",
             "LTX2DistilledPipeline",
         )
     },


### PR DESCRIPTION
## Summary

- add ordinary and full-distilled LTX two-stage T2V/I2V pipelines for LTX-2 and LTX-2.3
- share the one-stage runtime while making phase recipes, latent transition, and phase-weight binding explicit
- default ordinary two-stage to dynamic LoRA, with a resident mode for official BF16-aligned arithmetic
- fix stage-one audio selection, Euler scalar arithmetic, video token layout, SP audio padding, and Ulysses cross-attention with unequal Q/K lengths
- reject unsupported Cache-DiT and resident serialized-quant combinations instead of silently degrading
- expand the official-reference accuracy harness to 19 one-stage, distilled, ordinary, resident, and dynamic T2V/I2V cases

## Scope

This builds on the LTX guidance and precision refactor merged in #5148 and is tracked by #4985.

HQ and Res2s are intentionally excluded from this PR because they introduce a separate sampler, schedule, and phase-strength math. They should be reviewed independently after ordinary two-stage support lands.

## Validation

- `249 passed` across the affected LTX, attention-config, and model-extra unit tests
- Ulysses unequal-length cross-attention baselines pass for SP=2 and SP=4
- all 19 accuracy cases collect successfully
- pre-commit passes on all changed files
- every commit carries a DCO sign-off
