### PR TITLE
[Bugfix] Leave MiniCPM-o vocoder memory headroom

### DIFF
--- a/examples/online_serving/minicpmo/README.md
+++ b/examples/online_serving/minicpmo/README.md
@@ -23,9 +23,11 @@ including `librosa`.
 
 The deploy config auto-loads via `--omni`.
 The default `vllm_omni/deploy/minicpmo_4_5.yaml` keeps all three stages on
-logical device 0 with memory budgets of 55%, 22%, and 22%. The profile admits
-at most four sequences per stage and bounds startup video profiling to 32
-frames per video. For throughput,`minicpmo_4_5_2gpu.yaml` gives the Thinker
+logical device 0 with memory budgets of 55%, 15%, and 15%, leaving headroom
+for runtime kernels such as the HiFi-GAN vocoder's cuDNN workspace. The
+profile admits at most four sequences per stage and bounds startup video
+profiling to 32 frames per video. For throughput,
+`minicpmo_4_5_2gpu.yaml` gives the Thinker
 GPU 0 (90%) and colocates the Talker (55%) and Code2Wav (35%) on GPU 1. That
 profile admits at most four concurrent sequences per stage.
 

--- a/recipes/OpenBMB/MiniCPM-o-4_5.md
+++ b/recipes/OpenBMB/MiniCPM-o-4_5.md
@@ -77,7 +77,9 @@ a fallback because it would duplicate state machines and correctness paths.
 The default
 [`vllm_omni/deploy/minicpmo_4_5.yaml`](../../vllm_omni/deploy/minicpmo_4_5.yaml)
 co-locates Thinker, codec-only Talker, and Code2Wav on GPU 0. Their
-`gpu_memory_utilization` budgets are 0.55, 0.22, and 0.22. All stages admit
+`gpu_memory_utilization` budgets are 0.55, 0.15, and 0.15. The remaining
+device memory is left available for runtime workspaces such as the HiFi-GAN
+vocoder's cuDNN kernels. All stages admit
 up to four sequences. Startup video profiling is bounded to 32 frames per
 video. Use the two-GPU profile for production throughput.
 
@@ -202,9 +204,10 @@ speech output (TTS)"** checkbox on / off.
 
 #### Notes
 
-- Memory budget: Thinker, Talker, and Code2Wav reserve 0.55, 0.22, and
-  0.22 of GPU 0. The larger Thinker share protects its multimodal KV cache;
-  all three model processes still share one CUDA device.
+- Memory budget: Thinker, Talker, and Code2Wav reserve 0.55, 0.15, and
+  0.15 of GPU 0. The larger Thinker share protects its multimodal KV cache,
+  while the unreserved memory remains available to runtime kernels; all three
+  model processes still share one CUDA device.
 - `--trust-remote-code` is required — the HF repo ships a custom
   `MiniCPMO` config / model class.
 - Stage 0 Thinker and Stage 1 Talker enable vLLM CUDA Graphs. Stage 2 remains

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -163,11 +163,13 @@ class TestDeployTopology:
         assert stages[1].yaml_engine_args["custom_process_next_stage_input_func"].endswith(expected_processor)
         if filename == "minicpmo_4_5.yaml":
             assert [stage.yaml_engine_args["max_num_seqs"] for stage in stages] == [4, 4, 4]
-            assert [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages] == [
+            memory_utilizations = [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages]
+            assert memory_utilizations == [
                 0.55,
-                0.22,
-                0.22,
+                0.15,
+                0.15,
             ]
+            assert sum(memory_utilizations) <= 0.9
             assert stages[0].yaml_engine_args["limit_mm_per_prompt"] == {"video": {"count": 1, "num_frames": 32}}
         elif filename in {"minicpmo_4_5_2gpu.yaml"}:
             assert [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages] == [

--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -169,7 +169,7 @@ class TestDeployTopology:
                 0.15,
                 0.15,
             ]
-            assert sum(memory_utilizations) <= 0.9
+            assert sum(memory_utilizations) <= 0.9 + 1e-6
             assert stages[0].yaml_engine_args["limit_mm_per_prompt"] == {"video": {"count": 1, "num_frames": 32}}
         elif filename in {"minicpmo_4_5_2gpu.yaml"}:
             assert [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages] == [

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -38,7 +38,8 @@ stages:
 
   - stage_id: 1
     max_num_seqs: 4
-    gpu_memory_utilization: 0.22
+    # Leave device-level headroom for the colocated HiFi-GAN cuDNN workspace.
+    gpu_memory_utilization: 0.15
     enforce_eager: false
     max_num_batched_tokens: 8192
     devices: "0"
@@ -58,7 +59,7 @@ stages:
 
   - stage_id: 2
     max_num_seqs: 4
-    gpu_memory_utilization: 0.22
+    gpu_memory_utilization: 0.15
     enforce_eager: true
     enable_chunked_prefill: false
     max_num_batched_tokens: 65536


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Resolves #5591

The MiniCPM-o 4.5 H100 CI tests failed in the Code2Wav HiFi-GAN vocoder:

```text
RuntimeError: GET was unable to find an engine to execute this computation
  at F.conv_transpose1d
```

The single-GPU deploy config reserved 0.55, 0.22, and 0.22 of the same GPU
for Thinker, Talker, and Code2Wav. The failing H100 log showed that Talker's
0.22 budget created 15.93 GiB of KV cache and 67.96x maximum concurrency for
4,096-token requests, although the deploy config admits only four sequences.
That left little device-level memory for Code2Wav's runtime cuDNN workspace.

This PR restores the Talker and Code2Wav budgets to 0.15, leaving 15% of the
shared device unreserved for runtime kernels. It also adds a topology
regression assertion that the default single-GPU stage budgets sum to at most
0.9 and updates the documented values.

cc @zhumingjue138 @y-null @natureofnature @R2-Y

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** c39f8c37

**Hardware:** 1x NVIDIA B300 SXM6 AC, CUDA 13.3

```bash
pytest -q tests/model_executor/models/minicpmo_4_5/test_pipeline.py

CUDA_VISIBLE_DEVICES=7 pytest -q -s \
  tests/e2e/offline_inference/test_minicpmo_4_5.py::test_mix_to_audio

CUDA_VISIBLE_DEVICES=7 pytest -q -s \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_mix_to_text_audio_001

pre-commit run --files \
  vllm_omni/deploy/minicpmo_4_5.yaml \
  tests/model_executor/models/minicpmo_4_5/test_pipeline.py \
  recipes/OpenBMB/MiniCPM-o-4_5.md \
  examples/online_serving/minicpmo/README.md
```

## Test Result

```text
tests/model_executor/models/minicpmo_4_5/test_pipeline.py
22 passed, 18 warnings in 0.07s

test_mix_to_audio
1 passed, 15 warnings in 250.05s

test_mix_to_text_audio_001
5 concurrent requests succeeded
1 passed, 15 warnings in 292.20s

pre-commit
All hooks passed
```

With the reduced Talker budget, the B300 run still reported 674,720 KV-cache
tokens and 164.73x maximum concurrency for 4,096-token requests, well above
the configured `max_num_seqs: 4`.

The original cuDNN engine failure is H100-specific and does not reproduce on
the available B300; the H100 CI job is the final target-hardware validation.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
