### PR TITLE
[CI/Build] Let audio assertions pin the transcript language

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -468,6 +468,10 @@ def test_one_word_prompt_001(omni_server, openai_client) -> None:
         "messages": messages,
         "stream": True,
         "key_words": {"text": ["london"]},
+        # A one-word English clip is too short for whisper's language detection to
+        # be stable; unpinned it renders "London" as 런던 / ランデ / 梁敦 and the
+        # containment check then fails on correct audio.
+        "transcript_language": "en",
     }
 
     # Retry only when assert_omni_response fails on text/audio cosine similarity (see tests/helpers/assertions.py).

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -632,6 +632,7 @@ def _assert_transcript_matches(
     *,
     threshold: float,
     escalation_model: str | None = None,
+    language: str | None = None,
 ) -> None:
     """Assert spoken audio matches ``expected_text``.
 
@@ -647,7 +648,8 @@ def _assert_transcript_matches(
     clip is re-transcribed with that stronger ASR and the assertion is decided on
     its verdict -- so a weak whisper-``small`` mishear on a short clip does not
     flake the gate, while a genuine model artifact still fails (the strong ASR
-    mismatches too).
+    mismatches too). ``language`` applies to that escalated pass too, so a request
+    that pins a language does not silently fall back to auto-detection on retry.
     """
     expected = str(expected_text).strip().lower()
     similarity = cosine_similarity_text(transcript.strip().lower(), expected)
@@ -664,7 +666,7 @@ def _assert_transcript_matches(
             f"whisper-small below threshold ({similarity:.2f} <= {threshold}); "
             f"escalating to whisper-{escalation_model} to rule out an ASR mishear"
         )
-        strong_transcript = convert_audio_bytes_to_text(audio_bytes, model_size=escalation_model)
+        strong_transcript = convert_audio_bytes_to_text(audio_bytes, model_size=escalation_model, language=language)
         strong_similarity = cosine_similarity_text(strong_transcript.strip().lower(), expected)
         print(
             f"audio content (whisper-{escalation_model}): {strong_transcript}\n"
@@ -741,6 +743,7 @@ def assert_audio_speech_response(response: Any, request_config: dict[str, Any], 
                     expected_text,
                     threshold=0.9,
                     escalation_model=request_config.get("transcript_escalation_model"),
+                    language=request_config.get("transcript_language"),
                 )
         _assert_preset_voice_gender_from_audio(
             response.audio_bytes,

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -527,7 +527,7 @@ def _resolve_audio_transcript(
     audio_bytes = getattr(response, "audio_bytes", None)
     if not audio_bytes:
         return None
-    return convert_audio_bytes_to_text(audio_bytes)
+    return convert_audio_bytes_to_text(audio_bytes, language=request_config.get("transcript_language"))
 
 
 def assert_omni_response(response: Any, request_config: dict[str, Any], run_level):

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -652,7 +652,9 @@ def _serialize_whisper_model_download(model_size: str = "small"):
         f.close()
 
 
-def _whisper_transcribe_in_current_process(output_path: str, model_size: str = "small") -> str:
+def _whisper_transcribe_in_current_process(
+    output_path: str, model_size: str = "small", language: str | None = None
+) -> str:
     import whisper
 
     device_index = None
@@ -684,6 +686,9 @@ def _whisper_transcribe_in_current_process(output_path: str, model_size: str = "
             temperature=0.0,
             word_timestamps=True,
             condition_on_previous_text=False,
+            # None keeps whisper's auto-detection. Do not default this to a
+            # language: callers include non-English audio tests.
+            language=language,
         )["text"]
     finally:
         del model
@@ -694,15 +699,15 @@ def _whisper_transcribe_in_current_process(output_path: str, model_size: str = "
     return text or ""
 
 
-def convert_audio_file_to_text(output_path: str, model_size: str = "small") -> str:
+def convert_audio_file_to_text(output_path: str, model_size: str = "small", language: str | None = None) -> str:
     """Convert an audio file to text in an isolated subprocess."""
     ctx = multiprocessing.get_context("spawn")
     with concurrent.futures.ProcessPoolExecutor(max_workers=1, mp_context=ctx) as executor:
-        future = executor.submit(_whisper_transcribe_in_current_process, output_path, model_size)
+        future = executor.submit(_whisper_transcribe_in_current_process, output_path, model_size, language)
         return future.result()
 
 
-def convert_audio_bytes_to_text(raw_bytes: bytes, model_size: str = "small") -> str:
+def convert_audio_bytes_to_text(raw_bytes: bytes, model_size: str = "small", language: str | None = None) -> str:
     output_fd, output_path = tempfile.mkstemp(prefix="test_", suffix=".wav")
     os.close(output_fd)
     if os.environ.get("VLLM_OMNI_KEEP_REQUEST_MEDIA", "").lower() not in ("1", "true", "yes"):
@@ -710,7 +715,7 @@ def convert_audio_bytes_to_text(raw_bytes: bytes, model_size: str = "small") -> 
     data, samplerate = sf.read(io.BytesIO(raw_bytes))
     sf.write(output_path, data, samplerate, format="WAV", subtype="PCM_16")
     print(f"audio data is saved: {output_path}")
-    return convert_audio_file_to_text(output_path, model_size)
+    return convert_audio_file_to_text(output_path, model_size, language)
 
 
 __all__ = [

--- a/tests/helpers/tests/test_assertions.py
+++ b/tests/helpers/tests/test_assertions.py
@@ -69,3 +69,22 @@ def test_resolve_transcript_leaves_language_unset_by_default(monkeypatch):
 
     assert captured["language"] is None
     assert captured["model_size"] == "small"
+
+
+def test_escalated_transcript_keeps_declared_language(monkeypatch):
+    # The escalated pass must honour the same language, otherwise a request that
+    # pins one silently falls back to auto-detection on retry.
+    captured = _capture_transcribe(monkeypatch)
+
+    with pytest.raises(AssertionError, match="after ASR escalation"):
+        _assert_transcript_matches(
+            "totally different words",
+            audio_bytes=b"fake-wav",
+            expected_text="how are you",
+            threshold=0.9,
+            escalation_model="large-v3",
+            language="en",
+        )
+
+    assert captured["model_size"] == "large-v3"
+    assert captured["language"] == "en"

--- a/tests/helpers/tests/test_assertions.py
+++ b/tests/helpers/tests/test_assertions.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 
-from tests.helpers.assertions import _assert_transcript_matches
+from tests.helpers import assertions
+from tests.helpers.assertions import _assert_transcript_matches, _resolve_audio_transcript
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -25,3 +28,44 @@ def test_short_transcript_unrelated_text_still_fails():
             expected_text="how are you",
             threshold=0.9,
         )
+
+
+def _capture_transcribe(monkeypatch) -> dict:
+    captured: dict = {}
+
+    def fake_convert(raw_bytes, model_size="small", language=None):
+        captured["model_size"] = model_size
+        captured["language"] = language
+        return "London"
+
+    monkeypatch.setattr(assertions, "convert_audio_bytes_to_text", fake_convert)
+    return captured
+
+
+def test_resolve_transcript_honors_declared_language(monkeypatch):
+    captured = _capture_transcribe(monkeypatch)
+    response = SimpleNamespace(audio_content=None, audio_bytes=b"fake-wav")
+
+    _resolve_audio_transcript(
+        response,
+        {"modalities": ["text", "audio"], "transcript_language": "en"},
+        "full_model",
+        speech_api=False,
+    )
+
+    assert captured["language"] == "en"
+
+
+def test_resolve_transcript_leaves_language_unset_by_default(monkeypatch):
+    captured = _capture_transcribe(monkeypatch)
+    response = SimpleNamespace(audio_content=None, audio_bytes=b"fake-wav")
+
+    _resolve_audio_transcript(
+        response,
+        {"modalities": ["text", "audio"]},
+        "full_model",
+        speech_api=False,
+    )
+
+    assert captured["language"] is None
+    assert captured["model_size"] == "small"

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tests.helpers import media
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _stub_transcribe(monkeypatch) -> dict:
+    """Capture the kwargs the helper hands to whisper, with no model and no device."""
+    captured: dict = {}
+
+    class FakeModel:
+        def transcribe(self, path, **kwargs):
+            captured.update(kwargs)
+            return {"text": "London"}
+
+    monkeypatch.setitem(sys.modules, "whisper", SimpleNamespace(load_model=lambda size, device=None: FakeModel()))
+    # Keep the unit test off the accelerator probe so it stays hermetic.
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_omni.platforms",
+        SimpleNamespace(current_omni_platform=SimpleNamespace(is_available=lambda: False)),
+    )
+    return captured
+
+
+def test_transcribe_forwards_requested_language(monkeypatch):
+    captured = _stub_transcribe(monkeypatch)
+
+    media._whisper_transcribe_in_current_process("/tmp/does-not-matter.wav", "small", language="en")
+
+    assert captured["language"] == "en"
+
+
+def test_transcribe_defaults_to_auto_language(monkeypatch):
+    # Auto-detect must stay the default: forcing a language globally would break
+    # the non-English audio tests (e.g. the Chinese Qwen3-Omni prompts).
+    captured = _stub_transcribe(monkeypatch)
+
+    media._whisper_transcribe_in_current_process("/tmp/does-not-matter.wav", "small")
+
+    assert captured.get("language") is None

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -4,7 +4,9 @@
 import sys
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
+import soundfile as sf
 
 from tests.helpers import media
 
@@ -46,3 +48,34 @@ def test_transcribe_defaults_to_auto_language(monkeypatch):
     media._whisper_transcribe_in_current_process("/tmp/does-not-matter.wav", "small")
 
     assert captured.get("language") is None
+
+
+def test_bytes_entrypoint_forwards_language_to_subprocess(monkeypatch, tmp_path):
+    """Cover the two hops the tests above skip: bytes -> file -> executor.submit.
+
+    The real call crosses a spawn ProcessPoolExecutor, so capture what gets
+    submitted rather than what the worker eventually does.
+    """
+    submitted: dict = {}
+
+    class FakeExecutor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def submit(self, fn, *args):
+            submitted["fn"] = fn
+            submitted["args"] = args
+            return SimpleNamespace(result=lambda: "London")
+
+    monkeypatch.setattr(media.concurrent.futures, "ProcessPoolExecutor", lambda *a, **kw: FakeExecutor())
+
+    wav = tmp_path / "clip.wav"
+    sf.write(wav, np.zeros(2400, dtype=np.float32), 24000)
+
+    assert media.convert_audio_bytes_to_text(wav.read_bytes(), "small", "en") == "London"
+
+    assert submitted["fn"] is media._whisper_transcribe_in_current_process
+    assert submitted["args"][1:] == ("small", "en")


### PR DESCRIPTION
## Purpose

Test-side half of #5395. `test_one_word_prompt_001` flakes because whisper's language
auto-detection is unstable on the sub-second clip a one-word answer produces: correct
"London" audio is transcribed as `런던` / `ランデ` / `梁敦`, and the short-text containment
check in `assert_omni_response` then fails on good output.

This PR:

- Threads an optional `language` through `convert_audio_bytes_to_text` →
  `convert_audio_file_to_text` → `_whisper_transcribe_in_current_process` →
  `model.transcribe(...)`. Default stays `None` (= whisper auto-detection), so no
  existing caller changes behaviour.
- Lets a request declare `transcript_language`, resolved in `_resolve_audio_transcript`
  the same way `similarity_threshold` / `transcript_escalation_model` already are.
- Carries the same language into the escalated pass in `_assert_transcript_matches`, so a
  request declaring both `transcript_language` and `transcript_escalation_model` does not
  get English on the first transcription and auto-detection on the retry.
- Pins `"en"` for `test_one_word_prompt_001` only.
- Adds unit coverage for the whole parameter chain and for the auto-detection default.

## Measurements

90 serial single requests, sync arm (`--no-async-chunk`), 2× RTX PRO 6000, vLLM 0.25.0,
stock `qwen3_omni_moe.yaml`, `--seed 0`. All four cells judge the **same** 90 WAVs with
CI's containment rule:

| judge | auto language | `language="en"` |
|---|---|---|
| whisper-`small` | 22/90 fail | **7/90 fail** |
| whisper-`large-v3` | 35/90 fail | 7/90 fail |

Of `small`'s 22 failures, forcing English recovers 15: 13 are non-Latin-script
renderings of correct audio (`런덴`×6, `런던`, `롱댄`, `ランデ`×2, `ランデン`, `ランダン`,
`梁敦`) and 2 are nearby Latin-script recognitions (`Longan`, `Ronden`). One of the 13,
`런던`, is literally "London" in Hangul.

**#5395 suggests upgrading the judge to `large-v3`; the data says not to.** Upgrading
without pinning the language is *worse* (35/90 — a more multilingual model drifts more
readily on a 0.7 s clip). With the language pinned, both models report the same aggregate
failure count (7/90), although they disagree on three samples in each direction.
Upgrading to `large-v3` therefore does not reduce the observed failure rate, while adding
a 2.9 GB download and a slower judge. Language pinning accounts for the entire aggregate
failure-rate reduction in this corpus; model size changes which individual clips pass, but
not the 7/90 total.

### Independent CTC cross-check (no external LM)

whisper is an encoder-decoder whose decoder is itself a language model, so it can snap a
mushy clip to a high-prior word — and "London" is high-prior here. Re-judging the same 90
clips with wav2vec2 CTC (`facebook/wav2vec2-large-960h-lv60-self`: per-frame characters, no
external LM) gives a readout that cannot autocorrect toward the expected word:

| judge | CTC mismatches caught | Whisper-only mismatches | CTC mismatches missed |
|---|---|---|---|
| `small` + `language="en"` | 6 | 1 | 4 |
| `large-v3` + `language="en"` | 5 | 2 | 5 |

`large-v3` transcribes five clips independently flagged by CTC as "London" (CTC reads them
`LONG DAY`, `LANDING`, `DON'T THEN`, `LANDED`, `ONE DAY`) and rejects two that CTC reads as
`LONDON`. So once the language is pinned, `small` agrees slightly more often with the
independent CTC readout on this corpus than `large-v3` does — which is a further reason not
to make the model swap, on top of the identical aggregate count.

CTC produces a non-London transcription for 10 of the 90 clips. That is a statement about
CTC's output, not a measured defect rate: wav2vec2 has no external LM (the property needed
here) but it still carries its own training priors, and on a separate 90-clip run it
rendered "London" as `LANDON` / `LANDE` / `LONDA` on clips that **both** whisper
configurations accepted. It is therefore useful as a tie-breaker on individual disputed
clips, and unreliable as a substring-matched rate estimator. Treat it as an independent
second opinion, not a verdict.

Seed determinism from the issue also reproduced: re-running after a full server restart
produced byte-identical WAVs for all 30 overlapping samples.

## Scope / what this does not fix

The residual is out of scope here and belongs to the model-side half of #5395. Four clips
are rejected by every whisper configuration (`I'm on that.` / `Today, Jordan` /
`Young that.` / `Long day.`) and CTC also reads them as non-London, making those the
strongest model-side candidates — though none has been confirmed by blinded listening.

Correcting an earlier revision of this description: two clips I had listed as failures only
`large-v3` detects (`Linden`, `LENDEN`) are ones CTC reads as `LONDON`, so I no longer
present them as `small` masking a real failure. Only one such clip is corroborated by CTC
(`One Dan`, CTC `ONE DEN`), and `small` transcribes it as "London" so containment passes;
escalation only fires on failure, so no judge change here surfaces it. This PR reduces the
flake rate of the gate; it does not make the judge correct.

## Not a duplicate

No open PR references #5395, and none touches `convert_audio_file_to_text`,
`transcript_escalation_model`, `one_word_prompt` or `assert_omni_response`. #5395 is
assigned to me.

Unrelated but worth flagging for anyone re-measuring this test on an older tree: the
`--async-chunk` path had a terminal-flush regression that truncated a one-word answer
from ~0.78 s to 0.297 s (only the initial 4-frame chunk survived), which would swamp any
talker-quality measurement.

- introduced by `e043818a` — [#5383](https://github.com/vllm-project/vllm-omni/pull/5383),
  2026-07-25, which made `is_segment_finished` false on a terminal stop;
- fixed by `8f115164` — [#5414](https://github.com/vllm-project/vllm-omni/pull/5414),
  2026-07-27, one line in `chunk_transfer_adapter.py`:
  `is_finished=is_segment_finished` → `is_finished=is_segment_finished or is_finished`.

Current `main` is well past the fix; the measurements above were taken on the sync arm,
which never enters that path.

## Test Plan

- [x] `pytest tests/helpers/tests/test_media.py tests/helpers/tests/test_assertions.py`
- [x] `ruff check` + `ruff format --check` (v0.14.10, as pinned in `.pre-commit-config.yaml`)
- [x] `tools/pre_commit/check_test_marks.py` on every touched test file
- [x] Audited all existing callers of the three helpers: each passes `output_path` /
      `raw_bytes` positionally and anything else by keyword, so appending `language` as a
      trailing optional parameter cannot change an existing call's meaning.
- [x] `pytest tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_one_word_prompt_001`
      on 2× RTX PRO 6000 with vLLM 0.26.0 and the stock `qwen3_omni_moe.yaml` (no local
      edits): **2 passed in 887s**, both the `default` and `async_chunk` parametrizations.
      (This needs two cards: the stage-CLI fixture initialises all three stages
      concurrently, so folding them onto one 96 GB card races stage 0's KV-cache profiling
      — `Available KV cache memory: 0.0 GiB (profiling fallback)` — and the server never
      boots.)

## Test Result

```
$ pytest tests/helpers/tests/test_media.py tests/helpers/tests/test_assertions.py -q
8 passed in 0.20s
```

Each new test was confirmed to fail against unmodified `main` before the change, for the
intended reason:

```
test_transcribe_forwards_requested_language
  TypeError: _whisper_transcribe_in_current_process() got an unexpected keyword argument 'language'
test_resolve_transcript_honors_declared_language
  AssertionError: assert None == 'en'
test_bytes_entrypoint_forwards_language_to_subprocess
  TypeError: convert_audio_bytes_to_text() takes from 1 to 2 positional arguments but 3 were given
test_escalated_transcript_keeps_declared_language
  TypeError: _assert_transcript_matches() got an unexpected keyword argument 'language'
```

The two pre-existing tests in `test_assertions.py` are untouched and still pass. The two
default-behaviour tests pass before and after, pinning auto-detection as the default.

The 2-GPU e2e run is worth reporting in full rather than just as a pass. Across both
parametrizations it consumed 4 of the test's 10 retries, and the 21 logged transcripts were:

```
London     x17   (containment passed)
Langdon    x1
Long den   x1
Why?       x2
```

So the gate is not deterministic after this change — but every residual failure is a
plausible talker artefact, and **none** is a script-drift mistranscription of the
`런던` / `ランデ` / `梁敦` kind this PR targets. That is the intended outcome: the
judge-induced failures are gone, the model-side ones remain and belong to #5395's other
half.

`tests/helpers/tests/` also contains `test_media_pydub_removal.py` (2 of its cases need
`vllm.multimodal.media.audio`) and `test_runtime_stage_cli.py` (needs `torch`); neither is
runnable in the local env used above and neither references the helpers changed here —
verified by re-running them with this branch's changes reverted and getting identical
results.

---

AI assistance was used for this change (investigation, measurement harness and drafting).
I have reviewed every changed line and run the tests reported above.
