### PR TITLE
[Core] Make KV prefetch H2D copies event-driven

### DIFF
--- a/benchmarks/distributed/omni_connectors/README.md
+++ b/benchmarks/distributed/omni_connectors/README.md
@@ -2,6 +2,23 @@
 
 This document explains how to configure the RDMA environment and run tests for `MooncakeTransferEngineConnector`.
 
+## Async KV Prefetch H2D Benchmark
+
+Measure how quickly a background KV prefetch future becomes available while its
+H2D copy continues on the dedicated copy stream:
+
+```bash
+python benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py \
+    --device cuda:0 \
+    --size-mib 256 \
+    --warmup 3 \
+    --iterations 20
+```
+
+`event_future_ready` is the event-based submission latency.
+`blocking_future_ready` includes waiting for the same copy event and models the
+previous future-ready behavior.
+
 ## Table of Contents
 
 - [Docker Container Permissions](#docker-container-permissions)

--- a/benchmarks/distributed/omni_connectors/README.md
+++ b/benchmarks/distributed/omni_connectors/README.md
@@ -15,7 +15,8 @@ python benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py \
     --iterations 20
 ```
 
-`event_future_ready` is the event-based submission latency.
+`event_future_ready` includes executor submission, background-thread scheduling,
+and the event-based H2D enqueue until the prefetch future becomes ready.
 `blocking_future_ready` includes waiting for the same copy event and models the
 previous future-ready behavior.
 

--- a/benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py
+++ b/benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py
@@ -48,6 +48,7 @@ def main() -> None:
         OmniKVCacheConfig(need_recv_cache=True),
         async_prefetch=True,
     )
+    assert manager._prefetch_executor is not None
 
     def fake_receive(
         request_id,
@@ -77,12 +78,14 @@ def main() -> None:
         torch.accelerator.synchronize()
         torch.accelerator.reset_peak_memory_stats()
         started = time.perf_counter()
-        result = manager._prefetch_payload(
+        future = manager._prefetch_executor.submit(
+            manager._prefetch_payload,
             f"bench-{iteration}",
             None,
             device,
         )
-        submitted = time.perf_counter()
+        result = future.result()
+        future_ready = time.perf_counter()
         event_incomplete += int(not result.ready_event.query())
         result.ready_event.synchronize()
         completed = time.perf_counter()
@@ -90,7 +93,7 @@ def main() -> None:
         manager._release_prefetch_result(result)
 
         if iteration >= args.warmup:
-            submit_ms.append((submitted - started) * 1000)
+            submit_ms.append((future_ready - started) * 1000)
             blocking_ready_ms.append((completed - started) * 1000)
             peak_memory_mib.append(peak_mib)
         del result

--- a/benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py
+++ b/benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Measure future-ready latency for asynchronous KV prefetch H2D copies."""
+
+import argparse
+import statistics
+import time
+
+import torch
+
+from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
+    OmniKVCacheConfig,
+    OmniKVTransferManager,
+)
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = min(int(len(ordered) * fraction), len(ordered) - 1)
+    return ordered[index]
+
+
+def _format_metrics(name: str, values: list[float]) -> str:
+    return (
+        f"{name}: median={statistics.median(values):.3f} ms, "
+        f"p95={_percentile(values, 0.95):.3f} ms, "
+        f"range=[{min(values):.3f}, {max(values):.3f}] ms"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--size-mib", type=int, default=256)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=20)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    torch.accelerator.set_device_index(device.index)
+    element_size = torch.empty((), dtype=torch.float32).element_size()
+    element_count = args.size_mib * 1024 * 1024 // element_size
+    source = torch.empty(element_count, dtype=torch.float32, pin_memory=True)
+    source.normal_()
+
+    manager = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+
+    def fake_receive(
+        request_id,
+        target_device=None,
+        *,
+        sender_info=None,
+        non_blocking_copy=False,
+        copy_stream=None,
+        deferred_copy_sources=None,
+        deferred_pool_buffers=None,
+    ):
+        assert non_blocking_copy
+        assert copy_stream is not None
+        assert deferred_copy_sources is not None
+        assert deferred_pool_buffers is not None
+        destination = source.to(target_device, non_blocking=True)
+        deferred_copy_sources.append(source)
+        return {"layer_blocks": {"key_cache": [destination], "value_cache": []}}, source.nbytes
+
+    manager.receive_kv_cache_for_request = fake_receive
+    submit_ms: list[float] = []
+    blocking_ready_ms: list[float] = []
+    peak_memory_mib: list[float] = []
+    event_incomplete = 0
+
+    for iteration in range(args.warmup + args.iterations):
+        torch.accelerator.synchronize()
+        torch.accelerator.reset_peak_memory_stats()
+        started = time.perf_counter()
+        result = manager._prefetch_payload(
+            f"bench-{iteration}",
+            None,
+            device,
+        )
+        submitted = time.perf_counter()
+        event_incomplete += int(not result.ready_event.query())
+        result.ready_event.synchronize()
+        completed = time.perf_counter()
+        peak_mib = torch.accelerator.max_memory_allocated() / (1024 * 1024)
+        manager._release_prefetch_result(result)
+
+        if iteration >= args.warmup:
+            submit_ms.append((submitted - started) * 1000)
+            blocking_ready_ms.append((completed - started) * 1000)
+            peak_memory_mib.append(peak_mib)
+        del result
+
+    manager.shutdown_prefetch()
+    print(f"device={device}, size={args.size_mib} MiB, warmup={args.warmup}, iterations={args.iterations}")
+    print(_format_metrics("event_future_ready", submit_ms))
+    print(_format_metrics("blocking_future_ready", blocking_ready_ms))
+    print(
+        f"event_incomplete_at_return={event_incomplete}/{args.warmup + args.iterations}, "
+        f"peak_memory={max(peak_memory_mib):.1f} MiB"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/omni_connectors/test_kv_async_prefetch.py
+++ b/tests/distributed/omni_connectors/test_kv_async_prefetch.py
@@ -358,6 +358,41 @@ def test_consume_and_distribute_attaches_prefetched_payload():
     assert req.past_key_values is not None
 
 
+def test_deserialization_failure_after_get_is_non_retryable(monkeypatch):
+    _, receiver, connector = _make_sender_receiver()
+    connector.get = lambda **_kwargs: (b"consumed-payload", 16)
+
+    def fail_deserialization(_payload):
+        raise RuntimeError("decode failed")
+
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.KVCacheTransferData.from_bytes",
+        fail_deserialization,
+    )
+
+    with pytest.raises(KVPrefetchConsumeError, match="payload already consumed"):
+        receiver.receive_kv_cache_for_request("rid-consumed")
+
+
+def test_partial_multi_key_timeout_after_get_is_non_retryable(monkeypatch):
+    _, receiver, connector = _make_sender_receiver()
+    receiver.config.recv_timeout = 0.0
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.build_rank_aware_recv_keys",
+        lambda *_args, **_kwargs: [("rank-0", 0), ("rank-1", 1)],
+    )
+
+    def get_one_rank(*, get_key, **_kwargs):
+        if get_key == "rank-0":
+            return {"layer_blocks": {}}, 1
+        return None
+
+    connector.get = get_one_rank
+
+    with pytest.raises(KVPrefetchConsumeError, match="payload already consumed"):
+        receiver.receive_kv_cache_for_request("rid-partial")
+
+
 def test_gpu_prefetch_records_event_without_synchronizing(monkeypatch):
     receiver = OmniKVTransferManager(
         OmniKVCacheConfig(need_recv_cache=True),
@@ -481,20 +516,21 @@ def test_consume_waits_event_and_records_destination_stream(monkeypatch):
         def wait_event(self, event):
             events.append(("wait_event", event))
 
+    compute_stream = _ComputeStream()
     monkeypatch.setattr(
         "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.current_stream",
-        lambda: _ComputeStream(),
+        lambda: compute_stream,
     )
     monkeypatch.setattr(
         receiver,
         "_record_stream_for_prefetched",
-        lambda payload: events.append(("record_stream", payload)),
+        lambda payload, stream=None: events.append(("record_stream", payload, stream)),
     )
 
     assert receiver.consume_prefetched_kv(_req("rid-gpu")) == (data, 7)
     assert events == [
         ("wait_event", ready_event),
-        ("record_stream", data),
+        ("record_stream", data, compute_stream),
     ]
 
 

--- a/tests/distributed/omni_connectors/test_kv_async_prefetch.py
+++ b/tests/distributed/omni_connectors/test_kv_async_prefetch.py
@@ -348,17 +348,13 @@ def test_start_prefetch_submits_for_owner(monkeypatch):
     receiver.shutdown_prefetch()
 
 
-def test_consume_then_apply_attaches_payload():
+def test_consume_and_distribute_attaches_prefetched_payload():
     sender, receiver, _ = _make_sender_receiver()
     _seed_payload(sender, "rid-apply")
     receiver.start_prefetch({"request_id": "rid-apply", "kv_sender_info": _SENDER_INFO})
-    data, _ = receiver.consume_prefetched_kv(_req("rid-apply"))
-    assert data is not None
 
     req = OmniDiffusionRequest(prompt="p", sampling_params=OmniDiffusionSamplingParams(), request_id="rid-apply")
-    # Mirror consume_and_distribute_kv_cache's LOCAL apply path (CPU: record_stream no-op).
-    receiver._record_stream_for_prefetched(data)
-    receiver.apply_kv_cache_to_request(req, data)
+    assert receiver.consume_and_distribute_kv_cache(req)
     assert req.past_key_values is not None
 
 

--- a/tests/distributed/omni_connectors/test_kv_async_prefetch.py
+++ b/tests/distributed/omni_connectors/test_kv_async_prefetch.py
@@ -534,12 +534,13 @@ def test_consume_waits_event_and_records_destination_stream(monkeypatch):
     ]
 
 
-def test_consumed_prefetch_releases_pool_buffer_after_event_completes():
+def test_consumed_prefetch_releases_pool_buffer_after_event_completes(monkeypatch):
     receiver = OmniKVTransferManager(
         OmniKVCacheConfig(need_recv_cache=True),
         async_prefetch=True,
     )
     events = []
+    waited_events = []
 
     class _Event:
         completed = False
@@ -547,7 +548,15 @@ def test_consumed_prefetch_releases_pool_buffer_after_event_completes():
         def query(self):
             return self.completed
 
+    class _ComputeStream:
+        def wait_event(self, event):
+            waited_events.append(event)
+
     ready_event = _Event()
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.current_stream",
+        _ComputeStream,
+    )
     pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
     future = Future()
     future.set_result(
@@ -561,6 +570,7 @@ def test_consumed_prefetch_releases_pool_buffer_after_event_completes():
     receiver._prefetch_futures["rid-gpu"] = future
 
     receiver.consume_prefetched_kv(_req("rid-gpu"))
+    assert waited_events == [ready_event]
     assert events == []
     assert len(receiver._pending_prefetch_releases) == 1
 

--- a/tests/distributed/omni_connectors/test_kv_async_prefetch.py
+++ b/tests/distributed/omni_connectors/test_kv_async_prefetch.py
@@ -5,6 +5,8 @@ mock connector, dedup, per-call sender_info isolation, role classification, and
 miss/abort paths.  GPU H2D and D2D paths need CUDA (integration tests).
 """
 
+from concurrent.futures import Future
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -12,9 +14,11 @@ import torch
 
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
+    KVPrefetchConsumeError,
     OmniKVCacheConfig,
     OmniKVTransferManager,
     ReceiveRole,
+    _PrefetchedKV,
 )
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
@@ -338,8 +342,10 @@ def test_start_prefetch_submits_for_owner(monkeypatch):
     _seed_payload(sender, "rid-own")
     _set_tp(receiver, 2, 2)
     _patch_topo(monkeypatch, world_size=4, cfg_size=2, cfg_rank=0)
+    monkeypatch.setattr(receiver, "_prefetch_payload", lambda *_args: _PrefetchedKV(data=None, size=0))
     receiver.start_prefetch({"request_id": "rid-own", "kv_sender_info": _SENDER_INFO})
     assert "rid-own" in receiver._prefetch_futures
+    receiver.shutdown_prefetch()
 
 
 def test_consume_then_apply_attaches_payload():
@@ -354,3 +360,339 @@ def test_consume_then_apply_attaches_payload():
     receiver._record_stream_for_prefetched(data)
     receiver.apply_kv_cache_to_request(req, data)
     assert req.past_key_values is not None
+
+
+def test_gpu_prefetch_records_event_without_synchronizing(monkeypatch):
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+
+    class _CopyStream:
+        def synchronize(self):
+            raise AssertionError("successful prefetch must not synchronize the CPU")
+
+    class _Event:
+        def record(self, stream):
+            events.append(("record", stream))
+
+    fake_stream = _CopyStream()
+    captured = {}
+
+    monkeypatch.setattr(torch.accelerator, "set_device_index", lambda _index: None)
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.Stream",
+        lambda: fake_stream,
+    )
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.stream",
+        lambda _stream: nullcontext(),
+    )
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.Event",
+        _Event,
+    )
+
+    def fake_receive(request_id, target_device=None, **kwargs):
+        captured.update(
+            request_id=request_id,
+            target_device=target_device,
+            **kwargs,
+        )
+        kwargs["deferred_pool_buffers"].append(pool_buffer)
+        return {"layer_blocks": {}}, 1
+
+    monkeypatch.setattr(receiver, "receive_kv_cache_for_request", fake_receive)
+
+    result = receiver._prefetch_payload(
+        "rid-gpu",
+        _SENDER_INFO,
+        torch.device("cuda:0"),
+    )
+
+    assert result.data is not None
+    assert result.size == 1
+    assert result.pool_buffers == [pool_buffer]
+    assert captured["non_blocking_copy"] is True
+    assert captured["deferred_pool_buffers"] is result.pool_buffers
+    assert events == [("record", fake_stream)]
+
+
+def test_gpu_prefetch_event_failure_is_non_retryable_and_releases_after_sync(monkeypatch):
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+    source = torch.ones(1)
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+
+    class _CopyStream:
+        def synchronize(self):
+            events.append("synchronize")
+
+    class _Event:
+        def record(self, stream):
+            raise RuntimeError("record failed")
+
+    fake_stream = _CopyStream()
+    monkeypatch.setattr(torch.accelerator, "set_device_index", lambda _index: None)
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.Stream",
+        lambda: fake_stream,
+    )
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.stream",
+        lambda _stream: nullcontext(),
+    )
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.Event",
+        _Event,
+    )
+
+    def fake_receive(request_id, target_device=None, **kwargs):
+        kwargs["deferred_copy_sources"].append(source)
+        kwargs["deferred_pool_buffers"].append(pool_buffer)
+        return {"layer_blocks": {}}, 1
+
+    monkeypatch.setattr(receiver, "receive_kv_cache_for_request", fake_receive)
+
+    with pytest.raises(KVPrefetchConsumeError, match="payload already consumed"):
+        receiver._prefetch_payload(
+            "rid-gpu",
+            _SENDER_INFO,
+            torch.device("cuda:0"),
+        )
+
+    assert events == ["synchronize", "release"]
+
+
+def test_consume_waits_event_and_records_destination_stream(monkeypatch):
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+    ready_event = SimpleNamespace(query=lambda: False)
+    data = {"layer_blocks": {}}
+    future = Future()
+    future.set_result(_PrefetchedKV(data=data, size=7, ready_event=ready_event))
+    receiver._prefetch_futures["rid-gpu"] = future
+
+    class _ComputeStream:
+        def wait_event(self, event):
+            events.append(("wait_event", event))
+
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.current_stream",
+        lambda: _ComputeStream(),
+    )
+    monkeypatch.setattr(
+        receiver,
+        "_record_stream_for_prefetched",
+        lambda payload: events.append(("record_stream", payload)),
+    )
+
+    assert receiver.consume_prefetched_kv(_req("rid-gpu")) == (data, 7)
+    assert events == [
+        ("wait_event", ready_event),
+        ("record_stream", data),
+    ]
+
+
+def test_consumed_prefetch_releases_pool_buffer_after_event_completes():
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        completed = False
+
+        def query(self):
+            return self.completed
+
+    ready_event = _Event()
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    future = Future()
+    future.set_result(
+        _PrefetchedKV(
+            data={"layer_blocks": {}},
+            size=7,
+            ready_event=ready_event,
+            pool_buffers=[pool_buffer],
+        )
+    )
+    receiver._prefetch_futures["rid-gpu"] = future
+
+    receiver.consume_prefetched_kv(_req("rid-gpu"))
+    assert events == []
+    assert len(receiver._pending_prefetch_releases) == 1
+
+    receiver._drain_prefetch_releases()
+    assert events == []
+
+    ready_event.completed = True
+    receiver._drain_prefetch_releases()
+    assert events == ["release"]
+    assert receiver._pending_prefetch_releases == []
+
+
+@pytest.mark.parametrize("completed_miss", [False, True])
+def test_prefetch_miss_drains_pending_sources_before_sync_fallback(completed_miss):
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        def query(self):
+            return False
+
+        def synchronize(self):
+            events.append("synchronize")
+
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    receiver._pending_prefetch_releases.append(
+        _PrefetchedKV(
+            data={"layer_blocks": {}},
+            size=7,
+            ready_event=_Event(),
+            pool_buffers=[pool_buffer],
+        )
+    )
+    if completed_miss:
+        future = Future()
+        future.set_result(_PrefetchedKV(data=None, size=0))
+        receiver._prefetch_futures["not-prefetched"] = future
+
+    assert receiver.consume_prefetched_kv(_req("not-prefetched")) == (None, 0)
+    assert events == ["synchronize", "release"]
+    assert receiver._pending_prefetch_releases == []
+
+
+def test_consume_stream_dependency_failure_synchronizes_and_raises(monkeypatch):
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        def synchronize(self):
+            events.append("synchronize")
+
+    class _ComputeStream:
+        def wait_event(self, event):
+            raise RuntimeError("wait failed")
+
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    future = Future()
+    future.set_result(
+        _PrefetchedKV(
+            data={"layer_blocks": {}},
+            size=7,
+            ready_event=_Event(),
+            pool_buffers=[pool_buffer],
+        )
+    )
+    receiver._prefetch_futures["rid-gpu"] = future
+    monkeypatch.setattr(
+        "vllm_omni.distributed.omni_connectors.kv_transfer_manager.current_omni_platform.current_stream",
+        lambda: _ComputeStream(),
+    )
+
+    with pytest.raises(KVPrefetchConsumeError, match="stream dependency"):
+        receiver.consume_prefetched_kv(_req("rid-gpu"))
+
+    assert events == ["synchronize", "release"]
+
+
+def test_discarded_prefetch_synchronizes_before_pool_buffer_release():
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        def synchronize(self):
+            events.append("synchronize")
+
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    future = Future()
+    future.set_result(
+        _PrefetchedKV(
+            data={"layer_blocks": {}},
+            size=7,
+            ready_event=_Event(),
+            pool_buffers=[pool_buffer],
+        )
+    )
+    receiver._prefetch_futures["rid-stale"] = future
+
+    receiver._discard_future("rid-stale")
+
+    assert events == ["synchronize", "release"]
+
+
+def test_discarded_prefetch_retains_source_when_event_sync_fails():
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        def synchronize(self):
+            raise RuntimeError("device error")
+
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    result = _PrefetchedKV(
+        data={"layer_blocks": {}},
+        size=7,
+        ready_event=_Event(),
+        pool_buffers=[pool_buffer],
+    )
+    future = Future()
+    future.set_result(result)
+    receiver._prefetch_futures["rid-stale"] = future
+
+    receiver._discard_future("rid-stale")
+
+    assert events == []
+    assert receiver._pending_prefetch_releases == [result]
+
+
+def test_shutdown_synchronizes_consumed_pending_release():
+    receiver = OmniKVTransferManager(
+        OmniKVCacheConfig(need_recv_cache=True),
+        async_prefetch=True,
+    )
+    events = []
+
+    class _Event:
+        def query(self):
+            return False
+
+        def synchronize(self):
+            events.append("synchronize")
+
+    pool_buffer = SimpleNamespace(release=lambda: events.append("release"))
+    receiver._pending_prefetch_releases.append(
+        _PrefetchedKV(
+            data={"layer_blocks": {}},
+            size=7,
+            ready_event=_Event(),
+            pool_buffers=[pool_buffer],
+        )
+    )
+
+    receiver.shutdown_prefetch()
+
+    assert events == ["synchronize", "release"]
+    assert receiver._pending_prefetch_releases == []

--- a/tests/distributed/omni_connectors/test_kv_flow.py
+++ b/tests/distributed/omni_connectors/test_kv_flow.py
@@ -590,6 +590,127 @@ def test_deferred_release_isolates_data_from_pool_buffer():
     assert torch.equal(data["layer_blocks"]["key_cache"][0], key_tensor)
 
 
+def test_non_blocking_copy_defers_pool_buffer_release(monkeypatch):
+    payload, _ = _make_serialized_payload()
+    raw_array = bytearray(payload)
+    buf_tensor = torch.frombuffer(raw_array, dtype=torch.uint8)
+    events = []
+
+    class _ManagedBuffer:
+        @property
+        def tensor(self):
+            return buf_tensor
+
+        def release(self):
+            events.append("release")
+
+    class _Connector:
+        def get(self, from_stage, to_stage, get_key, metadata=None):
+            return _ManagedBuffer(), len(raw_array)
+
+    class _CopyStream:
+        def synchronize(self):
+            raise AssertionError("successful non-blocking copy must not synchronize")
+
+    original_to = torch.Tensor.to
+
+    def fake_to(tensor, *args, **kwargs):
+        events.append(("copy", kwargs.get("non_blocking")))
+        return tensor.clone()
+
+    monkeypatch.setattr(torch.Tensor, "to", fake_to)
+    manager = OmniKVTransferManager(
+        OmniKVCacheConfig(
+            connector_config={"type": "mock"},
+            from_stage="sender",
+            stage_id="receiver",
+            need_recv_cache=True,
+            recv_timeout=1.0,
+        )
+    )
+    manager._connector = _Connector()
+    deferred_copy_sources = []
+    deferred_pool_buffers = []
+
+    try:
+        data, size = manager.receive_kv_cache_for_request(
+            "req-payload",
+            target_device=torch.device("cuda:0"),
+            non_blocking_copy=True,
+            copy_stream=_CopyStream(),
+            deferred_copy_sources=deferred_copy_sources,
+            deferred_pool_buffers=deferred_pool_buffers,
+        )
+    finally:
+        monkeypatch.setattr(torch.Tensor, "to", original_to)
+
+    assert data is not None
+    assert size > 0
+    assert ("copy", True) in events
+    assert events == [("copy", True)]
+    assert len(deferred_copy_sources) == 1
+    assert len(deferred_pool_buffers) == 1
+
+    deferred_copy_sources.clear()
+    deferred_pool_buffers[0].release()
+    assert events[-1] == "release"
+
+
+def test_non_blocking_copy_failure_syncs_before_pool_buffer_release(monkeypatch):
+    payload, _ = _make_serialized_payload()
+    raw_array = bytearray(payload)
+    buf_tensor = torch.frombuffer(raw_array, dtype=torch.uint8)
+    events = []
+
+    class _ManagedBuffer:
+        @property
+        def tensor(self):
+            return buf_tensor
+
+        def release(self):
+            events.append("release")
+
+    class _Connector:
+        def get(self, from_stage, to_stage, get_key, metadata=None):
+            return _ManagedBuffer(), len(raw_array)
+
+    class _CopyStream:
+        def synchronize(self):
+            events.append("synchronize")
+
+    original_to = torch.Tensor.to
+
+    def fake_to(tensor, *args, **kwargs):
+        events.append(("copy", kwargs.get("non_blocking")))
+        raise RuntimeError("copy failed")
+
+    monkeypatch.setattr(torch.Tensor, "to", fake_to)
+    manager = OmniKVTransferManager(
+        OmniKVCacheConfig(
+            connector_config={"type": "mock"},
+            from_stage="sender",
+            stage_id="receiver",
+            need_recv_cache=True,
+            recv_timeout=1.0,
+        )
+    )
+    manager._connector = _Connector()
+
+    try:
+        with pytest.raises(RuntimeError, match="payload already consumed"):
+            manager.receive_kv_cache_for_request(
+                "req-payload",
+                target_device=torch.device("cuda:0"),
+                non_blocking_copy=True,
+                copy_stream=_CopyStream(),
+            )
+    finally:
+        monkeypatch.setattr(torch.Tensor, "to", original_to)
+
+    assert ("copy", True) in events
+    assert events[-2:] == ["synchronize", "release"]
+
+
 def test_manager_extraction_no_connector(kv_config, common_constants):
     """Test extraction when connector is unavailable (should still return IDs)."""
     block_size = common_constants["block_size"]

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -8,7 +8,7 @@ import struct
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import torch
@@ -45,6 +45,17 @@ LayerKV = torch.Tensor | tuple[torch.Tensor, torch.Tensor]
 
 class KVPrefetchConsumeError(RuntimeError):
     """Payload consumed from connector but post-get processing failed — sync retry impossible."""
+
+
+@dataclass
+class _PrefetchedKV:
+    """A prefetched payload plus the resources backing its asynchronous H2D copy."""
+
+    data: dict[str, Any] | None
+    size: int
+    ready_event: Any | None = None
+    source_tensors: list[torch.Tensor] = field(default_factory=list)
+    pool_buffers: list[Any] = field(default_factory=list)
 
 
 class ReceiveRole(enum.Enum):
@@ -405,6 +416,7 @@ class OmniKVTransferManager:
         )
         self._prefetch_futures: dict[str, Any] = {}
         self._bg_copy_stream: current_omni_platform.Stream | None = None
+        self._pending_prefetch_releases: list[_PrefetchedKV] = []
 
         self._topo_config: _TransferTopoConfig | None = None
 
@@ -1208,6 +1220,7 @@ class OmniKVTransferManager:
 
     def start_prefetch(self, kv_prefetch_job: KVPrefetchJob | None, target_device: torch.device | None = None) -> None:
         """Kick off a background KV load (non-blocking). No-op unless prefetch enabled."""
+        self._drain_prefetch_releases()
         if not (self._async_prefetch and self.config.need_recv_cache) or not kv_prefetch_job:
             return
         # Followers receive via collective distribute; bg pull would consume the owner's payload.
@@ -1244,11 +1257,14 @@ class OmniKVTransferManager:
         request_id: str,
         sender_info: dict[str, Any] | None,
         target_device: torch.device | None,
-    ) -> tuple[dict[str, Any] | None, int]:
+    ) -> _PrefetchedKV:
         """Bg-thread body: get + deserialize + H2D on the dedicated ``_bg_copy_stream``.
 
         Raises on failure (payload may be consumed → no sync retry).
         """
+        source_tensors: list[torch.Tensor] = []
+        pool_buffers: list[Any] = []
+        payload_consumed = False
         try:
             on_device = target_device is not None and target_device.type != "cpu"
             if on_device:
@@ -1259,19 +1275,52 @@ class OmniKVTransferManager:
                     self._bg_copy_stream = current_omni_platform.Stream()
                 with current_omni_platform.stream(self._bg_copy_stream):
                     data, size = self.receive_kv_cache_for_request(
-                        request_id, target_device=target_device, sender_info=sender_info
+                        request_id,
+                        target_device=target_device,
+                        sender_info=sender_info,
+                        non_blocking_copy=True,
+                        copy_stream=self._bg_copy_stream,
+                        deferred_copy_sources=source_tensors,
+                        deferred_pool_buffers=pool_buffers,
                     )
+                    payload_consumed = data is not None
+                    if data is not None:
+                        ready_event = current_omni_platform.Event()
+                        ready_event.record(self._bg_copy_stream)
+                    else:
+                        ready_event = None
             else:
                 data, size = self.receive_kv_cache_for_request(
                     request_id, target_device=target_device, sender_info=sender_info
                 )
-        except Exception:
+                payload_consumed = data is not None
+                ready_event = None
+        except Exception as exc:
+            if source_tensors or pool_buffers:
+                try:
+                    if self._bg_copy_stream is not None:
+                        self._bg_copy_stream.synchronize()
+                finally:
+                    source_tensors.clear()
+                    self._release_pool_buffers(pool_buffers)
             logger.exception("KV prefetch payload failed for %s (payload may be lost)", request_id)
+            if payload_consumed and not isinstance(exc, KVPrefetchConsumeError):
+                raise KVPrefetchConsumeError(
+                    f"Post-get prefetch setup failed for {request_id} (payload already consumed)"
+                ) from exc
             raise
 
         if data is None:
-            return None, 0
-        return data, size
+            source_tensors.clear()
+            self._release_pool_buffers(pool_buffers)
+            return _PrefetchedKV(data=None, size=0)
+        return _PrefetchedKV(
+            data=data,
+            size=size,
+            ready_event=ready_event,
+            source_tensors=source_tensors,
+            pool_buffers=pool_buffers,
+        )
 
     def consume_prefetched_kv(self, req: Any) -> tuple[dict[str, Any] | None, int]:
         """Consume a prefetched KV payload; (None, 0) on miss/recoverable failure.
@@ -1282,16 +1331,40 @@ class OmniKVTransferManager:
         if not request_id:
             return None, 0
 
+        self._drain_prefetch_releases()
         fut = self._prefetch_futures.pop(request_id, None)
         # Serial mode: any other request still in the table is an orphan — drop it.
         for stale_rid in list(self._prefetch_futures):
             self._discard_future(stale_rid)
 
         if fut is None:
+            self._drain_prefetch_releases(wait=True)
             return None, 0
 
         try:
-            return fut.result()
+            result = fut.result()
+            if not isinstance(result, _PrefetchedKV):
+                return result
+            if result.ready_event is not None:
+                try:
+                    current_stream = current_omni_platform.current_stream()
+                    current_stream.wait_event(result.ready_event)
+                    if result.data is not None:
+                        self._record_stream_for_prefetched(result.data)
+                except Exception as exc:
+                    if not self._release_prefetch_result(result, wait=True):
+                        self._pending_prefetch_releases.append(result)
+                    raise KVPrefetchConsumeError(
+                        f"Failed to establish stream dependency for prefetched KV {request_id}"
+                    ) from exc
+                if result.source_tensors or result.pool_buffers:
+                    self._pending_prefetch_releases.append(result)
+                self._drain_prefetch_releases()
+            else:
+                self._release_prefetch_result(result)
+                if result.data is None:
+                    self._drain_prefetch_releases(wait=True)
+            return result.data, result.size
         except KVPrefetchConsumeError:
             logger.exception("KV load failed for %s (payload consumed, cannot retry)", request_id)
             raise
@@ -1305,7 +1378,50 @@ class OmniKVTransferManager:
         if fut is None:
             return
         if not fut.cancel():
-            fut.add_done_callback(_drop_prefetch_result)
+            fut.add_done_callback(self._drop_prefetch_result)
+
+    def _drop_prefetch_result(self, fut: Any) -> None:
+        try:
+            if fut.cancelled():
+                return
+            result = fut.result()
+        except Exception:
+            return
+        if isinstance(result, _PrefetchedKV):
+            if not self._release_prefetch_result(result, wait=True):
+                self._pending_prefetch_releases.append(result)
+
+    def _release_prefetch_result(self, result: _PrefetchedKV, *, wait: bool = False) -> bool:
+        if wait and result.ready_event is not None:
+            try:
+                result.ready_event.synchronize()
+            except Exception:
+                logger.exception("Failed to synchronize KV prefetch before releasing its source")
+                return False
+        result.source_tensors.clear()
+        self._release_pool_buffers(result.pool_buffers)
+        return True
+
+    def _drain_prefetch_releases(self, *, wait: bool = False) -> None:
+        pending = self._pending_prefetch_releases
+        self._pending_prefetch_releases = []
+        for result in pending:
+            ready = result.ready_event is None
+            if not ready and wait:
+                try:
+                    result.ready_event.synchronize()
+                    ready = True
+                except Exception:
+                    logger.exception("Failed to synchronize pending KV prefetch release")
+            elif not ready:
+                try:
+                    ready = result.ready_event.query()
+                except Exception:
+                    logger.exception("Failed to query pending KV prefetch release")
+            if ready:
+                self._release_prefetch_result(result)
+            else:
+                self._pending_prefetch_releases.append(result)
 
     def shutdown_prefetch(self) -> None:
         """Cancel pending prefetches and stop the executor (call on teardown)."""
@@ -1317,6 +1433,7 @@ class OmniKVTransferManager:
             except Exception:
                 logger.exception("Failed to shut down KV prefetch executor")
             self._prefetch_executor = None
+        self._drain_prefetch_releases(wait=True)
 
     @staticmethod
     def _record_stream_for_prefetched(data: dict[str, Any]) -> None:
@@ -1342,6 +1459,10 @@ class OmniKVTransferManager:
         target_device: torch.device | None = None,
         *,
         sender_info: dict[str, Any] | None = None,
+        non_blocking_copy: bool = False,
+        copy_stream: Any | None = None,
+        deferred_copy_sources: list[torch.Tensor] | None = None,
+        deferred_pool_buffers: list[Any] | None = None,
     ) -> tuple[dict[str, Any] | None, int]:
         """Receive KV cache for *request_id*; returns (data dict, size) or (None, 0).
 
@@ -1377,6 +1498,14 @@ class OmniKVTransferManager:
         pending_pairs = list(recv_key_pairs)
         received_payloads: dict[str, tuple[dict[str, Any], int]] = {}
         deferred_memory: list[Any] = []
+        copy_sources: list[torch.Tensor] = []
+
+        if non_blocking_copy and copy_stream is None:
+            raise ValueError("copy_stream is required for non-blocking KV cache copies")
+        if (deferred_copy_sources is not None or deferred_pool_buffers is not None) and not non_blocking_copy:
+            raise ValueError("deferred copy resources require non-blocking KV cache copies")
+        if (deferred_copy_sources is None) != (deferred_pool_buffers is None):
+            raise ValueError("deferred copy sources and pool buffers must be provided together")
 
         # Per-call sender_info takes precedence over instance fields.
         if sender_info is not None:
@@ -1474,7 +1603,14 @@ class OmniKVTransferManager:
                                     if not isinstance(tensor, torch.Tensor):
                                         continue
                                     if target_device is not None and tensor.device != target_device:
-                                        cache_list[i] = tensor.to(target_device).contiguous()
+                                        if non_blocking_copy:
+                                            copy_sources.append(tensor)
+                                            cache_list[i] = tensor.to(
+                                                target_device,
+                                                non_blocking=True,
+                                            ).contiguous()
+                                        else:
+                                            cache_list[i] = tensor.to(target_device).contiguous()
                                     elif needs_clone:
                                         cache_list[i] = tensor.clone()
                     except Exception as exc:
@@ -1491,6 +1627,12 @@ class OmniKVTransferManager:
                         elapsed,
                         link_ms,
                     )
+                    if deferred_copy_sources is not None:
+                        deferred_copy_sources.extend(copy_sources)
+                        copy_sources.clear()
+                    if deferred_pool_buffers is not None:
+                        deferred_pool_buffers.extend(deferred_memory)
+                        deferred_memory.clear()
                     return data, total_size
 
                 if time.time() - start_time > timeout:
@@ -1506,7 +1648,11 @@ class OmniKVTransferManager:
             logger.exception("Error receiving KV cache for %s", request_id)
             return None, 0
         finally:
-            self._release_pool_buffers(deferred_memory)
+            try:
+                if copy_sources:
+                    copy_stream.synchronize()
+            finally:
+                self._release_pool_buffers(deferred_memory)
 
     def apply_kv_cache_to_request(self, req: Any, data: dict[str, Any]) -> None:
         """Apply received KV cache data to a request object.
@@ -1770,7 +1916,6 @@ class OmniKVTransferManager:
             try:
                 data, _ = self.consume_prefetched_kv(req)
                 if data is not None:
-                    self._record_stream_for_prefetched(data)
                     self.apply_kv_cache_to_request(req, data)
                     received = True
             except KVPrefetchConsumeError:
@@ -1847,14 +1992,6 @@ class OmniKVTransferManager:
             kv_payload = self._collect_request_kv_payload(req)
         kv_payload = self._broadcast_kv_payload(pt.world, kv_payload, device, src=0)
         return kv_payload or None
-
-
-def _drop_prefetch_result(fut: Any) -> None:
-    try:
-        if not fut.cancelled():
-            fut.result()
-    except Exception:
-        pass
 
 
 def _move_to_device(obj: object, device: torch.device) -> object:

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -1646,8 +1646,7 @@ class OmniKVTransferManager:
                     logger.error(f"Timeout waiting for KV cache for request {request_id} after {timeout}s")
                     if payload_consumed:
                         raise KVPrefetchConsumeError(
-                            f"KV receive timed out for {request_id} "
-                            "(payload already consumed for at least one rank)"
+                            f"KV receive timed out for {request_id} (payload already consumed for at least one rank)"
                         )
                     return None, 0
 

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -1350,7 +1350,7 @@ class OmniKVTransferManager:
                     current_stream = current_omni_platform.current_stream()
                     current_stream.wait_event(result.ready_event)
                     if result.data is not None:
-                        self._record_stream_for_prefetched(result.data)
+                        self._record_stream_for_prefetched(result.data, stream=current_stream)
                 except Exception as exc:
                     if not self._release_prefetch_result(result, wait=True):
                         self._pending_prefetch_releases.append(result)
@@ -1436,7 +1436,11 @@ class OmniKVTransferManager:
         self._drain_prefetch_releases(wait=True)
 
     @staticmethod
-    def _record_stream_for_prefetched(data: dict[str, Any]) -> None:
+    def _record_stream_for_prefetched(
+        data: dict[str, Any],
+        *,
+        stream: current_omni_platform.Stream | None = None,
+    ) -> None:
         """``record_stream(current_stream)`` on GPU tensors in *data*.
 
         Protects prefetch-thread tensors from allocator reuse on LEADER collective paths.
@@ -1445,12 +1449,13 @@ class OmniKVTransferManager:
             return
         if current_omni_platform.get_device_count() < 1:
             return
-        current_stream = current_omni_platform.current_stream()
+        if stream is None:
+            stream = current_omni_platform.current_stream()
         layer_blocks = data["layer_blocks"]
         for cache_list in (layer_blocks.get("key_cache", []), layer_blocks.get("value_cache", [])):
             for tensor in cache_list:
                 if isinstance(tensor, torch.Tensor) and tensor.device.type != "cpu":
-                    tensor.record_stream(current_stream)
+                    tensor.record_stream(stream)
 
     @torch.inference_mode()
     def receive_kv_cache_for_request(
@@ -1499,6 +1504,7 @@ class OmniKVTransferManager:
         received_payloads: dict[str, tuple[dict[str, Any], int]] = {}
         deferred_memory: list[Any] = []
         copy_sources: list[torch.Tensor] = []
+        payload_consumed = False
 
         if non_blocking_copy and copy_stream is None:
             raise ValueError("copy_stream is required for non-blocking KV cache copies")
@@ -1550,6 +1556,7 @@ class OmniKVTransferManager:
                     if not result:
                         continue
 
+                    payload_consumed = True
                     raw_data, size = result
 
                     if hasattr(raw_data, "tensor") and hasattr(raw_data, "release"):
@@ -1561,10 +1568,10 @@ class OmniKVTransferManager:
                             else:
                                 data = KVCacheTransferData.from_bytes(memoryview(buf_tensor.numpy()))
                                 deferred_memory.append(raw_data)
-                        except Exception as e:
-                            logger.error("Failed to deserialize KV cache from ManagedBuffer: %s", e)
+                        except Exception as exc:
+                            logger.error("Failed to deserialize KV cache from ManagedBuffer: %s", exc)
                             raw_data.release()
-                            return None, 0
+                            raise
                     elif isinstance(raw_data, (bytes, bytearray)):
                         data = KVCacheTransferData.from_bytes(raw_data)
                     elif isinstance(raw_data, torch.Tensor) and raw_data.dtype == torch.uint8 and raw_data.dim() == 1:
@@ -1637,6 +1644,11 @@ class OmniKVTransferManager:
 
                 if time.time() - start_time > timeout:
                     logger.error(f"Timeout waiting for KV cache for request {request_id} after {timeout}s")
+                    if payload_consumed:
+                        raise KVPrefetchConsumeError(
+                            f"KV receive timed out for {request_id} "
+                            "(payload already consumed for at least one rank)"
+                        )
                     return None, 0
 
                 time.sleep(poll_interval)
@@ -1644,8 +1656,12 @@ class OmniKVTransferManager:
 
         except KVPrefetchConsumeError:
             raise
-        except Exception:
+        except Exception as exc:
             logger.exception("Error receiving KV cache for %s", request_id)
+            if payload_consumed:
+                raise KVPrefetchConsumeError(
+                    f"Post-get processing failed for {request_id} (payload already consumed)"
+                ) from exc
             return None, 0
         finally:
             try:


### PR DESCRIPTION
## Purpose

The existing asynchronous diffusion KV prefetch runs on a background thread and a dedicated device stream, but its H2D tensor moves are synchronous. The prefetch future therefore cannot complete until the copy finishes, preventing the consumer from expressing the dependency as a device-stream wait.

This change:

- uses non-blocking H2D copies for prefetched KV tensors;
- records a completion event on the copy stream and lets the background future return immediately after enqueue;
- makes the consumer stream wait on that event and calls `record_stream` on destination tensors;
- retains source tensors and connector pool buffers until the copy event completes;
- synchronizes and releases resources safely for stale futures, failures, misses, and shutdown;
- adds a reproducible manager-level H2D benchmark.

Related to #4237.

## Performance

Review follow-up in `279830b3`: the benchmark now starts timing before
`_prefetch_executor.submit(...)` and waits for `future.result()`, so
`event_future_ready` includes executor submission, background-thread
scheduling, and the event-based H2D enqueue. The earlier `0.090 ms` result
called `_prefetch_payload(...)` directly and therefore excluded executor
scheduling; that number is superseded and is no longer used as the current
performance claim.

Refreshed A100 measurement:

- GPU: 1x NVIDIA A100 80GB PCIe
- PyTorch: 2.11.0
- CUDA runtime: 13.1
- vLLM: 0.26.0
- Transfer: 256 MiB pinned host tensor
- Warmup/measured iterations: 3/20

```bash
PYTHONPATH=. python benchmarks/distributed/omni_connectors/benchmark_async_prefetch_h2d.py   --device cuda:0   --size-mib 256   --warmup 3   --iterations 20
```

| Future-ready behavior | Median | P95 | Range |
|---|---:|---:|---:|
| Blocking until copy event | 10.730 ms | 10.868 ms | 10.704-10.868 ms |
| Executor-submitted event return | 0.219 ms | 0.342 ms | 0.200-0.342 ms |

Including executor submission and background-thread scheduling, median
future-ready latency is 49.00x lower (97.96% reduction). The copy event was
still incomplete at return in 23/23 runs. Peak device memory was 256.0 MiB.

This benchmark measures future availability, not end-to-end request
throughput. It separately reports the time until the background future is
ready and the time until the same copy event completes.

## Test Plan

- Unit tests cover event recording, consumer `wait_event`, destination `record_stream`, deferred source release, stale futures, misses/fallback, event failures, copy failures, and shutdown cleanup.
- Real A100 integration used a 16 MiB serialized `ManagedBuffer`, delayed the copy stream, verified that prefetch and consume returned while the event was incomplete, then verified data integrity after release.
- Compared the broad connector suite with an unmodified baseline checkout. Both have the same 18 macOS `/dev/shm` failures and 2 CPU cleanup teardown errors; the changed branch adds 12 passing tests.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `279830b382b5d5e1044ad814b0a34ad7700a5b35`

## Test Result

```text
55 passed, 15 warnings in 0.87s
Ruff check: passed
Ruff format --check: passed
compileall: passed
git diff --check: passed

Review follow-up:
34 passed, 16 warnings in 1.13s
Focused full-path consume/apply regression: 1 passed

Broad connector suite (changed): 18 failed, 200 passed, 28 skipped, 2 errors
Broad connector suite (baseline): 18 failed, 188 passed, 28 skipped, 2 errors
Failure/error set is identical and environment-specific (/dev/shm unavailable on macOS; CPU fixture calls empty_cache).

A100 integration:
ASYNC_KV_EVENT_INTEGRATION_OK bytes=16777400 prefetch_submit_ms=1.251 consume_submit_ms=0.197 shape=(2048, 2048)
```

