### PR TITLE
[Model] Add optional HiFT startup warmup for MiniCPM-o 4.5

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -776,3 +776,42 @@ class MiniCPMO45Code2Wav(nn.Module):
         finally:
             torch.set_default_dtype(previous_dtype)
         self.backend = BatchedToken2Wav(token2wav)
+        self._maybe_warmup_hift()
+
+    def _maybe_warmup_hift(self) -> None:
+        """Run one representative HiFT inference before serving requests.
+
+        Gated by ``enable_hift_warmup`` in the stage extra config. The first
+        HiFT forward after loading pays a one-time kernel-compile /
+        weight-load cost (observed ~5.6s on Ascend 910C). Executing it here,
+        during model load and before the API is ready, moves that one-time
+        cost out of the first user request. Uses an independent cache source
+        so no real request state is touched.
+        """
+        extra = self._extra_config()
+        if not extra.get("enable_hift_warmup", False):
+            return
+        backend = getattr(self, "backend", None)
+        if backend is None:
+            return
+        hift = getattr(backend, "hift", None)
+        if hift is None:
+            return
+        device = next(hift.parameters()).device
+        dtype = next(hift.parameters()).dtype
+        # Representative first-chunk mel: [B=1, mel_bins=80, frames].
+        mel = torch.randn(1, 80, 86, device=device, dtype=dtype)
+        cache_source = torch.zeros(1, 1, 0, device=device, dtype=dtype)
+        try:
+            with torch.inference_mode():
+                hift(mel, cache_source)
+            torch.synchronize(device)
+            logger.info("HiFT startup warmup done")
+        except Exception:
+            # Warmup is a performance optimization, not a correctness
+            # requirement; never block serving on it.
+            logger.warning(
+                "HiFT startup warmup failed; continuing with cold execution",
+                exc_info=True,
+            )
+        del mel, cache_source

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -805,7 +805,7 @@ class MiniCPMO45Code2Wav(nn.Module):
         try:
             with torch.inference_mode():
                 hift(mel, cache_source)
-            torch.synchronize(device)
+            torch.accelerator.synchronize(device)
             logger.info("HiFT startup warmup done")
         except Exception:
             # Warmup is a performance optimization, not a correctness


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR adds an optional startup warmup for the MiniCPM-o 4.5 HiFT
backend.

When enabled, the backend runs one representative HiFT inference after
`token2wav` initialization and before the service becomes ready. This moves
the one-time kernel compilation and runtime initialization cost out of the
first real user request.

The feature is disabled by default. Warmup failures only emit a warning and
do not prevent the service from starting.

### Changes

- Add the `enable_hift_warmup` stage extra configuration option.
- Run a representative HiFT inference after backend initialization.
- Use an isolated temporary `cache_source` to avoid request-state pollution.
- Synchronize the accelerator before reporting warmup completion.
- Log warmup duration.
- Preserve the original cold path when warmup is disabled or fails.

### Performance evidence

#### Cold-start first-request latency

Measured in the fixed MiniCPM-o 4.5 competition environment on Ascend 910C:

- First HiFT call without warmup: approximately 5.6 seconds.
- Subsequent HiFT calls: approximately 46–50 milliseconds.
- First-request TTFP without startup warmup: approximately 8 seconds.
- First-request TTFP with startup warmup: approximately 3.2 seconds.

This optimization does not eliminate the underlying compilation or runtime
initialization cost. Instead, it moves that one-time cost from the first real
request into model startup, before API readiness.

The intended optimization target is therefore the latency of the first real
request after a cold start, rather than steady-state inference throughput.

#### Ranked benchmark behavior

The standard ranked performance harness runs two warmup requests before the
timed measurement window (`--num-warmups 2`).

Without this PR, those untimed warmup requests already trigger and pay the
one-time HiFT first-forward initialization cost. As a result, that cost is
discarded before steady-state RTF measurement begins.

An independent reproduction on Atlas A3 (910C), using the repository's
standard harness with 32 prompts and concurrency 1, reported:

| Configuration | RTF |
| --- | ---: |
| Control | 0.46316 |
| This PR | 0.46480 |
| Delta | +0.35% |

Both runs completed 32/32 requests and produced the same amount of output
audio.

The near-identical steady-state RTF is expected for this change: the startup
warmup is intended to remove cold-path latency from the first real request,
not to improve steady-state inference throughput.

A benchmark that directly measures this feature should therefore issue the
first timed request immediately after the server reports ready, without
benchmark-side warmup requests.

## Test Plan

Completed in the competition environment:

- Python syntax compilation.
- Startup warmup execution.
- Three consecutive real requests after warmup.
- Audio decoding validation.
- No NaN, Inf, or all-zero audio.
- No warmup audio or cache leakage into real requests.
- Default-disabled compatibility path.
- Warmup failure does not block service startup.

Performance validation covered:

- HiFT cold first-forward latency.
- Subsequent steady-state HiFT latency.
- First-request TTFP with and without startup warmup.
- Steady-state RTF behavior was independently reproduced with the standard
  ranked harness.

Not completed on the latest upstream runtime:

- Full runtime validation on the latest `minicpm-challenge` dependency stack.
- Full pre-commit execution because hook initialization timed out due to
  restricted network access.
- Upstream L1/L2 test suite.

The cold-start performance results were collected from the fixed competition
runtime. CI and maintainer-side validation on the latest upstream environment
are requested.

**vLLM Version:**
Competition image version / commit: `e5588e49b`

**vLLM-Omni Commit:**
Competition runtime base: `3f4abedbd`
PR branch base: `minicpm-challenge`

## Test Result

- Warmup is disabled by default.
- Warmup failure does not block service startup.
- Warmup uses isolated temporary state.
- The first real request enters the steady HiFT execution path.
- Three consecutive requests completed without state leakage.
- Standard steady-state RTF is effectively unchanged, as expected for a
  cold-start latency optimization.

**BEFORE SUBMITTING:** read https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)