### PR TITLE
[Bugfix][Tests] Fix DreamZero OpenPI reset assertion index

### DIFF
--- a/tests/e2e/online_serving/test_dreamzero_expansion.py
+++ b/tests/e2e/online_serving/test_dreamzero_expansion.py
@@ -71,7 +71,10 @@ def _validate_dreamzero_openpi_session(response: OpenPIWebSocketResponse) -> Non
     assert metadata["needs_stereo_camera"] is False
     assert metadata["needs_session_id"] is True
     assert metadata["action_space"] == "joint_position"
-    assert response.operation_responses[-1]["status"] == "reset successful"
+    # The policy session runs infer, infer, reset, infer, so the reset response is
+    # second to last; indexing the trailing infer's action array with a string key
+    # raises IndexError from NumPy instead of comparing a status.
+    assert response.operation_responses[-2]["status"] == "reset successful"
 
     action_tensors = response.action_tensors
     assert action_tensors is not None


### PR DESCRIPTION
## Purpose

`test_dreamzero_openpi_online` cannot reach its action assertions. The DreamZero policy session runs
`infer, infer, reset, infer` (`tests/helpers/runtime.py:1817-1819` — reset is appended, then one more
infer), so the reset response is second to last. The validator asserts on the last one:

```python
assert response.operation_responses[-1]["status"] == "reset successful"
```

`operation_responses[-1]` is the trailing infer's action `ndarray`, and indexing it with a string key
raises `IndexError: only integers, slices ... are valid indices` from NumPy before any of the
`action_tensors` shape / dtype / finiteness assertions run.

This is platform-independent — it is index arithmetic over a fixed operation list, so it fails the same
way on H100. The test carries `slow` + `H100` + 2-card marks, which is likely why it has not been hit.

Two things this deliberately leaves alone:

- **`test_gr00t_openpi_expansion.py:128` keeps `[-1]`, and is correct.** The default policy session is
  `infer, reset` (`runtime.py:1822-1825`), so there reset really is last.
- **Reset itself is already validated.** `_send_operation` raises unless the reset response is
  `"reset successful"` (`runtime.py:983`), so this assertion was always a redundant double-check; the
  value it was blocking is the action-tensor contract after it.

## Test Plan

```bash
pytest -sv tests/e2e/online_serving/test_dreamzero_expansion.py::test_dreamzero_openpi_online
```

Needs 2 GPUs and `GEAR-Dreams/DreamZero-DROID` (43 GiB excluding `tensorrt/*`) plus the
`google/umt5-xxl` tokenizer. Deploy config `vllm_omni/deploy/dreamzero_tp1_cfg2.yaml` (TP=1,
CFG-parallel=2).

**vLLM Version:** 0.23.1rc1.dev1533+g49f31d7ce.rocm723

**vLLM-Omni Commit:** b3f4fbf9

## Test Result

```
1 passed in 349.17s
```

Run on 2x MI350X (gfx950). All assertions now execute: metadata contract, reset status, and 3 action
tensors of shape `(ACTION_HORIZON, ACTION_DIM)`, dtype float32, all finite.

Disclosure: I verified on ROCm only — that run additionally needs #5592 for the ROCm paged-KV
attention path, a dependency unrelated to this assertion. I have not run it on H100; the reasoning
that it fails there too is by inspection of the operation list, not measurement.
