### PR TITLE
[Bugfix][Core] Resync num_waiting_for_streaming_input so an abort cannot park a stage

### DIFF
--- a/tests/core/sched/test_omni_scheduler_streaming_input_counter.py
+++ b/tests/core/sched/test_omni_scheduler_streaming_input_counter.py
@@ -1,0 +1,254 @@
+"""Tests for the ``num_waiting_for_streaming_input`` resync placed in
+``OmniARScheduler.finish_requests`` / ``OmniGenerationScheduler.finish_requests``
+and in ``OmniARScheduler.schedule``.
+
+Upstream keeps that counter incrementally (``+1`` when a resumable request
+parks in a waiting queue as ``WAITING_FOR_STREAMING_REQ``, ``-1`` when the
+next update arrives or the request is finished) and
+``Scheduler.get_num_unfinished_requests`` *subtracts* it from the waiting
+queues. Omni rewrites ``request.status`` outside both hooks -- the
+chunk-transfer adapter's park/restore and
+``_realign_request_status_to_queues`` -- so a counted request can leave
+``WAITING_FOR_STREAMING_REQ`` without the matching decrement and inflate the
+counter for the lifetime of the process.
+
+An inflated counter does not degrade throughput, it hangs the stage:
+``EngineCore.has_work()`` reads false while a live request sits in
+``waiting``, so the engine blocks in ``input_queue.get()`` and never calls
+``schedule()`` again. Regression for the Qwen3-Omni duplex symptom where the
+server answered the first conversation after a boot and was silent from the
+second on while still reporting healthy.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.request import RequestStatus
+
+import vllm_omni.core.sched.omni_ar_scheduler as ar_sched_mod
+import vllm_omni.core.sched.omni_generation_scheduler as gen_sched_mod
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _StubRequest:
+    def __init__(self, request_id: str, status: RequestStatus) -> None:
+        self.request_id = request_id
+        self.status = status
+
+    def is_finished(self) -> bool:
+        return RequestStatus.is_finished(self.status)
+
+
+_SCHEDULER_PARAMS = [
+    pytest.param(OmniARScheduler, ar_sched_mod, id="ar"),
+    pytest.param(OmniGenerationScheduler, gen_sched_mod, id="generation"),
+]
+
+
+def _make_scheduler(scheduler_cls, *, requests, running, waiting, counter, skipped=None):
+    scheduler = scheduler_cls.__new__(scheduler_cls)
+    scheduler.chunk_transfer_adapter = None
+    scheduler.input_coordinator = None
+    scheduler.requests = requests
+    scheduler.running = running
+    scheduler.waiting = waiting
+    scheduler.skipped_waiting = skipped if skipped is not None else []
+    scheduler.num_waiting_for_streaming_input = counter
+    return scheduler
+
+
+def _upstream_num_unfinished(scheduler) -> int:
+    """Mirror of ``Scheduler.get_num_unfinished_requests`` arithmetic."""
+    num_waiting = (
+        len(scheduler.waiting) + len(scheduler.skipped_waiting) - scheduler.num_waiting_for_streaming_input
+    )
+    return num_waiting + len(scheduler.running)
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_finish_requests_clears_counter_left_by_a_stomped_status(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The abort case that wedged the talker.
+
+    The request was counted while parked for streaming input, then had its
+    status rewritten to ``RUNNING`` by omni's queue surgery, so upstream's
+    ``finish_requests`` took the running branch and never decremented. With
+    no parked requests left, the counter must land at 0.
+    """
+    aborted = _StubRequest("req-aborted", RequestStatus.RUNNING)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={},  # upstream already dropped it
+        running=[],
+        waiting=[],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [aborted],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [aborted.request_id], RequestStatus.FINISHED_ABORTED)
+
+    assert scheduler.num_waiting_for_streaming_input == 0
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_next_request_is_visible_as_work_after_the_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The consequence, stated as the engine sees it.
+
+    A fresh request queued behind the leak must read as unfinished work.
+    Without the resync this is ``(1 + 0 - 1) + 0 == 0`` and the engine parks
+    in ``input_queue.get()`` with a live request in ``waiting``.
+    """
+    aborted = _StubRequest("req-aborted", RequestStatus.RUNNING)
+    incoming = _StubRequest("req-next-session", RequestStatus.WAITING)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={incoming.request_id: incoming},
+        running=[],
+        waiting=[incoming],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [aborted],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [aborted.request_id], RequestStatus.FINISHED_ABORTED)
+
+    assert _upstream_num_unfinished(scheduler) == 1
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_finish_requests_keeps_counting_a_genuinely_parked_request(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The resync must not over-correct.
+
+    A request still parked as ``WAITING_FOR_STREAMING_REQ`` in ``waiting`` is
+    exactly what the counter is for -- it must stay counted, so the engine
+    does not spin on a request that has no input to process.
+    """
+    parked = _StubRequest("req-parked", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    leaving = _StubRequest("req-leaving", RequestStatus.FINISHED_STOPPED)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={parked.request_id: parked},
+        running=[],
+        waiting=[parked],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [leaving],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [leaving.request_id], RequestStatus.FINISHED_STOPPED)
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+    assert _upstream_num_unfinished(scheduler) == 0
+
+
+def test_resync_counts_parked_requests_in_skipped_waiting() -> None:
+    """``get_num_unfinished_requests`` sums ``waiting`` and ``skipped_waiting``,
+    so the resync has to look at both or it under-counts and reintroduces the
+    spin the counter exists to prevent."""
+    parked = _StubRequest("req-skipped", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    scheduler = _make_scheduler(
+        OmniARScheduler,
+        requests={parked.request_id: parked},
+        running=[],
+        waiting=[],
+        counter=0,
+        skipped=[parked],
+    )
+
+    scheduler._resync_streaming_input_counter()
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+
+
+def test_resync_is_a_no_op_when_upstream_accounting_is_correct() -> None:
+    """In the healthy case the derived value equals upstream's incremental one,
+    so the helper must leave it alone rather than fight it."""
+    parked = _StubRequest("req-parked", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    running = _StubRequest("req-running", RequestStatus.RUNNING)
+    scheduler = _make_scheduler(
+        OmniARScheduler,
+        requests={r.request_id: r for r in (parked, running)},
+        running=[running],
+        waiting=[parked],
+        counter=1,
+    )
+
+    scheduler._resync_streaming_input_counter()
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+
+
+def test_resync_tolerates_a_scheduler_without_the_counter() -> None:
+    """Guard for vLLM versions that predate ``num_waiting_for_streaming_input``:
+    the helper must no-op rather than invent the attribute."""
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+
+    scheduler._resync_streaming_input_counter()
+
+    assert not hasattr(scheduler, "num_waiting_for_streaming_input")
+
+
+def test_ar_schedule_resyncs_before_delegating_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pins placement in ``schedule``: the chunk-transfer adapter rewrites
+    status during ``process_pending_chunks``, so the resync has to run after
+    that and before upstream schedules, while ``self.waiting`` is still the
+    real queue."""
+    parked = _StubRequest("req-resumed", RequestStatus.RUNNING)
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.chunk_transfer_adapter = None
+    scheduler.input_coordinator = None
+    scheduler.requests = {parked.request_id: parked}
+    scheduler.running = [parked]
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+    scheduler.num_waiting_for_streaming_input = 1  # leaked by the status rewrite
+    scheduler.policy = "fcfs"
+
+    seen: dict[str, int] = {}
+
+    monkeypatch.setattr(ar_sched_mod.OmniSchedulerMixin, "_consume_pending_connector_output", lambda self, model_mode: None)
+    monkeypatch.setattr(ar_sched_mod.OmniSchedulerMixin, "_process_pending_input_timeouts", lambda self: None)
+    monkeypatch.setattr(OmniARScheduler, "_should_defer_waiting_admission", lambda self: False)
+
+    def fake_schedule(self, throttle_prefills=False):
+        seen["counter"] = self.num_waiting_for_streaming_input
+        raise _StopSchedule
+
+    class _StopSchedule(Exception):
+        pass
+
+    monkeypatch.setattr(ar_sched_mod.VLLMScheduler, "schedule", fake_schedule)
+
+    with pytest.raises(_StopSchedule):
+        OmniARScheduler.schedule(scheduler)
+
+    assert seen["counter"] == 0

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -259,6 +259,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self.waiting, self.running, scheduler_requests=self.requests
             )
 
+        # `process_pending_chunks` above rewrites `request.status` when it parks
+        # and un-parks requests, which can move a request out of
+        # WAITING_FOR_STREAMING_REQ without unwinding upstream's counter. Restate
+        # it from queue membership while `self.waiting` is still the real queue
+        # (the deferred-admission dance below swaps in an empty one).
+        self._resync_streaming_input_counter()
+
         original_waiting = None
         if self._should_defer_waiting_admission():
             original_waiting = self.waiting
@@ -763,6 +770,14 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # ``input_batch`` slot never pins a freed request and starves
         # new admissions. See ``OmniSchedulerMixin._purge_finished_from_running``.
         self._purge_finished_from_running()
+
+        # An abort is the one leak that is never recoverable on its own: the
+        # engine only calls `schedule()` when `has_work()` is true, and an
+        # inflated `num_waiting_for_streaming_input` is precisely what makes
+        # `has_work()` false. Resync here, on the path that removes the
+        # request, or the next request to arrive at this stage is masked and
+        # the engine parks in `input_queue.get()` forever.
+        self._resync_streaming_input_counter()
 
         input_coordinator = getattr(self, "input_coordinator", None)
         if input_coordinator is not None:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -403,6 +403,12 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         # corner case slips past upstream's status-driven removal.
         self._purge_finished_from_running()
 
+        # See ``OmniSchedulerMixin._resync_streaming_input_counter`` -- keeps
+        # ``num_waiting_for_streaming_input`` from outliving the request it was
+        # counted for, which otherwise makes ``EngineCore.has_work()`` read
+        # false with live work queued and parks the stage permanently.
+        self._resync_streaming_input_counter()
+
         if self.input_coordinator is not None:
             for request in finished:
                 self._free_input_coordinator_request(request.request_id)

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -306,3 +306,60 @@ class OmniSchedulerMixin:
         if not self.running:
             return
         self.running[:] = [req for req in self.running if not req.is_finished() and req.request_id in self.requests]
+
+    def _resync_streaming_input_counter(self) -> None:
+        """Re-derive ``num_waiting_for_streaming_input`` from queue membership.
+
+        Upstream maintains that counter incrementally: ``+1`` when a
+        resumable request runs out of input and parks in a waiting queue as
+        ``WAITING_FOR_STREAMING_REQ``, ``-1`` when the next streaming update
+        arrives or when ``finish_requests`` removes a request still in that
+        status.  ``get_num_unfinished_requests`` then *subtracts* it from the
+        waiting queues, so a parked request does not read as runnable work.
+
+        Omni moves requests between queues and rewrites ``request.status``
+        outside those two hooks -- the chunk-transfer adapter parks a request
+        as ``WAITING_FOR_CHUNK`` and restores it from
+        ``requests_origin_status``, and ``_realign_request_status_to_queues``
+        rewrites status to match queue membership.  Any of those that lands on
+        a request counted as ``WAITING_FOR_STREAMING_REQ`` moves it out of
+        that status without the matching ``-1``, and the counter is left one
+        too high *permanently*: nothing in either code path ever recomputes
+        it.
+
+        The consequence is a hung stage, not a slow one. Observed on
+        Qwen3-Omni duplex: the talker's request was aborted at session close
+        while counted but with status already stomped to ``RUNNING``, leaving
+        the counter at 1. On the next session ``get_num_unfinished_requests``
+        computed ``(1 waiting + 0 skipped - 1 phantom) + 0 running == 0``, so
+        ``EngineCore.has_work()`` was False with a live request sitting in
+        ``waiting``. The engine parked in ``input_queue.get()`` and never
+        called ``schedule()`` again -- the talker never ran, no codec tokens
+        reached Code2Wav, and the client waited forever on a server that
+        still reported healthy and still accepted audio. One leak per
+        session, so the endpoint answered the first conversation after every
+        boot and went silent from the second on.
+
+        Rather than chase every status write, restate the invariant the
+        counter is *supposed* to encode -- the number of requests currently
+        in the waiting queues that are parked for streaming input -- and
+        recompute it from that ground truth. In the healthy case this is
+        exactly what upstream's incremental arithmetic produces, so it is a
+        no-op; when a status stomp has desynced it, it self-heals on the next
+        call. O(len(waiting)), which is bounded by ``max_num_seqs``.
+        """
+        counter = getattr(self, "num_waiting_for_streaming_input", None)
+        if counter is None:
+            return
+        parked = 0
+        for queue in (getattr(self, "waiting", None), getattr(self, "skipped_waiting", None)):
+            if not queue:
+                continue
+            parked += sum(1 for req in queue if req.status == RequestStatus.WAITING_FOR_STREAMING_REQ)
+        if parked != counter:
+            logger.debug(
+                "[Omni] resynced num_waiting_for_streaming_input %s -> %s",
+                counter,
+                parked,
+            )
+            self.num_waiting_for_streaming_input = parked


### PR DESCRIPTION
## Purpose

A multi-stage duplex pipeline stops scheduling one of its stages after the
first session, and the stage never recovers. The server stays healthy, accepts
connections, accepts input, and silently produces nothing.

Root cause is an accounting leak in `num_waiting_for_streaming_input`.

Upstream computes

```python
# Scheduler.get_num_unfinished_requests
num_waiting = len(self.waiting) + len(self.skipped_waiting) - self.num_waiting_for_streaming_input
return num_waiting + len(self.running)
```

and maintains that counter incrementally: `+1` when a resumable request runs out
of input and parks as `WAITING_FOR_STREAMING_REQ`, `-1` in
`_update_request_as_session` when the next streaming update arrives, or in
`finish_requests` when the request is removed **while still in that status**.

Omni rewrites `request.status` outside both of those hooks — the chunk-transfer
adapter parks/restores requests via `requests_origin_status`, and
`_realign_request_status_to_queues` rewrites status to match queue membership.
When either lands on a request that is currently counted, the request leaves
`WAITING_FOR_STREAMING_REQ` without the matching decrement, and nothing in
either path ever recomputes the counter.

**One phantom is enough to park the stage permanently.** `EngineCore.has_work()`
consults `has_requests()`, which reads through that counter. Observed with a
single queued request:

```
(1 waiting + 0 skipped - 1 phantom) + 0 running == 0   ->  has_work() == False
```

so the engine blocked in `input_queue.get()` and never called `schedule()`
again, while holding a live request in `waiting`.

### Fix

Rather than chase every status write, restate the invariant the counter is
supposed to encode — how many requests in the waiting queues are parked for
streaming input — and recompute it from that ground truth.

`OmniSchedulerMixin._resync_streaming_input_counter()` is a no-op whenever
upstream's incremental arithmetic is correct (the two agree by construction),
and self-heals when a status rewrite has desynced it. It is `O(len(waiting))`,
bounded by `max_num_seqs`.

Called from:
- both schedulers' `finish_requests` — an abort is the one leak that cannot
  recover on its own, since an inflated counter is precisely what stops
  `schedule()` from running again;
- `OmniARScheduler.schedule`, after the chunk-transfer park/restore surgery and
  while `self.waiting` is still the real queue.

### Note for reviewers

The counter is upstream vLLM's, but the desync is caused by omni-side status
rewrites, so the repair belongs here rather than in vLLM. If you would rather
see the adapter and realign paths decrement explicitly instead, I am happy to
rework it — I chose the recompute because it is invariant-based and cannot be
defeated by a future call site that rewrites status without knowing about the
counter, which is exactly how this arose.

Found while bringing up a second native full-duplex model; nothing in the fix
or the tests is model-specific.

## Test Plan

New: `tests/core/sched/test_omni_scheduler_streaming_input_counter.py`, run
against both `OmniARScheduler` and `OmniGenerationScheduler`:

- the abort case that leaks (counted request whose status was stomped to `RUNNING`)
- the consequence stated as the engine sees it — a fresh request queued behind
  the leak must read as unfinished work
- the resync must **not** over-correct a genuinely parked request
- `skipped_waiting` is counted too, since `get_num_unfinished_requests` sums both
- no-op when upstream's accounting is already correct
- tolerates a scheduler without the attribute
- placement in `schedule()`: resync happens after chunk-transfer surgery and
  before delegating upstream

Plus an end-to-end run on a real 3-stage duplex pipeline, driven by a scripted
client replaying a browser demo's exact wire protocol.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 896f05e7

## Test Result

```
tests/core/sched: 96 passed
```

The 6 new behavioural tests fail without the fix and pass with it (verified by
stubbing `_resync_streaming_input_counter` to a no-op).

End to end, on a freshly booted 3-stage duplex server:

| | before | after |
|---|---|---|
| consecutive sessions answering | 1 / 2 | 5 / 5 |
| turns producing audio (4 sessions x 3 turns) | — | 12 / 12 |

Diagnosis note, since the failure is invisible in logs: every layer looked
healthy and the parked stage logged nothing at all. `py-spy dump` on that
stage's process showed the main loop in `_process_input_queue`, which is only
reachable when `has_work()` is false — i.e. the engine believed it was idle
while holding a queued request.
