### PR TITLE
[Bugfix][Diffusion] Load prequantized BitsAndBytes checkpoints

### DIFF
--- a/docs/user_guide/quantization/bitsandbytes.md
+++ b/docs/user_guide/quantization/bitsandbytes.md
@@ -3,11 +3,13 @@
 ## Overview
 
 BitsAndBytes 4-bit quantization supports weight-only NF4/FP4 diffusion transformer
-inference on CUDA GPUs. It quantizes BF16/FP16 weights at load time; activations
-stay in BF16/FP16. No pre-quantized checkpoint is required.
+inference on CUDA GPUs. It can either quantize BF16/FP16 weights at load time or
+load a checkpoint that already contains BitsAndBytes weights and quantization
+state tensors. Activations stay in BF16/FP16.
 
-This is an online (dynamic) path: load the normal HuggingFace checkpoint and
-quantize during model loading via the `bitsandbytes` CUDA kernels.
+For online (dynamic) quantization, load a normal HuggingFace checkpoint and
+select `bitsandbytes` explicitly. For pre-quantized checkpoints, vLLM-Omni
+auto-detects the `quantization_config` in `transformer/config.json`.
 
 ## Hardware Support
 
@@ -34,6 +36,7 @@ Requires the optional `bitsandbytes` package (`pip install bitsandbytes`).
 |-------|-----------|:----:|------|----------------|
 | Z-Image | `Tongyi-MAI/Z-Image-Turbo` | Yes | Online W4 weight-only | All heavy linear layers; sensitive embedders stay BF16 |
 | Qwen-Image | `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512` | Not validated | Online W4 weight-only | Compare vs BF16 before enabling |
+| Qwen-Image 2512 BnB | `ovedrive/Qwen-Image-2512-4bit` | Not validated | Pre-quantized NF4 checkpoint | Single-GPU loading path |
 | Wan2.2 | Wan2.2 diffusion pipelines | Not validated | Online W4 weight-only | Validate before enabling in docs |
 
 Other diffusion models may work if their transformer uses supported linear
@@ -85,6 +88,15 @@ python text_to_image.py --model Tongyi-MAI/Z-Image-Turbo --quantization bitsandb
 vllm serve Tongyi-MAI/Z-Image-Turbo --omni --quantization bitsandbytes
 ```
 
+Pre-quantized checkpoint:
+
+```bash
+vllm serve ovedrive/Qwen-Image-2512-4bit --omni --tensor-parallel-size 1
+```
+
+Do not pass `--quantization bitsandbytes` for a pre-quantized checkpoint. Its
+`transformer/config.json` selects the checkpoint-native loader automatically.
+
 ## Parameters
 
 | Parameter | Type | Default | Description |
@@ -100,9 +112,10 @@ On Z-Image-Turbo (single GPU, 1024×1024, 50 steps), BitsAndBytes W4 typically
 reduces peak VRAM from roughly 24.5 GiB (BF16) to roughly 17 GiB. Compare output
 quality against a BF16 baseline before enabling on new models.
 
-Multi-GPU tensor parallelism (`tensor_parallel_size` > 1) is not validated for
-BitsAndBytes in diffusion models; each rank quantizes its own weight shard
-independently.
+Online quantization with multiple tensor-parallel ranks remains unvalidated;
+each rank quantizes its own weight shard independently. Pre-quantized
+BitsAndBytes checkpoints require `tensor_parallel_size=1` because their
+quantization states cannot be split across tensor-parallel ranks.
 
 If quality regresses, use `ignored_layers` to keep sensitive projections in BF16
 (for example `to_out` or `w2`).

--- a/tests/diffusion/model_loader/test_bitsandbytes_loader.py
+++ b/tests/diffusion/model_loader/test_bitsandbytes_loader.py
@@ -16,6 +16,13 @@ from vllm.model_executor.model_loader.bitsandbytes_loader import (
 )
 
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import (
+    QwenImagePipeline,
+)
+from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
+    QwenImageTransformer2DModel,
+)
+from vllm_omni.quantization import build_quant_config
 
 
 class _DummyPipelineModel(nn.Module):
@@ -150,6 +157,10 @@ def test_prequant_bitsandbytes_initializes_packed_linear_state(
         "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
         return_value=0,
     )
+    mocker.patch(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
 
     quant_config = BitsAndBytesConfig.from_config(
         {
@@ -189,3 +200,86 @@ def test_prequant_bitsandbytes_initializes_packed_linear_state(
         "to_qkv",
         0,
     )
+
+
+def test_qwen_image_checkpoint_bnb_packs_unskipped_precision_sensitive_linears(
+    mocker,
+    monkeypatch,
+):
+    bnb = types.ModuleType("bitsandbytes")
+    bnb.__version__ = "0.48.1"
+    bnb_nn = types.ModuleType("bitsandbytes.nn")
+    bnb_nn.Int8Params = nn.Parameter
+    bnb.nn = bnb_nn
+    monkeypatch.setitem(sys.modules, "bitsandbytes", bnb)
+    monkeypatch.setitem(sys.modules, "bitsandbytes.nn", bnb_nn)
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        return_value=1,
+    )
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+    mocker.patch(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+    mocker.patch(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        return_value=1,
+    )
+
+    quant_config = build_quant_config(
+        {
+            "quant_method": "bitsandbytes",
+            "_load_in_4bit": True,
+            "load_in_4bit": True,
+            "llm_int8_skip_modules": [
+                "transformer_blocks.0.img_mod.1",
+                "norm_out.linear",
+                "proj_out",
+            ],
+        }
+    )
+    od_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            sequence_parallel_size=1,
+            tensor_parallel_size=1,
+        )
+    )
+
+    previous_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        transformer = QwenImageTransformer2DModel(
+            od_config=od_config,
+            in_channels=4,
+            out_channels=4,
+            num_layers=2,
+            attention_head_dim=4,
+            num_attention_heads=2,
+            joint_attention_dim=6,
+            axes_dims_rope=(2, 2, 4),
+            quant_config=quant_config,
+        )
+    finally:
+        torch.set_default_dtype(previous_dtype)
+
+    assert transformer.img_in.weight.use_bitsandbytes_4bit is True
+    assert transformer.img_in.weight.pack_factor == 2
+    assert transformer.img_in.weight.shape == (16, 1)
+    assert transformer.txt_in.weight.use_bitsandbytes_4bit is True
+    assert transformer.txt_in.weight.shape == (24, 1)
+    assert not hasattr(
+        transformer.transformer_blocks[0].img_mod[1].weight,
+        "use_bitsandbytes_4bit",
+    )
+    assert transformer.transformer_blocks[1].img_mod[1].weight.use_bitsandbytes_4bit is True
+    assert transformer.transformer_blocks[1].txt_mod[1].weight.use_bitsandbytes_4bit is True
+
+
+def test_qwen_image_checkpoint_bnb_normalizes_quant_state_parameter_names():
+    assert QwenImagePipeline.hf_to_vllm_mapper._map_name(
+        "transformer_blocks.1.attn.to_out.0.weight"
+    ) == "transformer_blocks.1.attn.to_out.weight"

--- a/tests/diffusion/model_loader/test_bitsandbytes_loader.py
+++ b/tests/diffusion/model_loader/test_bitsandbytes_loader.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from vllm.config.load import LoadConfig
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization.bitsandbytes import BitsAndBytesConfig
+from vllm.model_executor.model_loader.bitsandbytes_loader import (
+    BitsAndBytesModelLoader,
+)
+
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+
+
+class _DummyPipelineModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.transformer = nn.Linear(2, 2, bias=False)
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path="dummy",
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+            )
+        ]
+
+    def load_weights(self, weights):
+        params = dict(self.named_parameters())
+        loaded = set()
+        for name, tensor in weights:
+            params[name].data.copy_(tensor)
+            loaded.add(name)
+        return loaded
+
+
+def test_prequant_bitsandbytes_uses_vllm_state_loader(mocker):
+    quant_config = BitsAndBytesConfig.from_config(
+        {
+            "quant_method": "bitsandbytes",
+            "load_in_4bit": True,
+            "load_in_8bit": False,
+            "bnb_4bit_quant_type": "nf4",
+        }
+    )
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        model="dummy",
+        revision=None,
+        parallel_config=SimpleNamespace(
+            use_hsdp=False,
+            tensor_parallel_size=1,
+        ),
+        quantization_config=quant_config,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    model = _DummyPipelineModel()
+    quant_state = object()
+    weights = iter([("weight", torch.zeros((2, 2)))])
+
+    bnb_loader = mocker.patch(
+        "vllm_omni.diffusion.model_loader.diffusers_loader.BitsAndBytesModelLoader",
+        autospec=True,
+    ).return_value
+    bnb_loader.weight_mapper = lambda name: name
+
+    def fake_quantized_generator(weight_files, use_safetensors, quant_states):
+        assert weight_files == ["model.safetensors"]
+        assert use_safetensors is True
+        quant_states[bnb_loader.weight_mapper("weight")] = quant_state
+        return weights
+
+    bnb_loader._quantized_4bit_generator.side_effect = fake_quantized_generator
+    bnb_loader._fuse_moe_quant_states.return_value = {}
+    bnb_loader._stack_quantization_states.return_value = {
+        "transformer.weight": {0: quant_state},
+    }
+    mocker.patch.object(
+        loader,
+        "_prepare_weights",
+        return_value=("dummy/transformer", ["model.safetensors"], True),
+    )
+
+    loader.load_weights(model)
+
+    bnb_loader._initialize_loader_state.assert_called_once_with(
+        model,
+        model_config=None,
+    )
+    bnb_loader._quantized_4bit_generator.assert_called_once_with(
+        ["model.safetensors"],
+        True,
+        {"transformer.weight": quant_state},
+    )
+    assert bnb_loader.weight_mapper("weight") == "weight"
+    bnb_loader._bind_quant_states_to_params.assert_called_once_with(
+        model,
+        {"transformer.weight": {0: quant_state}},
+    )
+
+
+def test_prequant_bitsandbytes_rejects_tensor_parallelism():
+    quant_config = BitsAndBytesConfig.from_config(
+        {
+            "quant_method": "bitsandbytes",
+            "load_in_4bit": True,
+        }
+    )
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        model="dummy",
+        revision=None,
+        parallel_config=SimpleNamespace(
+            use_hsdp=False,
+            tensor_parallel_size=2,
+        ),
+        quantization_config=quant_config,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+
+    with pytest.raises(
+        ValueError,
+        match="do not support tensor parallelism",
+    ):
+        loader.load_weights(_DummyPipelineModel())
+
+
+def test_prequant_bitsandbytes_initializes_packed_linear_state(
+    mocker,
+    monkeypatch,
+):
+    bnb = types.ModuleType("bitsandbytes")
+    bnb.__version__ = "0.48.1"
+    bnb_nn = types.ModuleType("bitsandbytes.nn")
+    bnb_nn.Int8Params = nn.Parameter
+    bnb.nn = bnb_nn
+    monkeypatch.setitem(sys.modules, "bitsandbytes", bnb)
+    monkeypatch.setitem(sys.modules, "bitsandbytes.nn", bnb_nn)
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        return_value=1,
+    )
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+
+    quant_config = BitsAndBytesConfig.from_config(
+        {
+            "quant_method": "bitsandbytes",
+            "load_in_4bit": True,
+        }
+    )
+
+    class _PackedTransformer(nn.Module):
+        packed_modules_mapping = {"to_qkv": ["to_q", "to_k", "to_v"]}
+
+        def __init__(self):
+            super().__init__()
+            self.to_qkv = ReplicatedLinear(
+                input_size=4,
+                output_size=12,
+                bias=False,
+                quant_config=quant_config,
+                prefix="to_qkv",
+                return_bias=False,
+            )
+
+    class _PackedPipeline(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.transformer = _PackedTransformer()
+
+    bnb_loader = BitsAndBytesModelLoader(LoadConfig())
+    bnb_loader.pre_quant = True
+
+    bnb_loader._initialize_loader_state(_PackedPipeline(), model_config=None)
+
+    assert "transformer.to_q" in bnb_loader.target_modules
+    assert "transformer.to_k" in bnb_loader.target_modules
+    assert "transformer.to_v" in bnb_loader.target_modules
+    assert bnb_loader.modules_mapping.inverse_packed_mapping["to_q"] == (
+        "to_qkv",
+        0,
+    )

--- a/tests/diffusion/model_loader/test_bitsandbytes_loader.py
+++ b/tests/diffusion/model_loader/test_bitsandbytes_loader.py
@@ -280,6 +280,7 @@ def test_qwen_image_checkpoint_bnb_packs_unskipped_precision_sensitive_linears(
 
 
 def test_qwen_image_checkpoint_bnb_normalizes_quant_state_parameter_names():
-    assert QwenImagePipeline.hf_to_vllm_mapper._map_name(
-        "transformer_blocks.1.attn.to_out.0.weight"
-    ) == "transformer_blocks.1.attn.to_out.weight"
+    assert (
+        QwenImagePipeline.hf_to_vllm_mapper._map_name("transformer_blocks.1.attn.to_out.0.weight")
+        == "transformer_blocks.1.attn.to_out.weight"
+    )

--- a/tests/diffusion/quantization/test_bitsandbytes_config.py
+++ b/tests/diffusion/quantization/test_bitsandbytes_config.py
@@ -11,6 +11,7 @@ import torch
 from pytest_mock import MockerFixture
 from torch.nn import Module, Parameter
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.bitsandbytes import BitsAndBytesConfig
 
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization import build_quant_config
@@ -50,16 +51,112 @@ def test_bitsandbytes_config_creation():
 
 def test_bitsandbytes_config_with_custom_params():
     """Test BitsAndBytes config with custom parameters."""
+    from vllm_omni.quantization.bitsandbytes_config import DiffusionBitsAndBytesConfig
+
     config = build_quant_config(
         "bitsandbytes",
         quant_type="fp4",
         compress_statistics=False,
         ignored_layers=["to_out"],
     )
-    assert config is not None
+    assert isinstance(config, DiffusionBitsAndBytesConfig)
     assert config.quant_type == "fp4"
     assert config.compress_statistics is False
     assert "to_out" in config.ignored_layers
+
+
+def test_bitsandbytes_checkpoint_config_uses_vllm_loader():
+    """Pre-quantized HF checkpoints must use vLLM's BnB weight loader."""
+    checkpoint_config = {
+        "quant_method": "bitsandbytes",
+        "_load_in_4bit": True,
+        "_load_in_8bit": False,
+        "load_in_4bit": True,
+        "load_in_8bit": False,
+        "bnb_4bit_compute_dtype": "bfloat16",
+        "bnb_4bit_quant_storage": "uint8",
+        "bnb_4bit_quant_type": "nf4",
+        "bnb_4bit_use_double_quant": True,
+        "llm_int8_skip_modules": [
+            "transformer_blocks.0.attn.to_q",
+            "proj_out",
+        ],
+    }
+
+    config = build_quant_config(checkpoint_config)
+
+    assert isinstance(config, BitsAndBytesConfig)
+    assert config.load_in_4bit is True
+    assert config.load_in_8bit is False
+    assert config.bnb_4bit_compute_dtype == "bfloat16"
+    assert config.bnb_4bit_quant_type == "nf4"
+    assert config.bnb_4bit_use_double_quant is True
+    assert config.llm_int8_skip_modules == [
+        "transformer_blocks.0.attn.to_q",
+        "proj_out",
+    ]
+
+
+def test_bitsandbytes_online_config_stays_on_diffusion_path():
+    from vllm_omni.quantization.bitsandbytes_config import DiffusionBitsAndBytesConfig
+
+    config = build_quant_config(
+        {
+            "quant_method": "bitsandbytes",
+            "quant_type": "nf4",
+            "compress_statistics": True,
+        }
+    )
+
+    assert isinstance(config, DiffusionBitsAndBytesConfig)
+
+
+def test_bitsandbytes_checkpoint_config_is_auto_detected():
+    from vllm_omni.diffusion.data import OmniDiffusionConfig, TransformerConfig
+
+    transformer_config = TransformerConfig.from_dict(
+        {
+            "quantization_config": {
+                "quant_method": "bitsandbytes",
+                "_load_in_4bit": True,
+                "load_in_4bit": True,
+                "bnb_4bit_quant_type": "nf4",
+            }
+        }
+    )
+
+    config = OmniDiffusionConfig(
+        model="test",
+        tf_model_config=transformer_config,
+    )
+
+    assert isinstance(config.quantization_config, BitsAndBytesConfig)
+    assert config.quantization_config.bnb_4bit_quant_type == "nf4"
+
+
+def test_bitsandbytes_checkpoint_config_skips_fused_linear(mocker):
+    config = build_quant_config(
+        {
+            "quant_method": "bitsandbytes",
+            "_load_in_4bit": True,
+            "load_in_4bit": True,
+            "llm_int8_skip_modules": [
+                "transformer_blocks.0.attn.to_q",
+                "transformer_blocks.0.attn.to_k",
+                "transformer_blocks.0.attn.to_v",
+            ],
+        }
+    )
+    config.packed_modules_mapping = {
+        "to_qkv": ["to_q", "to_k", "to_v"],
+    }
+
+    method = config.get_quant_method(
+        mocker.Mock(spec=LinearBase),
+        "transformer_blocks.0.attn.to_qkv",
+    )
+
+    assert isinstance(method, UnquantizedLinearMethod)
 
 
 def test_supported_methods():

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -15,6 +15,10 @@ from torch import nn
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.layers.quantization.bitsandbytes import BitsAndBytesConfig
+from vllm.model_executor.model_loader.bitsandbytes_loader import (
+    BitsAndBytesModelLoader,
+)
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -298,6 +302,62 @@ class DiffusersPipelineLoader:
         for source in sources:
             yield from self._get_weights_iterator(source, model=model)
 
+    def _get_prequant_bitsandbytes_weights(
+        self,
+        model: nn.Module,
+    ) -> tuple[
+        Generator[tuple[str, torch.Tensor], None, None],
+        BitsAndBytesModelLoader,
+        dict[str, object],
+    ]:
+        if self.parallel_config.tensor_parallel_size > 1:
+            raise ValueError(
+                "Prequant BitsAndBytes diffusion checkpoints do not support "
+                "tensor parallelism. Use tensor_parallel_size=1."
+            )
+
+        bnb_loader = BitsAndBytesModelLoader(self.load_config)
+        bnb_loader.pre_quant = True
+        bnb_loader.load_8bit = self.quant_config.load_in_8bit
+        bnb_loader._initialize_loader_state(model, model_config=None)
+        quant_state_dict: dict[str, object] = {}
+
+        def _iter_weights() -> Generator[tuple[str, torch.Tensor], None, None]:
+            base_weight_mapper = bnb_loader.weight_mapper
+            try:
+                for source in self._get_weight_sources(model):
+                    _, weight_files, use_safetensors = self._prepare_weights(
+                        source.model_or_path,
+                        source.subfolder,
+                        source.revision,
+                        source.fall_back_to_pt,
+                        source.allow_patterns_overrides,
+                    )
+                    prefix = source.prefix
+                    bnb_loader.weight_mapper = lambda name, mapper=base_weight_mapper, source_prefix=prefix: (
+                        source_prefix + mapper(name)
+                    )
+                    source_quant_states: dict[str, object] = {}
+                    if bnb_loader.load_8bit:
+                        source_weights = bnb_loader._quantized_8bit_generator(
+                            weight_files,
+                            use_safetensors,
+                            source_quant_states,
+                        )
+                    else:
+                        source_weights = bnb_loader._quantized_4bit_generator(
+                            weight_files,
+                            use_safetensors,
+                            source_quant_states,
+                        )
+                    for name, tensor in source_weights:
+                        yield prefix + name, tensor
+                    quant_state_dict.update(source_quant_states)
+            finally:
+                bnb_loader.weight_mapper = base_weight_mapper
+
+        return _iter_weights(), bnb_loader, quant_state_dict
+
     def _get_weight_sources(self, model: nn.Module) -> tuple["ComponentSource", ...]:
         return tuple(
             cast(
@@ -341,8 +401,10 @@ class DiffusersPipelineLoader:
         offload_after_quant = False
         if load_device == "cpu" and self.quant_config is not None and device is not None:
             quant_cfg = self.quant_config
-            is_offline = getattr(quant_cfg, "data_type", None) == "mx_fp" or getattr(
-                quant_cfg, "is_checkpoint_quantized", False
+            is_offline = (
+                isinstance(quant_cfg, BitsAndBytesConfig)
+                or getattr(quant_cfg, "data_type", None) == "mx_fp"
+                or getattr(quant_cfg, "is_checkpoint_quantized", False)
             )
             if not is_offline:
                 load_device = device.type
@@ -500,7 +562,20 @@ class DiffusersPipelineLoader:
 
     def load_weights(self, model: nn.Module) -> None:
         weights_to_load = self._get_expected_parameter_names(model)
-        loaded_weights = model.load_weights(self.get_all_weights(model))
+        if isinstance(self.quant_config, BitsAndBytesConfig):
+            weights, bnb_loader, quant_state_dict = self._get_prequant_bitsandbytes_weights(model)
+            loaded_weights = model.load_weights(weights)
+            expert_quant_states = bnb_loader._fuse_moe_quant_states(model, quant_state_dict)
+            stacked_quant_states = bnb_loader._stack_quantization_states(model, quant_state_dict)
+            bnb_loader._bind_quant_states_to_params(
+                model,
+                {
+                    **expert_quant_states,
+                    **stacked_quant_states,
+                },
+            )
+        else:
+            loaded_weights = model.load_weights(self.get_all_weights(model))
 
         self.counter_after_loading_weights = time.perf_counter()
         logger.info_once(

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -20,7 +20,7 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
 from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
 from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer
-from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_qwenimage import DistributedAutoencoderKLQwenImage
@@ -267,6 +267,11 @@ class QwenImagePipeline(
     nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
 ):
     packed_modules_mapping = QwenImageTransformer2DModel.packed_modules_mapping
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_substr={
+            ".to_out.0.": ".to_out.",
+        }
+    )
     supports_request_batch = True
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
@@ -1091,7 +1096,7 @@ class QwenImagePipeline(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
 class QwenImageDMD2Pipeline(DMD2PipelineMixin, QwenImagePipeline):

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -266,6 +266,7 @@ def apply_rotary_emb_qwen(
 class QwenImagePipeline(
     nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
 ):
+    packed_modules_mapping = QwenImageTransformer2DModel.packed_modules_mapping
     supports_request_batch = True
     _dit_modules: ClassVar[list[str]] = ["transformer"]
     _encoder_modules: ClassVar[list[str]] = ["text_encoder"]

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -186,6 +186,7 @@ class QwenTimestepProjEmbeddings(nn.Module):
         quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
+        protected_quant_config = safe_quant_config(quant_config)
 
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0, scale=1000)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
@@ -197,7 +198,7 @@ class QwenTimestepProjEmbeddings(nn.Module):
             embedding_dim,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="timestep_embedder.linear_1",
         )
         self.timestep_embedder.linear_2 = ReplicatedLinear(
@@ -205,7 +206,7 @@ class QwenTimestepProjEmbeddings(nn.Module):
             embedding_dim,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="timestep_embedder.linear_2",
         )
         self.use_additional_t_cond = use_additional_t_cond
@@ -730,7 +731,7 @@ class QwenImageTransformerBlock(nn.Module):
         self.dim = dim
         self.num_attention_heads = num_attention_heads
         self.attention_head_dim = attention_head_dim
-        txt_mod_quant_config = safe_quant_config(quant_config)
+        protected_quant_config = safe_quant_config(quant_config)
 
         # Image processing modules.
         # The re-quantized W4A16 checkpoint keeps img_mod.1 in full precision.
@@ -741,7 +742,7 @@ class QwenImageTransformerBlock(nn.Module):
                 6 * dim,
                 bias=True,
                 return_bias=False,
-                quant_config=None,
+                quant_config=protected_quant_config,
                 prefix=f"{prefix}.img_mod.1",
             ),
         )
@@ -772,7 +773,7 @@ class QwenImageTransformerBlock(nn.Module):
                 6 * dim,
                 bias=True,
                 return_bias=False,
-                quant_config=txt_mod_quant_config,
+                quant_config=protected_quant_config,
                 prefix=f"{prefix}.txt_mod.1",
             ),
         )
@@ -994,6 +995,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.inner_dim = num_attention_heads * attention_head_dim
         self.guidance_embeds = guidance_embeds
         self.quant_config = quant_config
+        protected_quant_config = safe_quant_config(quant_config)
 
         if not use_layer3d_rope:
             self.pos_embed = QwenEmbedRope(theta=10000, axes_dim=list(axes_dims_rope), scale_rope=True)
@@ -1015,7 +1017,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
             self.inner_dim,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="img_in",
         )
         self.txt_in = ReplicatedLinear(
@@ -1023,7 +1025,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
             self.inner_dim,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="txt_in",
         )
 
@@ -1050,7 +1052,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
             2 * self.inner_dim,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="norm_out.linear",
         )
         self.proj_out = ReplicatedLinear(
@@ -1058,7 +1060,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
             patch_size * patch_size * self.out_channels,
             bias=True,
             return_bias=False,
-            quant_config=None,
+            quant_config=protected_quant_config,
             prefix="proj_out",
         )
 

--- a/vllm_omni/quantization/bitsandbytes_config.py
+++ b/vllm_omni/quantization/bitsandbytes_config.py
@@ -20,6 +20,10 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.bitsandbytes import (
+    BitsAndBytesConfig,
+    BitsAndBytesLinearMethod,
+)
 from vllm.model_executor.layers.quantization.fp8 import _copy_missing_attrs
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
@@ -33,6 +37,25 @@ from vllm_omni.quantization.int8_config import LazyWeightMixin
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
+
+
+class DiffusionCheckpointBitsAndBytesConfig(BitsAndBytesConfig):
+    """Checkpoint-native BnB config with diffusion fused-layer skip support."""
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> Optional["QuantizeMethodBase"]:
+        if isinstance(layer, LinearBase):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.llm_int8_skip_modules,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedLinearMethod()
+            return BitsAndBytesLinearMethod(self)
+        return super().get_quant_method(layer, prefix)
 
 
 class DiffusionBitsAndBytesConfig(QuantizationConfig):

--- a/vllm_omni/quantization/component_config.py
+++ b/vllm_omni/quantization/component_config.py
@@ -55,9 +55,10 @@ def safe_quant_config(
 
     Norm and modulation layers (LayerNorm, RMSNorm, AdaLayerNorm, img_mod,
     txt_mod, etc.) produce precision-sensitive shift/scale/gate values and
-    should not receive FP8 quant configs (see #2728).  Pre-quantized methods
-    like INC/AutoRound W4A16 need the config propagated so packed weights
-    load correctly.
+    should not receive online quant configs (see #2728). Pre-quantized methods
+    like INC/AutoRound W4A16 and BitsAndBytes need the config propagated so
+    packed weights load correctly and their checkpoint skip lists decide
+    which layers remain full precision.
 
     This is the inverse of :func:`resolve_encoder_quant_config`: that function
     strips pre-quantized configs from encoders, while this one strips
@@ -66,8 +67,11 @@ def safe_quant_config(
     if quant_config is None:
         return None
     from vllm.model_executor.layers.quantization.inc import INCConfig
+    from vllm.model_executor.layers.quantization.bitsandbytes import (
+        BitsAndBytesConfig,
+    )
 
-    if isinstance(quant_config, INCConfig):
+    if isinstance(quant_config, (BitsAndBytesConfig, INCConfig)):
         return quant_config
     return None
 

--- a/vllm_omni/quantization/component_config.py
+++ b/vllm_omni/quantization/component_config.py
@@ -66,10 +66,10 @@ def safe_quant_config(
     """
     if quant_config is None:
         return None
-    from vllm.model_executor.layers.quantization.inc import INCConfig
     from vllm.model_executor.layers.quantization.bitsandbytes import (
         BitsAndBytesConfig,
     )
+    from vllm.model_executor.layers.quantization.inc import INCConfig
 
     if isinstance(quant_config, (BitsAndBytesConfig, INCConfig)):
         return quant_config

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -89,7 +89,12 @@ def _build_int8(**kw: Any) -> QuantizationConfig:
 
 
 def _build_bitsandbytes(**kw: Any) -> QuantizationConfig:
-    """Lazy import for BitsAndBytes 4-bit diffusion config (CUDA only)."""
+    """Build online or checkpoint-native BitsAndBytes config."""
+    if "_load_in_4bit" in kw or "_load_in_8bit" in kw:
+        from .bitsandbytes_config import DiffusionCheckpointBitsAndBytesConfig
+
+        return DiffusionCheckpointBitsAndBytesConfig.from_config({"quant_method": "bitsandbytes", **kw})
+
     from .bitsandbytes_config import DiffusionBitsAndBytesConfig
 
     return DiffusionBitsAndBytesConfig(**kw)


### PR DESCRIPTION
## Purpose

Fixes #5601.

Pre-quantized Hugging Face BitsAndBytes diffusion checkpoints currently fail while parsing `transformer/config.json` because private Transformers fields such as `_load_in_4bit` are passed to the online diffusion BitsAndBytes config.

This change:

- detects checkpoint-native BitsAndBytes configs while preserving the existing online quantization path;
- reuses vLLM's BitsAndBytes loader to parse checkpoint quantization-state tensors and bind them to diffusion parameters;
- preserves component prefixes and packed-projection quantization states;
- applies Qwen-Image packed-module mappings so checkpoint skip lists correctly handle fused projections;
- rejects tensor parallelism for pre-quantized BitsAndBytes checkpoints, matching the upstream loader constraint;
- documents the checkpoint-native single-GPU loading path.

## Test Plan

### Repository tests

- `31 passed, 3 skipped`:
  - `tests/diffusion/quantization/test_bitsandbytes_config.py`
  - `tests/diffusion/model_loader/test_bitsandbytes_loader.py`
  - `tests/diffusion/test_diffusion_config_fields.py`
  - `tests/diffusion/test_diffusion_config_propagation.py`
- `31 passed`:
  - `tests/diffusion/models/qwen_image`
- Full repository pre-commit, using the same `SKIP=check-test-ci-coverage` setting as CI.
- Python compile checks and `git diff --check`.

### Real checkpoint E2E

- Hardware: NVIDIA A100 80GB PCIe, single GPU.
- Dependency: `bitsandbytes==0.49.2`, loading `libbitsandbytes_cuda130.so`.
- Checkpoint: `ovedrive/Qwen-Image-2512-4bit`, pinned snapshot `eeeeb8185634bbcaffeb9a46e4c8c3bf654f2c68`.
- Runtime source: the validation archive's two changed loader/config files have byte-identical SHA-256 hashes to PR commit `8dfaece81eb7553ba8a8aa74143f85cc6f2edcf0`; `63b7734e9c954be9a536822c12a7c7ec7808305c` only applies pre-commit formatting.
- Command:

```bash
python examples/offline_inference/text_to_image/text_to_image.py \
  --model /hf-model/snapshots/eeeeb8185634bbcaffeb9a46e4c8c3bf654f2c68 \
  --prompt "a red panda reading a book" \
  --height 256 \
  --width 256 \
  --num-inference-steps 20 \
  --seed 42 \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --output /evidence/pr5633.png
```

## Test Result

- The real 4-bit checkpoint loaded all 729 transformer entries and completed startup warmup and image generation without the previous quant-state binding failure.
- Runtime logs exercised the BitsAndBytes CUDA backend; the CLI's `Quantization: None (BF16)` line refers to no additional online quantization request, not to the checkpoint-native packed weights.
- 20-step E2E:
  - return code: `0`
  - wall time including initialization: `49.682 s`
  - peak process GPU memory: `20,218 MiB`
  - output: 256x256 RGB PNG, `107,041` bytes
  - SHA-256: `0355e14e3b5e2e4a91caab534579e6d5a7b56c5908a5a9e23427b02482da3577`
  - channel means: `[86.138, 68.768, 50.622]`; extrema: `R 0-229`, `G 0-218`, `B 0-204`
- A second 4-step run also completed successfully:
  - return code: `0`
  - wall time including initialization: `48.725 s`
  - peak process GPU memory: `20,216 MiB`
  - output SHA-256: `9298d423fe69d1e7be7915a71a364c3d6b67158780ddac87b8b6960f3aae4c96`
- A 1-step smoke technically returned successfully but produced an all-black 270-byte PNG, so it is intentionally not used as image-quality evidence.

Validation boundary: this proves the single-GPU checkpoint-native BitsAndBytes loading and complete text-to-image path for the pinned checkpoint. It does not claim tensor-parallel support, and it is not a throughput benchmark.
