### PR TITLE
[Frontend] Add conversation history to /v1/realtime for Qwen3-Omni

### DIFF
--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -208,6 +208,37 @@ WEATHER_TOOL = {
 }
 
 
+# Two cities in one utterance, to make the model request two calls in one turn.
+TOOL_CALLING_TWO_CITY_PHRASE_TEXT = "What is the weather like in Boston and in Denver right now?"
+
+# Distinct results per city, so the final reply shows each result reached the call
+# that asked for it rather than both being collapsed into one <tool_response>.
+_TOOL_RESULT_BY_CITY = {
+    "boston": "sunny and 72 degrees",
+    "denver": "snowing and 28 degrees",
+}
+
+
+def _tool_result_for(arguments: str) -> str:
+    """Answer a get_weather call based on the city it asked about."""
+    city = (json.loads(arguments).get("city") or "").lower()
+    for key, result in _TOOL_RESULT_BY_CITY.items():
+        if key in city:
+            return result
+    raise AssertionError(f"Tool call asked about an unexpected city: {arguments!r}")
+
+
+def _two_city_tool_calling_pcm16_input() -> bytes:
+    syn = generate_synthetic_audio(
+        10,
+        1,
+        sample_rate=16000,
+        phrase_text=TOOL_CALLING_TWO_CITY_PHRASE_TEXT,
+    )
+    wav_bytes = base64.b64decode(syn["base64"])
+    return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
+
+
 def _tool_calling_pcm16_input() -> bytes:
     syn = generate_synthetic_audio(
         10,
@@ -233,8 +264,10 @@ async def _run_realtime_tool_call_roundtrip(
     bytes_per_ms = 16000 * 2 // 1000
     chunk_bytes = max(bytes_per_ms * chunk_ms, 2)
 
-    tool_call_name: str | None = None
-    tool_call_args = ""
+    # Keyed by call_id: with parallel calls the added/delta/done events for the
+    # two calls interleave, so per-call state cannot be a single accumulator.
+    calls: dict[str, dict[str, str]] = {}
+    call_order: list[str] = []
     final_text_chunks: list[str] = []
     final_text = ""
     saw_final_audio_delta = False
@@ -259,13 +292,16 @@ async def _run_realtime_tool_call_roundtrip(
             if event_type in ("session.created", "transcription.delta"):
                 continue
             if event_type == "response.output_item.added":
-                tool_call_name = event["item"]["name"]
+                call_id = event["item"]["call_id"]
+                calls[call_id] = {"name": event["item"]["name"], "arguments": ""}
+                call_order.append(call_id)
                 continue
             if event_type == "response.function_call_arguments.delta":
-                tool_call_args += event["delta"]
+                calls[event["call_id"]]["arguments"] += event["delta"]
                 continue
             if event_type == "response.function_call_arguments.done":
-                # Answer the tool call so generation resumes with a real result.
+                # Answer with a result keyed to the requested city, so a parallel
+                # pair can be checked for having each result matched to its call.
                 await ws.send(
                     json.dumps(
                         {
@@ -273,7 +309,7 @@ async def _run_realtime_tool_call_roundtrip(
                             "item": {
                                 "type": "function_call_output",
                                 "call_id": event["call_id"],
-                                "output": "sunny and 72 degrees",
+                                "output": _tool_result_for(event["arguments"]),
                             },
                         }
                     )
@@ -292,9 +328,14 @@ async def _run_realtime_tool_call_roundtrip(
                 raise AssertionError(f"WebSocket error: {event}")
             raise AssertionError(f"Unexpected WebSocket event: {event}")
 
+    ordered = [calls[cid] for cid in call_order]
     return {
-        "tool_call_name": tool_call_name,
-        "tool_call_arguments": tool_call_args,
+        # Single-call view, kept for the one-city test.
+        "tool_call_name": ordered[0]["name"] if ordered else None,
+        "tool_call_arguments": ordered[0]["arguments"] if ordered else "",
+        # Full view, in the order the model requested the calls.
+        "calls": ordered,
+        "call_ids": list(call_order),
         "final_text": final_text,
         "saw_final_audio_delta": saw_final_audio_delta,
     }
@@ -310,6 +351,25 @@ def _assert_tool_call_roundtrip(result: dict) -> None:
     assert "boston" in parsed_args["city"].lower()
     assert result["final_text"], "Expected a spoken final reply after the tool result was submitted"
     assert "72" in result["final_text"], f"Expected the mocked tool result to reach the final reply: {result}"
+    assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
+
+
+def _assert_two_call_roundtrip(result: dict) -> None:
+    """Both results must reach the reply, which requires each `role="tool"` message
+    to be its own `<tool_response>` block - joining them into one leaves the model
+    unable to tell which result answered which call."""
+    calls = result["calls"]
+    assert len(calls) == 2, f"Expected two parallel tool calls, got {len(calls)}: {calls}"
+    assert len(set(result["call_ids"])) == 2, f"Expected distinct call_ids: {result['call_ids']}"
+    assert {c["name"] for c in calls} == {"get_weather"}, calls
+
+    cities = [json.loads(c["arguments"])["city"].lower() for c in calls]
+    assert any("boston" in c for c in cities), cities
+    assert any("denver" in c for c in cities), cities
+
+    final = result["final_text"].lower()
+    assert "72" in final, f"Boston's result did not reach the reply: {result['final_text']!r}"
+    assert "28" in final, f"Denver's result did not reach the reply: {result['final_text']!r}"
     assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
 
 
@@ -432,3 +492,30 @@ class TestQwen3OmniRealtimeWebSocket:
         )
 
         _assert_tool_call_roundtrip(result)
+
+    @pytest.mark.advanced_model
+    @pytest.mark.omni
+    @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+    @pytest.mark.parametrize("omni_server", realtime_sync_server_params, indirect=True)
+    def test_two_call_tool_round_trip(self, omni_server) -> None:
+        """Merge CI: one utterance naming two cities -> the model requests two
+        `get_weather` calls -> the test client answers each with a distinct result
+        -> both results reach the spoken reply.
+
+        This is the case that fails when parallel results are joined into a single
+        `role="tool"` message: the template then emits one `<tool_response>` holding
+        both outputs, and the model cannot tell which result answered which call.
+        Same `async_chunk`-off requirement as the single-call test above.
+        """
+        pcm16 = _two_city_tool_calling_pcm16_input()
+
+        result = asyncio.run(
+            _run_realtime_tool_call_roundtrip(
+                omni_server.host,
+                omni_server.port,
+                omni_server.model,
+                pcm16,
+            )
+        )
+
+        _assert_two_call_roundtrip(result)

--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -189,6 +189,130 @@ def _synthetic_pcm16_input() -> bytes:
     return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
 
 
+# Distinct cache entry from REALTIME_SYNTH_PHRASE_TEXT above - must actually ask
+# something the weather tool below plausibly answers, so the model has a real
+# reason to call it (not just prompted to via `tools=`).
+TOOL_CALLING_PHRASE_TEXT = "What is the weather like in Boston right now?"
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def _tool_calling_pcm16_input() -> bytes:
+    syn = generate_synthetic_audio(
+        10,
+        1,
+        sample_rate=16000,
+        phrase_text=TOOL_CALLING_PHRASE_TEXT,
+    )
+    wav_bytes = base64.b64decode(syn["base64"])
+    return _pcm16_mono_16k_from_wav_bytes(wav_bytes)
+
+
+async def _run_realtime_tool_call_roundtrip(
+    host: str,
+    port: int,
+    model: str,
+    pcm16: bytes,
+    *,
+    chunk_ms: int = 200,
+) -> dict:
+    """Drive one full tool-calling exchange: model calls a tool, test client
+    answers it, generation resumes and speaks the final reply."""
+    uri = f"ws://{host}:{port}/v1/realtime"
+    bytes_per_ms = 16000 * 2 // 1000
+    chunk_bytes = max(bytes_per_ms * chunk_ms, 2)
+
+    tool_call_name: str | None = None
+    tool_call_args = ""
+    final_text_chunks: list[str] = []
+    final_text = ""
+    saw_final_audio_delta = False
+
+    async with websockets.connect(uri, max_size=64 * 1024 * 1024) as ws:
+        await ws.send(json.dumps({"type": "session.update", "model": model, "tools": [WEATHER_TOOL]}))
+        await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": False}))
+        for i in range(0, len(pcm16), chunk_bytes):
+            chunk = pcm16[i : i + chunk_bytes]
+            await ws.send(
+                json.dumps({"type": "input_audio_buffer.append", "audio": base64.b64encode(chunk).decode("utf-8")})
+            )
+        await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": True}))
+
+        while True:
+            message = await asyncio.wait_for(ws.recv(), timeout=600)
+            if isinstance(message, bytes):
+                continue
+            event = json.loads(message)
+            event_type = event.get("type")
+
+            if event_type in ("session.created", "transcription.delta"):
+                continue
+            if event_type == "response.output_item.added":
+                tool_call_name = event["item"]["name"]
+                continue
+            if event_type == "response.function_call_arguments.delta":
+                tool_call_args += event["delta"]
+                continue
+            if event_type == "response.function_call_arguments.done":
+                # Answer the tool call so generation resumes with a real result.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "conversation.item.create",
+                            "item": {
+                                "type": "function_call_output",
+                                "call_id": event["call_id"],
+                                "output": "sunny and 72 degrees",
+                            },
+                        }
+                    )
+                )
+                continue
+            if event_type == "response.audio.delta":
+                saw_final_audio_delta = True
+                continue
+            if event_type == "transcription.done":
+                final_text_chunks.append(event.get("text", ""))
+                final_text = event.get("text", "") or "".join(final_text_chunks)
+                continue
+            if event_type == "response.audio.done":
+                break
+            if event_type == "error":
+                raise AssertionError(f"WebSocket error: {event}")
+            raise AssertionError(f"Unexpected WebSocket event: {event}")
+
+    return {
+        "tool_call_name": tool_call_name,
+        "tool_call_arguments": tool_call_args,
+        "final_text": final_text,
+        "saw_final_audio_delta": saw_final_audio_delta,
+    }
+
+
+def _assert_tool_call_roundtrip(result: dict) -> None:
+    assert result["tool_call_name"] == "get_weather", (
+        f"Expected the model to call get_weather, got {result['tool_call_name']!r} "
+        f"(final_text={result['final_text']!r})"
+    )
+    parsed_args = json.loads(result["tool_call_arguments"])  # must be valid JSON, not e.g. '{"city": "Boston"}}\\n'
+    assert "city" in parsed_args
+    assert "boston" in parsed_args["city"].lower()
+    assert result["final_text"], "Expected a spoken final reply after the tool result was submitted"
+    assert "72" in result["final_text"], f"Expected the mocked tool result to reach the final reply: {result}"
+    assert result["saw_final_audio_delta"], "Expected audio for the final (non-tool-call) reply leg"
+
+
 def _assert_realtime_smoke(result: dict) -> None:
     out_pcm = result["output_pcm"]
     assert result["delta_events"] >= 1
@@ -281,3 +405,30 @@ class TestQwen3OmniRealtimeWebSocket:
 
         _assert_realtime_smoke(result)
         _assert_realtime_accuracy(result)
+
+    @pytest.mark.advanced_model
+    @pytest.mark.omni
+    @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+    @pytest.mark.parametrize("omni_server", realtime_sync_server_params, indirect=True)
+    def test_tool_calling_round_trip(self, omni_server) -> None:
+        """Merge CI: session.update.tools -> model calls get_weather -> test
+        client submits a function_call_output -> generation resumes and
+        speaks a final reply that incorporates the (mocked) tool result.
+
+        Requires async_chunk off (same server config as the non-async_chunk
+        streaming test above) - the realtime endpoint's generation loop only
+        sees one complete thinker turn to scan for a <tool_call> block when
+        async_chunk is disabled.
+        """
+        pcm16 = _tool_calling_pcm16_input()
+
+        result = asyncio.run(
+            _run_realtime_tool_call_roundtrip(
+                omni_server.host,
+                omni_server.port,
+                omni_server.model,
+                pcm16,
+            )
+        )
+
+        _assert_tool_call_roundtrip(result)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -48,8 +48,21 @@ def tool_call_conn() -> RealtimeConnection:
     # Tool calling is only supported with async_chunk off, so that is the default
     # here; tests that care about the other mode set it explicitly.
     conn.serving = _FakeServing()
-    # handle_event's session.update branch now also assigns _speaker.
+    # handle_event's session.update branch now also assigns these.
     conn._speaker = None
+    conn._instructions = None
+    return conn
+
+
+@pytest.fixture
+def instructions_conn() -> RealtimeConnection:
+    conn = RealtimeConnection.__new__(RealtimeConnection)
+    conn._instructions = None
+    # ...and the siblings session.update also assigns.
+    conn._tools = None
+    conn._speaker = None
+    # session.update now consults serving.model_config for the async_chunk gate.
+    conn.serving = _FakeServing()
     return conn
 
 
@@ -57,8 +70,9 @@ def tool_call_conn() -> RealtimeConnection:
 def speaker_conn() -> RealtimeConnection:
     conn = RealtimeConnection.__new__(RealtimeConnection)
     conn._speaker = None
-    # ...and _tools, so a session.update event exercises the whole branch.
+    # ...and the siblings, so a session.update event exercises the whole branch.
     conn._tools = None
+    conn._instructions = None
     # session.update now consults serving.model_config for the async_chunk gate.
     conn.serving = _FakeServing()
     return conn
@@ -222,6 +236,43 @@ class TestRealtimeConnectionSpeakerRouting:
         base_handle_event.assert_awaited_once_with(event)
 
 
+class TestRealtimeConnectionInstructionsRouting:
+    """handle_event's instructions (system prompt) addition to session.update."""
+
+    def _patch_base_handle_event(self, mocker):
+        return mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+
+    def test_session_update_captures_instructions(self, instructions_conn, mocker) -> None:
+        self._patch_base_handle_event(mocker)
+        event = {
+            "type": "session.update",
+            "model": "qwen3-omni",
+            "instructions": "Only use tools directly relevant to what the user asked.",
+        }
+
+        asyncio.run(instructions_conn.handle_event(event))
+
+        assert instructions_conn._instructions == "Only use tools directly relevant to what the user asked."
+
+    def test_session_update_without_instructions_leaves_existing_value_untouched(
+        self, instructions_conn, mocker
+    ) -> None:
+        self._patch_base_handle_event(mocker)
+        instructions_conn._instructions = "existing"
+
+        asyncio.run(instructions_conn.handle_event({"type": "session.update", "model": "qwen3-omni"}))
+
+        assert instructions_conn._instructions == "existing"
+
+    def test_unrelated_event_types_still_delegate_to_base(self, instructions_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        event = {"type": "input_audio_buffer.commit", "final": True}
+
+        asyncio.run(instructions_conn.handle_event(event))
+
+        base_handle_event.assert_awaited_once_with(event)
+
+
 class TestRenderTokenPromptReattachesAudio:
     """Regression test for a real bug: the tool-call continuation re-submitted
     the engine's POST-expansion `output.prompt_token_ids` as a bare
@@ -288,8 +339,9 @@ class TestRenderTokenPromptReattachesAudio:
         the continuation has something audio-bearing to splice onto."""
         conn = self._conn(mocker)
         conn._tools = None
-        # _buffer_realtime_audio_with_tools now also reads _speaker.
+        # _buffer_realtime_audio_with_tools now also reads _speaker/_instructions.
         conn._speaker = None
+        conn._instructions = None
         conn._turn_prompt = None
         audio = {"audio": np.zeros(8000, dtype=np.float32)}
         prompt = TokensPrompt(prompt_token_ids=[10, 11], multi_modal_data=audio)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -48,6 +48,19 @@ def tool_call_conn() -> RealtimeConnection:
     # Tool calling is only supported with async_chunk off, so that is the default
     # here; tests that care about the other mode set it explicitly.
     conn.serving = _FakeServing()
+    # handle_event's session.update branch now also assigns _speaker.
+    conn._speaker = None
+    return conn
+
+
+@pytest.fixture
+def speaker_conn() -> RealtimeConnection:
+    conn = RealtimeConnection.__new__(RealtimeConnection)
+    conn._speaker = None
+    # ...and _tools, so a session.update event exercises the whole branch.
+    conn._tools = None
+    # session.update now consults serving.model_config for the async_chunk gate.
+    conn.serving = _FakeServing()
     return conn
 
 
@@ -166,6 +179,49 @@ class TestRealtimeConnectionToolCallEventRouting:
         base_handle_event.assert_awaited_once_with(event)
 
 
+class TestRealtimeConnectionSpeakerRouting:
+    """handle_event's voice/speaker-selection addition to session.update -
+    threaded into buffer_realtime_audio's own `speaker` param (see
+    Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio), the same
+    `additional_information={"speaker": [...]}` shape /v1/chat/completions
+    already uses (serving_chat.py)."""
+
+    def _patch_base_handle_event(self, mocker):
+        return mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+
+    def test_session_update_captures_voice_field(self, speaker_conn, mocker) -> None:
+        self._patch_base_handle_event(mocker)
+
+        asyncio.run(speaker_conn.handle_event({"type": "session.update", "model": "qwen3-omni", "voice": "aiden"}))
+
+        assert speaker_conn._speaker == "aiden"
+
+    def test_session_update_captures_speaker_field(self, speaker_conn, mocker) -> None:
+        self._patch_base_handle_event(mocker)
+
+        asyncio.run(speaker_conn.handle_event({"type": "session.update", "model": "qwen3-omni", "speaker": "ethan"}))
+
+        assert speaker_conn._speaker == "ethan"
+
+    def test_session_update_without_voice_or_speaker_leaves_existing_value_untouched(
+        self, speaker_conn, mocker
+    ) -> None:
+        self._patch_base_handle_event(mocker)
+        speaker_conn._speaker = "aiden"
+
+        asyncio.run(speaker_conn.handle_event({"type": "session.update", "model": "qwen3-omni"}))
+
+        assert speaker_conn._speaker == "aiden"
+
+    def test_unrelated_event_types_still_delegate_to_base(self, speaker_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        event = {"type": "input_audio_buffer.commit", "final": True}
+
+        asyncio.run(speaker_conn.handle_event(event))
+
+        base_handle_event.assert_awaited_once_with(event)
+
+
 class TestRenderTokenPromptReattachesAudio:
     """Regression test for a real bug: the tool-call continuation re-submitted
     the engine's POST-expansion `output.prompt_token_ids` as a bare
@@ -182,6 +238,7 @@ class TestRenderTokenPromptReattachesAudio:
         conn.serving = mocker.Mock()
         conn.serving.model_config.is_encoder_decoder = False
         conn.serving.renderer.render_cmpl_async = mocker.AsyncMock(side_effect=lambda prompts: [dict(prompts[0])])
+        conn._speaker = None
         return conn
 
     @staticmethod
@@ -199,6 +256,26 @@ class TestRenderTokenPromptReattachesAudio:
 
         assert result.prompt["multi_modal_data"] is audio
 
+    def test_continuation_keeps_the_selected_voice(self, mocker) -> None:
+        """Without this the voice audibly changes mid-turn: the continuation is
+        built as its own TokensPrompt, bypassing buffer_realtime_audio where the
+        speaker is normally attached, so the spoken reply after a tool call fell
+        back to the checkpoint default."""
+        conn = self._conn(mocker)
+        conn._speaker = "aiden"
+
+        result = self._first(conn._render_token_prompt([1, 2, 3]))
+
+        assert result.prompt["additional_information"] == {"speaker": ["aiden"]}
+
+    def test_continuation_without_a_selected_voice_is_a_noop(self, mocker) -> None:
+        conn = self._conn(mocker)
+        conn._speaker = None
+
+        result = self._first(conn._render_token_prompt([1, 2, 3]))
+
+        assert "additional_information" not in result.prompt
+
     def test_no_multi_modal_data_is_a_noop(self, mocker) -> None:
         conn = self._conn(mocker)
 
@@ -211,6 +288,8 @@ class TestRenderTokenPromptReattachesAudio:
         the continuation has something audio-bearing to splice onto."""
         conn = self._conn(mocker)
         conn._tools = None
+        # _buffer_realtime_audio_with_tools now also reads _speaker.
+        conn._speaker = None
         conn._turn_prompt = None
         audio = {"audio": np.zeros(8000, dtype=np.float32)}
         prompt = TokensPrompt(prompt_token_ids=[10, 11], multi_modal_data=audio)
@@ -502,3 +581,42 @@ class TestToolsRejectedUnderAsyncChunk:
         send_error, _ = self._session_update(tool_call_conn, mocker, async_chunk=False)
         send_error.assert_not_awaited()
         assert tool_call_conn._tools == [{"type": "function", "function": {"name": "get_weather"}}]
+
+
+class TestRenderPromptPropagatesAdditionalInformation:
+    """Regression test for a real bug: BaseRenderer.render_cmpl_async's
+    internal pipeline (process_for_engine_async) only carries over fields
+    it explicitly knows about, so `additional_information` set on the
+    pre-render prompt (buffer_realtime_audio's `speaker`) was silently
+    dropped and never reached the engine - the voice selection feature
+    looked correct in isolation but produced no audible effect. Fixed by
+    reapplying it to the rendered engine_input, mirroring how
+    serving_chat.py._preprocess_chat does it for /v1/chat/completions."""
+
+    def _conn_with_fake_renderer(self, mocker, rendered_engine_input: dict):
+        conn = RealtimeConnection.__new__(RealtimeConnection)
+        conn.serving = mocker.Mock()
+        conn.serving.model_config.is_encoder_decoder = False
+        conn.serving.renderer.render_cmpl_async = mocker.AsyncMock(return_value=[rendered_engine_input])
+        return conn
+
+    def test_additional_information_survives_render(self, mocker) -> None:
+        # render_cmpl_async's fake return simulates the real pipeline: it never
+        # echoes back fields it doesn't recognize, so additional_information
+        # must NOT be in here even though the input prompt has it.
+        rendered = {"prompt_token_ids": [1, 2, 3]}
+        conn = self._conn_with_fake_renderer(mocker, rendered)
+        prompt = TokensPrompt(prompt_token_ids=[1, 2, 3], additional_information={"speaker": ["aiden"]})
+
+        result = asyncio.run(conn._render_prompt(prompt))
+
+        assert result.prompt["additional_information"] == {"speaker": ["aiden"]}
+
+    def test_no_additional_information_is_a_noop(self, mocker) -> None:
+        rendered = {"prompt_token_ids": [1, 2, 3]}
+        conn = self._conn_with_fake_renderer(mocker, rendered)
+        prompt = TokensPrompt(prompt_token_ids=[1, 2, 3])
+
+        result = asyncio.run(conn._render_prompt(prompt))
+
+        assert "additional_information" not in result.prompt

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from dataclasses import dataclass, field
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -339,9 +340,10 @@ class TestRenderTokenPromptReattachesAudio:
         the continuation has something audio-bearing to splice onto."""
         conn = self._conn(mocker)
         conn._tools = None
-        # _buffer_realtime_audio_with_tools now also reads _speaker/_instructions.
+        # _buffer_realtime_audio_with_tools also reads these now.
         conn._speaker = None
         conn._instructions = None
+        conn._history = []
         conn._turn_prompt = None
         audio = {"audio": np.zeros(8000, dtype=np.float32)}
         prompt = TokensPrompt(prompt_token_ids=[10, 11], multi_modal_data=audio)
@@ -672,3 +674,86 @@ class TestRenderPromptPropagatesAdditionalInformation:
         result = asyncio.run(conn._render_prompt(prompt))
 
         assert "additional_information" not in result.prompt
+
+
+class TestConversationHistory:
+    """Audio conversation history: the omni realtime endpoint is stateless per
+    turn and returns only the assistant's own reply text (no ASR of the user),
+    so prior turns are replayed as the user's ORIGINAL AUDIO paired with the
+    model's reply text. These cover the pairing state machine; the prompt-side
+    contract (one audio placeholder per replayed turn, in the same order as the
+    multi_modal_data audio list) lives in buffer_realtime_audio."""
+
+    def _conn(self):
+        conn = RealtimeConnection.__new__(RealtimeConnection)
+        conn._history = []
+        conn._pending_user_audio = None
+        conn.send_error = mock.AsyncMock()
+        return conn
+
+    @staticmethod
+    def _pcm_b64(samples: list[int]) -> str:
+        return base64.b64encode(np.array(samples, dtype=np.int16).tobytes()).decode()
+
+    def _user(self, samples):
+        return {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_audio", "audio": self._pcm_b64(samples)}],
+        }
+
+    @staticmethod
+    def _assistant(text):
+        return {"type": "message", "role": "assistant", "content": [{"type": "text", "text": text}]}
+
+    def test_user_then_assistant_forms_one_turn(self) -> None:
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._user([32767, -32768])))
+        assert conn._history == []  # held until the reply arrives
+        asyncio.run(conn._handle_history_item(self._assistant("sunny in Madrid")))
+        assert len(conn._history) == 1
+        assert conn._history[0]["text"] == "sunny in Madrid"
+        np.testing.assert_allclose(conn._history[0]["audio"], [32767 / 32768.0, -1.0], rtol=1e-6)
+        assert conn._pending_user_audio is None
+
+    def test_unpaired_user_turn_is_not_replayed(self) -> None:
+        """The turn currently being spoken has no reply yet; replaying a dangling
+        user turn would leave the conversation malformed."""
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._user([1, 2, 3])))
+        assert conn._history == []
+
+    def test_assistant_without_user_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._assistant("orphan")))
+        assert conn._history == []
+        conn.send_error.assert_awaited_once()
+
+    def test_user_without_audio_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(
+            conn._handle_history_item(
+                {"type": "message", "role": "user", "content": [{"type": "text", "text": "no audio"}]}
+            )
+        )
+        assert conn._pending_user_audio is None
+        conn.send_error.assert_awaited_once()
+
+    def test_unknown_role_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(
+            conn._handle_history_item({"type": "message", "role": "system", "content": [{"type": "text", "text": "x"}]})
+        )
+        assert conn._history == []
+        conn.send_error.assert_awaited_once()
+
+    def test_multiple_turns_accumulate_in_order(self) -> None:
+        conn = self._conn()
+        for i, reply in enumerate(["first", "second", "third"], start=1):
+            asyncio.run(conn._handle_history_item(self._user([i])))
+            asyncio.run(conn._handle_history_item(self._assistant(reply)))
+        assert [h["text"] for h in conn._history] == ["first", "second", "third"]
+
+    def test_decode_matches_base_class_pcm16_conversion(self) -> None:
+        out = RealtimeConnection._decode_pcm16(self._pcm_b64([0, 16384, -16384]))
+        np.testing.assert_allclose(out, [0.0, 0.5, -0.5], rtol=1e-6)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -210,3 +210,52 @@ class TestRenderTokenPromptReattachesAudio:
 
         assert conn._turn_prompt["prompt_token_ids"] == [10, 11]
         assert conn._turn_prompt["multi_modal_data"] is audio
+
+
+class TestCloseAssistantTurnBeforeToolResult:
+    """Regression test for a real bug: the tool-result suffix opens with
+    `<|im_start|>user`, but the raw generated token ids stop at the tool call
+    without the `<|im_end|>` the chat template would emit. Splicing them
+    directly produced `</tool_call><|im_start|>user`, leaving the assistant turn
+    open. The thinker answered that malformed conversation by re-emitting the
+    same tool call, looping until something bounded it - while the reference HF
+    path (apply_chat_template, which closes the turn) answered the identical
+    prompt correctly. Verified against a live Qwen3-Omni realtime session:
+    tool results that previously looped 8+ times now answer in one round, with
+    wording matching the reference implementation."""
+
+    class _Tok:
+        unk_token_id = 0
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            assert token == "<|im_end|>"
+            return 151645
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert text == "\n"
+            return [198]
+
+    def test_appends_terminator_and_newline(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 2, 3])
+        assert out == [1, 2, 3, 151645, 198]
+
+    def test_adds_only_newline_when_terminator_present(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 2, 151645])
+        assert out == [1, 2, 151645, 198]
+
+    def test_is_idempotent_when_already_closed(self) -> None:
+        out = RealtimeConnection._close_assistant_turn(self._Tok(), [1, 151645, 198])
+        assert out == [1, 151645, 198]
+
+    def test_does_not_mutate_caller_list(self) -> None:
+        original = [1, 2, 3]
+        RealtimeConnection._close_assistant_turn(self._Tok(), original)
+        assert original == [1, 2, 3]
+
+    def test_unknown_terminator_leaves_splice_untouched(self) -> None:
+        class _Bad(self._Tok().__class__):
+            def convert_tokens_to_ids(self, token: str) -> int:
+                return 0  # == unk_token_id
+
+        out = RealtimeConnection._close_assistant_turn(_Bad(), [1, 2, 3])
+        assert out == [1, 2, 3]

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 
 import numpy as np
 import pytest
 import torch
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -20,6 +22,15 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 @pytest.fixture
 def realtime_conn() -> RealtimeConnection:
     return RealtimeConnection.__new__(RealtimeConnection)
+
+
+@pytest.fixture
+def tool_call_conn() -> RealtimeConnection:
+    conn = RealtimeConnection.__new__(RealtimeConnection)
+    conn._tools = None
+    conn._tool_result_queue = asyncio.Queue()
+    conn._pending_tool_calls = {}
+    return conn
 
 
 class TestRealtimeConnectionTensorAndPcm:
@@ -84,3 +95,54 @@ class TestAsyncOmniStreamingParamsValidation:
         p = SamplingParams(n=1, stop=["\n"], output_kind=RequestOutputKind.DELTA)
         with pytest.raises(ValueError, match="Input streaming"):
             AsyncOmni._validate_streaming_input_sampling_params(p)
+
+
+class TestRealtimeConnectionToolCallEventRouting:
+    """handle_event's tool-calling additions (session.update.tools capture,
+    conversation.item.create routing) - see realtime_tool_calls.py for the
+    <tool_call> text parser these events feed."""
+
+    def _patch_base_handle_event(self, mocker):
+        return mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+
+    def test_session_update_captures_tools_and_delegates_to_base(self, tool_call_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        event = {"type": "session.update", "model": "qwen3-omni", "tools": tools}
+
+        asyncio.run(tool_call_conn.handle_event(event))
+
+        assert tool_call_conn._tools == tools
+        base_handle_event.assert_awaited_once_with(event)
+
+    def test_session_update_without_tools_leaves_existing_tools_untouched(self, tool_call_conn, mocker) -> None:
+        self._patch_base_handle_event(mocker)
+        tool_call_conn._tools = [{"type": "function", "function": {"name": "existing"}}]
+
+        asyncio.run(tool_call_conn.handle_event({"type": "session.update", "model": "qwen3-omni"}))
+
+        assert tool_call_conn._tools == [{"type": "function", "function": {"name": "existing"}}]
+
+    def test_conversation_item_create_function_call_output_is_queued(self, tool_call_conn) -> None:
+        item = {"type": "function_call_output", "call_id": "call_1", "output": "sunny and 72"}
+
+        asyncio.run(tool_call_conn.handle_event({"type": "conversation.item.create", "item": item}))
+
+        assert tool_call_conn._tool_result_queue.qsize() == 1
+        assert tool_call_conn._tool_result_queue.get_nowait() == item
+
+    def test_conversation_item_create_unsupported_item_type_sends_error(self, tool_call_conn, mocker) -> None:
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+
+        asyncio.run(tool_call_conn.handle_event({"type": "conversation.item.create", "item": {"type": "not_a_thing"}}))
+
+        send_error.assert_awaited_once()
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_unrelated_event_types_still_delegate_to_base(self, tool_call_conn, mocker) -> None:
+        base_handle_event = self._patch_base_handle_event(mocker)
+        event = {"type": "input_audio_buffer.commit", "final": True}
+
+        asyncio.run(tool_call_conn.handle_event(event))
+
+        base_handle_event.assert_awaited_once_with(event)

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
+from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -146,3 +147,66 @@ class TestRealtimeConnectionToolCallEventRouting:
         asyncio.run(tool_call_conn.handle_event(event))
 
         base_handle_event.assert_awaited_once_with(event)
+
+
+class TestRenderTokenPromptReattachesAudio:
+    """Regression test for a real bug: the tool-call continuation re-submitted
+    the engine's POST-expansion `output.prompt_token_ids` as a bare
+    TokensPrompt. Those ids still contain the expanded `<|audio_pad|>` run for
+    the user's spoken turn, but with no `multi_modal_data` the audio encoder
+    output is gone - so the thinker saw placeholder tokens backed by nothing,
+    lost the question entirely, and "answered" by emitting further tool calls
+    for unrelated cities/items (and even fabricating tool results) instead of
+    replying, never terminating. Fixed by splicing onto the PRE-expansion
+    prompt and re-attaching its audio on every continuation."""
+
+    def _conn(self, mocker):
+        conn = RealtimeConnection.__new__(RealtimeConnection)
+        conn.serving = mocker.Mock()
+        conn.serving.model_config.is_encoder_decoder = False
+        conn.serving.renderer.render_cmpl_async = mocker.AsyncMock(side_effect=lambda prompts: [dict(prompts[0])])
+        return conn
+
+    @staticmethod
+    def _first(gen):
+        async def _run():
+            return await anext(gen)
+
+        return asyncio.run(_run())
+
+    def test_audio_is_reattached_to_continuation_prompt(self, mocker) -> None:
+        conn = self._conn(mocker)
+        audio = {"audio": np.zeros(16000, dtype=np.float32)}
+
+        result = self._first(conn._render_token_prompt([1, 2, 3], audio))
+
+        assert result.prompt["multi_modal_data"] is audio
+
+    def test_no_multi_modal_data_is_a_noop(self, mocker) -> None:
+        conn = self._conn(mocker)
+
+        result = self._first(conn._render_token_prompt([1, 2, 3]))
+
+        assert "multi_modal_data" not in result.prompt
+
+    def test_turn_prompt_capture_keeps_unexpanded_ids_and_audio(self, mocker) -> None:
+        """_buffer_realtime_audio_with_tools must stash the pre-render prompt so
+        the continuation has something audio-bearing to splice onto."""
+        conn = self._conn(mocker)
+        conn._tools = None
+        conn._turn_prompt = None
+        audio = {"audio": np.zeros(8000, dtype=np.float32)}
+        prompt = TokensPrompt(prompt_token_ids=[10, 11], multi_modal_data=audio)
+
+        async def _fake_buffer(*_args, **_kwargs):
+            yield prompt
+
+        conn.serving.model_cls.buffer_realtime_audio = _fake_buffer
+
+        async def _drain():
+            return [x async for x in conn._buffer_realtime_audio_with_tools(None, None)]
+
+        asyncio.run(_drain())
+
+        assert conn._turn_prompt["prompt_token_ids"] == [10, 11]
+        assert conn._turn_prompt["multi_modal_data"] is audio

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from dataclasses import dataclass, field
 
 import numpy as np
 import pytest
@@ -25,6 +26,18 @@ def realtime_conn() -> RealtimeConnection:
     return RealtimeConnection.__new__(RealtimeConnection)
 
 
+@dataclass
+class _FakeModelConfig:
+    """Only the field `_async_chunk_enabled` reads."""
+
+    async_chunk: bool = False
+
+
+@dataclass
+class _FakeServing:
+    model_config: _FakeModelConfig = field(default_factory=_FakeModelConfig)
+
+
 @pytest.fixture
 def tool_call_conn() -> RealtimeConnection:
     conn = RealtimeConnection.__new__(RealtimeConnection)
@@ -32,6 +45,9 @@ def tool_call_conn() -> RealtimeConnection:
     conn._tool_result_queue = asyncio.Queue()
     conn._pending_tool_calls = {}
     conn._tool_rounds = 0
+    # Tool calling is only supported with async_chunk off, so that is the default
+    # here; tests that care about the other mode set it explicitly.
+    conn.serving = _FakeServing()
     return conn
 
 
@@ -323,3 +339,166 @@ class TestToolResultWaitReleasesOnDisconnect:
         asyncio.run(asyncio.wait_for(tool_call_conn._await_tool_results_and_continue([1], [2]), timeout=5))
 
         run_generation.assert_not_awaited()
+
+
+class TestParallelToolResultsRenderSeparateBlocks:
+    """Review #5555: joining parallel tool results into one `role="tool"` message
+    produced a single `<tool_response>` holding both outputs, so the model could
+    not associate each result with its call. The chat template emits one
+    `<tool_response>` per tool message (grouping consecutive tool messages under
+    one user turn), so each result must be its own message, in call order.
+    """
+
+    @staticmethod
+    def _capture_suffix(conn, mocker, pending: dict[int, _PendingToolCall]) -> list[dict[str, str]]:
+        """Drive `_await_tool_results_and_continue` and return the message list
+        handed to the chat template."""
+        conn._is_connected = True
+        conn._tool_rounds = 0
+        conn._turn_prompt = None
+        conn._pending_tool_calls = pending
+        conn.serving = mocker.Mock()
+        mocker.patch.object(conn, "_run_generation", new_callable=mocker.AsyncMock)
+        mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.cached_tokenizer_from_config",
+            return_value=mocker.Mock(
+                encode=lambda text, add_special_tokens=True: [9],
+                convert_tokens_to_ids=lambda token: 151645,
+                unk_token_id=0,
+            ),
+        )
+        mocker.patch("vllm_omni.entrypoints.openai.realtime_connection.cached_processor_from_config")
+        apply_tmpl = mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.safe_apply_chat_template",
+            return_value="<|im_start|>user\nr<|im_end|>\n<|im_start|>assistant\n",
+        )
+        asyncio.run(conn._await_tool_results_and_continue([1, 2], [3]))
+        return apply_tmpl.call_args.args[2]
+
+    def test_two_results_become_two_tool_messages_in_call_order(self, tool_call_conn, mocker) -> None:
+        pending = {
+            0: _PendingToolCall(call_id="call_a", name="get_weather"),
+            1: _PendingToolCall(call_id="call_b", name="get_weather"),
+        }
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "sunny 72"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_b", "output": "rainy 55"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert messages == [
+            {"role": "tool", "content": "sunny 72"},
+            {"role": "tool", "content": "rainy 55"},
+        ]
+
+    def test_call_order_is_kept_when_results_arrive_reversed(self, tool_call_conn, mocker) -> None:
+        """Arrival order is the client's choice; call order is the model's."""
+        pending = {
+            0: _PendingToolCall(call_id="call_a", name="get_weather"),
+            1: _PendingToolCall(call_id="call_b", name="get_weather"),
+        }
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_b", "output": "rainy 55"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "sunny 72"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert [m["content"] for m in messages] == ["sunny 72", "rainy 55"]
+
+    def test_duplicate_result_for_one_call_does_not_desync_the_wait(self, tool_call_conn, mocker) -> None:
+        pending = {0: _PendingToolCall(call_id="call_a", name="get_weather")}
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "first"})
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_a", "output": "second"})
+
+        messages = self._capture_suffix(tool_call_conn, mocker, pending)
+
+        assert messages == [{"role": "tool", "content": "first"}]
+
+
+class TestToolResultValidation:
+    """Review #5555: any dict with `type="function_call_output"` was enqueued, so a
+    missing/non-string `call_id` or a non-string `output` was accepted and the turn
+    then waited for a result that could never match - with nothing reported to the
+    client. Shape problems are protocol errors."""
+
+    @staticmethod
+    def _create(item: dict) -> dict:
+        return {"type": "conversation.item.create", "item": item}
+
+    def _run(self, conn, mocker, item: dict):
+        send_error = mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+        asyncio.run(conn.handle_event(self._create(item)))
+        return send_error
+
+    def test_missing_call_id_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(tool_call_conn, mocker, {"type": "function_call_output", "output": "x"})
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_non_string_call_id_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(tool_call_conn, mocker, {"type": "function_call_output", "call_id": 7, "output": "x"})
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_non_string_output_is_rejected(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(
+            tool_call_conn, mocker, {"type": "function_call_output", "call_id": "call_a", "output": {"a": 1}}
+        )
+        assert send_error.await_args.args[1] == "invalid_function_call_output"
+        assert tool_call_conn._tool_result_queue.empty()
+
+    def test_well_formed_result_is_enqueued(self, tool_call_conn, mocker) -> None:
+        send_error = self._run(
+            tool_call_conn, mocker, {"type": "function_call_output", "call_id": "call_a", "output": "sunny"}
+        )
+        send_error.assert_not_awaited()
+        assert tool_call_conn._tool_result_queue.qsize() == 1
+
+    def test_unknown_call_id_is_reported_to_the_client(self, tool_call_conn, mocker) -> None:
+        """Previously only logged, so a client typo produced silence."""
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = 0
+        tool_call_conn._pending_tool_calls = {0: _PendingToolCall(call_id="call_a", name="get_weather")}
+        tool_call_conn._tool_result_queue.put_nowait({"call_id": "call_TYPO", "output": "sunny"})
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        async def _drive() -> None:
+            task = asyncio.ensure_future(tool_call_conn._await_tool_results_and_continue([1], [2]))
+            for _ in range(40):
+                await asyncio.sleep(0.02)
+                if send_error.await_count:
+                    break
+            tool_call_conn._is_connected = False
+            await asyncio.wait_for(task, timeout=5)
+
+        asyncio.run(_drive())
+
+        assert send_error.await_args.args[1] == "unknown_tool_call_id"
+
+
+class TestToolsRejectedUnderAsyncChunk:
+    """Review #5555: with async_chunk on, the buffer yields one TokensPrompt per
+    segment, so a tool-call continuation reattached only the final segment and lost
+    the start of the utterance. Aggregating the audio would not be enough - the
+    generation loop also never sees one complete thinker turn to scan for a
+    <tool_call> block - so tools are refused outright instead."""
+
+    def _session_update(self, conn, mocker, async_chunk: bool):
+        conn.serving = _FakeServing(_FakeModelConfig(async_chunk=async_chunk))
+        send_error = mocker.patch.object(conn, "send_error", new_callable=mocker.AsyncMock)
+        base = mocker.patch.object(VllmRealtimeConnection, "handle_event", new_callable=mocker.AsyncMock)
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        asyncio.run(conn.handle_event({"type": "session.update", "model": "m", "tools": tools}))
+        return send_error, base
+
+    def test_tools_rejected_when_async_chunk_enabled(self, tool_call_conn, mocker) -> None:
+        send_error, base = self._session_update(tool_call_conn, mocker, async_chunk=True)
+        assert send_error.await_args.args[1] == "tools_require_no_async_chunk"
+        assert tool_call_conn._tools is None
+        base.assert_awaited_once()
+
+    def test_tools_accepted_when_async_chunk_disabled(self, tool_call_conn, mocker) -> None:
+        send_error, _ = self._session_update(tool_call_conn, mocker, async_chunk=False)
+        send_error.assert_not_awaited()
+        assert tool_call_conn._tools == [{"type": "function", "function": {"name": "get_weather"}}]

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -677,17 +677,22 @@ class TestRenderPromptPropagatesAdditionalInformation:
 
 
 class TestConversationHistory:
-    """Audio conversation history: the omni realtime endpoint is stateless per
-    turn and returns only the assistant's own reply text (no ASR of the user),
-    so prior turns are replayed as the user's ORIGINAL AUDIO paired with the
-    model's reply text. These cover the pairing state machine; the prompt-side
-    contract (one audio placeholder per replayed turn, in the same order as the
-    multi_modal_data audio list) lives in buffer_realtime_audio."""
+    """Audio conversation history. The endpoint is audio-in and returns only the
+    assistant's own reply text (no ASR of the user), so prior turns are replayed as
+    the user's ORIGINAL AUDIO plus text for everything else.
+
+    A completed TOOL turn must be replayed in full - assistant `<tool_call>`, the
+    `tool` result, then the spoken answer. Replaying only the answer makes the
+    history read as "the model answers these from its own knowledge" and it stops
+    calling tools on later turns, confabulating instead; replaying a `<tool_call>`
+    with no result reads as an unanswered call and it retries forever. Both were
+    reproduced on the reference HF path, i.e. they are prompt-shape issues rather
+    than serving details.
+    """
 
     def _conn(self):
         conn = RealtimeConnection.__new__(RealtimeConnection)
         conn._history = []
-        conn._pending_user_audio = None
         conn.send_error = mock.AsyncMock()
         return conn
 
@@ -703,31 +708,34 @@ class TestConversationHistory:
         }
 
     @staticmethod
-    def _assistant(text):
-        return {"type": "message", "role": "assistant", "content": [{"type": "text", "text": text}]}
+    def _msg(role, text):
+        return {"type": "message", "role": role, "content": [{"type": "text", "text": text}]}
 
-    def test_user_then_assistant_forms_one_turn(self) -> None:
+    def test_user_audio_is_decoded_and_appended(self) -> None:
         conn = self._conn()
         asyncio.run(conn._handle_history_item(self._user([32767, -32768])))
-        assert conn._history == []  # held until the reply arrives
-        asyncio.run(conn._handle_history_item(self._assistant("sunny in Madrid")))
         assert len(conn._history) == 1
-        assert conn._history[0]["text"] == "sunny in Madrid"
+        assert conn._history[0]["role"] == "user"
         np.testing.assert_allclose(conn._history[0]["audio"], [32767 / 32768.0, -1.0], rtol=1e-6)
-        assert conn._pending_user_audio is None
 
-    def test_unpaired_user_turn_is_not_replayed(self) -> None:
-        """The turn currently being spoken has no reply yet; replaying a dangling
-        user turn would leave the conversation malformed."""
+    def test_full_tool_turn_is_preserved_in_order(self) -> None:
+        """The regression this class exists for: all four messages, in order."""
         conn = self._conn()
-        asyncio.run(conn._handle_history_item(self._user([1, 2, 3])))
-        assert conn._history == []
+        call = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Madrid"}}\n</tool_call>'
+        asyncio.run(conn._handle_history_item(self._user([1, 2])))
+        asyncio.run(conn._handle_history_item(self._msg("assistant", call)))
+        asyncio.run(conn._handle_history_item(self._msg("tool", "sunny and 72 degrees")))
+        asyncio.run(conn._handle_history_item(self._msg("assistant", "It is sunny in Madrid.")))
 
-    def test_assistant_without_user_is_rejected(self) -> None:
+        assert [m["role"] for m in conn._history] == ["user", "assistant", "tool", "assistant"]
+        assert conn._history[1]["content"] == call
+        assert conn._history[2]["content"] == "sunny and 72 degrees"
+
+    def test_tool_role_is_accepted(self) -> None:
         conn = self._conn()
-        asyncio.run(conn._handle_history_item(self._assistant("orphan")))
-        assert conn._history == []
-        conn.send_error.assert_awaited_once()
+        asyncio.run(conn._handle_history_item(self._msg("tool", "12 units in stock")))
+        assert conn._history == [{"role": "tool", "content": "12 units in stock"}]
+        conn.send_error.assert_not_awaited()
 
     def test_user_without_audio_is_rejected(self) -> None:
         conn = self._conn()
@@ -736,23 +744,20 @@ class TestConversationHistory:
                 {"type": "message", "role": "user", "content": [{"type": "text", "text": "no audio"}]}
             )
         )
-        assert conn._pending_user_audio is None
+        assert conn._history == []
+        conn.send_error.assert_awaited_once()
+
+    def test_empty_text_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._msg("assistant", "   ")))
+        assert conn._history == []
         conn.send_error.assert_awaited_once()
 
     def test_unknown_role_is_rejected(self) -> None:
         conn = self._conn()
-        asyncio.run(
-            conn._handle_history_item({"type": "message", "role": "system", "content": [{"type": "text", "text": "x"}]})
-        )
+        asyncio.run(conn._handle_history_item(self._msg("system", "x")))
         assert conn._history == []
         conn.send_error.assert_awaited_once()
-
-    def test_multiple_turns_accumulate_in_order(self) -> None:
-        conn = self._conn()
-        for i, reply in enumerate(["first", "second", "third"], start=1):
-            asyncio.run(conn._handle_history_item(self._user([i])))
-            asyncio.run(conn._handle_history_item(self._assistant(reply)))
-        assert [h["text"] for h in conn._history] == ["first", "second", "third"]
 
     def test_decode_matches_base_class_pcm16_conversion(self) -> None:
         out = RealtimeConnection._decode_pcm16(self._pcm_b64([0, 16384, -16384]))

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -18,6 +18,7 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection, _PendingToolCall
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni import _replay_messages
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -677,9 +678,10 @@ class TestRenderPromptPropagatesAdditionalInformation:
 
 
 class TestConversationHistory:
-    """Audio conversation history. The endpoint is audio-in and returns only the
-    assistant's own reply text (no ASR of the user), so prior turns are replayed as
-    the user's ORIGINAL AUDIO plus text for everything else.
+    """Conversation history. The endpoint is audio-in and returns only the
+    assistant's own reply text (no ASR of the user), so a user turn is normally
+    replayed as its ORIGINAL AUDIO; text is accepted too for callers that have a
+    transcript instead. Everything else is text.
 
     A completed TOOL turn must be replayed in full - assistant `<tool_call>`, the
     `tool` result, then the spoken answer. Replaying only the answer makes the
@@ -737,13 +739,57 @@ class TestConversationHistory:
         assert conn._history == [{"role": "tool", "content": "12 units in stock"}]
         conn.send_error.assert_not_awaited()
 
-    def test_user_without_audio_is_rejected(self) -> None:
+    def test_user_text_is_accepted(self) -> None:
+        """A caller with a text transcript and no audio (ASR elsewhere, or a
+        migrated text conversation) can still seed history. Text costs a fraction
+        of the tokens and bytes that replayed audio does."""
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._msg("user", "my name is Nathan")))
+        assert conn._history == [{"role": "user", "content": "my name is Nathan"}]
+        conn.send_error.assert_not_awaited()
+
+    def test_user_input_text_is_accepted(self) -> None:
+        """OpenAI's Realtime API uses `input_text` on a user message (and `text` on
+        an assistant one), so both spellings are honoured - same tolerance the
+        audio side already has for `input_audio`/`audio`."""
         conn = self._conn()
         asyncio.run(
             conn._handle_history_item(
-                {"type": "message", "role": "user", "content": [{"type": "text", "text": "no audio"}]}
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "my name is Nathan"}]}
             )
         )
+        assert conn._history == [{"role": "user", "content": "my name is Nathan"}]
+        conn.send_error.assert_not_awaited()
+
+    def test_user_audio_and_text_are_both_kept(self) -> None:
+        """A user turn may be audio PLUS text - the spoken part and a written
+        instruction about it - which /v1/chat/completions already supports for this
+        checkpoint. Neither part is discarded."""
+        conn = self._conn()
+        asyncio.run(
+            conn._handle_history_item(
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_audio", "audio": self._pcm_b64([16384])},
+                        {"type": "input_text", "text": "translate that"},
+                    ],
+                }
+            )
+        )
+        assert conn._history[0]["content"] == "translate that"
+        np.testing.assert_allclose(conn._history[0]["audio"], [0.5], rtol=1e-6)
+
+    def test_user_with_neither_audio_nor_text_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item({"type": "message", "role": "user", "content": []}))
+        assert conn._history == []
+        conn.send_error.assert_awaited_once()
+
+    def test_user_with_blank_text_is_rejected(self) -> None:
+        conn = self._conn()
+        asyncio.run(conn._handle_history_item(self._msg("user", "   ")))
         assert conn._history == []
         conn.send_error.assert_awaited_once()
 
@@ -762,3 +808,101 @@ class TestConversationHistory:
     def test_decode_matches_base_class_pcm16_conversion(self) -> None:
         out = RealtimeConnection._decode_pcm16(self._pcm_b64([0, 16384, -16384]))
         np.testing.assert_allclose(out, [0.0, 0.5, -0.5], rtol=1e-6)
+
+
+class TestReplayMessagePairing:
+    """`_replay_messages` emits the chat messages and the audio list together
+    because they are matched POSITIONALLY: the Nth audio placeholder in the prompt
+    binds to the Nth entry of multi_modal_data. If the two ever disagree the model
+    attributes one turn's audio to a different turn - silently, with no error - so
+    the count/order invariant is asserted directly here."""
+
+    PH = "<|audio_start|><|audio_pad|><|audio_end|>"
+
+    @staticmethod
+    def _audio(n=8):
+        return np.zeros(n, dtype=np.float32)
+
+    def test_audio_turn_emits_placeholder_and_audio(self) -> None:
+        msgs, audio = _replay_messages([{"role": "user", "audio": self._audio()}], self.PH, None)
+        assert [m["content"] for m in msgs] == [self.PH]
+        assert len(audio) == 1
+
+    def test_text_user_turn_emits_text_and_no_audio(self) -> None:
+        msgs, audio = _replay_messages([{"role": "user", "content": "my name is Nathan"}], self.PH, None)
+        assert msgs == [{"role": "user", "content": "my name is Nathan"}]
+        assert audio == []
+
+    def test_mixed_audio_and_text_turn_renders_both(self) -> None:
+        """Content is a plain string here, so a mixed turn is just concatenation -
+        one placeholder (so one audio entry) followed by the text."""
+        msgs, audio = _replay_messages(
+            [{"role": "user", "audio": self._audio(), "content": "translate that"}], self.PH, None
+        )
+        assert msgs == [{"role": "user", "content": self.PH + "translate that"}]
+        assert len(audio) == 1
+
+    def test_placeholder_count_always_equals_audio_count(self) -> None:
+        """The invariant, over a mixed history: audio user turns, text user turns,
+        assistant and tool turns interleaved."""
+        history = [
+            {"role": "user", "content": "text one"},
+            {"role": "assistant", "content": "reply one"},
+            {"role": "user", "audio": self._audio()},
+            {"role": "assistant", "content": "reply two"},
+            {"role": "tool", "content": "sunny and 72"},
+            {"role": "user", "audio": self._audio()},
+            {"role": "user", "content": "text two"},
+            {"role": "user", "audio": self._audio(), "content": "and this"},
+        ]
+        msgs, audio = _replay_messages(history, self.PH, None)
+        assert len(msgs) == len(history)
+        assert sum(1 for m in msgs if m["content"].startswith(self.PH)) == len(audio) == 3
+
+    def test_order_is_preserved(self) -> None:
+        history = [
+            {"role": "user", "audio": np.full(4, 0.25, dtype=np.float32)},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "audio": np.full(4, 0.75, dtype=np.float32)},
+        ]
+        _, audio = _replay_messages(history, self.PH, None)
+        assert [float(a[0]) for a in audio] == [0.25, 0.75]
+
+    def test_instructions_lead_and_add_no_audio(self) -> None:
+        msgs, audio = _replay_messages([{"role": "user", "audio": self._audio()}], self.PH, "be brief")
+        assert msgs[0] == {"role": "system", "content": "be brief"}
+        assert len(audio) == 1
+
+    def test_empty_history_is_empty(self) -> None:
+        assert _replay_messages([], self.PH, None) == ([], [])
+
+    def test_unknown_role_defaults_to_assistant(self) -> None:
+        msgs, audio = _replay_messages([{"content": "x"}], self.PH, None)
+        assert msgs == [{"role": "assistant", "content": "x"}]
+        assert audio == []
+
+
+class TestModelStaysRegisteredAsMultimodal:
+    """Guard for a real mistake: a module-level helper was added between
+    `@MULTIMODAL_REGISTRY.register_processor(...)` and the model class, so the
+    decorator registered the HELPER instead of the model. The file still parsed
+    and every other unit test still passed - a decorator may legally decorate a
+    function - but at runtime the renderer no longer saw the model as multimodal
+    and every request died with `'HfRenderer' object has no attribute
+    '_mm_req_counter'`. Assert the decorator is attached to the class."""
+
+    def test_register_processor_decorates_the_model_class(self) -> None:
+        import inspect
+
+        from vllm_omni.model_executor.models.qwen3_omni import qwen3_omni as mod
+
+        src = inspect.getsource(mod)
+        idx = src.index("@MULTIMODAL_REGISTRY.register_processor(")
+        after = src[idx:]
+        # The next top-level statement after the decorator block must be the class.
+        following = [ln for ln in after.splitlines()[1:] if ln and not ln[0].isspace() and not ln.startswith(")")]
+        assert following, "nothing follows the decorator"
+        assert following[0].startswith("class Qwen3OmniMoeForConditionalGeneration"), (
+            f"@MULTIMODAL_REGISTRY.register_processor decorates {following[0]!r}, "
+            "not the model class - the model will not be treated as multimodal"
+        )

--- a/tests/entrypoints/test_realtime_connection_helpers.py
+++ b/tests/entrypoints/test_realtime_connection_helpers.py
@@ -15,7 +15,7 @@ from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
-from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection
+from vllm_omni.entrypoints.openai.realtime_connection import RealtimeConnection, _PendingToolCall
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -31,6 +31,7 @@ def tool_call_conn() -> RealtimeConnection:
     conn._tools = None
     conn._tool_result_queue = asyncio.Queue()
     conn._pending_tool_calls = {}
+    conn._tool_rounds = 0
     return conn
 
 
@@ -259,3 +260,66 @@ class TestCloseAssistantTurnBeforeToolResult:
 
         out = RealtimeConnection._close_assistant_turn(_Bad(), [1, 2, 3])
         assert out == [1, 2, 3]
+
+
+class TestToolChainIsBounded:
+    """A model that keeps re-emitting tool calls instead of answering must not
+    recurse without bound: `_await_tool_results_and_continue` re-enters
+    `_run_generation`, so an unbounded chain grows the stack and holds every
+    round's result generator open. Observed during bring-up when the spliced
+    prompt was malformed (see TestCloseAssistantTurnBeforeToolResult)."""
+
+    def test_exceeding_max_rounds_reports_error_and_stops(self, tool_call_conn, mocker) -> None:
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = RealtimeConnection.MAX_TOOL_ROUNDS
+        send_error = mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        asyncio.run(tool_call_conn._await_tool_results_and_continue([1, 2], [3]))
+
+        send_error.assert_awaited_once()
+        assert send_error.await_args.args[1] == "tool_call_loop"
+        run_generation.assert_not_awaited()
+
+    def test_rounds_below_the_cap_still_continue(self, tool_call_conn, mocker) -> None:
+        """The cap must not fire early: with no pending calls the wait loop is
+        skipped and generation continues."""
+        tool_call_conn._is_connected = True
+        tool_call_conn._tool_rounds = 0
+        tool_call_conn._turn_prompt = None
+        mocker.patch.object(tool_call_conn, "send_error", new_callable=mocker.AsyncMock)
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.cached_tokenizer_from_config",
+            return_value=mocker.Mock(
+                encode=lambda text, add_special_tokens=True: [9],
+                convert_tokens_to_ids=lambda token: 151645,
+                unk_token_id=0,
+            ),
+        )
+        mocker.patch("vllm_omni.entrypoints.openai.realtime_connection.cached_processor_from_config")
+        mocker.patch(
+            "vllm_omni.entrypoints.openai.realtime_connection.safe_apply_chat_template",
+            return_value="<|im_start|>user\nresult<|im_end|>\n<|im_start|>assistant\n",
+        )
+        tool_call_conn.serving = mocker.Mock()
+
+        asyncio.run(tool_call_conn._await_tool_results_and_continue([1, 2], [3]))
+
+        run_generation.assert_awaited_once()
+
+
+class TestToolResultWaitReleasesOnDisconnect:
+    """A client that vanishes mid-tool-call must not park the generation task
+    forever. The wait is bounded so `_is_connected` is re-checked instead of
+    blocking indefinitely on an empty queue."""
+
+    def test_wait_returns_when_client_disconnects(self, tool_call_conn, mocker) -> None:
+        tool_call_conn._is_connected = False  # client already gone
+        tool_call_conn._pending_tool_calls = {0: _PendingToolCall(call_id="call_x", name="get_weather")}
+        run_generation = mocker.patch.object(tool_call_conn, "_run_generation", new_callable=mocker.AsyncMock)
+
+        # Returns rather than hanging on the empty queue.
+        asyncio.run(asyncio.wait_for(tool_call_conn._await_tool_results_and_continue([1], [2]), timeout=5))
+
+        run_generation.assert_not_awaited()

--- a/tests/entrypoints/test_realtime_tool_calls.py
+++ b/tests/entrypoints/test_realtime_tool_calls.py
@@ -7,12 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_omni.entrypoints.openai.realtime_tool_calls import (
-    ToolCallStreamState,
-    extract_complete_tool_calls,
-    extract_deltas,
-    strip_tool_calls,
-)
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -118,45 +113,3 @@ class TestExtractDeltasToolCallLifecycle:
                 args_by_index[d.index] += d.arguments_delta
         assert args_by_index[0] == '{"city": "Boston"}'
         assert args_by_index[1] == '{"tz": "EST"}'
-
-
-class TestExtractCompleteToolCalls:
-    def test_single_complete_call(self) -> None:
-        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
-        calls = extract_complete_tool_calls(text)
-        assert calls == [{"name": "get_weather", "arguments": {"city": "Boston"}}]
-
-    def test_no_tool_call_returns_empty(self) -> None:
-        assert extract_complete_tool_calls("just some regular text") == []
-
-    def test_incomplete_block_ignored(self) -> None:
-        text = '<tool_call>\n{"name": "get_weather", "arguments": {'
-        assert extract_complete_tool_calls(text) == []
-
-    def test_malformed_json_skipped_not_raised(self) -> None:
-        text = "<tool_call>\nnot json at all\n</tool_call>"
-        assert extract_complete_tool_calls(text) == []
-
-    def test_multiple_calls_all_parsed(self) -> None:
-        text = (
-            '<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
-            '<tool_call>\n{"name": "b", "arguments": {"x": 1}}\n</tool_call>'
-        )
-        calls = extract_complete_tool_calls(text)
-        assert [c["name"] for c in calls] == ["a", "b"]
-
-
-class TestStripToolCalls:
-    def test_removes_tool_call_block(self) -> None:
-        text = 'Sure.<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
-        assert strip_tool_calls(text) == "Sure."
-
-    def test_no_tool_call_returns_stripped_text(self) -> None:
-        assert strip_tool_calls("  plain text  ") == "plain text"
-
-    def test_multiple_tool_calls_all_removed(self) -> None:
-        text = (
-            'Before<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
-            'Middle<tool_call>\n{"name": "b", "arguments": {}}\n</tool_call>After'
-        )
-        assert strip_tool_calls(text) == "BeforeMiddleAfter"

--- a/tests/entrypoints/test_realtime_tool_calls.py
+++ b/tests/entrypoints/test_realtime_tool_calls.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the self-contained <tool_call> parser used by the
+/v1/realtime tool-calling extension (see realtime_tool_calls.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_omni.entrypoints.openai.realtime_tool_calls import (
+    ToolCallStreamState,
+    extract_complete_tool_calls,
+    extract_deltas,
+    strip_tool_calls,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestExtractDeltasPlainContent:
+    def test_plain_text_no_tool_call_streams_as_content(self) -> None:
+        state = ToolCallStreamState()
+        content, deltas = extract_deltas("Hello", state)
+        assert content == "Hello"
+        assert deltas == []
+        assert not state.has_tool_calls()
+
+    def test_content_only_advances_incrementally(self) -> None:
+        state = ToolCallStreamState()
+        first, _ = extract_deltas("Hello", state)
+        second, _ = extract_deltas("Hello, world", state)
+        assert first == "Hello"
+        assert second == ", world"
+
+    def test_withholds_partial_start_tag_suffix(self) -> None:
+        state = ToolCallStreamState()
+        content, deltas = extract_deltas("Sure thing<tool_c", state)
+        # "<tool_c" could still turn into "<tool_call>"; must not be sent as content yet.
+        assert content == "Sure thing"
+        assert deltas == []
+
+
+class TestExtractDeltasToolCallLifecycle:
+    def test_name_delta_emitted_once_available(self) -> None:
+        state = ToolCallStreamState()
+        text = '<tool_call>\n{"name": "get_weather", "arguments": '
+        _, deltas = extract_deltas(text, state)
+        assert len(deltas) == 1
+        assert deltas[0].index == 0
+        assert deltas[0].name == "get_weather"
+        assert deltas[0].arguments_delta == ""
+        assert state.has_tool_calls()
+
+    def test_name_not_emitted_twice(self) -> None:
+        state = ToolCallStreamState()
+        extract_deltas('<tool_call>\n{"name": "get_weather", "arguments": {}', state)
+        _, deltas = extract_deltas('<tool_call>\n{"name": "get_weather", "arguments": {}}', state)
+        assert all(d.name is None for d in deltas)
+
+    def test_arguments_stream_incrementally_as_suffix_diff(self) -> None:
+        state = ToolCallStreamState()
+        chunks = [
+            '<tool_call>\n{"name": "get_weather", "arguments": {"',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city":',
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}',
+        ]
+        collected_args = ""
+        for chunk in chunks:
+            _, deltas = extract_deltas(chunk, state)
+            for d in deltas:
+                collected_args += d.arguments_delta
+        assert collected_args == '{"city": "Boston"}'
+
+    def test_full_block_including_trailing_outer_brace_and_newline(self) -> None:
+        """Regression: the outer {"name":..., "arguments":...} object's own
+        closing brace and the newline before </tool_call> must never leak
+        into the arguments value, even when they arrive in the same chunk
+        as the arguments value's own closing brace."""
+        state = ToolCallStreamState()
+        full_text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+        _, deltas = extract_deltas(full_text, state)
+        args_deltas = [d.arguments_delta for d in deltas if d.arguments_delta]
+        combined = "".join(args_deltas)
+        assert combined == '{"city": "Boston"}'
+        import json
+
+        json.loads(combined)  # must be valid JSON, not '{"city": "Boston"}}\n'
+
+    def test_nested_object_in_arguments_not_truncated_early(self) -> None:
+        state = ToolCallStreamState()
+        full_text = (
+            '<tool_call>\n{"name": "book_flight", '
+            '"arguments": {"from": "BOS", "to": "SFO", "options": {"nonstop": true}}}\n</tool_call>'
+        )
+        _, deltas = extract_deltas(full_text, state)
+        combined = "".join(d.arguments_delta for d in deltas if d.arguments_delta)
+        assert combined == '{"from": "BOS", "to": "SFO", "options": {"nonstop": true}}'
+
+    def test_content_before_tool_call_is_still_streamed(self) -> None:
+        state = ToolCallStreamState()
+        text = 'One moment<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+        content, _ = extract_deltas(text, state)
+        assert content == "One moment"
+
+    def test_multiple_tool_calls_tracked_by_independent_index(self) -> None:
+        state = ToolCallStreamState()
+        text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+            '<tool_call>\n{"name": "get_time", "arguments": {"tz": "EST"}}\n</tool_call>'
+        )
+        _, deltas = extract_deltas(text, state)
+        names = {d.index: d.name for d in deltas if d.name is not None}
+        assert names == {0: "get_weather", 1: "get_time"}
+        args_by_index: dict[int, str] = {0: "", 1: ""}
+        for d in deltas:
+            if d.arguments_delta:
+                args_by_index[d.index] += d.arguments_delta
+        assert args_by_index[0] == '{"city": "Boston"}'
+        assert args_by_index[1] == '{"tz": "EST"}'
+
+
+class TestExtractCompleteToolCalls:
+    def test_single_complete_call(self) -> None:
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Boston"}}\n</tool_call>'
+        calls = extract_complete_tool_calls(text)
+        assert calls == [{"name": "get_weather", "arguments": {"city": "Boston"}}]
+
+    def test_no_tool_call_returns_empty(self) -> None:
+        assert extract_complete_tool_calls("just some regular text") == []
+
+    def test_incomplete_block_ignored(self) -> None:
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {'
+        assert extract_complete_tool_calls(text) == []
+
+    def test_malformed_json_skipped_not_raised(self) -> None:
+        text = "<tool_call>\nnot json at all\n</tool_call>"
+        assert extract_complete_tool_calls(text) == []
+
+    def test_multiple_calls_all_parsed(self) -> None:
+        text = (
+            '<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
+            '<tool_call>\n{"name": "b", "arguments": {"x": 1}}\n</tool_call>'
+        )
+        calls = extract_complete_tool_calls(text)
+        assert [c["name"] for c in calls] == ["a", "b"]
+
+
+class TestStripToolCalls:
+    def test_removes_tool_call_block(self) -> None:
+        text = 'Sure.<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+        assert strip_tool_calls(text) == "Sure."
+
+    def test_no_tool_call_returns_stripped_text(self) -> None:
+        assert strip_tool_calls("  plain text  ") == "plain text"
+
+    def test_multiple_tool_calls_all_removed(self) -> None:
+        text = (
+            'Before<tool_call>\n{"name": "a", "arguments": {}}\n</tool_call>'
+            'Middle<tool_call>\n{"name": "b", "arguments": {}}\n</tool_call>After'
+        )
+        assert strip_tool_calls(text) == "BeforeMiddleAfter"

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -58,6 +58,13 @@ class RealtimeConnection(VllmRealtimeConnection):
         self.engine = cast(AsyncOmni, self.serving.engine_client)
         self._realtime_audio_ref: np.ndarray | None = None
         self._tools: list[dict[str, Any]] | None = None
+        # The current turn's prompt as handed to the engine BEFORE multimodal
+        # expansion: un-expanded `prompt_token_ids` (one `<|audio_pad|>`) plus the
+        # audio in `multi_modal_data`. Tool-call continuations rebuild from this
+        # rather than from the engine's post-expansion `output.prompt_token_ids`,
+        # because those contain the expanded audio placeholder run with no way to
+        # re-attach the audio - see _await_tool_results_and_continue.
+        self._turn_prompt: dict[str, Any] | None = None
         # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
         self._pending_tool_calls: dict[int, dict[str, Any]] = {}
         self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -109,10 +116,25 @@ class RealtimeConnection(VllmRealtimeConnection):
             audio_stream, input_stream, self.serving.model_config, tools=self._tools
         )
         async for prompt in stream_input_iter:
+            # Remember the pre-expansion prompt so tool-call continuations can
+            # re-anchor on the user's audio (see self._turn_prompt).
+            if isinstance(prompt, dict):
+                self._turn_prompt = dict(prompt)
             yield await self._render_prompt(prompt)
 
-    async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
-        yield await self._render_prompt(TokensPrompt(prompt_token_ids=prompt_token_ids))
+    async def _render_token_prompt(
+        self,
+        prompt_token_ids: list[int],
+        multi_modal_data: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[StreamingInput, None]:
+        token_prompt = TokensPrompt(prompt_token_ids=prompt_token_ids)
+        # Tool-call continuation: re-attach the turn's audio. Without it the
+        # `<|audio_pad|>` placeholder still sits in the token ids but has no
+        # encoder output behind it, so the thinker cannot see what the user asked
+        # and free-associates unrelated tool calls instead of answering.
+        if multi_modal_data:
+            token_prompt["multi_modal_data"] = multi_modal_data
+        yield await self._render_prompt(token_prompt)
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:
@@ -397,12 +419,27 @@ class RealtimeConnection(VllmRealtimeConnection):
             add_generation_prompt=True,
             tokenize=False,
         )
-        continuation_token_ids = (
-            list(prior_prompt_token_ids) + list(assistant_token_ids) + tokenizer.encode(suffix_text)
-        )
+        # Splice onto the turn's PRE-expansion prompt, not the engine's
+        # post-expansion `output.prompt_token_ids`. The latter carries the expanded
+        # `<|audio_pad|>` run, and re-submitting it as a bare TokensPrompt drops the
+        # audio itself: the thinker then sees placeholder tokens with no encoder
+        # output, loses the user's question entirely, and answers by inventing
+        # further tool calls (unrelated cities/items) instead of replying. Falling
+        # back to `prior_prompt_token_ids` only matters for a continuation that never
+        # went through buffer_realtime_audio (no audio to lose in that case).
+        base_prompt = self._turn_prompt or {}
+        base_token_ids = list(base_prompt.get("prompt_token_ids") or prior_prompt_token_ids)
+        multi_modal_data = base_prompt.get("multi_modal_data")
+        continuation_token_ids = base_token_ids + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+
+        # Advance the base so a chained tool call next round splices onto this
+        # turn's full history while the audio stays attached exactly once, at the
+        # front, still un-expanded.
+        if self._turn_prompt is not None:
+            self._turn_prompt = {**base_prompt, "prompt_token_ids": continuation_token_ids}
 
         input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
-        await self._run_generation(self._render_token_prompt(continuation_token_ids), input_stream)
+        await self._run_generation(self._render_token_prompt(continuation_token_ids, multi_modal_data), input_stream)
 
     async def send_json(self, payload: dict):
         try:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -121,11 +121,14 @@ class RealtimeConnection(VllmRealtimeConnection):
         self._tool_rounds = 0
         self._speaker: str | None = None
         self._instructions: str | None = None
-        # Completed prior turns, each {"audio": np.ndarray, "text": str}, replayed
-        # into every subsequent prompt so the model can refer back to them.
+        # Prior conversation as an ordered message list, replayed into every
+        # subsequent prompt. Entries are {"role": ..., "audio": np.ndarray} for the
+        # user's spoken turns and {"role": ..., "content": str} otherwise. A flat
+        # message list (rather than user/assistant pairs) is what lets a completed
+        # TOOL turn be replayed in full - assistant `<tool_call>`, the
+        # `<tool_response>` result, then the spoken answer - which the model needs
+        # in order to keep calling tools on later turns. See _handle_history_item.
         self._history: list[dict[str, Any]] = []
-        # A user message whose assistant reply has not arrived yet.
-        self._pending_user_audio: np.ndarray | None = None
 
     @staticmethod
     def _decode_pcm16(b64_audio: str) -> np.ndarray:
@@ -135,17 +138,23 @@ class RealtimeConnection(VllmRealtimeConnection):
         return np.frombuffer(base64.b64decode(b64_audio), dtype=np.int16).astype(np.float32) / 32768.0
 
     async def _handle_history_item(self, item: dict) -> None:
-        """Accept a prior conversation turn, OpenAI-Realtime shaped:
+        """Append a prior conversation turn, OpenAI-Realtime shaped:
 
             {"type": "message", "role": "user",
              "content": [{"type": "input_audio", "audio": "<b64 pcm16>"}]}
             {"type": "message", "role": "assistant",
              "content": [{"type": "text", "text": "..."}]}
+            {"type": "message", "role": "tool",
+             "content": [{"type": "text", "text": "<tool result>"}]}
 
-        A user item is held until its assistant reply arrives; the pair is then
-        appended to the replayed history. A user item with no reply yet (the
-        turn currently being spoken) is simply never paired, so it cannot be
-        replayed twice.
+        A completed tool turn MUST be replayed in full: the assistant message
+        carrying the `<tool_call>` block, then the `tool` message with its result,
+        then the spoken answer. Replaying only the answer makes the history read as
+        "the model answers these questions from its own knowledge", and it stops
+        calling the tool on later turns and confabulates instead - reproduced on the
+        reference HF path, so it is the prompt shape rather than any serving detail.
+        Conversely a `<tool_call>` replayed with no matching result reads as an
+        unanswered call, and the model retries it indefinitely.
         """
         role = item.get("role")
         contents = item.get("content") or []
@@ -157,17 +166,17 @@ class RealtimeConnection(VllmRealtimeConnection):
             if audio_b64 is None:
                 await self.send_error("history user message needs input_audio content", "invalid_history_item")
                 return
-            self._pending_user_audio = self._decode_pcm16(audio_b64)
-        elif role == "assistant":
-            if self._pending_user_audio is None:
-                await self.send_error("history assistant message has no preceding user message", "invalid_history_item")
-                return
+            self._history.append({"role": "user", "audio": self._decode_pcm16(audio_b64)})
+        elif role in ("assistant", "tool"):
             text = " ".join(c.get("text") or "" for c in contents if c.get("type") == "text").strip()
-            self._history.append({"audio": self._pending_user_audio, "text": text})
-            self._pending_user_audio = None
-            logger.info("realtime history: %d prior turn(s) will be replayed", len(self._history))
+            if not text:
+                await self.send_error(f"history {role} message needs text content", "invalid_history_item")
+                return
+            self._history.append({"role": role, "content": text})
         else:
             await self.send_error(f"Unsupported history message role: {role!r}", "invalid_history_item")
+            return
+        logger.info("realtime history: %d message(s) queued for replay", len(self._history))
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -121,6 +121,53 @@ class RealtimeConnection(VllmRealtimeConnection):
         self._tool_rounds = 0
         self._speaker: str | None = None
         self._instructions: str | None = None
+        # Completed prior turns, each {"audio": np.ndarray, "text": str}, replayed
+        # into every subsequent prompt so the model can refer back to them.
+        self._history: list[dict[str, Any]] = []
+        # A user message whose assistant reply has not arrived yet.
+        self._pending_user_audio: np.ndarray | None = None
+
+    @staticmethod
+    def _decode_pcm16(b64_audio: str) -> np.ndarray:
+        """Same PCM16 -> float32 conversion the base class applies to
+        `input_audio_buffer.append`, so history audio and live audio are
+        represented identically."""
+        return np.frombuffer(base64.b64decode(b64_audio), dtype=np.int16).astype(np.float32) / 32768.0
+
+    async def _handle_history_item(self, item: dict) -> None:
+        """Accept a prior conversation turn, OpenAI-Realtime shaped:
+
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_audio", "audio": "<b64 pcm16>"}]}
+            {"type": "message", "role": "assistant",
+             "content": [{"type": "text", "text": "..."}]}
+
+        A user item is held until its assistant reply arrives; the pair is then
+        appended to the replayed history. A user item with no reply yet (the
+        turn currently being spoken) is simply never paired, so it cannot be
+        replayed twice.
+        """
+        role = item.get("role")
+        contents = item.get("content") or []
+        if role == "user":
+            audio_b64 = next(
+                (c.get("audio") for c in contents if c.get("type") in ("input_audio", "audio") and c.get("audio")),
+                None,
+            )
+            if audio_b64 is None:
+                await self.send_error("history user message needs input_audio content", "invalid_history_item")
+                return
+            self._pending_user_audio = self._decode_pcm16(audio_b64)
+        elif role == "assistant":
+            if self._pending_user_audio is None:
+                await self.send_error("history assistant message has no preceding user message", "invalid_history_item")
+                return
+            text = " ".join(c.get("text") or "" for c in contents if c.get("type") == "text").strip()
+            self._history.append({"audio": self._pending_user_audio, "text": text})
+            self._pending_user_audio = None
+            logger.info("realtime history: %d prior turn(s) will be replayed", len(self._history))
+        else:
+            await self.send_error(f"Unsupported history message role: {role!r}", "invalid_history_item")
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")
@@ -153,10 +200,13 @@ class RealtimeConnection(VllmRealtimeConnection):
             await super().handle_event(event)
         elif event_type == "conversation.item.create":
             item = event.get("item") or {}
-            if item.get("type") == "function_call_output":
+            item_type = item.get("type")
+            if item_type == "function_call_output":
                 await self._enqueue_tool_result(item)
+            elif item_type == "message":
+                await self._handle_history_item(item)
             else:
-                await self.send_error(f"Unsupported conversation.item type: {item.get('type')!r}", "unsupported_item")
+                await self.send_error(f"Unsupported conversation.item type: {item_type!r}", "unsupported_item")
         else:
             await super().handle_event(event)
 
@@ -235,13 +285,12 @@ class RealtimeConnection(VllmRealtimeConnection):
         input_stream: asyncio.Queue[list[int]],
     ) -> AsyncGenerator[StreamingInput, None]:
         """Equivalent to `OpenAIServingRealtime.transcribe_realtime`, but
-        threads `self._tools`/`self._speaker`/`self._instructions` through
-        to the model's
-        `buffer_realtime_audio`. The base class's `transcribe_realtime` has a
-        fixed (audio_stream, input_stream, model_config) call signature with
-        no seam for extra per-connection state like these, so this
-        reimplements its (short) body directly rather than patching upstream
-        vLLM."""
+        threads `self._tools`/`self._speaker`/`self._instructions`/
+        `self._history` through to the model's `buffer_realtime_audio`. The
+        base class's `transcribe_realtime` has a fixed (audio_stream,
+        input_stream, model_config) call signature with no seam for extra
+        per-connection state like these, so this reimplements its (short)
+        body directly rather than patching upstream vLLM."""
         stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
             audio_stream,
             input_stream,
@@ -249,6 +298,7 @@ class RealtimeConnection(VllmRealtimeConnection):
             tools=self._tools,
             speaker=self._speaker,
             instructions=self._instructions,
+            history=self._history,
         )
         async for prompt in stream_input_iter:
             # Remember the pre-expansion prompt so tool-call continuations can

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator, Mapping
+from dataclasses import dataclass
 from typing import Any, cast
 from uuid import uuid4
 
@@ -20,10 +21,25 @@ from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
-from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallDelta, ToolCallStreamState, extract_deltas
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
+
+# How long to block on a client tool result before re-checking the connection.
+# Only bounds the wait between liveness checks, not the total wait: a tool may
+# legitimately take a long time, but a client that has gone away must not leave
+# the generation task parked forever.
+_TOOL_RESULT_POLL_S = 0.5
+
+
+@dataclass
+class _PendingToolCall:
+    """A tool call being accumulated from the model's streamed output."""
+
+    call_id: str
+    name: str
+    arguments: str = ""
 
 
 class RealtimeConnection(VllmRealtimeConnection):
@@ -46,12 +62,20 @@ class RealtimeConnection(VllmRealtimeConnection):
       - generation then continues automatically with the tool result appended,
         streaming the model's actual spoken reply as normal.
 
-    No audio is synthesized/forwarded for a turn that turns out to be a tool
-    call - the underlying 3-stage pipeline (thinker->talker->code2wav) still
-    runs end to end for it (there is no clean lower-level hook to skip talker/
-    code2wav without changing the shared orchestrator - see PR description),
-    but the resulting audio bytes are simply not sent to the client.
+    Audio for a tool-call turn is not forwarded to the client once the
+    `<tool_call>` tag has been parsed - the underlying 3-stage pipeline
+    (thinker->talker->code2wav) still synthesizes it (there is no clean
+    lower-level hook to skip talker/code2wav without changing the shared
+    orchestrator - see PR description), the bytes are just dropped. Any audio
+    that arrived before the tag was recognized has already been sent; in
+    practice the tag appears in the thinker's text well ahead of the
+    corresponding synthesized audio.
+
+    A chain of tool calls is bounded by MAX_TOOL_ROUNDS.
     """
+
+    # Upper bound on consecutive tool-call rounds within one user turn.
+    MAX_TOOL_ROUNDS = 8
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,9 +89,11 @@ class RealtimeConnection(VllmRealtimeConnection):
         # because those contain the expanded audio placeholder run with no way to
         # re-attach the audio - see _await_tool_results_and_continue.
         self._turn_prompt: dict[str, Any] | None = None
-        # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
-        self._pending_tool_calls: dict[int, dict[str, Any]] = {}
+        # parser-assigned index (per generation) -> the call being accumulated
+        self._pending_tool_calls: dict[int, _PendingToolCall] = {}
         self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        # Consecutive tool-call rounds in this turn, bounded by MAX_TOOL_ROUNDS.
+        self._tool_rounds = 0
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")
@@ -89,6 +115,13 @@ class RealtimeConnection(VllmRealtimeConnection):
         if self.generation_task is not None and not self.generation_task.done():
             logger.warning("Generation already in progress, ignoring commit")
             return
+
+        # New user turn: reset the tool-round budget and discard any tool result
+        # left over from a previous turn, which would otherwise be consumed as if
+        # it answered one of this turn's calls.
+        self._tool_rounds = 0
+        while not self._tool_result_queue.empty():
+            self._tool_result_queue.get_nowait()
 
         audio_stream = self.audio_stream_generator()
         input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
@@ -219,26 +252,26 @@ class RealtimeConnection(VllmRealtimeConnection):
         pcm16 = (clipped * 32767.0).astype(np.int16)
         return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
-    async def _emit_tool_call_deltas(self, tool_deltas: list) -> None:
+    async def _emit_tool_call_deltas(self, tool_deltas: list[ToolCallDelta]) -> None:
         for delta in tool_deltas:
             if delta.name is not None:
-                call_id = f"call_{uuid4().hex[:24]}"
-                self._pending_tool_calls[delta.index] = {"call_id": call_id, "name": delta.name, "arguments": ""}
+                call = _PendingToolCall(call_id=f"call_{uuid4().hex[:24]}", name=delta.name)
+                self._pending_tool_calls[delta.index] = call
                 await self.send_json(
                     {
                         "type": "response.output_item.added",
-                        "item": {"type": "function_call", "name": delta.name, "call_id": call_id},
+                        "item": {"type": "function_call", "name": call.name, "call_id": call.call_id},
                     }
                 )
             if delta.arguments_delta:
-                info = self._pending_tool_calls.get(delta.index)
-                if info is None:
+                call = self._pending_tool_calls.get(delta.index)
+                if call is None:
                     continue  # shouldn't happen: name delta always precedes argument deltas for the same index
-                info["arguments"] += delta.arguments_delta
+                call.arguments += delta.arguments_delta
                 await self.send_json(
                     {
                         "type": "response.function_call_arguments.delta",
-                        "call_id": info["call_id"],
+                        "call_id": call.call_id,
                         "delta": delta.arguments_delta,
                     }
                 )
@@ -325,12 +358,12 @@ class RealtimeConnection(VllmRealtimeConnection):
                     break
 
             if tool_state.has_tool_calls():
-                for idx, info in self._pending_tool_calls.items():
+                for call in self._pending_tool_calls.values():
                     await self.send_json(
                         {
                             "type": "response.function_call_arguments.done",
-                            "call_id": info["call_id"],
-                            "arguments": info["arguments"],
+                            "call_id": call.call_id,
+                            "arguments": call.arguments,
                         }
                     )
                 if self._is_connected:
@@ -406,13 +439,31 @@ class RealtimeConnection(VllmRealtimeConnection):
         own generated tool-call tokens + a freshly-rendered tool-result turn)
         and continue generation - which streams the model's actual spoken
         reply as a normal `_run_generation` call, recursing again if the
-        model chains into another tool call."""
+        model chains into another tool call (bounded by MAX_TOOL_ROUNDS)."""
+        self._tool_rounds += 1
+        if self._tool_rounds > self.MAX_TOOL_ROUNDS:
+            # A model that keeps re-emitting tool calls instead of answering
+            # would otherwise recurse without bound. Observed during bring-up
+            # when the spliced prompt was malformed (see _close_assistant_turn).
+            logger.warning("tool-call chain exceeded %d rounds; abandoning turn", self.MAX_TOOL_ROUNDS)
+            if self._is_connected:
+                await self.send_error(
+                    f"Tool-call chain exceeded {self.MAX_TOOL_ROUNDS} rounds without a final response",
+                    "tool_call_loop",
+                )
+            return
+
         pending = dict(self._pending_tool_calls)
-        call_id_to_index = {info["call_id"]: idx for idx, info in pending.items()}
+        call_id_to_index = {call.call_id: idx for idx, call in pending.items()}
         results_by_index: dict[int, str] = {}
 
         while len(results_by_index) < len(pending) and self._is_connected:
-            item = await self._tool_result_queue.get()
+            # Bounded wait so a client that disappears mid-tool-call cannot park
+            # this task forever; a slow-but-live client is unaffected.
+            try:
+                item = await asyncio.wait_for(self._tool_result_queue.get(), timeout=_TOOL_RESULT_POLL_S)
+            except TimeoutError:
+                continue
             call_id = item.get("call_id")
             idx = call_id_to_index.get(call_id)
             if idx is None:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -72,6 +72,20 @@ class RealtimeConnection(VllmRealtimeConnection):
     corresponding synthesized audio.
 
     A chain of tool calls is bounded by MAX_TOOL_ROUNDS.
+
+    Scope and limitations of the tool-calling path:
+
+    - **Non-duplex only.** This is the half-duplex `/v1/realtime` path. The
+      full-duplex runtime under `experimental/fullduplex/` has no tool-calling
+      support and shares no code with this.
+    - **Requires `async_chunk` disabled.** `session.update` with `tools` is
+      rejected when the server runs in async-chunk mode; see
+      `_async_chunk_enabled` for why aggregating instead would not be enough.
+    - **Waits on client liveness.** Once the model has requested a tool, the turn
+      blocks until a `function_call_output` arrives for every pending call. There
+      is deliberately no deadline, because a slow tool is indistinguishable from
+      an absent one; a client that disconnects releases the wait, and malformed
+      or unknown results are reported back rather than silently dropped.
     """
 
     # Upper bound on consecutive tool-call rounds within one user turn.
@@ -100,16 +114,67 @@ class RealtimeConnection(VllmRealtimeConnection):
         if event_type == "session.update":
             tools = event.get("tools")
             if tools is not None:
-                self._tools = tools
+                if self._async_chunk_enabled():
+                    # Refuse rather than half-work. Two independent things break
+                    # under async_chunk: the buffer yields one TokensPrompt per
+                    # segment, so a tool-call continuation would reattach only the
+                    # final segment's audio and lose the start of the utterance;
+                    # and the generation loop never sees one complete thinker turn
+                    # to scan for a <tool_call> block. Aggregating the audio would
+                    # fix only the first, leaving the feature looking supported
+                    # while still broken -- so the limitation is explicit instead.
+                    await self.send_error(
+                        "Tool calling on /v1/realtime requires async_chunk to be disabled "
+                        "(serve with --no-async-chunk); tools were not applied.",
+                        "tools_require_no_async_chunk",
+                    )
+                else:
+                    self._tools = tools
             await super().handle_event(event)
         elif event_type == "conversation.item.create":
             item = event.get("item") or {}
             if item.get("type") == "function_call_output":
-                self._tool_result_queue.put_nowait(item)
+                await self._enqueue_tool_result(item)
             else:
                 await self.send_error(f"Unsupported conversation.item type: {item.get('type')!r}", "unsupported_item")
         else:
             await super().handle_event(event)
+
+    def _async_chunk_enabled(self) -> bool:
+        """Whether the server runs in async-chunk mode.
+
+        Read off ``model_config`` the same way ``serving_speech.py`` does
+        (``:3232``, ``:3569``).
+        """
+        return bool(getattr(self.serving.model_config, "async_chunk", False))
+
+    async def _enqueue_tool_result(self, item: dict) -> None:
+        """Validate a `function_call_output` before it can influence generation.
+
+        Without this, any dict carrying the right `type` was accepted: a missing
+        or non-string `call_id` never matched a pending call, and `output` was
+        coerced with `str()`. A client typo therefore left generation waiting
+        with nothing reported back. Shape errors are protocol errors, so they are
+        rejected here rather than discovered later.
+
+        (Kept as explicit checks for now; supersede with pydantic tool-event
+        models when those land.)
+        """
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            await self.send_error(
+                "function_call_output requires a non-empty string 'call_id'",
+                "invalid_function_call_output",
+            )
+            return
+        output = item.get("output")
+        if not isinstance(output, str):
+            await self.send_error(
+                f"function_call_output 'output' must be a string, got {type(output).__name__}",
+                "invalid_function_call_output",
+            )
+            return
+        self._tool_result_queue.put_nowait(item)
 
     async def start_generation(self):
         if self.generation_task is not None and not self.generation_task.done():
@@ -467,9 +532,17 @@ class RealtimeConnection(VllmRealtimeConnection):
             call_id = item.get("call_id")
             idx = call_id_to_index.get(call_id)
             if idx is None:
+                # Tell the client: silently dropping this would leave the turn
+                # waiting for a result that is never going to match. Keep waiting
+                # afterwards, since the correct result may still arrive.
                 logger.warning("received function_call_output for unknown call_id=%s", call_id)
+                await self.send_error(
+                    f"No pending tool call with call_id={call_id!r}; expected one of {sorted(call_id_to_index)}",
+                    "unknown_tool_call_id",
+                )
                 continue
-            results_by_index[idx] = str(item.get("output", ""))
+            # `output` is validated as a string at ingress (_enqueue_tool_result).
+            results_by_index[idx] = item["output"]
 
         if not self._is_connected:
             return
@@ -481,16 +554,27 @@ class RealtimeConnection(VllmRealtimeConnection):
         # for why relying on safe_apply_chat_template's own auto-resolution
         # is unsafe for this checkpoint.
         processor = cached_processor_from_config(model_config)
-        # Multiple tool calls in one turn -> one combined tool-role message,
-        # matching how Qwen's own chat template batches consecutive tool
-        # results under a single <|im_start|>user block. No `tools=` here:
-        # this is a continuation of a conversation that already has the
-        # tools system preamble in its token history, not a fresh turn.
-        combined_result_text = "\n".join(results_by_index[i] for i in sorted(results_by_index))
+        # One `role="tool"` message PER result, in call order. The chat template
+        # emits one <tool_response> block per tool message and groups consecutive
+        # tool messages under a single <|im_start|>user turn, so passing separate
+        # messages is what lets the model associate each result with its call.
+        # Joining the results instead produces a single <tool_response> holding
+        # both outputs, which breaks parallel calls.
+        #
+        # `sorted()` on the parser-assigned index is call order: extract_deltas
+        # appends `tool_call_starts` in the order <tool_call> appears in the
+        # generated text, so this is stable regardless of the order in which the
+        # client returns the results.
+        #
+        # No `tools=` here: this continues a conversation whose token history
+        # already carries the tools system preamble; it is not a fresh turn.
+        tool_messages: list[dict[str, str]] = [
+            {"role": "tool", "content": results_by_index[i]} for i in sorted(results_by_index)
+        ]
         suffix_text = safe_apply_chat_template(
             model_config,
             tokenizer,
-            [{"role": "tool", "content": combined_result_text}],
+            tool_messages,
             chat_template=processor.chat_template,
             add_generation_prompt=True,
             tokenize=False,

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -79,6 +79,10 @@ class RealtimeConnection(VllmRealtimeConnection):
     no way to select a voice at all - every session silently used whichever
     key HF's `talker_config.speaker_id` lists first for the checkpoint.
 
+    Instructions: `session.update` gains an optional `instructions` field
+    (system prompt), mirroring OpenAI's Realtime API. Previously there was
+    no way to set a system prompt at all for /v1/realtime.
+
     Scope and limitations of the tool-calling path:
 
     - **Non-duplex only.** This is the half-duplex `/v1/realtime` path. The
@@ -116,6 +120,7 @@ class RealtimeConnection(VllmRealtimeConnection):
         # Consecutive tool-call rounds in this turn, bounded by MAX_TOOL_ROUNDS.
         self._tool_rounds = 0
         self._speaker: str | None = None
+        self._instructions: str | None = None
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")
@@ -142,6 +147,9 @@ class RealtimeConnection(VllmRealtimeConnection):
             speaker = event.get("voice") or event.get("speaker")
             if speaker is not None:
                 self._speaker = speaker
+            instructions = event.get("instructions")
+            if instructions is not None:
+                self._instructions = instructions
             await super().handle_event(event)
         elif event_type == "conversation.item.create":
             item = event.get("item") or {}
@@ -227,14 +235,20 @@ class RealtimeConnection(VllmRealtimeConnection):
         input_stream: asyncio.Queue[list[int]],
     ) -> AsyncGenerator[StreamingInput, None]:
         """Equivalent to `OpenAIServingRealtime.transcribe_realtime`, but
-        threads `self._tools`/`self._speaker` through to the model's
+        threads `self._tools`/`self._speaker`/`self._instructions` through
+        to the model's
         `buffer_realtime_audio`. The base class's `transcribe_realtime` has a
         fixed (audio_stream, input_stream, model_config) call signature with
         no seam for extra per-connection state like these, so this
         reimplements its (short) body directly rather than patching upstream
         vLLM."""
         stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
-            audio_stream, input_stream, self.serving.model_config, tools=self._tools, speaker=self._speaker
+            audio_stream,
+            input_stream,
+            self.serving.model_config,
+            tools=self._tools,
+            speaker=self._speaker,
+            instructions=self._instructions,
         )
         async for prompt in stream_input_iter:
             # Remember the pre-expansion prompt so tool-call continuations can

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -44,7 +44,8 @@ class _PendingToolCall:
 
 class RealtimeConnection(VllmRealtimeConnection):
     """Omni realtime connection with audio-only server events, plus
-    OpenAI-Realtime-shaped tool/function calling.
+    OpenAI-Realtime-shaped tool/function calling and voice (TTS speaker)
+    selection.
 
     Reuses upstream vLLM websocket/session lifecycle and customizes
     generation output handling to emit audio deltas and tool-call events.
@@ -73,6 +74,11 @@ class RealtimeConnection(VllmRealtimeConnection):
 
     A chain of tool calls is bounded by MAX_TOOL_ROUNDS.
 
+    Voice selection: `session.update` gains an optional `voice` (or
+    `speaker`) field, mirroring OpenAI's Realtime API. Previously there was
+    no way to select a voice at all - every session silently used whichever
+    key HF's `talker_config.speaker_id` lists first for the checkpoint.
+
     Scope and limitations of the tool-calling path:
 
     - **Non-duplex only.** This is the half-duplex `/v1/realtime` path. The
@@ -81,6 +87,7 @@ class RealtimeConnection(VllmRealtimeConnection):
     - **Requires `async_chunk` disabled.** `session.update` with `tools` is
       rejected when the server runs in async-chunk mode; see
       `_async_chunk_enabled` for why aggregating instead would not be enough.
+      Voice selection is unaffected and works in either mode.
     - **Waits on client liveness.** Once the model has requested a tool, the turn
       blocks until a `function_call_output` arrives for every pending call. There
       is deliberately no deadline, because a slow tool is indistinguishable from
@@ -108,6 +115,7 @@ class RealtimeConnection(VllmRealtimeConnection):
         self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         # Consecutive tool-call rounds in this turn, bounded by MAX_TOOL_ROUNDS.
         self._tool_rounds = 0
+        self._speaker: str | None = None
 
     async def handle_event(self, event: dict):
         event_type = event.get("type")
@@ -130,6 +138,10 @@ class RealtimeConnection(VllmRealtimeConnection):
                     )
                 else:
                     self._tools = tools
+            # Voice selection is independent of the async_chunk gate above.
+            speaker = event.get("voice") or event.get("speaker")
+            if speaker is not None:
+                self._speaker = speaker
             await super().handle_event(event)
         elif event_type == "conversation.item.create":
             item = event.get("item") or {}
@@ -197,6 +209,16 @@ class RealtimeConnection(VllmRealtimeConnection):
         model_config = self.serving.model_config
         parsed_prompt = parse_model_prompt(model_config, prompt)
         (engine_input,) = await self.serving.renderer.render_cmpl_async([parsed_prompt])
+        # render_cmpl_async's internal pipeline (BaseRenderer.process_for_engine_async)
+        # only carries over fields it explicitly knows about - additional_information
+        # set on the pre-render prompt (buffer_realtime_audio's `speaker`) is silently
+        # dropped unless reapplied to the *rendered* engine_input, exactly like
+        # serving_chat.py._preprocess_chat does for /v1/chat/completions.
+        additional_information = (
+            parsed_prompt.get("additional_information") if isinstance(parsed_prompt, dict) else None
+        )
+        if additional_information:
+            engine_input["additional_information"] = additional_information
         return StreamingInput(prompt=engine_input)
 
     async def _buffer_realtime_audio_with_tools(
@@ -205,13 +227,14 @@ class RealtimeConnection(VllmRealtimeConnection):
         input_stream: asyncio.Queue[list[int]],
     ) -> AsyncGenerator[StreamingInput, None]:
         """Equivalent to `OpenAIServingRealtime.transcribe_realtime`, but
-        threads `self._tools` through to the model's `buffer_realtime_audio`.
-        The base class's `transcribe_realtime` has a fixed
-        (audio_stream, input_stream, model_config) call signature with no
-        seam for extra per-connection state like tools, so this reimplements
-        its (short) body directly rather than patching upstream vLLM."""
+        threads `self._tools`/`self._speaker` through to the model's
+        `buffer_realtime_audio`. The base class's `transcribe_realtime` has a
+        fixed (audio_stream, input_stream, model_config) call signature with
+        no seam for extra per-connection state like these, so this
+        reimplements its (short) body directly rather than patching upstream
+        vLLM."""
         stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
-            audio_stream, input_stream, self.serving.model_config, tools=self._tools
+            audio_stream, input_stream, self.serving.model_config, tools=self._tools, speaker=self._speaker
         )
         async for prompt in stream_input_iter:
             # Remember the pre-expansion prompt so tool-call continuations can
@@ -232,6 +255,13 @@ class RealtimeConnection(VllmRealtimeConnection):
         # and free-associates unrelated tool calls instead of answering.
         if multi_modal_data:
             token_prompt["multi_modal_data"] = multi_modal_data
+        # Keep the selected voice for the model's actual spoken reply too, not just
+        # the pre-tool-call turn. This path builds its own TokensPrompt rather than
+        # going through buffer_realtime_audio, so without this the continuation
+        # carries no `speaker` and silently falls back to the checkpoint default -
+        # the voice audibly changes halfway through a tool-calling turn.
+        if self._speaker:
+            token_prompt["additional_information"] = {"speaker": [self._speaker]}
         yield await self._render_prompt(token_prompt)
 
     @staticmethod

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -370,6 +370,31 @@ class RealtimeConnection(VllmRealtimeConnection):
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
 
+    @staticmethod
+    def _close_assistant_turn(tokenizer, assistant_token_ids: list[int]) -> list[int]:
+        """Terminate the model's tool-call turn with `<|im_end|>\\n` before a
+        tool-result turn is appended.
+
+        The tool-result suffix opens with `<|im_start|>user`, but the raw generated
+        token ids stop at the tool call without the closing `<|im_end|>` that the
+        chat template would emit. Splicing them directly yields
+        `</tool_call><|im_start|>user`, leaving the assistant turn open - a
+        malformed conversation the thinker responds to by re-emitting the same tool
+        call instead of answering, looping until something bounds it. The reference
+        HF path answers the identical prompt because `apply_chat_template` closes
+        the turn. Idempotent: only the missing pieces are added.
+        """
+        ids = list(assistant_token_ids)
+        im_end_id = tokenizer.convert_tokens_to_ids("<|im_end|>")
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if im_end_id in (None, getattr(tokenizer, "unk_token_id", None)):
+            return ids  # unexpected tokenizer; leave the splice untouched
+        if im_end_id not in ids[-2:]:
+            ids.append(im_end_id)
+        if newline_ids and ids[-len(newline_ids) :] != newline_ids:
+            ids.extend(newline_ids)
+        return ids
+
     async def _await_tool_results_and_continue(
         self,
         prior_prompt_token_ids: list[int],
@@ -430,7 +455,9 @@ class RealtimeConnection(VllmRealtimeConnection):
         base_prompt = self._turn_prompt or {}
         base_token_ids = list(base_prompt.get("prompt_token_ids") or prior_prompt_token_ids)
         multi_modal_data = base_prompt.get("multi_modal_data")
-        continuation_token_ids = base_token_ids + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+        continuation_token_ids = (
+            base_token_ids + self._close_assistant_turn(tokenizer, assistant_token_ids) + tokenizer.encode(suffix_text)
+        )
 
         # Advance the base so a chained tool call next round splices onto this
         # turn's full history while the audio stays attached exactly once, at the

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -4,35 +4,117 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator, Mapping
-from typing import cast
+from typing import Any, cast
 from uuid import uuid4
 
 import numpy as np
+from vllm.engine.protocol import StreamingInput
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.entrypoints.speech_to_text.realtime.protocol import TranscriptionDelta, TranscriptionDone
+from vllm.inputs import TokensPrompt
 from vllm.logger import init_logger
+from vllm.renderers.hf import safe_apply_chat_template
+from vllm.renderers.inputs.preprocess import parse_model_prompt
+from vllm.tokenizers import cached_tokenizer_from_config
+from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.entrypoints.openai.realtime_tool_calls import ToolCallStreamState, extract_deltas
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
 
 
 class RealtimeConnection(VllmRealtimeConnection):
-    """Omni realtime connection with audio-only server events.
+    """Omni realtime connection with audio-only server events, plus
+    OpenAI-Realtime-shaped tool/function calling.
 
-    Reuses upstream vLLM websocket/session lifecycle and only customizes
-    generation output handling to emit audio deltas.
+    Reuses upstream vLLM websocket/session lifecycle and customizes
+    generation output handling to emit audio deltas and tool-call events.
+
+    Tool-calling protocol (mirrors OpenAI's Realtime API event shapes):
+      - client -> server: `session.update` gains an optional `tools` field
+        (list of OpenAI-style tool/function definitions).
+      - server -> client, once the model starts a tool call:
+        `response.output_item.added` (item.type="function_call", name, call_id)
+        `response.function_call_arguments.delta` (call_id, delta)
+        `response.function_call_arguments.done` (call_id, arguments)
+      - client -> server, once the tool has run:
+        `conversation.item.create` with
+        `item = {"type": "function_call_output", "call_id": ..., "output": "..."}`
+      - generation then continues automatically with the tool result appended,
+        streaming the model's actual spoken reply as normal.
+
+    No audio is synthesized/forwarded for a turn that turns out to be a tool
+    call - the underlying 3-stage pipeline (thinker->talker->code2wav) still
+    runs end to end for it (there is no clean lower-level hook to skip talker/
+    code2wav without changing the shared orchestrator - see PR description),
+    but the resulting audio bytes are simply not sent to the client.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.engine = cast(AsyncOmni, self.serving.engine_client)
         self._realtime_audio_ref: np.ndarray | None = None
+        self._tools: list[dict[str, Any]] | None = None
+        # index (parser-assigned, per generation) -> {"call_id", "name", "arguments"}
+        self._pending_tool_calls: dict[int, dict[str, Any]] = {}
+        self._tool_result_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def handle_event(self, event: dict):
+        event_type = event.get("type")
+        if event_type == "session.update":
+            tools = event.get("tools")
+            if tools is not None:
+                self._tools = tools
+            await super().handle_event(event)
+        elif event_type == "conversation.item.create":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call_output":
+                self._tool_result_queue.put_nowait(item)
+            else:
+                await self.send_error(f"Unsupported conversation.item type: {item.get('type')!r}", "unsupported_item")
+        else:
+            await super().handle_event(event)
 
     async def start_generation(self):
-        await super().start_generation()
+        if self.generation_task is not None and not self.generation_task.done():
+            logger.warning("Generation already in progress, ignoring commit")
+            return
+
+        audio_stream = self.audio_stream_generator()
+        input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
+        streaming_input_gen = self._buffer_realtime_audio_with_tools(audio_stream, input_stream)
+        self.generation_task = asyncio.create_task(self._run_generation(streaming_input_gen, input_stream))
+
+    async def _buffer_realtime_audio_with_tools(
+        self,
+        audio_stream: AsyncGenerator[np.ndarray, None],
+        input_stream: asyncio.Queue[list[int]],
+    ) -> AsyncGenerator[StreamingInput, None]:
+        """Equivalent to `OpenAIServingRealtime.transcribe_realtime`, but
+        threads `self._tools` through to the model's `buffer_realtime_audio`.
+        The base class's `transcribe_realtime` has a fixed
+        (audio_stream, input_stream, model_config) call signature with no
+        seam for extra per-connection state like tools, so this reimplements
+        its (short) body directly rather than patching upstream vLLM."""
+        model_config = self.serving.model_config
+        renderer = self.serving.renderer
+        stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
+            audio_stream, input_stream, model_config, tools=self._tools
+        )
+        async for prompt in stream_input_iter:
+            parsed_prompt = parse_model_prompt(model_config, prompt)
+            (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
+            yield StreamingInput(prompt=engine_input)
+
+    async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
+        model_config = self.serving.model_config
+        renderer = self.serving.renderer
+        parsed_prompt = parse_model_prompt(model_config, TokensPrompt(prompt_token_ids=prompt_token_ids))
+        (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
+        yield StreamingInput(prompt=engine_input)
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:
@@ -117,6 +199,30 @@ class RealtimeConnection(VllmRealtimeConnection):
         pcm16 = (clipped * 32767.0).astype(np.int16)
         return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
+    async def _emit_tool_call_deltas(self, tool_deltas: list) -> None:
+        for delta in tool_deltas:
+            if delta.name is not None:
+                call_id = f"call_{uuid4().hex[:24]}"
+                self._pending_tool_calls[delta.index] = {"call_id": call_id, "name": delta.name, "arguments": ""}
+                await self.send_json(
+                    {
+                        "type": "response.output_item.added",
+                        "item": {"type": "function_call", "name": delta.name, "call_id": call_id},
+                    }
+                )
+            if delta.arguments_delta:
+                info = self._pending_tool_calls.get(delta.index)
+                if info is None:
+                    continue  # shouldn't happen: name delta always precedes argument deltas for the same index
+                info["arguments"] += delta.arguments_delta
+                await self.send_json(
+                    {
+                        "type": "response.function_call_arguments.delta",
+                        "call_id": info["call_id"],
+                        "delta": delta.arguments_delta,
+                    }
+                )
+
     async def _run_generation(
         self,
         streaming_input_gen: AsyncGenerator,
@@ -129,6 +235,11 @@ class RealtimeConnection(VllmRealtimeConnection):
         prompt_token_ids_len = 0
         completion_tokens_len = 0
         self._realtime_audio_ref = None
+
+        request_prompt_token_ids: list[int] = []
+        assistant_token_ids: list[int] = []
+        tool_state = ToolCallStreamState()
+        self._pending_tool_calls = {}
 
         # Coerce cumulative outputs to delta outputs; this ensures
         # we don't emit redundant MM data & drain after emitting.
@@ -153,35 +264,58 @@ class RealtimeConnection(VllmRealtimeConnection):
                     new_token_ids = list(first_output.token_ids)
                     if new_token_ids:
                         input_stream.put_nowait(new_token_ids)
+                        assistant_token_ids.extend(new_token_ids)
 
                     if output.prompt_token_ids:
                         prompt_token_ids_len = max(
                             prompt_token_ids_len,
                             len(output.prompt_token_ids),
                         )
+                        if not request_prompt_token_ids:
+                            request_prompt_token_ids = list(output.prompt_token_ids)
 
                     delta_text = first_output.text or ""
                     full_text += delta_text
                     completion_tokens_len += len(new_token_ids)
 
                     if delta_text:
-                        await self.send(TranscriptionDelta(delta=delta_text))
+                        content_delta, tool_deltas = extract_deltas(full_text, tool_state)
+                        if content_delta:
+                            await self.send(TranscriptionDelta(delta=content_delta))
+                        if tool_deltas:
+                            await self._emit_tool_call_deltas(tool_deltas)
 
                 audio_chunks, sample_rate = self._extract_audio_chunks(output)
-
-                for chunk in audio_chunks:
-                    sent_audio = True
-                    await self.send_json(
-                        {
-                            "type": "response.audio.delta",
-                            "audio": self._pcm16_b64(chunk),
-                            "format": "pcm16",
-                            "sample_rate_hz": sample_rate,
-                        }
-                    )
+                if audio_chunks and not tool_state.has_tool_calls():
+                    for chunk in audio_chunks:
+                        sent_audio = True
+                        await self.send_json(
+                            {
+                                "type": "response.audio.delta",
+                                "audio": self._pcm16_b64(chunk),
+                                "format": "pcm16",
+                                "sample_rate_hz": sample_rate,
+                            }
+                        )
+                # else: a tool-call turn - the pipeline still synthesizes audio for the
+                # raw <tool_call> text (no cheap hook to skip talker/code2wav for just
+                # this turn), we just don't forward it to the client.
 
                 if not self._is_connected:
                     break
+
+            if tool_state.has_tool_calls():
+                for idx, info in self._pending_tool_calls.items():
+                    await self.send_json(
+                        {
+                            "type": "response.function_call_arguments.done",
+                            "call_id": info["call_id"],
+                            "arguments": info["arguments"],
+                        }
+                    )
+                if self._is_connected:
+                    await self._await_tool_results_and_continue(request_prompt_token_ids, assistant_token_ids)
+                return
 
             usage = UsageInfo(
                 prompt_tokens=prompt_token_ids_len,
@@ -208,13 +342,69 @@ class RealtimeConnection(VllmRealtimeConnection):
                 except Exception:
                     logger.exception("Failed to close realtime result generator")
             # Always send terminal event so clients don't hang forever.
-            if self._is_connected and not audio_done_sent:
+            if self._is_connected and not audio_done_sent and not tool_state.has_tool_calls():
                 try:
                     await self.send_json({"type": "response.audio.done", "has_audio": sent_audio})
                 except Exception:
                     logger.exception("Failed to send response.audio.done")
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
+
+    async def _await_tool_results_and_continue(
+        self,
+        prior_prompt_token_ids: list[int],
+        assistant_token_ids: list[int],
+    ) -> None:
+        """Block until the client has submitted a `function_call_output` for
+        every pending tool call from the turn that just finished, then splice
+        the results onto the raw token sequence (prior prompt + the model's
+        own generated tool-call tokens + a freshly-rendered tool-result turn)
+        and continue generation - which streams the model's actual spoken
+        reply as a normal `_run_generation` call, recursing again if the
+        model chains into another tool call."""
+        pending = dict(self._pending_tool_calls)
+        call_id_to_index = {info["call_id"]: idx for idx, info in pending.items()}
+        results_by_index: dict[int, str] = {}
+
+        while len(results_by_index) < len(pending) and self._is_connected:
+            item = await self._tool_result_queue.get()
+            call_id = item.get("call_id")
+            idx = call_id_to_index.get(call_id)
+            if idx is None:
+                logger.warning("received function_call_output for unknown call_id=%s", call_id)
+                continue
+            results_by_index[idx] = str(item.get("output", ""))
+
+        if not self._is_connected:
+            return
+
+        model_config = self.serving.model_config
+        tokenizer = cached_tokenizer_from_config(model_config)
+        # Pass the processor's chat_template explicitly - see the matching
+        # comment in Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio
+        # for why relying on safe_apply_chat_template's own auto-resolution
+        # is unsafe for this checkpoint.
+        processor = cached_processor_from_config(model_config)
+        # Multiple tool calls in one turn -> one combined tool-role message,
+        # matching how Qwen's own chat template batches consecutive tool
+        # results under a single <|im_start|>user block. No `tools=` here:
+        # this is a continuation of a conversation that already has the
+        # tools system preamble in its token history, not a fresh turn.
+        combined_result_text = "\n".join(results_by_index[i] for i in sorted(results_by_index))
+        suffix_text = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            [{"role": "tool", "content": combined_result_text}],
+            chat_template=processor.chat_template,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        continuation_token_ids = (
+            list(prior_prompt_token_ids) + list(assistant_token_ids) + tokenizer.encode(suffix_text)
+        )
+
+        input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
+        await self._run_generation(self._render_token_prompt(continuation_token_ids), input_stream)
 
     async def send_json(self, payload: dict):
         try:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -12,7 +12,7 @@ from vllm.engine.protocol import StreamingInput
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection as VllmRealtimeConnection
 from vllm.entrypoints.speech_to_text.realtime.protocol import TranscriptionDelta, TranscriptionDone
-from vllm.inputs import TokensPrompt
+from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.renderers.hf import safe_apply_chat_template
 from vllm.renderers.inputs.preprocess import parse_model_prompt
@@ -88,6 +88,12 @@ class RealtimeConnection(VllmRealtimeConnection):
         streaming_input_gen = self._buffer_realtime_audio_with_tools(audio_stream, input_stream)
         self.generation_task = asyncio.create_task(self._run_generation(streaming_input_gen, input_stream))
 
+    async def _render_prompt(self, prompt: PromptType) -> StreamingInput:
+        model_config = self.serving.model_config
+        parsed_prompt = parse_model_prompt(model_config, prompt)
+        (engine_input,) = await self.serving.renderer.render_cmpl_async([parsed_prompt])
+        return StreamingInput(prompt=engine_input)
+
     async def _buffer_realtime_audio_with_tools(
         self,
         audio_stream: AsyncGenerator[np.ndarray, None],
@@ -99,22 +105,14 @@ class RealtimeConnection(VllmRealtimeConnection):
         (audio_stream, input_stream, model_config) call signature with no
         seam for extra per-connection state like tools, so this reimplements
         its (short) body directly rather than patching upstream vLLM."""
-        model_config = self.serving.model_config
-        renderer = self.serving.renderer
         stream_input_iter = self.serving.model_cls.buffer_realtime_audio(
-            audio_stream, input_stream, model_config, tools=self._tools
+            audio_stream, input_stream, self.serving.model_config, tools=self._tools
         )
         async for prompt in stream_input_iter:
-            parsed_prompt = parse_model_prompt(model_config, prompt)
-            (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
-            yield StreamingInput(prompt=engine_input)
+            yield await self._render_prompt(prompt)
 
     async def _render_token_prompt(self, prompt_token_ids: list[int]) -> AsyncGenerator[StreamingInput, None]:
-        model_config = self.serving.model_config
-        renderer = self.serving.renderer
-        parsed_prompt = parse_model_prompt(model_config, TokensPrompt(prompt_token_ids=prompt_token_ids))
-        (engine_input,) = await renderer.render_cmpl_async([parsed_prompt])
-        yield StreamingInput(prompt=engine_input)
+        yield await self._render_prompt(TokensPrompt(prompt_token_ids=prompt_token_ids))
 
     @staticmethod
     def _tensor_to_numpy(value) -> np.ndarray | None:

--- a/vllm_omni/entrypoints/openai/realtime_connection.py
+++ b/vllm_omni/entrypoints/openai/realtime_connection.py
@@ -33,6 +33,16 @@ logger = init_logger(__name__)
 _TOOL_RESULT_POLL_S = 0.5
 
 
+def _text_of(contents: list[dict[str, Any]]) -> str:
+    """Join the text parts of an OpenAI-Realtime content list.
+
+    Accepts `input_text` as well as `text`: OpenAI's Realtime API uses `input_text`
+    on a USER message and `text` on an assistant one, and callers port either way
+    round. Mirrors the existing `input_audio`/`audio` tolerance next to it.
+    """
+    return " ".join(c.get("text") or "" for c in contents if c.get("type") in ("text", "input_text")).strip()
+
+
 @dataclass
 class _PendingToolCall:
     """A tool call being accumulated from the model's streamed output."""
@@ -122,8 +132,9 @@ class RealtimeConnection(VllmRealtimeConnection):
         self._speaker: str | None = None
         self._instructions: str | None = None
         # Prior conversation as an ordered message list, replayed into every
-        # subsequent prompt. Entries are {"role": ..., "audio": np.ndarray} for the
-        # user's spoken turns and {"role": ..., "content": str} otherwise. A flat
+        # subsequent prompt. Entries are {"role": ..., "audio": np.ndarray} for a
+        # user turn replayed as speech, and {"role": ..., "content": str} for
+        # everything else (assistant, tool, or a user turn given as text). A flat
         # message list (rather than user/assistant pairs) is what lets a completed
         # TOOL turn be replayed in full - assistant `<tool_call>`, the
         # `<tool_response>` result, then the spoken answer - which the model needs
@@ -142,6 +153,11 @@ class RealtimeConnection(VllmRealtimeConnection):
 
             {"type": "message", "role": "user",
              "content": [{"type": "input_audio", "audio": "<b64 pcm16>"}]}
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "..."}]}
+            {"type": "message", "role": "user",                   # both is fine too
+             "content": [{"type": "input_audio", "audio": "..."},
+                         {"type": "input_text", "text": "..."}]}
             {"type": "message", "role": "assistant",
              "content": [{"type": "text", "text": "..."}]}
             {"type": "message", "role": "tool",
@@ -163,12 +179,26 @@ class RealtimeConnection(VllmRealtimeConnection):
                 (c.get("audio") for c in contents if c.get("type") in ("input_audio", "audio") and c.get("audio")),
                 None,
             )
-            if audio_b64 is None:
-                await self.send_error("history user message needs input_audio content", "invalid_history_item")
+            text = _text_of(contents)
+            if audio_b64 is None and not text:
+                await self.send_error(
+                    "history user message needs input_audio or text content",
+                    "invalid_history_item",
+                )
                 return
-            self._history.append({"role": "user", "audio": self._decode_pcm16(audio_b64)})
+            # Keep whichever parts were given, including both: a user turn may
+            # legitimately be audio PLUS text (the spoken part and a written
+            # instruction about it), which is what /v1/chat/completions already
+            # supports for this checkpoint. Audio alone is the shape a live turn has;
+            # text alone is what a caller with a transcript and no audio can offer.
+            past: dict[str, Any] = {"role": "user"}
+            if audio_b64 is not None:
+                past["audio"] = self._decode_pcm16(audio_b64)
+            if text:
+                past["content"] = text
+            self._history.append(past)
         elif role in ("assistant", "tool"):
-            text = " ".join(c.get("text") or "" for c in contents if c.get("type") == "text").strip()
+            text = _text_of(contents)
             if not text:
                 await self.send_error(f"history {role} message needs text content", "invalid_history_item")
                 return

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -29,6 +29,7 @@ tool-parser internals that may change across versions.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 
@@ -36,6 +37,7 @@ _TOOL_CALL_START = "<tool_call>"
 _TOOL_CALL_END = "</tool_call>"
 _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
 _ARGS_KEY_RE = re.compile(r'"arguments"\s*:\s*')
+_JSON_DECODER = json.JSONDecoder()
 
 
 @dataclass
@@ -77,36 +79,25 @@ def _partial_tag_overlap(text: str, tag: str) -> int:
 
 def _json_value_end(text: str) -> int | None:
     """If `text` starts (after optional leading whitespace) with a complete
-    JSON object or array, return the index just past its matching closing
-    bracket. Returns None if `text` doesn't start with '{'/'[' or the value
-    isn't complete yet. Used to find exactly where an "arguments" value ends
+    JSON object or array, return the index just past its closing bracket.
+    Returns None if `text` doesn't start with '{'/'[' or the value isn't
+    complete yet. Used to find exactly where an "arguments" value ends
     without assuming anything about what (if anything) follows it - argument
-    values can themselves contain nested objects/arrays."""
+    values can themselves contain nested objects/arrays.
+
+    `raw_decode` is exactly this primitive: it parses one JSON value from the
+    start of the string and reports where it stopped, ignoring trailing text,
+    and raises on an incomplete value (the normal case mid-stream)."""
     stripped = text.lstrip()
+    # Restrict to object/array: `raw_decode` would also accept a bare scalar,
+    # but "arguments" is always a JSON object per the tool-call format.
     if not stripped or stripped[0] not in "{[":
         return None
-    offset = len(text) - len(stripped)
-    depth = 0
-    in_string = False
-    escape = False
-    for i, ch in enumerate(stripped):
-        if in_string:
-            if escape:
-                escape = False
-            elif ch == "\\":
-                escape = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-        elif ch in "{[":
-            depth += 1
-        elif ch in "}]":
-            depth -= 1
-            if depth == 0:
-                return offset + i + 1
-    return None
+    try:
+        _, end = _JSON_DECODER.raw_decode(stripped)
+    except ValueError:
+        return None
+    return (len(text) - len(stripped)) + end
 
 
 def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, list[ToolCallDelta]]:

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -29,7 +29,6 @@ tool-parser internals that may change across versions.
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 
@@ -172,36 +171,3 @@ def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, 
             state.streamed_args[i] = args_str
 
     return content_delta, tool_deltas
-
-
-def extract_complete_tool_calls(text: str) -> list[dict]:
-    """Non-streaming: parse all complete <tool_call> blocks out of finished
-    text, returning [{"name": ..., "arguments": {...}}, ...]. Malformed
-    blocks are skipped rather than raising."""
-    calls: list[dict] = []
-    pos = 0
-    while True:
-        start = text.find(_TOOL_CALL_START, pos)
-        if start == -1:
-            break
-        end = text.find(_TOOL_CALL_END, start)
-        if end == -1:
-            break
-        body = text[start + len(_TOOL_CALL_START) : end].strip()
-        try:
-            calls.append(json.loads(body))
-        except json.JSONDecodeError:
-            pass
-        pos = end + len(_TOOL_CALL_END)
-    return calls
-
-
-def strip_tool_calls(text: str) -> str:
-    """Remove <tool_call>...</tool_call> blocks, returning whatever plain
-    spoken content (if any) surrounds them."""
-    return re.sub(
-        re.escape(_TOOL_CALL_START) + r".*?" + re.escape(_TOOL_CALL_END),
-        "",
-        text,
-        flags=re.DOTALL,
-    ).strip()

--- a/vllm_omni/entrypoints/openai/realtime_tool_calls.py
+++ b/vllm_omni/entrypoints/openai/realtime_tool_calls.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Self-contained <tool_call> XML-tag parser for vLLM-Omni's /v1/realtime endpoint.
+
+Qwen's own chat template (see the model's chat_template.json) instructs the
+model to emit tool calls as:
+
+    <tool_call>
+    {"name": <function-name>, "arguments": <args-json-object>}
+    </tool_call>
+
+This is the same wire format vLLM's `Hermes2ProToolParser`
+(vllm/tool_parsers/hermes_tool_parser.py) already parses for
+/v1/chat/completions, and the algorithm below (regex name extraction,
+length-based suffix diff for streaming arguments, partial-tag-overlap
+withholding) intentionally mirrors that parser's approach.
+
+We do not import that class directly: `ToolParser.extract_tool_calls*`
+methods are typed against `ChatCompletionRequest | ResponsesRequest` and read
+`request.tools`/`request.tool_choice` from it, and for Qwen3 specifically
+tool-call parsing has moved to vLLM's structured-output/guided-decoding
+engine rather than a plain text parser (see `vllm/tool_parsers/
+qwen3_engine_tool_parser.py`) - neither shape fits this self-hosted,
+websocket-driven streaming loop without either duck-typing a fake request
+object or pulling in the structured-output engine. A small, self-contained
+parser is easier to review and keeps this feature independent of vLLM
+tool-parser internals that may change across versions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+_TOOL_CALL_START = "<tool_call>"
+_TOOL_CALL_END = "</tool_call>"
+_NAME_RE = re.compile(r'"name"\s*:\s*"([^"]+)"')
+_ARGS_KEY_RE = re.compile(r'"arguments"\s*:\s*')
+
+
+@dataclass
+class ToolCallDelta:
+    """One incremental piece of a tool call. `name` is set at most once per
+    index (the first time it becomes available); `arguments_delta` is the new
+    tail of the arguments JSON text since the last delta for this index."""
+
+    index: int
+    name: str | None = None
+    arguments_delta: str = ""
+
+
+@dataclass
+class ToolCallStreamState:
+    """Tracks incremental parsing progress across repeated calls with the
+    growing `current_text` of a single generation."""
+
+    sent_content_idx: int = 0
+    tool_call_starts: list[int] = field(default_factory=list)
+    names_sent: list[bool] = field(default_factory=list)
+    streamed_args: list[str] = field(default_factory=list)
+
+    def has_tool_calls(self) -> bool:
+        return bool(self.tool_call_starts)
+
+
+def _partial_tag_overlap(text: str, tag: str) -> int:
+    """Length of the longest suffix of `text` that is a proper prefix of
+    `tag` - e.g. text ending in "...</tool_c" against tag "</tool_call>"
+    returns 5, so callers can withhold that suffix until it's known whether
+    it's about to become part of the tag."""
+    max_overlap = min(len(text), len(tag) - 1)
+    for size in range(max_overlap, 0, -1):
+        if text.endswith(tag[:size]):
+            return size
+    return 0
+
+
+def _json_value_end(text: str) -> int | None:
+    """If `text` starts (after optional leading whitespace) with a complete
+    JSON object or array, return the index just past its matching closing
+    bracket. Returns None if `text` doesn't start with '{'/'[' or the value
+    isn't complete yet. Used to find exactly where an "arguments" value ends
+    without assuming anything about what (if anything) follows it - argument
+    values can themselves contain nested objects/arrays."""
+    stripped = text.lstrip()
+    if not stripped or stripped[0] not in "{[":
+        return None
+    offset = len(text) - len(stripped)
+    depth = 0
+    in_string = False
+    escape = False
+    for i, ch in enumerate(stripped):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+            if depth == 0:
+                return offset + i + 1
+    return None
+
+
+def extract_deltas(current_text: str, state: ToolCallStreamState) -> tuple[str, list[ToolCallDelta]]:
+    """Given the full accumulated generation text so far, return
+    (new plain-content substring, new tool-call deltas) since the last call
+    with this `state`. Mutates `state` in place."""
+    tool_deltas: list[ToolCallDelta] = []
+
+    search_from = state.tool_call_starts[-1] + len(_TOOL_CALL_START) if state.tool_call_starts else 0
+    while (idx := current_text.find(_TOOL_CALL_START, search_from)) != -1:
+        state.tool_call_starts.append(idx)
+        state.names_sent.append(False)
+        state.streamed_args.append("")
+        search_from = idx + len(_TOOL_CALL_START)
+
+    if state.tool_call_starts:
+        content_end = state.tool_call_starts[0]
+    else:
+        content_end = len(current_text) - _partial_tag_overlap(current_text, _TOOL_CALL_START)
+    content_delta = ""
+    if content_end > state.sent_content_idx:
+        content_delta = current_text[state.sent_content_idx : content_end]
+        state.sent_content_idx = content_end
+
+    for i, start in enumerate(state.tool_call_starts):
+        block_start = start + len(_TOOL_CALL_START)
+        end_idx = current_text.find(_TOOL_CALL_END, block_start)
+        if end_idx == -1:
+            raw = current_text[block_start:]
+            overlap = _partial_tag_overlap(raw, _TOOL_CALL_END)
+            if overlap:
+                raw = raw[: len(raw) - overlap]
+        else:
+            raw = current_text[block_start:end_idx]
+
+        if not state.names_sent[i]:
+            name_match = _NAME_RE.search(raw)
+            if name_match is None:
+                continue  # don't parse ahead to arguments until a name is available
+            tool_deltas.append(ToolCallDelta(index=i, name=name_match.group(1)))
+            state.names_sent[i] = True
+
+        args_match = _ARGS_KEY_RE.search(raw)
+        if args_match is None:
+            continue
+        tail = raw[args_match.end() :]
+        # Find the exact end of the arguments JSON value via bracket-depth
+        # matching, rather than assuming "the last '}' in the block is the
+        # outer object's, not the value's" - that assumption breaks whenever
+        # the trailing "}\n" (closing the outer {"name":..., "arguments":...}
+        # object, before </tool_call>) arrives in the same chunk as the
+        # arguments value's own closing brace: naively stripping one trailing
+        # '}' either over- or under-trims depending on exact token boundaries,
+        # and (worse) can desync the running length-based diff against
+        # state.streamed_args so the final delta silently never gets sent,
+        # leaving invalid trailing "}\n" baked into the accumulated arguments.
+        value_end = _json_value_end(tail)
+        args_str = tail[:value_end] if value_end is not None else tail
+        new_args = args_str[len(state.streamed_args[i]) :]
+        if new_args:
+            tool_deltas.append(ToolCallDelta(index=i, arguments_delta=new_args))
+            state.streamed_args[i] = args_str
+
+    return content_delta, tool_deltas
+
+
+def extract_complete_tool_calls(text: str) -> list[dict]:
+    """Non-streaming: parse all complete <tool_call> blocks out of finished
+    text, returning [{"name": ..., "arguments": {...}}, ...]. Malformed
+    blocks are skipped rather than raising."""
+    calls: list[dict] = []
+    pos = 0
+    while True:
+        start = text.find(_TOOL_CALL_START, pos)
+        if start == -1:
+            break
+        end = text.find(_TOOL_CALL_END, start)
+        if end == -1:
+            break
+        body = text[start + len(_TOOL_CALL_START) : end].strip()
+        try:
+            calls.append(json.loads(body))
+        except json.JSONDecodeError:
+            pass
+        pos = end + len(_TOOL_CALL_END)
+    return calls
+
+
+def strip_tool_calls(text: str) -> str:
+    """Remove <tool_call>...</tool_call> blocks, returning whatever plain
+    spoken content (if any) surrounds them."""
+    return re.sub(
+        re.escape(_TOOL_CALL_START) + r".*?" + re.escape(_TOOL_CALL_END),
+        "",
+        text,
+        flags=re.DOTALL,
+    ).strip()

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -245,13 +245,20 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
         audio_placeholder = Qwen3OmniMoeThinkerForConditionalGeneration.get_placeholder_str("audio", 0)
-        # Prior turns of this conversation, each `{"audio": np.ndarray, "text": str}`
-        # (what the user said, and what the model answered). They are replayed as
-        # real conversation turns - the user's ORIGINAL AUDIO, not a transcript -
-        # because this endpoint is audio-in and the model returns only its own
-        # reply text, so there is no transcript of the user's speech to replay.
-        # Cheap in context: audio costs ~25 thinker tokens/second here.
+        # Prior conversation as an ordered message list. User turns carry the
+        # ORIGINAL AUDIO (`{"role": "user", "audio": ndarray}`) because this endpoint
+        # is audio-in and returns only the model's own reply text - there is no
+        # transcript of the user's speech to replay. Everything else carries text,
+        # including the `assistant` message holding a `<tool_call>` and the `tool`
+        # message holding its result: a completed tool turn has to be replayed in
+        # full or the model stops calling tools on later turns (it reads the history
+        # as "answer these from knowledge") and confabulates instead. Cheap in
+        # context: audio costs ~25 thinker tokens/second here.
         history = list(history or [])
+        # Drop a trailing user turn with no reply yet - that is the turn being
+        # spoken now, and replaying it would duplicate the live audio.
+        while history and history[-1].get("role") == "user":
+            history.pop()
 
         if tools or instructions or history:
             # Render through the model's own chat template (rather than the
@@ -283,16 +290,18 @@ class Qwen3OmniMoeForConditionalGeneration(
             # always wins and still respects `tools` when applying it).
             from vllm.renderers.hf import safe_apply_chat_template
 
-            # One user/assistant pair per prior turn, then the turn being spoken
-            # now. Every user turn is an audio placeholder; the placeholders are
-            # matched positionally against the multi_modal_data audio list below,
+            # Replay the prior messages verbatim, then the turn being spoken now.
+            # Each replayed user turn becomes an audio placeholder; the placeholders
+            # are matched POSITIONALLY against the multi_modal_data audio list below,
             # so the two MUST stay in the same order and count.
             messages: list[dict[str, Any]] = []
             if instructions:
                 messages.append({"role": "system", "content": instructions})
             for past in history:
-                messages.append({"role": "user", "content": audio_placeholder})
-                messages.append({"role": "assistant", "content": past.get("text") or ""})
+                if past.get("role") == "user":
+                    messages.append({"role": "user", "content": audio_placeholder})
+                else:
+                    messages.append({"role": past.get("role") or "assistant", "content": past.get("content") or ""})
             messages.append({"role": "user", "content": audio_placeholder})
 
             prompt_template = safe_apply_chat_template(
@@ -321,7 +330,8 @@ class Qwen3OmniMoeForConditionalGeneration(
         # flush so the thinker sees one complete prompt.
         async_chunk = getattr(model_config, "async_chunk", False)
 
-        past_audio = [past["audio"] for past in history if past.get("audio") is not None]
+        # Same order as the replayed user placeholders above.
+        past_audio = [p["audio"] for p in history if p.get("role") == "user" and p.get("audio") is not None]
 
         def _mm(current: np.ndarray) -> dict[str, Any]:
             # Prior turns first, current turn last - same order as the audio

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -230,6 +230,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         tools: list[dict[str, Any]] | None = None,
         speaker: str | None = None,
         instructions: str | None = None,
+        history: list[dict[str, Any]] | None = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -244,15 +245,24 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
         audio_placeholder = Qwen3OmniMoeThinkerForConditionalGeneration.get_placeholder_str("audio", 0)
-        if tools or instructions:
+        # Prior turns of this conversation, each `{"audio": np.ndarray, "text": str}`
+        # (what the user said, and what the model answered). They are replayed as
+        # real conversation turns - the user's ORIGINAL AUDIO, not a transcript -
+        # because this endpoint is audio-in and the model returns only its own
+        # reply text, so there is no transcript of the user's speech to replay.
+        # Cheap in context: audio costs ~25 thinker tokens/second here.
+        history = list(history or [])
+
+        if tools or instructions or history:
             # Render through the model's own chat template (rather than the
             # hardcoded f-string below) so the thinker gets the <tools>...</tools>
             # system preamble and <tool_call></tool_call> output format it was
-            # trained on (see chat_template.json) when tools are present, and/or
-            # an actual system message when instructions are present - this is
-            # the same mechanism /v1/chat/completions already supports for this
-            # checkpoint, just never previously wired into the realtime audio-in
-            # path. When both are empty this renders byte-identical to the plain
+            # trained on (see chat_template.json) when tools are present, an
+            # actual system message when instructions are present, and the prior
+            # turns when history is present - the same mechanisms
+            # /v1/chat/completions already supports for this checkpoint, just
+            # never previously wired into the realtime audio-in path. When all
+            # three are empty this renders byte-identical to the plain
             # f-string below, so that path is untouched to keep this change
             # scoped to the new capability.
             #
@@ -273,11 +283,22 @@ class Qwen3OmniMoeForConditionalGeneration(
             # always wins and still respects `tools` when applying it).
             from vllm.renderers.hf import safe_apply_chat_template
 
+            # One user/assistant pair per prior turn, then the turn being spoken
+            # now. Every user turn is an audio placeholder; the placeholders are
+            # matched positionally against the multi_modal_data audio list below,
+            # so the two MUST stay in the same order and count.
+            messages: list[dict[str, Any]] = []
+            if instructions:
+                messages.append({"role": "system", "content": instructions})
+            for past in history:
+                messages.append({"role": "user", "content": audio_placeholder})
+                messages.append({"role": "assistant", "content": past.get("text") or ""})
+            messages.append({"role": "user", "content": audio_placeholder})
+
             prompt_template = safe_apply_chat_template(
                 model_config,
                 tokenizer,
-                ([{"role": "system", "content": instructions}] if instructions else [])
-                + [{"role": "user", "content": audio_placeholder}],
+                messages,
                 tools=tools,
                 chat_template=processor.chat_template,
                 add_generation_prompt=True,
@@ -300,6 +321,15 @@ class Qwen3OmniMoeForConditionalGeneration(
         # flush so the thinker sees one complete prompt.
         async_chunk = getattr(model_config, "async_chunk", False)
 
+        past_audio = [past["audio"] for past in history if past.get("audio") is not None]
+
+        def _mm(current: np.ndarray) -> dict[str, Any]:
+            # Prior turns first, current turn last - same order as the audio
+            # placeholders rendered above. With no history keep passing the bare
+            # array rather than a 1-element list, so the existing single-turn
+            # path stays byte-identical.
+            return {"audio": [*past_audio, current] if past_audio else current}
+
         async for audio_chunk in audio_stream:
             buffer.write_audio(audio_chunk)
 
@@ -307,7 +337,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                 while (segment := buffer.read_audio()) is not None:
                     yield TokensPrompt(
                         prompt_token_ids=prompt_token_ids,
-                        multi_modal_data={"audio": segment},
+                        multi_modal_data=_mm(segment),
                         **extra_prompt_kwargs,
                     )
 
@@ -315,7 +345,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         if remaining is not None and len(remaining) > 0:
             yield TokensPrompt(
                 prompt_token_ids=prompt_token_ids,
-                multi_modal_data={"audio": remaining},
+                multi_modal_data=_mm(remaining),
                 **extra_prompt_kwargs,
             )
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -73,6 +73,45 @@ TALKER_CODEC_THINK_EOS_ID = 4205  # Think mode end
 logger = init_logger(__name__)
 
 
+def _replay_messages(
+    history: list[dict[str, Any]],
+    audio_placeholder: str,
+    instructions: str | None,
+) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Build the replayed chat messages and the audio that backs them.
+
+    Returned as a pair on purpose: the audio placeholders in `messages` are matched
+    POSITIONALLY against this audio list when it becomes `multi_modal_data`, so any
+    drift between the two silently misattributes one turn's audio to another. Emitting
+    both from one loop makes that drift impossible by construction.
+
+    A user turn may carry audio, text, or both:
+      * audio    -> one placeholder, the shape a live turn has. Preferred when that is
+                    all there is, since this endpoint returns no transcript of the
+                    user's speech and audio keeps prosody a transcript loses.
+      * text     -> the text, no placeholder. What a caller with an existing transcript
+                    (ASR elsewhere, or a migrated text conversation) can offer, at a
+                    small fraction of the tokens and bytes.
+      * both     -> placeholder followed by the text, in one message. Content here is a
+                    plain string rather than a content-part list, so this is simply
+                    concatenation - the same rendering the chat template produces for a
+                    mixed audio+text user turn on /v1/chat/completions.
+    """
+    messages: list[dict[str, Any]] = []
+    if instructions:
+        messages.append({"role": "system", "content": instructions})
+    past_audio: list[Any] = []
+    for past in history:
+        role = past.get("role") or "assistant"
+        text = past.get("content") or ""
+        if role == "user" and past.get("audio") is not None:
+            messages.append({"role": "user", "content": audio_placeholder + text})
+            past_audio.append(past["audio"])
+        else:
+            messages.append({"role": role, "content": text})
+    return messages, past_audio
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3OmniMoeThinkerMultiModalProcessor,
     info=Qwen3OmniMoeThinkerProcessingInfo,
@@ -260,6 +299,11 @@ class Qwen3OmniMoeForConditionalGeneration(
         while history and history[-1].get("role") == "user":
             history.pop()
 
+        # Audio for the replayed user turns, in placeholder order. Filled by
+        # _replay_messages so it cannot drift from the placeholders it emits;
+        # stays empty when the chat-template branch below is skipped.
+        past_audio: list[np.ndarray] = []
+
         if tools or instructions or history:
             # Render through the model's own chat template (rather than the
             # hardcoded f-string below) so the thinker gets the <tools>...</tools>
@@ -291,17 +335,7 @@ class Qwen3OmniMoeForConditionalGeneration(
             from vllm.renderers.hf import safe_apply_chat_template
 
             # Replay the prior messages verbatim, then the turn being spoken now.
-            # Each replayed user turn becomes an audio placeholder; the placeholders
-            # are matched POSITIONALLY against the multi_modal_data audio list below,
-            # so the two MUST stay in the same order and count.
-            messages: list[dict[str, Any]] = []
-            if instructions:
-                messages.append({"role": "system", "content": instructions})
-            for past in history:
-                if past.get("role") == "user":
-                    messages.append({"role": "user", "content": audio_placeholder})
-                else:
-                    messages.append({"role": past.get("role") or "assistant", "content": past.get("content") or ""})
+            messages, past_audio = _replay_messages(history, audio_placeholder, instructions)
             messages.append({"role": "user", "content": audio_placeholder})
 
             prompt_template = safe_apply_chat_template(
@@ -329,9 +363,6 @@ class Qwen3OmniMoeForConditionalGeneration(
         # talker to emit duplicate audio. Defer all audio to the final
         # flush so the thinker sees one complete prompt.
         async_chunk = getattr(model_config, "async_chunk", False)
-
-        # Same order as the replayed user placeholders above.
-        past_audio = [p["audio"] for p in history if p.get("role") == "user" and p.get("audio") is not None]
 
         def _mm(current: np.ndarray) -> dict[str, Any]:
             # Prior turns first, current turn last - same order as the audio

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -229,6 +229,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         model_config: ModelConfig,
         tools: list[dict[str, Any]] | None = None,
         speaker: str | None = None,
+        instructions: str | None = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -243,14 +244,15 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
         audio_placeholder = Qwen3OmniMoeThinkerForConditionalGeneration.get_placeholder_str("audio", 0)
-        if tools:
-            # Render through the model's own chat template with `tools=` so the
-            # thinker gets the <tools>...</tools> system preamble and the
-            # <tool_call></tool_call> output instructions it was trained on
-            # (see chat_template.json) - this is the same tool-calling format
-            # /v1/chat/completions already supports for this checkpoint, just
-            # never previously wired into the realtime audio-in path. When
-            # `tools` is empty this renders byte-identical to the plain
+        if tools or instructions:
+            # Render through the model's own chat template (rather than the
+            # hardcoded f-string below) so the thinker gets the <tools>...</tools>
+            # system preamble and <tool_call></tool_call> output format it was
+            # trained on (see chat_template.json) when tools are present, and/or
+            # an actual system message when instructions are present - this is
+            # the same mechanism /v1/chat/completions already supports for this
+            # checkpoint, just never previously wired into the realtime audio-in
+            # path. When both are empty this renders byte-identical to the plain
             # f-string below, so that path is untouched to keep this change
             # scoped to the new capability.
             #
@@ -274,7 +276,8 @@ class Qwen3OmniMoeForConditionalGeneration(
             prompt_template = safe_apply_chat_template(
                 model_config,
                 tokenizer,
-                [{"role": "user", "content": audio_placeholder}],
+                ([{"role": "system", "content": instructions}] if instructions else [])
+                + [{"role": "user", "content": audio_placeholder}],
                 tools=tools,
                 chat_template=processor.chat_template,
                 add_generation_prompt=True,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -228,6 +228,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         input_stream: asyncio.Queue[list[int]],
         model_config: ModelConfig,
         tools: list[dict[str, Any]] | None = None,
+        speaker: str | None = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -283,6 +284,11 @@ class Qwen3OmniMoeForConditionalGeneration(
             prompt_template = f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
 
         prompt_token_ids = tokenizer.encode(prompt_template)
+        # Same shape /v1/chat/completions uses (serving_chat.py): a one-element
+        # list under "speaker" in additional_information, read back out by
+        # talker_preprocess_prefill via payload.get("speaker").
+        additional_information = {"speaker": [speaker]} if speaker else None
+        extra_prompt_kwargs = {"additional_information": additional_information} if additional_information else {}
 
         # In non-async-chunk (full-payload) mode the engine treats each
         # streaming TokensPrompt as a fresh decode, so mid-stream segment
@@ -299,6 +305,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                     yield TokensPrompt(
                         prompt_token_ids=prompt_token_ids,
                         multi_modal_data={"audio": segment},
+                        **extra_prompt_kwargs,
                     )
 
         remaining = buffer.flush()
@@ -306,6 +313,7 @@ class Qwen3OmniMoeForConditionalGeneration(
             yield TokensPrompt(
                 prompt_token_ids=prompt_token_ids,
                 multi_modal_data={"audio": remaining},
+                **extra_prompt_kwargs,
             )
 
     # ==================== Device utilities ====================

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -227,6 +227,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
         model_config: ModelConfig,
+        tools: list[dict[str, Any]] | None = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -241,7 +242,45 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
         audio_placeholder = Qwen3OmniMoeThinkerForConditionalGeneration.get_placeholder_str("audio", 0)
-        prompt_template = f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
+        if tools:
+            # Render through the model's own chat template with `tools=` so the
+            # thinker gets the <tools>...</tools> system preamble and the
+            # <tool_call></tool_call> output instructions it was trained on
+            # (see chat_template.json) - this is the same tool-calling format
+            # /v1/chat/completions already supports for this checkpoint, just
+            # never previously wired into the realtime audio-in path. When
+            # `tools` is empty this renders byte-identical to the plain
+            # f-string below, so that path is untouched to keep this change
+            # scoped to the new capability.
+            #
+            # tokenizer.apply_chat_template() alone raises here: the tokenizer
+            # object itself has no .chat_template set. safe_apply_chat_template
+            # is the same helper vLLM's own /v1/chat/completions path uses to
+            # resolve the template from model_config before calling
+            # apply_chat_template - but its own auto-resolution
+            # (resolve_chat_template in vllm/renderers/hf.py) explicitly skips
+            # the AutoProcessor-based lookup whenever `tools` is given (its
+            # 2nd-priority path is gated on `tools is None`), and for this
+            # multimodal checkpoint the chat_template genuinely lives on the
+            # processor, not the raw tokenizer - so with tools set it falls
+            # through silently to vLLM's generic (non-tool-aware) fallback
+            # template instead of erroring. Passing the processor's own
+            # chat_template explicitly bypasses that broken auto-resolution
+            # (resolve_chat_template's 1st priority: an explicit template
+            # always wins and still respects `tools` when applying it).
+            from vllm.renderers.hf import safe_apply_chat_template
+
+            prompt_template = safe_apply_chat_template(
+                model_config,
+                tokenizer,
+                [{"role": "user", "content": audio_placeholder}],
+                tools=tools,
+                chat_template=processor.chat_template,
+                add_generation_prompt=True,
+                tokenize=False,
+            )
+        else:
+            prompt_template = f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
 
         prompt_token_ids = tokenizer.encode(prompt_template)
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #5555 → #5565 → #5566.** GitHub only allows `base: main` for a
> cross-fork PR, so the diff below is cumulative — it contains those PRs'
> commits as well as this one's.
>
> This PR's own change is **+414/-20 across 3 files** (3 commits).
> Best reviewed once #5566 has landed.

## Problem

`/v1/realtime` rebuilds its prompt from scratch on every turn — `[system][tools][user: <audio>][assistant:]` — and clients open a fresh connection per utterance, so nothing persists on either side. Each turn is an independent conversation: the model answers the current question well, then has no idea what was said a moment earlier.

Carrying history as **text** isn't available on this path. The endpoint is audio-in and returns only the model's own reply text, never a transcript of the user's speech, so there is no text form of the user's turns to replay.

## Approach

Replay the user's **original audio**, and replay each prior turn as an ordered **message list** rather than a user/assistant pair. Items arrive as OpenAI-Realtime-shaped `conversation.item.create` messages:

```jsonc
{"type": "conversation.item.create", "item": {
  "type": "message", "role": "user",
  "content": [{"type": "input_audio", "audio": "<b64 pcm16>"}]}}
{"type": "conversation.item.create", "item": {
  "type": "message", "role": "assistant",
  "content": [{"type": "text", "text": "<tool_call>...</tool_call>"}]}}
{"type": "conversation.item.create", "item": {
  "type": "message", "role": "tool",
  "content": [{"type": "text", "text": "<tool result>"}]}}
```

A flat message list is what makes a completed **tool** turn replayable in full — the assistant's `<tool_call>`, the `tool` result, then the spoken answer. That matters more than it looks; see below.

One audio placeholder is rendered per replayed user turn, matched positionally against the `multi_modal_data` audio list. Audio is cheap in context here — roughly 25 thinker tokens per second — so 20 turns is about 1.9k tokens, ~6% of a 32k batch. **With no history the prompt and multimodal payload are byte-identical to before**, leaving the existing single-turn path untouched.

## Why the tool exchange has to be replayed too

Replaying only the final assistant text drops the tool exchange, so the history reads as *"the model answers these questions from its own knowledge."* From the second turn onward the model stops calling tools and confabulates — inventing weather it was never given.

Reproduced on the **reference HF path** with the same checkpoint, audio and greedy settings, which produced the *identical* fabricated values — so this is prompt shape, not a serving detail:

| history shape | turns that skipped the tool |
| --- | --- |
| user audio + final text only | 2/3 |
| full tool exchange preserved | **0/3** |

The mirror-image failure is just as real: a `<tool_call>` replayed **without** its result reads as an unanswered call, and the model retries it indefinitely. So trimming is turn-aware — it never cuts between a call and its result.

The rendered prompt is now byte-identical to what `apply_chat_template` produces for the same conversation.

## Verification

End to end over `/v1/realtime`, each turn about a different city plus a recall turn:

```
turn 1  Madrid   -> get_weather(Madrid)    answered from the tool result
turn 2  Portland -> get_weather(Portland)  answered from the tool result
turn 3  Tokyo    -> get_weather(Tokyo)     answered from the tool result
turn 4  Denver   -> get_weather(Denver)    answered from the tool result
turn 5  recall   -> no tool call, "You just asked about Denver."
```

Tool discipline and recall hold simultaneously; before the fix only turn 1 called its tool. Also confirmed the engine accepts multiple audio items per prompt (two clips in one request, and the model reported both cities correctly).

40 unit tests pass, covering the message-list shape, full-tool-turn ordering, rejection paths, and PCM16 decode parity with the base class.

## Note on stacking

Stacked on #5555 — it reuses that PR's `conversation.item.create` handling and the `buffer_realtime_audio` seam rather than duplicating them, so GitHub shows those commits here too (a cross-fork PR can only target `main`). The feature itself is independent of tool calling; happy to rebase onto `main` with the plumbing inlined if you'd prefer it standalone.
### Update: text and mixed audio+text user turns

A replayed user turn originally had to carry `input_audio`; text was rejected. That
was an artifact of this feature being built for the audio-in path (the endpoint
returns no transcript of the user's speech, so audio was all a realtime client
had), not a model limitation — Qwen3-Omni's chat template handles text and mixed
user turns, which `/v1/chat/completions` already relies on.

A user history item may now be **audio**, **text**, or **both** (placeholder then
text, in one message); `text` and OpenAI's `input_text` spelling are both accepted.
Text matters in practice: replaying 20 turns as audio is ~2.4 MiB of base64 per
reseed, versus a few KB as text.

`_replay_messages` is extracted so the chat messages and the audio list are emitted
from **one** loop. They are matched positionally when the audio becomes
`multi_modal_data`, and the audio list was previously derived by a separate
comprehension whose filter had to be kept in sync by hand — a mismatch
misattributes one turn's audio to another turn silently, with no error.

Verified against a live Qwen3-Omni instance: the same two facts seeded as
audio-only, text-only, and mixed all recall identically
("Your name is Nathan, and you like to eat hamburgers."), while an unseeded control
answers "I don't know your name or your food preferences."
