### PR TITLE
[Perf][Ming-TTS] Batch output snapshot transfers

### DIFF
--- a/tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py
@@ -155,7 +155,7 @@ def test_ming_full_payload_reuses_snapshot_for_patches_and_metadata():
     outputs = llm2audio_vae([stage_output])
 
     assert len(outputs) == 1
-    additional_information = outputs[0].additional_information
+    additional_information = outputs[0]["additional_information"]
     torch.testing.assert_close(
         additional_information["ming_latent_patches"],
         patches[[0, 2]],

--- a/tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py
@@ -10,6 +10,10 @@ import torch
 from vllm_omni.model_executor.models.ming_tts.constants import LATENT_DIM, PATCH_SIZE
 from vllm_omni.model_executor.stage_input_processors.ming_tts import (
     MING_EMIT_PATCH_COUNT_KEY,
+    MING_FINAL_DECODE_STEP_KEY,
+    MING_STOP_REASON_KEY,
+    _extract_ming_output_snapshot,
+    llm2audio_vae,
     llm2audio_vae_async_chunk,
 )
 
@@ -54,6 +58,110 @@ def _append_patch(tm, req_id: str, idx: int, *, finished: bool = False):
         _make_request(req_id, finished=finished),
         is_finished=finished,
     )
+
+
+def test_ming_output_snapshot_selects_last_active_row():
+    patches = torch.arange(3 * PATCH_SIZE * LATENT_DIM, dtype=torch.float32).reshape(
+        3,
+        PATCH_SIZE,
+        LATENT_DIM,
+    )
+    pooling_output = {
+        "ming_has_patch": torch.tensor([1, 0, 1], dtype=torch.bool),
+        "ming_latent_patch": patches,
+        "ming_decode_step": torch.tensor([11, 22, 33]),
+        MING_STOP_REASON_KEY: torch.tensor([0, 1, 2]),
+    }
+
+    patch, decode_step, stop_reason = _extract_ming_output_snapshot(pooling_output)
+
+    torch.testing.assert_close(patch, patches[2])
+    assert decode_step == 33
+    assert stop_reason == "max_decode_steps"
+
+
+def test_ming_output_snapshot_selects_all_active_rows_for_full_payload():
+    patches = torch.arange(3 * PATCH_SIZE * LATENT_DIM, dtype=torch.float32).reshape(
+        3,
+        PATCH_SIZE,
+        LATENT_DIM,
+    )
+    pooling_output = {
+        "ming_has_patch": torch.tensor([1, 0, 1], dtype=torch.bool),
+        "ming_latent_patch": patches,
+        "ming_decode_step": torch.tensor([11, 22, 33]),
+        MING_STOP_REASON_KEY: torch.tensor([0, 1, 2]),
+    }
+
+    selected, decode_step, stop_reason = _extract_ming_output_snapshot(
+        pooling_output,
+        all_patches=True,
+    )
+
+    torch.testing.assert_close(selected, patches[[0, 2]])
+    assert decode_step == 33
+    assert stop_reason == "max_decode_steps"
+
+
+def test_ming_output_snapshot_returns_empty_when_no_row_is_active():
+    pooling_output = {
+        "ming_has_patch": torch.tensor([0, 0], dtype=torch.bool),
+        "ming_latent_patch": torch.ones(2, PATCH_SIZE, LATENT_DIM),
+        "ming_decode_step": torch.tensor([11, 22]),
+        MING_STOP_REASON_KEY: torch.tensor([0, 1]),
+    }
+
+    assert _extract_ming_output_snapshot(pooling_output) == (None, None, None)
+
+
+def test_ming_output_snapshot_preserves_list_metadata_fallback():
+    patches = torch.arange(2 * PATCH_SIZE * LATENT_DIM, dtype=torch.float32).reshape(
+        2,
+        PATCH_SIZE,
+        LATENT_DIM,
+    )
+    pooling_output = {
+        "ming_has_patch": torch.tensor([0, 1], dtype=torch.bool),
+        "ming_latent_patch": patches,
+        "ming_decode_step": [11, 22],
+        MING_STOP_REASON_KEY: [0, 1],
+    }
+
+    patch, decode_step, stop_reason = _extract_ming_output_snapshot(pooling_output)
+
+    torch.testing.assert_close(patch, patches[1])
+    assert decode_step == 22
+    assert stop_reason == "stop_head"
+
+
+def test_ming_full_payload_reuses_snapshot_for_patches_and_metadata():
+    patches = torch.arange(3 * PATCH_SIZE * LATENT_DIM, dtype=torch.float32).reshape(
+        3,
+        PATCH_SIZE,
+        LATENT_DIM,
+    )
+    multimodal_output = {
+        "ming_has_patch": torch.tensor([1, 0, 1], dtype=torch.bool),
+        "ming_latent_patch": patches,
+        "ming_decode_step": torch.tensor([11, 22, 33]),
+        MING_STOP_REASON_KEY: torch.tensor([0, 1, 2]),
+    }
+    stage_output = SimpleNamespace(
+        finished=True,
+        request_id="req",
+        outputs=[SimpleNamespace(multimodal_output=multimodal_output)],
+    )
+
+    outputs = llm2audio_vae([stage_output])
+
+    assert len(outputs) == 1
+    additional_information = outputs[0].additional_information
+    torch.testing.assert_close(
+        additional_information["ming_latent_patches"],
+        patches[[0, 2]],
+    )
+    assert additional_information[MING_FINAL_DECODE_STEP_KEY] == 33
+    assert additional_information[MING_STOP_REASON_KEY] == "max_decode_steps"
 
 
 def test_ming_async_chunk_emits_small_initial_chunk_then_steady_chunks():

--- a/vllm_omni/model_executor/stage_input_processors/ming_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/ming_tts.py
@@ -35,78 +35,117 @@ MING_FINAL_DECODE_STEP_KEY = "ming_final_decode_step"
 MING_STOP_REASON_BY_CODE = {code: reason for reason, code in MING_STOP_REASON_CODES.items()}
 
 
-def _extract_last_patch(pooling_output: Mapping[str, Any] | None) -> torch.Tensor | None:
-    if not isinstance(pooling_output, Mapping):
-        return None
-    has_patch = pooling_output.get("ming_has_patch")
-    patch = pooling_output.get("ming_latent_patch")
-    if not isinstance(patch, torch.Tensor) or patch.numel() == 0:
-        return None
-
-    if isinstance(has_patch, torch.Tensor) and has_patch.numel() > 0:
-        active = (has_patch.reshape(-1) > 0).nonzero(as_tuple=True)[0]
-        if active.numel() == 0:
-            return None
-        patch = patch[int(active[-1].item())]
-    elif patch.ndim == 3:
-        patch = patch[-1]
-
-    if patch.ndim != 2:
-        raise ValueError(f"Invalid Ming latent patch shape: {tuple(patch.shape)}")
-    return patch.to(torch.float32).cpu()
-
-
-def _extract_all_patches(pooling_output: Mapping[str, Any] | None) -> torch.Tensor | None:
-    if not isinstance(pooling_output, Mapping):
-        return None
-    has_patch = pooling_output.get("ming_has_patch")
-    patch = pooling_output.get("ming_latent_patch")
-    if not isinstance(patch, torch.Tensor) or patch.numel() == 0:
-        return None
-
-    if patch.ndim == 2:
-        patch = patch.unsqueeze(0)
-    if patch.ndim != 3:
-        raise ValueError(f"Invalid Ming latent patch tensor shape: {tuple(patch.shape)}")
-
-    if isinstance(has_patch, torch.Tensor) and has_patch.numel() > 0:
-        active = (has_patch.reshape(-1) > 0).nonzero(as_tuple=True)[0]
-        if active.numel() == 0:
-            return None
-        patch = patch.index_select(0, active.to(device=patch.device))
-
-    if patch.numel() == 0:
-        return None
-    return patch.to(torch.float32).cpu()
-
-
-def _extract_last_value(pooling_output: Mapping[str, Any] | None, key: str) -> Any:
-    if not isinstance(pooling_output, Mapping):
-        return None
-    value = pooling_output.get(key)
-    if value is None:
-        return None
-
-    has_patch = pooling_output.get("ming_has_patch")
-    selected_index = -1
-    if isinstance(has_patch, torch.Tensor) and has_patch.numel() > 0:
-        active = (has_patch.reshape(-1) > 0).nonzero(as_tuple=True)[0]
-        if active.numel() == 0:
-            return None
-        selected_index = int(active[-1].item())
-
+def _select_snapshot_value(value: Any, selected_index: int | torch.Tensor) -> Any:
     if isinstance(value, torch.Tensor):
         flat = value.reshape(-1)
         if flat.numel() == 0:
             return None
-        return flat[min(selected_index, flat.numel() - 1)].item()
+        if isinstance(selected_index, torch.Tensor):
+            value_index = selected_index.to(device=flat.device).clamp_max(flat.numel() - 1)
+        else:
+            value_index = min(selected_index, flat.numel() - 1)
+        return flat[value_index]
     if isinstance(value, (list, tuple)):
         if not value:
             return None
-        if selected_index < 0:
-            return value[-1]
-        return value[min(selected_index, len(value) - 1)]
+        value_index = int(selected_index.item()) if isinstance(selected_index, torch.Tensor) else selected_index
+        return value[-1] if value_index < 0 else value[min(value_index, len(value) - 1)]
     return value
+
+
+def _extract_snapshot_metadata(
+    pooling_output: Mapping[str, Any],
+    selected_index: int | torch.Tensor,
+) -> tuple[Any, Any]:
+    decode_step_value = pooling_output.get("ming_decode_step")
+    stop_reason_value = pooling_output.get(MING_STOP_REASON_KEY)
+    if isinstance(selected_index, torch.Tensor) and (
+        isinstance(decode_step_value, (list, tuple)) or isinstance(stop_reason_value, (list, tuple))
+    ):
+        selected_index = int(selected_index.item())
+
+    final_decode_step = _select_snapshot_value(decode_step_value, selected_index)
+    stop_reason_code = _select_snapshot_value(stop_reason_value, selected_index)
+
+    if (
+        isinstance(final_decode_step, torch.Tensor)
+        and isinstance(stop_reason_code, torch.Tensor)
+        and final_decode_step.device == stop_reason_code.device
+    ):
+        final_decode_step, stop_reason_code = (
+            torch.stack(
+                (
+                    final_decode_step.to(torch.int64),
+                    stop_reason_code.to(torch.int64),
+                )
+            )
+            .cpu()
+            .tolist()
+        )
+    else:
+        if isinstance(final_decode_step, torch.Tensor):
+            final_decode_step = final_decode_step.item()
+        if isinstance(stop_reason_code, torch.Tensor):
+            stop_reason_code = stop_reason_code.item()
+    return final_decode_step, stop_reason_code
+
+
+def _extract_ming_output_snapshot(
+    pooling_output: Mapping[str, Any] | None,
+    *,
+    all_patches: bool = False,
+) -> tuple[torch.Tensor | None, Any, str | None]:
+    if not isinstance(pooling_output, Mapping):
+        return None, None, None
+
+    has_patch = pooling_output.get("ming_has_patch")
+    active: torch.Tensor | None = None
+    selected_index: int | torch.Tensor = -1
+    if isinstance(has_patch, torch.Tensor) and has_patch.numel() > 0:
+        patch_mask = has_patch.reshape(-1) > 0
+        if all_patches:
+            active = patch_mask.nonzero(as_tuple=True)[0]
+            if active.numel() == 0:
+                return None, None, None
+            selected_index = active[-1]
+        else:
+            reversed_mask = patch_mask.flip(0)
+            reverse_offset, has_active = (
+                torch.stack(
+                    (
+                        reversed_mask.to(torch.int64).argmax(),
+                        reversed_mask.any().to(torch.int64),
+                    )
+                )
+                .cpu()
+                .tolist()
+            )
+            if not has_active:
+                return None, None, None
+            selected_index = patch_mask.numel() - 1 - reverse_offset
+
+    patch = pooling_output.get("ming_latent_patch")
+    selected_patch: torch.Tensor | None = None
+    if isinstance(patch, torch.Tensor) and patch.numel() > 0:
+        if all_patches:
+            if patch.ndim == 2:
+                patch = patch.unsqueeze(0)
+            if patch.ndim != 3:
+                raise ValueError(f"Invalid Ming latent patch tensor shape: {tuple(patch.shape)}")
+            selected_patch = patch if active is None else patch.index_select(0, active.to(device=patch.device))
+        else:
+            if patch.ndim == 3:
+                if isinstance(selected_index, torch.Tensor):
+                    selected_index = selected_index.to(device=patch.device)
+                patch = patch[selected_index]
+            if patch.ndim != 2:
+                raise ValueError(f"Invalid Ming latent patch shape: {tuple(patch.shape)}")
+            selected_patch = patch
+
+        selected_patch = selected_patch.to(torch.float32).cpu() if selected_patch.numel() > 0 else None
+
+    final_decode_step, stop_reason_code = _extract_snapshot_metadata(pooling_output, selected_index)
+    return selected_patch, final_decode_step, _decode_stop_reason(stop_reason_code)
 
 
 def _decode_stop_reason(value: Any) -> str | None:
@@ -187,8 +226,7 @@ def llm2audio_vae_async_chunk(
     request_id = request.external_req_id
     chunk_id = int(transfer_manager.put_req_chunk[request_id])
     finished = bool(is_finished or request.is_finished())
-    final_decode_step = _extract_last_value(pooling_output, "ming_decode_step")
-    stop_reason = _decode_stop_reason(_extract_last_value(pooling_output, MING_STOP_REASON_KEY))
+    patch, final_decode_step, stop_reason = _extract_ming_output_snapshot(pooling_output)
     request_payload = transfer_manager.request_payload
     request_state = request_payload.get(request_id)
     if not isinstance(request_state, dict) or "_ming_async_state" not in request_state:
@@ -203,7 +241,6 @@ def llm2audio_vae_async_chunk(
     if bool(state.get("terminal_sent", False)):
         return None
 
-    patch = _extract_last_patch(pooling_output)
     if patch is not None:
         transfer_manager.code_prompt_token_ids[request_id].append(patch)
 
@@ -290,7 +327,10 @@ def llm2audio_vae(
         if not finished:
             continue
         output = stage_output.outputs[0]
-        patches = _extract_all_patches(output.multimodal_output)
+        patches, final_decode_step, stop_reason = _extract_ming_output_snapshot(
+            output.multimodal_output,
+            all_patches=True,
+        )
         additional_information = {
             "ming_latent_patches": patches
             if patches is not None
@@ -298,8 +338,6 @@ def llm2audio_vae(
             KEY_REQUEST_ID: getattr(stage_output, "request_id", None),
             "finished": torch.tensor(finished, dtype=torch.bool),
         }
-        final_decode_step = _extract_last_value(output.multimodal_output, "ming_decode_step")
-        stop_reason = _decode_stop_reason(_extract_last_value(output.multimodal_output, MING_STOP_REASON_KEY))
         if final_decode_step is not None:
             additional_information[MING_FINAL_DECODE_STEP_KEY] = int(final_decode_step)
         if stop_reason is not None:


### PR DESCRIPTION
## Summary

- resolve the active Ming-TTS output row once per stage-output snapshot
- batch the decode-step and stop-reason D2H transfer
- reuse the same snapshot logic for async-chunk and full-payload paths
- preserve sparse masks, empty masks, Python/list metadata, and 2D/3D latent inputs

## Problem

`llm2audio_vae_async_chunk` previously called `_extract_last_value` twice and
`_extract_last_patch` once for every generated latent patch. Each helper
independently scanned `ming_has_patch`, and the scalar helpers converted the
active index and selected value with `.item()`.

On CUDA output tensors this repeated the same mask work three times and placed
multiple GPU-to-host synchronizations on the streaming output critical path.

## Root cause

The patch, final decode step, and stop reason are fields of one logical model
output, but they were extracted independently. The helpers therefore could not
share the active row or batch metadata transfers.

## Design

`_extract_ming_output_snapshot` now:

1. resolves the last active row once;
2. uses a fixed-shape reverse-mask reduction for the per-step last-row path;
3. transfers decode-step and stop-reason metadata together;
4. selects the latent patch using the same row;
5. supports `all_patches=True` for the full-payload path.

The list/Python metadata fallback remains supported, while the normal tensor
path avoids repeated scalar extraction.

## Performance

### Focused extraction microbenchmark

Environment:

- NVIDIA A100 80GB PCIe
- PyTorch 2.7.0+cu126
- latent shape per row: `[4, 64]`
- 100 warmup calls
- 1,000 iterations per round, 7 rounds, median
- each case asserts old/new patch and metadata equality before timing

| Batch | Before (us) | After (us) | Speedup | Time saved |
|---:|---:|---:|---:|---:|
| 1 | 246.284 | 175.314 | 1.40x | 28.8% |
| 8 | 254.055 | 171.922 | 1.48x | 32.3% |
| 32 | 245.826 | 173.739 | 1.41x | 29.3% |

PyTorch profiler counts for batch 32:

| Operation | Before | After |
|---|---:|---:|
| `aten::nonzero` | 3 | 0 |
| `cudaMemcpyAsync` | 9 | 3 |
| `cudaStreamSynchronize` | 9 | 3 |

### Real-model end-to-end validation

I also ran the full two-stage streaming pipeline with the public checkpoint,
not a source-extraction harness:

- model: `inclusionAI/Ming-omni-tts-0.5B`
- checkpoint revision: `9154772e7fbc585907b6237e3190790676f28975`
- checkpoint: 12 files, 3.1 GB cache, 1,181 readable safetensors tensors
- hardware: NVIDIA A100 80GB PCIe
- case: `style`
- mode: `--streaming --enforce-eager`
- base: direct parent `226cb4a38cee37d2cc6a3d509703b5473f815e81`
- optimized implementation: `6de07c561ec18e47374a08bcb22654abebeae1af`

| Metric | Base | Optimized | Delta |
|---|---:|---:|---:|
| Pipeline E2E wall time | 22,441.339 ms | 21,960.589 ms | -2.14% |
| Stage 0 generation | 21,637.977 ms | 21,285.235 ms | -1.63% |
| Stage 1 generation | 22,427.015 ms | 21,942.719 ms | -2.16% |
| Time to first audio | 21.910 s | 21.463 s | -2.04% |
| Mean inter-chunk time | 0.5320 s | 0.4986 s | -6.28% |
| Peak GPU memory above pre-run baseline | 39,082 MiB | 39,084 MiB | +2 MiB |

This is one sequential base/head E2E pair, so the latency deltas are
directional evidence rather than a statistically stable throughput claim. The
focused benchmark and profiler counts isolate the intended synchronization
reduction.

## Correctness

The real-model base and optimized runs both produced:

- mono 44.1 kHz PCM16 audio
- 352,800 samples / 8.0 seconds
- non-silent waveform (`RMS = 0.07408`, max amplitude `0.61943`)
- no clipped samples

The two output WAV files are bitwise identical:

`SHA256 6f5ed321f222cd0bb282c5e3c6225de5ac6050c491015d01233130640d2707c4`

Added focused coverage for:

- selecting the last row from a sparse active mask;
- selecting all active rows for the full-payload path;
- no-active-row behavior;
- Python/list metadata fallback;
- full-payload patch and terminal metadata propagation.

Repository-level validation in the same full vLLM-Omni environment:

- `8 passed, 17 warnings` for
  `tests/model_executor/stage_input_processors/test_ming_tts_async_chunk.py`
- Python compile check passed
- `git diff --check` passed

The first repository-level run exposed that the new full-payload test used
attribute access for the real dict-like `OmniTokensPrompt` result. Commit
`4c15fff7` corrects the test to exercise the repository's actual mapping
contract. The validation image does not include `ruff`, so the repository CI
pre-commit job remains the formatting/lint gate.
