### PR TITLE
[Bugfix] Use MiniCPM-o speech template in long audio test

### DIFF
--- a/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
@@ -150,7 +150,16 @@ def test_text_to_audio_long_output_001(omni_server, openai_client) -> None:
     request_config = {
         "model": omni_server.model,
         "messages": messages,
+        "modalities": ["text", "audio"],
         "stream": True,
+        # Delimit the assistant answer with the TTS template so the Talker
+        # does not spend its codec-token budget speaking hidden reasoning.
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
         "key_words": {"audio": ["Beijing"]},
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Resolves #5486

The long-text MiniCPM-o audio test used the plain chat template with thinking
enabled. The Talker could therefore spend its codec-token budget speaking the
reasoning span and truncate the final answer, causing the audio/text similarity
check to fail.

This test-only fix explicitly requests text and audio output, enables the
MiniCPM-o TTS template, and disables thinking. The existing plain-chat
`llm2tts` fallback is intentionally preserved because it is a supported runtime
path and is covered by existing contract tests.

cc @congw729 @Gaohan123 @Sy0307 @akshatvishu

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 0e3616e9 (based on 273fc8eb)

## Test Result

Targeted MiniCPM-o routing and stage-input tests:

```text
24 passed, 1 skipped
```

B300 full-model validation:

```bash
CUDA_VISIBLE_DEVICES=7 HF_HUB_DISABLE_TELEMETRY=1 \
  python -m pytest -sv \
  'tests/e2e/online_serving/test_minicpmo_4_5_expansion.py::test_text_to_audio_long_output_001[default]' \
  --run-level full_model --tb=short
```

```text
1 passed, 15 warnings in 562.13s (0:09:22)
```

All five concurrent requests completed. The observed audio/text cosine
similarities were above the test threshold, including approximately `0.9942`
and `1.0000`.

Pre-commit on the modified file:

```text
All hooks passed
```
