### PR TITLE
[Bugfix][NPU] Fallback to BSND RoPE when Qwen3-TTS short-seq BNSD li…

### DIFF
--- a/tests/platforms/npu/test_310p_patches.py
+++ b/tests/platforms/npu/test_310p_patches.py
@@ -489,6 +489,14 @@ def test_qwen3_tts_tokenizer_npu_patch_dispatches_fused_ops(monkeypatch: pytest.
     _install_fake_module(monkeypatch, "vllm")
     _install_fake_module(monkeypatch, "vllm.logger", init_logger=lambda _name: SimpleNamespace(debug=lambda *_: None))
 
+    rotary_path = _repo_root() / "vllm_omni" / "platforms" / "npu" / "layers" / "rotary_embedding.py"
+    rotary_module = _load_source_module("vllm_omni_test_npu_rotary_embedding", rotary_path)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_omni.platforms.npu.layers.rotary_embedding",
+        rotary_module,
+    )
+
     class FakeRMSNorm(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -536,7 +544,7 @@ def test_qwen3_tts_tokenizer_npu_patch_dispatches_fused_ops(monkeypatch: pytest.
     norm_out = norm(torch.ones(1, 2))
 
     assert len(rotary_calls) == 2
-    assert rotary_calls[0][1].shape == (1, 1, 3, 2)
+    assert rotary_calls[0][1].shape == (1, 3, 1, 2)
     torch.testing.assert_close(q_out, q + 1)
     torch.testing.assert_close(k_out, k + 1)
     assert len(rms_calls) == 1

--- a/vllm_omni/platforms/npu/layers/rotary_embedding.py
+++ b/vllm_omni/platforms/npu/layers/rotary_embedding.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared NPU rotary embedding helpers."""
+
+from __future__ import annotations
+
+import torch
+import torch_npu
+
+
+def _bnsd_rotary_shape_is_supported(hidden_states: torch.Tensor) -> bool:
+    """Return whether the fused half-mode BNSD tiler supports the shape.
+
+    For the aligned-head-dimension branch, CANN requires
+    ``batch * num_heads <= seq_len * 8``. Other alignments are handled with
+    the BSND layout, which does not have this short-sequence limit.
+    """
+    if hidden_states.ndim != 4:
+        return False
+
+    batch_size, num_heads, seq_len, head_dim = hidden_states.shape
+    element_size = hidden_states.element_size()
+    if head_dim % 2 != 0 or element_size <= 0 or 32 % element_size != 0:
+        return False
+
+    half_dim_alignment = 32 // element_size
+    return head_dim // 2 % half_dim_alignment == 0 and batch_size * num_heads <= seq_len * 8
+
+
+def npu_rotary_mul_with_bsnd_fallback(
+    hidden_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int,
+) -> torch.Tensor:
+    """Apply fused rotary multiplication, falling back from BNSD to BSND.
+
+    ``unsqueeze_dim=1`` denotes BNSD input following the Transformers rotary
+    embedding convention. Supported BNSD shapes stay on the fast path. Shapes
+    rejected by the CANN BNSD tiler are transposed to BSND for the fused op and
+    transposed back before returning.
+    """
+    if unsqueeze_dim != 1 or _bnsd_rotary_shape_is_supported(hidden_states):
+        return torch_npu.npu_rotary_mul(
+            hidden_states,
+            cos.unsqueeze(unsqueeze_dim),
+            sin.unsqueeze(unsqueeze_dim),
+        )
+
+    hidden_states_bsnd = hidden_states.transpose(1, 2).contiguous()
+    output_bsnd = torch_npu.npu_rotary_mul(
+        hidden_states_bsnd,
+        cos.unsqueeze(2),
+        sin.unsqueeze(2),
+    )
+    return output_bsnd.transpose(1, 2)

--- a/vllm_omni/platforms/npu/models/qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/platforms/npu/models/qwen3_tts_tokenizer_v2.py
@@ -14,6 +14,50 @@ logger = init_logger(__name__)
 _PATCHED = False
 
 
+def _bnsd_rotary_shape_is_supported(hidden_states: torch.Tensor) -> bool:
+    """Return whether the fused half-mode BNSD RoPE tiler supports this shape.
+
+    Qwen3-TTS uses ``[batch, heads, seq_len, head_dim]`` tensors.  For the
+    aligned-head-dimension branch used by its 64-wide heads, CANN requires
+    ``batch * heads <= seq_len * 8``.  Treat other alignments conservatively
+    and use the BSND layout, which does not have this short-sequence limit.
+    """
+    if hidden_states.ndim != 4:
+        return False
+
+    batch_size, num_heads, seq_len, head_dim = hidden_states.shape
+    element_size = hidden_states.element_size()
+    if head_dim % 2 != 0 or element_size <= 0 or 32 % element_size != 0:
+        return False
+
+    half_dim_alignment = 32 // element_size
+    return head_dim // 2 % half_dim_alignment == 0 and batch_size * num_heads <= seq_len * 8
+
+
+def _rotary_mul_npu(
+    hidden_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int,
+) -> torch.Tensor:
+    if unsqueeze_dim != 1 or _bnsd_rotary_shape_is_supported(hidden_states):
+        return torch_npu.npu_rotary_mul(
+            hidden_states,
+            cos.unsqueeze(unsqueeze_dim),
+            sin.unsqueeze(unsqueeze_dim),
+        )
+
+    hidden_states_bsnd = hidden_states.transpose(1, 2)
+    if not hidden_states_bsnd.is_contiguous():
+        hidden_states_bsnd = hidden_states_bsnd.contiguous()
+    output_bsnd = torch_npu.npu_rotary_mul(
+        hidden_states_bsnd,
+        cos.unsqueeze(2),
+        sin.unsqueeze(2),
+    )
+    return output_bsnd.transpose(1, 2)
+
+
 def _apply_rotary_pos_emb_npu(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -23,9 +67,10 @@ def _apply_rotary_pos_emb_npu(
     unsqueeze_dim: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del position_ids
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-    return torch_npu.npu_rotary_mul(q, cos, sin), torch_npu.npu_rotary_mul(k, cos, sin)
+    return (
+        _rotary_mul_npu(q, cos, sin, unsqueeze_dim),
+        _rotary_mul_npu(k, cos, sin, unsqueeze_dim),
+    )
 
 
 def _rms_norm_forward_npu(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm_omni/platforms/npu/models/qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/platforms/npu/models/qwen3_tts_tokenizer_v2.py
@@ -9,53 +9,13 @@ import torch
 import torch_npu
 from vllm.logger import init_logger
 
+from vllm_omni.platforms.npu.layers.rotary_embedding import (
+    npu_rotary_mul_with_bsnd_fallback,
+)
+
 logger = init_logger(__name__)
 
 _PATCHED = False
-
-
-def _bnsd_rotary_shape_is_supported(hidden_states: torch.Tensor) -> bool:
-    """Return whether the fused half-mode BNSD RoPE tiler supports this shape.
-
-    Qwen3-TTS uses ``[batch, heads, seq_len, head_dim]`` tensors.  For the
-    aligned-head-dimension branch used by its 64-wide heads, CANN requires
-    ``batch * heads <= seq_len * 8``.  Treat other alignments conservatively
-    and use the BSND layout, which does not have this short-sequence limit.
-    """
-    if hidden_states.ndim != 4:
-        return False
-
-    batch_size, num_heads, seq_len, head_dim = hidden_states.shape
-    element_size = hidden_states.element_size()
-    if head_dim % 2 != 0 or element_size <= 0 or 32 % element_size != 0:
-        return False
-
-    half_dim_alignment = 32 // element_size
-    return head_dim // 2 % half_dim_alignment == 0 and batch_size * num_heads <= seq_len * 8
-
-
-def _rotary_mul_npu(
-    hidden_states: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-    unsqueeze_dim: int,
-) -> torch.Tensor:
-    if unsqueeze_dim != 1 or _bnsd_rotary_shape_is_supported(hidden_states):
-        return torch_npu.npu_rotary_mul(
-            hidden_states,
-            cos.unsqueeze(unsqueeze_dim),
-            sin.unsqueeze(unsqueeze_dim),
-        )
-
-    hidden_states_bsnd = hidden_states.transpose(1, 2)
-    if not hidden_states_bsnd.is_contiguous():
-        hidden_states_bsnd = hidden_states_bsnd.contiguous()
-    output_bsnd = torch_npu.npu_rotary_mul(
-        hidden_states_bsnd,
-        cos.unsqueeze(2),
-        sin.unsqueeze(2),
-    )
-    return output_bsnd.transpose(1, 2)
 
 
 def _apply_rotary_pos_emb_npu(
@@ -68,8 +28,8 @@ def _apply_rotary_pos_emb_npu(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del position_ids
     return (
-        _rotary_mul_npu(q, cos, sin, unsqueeze_dim),
-        _rotary_mul_npu(k, cos, sin, unsqueeze_dim),
+        npu_rotary_mul_with_bsnd_fallback(q, cos, sin, unsqueeze_dim),
+        npu_rotary_mul_with_bsnd_fallback(k, cos, sin, unsqueeze_dim),
     )
 
 


### PR DESCRIPTION
Reproduced on NPU while serving CustomVoice with codec_chunk_ramp enabled. Stage-1 Code2Wav crashed during the first short ramp decode:

`(StageEngineCoreProc_stage1_replica0 pid=4713) EZ9999[PID: 4713] 2026-07-30-08:45:37.996.394 (EZ9999):  when input is BNSD layout and  B * N is large or D is not aligned, please do not use RotaryPositionEmbedding fusion operator.[FUNC:DoRotateHalfTiling][FILE:rope_rotate_half_tiling.cpp][LINE:549]`

## Purpose
Fix an NPU crash in Qwen3-TTS CustomVoice when `codec_chunk_ramp` is enabled (e.g. `[4, 4, 8, 16, 25]`) and concurrency is ≥ 4. Short decode steps can violate CANN's BNSD RoPE constraint (`batch * heads <= seq_len * 8`); fall back to BSND for unsupported shapes.

## Test Result

### Environment
- Hardware: 910B3 * 1
- Model: Qwen3-TTS-12Hz-1.7B-CustomVoice
- vLLM-Omni: 0.25.0rc2
- CANN: 9.0.0

### Performance
```
nohup python /vllm-workspace/vllm-omni/benchmarks/tts/bench_tts.py \
  --model /nas/disk1/Qwen3-TTS-12Hz-1.7B-CustomVoice \
  --task default_voice \
  --dataset-path ./seedtts_testset \
  --locale zh \
  --concurrency 1 4 8 16\
  --num-prompts 48 \
  --host 55.122.12.76 \
  --port 30488 \
  --output-dir ./results > test.log 2>&1 &
```
Benchmark results with codec_chunk_ramp=[4, 4, 6, 8, 10, 12, 16, 20, 25] enabled are shown below：
| Metric | c=1 | c=4 | c=8 | c=16 |
|---|---:|---:|---:|---:|
| Mean E2EL (ms) | 2884.76 | 3324.27 | 4005.14 | 9194.68 |
| Median E2EL (ms) | 2762.81 | 3238.31 | 3928.74 | 5963.11 |
| P99 E2EL (ms) | 5368.51 | 6174.25 | 6685.87 | 19071.04 |
| Total audio duration (s) | 266.00 | 266.08 | 267.92 | 265.76 |
| Audio throughput (s/s) | 1.92 | 6.62 | 10.62 | 8.46 |
| Streaming continuity OK rate | 100.00% | 100.00% | 100.00% | 8.33% |
| Mean AUDIO_RTF | 0.52 | 0.60 | 0.72 | 1.74 |
| Median AUDIO_RTF | 0.52 | 0.60 | 0.73 | 1.01 |
| P99 AUDIO_RTF | 0.55 | 0.65 | 0.77 | 4.53 |
| Mean AUDIO_TTFP (ms) | 303.28 | 387.43 | 495.83 | 4677.46 |
| Median AUDIO_TTFP (ms) | 303.04 | 362.82 | 489.34 | 906.25 |
| P99 AUDIO_TTFP (ms) | 321.24 | 611.85 | 659.48 | 12496.51 |
| Mean AUDIO_DURATION (s) | 5.54 | 5.54 | 5.58 | 5.54 |
| Median AUDIO_DURATION (s) | 5.28 | 5.40 | 5.56 | 5.36 |
| P99 AUDIO_DURATION (s) | 10.57 | 10.64 | 9.40 | 10.04 |
| Mean AUDIO_UNDERRUN (s) | 0.00 | 0.00 | 0.01 | 0.48 |
| Median AUDIO_UNDERRUN (s) | 0.00 | 0.00 | 0.00 | 0.40 |
| P99 AUDIO_UNDERRUN (s) | 0.00 | 0.00 | 0.08 | 1.24 |

### Accuracy    
The WER evaluation results on the seed-tts-eval dataset are as follows:

| Metric | Results |
|---|---:|
| WER | 0.982% | 