### PR TITLE
[Bugfix] Preserve short channel-last video tensors

### DIFF
--- a/tests/entrypoints/openai_api/test_video_api_utils.py
+++ b/tests/entrypoints/openai_api/test_video_api_utils.py
@@ -48,6 +48,25 @@ def test_encode_video_bytes_exports_frames_without_interpolation(monkeypatch):
     assert mux_calls[0]["audio"] is None
 
 
+@pytest.mark.parametrize("frame_count", [3, 4])
+def test_coerce_video_preserves_ambiguous_channel_last_tensor(frame_count):
+    video = torch.arange(frame_count * 2 * 5 * 3, dtype=torch.uint8).reshape(frame_count, 2, 5, 3)
+
+    frames = video_api_utils._coerce_video_to_uint8_frames(video)
+
+    assert frames.shape == (frame_count, 2, 5, 3)
+    np.testing.assert_array_equal(frames, video.numpy())
+
+
+def test_coerce_video_converts_channel_first_tensor():
+    video = torch.arange(3 * 4 * 2 * 5, dtype=torch.uint8).reshape(3, 4, 2, 5)
+
+    frames = video_api_utils._coerce_video_to_uint8_frames(video)
+
+    assert frames.shape == (4, 2, 5, 3)
+    np.testing.assert_array_equal(frames, video.permute(1, 2, 3, 0).numpy())
+
+
 def test_fragmented_mp4_video_encoder_reuses_single_muxer(monkeypatch):
     muxers = []
 

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -308,9 +308,6 @@ def _normalize_video_tensor(video_tensor: torch.Tensor) -> np.ndarray:
     video_tensor = video_tensor.detach().cpu()
     if video_tensor.dim() == 5:
         raise ValueError("Batched video tensors are not supported for single-video encoding.")
-    elif video_tensor.dim() == 4 and video_tensor.shape[0] in (3, 4):
-        # [C, F, H, W] -> [F, H, W, C]
-        video_tensor = video_tensor.permute(1, 2, 3, 0)
 
     if video_tensor.is_floating_point():
         # Cast to float32 first: bf16 (e.g. SANA-WM's refiner output) has no


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Resolves #5417.

`_normalize_video_tensor()` transposed every rank-4 Torch tensor whose first dimension was 3 or 4. That is ambiguous with the supported `[frames, height, width, channels]` layout, so three- and four-frame RGB videos were corrupted before encoding.

This change removes the Torch-only early transpose and lets the shared array normalizer resolve layouts. A valid channel-last dimension takes precedence, while unambiguous `[channels, frames, height, width]` tensors are still converted.

cc @pxljs

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `18882c6e`

```bash
pytest -q tests/entrypoints/openai_api/test_video_api_utils.py
```

CUDA validation uses NVIDIA B300 (SM103), PyTorch 2.11.0+cu130, and CUDA 13.0.

## Test Result

```text
10 passed
```

| input layout | parent result | PR result |
|---|---|---|
| `(3, 2, 5, 3)` | `(2, 5, 3, 3)` | `(3, 2, 5, 3)` |
| `(4, 2, 5, 3)` | `(2, 5, 3, 3)` | `(4, 2, 5, 3)` |

Both PR outputs are byte-for-byte equal to their original channel-last inputs. An additional regression test confirms unambiguous channel-first tensors are still converted. File-scoped pre-commit hooks pass.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
