### PR TITLE
[Bugfix] Fall back from unsupported FA3 ring kernels

### DIFF
--- a/tests/diffusion/attention/test_ring_backend_selection.py
+++ b/tests/diffusion/attention/test_ring_backend_selection.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.parallel import ring
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ((8, 0), True),
+        ((8, 9), True),
+        ((9, 0), True),
+        ((10, 0), False),
+        ((10, 3), False),
+        ((12, 0), False),
+    ],
+)
+def test_can_use_fa3_checks_device_arch(monkeypatch, capability, expected):
+    monkeypatch.setattr(ring, "HAS_FA3", True)
+    monkeypatch.setattr(ring, "FA3_SUPPORTED_CUDA_MAJORS", frozenset({8, 9}))
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: capability)
+
+    assert ring._can_use_fa3(torch.device("cuda")) is expected
+
+
+def test_can_use_fa3_preserves_unknown_extension_contract(monkeypatch):
+    monkeypatch.setattr(ring, "HAS_FA3", True)
+    monkeypatch.setattr(ring, "FA3_SUPPORTED_CUDA_MAJORS", None)
+
+    assert ring._can_use_fa3(torch.device("cuda"))
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ((8, 0), True),
+        ((9, 0), True),
+        ((10, 0), False),
+        ((10, 3), False),
+        ((12, 0), False),
+    ],
+)
+def test_can_use_fa2_checks_device_arch(monkeypatch, capability, expected):
+    monkeypatch.setattr(ring, "HAS_FLASH_ATTN", True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: capability)
+
+    assert ring._can_use_fa2(torch.device("cuda")) is expected
+
+
+def test_ring_falls_back_to_sdpa_when_fa3_extension_has_no_device_kernel(monkeypatch):
+    monkeypatch.setattr(ring, "HAS_FA3", True)
+    monkeypatch.setattr(ring, "HAS_FLASH_ATTN", False)
+    monkeypatch.setattr(ring, "HAS_AITER", False)
+    monkeypatch.setattr(ring, "_can_use_fa3", lambda _device: False)
+
+    expected = torch.randn(1, 2, 1, 8)
+
+    def fake_ring_sdpa(*args, **kwargs):
+        return expected
+
+    module_name = "vllm_omni.diffusion.attention.backends.ring_pytorch_attn"
+    monkeypatch.setitem(sys.modules, module_name, SimpleNamespace(ring_pytorch_attn_func=fake_ring_sdpa))
+
+    strategy = ring.RingParallelAttention(SimpleNamespace(ring_group=object()))
+    query = torch.randn(1, 2, 1, 8)
+    actual = strategy.run_attention(query, query, query, attn_metadata=None)
+
+    assert actual is expected

--- a/tests/diffusion/attention/test_ring_backend_selection.py
+++ b/tests/diffusion/attention/test_ring_backend_selection.py
@@ -1,15 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 import sys
 from types import SimpleNamespace
 
 import pytest
 import torch
 
+from vllm_omni.diffusion.attention.backends.ring import ring_globals
 from vllm_omni.diffusion.attention.parallel import ring
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_source_build_fa3_is_hopper_only(monkeypatch):
+    fake_interface = SimpleNamespace(
+        _flash_attn_forward=lambda *args, **kwargs: None,
+        flash_attn_func=lambda *args, **kwargs: None,
+    )
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "flash_attn_interface", fake_interface)
+            reloaded = importlib.reload(ring_globals)
+            assert reloaded.HAS_FA3
+            assert reloaded.FA3_SUPPORTED_CUDA_MAJORS == frozenset({9})
+    finally:
+        importlib.reload(ring_globals)
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/diffusion/attention/backends/ring/ring_globals.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_globals.py
@@ -22,6 +22,11 @@ except (ImportError, ModuleNotFoundError):
 HAS_FA3 = False
 fa3_fwd_func = None  # Low-level forward function (_flash_attn_forward)
 fa3_attn_func = None  # High-level attention function (flash_attn_func)
+# ``None`` means that the extension does not publish an architecture contract,
+# so retain the historical import-only behavior.  The pinned fa3-fwd wheel is
+# handled below because importing its Python module succeeds on Blackwell even
+# though its CUDA binary only contains SM8x/SM90 kernels.
+FA3_SUPPORTED_CUDA_MAJORS: frozenset[int] | None = None
 
 # Try flash_attn_interface first (from flash-attention source build)
 try:
@@ -35,10 +40,27 @@ except (ImportError, ModuleNotFoundError):
 # Fallback: try fa3_fwd_interface (PyPI package, supports Ampere/Ada/Hopper)
 if not HAS_FA3:
     try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        import fa3_fwd_interface
         from fa3_fwd_interface import _flash_attn_forward as fa3_fwd_func  # noqa: F401
         from fa3_fwd_interface import flash_attn_func as fa3_attn_func  # noqa: F401
 
         HAS_FA3 = True
+        published_majors = getattr(fa3_fwd_interface, "SUPPORTED_CUDA_MAJORS", None)
+        if published_majors is not None:
+            FA3_SUPPORTED_CUDA_MAJORS = frozenset(int(major) for major in published_majors)
+        else:
+            try:
+                fa3_fwd_version = version("fa3_fwd")
+            except PackageNotFoundError:
+                fa3_fwd_version = None
+            # requirements/cuda.txt pins this wheel.  Its fat binary contains
+            # SM80 and SM90 cubins, but no Blackwell kernel.  Do not apply this
+            # restriction to an unknown/future build unless it publishes its
+            # own supported-major metadata above.
+            if fa3_fwd_version == "0.0.3":
+                FA3_SUPPORTED_CUDA_MAJORS = frozenset({8, 9})
     except (ImportError, ModuleNotFoundError):
         pass
 

--- a/vllm_omni/diffusion/attention/backends/ring/ring_globals.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_globals.py
@@ -34,6 +34,9 @@ try:
     from flash_attn_interface import flash_attn_func as fa3_attn_func  # noqa: F401
 
     HAS_FA3 = True
+    # The source-build FA3 interface is the Hopper implementation. Importing
+    # its Python module on Blackwell does not imply that an SM10x kernel exists.
+    FA3_SUPPORTED_CUDA_MAJORS = frozenset({9})
 except (ImportError, ModuleNotFoundError):
     pass
 

--- a/vllm_omni/diffusion/attention/parallel/ring.py
+++ b/vllm_omni/diffusion/attention/parallel/ring.py
@@ -10,7 +10,12 @@ import torch
 from vllm.logger import init_logger
 
 # import torch.distributed as dist # Not used directly here, but good practice if needed
-from vllm_omni.diffusion.attention.backends.ring.ring_globals import HAS_AITER, HAS_FA3, HAS_FLASH_ATTN
+from vllm_omni.diffusion.attention.backends.ring.ring_globals import (
+    FA3_SUPPORTED_CUDA_MAJORS,
+    HAS_AITER,
+    HAS_FA3,
+    HAS_FLASH_ATTN,
+)
 from vllm_omni.diffusion.attention.backends.ring.ring_selector import AttnType
 from vllm_omni.diffusion.attention.parallel.base import (
     ParallelAttentionContext,
@@ -22,6 +27,34 @@ if TYPE_CHECKING:
     from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 
 logger = init_logger(__name__)
+
+
+def _can_use_fa3(device: torch.device) -> bool:
+    """Return whether the installed FA3 kernels support ``device``.
+
+    Importing an extension only proves that its Python module is installed.
+    When the source publishes a supported-major contract, also check it before
+    entering a CUDA launcher that may abort instead of raising an exception.
+    """
+    if not HAS_FA3 or device.type != "cuda":
+        return False
+    if FA3_SUPPORTED_CUDA_MAJORS is None:
+        return True
+    major, _minor = torch.cuda.get_device_capability(device)
+    return major in FA3_SUPPORTED_CUDA_MAJORS
+
+
+def _can_use_fa2(device: torch.device) -> bool:
+    """Return whether the FA2 backend supports ``device``.
+
+    FA2's CUDA backend supports Ampere, Ada, and Hopper.  Blackwell support is
+    provided by the separate FA4 implementation, which this ring backend does
+    not expose.
+    """
+    if not HAS_FLASH_ATTN or device.type != "cuda":
+        return False
+    major, _minor = torch.cuda.get_device_capability(device)
+    return major in (8, 9)
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,12 +143,17 @@ class RingParallelAttention:
         if backend_pref is not None:
             backend_pref = backend_pref.lower()
 
+        can_use_fa3 = _can_use_fa3(query.device)
+        can_use_fa2 = _can_use_fa2(query.device)
+
         # FP32 is not supported by Flash Attention, force SDPA
         if query.dtype == torch.float32:
             backend_pref = "sdpa"
-        elif not HAS_FA3 and not HAS_FLASH_ATTN and not HAS_AITER:
+        elif not can_use_fa3 and not can_use_fa2 and not HAS_AITER:
             if backend_pref != "sdpa":
-                logger.warning_once("Flash Attention (FA2/FA3/AITER) is not available! Force enabling SDPA.")
+                logger.warning_once(
+                    "Flash Attention (FA2/FA3/AITER) is not available for this device! Force enabling SDPA."
+                )
             backend_pref = "sdpa"
 
         # Extract joint tensors
@@ -147,12 +185,14 @@ class RingParallelAttention:
 
         # Prefer FA3 over FA2 for better performance (FA3 supports Ampere/Ada/Hopper)
         # On ROCm, use AITER
-        if HAS_FA3:
+        if can_use_fa3:
             attn_type = AttnType.FA3
         elif HAS_AITER:
             attn_type = AttnType.AITER
-        else:
+        elif can_use_fa2:
             attn_type = AttnType.FA
+        else:
+            raise RuntimeError("No compatible Flash Attention backend is available for ring attention.")
 
         return ring_flash_attn_func(
             query,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Addresses the ring-attention failure reported in #5611.

The pinned `fa3-fwd==0.0.3` module imports on Blackwell, but its extension contains only SM80 and SM90a cubins. The import-only availability check therefore selected FA3 on B200/B300 and failed at execution with `no kernel image is available for execution on the device`.

This change records the architecture contract for the pinned wheel, checks the actual query device before selecting FA3 or FA2, and falls back to the existing ring SDPA implementation when neither installed backend supports that device. The separate non-ring LTX2 SDPA traceback in #5611 is outside this patch.

cc @yenuo26 @david6666666

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `bf928460`

```bash
pytest -q \
  tests/diffusion/attention/test_ring_backend_selection.py \
  tests/diffusion/attention/test_attention_sp.py
```

GPU validation uses NVIDIA B300 (SM103), PyTorch 2.11.0+cu130, and CUDA 13.0, including a real two-rank NCCL ring.

## Test Result

```text
22 passed
```

- Parent commit: imports `fa3-fwd`, selects FA3, and reproduces `no kernel image is available for execution on the device`.
- This PR, one GPU: selects SDPA and returns a finite BF16 tensor of shape `(1, 32, 8, 64)`.
- This PR, two GPUs: both NCCL ranks return finite BF16 tensors of the same shape.
- `cuobjdump --list-elf` confirms the pinned extension has SM80/SM90a cubins and no Blackwell cubin.

File-scoped pre-commit hooks pass.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
