### PR TITLE
[Bugfix][Full Duplex] Make runtime_control payloads JSON serializable

### DIFF
--- a/tests/e2e/features/fullduplex/openai/test_runtime_control_redaction.py
+++ b/tests/e2e/features/fullduplex/openai/test_runtime_control_redaction.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression tests for duplex ``runtime_control`` payload redaction.
+
+The redacted result is emitted on the WebSocket (for example
+``session.created.runtime_control``), so it must always survive
+``json.dumps``. Control results carry typed values straight from the engine --
+``fence`` and ``accepted_fence`` are ``DuplexFence`` instances added by
+``DuplexControlClient.execute`` -- which previously reached
+``WebSocket.send_json`` unconverted and killed the session at handshake.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+
+from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+from vllm_omni.experimental.fullduplex.openai.runtime_bridge import NativeRuntimeBridgeMixin
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_redact = NativeRuntimeBridgeMixin._redact_runtime_control_result
+
+
+def _control_result() -> dict[str, object]:
+    """The shape ``DuplexControlClient.execute`` returns for an open."""
+    return {
+        "ok": True,
+        "operation": "open",
+        "session_id": "sess-1",
+        "fence": DuplexFence("sess-1", epoch=0, turn_id=0, response_seq=0, incarnation=0),
+        "accepted_fence": DuplexFence("sess-1", epoch=1, turn_id=2, response_seq=3, incarnation=4),
+        "stage_results": [{"stage_id": -1, "replica_id": -1, "result": {"supported": True}}],
+    }
+
+
+def test_redacted_control_result_is_json_serializable() -> None:
+    """The whole payload must serialize the way send_json does."""
+    redacted = _redact(_control_result())
+    # Must not raise.
+    json.dumps({"type": "session.created", "runtime_control": redacted})
+
+
+def test_fences_are_converted_to_plain_dicts() -> None:
+    redacted = _redact(_control_result())
+    assert redacted["fence"] == {
+        "session_id": "sess-1",
+        "epoch": 0,
+        "turn_id": 0,
+        "response_seq": 0,
+        "incarnation": 0,
+    }
+    # Field values are preserved, not just the type.
+    assert redacted["accepted_fence"]["epoch"] == 1
+    assert redacted["accepted_fence"]["turn_id"] == 2
+    assert redacted["accepted_fence"]["response_seq"] == 3
+    assert redacted["accepted_fence"]["incarnation"] == 4
+
+
+def test_nested_dataclasses_are_converted() -> None:
+    """Fences can appear inside stage results, not only at the top level."""
+    redacted = _redact(
+        {
+            "stage_results": [
+                {"stage_id": 0, "result": {"fence": DuplexFence("sess-2", epoch=7)}},
+            ]
+        }
+    )
+    json.dumps(redacted)
+    assert redacted["stage_results"][0]["result"]["fence"]["epoch"] == 7
+
+
+def test_enums_are_reduced_to_values() -> None:
+    class _Mode(str, Enum):
+        APPEND = "append_audio_chunk"
+
+    redacted = _redact({"mode": _Mode.APPEND})
+    json.dumps(redacted)
+    assert redacted["mode"] == "append_audio_chunk"
+
+
+def test_redaction_still_drops_heavy_payload_keys() -> None:
+    """The pre-existing contract must be preserved."""
+    redacted = _redact(
+        {
+            "ok": True,
+            "stage_handoff": object(),
+            "tts_handoff": object(),
+            "omni_payload": object(),
+            "tts_hidden_states": object(),
+            "tts_token_ids": object(),
+            "traceback": "long trace",
+        }
+    )
+    assert redacted == {"ok": True}
+
+
+def test_plain_values_pass_through_unchanged() -> None:
+    payload = {"ok": True, "count": 3, "name": "x", "missing": None, "items": [1, "two"]}
+    assert _redact(payload) == payload
+
+
+def test_dataclass_types_are_not_treated_as_instances() -> None:
+    """A class object is not a dataclass instance and must not be asdict'd."""
+
+    @dataclass
+    class _Shape:
+        x: int = 1
+
+    assert _redact(_Shape) is _Shape

--- a/vllm_omni/experimental/fullduplex/openai/runtime_bridge.py
+++ b/vllm_omni/experimental/fullduplex/openai/runtime_bridge.py
@@ -4,6 +4,8 @@ import asyncio
 import base64
 import inspect
 from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from enum import Enum
 
 import numpy as np
 from vllm.logger import init_logger
@@ -620,6 +622,17 @@ class NativeRuntimeBridgeMixin:
             return redacted
         if isinstance(value, list | tuple):
             return [cls._redact_runtime_control_result(item) for item in value]
+        if is_dataclass(value) and not isinstance(value, type):
+            # Control results carry typed values straight from the engine:
+            # `fence` and `accepted_fence` are `DuplexFence` instances added by
+            # `DuplexControlClient.execute`. This redacted value is emitted on
+            # the wire (for example `session.created.runtime_control` in
+            # `session_runner`), where `WebSocket.send_json` would raise
+            # `TypeError: Object of type DuplexFence is not JSON serializable`
+            # and kill the session during the handshake.
+            return {key: cls._redact_runtime_control_result(child) for key, child in asdict(value).items()}
+        if isinstance(value, Enum):
+            return value.value
         return value
 
     async def _send_native_duplex_events(


### PR DESCRIPTION
Fixes #5612.

## The bug

`_redact_runtime_control_result` returned non-`dict`, non-`list` values unchanged, but
duplex control results carry typed values straight from the engine: `fence` and
`accepted_fence` are `DuplexFence` **dataclass instances** added by
`DuplexControlClient.execute`
([duplex_control_client.py#L74](https://github.com/vllm-project/vllm-omni/blob/1b718f7b/vllm_omni/experimental/fullduplex/engine/duplex_control_client.py#L74),
[#L81](https://github.com/vllm-project/vllm-omni/blob/1b718f7b/vllm_omni/experimental/fullduplex/engine/duplex_control_client.py#L81)).

That redacted value goes on the wire — `session.created` sets `runtime_control` from it
([session_runner.py#L695](https://github.com/vllm-project/vllm-omni/blob/1b718f7b/vllm_omni/experimental/fullduplex/openai/session_runner.py#L695))
— so `WebSocket.send_json` raised:

```
TypeError: Object of type DuplexFence is not JSON serializable
```

and the duplex session **died during the handshake**, before any audio could be
appended. The client received only `{"type": "error", "code": "internal_error"}`.

Not model specific: `runtime_control` is attached whenever the open result is a `dict`,
which is the case for any adapter declaring
`implementation_level="model_native_duplex"` (`runtime_bridge.py:88`).

## The fix

The redactor exists to produce a client-visible payload, so it seemed like the right
place to guarantee JSON-safety rather than requiring every producer to pre-serialize.
Dataclasses are converted with `asdict` and recursed; enums are reduced to their values.

## Why the conversion is safe

I checked every consumer of the redacted value before changing its type:

| call site | consumer |
|---|---|
| `runtime_bridge.py:84` | `send_json` |
| `runtime_bridge.py:487` | `logger.warning` |
| `runtime_bridge.py:565` | `send_json` |
| `runtime_bridge.py:1296` | `send_json` |
| `session_runner.py:695` | `created_payload` → `send_json` |

All wire or log; nothing consumes it as typed data. The one programmatic reader of
`accepted_fence` — `DuplexControlRequestError.__init__`
([duplex_control_client.py#L41-L42](https://github.com/vllm-project/vllm-omni/blob/1b718f7b/vllm_omni/experimental/fullduplex/engine/duplex_control_client.py#L41-L42))
— reads the **raw** result dict, which this PR does not touch.

The `Enum` branch is defensive rather than something I hit; control results carry
several (`mode`, `session_mode`) and they are equally unserializable. Happy to drop it
if you'd prefer a more minimal change.

## Testing

New `tests/e2e/features/fullduplex/openai/test_runtime_control_redaction.py` covers
top-level fences, fences nested inside `stage_results`, enum reduction, preservation of
the existing heavy-payload key dropping (`stage_handoff`, `tts_handoff`, …), plain-value
pass-through, and that dataclass *types* are not mistaken for instances.

Verified the tests actually catch the bug rather than merely passing. Full
`tests/e2e/features/fullduplex` suite, same environment, toggling only this patch:

```
base (this patch's source change reverted):   3 failed, 170 passed
with this patch:                              0 failed, 173 passed
```

The 3 failures on the base are exactly the new tests in this PR, each on the
`DuplexFence` serialization path:

```
test_redacted_control_result_is_json_serializable
test_fences_are_converted_to_plain_dicts
test_nested_dataclasses_are_converted
```

Also confirmed end to end: with this applied, a live Qwen3-Omni 3-stage duplex server
completes the `/v1/duplex` handshake and delivers `session.created`, where previously
the session errored out during the handshake.

## Alternatives considered

1. **Serialize at the producer** (`DuplexControlClient.execute` emits fence dicts) —
   arguably cleaner layering, but `accepted_fence` is consumed as a typed `DuplexFence`
   in the error path, so it would need a separate wire-shaped copy.
2. **Drop `fence` / `accepted_fence` in the redactor**, as is already done for
   `stage_handoff` and friends — simplest, but those values look genuinely useful to
   clients for debugging epoch/turn behaviour.

Happy to switch to either if maintainers prefer.
