### PR TITLE
[Bufix] Ming-omni-tts-16.8B Skip rejected and unused weights loading

### DIFF
--- a/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
+++ b/vllm_omni/model_executor/models/ming_tts/ming_tts_llm.py
@@ -58,10 +58,20 @@ _CFM_STEPS = 10
 
 
 class MingLLMModel(nn.Module):
+    # Drop the tensor on purpose, otherwise upstream vLLM would reject.
+    # The vendor never reaches them either (audio_gate/image_gate never fire)
+    # dropping them keeps routing identical to the reference implementation.
+    # https://github.com/inclusionAI/Ming-omni-tts/blob/main/modeling_bailingmm.py#L427-L428
+    # https://github.com/inclusionAI/Ming-omni-tts/blob/main/modeling_bailing_moe.py#L510-L520
     hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_substr={
+            ".mlp.audio_gate.": None,
+            ".mlp.image_gate.": None,
+        },
         orig_to_new_prefix={
+            "model.lm_head.": None,
             "model.model.": "model.",
-        }
+        },
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Resolves #5602 

cc @LHXuuu , @ZhengWG 

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 1d6c0816

## Test Result

Launch with
```bash
vllm-omni serve inclusionAI/Ming-omni-tts-16.8B-A3B \
	--omni
```

Send requests
```bash
BASE=https://raw.githubusercontent.com/inclusionAI/Ming-omni-tts/main/data/wavs
REF_AUDIO="$BASE/10002287-00000094.wav"
jq -n --arg ref_audio "$REF_AUDIO" \
    '{
       model: "inclusionAI/Ming-omni-tts-16.8B-A3B",
       input: "我们的愿景是构建未来服务业的数字化基础设施，为世界带来更多微小而美好的改变。",
       ref_audio: $ref_audio,
       ref_text: "在此奉劝大家别乱打美白针。",
       max_new_tokens: 200,
       response_format: "wav"
     }' \
| curl -X POST http://localhost:8000/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d @- --output ming_tts_zero_shot.wav

REF_A="$BASE/CTS-CN-F2F-2019-11-11-423-012-A.wav"
REF_B="$BASE/CTS-CN-F2F-2019-11-11-423-012-B.wav"

INPUT=' speaker_1:你可以说一下，就大概说一下，可能虽然我也不知道，我看过那部电影没有。
 speaker_2:就是那个叫什么，变相一节课的嘛。
 speaker_1:嗯。
 speaker_2:一部搞笑的电影。
 speaker_1:一部搞笑的。'

REF_TEXT=' speaker_1:并且我们还要进行每个月还要考核 笔试的话还要进行笔试，做个，当服务员还要去笔试了
 speaker_2:对啊，这真的很奇怪，就是 单纯的因，单纯自己工资不高，只是因为可能人家那个店比较出名一点，就对你苛刻要求'

jq -n \
    --arg input "$INPUT" \
    --arg ref_text "$REF_TEXT" \
    --arg a "$REF_A" \
    --arg b "$REF_B" \
    '{
       model: "inclusionAI/Ming-omni-tts-16.8B-A3B",
       input: $input,
       ref_audio: [$a, $b],
       ref_text: $ref_text,
       response_format: "wav"
     }' \
| curl -X POST http://localhost:8000/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d @- --output ming_tts_podcast_style.wav
```


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
