### PR TITLE
[Bugfix] Use MiniCPM-o speech template in long audio test (#5623)

### DIFF
--- a/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
@@ -150,7 +150,16 @@ def test_text_to_audio_long_output_001(omni_server, openai_client) -> None:
     request_config = {
         "model": omni_server.model,
         "messages": messages,
+        "modalities": ["text", "audio"],
         "stream": True,
+        # Delimit the assistant answer with the TTS template so the Talker
+        # does not spend its codec-token budget speaking hidden reasoning.
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
         "key_words": {"audio": ["Beijing"]},
     }
 


### PR DESCRIPTION
(cherry picked from commit 499d930fe599486a55f1ccc6fb695983aef52ef9)

## Purpose
Backport of bug fix from #5623 to minicpm-challenge branch

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 499d930fe599486a55f1ccc6fb695983aef52ef9

run `pytest tests/e2e/online_serving/test_minicpmo_4_5.py::test_image_to_text_audio_001[default] tests/e2e/online_serving/test_minicpmo_4_5_expansion.py::test_text_to_audio_long_output_001[default] --run-level "full_model" -m "full_model and H100 and omni" --ignore=tests/e2e/accuracy --ignore=tests/e2e/online_serving/test_qwen3_omni_multi_replicas.py --ignore=tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py` on minicpm-challenge branch with cherry-pick

## Test Result

================== 2 passed, 15 warnings in 630.77s (0:10:30) ==================