### PR TITLE
[Bug fix ] fix kv connector with unexpected local_rank

### DIFF
--- a/tests/dfx/perf/tests/test_hunyuan_image3_it2i.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image3_it2i.json
@@ -27,16 +27,8 @@
             "async_chunk": false,
             "trust_remote_code": true,
             "connectors": {
-              "rdma_connector": {
-                "name": "MooncakeTransferEngineConnector",
-                "extra": {
-                  "host": "auto",
-                  "zmq_port": 50051,
-                  "protocol": "rdma",
-                  "device_name": "",
-                  "memory_pool_size": 17179869184,
-                  "memory_pool_device": "cpu"
-                }
+              "shared_memory_connector": {
+                  "name": "SharedMemoryConnector"
               }
             },
             "stages": [
@@ -66,7 +58,7 @@
                   "need_send_cache": true
                 },
                 "output_connectors": {
-                  "to_stage_1": "rdma_connector"
+                  "to_stage_1": "shared_memory_connector"
                 },
                 "default_sampling_params": {
                   "temperature": 0.0,
@@ -87,7 +79,8 @@
                 "devices": "2,3",
                 "distributed_executor_backend": "mp",
                 "omni_kv_config": {
-                  "need_recv_cache": true
+                  "need_recv_cache": true,
+                  "enable_kv_async_prefetch": true
                 },
                 "parallel_config": {
                   "tensor_parallel_size": 2,
@@ -96,7 +89,7 @@
                 },
                 "vae_use_tiling": true,
                 "input_connectors": {
-                  "from_stage_0": "rdma_connector"
+                  "from_stage_0": "shared_memory_connector"
                 },
                 "default_sampling_params": {
                   "num_inference_steps": 50,

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -1164,17 +1164,19 @@ def get_stage_connector_spec(
     stage_id: int,
     async_chunk: bool,
 ) -> dict[str, Any]:
-    """Return the first connector spec for a stage data-plane edge."""
+    """Return the first connector spec for the stage when async chunking is enabled."""
     from vllm_omni.distributed.omni_connectors import get_stage_connector_config
+
+    if not async_chunk:
+        return {}
 
     stage_connectors_cfg = get_stage_connector_config(omni_transfer_config, stage_id)
     for cfg in stage_connectors_cfg.values():
         return dict(cfg.get("spec", {}))
 
-    # A producer does not consume connector data itself. Keep its connector
-    # for both async-chunk and terminal full-payload sends, but mark it
-    # sender-only so the scheduler does not park orchestrator-provided inputs
-    # waiting for an upstream payload.
+    # A stage can be an async producer without consuming chunks itself. Keep
+    # its connector for save_async(), but mark it sender-only so the scheduler
+    # does not park normal orchestrator-provided inputs waiting for a chunk.
     target_stage = str(stage_id)
     for (from_stage, _to_stage), spec in getattr(omni_transfer_config, "connectors", {}).items():
         if from_stage == target_stage:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
https://github.com/vllm-project/vllm-omni/issues/5595#issuecomment-5138555004

**The bug is**: 
(1) In ar + dit,  the dit rank 0 success to recive kv, but dit rank1 failed to recive kv.
(2) kv manager connector bind an already used port.
(3) Incomplete RDMA configuration in the CI environment.
```
ls -l /sys/class/infiniband/mlx5_bond_1/device/net/
total 0
```
### Root Cause
https://github.com/vllm-project/vllm-omni/pull/5455 change the behavior that  AR stage enter `init_omni_connectors`, which is only called when async_chunk enable. 

The problem is that there are few problem in omni connector.
(1) for first bug, the  reason is: In `init_omni_connectors` , it init self._kv_transfer_manager.kv_send_key_builder, and it use local rank to build kv key. However, `_parse_rank_mapping` init `local_rank` from env value `LOCAL_RANK`. But in ar worker process, it never set `LOCAL_RANK`, so both tp1,tp2 set local_rank to 0, their kv key are both base on rank0. The Dit stage so that can't recived the kv which identify by rank1.

(2) for second bug, the reason is:  
<1> omni connector overlooked the case `tp > 1`,  all rank  used the same port for rdma， so it conflict
**<2>** After <1> fix，there are confict between  `omni connector` and `kv manager connector`, they both try to combine the connector info in yaml so they conflict. 


I believe there is a conflict in the current connector design. OmniConnect is responsible for transferring non-KV data between stages, while the KV Manager handles KV transfer. Since both read from the same connector configuration, they can end up competing with each other, which makes them difficult to use together safely. Addressing this properly would likely require a connector-system refactor, so for now I am presenting the changes that revert the problematic implementation.

### Fix

(1) restore the `stage_init_utils.py` change by https://github.com/vllm-project/vllm-omni/pull/5455
(2) set tcp transfer
## Test Plan
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3.py`
`pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py \
  --test-config-file tests/dfx/perf/tests/test_hunyuan_image3_it2i.json`

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result
<img width="2746" height="1138" alt="image" src="https://github.com/user-attachments/assets/7cdc54d2-bfee-4409-9bc3-a7da7773fd18" />

<img width="2708" height="820" alt="image" src="https://github.com/user-attachments/assets/6e025c04-37a2-4295-b7a0-a1745645b043" />



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
