### PR TITLE
[ROCm] Dispatch AR-Diffusion paged KV attention to AITER

### DIFF
--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -354,6 +354,63 @@ def test_prepare_is_idempotent_and_layers_share_metadata():
     assert i0.video_slots is i1.video_slots
 
 
+def test_packed_kv_index_is_published_once_and_reused_by_every_layer():
+    """The packed-varlen gather index is a function of the block table, so
+    prepare() builds it for all layers. Reusing it must give exactly what an
+    inline per-layer build gives, and metadata that was not the published one
+    must fall back rather than gather through a foreign index."""
+    from vllm_omni.experimental.ar_diffusion.kv_cache import paged_attention as pa
+
+    device = torch.device("cpu")
+    _, st = make_state(num_layers=2, window_chunks=2)
+    contexts = st.get_kv_caches(POS, seq_len=BLOCK, commit_current=True)
+    fctx = contexts[0].forward_ctx
+    fctx.prepare(device=device, action_len=0, query_len=BLOCK)
+
+    page = fctx.block_size
+    block_table, seq_lens = fctx.block_table, fctx.seq_lens
+    num_blocks = int(block_table.max()) + 1
+    key_cache = torch.randn(num_blocks, page, N_HEADS, HEAD_DIM)
+    value_cache = torch.randn(num_blocks, page, N_HEADS, HEAD_DIM)
+
+    saved = pa._CURRENT_PACKED_KV_INDEX
+    try:
+        pa._CURRENT_PACKED_KV_INDEX = None
+        k_inline, v_inline, cu_inline = pa._pack_paged_kv(key_cache, value_cache, block_table, seq_lens)
+
+        flat, cu = pa._build_packed_kv_index(block_table, seq_lens, page)
+        pa.set_current_packed_kv_index(block_table, seq_lens, page, flat, cu)
+        k_hit, v_hit, cu_hit = pa._pack_paged_kv(key_cache, value_cache, block_table, seq_lens)
+
+        assert torch.equal(k_hit, k_inline)
+        assert torch.equal(v_hit, v_inline)
+        assert torch.equal(cu_hit, cu_inline)
+        assert pa._prepared_packed_kv_index(block_table, seq_lens, page) is not None
+
+        # Another forward's metadata, or another pool's page size, is not a hit.
+        assert pa._prepared_packed_kv_index(block_table.clone(), seq_lens, page) is None
+        assert pa._prepared_packed_kv_index(block_table, seq_lens.clone(), page) is None
+        assert pa._prepared_packed_kv_index(block_table, seq_lens, page * 2) is None
+    finally:
+        pa._CURRENT_PACKED_KV_INDEX = saved
+
+
+def test_prepare_publishes_the_index_only_on_the_aiter_path():
+    """CPU and non-ROCm CUDA reach the reference / vllm_flash_attn paths, which
+    never pack, so prepare() must not leave an index behind for them."""
+    from vllm_omni.experimental.ar_diffusion.kv_cache import paged_attention as pa
+
+    saved = pa._CURRENT_PACKED_KV_INDEX
+    try:
+        pa._CURRENT_PACKED_KV_INDEX = None
+        _, st = make_state()
+        fctx = st.get_kv_caches(POS, seq_len=BLOCK, commit_current=False)[0].forward_ctx
+        fctx.prepare(device=torch.device("cpu"), action_len=0, query_len=BLOCK)
+        assert pa._CURRENT_PACKED_KV_INDEX is None
+    finally:
+        pa._CURRENT_PACKED_KV_INDEX = saved
+
+
 def test_layer_inputs_before_prepare_raises():
     _, st = make_state()
     layer_ctx = st.get_kv_caches(POS, seq_len=BLOCK, commit_current=False)[0]

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -60,6 +60,13 @@ def _dense_attention(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
     return torch.einsum("bhqk,bkhd->bqhd", probs, value)
 
 
+def _rocm_flash_attn_usable() -> bool:
+    """ROCm reaches the paged kernel through aiter's vLLM provider, not vllm.vllm_flash_attn."""
+    from vllm.platforms import current_platform
+
+    return current_platform.is_rocm() and find_spec("aiter") is not None and find_spec("vllm._aiter_ops") is not None
+
+
 def _cuda_flash_attn_usable() -> bool:
     if not torch.cuda.is_available():
         return False
@@ -227,12 +234,16 @@ def test_paged_attention_matches_dense_reference_cpu(history_chunks, action_len,
     assert st.adapter(POS).completed_chunks == before + (1 if commit_current else 0)
 
 
-@pytest.mark.skipif(not _cuda_flash_attn_usable(), reason="usable CUDA FlashAttention is required")
+@pytest.mark.skipif(
+    not (_cuda_flash_attn_usable() or _rocm_flash_attn_usable()),
+    reason="a usable CUDA FlashAttention or ROCm aiter is required",
+)
 @pytest.mark.parametrize("history_chunks", [1, 3])
 @pytest.mark.parametrize("action_len", [0, 3])
 @pytest.mark.parametrize("commit_current", [False, True])
 def test_paged_attention_matches_dense_reference_gpu(history_chunks, action_len, commit_current):
-    pytest.importorskip("vllm.vllm_flash_attn")
+    if not _rocm_flash_attn_usable():
+        pytest.importorskip("vllm.vllm_flash_attn")
     torch.manual_seed(0)
     device = torch.device("cuda")
     dtype = torch.float16

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -25,6 +25,25 @@ def set_current_paged_kv_cache(kv_cache: Any) -> None:
     _CURRENT_PAGED_KV_CACHE = kv_cache
 
 
+# Packed-varlen gather index published by prepare() on the aiter path, same lifetime as
+# the pool registry above. It depends only on (block_table, seq_lens, page), which every
+# layer of one forward shares, so one build serves all of them. Kept next to the tensors
+# it was built from because ar_diffusion_paged_attention() is also reachable without a
+# prepare() (tests call it directly), and those calls must not pick up a stale index.
+_CURRENT_PACKED_KV_INDEX: tuple[torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor] | None = None
+
+
+def set_current_packed_kv_index(
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page: int,
+    flat: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+) -> None:
+    global _CURRENT_PACKED_KV_INDEX
+    _CURRENT_PACKED_KV_INDEX = (block_table, seq_lens, page, flat, cu_seqlens_k)
+
+
 _LAYER_IDX_TENSORS: dict[int, torch.Tensor] = {}
 
 
@@ -217,6 +236,11 @@ class ARDiffusionPagedForwardContext:
         the padded block-table metadata ONCE for all layers, and publishes the
         pool registry for the fused custom op. The compiled per-layer code then
         only consumes prebuilt tensors via ``ARDiffusionPagedLayerInputs``.
+
+        On the aiter path it also builds the packed-varlen gather index here, for
+        the same reason and with the same reach: it is a function of the block
+        table, so rebuilding it per layer costs 40x its 22 kernels and 3 host
+        syncs for an identical answer.
         """
         if getattr(self, "_prepared", False):
             return
@@ -230,6 +254,10 @@ class ARDiffusionPagedForwardContext:
         ) = self.build_block_table(action_len=action_len, query_len=query_len, device=device)
         if self.action_slot_mapping is None:
             self.action_slot_mapping = torch.empty(0, dtype=torch.long, device=device)
+        if device.type == "cuda" and _rocm_varlen_fa() is not None:
+            page = self.block_size
+            flat, cu_seqlens_k = _build_packed_kv_index(self.block_table, self.seq_lens, page)
+            set_current_packed_kv_index(self.block_table, self.seq_lens, page, flat, cu_seqlens_k)
         set_current_paged_kv_cache(self.kv_cache)
         self._prepared = True
 
@@ -386,6 +414,55 @@ def _rocm_varlen_fa() -> Callable[..., Any] | None:
     return rocm_aiter_ops.flash_attn_varlen_func if is_aiter_found() else None
 
 
+def _build_packed_kv_index(
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flat gather index into the K/V pool, plus ``cu_seqlens_k``, for the packed layout.
+
+    Pure function of the block table, the sequence lengths and the page size, so one
+    build serves every layer of a forward. ``prepare()`` calls this; ``_pack_paged_kv``
+    falls back to it when there is no prepared index to reuse.
+    """
+    lens = seq_lens.to(torch.int64)
+    cu_seqlens_k = torch.cat([lens.new_zeros(1), lens.cumsum(0)])
+    total = int(cu_seqlens_k[-1])
+    seq_id = torch.repeat_interleave(
+        torch.arange(lens.numel(), device=lens.device),
+        lens,
+    )
+    pos = torch.arange(total, device=lens.device) - cu_seqlens_k[seq_id]
+    logical = torch.div(pos, page, rounding_mode="floor")
+    flat = block_table[seq_id, logical].to(torch.int64) * page + pos % page
+    return flat, cu_seqlens_k.to(torch.int32)
+
+
+def _prepared_packed_kv_index(
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page: int,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """The index ``prepare()`` published for these metadata tensors, or ``None``.
+
+    Matched on storage rather than object identity: the compiled block hands the op
+    whatever inductor holds for those graph inputs, which need not be the same python
+    object ``prepare()`` stored. Holding a reference to the originals keeps their
+    storage alive, so a matching ``data_ptr`` cannot be a recycled address.
+    """
+    prepared = _CURRENT_PACKED_KV_INDEX
+    if prepared is None:
+        return None
+    kept_block_table, kept_seq_lens, kept_page, flat, cu_seqlens_k = prepared
+    if kept_page != page:
+        return None
+    if kept_block_table.data_ptr() != block_table.data_ptr() or kept_block_table.shape != block_table.shape:
+        return None
+    if kept_seq_lens.data_ptr() != seq_lens.data_ptr() or kept_seq_lens.shape != seq_lens.shape:
+        return None
+    return flat, cu_seqlens_k
+
+
 def _pack_paged_kv(
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
@@ -397,25 +474,16 @@ def _pack_paged_kv(
     KV is gathered because aiter has no usable paged path for this cache -- passing it a
     ``block_table`` faults the GPU on gfx950. The copy runs at HBM bandwidth, 3-7% of
     attention time.
-
-    TODO: build the index once per forward rather than per layer. It depends only on the block
-    table, and per layer its flat ~0.055ms is 1-22% of attention time, worst at small windows.
     """
     page = key_cache.shape[1]
-    lens = seq_lens.to(torch.int64)
-    cu_seqlens_k = torch.cat([lens.new_zeros(1), lens.cumsum(0)])
-    total = int(cu_seqlens_k[-1])
-    seq_id = torch.repeat_interleave(
-        torch.arange(lens.numel(), device=lens.device),
-        lens,
-    )
-    pos = torch.arange(total, device=lens.device) - cu_seqlens_k[seq_id]
-    logical = torch.div(pos, page, rounding_mode="floor")
-    flat = block_table[seq_id, logical].to(torch.int64) * page + pos % page
+    index = _prepared_packed_kv_index(block_table, seq_lens, page)
+    if index is None:
+        index = _build_packed_kv_index(block_table, seq_lens, page)
+    flat, cu_seqlens_k = index
     return (
         key_cache.flatten(0, 1)[flat],
         value_cache.flatten(0, 1)[flat],
-        cu_seqlens_k.to(torch.int32),
+        cu_seqlens_k,
     )
 
 

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
 
@@ -365,6 +366,65 @@ def _resolve_fa_version(head_size: int) -> int:
     return version
 
 
+_ROCM_VARLEN_FA: Callable[..., Any] | None = None
+_ROCM_VARLEN_FA_RESOLVED = False
+
+
+def _rocm_varlen_fa() -> Callable[..., Any] | None:
+    """aiter's varlen attention via vLLM's ``_aiter_ops``, or ``None`` off ROCm / without aiter.
+
+    Ungated by ``VLLM_ROCM_USE_AITER``, like the provider itself (vllm-project/vllm#33749),
+    since aiter is the only working kernel here. Resolved once: ``find_spec`` is not traceable.
+    """
+    global _ROCM_VARLEN_FA, _ROCM_VARLEN_FA_RESOLVED
+    if not _ROCM_VARLEN_FA_RESOLVED:
+        _ROCM_VARLEN_FA_RESOLVED = True
+        from vllm.platforms import current_platform
+
+        if current_platform.is_rocm():
+            try:
+                from vllm._aiter_ops import is_aiter_found, rocm_aiter_ops
+            except ImportError:
+                pass
+            else:
+                if is_aiter_found():
+                    _ROCM_VARLEN_FA = rocm_aiter_ops.flash_attn_varlen_func
+    return _ROCM_VARLEN_FA
+
+
+def _pack_paged_kv(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Copy paged K/V into the packed varlen layout, returning ``(k, v, cu_seqlens_k)``.
+
+    KV is gathered because aiter has no usable paged path for this cache -- passing it a
+    ``block_table`` faults the GPU on gfx950. The copy runs at HBM bandwidth, 3-7% of
+    attention time.
+
+    TODO: build the index once per forward rather than per layer. It depends only on the block
+    table, and per layer its flat ~0.055ms is 1-22% of attention time, worst at small windows.
+    """
+    page = key_cache.shape[1]
+    lens = seq_lens.to(torch.int64)
+    cu_seqlens_k = torch.cat([lens.new_zeros(1), lens.cumsum(0)])
+    total = int(cu_seqlens_k[-1])
+    seq_id = torch.repeat_interleave(
+        torch.arange(lens.numel(), device=lens.device),
+        lens,
+    )
+    pos = torch.arange(total, device=lens.device) - cu_seqlens_k[seq_id]
+    logical = torch.div(pos, page, rounding_mode="floor")
+    flat = block_table[seq_id, logical].to(torch.int64) * page + pos % page
+    return (
+        key_cache.flatten(0, 1)[flat],
+        value_cache.flatten(0, 1)[flat],
+        cu_seqlens_k.to(torch.int32),
+    )
+
+
 def ar_diffusion_paged_attention(
     query: torch.Tensor,
     key_cache: torch.Tensor,
@@ -390,6 +450,8 @@ def ar_diffusion_paged_attention(
     else:
         query_flat = query
 
+    rocm_fa = _rocm_varlen_fa() if query_flat.is_cuda else None
+
     if not query_flat.is_cuda:
         out = _reference_paged_attention(
             query_flat,
@@ -401,6 +463,25 @@ def ar_diffusion_paged_attention(
             softmax_scale,
             causal=causal,
         )
+    elif rocm_fa is not None:
+        packed_k, packed_v, cu_seqlens_k = _pack_paged_kv(key_cache, value_cache, block_table, seq_lens)
+        out = rocm_fa(
+            q=query_flat,
+            k=packed_k,
+            v=packed_v,
+            cu_seqlens_q=query_start_loc.to(torch.int32),
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=int(max_query_len),
+            max_seqlen_k=int(max_seq_len),
+            softmax_scale=float(softmax_scale),
+            causal=causal,
+            # The provider forwards None for these two, which aiter rejects; both values below
+            # are aiter's own defaults, i.e. no sliding window and no minimum query length.
+            window_size=(-1, -1),
+            min_seqlen_q=0,
+        )
+        if isinstance(out, (tuple, list)):
+            out = out[0]
     else:
         from vllm.vllm_flash_attn import flash_attn_varlen_func
 

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import cache
 from typing import Any, ClassVar, NamedTuple
 
 import torch
@@ -366,30 +367,23 @@ def _resolve_fa_version(head_size: int) -> int:
     return version
 
 
-_ROCM_VARLEN_FA: Callable[..., Any] | None = None
-_ROCM_VARLEN_FA_RESOLVED = False
-
-
+@cache
 def _rocm_varlen_fa() -> Callable[..., Any] | None:
     """aiter's varlen attention via vLLM's ``_aiter_ops``, or ``None`` off ROCm / without aiter.
 
     Ungated by ``VLLM_ROCM_USE_AITER``, like the provider itself (vllm-project/vllm#33749),
     since aiter is the only working kernel here. Resolved once: ``find_spec`` is not traceable.
+    Same pattern as ``diffusion/attention/selector.py``'s ``_cached_get_backend_cls``.
     """
-    global _ROCM_VARLEN_FA, _ROCM_VARLEN_FA_RESOLVED
-    if not _ROCM_VARLEN_FA_RESOLVED:
-        _ROCM_VARLEN_FA_RESOLVED = True
-        from vllm.platforms import current_platform
+    from vllm.platforms import current_platform
 
-        if current_platform.is_rocm():
-            try:
-                from vllm._aiter_ops import is_aiter_found, rocm_aiter_ops
-            except ImportError:
-                pass
-            else:
-                if is_aiter_found():
-                    _ROCM_VARLEN_FA = rocm_aiter_ops.flash_attn_varlen_func
-    return _ROCM_VARLEN_FA
+    if not current_platform.is_rocm():
+        return None
+    try:
+        from vllm._aiter_ops import is_aiter_found, rocm_aiter_ops
+    except ImportError:
+        return None
+    return rocm_aiter_ops.flash_attn_varlen_func if is_aiter_found() else None
 
 
 def _pack_paged_kv(


### PR DESCRIPTION
## Purpose

On ROCm, every GPU parametrization of `tests/diffusion/ar_diffusion/test_paged_attention.py` fails:

```
ImportError: vllm.vllm_flash_attn requires the CUDA flash attention extensions
(_vllm_fa2_C or _vllm_fa3_C). On ROCm, use upstream flash_attn.
```

`ar_diffusion_paged_attention()` picks its backend with `query_flat.is_cuda`, which is `True` for HIP
tensors. ROCm therefore skips the CPU reference path and lands on the unguarded CUDA-only import.
The diffusion tower's attention path already tries aiter first on ROCm
(`diffusion/attention/backends/utils/fa.py:29-37`); this path never got the equivalent branch.

This PR adds that branch, between the existing CPU and CUDA ones and touching neither, so CUDA
behaviour is unchanged:

- `_rocm_varlen_fa()` resolves aiter's varlen attention once per process, through vLLM's
  `_aiter_ops` provider.
- `_pack_paged_kv()` maps `(block_table, seq_lens)` into aiter's packed varlen layout, vectorized.
- `_build_packed_kv_index()` builds that mapping's gather index, once per forward from `prepare()`.

It gathers KV instead of passing `block_table` to aiter because neither aiter paged entry point fits
this cache: `flash_attn_varlen_func(block_table=...)` faults the GPU on gfx950, and
`mha_batch_prefill_func` only ships bf16 kernels for `page_size ∈ {16, 1024}` while AR-Diffusion
pages at `tokens_per_frame` (1560 at 480p). The copy runs at HBM bandwidth (3.4-4.9 TiB/s) and is
~6% of attention time.

The test guard needed fixing too: `_cuda_flash_attn_usable()` returns `True` on ROCm because its
`ldd` probe raises, which is why these tests fail rather than skip. Without also accepting a
ROCm+aiter platform they would flip to *skipped* instead of passing.

What this PR does not do is route the dispatch itself through the diffusion attention registry and its
per-platform `get_diffusion_attn_backend_cls()` overrides; the branch stays inline. That refactor would
touch the CUDA path, which reviewers without AMD hardware cannot validate, so it belongs with #5582's
outcome rather than a platform fix.

Scope: this is the platform branch only, not end-to-end DreamZero on ROCm — a full rollout still
stops at FlowUniPC's `torch.linalg.solve` (no LAPACK), the blocker #5528 skips a test for and #5329
addresses.

## Test Plan

```bash
pytest -sv tests/diffusion/ar_diffusion/test_paged_attention.py
```

Oracle is the file's own `_dense_attention` reference (fp16, `rtol=atol=2e-2`), platform-independent.
Run on MI350X (gfx950), single GPU, image
`vllm/vllm-openai-rocm:nightly-49f31d7cee425a6d38f8c5bc76877986daf832ed`, torch 2.11.0+gitd0c8b1f.

**vLLM Version:** 0.23.1rc1.dev1533+g49f31d7ce.rocm723

**vLLM-Omni Commit:** 1d6c0816a4fbd9079878d62bbe28c1a12f146a1f

## Test Result

Before and after on the same base, toggled only by stashing the patch.

Before:

```
8 failed, 20 passed, 18 warnings in 1.59s
```

All 8 are `test_paged_attention_matches_dense_reference_gpu`, all the same ImportError. The other 20
already passed, so this file holds no platform assumption beyond that one missing branch.

After:

```
28 passed, 18 warnings in 68.22s
```
