### PR TITLE
[Bugfix][Core] Key streaming segment state by stage in the orchestrator

### DIFF
--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -29,6 +29,7 @@ from vllm_omni.engine.messages import (
 from vllm_omni.engine.orchestrator import (
     Orchestrator,
     OrchestratorRequestState,
+    StreamingSegmentState,
     _build_terminal_empty_output,
 )
 from vllm_omni.engine.stage_pool import StagePool
@@ -1923,7 +1924,7 @@ async def test_resumable_segment_boundary_builds_stage_metrics() -> None:
         final_stage_id=0,
     )
     req_state.streaming.enabled = True
-    req_state.streaming.segment_finished = True
+    req_state.streaming.segments[0] = StreamingSegmentState(finished=True)
     req_state.stage_submit_ts[0] = time.time()
     orchestrator.request_states = {"req-stream": req_state}
     orchestrator.stage_pools = [pool]

--- a/tests/engine/test_orchestrator_segment_stage_keying.py
+++ b/tests/engine/test_orchestrator_segment_stage_keying.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Streaming segment-boundary state must be keyed by stage.
+
+``Orchestrator._orchestration_loop`` polls every stage into the same
+``OrchestratorRequestState``. While the segment-boundary fields lived in a single
+flat slot per request, whichever stage polled most recently overwrote the others,
+and the per-stage consumers then read back a different stage's boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_omni.engine.orchestrator import (
+    Orchestrator,
+    OrchestratorRequestState,
+    StreamingSegmentState,
+)
+from vllm_omni.experimental.fullduplex.engine.contracts import DuplexRequestIdentity
+from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+THINKER_STAGE = 0
+TALKER_STAGE = 1
+
+
+@dataclass
+class _StageMetrics:
+    pipeline_timings: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class _StageOutput:
+    """Stand-in for a processed stage output, with the fields the router reads."""
+
+    request_id: str
+    finished: bool = False
+    error: object | None = None
+
+
+class _RecordingPool:
+    """Stage pool that records the requests it was asked to build metrics for."""
+
+    final_output = False
+
+    def __init__(self) -> None:
+        self.built_for: list[str] = []
+
+    def build_stage_metrics(self, outputs: list[_StageOutput], **_kwargs: object) -> _StageMetrics:
+        self.built_for.extend(output.request_id for output in outputs)
+        return _StageMetrics()
+
+
+def _duplex_req_state(request_id: str = "req-duplex") -> OrchestratorRequestState:
+    req_state = OrchestratorRequestState(
+        request_id=request_id,
+        sampling_params_list=[SamplingParams(max_tokens=1), SamplingParams(max_tokens=1)],
+        final_stage_id=TALKER_STAGE,
+    )
+    req_state.streaming.enabled = True
+    req_state.duplex_identity = DuplexRequestIdentity(
+        session_id="session-1",
+        fence=DuplexFence(session_id="session-1"),
+    )
+    return req_state
+
+
+def test_duplex_output_context_reads_only_its_own_stage_segment() -> None:
+    req_state = _duplex_req_state()
+    req_state.streaming.segments[THINKER_STAGE] = StreamingSegmentState(
+        finished=True,
+        token_ids=[11, 22],
+        output_metadata={"stage": "thinker"},
+    )
+    # The talker polls after the thinker and is still mid-segment.
+    req_state.streaming.segments[TALKER_STAGE] = StreamingSegmentState(finished=False)
+
+    thinker = Orchestrator._duplex_output_context(req_state, stage_id=THINKER_STAGE)
+    talker = Orchestrator._duplex_output_context(req_state, stage_id=TALKER_STAGE)
+
+    assert thinker is not None
+    assert talker is not None
+
+    assert thinker.segment_finished is True
+    assert thinker.segment_token_ids == (11, 22)
+    assert thinker.segment_output_metadata == {"stage": "thinker"}
+
+    # Read back the thinker's boundary from the shared slot before the fix.
+    assert talker.segment_finished is False
+    assert talker.segment_token_ids == ()
+    assert talker.segment_output_metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_segment_boundary_on_one_stage_does_not_build_metrics_on_another() -> None:
+    req_state = _duplex_req_state()
+    req_state.streaming.segments[THINKER_STAGE] = StreamingSegmentState(finished=True)
+
+    talker_pool = _RecordingPool()
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator.request_states = {req_state.request_id: req_state}
+    orchestrator.stage_pools = [_RecordingPool(), talker_pool]
+
+    routed: list[_StageMetrics | None] = []
+
+    async def record_route(
+        _stage: int,
+        _replica: int,
+        _output: _StageOutput,
+        _state: OrchestratorRequestState,
+        metrics: _StageMetrics | None,
+    ) -> None:
+        routed.append(metrics)
+
+    orchestrator._route_output = record_route
+
+    # The talker's own output is neither finished nor at a segment boundary, so
+    # it must not be treated as one just because the thinker reached one.
+    await orchestrator._handle_processed_outputs(
+        TALKER_STAGE,
+        0,
+        [_StageOutput(request_id=req_state.request_id)],
+    )
+
+    assert talker_pool.built_for == []
+    assert routed == [None]

--- a/tests/engine/test_orchestrator_segment_stage_keying.py
+++ b/tests/engine/test_orchestrator_segment_stage_keying.py
@@ -46,8 +46,6 @@ class _StageOutput:
 class _RecordingPool:
     """Stage pool that records the requests it was asked to build metrics for."""
 
-    final_output = False
-
     def __init__(self) -> None:
         self.built_for: list[str] = []
 
@@ -86,11 +84,12 @@ def test_duplex_output_context_reads_only_its_own_stage_segment() -> None:
     assert thinker is not None
     assert talker is not None
 
+    # These are the assertions that fail on the flat field: the talker is written
+    # second, so the thinker loses its boundary to whichever stage polled last.
     assert thinker.segment_finished is True
     assert thinker.segment_token_ids == (11, 22)
     assert thinker.segment_output_metadata == {"stage": "thinker"}
 
-    # Read back the thinker's boundary from the shared slot before the fix.
     assert talker.segment_finished is False
     assert talker.segment_token_ids == ()
     assert talker.segment_output_metadata == {}

--- a/tests/engine/test_orchestrator_stage_input_bridge.py
+++ b/tests/engine/test_orchestrator_stage_input_bridge.py
@@ -17,6 +17,7 @@ from vllm.sampling_params import SamplingParams
 from vllm_omni.engine.orchestrator import (
     Orchestrator,
     OrchestratorRequestState,
+    StreamingSegmentState,
     _OrchestratorDuplexStagePort,
 )
 from vllm_omni.engine.stage_pool import StagePool
@@ -332,7 +333,7 @@ async def test_streaming_segment_does_not_complete_final_output_stage() -> None:
         final_output_stage_ids={0},
     )
     req_state.streaming.enabled = True
-    req_state.streaming.segment_finished = True
+    req_state.streaming.segments[0] = StreamingSegmentState(finished=True)
     output = SimpleNamespace(
         request_id=req_state.request_id,
         finished=True,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -189,16 +189,29 @@ class OrchestratorRequestState:
 
 
 @dataclass
-class StreamingInputState:
-    # Flag of streaming input request
-    enabled: bool = False
+class StreamingSegmentState:
+    """Streaming segment-boundary state for one stage of a request.
+
+    Every stage of a multi-stage pipeline reaches its own segment boundaries
+    independently, so this is tracked per stage rather than per request.
+    """
+
     # Flag of segment of streaming input finished
-    segment_finished: bool = False
+    finished: bool = False
     # Tokens from the current raw segment boundary. The vLLM output processor
     # does not guarantee that EngineCoreOutput.new_token_ids survives on the
     # processed RequestOutput used by the routing layer.
-    segment_token_ids: list[int] = field(default_factory=list)
-    segment_output_metadata: dict[str, Any] = field(default_factory=dict)
+    token_ids: list[int] = field(default_factory=list)
+    output_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StreamingInputState:
+    # Flag of streaming input request
+    enabled: bool = False
+    # Keyed by stage: ``_orchestration_loop`` polls every stage into this one
+    # ``req_state``, so a flat slot would be last-writer-wins across stages.
+    segments: dict[int, StreamingSegmentState] = field(default_factory=dict)
     # Streaming update prompt length
     new_prompt_len_snapshot: int | None = None
     # Model/bridge-specific runtime states (e.g., thinker->talker)
@@ -206,6 +219,14 @@ class StreamingInputState:
     # Synchronous stage-transition capability installed by the orchestrator
     # while the downstream input processor consumes upstream token output.
     source_token_decoder: Callable[..., str] | None = None
+
+    def segment(self, stage_id: int | None) -> StreamingSegmentState:
+        """Return ``stage_id``'s segment state, or a fresh empty one if unreported.
+
+        Fresh rather than shared: ``output_metadata`` is handed out by reference.
+        """
+        segment = self.segments.get(stage_id)
+        return segment if segment is not None else StreamingSegmentState()
 
 
 class _OrchestratorDuplexStagePort:
@@ -918,17 +939,18 @@ class Orchestrator:
                                 req_state = self.request_states.get(getattr(eco, "request_id", None))
                                 if req_state is None or not req_state.streaming.enabled:
                                     continue
-                                req_state.streaming.segment_finished = bool(getattr(eco, "is_segment_finished", False))
-                                req_state.streaming.segment_token_ids = (
-                                    self._coerce_int_list(getattr(eco, "new_token_ids", None))
-                                    if req_state.streaming.segment_finished
-                                    else []
-                                )
+                                segment_finished = bool(getattr(eco, "is_segment_finished", False))
                                 raw_mm = self._completion_multimodal_output(eco, None)
-                                req_state.streaming.segment_output_metadata = (
-                                    dict(raw_mm)
-                                    if req_state.streaming.segment_finished and isinstance(raw_mm, dict)
-                                    else {}
+                                req_state.streaming.segments[stage_id] = StreamingSegmentState(
+                                    finished=segment_finished,
+                                    token_ids=(
+                                        self._coerce_int_list(getattr(eco, "new_token_ids", None))
+                                        if segment_finished
+                                        else []
+                                    ),
+                                    output_metadata=(
+                                        dict(raw_mm) if segment_finished and isinstance(raw_mm, dict) else {}
+                                    ),
                                 )
                                 req_state.streaming.new_prompt_len_snapshot = getattr(
                                     eco,
@@ -1055,7 +1077,7 @@ class Orchestrator:
                 continue
 
             stage_metrics = None
-            segment_finished = req_state.streaming.enabled and req_state.streaming.segment_finished
+            segment_finished = req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished
             if output.finished or segment_finished:
                 stage_metrics = pool.build_stage_metrics(
                     [output],
@@ -1264,7 +1286,7 @@ class Orchestrator:
         if (
             finished
             and self.stage_pools[stage_id].final_output
-            and not (req_state.streaming.enabled and req_state.streaming.segment_finished)
+            and not (req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished)
         ):
             req_state.finished_final_output_stage_ids.add(stage_id)
             final_output_stage_ids = req_state.final_output_stage_ids or {req_state.final_stage_id}
@@ -1277,7 +1299,9 @@ class Orchestrator:
         # filter out again (the official implementation returns exactly one
         # result per audio chunk).
         is_duplex_stage0_segment = (
-            stage_id == 0 and self._is_duplex_session_request(req_state) and req_state.streaming.segment_finished
+            stage_id == 0
+            and self._is_duplex_session_request(req_state)
+            and req_state.streaming.segment(stage_id).finished
         )
         if self.stage_pools[stage_id].final_output and not is_duplex_stage0_segment:
             await self.output_async_queue.put(
@@ -1289,7 +1313,10 @@ class Orchestrator:
                     metrics=stage_metrics,
                     finished=(
                         request_finished
-                        or (self._is_duplex_session_request(req_state) and req_state.streaming.segment_finished)
+                        or (
+                            self._is_duplex_session_request(req_state)
+                            and req_state.streaming.segment(stage_id).finished
+                        )
                     ),
                     stage_submit_ts=submit_ts,
                 )
@@ -1324,7 +1351,7 @@ class Orchestrator:
             return
 
         if (
-            (finished or (req_state.streaming.enabled and req_state.streaming.segment_finished))
+            (finished or (req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished))
             and stage_id < req_state.final_stage_id
             and (not self.async_chunk or not self._stage_receives_async_chunks(stage_id + 1))
             and (not self._next_stage_already_submitted(stage_id, req_state) or req_state.streaming.enabled)
@@ -1466,15 +1493,16 @@ class Orchestrator:
         )
 
         fence = req_state.duplex_stage_fences.get(stage_id, identity.fence) if stage_id is not None else identity.fence
+        segment = req_state.streaming.segment(stage_id)
         return DuplexOutputContext(
             identity=DuplexRequestIdentity(
                 session_id=identity.session_id,
                 fence=fence,
             ),
             final_stage_id=req_state.final_stage_id,
-            segment_finished=req_state.streaming.enabled and req_state.streaming.segment_finished,
-            segment_token_ids=tuple(req_state.streaming.segment_token_ids),
-            segment_output_metadata=req_state.streaming.segment_output_metadata,
+            segment_finished=req_state.streaming.enabled and segment.finished,
+            segment_token_ids=tuple(segment.token_ids),
+            segment_output_metadata=segment.output_metadata,
         )
 
     @staticmethod

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -209,10 +209,17 @@ class StreamingSegmentState:
 class StreamingInputState:
     # Flag of streaming input request
     enabled: bool = False
-    # Keyed by stage: ``_orchestration_loop`` polls every stage into this one
-    # ``req_state``, so a flat slot would be last-writer-wins across stages.
+    # Keyed by stage. ``_orchestration_loop`` records a boundary per stage poll
+    # into this one ``req_state``, while every consumer reads it for a specific
+    # ``stage_id``, so a flat slot is only correct as long as each read happens in
+    # the same iteration as its own stage's write. It is not for a stage that
+    # never records one (the ``poll_diffusion_output`` branch reaches
+    # ``_handle_processed_outputs`` without the raw-output loop) or for any
+    # consumer reading outside the writing iteration.
     segments: dict[int, StreamingSegmentState] = field(default_factory=dict)
-    # Streaming update prompt length
+    # Streaming update prompt length. NOT stage-keyed: its only consumer reads it
+    # through the streaming context on the stage-input-bridge path, not by stage
+    # id. Do not assume the rest of this struct is stage-safe.
     new_prompt_len_snapshot: int | None = None
     # Model/bridge-specific runtime states (e.g., thinker->talker)
     bridge_states: dict[str, Any] = field(default_factory=dict)
@@ -1274,6 +1281,7 @@ class Orchestrator:
         req_id = output.request_id
         finished = output.finished
         submit_ts = req_state.stage_submit_ts.get(stage_id)
+        segment_finished = req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished
         # CFG companion: stash output so parent can bundle [parent, *companions]
         # into source_outputs for the bridge (e.g. thinker2imagegen).
         if finished and self._cfg_tracker.is_companion(req_id):
@@ -1283,11 +1291,7 @@ class Orchestrator:
             return
 
         request_finished = False
-        if (
-            finished
-            and self.stage_pools[stage_id].final_output
-            and not (req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished)
-        ):
+        if finished and self.stage_pools[stage_id].final_output and not segment_finished:
             req_state.finished_final_output_stage_ids.add(stage_id)
             final_output_stage_ids = req_state.final_output_stage_ids or {req_state.final_stage_id}
             request_finished = final_output_stage_ids.issubset(req_state.finished_final_output_stage_ids)
@@ -1299,9 +1303,7 @@ class Orchestrator:
         # filter out again (the official implementation returns exactly one
         # result per audio chunk).
         is_duplex_stage0_segment = (
-            stage_id == 0
-            and self._is_duplex_session_request(req_state)
-            and req_state.streaming.segment(stage_id).finished
+            stage_id == 0 and self._is_duplex_session_request(req_state) and req_state.streaming.segment(0).finished
         )
         if self.stage_pools[stage_id].final_output and not is_duplex_stage0_segment:
             await self.output_async_queue.put(
@@ -1351,7 +1353,7 @@ class Orchestrator:
             return
 
         if (
-            (finished or (req_state.streaming.enabled and req_state.streaming.segment(stage_id).finished))
+            (finished or segment_finished)
             and stage_id < req_state.final_stage_id
             and (not self.async_chunk or not self._stage_receives_async_chunks(stage_id + 1))
             and (not self._next_stage_already_submitted(stage_id, req_state) or req_state.streaming.enabled)
@@ -1482,7 +1484,9 @@ class Orchestrator:
     def _duplex_output_context(
         req_state: OrchestratorRequestState,
         *,
-        stage_id: int | None = None,
+        # Required: segment state is stage-keyed, so a caller that omitted this
+        # would silently read "no boundary" rather than the intended stage's.
+        stage_id: int | None,
     ) -> DuplexOutputContext | None:
         identity = req_state.duplex_identity
         if identity is None:


### PR DESCRIPTION
## Purpose

**Symptom: none on any currently-supported model.** This is a latent correctness fix, not a reported bug — the section below shows how to observe it on `main`.

`_orchestration_loop` records a streaming segment boundary per stage poll into a single flat slot on the request:

```python
req_state.streaming.segment_finished = ...
req_state.streaming.segment_token_ids = ...
req_state.streaming.segment_output_metadata = ...
```

Every consumer reads it back for a specific `stage_id`:

| Consumer | Uses the boundary to decide |
|---|---|
| `_handle_processed_outputs` | whether to build stage metrics for `stage_id` |
| `_route_output` | final-output completion; whether a duplex stage-0 segment is client-visible; whether to forward to the next stage |
| `_duplex_output_context(req_state, stage_id=...)` | what boundary to report to a model's duplex runtime extension for one stage |

One flat slot is therefore only correct while each read happens in the same iteration as its *own* stage's write. On the AR poll path that holds today — the write precedes `_handle_processed_outputs` for the same stage. It does **not** hold for:

- a stage that never records a boundary — the `poll_diffusion_output` branch reaches `_handle_processed_outputs` without the raw-output loop, so it reads whichever stage wrote last;
- any consumer reading outside the writing iteration, which is what a stage-aware duplex adapter has to do.

The clearest structural tell is inside `_duplex_output_context` itself: it already resolves the **fence** per stage via `duplex_stage_fences.get(stage_id, identity.fence)`, then read segment state off the un-keyed slot three lines later. Half its per-stage inputs were keyed and half were not.

I hit this bringing up a second native duplex model (Qwen3-Omni: thinker → talker → code2wav), where an adapter must read a specific stage's segment metadata.

## Repro on `main`

Runs unmodified against `main` — it only touches the flat field that exists there:

```bash
python3 - <<'EOF'
import asyncio
from dataclasses import dataclass, field
from vllm.sampling_params import SamplingParams
from vllm_omni.engine.orchestrator import Orchestrator, OrchestratorRequestState

@dataclass
class Pool:
    final_output: bool = False
    built_for: list = field(default_factory=list)
    def build_stage_metrics(self, outputs, **kw):
        self.built_for += [o.request_id for o in outputs]
        return type("M", (), {"pipeline_timings": {}})()

@dataclass
class Out:
    request_id: str = "r"
    finished: bool = False
    error: object = None

rs = OrchestratorRequestState(request_id="r",
    sampling_params_list=[SamplingParams(max_tokens=1)] * 2, final_stage_id=1)
rs.streaming.enabled = True
rs.streaming.segment_finished = True        # stage 0 reached a segment boundary

talker = Pool()
orch = object.__new__(Orchestrator)
orch.request_states = {"r": rs}
orch.stage_pools = [Pool(), talker]
async def noop(*a): pass
orch._route_output = noop

asyncio.run(orch._handle_processed_outputs(1, 0, [Out()]))   # stage 1 never wrote one
print("stage-1 built metrics for:", talker.built_for, "-- expected []")
EOF
```

```
on main         -> stage-1 built metrics for: ['r'] -- expected []
on this branch  -> stage-1 built metrics for: []    -- expected []
```

Stage 1 never recorded a boundary, so on `main` it reads stage 0's and builds stage metrics for an output that is neither finished nor at a boundary.

## Changes

- Add `StreamingSegmentState` (`finished` / `token_ids` / `output_metadata`), held in `StreamingInputState.segments` keyed by stage id. This follows the per-stage keying already used on the same structures: `duplex_stage_fences: dict[int, DuplexFence]` (`orchestrator.py:186`) and `stage_submit_ts: dict[int, float]` (`:176`).
- Pass `stage_id` at every read site; each keeps its existing guard structure, so behavior is unchanged apart from reading its own stage.
- `stage_id` is now **required** on `_duplex_output_context`: with stage-keyed state, a caller that omitted it would silently read "no boundary" instead of the intended stage's. The only path that passed `None` was `_duplex_fence_for_req_state`, which has zero callers repo-wide.
- `segment(stage_id)` returns a fresh empty state for an unreported stage rather than a shared default, since `output_metadata` is handed out by reference.

Deliberately out of scope: `new_prompt_len_snapshot` sits on the same struct and is written in the same loop, but its only consumer reads it through the streaming context on the stage-input-bridge path rather than by stage id. It now carries a comment saying so, so the next reader doesn't assume the whole struct is stage-safe. Happy to fold it in if you'd rather fix both.

## Test Plan

CPU-only container (`vllm 0.26.0`, no `vllm._C`), sufficient for these `cpu`-marked unit tests.

**New tests** — `tests/engine/test_orchestrator_segment_stage_keying.py` (`core_model`, `cpu`), 2 passed:

- `test_duplex_output_context_reads_only_its_own_stage_segment` — thinker at a boundary with tokens and metadata, talker mid-segment; each stage's context reports its own state.
- `test_segment_boundary_on_one_stage_does_not_build_metrics_on_another` — drives `_handle_processed_outputs` for the talker with an unfinished output while the thinker is at a boundary, and asserts no stage metrics are built. **This is the load-bearing one**: it is the case where a stage reads a boundary it never recorded.

**Observing it on `main`.** Neither test can run unmodified against `main` (both import `StreamingSegmentState`), so I ported them to the flat field. On `main` (`4715570a`):

```
TEST 1 (context per stage), flat field, writes in loop order thinker->talker:
  FAIL on main: thinker.segment_finished is True  -> assert False is True
  FAIL on main: thinker.token_ids == (11,22)      -> assert () == (11,22)
  PASS on main: talker.segment_finished is False

TEST 2 (metrics not built on another stage), flat field, only thinker writes:
  FAIL on main: talker_pool.built_for == []       -> assert ['req-duplex'] == []
  PASS on main: routed == [None]
```

Note the direction in test 1: because the talker's slot is written second, the flat field makes the **thinker** lose its boundary. Test 2 is where a stage inherits a boundary it never recorded. Both are the same aliasing; happy to check the flat-field adaptation in if it's worth having as a permanent guard.

**No regression** — the exact CI selection from `.buildkite/cuda/test-ready.yml`, `pytest tests/entrypoints tests/engine -m 'core_model and cpu'`:

| | result |
|---|---|
| `main` | 1527 passed, 2 failed |
| this branch | **1529 passed**, 2 failed |

The two failures are `test_resolve_dreamzero_config.py::test_dreamzero_vla_resolves_to_dreamzero_config` and `test_utils.py::TestResolveModelConfigPath::test_uses_registry_default_deploy_when_hf_model_type_differs`, both of which **fail identically on unmodified `main`** — pre-existing and unrelated to the orchestrator. The +2 are the new tests.

**Duplex consumers of the changed state** — `tests/e2e/features/fullduplex` + `tests/entrypoints/test_async_omni_duplex.py` + `tests/entrypoints/openai_api/test_duplex_handler.py`: **384 passed on both this branch and `main`**, identical.

Two existing tests set the old flat field and are updated to the stage-keyed form; both already operated on stage 0 only, so their assertions are unchanged.

Full `pre-commit` hook set passes on the changed files.

## Related

- #3745 — the full-duplex RFC. This is a prerequisite for any stage-aware duplex adapter policy, but stands on its own as a correctness fix.
