### PR TITLE
[Model][Full Duplex] Qwen3-Omni native full-duplex support (draft, for decomposition)

### DIFF
--- a/docs/design/qwen3_omni_duplex_assessment.md
+++ b/docs/design/qwen3_omni_duplex_assessment.md
@@ -18,13 +18,17 @@ serving layers port cleanly; the worker-side audio ingress does not, and that
 is the binding constraint. It does *not* need the scheduler work the RFC
 implies.**
 
-> **Update (2026-07-29, after implementing the engine/serving layers on
+> **Update 1 (2026-07-29, after implementing the engine/serving layers on
 > `feat/qwen3-omni-fullduplex`):** two further blockers were found that are
-> not visible from reading the adapter contracts alone. They are the reason
-> the port cannot be completed as an adapter-only change. See §2.10. The
-> engine-side and serving-side layers are now implemented and pass the
-> framework's own duck-type gates; the worker-side stage-0 audio embedding
-> path is unimplemented and raises.
+> not visible from reading the adapter contracts alone. See §2.10.
+>
+> **Update 2 (2026-07-30, after implementing stage-0 audio ingress):** both
+> §2.10 blockers are now **resolved**, and one of them turned out to be much
+> smaller than this document originally claimed. See §2.11. Current state:
+> engine, serving and worker-side audio ingress are all implemented; the
+> audio tower has been driven with real checkpoint weights on a GPU and
+> produces exactly the reserved embedding count. What remains unvalidated is
+> the full 3-stage duplex serving path.
 
 Three things drive this verdict:
 
@@ -377,6 +381,68 @@ pooling ratio → embeddings per chunk) must be derived from the checkpoint.
 placeholder**, and it is load-bearing: the engine reserves scheduler slots
 from it and the worker must produce exactly that many embeddings, or the model
 runner truncates/pads with no error.
+
+### 2.11 Resolution of §2.10 (2026-07-30)
+
+Both blockers are closed. One was real but small; the other was overstated in
+§2.10 and is worth correcting explicitly.
+
+**Blocker (a) — no thinker `preprocess` hook: real, and fixed.**
+`qwen3_omni.py` now sets `has_preprocess = True` on the thinker stage and
+registers `thinker_duplex_preprocess` via `set_custom_preprocess`. This is
+behaviour-neutral for ordinary serving: the thinker is a multimodal stage
+(`requires_multimodal_data=True`, `pipeline.py:57`), so the runner already
+routed it through `inputs_embeds` (`gpu_model_runner.py:1569`) rather than
+the token-id fast path. `has_preprocess` only adds the dispatch at
+`gpu_model_runner.py:1685`, and the hook returns the ordinary embeddings
+when no duplex payload is present.
+
+**Blocker (b) — "no incremental audio encode": substantially overstated.**
+§2.10 assumed Qwen3-Omni needs MiniCPM-style encoder-state carryover. It does
+not. `Qwen3OmniMoeAudioEncoder.forward` already splits its conv input into
+`n_window * 2 == 100` mel-frame chunks and runs the conv stack on each
+independently. At `hop_length=160` / 16 kHz that is exactly 1.0 s. So a 1 s
+duplex chunk lands on the model's own conv boundary and per-chunk encoding
+carries **no convolutional boundary error at all** — the sliding-window
+scheme §2.10 called for is unnecessary.
+
+The residual approximation is at the *attention* level only: the tower's
+attention spans up to `n_window_infer // (n_window * 2) == 8` chunks, so
+encoding one chunk at a time is not bit-identical to encoding 8 s at once.
+That is a real but bounded inaccuracy, and it is not corrected.
+
+**The token geometry was the actual hazard, and it was wrong.** The original
+`SAMPLES_PER_AUDIO_TOKEN = 1600` placeholder implied 10 tokens/s; the model
+produces **13**. Two independent ways to get this wrong were found and fixed:
+
+1. The linear ratio itself (10 vs 13 — a 30% under-reservation).
+2. Whisper's feature extractor pads to its 30 s `n_samples` by default,
+   yielding **3000** mel frames for a 1 s chunk instead of 100 — a 230×
+   over-run of the reservation. `stage0._encode_chunk` passes
+   `padding="longest", truncation=False`.
+
+Both are silent failures: the model runner absorbs an embedding/reservation
+mismatch by truncating or padding without raising. `_encode_chunk` now
+asserts the counts agree.
+
+**What was actually executed** (see commit `bc9648e8`):
+
+- Real checkpoint weights on a GPU: 525 `thinker.audio_tower` tensors loaded
+  from Qwen3-Omni-30B-A3B-Instruct; 1 s of audio → mel `(128, 100)` → tower →
+  `(13, 2048)` bf16, rows equal to the reservation, all finite.
+- Real feature extractor with a stubbed tower: chunk accumulation, 3 s → 39
+  embeddings via 3 per-chunk calls, `(epoch, seq)` replay memoized without
+  re-encoding, per-session buffer isolation, mismatch raises, bad format
+  rejected.
+- `validate_duplex_runtime_extension` and `validate_serving_runtime_adapter`
+  — the engine's and API server's own startup gates — pass.
+- Our token-geometry helper equals vLLM's `_get_feat_extract_output_lengths`
+  for mel-frame counts 1–1000.
+
+**Still unvalidated:** the full 3-stage duplex serving path. That requires an
+environment matching upstream/main's vLLM (`v0.26.0`, per
+`docker/Dockerfile.cuda:1`); the available image ships vLLM 0.24.0, which
+lacks `vllm.entrypoints.scale_out` and cannot import `api_server`.
 
 ### 2.9 Comparable PRs offer no better template
 

--- a/docs/design/qwen3_omni_duplex_assessment.md
+++ b/docs/design/qwen3_omni_duplex_assessment.md
@@ -444,6 +444,70 @@ environment matching upstream/main's vLLM (`v0.26.0`, per
 `docker/Dockerfile.cuda:1`); the available image ships vLLM 0.24.0, which
 lacks `vllm.entrypoints.scale_out` and cannot import `api_server`.
 
+### 2.12 End-to-end bring-up log (2026-07-30)
+
+A live 3-stage duplex server was stood up on vLLM 0.26.0 (GPUs 2-3) and
+driven over `/v1/duplex`. Four defects surfaced that no amount of code
+review or mocked testing had caught.
+
+**Endpoint note.** Qwen3-Omni cannot use `/v1/realtime?duplex=1` the way
+MiniCPM's demo does: that route is already owned by Qwen3-Omni's existing
+half-duplex handler. Duplex must use `/v1/duplex`, which appears to be the
+less-exercised protocol path -- see defect 3.
+
+| # | defect | origin | failure mode |
+|---|--------|--------|--------------|
+| 1 | token geometry 10 vs 13 tokens/s | this port | silent truncation |
+| 2 | Whisper 30 s default padding (3000 vs 100 mel frames) | this port | 230x reservation over-run |
+| 3 | `DuplexFence` not JSON serializable in `runtime_control` | **framework** | session dies at handshake |
+| 4 | `mtp_inputs` demanded on thinker decode | this port | stage-0 engine core crash |
+
+Defect 3 is not Qwen3-Omni specific: any adapter declaring
+`implementation_level="model_native_duplex"` hits it on `/v1/duplex`.
+Defect 4 was latent -- `talker_mtp` is an unconditional method on the
+unified model class, so `has_talker_mtp` was already True for the thinker;
+enabling `has_preprocess` merely opened the path that acts on it.
+
+**What now works, verified against the live server:**
+
+- session handshake on `/v1/duplex`
+- audio append + commit, with the engine creating resumable stage-0 requests
+- **barge-in**: `input.cancel` bumps the epoch and aborts the in-flight
+  stage-0 request. Observed directly in request ids:
+  `...i.0.e.0.r.stage0` -> `...i.0.e.1.r.stage0`
+- **session persistence**: a second turn is served on the same session after
+  the barge-in, which is exactly what the half-duplex path cannot do
+- clean shutdown via `session.close`
+
+**What does not work yet: the model produces no reply.** Both turns end as
+`response.listen` with no text and no audio, and the pipeline logs no error.
+
+The cause is conversation scaffolding, not audio. `plan_append` currently
+builds a prompt of `[scheduler_token_id] * budget` -- 13 placeholder slots
+that stage 0 overwrites with audio embeddings -- and nothing else. There is
+no system prompt, no `<|im_start|>user` / `<|im_end|>` framing, and no
+`<|im_start|>assistant` generation prompt, so the thinker has nothing
+instructing it to respond and emits EOS immediately. The turn then completes
+with no output and the bridge projects `response.listen`
+(`runtime_bridge.py:936-956`).
+
+MiniCPM solves this with `duplex_first_append_context_reserve`
+(`minicpmo45/runtime.py:73`, applied at `:113-114`), which reserves extra
+slots on the first append that stage 0 fills from
+`_prepare_session_context` (`minicpmo45/stage0.py:112-143`).
+
+Remaining work, in order:
+
+1. Reserve context tokens on the first append and a generation-prompt suffix
+   on every turn, in `runtime.duplex_scheduler_token_budget`.
+2. Build those embeddings in `stage0`: render the chat template (reusing the
+   `safe_apply_chat_template` path already established for tools and
+   instructions at `qwen3_omni.py:274-291`), embed it, and splice prefix +
+   audio + suffix.
+3. Keep the reservation arithmetic in exact agreement with what stage 0
+   produces. This invariant has already produced two of the four defects
+   above, and the model runner absorbs violations silently.
+
 ### 2.9 Comparable PRs offer no better template
 
 Checked the three PRs #3745 cites as having hit the same wall:

--- a/docs/design/qwen3_omni_duplex_assessment.md
+++ b/docs/design/qwen3_omni_duplex_assessment.md
@@ -1,0 +1,689 @@
+# Qwen3-Omni Full-Duplex Feasibility Assessment
+
+Status: assessment only. No implementation, no hardware validation.
+Author: TheCodeWrangler (nathan@abridge.com)
+Date: 2026-07-29
+Scope: can `vllm_omni/experimental/fullduplex/` (merged in #3907 for MiniCPM-o 4.5)
+be extended to Qwen3-Omni-30B-A3B-Instruct (thinker → talker → code2wav)?
+
+Related: RFC #3745, PR #3907 (`05b794f2`), closed PR #5328, half-duplex
+`/v1/realtime` work in #5555 / #5565 / #5566.
+
+---
+
+## 1. Summary verdict
+
+**Tractable as a follow-on PR, but not as a pure adapter. The engine and
+serving layers port cleanly; the worker-side audio ingress does not, and that
+is the binding constraint. It does *not* need the scheduler work the RFC
+implies.**
+
+> **Update (2026-07-29, after implementing the engine/serving layers on
+> `feat/qwen3-omni-fullduplex`):** two further blockers were found that are
+> not visible from reading the adapter contracts alone. They are the reason
+> the port cannot be completed as an adapter-only change. See §2.10. The
+> engine-side and serving-side layers are now implemented and pass the
+> framework's own duck-type gates; the worker-side stage-0 audio embedding
+> path is unimplemented and raises.
+
+Three things drive this verdict:
+
+1. **The multi-process worry is unfounded.** MiniCPM-o 4.5 is *already* a
+   genuine three-stage, three-process pipeline
+   (`vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py:42-79`),
+   structurally the same shape as Qwen3-Omni. #3907 did not solve duplex for a
+   single-process model and then leave multi-process as an open problem —
+   its topology precedent already matches ours.
+
+2. **The scheduler blocker in the RFC is already closed for our path.**
+   Resumable, KV-preserving request re-entry exists today
+   (`vllm_omni/core/sched/omni_generation_scheduler.py:59-72`) and
+   Qwen3-Omni's shipped `async_chunk: true` deploy already rides it. The
+   RFC's blocker #1/#2 ("every turn re-prefills") does not describe the
+   current Qwen3-Omni async-chunk path.
+
+3. **The real blockers are elsewhere, and one of them is a framework defect.**
+   The orchestrator's per-request streaming segment buffer is *not keyed by
+   stage*, so `decide_output(stage_id=...)` receives a last-writer-wins
+   snapshot across all three stages (§2.3). This is latent-benign for MiniCPM
+   and actively wrong for any model that must read talker/code2wav metadata.
+   Separately, Qwen3-Omni has **no learned listen/speak control token** —
+   the single affordance MiniCPM's entire turn-taking policy rests on (§2.5).
+
+So the honest framing is: the plumbing generalizes better than expected, the
+turn-taking *policy* has no model-level foundation to stand on, and there is a
+stage-aliasing bug to fix before a 3-stage adapter can be written correctly.
+
+---
+
+## 2. Architectural compatibility findings
+
+### 2.1 MiniCPM-o 4.5 is genuinely 3 processes — the topology precedent holds
+
+The brief's premise (that MiniCPM might be effectively single-process, with
+`stage_id` only nominally present) is **incorrect**. `MINICPMO_4_5_PIPELINE`
+declares three `StagePipelineConfig` entries:
+
+- `stage_id=0`, `model_stage="llm"` — thinker
+  (`minicpmo_4_5/pipeline.py:44-55`)
+- `stage_id=1`, `model_stage="tts"`, `input_sources=(0,)` — talker
+  (`pipeline.py:56-66`)
+- `stage_id=2`, `model_stage="code2wav"`, `input_sources=(1,)`,
+  `model_arch="MiniCPMO45Code2Wav"` (`pipeline.py:67-77`)
+
+The deploy YAML confirms three independently-configured stages with a
+shared-memory connector on the stage-1 → stage-2 edge
+(`vllm_omni/deploy/minicpmo_4_5.yaml:18-60`, `output_connectors: to_stage_2`).
+`_OrchestratorDuplexStagePort.stage_count` returns `len(self._stage_pools)`
+(`vllm_omni/engine/orchestrator.py:235-237`), so `final_stage_id` is genuinely
+`2` for MiniCPM, not `0`.
+
+Compare Qwen3-Omni (`vllm_omni/model_executor/models/qwen3_omni/pipeline.py:34-69`):
+`stage_id=0` thinker (`LLM_AR`, `final_output=True`, text), `stage_id=1` talker
+(`LLM_AR`), `stage_id=2` code2wav (`LLM_GENERATION`, `final_output=True`,
+audio). **The two topologies are near-identical.** Qwen3-Omni's only
+structural difference is that it declares *two* final-output stages (text from
+thinker, audio from code2wav) where MiniCPM also declares two
+(`pipeline.py:49,72`). This is the same shape.
+
+> Note this contradicts a plausible reading of `DESIGN.md`, which never
+> mentions `StagePool` beyond one box in a diagram (`DESIGN.md:85`), never
+> mentions ZMQ, and never defines `stage_id`/`final_stage_id` at all. The doc's
+> silence is not evidence of single-process design — the pipeline config is.
+
+### 2.2 …but the duplex control plane only ever drives stage 0
+
+Topology support is not the same as topology *use*. Every write path in the
+control plane is hard-coded to stage 0:
+
+- `handle_open` reserves only stage 0:
+  `ensure_stage_request(session, stage_id=0)`
+  (`engine/duplex_control_plane.py:289`)
+- `append_via_data_plane` opens with a literal `stage_id = 0`
+  (`duplex_control_plane.py:444`), builds one `DuplexStageSubmission`, and
+  makes exactly one `await self._stage_port.submit(...)` call — no loop, no
+  `gather` over stages.
+- `handle_signal` / `handle_close` / `handle_touch` / `handle_resume` all emit
+  a sentinel `{"stage_id": -1, "replica_id": -1}` rather than per-stage results
+  (e.g. `duplex_control_plane.py:551-563`).
+
+`plan_append` in the protocol has **no `stage_id` parameter at all**
+(`engine/contracts.py:73-86`) — appends are structurally stage-0-only by
+design. That is defensible (audio enters at the thinker) and Qwen3-Omni would
+inherit the same assumption harmlessly.
+
+`decide_output` *is* invoked per-stage: `_route_output` calls
+`self._duplex_output_decision(stage_id, output, req_state)` for every stage's
+output (`orchestrator.py:1284`, inside the loop over
+`for stage_id in range(self.num_stages)` at `orchestrator.py:896`). MiniCPM's
+implementation then discards all but the pre-final stages via
+`if stage_id >= final_stage_id or not segment_finished: return None`
+(`minicpmo45/runtime.py:314-315`), and in practice only stage 0 carries the
+`listen_token_id` metadata it looks for (`runtime.py:317-323`).
+
+**So: the framework is multi-stage-aware in its invocation, and
+single-stage in every decision it actually makes.**
+
+### 2.3 Concrete defect: segment metadata is aliased across stages
+
+This is the finding that most affects a Qwen3-Omni port, and it is not
+documented anywhere in `DESIGN.md`.
+
+The orchestration loop iterates all stages
+(`orchestrator.py:896` `for stage_id in range(self.num_stages)`), and for each
+LLM-type stage's raw output writes into a **single, non-stage-keyed** buffer on
+the request state (`orchestrator.py:918-932`):
+
+```python
+req_state.streaming.segment_finished = bool(getattr(eco, "is_segment_finished", False))
+req_state.streaming.segment_token_ids = (...)
+req_state.streaming.segment_output_metadata = (dict(raw_mm) if ... else {})
+```
+
+Those fields are declared once per request, not per stage
+(`orchestrator.py:196-201`).
+
+`_duplex_output_context` then reads that same buffer regardless of which
+`stage_id` it is building context for (`orchestrator.py:1444-1447`):
+
+```python
+segment_finished=req_state.streaming.enabled and req_state.streaming.segment_finished,
+segment_token_ids=tuple(req_state.streaming.segment_token_ids),
+segment_output_metadata=req_state.streaming.segment_output_metadata,
+```
+
+**Consequence:** when `decide_output(stage_id=1, ...)` is called, the
+`segment_token_ids` / `segment_output_metadata` it receives belong to whichever
+stage's raw output landed most recently — which, given that the three stages
+are independently scheduled and explicitly designed to run at different paces
+(§2.4), is frequently *not* stage 1.
+
+For MiniCPM this is latent-benign: its `decide_output` only ever reads
+`listen_token_id`, which only stage 0 emits, so a stale stage-1 snapshot yields
+`listen_id is None → return None` (`runtime.py:321-322`). The bug is masked by
+the policy being stage-0-only.
+
+For Qwen3-Omni, any policy that needs to read talker or code2wav segment
+metadata (e.g. "how much audio has actually been committed to the vocoder")
+would read cross-stage-contaminated data. **This must be fixed — segment state
+keyed by `stage_id` — before a 3-stage-aware `decide_output` can be written
+correctly.** It is a small, self-contained orchestrator change, but it is a
+change to shared non-experimental code, not to `experimental/fullduplex/`.
+
+### 2.4 Fencing and leasing are session-scoped singletons, not per-stage
+
+Nothing in the session/control-plane layer coordinates N processes:
+
+- `DuplexSessionRuntimeState` holds exactly one `fence: DuplexFence` and one
+  `lease: DuplexLeaseState` (`engine/duplex_session.py:80-81`).
+- `DuplexFence` has fields `session_id, epoch, turn_id, response_seq,
+  incarnation` (`engine/messages.py:15-22`) — **no `stage_id`**. It is a single
+  logical clock, not a vector clock over stages.
+- `stage_bindings: dict[int, DuplexStageBinding]` and
+  `request_resources: dict[tuple[int, str], ...]`
+  (`duplex_session.py:87-88`) are *shaped* for N stages and `release_fence`
+  iterates them (`duplex_session.py:313-323`) — but only `stage_id=0` is ever
+  written (§2.2), so they hold at most one entry today.
+- Barge-in fan-out is delegated wholesale to one opaque call:
+  `await self._stage_port.cleanup(list(pending.submitted_request_ids), abort=True)`
+  (`duplex_control_plane.py:878-881`). There is no per-stage acknowledgment,
+  no two-phase commit, no "commit only if all three stages accepted the new
+  epoch."
+
+The module docstring is explicit that this is intentional: *"The module owns
+duplex session/control algorithms. It deliberately does not own stage pools,
+request queues, or OpenAI Realtime protocol state."*
+(`duplex_control_plane.py:12-14`).
+
+**Assessment:** this is *adequate but unproven* for Qwen3-Omni. Because the
+whole pipeline shares one external `req_id` across all three stages
+(`orchestrator.py:109-158`, `external_req_id = request_id` at
+`orchestrator.py:1408`), a single `cleanup([req_id], abort=True)` does fan out
+to all three stage pools via `_cleanup_request_ids` /`_abort_request_ids`
+(`orchestrator.py:819-830`). So barge-in *can* reach all three processes.
+What does not exist is any guarantee about **atomicity or ordering** — stage 2
+may emit one more audio chunk after stage 0 has accepted the new epoch. MiniCPM
+tolerates this because its barge-in granularity is a full 1-second chunk
+anyway. Qwen3-Omni would inherit the same "in-flight audio plays out" behavior,
+which is acceptable for a first cut but should be stated, not hidden.
+
+### 2.5 The real gap: Qwen3-Omni has no learned listen/speak token
+
+This is the blocker that no amount of framework work removes.
+
+MiniCPM's entire turn-taking policy is: the model itself emits `<|listen|>` /
+`<|speak|>` control tokens at chunk boundaries, and `decide_output` simply
+detects `<|listen|>` and reports it
+(`minicpmo45/runtime.py:317-328`; token vocabulary at
+`minicpmo45/policy.py:58-74`). `DESIGN.md:66-67` is explicit that this is the
+*only* interruption mechanism the checkpoint claims: *"deterministic
+VAD-triggered interruption (the browser intentionally does not run VAD;
+MiniCPM owns listen/speak decisions at model-unit boundaries)"* is listed
+under **"The checkpoint does not claim"**.
+
+Qwen3-Omni has no equivalent. A grep for listen/speak control tokens across
+`vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py` returns only
+`speaker`-as-voice-selection hits (lines 231, 295-297, 715-732, 854-922) —
+i.e. the voice-ID feature added in #5565, semantically unrelated. Qwen3-Omni's
+thinker is a standard instruct LLM that emits text and stops; it has no trained
+notion of "the user is still talking, stay quiet."
+
+MiniCPM's per-unit turn state machine also depends on **re-injecting the
+model's own previous decision token into context** each unit, precisely because
+"the model's listen/speak policy depends on seeing its own past decisions in
+context" (`minicpmo45/stage0.py:231-244`). There is nothing to re-inject for
+Qwen3-Omni.
+
+**Therefore Qwen3-Omni cannot use the model-owned turn-taking path at all.**
+Its options are:
+
+- **(a) External VAD** gating the thinker. This is exactly the path
+  `DESIGN.md:66-67` disclaims, `#3745`'s Phase 2 defers, and `tc-mb` warns is
+  "structurally much heavier" than end-to-end duplex
+  (issue #3745 comment, 2026-05-21). It needs the `DUPLEX_VAD` stage type that
+  does not exist yet (`StageExecutionType` has only `LLM_AR`,
+  `LLM_GENERATION`, `DIFFUSION` — RFC blocker #6).
+- **(b) Client/server-side barge-in only** — no model turn-taking; the client
+  signals `input.cancel`, the server bumps the epoch and flushes. This is
+  achievable with the existing framework and is the honest first cut, but it
+  is *interruption*, not *full duplex*: the model never decides to stay silent
+  because the user is mid-sentence.
+
+Option (b) is the tractable follow-on PR. Option (a) is a separate,
+larger project.
+
+### 2.6 Resumable append already works — the RFC's scheduler blocker does not bind here
+
+Good news that changes the recommendation materially.
+
+`DESIGN.md:527-544` ("Why Scheduler Changes Remain") describes the required
+contract as one resumable request parked in `WAITING_FOR_STREAMING_REQ` with KV
+retained between segments, released only at session close. That machinery
+**exists and is in use**:
+
+- `OmniGenerationScheduler._handle_stopped_request` re-enqueues a `resumable`
+  request as `WAITING` instead of finishing it
+  (`vllm_omni/core/sched/omni_generation_scheduler.py:59-72`).
+- KV is only freed on `finished=True`
+  (`vllm_omni/core/sched/omni_ar_scheduler.py:507-520`), so a parked resumable
+  request keeps its blocks.
+- Qwen3-Omni's shipped deploy sets `async_chunk: true`
+  (`vllm_omni/deploy/qwen3_omni_moe.yaml:15`) and its stage input processors
+  have an explicit resumable branch
+  (`vllm_omni/model_executor/stage_input_processors/qwen3_omni.py:506-509`
+  dispatching to `_construct_thinker2talker_streaming_input_async_chunk`).
+- `talker_preprocess` already threads `meta.get('resumable', False)` through
+  its token bookkeeping (`qwen3_omni.py:743-789`).
+
+So RFC blockers #1 and #2 ("KV freed on finish", "streaming update sets
+`num_computed_tokens = 0`") **do not describe the Qwen3-Omni async-chunk
+path**. `DESIGN.md:65` still lists "scheduler-native KV append" as not
+claimed — that refers to a deeper scheduler-native primitive, not to the
+resumable-request workaround, which is what actually carries #3907 and would
+carry us.
+
+**This is the single biggest de-risking finding: we do not need scheduler
+changes.**
+
+### 2.7 Stage skew is designed-for, not a hazard
+
+Qwen3-Omni's three stages are explicitly intended to run at different
+wall-clock paces: `async_chunk` exists so "each stage forwards chunks so the
+next stage can start as soon as the first chunk is ready"
+(`docs/design/qwen3_omni_tts_performance_optimization.md:228`), stages use
+different batching policies (thinker/talker continuous, code2wav static, same
+doc), and the orchestration loop polls every stage non-blockingly with no
+inter-stage barrier (`orchestrator.py:892-1037`, `timeout_s=0.001` at
+`orchestrator.py:912`). Failure handling marks individual replicas unavailable
+rather than failing the pipeline (`orchestrator.py:960-1019`).
+
+No explicit skew bound exists. This is fine for duplex — it is the same
+property MiniCPM relies on — but it means barge-in latency is bounded by
+in-flight code2wav buffer depth, not by the control plane.
+
+### 2.8 Volume of model-specific work required
+
+MiniCPM's three protocol methods (`runtime.py`, 354 lines) are backed by
+~1,650 lines of supporting state in `stage0.py` (816) and `data_plane.py`
+(837). Reviewing both: roughly two-thirds is model-specific and would need a
+from-scratch rewrite for a different audio front-end.
+
+`stage0.py` is almost entirely MiniCPM-coupled — the `<unit>`/`</unit>` framing
+grammar, 1000 ms/1035 ms chunk cadence with CNN warm-up padding
+(`stage0.py:359-425`), the stateful streaming audio-encoder KV carried across
+chunks (`stage0.py:443-489`), and the decision-token re-injection loop
+(`stage0.py:231-244`). Qwen3-Omni's audio path is architecturally different
+(the thinker consumes a processor-produced audio feature via
+`buffer_realtime_audio`, `qwen3_omni.py:224-324`, with a 5.0 s segment default
+at line 244 — five times MiniCPM's cadence).
+
+`data_plane.py` is roughly half generic metadata-coercion scaffolding and half
+MiniCPM-specific fusion logic. Critically, its core `project_output`
+(`data_plane.py:114-454`) assumes **one stage output carries text + audio +
+turn decision together** — and it contains a hard-coded Qwen tokenizer constant
+`151645` as an EOS fallback (`data_plane.py:227-234`). For Qwen3-Omni, where
+text comes from stage 0 and audio from stage 2 as separate outputs at
+different times, that fusion logic needs replacing with genuine cross-stage
+correlation.
+
+Realistic estimate: **~1,000-1,500 new lines** of Qwen3-Omni-specific runtime
+state, plus the orchestrator fix in §2.3, plus a serving adapter (~100 lines,
+`serving_adapter.py` is a thin delegating wrapper and ports easily).
+
+### 2.10 The binding constraint: audio cannot reach the thinker
+
+Found while implementing, not while reading contracts. This is the reason the
+port is not adapter-only.
+
+**Audio has no route into the thinker except the model's own `preprocess`
+hook.** In the duplex append path:
+
+- `build_engine_core_request_from_tokens` forwards only `prompt_token_ids`,
+  `prompt_embeds`, `cache_salt`, `additional_information` and
+  `model_intermediate_buffer` (`orchestrator.py:118-158`). Every other prompt
+  key — **including `multi_modal_data`** — is dropped silently.
+- `_OrchestratorDuplexStagePort.submit` passes no `mm_features`
+  (`orchestrator.py:289-302`).
+
+So Qwen3-Omni's normal multimodal audio route is unavailable in duplex mode.
+Audio must ride as base64 PCM inside
+`model_intermediate_buffer["duplex"]["payload"]` and be converted to
+embeddings by `model.preprocess`, dispatched at `gpu_model_runner.py:1685`
+under `model.has_preprocess`. Two things block that:
+
+**(a) The Qwen3-Omni thinker has no `preprocess` hook.**
+`Qwen3OmniMoeForConditionalGeneration` sets `has_preprocess = False`
+(`qwen3_omni.py:107`) and enables it only for the talker
+(`qwen3_omni.py:156`). MiniCPM enables it for both its LM and TTS stages
+(`minicpmo_4_5_omni.py:140`). Adding one is core model-code work, outside
+`experimental/`.
+
+**(b) Qwen3-Omni has no incremental audio encode.** MiniCPM carries an
+audio-encoder KV cache across chunks — `get_audio_embedding_streaming` plus
+`audio_past_key_values`, with explicit prefix/suffix context frames
+(`minicpmo45/stage0.py:443-489`). Qwen3-Omni exposes no equivalent; its only
+streaming affordance is `code2wav.chunked_decode_streaming`
+(`qwen3_omni.py:593`), which is on the **output** side. Without incremental
+encode the options are: re-encode the whole buffer each append (correct but
+quadratic in session length, defeating the persistent session); encode each
+chunk in isolation (cheap but wrong at boundaries, since the conv front end
+loses left context); or encode a bounded sliding window and keep only the new
+chunk's embeddings (bounded and approximately correct — recommended, and what
+MiniCPM achieves via `cnn_redundancy_ms`).
+
+Option (c) is implementable, but the frame arithmetic (mel hop → conv stride →
+pooling ratio → embeddings per chunk) must be derived from the checkpoint.
+`Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN` is currently an **unverified
+placeholder**, and it is load-bearing: the engine reserves scheduler slots
+from it and the worker must produce exactly that many embeddings, or the model
+runner truncates/pads with no error.
+
+### 2.9 Comparable PRs offer no better template
+
+Checked the three PRs #3745 cites as having hit the same wall:
+
+- **#3642** (MiniCPM-o 4.5) — merged; became #3907. Same 3-stage shape as
+  us. This *is* the best template.
+- **#3512** (Nemotron VoiceChat) — still open/draft with failing CI gates.
+  Its vllm-omni-side diff is generic plumbing only; the actual pipeline lives
+  in an unmerged external NeMo plugin and defines **2** stages
+  (thinker + EarTTS talker, no separate vocoder stage).
+- **#1967** (SoulX-Duplug) — **not a PR at all**; it is an open New Model
+  Request issue with no code. A maintainer explicitly steered it toward
+  request/response rather than duplex (linyueqian, 2026-03-21).
+
+No alternative multi-stage precedent exists. #3907 is the only template.
+
+---
+
+## 3. `Qwen3OmniDuplexRuntimeExtension` skeleton
+
+Method signatures match `DuplexRuntimeExtension`
+(`engine/contracts.py:63-97`) exactly. Bodies are deliberately unimplemented.
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SKELETON — not implemented, not validated on hardware.
+
+Sketch of a Qwen3-Omni duplex runtime extension for
+``vllm_omni/experimental/fullduplex/qwen3omni/runtime.py``.
+
+Assumes the client-signalled barge-in model (assessment option (b), §2.5):
+Qwen3-Omni has no learned listen/speak control token, so this extension
+CANNOT implement model-owned turn-taking the way MiniCPM's does.
+"""
+
+from typing import Any
+
+from vllm_omni.experimental.fullduplex.engine.contracts import (
+    DuplexAppendPlan,
+    DuplexInputMode,
+    DuplexOutputDecision,
+)
+from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+
+
+class Qwen3OmniDuplexRuntimeExtension:
+    """Pure model policy for Qwen3-Omni thinker -> talker -> code2wav."""
+
+    def configure_sampling_params(
+        self,
+        *,
+        runtime_config: dict[str, Any],
+        defaults: tuple[object, ...],
+    ) -> tuple[object, ...]:
+        """Return per-stage SamplingParams, one entry per pipeline stage.
+
+        ``defaults`` has length 3 for Qwen3-Omni (thinker, talker, code2wav);
+        the return tuple MUST be the same length and order.
+
+        Qwen3-Omni-specific work:
+
+        TODO(stage 0 / thinker): clone the default and override ``max_tokens``
+          from ``runtime_config`` so a duplex segment is bounded. Unlike
+          MiniCPM there is no ``<|chunk_eos|>`` to terminate a unit, so the
+          per-segment token budget is the ONLY stop condition. Getting this
+          wrong means the thinker runs away past the user's next utterance.
+        TODO(stage 0): preserve ``detokenize: True`` — the thinker is a
+          ``final_output`` text stage (pipeline.py:38-39) and the Realtime
+          projection needs text deltas.
+        TODO(stage 1 / talker): keep ``detokenize: False`` and the
+          checkpoint's codec ``stop_token_ids``; do NOT let runtime_config
+          override codec sampling, which comes from ``talker_config``.
+        TODO(stage 2 / code2wav): almost certainly pass ``defaults[2]``
+          through untouched — it is a vocoder, not a sampler.
+        TODO: reuse MiniCPM's ``_stage_config_value`` indexing helper
+          (minicpmo45/runtime.py:236-243) so per-stage overrides can be
+          addressed as ``runtime_config[key][stage_id]``.
+        TODO: thread the ``speaker`` / voice selection added in #5565 through
+          here rather than through ``additional_information``, so voice is
+          session-scoped rather than per-utterance.
+        """
+        raise NotImplementedError
+
+    def plan_append(
+        self,
+        *,
+        request_id: str,
+        fence: DuplexFence,
+        session_config: dict[str, Any],
+        runtime_config: dict[str, Any],
+        seq: int,
+        turn_seq: int,
+        mode: DuplexInputMode,
+        payload: object,
+        final: bool,
+        sampling_params: object,
+    ) -> DuplexAppendPlan:
+        """Build the stage-0 prompt for one appended input chunk.
+
+        Note there is no ``stage_id`` parameter: appends are structurally
+        stage-0-only (control plane hard-codes ``stage_id = 0`` at
+        duplex_control_plane.py:444). Audio enters at the thinker; the talker
+        and code2wav are fed by the orchestrator's async-chunk forwarding,
+        not by this method.
+
+        Qwen3-Omni-specific work:
+
+        TODO: accept only ``DuplexInputMode.APPEND_AUDIO_CHUNK`` and
+          ``TURN_COMMIT_ONLY``; reject ROLLBACK_TO_CHECKPOINT and
+          REPLACE_LATEST_CHUNK explicitly (Qwen3-Omni has no ASR-correction
+          rollback affordance). Fail closed rather than silently degrading.
+        TODO: decode ``payload`` as base64 pcm_f32le and accumulate into
+          per-session state. Qwen3-Omni's realtime buffer currently uses a
+          5.0 s segment (qwen3_omni.py:240) vs MiniCPM's 1.0 s unit — this
+          MUST be reduced for usable barge-in latency, and reducing it is a
+          model-behavior change that needs its own evaluation, not a config
+          tweak. Segment length directly sets the interruption floor.
+        TODO: build ``prompt_token_ids`` via the chat template, reusing the
+          ``safe_apply_chat_template`` path already established for tools and
+          instructions (qwen3_omni.py:274-291 from #5555/#5566), so a duplex
+          session keeps tool-calling and system-prompt support.
+        TODO: carry the fence (epoch/turn_id/response_seq) into the prompt's
+          intermediate-buffer payload so stale-epoch outputs can be dropped
+          downstream — mirror build_duplex_data_plane_prompt
+          (minicpmo45/runtime.py:99-162).
+        TODO(VERIFY BY TRACING, DO NOT ASSUME): confirm every key placed in
+          the returned prompt dict actually survives to the worker. The
+          render pipeline silently drops unrecognized prompt-dict keys — this
+          exact class of bug already shipped once in this project (fixed in
+          54d71650, voice selection dropped by render_cmpl_async). Assert on
+          observed worker-side keys, not on a mocked unit test.
+        TODO: size ``prompt_token_ids`` against the scheduler token budget so
+          the resumable request is not starved.
+        """
+        raise NotImplementedError
+
+    def decide_output(
+        self,
+        *,
+        stage_id: int,
+        final_stage_id: int,
+        segment_finished: bool,
+        segment_token_ids: tuple[int, ...],
+        segment_output_metadata: dict[str, Any],
+        output: object,
+    ) -> DuplexOutputDecision | None:
+        """Optionally short-circuit a stage output into a direct response.
+
+        Invoked once per stage per output (orchestrator.py:1284, inside the
+        loop over all stages). ``final_stage_id`` is 2 for Qwen3-Omni.
+
+        !! BLOCKED ON THE §2.3 DEFECT !!
+        ``segment_token_ids`` and ``segment_output_metadata`` are read from a
+        per-request, NOT per-stage buffer (orchestrator.py:918-932 writes,
+        orchestrator.py:1444-1447 reads). For a 3-stage model whose stages run
+        at different paces by design, the snapshot passed alongside
+        ``stage_id=N`` may belong to a different stage. Any implementation
+        here that reads stage-1 or stage-2 metadata is unsound until the
+        orchestrator keys that state by stage_id. MiniCPM does not hit this
+        because it only ever reads stage-0 metadata.
+
+        Qwen3-Omni-specific work:
+
+        TODO: return None for ``stage_id >= final_stage_id`` and for
+          ``not segment_finished``, matching minicpmo45/runtime.py:314-315.
+        TODO: DO NOT port MiniCPM's listen-token detection
+          (runtime.py:317-328). Qwen3-Omni emits no ``<|listen|>``; there is
+          no model-native turn decision to detect (§2.5). Attempting to
+          synthesize one from text EOS would conflate "finished this reply"
+          with "the user should speak now" — those are different events and
+          the model was not trained to distinguish them.
+        TODO: decide what, if anything, this method is FOR under the
+          client-signalled barge-in model. Plausibly nothing: if turn
+          boundaries come from the client and audio flows through the normal
+          stage-2 final_output path, returning None unconditionally may be
+          correct, and the class exists only for
+          configure_sampling_params + plan_append. Resist inventing a
+          decision that has no model signal behind it.
+        TODO(IF a VAD stage is added later): this becomes the seam where a
+          DUPLEX_VAD stage's turn verdict is translated into a
+          DIRECT_RESPONSE — but that stage type does not exist
+          (StageExecutionType has only LLM_AR / LLM_GENERATION / DIFFUSION)
+          and is out of scope here.
+        """
+        raise NotImplementedError
+```
+
+A `Qwen3OmniServingRuntimeAdapter` would also be needed, implementing
+`ServingRuntimeAdapter` (`experimental/fullduplex/openai/runtime_adapter.py:107-146`),
+wired via `PipelineConfig.duplex_serving_adapter`
+(`vllm_omni/config/stage_config.py:283`). MiniCPM's is a thin delegating
+wrapper (`minicpmo45/serving_adapter.py:21-96`) and ports with low risk.
+`vllm_omni/model_executor/models/qwen3_omni/pipeline.py` currently declares
+**no** duplex fields at all — `duplex_runtime_extension`,
+`duplex_serving_adapter`, and `duplex_control_enabled=True` would all need
+adding, mirroring `minicpmo_4_5/pipeline.py:26-30`.
+
+---
+
+## 4. What this assessment does not claim to solve
+
+Mirroring the pattern at `DESIGN.md:63-70`. This assessment does not claim:
+
+- **any working code.** Nothing here has been executed. The skeleton in §3
+  does not compile as a functioning extension and has never been run.
+- **any hardware validation.** #3907 required a dedicated H20 host to
+  validate; no GPU was available for this assessment. Every finding above is
+  from code reading, not from observed runtime behavior.
+- **that the §2.3 aliasing defect is a live production bug.** It is
+  *latent-benign* for MiniCPM by the reasoning given, and I have not
+  reproduced it. It is a hazard for a 3-stage-aware policy, established by
+  reading, not by a failing test.
+- **model-owned turn-taking for Qwen3-Omni.** §2.5 concludes the checkpoint
+  has no affordance for it. Only client-signalled barge-in is in scope.
+- **deterministic VAD-triggered interruption** — same disclaimer as
+  `DESIGN.md:66-67`, and additionally the `DUPLEX_VAD` stage type does not
+  exist.
+- **any barge-in latency figure.** In-flight code2wav audio will still play
+  out after an interrupt (§2.4, §2.7). The floor is set by buffer depth and
+  by the input segment length (currently 5.0 s, `qwen3_omni.py:240`), and I
+  have measured neither.
+- **bounded long-session KV** — unsolved for MiniCPM too (`DESIGN.md:69`);
+  nothing here improves it.
+- **multi-session admission, fairness, or capacity** for Qwen3-Omni.
+  `DESIGN.md:774-788` limits even MiniCPM's claims to a validated
+  two-session shape.
+- **that the estimate in §2.8 is reliable.** ~1,000-1,500 lines is a
+  reading-based guess, not a plan.
+- **the plugin-descriptor prerequisite is met.** `DESIGN.md:718-719` states
+  that *"Adding a second native model should first introduce that descriptor
+  and reject serving/engine plugin mismatches explicitly."* Qwen3-Omni would
+  be that second native model, and no such descriptor exists. This is an
+  explicit, documented precondition that this assessment does not satisfy.
+
+---
+
+## 5. Coordination status on #3745
+
+I posted a comment on issue #3745 asking whether the Qwen3-Omni duplex adapter
+slot is claimed
+(https://github.com/vllm-project/vllm-omni/issues/3745#issuecomment-5122402496,
+2026-07-29T19:13:18Z).
+
+**As of writing, there are no replies.** It is the most recent comment on the
+thread. No adjustment to the recommendation is possible yet; the cc list
+(@linyueqian @yinpeiqi @Sy0307 @hsliuustc0106 @tc-mb @vklimkov-nvidia) has not
+responded, and the slot should be treated as *unconfirmed* rather than open.
+
+Relevant prior maintainer positions from the thread that do bear on the
+recommendation:
+
+- **tc-mb (2026-05-21):** end-to-end duplex models are "much simpler at the
+  engine level"; a half-duplex + external-VAD pipeline is "structurally much
+  heavier." Qwen3-Omni falls in the *heavier* category per §2.5 — this is
+  direct maintainer support for keeping the first cut narrow.
+- **Sy0307 (2026-05-20):** append mode "should be a model capability, not the
+  default input semantics for all duplex models." Consistent with §3's
+  recommendation to explicitly reject unsupported `DuplexInputMode` values.
+- **Sy0307 (2026-05-20), point 4:** barge-in "does not define history commit…
+  server generated/sent does not mean the user actually played/heard it."
+  Directly relevant to §2.4/§2.7 — unresolved for Qwen3-Omni as well.
+- **linyueqian (2026-05-20):** puts the one-chunk barge-in floor at ~1 s for
+  chunk-based models and notes sub-300 ms "needs new engine work." Qwen3-Omni
+  starts from a 5.0 s segment, i.e. worse than MiniCPM's floor until the
+  segment size is addressed.
+
+---
+
+## 6. Recommendation
+
+**Proceed, but in three separately-reviewable pieces, and do not describe any
+of them as "full duplex for Qwen3-Omni."**
+
+1. **Fix the stage-aliasing defect (§2.3) first, standalone.** Key
+   `segment_finished` / `segment_token_ids` / `segment_output_metadata` by
+   `stage_id` in `OrchestratorRequestState.streaming`. This is small, is
+   independently justifiable as a correctness fix, touches shared code rather
+   than `experimental/`, and is a hard prerequisite for any stage-aware
+   policy. It is also the piece most likely to be accepted quickly on its own
+   merits. Needs a regression test demonstrating cross-stage contamination.
+
+2. **Then reduce and parameterize the realtime input segment length**
+   (currently 5.0 s, `qwen3_omni.py:240`). This is a model-behavior change
+   requiring quality evaluation — MiniCPM's own paper reportedly shows quality
+   collapse at very short chunks, so this cannot be assumed safe. Without it,
+   barge-in latency is bounded at ~5 s regardless of framework work, which is
+   not a usable voice assistant. **This, not the duplex framework, is the
+   critical path to the user-visible outcome.**
+
+3. **Only then** add the `Qwen3OmniDuplexRuntimeExtension` +
+   `Qwen3OmniServingRuntimeAdapter` + pipeline wiring, scoped explicitly to
+   *client-signalled barge-in over a persistent session*, and named as such.
+   Raise the plugin-descriptor question from `DESIGN.md:718-719` with
+   maintainers before writing it, since Qwen3-Omni is precisely the "second
+   native model" that precondition names.
+
+**Does it need scheduler changes first? No** — §2.6 establishes the resumable
+KV-preserving path already exists and Qwen3-Omni already uses it. This is the
+main way the task is smaller than the RFC's "Concrete blockers" table implies.
+
+**Does it need Qwen3-Omni model-level changes first? Partly** — not to the
+network, but the input segmentation (item 2) is a model-behavior change and is
+the real latency determinant. And no amount of engine work gives Qwen3-Omni
+model-owned turn-taking; that would require a differently-trained checkpoint.
+
+**Suggested next action:** wait for a reply on #3745 before writing code
+beyond item 1. Item 1 is worth opening regardless, as it stands on its own as
+a correctness fix.

--- a/docs/design/qwen3_omni_duplex_deploy.example.yaml
+++ b/docs/design/qwen3_omni_duplex_deploy.example.yaml
@@ -2,7 +2,10 @@
 # Derived from the production 2-GPU config; adds session_mode: duplex.
 async_chunk: true
 session_mode: duplex
-active_stream_window: 1
+# 0 = unbounded: every session's stream is schedulable, so vLLM batches
+# them. At 1 only one stream is ever active, which serialises the server --
+# 12 concurrent sessions took 100 s instead of 9.6 s.
+active_stream_window: 0
 
 duplex_session:
   idle_ttl_s: 300

--- a/docs/design/qwen3_omni_duplex_deploy.example.yaml
+++ b/docs/design/qwen3_omni_duplex_deploy.example.yaml
@@ -1,0 +1,74 @@
+# Qwen3-Omni-MoE experimental full-duplex deploy (test only, GPUs 2/3).
+# Derived from the production 2-GPU config; adds session_mode: duplex.
+async_chunk: true
+session_mode: duplex
+active_stream_window: 1
+
+duplex_session:
+  idle_ttl_s: 300
+  disconnect_grace_s: 30
+  reaper_interval_s: 5
+  resume_replay_ttl_s: 60
+  resume_replay_max_bytes_per_session: 8388608
+  max_pending_input_bytes_per_session: 16777216
+  max_pending_turns_per_session: 4
+  max_sessions: 1
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      initial_codec_chunk_frames: 4
+      codec_chunk_frames: 25
+      codec_left_context_frames: 25
+
+stages:
+  - stage_id: 0
+    max_num_batched_tokens: 32768
+    max_num_seqs: 2
+    async_scheduling: false
+    gpu_memory_utilization: 0.90
+    max_model_len: 32768
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      max_tokens: 2048
+
+  - stage_id: 1
+    max_num_batched_tokens: 32768
+    max_num_seqs: 2
+    async_scheduling: false
+    gpu_memory_utilization: 0.6
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "1"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.9
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      repetition_penalty: 1.05
+
+  - stage_id: 2
+    max_num_batched_tokens: 65536
+    max_num_seqs: 2
+    gpu_memory_utilization: 0.15
+    enforce_eager: false
+    trust_remote_code: true
+    enable_prefix_caching: false
+    enable_chunked_prefill: false
+    async_scheduling: false
+    devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      repetition_penalty: 1.1

--- a/docs/design/qwen3_omni_duplex_pr_map.md
+++ b/docs/design/qwen3_omni_duplex_pr_map.md
@@ -94,7 +94,13 @@ cost the most time.
   worker-side duplex branch silently no-ops.
 - **Reservation must equal produced embeddings.** The model runner absorbs a
   mismatch by truncating or padding without raising. This invariant caused
-  three separate defects here.
+  four separate defects here, the last being the splice-offset frame mismatch
+  (commit `d143f64a`): audio was produced, landed nowhere, and the request
+  still succeeded with placeholders in place. Any code path that can decline to
+  fill a reserved span must say so out loud.
+- **`audio_offset` is append-relative; `duplex_token_offset` is
+  session-absolute.** They coincide only on a session's first append. Rebase
+  with `prompt_len - append_token_count` before comparing them.
 - **Direct response and stage advancement are mutually exclusive.** Returning a
   decision from `decide_output` short-circuits forwarding
   (`orchestrator.py:1284-1295`), so you can surface stage-0 text *or* get audio,
@@ -162,6 +168,14 @@ each of these cost a measurement:
 ## Fixes that were wrong
 
 Left in history deliberately, so nobody re-runs the experiment:
+
+- A ruled-out entry in the demo README claimed turn 2's audio "*does* reach the
+  model ... spliced at the right offset". It did not. The `audio embeds=` line
+  says the embeddings were **built**; the `[splice]` line says they were
+  **installed**, and turn 2 only ever logged the first. That one misread turned
+  the actual root cause into a ruled-out branch and cost more time than any
+  other single thing on this branch. Ruled-out lists are load-bearing — an
+  entry asserted from the wrong log line is worse than no entry.
 
 - Per-chunk audio encoding was claimed lossless because 1 s aligns with the
   tower's conv chunk. The conv part is true; the 8-chunk *attention* window is

--- a/docs/design/qwen3_omni_duplex_pr_map.md
+++ b/docs/design/qwen3_omni_duplex_pr_map.md
@@ -32,6 +32,13 @@ defensible without reference to Qwen3-Omni.
 | 1 | `DuplexFence` not JSON serializable in `runtime_control` — kills the session at handshake | issue #5612, **PR #5613** |
 | 2 | `chat_fallback.py` raises `AttributeError` while reporting an error, hiding the real cause | draft **PR #5626** |
 | 3 | Abort raised inside the AR scheduler's dequeue kills the engine core | commit `fb8c46fc`, unfiled |
+| 6 | `num_waiting_for_streaming_input` leaks on abort, parking the stage forever | commit `97cefb59`, unfiled |
+
+Defect 6 is the one-session-per-boot wedge, and it is the strongest Tier 1
+candidate after #5613: upstream's counter, omni's status rewrites, no
+Qwen3-Omni in the reproduction. Full mechanism in
+`OmniSchedulerMixin._resync_streaming_input_counter`; regression test in
+`tests/core/sched/test_omni_scheduler_streaming_input_counter.py`.
 
 Defect 3 is worth adding to #5626 or filing separately. Note the mechanism:
 upstream pops from `waiting`, appends to `running`, *then* checks status, so
@@ -98,10 +105,47 @@ cost the most time.
 - **Code2Wav output is cumulative** and shaped `[1, samples]`, so `len()` gives
   the batch dimension.
 
-## Ruled out for the one-turn-per-boot bug
+## The one-session-per-boot bug: solved
 
-Kept because a negative result is worth as much as a positive one when someone
-picks this up:
+**Root cause: upstream's `num_waiting_for_streaming_input` counter leaked one
+per session, and `EngineCore.has_work()` reads through it.**
+
+`get_num_unfinished_requests` computes
+`len(waiting) + len(skipped_waiting) - num_waiting_for_streaming_input + len(running)`.
+Upstream keeps the counter incrementally — `+1` when a resumable request parks
+as `WAITING_FOR_STREAMING_REQ`, `-1` in `_update_request_as_session` or in
+`finish_requests` when the request is *still in that status*. Omni rewrites
+`request.status` outside both hooks (the chunk-transfer adapter's park/restore,
+and `_realign_request_status_to_queues`), so at session close the talker's
+request was aborted while counted but with status already stomped to `RUNNING`.
+Upstream took the running branch, never decremented, and the counter stayed at
+1 for the life of the process.
+
+One phantom is enough. On the next session stage 1 had exactly one request in
+`waiting`, so `(1 + 0 - 1) + 0 == 0`, `has_work()` was false, and the engine
+blocked in `input_queue.get()` — it never called `schedule()` again. The talker
+never ran, no codec tokens reached Code2Wav, and the client waited forever on a
+server that stayed healthy and kept accepting audio.
+
+Fixed by restating the invariant instead of chasing the writes:
+`_resync_streaming_input_counter` re-derives the counter from the waiting
+queues (a no-op when upstream's arithmetic is right, self-healing when it
+isn't), called from both schedulers' `finish_requests` and from
+`OmniARScheduler.schedule`. Measured on a freshly booted server, scripted
+client replaying the browser's exact wire protocol: **before 1/2 sessions
+answered, after 5/5, and 4 sessions × 3 turns = 12/12 turns.**
+
+How it was found, since the log evidence was misleading three times over: the
+API server, orchestrator and stage 0 all looked healthy, and stage 1 logged
+*nothing*. `py-spy dump` on the stage-1 process was the turn — it showed the
+main loop parked in `_process_input_queue`, which is only reachable when
+`has_work()` is false, i.e. the engine believed it had no work while holding a
+queued request. Everything after that was arithmetic.
+
+## Ruled out for the one-session-per-boot bug
+
+Kept because a negative result is worth as much as a positive one, and because
+each of these cost a measurement:
 
 - not session capacity (reproduces at `max_sessions: 4` with matching stage
   slots)
@@ -110,8 +154,10 @@ picks this up:
 - not stage-0 admission (request created, first token generated)
 - not the stop token (removing `stop_token_ids` changes nothing)
 - not a race (deterministic on a freshly booted server)
-
-Next place to look: whether stage 1 receives anything at all on turn 2.
+- not the orchestrator's submit path: stage 1 *was* submitted every session,
+  the request reached its engine core, and `scheduler.add_request` ran. Chasing
+  the submit path cost the most time of anything here — the request arrives
+  fine, it is the engine's decision to sleep that is wrong.
 
 ## Fixes that were wrong
 

--- a/docs/design/qwen3_omni_duplex_pr_map.md
+++ b/docs/design/qwen3_omni_duplex_pr_map.md
@@ -1,0 +1,125 @@
+# Qwen3-Omni duplex: PR decomposition map
+
+This branch was built whole-first to find the hairy cases, then sliced. This
+is the slicing map — the natural fault lines, recorded while they were fresh so
+carving PRs later is a jigsaw puzzle rather than an archaeology dig.
+
+Read with `git log --oneline upstream/main..HEAD`. Every defect is its own
+commit with its evidence in the message, so most commits are already PR-shaped.
+
+---
+
+## The organising principle
+
+**Framework fixes land independently of whether the adapter ever ships.**
+
+That is the cleanest first cut, and it is not a technicality: each of these is
+a bug the *next* native duplex model hits too. They are worth landing on their
+own merits even if Qwen3-Omni duplex is abandoned tomorrow.
+
+So the slice order is: framework fixes → model-code fixes → the adapter itself
+→ the demo. Value front-loaded, risk back-loaded.
+
+---
+
+## Tier 1 — framework fixes, no dependency on this port
+
+Land these first. Each is small, has a reproduction that needs no GPU, and is
+defensible without reference to Qwen3-Omni.
+
+| # | Defect | State |
+|---|---|---|
+| 1 | `DuplexFence` not JSON serializable in `runtime_control` — kills the session at handshake | issue #5612, **PR #5613** |
+| 2 | `chat_fallback.py` raises `AttributeError` while reporting an error, hiding the real cause | draft **PR #5626** |
+| 3 | Abort raised inside the AR scheduler's dequeue kills the engine core | commit `fb8c46fc`, unfiled |
+
+Defect 3 is worth adding to #5626 or filing separately. Note the mechanism:
+upstream pops from `waiting`, appends to `running`, *then* checks status, so
+sweeping the queues beforehand cannot prevent it — the fix recovers and retries
+rather than preventing.
+
+**Also unfiled and worth a look:** twelve abandoned browser sessions produced
+zero reaping despite `disconnect_grace_s` and `reaper_interval_s` being
+configured. If that reproduces deliberately it is a real orphan-reaping bug,
+and the framework claims that mechanism as implemented.
+
+## Tier 2 — Qwen3-Omni model code, small and self-contained
+
+| # | Change | Commit |
+|---|---|---|
+| 4 | Do not advertise talker MTP on the thinker stage (`KeyError: 'mtp_inputs'`) | in **PR #5626** |
+| 5 | Thinker `preprocess` hook + `has_preprocess=True` for duplex audio ingest | `bc9648e8` |
+
+Item 5 only makes sense alongside the adapter, so it rides with Tier 3.
+
+## Tier 3 — the adapter
+
+`vllm_omni/experimental/fullduplex/qwen3omni/` plus pipeline registration.
+Roughly 1,900 lines. Natural sub-seams if it needs splitting further:
+
+1. **policy + audio geometry** — constants, the 13-tokens-per-second formula
+   verified against vLLM's own `_get_feat_extract_output_lengths`. Standalone
+   and unit-testable.
+2. **serving adapter + session state + PCM buffer** — satisfies
+   `ServingRuntimeAdapter`. No engine dependency.
+3. **runtime extension** — `configure_sampling_params` / `plan_append` /
+   `decide_output`, plus prompt assembly.
+4. **stage-0 audio ingest** — the worker-side encode. Needs item 5.
+5. **data plane** — projection of stage outputs into Realtime events.
+
+## Tier 4 — demo and docs
+
+`examples/online_serving/qwen3_omni_duplex/` and `docs/design/*`. Independent
+of everything above; useful to land late so it documents what actually shipped.
+
+---
+
+## Seams worth knowing before slicing
+
+These are the boundaries that turned out to matter. Getting them wrong is what
+cost the most time.
+
+- **Only five prompt keys survive** `build_engine_core_request_from_tokens`
+  (`orchestrator.py:118-158`). `multi_modal_data` is *not* one of them, which
+  is why duplex audio must ride in `model_intermediate_buffer` and become
+  embeddings in the model's own `preprocess`.
+- **`duplex.data_plane = True` is a mandatory gate.** Absent it, every
+  worker-side duplex branch silently no-ops.
+- **Reservation must equal produced embeddings.** The model runner absorbs a
+  mismatch by truncating or padding without raising. This invariant caused
+  three separate defects here.
+- **Direct response and stage advancement are mutually exclusive.** Returning a
+  decision from `decide_output` short-circuits forwarding
+  (`orchestrator.py:1284-1295`), so you can surface stage-0 text *or* get audio,
+  not both. That is why the transcript is empty.
+- **Stage 0 emits a raw vLLM `RequestOutput`;** other stages wrap it in
+  `OmniRequestOutput`. Reading only the wrapped form sees empty text
+  everywhere.
+- **Code2Wav output is cumulative** and shaped `[1, samples]`, so `len()` gives
+  the batch dimension.
+
+## Ruled out for the one-turn-per-boot bug
+
+Kept because a negative result is worth as much as a positive one when someone
+picks this up:
+
+- not session capacity (reproduces at `max_sessions: 4` with matching stage
+  slots)
+- not the client (browser and scripted client fail identically)
+- not `session.close` (a session that never closes still stalls)
+- not stage-0 admission (request created, first token generated)
+- not the stop token (removing `stop_token_ids` changes nothing)
+- not a race (deterministic on a freshly booted server)
+
+Next place to look: whether stage 1 receives anything at all on turn 2.
+
+## Fixes that were wrong
+
+Left in history deliberately, so nobody re-runs the experiment:
+
+- Per-chunk audio encoding was claimed lossless because 1 s aligns with the
+  tower's conv chunk. The conv part is true; the 8-chunk *attention* window is
+  not, and it dominates. Cumulative re-encode improved cosine 0.844 → 0.949 and
+  changed the output not at all.
+- Marking thinker output as a direct response did surface the transcript, and
+  cost all the audio.

--- a/docs/design/vllm_omni_architecture_primer.md
+++ b/docs/design/vllm_omni_architecture_primer.md
@@ -1,0 +1,260 @@
+# vLLM-Omni architecture primer
+
+Written to orient someone joining the Qwen3-Omni full-duplex work. Everything
+here was verified against the code or observed on a live server during
+bring-up; where something is inferred rather than observed it says so.
+
+---
+
+## 1. vLLM-Omni in general
+
+vLLM serves one model. vLLM-Omni serves a **pipeline of models** — a
+"multi-stage" model where each stage is its own vLLM engine in its own OS
+process, and an orchestrator moves data between them.
+
+```
+                 ┌──────────────────────────────────────────┐
+   HTTP/WS  ───▶ │  API server  (entrypoints/openai/)        │
+                 └───────────────────┬──────────────────────┘
+                                     │
+                 ┌───────────────────▼──────────────────────┐
+                 │  Orchestrator  (engine/orchestrator.py)   │
+                 │  • owns per-request state                 │
+                 │  • polls every stage, routes outputs      │
+                 │  • forwards stage N output -> stage N+1   │
+                 └────┬───────────────┬───────────────┬──────┘
+                      │ ZMQ           │ ZMQ           │ ZMQ
+                 ┌────▼────┐     ┌────▼────┐     ┌────▼────┐
+                 │ Stage 0 │     │ Stage 1 │     │ Stage 2 │   each = its own
+                 │ process │     │ process │     │ process │   StageEngineCoreProc
+                 └─────────┘     └─────────┘     └─────────┘   subprocess + GPU
+                       └──── SharedMemoryConnector ────┘
+                            (bulk tensors/codec chunks)
+```
+
+### The pieces worth knowing
+
+| Concept | Where | What it is |
+|---|---|---|
+| **PipelineConfig** | `config/stage_config.py`, per-model `pipeline.py` | Frozen topology: how many stages, what each one is, how they connect. Registered per model architecture. |
+| **StagePipelineConfig** | same | One stage: `stage_id`, `model_stage` name, execution type, `input_sources`, whether its output is client-visible (`final_output`). |
+| **Deploy YAML** | `vllm_omni/deploy/*.yaml` | Runtime knobs per stage — GPU placement, memory, batching, samplers. Can overlay another via `base_config:`. |
+| **Orchestrator** | `engine/orchestrator.py` | The hub. Polls all stages in one loop, routes each output, decides when the whole request is done. |
+| **StagePool** | `engine/stage_pool.py` | One per stage; holds N replica clients. |
+| **Connectors** | `distributed/omni_connectors/` | Move bulk data stage→stage. Default `SharedMemoryConnector`. ZMQ carries control; SHM carries tensors. |
+
+### Two things that surprise people
+
+**Control and data travel differently.** Request submission and output polling
+go over ZMQ to each stage subprocess. The heavy payloads (hidden states, codec
+frames) go through shared memory. So "it's all ZMQ" is wrong.
+
+**One request ID spans all stages.** The same `req_id` is reused as a key in
+three disjoint scheduler namespaces. The orchestrator tracks
+`final_output_stage_ids` (a *set* — text and audio can both be client-visible)
+and only finishes the logical request when all of them have finished
+(`orchestrator.py:1233-1241`).
+
+---
+
+## 2. Full duplex
+
+### The problem it solves
+
+Normal serving is request-shaped: prompt in → output out → KV freed → done.
+A live voice assistant is stream-shaped: audio flows in continuously *while*
+audio flows out, the user can interrupt, and one conversation lives for
+minutes. RFC #3745 calls this the impedance mismatch.
+
+Concretely, without duplex you get one WebSocket connection per utterance and
+no way to interrupt without killing the connection.
+
+### How the framework does it
+
+Everything lives under `vllm_omni/experimental/fullduplex/`. It was built for
+MiniCPM-o 4.5 in PR #3907 and is targeted to leave `experimental/` in v0.28.
+
+```
+  WebSocket  /v1/realtime?duplex=1
+       │
+       ▼
+  OmniDuplexSessionHandler        openai/serving.py
+       │   session lifetime, admission, capabilities
+       ▼
+  DuplexSession  (+ per-model serving state)
+       │   epoch, turn, playback cursor, pending input
+       ▼
+  DuplexControlPlane              engine/duplex_control_plane.py
+       │   open / append / signal / close, all fenced
+       ▼
+  DuplexRuntimeExtension          ← THE MODEL PLUGS IN HERE
+       │
+       ▼
+  StagePool  ->  resumable scheduler request  ->  stages 0/1/2
+```
+
+### The three ideas that make it work
+
+**1. The session is the unit, not the request.** A stage-0 request is
+*resumable*: at a segment boundary it parks in `WAITING_FOR_STREAMING_REQ`
+with its KV intact instead of finishing, then accepts more input. KV is freed
+only at session close.
+
+**2. Fencing.** Every operation carries a `DuplexFence`
+(`session_id, epoch, turn_id, response_seq, incarnation`). Barge-in bumps the
+epoch; anything tagged with a stale epoch is dropped. This is how "stop
+talking, the user interrupted" works without tearing down the session.
+
+**3. A narrow model seam.** A model supplies exactly two objects:
+
+| Protocol | File | Methods |
+|---|---|---|
+| `DuplexRuntimeExtension` | `engine/contracts.py:63-97` | `configure_sampling_params`, `plan_append`, `decide_output` |
+| `ServingRuntimeAdapter` | `openai/runtime_adapter.py:107-146` | 9 methods + a 6-method `data_plane` |
+
+Registered by dotted path on the model's `PipelineConfig`
+(`duplex_runtime_extension`, `duplex_serving_adapter`,
+`duplex_control_enabled`).
+
+### The wire protocol that actually works
+
+This cost real time to discover — the working path is not the obvious one.
+
+- **Endpoint:** `ws://host/v1/realtime?duplex=1` — **not** `/v1/duplex`.
+  `/v1/duplex` exists but is a separate, far less exercised entry point.
+- Query params: `duplex=1`, `model=...`, `<model>_native_duplex=1`,
+  `autostart=0`.
+- Handshake: `session.update` (not `session.create`); server replies
+  `session.created`.
+- **`extra_body.auto_response: true` is the master switch.** Without it the
+  server never starts a response on commit, and the session silently produces
+  nothing.
+- Audio in: `input_audio_buffer.append`, base64 **pcm16** @ 16 kHz, ~200 ms
+  chunks.
+- Turn end: `input_audio_buffer.commit` with `final: true`. **Never send
+  `response.create`** — it routes to the chat fallback.
+- `turn_detection: null` — for a model-driven duplex model, the model owns
+  turn-taking, not server VAD.
+- Audio out: `response.audio.delta` (base64 pcm16 @ 24 kHz), bracketed by
+  `response.speak` and `response.audio.done`.
+
+### What the framework does *not* claim (`DESIGN.md:63-70`)
+
+- scheduler-native KV append
+- deterministic VAD-triggered interruption
+- production multi-session admission / fairness / failure recovery
+- bounded long-session KV
+- video input
+
+---
+
+## 3. Qwen3-Omni specifically
+
+### The model
+
+```
+Stage 0  Thinker    audio+text+video in -> text out        (LLM_AR,        final_output: text)
+Stage 1  Talker     text/hidden -> RVQ codec codes         (LLM_AR)
+Stage 2  Code2Wav   codec codes -> waveform                (LLM_GENERATION, final_output: audio)
+```
+
+Defined in `model_executor/models/qwen3_omni/pipeline.py:34-69`. Structurally
+near-identical to MiniCPM-o 4.5's topology, which is why the port is viable at
+all.
+
+### Where Qwen3-Omni differs from MiniCPM — and why it matters
+
+| | MiniCPM-o 4.5 | Qwen3-Omni |
+|---|---|---|
+| Turn-taking | **Learned `<\|listen\|>` / `<\|speak\|>` tokens** — the model decides | **None.** Standard instruct LLM. Turn boundaries must come from the client |
+| Audio encode | Streaming encoder with KV carried across chunks | No incremental encode — but its conv stack is chunked at exactly 1 s, so per-chunk encoding is lossless at the conv level |
+| Prompt | Model-native unit framing | Needs explicit chat-template scaffolding to reply at all |
+| `/v1/realtime` | Free | **Already taken** by the existing half-duplex handler |
+
+The first row is the deep one: MiniCPM's whole duplex design assumes the model
+owns listen/speak. Qwen3-Omni can't, so this port advertises
+`supports_model_native_turn_policy=False` and relies on client-signalled turns.
+
+### Audio geometry (load-bearing, and easy to get wrong)
+
+The thinker uses a `WhisperFeatureExtractor`, `hop_length=160` @ 16 kHz →
+100 mel frames per second. Token count follows vLLM's
+`_get_feat_extract_output_lengths`: **13 tokens per second**, not a linear
+ratio.
+
+Two ways this bites:
+- A linear `samples/token` approximation gives 10 tokens/s — 30% under.
+- Whisper's extractor pads to 30 s by default → 3000 mel frames for a 1 s
+  chunk instead of 100.
+
+Both are **silent**: the model runner absorbs an embedding/reservation
+mismatch by truncating or padding without raising.
+
+### Why 1-second chunks
+
+`Qwen3OmniMoeAudioEncoder.forward` splits its conv input into `n_window * 2 ==
+100` mel frames = exactly 1.0 s. A 1 s duplex chunk lands on the model's own
+conv boundary, so per-chunk encoding has **zero** convolutional boundary error.
+Attention still spans 8 such chunks, so streaming remains an approximation at
+the attention level only.
+
+### Current state of the port
+
+Branch `feat/qwen3-omni-fullduplex`, worktree `~/vllm-omni-duplex`.
+
+**Working, observed on a live 3-stage server:**
+- session handshake, audio ingest through the real audio tower
+- chat scaffolding and turn closure
+- thinker generation
+- **speech output** — 20 `response.audio.delta`, 24 kHz, verified speech-like
+  by envelope analysis (33% silent / 42% loud 100 ms frames), not just
+  "bytes arrived"
+
+**Not yet — and the first item is serious:**
+- **The reply does not terminate sensibly.** A 4 s input produces ~385 s of
+  audio, byte-identical across runs, which is the `max_tokens` ceiling rather
+  than an end-of-speech decision. Speech comes out, but the turn never ends on
+  its own. Until this is fixed the endpoint is not usable.
+- transcript deltas arrive but carry no text (extraction or projection issue)
+- barge-in still unproven: in the one attempt, zero audio deltas had arrived
+  before the interrupt, so no true overlap was exercised
+- stage 1 crashes on abort: `RuntimeError: Invalid request status:
+  FINISHED_ABORTED` (framework, defect 7)
+
+### Defects found during bring-up
+
+| # | Defect | Origin |
+|---|---|---|
+| 1 | Audio token geometry 10 vs 13 per second | this port |
+| 2 | Whisper 30 s default padding (230x over-reservation) | this port |
+| 3 | `DuplexFence` not JSON serializable in `runtime_control` | **framework** — issue #5612, PR #5613 |
+| 4 | `mtp_inputs` demanded on thinker decode | this port |
+| 5 | Data plane dropped every output (objects vs Mappings) | this port |
+| 6 | `chat_fallback.py:38` crashes reporting an error (`result.message`) | **framework**, unfiled |
+| 7 | Stage 1 abort → `FINISHED_ABORTED` in waiting queue | **framework**, under investigation |
+
+Every one presented identically: **nothing happens, no error**. The recurring
+shape is a silent drop at a boundary.
+
+---
+
+## 4. Where help is most useful
+
+**Highest leverage, no context needed**
+- Listen to a captured reply and judge whether it's a sensible answer to the
+  input, not just speech-shaped audio. Automated checks can only prove
+  "speech-like".
+- Decide the product answer for turn-taking. Qwen3-Omni has no learned
+  listen/speak, so *something* must decide when the user stopped: client
+  push-to-talk, client VAD, or a server VAD stage. This is a product call, not
+  a code one, and it shapes the design.
+
+**Needs repo context**
+- Defect 7 (stage-1 abort) — a framework bug that blocks barge-in.
+- Whether `response.audio_transcript.delta` is meant to carry text for a model
+  whose transcript comes from a different stage than its audio.
+
+**Worth knowing before deep investment**
+- A maintainer opened an architecture discussion for full duplex on #3745 and
+  targets v0.28 (~4 weeks) for moving it out of `experimental/`. The
+  model-facing seams are the likely survivors; packaging is the likely churn.

--- a/examples/online_serving/qwen3_omni_duplex/.gitignore
+++ b/examples/online_serving/qwen3_omni_duplex/.gitignore
@@ -1,0 +1,1 @@
+deploy.local.yaml

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -123,55 +123,49 @@ If you are debugging something new here, still **reset before each experiment**
 nothing, so measurements taken after a wedge look like data and are not. Two of
 ours were contaminated that way.
 
-## Open: later turns answer the first question
+## Solved: later turns answered the first question
 
-Canonical reproduction, two spoken turns in one session:
+Symptoms, all one bug: later turns affirming turn 1's topic, generic greetings
+("I'm doing well, how can I assist you today"), and finally the model saying
+outright that it was being sent *a lot of empty messages*. It was: from turn 2
+on, the thinker received a span of unfilled `<|audio_pad|>` placeholders where
+the audio should have been.
 
-```
-turn 1  "What is the capital of France?"  ->  "The capital of France is Paris."   correct
-turn 2  "What is the capital of the USA?" ->  "Yes, Paris is the capital of France."
-```
+Two coordinate systems were compared directly. `audio_offset` is `len(prefix)`,
+relative to **this append's** token span; `duplex_token_offset` is
+`num_computed_tokens`, absolute within the **session**. They coincide on the
+first append (both anchored at 0), which is why turn 1 always worked. On turn 2
+the absolute offset has advanced past the whole conversation so far, so
+`take_from` became 140 into a 78-row tensor, the window came out empty, and the
+guard returned without splicing -- silently, because the model runner absorbs a
+reservation/embedding mismatch rather than raising.
 
-and every turn after that keeps affirming turn 1. So turn 1 is heard correctly
-and later turns are not heard at all -- the model is answering from context
-rather than from new audio.
+Verified by sending *different* audio on each turn (the sample clip split in
+half) and transcribing the replies with a separate Qwen3-Omni:
 
-What is already ruled out:
+| turn | audio | before | after |
+|---|---|---|---|
+| 1 | 他当时还跟线下其他的站姐吵 | 他当时还跟线下其他站姐一起吗？ | *(identical -- control)* |
+| 2 | 吵架，然后打架进局子了 | 是的，她当时还和其他站姐一起线下活动。 | 真的假的啊？打架还进去了？现在人怎么样了？ |
 
-- Turn 2's audio *does* reach the model. Instrumenting the splice showed
-  `seq=2 embeds=(52, 2048)` spliced at the right offset, the same count as
-  turn 1.
-- Not accumulated audio context. `turn_audio` now resets when a turn closes,
-  and the earlier "re-encodes the whole conversation" bug is fixed.
-- Not the unclosed assistant turn. Later turns now open with `<|im_end|>` and a
-  newline.
-- Not microphone quality. Turn 1 is transcribed correctly, and capture now runs
-  at 16 kHz natively.
+Turn 2's reply now uses 打架 and 进去了, which appear only in the second half.
 
-So fresh embeddings are spliced into a well-formed prompt and the model still
-ignores them. The next thing to check is whether those embeddings actually
-differ between turns -- log a cheap fingerprint (mean and norm) of the spliced
-span per turn. If turn 2's fingerprint matches turn 1's, stage 0 is serving
-stale audio despite the reset; if it differs, the problem is positional, and
-the resumable request's KV or position offsets for the appended span are the
-place to look.
+**Two lessons worth keeping.**
 
-## Open: generic replies
+The old ruled-out list here asserted "turn 2's audio *does* reach the model --
+instrumenting the splice showed `embeds=(52, 2048)` spliced at the right
+offset". That was false, and it cost the most time of anything in this
+investigation. The `audio embeds=` log line reports that the embeddings were
+*built*; the separate `[splice]` line reports that they were *installed*. Turn 2
+logged the first and not the second. Reading the wrong line as proof turned the
+real cause into a ruled-out branch, and sent the next three experiments at KV
+and position offsets instead.
 
-Later turns have been observed returning a generic greeting ("I'm doing well,
-how can I assist you today") regardless of what was said. The same clip has
-previously produced contextual replies, so this is not simply determinism.
-
-A generic greeting is what the model produces when the user turn carries no
-meaningful content, which points at the audio embeddings not landing for that
-turn rather than at generation. Worth checking first: whether the spliced
-embedding norm on turn 2+ matches turn 1 (instrument the splice in
-`thinker_duplex_preprocess`), since a silent or zeroed span would look exactly
-like this.
-
-Note the test clip is identical every time, so repeating it *should* give the
-same answer. Only differing spoken input producing identical replies is
-evidence of this bug.
+The proposed next step here -- fingerprint the spliced span's mean and norm per
+turn -- would not have found it either. The embeddings were fine and identical
+to turn 1's; they simply never landed. When output looks like the input was
+empty, check that the input was *installed* before checking whether it was
+*correct*.
 
 ## Troubleshooting
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -80,10 +80,22 @@ audio does not affect it. The session and its KV survive a cancel.
 starts a response on commit. Do not send `response.create` — on this path it
 routes to the chat fallback rather than the native duplex runtime.
 
-## Multi-turn
+## Multi-turn, and the remaining wedge
 
-Multi-turn works. Verified: two spoken turns in one session produce two
-independent replies, 9 audio deltas total.
+Two spoken turns in one session work: two independent replies, 9 audio deltas.
+
+**But the server still wedges after a few sessions.** Once wedged, every client
+fails identically -- audio is accepted and framed correctly, `response.created`
+is never emitted, and the session panel stays at 0 turns. A restart clears it.
+
+This is not client specific. `is_speech: true` on appends was suspected and
+ruled out: it works on a freshly started server and fails on a wedged one,
+exactly like every other payload shape. Any measurement taken after the wedge
+is worthless, so **reset before each experiment** -- two of ours were
+contaminated this way.
+
+The browser reaches the wedge sooner than a script because each interaction
+opens a session.
 
 This needed a framework fix. Downstream async-chunk stages stop polling the
 connector once their segment finishes, and only resume when they receive a

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -80,38 +80,34 @@ audio does not affect it. The session and its KV survive a cancel.
 starts a response on commit. Do not send `response.create` — on this path it
 routes to the chat fallback rather than the native duplex runtime.
 
-## Multi-turn, and the remaining wedge
+## Multi-turn and multi-session
 
-Two spoken turns in one session work: two independent replies, 9 audio deltas.
+Both work. Measured on one boot with a scripted client replaying this page's
+exact wire protocol: 5 consecutive sessions all answered, and 4 sessions × 3
+turns produced audio on all 12 turns.
 
-**But the server stops responding after two sessions.** It stays healthy and
-keeps accepting connections and audio; it simply never produces output again
-until restarted.
+Two framework fixes got it there.
 
-Capacity is not the cause. Raising stage `max_num_seqs` from 4 to 16 and
-`max_sessions` to 12 changed nothing: sessions 1 and 2 answer, session 3
-onward is silent. The limit is two regardless of configured capacity, which
-rules out slot exhaustion and points at per-session state that is established
-twice and then blocks. Once wedged, every client
-fails identically -- audio is accepted and framed correctly, `response.created`
-is never emitted, and the session panel stays at 0 turns. A restart clears it.
+**One session per boot** — `num_waiting_for_streaming_input` leaked one per
+session. `EngineCore.has_work()` reads through that counter, so a single
+phantom made stage 1 conclude it had no work while a live request sat in its
+`waiting` queue; the engine parked in `input_queue.get()` and never scheduled
+again. The talker never ran, so no codec tokens reached Code2Wav and the client
+waited forever on a healthy-looking server that kept accepting audio. Fixed in
+`OmniSchedulerMixin._resync_streaming_input_counter` — full mechanism in that
+docstring and in `docs/design/qwen3_omni_duplex_pr_map.md`.
 
-This is not client specific. `is_speech: true` on appends was suspected and
-ruled out: it works on a freshly started server and fails on a wedged one,
-exactly like every other payload shape. Any measurement taken after the wedge
-is worthless, so **reset before each experiment** -- two of ours were
-contaminated this way.
-
-The browser reaches the wedge sooner than a script because each interaction
-opens a session.
-
-This needed a framework fix. Downstream async-chunk stages stop polling the
+**One turn per session** — downstream async-chunk stages stop polling the
 connector once their segment finishes, and only resume when they receive a
 streaming update. The orchestrator prewarmed them on the *initial* stage-0
 submit but not on updates, so a second turn deadlocked: stage 0 generated and
 marked its segment finished while stage 1 was still parked from the previous
-turn and never read the new chunks. Stages 1 and 2 sat idle and the client saw
-nothing.
+turn and never read the new chunks.
+
+If you are debugging something new here, still **reset before each experiment**
+-- a wedged server accepts audio and frames it correctly while producing
+nothing, so measurements taken after a wedge look like data and are not. Two of
+ours were contaminated that way.
 
 ## Open: later turns answer the first question
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -80,46 +80,18 @@ audio does not affect it. The session and its KV survive a cancel.
 starts a response on commit. Do not send `response.create` — on this path it
 routes to the chat fallback rather than the native duplex runtime.
 
-## Known limitation: one turn per server boot
+## Multi-turn
 
-The pipeline currently serves **one spoken turn per server start**. The first
-turn works end to end. The next one -- whether it is a second question in the
-same session or a new session entirely -- completes the handshake, accepts
-audio, frames it correctly, and produces no output.
+Multi-turn works. Verified: two spoken turns in one session produce two
+independent replies, 9 audio deltas total.
 
-Observed directly in the browser demo: the first question produced a spoken
-reply with every stage lighting up, and the second stalled with no stage
-advancing past the microphone.
-
-Isolated so far:
-
-- Not session capacity. Reproduces with `max_sessions: 4` and matching stage
-  `max_num_seqs`.
-- Not the client. The scripted client and the browser fail identically.
-- Not `session.close`. A first session that never closes still poisons the
-  second.
-- Not stage 0 admission. The second request is created and generates its
-  first token; the reply never reaches the client, and the data plane sees
-  `outputs=None`.
-- Not session lifecycle. It reproduces across a session boundary *and* within
-  one open session, so the trigger is a completed turn rather than a completed
-  session.
-- Not the stop token. Removing `stop_token_ids` from stage-0 sampling was
-  tried on the theory that finishing the request made it unresumable
-  (`_handle_stopped_request` only re-enqueues stages where
-  `receives_chunks` is true, which excludes stage 0). Turn 2 fails identically
-  without it.
-
-Reproduces deterministically with two turns in one session against a freshly
-started server, so it is a state problem rather than a race.
-
-Between conversations:
-
-```bash
-./reset_server.sh              # restart and wait for :8099
-```
-
-Roughly a five minute model reload, so this is a workaround rather than a fix.
+This needed a framework fix. Downstream async-chunk stages stop polling the
+connector once their segment finishes, and only resume when they receive a
+streaming update. The orchestrator prewarmed them on the *initial* stage-0
+submit but not on updates, so a second turn deadlocked: stage 0 generated and
+marked its segment finished while stage 1 was still parked from the previous
+turn and never read the new chunks. Stages 1 and 2 sat idle and the client saw
+nothing.
 
 ## Troubleshooting
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -105,6 +105,23 @@ marked its segment finished while stage 1 was still parked from the previous
 turn and never read the new chunks. Stages 1 and 2 sat idle and the client saw
 nothing.
 
+## Open: generic replies
+
+Later turns have been observed returning a generic greeting ("I'm doing well,
+how can I assist you today") regardless of what was said. The same clip has
+previously produced contextual replies, so this is not simply determinism.
+
+A generic greeting is what the model produces when the user turn carries no
+meaningful content, which points at the audio embeddings not landing for that
+turn rather than at generation. Worth checking first: whether the spliced
+embedding norm on turn 2+ matches turn 1 (instrument the splice in
+`thinker_duplex_preprocess`), since a silent or zeroed span would look exactly
+like this.
+
+Note the test clip is identical every time, so repeating it *should* give the
+same answer. Only differing spoken input producing identical replies is
+evidence of this bug.
+
 ## Troubleshooting
 
 | Symptom | Cause |

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -48,6 +48,20 @@ work without setting up TLS.
 
 The reply plays automatically and the transcript appears as it arrives.
 
+## Without a browser
+
+`headless_client.py` speaks the same protocol this page does, reading
+`sample_16k.wav` instead of a microphone, so you can exercise the pipeline over
+SSH with no tunnel and no mic — and repeat it enough times to turn "it goes
+quiet sometimes" into a number:
+
+```bash
+python examples/online_serving/qwen3_omni_duplex/headless_client.py \
+  --sessions 5 --turns 3
+```
+
+It exits non-zero unless every turn of every session produced audio.
+
 ## What the diagram shows
 
 ```

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -105,6 +105,39 @@ marked its segment finished while stage 1 was still parked from the previous
 turn and never read the new chunks. Stages 1 and 2 sat idle and the client saw
 nothing.
 
+## Open: later turns answer the first question
+
+Canonical reproduction, two spoken turns in one session:
+
+```
+turn 1  "What is the capital of France?"  ->  "The capital of France is Paris."   correct
+turn 2  "What is the capital of the USA?" ->  "Yes, Paris is the capital of France."
+```
+
+and every turn after that keeps affirming turn 1. So turn 1 is heard correctly
+and later turns are not heard at all -- the model is answering from context
+rather than from new audio.
+
+What is already ruled out:
+
+- Turn 2's audio *does* reach the model. Instrumenting the splice showed
+  `seq=2 embeds=(52, 2048)` spliced at the right offset, the same count as
+  turn 1.
+- Not accumulated audio context. `turn_audio` now resets when a turn closes,
+  and the earlier "re-encodes the whole conversation" bug is fixed.
+- Not the unclosed assistant turn. Later turns now open with `<|im_end|>` and a
+  newline.
+- Not microphone quality. Turn 1 is transcribed correctly, and capture now runs
+  at 16 kHz natively.
+
+So fresh embeddings are spliced into a well-formed prompt and the model still
+ignores them. The next thing to check is whether those embeddings actually
+differ between turns -- log a cheap fingerprint (mean and norm) of the spliced
+span per turn. If turn 2's fingerprint matches turn 1's, stage 0 is serving
+stale audio despite the reset; if it differs, the problem is positional, and
+the resumable request's KV or position offsets for the appended span are the
+place to look.
+
 ## Open: generic replies
 
 Later turns have been observed returning a generic greeting ("I'm doing well,

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -80,11 +80,16 @@ audio does not affect it. The session and its KV survive a cancel.
 starts a response on commit. Do not send `response.create` — on this path it
 routes to the chat fallback rather than the native duplex runtime.
 
-## Known limitation: one session per server boot
+## Known limitation: one turn per server boot
 
-The pipeline currently serves **one conversation per server start**. The first
-session works; every later one completes the handshake, accepts audio, frames
-it correctly, and produces no output.
+The pipeline currently serves **one spoken turn per server start**. The first
+turn works end to end. The next one -- whether it is a second question in the
+same session or a new session entirely -- completes the handshake, accepts
+audio, frames it correctly, and produces no output.
+
+Observed directly in the browser demo: the first question produced a spoken
+reply with every stage lighting up, and the second stalled with no stage
+advancing past the microphone.
 
 Isolated so far:
 
@@ -93,9 +98,13 @@ Isolated so far:
 - Not the client. The scripted client and the browser fail identically.
 - Not `session.close`. A first session that never closes still poisons the
   second.
-- Not stage 0 admission. The second session's stage-0 request is created and
-  generates its first token; the reply never reaches the client, and the data
-  plane sees `outputs=None`.
+- Not stage 0 admission. The second request is created and generates its
+  first token; the reply never reaches the client, and the data plane sees
+  `outputs=None`.
+- Not session lifecycle. It reproduces across a session boundary *and* within
+  one open session, so the trigger is a completed turn rather than a completed
+  session. The likely area is the resumable stage-0 request not returning to a
+  state that accepts the next append.
 
 Between conversations:
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -84,7 +84,15 @@ routes to the chat fallback rather than the native duplex runtime.
 
 Two spoken turns in one session work: two independent replies, 9 audio deltas.
 
-**But the server still wedges after a few sessions.** Once wedged, every client
+**But the server stops responding after two sessions.** It stays healthy and
+keeps accepting connections and audio; it simply never produces output again
+until restarted.
+
+Capacity is not the cause. Raising stage `max_num_seqs` from 4 to 16 and
+`max_sessions` to 12 changed nothing: sessions 1 and 2 answer, session 3
+onward is silent. The limit is two regardless of configured capacity, which
+rules out slot exhaustion and points at per-session state that is established
+twice and then blocks. Once wedged, every client
 fails identically -- audio is accepted and framed correctly, `response.created`
 is never emitted, and the session panel stays at 0 turns. A restart clears it.
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -80,6 +80,31 @@ audio does not affect it. The session and its KV survive a cancel.
 starts a response on commit. Do not send `response.create` — on this path it
 routes to the chat fallback rather than the native duplex runtime.
 
+## Known limitation: one session per server boot
+
+The pipeline currently serves **one conversation per server start**. The first
+session works; every later one completes the handshake, accepts audio, frames
+it correctly, and produces no output.
+
+Isolated so far:
+
+- Not session capacity. Reproduces with `max_sessions: 4` and matching stage
+  `max_num_seqs`.
+- Not the client. The scripted client and the browser fail identically.
+- Not `session.close`. A first session that never closes still poisons the
+  second.
+- Not stage 0 admission. The second session's stage-0 request is created and
+  generates its first token; the reply never reaches the client, and the data
+  plane sees `outputs=None`.
+
+Between conversations:
+
+```bash
+./reset_server.sh              # restart and wait for :8099
+```
+
+Roughly a five minute model reload, so this is a workaround rather than a fix.
+
 ## Troubleshooting
 
 | Symptom | Cause |

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -103,8 +103,15 @@ Isolated so far:
   `outputs=None`.
 - Not session lifecycle. It reproduces across a session boundary *and* within
   one open session, so the trigger is a completed turn rather than a completed
-  session. The likely area is the resumable stage-0 request not returning to a
-  state that accepts the next append.
+  session.
+- Not the stop token. Removing `stop_token_ids` from stage-0 sampling was
+  tried on the theory that finishing the request made it unresumable
+  (`_handle_stopped_request` only re-enqueues stages where
+  `receives_chunks` is true, which excludes stage 0). Turn 2 fails identically
+  without it.
+
+Reproduces deterministically with two turns in one session against a freshly
+started server, so it is a state problem rather than a race.
 
 Between conversations:
 

--- a/examples/online_serving/qwen3_omni_duplex/README.md
+++ b/examples/online_serving/qwen3_omni_duplex/README.md
@@ -1,0 +1,90 @@
+# Qwen3-Omni full-duplex browser demo
+
+Talk to Qwen3-Omni over the duplex WebSocket and watch the three stages light
+up as your turn moves through them.
+
+Status: experimental. See
+`vllm_omni/experimental/fullduplex/qwen3omni/` and
+`docs/design/vllm_omni_architecture_primer.md`.
+
+## 1. Start the server
+
+```bash
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
+  --deploy-config <your duplex deploy yaml> \
+  --host 0.0.0.0 --port 8099
+```
+
+The deploy config must set `session_mode: duplex` at the top level — that is
+what registers the duplex routes. See
+`docs/design/qwen3_omni_duplex_deploy.example.yaml`.
+
+## 2. Serve this page
+
+```bash
+python -m http.server 8100 --directory examples/online_serving/qwen3_omni_duplex
+```
+
+## 3. Open it
+
+**Local machine:** <http://localhost:8100/app.html>
+
+**Remote server:** forward both ports, then open the same URL locally.
+
+```bash
+ssh -L 8100:localhost:8100 -L 8099:localhost:8099 user@host
+```
+
+Forwarding matters for more than reach: browsers only grant microphone access
+on `localhost` or HTTPS, so tunnelling to `localhost` is what makes the mic
+work without setting up TLS.
+
+## Using it
+
+1. **Connect** — opens the WebSocket and sends the `session.update` handshake.
+2. **Hold to talk** — streams 200 ms `input_audio_buffer.append` frames while
+   held; release sends `input_audio_buffer.commit`.
+3. **Barge in** — sends `input.cancel` mid-reply, bumping the session epoch.
+
+The reply plays automatically and the transcript appears as it arrives.
+
+## What the diagram shows
+
+```
+mic ──ws append──▶ Stage 0 ──hidden──▶ Stage 1 ──shm──▶ Stage 2 ──ws audio──▶ playback
+                   Thinker             Talker           Code2Wav
+                   audio→text          text→codec       codec→audio
+```
+
+Each stage is a separate OS process with its own GPU allocation and scheduler.
+A card turns blue while its stage is active and green when it finishes; the
+counters are driven by real events on the wire.
+
+Stage 1 shows `flowing` rather than a count. Its codec tokens are internal to
+the pipeline and never surface as client events — you only see the effect when
+Stage 2 starts emitting audio.
+
+## Notes on this adapter
+
+**Audio is held until commit.** The framework can stream each appended chunk
+to the thinker as it arrives, which is right for a model with learned
+listen/speak tokens. Qwen3-Omni has none, so an intermediate append asks it to
+continue a user turn that has no `<|audio_end|>` yet, and it produces garbage.
+Holding until commit gives it one well-formed turn. The cost is that
+time-to-first-token starts at release rather than during speech.
+
+**Barge-in works on the session epoch,** not on append cadence, so holding
+audio does not affect it. The session and its KV survive a cancel.
+
+**`extra_body.auto_response: true` is required.** Without it the server never
+starts a response on commit. Do not send `response.create` — on this path it
+routes to the chat fallback rather than the native duplex runtime.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Connect fails | Server not up, or port 8099 not forwarded. Check `curl localhost:8099/health`. |
+| No mic prompt | Page not on `localhost`/HTTPS. Use the SSH tunnel above. |
+| Connects, no reply | `auto_response` missing, or the deploy config lacks `session_mode: duplex`. |
+| Reply is garbled | Server is running an older build without the hold-until-commit fix. |

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -83,6 +83,8 @@
   <button id="talk" disabled>Hold to talk</button>
   <button id="bargein" disabled>Barge in</button>
   <button id="sendclip" disabled title="Send a known-good 16 kHz clip, bypassing the mic">Send test clip</button>
+  <input id="textin" disabled placeholder="…or type a message and press Enter"
+         title="Sends input.text.append: one text message is one complete user turn">
   <span id="status" class="sub">idle</span>
 </header>
 
@@ -265,6 +267,7 @@ $("connect").onclick = () => {
     ws = null; recording = false;
     $("connect").textContent = "Connect"; $("talk").disabled = true;
     $("bargein").disabled = true; $("sendclip").disabled = true;
+    $("textin").disabled = true;
     $("status").textContent = "disconnected — click Connect";
     $("k-state").textContent = "disconnected";
     ["s-mic","s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
@@ -277,7 +280,7 @@ $("connect").onclick = () => {
 
     if (t === "session.created" || t === "session.updated") {
       $("talk").disabled = false; $("bargein").disabled = false;
-      $("sendclip").disabled = false;
+      $("sendclip").disabled = false; $("textin").disabled = false;
       $("status").textContent = "ready";
       $("k-state").textContent = "open";
       if (m.session?.id || m.session_id) $("k-sid").textContent = (m.session?.id || m.session_id).slice(0, 22);
@@ -463,6 +466,23 @@ $("sendclip").onclick = async () => {
 // cases `beforeunload` does not (bfcache, mobile), so handle both.
 window.addEventListener("pagehide", closeSession);
 window.addEventListener("beforeunload", closeSession);
+
+// Text turn. Unlike audio there is no buffer and no commit: one message is one
+// complete user turn, so the server treats input.text.append as final.
+$("textin").addEventListener("keydown", e => {
+  if (e.key !== "Enter" || e.shiftKey) return;
+  e.preventDefault();
+  const text = $("textin").value.trim();
+  if (!text || !ws || ws.readyState !== 1) return;
+  $("textin").value = "";
+  ["s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
+  setStage("s-mic", "done");
+  $("transcript").classList.add("muted"); $("transcript").textContent = "—";
+  $("status").textContent = "thinking…";
+  commitAt = performance.now();
+  ws.send(JSON.stringify({type:"input.text.append", text}));
+  log(`input.text.append ${JSON.stringify(text)}`, "life");
+});
 
 $("bargein").onclick = () => {
   if (!ws || ws.readyState !== 1) return;

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -347,6 +347,11 @@ async function startMic() {
         sample_rate_hz: SR_IN,
         duration_ms: CHUNK_MS,
         audio_end_ms: sentMs,
+        // Push-to-talk is itself the speech assertion. Without this the
+        // server falls back to an RMS heuristic and a quiet or slow-starting
+        // utterance is treated as silence, which never starts a response
+        // (commit_policy: auto_responds AND speech_since_commit).
+        is_speech: true,
       }));
       $("m-mic").textContent = (sentMs / 1000).toFixed(1);
     }
@@ -406,7 +411,7 @@ $("sendclip").onclick = async () => {
         type: "input_audio_buffer.append",
         audio: b64(pcm.slice(off, off + bytesPerChunk).buffer),
         input_audio_format: "pcm16", sample_rate_hz: SR_IN,
-        duration_ms: CHUNK_MS, audio_end_ms: sentMs,
+        duration_ms: CHUNK_MS, audio_end_ms: sentMs, is_speech: true,
       }));
       $("m-mic").textContent = (sentMs / 1000).toFixed(1);
       await new Promise(r => setTimeout(r, 10));

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -199,6 +199,16 @@ const TOOLS = [
 // server intercepts it before the talker can speak it, so it arrives as text
 // rather than audio. Run it and hand the result straight back as the next turn.
 let turnText = "", toolsFired = false;
+// Every tool call already dispatched this session, by signature.
+//
+// A tool result is itself a turn, so re-dispatching one is self-sustaining: it
+// produces a reply, which is scanned, which dispatches again. That ran away
+// once for real (1204 turns, 105 s of audio repeating a single sentence) when
+// the server was replaying cumulative text. The server no longer does that,
+// but this is the client's own brake -- a loop here costs GPU on every
+// iteration, so it should not depend on the server being correct.
+const dispatched = new Set();
+const MAX_TOOL_DISPATCHES = 8;
 
 // Fire once per turn, as soon as a `<tool_call>` block is closed -- an
 // unterminated one means the arguments are still streaming.
@@ -213,8 +223,16 @@ function maybeRunTools(explicit) {
       catch (e) { log(`unparseable tool call: ${m[1].slice(0, 120)}`, "err"); }
     }
   }
+  calls = calls.filter(c => {
+    const sig = `${c.name}:${JSON.stringify(c.arguments || {})}`;
+    if (dispatched.has(sig)) { log(`tool ${c.name} already dispatched — ignoring repeat`, "warn"); return false; }
+    if (dispatched.size >= MAX_TOOL_DISPATCHES) { log(`tool dispatch cap (${MAX_TOOL_DISPATCHES}) hit — ignoring`, "err"); return false; }
+    dispatched.add(sig);
+    return true;
+  });
   if (!calls.length) return;
   toolsFired = true;
+  stopPlayback();
   $("transcript").classList.remove("muted");
   $("transcript").textContent = calls.map(c => `→ ${c.name}(${JSON.stringify(c.arguments)})`).join("\n");
   runToolCalls(calls);
@@ -244,7 +262,7 @@ async function runToolCalls(calls) {
 const MODEL = "Qwen/Qwen3-Omni-30B-A3B-Instruct";
 const $ = id => document.getElementById(id);
 
-let ws, audioCtx, micStream, micNode, playCtx, playAt = 0;
+let ws, audioCtx, micStream, micNode, playCtx, playAt = 0, scheduled = [];
 let sentMs = 0, recvBytes = 0, turns = 0, textDeltas = 0, audioDeltas = 0;
 let commitAt = 0, recording = false, buf = [];
 
@@ -311,6 +329,21 @@ function playPcm16(u8, sr) {
   const now = playCtx.currentTime;
   playAt = Math.max(playAt, now + 0.03);
   src.start(playAt); playAt += b.duration;
+  scheduled.push(src);
+  src.onended = () => { const i = scheduled.indexOf(src); if (i >= 0) scheduled.splice(i, 1); };
+}
+
+// Audio already scheduled for the current response, so it can be cut short.
+//
+// A tool call is spoken before it can be intercepted: under async_chunk the
+// talker consumes the thinker's tokens as they stream, so by the time
+// `</tool_call>` closes, the audio for it already exists. Nothing server-side
+// can unmake it -- measured at 6-9 s of the model reading JSON aloud
+// ("Cough name check inventory argument item spoons"). The client hears it
+// only if it plays it, so on detecting a tool call, drop what is queued.
+function stopPlayback() {
+  for (const src of scheduled.splice(0)) { try { src.stop(); } catch (e) { /* already ended */ } }
+  playAt = 0;
 }
 
 function closeSession() {
@@ -331,6 +364,7 @@ $("connect").onclick = () => {
   $("status").textContent = "connecting…";
 
   ws.onopen = () => {
+    dispatched.clear(); turnText = ""; toolsFired = false;
     $("connect").textContent = "Disconnect";
     $("k-state").textContent = "handshaking";
     // Shapes from vllm_omni/experimental/fullduplex/client.py, with the

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -219,8 +219,18 @@ function playPcm16(u8, sr) {
   src.start(playAt); playAt += b.duration;
 }
 
+function closeSession() {
+  // A duplex session outlives the socket: dropping the transport alone leaves
+  // the session holding its stage-0 slot until it is reaped. With one slot per
+  // session and a small max_num_seqs, a few reloads exhaust the pipeline and
+  // every later turn silently produces nothing. Always tell the server.
+  if (ws && ws.readyState === 1) {
+    try { ws.send(JSON.stringify({type:"session.close"})); } catch (e) { /* closing anyway */ }
+  }
+}
+
 $("connect").onclick = () => {
-  if (ws) { ws.close(); return; }
+  if (ws) { closeSession(); ws.close(); return; }
   const url = `${$("url").value}?duplex=1&model=${encodeURIComponent(MODEL)}`
             + `&qwen3_omni_native_duplex=1&autostart=0`;
   ws = new WebSocket(url);
@@ -427,6 +437,11 @@ $("sendclip").onclick = async () => {
     setTimeout(() => { $("sendclip").disabled = false; }, 1500);
   }
 };
+
+// A refresh or tab close must release the session too. `pagehide` fires in
+// cases `beforeunload` does not (bfcache, mobile), so handle both.
+window.addEventListener("pagehide", closeSession);
+window.addEventListener("beforeunload", closeSession);
 
 $("bargein").onclick = () => {
   if (!ws || ws.readyState !== 1) return;

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -69,6 +69,7 @@
   .ev.text  .ty { color:var(--live); }
   .ev.err   .ty { color:var(--err); }
   .ev.life  .ty { color:var(--warn); }
+  .ev.tool  .ty { color:#c792ea; font-weight:600; }
 
   #transcript { min-height:52px; font-size:15px; line-height:1.6; }
   .muted { color:var(--dim); }
@@ -156,6 +157,90 @@
 
 <script>
 const SR_IN = 16000, SR_OUT = 24000, CHUNK_MS = 200;
+
+// Demo tools. `schema` goes to the model as its <tools> block; `run` is the
+// canned implementation. Tools execute client-side, as they do in the OpenAI
+// Realtime API -- the server only reports the call and takes the result back
+// as an ordinary text turn.
+const TOOLS = [
+  {
+    schema: {
+      type: "function",
+      function: {
+        name: "lookup_weather",
+        description: "Get the current weather for a city.",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string", description: "City name, e.g. Paris" } },
+          required: ["city"],
+        },
+      },
+    },
+    run: ({ city }) => ({ city: city || "unknown", temperature_c: 18, conditions: "light rain", humidity_pct: 71 }),
+  },
+  {
+    schema: {
+      type: "function",
+      function: {
+        name: "check_inventory",
+        description: "Check warehouse stock for an item.",
+        parameters: {
+          type: "object",
+          properties: { item: { type: "string", description: "Item name, e.g. blue widget" } },
+          required: ["item"],
+        },
+      },
+    },
+    run: ({ item }) => ({ item: item || "unknown", in_stock: 42, warehouse: "Oakland", restock_date: "2026-08-14" }),
+  },
+];
+
+// The model replies to a tool call with `<tool_call>{...}</tool_call>` and the
+// server intercepts it before the talker can speak it, so it arrives as text
+// rather than audio. Run it and hand the result straight back as the next turn.
+let turnText = "", toolsFired = false;
+
+// Fire once per turn, as soon as a `<tool_call>` block is closed -- an
+// unterminated one means the arguments are still streaming.
+function maybeRunTools(explicit) {
+  if (toolsFired) return;
+  let calls = explicit;
+  if (!calls) {
+    if (!turnText.includes("</tool_call>")) return;
+    calls = [];
+    for (const m of turnText.matchAll(/<tool_call>\s*(\{[\s\S]*?\})\s*<\/tool_call>/g)) {
+      try { const c = JSON.parse(m[1]); if (c && c.name) calls.push({name: c.name, arguments: c.arguments || {}}); }
+      catch (e) { log(`unparseable tool call: ${m[1].slice(0, 120)}`, "err"); }
+    }
+  }
+  if (!calls.length) return;
+  toolsFired = true;
+  $("transcript").classList.remove("muted");
+  $("transcript").textContent = calls.map(c => `→ ${c.name}(${JSON.stringify(c.arguments)})`).join("\n");
+  runToolCalls(calls);
+}
+
+async function runToolCalls(calls) {
+  for (const call of calls) {
+    const tool = TOOLS.find(t => t.schema.function.name === call.name);
+    const args = call.arguments || {};
+    let result;
+    if (!tool) {
+      result = { error: `no such tool: ${call.name}` };
+      log(`tool ${call.name} — not registered`, "err");
+    } else {
+      result = tool.run(args);
+      log(`tool ${call.name}(${JSON.stringify(args)}) -> ${JSON.stringify(result)}`, "tool");
+    }
+    if (!ws || ws.readyState !== 1) return;
+    // <tool_response> is the wrapper the checkpoint's chat template uses for a
+    // tool result, carried on a user turn.
+    const payload = `<tool_response>\n${JSON.stringify(result)}\n</tool_response>`;
+    commitAt = performance.now();
+    $("status").textContent = "tool result sent…";
+    ws.send(JSON.stringify({ type: "input.text.append", text: payload }));
+  }
+}
 const MODEL = "Qwen/Qwen3-Omni-30B-A3B-Instruct";
 const $ = id => document.getElementById(id);
 
@@ -259,7 +344,10 @@ $("connect").onclick = () => {
       turn_detection: null,
       overlap_policy: "listen_only",
       playback_commit_policy: "ack_only",
-      extra_body: { auto_response: true, qwen3_omni_native_duplex: true, force_listen_count: 0 },
+      extra_body: {
+        auto_response: true, qwen3_omni_native_duplex: true, force_listen_count: 0,
+        realtime_tools: TOOLS.map(t => t.schema),
+      },
     }}));
   };
 
@@ -287,7 +375,7 @@ $("connect").onclick = () => {
       log(t, "life");
     } else if (t === "response.created") {
       turns++; $("k-turns").textContent = turns;
-      textDeltas = 0; audioDeltas = 0;
+      textDeltas = 0; audioDeltas = 0; turnText = ""; toolsFired = false;
       setStage("s-0", "live"); flow("a-0", true); flow("a-1", true);
       log(t, "life");
     } else if (t === "response.audio_transcript.delta" || t === "response.output_text.delta") {
@@ -301,6 +389,8 @@ $("connect").onclick = () => {
       textDeltas++; $("m-0").textContent = textDeltas;
       setStage("s-0", "live");
       log(t + (d ? ` ${JSON.stringify(d)}` : " (empty)"), "text");
+      turnText += d;
+      maybeRunTools();
     } else if (t === "response.audio_transcript.done") {
       if (m.transcript) {
         $("transcript").classList.remove("muted");
@@ -325,6 +415,8 @@ $("connect").onclick = () => {
       if (commitAt) { $("k-lat").textContent = ((performance.now() - commitAt) / 1000).toFixed(2) + " s"; commitAt = 0; }
       log(`${t} ${(m.delta || m.audio || "").length}b`, "audio");
     } else if (t === "response.audio.done" || t === "response.done") {
+      // The server may also report the calls structurally; either path works.
+      maybeRunTools(Array.isArray(m.tool_calls) && m.tool_calls.length ? m.tool_calls : undefined);
       setStage("s-2", "done"); setStage("s-spk", "done");
       ["a-0","a-1","a-2","a-3"].forEach(a => flow(a, false));
       $("status").textContent = "ready";

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -1,0 +1,397 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: Copyright contributors to the vLLM project -->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Qwen3-Omni full duplex</title>
+<style>
+  :root {
+    --bg:#0f1115; --panel:#171a21; --line:#252a34; --txt:#e6e9ef; --dim:#8b93a7;
+    --idle:#2a3040; --live:#4ea1ff; --done:#38d39f; --warn:#ffb454; --err:#ff6b6b;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--txt);
+         font:14px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
+  header { padding:14px 20px; border-bottom:1px solid var(--line); display:flex;
+           align-items:center; gap:16px; flex-wrap:wrap; }
+  h1 { font-size:15px; margin:0; font-weight:600; letter-spacing:.2px; }
+  .sub { color:var(--dim); font-size:12px; }
+  main { display:grid; grid-template-columns:1fr 380px; gap:0; height:calc(100vh - 59px); }
+  @media (max-width:1000px){ main { grid-template-columns:1fr; height:auto; } }
+  #left { padding:20px; overflow:auto; }
+  #right { border-left:1px solid var(--line); padding:16px 18px; overflow:auto; background:#12151b; }
+
+  button { background:var(--panel); color:var(--txt); border:1px solid var(--line);
+           padding:8px 16px; border-radius:7px; cursor:pointer; font-size:13px; }
+  button:hover:not(:disabled) { border-color:var(--live); }
+  button:disabled { opacity:.4; cursor:not-allowed; }
+  button.primary { background:var(--live); border-color:var(--live); color:#05204a; font-weight:600; }
+  button.rec { background:var(--err); border-color:var(--err); color:#fff; font-weight:600; }
+  input { background:var(--panel); color:var(--txt); border:1px solid var(--line);
+          padding:7px 10px; border-radius:6px; font-size:12px; width:270px; }
+
+  .pipe { display:flex; align-items:stretch; gap:0; margin:8px 0 26px; flex-wrap:wrap; }
+  .stage { flex:1; min-width:150px; background:var(--panel); border:1px solid var(--line);
+           border-radius:10px; padding:14px; position:relative; transition:all .18s; }
+  .stage.live { border-color:var(--live); box-shadow:0 0 0 1px var(--live),0 0 22px -6px var(--live); }
+  .stage.done { border-color:var(--done); }
+  .stage h3 { margin:0 0 3px; font-size:13px; }
+  .stage .role { color:var(--dim); font-size:11px; margin-bottom:9px; }
+  .stage .metric { font-variant-numeric:tabular-nums; font-size:19px; font-weight:600; }
+  .stage .unit { color:var(--dim); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
+  .dot { position:absolute; top:12px; right:12px; width:8px; height:8px; border-radius:50%;
+         background:var(--idle); transition:background .18s; }
+  .stage.live .dot { background:var(--live); animation:pulse 1s infinite; }
+  .stage.done .dot { background:var(--done); }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.35} }
+  .arrow { display:flex; align-items:center; padding:0 10px; color:var(--dim);
+           font-size:11px; flex-direction:column; justify-content:center; min-width:74px; }
+  .arrow .t { font-size:9px; text-transform:uppercase; letter-spacing:.05em; opacity:.7; }
+  .arrow.flow { color:var(--live); }
+
+  .card { background:var(--panel); border:1px solid var(--line); border-radius:10px;
+          padding:14px 16px; margin-bottom:16px; }
+  .card h2 { font-size:12px; margin:0 0 10px; color:var(--dim); text-transform:uppercase;
+             letter-spacing:.07em; font-weight:600; }
+  .kv { display:flex; justify-content:space-between; padding:3px 0; font-size:12px; }
+  .kv span:first-child { color:var(--dim); }
+  .kv span:last-child { font-variant-numeric:tabular-nums; }
+
+  #meter { height:5px; background:var(--idle); border-radius:3px; overflow:hidden; margin-top:9px; }
+  #meterBar { height:100%; width:0%; background:var(--done); transition:width .06s; }
+
+  #events { font:11px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; }
+  .ev { padding:2px 0; border-bottom:1px solid #1b1f27; display:flex; gap:8px; }
+  .ev .ts { color:#5a6478; min-width:52px; }
+  .ev .ty { flex:1; word-break:break-all; }
+  .ev.audio .ty { color:var(--done); }
+  .ev.text  .ty { color:var(--live); }
+  .ev.err   .ty { color:var(--err); }
+  .ev.life  .ty { color:var(--warn); }
+
+  #transcript { min-height:52px; font-size:15px; line-height:1.6; }
+  .muted { color:var(--dim); }
+  code { background:#0b0d12; padding:1px 5px; border-radius:4px; font-size:11px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Qwen3-Omni <span class="sub">full duplex</span></h1>
+  <input id="url" value="ws://127.0.0.1:8099/v1/realtime">
+  <button id="connect" class="primary">Connect</button>
+  <button id="talk" disabled>Hold to talk</button>
+  <button id="bargein" disabled>Barge in</button>
+  <span id="status" class="sub">idle</span>
+</header>
+
+<main>
+<div id="left">
+  <div class="pipe">
+    <div class="stage" id="s-mic">
+      <div class="dot"></div><h3>Your mic</h3><div class="role">pcm16 · 16 kHz</div>
+      <div class="metric" id="m-mic">0.0</div><div class="unit">seconds sent</div>
+      <div id="meter"><div id="meterBar"></div></div>
+    </div>
+    <div class="arrow" id="a-0"><div>&#8594;</div><div class="t">ws append</div></div>
+    <div class="stage" id="s-0">
+      <div class="dot"></div><h3>Stage 0 · Thinker</h3><div class="role">audio &#8594; text</div>
+      <div class="metric" id="m-0">0</div><div class="unit">text deltas</div>
+    </div>
+    <div class="arrow" id="a-1"><div>&#8594;</div><div class="t">hidden states</div></div>
+    <div class="stage" id="s-1">
+      <div class="dot"></div><h3>Stage 1 · Talker</h3><div class="role">text &#8594; codec</div>
+      <div class="metric" id="m-1">&#8212;</div><div class="unit">codec (internal)</div>
+    </div>
+    <div class="arrow" id="a-2"><div>&#8594;</div><div class="t">shared memory</div></div>
+    <div class="stage" id="s-2">
+      <div class="dot"></div><h3>Stage 2 · Code2Wav</h3><div class="role">codec &#8594; audio</div>
+      <div class="metric" id="m-2">0</div><div class="unit">audio deltas</div>
+    </div>
+    <div class="arrow" id="a-3"><div>&#8594;</div><div class="t">ws audio</div></div>
+    <div class="stage" id="s-spk">
+      <div class="dot"></div><h3>Playback</h3><div class="role">pcm16 · 24 kHz</div>
+      <div class="metric" id="m-spk">0.0</div><div class="unit">seconds received</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Assistant said</h2>
+    <div id="transcript" class="muted">&#8212;</div>
+  </div>
+
+  <div class="card">
+    <h2>How a turn flows</h2>
+    <div style="font-size:12.5px;color:#b9c0d0">
+      <p style="margin:0 0 8px">Hold <b>talk</b> and speak. Audio streams to the server as
+      <code>input_audio_buffer.append</code> at 200&nbsp;ms. On release the client sends
+      <code>input_audio_buffer.commit</code>.</p>
+      <p style="margin:0 0 8px">This adapter <b>holds audio until commit</b>, then hands the
+      thinker one complete turn. Qwen3-Omni has no learned listen/speak token, so it cannot
+      decide mid-utterance whether you have finished &mdash; the client decides.</p>
+      <p style="margin:0"><b>Barge in</b> cancels the in-flight response and bumps the session
+      epoch. Stale audio is dropped, the session and its KV survive.</p>
+    </div>
+  </div>
+</div>
+
+<div id="right">
+  <div class="card">
+    <h2>Session</h2>
+    <div class="kv"><span>state</span><span id="k-state">disconnected</span></div>
+    <div class="kv"><span>session id</span><span id="k-sid">&#8212;</span></div>
+    <div class="kv"><span>epoch</span><span id="k-epoch">&#8212;</span></div>
+    <div class="kv"><span>turns</span><span id="k-turns">0</span></div>
+    <div class="kv"><span>reply latency</span><span id="k-lat">&#8212;</span></div>
+  </div>
+  <div class="card">
+    <h2>Events</h2>
+    <div id="events"></div>
+  </div>
+</div>
+</main>
+
+<script>
+const SR_IN = 16000, SR_OUT = 24000, CHUNK_MS = 200;
+const MODEL = "Qwen/Qwen3-Omni-30B-A3B-Instruct";
+const $ = id => document.getElementById(id);
+
+let ws, audioCtx, micStream, micNode, playCtx, playAt = 0;
+let sentMs = 0, recvBytes = 0, turns = 0, textDeltas = 0, audioDeltas = 0;
+let commitAt = 0, recording = false, buf = [];
+
+const setStage = (id, cls) => {
+  const el = $(id); el.classList.remove("live", "done");
+  if (cls) el.classList.add(cls);
+};
+const flow = (id, on) => $(id).classList.toggle("flow", on);
+
+function log(type, cls) {
+  const d = document.createElement("div");
+  d.className = "ev " + (cls || "");
+  const t = new Date().toLocaleTimeString("en-GB", {hour12:false});
+  d.innerHTML = `<span class="ts">${t}</span><span class="ty"></span>`;
+  d.querySelector(".ty").textContent = type;
+  $("events").prepend(d);
+  while ($("events").children.length > 250) $("events").lastChild.remove();
+}
+
+function resample(f32, from, to) {
+  if (from === to) return f32;
+  const ratio = from / to, out = new Float32Array(Math.floor(f32.length / ratio));
+  for (let i = 0; i < out.length; i++) {
+    const src = i * ratio, i0 = Math.floor(src), frac = src - i0;
+    out[i] = (f32[i0] || 0) * (1 - frac) + (f32[i0 + 1] || 0) * frac;
+  }
+  return out;
+}
+const toPcm16 = f32 => {
+  const b = new ArrayBuffer(f32.length * 2), v = new DataView(b);
+  for (let i = 0; i < f32.length; i++) {
+    const s = Math.max(-1, Math.min(1, f32[i]));
+    v.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return b;
+};
+const b64 = ab => {
+  let s = "", u = new Uint8Array(ab);
+  for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]);
+  return btoa(s);
+};
+const unb64 = s => {
+  const bin = atob(s), u = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+  return u;
+};
+
+function playPcm16(u8, sr) {
+  if (!playCtx) playCtx = new AudioContext();
+  const n = u8.byteLength / 2, dv = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
+  const f = new Float32Array(n);
+  for (let i = 0; i < n; i++) f[i] = dv.getInt16(i * 2, true) / 32768;
+  const b = playCtx.createBuffer(1, n, sr);
+  b.getChannelData(0).set(f);
+  const src = playCtx.createBufferSource();
+  src.buffer = b; src.connect(playCtx.destination);
+  const now = playCtx.currentTime;
+  playAt = Math.max(playAt, now + 0.03);
+  src.start(playAt); playAt += b.duration;
+}
+
+$("connect").onclick = () => {
+  if (ws) { ws.close(); return; }
+  const url = `${$("url").value}?duplex=1&model=${encodeURIComponent(MODEL)}`
+            + `&qwen3_omni_native_duplex=1&autostart=0`;
+  ws = new WebSocket(url);
+  $("status").textContent = "connecting…";
+
+  ws.onopen = () => {
+    $("connect").textContent = "Disconnect";
+    $("k-state").textContent = "handshaking";
+    // Shapes from vllm_omni/experimental/fullduplex/client.py, with the
+    // Qwen3-Omni opt-in. auto_response is the master switch: without it the
+    // server never starts a response on commit.
+    ws.send(JSON.stringify({type:"session.update", session:{
+      model: MODEL,
+      modalities: ["audio","text"],
+      input_audio_format: "pcm16",
+      output_audio_format: "pcm16",
+      turn_detection: null,
+      overlap_policy: "listen_only",
+      playback_commit_policy: "ack_only",
+      extra_body: { auto_response: true, qwen3_omni_native_duplex: true, force_listen_count: 0 },
+    }}));
+  };
+
+  ws.onclose = () => {
+    ws = null; recording = false;
+    $("connect").textContent = "Connect"; $("talk").disabled = true;
+    $("bargein").disabled = true; $("status").textContent = "idle";
+    $("k-state").textContent = "disconnected";
+    ["s-mic","s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
+  };
+  ws.onerror = () => log("websocket error", "err");
+
+  ws.onmessage = ev => {
+    if (typeof ev.data !== "string") return;
+    const m = JSON.parse(ev.data), t = m.type;
+
+    if (t === "session.created" || t === "session.updated") {
+      $("talk").disabled = false; $("bargein").disabled = false;
+      $("status").textContent = "ready";
+      $("k-state").textContent = "open";
+      if (m.session?.id || m.session_id) $("k-sid").textContent = (m.session?.id || m.session_id).slice(0, 22);
+      log(t, "life");
+    } else if (t === "response.created") {
+      turns++; $("k-turns").textContent = turns;
+      textDeltas = 0; audioDeltas = 0;
+      setStage("s-0", "live"); flow("a-0", true); flow("a-1", true);
+      log(t, "life");
+    } else if (t === "response.audio_transcript.delta" || t === "response.output_text.delta") {
+      const d = m.delta || "";
+      if (d) {
+        if ($("transcript").classList.contains("muted")) {
+          $("transcript").classList.remove("muted"); $("transcript").textContent = "";
+        }
+        $("transcript").textContent += d;
+      }
+      textDeltas++; $("m-0").textContent = textDeltas;
+      setStage("s-0", "live");
+      log(t + (d ? ` ${JSON.stringify(d)}` : " (empty)"), "text");
+    } else if (t === "response.audio_transcript.done") {
+      if (m.transcript) {
+        $("transcript").classList.remove("muted");
+        $("transcript").textContent = m.transcript;
+      }
+      log(t, "text");
+    } else if (t === "response.speak") {
+      setStage("s-0", "done"); setStage("s-1", "live"); flow("a-2", true);
+      log(t, "life");
+    } else if (t === "response.audio.delta") {
+      const data = m.delta || m.audio;
+      if (data) {
+        const u8 = unb64(data);
+        recvBytes += u8.byteLength;
+        playPcm16(u8, m.sample_rate_hz || SR_OUT);
+        $("m-spk").textContent = (recvBytes / 2 / (m.sample_rate_hz || SR_OUT)).toFixed(1);
+      }
+      audioDeltas++; $("m-2").textContent = audioDeltas;
+      $("m-1").textContent = "flowing";
+      setStage("s-1", "done"); setStage("s-2", "live"); setStage("s-spk", "live");
+      flow("a-3", true);
+      if (commitAt) { $("k-lat").textContent = ((performance.now() - commitAt) / 1000).toFixed(2) + " s"; commitAt = 0; }
+      log(`${t} ${(m.delta || m.audio || "").length}b`, "audio");
+    } else if (t === "response.audio.done" || t === "response.done") {
+      setStage("s-2", "done"); setStage("s-spk", "done");
+      ["a-0","a-1","a-2","a-3"].forEach(a => flow(a, false));
+      $("status").textContent = "ready";
+      log(t, "life");
+    } else if (t === "error") {
+      log("ERROR " + JSON.stringify(m.error || m.code || m), "err");
+      $("status").textContent = "error";
+    } else if (t === "audio.cancelled" || t === "input.cancelled") {
+      log(t + " (barge-in)", "warn");
+      playAt = 0;
+    } else {
+      if (m.epoch !== undefined) $("k-epoch").textContent = m.epoch;
+      log(t);
+    }
+    if (m.epoch !== undefined) $("k-epoch").textContent = m.epoch;
+  };
+};
+
+async function startMic() {
+  if (!audioCtx) audioCtx = new AudioContext();
+  micStream = await navigator.mediaDevices.getUserMedia({audio:{channelCount:1,
+    echoCancellation:true, noiseSuppression:true}});
+  const src = audioCtx.createMediaStreamSource(micStream);
+  micNode = audioCtx.createScriptProcessor(4096, 1, 1);
+  const need = Math.floor(SR_IN * CHUNK_MS / 1000);
+  micNode.onaudioprocess = e => {
+    if (!recording || !ws || ws.readyState !== 1) return;
+    const raw = e.inputBuffer.getChannelData(0);
+    let peak = 0; for (let i = 0; i < raw.length; i++) peak = Math.max(peak, Math.abs(raw[i]));
+    $("meterBar").style.width = Math.min(100, peak * 160) + "%";
+    const rs = resample(raw, audioCtx.sampleRate, SR_IN);
+    for (let i = 0; i < rs.length; i++) buf.push(rs[i]);
+    while (buf.length >= need) {
+      const slice = Float32Array.from(buf.splice(0, need));
+      sentMs += CHUNK_MS;
+      ws.send(JSON.stringify({
+        type: "input_audio_buffer.append",
+        audio: b64(toPcm16(slice)),
+        input_audio_format: "pcm16",
+        sample_rate_hz: SR_IN,
+        duration_ms: CHUNK_MS,
+        audio_end_ms: sentMs,
+      }));
+      $("m-mic").textContent = (sentMs / 1000).toFixed(1);
+    }
+  };
+  src.connect(micNode); micNode.connect(audioCtx.destination);
+}
+
+const beginTalk = async e => {
+  e.preventDefault();
+  if (!ws || ws.readyState !== 1 || recording) return;
+  if (!micNode) await startMic();
+  if (audioCtx.state === "suspended") await audioCtx.resume();
+  recording = true; buf = [];
+  $("talk").classList.add("rec"); $("talk").textContent = "Listening… release to send";
+  $("status").textContent = "listening";
+  setStage("s-mic", "live");
+  ["s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
+  $("transcript").classList.add("muted"); $("transcript").textContent = "—";
+  log("recording started", "life");
+};
+
+const endTalk = e => {
+  e.preventDefault();
+  if (!recording) return;
+  recording = false;
+  $("talk").classList.remove("rec"); $("talk").textContent = "Hold to talk";
+  $("meterBar").style.width = "0%";
+  setStage("s-mic", "done");
+  $("status").textContent = "thinking…";
+  commitAt = performance.now();
+  // No response.create: that routes to the chat fallback. The commit plus
+  // extra_body.auto_response is what starts the reply.
+  ws.send(JSON.stringify({type:"input_audio_buffer.commit", final:true}));
+  log("input_audio_buffer.commit", "life");
+};
+
+$("talk").addEventListener("mousedown", beginTalk);
+$("talk").addEventListener("touchstart", beginTalk, {passive:false});
+window.addEventListener("mouseup", endTalk);
+window.addEventListener("touchend", endTalk);
+
+$("bargein").onclick = () => {
+  if (!ws || ws.readyState !== 1) return;
+  ws.send(JSON.stringify({type:"input.cancel", scope:"current"}));
+  playAt = 0;
+  log("input.cancel sent (barge-in)", "warn");
+  $("status").textContent = "cancelled";
+};
+</script>
+</body>
+</html>

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -179,10 +179,17 @@ function log(type, cls) {
 
 function resample(f32, from, to) {
   if (from === to) return f32;
-  const ratio = from / to, out = new Float32Array(Math.floor(f32.length / ratio));
+  const ratio = from / to;
+  // Fallback only -- used when the browser will not give a 16 kHz context.
+  // Box-average over the source span before picking a sample, which is a
+  // crude but real low-pass; plain interpolation aliases badly at 3:1.
+  const span = Math.max(1, Math.round(ratio));
+  const out = new Float32Array(Math.floor(f32.length / ratio));
   for (let i = 0; i < out.length; i++) {
-    const src = i * ratio, i0 = Math.floor(src), frac = src - i0;
-    out[i] = (f32[i0] || 0) * (1 - frac) + (f32[i0 + 1] || 0) * frac;
+    const start = Math.floor(i * ratio);
+    let acc = 0, n = 0;
+    for (let k = 0; k < span && start + k < f32.length; k++) { acc += f32[start + k]; n++; }
+    out[i] = n ? acc / n : 0;
   }
   return out;
 }
@@ -334,7 +341,21 @@ $("connect").onclick = () => {
 };
 
 async function startMic() {
-  if (!audioCtx) audioCtx = new AudioContext();
+  // Request the capture context at the model's rate. Browsers resample
+  // properly (with anti-aliasing); the hand-rolled 3:1 decimation this
+  // replaces had no low-pass, so everything above 8 kHz aliased back into the
+  // speech band and the model heard mush -- it answered with a generic
+  // greeting because the turn carried no intelligible content.
+  if (!audioCtx) {
+    try {
+      audioCtx = new AudioContext({sampleRate: SR_IN});
+    } catch (e) {
+      audioCtx = new AudioContext();
+    }
+  }
+  if (audioCtx.sampleRate !== SR_IN) {
+    log(`mic context is ${audioCtx.sampleRate} Hz, resampling to ${SR_IN}`, "life");
+  }
   micStream = await navigator.mediaDevices.getUserMedia({audio:{channelCount:1,
     echoCancellation:true, noiseSuppression:true}});
   const src = audioCtx.createMediaStreamSource(micStream);

--- a/examples/online_serving/qwen3_omni_duplex/app.html
+++ b/examples/online_serving/qwen3_omni_duplex/app.html
@@ -82,6 +82,7 @@
   <button id="connect" class="primary">Connect</button>
   <button id="talk" disabled>Hold to talk</button>
   <button id="bargein" disabled>Barge in</button>
+  <button id="sendclip" disabled title="Send a known-good 16 kHz clip, bypassing the mic">Send test clip</button>
   <span id="status" class="sub">idle</span>
 </header>
 
@@ -246,7 +247,8 @@ $("connect").onclick = () => {
   ws.onclose = () => {
     ws = null; recording = false;
     $("connect").textContent = "Connect"; $("talk").disabled = true;
-    $("bargein").disabled = true; $("status").textContent = "idle";
+    $("bargein").disabled = true; $("sendclip").disabled = true;
+    $("status").textContent = "disconnected — click Connect";
     $("k-state").textContent = "disconnected";
     ["s-mic","s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
   };
@@ -258,6 +260,7 @@ $("connect").onclick = () => {
 
     if (t === "session.created" || t === "session.updated") {
       $("talk").disabled = false; $("bargein").disabled = false;
+      $("sendclip").disabled = false;
       $("status").textContent = "ready";
       $("k-state").textContent = "open";
       if (m.session?.id || m.session_id) $("k-sid").textContent = (m.session?.id || m.session_id).slice(0, 22);
@@ -384,6 +387,41 @@ $("talk").addEventListener("mousedown", beginTalk);
 $("talk").addEventListener("touchstart", beginTalk, {passive:false});
 window.addEventListener("mouseup", endTalk);
 window.addEventListener("touchend", endTalk);
+
+$("sendclip").onclick = async () => {
+  if (!ws || ws.readyState !== 1) { log("not connected", "err"); return; }
+  $("sendclip").disabled = true;
+  $("status").textContent = "sending test clip…";
+  ["s-0","s-1","s-2","s-spk"].forEach(s => setStage(s, null));
+  setStage("s-mic", "live");
+  $("transcript").classList.add("muted"); $("transcript").textContent = "—";
+  try {
+    const wav = await (await fetch("sample_16k.wav")).arrayBuffer();
+    // 44-byte canonical WAV header, then 16-bit mono LE samples.
+    const pcm = new Uint8Array(wav, 44);
+    const bytesPerChunk = SR_IN * 2 * CHUNK_MS / 1000;
+    for (let off = 0; off + bytesPerChunk <= pcm.byteLength; off += bytesPerChunk) {
+      sentMs += CHUNK_MS;
+      ws.send(JSON.stringify({
+        type: "input_audio_buffer.append",
+        audio: b64(pcm.slice(off, off + bytesPerChunk).buffer),
+        input_audio_format: "pcm16", sample_rate_hz: SR_IN,
+        duration_ms: CHUNK_MS, audio_end_ms: sentMs,
+      }));
+      $("m-mic").textContent = (sentMs / 1000).toFixed(1);
+      await new Promise(r => setTimeout(r, 10));
+    }
+    setStage("s-mic", "done");
+    commitAt = performance.now();
+    ws.send(JSON.stringify({type:"input_audio_buffer.commit", final:true}));
+    log("test clip sent + commit", "life");
+    $("status").textContent = "thinking…";
+  } catch (err) {
+    log("test clip failed: " + err, "err");
+  } finally {
+    setTimeout(() => { $("sendclip").disabled = false; }, 1500);
+  }
+};
 
 $("bargein").onclick = () => {
   if (!ws || ws.readyState !== 1) return;

--- a/examples/online_serving/qwen3_omni_duplex/headless_client.py
+++ b/examples/online_serving/qwen3_omni_duplex/headless_client.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Drive this demo's duplex session from the command line, no browser.
+
+Mirrors app.html on the wire -- same query string, same ``session.update``,
+same 200 ms ``is_speech`` appends read from ``sample_16k.wav``, same commit,
+same ``session.close``. One "session" here is one Connect click.
+
+Useful because the browser needs a microphone and a tunnel, and because a
+reproduction you can run N times in a row is what turns "it goes silent
+sometimes" into a number:
+
+    python headless_client.py --sessions 5 --turns 3
+
+Exits non-zero unless every turn of every session produced audio.
+
+Turns are framed by silence on the wire, not by a terminator event:
+``response.audio.done`` and ``response.done`` both arrive, and a trailing one
+left queued reads as the *next* turn's terminator, which reports a working turn
+as empty. That artifact cost a wrong conclusion once already.
+"""
+
+import argparse
+import asyncio
+import base64
+import json
+import pathlib
+import sys
+import time
+
+import websockets
+
+MODEL = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+SR_IN = 16000
+CHUNK_MS = 200
+CLIP = pathlib.Path(__file__).parent / "sample_16k.wav"
+
+URL = (
+    "ws://127.0.0.1:8099/v1/realtime"
+    f"?duplex=1&model={MODEL.replace('/', '%2F')}"
+    "&qwen3_omni_native_duplex=1&autostart=0"
+)
+
+SESSION_UPDATE = {
+    "type": "session.update",
+    "session": {
+        "model": MODEL,
+        "modalities": ["audio", "text"],
+        "input_audio_format": "pcm16",
+        "output_audio_format": "pcm16",
+        "turn_detection": None,
+        "overlap_policy": "listen_only",
+        "playback_commit_policy": "ack_only",
+        "extra_body": {
+            "auto_response": True,
+            "qwen3_omni_native_duplex": True,
+            "force_listen_count": 0,
+        },
+    },
+}
+
+
+def stamp() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+class Turn:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.text = ""
+        self.audio_deltas = 0
+        self.audio_bytes = 0
+        self.response_created = False
+        self.errors: list[str] = []
+
+
+async def run_session(idx: int, turns: int, timeout: float, pcm: bytes) -> list[Turn]:
+    results: list[Turn] = []
+    print(f"[{stamp()}] session {idx}: connecting", flush=True)
+    async with websockets.connect(URL, max_size=None, open_timeout=30) as ws:
+        await ws.send(json.dumps(SESSION_UPDATE))
+
+        # Wait for session.created / session.updated before talking, like the
+        # browser enabling its buttons.
+        ready = False
+        deadline = time.monotonic() + 30
+        while not ready and time.monotonic() < deadline:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=5)
+            except asyncio.TimeoutError:
+                continue
+            msg = json.loads(raw)
+            if msg.get("type") in ("session.created", "session.updated"):
+                sid = (msg.get("session") or {}).get("id") or msg.get("session_id")
+                print(f"[{stamp()}] session {idx}: {msg['type']} sid={sid}", flush=True)
+                ready = True
+        if not ready:
+            print(f"[{stamp()}] session {idx}: NO session.created -- handshake hung", flush=True)
+            return results
+
+        bytes_per_chunk = SR_IN * 2 * CHUNK_MS // 1000
+        for turn_no in range(1, turns + 1):
+            turn = Turn()
+            results.append(turn)
+            sent_ms = 0
+            for off in range(0, len(pcm) - bytes_per_chunk + 1, bytes_per_chunk):
+                sent_ms += CHUNK_MS
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(pcm[off : off + bytes_per_chunk]).decode(),
+                            "input_audio_format": "pcm16",
+                            "sample_rate_hz": SR_IN,
+                            "duration_ms": CHUNK_MS,
+                            "audio_end_ms": sent_ms,
+                            "is_speech": True,
+                        }
+                    )
+                )
+                await asyncio.sleep(0.01)
+            await ws.send(json.dumps({"type": "input_audio_buffer.commit", "final": True}))
+            t_commit = time.monotonic()
+            print(f"[{stamp()}] session {idx} turn {turn_no}: committed {sent_ms} ms", flush=True)
+
+            # Drain everything this turn produces. Terminators are not a
+            # reliable frame boundary here (`response.audio.done` and
+            # `response.done` both arrive, and a trailing one left queued gets
+            # misread as the *next* turn's terminator), so read until the wire
+            # goes quiet for `idle_s` instead.
+            idle_s = 4.0
+            while True:
+                left = timeout - (time.monotonic() - t_commit)
+                if left <= 0:
+                    print(
+                        f"[{stamp()}] session {idx} turn {turn_no}: TIMEOUT after {timeout:.0f}s"
+                        f" (events: {turn.events or 'NONE'})",
+                        flush=True,
+                    )
+                    break
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=min(left, idle_s))
+                except asyncio.TimeoutError:
+                    if turn.events:
+                        break  # quiet after real activity: turn is over
+                    continue
+                except websockets.ConnectionClosed as exc:
+                    turn.errors.append(f"closed: {exc}")
+                    print(f"[{stamp()}] session {idx} turn {turn_no}: SOCKET CLOSED {exc}", flush=True)
+                    return results
+                msg = json.loads(raw)
+                t = msg.get("type", "?")
+                turn.events.append(t)
+                if t == "response.created":
+                    turn.response_created = True
+                elif t in ("response.audio_transcript.delta", "response.output_text.delta"):
+                    turn.text += msg.get("delta") or ""
+                elif t == "response.audio_transcript.done" and msg.get("transcript"):
+                    turn.text = msg["transcript"]
+                elif t == "response.audio.delta":
+                    data = msg.get("delta") or msg.get("audio") or ""
+                    turn.audio_deltas += 1
+                    turn.audio_bytes += len(base64.b64decode(data)) if data else 0
+                elif t == "error":
+                    turn.errors.append(json.dumps(msg))
+                    print(f"[{stamp()}] session {idx} turn {turn_no}: ERROR {msg}", flush=True)
+            dt = time.monotonic() - t_commit
+            print(
+                f"[{stamp()}] session {idx} turn {turn_no}: text={turn.text!r} "
+                f"audio_deltas={turn.audio_deltas} bytes={turn.audio_bytes} in {dt:.1f}s",
+                flush=True,
+            )
+
+        await ws.send(json.dumps({"type": "session.close"}))
+        await asyncio.sleep(0.5)
+    print(f"[{stamp()}] session {idx}: closed", flush=True)
+    return results
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sessions", type=int, default=3)
+    ap.add_argument("--turns", type=int, default=1)
+    ap.add_argument("--timeout", type=float, default=90)
+    args = ap.parse_args()
+
+    pcm = CLIP.read_bytes()[44:]
+    print(f"clip: {len(pcm)} bytes = {len(pcm) / 2 / SR_IN:.1f}s", flush=True)
+
+    ok = 0
+    for idx in range(1, args.sessions + 1):
+        try:
+            turns = await run_session(idx, args.turns, args.timeout, pcm)
+        except Exception as exc:  # noqa: BLE001 - reporting, not handling
+            print(f"[{stamp()}] session {idx}: EXCEPTION {type(exc).__name__}: {exc}", flush=True)
+            continue
+        if turns and all(t.audio_deltas > 0 for t in turns):
+            ok += 1
+        await asyncio.sleep(2)
+
+    print(f"\n{ok}/{args.sessions} sessions produced audio on every turn", flush=True)
+    return 0 if ok == args.sessions else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/online_serving/qwen3_omni_duplex/reset_server.sh
+++ b/examples/online_serving/qwen3_omni_duplex/reset_server.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Restart the duplex server and wait until it is serving.
+#
+# Currently required between conversations: the pipeline serves exactly one
+# session per boot. See "Known limitation" in README.md.
+set -euo pipefail
+NAME="${1:-qwen-duplex-test}"
+PORT="${2:-8099}"
+docker restart "$NAME" >/dev/null
+printf 'restarting %s' "$NAME"
+until [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${PORT}/health")" = "200" ]; do
+  docker ps --format '{{.Names}}' | grep -q "^${NAME}$" || { echo " -- container exited"; exit 1; }
+  printf '.'; sleep 10
+done
+echo " -- ready on :${PORT}"

--- a/examples/online_serving/qwen3_omni_duplex/reset_server.sh
+++ b/examples/online_serving/qwen3_omni_duplex/reset_server.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Restart the duplex server and wait until it is serving.
 #
-# Currently required between conversations: the pipeline serves exactly one
-# session per boot. See "Known limitation" in README.md.
+# No longer required between conversations -- multiple sessions per boot work.
+# Still the right first move when debugging: a wedged pipeline accepts audio
+# and produces nothing, so anything measured after a wedge is worthless.
 set -euo pipefail
 NAME="${1:-qwen-duplex-test}"
 PORT="${2:-8099}"

--- a/examples/qwen3_omni_duplex.yaml
+++ b/examples/qwen3_omni_duplex.yaml
@@ -1,0 +1,74 @@
+# Qwen3-Omni-MoE experimental full-duplex deploy (test only, GPUs 2/3).
+# Derived from the production 2-GPU config; adds session_mode: duplex.
+async_chunk: false
+session_mode: duplex
+active_stream_window: 1
+
+duplex_session:
+  idle_ttl_s: 300
+  disconnect_grace_s: 30
+  reaper_interval_s: 5
+  resume_replay_ttl_s: 60
+  resume_replay_max_bytes_per_session: 8388608
+  max_pending_input_bytes_per_session: 16777216
+  max_pending_turns_per_session: 4
+  max_sessions: 1
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      initial_codec_chunk_frames: 4
+      codec_chunk_frames: 25
+      codec_left_context_frames: 25
+
+stages:
+  - stage_id: 0
+    max_num_batched_tokens: 32768
+    max_num_seqs: 2
+    async_scheduling: false
+    gpu_memory_utilization: 0.90
+    max_model_len: 32768
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      max_tokens: 2048
+
+  - stage_id: 1
+    max_num_batched_tokens: 32768
+    max_num_seqs: 2
+    async_scheduling: false
+    gpu_memory_utilization: 0.6
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "1"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.9
+      top_k: 50
+      max_tokens: 4096
+      seed: 42
+      repetition_penalty: 1.05
+
+  - stage_id: 2
+    max_num_batched_tokens: 65536
+    max_num_seqs: 2
+    gpu_memory_utilization: 0.15
+    enforce_eager: false
+    trust_remote_code: true
+    enable_prefix_caching: false
+    enable_chunked_prefill: false
+    async_scheduling: false
+    devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      repetition_penalty: 1.1

--- a/examples/qwen3_omni_duplex.yaml
+++ b/examples/qwen3_omni_duplex.yaml
@@ -2,7 +2,10 @@
 # Derived from the production 2-GPU config; adds session_mode: duplex.
 async_chunk: false
 session_mode: duplex
-active_stream_window: 1
+# 0 = unbounded: every session's stream is schedulable, so vLLM batches
+# them. At 1 only one stream is ever active, which serialises the server --
+# 12 concurrent sessions took 100 s instead of 9.6 s.
+active_stream_window: 0
 
 duplex_session:
   idle_ttl_s: 300

--- a/tests/core/sched/test_omni_scheduler_streaming_input_counter.py
+++ b/tests/core/sched/test_omni_scheduler_streaming_input_counter.py
@@ -1,0 +1,254 @@
+"""Tests for the ``num_waiting_for_streaming_input`` resync placed in
+``OmniARScheduler.finish_requests`` / ``OmniGenerationScheduler.finish_requests``
+and in ``OmniARScheduler.schedule``.
+
+Upstream keeps that counter incrementally (``+1`` when a resumable request
+parks in a waiting queue as ``WAITING_FOR_STREAMING_REQ``, ``-1`` when the
+next update arrives or the request is finished) and
+``Scheduler.get_num_unfinished_requests`` *subtracts* it from the waiting
+queues. Omni rewrites ``request.status`` outside both hooks -- the
+chunk-transfer adapter's park/restore and
+``_realign_request_status_to_queues`` -- so a counted request can leave
+``WAITING_FOR_STREAMING_REQ`` without the matching decrement and inflate the
+counter for the lifetime of the process.
+
+An inflated counter does not degrade throughput, it hangs the stage:
+``EngineCore.has_work()`` reads false while a live request sits in
+``waiting``, so the engine blocks in ``input_queue.get()`` and never calls
+``schedule()`` again. Regression for the Qwen3-Omni duplex symptom where the
+server answered the first conversation after a boot and was silent from the
+second on while still reporting healthy.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.request import RequestStatus
+
+import vllm_omni.core.sched.omni_ar_scheduler as ar_sched_mod
+import vllm_omni.core.sched.omni_generation_scheduler as gen_sched_mod
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _StubRequest:
+    def __init__(self, request_id: str, status: RequestStatus) -> None:
+        self.request_id = request_id
+        self.status = status
+
+    def is_finished(self) -> bool:
+        return RequestStatus.is_finished(self.status)
+
+
+_SCHEDULER_PARAMS = [
+    pytest.param(OmniARScheduler, ar_sched_mod, id="ar"),
+    pytest.param(OmniGenerationScheduler, gen_sched_mod, id="generation"),
+]
+
+
+def _make_scheduler(scheduler_cls, *, requests, running, waiting, counter, skipped=None):
+    scheduler = scheduler_cls.__new__(scheduler_cls)
+    scheduler.chunk_transfer_adapter = None
+    scheduler.input_coordinator = None
+    scheduler.requests = requests
+    scheduler.running = running
+    scheduler.waiting = waiting
+    scheduler.skipped_waiting = skipped if skipped is not None else []
+    scheduler.num_waiting_for_streaming_input = counter
+    return scheduler
+
+
+def _upstream_num_unfinished(scheduler) -> int:
+    """Mirror of ``Scheduler.get_num_unfinished_requests`` arithmetic."""
+    num_waiting = (
+        len(scheduler.waiting) + len(scheduler.skipped_waiting) - scheduler.num_waiting_for_streaming_input
+    )
+    return num_waiting + len(scheduler.running)
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_finish_requests_clears_counter_left_by_a_stomped_status(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The abort case that wedged the talker.
+
+    The request was counted while parked for streaming input, then had its
+    status rewritten to ``RUNNING`` by omni's queue surgery, so upstream's
+    ``finish_requests`` took the running branch and never decremented. With
+    no parked requests left, the counter must land at 0.
+    """
+    aborted = _StubRequest("req-aborted", RequestStatus.RUNNING)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={},  # upstream already dropped it
+        running=[],
+        waiting=[],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [aborted],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [aborted.request_id], RequestStatus.FINISHED_ABORTED)
+
+    assert scheduler.num_waiting_for_streaming_input == 0
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_next_request_is_visible_as_work_after_the_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The consequence, stated as the engine sees it.
+
+    A fresh request queued behind the leak must read as unfinished work.
+    Without the resync this is ``(1 + 0 - 1) + 0 == 0`` and the engine parks
+    in ``input_queue.get()`` with a live request in ``waiting``.
+    """
+    aborted = _StubRequest("req-aborted", RequestStatus.RUNNING)
+    incoming = _StubRequest("req-next-session", RequestStatus.WAITING)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={incoming.request_id: incoming},
+        running=[],
+        waiting=[incoming],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [aborted],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [aborted.request_id], RequestStatus.FINISHED_ABORTED)
+
+    assert _upstream_num_unfinished(scheduler) == 1
+
+
+@pytest.mark.parametrize(("scheduler_cls", "scheduler_mod"), _SCHEDULER_PARAMS)
+def test_finish_requests_keeps_counting_a_genuinely_parked_request(
+    monkeypatch: pytest.MonkeyPatch,
+    scheduler_cls,
+    scheduler_mod,
+) -> None:
+    """The resync must not over-correct.
+
+    A request still parked as ``WAITING_FOR_STREAMING_REQ`` in ``waiting`` is
+    exactly what the counter is for -- it must stay counted, so the engine
+    does not spin on a request that has no input to process.
+    """
+    parked = _StubRequest("req-parked", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    leaving = _StubRequest("req-leaving", RequestStatus.FINISHED_STOPPED)
+    scheduler = _make_scheduler(
+        scheduler_cls,
+        requests={parked.request_id: parked},
+        running=[],
+        waiting=[parked],
+        counter=1,
+    )
+
+    monkeypatch.setattr(
+        scheduler_mod.VLLMScheduler,
+        "finish_requests",
+        lambda self, request_ids, finished_status: [leaving],
+    )
+
+    scheduler_cls.finish_requests(scheduler, [leaving.request_id], RequestStatus.FINISHED_STOPPED)
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+    assert _upstream_num_unfinished(scheduler) == 0
+
+
+def test_resync_counts_parked_requests_in_skipped_waiting() -> None:
+    """``get_num_unfinished_requests`` sums ``waiting`` and ``skipped_waiting``,
+    so the resync has to look at both or it under-counts and reintroduces the
+    spin the counter exists to prevent."""
+    parked = _StubRequest("req-skipped", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    scheduler = _make_scheduler(
+        OmniARScheduler,
+        requests={parked.request_id: parked},
+        running=[],
+        waiting=[],
+        counter=0,
+        skipped=[parked],
+    )
+
+    scheduler._resync_streaming_input_counter()
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+
+
+def test_resync_is_a_no_op_when_upstream_accounting_is_correct() -> None:
+    """In the healthy case the derived value equals upstream's incremental one,
+    so the helper must leave it alone rather than fight it."""
+    parked = _StubRequest("req-parked", RequestStatus.WAITING_FOR_STREAMING_REQ)
+    running = _StubRequest("req-running", RequestStatus.RUNNING)
+    scheduler = _make_scheduler(
+        OmniARScheduler,
+        requests={r.request_id: r for r in (parked, running)},
+        running=[running],
+        waiting=[parked],
+        counter=1,
+    )
+
+    scheduler._resync_streaming_input_counter()
+
+    assert scheduler.num_waiting_for_streaming_input == 1
+
+
+def test_resync_tolerates_a_scheduler_without_the_counter() -> None:
+    """Guard for vLLM versions that predate ``num_waiting_for_streaming_input``:
+    the helper must no-op rather than invent the attribute."""
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+
+    scheduler._resync_streaming_input_counter()
+
+    assert not hasattr(scheduler, "num_waiting_for_streaming_input")
+
+
+def test_ar_schedule_resyncs_before_delegating_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pins placement in ``schedule``: the chunk-transfer adapter rewrites
+    status during ``process_pending_chunks``, so the resync has to run after
+    that and before upstream schedules, while ``self.waiting`` is still the
+    real queue."""
+    parked = _StubRequest("req-resumed", RequestStatus.RUNNING)
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.chunk_transfer_adapter = None
+    scheduler.input_coordinator = None
+    scheduler.requests = {parked.request_id: parked}
+    scheduler.running = [parked]
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+    scheduler.num_waiting_for_streaming_input = 1  # leaked by the status rewrite
+    scheduler.policy = "fcfs"
+
+    seen: dict[str, int] = {}
+
+    monkeypatch.setattr(ar_sched_mod.OmniSchedulerMixin, "_consume_pending_connector_output", lambda self, model_mode: None)
+    monkeypatch.setattr(ar_sched_mod.OmniSchedulerMixin, "_process_pending_input_timeouts", lambda self: None)
+    monkeypatch.setattr(OmniARScheduler, "_should_defer_waiting_admission", lambda self: False)
+
+    def fake_schedule(self, throttle_prefills=False):
+        seen["counter"] = self.num_waiting_for_streaming_input
+        raise _StopSchedule
+
+    class _StopSchedule(Exception):
+        pass
+
+    monkeypatch.setattr(ar_sched_mod.VLLMScheduler, "schedule", fake_schedule)
+
+    with pytest.raises(_StopSchedule):
+        OmniARScheduler.schedule(scheduler)
+
+    assert seen["counter"] == 0

--- a/tests/e2e/features/fullduplex/qwen3omni/__init__.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -457,10 +457,20 @@ def test_later_turn_reopens_user_without_repeating_system_block() -> None:
 
 
 def test_final_append_closes_user_and_opens_assistant() -> None:
-    """This suffix is what actually prompts a reply."""
-    ids, _, audio_tokens = _prompt(seq=3, turn_seq=3, final=True)
+    """This suffix is what actually prompts a reply.
+
+    A closing append carries the whole turn, so it is framed on both sides:
+    user opener + <|audio_start|> ... <|audio_end|> + assistant opener.
+    """
+    ids, audio_offset, audio_tokens = _prompt(seq=3, turn_seq=3, final=True)
     assert ids[-3:] == [6, 7, 8]
-    assert ids == [_PAD] * audio_tokens + [Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID, 6, 7, 8]
+    assert ids == [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
+        Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID,
+        6,
+        7,
+        8,
+    ]
+    assert audio_offset == 3
 
 
 def test_prompt_length_equals_reservation() -> None:
@@ -509,7 +519,12 @@ def test_commit_payload_closes_the_turn_without_the_final_flag() -> None:
         runtime_config=dict(_SCAFFOLD), payload=payload, seq=2, turn_seq=2, final=False
     )
     assert ids[-3:] == [6, 7, 8], "assistant generation prompt must be appended"
-    assert ids == [_PAD] * audio_tokens + [Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID, 6, 7, 8]
+    assert ids == [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
+        Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID,
+        6,
+        7,
+        8,
+    ], "a later turn is framed too, not just the first"
 
 
 def test_prepare_commit_marks_the_payload_turn_final() -> None:
@@ -678,3 +693,26 @@ def test_audio_span_is_delimited_for_the_model() -> None:
     assert ids[audio_offset - 1] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
     assert ids[audio_offset + audio_tokens] == Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID
     assert ids[audio_offset : audio_offset + audio_tokens] == [_PAD] * audio_tokens
+
+
+def test_every_turn_is_framed_not_just_the_first() -> None:
+    """turn_seq counts turns, not appends within a turn.
+
+    Gating the opener on turn_seq <= 1 framed only the session's first turn;
+    later turns arrived as bare audio with no <|im_start|>user and no
+    <|audio_start|>, and produced nothing usable. Observed live as
+    prefix=0 on turns 2 and 3.
+    """
+    for turn_seq in (1, 2, 5):
+        ids, audio_offset, audio_tokens = build_duplex_prompt_token_ids(
+            runtime_config=dict(_SCAFFOLD),
+            payload={**_pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES), Qwen3OmniDuplexPolicy.TURN_FINAL_KEY: True},
+            seq=turn_seq,
+            turn_seq=turn_seq,
+            final=False,
+        )
+        assert 4 in ids and 5 in ids, f"turn {turn_seq} lost its user opener"
+        assert ids[audio_offset - 1] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+        assert ids[audio_offset + audio_tokens] == Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID
+        # Only the first turn of the session repeats the system block.
+        assert (1 in ids) == (turn_seq == 1)

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -272,37 +272,37 @@ def test_decide_output_never_short_circuits() -> None:
 # --- PCM buffer ------------------------------------------------------------
 
 
-def test_buffer_emits_only_whole_chunks() -> None:
+def test_appends_never_emit_mid_turn() -> None:
+    """Audio is held until commit so the thinker gets one well-formed turn.
+
+    Emitting mid-turn makes the framework append a partial user turn with no
+    <|audio_end|> and no assistant generation prompt, and auto_response then
+    asks the model to continue it. Observed live: only the first second of a
+    4 s utterance reached the model and it emitted ' 1000000...'.
+    """
     buffer = Qwen3OmniPcmAppendBuffer()
-    half = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES // 2
-    assert (
-        buffer.prepare_append(
-            _pcm_payload(half),
-            operation_id="op-1",
-            chunk_period_ms=CHUNK_MS,
-            allow_emit=True,
-        )
-        is None
-    )
-    reservation = buffer.prepare_append(
-        _pcm_payload(half),
-        operation_id="op-2",
-        chunk_period_ms=CHUNK_MS,
-        allow_emit=True,
-    )
-    assert reservation is not None
-    assert reservation.payload is not None
-    assert reservation.payload["num_samples"] == Qwen3OmniDuplexPolicy.CHUNK_SAMPLES
+    for i in range(4):
+        assert (
+            buffer.prepare_append(
+                _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+                operation_id=f"op-{i}",
+                chunk_period_ms=CHUNK_MS,
+                allow_emit=True,
+            )
+            is None
+        ), "no append may emit mid-turn"
+    assert buffer.has_pending(), "audio is retained for the commit"
 
 
 def test_buffer_rollback_restores_audio_in_wire_order() -> None:
     buffer = Qwen3OmniPcmAppendBuffer()
-    reservation = buffer.prepare_append(
+    buffer.prepare_append(
         _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
-        operation_id="op-1",
+        operation_id="op-0",
         chunk_period_ms=CHUNK_MS,
         allow_emit=True,
     )
+    reservation = buffer.prepare_commit(operation_id="op-1", chunk_period_ms=CHUNK_MS)
     assert reservation is not None
     assert buffer.pending_byte_count == 0
     reservation.rollback()
@@ -312,12 +312,13 @@ def test_buffer_rollback_restores_audio_in_wire_order() -> None:
 
 def test_buffer_commit_consumes_audio() -> None:
     buffer = Qwen3OmniPcmAppendBuffer()
-    reservation = buffer.prepare_append(
+    buffer.prepare_append(
         _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
-        operation_id="op-1",
+        operation_id="op-0",
         chunk_period_ms=CHUNK_MS,
         allow_emit=True,
     )
+    reservation = buffer.prepare_commit(operation_id="op-1", chunk_period_ms=CHUNK_MS)
     assert reservation is not None
     reservation.commit()
     assert buffer.pending_byte_count == 0
@@ -524,16 +525,18 @@ def test_prepare_commit_marks_the_payload_turn_final() -> None:
     assert reservation.payload[Qwen3OmniDuplexPolicy.TURN_FINAL_KEY] is True
 
 
-def test_plain_append_is_not_marked_turn_final() -> None:
+def test_plain_append_yields_no_reservation() -> None:
+    """Only a commit produces a payload, and it is always turn-final."""
     buffer = Qwen3OmniPcmAppendBuffer()
-    reservation = buffer.prepare_append(
-        _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
-        operation_id="o1",
-        chunk_period_ms=CHUNK_MS,
-        allow_emit=True,
+    assert (
+        buffer.prepare_append(
+            _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+            operation_id="o1",
+            chunk_period_ms=CHUNK_MS,
+            allow_emit=True,
+        )
+        is None
     )
-    assert reservation is not None and reservation.payload is not None
-    assert Qwen3OmniDuplexPolicy.TURN_FINAL_KEY not in reservation.payload
 
 
 def test_sample_count_measured_from_audio_not_a_stale_key() -> None:

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -804,3 +804,38 @@ def test_audio_length_uses_the_sample_axis_not_the_batch_axis() -> None:
     assert _audio_length(_T(7125)) == 7125
     assert _audio_length([0] * 40) == 40
     assert _audio_tail(_T(55125), 7125).shape == (1, 48000)
+
+
+def test_audio_cursor_survives_a_turn_boundary() -> None:
+    """One request id spans the session; Code2Wav accumulates across it.
+
+    Resetting the cursor per turn made each reply resend every previously
+    spoken sample before the new audio, so replies grew by repeating the whole
+    conversation.
+    """
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        Qwen3OmniDataPlaneContext,
+        Qwen3OmniDataPlaneSession,
+    )
+
+    seen: list[int] = []
+    dp = Qwen3OmniDataPlaneSession(lambda a, *_: (seen.append(len(a)), "x" * len(a))[1])
+    ctx = Qwen3OmniDataPlaneContext(modalities=("audio",))
+
+    def turn(total: int) -> None:
+        out = SimpleNamespace(
+            request_id="r1",
+            finished=False,
+            stage_id=2,
+            multimodal_output={"audio": list(range(total)), "sr": 24000},
+        )
+        list(dp.project({"data_plane_outputs": [out]}, context=ctx))
+
+    dp.begin_request("r1")
+    turn(100)
+    dp.begin_request("r1")  # next turn, same request id
+    turn(260)
+
+    assert seen == [100, 160], f"turn 2 must send only its own 160 samples, got {seen}"

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Contract tests for the Qwen3-Omni duplex integration.
+
+These exercise the framework's real duck-type gates -- the same functions the
+engine and API server call at startup -- rather than mocks of them. They do
+NOT establish that the integration works end to end: the worker-side stage-0
+audio embedding path is unimplemented (see
+``vllm_omni/experimental/fullduplex/qwen3omni/stage0.py``) and no test here
+runs a model.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_omni.experimental.fullduplex.engine.contracts import (
+    DuplexAppendPlan,
+    DuplexInputMode,
+)
+from vllm_omni.experimental.fullduplex.engine.duplex_runtime import (
+    validate_duplex_runtime_extension,
+)
+from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+from vllm_omni.experimental.fullduplex.openai.runtime_adapter import (
+    validate_serving_runtime_adapter,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.input import Qwen3OmniPcmAppendBuffer
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+from vllm_omni.experimental.fullduplex.qwen3omni.runtime import (
+    Qwen3OmniDuplexRuntimeExtension,
+    duplex_scheduler_token_budget,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.serving_adapter import (
+    Qwen3OmniServingRuntimeAdapter,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.stage0 import (
+    Qwen3OmniStage0DuplexRuntime,
+)
+
+CHUNK_MS = Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS
+
+
+def _fence(seq: int = 1) -> DuplexFence:
+    return DuplexFence(
+        session_id="sess-1",
+        epoch=0,
+        turn_id=0,
+        response_seq=seq,
+        incarnation=1,
+    )
+
+
+def _pcm_payload(num_samples: int) -> dict[str, object]:
+    data = b"\x00\x00\x00\x00" * num_samples
+    return {
+        "audio": base64.b64encode(data).decode("ascii"),
+        "format": Qwen3OmniDuplexPolicy.PCM_FORMAT,
+        "sample_rate_hz": Qwen3OmniDuplexPolicy.SAMPLE_RATE_HZ,
+        "num_samples": num_samples,
+    }
+
+
+# --- framework gates -------------------------------------------------------
+
+
+def test_runtime_extension_passes_engine_gate() -> None:
+    """The engine's own validator accepts the extension for a 3-stage pipeline."""
+    defaults = (SamplingParams(), SamplingParams(), SamplingParams())
+    validate_duplex_runtime_extension(
+        Qwen3OmniDuplexRuntimeExtension(),
+        sampling_defaults=defaults,
+    )
+
+
+def test_serving_adapter_passes_api_server_gate() -> None:
+    """``load_serving_runtime_adapter``'s validator accepts the adapter."""
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
+    validate_serving_runtime_adapter(adapter)
+
+
+def test_pipeline_declares_duplex_paths_that_import() -> None:
+    """The dotted paths on the pipeline config resolve to the real classes."""
+    from importlib import import_module
+
+    from vllm_omni.model_executor.models.qwen3_omni.pipeline import (
+        QWEN3_OMNI_PIPELINE,
+    )
+
+    for path, expected in (
+        (QWEN3_OMNI_PIPELINE.duplex_runtime_extension, Qwen3OmniDuplexRuntimeExtension),
+        (QWEN3_OMNI_PIPELINE.duplex_serving_adapter, Qwen3OmniServingRuntimeAdapter),
+    ):
+        assert isinstance(path, str) and path
+        module_name, _, attribute = path.rpartition(".")
+        assert getattr(import_module(module_name), attribute) is expected
+
+
+# --- append plan -----------------------------------------------------------
+
+
+def test_plan_append_emits_only_surviving_prompt_keys() -> None:
+    """Guards the silent key-drop in build_engine_core_request_from_tokens.
+
+    Only prompt_token_ids / prompt_embeds / cache_salt /
+    additional_information / model_intermediate_buffer survive
+    ``orchestrator.py:118-158``. A key added here that is not in that set
+    would be discarded with no error, so assert the prompt carries nothing
+    that would be lost.
+    """
+    surviving = {
+        "prompt_token_ids",
+        "prompt_embeds",
+        "cache_salt",
+        "additional_information",
+        "model_intermediate_buffer",
+    }
+    plan = Qwen3OmniDuplexRuntimeExtension().plan_append(
+        request_id="req-1",
+        fence=_fence(),
+        session_config={},
+        runtime_config={},
+        seq=1,
+        turn_seq=1,
+        mode=DuplexInputMode.APPEND_AUDIO_CHUNK,
+        payload=_pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        final=False,
+        sampling_params=None,
+    )
+    assert isinstance(plan, DuplexAppendPlan)
+    assert set(plan.prompt) <= surviving, f"prompt keys would be dropped: {set(plan.prompt) - surviving}"
+
+
+def test_plan_append_sets_the_data_plane_gate() -> None:
+    """``duplex.data_plane`` must be True or every worker branch no-ops."""
+    plan = Qwen3OmniDuplexRuntimeExtension().plan_append(
+        request_id="req-1",
+        fence=_fence(),
+        session_config={},
+        runtime_config={},
+        seq=1,
+        turn_seq=1,
+        mode=DuplexInputMode.APPEND_AUDIO_CHUNK,
+        payload=_pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        final=False,
+        sampling_params=None,
+    )
+    duplex = plan.prompt["model_intermediate_buffer"]["duplex"]
+    assert duplex["data_plane"] is True
+    assert duplex["session_id"] == "sess-1"
+
+
+def test_plan_append_emits_all_duplex_keys_every_time() -> None:
+    """The worker-side merge is additive, so omitted keys would go stale.
+
+    ``gpu_model_runner.py:2035-2042`` overlays the new ``duplex`` dict onto
+    the previous one. A conditionally-omitted key keeps its old value instead
+    of clearing, so every append must carry the full set.
+    """
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    keysets = []
+    for seq, final in ((1, False), (2, False), (3, True)):
+        plan = extension.plan_append(
+            request_id="req-1",
+            fence=_fence(seq),
+            session_config={},
+            runtime_config={},
+            seq=seq,
+            turn_seq=1,
+            mode=DuplexInputMode.APPEND_AUDIO_CHUNK,
+            payload=_pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+            final=final,
+            sampling_params=None,
+        )
+        keysets.append(set(plan.prompt["model_intermediate_buffer"]["duplex"]))
+    assert keysets[0] == keysets[1] == keysets[2]
+
+
+def test_plan_append_rejects_unsupported_input_mode() -> None:
+    with pytest.raises(ValueError, match="does not support input mode"):
+        Qwen3OmniDuplexRuntimeExtension().plan_append(
+            request_id="req-1",
+            fence=_fence(),
+            session_config={},
+            runtime_config={},
+            seq=1,
+            turn_seq=1,
+            mode=DuplexInputMode.ROLLBACK_TO_CHECKPOINT,
+            payload=_pcm_payload(16),
+            final=False,
+            sampling_params=None,
+        )
+
+
+def test_token_budget_matches_worker_expected_embedding_count() -> None:
+    """The reservation and the worker's embedding count must agree.
+
+    A mismatch is absorbed silently by the model runner (truncate/pad), so
+    pin the two calculations together.
+    """
+    for num_samples in (1600, 16000, 24000):
+        payload = _pcm_payload(num_samples)
+        assert duplex_scheduler_token_budget(payload, {}) == Qwen3OmniStage0DuplexRuntime.expected_embedding_count(
+            num_samples
+        )
+
+
+# --- sampling params -------------------------------------------------------
+
+
+def test_configure_sampling_params_is_per_stage_and_length_preserving() -> None:
+    defaults = (SamplingParams(max_tokens=1), SamplingParams(max_tokens=2), SamplingParams(max_tokens=3))
+    configured = Qwen3OmniDuplexRuntimeExtension().configure_sampling_params(
+        runtime_config={"duplex_stage_max_tokens": {"0": 128, "1": 4096}},
+        defaults=defaults,
+    )
+    assert len(configured) == len(defaults)
+    assert configured[0].max_tokens == 128
+    assert configured[1].max_tokens == 4096
+    # Untouched stage keeps the checkpoint's own value.
+    assert configured[2].max_tokens == 3
+
+
+def test_decide_output_never_short_circuits() -> None:
+    """Qwen3-Omni has no model-native turn signal; None for every stage."""
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    for stage_id in (0, 1, 2):
+        assert (
+            extension.decide_output(
+                stage_id=stage_id,
+                final_stage_id=2,
+                segment_finished=True,
+                segment_token_ids=(1, 2, 3),
+                segment_output_metadata={"meta.listen_token_id": 151645},
+                output=object(),
+            )
+            is None
+        )
+
+
+# --- PCM buffer ------------------------------------------------------------
+
+
+def test_buffer_emits_only_whole_chunks() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    half = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES // 2
+    assert (
+        buffer.prepare_append(
+            _pcm_payload(half),
+            operation_id="op-1",
+            chunk_period_ms=CHUNK_MS,
+            allow_emit=True,
+        )
+        is None
+    )
+    reservation = buffer.prepare_append(
+        _pcm_payload(half),
+        operation_id="op-2",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=True,
+    )
+    assert reservation is not None
+    assert reservation.payload is not None
+    assert reservation.payload["num_samples"] == Qwen3OmniDuplexPolicy.CHUNK_SAMPLES
+
+
+def test_buffer_rollback_restores_audio_in_wire_order() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    reservation = buffer.prepare_append(
+        _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        operation_id="op-1",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=True,
+    )
+    assert reservation is not None
+    assert buffer.pending_byte_count == 0
+    reservation.rollback()
+    assert buffer.pending_byte_count == Qwen3OmniDuplexPolicy.CHUNK_SAMPLES * 4
+    assert not buffer.has_reserved()
+
+
+def test_buffer_commit_consumes_audio() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    reservation = buffer.prepare_append(
+        _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        operation_id="op-1",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=True,
+    )
+    assert reservation is not None
+    reservation.commit()
+    assert buffer.pending_byte_count == 0
+    assert not buffer.has_reserved()
+
+
+def test_prepare_commit_pads_partial_chunk() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    buffer.prepare_append(
+        _pcm_payload(10),
+        operation_id="op-1",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=False,
+    )
+    reservation = buffer.prepare_commit(operation_id="op-2", chunk_period_ms=CHUNK_MS)
+    assert reservation.payload is not None
+    assert reservation.payload["num_samples"] == Qwen3OmniDuplexPolicy.CHUNK_SAMPLES
+
+
+def test_buffer_rejects_unsupported_format() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    with pytest.raises(ValueError, match="unsupported duplex audio format"):
+        buffer.prepare_append(
+            {"audio": "", "format": "pcm_s16le"},
+            operation_id="op-1",
+            chunk_period_ms=CHUNK_MS,
+            allow_emit=True,
+        )
+
+
+# --- serving policy --------------------------------------------------------
+
+
+def test_private_runtime_config_keys_are_rejected_from_clients() -> None:
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
+    with pytest.raises(ValueError, match="server-owned"):
+        adapter.validate_client_extra_body({"duplex_stage_max_tokens": {"0": 1}})
+
+
+def test_capabilities_do_not_claim_model_native_turn_policy() -> None:
+    """Qwen3-Omni has no listen/speak token; claiming otherwise misleads clients."""
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
+    capabilities = adapter.capabilities(max_sessions=1)
+    assert capabilities.supports_model_native_turn_policy is False
+    assert capabilities.chunk_period_ms == Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS
+
+
+def test_runtime_config_update_preserves_server_owned_state() -> None:
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
+    current = {
+        "duplex_samples_per_audio_token": 1600,
+        "duplex_stage_max_tokens": {"0": 64, "1": 8192},
+    }
+
+    class _Config:
+        instructions = "be brief"
+        max_tokens = 99
+        temperature = None
+
+    updated = adapter.runtime_config_for_update(_Config(), current)
+    assert updated["duplex_samples_per_audio_token"] == 1600
+    assert updated["duplex_stage_max_tokens"]["0"] == 99
+    assert updated["duplex_stage_max_tokens"]["1"] == 8192
+    assert updated["instructions"] == "be brief"
+    # The caller's mapping must not be mutated in place.
+    assert current["duplex_stage_max_tokens"]["0"] == 64
+
+
+def test_session_state_satisfies_committed_audio_contract() -> None:
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
+    state = adapter.session_state("sess-1")
+    state.retain_committed_audio({"audio": ""}, operation_id="op-1", reserved_bytes=128)
+    assert state.committed_audio_reserved_bytes == 128
+    assert state.clear_committed_audio() == 128
+    assert state.committed_audio_payload is None
+    assert adapter.session_state("sess-1") is state
+    adapter.remove_session_state("sess-1")
+    assert adapter.session_state("sess-1") is not state
+
+
+# --- the unimplemented boundary -------------------------------------------
+
+
+def test_stage0_audio_embedding_is_explicitly_unimplemented() -> None:
+    """Fails loudly rather than silently producing wrong embeddings."""
+    runtime = Qwen3OmniStage0DuplexRuntime(object())
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        runtime.build_append_embeddings(duplex={}, token_offset=0, prompt_len=10)

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -419,7 +419,10 @@ _SCAFFOLD = {
     Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY: [1, 2, 3],
     Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY: [4, 5],
     Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY: [6, 7, 8],
+    Qwen3OmniDuplexPolicy.NEWLINE_IDS_KEY: [9],
 }
+#: A later turn opens by closing the assistant's previous turn.
+_CLOSE_PREV = [Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID, 9]
 _PAD = Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID
 
 
@@ -451,9 +454,10 @@ def test_mid_turn_append_has_no_scaffolding() -> None:
 
 def test_later_turn_reopens_user_without_repeating_system_block() -> None:
     ids, audio_offset, _ = _prompt(seq=9, turn_seq=1, final=False)
-    assert ids[:2] == [4, 5]
-    assert ids[2] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
-    assert audio_offset == 3, "system block belongs to the session, not each turn"
+    assert ids[:2] == _CLOSE_PREV, "must close the assistant's previous turn"
+    assert ids[2:4] == [4, 5]
+    assert ids[4] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+    assert audio_offset == 5, "system block belongs to the session, not each turn"
 
 
 def test_final_append_closes_user_and_opens_assistant() -> None:
@@ -464,13 +468,13 @@ def test_final_append_closes_user_and_opens_assistant() -> None:
     """
     ids, audio_offset, audio_tokens = _prompt(seq=3, turn_seq=3, final=True)
     assert ids[-3:] == [6, 7, 8]
-    assert ids == [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
+    assert ids == _CLOSE_PREV + [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
         Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID,
         6,
         7,
         8,
     ]
-    assert audio_offset == 3
+    assert audio_offset == 5
 
 
 def test_prompt_length_equals_reservation() -> None:
@@ -481,6 +485,8 @@ def test_prompt_length_equals_reservation() -> None:
         assert ids.count(_PAD) == audio_tokens, "audio span is exactly the pad tokens"
         trailing = len(ids) - audio_offset - audio_tokens
         assert trailing == (4 if final else 0), "audio_end + turn suffix when closing"
+        if seq > 1 and audio_offset >= 2:
+            assert ids[:2] == _CLOSE_PREV, "later turns close the assistant first"
 
 
 def test_audio_span_is_contiguous_and_located_by_audio_offset() -> None:
@@ -519,7 +525,7 @@ def test_commit_payload_closes_the_turn_without_the_final_flag() -> None:
         runtime_config=dict(_SCAFFOLD), payload=payload, seq=2, turn_seq=2, final=False
     )
     assert ids[-3:] == [6, 7, 8], "assistant generation prompt must be appended"
-    assert ids == [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
+    assert ids == _CLOSE_PREV + [4, 5, Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
         Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID,
         6,
         7,

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -435,9 +435,10 @@ def _prompt(*, seq: int, turn_seq: int, final: bool, samples: int = Qwen3OmniDup
 def test_session_opener_carries_system_block_and_user_turn() -> None:
     ids, audio_offset, audio_tokens = _prompt(seq=1, turn_seq=1, final=False)
     assert ids[:5] == [1, 2, 3, 4, 5], "session prefix then turn prefix"
-    assert audio_offset == 5
+    assert ids[5] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+    assert audio_offset == 6
     assert audio_tokens == 13
-    assert ids[5:] == [_PAD] * 13
+    assert ids[6:] == [_PAD] * 13
 
 
 def test_mid_turn_append_has_no_scaffolding() -> None:
@@ -450,24 +451,25 @@ def test_mid_turn_append_has_no_scaffolding() -> None:
 def test_later_turn_reopens_user_without_repeating_system_block() -> None:
     ids, audio_offset, _ = _prompt(seq=9, turn_seq=1, final=False)
     assert ids[:2] == [4, 5]
-    assert audio_offset == 2, "system block belongs to the session, not each turn"
+    assert ids[2] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+    assert audio_offset == 3, "system block belongs to the session, not each turn"
 
 
 def test_final_append_closes_user_and_opens_assistant() -> None:
     """This suffix is what actually prompts a reply."""
     ids, _, audio_tokens = _prompt(seq=3, turn_seq=3, final=True)
     assert ids[-3:] == [6, 7, 8]
-    assert ids == [_PAD] * audio_tokens + [6, 7, 8]
+    assert ids == [_PAD] * audio_tokens + [Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID, 6, 7, 8]
 
 
 def test_prompt_length_equals_reservation() -> None:
     """Budget must equal produced embeddings; the runner truncates silently."""
     for seq, turn_seq, final in ((1, 1, False), (2, 2, False), (3, 3, True), (9, 1, True)):
         ids, audio_offset, audio_tokens = _prompt(seq=seq, turn_seq=turn_seq, final=final)
-        scaffold = len(ids) - audio_tokens
         assert audio_offset + audio_tokens <= len(ids)
         assert ids.count(_PAD) == audio_tokens, "audio span is exactly the pad tokens"
-        assert scaffold == audio_offset + (3 if final else 0)
+        trailing = len(ids) - audio_offset - audio_tokens
+        assert trailing == (4 if final else 0), "audio_end + turn suffix when closing"
 
 
 def test_audio_span_is_contiguous_and_located_by_audio_offset() -> None:
@@ -486,8 +488,11 @@ def test_missing_scaffolding_degrades_to_audio_only() -> None:
         turn_seq=1,
         final=True,
     )
-    assert audio_offset == 0
-    assert ids == [_PAD] * audio_tokens
+    # Delimiters are model constants, not scaffolding, so they survive.
+    assert audio_offset == 1
+    assert ids == [Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID] + [_PAD] * audio_tokens + [
+        Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID
+    ]
 
 
 def test_commit_payload_closes_the_turn_without_the_final_flag() -> None:
@@ -503,7 +508,7 @@ def test_commit_payload_closes_the_turn_without_the_final_flag() -> None:
         runtime_config=dict(_SCAFFOLD), payload=payload, seq=2, turn_seq=2, final=False
     )
     assert ids[-3:] == [6, 7, 8], "assistant generation prompt must be appended"
-    assert ids == [_PAD] * audio_tokens + [6, 7, 8]
+    assert ids == [_PAD] * audio_tokens + [Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID, 6, 7, 8]
 
 
 def test_prepare_commit_marks_the_payload_turn_final() -> None:
@@ -657,3 +662,16 @@ def test_data_plane_reads_text_from_raw_request_output() -> None:
     dp.begin_request("r1")
     events = list(dp.project({"data_plane_outputs": [raw]}, context=Qwen3OmniDataPlaneContext()))
     assert events and events[0]["text"] == "unwrapped text"
+
+
+def test_audio_span_is_delimited_for_the_model() -> None:
+    """Missing <|audio_start|>/<|audio_end|> makes the thinker emit garbage.
+
+    Observed live without them: ' a i \\n\\n\\nuser\\n\\n\\nuser\\n...' -- the model
+    does not read the embeddings as audio and leaks chat role markers, which
+    the talker then synthesizes.
+    """
+    ids, audio_offset, audio_tokens = _prompt(seq=1, turn_seq=1, final=True)
+    assert ids[audio_offset - 1] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+    assert ids[audio_offset + audio_tokens] == Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID
+    assert ids[audio_offset : audio_offset + audio_tokens] == [_PAD] * audio_tokens

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -33,6 +33,8 @@ from vllm_omni.experimental.fullduplex.qwen3omni.input import Qwen3OmniPcmAppend
 from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
 from vllm_omni.experimental.fullduplex.qwen3omni.runtime import (
     Qwen3OmniDuplexRuntimeExtension,
+    parse_tool_calls,
+    Qwen3OmniDuplexRuntimeExtension,
     build_duplex_prompt_token_ids,
     duplex_audio_token_count,
 )
@@ -913,3 +915,119 @@ def test_audio_turn_is_unchanged_by_the_text_path() -> None:
     assert audio_tokens == 13
     assert ids[5] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
     assert audio_offset == 6
+
+
+# --- tool calls -------------------------------------------------------------
+#
+# Stage 0 is one resumable request for the whole session, so its text
+# accumulates across every turn. Re-reporting a call that was already
+# dispatched is self-sustaining -- the result is itself a turn, whose reply
+# still carries the original call -- and it ran away for real: 1204 turns and
+# 105 s of audio repeating one sentence.
+
+
+class _Completion:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _StageOutput:
+    def __init__(self, text: str, request_id: str = "req-1") -> None:
+        self.request_id = request_id
+        self.outputs = [_Completion(text)]
+
+
+_CALL = '<tool_call>\n{"name": "lookup_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+_CALL2 = '<tool_call>\n{"name": "check_inventory", "arguments": {"item": "spoons"}}\n</tool_call>'
+
+
+def test_parse_tool_calls_reads_the_template_format() -> None:
+    assert parse_tool_calls(_CALL) == [{"name": "lookup_weather", "arguments": {"city": "Paris"}}]
+
+
+def test_parse_tool_calls_ignores_an_unterminated_block() -> None:
+    """The thinker streams; a call without its closing tag is still arriving."""
+    assert parse_tool_calls('<tool_call>\n{"name": "lookup_weather"') == []
+
+
+def test_a_tool_call_is_reported_once_even_as_text_accumulates() -> None:
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    first = extension._new_tool_calls(_StageOutput(f"{_CALL}"))
+    assert [call["name"] for call in first] == ["lookup_weather"]
+
+    # Later turns append to the same cumulative text. The original call is
+    # still in there and must not be dispatched again.
+    again = extension._new_tool_calls(_StageOutput(f"{_CALL}It is 18 degrees in Paris."))
+    assert again == []
+
+
+def test_a_genuinely_new_call_is_still_reported() -> None:
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    extension._new_tool_calls(_StageOutput(_CALL))
+    later = extension._new_tool_calls(_StageOutput(f"{_CALL}It is 18 degrees.{_CALL2}"))
+    assert [call["name"] for call in later] == ["check_inventory"]
+
+
+def test_a_partially_streamed_call_is_not_skipped() -> None:
+    """The cursor may only advance past a closed block.
+
+    Advancing past a half-arrived call would consume its opening tag, so the
+    closing tag would never match and the call would be lost silently.
+    """
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    assert extension._new_tool_calls(_StageOutput('<tool_call>\n{"name": "lookup_weather"')) == []
+    complete = extension._new_tool_calls(_StageOutput(_CALL))
+    assert [call["name"] for call in complete] == ["lookup_weather"]
+
+
+def test_scan_state_is_per_request() -> None:
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    extension._new_tool_calls(_StageOutput(_CALL, request_id="req-a"))
+    other = extension._new_tool_calls(_StageOutput(_CALL, request_id="req-b"))
+    assert [call["name"] for call in other] == ["lookup_weather"]
+
+
+def test_a_reused_request_id_rescans_from_the_start() -> None:
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    extension._new_tool_calls(_StageOutput(f"{_CALL}some more text here"))
+    # Shorter text under the same id means a new request took the id over.
+    fresh = extension._new_tool_calls(_StageOutput(_CALL))
+    assert [call["name"] for call in fresh] == ["lookup_weather"]
+
+
+def test_tool_decision_releases_the_prewarmed_downstream_stages() -> None:
+    """The talker and code2wav were warmed for a reply that is not coming.
+
+    Without the release flag they park waiting for chunks that never arrive,
+    hold their slots, and make `has_work()` read false for later sessions --
+    the same wedge as the streaming-input counter leak, reached from the
+    direct-response path.
+    """
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    decision = extension.decide_output(
+        stage_id=0,
+        final_stage_id=2,
+        segment_finished=True,
+        segment_token_ids=(),
+        segment_output_metadata={},
+        output=_StageOutput(_CALL),
+    )
+    assert decision is not None
+    assert decision.metadata["duplex_direct_response"] is True
+    assert decision.metadata["duplex_release_downstream"] is True
+    assert [call["name"] for call in decision.metadata["tool_calls"]] == ["lookup_weather"]
+
+
+def test_a_plain_reply_still_reaches_the_talker() -> None:
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    assert (
+        extension.decide_output(
+            stage_id=0,
+            final_stage_id=2,
+            segment_finished=True,
+            segment_token_ids=(),
+            segment_output_metadata={},
+            output=_StageOutput("The capital of France is Paris."),
+        )
+        is None
+    )

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -202,11 +202,39 @@ def test_token_budget_matches_worker_expected_embedding_count() -> None:
     A mismatch is absorbed silently by the model runner (truncate/pad), so
     pin the two calculations together.
     """
-    for num_samples in (1600, 16000, 24000):
+    for num_samples in (1600, 8000, 16000, 24000, 80000):
         payload = _pcm_payload(num_samples)
         assert duplex_scheduler_token_budget(payload, {}) == Qwen3OmniStage0DuplexRuntime.expected_embedding_count(
             num_samples
         )
+
+
+def test_audio_token_geometry_matches_vllm_thinker_formula() -> None:
+    """Pin our integer reimplementation to vLLM's own conv length arithmetic.
+
+    Mirrors ``_get_feat_extract_output_lengths`` in vLLM's
+    ``qwen3_omni_moe_thinker.py``. If that function changes upstream this
+    test must fail -- the serving layer reserves scheduler slots from it, and
+    under-reserving truncates embeddings with no error.
+
+    Derived from Qwen3-Omni-30B-A3B-Instruct: WhisperFeatureExtractor,
+    hop_length=160 @ 16 kHz => 100 mel frames per second => 13 tokens/second.
+    A linear samples-per-token approximation gives 10 and is wrong.
+    """
+
+    def reference(mel_frames: int) -> int:
+        leave = mel_frames % 100
+        feat_lengths = (leave - 1) // 2 + 1
+        return ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (mel_frames // 100) * 13
+
+    for mel_frames in range(1, 1001):
+        assert Qwen3OmniDuplexPolicy.audio_tokens_for_mel_frames(mel_frames) == reference(mel_frames)
+
+    # Anchor the headline cases so a silent drift is obvious in the diff.
+    assert Qwen3OmniDuplexPolicy.audio_tokens_for_samples(16000) == 13
+    assert Qwen3OmniDuplexPolicy.audio_tokens_for_samples(8000) == 7
+    assert Qwen3OmniDuplexPolicy.audio_tokens_for_samples(80000) == 65
+    assert Qwen3OmniDuplexPolicy.tokens_per_chunk() == 13
 
 
 # --- sampling params -------------------------------------------------------
@@ -341,7 +369,7 @@ def test_capabilities_do_not_claim_model_native_turn_policy() -> None:
 def test_runtime_config_update_preserves_server_owned_state() -> None:
     adapter = Qwen3OmniServingRuntimeAdapter(lambda *_args: "")
     current = {
-        "duplex_samples_per_audio_token": 1600,
+        "duplex_chunk_period_ms": 1000,
         "duplex_stage_max_tokens": {"0": 64, "1": 8192},
     }
 
@@ -351,7 +379,7 @@ def test_runtime_config_update_preserves_server_owned_state() -> None:
         temperature = None
 
     updated = adapter.runtime_config_for_update(_Config(), current)
-    assert updated["duplex_samples_per_audio_token"] == 1600
+    assert updated["duplex_chunk_period_ms"] == 1000
     assert updated["duplex_stage_max_tokens"]["0"] == 99
     assert updated["duplex_stage_max_tokens"]["1"] == 8192
     assert updated["instructions"] == "be brief"

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -542,3 +542,33 @@ def test_sample_count_measured_from_audio_not_a_stale_key() -> None:
     assert duplex_audio_token_count(payload) == Qwen3OmniDuplexPolicy.audio_tokens_for_samples(
         Qwen3OmniDuplexPolicy.CHUNK_SAMPLES * 3
     )
+
+
+def test_data_plane_reads_omni_request_output_objects() -> None:
+    """collect_registered_outputs yields objects, not dicts.
+
+    Guarding projection on isinstance(..., Mapping) silently discards every
+    stage output, which presents as "the model never replies" with no error
+    anywhere.
+    """
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        Qwen3OmniDataPlaneContext,
+        Qwen3OmniDataPlaneSession,
+    )
+
+    completion = SimpleNamespace(text="hello there")
+    output = SimpleNamespace(
+        request_id="r1",
+        finished=False,
+        stage_id=0,
+        request_output=SimpleNamespace(outputs=[completion]),
+        multimodal_output={},
+    )
+    dp = Qwen3OmniDataPlaneSession(lambda *_a: "enc")
+    dp.begin_request("r1")
+    events = list(dp.project({"data_plane_outputs": [output]}, context=Qwen3OmniDataPlaneContext()))
+    assert events, "object-shaped outputs must not be dropped"
+    assert events[0]["text"] == "hello there"
+    assert events[0]["stage_role"] == "llm"

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -33,7 +33,8 @@ from vllm_omni.experimental.fullduplex.qwen3omni.input import Qwen3OmniPcmAppend
 from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
 from vllm_omni.experimental.fullduplex.qwen3omni.runtime import (
     Qwen3OmniDuplexRuntimeExtension,
-    duplex_scheduler_token_budget,
+    build_duplex_prompt_token_ids,
+    duplex_audio_token_count,
 )
 from vllm_omni.experimental.fullduplex.qwen3omni.serving_adapter import (
     Qwen3OmniServingRuntimeAdapter,
@@ -204,9 +205,7 @@ def test_token_budget_matches_worker_expected_embedding_count() -> None:
     """
     for num_samples in (1600, 8000, 16000, 24000, 80000):
         payload = _pcm_payload(num_samples)
-        assert duplex_scheduler_token_budget(payload, {}) == Qwen3OmniStage0DuplexRuntime.expected_embedding_count(
-            num_samples
-        )
+        assert duplex_audio_token_count(payload) == Qwen3OmniStage0DuplexRuntime.expected_embedding_count(num_samples)
 
 
 def test_audio_token_geometry_matches_vllm_thinker_formula() -> None:
@@ -399,11 +398,93 @@ def test_session_state_satisfies_committed_audio_contract() -> None:
     assert adapter.session_state("sess-1") is not state
 
 
-# --- the unimplemented boundary -------------------------------------------
+# --- stage-0 boundary ------------------------------------------------------
 
 
-def test_stage0_audio_embedding_is_explicitly_unimplemented() -> None:
-    """Fails loudly rather than silently producing wrong embeddings."""
+def test_stage0_fails_loudly_without_a_usable_thinker_stage() -> None:
+    """Never silently no-ops: a bad stage raises rather than dropping audio."""
     runtime = Qwen3OmniStage0DuplexRuntime(object())
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        runtime.build_append_embeddings(duplex={}, token_offset=0, prompt_len=10)
+    with pytest.raises(RuntimeError, match="Qwen3-Omni duplex stage 0"):
+        runtime.build_append_embeddings(
+            duplex={"session_id": "s", "incarnation": 0, "payload": _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES)},
+            token_offset=0,
+            prompt_len=13,
+        )
+
+
+# --- conversation scaffolding ----------------------------------------------
+
+_SCAFFOLD = {
+    Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY: [1, 2, 3],
+    Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY: [4, 5],
+    Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY: [6, 7, 8],
+}
+_PAD = Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID
+
+
+def _prompt(*, seq: int, turn_seq: int, final: bool, samples: int = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES):
+    return build_duplex_prompt_token_ids(
+        runtime_config=dict(_SCAFFOLD),
+        payload=_pcm_payload(samples),
+        seq=seq,
+        turn_seq=turn_seq,
+        final=final,
+    )
+
+
+def test_session_opener_carries_system_block_and_user_turn() -> None:
+    ids, audio_offset, audio_tokens = _prompt(seq=1, turn_seq=1, final=False)
+    assert ids[:5] == [1, 2, 3, 4, 5], "session prefix then turn prefix"
+    assert audio_offset == 5
+    assert audio_tokens == 13
+    assert ids[5:] == [_PAD] * 13
+
+
+def test_mid_turn_append_has_no_scaffolding() -> None:
+    """Only audio: the turn is already open and not yet closed."""
+    ids, audio_offset, audio_tokens = _prompt(seq=2, turn_seq=2, final=False)
+    assert audio_offset == 0
+    assert ids == [_PAD] * audio_tokens
+
+
+def test_later_turn_reopens_user_without_repeating_system_block() -> None:
+    ids, audio_offset, _ = _prompt(seq=9, turn_seq=1, final=False)
+    assert ids[:2] == [4, 5]
+    assert audio_offset == 2, "system block belongs to the session, not each turn"
+
+
+def test_final_append_closes_user_and_opens_assistant() -> None:
+    """This suffix is what actually prompts a reply."""
+    ids, _, audio_tokens = _prompt(seq=3, turn_seq=3, final=True)
+    assert ids[-3:] == [6, 7, 8]
+    assert ids == [_PAD] * audio_tokens + [6, 7, 8]
+
+
+def test_prompt_length_equals_reservation() -> None:
+    """Budget must equal produced embeddings; the runner truncates silently."""
+    for seq, turn_seq, final in ((1, 1, False), (2, 2, False), (3, 3, True), (9, 1, True)):
+        ids, audio_offset, audio_tokens = _prompt(seq=seq, turn_seq=turn_seq, final=final)
+        scaffold = len(ids) - audio_tokens
+        assert audio_offset + audio_tokens <= len(ids)
+        assert ids.count(_PAD) == audio_tokens, "audio span is exactly the pad tokens"
+        assert scaffold == audio_offset + (3 if final else 0)
+
+
+def test_audio_span_is_contiguous_and_located_by_audio_offset() -> None:
+    ids, audio_offset, audio_tokens = _prompt(seq=1, turn_seq=1, final=True)
+    assert ids[audio_offset : audio_offset + audio_tokens] == [_PAD] * audio_tokens
+    assert _PAD not in ids[:audio_offset]
+    assert _PAD not in ids[audio_offset + audio_tokens :]
+
+
+def test_missing_scaffolding_degrades_to_audio_only() -> None:
+    """No tokenizer at config time must not crash the append path."""
+    ids, audio_offset, audio_tokens = build_duplex_prompt_token_ids(
+        runtime_config={},
+        payload=_pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        seq=1,
+        turn_seq=1,
+        final=True,
+    )
+    assert audio_offset == 0
+    assert ids == [_PAD] * audio_tokens

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -845,3 +845,71 @@ def test_audio_cursor_survives_a_turn_boundary() -> None:
     turn(260)
 
     assert seen == [100, 160], f"turn 2 must send only its own 160 samples, got {seen}"
+
+
+# --- text turns -------------------------------------------------------------
+#
+# A text turn is the same chat turn as an audio one with real token ids where
+# the audio span would be. Two things must hold or the thinker reads the turn
+# as empty and answers as if the user said nothing:
+#   * zero `<|audio_pad|>` slots are reserved, since stage 0 fills none;
+#   * no `<|audio_start|>` / `<|audio_end|>`, which tell the thinker to expect
+#     an audio span and make it treat the words as a transcription task.
+
+
+def _text_prompt(*, seq: int, turn_seq: int, final: bool = True, text: str = "hello there", ids=(41, 42)):
+    import vllm_omni.experimental.fullduplex.qwen3omni.runtime as runtime_mod
+
+    original = runtime_mod._encode_text
+    runtime_mod._encode_text = lambda value: list(ids) if value == text else []
+    try:
+        return build_duplex_prompt_token_ids(
+            runtime_config=dict(_SCAFFOLD),
+            payload=text,
+            seq=seq,
+            turn_seq=turn_seq,
+            final=final,
+        )
+    finally:
+        runtime_mod._encode_text = original
+
+
+def test_text_turn_reserves_no_audio_slots() -> None:
+    ids, _audio_offset, audio_tokens = _text_prompt(seq=1, turn_seq=1)
+    assert audio_tokens == 0
+    assert _PAD not in ids
+
+
+def test_text_turn_omits_the_audio_delimiters() -> None:
+    ids, _audio_offset, _audio_tokens = _text_prompt(seq=1, turn_seq=1)
+    assert Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID not in ids
+    assert Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID not in ids
+
+
+def test_text_turn_is_a_well_formed_first_turn() -> None:
+    ids, _audio_offset, _audio_tokens = _text_prompt(seq=1, turn_seq=1)
+    # system block, user opener, the text itself, then close-user/open-assistant
+    assert ids == [1, 2, 3, 4, 5, 41, 42, 6, 7, 8]
+
+
+def test_later_text_turn_closes_the_assistant_turn_first() -> None:
+    ids, _audio_offset, _audio_tokens = _text_prompt(seq=2, turn_seq=2)
+    assert ids == [*_CLOSE_PREV, 4, 5, 41, 42, 6, 7, 8]
+
+
+def test_text_turn_without_a_tokenizer_is_refused() -> None:
+    """Encoding to nothing must fail loudly.
+
+    Sending an empty user turn would prompt the model to answer a question the
+    user never asked, which reads to them as being ignored -- the same failure
+    mode as the unfilled-placeholder bug.
+    """
+    with pytest.raises(ValueError, match="tokenizer"):
+        _text_prompt(seq=1, turn_seq=1, ids=())
+
+
+def test_audio_turn_is_unchanged_by_the_text_path() -> None:
+    ids, audio_offset, audio_tokens = _prompt(seq=1, turn_seq=1, final=False)
+    assert audio_tokens == 13
+    assert ids[5] == Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID
+    assert audio_offset == 6

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -488,3 +488,57 @@ def test_missing_scaffolding_degrades_to_audio_only() -> None:
     )
     assert audio_offset == 0
     assert ids == [_PAD] * audio_tokens
+
+
+def test_commit_payload_closes_the_turn_without_the_final_flag() -> None:
+    """The framework never passes final=True; the commit rides on the payload.
+
+    session_runner.py:1184,1434 hard-code final=False because MiniCPM decides
+    listen/speak natively. Qwen3-Omni needs the assistant generation prompt,
+    so a commit is signalled on the payload instead.
+    """
+    payload = _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES)
+    payload[Qwen3OmniDuplexPolicy.TURN_FINAL_KEY] = True
+    ids, _, audio_tokens = build_duplex_prompt_token_ids(
+        runtime_config=dict(_SCAFFOLD), payload=payload, seq=2, turn_seq=2, final=False
+    )
+    assert ids[-3:] == [6, 7, 8], "assistant generation prompt must be appended"
+    assert ids == [_PAD] * audio_tokens + [6, 7, 8]
+
+
+def test_prepare_commit_marks_the_payload_turn_final() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    buffer.prepare_append(
+        _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        operation_id="o1",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=False,
+    )
+    reservation = buffer.prepare_commit(operation_id="o2", chunk_period_ms=CHUNK_MS)
+    assert reservation.payload is not None
+    assert reservation.payload[Qwen3OmniDuplexPolicy.TURN_FINAL_KEY] is True
+
+
+def test_plain_append_is_not_marked_turn_final() -> None:
+    buffer = Qwen3OmniPcmAppendBuffer()
+    reservation = buffer.prepare_append(
+        _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES),
+        operation_id="o1",
+        chunk_period_ms=CHUNK_MS,
+        allow_emit=True,
+    )
+    assert reservation is not None and reservation.payload is not None
+    assert Qwen3OmniDuplexPolicy.TURN_FINAL_KEY not in reservation.payload
+
+
+def test_sample_count_measured_from_audio_not_a_stale_key() -> None:
+    """_merge_native_audio_payloads rebuilds `audio` but copies num_samples.
+
+    A concatenated payload therefore carries the tail's num_samples. Trusting
+    it would under-reserve slots and the runner would truncate silently.
+    """
+    payload = _pcm_payload(Qwen3OmniDuplexPolicy.CHUNK_SAMPLES * 3)
+    payload["num_samples"] = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES  # stale, as after a merge
+    assert duplex_audio_token_count(payload) == Qwen3OmniDuplexPolicy.audio_tokens_for_samples(
+        Qwen3OmniDuplexPolicy.CHUNK_SAMPLES * 3
+    )

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -572,3 +572,88 @@ def test_data_plane_reads_omni_request_output_objects() -> None:
     assert events, "object-shaped outputs must not be dropped"
     assert events[0]["text"] == "hello there"
     assert events[0]["stage_role"] == "llm"
+
+
+# --- stop condition and transcript ------------------------------------------
+
+
+def test_stage0_sampling_stops_on_im_end() -> None:
+    """Without an EOS stop token the thinker runs to max_tokens.
+
+    Observed live: a 4 s input produced ~385 s of audio because generation
+    only ended at the cap. Every extra token becomes synthesized speech.
+    """
+    import asyncio
+
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_a: "")
+
+    class _Config:
+        instructions = None
+        max_tokens = None
+        temperature = 0.7
+        extra_body: dict = {}
+
+    cfg = asyncio.run(adapter.prepare_runtime_config(_Config(), model_config=None))
+    stage0 = cfg["duplex_stage_sampling_params"]["0"]
+    assert Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID in stage0["stop_token_ids"]
+    assert cfg["duplex_stage_max_tokens"]["0"] <= 256, "a spoken turn should be short"
+
+
+def test_runtime_config_update_keeps_the_stop_token() -> None:
+    adapter = Qwen3OmniServingRuntimeAdapter(lambda *_a: "")
+
+    class _Config:
+        instructions = None
+        max_tokens = None
+        temperature = 0.5
+
+    updated = adapter.runtime_config_for_update(_Config(), {})
+    assert Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID in updated["duplex_stage_sampling_params"]["0"]["stop_token_ids"]
+
+
+def test_decide_output_returns_none_so_audio_still_flows() -> None:
+    """A direct response would surface text but kill the audio.
+
+    orchestrator.py:1284-1295 returns immediately after emitting a direct
+    response, skipping _forward_to_next_stage. Verified live: marking thinker
+    output as a direct response delivered the transcript and zero audio,
+    because stage 2 never ran.
+    """
+    from types import SimpleNamespace
+
+    ext = Qwen3OmniDuplexRuntimeExtension()
+    output = SimpleNamespace(outputs=[SimpleNamespace(text="hello there")])
+    for stage_id in (0, 1, 2):
+        assert (
+            ext.decide_output(
+                stage_id=stage_id,
+                final_stage_id=2,
+                segment_finished=True,
+                segment_token_ids=(1, 2),
+                segment_output_metadata={},
+                output=output,
+            )
+            is None
+        )
+
+
+def test_data_plane_reads_text_from_raw_request_output() -> None:
+    """Stage 0 sends a raw vllm RequestOutput, not a wrapped OmniRequestOutput."""
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        Qwen3OmniDataPlaneContext,
+        Qwen3OmniDataPlaneSession,
+    )
+
+    raw = SimpleNamespace(
+        request_id="r1",
+        finished=False,
+        stage_id=0,
+        outputs=[SimpleNamespace(text="unwrapped text")],
+        multimodal_output={},
+    )
+    dp = Qwen3OmniDataPlaneSession(lambda *_a: "enc")
+    dp.begin_request("r1")
+    events = list(dp.project({"data_plane_outputs": [raw]}, context=Qwen3OmniDataPlaneContext()))
+    assert events and events[0]["text"] == "unwrapped text"

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -716,3 +716,91 @@ def test_every_turn_is_framed_not_just_the_first() -> None:
         assert ids[audio_offset + audio_tokens] == Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID
         # Only the first turn of the session repeats the system block.
         assert (1 in ids) == (turn_seq == 1)
+
+
+def test_cumulative_audio_is_sliced_to_the_new_tail() -> None:
+    """Code2Wav emits the whole waveform each time; only the tail is new.
+
+    Forwarding each output in full makes the client replay the reply from the
+    start repeatedly -- heard as "I. I. I. I'm doing great". Measured delta
+    sizes for one reply: 14250, 110250, 206250, 217770 bytes.
+    """
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        Qwen3OmniDataPlaneContext,
+        Qwen3OmniDataPlaneSession,
+    )
+
+    seen: list[int] = []
+
+    def encode(audio, sr, fmt, speed):
+        seen.append(len(audio))
+        return "x" * len(audio)
+
+    dp = Qwen3OmniDataPlaneSession(encode)
+    dp.begin_request("r1")
+    ctx = Qwen3OmniDataPlaneContext(modalities=("audio",))
+
+    # Cumulative: 100 samples, then 250, then 400.
+    for total in (100, 250, 400):
+        out = SimpleNamespace(
+            request_id="r1",
+            finished=False,
+            stage_id=2,
+            multimodal_output={"audio": list(range(total)), "sr": 24000},
+        )
+        list(dp.project({"data_plane_outputs": [out]}, context=ctx))
+
+    assert seen == [100, 150, 150], f"expected new tails only, got {seen}"
+
+
+def test_repeated_identical_audio_emits_nothing_new() -> None:
+    from types import SimpleNamespace
+
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        Qwen3OmniDataPlaneContext,
+        Qwen3OmniDataPlaneSession,
+    )
+
+    dp = Qwen3OmniDataPlaneSession(lambda a, *_: "y" * len(a))
+    dp.begin_request("r1")
+    ctx = Qwen3OmniDataPlaneContext(modalities=("audio",))
+    out = SimpleNamespace(
+        request_id="r1",
+        finished=False,
+        stage_id=2,
+        multimodal_output={"audio": list(range(64)), "sr": 24000},
+    )
+    first = list(dp.project({"data_plane_outputs": [out]}, context=ctx))
+    second = list(dp.project({"data_plane_outputs": [out]}, context=ctx))
+    assert first, "first delta must be emitted"
+    assert second == [], "an unchanged cumulative buffer has no new audio"
+
+
+def test_audio_length_uses_the_sample_axis_not_the_batch_axis() -> None:
+    """Code2Wav returns [1, samples]; len() would give the batch dim.
+
+    Reading len() made every cumulative output look like length 1, so only the
+    first delta was ever emitted and the reply was truncated to 0.30 s.
+    """
+    from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+        _audio_length,
+        _audio_tail,
+    )
+
+    class _T:
+        def __init__(self, n):
+            self.shape = (1, n)
+            self._n = n
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, key):
+            assert isinstance(key, tuple) and key[0] is Ellipsis, "must slice the sample axis"
+            return _T(self._n - (key[1].start or 0))
+
+    assert _audio_length(_T(7125)) == 7125
+    assert _audio_length([0] * 40) == 40
+    assert _audio_tail(_T(55125), 7125).shape == (1, 48000)

--- a/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_contracts.py
@@ -964,8 +964,32 @@ def test_a_tool_call_is_reported_once_even_as_text_accumulates() -> None:
 def test_a_genuinely_new_call_is_still_reported() -> None:
     extension = Qwen3OmniDuplexRuntimeExtension()
     extension._new_tool_calls(_StageOutput(_CALL))
-    later = extension._new_tool_calls(_StageOutput(f"{_CALL}It is 18 degrees.{_CALL2}"))
+    later = extension._new_tool_calls(_StageOutput(f"{_CALL}{_CALL2}"))
     assert [call["name"] for call in later] == ["check_inventory"]
+
+
+def test_a_turn_carrying_speech_is_not_a_tool_call() -> None:
+    """Speaking wins when the turn has something to say.
+
+    Claiming the turn produces a direct response, which suppresses its audio --
+    right for a bare tool call, fatal when the model appends a redundant call to
+    a real answer. Observed live: after a tool result the model replied "The
+    weather in Barcelona is 18C with light rain." *and* re-emitted the same
+    call. Intercepting that threw away the answer and dead-ended the
+    conversation in silence, because the client rightly refuses to re-run a call
+    it has already run.
+    """
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    mixed = extension._new_tool_calls(_StageOutput(f"The weather in Barcelona is 18C.{_CALL}"))
+    assert mixed == []
+
+
+def test_an_ignored_mixed_call_is_not_re_examined_later() -> None:
+    """A call skipped for carrying speech must still advance the cursor."""
+    extension = Qwen3OmniDuplexRuntimeExtension()
+    extension._new_tool_calls(_StageOutput(f"Some spoken answer.{_CALL}"))
+    again = extension._new_tool_calls(_StageOutput(f"Some spoken answer.{_CALL} and more"))
+    assert again == []
 
 
 def test_a_partially_streamed_call_is_not_skipped() -> None:

--- a/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stage-0 audio ingress tests for the Qwen3-Omni duplex path.
+
+These use the checkpoint's REAL ``WhisperFeatureExtractor`` with a stubbed
+audio tower, so they verify the mel geometry and the reservation invariant
+without needing GPU weights. They skip when the checkpoint is unavailable.
+
+The mel-shape assertion is the important one: Whisper's extractor pads to its
+30 s ``n_samples`` by default, which yields 3000 mel frames for a 1 s chunk
+instead of 100 -- a 230x over-run of the 13-slot reservation that the model
+runner would absorb silently.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
+
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import (  # noqa: E402
+    Qwen3OmniDuplexPolicy,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.stage0 import (  # noqa: E402
+    Qwen3OmniStage0DuplexRuntime,
+)
+
+MODEL_ID = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+HIDDEN = 2048
+CHUNK = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES
+
+
+class _FakeTower(torch.nn.Module):
+    """Stands in for ``Qwen3OmniMoeAudioEncoder``.
+
+    Returns ``sum(aftercnn_lens)`` rows, which is the contract
+    ``_process_audio_input`` relies on when it splits the tower output by
+    ``audio_output_lengths``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._p = torch.nn.Parameter(torch.zeros(1))
+        self.dtype = torch.float32
+        self.calls: list[tuple[tuple[int, ...], int, int]] = []
+
+    def forward(self, input_features, feature_lens, aftercnn_lens):
+        self.calls.append((tuple(input_features.shape), int(feature_lens[0]), int(aftercnn_lens[0])))
+        return torch.ones(int(aftercnn_lens.sum()), HIDDEN)
+
+
+class _FakeThinker:
+    def __init__(self) -> None:
+        self.audio_tower = _FakeTower()
+
+
+class _FakeModel:
+    def __init__(self) -> None:
+        self.thinker = _FakeThinker()
+
+
+@pytest.fixture(scope="module")
+def feature_extractor():
+    transformers = pytest.importorskip("transformers")
+    try:
+        processor = transformers.AutoProcessor.from_pretrained(MODEL_ID, trust_remote_code=True)
+    except Exception as exc:  # noqa: BLE001 - offline / no checkpoint
+        pytest.skip(f"{MODEL_ID} processor unavailable: {exc}")
+    return processor.feature_extractor
+
+
+@pytest.fixture
+def runtime(feature_extractor):
+    rt = Qwen3OmniStage0DuplexRuntime(_FakeModel())
+    rt._feature_extractor = feature_extractor
+    return rt
+
+
+def _payload(num_samples: int) -> dict[str, object]:
+    return {
+        "audio": base64.b64encode(np.zeros(num_samples, dtype="<f4").tobytes()).decode("ascii"),
+        "format": Qwen3OmniDuplexPolicy.PCM_FORMAT,
+        "sample_rate_hz": Qwen3OmniDuplexPolicy.SAMPLE_RATE_HZ,
+        "num_samples": num_samples,
+    }
+
+
+def _duplex(num_samples: int, *, seq: int = 1, epoch: int = 0, session_id: str = "s1") -> dict[str, object]:
+    return {
+        "data_plane": True,
+        "session_id": session_id,
+        "incarnation": 1,
+        "epoch": epoch,
+        "seq": seq,
+        "payload": _payload(num_samples),
+    }
+
+
+def test_one_second_chunk_yields_thirteen_embeddings(runtime) -> None:
+    """1 s -> mel (128, 100) -> 13 embeddings, matching the reservation."""
+    embeds = runtime.build_append_embeddings(duplex=_duplex(CHUNK), token_offset=0, prompt_len=13)
+    assert embeds is not None
+    assert embeds.shape == (13, HIDDEN)
+
+    mel_shape, feature_lens, aftercnn_lens = runtime._model.thinker.audio_tower.calls[-1]
+    # Guards the Whisper default-padding trap: 3000 here instead of 100 means
+    # padding="longest"/truncation=False was lost.
+    assert mel_shape == (128, 100), f"tower saw mel {mel_shape}, expected (128, 100)"
+    assert feature_lens == 100
+    assert aftercnn_lens == 13
+
+
+def test_partial_chunks_accumulate(runtime) -> None:
+    assert runtime.build_append_embeddings(duplex=_duplex(CHUNK // 2), token_offset=0, prompt_len=13) is None
+    embeds = runtime.build_append_embeddings(
+        duplex=_duplex(CHUNK // 2, seq=2),
+        token_offset=0,
+        prompt_len=13,
+    )
+    assert embeds is not None
+    assert embeds.shape[0] == 13
+
+
+def test_multi_chunk_append_encodes_per_chunk(runtime) -> None:
+    embeds = runtime.build_append_embeddings(duplex=_duplex(CHUNK * 3), token_offset=0, prompt_len=39)
+    assert embeds.shape[0] == 39
+    # Encoding per 1 s chunk is what keeps each call on the tower's own
+    # n_window*2 conv boundary.
+    assert len(runtime._model.thinker.audio_tower.calls) == 3
+
+
+def test_replay_of_same_append_is_memoized(runtime) -> None:
+    duplex = _duplex(CHUNK, seq=7)
+    first = runtime.build_append_embeddings(duplex=duplex, token_offset=0, prompt_len=13)
+    calls = len(runtime._model.thinker.audio_tower.calls)
+    second = runtime.build_append_embeddings(duplex=duplex, token_offset=0, prompt_len=13)
+    assert torch.equal(first, second)
+    assert len(runtime._model.thinker.audio_tower.calls) == calls, "replay must not re-encode"
+
+
+def test_sessions_have_independent_buffers(runtime) -> None:
+    half = CHUNK // 2
+    assert runtime.build_append_embeddings(duplex=_duplex(half, session_id="A"), token_offset=0, prompt_len=13) is None
+    assert runtime.build_append_embeddings(duplex=_duplex(half, session_id="B"), token_offset=0, prompt_len=13) is None
+    assert len(runtime.sessions) == 2
+
+
+def test_embedding_reservation_mismatch_raises(runtime) -> None:
+    """A miscount must fail loudly; the model runner would truncate silently."""
+
+    class _OverProducingTower(_FakeTower):
+        def forward(self, input_features, feature_lens, aftercnn_lens):
+            super().forward(input_features, feature_lens, aftercnn_lens)
+            return torch.ones(int(aftercnn_lens.sum()) + 1, HIDDEN)
+
+    runtime._model.thinker.audio_tower = _OverProducingTower()
+    with pytest.raises(RuntimeError, match="reserved"):
+        runtime.build_append_embeddings(duplex=_duplex(CHUNK), token_offset=0, prompt_len=13)
+
+
+def test_non_pcm_f32le_payload_is_rejected(runtime) -> None:
+    duplex = _duplex(16)
+    duplex["payload"]["format"] = "pcm_s16le"
+    with pytest.raises(ValueError, match="unsupported duplex audio format"):
+        runtime.build_append_embeddings(duplex=duplex, token_offset=0, prompt_len=1)

--- a/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
@@ -185,3 +185,21 @@ def test_non_pcm_f32le_payload_is_rejected(runtime) -> None:
     duplex["payload"]["format"] = "pcm_s16le"
     with pytest.raises(ValueError, match="unsupported duplex audio format"):
         runtime.build_append_embeddings(duplex=duplex, token_offset=0, prompt_len=1)
+
+
+def test_turn_audio_resets_at_a_turn_boundary(runtime) -> None:
+    """A turn is encoded with its own context, not the whole conversation.
+
+    Carrying `turn_audio` across turns made every later turn re-encode all
+    prior audio, so replies kept answering the first question.
+    """
+    final = {**_duplex(CHUNK, seq=1), "final": True}
+    runtime.build_append_embeddings(duplex=final, token_offset=0, prompt_len=13)
+
+    state = runtime.session("s1", 1)
+    assert state.turn_audio is None, "closing a turn must clear its audio context"
+    assert state.chunk_index == 0
+
+    runtime.build_append_embeddings(duplex={**_duplex(CHUNK, seq=2), "final": True}, token_offset=0, prompt_len=13)
+    mel_shape, feature_lens, _ = runtime._model.thinker.audio_tower.calls[-1]
+    assert feature_lens == 100, "turn 2 encodes 1 s, not 2 s of accumulated audio"

--- a/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
+++ b/tests/e2e/features/fullduplex/qwen3omni/test_stage0.py
@@ -125,12 +125,30 @@ def test_partial_chunks_accumulate(runtime) -> None:
     assert embeds.shape[0] == 13
 
 
-def test_multi_chunk_append_encodes_per_chunk(runtime) -> None:
+def test_multi_chunk_append_encodes_with_context(runtime) -> None:
+    """The whole turn is encoded once, not each second in isolation.
+
+    The tower attends across 8 one-second chunks, so an isolated chunk sees no
+    context. Measured against a whole-utterance encode of the same 4 s audio:
+    per-chunk cosine 0.844 (min 0.154) vs cumulative 0.949 (min 0.727).
+    """
     embeds = runtime.build_append_embeddings(duplex=_duplex(CHUNK * 3), token_offset=0, prompt_len=39)
     assert embeds.shape[0] == 39
-    # Encoding per 1 s chunk is what keeps each call on the tower's own
-    # n_window*2 conv boundary.
-    assert len(runtime._model.thinker.audio_tower.calls) == 3
+    calls = runtime._model.thinker.audio_tower.calls
+    assert len(calls) == 1, "one encode over the whole span, not three"
+    mel_shape, feature_lens, _ = calls[-1]
+    assert feature_lens == 300, "3 s of audio at 100 mel frames per second"
+    assert mel_shape == (128, 300)
+
+
+def test_successive_appends_re_encode_the_whole_turn(runtime) -> None:
+    """Each append re-encodes the turn so far and returns only the new rows."""
+    first = runtime.build_append_embeddings(duplex=_duplex(CHUNK, seq=1), token_offset=0, prompt_len=13)
+    second = runtime.build_append_embeddings(duplex=_duplex(CHUNK, seq=2), token_offset=13, prompt_len=13)
+    assert first.shape[0] == 13
+    assert second.shape[0] == 13, "only the newly completed second is returned"
+    calls = runtime._model.thinker.audio_tower.calls
+    assert calls[-1][1] == 200, "second append encodes 2 s of context"
 
 
 def test_replay_of_same_append_is_memoized(runtime) -> None:

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -243,15 +243,21 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         return False
 
-    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        # Remove FINISHED_ABORTED requests before the upstream scheduler sees
-        # them. Upstream vllm raises RuntimeError on this status; omni allows
-        # async abort (e.g. client disconnect during TTS streaming) to leave
-        # requests in the waiting/running queues temporarily.
+    def _drop_aborted_queued_requests(self) -> None:
+        """Evict FINISHED_ABORTED requests from the scheduler queues.
+
+        Upstream vllm raises ``RuntimeError: Invalid request status`` when it
+        dequeues one (``scheduler.py``); omni allows async abort -- client
+        disconnect during TTS streaming, or a duplex barge-in / session close
+        -- to leave requests queued briefly.
+        """
         for queue in (self.waiting, self.running):
             for req in list(queue):
                 if getattr(req, "status", None) == RequestStatus.FINISHED_ABORTED:
                     queue.remove(req)
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        self._drop_aborted_queued_requests()
         self._consume_pending_connector_output(model_mode="ar")
         self._process_pending_input_timeouts()
         if self.chunk_transfer_adapter:
@@ -259,13 +265,45 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self.waiting, self.running, scheduler_requests=self.requests
             )
 
+        # The three calls above re-enqueue requests -- notably
+        # `process_pending_chunks`, which wakes a downstream stage when its
+        # next chunk lands. If that request was aborted in the meantime it
+        # goes back into `waiting` after the first sweep, and the upstream
+        # scheduler then dequeues it and raises, killing the engine core.
+        # Observed on a Qwen3-Omni duplex session close: stage 1 died with
+        # "Invalid request status: FINISHED_ABORTED", taking the orchestrator
+        # with it. Sweep again immediately before handing over.
+        self._drop_aborted_queued_requests()
+
         original_waiting = None
         if self._should_defer_waiting_admission():
             original_waiting = self.waiting
             self.waiting = create_request_queue(self.policy)
 
         try:
-            scheduler_output = super().schedule(throttle_prefills)
+            try:
+                scheduler_output = super().schedule(throttle_prefills)
+            except RuntimeError as exc:
+                # Upstream raises on dequeueing a FINISHED_ABORTED request. It
+                # appends to `self.running` *before* checking status, so the
+                # entry is only observable once the exception is in flight --
+                # sweeping the queues beforehand cannot prevent it, as the
+                # request is still schedulable at that point and is aborted
+                # while the call is in progress.
+                #
+                # Observed on Qwen3-Omni duplex session close: stage 1 raised
+                # "Invalid request status: FINISHED_ABORTED" and killed its
+                # engine core, taking the orchestrator down with it, so every
+                # session ended by tearing down the server.
+                #
+                # Drop the aborted residue and retry once. The retry sees a
+                # clean queue; a second failure is a different fault and
+                # propagates.
+                if "Invalid request status" not in str(exc):
+                    raise
+                logger.warning("Recovering from aborted request during schedule: %s", exc)
+                self._drop_aborted_queued_requests()
+                scheduler_output = super().schedule(throttle_prefills)
         finally:
             if original_waiting is not None:
                 deferred_waiting = list(self.waiting)

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -251,7 +251,15 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         disconnect during TTS streaming, or a duplex barge-in / session close
         -- to leave requests queued briefly.
         """
-        for queue in (self.waiting, self.running):
+        # All three queues upstream's `schedule()` reads from. `skipped_waiting`
+        # matters as much as the other two: upstream parks requests there mid
+        # schedule and prepends them back onto `waiting`, so an aborted entry
+        # left in it reappears and raises on the very next attempt -- which made
+        # retrying look useless. Missing it is why ten concurrent session closes
+        # could still kill the stage.
+        for queue in (self.waiting, self.running, getattr(self, "skipped_waiting", None)):
+            if queue is None:
+                continue
             for req in list(queue):
                 if getattr(req, "status", None) == RequestStatus.FINISHED_ABORTED:
                     queue.remove(req)
@@ -288,29 +296,36 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             self.waiting = create_request_queue(self.policy)
 
         try:
-            try:
-                scheduler_output = super().schedule(throttle_prefills)
-            except RuntimeError as exc:
-                # Upstream raises on dequeueing a FINISHED_ABORTED request. It
-                # appends to `self.running` *before* checking status, so the
-                # entry is only observable once the exception is in flight --
-                # sweeping the queues beforehand cannot prevent it, as the
-                # request is still schedulable at that point and is aborted
-                # while the call is in progress.
-                #
-                # Observed on Qwen3-Omni duplex session close: stage 1 raised
-                # "Invalid request status: FINISHED_ABORTED" and killed its
-                # engine core, taking the orchestrator down with it, so every
-                # session ended by tearing down the server.
-                #
-                # Drop the aborted residue and retry once. The retry sees a
-                # clean queue; a second failure is a different fault and
-                # propagates.
-                if "Invalid request status" not in str(exc):
-                    raise
-                logger.warning("Recovering from aborted request during schedule: %s", exc)
-                self._drop_aborted_queued_requests()
-                scheduler_output = super().schedule(throttle_prefills)
+            # Upstream raises on dequeueing a FINISHED_ABORTED request. It
+            # appends to `self.running` *before* checking status, so the entry
+            # is only observable once the exception is in flight -- sweeping the
+            # queues beforehand cannot prevent it, as the request is still
+            # schedulable at that point and is aborted while the call is in
+            # progress.
+            #
+            # Observed on Qwen3-Omni duplex session close: stage 1 raised
+            # "Invalid request status: FINISHED_ABORTED" and killed its engine
+            # core, taking the orchestrator down with it, so every session ended
+            # by tearing down the server.
+            #
+            # Recover instead of prevent: drop the aborted residue and retry.
+            # Each attempt can only surface one aborted request, so a single
+            # retry is not enough when several abort at once -- ten concurrent
+            # duplex sessions closing together exhausted a one-shot retry and
+            # killed the stage. Retry once per queued request at most, which
+            # bounds the loop by construction, since every recovery removes at
+            # least the entry that raised.
+            attempts_left = len(self.waiting) + len(self.running) + 1
+            while True:
+                try:
+                    scheduler_output = super().schedule(throttle_prefills)
+                    break
+                except RuntimeError as exc:
+                    attempts_left -= 1
+                    if "Invalid request status" not in str(exc) or attempts_left <= 0:
+                        raise
+                    logger.warning("Recovering from aborted request during schedule: %s", exc)
+                    self._drop_aborted_queued_requests()
         finally:
             if original_waiting is not None:
                 deferred_waiting = list(self.waiting)

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -275,6 +275,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # with it. Sweep again immediately before handing over.
         self._drop_aborted_queued_requests()
 
+        # `process_pending_chunks` above rewrites `request.status` when it parks
+        # and un-parks requests, which can move a request out of
+        # WAITING_FOR_STREAMING_REQ without unwinding upstream's counter. Restate
+        # it from queue membership while `self.waiting` is still the real queue
+        # (the deferred-admission dance below swaps in an empty one).
+        self._resync_streaming_input_counter()
+
         original_waiting = None
         if self._should_defer_waiting_admission():
             original_waiting = self.waiting
@@ -801,6 +808,14 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # ``input_batch`` slot never pins a freed request and starves
         # new admissions. See ``OmniSchedulerMixin._purge_finished_from_running``.
         self._purge_finished_from_running()
+
+        # An abort is the one leak that is never recoverable on its own: the
+        # engine only calls `schedule()` when `has_work()` is true, and an
+        # inflated `num_waiting_for_streaming_input` is precisely what makes
+        # `has_work()` false. Resync here, on the path that removes the
+        # request, or the next request to arrive at this stage is masked and
+        # the engine parks in `input_queue.get()` forever.
+        self._resync_streaming_input_counter()
 
         input_coordinator = getattr(self, "input_coordinator", None)
         if input_coordinator is not None:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -403,6 +403,12 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         # corner case slips past upstream's status-driven removal.
         self._purge_finished_from_running()
 
+        # See ``OmniSchedulerMixin._resync_streaming_input_counter`` -- keeps
+        # ``num_waiting_for_streaming_input`` from outliving the request it was
+        # counted for, which otherwise makes ``EngineCore.has_work()`` read
+        # false with live work queued and parks the stage permanently.
+        self._resync_streaming_input_counter()
+
         if self.input_coordinator is not None:
             for request in finished:
                 self._free_input_coordinator_request(request.request_id)

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -306,3 +306,60 @@ class OmniSchedulerMixin:
         if not self.running:
             return
         self.running[:] = [req for req in self.running if not req.is_finished() and req.request_id in self.requests]
+
+    def _resync_streaming_input_counter(self) -> None:
+        """Re-derive ``num_waiting_for_streaming_input`` from queue membership.
+
+        Upstream maintains that counter incrementally: ``+1`` when a
+        resumable request runs out of input and parks in a waiting queue as
+        ``WAITING_FOR_STREAMING_REQ``, ``-1`` when the next streaming update
+        arrives or when ``finish_requests`` removes a request still in that
+        status.  ``get_num_unfinished_requests`` then *subtracts* it from the
+        waiting queues, so a parked request does not read as runnable work.
+
+        Omni moves requests between queues and rewrites ``request.status``
+        outside those two hooks -- the chunk-transfer adapter parks a request
+        as ``WAITING_FOR_CHUNK`` and restores it from
+        ``requests_origin_status``, and ``_realign_request_status_to_queues``
+        rewrites status to match queue membership.  Any of those that lands on
+        a request counted as ``WAITING_FOR_STREAMING_REQ`` moves it out of
+        that status without the matching ``-1``, and the counter is left one
+        too high *permanently*: nothing in either code path ever recomputes
+        it.
+
+        The consequence is a hung stage, not a slow one. Observed on
+        Qwen3-Omni duplex: the talker's request was aborted at session close
+        while counted but with status already stomped to ``RUNNING``, leaving
+        the counter at 1. On the next session ``get_num_unfinished_requests``
+        computed ``(1 waiting + 0 skipped - 1 phantom) + 0 running == 0``, so
+        ``EngineCore.has_work()`` was False with a live request sitting in
+        ``waiting``. The engine parked in ``input_queue.get()`` and never
+        called ``schedule()`` again -- the talker never ran, no codec tokens
+        reached Code2Wav, and the client waited forever on a server that
+        still reported healthy and still accepted audio. One leak per
+        session, so the endpoint answered the first conversation after every
+        boot and went silent from the second on.
+
+        Rather than chase every status write, restate the invariant the
+        counter is *supposed* to encode -- the number of requests currently
+        in the waiting queues that are parked for streaming input -- and
+        recompute it from that ground truth. In the healthy case this is
+        exactly what upstream's incremental arithmetic produces, so it is a
+        no-op; when a status stomp has desynced it, it self-heals on the next
+        call. O(len(waiting)), which is bounded by ``max_num_seqs``.
+        """
+        counter = getattr(self, "num_waiting_for_streaming_input", None)
+        if counter is None:
+            return
+        parked = 0
+        for queue in (getattr(self, "waiting", None), getattr(self, "skipped_waiting", None)):
+            if not queue:
+                continue
+            parked += sum(1 for req in queue if req.status == RequestStatus.WAITING_FOR_STREAMING_REQ)
+        if parked != counter:
+            logger.debug(
+                "[Omni] resynced num_waiting_for_streaming_input %s -> %s",
+                counter,
+                parked,
+            )
+            self.num_waiting_for_streaming_input = parked

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import time as _time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -827,11 +827,12 @@ class Orchestrator:
                 )
             )
 
-    async def _abort_request_ids(self, request_ids: list[str]) -> None:
-        """Forward abort requests to all stage pools."""
+    async def _abort_request_ids(self, request_ids: list[str], *, stage_ids: Iterable[int] | None = None) -> None:
+        """Forward abort requests to stage pools, or to ``stage_ids`` only."""
         if not request_ids:
             return
-        for pool in self.stage_pools:
+        pools = self.stage_pools if stage_ids is None else [self.stage_pools[stage_id] for stage_id in stage_ids]
+        for pool in pools:
             await pool.abort_requests(request_ids)
             pool.release_bindings(request_ids)
 
@@ -1552,32 +1553,24 @@ class Orchestrator:
             )
         )
 
-        # A direct response returns without forwarding, which strands whatever
-        # `_prewarm_async_chunk_stages` already submitted downstream: those
-        # requests are waiting for chunks that will now never be sent. They sit
-        # in their stage's waiting queue as WAITING_FOR_STREAMING_REQ forever,
-        # holding a slot and — because `get_num_unfinished_requests` subtracts
-        # parked requests — making `EngineCore.has_work()` read false. The next
-        # session's request is then invisible and that stage never schedules
-        # again. Same wedge as vllm-omni#5662, reached from the direct-response
-        # path instead of the abort path.
+        # A direct response returns without forwarding, so anything
+        # `_prewarm_async_chunk_stages` already submitted downstream is left
+        # waiting for chunks that will never be sent. When the runtime says
+        # this response ends the turn, release those stages; otherwise they
+        # park forever holding a slot -- and because
+        # `get_num_unfinished_requests` subtracts requests parked for streaming
+        # input, `EngineCore.has_work()` reads false and that stage never
+        # schedules again, for this request or any later one.
         #
-        # Opt-in, because a runtime that expects its prewarmed stages to
-        # survive a direct response would be broken by this. The next stage-0
-        # submit re-prewarms, so releasing here costs only the warm slot.
+        # Opt-in, because a parked downstream stage is correct for a runtime
+        # whose direct response is *not* terminal: MiniCPM's `listen` decision
+        # reuses those same warm stages when the model later speaks, and
+        # upstream only prewarms on the initial submit, so releasing them there
+        # would leave a later speak turn with no talker.
         if decision.metadata.get("duplex_release_downstream") is True:
-            req_state = self.request_states.get(req_id)
-            final_stage_id = req_state.final_stage_id if req_state is not None else stage_id
-            for downstream_id in range(stage_id + 1, final_stage_id + 1):
-                pool = self.stage_pools[downstream_id]
-                await pool.abort_requests([req_id])
-                pool.release_bindings([req_id])
-            logger.info(
-                "[Orchestrator] released stranded downstream stages %s-%s for direct response on req=%s",
-                stage_id + 1,
-                final_stage_id,
-                req_id,
-            )
+            # Pools this request never reached have no route binding, so
+            # aborting them is a no-op; no need to know the final stage id.
+            await self._abort_request_ids([req_id], stage_ids=range(stage_id + 1, len(self.stage_pools)))
 
     @staticmethod
     def _completion_multimodal_output(output: Any, completion: Any) -> dict[str, Any]:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1311,15 +1311,6 @@ class Orchestrator:
                 self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
             req_state.pd_prefill_multimodal_output = getattr(output, "multimodal_output", None)
 
-        if self._is_duplex_session_request(req_state) and stage_id == 0:
-            _ro = getattr(output, "request_output", None) or output
-            _c = getattr(_ro, "outputs", None)
-            if _c:
-                _t = getattr(_c[0], "text", "") or ""
-                _n = len(getattr(_c[0], "token_ids", None) or [])
-                if getattr(output, "finished", False) or _n % 25 == 0:
-                    logger.info("[s0] ntok=%s finish=%r text=%r", _n,
-                                getattr(_c[0], "finish_reason", None), _t[:200])
         duplex_output_decision = self._duplex_output_decision(stage_id, output, req_state)
         if duplex_output_decision is not None:
             await self._emit_duplex_direct_output(

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1552,6 +1552,33 @@ class Orchestrator:
             )
         )
 
+        # A direct response returns without forwarding, which strands whatever
+        # `_prewarm_async_chunk_stages` already submitted downstream: those
+        # requests are waiting for chunks that will now never be sent. They sit
+        # in their stage's waiting queue as WAITING_FOR_STREAMING_REQ forever,
+        # holding a slot and — because `get_num_unfinished_requests` subtracts
+        # parked requests — making `EngineCore.has_work()` read false. The next
+        # session's request is then invisible and that stage never schedules
+        # again. Same wedge as vllm-omni#5662, reached from the direct-response
+        # path instead of the abort path.
+        #
+        # Opt-in, because a runtime that expects its prewarmed stages to
+        # survive a direct response would be broken by this. The next stage-0
+        # submit re-prewarms, so releasing here costs only the warm slot.
+        if decision.metadata.get("duplex_release_downstream") is True:
+            req_state = self.request_states.get(req_id)
+            final_stage_id = req_state.final_stage_id if req_state is not None else stage_id
+            for downstream_id in range(stage_id + 1, final_stage_id + 1):
+                pool = self.stage_pools[downstream_id]
+                await pool.abort_requests([req_id])
+                pool.release_bindings([req_id])
+            logger.info(
+                "[Orchestrator] released stranded downstream stages %s-%s for direct response on req=%s",
+                stage_id + 1,
+                final_stage_id,
+                req_id,
+            )
+
     @staticmethod
     def _completion_multimodal_output(output: Any, completion: Any) -> dict[str, Any]:
         mm_output = getattr(output, "multimodal_output", None)

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -306,12 +306,23 @@ class _OrchestratorDuplexStagePort:
             replica_id = await pool.submit_update(context.request_id, request_state, request)
         else:
             replica_id = await pool.submit_initial(context.request_id, request_state, request, prompt_text=None)
-            if self._async_chunk and context.stage_id == 0:
-                await self._prewarm_async_chunk_stages(
-                    context.request_id,
-                    request,
-                    request_state,
-                )
+        # Re-arm the downstream async-chunk stages on every stage-0 submit,
+        # not only the first.
+        #
+        # A downstream stage stops polling the connector once its segment
+        # finishes (`is_done_receiving_chunks` covers
+        # `segment_finished_requests`), and its marker is only cleared when it
+        # receives a streaming update. Prewarming just the initial submit left
+        # a second turn deadlocked: stage 0 generated and marked its segment
+        # finished, while stage 1 was still parked from the previous turn and
+        # never read the new chunks. Observed as turn 1 answering normally and
+        # every later turn producing nothing, with stage 1 and stage 2 idle.
+        if self._async_chunk and context.stage_id == 0:
+            await self._prewarm_async_chunk_stages(
+                context.request_id,
+                request,
+                request_state,
+            )
         request_state.duplex_stage_fences[context.stage_id] = context.fence
         request_state.stage_submit_ts[context.stage_id] = _time.time()
         if not request_state.running_counter_registered and self._running_counter is not None:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1311,6 +1311,15 @@ class Orchestrator:
                 self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
             req_state.pd_prefill_multimodal_output = getattr(output, "multimodal_output", None)
 
+        if self._is_duplex_session_request(req_state) and stage_id == 0:
+            _ro = getattr(output, "request_output", None) or output
+            _c = getattr(_ro, "outputs", None)
+            if _c:
+                _t = getattr(_c[0], "text", "") or ""
+                _n = len(getattr(_c[0], "token_ids", None) or [])
+                if getattr(output, "finished", False) or _n % 25 == 0:
+                    logger.info("[s0] ntok=%s finish=%r text=%r", _n,
+                                getattr(_c[0], "finish_reason", None), _t[:200])
         duplex_output_decision = self._duplex_output_decision(stage_id, output, req_state)
         if duplex_output_decision is not None:
             await self._emit_duplex_direct_output(

--- a/vllm_omni/experimental/fullduplex/openai/session_runner.py
+++ b/vllm_omni/experimental/fullduplex/openai/session_runner.py
@@ -319,6 +319,7 @@ class DuplexSessionRunnerMixin:
             retained_committed_payload: dict[str, object] | None = None,
             silence_continuation: bool = False,
             before_append=None,
+            mode: str = "append_audio_chunk",
         ) -> asyncio.Task[bool] | None:
             if session is None:
                 return
@@ -353,7 +354,7 @@ class DuplexSessionRunnerMixin:
                         operation_id=(pcm_reservation.operation_id if pcm_reservation is not None else operation_id),
                         final=final,
                         send_json=emit_event,
-                        mode="append_audio_chunk",
+                        mode=mode,
                         expected_epoch=append_epoch,
                     )
                     if append_ok:
@@ -467,7 +468,7 @@ class DuplexSessionRunnerMixin:
             actor.track_append_task(
                 task,
                 epoch=append_epoch,
-                mode="append_audio_chunk",
+                mode=mode,
                 final=final,
                 response_bound=final or precreate_response,
             )
@@ -1169,7 +1170,10 @@ class DuplexSessionRunnerMixin:
                             }
                         )
                         continue
-                    if self._uses_native_input_append(session):
+                    native_text = self._uses_native_input_append(session) and "append_tokens" in (
+                        session.capabilities.input_modes or ()
+                    )
+                    if self._uses_native_input_append(session) and not native_text:
                         await emit_event(
                             {
                                 "type": "error",
@@ -1178,8 +1182,23 @@ class DuplexSessionRunnerMixin:
                             }
                         )
                         continue
-                    else:
-                        session.append_text(text)
+                    if native_text:
+                        # A native text turn is complete as sent: no buffer to
+                        # drain and no commit to wait for, unlike the audio path
+                        # where `final` closes a stream of appends. It also has
+                        # to go through the native path rather than
+                        # `start_runtime_append`, because only that one opens
+                        # the data-plane response stream the spoken reply
+                        # arrives on.
+                        session.mark_user_input_activity()
+                        await start_native_append(
+                            text,
+                            final=True,
+                            precreate_response=True,
+                            mode="append_tokens",
+                        )
+                        continue
+                    session.append_text(text)
                     if session.capabilities.supports_input_append:
                         await start_runtime_append(text, final=False, mode="append_tokens")
                     continue

--- a/vllm_omni/experimental/fullduplex/qwen3omni/__init__.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Experimental Qwen3-Omni full-duplex integration.
+
+Status: engine/serving layers implemented and contract-validated; the
+worker-side stage-0 audio embedding path is NOT implemented. See
+``stage0.py`` and ``docs/design/qwen3_omni_duplex_assessment.md``.
+
+This package mirrors the structure of the MiniCPM-o 4.5 integration in
+``vllm_omni/experimental/fullduplex/minicpmo45/``, which is the only
+working reference for a native multi-stage duplex model.
+"""

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -35,6 +35,38 @@ _DEFAULT_INSTRUCTIONS = (
 _DEFAULT_TALKER_MAX_TOKENS = 8192
 
 
+#: Checkpoint tokenizer, cached when a session prepares its runtime config.
+#:
+#: Scaffolding is pre-tokenized at session open (``_scaffolding_token_ids``),
+#: but a client text turn arrives later and has to be encoded on the spot. Both
+#: run in the API server process, so the tokenizer built there is reused rather
+#: than constructed per message. Keyed by model so a mixed-model server cannot
+#: encode with the wrong vocabulary.
+_TOKENIZER_CACHE: dict[str, Any] = {}
+
+
+def _tokenizer_cache_key(model_config: Any) -> str:
+    return str(getattr(model_config, "model", None) or getattr(model_config, "served_model_name", "") or "default")
+
+
+def encode_duplex_text(text: str, *, model_key: str | None = None) -> list[int]:
+    """Encode a client text turn with the checkpoint tokenizer.
+
+    Returns ``[]`` when no tokenizer has been cached yet, which the caller must
+    treat as "cannot accept text" rather than "empty turn" -- reserving zero
+    tokens for a turn the user did type would prompt the model to answer
+    nothing, which reads to them as the model ignoring them.
+    """
+    if not text:
+        return []
+    tokenizer = _TOKENIZER_CACHE.get(model_key) if model_key else None
+    if tokenizer is None:
+        if len(_TOKENIZER_CACHE) != 1:
+            return []
+        tokenizer = next(iter(_TOKENIZER_CACHE.values()))
+    return [int(token_id) for token_id in tokenizer.encode(text)]
+
+
 class Qwen3OmniClientRuntimeConfigError(ServingRuntimeConfigError):
     """A client tried to set server-owned Qwen3-Omni duplex configuration."""
 
@@ -99,7 +131,7 @@ class Qwen3OmniNativeDuplexServingAdapter:
             requires_native_stage_role=True,
             implementation_level="model_native_duplex",
             adapter_patterns=["scheduler_data_plane"],
-            input_modes=["append_audio_chunk", "turn_commit_only"],
+            input_modes=["append_audio_chunk", "turn_commit_only", "append_tokens"],
             signal_sources=["client_event", "server_policy"],
             stage_handoff_transport="scheduler_data_plane",
             chunk_period_ms=Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
@@ -125,6 +157,9 @@ class Qwen3OmniNativeDuplexServingAdapter:
             tokenizer = cached_tokenizer_from_config(model_config)
         except Exception:  # noqa: BLE001 - no tokenizer, fall back to no scaffolding
             return {}
+
+        # Keep it for client text turns, which cannot be pre-tokenized here.
+        _TOKENIZER_CACHE[_tokenizer_cache_key(model_config)] = tokenizer
 
         def encode(text: str) -> list[int]:
             return [int(token_id) for token_id in tokenizer.encode(text)]

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -136,6 +136,7 @@ class Qwen3OmniNativeDuplexServingAdapter:
             Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY: encode(session_prefix),
             Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY: encode(Qwen3OmniDuplexPolicy.TURN_PREFIX),
             Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY: encode(Qwen3OmniDuplexPolicy.TURN_SUFFIX),
+            Qwen3OmniDuplexPolicy.NEWLINE_IDS_KEY: encode("\n"),
         }
 
     @classmethod

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -19,14 +19,19 @@ from vllm_omni.experimental.fullduplex.openai.protocol import DuplexCapabilities
 from vllm_omni.experimental.fullduplex.openai.runtime_adapter import ServingRuntimeConfigError
 from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
 
-#: Default stage-0 token bound per duplex segment. Qwen3-Omni emits no
-#: chunk-terminating control token, so this budget is the only stop
-#: condition for a segment.
-_DEFAULT_STAGE0_MAX_TOKENS = 256
+#: Default stage-0 token bound for one spoken reply. A backstop only -- the
+#: real terminator is ``<|im_end|>`` in ``stop_token_ids`` below. Kept in the
+#: same range as the half-duplex realtime path
+#: (``qwen3_omni.py: realtime_max_tokens = 64``), since a spoken turn should
+#: be short; every generated token becomes synthesized speech.
+_DEFAULT_STAGE0_MAX_TOKENS = 128
 
 #: Used when the client sets no `instructions`. The thinker needs a system
 #: turn for the chat template to be well-formed.
-_DEFAULT_INSTRUCTIONS = "You are a helpful voice assistant. Reply naturally and concisely."
+_DEFAULT_INSTRUCTIONS = (
+    "You are a helpful voice assistant. Reply in the same language the user "
+    "speaks. Keep replies short and conversational -- one or two sentences."
+)
 _DEFAULT_TALKER_MAX_TOKENS = 8192
 
 
@@ -142,7 +147,11 @@ class Qwen3OmniNativeDuplexServingAdapter:
         temperature = getattr(config, "temperature", None)
         instructions = getattr(config, "instructions", None)
 
-        stage0_sampling: dict[str, object] = {}
+        # Stop on the thinker's own EOS. Without this the model answers and
+        # then keeps going to the token cap, and every extra token is spoken.
+        stage0_sampling: dict[str, object] = {
+            "stop_token_ids": [Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID],
+        }
         if isinstance(temperature, (int, float)):
             stage0_sampling["temperature"] = float(temperature)
 
@@ -186,6 +195,7 @@ class Qwen3OmniNativeDuplexServingAdapter:
             sampling = updated.get("duplex_stage_sampling_params")
             sampling = dict(sampling) if isinstance(sampling, Mapping) else {}
             stage0 = dict(sampling.get("0")) if isinstance(sampling.get("0"), Mapping) else {}
+            stage0.setdefault("stop_token_ids", [Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID])
             stage0["temperature"] = float(temperature)
             sampling["0"] = stage0
             updated["duplex_stage_sampling_params"] = sampling

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -117,7 +117,6 @@ class Qwen3OmniNativeDuplexServingAdapter:
                 "1": _DEFAULT_TALKER_MAX_TOKENS,
             },
             "duplex_chunk_period_ms": Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
-            "duplex_samples_per_audio_token": Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN,
         }
         if instructions:
             runtime_config["instructions"] = instructions

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -153,13 +153,26 @@ class Qwen3OmniNativeDuplexServingAdapter:
         if not isinstance(tools, list) or not tools:
             return ""
         rendered = "\n".join(json.dumps(tool, ensure_ascii=False) for tool in tools)
+        # Appended to the trained wording, not a substitute for it.
+        #
+        # Interception happens when `</tool_call>` closes, but under
+        # `async_chunk` the talker has already been fed everything generated
+        # before that -- so any prose the model emits ahead of the call gets
+        # spoken, and the tail of the call itself with it. Users hear the model
+        # read JSON aloud. Nothing downstream can undo that after the fact, so
+        # the only reliable fix is for the call to be the entire turn.
+        no_preamble = (
+            "\n\nWhen you call a function, the tool call must be your entire reply: emit only the "
+            "<tool_call> block, with no words before or after it. Anything you say alongside a tool "
+            "call is spoken aloud to the user before the call can run."
+        )
         return (
             "\n\n# Tools\n\nYou may call one or more functions to assist with the user query."
             "\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n"
             f"{rendered}"
             "\n</tools>\n\nFor each function call, return a json object with function name and "
             'arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, '
-            '"arguments": <args-json-object>}\n</tool_call>'
+            '"arguments": <args-json-object>}\n</tool_call>' + no_preamble
         )
 
     @classmethod

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Qwen3-Omni duplex serving policy: config validation and capabilities.
+
+Boundary invariant carried over from MiniCPM's adapter: the serving layer
+owns client-facing validation and normalization; workers receive only
+already-normalized values. Nothing here may resolve URIs or filesystem
+paths on a worker's behalf.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from vllm_omni.experimental.fullduplex.openai.protocol import DuplexCapabilities
+from vllm_omni.experimental.fullduplex.openai.runtime_adapter import ServingRuntimeConfigError
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+#: Default stage-0 token bound per duplex segment. Qwen3-Omni emits no
+#: chunk-terminating control token, so this budget is the only stop
+#: condition for a segment.
+_DEFAULT_STAGE0_MAX_TOKENS = 256
+_DEFAULT_TALKER_MAX_TOKENS = 8192
+
+
+class Qwen3OmniClientRuntimeConfigError(ServingRuntimeConfigError):
+    """A client tried to set server-owned Qwen3-Omni duplex configuration."""
+
+
+class Qwen3OmniNativeDuplexServingAdapter:
+    """Stateless serving policy for the Qwen3-Omni duplex path."""
+
+    PRIVATE_RUNTIME_CONFIG_KEYS = Qwen3OmniDuplexPolicy.PRIVATE_RUNTIME_CONFIG_KEYS
+
+    @staticmethod
+    def is_enabled(config: object) -> bool:
+        extra_body = getattr(config, "extra_body", None)
+        if not isinstance(extra_body, Mapping):
+            return False
+        return extra_body.get(Qwen3OmniDuplexPolicy.ENABLE_FLAG) is True
+
+    @classmethod
+    def validate_client_extra_body(cls, extra_body: object) -> None:
+        if not isinstance(extra_body, dict):
+            return
+        private_keys = sorted(cls.PRIVATE_RUNTIME_CONFIG_KEYS.intersection(extra_body))
+        if private_keys:
+            raise Qwen3OmniClientRuntimeConfigError(
+                "native duplex runtime configuration is server-owned: " + ", ".join(private_keys)
+            )
+
+    @classmethod
+    def capabilities(cls, *, max_sessions: int = 1) -> DuplexCapabilities:
+        """Advertise what this integration actually supports.
+
+        Deliberately conservative. In particular
+        ``supports_model_native_turn_policy=False`` -- Qwen3-Omni has no
+        learned listen/speak control token, so turn boundaries come from the
+        client, not the model. Claiming otherwise would make the endpoint
+        advertise MiniCPM's behavior and mislead clients.
+        """
+        supports_multi_session = max_sessions > 1
+        return DuplexCapabilities(
+            # Qwen3-Omni owns no turn policy; the client signals boundaries.
+            supports_model_native_turn_policy=False,
+            supports_barge_in=True,
+            supports_input_append=True,
+            supports_replace_latest_chunk=False,
+            supports_reencode_context=False,
+            supports_turn_commit_only=True,
+            supports_kv_lease=False,
+            supports_core_kv_lease=False,
+            supports_model_internal_state=True,
+            supports_stage_resumption=True,
+            supports_scheduler_native_append=False,
+            supports_core_resumable_request=True,
+            supports_stage_connector_handoff=True,
+            supports_independent_io_streams=True,
+            supports_realtime_endpoint=True,
+            supports_multi_session=supports_multi_session,
+            supports_multi_session_same_replica=supports_multi_session,
+            supports_session_lease=True,
+            supports_session_resume=True,
+            session_admission_mode="engine_managed",
+            supports_audio_truncate=True,
+            requires_model_runner_kv=True,
+            requires_native_stage_role=True,
+            implementation_level="model_native_duplex",
+            adapter_patterns=["scheduler_data_plane"],
+            input_modes=["append_audio_chunk", "turn_commit_only"],
+            signal_sources=["client_event", "server_policy"],
+            stage_handoff_transport="scheduler_data_plane",
+            chunk_period_ms=Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
+            target_barge_in_latency_ms=None,
+        )
+
+    @classmethod
+    async def prepare_runtime_config(cls, config: object, *, model_config: Any) -> dict[str, object]:
+        """Build the server-owned runtime config shipped to the engine."""
+        del model_config  # no client media to resolve on this path
+        cls.validate_client_extra_body(getattr(config, "extra_body", None))
+
+        max_tokens = _positive_int(getattr(config, "max_tokens", None)) or _DEFAULT_STAGE0_MAX_TOKENS
+        temperature = getattr(config, "temperature", None)
+        instructions = getattr(config, "instructions", None)
+
+        stage0_sampling: dict[str, object] = {}
+        if isinstance(temperature, (int, float)):
+            stage0_sampling["temperature"] = float(temperature)
+
+        runtime_config: dict[str, object] = {
+            "duplex_stage_max_tokens": {
+                "0": max_tokens,
+                "1": _DEFAULT_TALKER_MAX_TOKENS,
+            },
+            "duplex_chunk_period_ms": Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
+            "duplex_samples_per_audio_token": Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN,
+        }
+        if instructions:
+            runtime_config["instructions"] = instructions
+        if stage0_sampling:
+            runtime_config["duplex_stage_sampling_params"] = {"0": stage0_sampling}
+        return runtime_config
+
+    @classmethod
+    def runtime_config_for_update(cls, config: object, current: Mapping[str, object]) -> dict[str, object]:
+        """Apply a ``session.update`` without discarding server-owned state.
+
+        Only the fields a client may change are overwritten; everything else
+        in ``current`` is preserved.
+        """
+        updated: dict[str, object] = deepcopy(dict(current)) if isinstance(current, Mapping) else {}
+
+        instructions = getattr(config, "instructions", None)
+        if instructions is not None:
+            updated["instructions"] = instructions
+
+        max_tokens = _positive_int(getattr(config, "max_tokens", None))
+        if max_tokens is not None:
+            stage_max_tokens = updated.get("duplex_stage_max_tokens")
+            stage_max_tokens = dict(stage_max_tokens) if isinstance(stage_max_tokens, Mapping) else {}
+            stage_max_tokens["0"] = max_tokens
+            stage_max_tokens.setdefault("1", _DEFAULT_TALKER_MAX_TOKENS)
+            updated["duplex_stage_max_tokens"] = stage_max_tokens
+
+        temperature = getattr(config, "temperature", None)
+        if isinstance(temperature, (int, float)):
+            sampling = updated.get("duplex_stage_sampling_params")
+            sampling = dict(sampling) if isinstance(sampling, Mapping) else {}
+            stage0 = dict(sampling.get("0")) if isinstance(sampling.get("0"), Mapping) else {}
+            stage0["temperature"] = float(temperature)
+            sampling["0"] = stage0
+            updated["duplex_stage_sampling_params"] = sampling
+
+        return updated
+
+
+def _positive_int(value: object) -> int | None:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -11,6 +11,7 @@ paths on a worker's behalf.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
@@ -139,7 +140,32 @@ class Qwen3OmniNativeDuplexServingAdapter:
         )
 
     @staticmethod
-    def _scaffolding_token_ids(instructions: object, *, model_config: Any) -> dict[str, object]:
+    def _tools_preamble(tools: object) -> str:
+        """The `# Tools` system block, verbatim from the checkpoint's template.
+
+        Copied from ``chat_template.json`` rather than paraphrased: the model
+        was trained on this exact wording, and the closing paragraph is what
+        makes it emit ``<tool_call>`` instead of describing the call in prose.
+        Rendering it here (rather than calling ``apply_chat_template``) keeps
+        the duplex prompt assembled from token ids we control, which is the
+        invariant the whole stage-0 reservation depends on.
+        """
+        if not isinstance(tools, list) or not tools:
+            return ""
+        rendered = "\n".join(json.dumps(tool, ensure_ascii=False) for tool in tools)
+        return (
+            "\n\n# Tools\n\nYou may call one or more functions to assist with the user query."
+            "\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n"
+            f"{rendered}"
+            "\n</tools>\n\nFor each function call, return a json object with function name and "
+            'arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{"name": <function-name>, '
+            '"arguments": <args-json-object>}\n</tool_call>'
+        )
+
+    @classmethod
+    def _scaffolding_token_ids(
+        cls, instructions: object, *, model_config: Any, tools: object = None
+    ) -> dict[str, object]:
         """Pre-tokenize the conversation scaffolding for the worker.
 
         The thinker needs chat-template framing around the audio embeddings;
@@ -164,8 +190,12 @@ class Qwen3OmniNativeDuplexServingAdapter:
         def encode(text: str) -> list[int]:
             return [int(token_id) for token_id in tokenizer.encode(text)]
 
+        # The tools block belongs inside the system turn, before its
+        # <|im_end|> -- the template emits it that way, and a tools block in
+        # its own turn is not something the model was trained on.
+        system_body = instructions if isinstance(instructions, str) and instructions else _DEFAULT_INSTRUCTIONS
         session_prefix = Qwen3OmniDuplexPolicy.SESSION_PREFIX_TEMPLATE.format(
-            instructions=instructions if isinstance(instructions, str) and instructions else _DEFAULT_INSTRUCTIONS
+            instructions=system_body + cls._tools_preamble(tools)
         )
         return {
             Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY: encode(session_prefix),
@@ -198,9 +228,15 @@ class Qwen3OmniNativeDuplexServingAdapter:
             },
             "duplex_chunk_period_ms": Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
         }
-        runtime_config.update(cls._scaffolding_token_ids(instructions, model_config=model_config))
+        extra_body = getattr(config, "extra_body", None)
+        tools = extra_body.get("realtime_tools") if isinstance(extra_body, Mapping) else None
+        runtime_config.update(cls._scaffolding_token_ids(instructions, model_config=model_config, tools=tools))
         if instructions:
             runtime_config["instructions"] = instructions
+        if isinstance(tools, list) and tools:
+            # Echoed back so the engine-side extension can tell a tool-calling
+            # session from a plain one without re-reading client config.
+            runtime_config["duplex_tools"] = deepcopy(tools)
         if stage0_sampling:
             runtime_config["duplex_stage_sampling_params"] = {"0": stage0_sampling}
         return runtime_config

--- a/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/adapter.py
@@ -23,6 +23,10 @@ from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPo
 #: chunk-terminating control token, so this budget is the only stop
 #: condition for a segment.
 _DEFAULT_STAGE0_MAX_TOKENS = 256
+
+#: Used when the client sets no `instructions`. The thinker needs a system
+#: turn for the chat template to be well-formed.
+_DEFAULT_INSTRUCTIONS = "You are a helpful voice assistant. Reply naturally and concisely."
 _DEFAULT_TALKER_MAX_TOKENS = 8192
 
 
@@ -97,10 +101,41 @@ class Qwen3OmniNativeDuplexServingAdapter:
             target_barge_in_latency_ms=None,
         )
 
+    @staticmethod
+    def _scaffolding_token_ids(instructions: object, *, model_config: Any) -> dict[str, object]:
+        """Pre-tokenize the conversation scaffolding for the worker.
+
+        The thinker needs chat-template framing around the audio embeddings;
+        without it there is nothing instructing the model to reply and it
+        emits EOS on the first token.
+
+        Tokenizing here rather than in the worker means the engine's slot
+        reservation and the worker's produced-embedding count are derived
+        from the same token ids, which is the invariant the model runner
+        silently violates on mismatch.
+        """
+        try:
+            from vllm.tokenizers import cached_tokenizer_from_config
+
+            tokenizer = cached_tokenizer_from_config(model_config)
+        except Exception:  # noqa: BLE001 - no tokenizer, fall back to no scaffolding
+            return {}
+
+        def encode(text: str) -> list[int]:
+            return [int(token_id) for token_id in tokenizer.encode(text)]
+
+        session_prefix = Qwen3OmniDuplexPolicy.SESSION_PREFIX_TEMPLATE.format(
+            instructions=instructions if isinstance(instructions, str) and instructions else _DEFAULT_INSTRUCTIONS
+        )
+        return {
+            Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY: encode(session_prefix),
+            Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY: encode(Qwen3OmniDuplexPolicy.TURN_PREFIX),
+            Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY: encode(Qwen3OmniDuplexPolicy.TURN_SUFFIX),
+        }
+
     @classmethod
     async def prepare_runtime_config(cls, config: object, *, model_config: Any) -> dict[str, object]:
         """Build the server-owned runtime config shipped to the engine."""
-        del model_config  # no client media to resolve on this path
         cls.validate_client_extra_body(getattr(config, "extra_body", None))
 
         max_tokens = _positive_int(getattr(config, "max_tokens", None)) or _DEFAULT_STAGE0_MAX_TOKENS
@@ -118,6 +153,7 @@ class Qwen3OmniNativeDuplexServingAdapter:
             },
             "duplex_chunk_period_ms": Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS,
         }
+        runtime_config.update(cls._scaffolding_token_ids(instructions, model_config=model_config))
         if instructions:
             runtime_config["instructions"] = instructions
         if stage0_sampling:

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Projection of Qwen3-Omni stage outputs into Realtime data-plane events.
+
+Implements ``RuntimeDataPlane``
+(``vllm_omni/experimental/fullduplex/openai/runtime_adapter.py:93-104``).
+
+Structural difference from MiniCPM-o 4.5, and the reason this is not a port
+of ``minicpmo45/data_plane.py``: MiniCPM's ``project_output`` assumes ONE
+stage output carries text, audio, and the turn decision together. Qwen3-Omni
+splits these across independently-scheduled stages -- text from the thinker
+(stage 0), audio from code2wav (stage 2) -- arriving at different times. This
+module therefore correlates per-stage outputs rather than unpacking a single
+fused one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+#: ``(audio, sample_rate_hz, response_format, speed) -> base64 | None``
+EncodeAudio = Callable[[object, int, str, float | None], str | None]
+
+#: Qwen3-Omni's code2wav vocoder output rate (differs from the 16 kHz input).
+OUTPUT_SAMPLE_RATE_HZ = 24000
+
+_THINKER_STAGE_ID = 0
+_CODE2WAV_STAGE_ID = 2
+
+
+@dataclass
+class Qwen3OmniDataPlaneContext:
+    """Serving state needed to project one Qwen3-Omni data-plane output.
+
+    Constructed with all eight keyword arguments by
+    ``runtime_bridge.py:752-761``; the generic layer never reads it back, so
+    the shape is private to this package.
+    """
+
+    epoch: int = 0
+    turn_id: int = 0
+    active_response_turn_id: int | None = None
+    active_response_id: str | None = None
+    auto_responds: bool = False
+    response_format: str = "wav"
+    speed: float | None = None
+    modalities: tuple[str, ...] = ()
+
+
+@dataclass
+class _RequestState:
+    """Per-request correlation state across the three stages."""
+
+    terminal: bool = False
+    #: Cumulative text already sent, for delta computation.
+    sent_text: str = ""
+    #: Byte offset into cumulative audio already sent.
+    audio_offset: int = 0
+    seen_stage_ids: set[int] = field(default_factory=set)
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+class Qwen3OmniDataPlaneSession:
+    """Projects Qwen3-Omni stage outputs into Realtime event dicts."""
+
+    def __init__(self, encode_audio: EncodeAudio) -> None:
+        self._encode_audio = encode_audio
+        self._requests: dict[str, _RequestState] = {}
+
+    # ---- RuntimeDataPlane protocol ----------------------------------------
+
+    def begin_request(self, request_id: str) -> None:
+        self._requests[request_id] = _RequestState()
+
+    def is_terminal(self, request_id: str | None) -> bool:
+        if request_id is None:
+            return False
+        state = self._requests.get(request_id)
+        return bool(state and state.terminal)
+
+    def mark_terminal(self, request_id: str) -> None:
+        state = self._requests.get(request_id)
+        if state is not None:
+            state.terminal = True
+
+    def close_stream(self, request_id: str) -> None:
+        self._requests.pop(request_id, None)
+
+    def close_session(self, session_id: str, *, active_request_id: str | None = None) -> None:
+        if active_request_id is not None:
+            self._requests.pop(active_request_id, None)
+        # Request ids are session-prefixed; drop anything still outstanding.
+        for request_id in [key for key in self._requests if key.startswith(session_id)]:
+            self._requests.pop(request_id, None)
+
+    def project(
+        self,
+        result: object,
+        *,
+        context: object | None = None,
+    ) -> Iterable[dict[str, object]]:
+        """Fan one engine result out into zero or more Realtime events."""
+        if not isinstance(result, Mapping):
+            return
+        ctx = context if isinstance(context, Qwen3OmniDataPlaneContext) else Qwen3OmniDataPlaneContext()
+        outputs = result.get("data_plane_outputs")
+        if not isinstance(outputs, list):
+            return
+        for output in outputs:
+            if isinstance(output, Mapping):
+                yield from self._project_output(output, ctx)
+
+    # ---- projection -------------------------------------------------------
+
+    def _project_output(
+        self,
+        output: Mapping[str, object],
+        ctx: Qwen3OmniDataPlaneContext,
+    ) -> Iterable[dict[str, object]]:
+        request_id = output.get("request_id")
+        request_id = request_id if isinstance(request_id, str) else None
+        state = self._requests.get(request_id) if request_id else None
+        if state is not None and state.terminal:
+            return
+
+        stage_id = _coerce_int(output.get("stage_id"))
+        metadata = output.get("multimodal_output")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+
+        # Drop outputs from a superseded epoch/turn. The fence travels with
+        # the append (runtime.py build_duplex_data_plane_prompt) and comes
+        # back on the output metadata.
+        output_epoch = _coerce_int(metadata.get("duplex_epoch"))
+        if output_epoch is not None and output_epoch != ctx.epoch:
+            return
+        model_turn_id = _coerce_int(metadata.get("duplex_turn_id"))
+
+        if state is not None and stage_id is not None:
+            state.seen_stage_ids.add(stage_id)
+
+        finished = bool(output.get("finished"))
+
+        if stage_id == _THINKER_STAGE_ID:
+            event = self._project_thinker(output, state, model_turn_id, finished)
+            if event is not None:
+                yield event
+            return
+
+        if stage_id == _CODE2WAV_STAGE_ID:
+            event = self._project_code2wav(output, state, ctx, model_turn_id, finished)
+            if event is not None:
+                yield event
+            return
+
+        # Stage 1 (talker) emits codec tokens consumed by code2wav, not
+        # client-visible content. Announce the handoff so the bridge knows a
+        # response is coming without reserving one yet
+        # (runtime_bridge.py:818-824).
+        if stage_id is not None and not finished:
+            yield {
+                "data_plane_request_id": request_id,
+                "requires_stage_handoff": True,
+                "stage_role": "talker",
+                "model_turn_id": model_turn_id,
+            }
+
+    def _project_thinker(
+        self,
+        output: Mapping[str, object],
+        state: _RequestState | None,
+        model_turn_id: int | None,
+        finished: bool,
+    ) -> dict[str, object] | None:
+        """Emit the incremental text delta from the thinker."""
+        text = self._cumulative_text(output)
+        delta = text
+        if state is not None:
+            if text.startswith(state.sent_text):
+                delta = text[len(state.sent_text) :]
+            state.sent_text = text
+        if not delta and not finished:
+            return None
+        return {
+            "data_plane_request_id": output.get("request_id"),
+            "stage_role": "llm",
+            "text": delta,
+            "end_of_turn": finished,
+            "model_turn_id": model_turn_id,
+            "runtime_impl": "qwen3_omni_native_duplex",
+            "owned_runtime": True,
+        }
+
+    def _project_code2wav(
+        self,
+        output: Mapping[str, object],
+        state: _RequestState | None,
+        ctx: Qwen3OmniDataPlaneContext,
+        model_turn_id: int | None,
+        finished: bool,
+    ) -> dict[str, object] | None:
+        """Emit newly-produced audio from the vocoder stage."""
+        if "audio" not in ctx.modalities:
+            return None
+        metadata = output.get("multimodal_output")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        audio = metadata.get("audio")
+        if audio is None:
+            return None
+        sample_rate_hz = _coerce_int(metadata.get("sr")) or OUTPUT_SAMPLE_RATE_HZ
+        encoded = self._encode_audio(audio, sample_rate_hz, ctx.response_format, ctx.speed)
+        if not encoded:
+            return None
+        return {
+            "data_plane_request_id": output.get("request_id"),
+            "stage_role": "tts",
+            "audio_data": encoded,
+            "audio_format": ctx.response_format,
+            "sample_rate_hz": sample_rate_hz,
+            "end_of_turn": finished,
+            "model_turn_id": model_turn_id,
+            "runtime_impl": "qwen3_omni_native_duplex",
+            "owned_runtime": True,
+        }
+
+    @staticmethod
+    def _cumulative_text(output: Mapping[str, object]) -> str:
+        request_output = output.get("request_output")
+        completions = getattr(request_output, "outputs", None)
+        if completions:
+            text = getattr(completions[0], "text", None)
+            if isinstance(text, str):
+                return text
+        text = output.get("text")
+        return text if isinstance(text, str) else ""
+
+
+__all__ = [
+    "OUTPUT_SAMPLE_RATE_HZ",
+    "Qwen3OmniDataPlaneContext",
+    "Qwen3OmniDataPlaneSession",
+    "Qwen3OmniDuplexPolicy",
+]

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -62,7 +62,7 @@ class _RequestState:
     terminal: bool = False
     #: Cumulative text already sent, for delta computation.
     sent_text: str = ""
-    #: Byte offset into cumulative audio already sent.
+    #: Samples of the cumulative waveform already sent to the client.
     audio_offset: int = 0
     seen_stage_ids: set[int] = field(default_factory=set)
 
@@ -77,6 +77,32 @@ def _field(output: object, name: str, default: object = None) -> object:
     if isinstance(output, Mapping):
         return output.get(name, default)
     return getattr(output, name, default)
+
+
+def _audio_length(audio: object) -> int:
+    """Sample count of a waveform, tolerating list / ndarray / tensor.
+
+    Code2Wav returns a tensor shaped ``[1, samples]``, so ``len()`` yields the
+    batch dimension -- always 1 -- rather than the sample count. Prefer the
+    last axis.
+    """
+    shape = getattr(audio, "shape", None)
+    if shape is not None and len(shape):
+        return int(shape[-1])
+    try:
+        return len(audio)  # type: ignore[arg-type]
+    except TypeError:
+        return 0
+
+
+def _audio_tail(audio: object, offset: int) -> object:
+    """Samples after ``offset``, slicing the sample axis, not the batch axis."""
+    if offset <= 0:
+        return audio
+    shape = getattr(audio, "shape", None)
+    if shape is not None and len(shape) > 1:
+        return audio[..., offset:]  # type: ignore[index]
+    return audio[offset:]  # type: ignore[index]
 
 
 def _coerce_int(value: object) -> int | None:
@@ -246,6 +272,23 @@ class Qwen3OmniDataPlaneSession:
         if audio is None:
             return None
         sample_rate_hz = _coerce_int(metadata.get("sr")) or OUTPUT_SAMPLE_RATE_HZ
+
+        # Code2Wav emits the waveform cumulatively: every output carries all
+        # audio generated so far, not just the newest frames. Measured sizes
+        # for one reply: 14250, 110250, 206250, 217770 bytes. Forwarding each
+        # in full makes the client replay the reply from the start over and
+        # over -- heard as "I. I. I. I'm doing great".
+        #
+        # Slice the raw samples, not the encoded string: base64 packs 3 bytes
+        # into 4 characters, so cutting the encoded form at an arbitrary
+        # offset corrupts it.
+        if state is not None:
+            total = _audio_length(audio)
+            if total <= state.audio_offset:
+                return None
+            audio = _audio_tail(audio, state.audio_offset)
+            state.audio_offset = total
+
         encoded = self._encode_audio(audio, sample_rate_hz, ctx.response_format, ctx.speed)
         if not encoded:
             return None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -122,17 +122,22 @@ class Qwen3OmniDataPlaneSession:
     # ---- RuntimeDataPlane protocol ----------------------------------------
 
     def begin_request(self, request_id: str) -> None:
-        # Preserve the audio cursor across turns.
+        # Preserve both cursors across turns.
         #
-        # Duplex reuses one request id for the whole session, while Code2Wav
-        # accumulates its waveform across the session too. Resetting the
-        # cursor here made every turn resend all previously spoken audio and
-        # then append the new part, so replies grew by repeating the whole
-        # conversation. Only the per-turn text state is cleared.
+        # Duplex reuses one request id for the whole session, and *both*
+        # downstream texts accumulate across it: Code2Wav's waveform and the
+        # thinker's generated text. Resetting the audio cursor made every turn
+        # resend all previously spoken audio; resetting `sent_text` did the
+        # same to the transcript, so each turn's first delta replayed the whole
+        # conversation. That is not cosmetic -- a client watching the
+        # transcript for `<tool_call>` re-runs every tool it has ever seen,
+        # which is an infinite loop, since dispatching one produces the next
+        # turn.
         existing = self._requests.get(request_id)
         state = _RequestState()
         if existing is not None:
             state.audio_offset = existing.audio_offset
+            state.sent_text = existing.sent_text
             state.terminal = False
         self._requests[request_id] = state
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -122,7 +122,19 @@ class Qwen3OmniDataPlaneSession:
     # ---- RuntimeDataPlane protocol ----------------------------------------
 
     def begin_request(self, request_id: str) -> None:
-        self._requests[request_id] = _RequestState()
+        # Preserve the audio cursor across turns.
+        #
+        # Duplex reuses one request id for the whole session, while Code2Wav
+        # accumulates its waveform across the session too. Resetting the
+        # cursor here made every turn resend all previously spoken audio and
+        # then append the new part, so replies grew by repeating the whole
+        # conversation. Only the per-turn text state is cleared.
+        existing = self._requests.get(request_id)
+        state = _RequestState()
+        if existing is not None:
+            state.audio_offset = existing.audio_offset
+            state.terminal = False
+        self._requests[request_id] = state
 
     def is_terminal(self, request_id: str | None) -> bool:
         if request_id is None:

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 
+from vllm.logger import init_logger
+
 from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+logger = init_logger(__name__)
 
 #: ``(audio, sample_rate_hz, response_format, speed) -> base64 | None``
 EncodeAudio = Callable[[object, int, str, float | None], str | None]
@@ -61,6 +65,18 @@ class _RequestState:
     #: Byte offset into cumulative audio already sent.
     audio_offset: int = 0
     seen_stage_ids: set[int] = field(default_factory=set)
+
+
+def _field(output: object, name: str, default: object = None) -> object:
+    """Read a field from a stage output.
+
+    ``collect_registered_outputs`` yields ``OmniRequestOutput`` *objects*
+    (``request_client.py:183``), not mappings. Reading them as dicts silently
+    discards every output, so both shapes are accepted here.
+    """
+    if isinstance(output, Mapping):
+        return output.get(name, default)
+    return getattr(output, name, default)
 
 
 def _coerce_int(value: object) -> int | None:
@@ -114,27 +130,40 @@ class Qwen3OmniDataPlaneSession:
             return
         ctx = context if isinstance(context, Qwen3OmniDataPlaneContext) else Qwen3OmniDataPlaneContext()
         outputs = result.get("data_plane_outputs")
+        logger.info(
+            "[qwen3omni-dp] project: result_keys=%s outputs=%s types=%s",
+            sorted(result.keys())[:8],
+            None if not isinstance(outputs, list) else len(outputs),
+            None if not isinstance(outputs, list) else [type(o).__name__ for o in outputs[:3]],
+        )
         if not isinstance(outputs, list):
             return
         for output in outputs:
-            if isinstance(output, Mapping):
+            if output is not None:
                 yield from self._project_output(output, ctx)
 
     # ---- projection -------------------------------------------------------
 
     def _project_output(
         self,
-        output: Mapping[str, object],
+        output: object,
         ctx: Qwen3OmniDataPlaneContext,
     ) -> Iterable[dict[str, object]]:
-        request_id = output.get("request_id")
+        request_id = _field(output, "request_id")
         request_id = request_id if isinstance(request_id, str) else None
         state = self._requests.get(request_id) if request_id else None
         if state is not None and state.terminal:
             return
 
-        stage_id = _coerce_int(output.get("stage_id"))
-        metadata = output.get("multimodal_output")
+        stage_id = _coerce_int(_field(output, "stage_id"))
+        logger.info(
+            "[qwen3omni-dp] output: stage=%s finished=%s rid=%s text=%r",
+            stage_id,
+            _field(output, "finished"),
+            request_id,
+            self._cumulative_text(output)[:60],
+        )
+        metadata = _field(output, "multimodal_output")
         metadata = metadata if isinstance(metadata, Mapping) else {}
 
         # Drop outputs from a superseded epoch/turn. The fence travels with
@@ -148,7 +177,7 @@ class Qwen3OmniDataPlaneSession:
         if state is not None and stage_id is not None:
             state.seen_stage_ids.add(stage_id)
 
-        finished = bool(output.get("finished"))
+        finished = bool(_field(output, "finished"))
 
         if stage_id == _THINKER_STAGE_ID:
             event = self._project_thinker(output, state, model_turn_id, finished)
@@ -176,7 +205,7 @@ class Qwen3OmniDataPlaneSession:
 
     def _project_thinker(
         self,
-        output: Mapping[str, object],
+        output: object,
         state: _RequestState | None,
         model_turn_id: int | None,
         finished: bool,
@@ -191,7 +220,7 @@ class Qwen3OmniDataPlaneSession:
         if not delta and not finished:
             return None
         return {
-            "data_plane_request_id": output.get("request_id"),
+            "data_plane_request_id": _field(output, "request_id"),
             "stage_role": "llm",
             "text": delta,
             "end_of_turn": finished,
@@ -202,7 +231,7 @@ class Qwen3OmniDataPlaneSession:
 
     def _project_code2wav(
         self,
-        output: Mapping[str, object],
+        output: object,
         state: _RequestState | None,
         ctx: Qwen3OmniDataPlaneContext,
         model_turn_id: int | None,
@@ -211,7 +240,7 @@ class Qwen3OmniDataPlaneSession:
         """Emit newly-produced audio from the vocoder stage."""
         if "audio" not in ctx.modalities:
             return None
-        metadata = output.get("multimodal_output")
+        metadata = _field(output, "multimodal_output")
         metadata = metadata if isinstance(metadata, Mapping) else {}
         audio = metadata.get("audio")
         if audio is None:
@@ -221,7 +250,7 @@ class Qwen3OmniDataPlaneSession:
         if not encoded:
             return None
         return {
-            "data_plane_request_id": output.get("request_id"),
+            "data_plane_request_id": _field(output, "request_id"),
             "stage_role": "tts",
             "audio_data": encoded,
             "audio_format": ctx.response_format,
@@ -233,14 +262,14 @@ class Qwen3OmniDataPlaneSession:
         }
 
     @staticmethod
-    def _cumulative_text(output: Mapping[str, object]) -> str:
-        request_output = output.get("request_output")
+    def _cumulative_text(output: object) -> str:
+        request_output = _field(output, "request_output")
         completions = getattr(request_output, "outputs", None)
         if completions:
             text = getattr(completions[0], "text", None)
             if isinstance(text, str):
                 return text
-        text = output.get("text")
+        text = _field(output, "text")
         return text if isinstance(text, str) else ""
 
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/data_plane.py
@@ -263,7 +263,11 @@ class Qwen3OmniDataPlaneSession:
 
     @staticmethod
     def _cumulative_text(output: object) -> str:
-        request_output = _field(output, "request_output")
+        # Stage 0 hands the orchestrator a raw vllm ``RequestOutput`` whose
+        # completions live on ``.outputs``; wrapped stages nest it under
+        # ``.request_output``. Reading only the wrapped form yields empty text
+        # for every thinker output.
+        request_output = _field(output, "request_output") or output
         completions = getattr(request_output, "outputs", None)
         if completions:
             text = getattr(completions[0], "text", None)

--- a/vllm_omni/experimental/fullduplex/qwen3omni/input.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/input.py
@@ -158,12 +158,15 @@ class Qwen3OmniPcmAppendBuffer:
             if reservation.payload is not None:
                 reservation.payload[Qwen3OmniDuplexPolicy.TURN_FINAL_KEY] = True
             return reservation
-        # Nothing buffered: hand back an empty, already-shaped reservation so
-        # the caller's commit/rollback bookkeeping stays uniform.
+        # Nothing buffered -- normally because `prepare_append` already
+        # streamed every whole chunk out. The turn still has to be closed, or
+        # the assistant generation prompt is never emitted and the model has
+        # nothing telling it to reply. Hand back a zero-audio payload carrying
+        # only the turn-final marker.
         return Qwen3OmniPcmReservation(
             self,
             operation_id=operation_id,
-            payload=None,
+            payload={**self._payload(b""), Qwen3OmniDuplexPolicy.TURN_FINAL_KEY: True},
             consumed=b"",
         )
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/input.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/input.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Serving-side PCM re-framing for Qwen3-Omni duplex appends.
+
+Realtime clients push arbitrarily sized PCM frames; the engine reserves
+scheduler slots from the payload size and the worker consumes whole chunks.
+This buffer accumulates raw PCM and emits only whole ``chunk_period_ms``
+units, with two-phase commit so a failed engine append restores the audio
+instead of dropping it.
+
+Satisfies ``vllm_omni.experimental.fullduplex.openai.runtime_adapter``'s
+``PcmAppendBuffer`` / ``PcmAppendReservation`` protocols. Modelled on
+``minicpmo45/input.py`` but audio-only: no video frame queue and no
+``force_listen`` span tracking, because Qwen3-Omni has no learned
+listen/speak control token for those to feed.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+_BYTES_PER_SAMPLE = 4  # float32 little-endian
+
+
+def decode_pcm_payload(payload: object) -> bytes:
+    """Decode a Realtime audio payload to raw ``pcm_f32le`` bytes."""
+    if not isinstance(payload, dict):
+        raise ValueError("duplex audio payload must be a mapping")
+    audio_format = payload.get("format", Qwen3OmniDuplexPolicy.PCM_FORMAT)
+    if audio_format != Qwen3OmniDuplexPolicy.PCM_FORMAT:
+        raise ValueError(
+            f"unsupported duplex audio format: {audio_format!r} (expected {Qwen3OmniDuplexPolicy.PCM_FORMAT})"
+        )
+    data = payload.get("audio")
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return base64.b64decode(data)
+    raise ValueError("duplex audio payload is missing base64 'audio' data")
+
+
+class Qwen3OmniPcmReservation:
+    """A prepared-but-uncommitted slice of buffered PCM."""
+
+    def __init__(
+        self,
+        buffer: Qwen3OmniPcmAppendBuffer,
+        *,
+        operation_id: str,
+        payload: dict[str, object] | None,
+        consumed: bytes,
+    ) -> None:
+        self.operation_id = operation_id
+        self.payload = payload
+        self._buffer = buffer
+        self._consumed = consumed
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def byte_count(self) -> int:
+        return len(self._consumed)
+
+    def commit(self) -> None:
+        """Accept the reservation; the consumed PCM is gone for good."""
+        if not self._active:
+            return
+        self._active = False
+        self._buffer._release_reservation(self)
+
+    def rollback(self) -> None:
+        """Return the consumed PCM to the front of the buffer."""
+        if not self._active:
+            return
+        self._active = False
+        self._buffer._restore_reservation(self, self._consumed)
+
+
+class Qwen3OmniPcmAppendBuffer:
+    """Chunk-aligned PCM accumulator with two-phase commit."""
+
+    def __init__(self, *, sample_rate_hz: int | None = None) -> None:
+        self._sample_rate_hz = sample_rate_hz or Qwen3OmniDuplexPolicy.SAMPLE_RATE_HZ
+        self._pending = bytearray()
+        self._reserved = 0
+
+    # ---- protocol surface -------------------------------------------------
+
+    @property
+    def pending_byte_count(self) -> int:
+        return len(self._pending)
+
+    def clear(self) -> None:
+        self._pending.clear()
+        self._reserved = 0
+
+    def clear_force_listen(self) -> None:
+        """No-op.
+
+        MiniCPM tracks per-span ``force_listen`` metadata so its model-owned
+        listen/speak policy can be overridden. Qwen3-Omni has no such control
+        token, so there is no force-listen state to clear. Implemented to
+        satisfy the ``PcmAppendBuffer`` protocol.
+        """
+        return None
+
+    def has_pending(self) -> bool:
+        return bool(self._pending)
+
+    def has_reserved(self) -> bool:
+        return self._reserved > 0
+
+    def prepare_append(
+        self,
+        payload: dict[str, object],
+        *,
+        operation_id: str,
+        chunk_period_ms: int,
+        allow_emit: bool,
+    ) -> Qwen3OmniPcmReservation | None:
+        """Buffer incoming PCM, returning a reservation once a whole chunk exists."""
+        self._pending.extend(decode_pcm_payload(payload))
+        if not allow_emit:
+            return None
+        return self._reserve_whole_chunks(operation_id=operation_id, chunk_period_ms=chunk_period_ms)
+
+    def prepare_commit(
+        self,
+        *,
+        operation_id: str,
+        chunk_period_ms: int,
+    ) -> Qwen3OmniPcmReservation:
+        """Reserve everything buffered, zero-padding the tail to a whole chunk.
+
+        Used on an explicit client commit, where the remaining partial chunk
+        must still reach the model. Padding rather than dropping keeps the
+        reserved scheduler slots and the produced embedding count in
+        agreement.
+        """
+        chunk_bytes = self._chunk_bytes(chunk_period_ms)
+        if self._pending:
+            remainder = len(self._pending) % chunk_bytes
+            if remainder:
+                self._pending.extend(b"\x00" * (chunk_bytes - remainder))
+        reservation = self._reserve_whole_chunks(
+            operation_id=operation_id,
+            chunk_period_ms=chunk_period_ms,
+        )
+        if reservation is not None:
+            return reservation
+        # Nothing buffered: hand back an empty, already-shaped reservation so
+        # the caller's commit/rollback bookkeeping stays uniform.
+        return Qwen3OmniPcmReservation(
+            self,
+            operation_id=operation_id,
+            payload=None,
+            consumed=b"",
+        )
+
+    def flush(self, *, chunk_period_ms: int) -> dict[str, object] | None:
+        """Drain buffered PCM as one payload, zero-padded to a whole chunk."""
+        if not self._pending:
+            return None
+        chunk_bytes = self._chunk_bytes(chunk_period_ms)
+        remainder = len(self._pending) % chunk_bytes
+        if remainder:
+            self._pending.extend(b"\x00" * (chunk_bytes - remainder))
+        drained = bytes(self._pending)
+        self._pending.clear()
+        return self._payload(drained)
+
+    # ---- internals --------------------------------------------------------
+
+    def _chunk_bytes(self, chunk_period_ms: int) -> int:
+        period = chunk_period_ms if chunk_period_ms > 0 else Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS
+        samples = self._sample_rate_hz * period // 1000
+        return max(_BYTES_PER_SAMPLE, samples * _BYTES_PER_SAMPLE)
+
+    def _reserve_whole_chunks(
+        self,
+        *,
+        operation_id: str,
+        chunk_period_ms: int,
+    ) -> Qwen3OmniPcmReservation | None:
+        chunk_bytes = self._chunk_bytes(chunk_period_ms)
+        whole = (len(self._pending) // chunk_bytes) * chunk_bytes
+        if whole <= 0:
+            return None
+        consumed = bytes(self._pending[:whole])
+        del self._pending[:whole]
+        self._reserved += whole
+        return Qwen3OmniPcmReservation(
+            self,
+            operation_id=operation_id,
+            payload=self._payload(consumed),
+            consumed=consumed,
+        )
+
+    def _payload(self, data: bytes) -> dict[str, object]:
+        return {
+            "audio": base64.b64encode(data).decode("ascii"),
+            "format": Qwen3OmniDuplexPolicy.PCM_FORMAT,
+            "sample_rate_hz": self._sample_rate_hz,
+            "num_samples": len(data) // _BYTES_PER_SAMPLE,
+        }
+
+    def _release_reservation(self, reservation: Qwen3OmniPcmReservation) -> None:
+        self._reserved = max(0, self._reserved - reservation.byte_count)
+
+    def _restore_reservation(self, reservation: Qwen3OmniPcmReservation, consumed: bytes) -> None:
+        self._reserved = max(0, self._reserved - reservation.byte_count)
+        # Restore to the FRONT: appends must stay in wire order.
+        self._pending[:0] = consumed

--- a/vllm_omni/experimental/fullduplex/qwen3omni/input.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/input.py
@@ -153,6 +153,10 @@ class Qwen3OmniPcmAppendBuffer:
             chunk_period_ms=chunk_period_ms,
         )
         if reservation is not None:
+            # Tell the engine this append closes the user's turn, so the
+            # prompt gets the assistant generation suffix.
+            if reservation.payload is not None:
+                reservation.payload[Qwen3OmniDuplexPolicy.TURN_FINAL_KEY] = True
             return reservation
         # Nothing buffered: hand back an empty, already-shaped reservation so
         # the caller's commit/rollback bookkeeping stays uniform.

--- a/vllm_omni/experimental/fullduplex/qwen3omni/input.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/input.py
@@ -126,9 +126,25 @@ class Qwen3OmniPcmAppendBuffer:
     ) -> Qwen3OmniPcmReservation | None:
         """Buffer incoming PCM, returning a reservation once a whole chunk exists."""
         self._pending.extend(decode_pcm_payload(payload))
-        if not allow_emit:
-            return None
-        return self._reserve_whole_chunks(operation_id=operation_id, chunk_period_ms=chunk_period_ms)
+        # Deliberately never emit mid-turn.
+        #
+        # The framework streams each emitted chunk to stage 0 as its own
+        # append, and with auto_response the thinker generates off whatever it
+        # has. For a model with learned listen/speak tokens (MiniCPM-o 4.5)
+        # that is the point. Qwen3-Omni has no such token, so an intermediate
+        # append asks it to continue a user turn that has no <|audio_end|> and
+        # no assistant generation prompt yet -- observed output was
+        # ' 1000000...' and ' a i \n\n\nuser\n...', i.e. the model completing a
+        # truncated prompt. Only the first second of a 4 s utterance ever
+        # reached it.
+        #
+        # Holding the audio until commit gives the thinker one well-formed
+        # turn, identical in shape to what the working non-duplex path builds.
+        # Cost: audio is not encoded incrementally, so time-to-first-token
+        # starts at commit rather than during speech. Barge-in is unaffected --
+        # it runs on the session epoch, not on append cadence.
+        del allow_emit, operation_id, chunk_period_ms
+        return None
 
     def prepare_commit(
         self,

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -102,6 +102,17 @@ class Qwen3OmniDuplexPolicy:
     #: Client opt-in flag on ``extra_body``.
     ENABLE_FLAG = "qwen3_omni_native_duplex"
 
+    #: Marks an audio payload produced by a client commit rather than a
+    #: mid-turn append.
+    #:
+    #: The framework's append path always passes ``final=False``
+    #: (``session_runner.py:1184,1434``) because MiniCPM decides listen/speak
+    #: natively and never needs the turn closed for it. Qwen3-Omni does: the
+    #: assistant generation prompt is what produces a reply. The commit is
+    #: therefore signalled on the payload, which is model-owned data and
+    #: survives ``_merge_native_audio_payloads`` (it does ``dict(second)``).
+    TURN_FINAL_KEY = "duplex_turn_final"
+
     @staticmethod
     def audio_tokens_for_mel_frames(mel_frames: int) -> int:
         """Thinker audio tokens produced by ``mel_frames`` mel frames.

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Qwen3-Omni duplex constants and server-owned configuration keys.
+
+Model-specific names live here so the generic scheduler/orchestrator path
+never learns about Qwen3-Omni. This mirrors
+``vllm_omni/experimental/fullduplex/minicpmo45/policy.py``.
+"""
+
+from __future__ import annotations
+
+
+class Qwen3OmniDuplexPolicy:
+    """Model-specific constants for the Qwen3-Omni duplex path."""
+
+    #: Thinker audio input rate. Qwen3-Omni's feature extractor reports this
+    #: via ``processor.feature_extractor.sampling_rate``; the serving layer
+    #: cannot import the processor, so the value is pinned here and MUST be
+    #: cross-checked against the checkpoint at startup.
+    SAMPLE_RATE_HZ = 16000
+
+    #: Input chunk cadence for a duplex append, in milliseconds.
+    #:
+    #: NOTE this is deliberately far shorter than the 5000 ms segment used by
+    #: the half-duplex ``/v1/realtime`` path
+    #: (``Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio``). That
+    #: 5 s segment is the dominant term in barge-in latency. 1000 ms matches
+    #: the cadence the duplex framework has actually been exercised at (for
+    #: MiniCPM-o 4.5) and is a starting point, NOT a validated value for
+    #: Qwen3-Omni. Shortening the chunk changes model input statistics and
+    #: needs a quality evaluation before it can be called correct.
+    CHUNK_PERIOD_MS = 1000
+
+    #: Samples consumed per emitted chunk.
+    CHUNK_SAMPLES = SAMPLE_RATE_HZ * CHUNK_PERIOD_MS // 1000
+
+    #: Audio samples represented by one thinker embedding slot.
+    #:
+    #: !! UNVERIFIED — MUST be confirmed against the checkpoint before this
+    #: path can work. It determines how many scheduler token slots each
+    #: append reserves; if it is wrong the reservation and the produced
+    #: embedding count disagree and the worker will truncate or pad silently.
+    #: Derive it from the audio tower's mel hop length, conv stride, and any
+    #: pooling ratio rather than trusting this default.
+    SAMPLES_PER_AUDIO_TOKEN = 1600
+
+    #: Wire format accepted from the Realtime client. The serving layer
+    #: normalizes to this before anything reaches the worker.
+    PCM_FORMAT = "pcm_f32le"
+
+    #: Server-owned runtime-config keys. A client that sets any of these in
+    #: ``extra_body`` is rejected rather than silently overridden.
+    PRIVATE_RUNTIME_CONFIG_KEYS = frozenset(
+        {
+            "duplex_stage_sampling_params",
+            "duplex_stage_max_tokens",
+            "duplex_scheduler_token_id",
+            "duplex_scheduler_token_budget",
+            "duplex_chunk_period_ms",
+            "duplex_samples_per_audio_token",
+        }
+    )
+
+    #: Client opt-in flag on ``extra_body``.
+    ENABLE_FLAG = "qwen3_omni_native_duplex"
+
+    @classmethod
+    def tokens_per_chunk(cls, *, samples_per_token: int | None = None) -> int:
+        """Scheduler token slots to reserve for one appended audio chunk."""
+        per_token = samples_per_token or cls.SAMPLES_PER_AUDIO_TOKEN
+        if per_token <= 0:
+            raise ValueError("samples_per_audio_token must be positive")
+        return max(1, -(-cls.CHUNK_SAMPLES // per_token))

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -56,6 +56,34 @@ class Qwen3OmniDuplexPolicy:
     #: normalizes to this before anything reaches the worker.
     PCM_FORMAT = "pcm_f32le"
 
+    #: ``<|audio_pad|>``. Occupies the prompt positions that stage 0 overwrites
+    #: with audio embeddings, so the token ids stay meaningful rather than
+    #: being filler. Matches ``qwen3_omni.py:AUDIO_PAD_TOKEN_ID``.
+    AUDIO_PAD_TOKEN_ID = 151675
+
+    #: Conversation scaffolding.
+    #:
+    #: Without this the thinker receives bare audio embeddings with no
+    #: instruction to reply and emits EOS immediately. These mirror the
+    #: framing the half-duplex path already uses in
+    #: ``Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio``, so
+    #: duplex and half-duplex present the model with the same shape.
+    #:
+    #: Emitted once per session, ahead of the first user turn.
+    SESSION_PREFIX_TEMPLATE = "<|im_start|>system\n{instructions}<|im_end|>\n"
+    #: Opens each user turn.
+    TURN_PREFIX = "<|im_start|>user\n"
+    #: Closes the user turn and hands the floor to the assistant.
+    TURN_SUFFIX = "<|im_end|>\n<|im_start|>assistant\n"
+
+    #: Runtime-config keys carrying the pre-tokenized scaffolding. Tokenizing
+    #: happens once in the serving layer, where the tokenizer lives; the
+    #: worker only embeds the ids. This keeps the engine's slot reservation
+    #: and the worker's produced-embedding count derived from one source.
+    SESSION_PREFIX_IDS_KEY = "duplex_session_prefix_token_ids"
+    TURN_PREFIX_IDS_KEY = "duplex_turn_prefix_token_ids"
+    TURN_SUFFIX_IDS_KEY = "duplex_turn_suffix_token_ids"
+
     #: Server-owned runtime-config keys. A client that sets any of these in
     #: ``extra_body`` is rejected rather than silently overridden.
     PRIVATE_RUNTIME_CONFIG_KEYS = frozenset(
@@ -65,6 +93,9 @@ class Qwen3OmniDuplexPolicy:
             "duplex_scheduler_token_id",
             "duplex_scheduler_token_budget",
             "duplex_chunk_period_ms",
+            "duplex_session_prefix_token_ids",
+            "duplex_turn_prefix_token_ids",
+            "duplex_turn_suffix_token_ids",
         }
     )
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -56,6 +56,12 @@ class Qwen3OmniDuplexPolicy:
     #: normalizes to this before anything reaches the worker.
     PCM_FORMAT = "pcm_f32le"
 
+    #: ``<|im_end|>``, the thinker's EOS. Without it in stage-0
+    #: ``stop_token_ids`` the thinker answers, then keeps generating until it
+    #: hits ``max_tokens`` -- observed as a 4 s input producing ~385 s of
+    #: audio. Verified against the checkpoint tokenizer.
+    IM_END_TOKEN_ID = 151645
+
     #: ``<|audio_pad|>``. Occupies the prompt positions that stage 0 overwrites
     #: with audio embeddings, so the token ids stay meaningful rather than
     #: being filler. Matches ``qwen3_omni.py:AUDIO_PAD_TOKEN_ID``.

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -22,6 +22,18 @@ class Qwen3OmniDuplexPolicy:
 
     #: Input chunk cadence for a duplex append, in milliseconds.
     #:
+    #: 1000 ms is not arbitrary: the thinker's audio tower splits its conv
+    #: input into ``n_window * 2 == 100`` mel-frame chunks
+    #: (``qwen3_omni_moe_thinker.py``, ``Qwen3OmniMoeAudioEncoder.forward``),
+    #: and at ``hop_length=160`` / 16 kHz that is exactly 16000 samples =
+    #: 1.0 s. A 1 s duplex chunk therefore lands on the model's own conv
+    #: chunk boundary, so per-chunk encoding introduces no convolutional
+    #: boundary error. (The tower's ATTENTION still spans up to
+    #: ``n_window_infer // (n_window * 2) == 8`` such chunks, so streaming
+    #: one chunk at a time remains an approximation at the attention level,
+    #: just not at the conv level.) Changing this value away from a multiple
+    #: of 1 s reintroduces conv boundary error.
+    #:
     #: NOTE this is deliberately far shorter than the 5000 ms segment used by
     #: the half-duplex ``/v1/realtime`` path
     #: (``Qwen3OmniMoeForConditionalGeneration.buffer_realtime_audio``). That
@@ -35,15 +47,10 @@ class Qwen3OmniDuplexPolicy:
     #: Samples consumed per emitted chunk.
     CHUNK_SAMPLES = SAMPLE_RATE_HZ * CHUNK_PERIOD_MS // 1000
 
-    #: Audio samples represented by one thinker embedding slot.
-    #:
-    #: !! UNVERIFIED — MUST be confirmed against the checkpoint before this
-    #: path can work. It determines how many scheduler token slots each
-    #: append reserves; if it is wrong the reservation and the produced
-    #: embedding count disagree and the worker will truncate or pad silently.
-    #: Derive it from the audio tower's mel hop length, conv stride, and any
-    #: pooling ratio rather than trusting this default.
-    SAMPLES_PER_AUDIO_TOKEN = 1600
+    #: Mel-spectrogram hop length. ``WhisperFeatureExtractor`` with
+    #: ``hop_length=160`` at 16 kHz => one mel frame per 10 ms. Verified
+    #: against Qwen3-Omni-30B-A3B-Instruct ``preprocessor_config.json``.
+    MEL_HOP_LENGTH = 160
 
     #: Wire format accepted from the Realtime client. The serving layer
     #: normalizes to this before anything reaches the worker.
@@ -58,17 +65,40 @@ class Qwen3OmniDuplexPolicy:
             "duplex_scheduler_token_id",
             "duplex_scheduler_token_budget",
             "duplex_chunk_period_ms",
-            "duplex_samples_per_audio_token",
         }
     )
 
     #: Client opt-in flag on ``extra_body``.
     ENABLE_FLAG = "qwen3_omni_native_duplex"
 
+    @staticmethod
+    def audio_tokens_for_mel_frames(mel_frames: int) -> int:
+        """Thinker audio tokens produced by ``mel_frames`` mel frames.
+
+        Mirrors ``_get_feat_extract_output_lengths`` in vLLM's
+        ``qwen3_omni_moe_thinker.py`` exactly -- the conv stack's own length
+        arithmetic. Kept as an integer reimplementation rather than an import
+        so the serving layer does not pull in torch, but it MUST stay in sync
+        with that function; ``test_contracts.py`` pins the shared cases.
+
+        Note this is not a linear samples-per-token ratio: the ``// 100 * 13``
+        term makes it 13 tokens per whole second plus a sub-second remainder.
+        A linear approximation is wrong by ~30% (10 vs 13 tokens/s) and would
+        under-reserve scheduler slots, which the model runner absorbs
+        silently by truncating embeddings.
+        """
+        if mel_frames <= 0:
+            return 0
+        leave = mel_frames % 100
+        feat_lengths = (leave - 1) // 2 + 1
+        return ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (mel_frames // 100) * 13
+
     @classmethod
-    def tokens_per_chunk(cls, *, samples_per_token: int | None = None) -> int:
-        """Scheduler token slots to reserve for one appended audio chunk."""
-        per_token = samples_per_token or cls.SAMPLES_PER_AUDIO_TOKEN
-        if per_token <= 0:
-            raise ValueError("samples_per_audio_token must be positive")
-        return max(1, -(-cls.CHUNK_SAMPLES // per_token))
+    def audio_tokens_for_samples(cls, num_samples: int) -> int:
+        """Thinker audio tokens produced by ``num_samples`` PCM samples."""
+        return cls.audio_tokens_for_mel_frames(num_samples // cls.MEL_HOP_LENGTH)
+
+    @classmethod
+    def tokens_per_chunk(cls) -> int:
+        """Scheduler token slots to reserve for one whole appended chunk."""
+        return max(1, cls.audio_tokens_for_samples(cls.CHUNK_SAMPLES))

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -67,6 +67,17 @@ class Qwen3OmniDuplexPolicy:
     #: being filler. Matches ``qwen3_omni.py:AUDIO_PAD_TOKEN_ID``.
     AUDIO_PAD_TOKEN_ID = 151675
 
+    #: ``<|audio_start|>`` / ``<|audio_end|>``. The audio span MUST be
+    #: delimited by these or the thinker does not read the embeddings as
+    #: audio at all: observed output was role-marker leakage
+    #: (``' a i \n\n\nuser\n\n\nuser\n...'``) and the talker faithfully
+    #: synthesized the nonsense. The working half-duplex path builds
+    #: ``<|im_start|>user\n<|audio_start|><|audio_pad|><|audio_end|><|im_end|>``
+    #: (``qwen3_omni.py:buffer_realtime_audio`` via the processor's
+    #: ``get_placeholder_str``).
+    AUDIO_START_TOKEN_ID = 151669
+    AUDIO_END_TOKEN_ID = 151670
+
     #: Conversation scaffolding.
     #:
     #: Without this the thinker receives bare audio embeddings with no

--- a/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/policy.py
@@ -100,6 +100,8 @@ class Qwen3OmniDuplexPolicy:
     SESSION_PREFIX_IDS_KEY = "duplex_session_prefix_token_ids"
     TURN_PREFIX_IDS_KEY = "duplex_turn_prefix_token_ids"
     TURN_SUFFIX_IDS_KEY = "duplex_turn_suffix_token_ids"
+    #: A bare newline, used to close the assistant's turn before the next one.
+    NEWLINE_IDS_KEY = "duplex_newline_token_ids"
 
     #: Server-owned runtime-config keys. A client that sets any of these in
     #: ``extra_body`` is rejected rather than silently overridden.
@@ -113,6 +115,7 @@ class Qwen3OmniDuplexPolicy:
             "duplex_session_prefix_token_ids",
             "duplex_turn_prefix_token_ids",
             "duplex_turn_suffix_token_ids",
+            "duplex_newline_token_ids",
         }
     )
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Qwen3-Omni duplex runtime extension (engine-side model policy).
+
+Implements ``DuplexRuntimeExtension``
+(``vllm_omni/experimental/fullduplex/engine/contracts.py``) for the
+thinker -> talker -> code2wav pipeline.
+
+Scope: client-signalled barge-in over a persistent session. Qwen3-Omni has
+no learned listen/speak control token, so unlike MiniCPM-o 4.5 this
+extension implements no model-owned turn policy -- see ``decide_output``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.sampling_params import SamplingParams
+
+from vllm_omni.experimental.fullduplex.engine.contracts import (
+    DuplexAppendPlan,
+    DuplexInputMode,
+    DuplexOutputDecision,
+)
+from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+#: Input modes this model accepts. Anything else is rejected rather than
+#: silently degraded -- per Sy0307's RFC #3745 review point that append mode
+#: must be an explicit per-model capability.
+SUPPORTED_INPUT_MODES = frozenset(
+    {
+        DuplexInputMode.APPEND_AUDIO_CHUNK,
+        DuplexInputMode.TURN_COMMIT_ONLY,
+    }
+)
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _stage_config_value(runtime_config: dict[str, Any], key: str, stage_id: int) -> object | None:
+    """Read a per-stage override addressed as ``cfg[key][stage_id]``."""
+    raw = runtime_config.get(key)
+    if isinstance(raw, dict):
+        value = raw.get(stage_id)
+        return raw.get(str(stage_id)) if value is None else value
+    if isinstance(raw, (list, tuple)) and stage_id < len(raw):
+        return raw[stage_id]
+    return None
+
+
+def duplex_scheduler_token_budget(payload: object, runtime_config: dict[str, Any]) -> int:
+    """Scheduler token slots to reserve for one appended audio chunk.
+
+    The worker must produce exactly this many thinker embeddings for the
+    chunk. If the two disagree the runner truncates or pads silently, so the
+    arithmetic here and the arithmetic in ``stage0.py`` must be derived from
+    the same constants.
+    """
+    samples_per_token = (
+        _coerce_int(runtime_config.get("duplex_samples_per_audio_token"))
+        or Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
+    )
+    num_samples = 0
+    if isinstance(payload, dict):
+        num_samples = _coerce_int(payload.get("num_samples")) or 0
+    if num_samples <= 0:
+        return Qwen3OmniDuplexPolicy.tokens_per_chunk(samples_per_token=samples_per_token)
+    return max(1, -(-num_samples // samples_per_token))
+
+
+def build_duplex_data_plane_prompt(
+    *,
+    request_id: str,
+    fence: DuplexFence,
+    session_config: dict[str, Any],
+    runtime_config: dict[str, Any],
+    seq: int,
+    turn_seq: int,
+    mode: DuplexInputMode,
+    payload: object,
+    final: bool,
+) -> dict[str, Any]:
+    """Build the stage-0 append prompt.
+
+    Only ``prompt_token_ids`` and ``model_intermediate_buffer`` survive
+    ``build_engine_core_request_from_tokens``
+    (``vllm_omni/engine/orchestrator.py:118-158``) -- every other top-level
+    key is dropped there with no error. Do not add keys here expecting them
+    to reach the worker.
+
+    Note ``multi_modal_data`` is among the dropped keys, and the duplex
+    submit path passes no ``mm_features``
+    (``orchestrator.py:289-302``). Audio therefore CANNOT travel by
+    Qwen3-Omni's normal multimodal route; it rides inside
+    ``model_intermediate_buffer["duplex"]["payload"]`` as base64 PCM and must
+    be turned into embeddings by the model's own ``preprocess`` hook.
+
+    All ``duplex`` sub-keys are emitted on every append, unconditionally. The
+    worker-side merge is additive per sub-key
+    (``gpu_model_runner.py:2035-2042``), so a conditionally-omitted key would
+    leave the previous append's value in place rather than clearing it.
+    """
+    token_budget = duplex_scheduler_token_budget(payload, runtime_config)
+    token_id = max(0, _coerce_int(runtime_config.get("duplex_scheduler_token_id")) or 0)
+    return {
+        "prompt_token_ids": [token_id] * token_budget,
+        "model_intermediate_buffer": {
+            "request_id": request_id,
+            # Session-scoped id used for cross-stage chunk routing
+            # (gpu_ar_model_runner.py:2155-2168).
+            "global_request_id": [fence.session_id],
+            "duplex": {
+                # Mandatory gate: every worker-side duplex branch checks this
+                # and silently no-ops when it is absent or not True.
+                "data_plane": True,
+                "session_id": fence.session_id,
+                "incarnation": fence.incarnation,
+                "epoch": fence.epoch,
+                "seq": seq,
+                "turn_id": fence.turn_id,
+                "response_seq": fence.response_seq,
+                "turn_seq": turn_seq,
+                "mode": mode.value,
+                "payload": payload,
+                "final": final,
+                "session_config": dict(session_config),
+                "runtime_config": dict(runtime_config),
+                "scheduler_token_budget": token_budget,
+                "scheduler_token_id": token_id,
+            },
+        },
+    }
+
+
+class Qwen3OmniDuplexRuntimeExtension:
+    """Pure model policy for Qwen3-Omni thinker -> talker -> code2wav."""
+
+    def configure_sampling_params(
+        self,
+        *,
+        runtime_config: dict[str, Any],
+        defaults: tuple[object, ...],
+    ) -> tuple[object, ...]:
+        """Apply per-stage sampling overrides.
+
+        ``defaults`` is one entry per pipeline stage (3 for Qwen3-Omni); the
+        returned tuple must match in length and order. Stages without an
+        override are passed through unchanged, which keeps codec sampling for
+        the talker and code2wav sourced from the checkpoint's own config.
+
+        The stage-0 ``max_tokens`` bound matters more here than it does for
+        MiniCPM: Qwen3-Omni emits no ``<|chunk_eos|>``, so the token budget is
+        the only thing stopping the thinker from running past the user's next
+        utterance.
+        """
+        configured: list[object] = []
+        for stage_id, default in enumerate(defaults):
+            max_tokens = _coerce_int(_stage_config_value(runtime_config, "duplex_stage_max_tokens", stage_id))
+            raw_overrides = _stage_config_value(runtime_config, "duplex_stage_sampling_params", stage_id)
+            overrides = dict(raw_overrides) if isinstance(raw_overrides, dict) else {}
+            if not isinstance(default, SamplingParams) or (not overrides and (max_tokens is None or max_tokens <= 0)):
+                configured.append(default)
+                continue
+            params = default.clone()
+            if max_tokens is not None and max_tokens > 0:
+                params.max_tokens = max_tokens
+            for name, value in overrides.items():
+                if not hasattr(params, name):
+                    continue
+                setattr(params, name, value)
+                if name == "stop_token_ids":
+                    all_stop_token_ids = getattr(params, "_all_stop_token_ids", None)
+                    if isinstance(all_stop_token_ids, set):
+                        all_stop_token_ids.update(int(token_id) for token_id in value)
+            configured.append(params)
+        return tuple(configured)
+
+    def plan_append(
+        self,
+        *,
+        request_id: str,
+        fence: DuplexFence,
+        session_config: dict[str, Any],
+        runtime_config: dict[str, Any],
+        seq: int,
+        turn_seq: int,
+        mode: DuplexInputMode,
+        payload: object,
+        final: bool,
+        sampling_params: object,
+    ) -> DuplexAppendPlan:
+        """Build the stage-0 append plan for one input chunk.
+
+        There is no ``stage_id`` parameter: the control plane hard-codes
+        stage 0 for appends (``duplex_control_plane.py:444``). Audio enters at
+        the thinker; the talker and code2wav are fed by the orchestrator's
+        async-chunk forwarding.
+        """
+        del sampling_params  # stage sampling is applied by the control plane
+        if mode not in SUPPORTED_INPUT_MODES:
+            raise ValueError(
+                f"Qwen3-Omni duplex does not support input mode {mode.value!r}; "
+                f"supported: {sorted(m.value for m in SUPPORTED_INPUT_MODES)}"
+            )
+        return DuplexAppendPlan(
+            prompt=build_duplex_data_plane_prompt(
+                request_id=request_id,
+                fence=fence,
+                session_config=session_config,
+                runtime_config=runtime_config,
+                seq=seq,
+                turn_seq=turn_seq,
+                mode=mode,
+                payload=payload,
+                final=final,
+            )
+        )
+
+    def decide_output(
+        self,
+        *,
+        stage_id: int,
+        final_stage_id: int,
+        segment_finished: bool,
+        segment_token_ids: tuple[int, ...],
+        segment_output_metadata: dict[str, Any],
+        output: object,
+    ) -> DuplexOutputDecision | None:
+        """Always returns ``None``. This is deliberate, not a stub.
+
+        MiniCPM's equivalent detects a ``<|listen|>`` token and reports a
+        model-owned "stop talking and listen" decision
+        (``minicpmo45/runtime.py:304-344``). Qwen3-Omni's checkpoint has no
+        such control token -- it is a standard instruct LLM that emits text
+        and stops -- so there is no model-native turn signal to detect.
+
+        Synthesizing one from text EOS would conflate "finished this reply"
+        with "the user should speak now". Those are different events and the
+        model was not trained to distinguish them, so no decision is emitted
+        and turn boundaries come from the client instead. Audio reaches the
+        client through the normal stage-2 ``final_output`` path.
+
+        Two further reasons not to grow logic here without care:
+
+        1. ``segment_token_ids`` / ``segment_output_metadata`` are read from a
+           per-request buffer that is NOT keyed by stage
+           (``orchestrator.py:918-932`` writes, ``:1444-1447`` reads). With
+           three independently-paced stages the snapshot passed alongside
+           ``stage_id`` may belong to a different stage. Any policy reading
+           stage-1 or stage-2 metadata is unsound until that is fixed.
+        2. Returning a decision short-circuits the output into a direct
+           response and skips normal routing (``orchestrator.py:1284-1295``).
+        """
+        del stage_id, final_stage_id, segment_finished
+        del segment_token_ids, segment_output_metadata, output
+        return None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -388,6 +388,11 @@ def build_duplex_data_plane_prompt(
 class Qwen3OmniDuplexRuntimeExtension:
     """Pure model policy for Qwen3-Omni thinker -> talker -> code2wav."""
 
+    def __init__(self) -> None:
+        #: request_id -> (index already scanned for tool calls, length of the
+        #: text when last scanned). See ``_new_tool_calls``.
+        self._tool_scan_pos: dict[str, tuple[int, int]] = {}
+
     def configure_sampling_params(
         self,
         *,
@@ -469,6 +474,47 @@ class Qwen3OmniDuplexRuntimeExtension:
             )
         )
 
+    def _new_tool_calls(self, output: object) -> list[dict[str, Any]]:
+        """Tool calls that appeared since the last time this request was scanned.
+
+        Stage 0 is a *single resumable request for the whole session*, so
+        ``outputs[0].text`` accumulates every turn's text, not just this one's.
+        Scanning all of it re-matches tool calls that were already dispatched,
+        and because dispatching one produces another turn, that is an infinite
+        loop: the client runs the tool, sends the result, the reply carries the
+        original call again, and it runs forever. Observed live -- 1204 turns
+        and 105 s of audio repeating one sentence before the session was killed.
+
+        The cursor only ever advances past a *closed* ``</tool_call>``, so a
+        call still streaming in is re-examined on the next output rather than
+        skipped.
+        """
+        text = _completion_text(output)
+        if not text:
+            return []
+        request_id = str(getattr(output, "request_id", "") or "")
+        start, previous_len = self._tool_scan_pos.get(request_id, (0, 0))
+        if len(text) < previous_len:
+            # The text shrank, so this is a different request that reused the
+            # id -- session ids get recycled. Compare against the previous
+            # length rather than the cursor: a fresh request whose text happens
+            # to be longer than the old cursor would otherwise inherit it and
+            # its first tool call would be skipped.
+            start = 0
+        matches = list(_TOOL_CALL_RE.finditer(text, start))
+        if not matches:
+            self._tool_scan_pos[request_id] = (start, len(text))
+            return []
+        self._tool_scan_pos[request_id] = (matches[-1].end(), len(text))
+        calls: list[dict[str, Any]] = []
+        for match in matches:
+            calls.extend(parse_tool_calls(match.group(0)))
+        return calls
+
+    def forget_request(self, request_id: str) -> None:
+        """Drop per-request tool-scan state when a session ends."""
+        self._tool_scan_pos.pop(str(request_id), None)
+
     def decide_output(
         self,
         *,
@@ -522,12 +568,26 @@ class Qwen3OmniDuplexRuntimeExtension:
         # needed here: surface the text, do not advance to the talker.
         if stage_id != _THINKER_STAGE_ID:
             return None
-        tool_calls = parse_tool_calls(_completion_text(output))
+        tool_calls = self._new_tool_calls(output)
         if not tool_calls:
             return None
         logger.info("[qwen3omni-duplex] tool call intercepted: %s", [call.get("name") for call in tool_calls])
         return DuplexOutputDecision(
             action=DuplexOutputAction.DIRECT_RESPONSE,
-            metadata={"tool_calls": tool_calls},
+            metadata={
+                # The collector admits an output when its stage is at or past
+                # `response_stage_id`, *or* when the metadata carries this flag
+                # (`request_client.is_direct_response`). Stage 0 is neither the
+                # response stage nor admitted without it, so omitting this
+                # silently drops the tool call: the decision fires, the talker
+                # is skipped, and the client is told nothing.
+                "duplex_direct_response": True,
+                # The talker and code2wav were prewarmed for a spoken reply
+                # that is not coming. Without this they stay parked waiting for
+                # chunks, hold their slots, and wedge the stage for every later
+                # session.
+                "duplex_release_downstream": True,
+                "tool_calls": tool_calls,
+            },
             final_output_type="text",
         )

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -37,6 +37,23 @@ logger = init_logger(__name__)
 #: float32 little-endian PCM.
 _BYTES_PER_SAMPLE = 4
 
+_THINKER_STAGE_ID = 0
+
+
+def _completion_text(output: object) -> str:
+    """Text from a stage output, tolerating both output shapes.
+
+    Stage 0 hands over a raw vllm ``RequestOutput`` (completions on
+    ``.outputs``); wrapped stages nest it under ``.request_output``.
+    """
+    request_output = getattr(output, "request_output", None) or output
+    completions = getattr(request_output, "outputs", None)
+    if not completions:
+        return ""
+    text = getattr(completions[0], "text", None)
+    return text if isinstance(text, str) else ""
+
+
 SUPPORTED_INPUT_MODES = frozenset(
     {
         DuplexInputMode.APPEND_AUDIO_CHUNK,
@@ -333,31 +350,37 @@ class Qwen3OmniDuplexRuntimeExtension:
         segment_output_metadata: dict[str, Any],
         output: object,
     ) -> DuplexOutputDecision | None:
-        """Always returns ``None``. This is deliberate, not a stub.
+        r"""Surface the thinker's text to the client.
 
-        MiniCPM's equivalent detects a ``<|listen|>`` token and reports a
-        model-owned "stop talking and listen" decision
-        (``minicpmo45/runtime.py:304-344``). Qwen3-Omni's checkpoint has no
-        such control token -- it is a standard instruct LLM that emits text
-        and stops -- so there is no model-native turn signal to detect.
+        The duplex output collector only accepts outputs whose stage_id is at
+        or past ``response_stage_id`` -- the final stage, code2wav
+        (``request_client.py:299``). Stage-0 text would therefore never reach
+        the client and ``response.audio_transcript.delta`` would always be
+        empty. Note this transcript is not ASR: the thinker *produces* the
+        text that the talker then speaks, so it is already available here.
 
-        Synthesizing one from text EOS would conflate "finished this reply"
-        with "the user should speak now". Those are different events and the
-        model was not trained to distinguish them, so no decision is emitted
-        and turn boundaries come from the client instead. Audio reaches the
-        client through the normal stage-2 ``final_output`` path.
+        Returning a decision would mark the output ``duplex_direct_response``
+        and bypass that filter (``request_client.py:348-354``) -- but the
+        orchestrator ``return``\ s immediately after emitting a direct
+        response (``orchestrator.py:1284-1295``), skipping
+        ``_forward_to_next_stage``. Doing that for thinker output delivers the
+        transcript and *no audio*: verified live, stage 2 never ran.
 
-        Two further reasons not to grow logic here without care:
+        Direct response and stage advancement are therefore mutually
+        exclusive for the same output, and audio matters more. Returning
+        ``None`` keeps the thinker feeding the talker.
 
-        1. ``segment_token_ids`` / ``segment_output_metadata`` are read from a
-           per-request buffer that is NOT keyed by stage
-           (``orchestrator.py:918-932`` writes, ``:1444-1447`` reads). With
-           three independently-paced stages the snapshot passed alongside
-           ``stage_id`` may belong to a different stage. Any policy reading
-           stage-1 or stage-2 metadata is unsound until that is fixed.
-        2. Returning a decision short-circuits the output into a direct
-           response and skips normal routing (``orchestrator.py:1284-1295``).
+        This is why ``response.audio_transcript.delta`` is currently empty.
+        The text exists and is correct -- the collector only admits
+        ``stage_id >= response_stage_id`` (2) and there is no per-output way
+        to both forward and surface. A fix belongs in the framework, not
+        here: either the collector accepts the pipeline's declared text
+        ``final_output`` stage, or a decision gains a "forward as well" mode.
+
+        No turn policy is expressed here either -- Qwen3-Omni has no learned
+        listen/speak token, so this never reports a model listen decision the
+        way MiniCPM's extension does.
         """
-        del stage_id, final_stage_id, segment_finished
-        del segment_token_ids, segment_output_metadata, output
+        del segment_token_ids, segment_output_metadata, segment_finished
+        del stage_id, final_stage_id, output
         return None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -505,6 +505,32 @@ class Qwen3OmniDuplexRuntimeExtension:
         if not matches:
             self._tool_scan_pos[request_id] = (start, len(text))
             return []
+
+        # Only claim the turn when the tool call is *all* of it.
+        #
+        # Intercepting produces a direct response, which suppresses this turn's
+        # audio -- that is the point for a bare tool call, since reading JSON
+        # aloud is never right. But the model also emits a redundant call
+        # alongside a real answer: after a tool result it replies
+        #
+        #   "The weather in Barcelona is 18C with light rain."
+        #   <tool_call>{"name": "lookup_weather", ...}</tool_call>
+        #
+        # Treating that as a tool call threw away the spoken answer the user was
+        # waiting for and dead-ended the conversation in silence -- the client
+        # correctly refuses to re-dispatch a call it has already run, so nothing
+        # further happened. Speaking wins whenever there is something to speak;
+        # the duplicate call is left for the client to ignore.
+        spoken = _TOOL_CALL_RE.sub("", text[start:]).strip()
+        if spoken:
+            # Advance past these calls anyway: they have been seen, and not
+            # advancing would re-examine them on every later output.
+            self._tool_scan_pos[request_id] = (matches[-1].end(), len(text))
+            logger.info(
+                "[qwen3omni-duplex] tool call ignored: turn also carries speech (%d chars)", len(spoken)
+            )
+            return []
+
         self._tool_scan_pos[request_id] = (matches[-1].end(), len(text))
         calls: list[dict[str, Any]] = []
         for match in matches:

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import base64
 import binascii
+import json
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -25,6 +27,7 @@ from vllm.sampling_params import SamplingParams
 from vllm_omni.experimental.fullduplex.engine.contracts import (
     DuplexAppendPlan,
     DuplexInputMode,
+    DuplexOutputAction,
     DuplexOutputDecision,
 )
 from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
@@ -62,6 +65,38 @@ SUPPORTED_INPUT_MODES = frozenset(
         DuplexInputMode.APPEND_TOKENS,
     }
 )
+
+
+#: Emitted by the model per the checkpoint's chat template:
+#: ``<tool_call>\n{"name": ..., "arguments": {...}}\n</tool_call>``.
+_TOOL_CALL_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+
+
+def parse_tool_calls(text: str) -> list[dict[str, Any]]:
+    """Extract completed tool calls from thinker text.
+
+    Only *closed* ``<tool_call>`` blocks count. The thinker streams, so an
+    unterminated block means the arguments are still arriving and parsing it
+    would dispatch a truncated call.
+    """
+    if not text or "</tool_call>" not in text:
+        return []
+    calls: list[dict[str, Any]] = []
+    for match in _TOOL_CALL_RE.finditer(text):
+        try:
+            call = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            logger.warning("[qwen3omni-duplex] unparseable tool call: %s", match.group(1)[:200])
+            continue
+        if isinstance(call, dict) and call.get("name"):
+            arguments = call.get("arguments")
+            calls.append(
+                {
+                    "name": str(call["name"]),
+                    "arguments": arguments if isinstance(arguments, dict) else {},
+                }
+            )
+    return calls
 
 
 def payload_text(payload: object) -> str | None:
@@ -476,5 +511,23 @@ class Qwen3OmniDuplexRuntimeExtension:
         way MiniCPM's extension does.
         """
         del segment_token_ids, segment_output_metadata, segment_finished
-        del stage_id, final_stage_id, output
-        return None
+        del final_stage_id
+
+        # ...with one exception: a tool call.
+        #
+        # Everything above is about wanting text *and* audio. A tool call is
+        # the case where text is all we want -- `<tool_call>{...}</tool_call>`
+        # is machine output, and speaking it aloud is never right. So the
+        # mutual exclusion that blocks the transcript is exactly the behaviour
+        # needed here: surface the text, do not advance to the talker.
+        if stage_id != _THINKER_STAGE_ID:
+            return None
+        tool_calls = parse_tool_calls(_completion_text(output))
+        if not tool_calls:
+            return None
+        logger.info("[qwen3omni-duplex] tool call intercepted: %s", [call.get("name") for call in tool_calls])
+        return DuplexOutputDecision(
+            action=DuplexOutputAction.DIRECT_RESPONSE,
+            metadata={"tool_calls": tool_calls},
+            final_output_type="text",
+        )

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -59,20 +59,17 @@ def duplex_scheduler_token_budget(payload: object, runtime_config: dict[str, Any
     """Scheduler token slots to reserve for one appended audio chunk.
 
     The worker must produce exactly this many thinker embeddings for the
-    chunk. If the two disagree the runner truncates or pads silently, so the
-    arithmetic here and the arithmetic in ``stage0.py`` must be derived from
-    the same constants.
+    chunk. If the two disagree the runner truncates or pads silently, so this
+    and ``Qwen3OmniStage0DuplexRuntime.expected_embedding_count`` both defer
+    to ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
     """
-    samples_per_token = (
-        _coerce_int(runtime_config.get("duplex_samples_per_audio_token"))
-        or Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
-    )
+    del runtime_config  # token geometry is a checkpoint property, not tunable
     num_samples = 0
     if isinstance(payload, dict):
         num_samples = _coerce_int(payload.get("num_samples")) or 0
     if num_samples <= 0:
-        return Qwen3OmniDuplexPolicy.tokens_per_chunk(samples_per_token=samples_per_token)
-    return max(1, -(-num_samples // samples_per_token))
+        return Qwen3OmniDuplexPolicy.tokens_per_chunk()
+    return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
 
 
 def build_duplex_data_plane_prompt(

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -161,15 +161,27 @@ def build_duplex_prompt_token_ids(
     needs to replace the audio span. ``audio_offset`` tells it where that
     span begins.
     """
+    audio_tokens = duplex_audio_token_count(payload)
+    closes_turn = final or (isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True)
+
+    # `turn_seq` counts turns in the session, not appends within one turn, so
+    # gating the opener on `turn_seq <= 1` framed only the session's first
+    # turn and left every later turn as bare audio with no <|im_start|>user
+    # and no <|audio_start|>. Observed: turn 1 answered correctly, turns 2 and
+    # 3 came through as prefix=0 and produced nothing usable.
+    #
+    # Audio is held until commit, so an append that closes a turn carries the
+    # whole turn and needs the opener as well as the closer. The `turn_seq`
+    # arm remains for a mid-turn append, which the current buffer never emits.
+    starts_turn = closes_turn or turn_seq <= 1
+
     prefix: list[int] = []
     if seq <= 1:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY)
-    if turn_seq <= 1:
+    if starts_turn:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
         prefix.append(Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID)
 
-    audio_tokens = duplex_audio_token_count(payload)
-    closes_turn = final or (isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True)
     suffix: list[int] = []
     if closes_turn:
         suffix.append(Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID)

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -14,6 +14,8 @@ extension implements no model-owned turn policy -- see ``decide_output``.
 
 from __future__ import annotations
 
+import base64
+import binascii
 from typing import Any
 
 from vllm.sampling_params import SamplingParams
@@ -29,6 +31,9 @@ from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPo
 #: Input modes this model accepts. Anything else is rejected rather than
 #: silently degraded -- per Sy0307's RFC #3745 review point that append mode
 #: must be an explicit per-model capability.
+#: float32 little-endian PCM.
+_BYTES_PER_SAMPLE = 4
+
 SUPPORTED_INPUT_MODES = frozenset(
     {
         DuplexInputMode.APPEND_AUDIO_CHUNK,
@@ -63,12 +68,33 @@ def duplex_audio_token_count(payload: object) -> int:
     ``Qwen3OmniStage0DuplexRuntime.expected_embedding_count`` both defer to
     ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
     """
-    num_samples = 0
-    if isinstance(payload, dict):
-        num_samples = _coerce_int(payload.get("num_samples")) or 0
+    num_samples = _payload_num_samples(payload)
     if num_samples <= 0:
         return Qwen3OmniDuplexPolicy.tokens_per_chunk()
     return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
+
+
+def _payload_num_samples(payload: object) -> int:
+    """Sample count of an audio payload, measured from the audio itself.
+
+    Deliberately does not trust a ``num_samples`` key: the serving layer may
+    concatenate two payloads (``serving.py:_merge_native_audio_payloads``),
+    and that merge rebuilds ``audio`` while copying the second payload's
+    other keys verbatim -- so a carried-over ``num_samples`` would describe
+    only the tail. Under-counting here under-reserves scheduler slots, which
+    the model runner absorbs by silently truncating embeddings.
+    """
+    if not isinstance(payload, dict):
+        return 0
+    audio = payload.get("audio")
+    if isinstance(audio, str) and audio:
+        try:
+            return len(base64.b64decode(audio, validate=True)) // _BYTES_PER_SAMPLE
+        except (binascii.Error, ValueError):
+            return 0
+    if isinstance(audio, (bytes, bytearray)):
+        return len(audio) // _BYTES_PER_SAMPLE
+    return _coerce_int(payload.get("num_samples")) or 0
 
 
 def _token_ids(runtime_config: dict[str, Any], key: str) -> list[int]:
@@ -112,7 +138,8 @@ def build_duplex_prompt_token_ids(
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
 
     audio_tokens = duplex_audio_token_count(payload)
-    suffix = _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY) if final else []
+    closes_turn = final or (isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True)
+    suffix = _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY) if closes_turn else []
 
     prompt_token_ids = prefix + [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens + suffix
     return prompt_token_ids, len(prefix), audio_tokens

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+from collections.abc import Mapping
 from typing import Any
 
 from vllm.logger import init_logger
@@ -58,8 +59,25 @@ SUPPORTED_INPUT_MODES = frozenset(
     {
         DuplexInputMode.APPEND_AUDIO_CHUNK,
         DuplexInputMode.TURN_COMMIT_ONLY,
+        DuplexInputMode.APPEND_TOKENS,
     }
 )
+
+
+def payload_text(payload: object) -> str | None:
+    """The client text of a text turn, or ``None`` for an audio turn.
+
+    ``input.text.append`` hands the runtime a bare ``str``; the dict form is
+    accepted so a caller can attach metadata without changing this contract.
+    Empty text is not a text turn -- it carries nothing to answer.
+    """
+    if isinstance(payload, str):
+        return payload or None
+    if isinstance(payload, Mapping):
+        text = payload.get("text")
+        if isinstance(text, str) and text:
+            return text
+    return None
 
 
 def _coerce_int(value: object) -> int | None:
@@ -88,6 +106,11 @@ def duplex_audio_token_count(payload: object) -> int:
     ``Qwen3OmniStage0DuplexRuntime.expected_embedding_count`` both defer to
     ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
     """
+    if payload_text(payload) is not None:
+        # A text turn carries no audio. Falling through to the default chunk
+        # reservation below would reserve `<|audio_pad|>` slots that stage 0
+        # never fills, and the thinker would read the turn as empty.
+        return 0
     num_samples = _payload_num_samples(payload)
     if num_samples > 0:
         return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
@@ -120,6 +143,17 @@ def _payload_num_samples(payload: object) -> int:
     if isinstance(audio, (bytes, bytearray)):
         return len(audio) // _BYTES_PER_SAMPLE
     return _coerce_int(payload.get("num_samples")) or 0
+
+
+def _encode_text(text: str) -> list[int]:
+    """Encode a client text turn with the checkpoint tokenizer.
+
+    Imported lazily: this module is imported by the worker, where the serving
+    layer's tokenizer cache does not exist and is not needed.
+    """
+    from vllm_omni.experimental.fullduplex.qwen3omni.adapter import encode_duplex_text
+
+    return encode_duplex_text(text)
 
 
 def _token_ids(runtime_config: dict[str, Any], key: str) -> list[int]:
@@ -187,16 +221,36 @@ def build_duplex_prompt_token_ids(
         # on the model answers generically regardless of what was said.
         prefix.append(Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID)
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.NEWLINE_IDS_KEY)
+    # A text turn is the same chat turn with real token ids where the audio
+    # span would be, and no <|audio_start|>/<|audio_end|> -- those delimiters
+    # tell the thinker to expect an audio span, so emitting them around text
+    # makes it read the words as a transcription task. Matches the checkpoint's
+    # own chat template, where a text user turn is just
+    # `<|im_start|>user\n{text}<|im_end|>\n`.
+    text = payload_text(payload)
+    body: list[int]
+    if text is not None:
+        body = _encode_text(text)
+        if not body:
+            raise ValueError(
+                "Qwen3-Omni duplex received a text turn but no tokenizer is available to encode it; "
+                "refusing to send an empty user turn"
+            )
+    else:
+        body = [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens
+
     if starts_turn:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
-        prefix.append(Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID)
+        if text is None:
+            prefix.append(Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID)
 
     suffix: list[int] = []
     if closes_turn:
-        suffix.append(Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID)
+        if text is None:
+            suffix.append(Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID)
         suffix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY)
 
-    prompt_token_ids = prefix + [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens + suffix
+    prompt_token_ids = prefix + body + suffix
     logger.info(
         "[qwen3omni-duplex] plan seq=%s turn_seq=%s final=%s closes_turn=%s "
         "prefix=%d audio=%d suffix=%d total=%d scaffold_keys=%s",

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -18,6 +18,7 @@ import base64
 import binascii
 from typing import Any
 
+from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 
 from vllm_omni.experimental.fullduplex.engine.contracts import (
@@ -31,6 +32,8 @@ from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPo
 #: Input modes this model accepts. Anything else is rejected rather than
 #: silently degraded -- per Sy0307's RFC #3745 review point that append mode
 #: must be an explicit per-model capability.
+logger = init_logger(__name__)
+
 #: float32 little-endian PCM.
 _BYTES_PER_SAMPLE = 4
 
@@ -69,9 +72,14 @@ def duplex_audio_token_count(payload: object) -> int:
     ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
     """
     num_samples = _payload_num_samples(payload)
-    if num_samples <= 0:
-        return Qwen3OmniDuplexPolicy.tokens_per_chunk()
-    return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
+    if num_samples > 0:
+        return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
+    if isinstance(payload, dict) and "audio" in payload:
+        # Explicitly empty audio, e.g. a commit whose buffer was already
+        # drained by earlier appends. Reserve nothing; the prompt is the
+        # turn-closing scaffolding alone.
+        return 0
+    return Qwen3OmniDuplexPolicy.tokens_per_chunk()
 
 
 def _payload_num_samples(payload: object) -> int:
@@ -142,6 +150,19 @@ def build_duplex_prompt_token_ids(
     suffix = _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY) if closes_turn else []
 
     prompt_token_ids = prefix + [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens + suffix
+    logger.info(
+        "[qwen3omni-duplex] plan seq=%s turn_seq=%s final=%s closes_turn=%s "
+        "prefix=%d audio=%d suffix=%d total=%d scaffold_keys=%s",
+        seq,
+        turn_seq,
+        final,
+        closes_turn,
+        len(prefix),
+        audio_tokens,
+        len(suffix),
+        len(prompt_token_ids),
+        sorted(k for k in runtime_config if "token_ids" in k),
+    )
     return prompt_token_ids, len(prefix), audio_tokens
 
 

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -279,8 +279,18 @@ def build_duplex_data_plane_prompt(
                 # Where stage 0 must splice the audio embeddings, and how
                 # many. Everything outside this span is real scaffolding
                 # tokens that embed through the ordinary lookup.
+                #
+                # `audio_offset` is relative to THIS APPEND's token span, not
+                # to the session. The consumer compares it against
+                # `duplex_token_offset`, which is absolute, so it must first
+                # rebase using `append_token_count`. Emitted explicitly rather
+                # than reusing `scheduler_token_budget` (numerically equal
+                # here) because conflating "how many slots to reserve" with
+                # "how long this append is" is what made the frame mismatch
+                # invisible in the first place.
                 "audio_offset": audio_offset,
                 "audio_tokens": audio_tokens,
+                "append_token_count": len(prompt_token_ids),
             },
         },
     }

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -178,6 +178,15 @@ def build_duplex_prompt_token_ids(
     prefix: list[int] = []
     if seq <= 1:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY)
+    elif starts_turn:
+        # Close the assistant's previous turn before opening a new user turn.
+        #
+        # Generation stops *at* <|im_end|>, so the stop token is not written
+        # back into the KV. Without this the conversation reads as a run-on
+        # assistant message followed by a user turn, and from the second turn
+        # on the model answers generically regardless of what was said.
+        prefix.append(Qwen3OmniDuplexPolicy.IM_END_TOKEN_ID)
+        prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.NEWLINE_IDS_KEY)
     if starts_turn:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
         prefix.append(Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID)

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -145,11 +145,16 @@ def build_duplex_prompt_token_ids(
     blob of audio embeddings:
 
     * first append of the session -- system block, then the user turn opener
-    * first append of any later turn -- the user turn opener
+    * first append of any later turn -- the user turn opener, then
+      ``<|audio_start|>``
     * every append -- ``<|audio_pad|>`` placeholders that stage 0 overwrites
       with audio embeddings
-    * final append of a turn -- close the user turn and open the assistant's,
-      which is what actually prompts a reply
+    * final append of a turn -- ``<|audio_end|>``, close the user turn, open
+      the assistant's, which is what actually prompts a reply
+
+    The ``<|audio_start|>`` / ``<|audio_end|>`` delimiters are not optional:
+    without them the thinker does not treat the span as audio and emits
+    role-marker garbage.
 
     Real token ids are used for the scaffolding (not filler), so the worker
     can embed those positions through the ordinary embedding lookup and only
@@ -161,10 +166,14 @@ def build_duplex_prompt_token_ids(
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY)
     if turn_seq <= 1:
         prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
+        prefix.append(Qwen3OmniDuplexPolicy.AUDIO_START_TOKEN_ID)
 
     audio_tokens = duplex_audio_token_count(payload)
     closes_turn = final or (isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True)
-    suffix = _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY) if closes_turn else []
+    suffix: list[int] = []
+    if closes_turn:
+        suffix.append(Qwen3OmniDuplexPolicy.AUDIO_END_TOKEN_ID)
+        suffix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY)
 
     prompt_token_ids = prefix + [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens + suffix
     logger.info(

--- a/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/runtime.py
@@ -55,21 +55,67 @@ def _stage_config_value(runtime_config: dict[str, Any], key: str, stage_id: int)
     return None
 
 
-def duplex_scheduler_token_budget(payload: object, runtime_config: dict[str, Any]) -> int:
-    """Scheduler token slots to reserve for one appended audio chunk.
+def duplex_audio_token_count(payload: object) -> int:
+    """Thinker embeddings the appended audio will produce.
 
-    The worker must produce exactly this many thinker embeddings for the
-    chunk. If the two disagree the runner truncates or pads silently, so this
-    and ``Qwen3OmniStage0DuplexRuntime.expected_embedding_count`` both defer
-    to ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
+    The worker must produce exactly this many. If the two disagree the runner
+    truncates or pads silently, so this and
+    ``Qwen3OmniStage0DuplexRuntime.expected_embedding_count`` both defer to
+    ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``.
     """
-    del runtime_config  # token geometry is a checkpoint property, not tunable
     num_samples = 0
     if isinstance(payload, dict):
         num_samples = _coerce_int(payload.get("num_samples")) or 0
     if num_samples <= 0:
         return Qwen3OmniDuplexPolicy.tokens_per_chunk()
     return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
+
+
+def _token_ids(runtime_config: dict[str, Any], key: str) -> list[int]:
+    raw = runtime_config.get(key)
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [int(token_id) for token_id in raw]
+
+
+def build_duplex_prompt_token_ids(
+    *,
+    runtime_config: dict[str, Any],
+    payload: object,
+    seq: int,
+    turn_seq: int,
+    final: bool,
+) -> tuple[list[int], int, int]:
+    """Assemble the stage-0 prompt for one append.
+
+    Returns ``(prompt_token_ids, audio_offset, audio_token_count)``.
+
+    Layout, so the thinker sees a well-formed chat turn rather than a bare
+    blob of audio embeddings:
+
+    * first append of the session -- system block, then the user turn opener
+    * first append of any later turn -- the user turn opener
+    * every append -- ``<|audio_pad|>`` placeholders that stage 0 overwrites
+      with audio embeddings
+    * final append of a turn -- close the user turn and open the assistant's,
+      which is what actually prompts a reply
+
+    Real token ids are used for the scaffolding (not filler), so the worker
+    can embed those positions through the ordinary embedding lookup and only
+    needs to replace the audio span. ``audio_offset`` tells it where that
+    span begins.
+    """
+    prefix: list[int] = []
+    if seq <= 1:
+        prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.SESSION_PREFIX_IDS_KEY)
+    if turn_seq <= 1:
+        prefix += _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_PREFIX_IDS_KEY)
+
+    audio_tokens = duplex_audio_token_count(payload)
+    suffix = _token_ids(runtime_config, Qwen3OmniDuplexPolicy.TURN_SUFFIX_IDS_KEY) if final else []
+
+    prompt_token_ids = prefix + [Qwen3OmniDuplexPolicy.AUDIO_PAD_TOKEN_ID] * audio_tokens + suffix
+    return prompt_token_ids, len(prefix), audio_tokens
 
 
 def build_duplex_data_plane_prompt(
@@ -104,10 +150,15 @@ def build_duplex_data_plane_prompt(
     (``gpu_model_runner.py:2035-2042``), so a conditionally-omitted key would
     leave the previous append's value in place rather than clearing it.
     """
-    token_budget = duplex_scheduler_token_budget(payload, runtime_config)
-    token_id = max(0, _coerce_int(runtime_config.get("duplex_scheduler_token_id")) or 0)
+    prompt_token_ids, audio_offset, audio_tokens = build_duplex_prompt_token_ids(
+        runtime_config=runtime_config,
+        payload=payload,
+        seq=seq,
+        turn_seq=turn_seq,
+        final=final,
+    )
     return {
-        "prompt_token_ids": [token_id] * token_budget,
+        "prompt_token_ids": prompt_token_ids,
         "model_intermediate_buffer": {
             "request_id": request_id,
             # Session-scoped id used for cross-stage chunk routing
@@ -129,8 +180,12 @@ def build_duplex_data_plane_prompt(
                 "final": final,
                 "session_config": dict(session_config),
                 "runtime_config": dict(runtime_config),
-                "scheduler_token_budget": token_budget,
-                "scheduler_token_id": token_id,
+                "scheduler_token_budget": len(prompt_token_ids),
+                # Where stage 0 must splice the audio embeddings, and how
+                # many. Everything outside this span is real scaffolding
+                # tokens that embed through the ordinary lookup.
+                "audio_offset": audio_offset,
+                "audio_tokens": audio_tokens,
             },
         },
     }

--- a/vllm_omni/experimental/fullduplex/qwen3omni/serving_adapter.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/serving_adapter.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Qwen3-Omni implementation of the model-neutral ``ServingRuntimeAdapter``.
+
+Selected by ``PipelineConfig.duplex_serving_adapter`` and instantiated by
+``load_serving_runtime_adapter`` with a single ``encode_audio`` callable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from vllm_omni.experimental.fullduplex.qwen3omni.adapter import (
+    Qwen3OmniNativeDuplexServingAdapter,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.data_plane import (
+    EncodeAudio,
+    Qwen3OmniDataPlaneContext,
+    Qwen3OmniDataPlaneSession,
+)
+from vllm_omni.experimental.fullduplex.qwen3omni.session import (
+    Qwen3OmniServingSessionState,
+)
+
+
+class Qwen3OmniServingRuntimeAdapter:
+    """Model-owned serving state and policy for Qwen3-Omni duplex sessions."""
+
+    adapter_id = "qwen3omni"
+    # No response-text prefixes are stripped for this model; MiniCPM uses
+    # these to clean up its own control-token artifacts.
+    clean_response_done_prefix = ""
+    interrupted_tts_prefix = ""
+    private_runtime_config_keys = Qwen3OmniNativeDuplexServingAdapter.PRIVATE_RUNTIME_CONFIG_KEYS
+
+    def __init__(self, encode_audio: EncodeAudio) -> None:
+        self.session_states: dict[str, Qwen3OmniServingSessionState] = {}
+        self.data_plane = Qwen3OmniDataPlaneSession(encode_audio)
+
+    # ---- session state ----------------------------------------------------
+
+    def create_session_state(self) -> Qwen3OmniServingSessionState:
+        return Qwen3OmniServingSessionState()
+
+    def session_state(self, session_id: str) -> Qwen3OmniServingSessionState:
+        state = self.session_states.get(session_id)
+        if state is None:
+            state = self.create_session_state()
+            self.session_states[session_id] = state
+        return state
+
+    def remove_session_state(self, session_id: str) -> None:
+        self.session_states.pop(session_id, None)
+
+    # ---- policy delegation ------------------------------------------------
+
+    @staticmethod
+    def is_enabled(config: object) -> bool:
+        return Qwen3OmniNativeDuplexServingAdapter.is_enabled(config)
+
+    @staticmethod
+    def capabilities(*, max_sessions: int) -> object:
+        return Qwen3OmniNativeDuplexServingAdapter.capabilities(max_sessions=max_sessions)
+
+    @staticmethod
+    def validate_client_extra_body(extra_body: object) -> None:
+        Qwen3OmniNativeDuplexServingAdapter.validate_client_extra_body(extra_body)
+
+    @staticmethod
+    async def prepare_runtime_config(config: object, *, model_config: Any) -> dict[str, object]:
+        return await Qwen3OmniNativeDuplexServingAdapter.prepare_runtime_config(config, model_config=model_config)
+
+    @staticmethod
+    def runtime_config_for_update(config: object, current: Mapping[str, object]) -> dict[str, object]:
+        return Qwen3OmniNativeDuplexServingAdapter.runtime_config_for_update(config, current)
+
+    # ---- data-plane context ----------------------------------------------
+
+    @staticmethod
+    def data_plane_context(
+        *,
+        epoch: int,
+        turn_id: int,
+        active_response_turn_id: int | None,
+        active_response_id: str | None,
+        auto_responds: bool,
+        response_format: str,
+        speed: float | None,
+        modalities: tuple[str, ...],
+    ) -> Qwen3OmniDataPlaneContext:
+        return Qwen3OmniDataPlaneContext(
+            epoch=epoch,
+            turn_id=turn_id,
+            active_response_turn_id=active_response_turn_id,
+            active_response_id=active_response_id,
+            auto_responds=auto_responds,
+            response_format=response_format,
+            speed=speed,
+            modalities=modalities,
+        )

--- a/vllm_omni/experimental/fullduplex/qwen3omni/session.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/session.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Serving-side session state for one Qwen3-Omni duplex session.
+
+Satisfies the ``ServingRuntimeSessionState`` protocol in
+``vllm_omni/experimental/fullduplex/openai/runtime_adapter.py``. Every field
+below is read by the generic serving layer, so none of them can be dropped
+even where Qwen3-Omni has no use for the concept.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from vllm_omni.experimental.fullduplex.qwen3omni.input import Qwen3OmniPcmAppendBuffer
+
+
+@dataclass(slots=True)
+class Qwen3OmniServingSessionState:
+    """Mutable serving state owned by one Qwen3-Omni duplex session."""
+
+    audio_buffer: Qwen3OmniPcmAppendBuffer = field(default_factory=Qwen3OmniPcmAppendBuffer)
+    input_since_commit: bool = False
+    speech_since_commit: bool = False
+    committed_audio_payload: dict[str, object] | None = None
+    committed_audio_operation_id: str | None = None
+    committed_audio_reserved_bytes: int = 0
+    deferred_response_create: bool = False
+    deferred_precreate_response: bool = False
+    data_plane_task: asyncio.Task[None] | None = None
+    data_plane_restart_requested: bool = False
+    # Continuation / silence scheduling exists for MiniCPM's model-owned
+    # listen policy, where the server re-issues a "keep listening" unit when
+    # the model stays silent. Qwen3-Omni has no such policy, so these stay at
+    # their defaults; they are retained because the generic session runner
+    # reads them unconditionally.
+    continuation_owner_id: str | None = None
+    continuation_units: int = 0
+    pending_silence_task: asyncio.Task[bool] | None = None
+    pending_silence_owner_id: str | None = None
+    silence_continuation_scheduler: Callable[..., Awaitable[bool]] | None = None
+
+    def retain_committed_audio(
+        self,
+        payload: dict[str, object],
+        *,
+        operation_id: str | None,
+        reserved_bytes: int = 0,
+    ) -> None:
+        self.committed_audio_payload = payload
+        self.committed_audio_operation_id = operation_id
+        self.committed_audio_reserved_bytes += max(0, int(reserved_bytes))
+
+    def clear_committed_audio(self) -> int:
+        reserved_bytes = self.committed_audio_reserved_bytes
+        self.committed_audio_payload = None
+        self.committed_audio_operation_id = None
+        self.committed_audio_reserved_bytes = 0
+        self.deferred_response_create = False
+        self.deferred_precreate_response = False
+        return reserved_bytes
+
+    def clear_continuation(self) -> None:
+        self.continuation_owner_id = None
+        self.continuation_units = 0
+        self.pending_silence_task = None
+        self.pending_silence_owner_id = None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -162,6 +162,10 @@ class Qwen3OmniStage0DuplexRuntime:
         incarnation = _coerce_int(duplex.get("incarnation")) or 0
         epoch = _coerce_int(duplex.get("epoch")) or 0
         seq = _coerce_int(duplex.get("seq")) or 0
+        payload = duplex.get("payload")
+        closes_turn = bool(duplex.get("final")) or (
+            isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True
+        )
 
         state = self.session(session_id, incarnation)
 
@@ -170,7 +174,7 @@ class Qwen3OmniStage0DuplexRuntime:
         if cache_key in state.prepared:
             return state.prepared[cache_key]
 
-        pcm = self._decode_pcm(duplex.get("payload"))
+        pcm = self._decode_pcm(payload)
         if pcm.size:
             state.audio_buffer = pcm if state.audio_buffer is None else np.concatenate([state.audio_buffer, pcm])
 
@@ -205,6 +209,18 @@ class Qwen3OmniStage0DuplexRuntime:
 
         state.audio_buffer = buffered[consumed:]
         state.chunk_index += num_chunks
+
+        # Start the next turn's context empty.
+        #
+        # `turn_audio` exists so a turn's chunks are encoded with each other's
+        # context, not so turns accumulate. Carrying it across a boundary made
+        # every later turn re-encode the whole conversation's audio: replies
+        # kept answering the first question, and the cost grew without bound.
+        # Earlier turns are already in the thinker's KV, so they do not need
+        # re-encoding here.
+        if closes_turn:
+            state.turn_audio = None
+            state.chunk_index = 0
 
         expected = self.expected_embedding_count(consumed)
         if embeds.shape[0] != expected:

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -68,6 +68,9 @@ class Qwen3OmniStage0SessionState:
     audio_buffer: Any = None
     #: Count of whole chunks already turned into embeddings.
     chunk_index: int = 0
+    #: All audio in the current turn, kept so each append can be encoded with
+    #: its context instead of in isolation. Reset at a turn boundary.
+    turn_audio: Any = None
     #: Memoized results keyed by ``(epoch, seq)`` so a scheduler retry of the
     #: same append is idempotent -- mirrors ``minicpmo45/stage0.py:164-173``.
     prepared: dict[tuple[int, int], Any] = field(default_factory=dict)
@@ -154,7 +157,6 @@ class Qwen3OmniStage0DuplexRuntime:
         prompt is the caller's job.
         """
         import numpy as np
-        import torch
 
         session_id = str(duplex.get("session_id") or "")
         incarnation = _coerce_int(duplex.get("incarnation")) or 0
@@ -179,13 +181,31 @@ class Qwen3OmniStage0DuplexRuntime:
 
         num_chunks = buffered.shape[0] // chunk_samples
         consumed = num_chunks * chunk_samples
-        chunk_embeds = [
-            self._encode_chunk(buffered[i * chunk_samples : (i + 1) * chunk_samples]) for i in range(num_chunks)
-        ]
+
+        # Encode the whole turn so far and keep only the newly completed rows,
+        # rather than encoding each chunk in isolation.
+        #
+        # The audio tower's attention spans n_window_infer // (n_window * 2) ==
+        # 8 one-second chunks, so a chunk encoded alone sees none of its
+        # context. Measured against a single whole-utterance encode of the same
+        # 4 s audio: per-chunk gives cosine 0.844 (min 0.154), cumulative gives
+        # 0.949 (min 0.727). Per-chunk embeddings were degrading the thinker's
+        # output to nonsense.
+        #
+        # Cost is quadratic in turn length, which is acceptable only because a
+        # spoken turn is short and `turn_audio` resets at each turn boundary.
+        # A model with a streaming audio encoder (as MiniCPM-o 4.5 has) would
+        # not need this.
+        state.turn_audio = (
+            buffered[:consumed] if state.turn_audio is None else np.concatenate([state.turn_audio, buffered[:consumed]])
+        )
+        already = self.expected_embedding_count(state.turn_audio.shape[0] - consumed) if state.chunk_index else 0
+        full = self._encode_chunk(state.turn_audio)
+        embeds = full[already:]
+
         state.audio_buffer = buffered[consumed:]
         state.chunk_index += num_chunks
 
-        embeds = torch.cat(chunk_embeds, dim=0)
         expected = self.expected_embedding_count(consumed)
         if embeds.shape[0] != expected:
             raise RuntimeError(

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -59,10 +59,12 @@ Two blockers, both real
 Reservation invariant
 ---------------------
 ``duplex_scheduler_token_budget`` in ``runtime.py`` reserves scheduler slots
-from ``Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN``. This module MUST
-produce exactly that many embeddings per chunk. If the counts disagree the
-model runner truncates or pads without raising, so the two calculations must
-be derived from the same constant and asserted against each other.
+via ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``, which reimplements
+vLLM's ``_get_feat_extract_output_lengths`` (13 tokens per whole second plus
+a sub-second remainder, derived from the checkpoint's Whisper feature
+extractor at ``hop_length=160``). This module MUST produce exactly that many
+embeddings per chunk. If the counts disagree the model runner truncates or
+pads without raising, so both sides call the same helper.
 """
 
 from __future__ import annotations
@@ -141,10 +143,11 @@ class Qwen3OmniStage0DuplexRuntime:
         5. Return embeddings positioned at ``token_offset`` within the
            request's prompt.
 
-        Deriving the frames-per-embedding ratio in step 2 from the
-        checkpoint's audio config -- not from
-        ``Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN``, which is currently
-        an unverified placeholder -- is the first thing to do.
+        The embedding count for step 4 is already settled:
+        ``expected_embedding_count`` implements the checkpoint's own conv
+        length arithmetic. What remains unknown is the receptive-field width
+        needed for ``left_context`` in step 3, which must come from the
+        audio tower's conv stack.
         """
         raise NotImplementedError(
             "Qwen3-Omni stage-0 duplex audio embedding is not implemented. "
@@ -157,12 +160,10 @@ class Qwen3OmniStage0DuplexRuntime:
         )
 
     @staticmethod
-    def expected_embedding_count(num_samples: int, *, samples_per_token: int | None = None) -> int:
+    def expected_embedding_count(num_samples: int) -> int:
         """Embeddings a chunk of ``num_samples`` must produce.
 
-        Must agree with ``runtime.duplex_scheduler_token_budget``.
+        Must agree with ``runtime.duplex_scheduler_token_budget``; both defer
+        to the same checkpoint-derived formula.
         """
-        per_token = samples_per_token or Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
-        if per_token <= 0:
-            raise ValueError("samples_per_audio_token must be positive")
-        return max(1, -(-num_samples // per_token))
+        return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -3,12 +3,14 @@
 
 """Worker-side stage-0 duplex runtime for Qwen3-Omni.
 
-STATUS: NOT IMPLEMENTED. This module defines the required structure and
-documents precisely what is missing. ``build_append_embeddings`` raises
-``NotImplementedError``; it has never been executed against a checkpoint.
+Turns appended PCM into thinker input embeddings.
 
-Why this piece is unavoidable
------------------------------
+STATUS: implemented but NOT validated against a checkpoint or a GPU. The
+shape and length arithmetic is verified against vLLM's own functions; the
+forward pass has never been executed.
+
+Why this piece is needed at all
+-------------------------------
 In the duplex append path, audio cannot reach the thinker by Qwen3-Omni's
 normal multimodal route:
 
@@ -25,50 +27,33 @@ So audio arrives as base64 PCM inside
 become thinker embeddings is the model's own ``preprocess`` hook, dispatched
 at ``gpu_model_runner.py:1685`` under ``model.has_preprocess``.
 
-Two blockers, both real
------------------------
-1. **The thinker has no preprocess hook.**
-   ``Qwen3OmniMoeForConditionalGeneration`` sets ``has_preprocess = False``
-   at ``qwen3_omni.py:107`` and only enables it for the talker stage
-   (``qwen3_omni.py:156``). MiniCPM enables it for both its LM and TTS stages
-   (``minicpmo_4_5_omni.py:140``). Enabling it for the Qwen3-Omni thinker and
-   implementing ``preprocess`` is core model-code work, outside this package.
+Chunk alignment (why per-chunk encoding is sound here)
+------------------------------------------------------
+``Qwen3OmniMoeAudioEncoder.forward`` splits its conv input into
+``n_window * 2 == 100`` mel-frame chunks and runs the conv stack on each
+independently. At ``hop_length=160`` / 16 kHz that is exactly 1.0 s, which is
+``Qwen3OmniDuplexPolicy.CHUNK_PERIOD_MS``. A duplex chunk therefore lands on
+the model's own conv boundary and per-chunk encoding introduces **no
+convolutional boundary error** -- unlike MiniCPM, which needs an audio
+encoder KV cache plus explicit prefix/suffix context frames.
 
-2. **Qwen3-Omni's audio tower has no incremental/streaming encode.**
-   MiniCPM carries an audio-encoder KV cache across chunks
-   (``minicpmo45/stage0.py:443-489``: ``get_audio_embedding_streaming`` plus
-   ``audio_past_key_values``, with explicit prefix/suffix context frames).
-   Qwen3-Omni exposes no equivalent -- the only streaming affordance in the
-   model is ``code2wav.chunked_decode_streaming`` (``qwen3_omni.py:593``),
-   which is on the OUTPUT side. Without incremental encode there are three
-   options, none free:
-
-   a. Re-encode the whole accumulated buffer each append: correct, but
-      quadratic in session length, which defeats the purpose of a persistent
-      session.
-   b. Encode each chunk in isolation: cheap, but wrong at chunk boundaries,
-      because the convolutional front end loses its left context.
-   c. Encode a bounded sliding window (new chunk + N frames of left context)
-      and keep only the new chunk's embeddings: bounded cost and
-      approximately correct. This is the shape MiniCPM achieves via
-      ``cnn_redundancy_ms`` / ``prefix_extra_frames``, and it is the
-      recommended approach -- but the exact frame arithmetic (mel hop ->
-      conv stride -> pooling ratio -> embeddings per chunk) must be derived
-      from the checkpoint, not guessed.
+The tower's *attention* still spans up to
+``n_window_infer // (n_window * 2) == 8`` such chunks, so encoding one chunk
+at a time remains an approximation at the attention level. That is the known
+residual inaccuracy of this design and is not corrected here.
 
 Reservation invariant
 ---------------------
 ``duplex_scheduler_token_budget`` in ``runtime.py`` reserves scheduler slots
 via ``Qwen3OmniDuplexPolicy.audio_tokens_for_samples``, which reimplements
-vLLM's ``_get_feat_extract_output_lengths`` (13 tokens per whole second plus
-a sub-second remainder, derived from the checkpoint's Whisper feature
-extractor at ``hop_length=160``). This module MUST produce exactly that many
-embeddings per chunk. If the counts disagree the model runner truncates or
-pads without raising, so both sides call the same helper.
+vLLM's ``_get_feat_extract_output_lengths``. This module MUST produce exactly
+that many embeddings per chunk; a mismatch is absorbed silently by the model
+runner, so ``_encode_chunk`` asserts it instead.
 """
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -81,13 +66,10 @@ class Qwen3OmniStage0SessionState:
 
     #: Raw float32 PCM not yet consumed into embeddings.
     audio_buffer: Any = None
-    #: Count of chunks already turned into embeddings.
+    #: Count of whole chunks already turned into embeddings.
     chunk_index: int = 0
-    #: Tail of the previous chunk retained as encoder left context (option
-    #: (c) above). Length is a function of the audio tower's receptive field.
-    left_context: Any = None
-    #: Memoized result keyed by (epoch, seq) so a scheduler retry of the same
-    #: append is idempotent -- mirrors minicpmo45/stage0.py:164-173.
+    #: Memoized results keyed by ``(epoch, seq)`` so a scheduler retry of the
+    #: same append is idempotent -- mirrors ``minicpmo45/stage0.py:164-173``.
     prepared: dict[tuple[int, int], Any] = field(default_factory=dict)
 
 
@@ -99,11 +81,18 @@ class Qwen3OmniStage0DuplexRuntime:
     imports and instantiates this itself on the first duplex append.
     """
 
+    #: Bound on memoized appends per session, so a long session cannot grow
+    #: this table without limit.
+    _MAX_PREPARED = 8
+
     def __init__(self, stage_model: Any, *, model_path: str | None = None, device: str | None = None) -> None:
         self._model = stage_model
         self._model_path = model_path
         self._device = device
+        self._feature_extractor: Any = None
         self.sessions: dict[tuple[str, int], Qwen3OmniStage0SessionState] = {}
+
+    # ---- session bookkeeping ---------------------------------------------
 
     def session(self, session_id: str, incarnation: int) -> Qwen3OmniStage0SessionState:
         key = (session_id, incarnation)
@@ -116,6 +105,36 @@ class Qwen3OmniStage0DuplexRuntime:
     def drop_session(self, session_id: str, incarnation: int) -> None:
         self.sessions.pop((session_id, incarnation), None)
 
+    # ---- model handles ----------------------------------------------------
+
+    @property
+    def thinker(self) -> Any:
+        thinker = getattr(self._model, "thinker", None)
+        if thinker is None:
+            raise RuntimeError("Qwen3-Omni duplex stage 0 requires the thinker submodule")
+        return thinker
+
+    @property
+    def audio_tower(self) -> Any:
+        tower = getattr(self.thinker, "audio_tower", None)
+        if tower is None:
+            raise RuntimeError("Qwen3-Omni thinker has no audio_tower; cannot encode duplex audio")
+        return tower
+
+    def feature_extractor(self) -> Any:
+        """The checkpoint's ``WhisperFeatureExtractor``."""
+        if self._feature_extractor is None:
+            from vllm.transformers_utils.processor import cached_processor_from_config
+
+            model_config = getattr(getattr(self._model, "vllm_config", None), "model_config", None)
+            if model_config is None:
+                raise RuntimeError("Qwen3-Omni duplex stage 0 requires a model_config to load the processor")
+            processor = cached_processor_from_config(model_config)
+            self._feature_extractor = processor.feature_extractor
+        return self._feature_extractor
+
+    # ---- audio -> embeddings ---------------------------------------------
+
     def build_append_embeddings(
         self,
         *,
@@ -125,39 +144,126 @@ class Qwen3OmniStage0DuplexRuntime:
     ) -> Any:
         """Decode appended PCM and return thinker input embeddings.
 
-        Not implemented. See the module docstring for the two blockers.
+        Returns a ``(num_tokens, hidden_size)`` tensor covering whole chunks
+        completed by this append. May return ``None`` when the append did not
+        complete a chunk (the serving-side buffer normally prevents that, so
+        it indicates a partial payload reached the worker).
 
-        A correct implementation must:
-
-        1. Decode ``duplex["payload"]`` (base64 ``pcm_f32le``) and append it
-           to ``state.audio_buffer``.
-        2. While a whole ``Qwen3OmniDuplexPolicy.CHUNK_SAMPLES`` unit is
-           available, encode ``left_context + chunk`` through the thinker's
-           audio tower and keep only the embeddings corresponding to
-           ``chunk`` -- discarding the left-context prefix outputs.
-        3. Retain a new ``left_context`` tail sized to the tower's receptive
-           field.
-        4. Assert the produced embedding count equals ``prompt_len`` (the
-           reserved slot count). A mismatch must raise here rather than be
-           silently absorbed downstream.
-        5. Return embeddings positioned at ``token_offset`` within the
-           request's prompt.
-
-        The embedding count for step 4 is already settled:
-        ``expected_embedding_count`` implements the checkpoint's own conv
-        length arithmetic. What remains unknown is the receptive-field width
-        needed for ``left_context`` in step 3, which must come from the
-        audio tower's conv stack.
+        ``token_offset`` / ``prompt_len`` describe the reserved prompt span
+        and are used only to validate the count; slicing into the request's
+        prompt is the caller's job.
         """
-        raise NotImplementedError(
-            "Qwen3-Omni stage-0 duplex audio embedding is not implemented. "
-            "Two prerequisites are unmet: (1) the thinker stage sets "
-            "has_preprocess=False (qwen3_omni.py:107) and has no preprocess hook; "
-            "(2) Qwen3-Omni exposes no incremental audio encode equivalent to "
-            "MiniCPM's get_audio_embedding_streaming/audio_past_key_values. "
-            "See this module's docstring and "
-            "docs/design/qwen3_omni_duplex_assessment.md."
+        import numpy as np
+        import torch
+
+        session_id = str(duplex.get("session_id") or "")
+        incarnation = _coerce_int(duplex.get("incarnation")) or 0
+        epoch = _coerce_int(duplex.get("epoch")) or 0
+        seq = _coerce_int(duplex.get("seq")) or 0
+
+        state = self.session(session_id, incarnation)
+
+        # Idempotent replay: the scheduler may re-present the same append.
+        cache_key = (epoch, seq)
+        if cache_key in state.prepared:
+            return state.prepared[cache_key]
+
+        pcm = self._decode_pcm(duplex.get("payload"))
+        if pcm.size:
+            state.audio_buffer = pcm if state.audio_buffer is None else np.concatenate([state.audio_buffer, pcm])
+
+        chunk_samples = Qwen3OmniDuplexPolicy.CHUNK_SAMPLES
+        buffered = state.audio_buffer
+        if buffered is None or buffered.shape[0] < chunk_samples:
+            return None
+
+        num_chunks = buffered.shape[0] // chunk_samples
+        consumed = num_chunks * chunk_samples
+        chunk_embeds = [
+            self._encode_chunk(buffered[i * chunk_samples : (i + 1) * chunk_samples]) for i in range(num_chunks)
+        ]
+        state.audio_buffer = buffered[consumed:]
+        state.chunk_index += num_chunks
+
+        embeds = torch.cat(chunk_embeds, dim=0)
+        expected = self.expected_embedding_count(consumed)
+        if embeds.shape[0] != expected:
+            raise RuntimeError(
+                f"Qwen3-Omni duplex stage 0 produced {embeds.shape[0]} embeddings for "
+                f"{consumed} samples but reserved {expected}. The model runner would "
+                f"absorb this silently; failing instead."
+            )
+
+        state.prepared[cache_key] = embeds
+        while len(state.prepared) > self._MAX_PREPARED:
+            state.prepared.pop(next(iter(state.prepared)))
+        return embeds
+
+    def _encode_chunk(self, chunk: Any) -> Any:
+        """Encode exactly one ``CHUNK_SAMPLES`` unit through the audio tower.
+
+        Mirrors ``Qwen3OmniMoeThinkerForConditionalGeneration._process_audio_input``
+        (``qwen3_omni_moe_thinker.py:1101-1116``) for a single item.
+        """
+        import torch
+
+        extractor = self.feature_extractor()
+        features = extractor(
+            chunk,
+            sampling_rate=Qwen3OmniDuplexPolicy.SAMPLE_RATE_HZ,
+            return_tensors="pt",
+            # Whisper's extractor pads to its 30 s ``n_samples`` by default,
+            # which would produce 3000 mel frames instead of 100 and blow the
+            # reservation. Take the natural length instead.
+            padding="longest",
+            truncation=False,
         )
+        input_features = features["input_features"]
+        # The tower expects (num_mel_bins, total_frames); the extractor
+        # returns a leading batch dim for a single item.
+        if input_features.dim() == 3:
+            input_features = input_features[0]
+
+        num_frames = int(input_features.shape[-1])
+        tower = self.audio_tower
+        device = self._tower_device(tower)
+        feature_lens = torch.tensor([num_frames], dtype=torch.long, device=device)
+        aftercnn_lens = torch.tensor(
+            [Qwen3OmniDuplexPolicy.audio_tokens_for_mel_frames(num_frames)],
+            dtype=torch.long,
+            device=device,
+        )
+        outputs = tower(
+            input_features.to(device=device, dtype=tower.dtype),
+            feature_lens=feature_lens,
+            aftercnn_lens=aftercnn_lens,
+        )
+        return outputs if isinstance(outputs, torch.Tensor) else outputs.last_hidden_state
+
+    @staticmethod
+    def _tower_device(tower: Any) -> Any:
+        for parameter in tower.parameters():
+            return parameter.device
+        raise RuntimeError("Qwen3-Omni audio_tower has no parameters; cannot resolve device")
+
+    @staticmethod
+    def _decode_pcm(payload: object) -> Any:
+        """Decode a duplex audio payload to a float32 mono array."""
+        import numpy as np
+
+        if not isinstance(payload, dict):
+            return np.zeros(0, dtype=np.float32)
+        audio_format = payload.get("format", Qwen3OmniDuplexPolicy.PCM_FORMAT)
+        if audio_format != Qwen3OmniDuplexPolicy.PCM_FORMAT:
+            raise ValueError(
+                f"unsupported duplex audio format: {audio_format!r} (expected {Qwen3OmniDuplexPolicy.PCM_FORMAT})"
+            )
+        data = payload.get("audio")
+        if isinstance(data, str):
+            data = base64.b64decode(data)
+        if not isinstance(data, (bytes, bytearray)):
+            return np.zeros(0, dtype=np.float32)
+        return np.frombuffer(bytes(data), dtype="<f4").astype(np.float32, copy=False)
 
     @staticmethod
     def expected_embedding_count(num_samples: int) -> int:
@@ -167,3 +273,10 @@ class Qwen3OmniStage0DuplexRuntime:
         to the same checkpoint-derived formula.
         """
         return max(1, Qwen3OmniDuplexPolicy.audio_tokens_for_samples(num_samples))
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Worker-side stage-0 duplex runtime for Qwen3-Omni.
+
+STATUS: NOT IMPLEMENTED. This module defines the required structure and
+documents precisely what is missing. ``build_append_embeddings`` raises
+``NotImplementedError``; it has never been executed against a checkpoint.
+
+Why this piece is unavoidable
+-----------------------------
+In the duplex append path, audio cannot reach the thinker by Qwen3-Omni's
+normal multimodal route:
+
+* ``build_engine_core_request_from_tokens``
+  (``vllm_omni/engine/orchestrator.py:118-158``) forwards only
+  ``prompt_token_ids``, ``prompt_embeds``, ``cache_salt``,
+  ``additional_information`` and ``model_intermediate_buffer``. Any other
+  prompt key -- including ``multi_modal_data`` -- is dropped silently.
+* ``_OrchestratorDuplexStagePort.submit`` (``orchestrator.py:289-302``)
+  passes no ``mm_features``.
+
+So audio arrives as base64 PCM inside
+``model_intermediate_buffer["duplex"]["payload"]``, and the only place it can
+become thinker embeddings is the model's own ``preprocess`` hook, dispatched
+at ``gpu_model_runner.py:1685`` under ``model.has_preprocess``.
+
+Two blockers, both real
+-----------------------
+1. **The thinker has no preprocess hook.**
+   ``Qwen3OmniMoeForConditionalGeneration`` sets ``has_preprocess = False``
+   at ``qwen3_omni.py:107`` and only enables it for the talker stage
+   (``qwen3_omni.py:156``). MiniCPM enables it for both its LM and TTS stages
+   (``minicpmo_4_5_omni.py:140``). Enabling it for the Qwen3-Omni thinker and
+   implementing ``preprocess`` is core model-code work, outside this package.
+
+2. **Qwen3-Omni's audio tower has no incremental/streaming encode.**
+   MiniCPM carries an audio-encoder KV cache across chunks
+   (``minicpmo45/stage0.py:443-489``: ``get_audio_embedding_streaming`` plus
+   ``audio_past_key_values``, with explicit prefix/suffix context frames).
+   Qwen3-Omni exposes no equivalent -- the only streaming affordance in the
+   model is ``code2wav.chunked_decode_streaming`` (``qwen3_omni.py:593``),
+   which is on the OUTPUT side. Without incremental encode there are three
+   options, none free:
+
+   a. Re-encode the whole accumulated buffer each append: correct, but
+      quadratic in session length, which defeats the purpose of a persistent
+      session.
+   b. Encode each chunk in isolation: cheap, but wrong at chunk boundaries,
+      because the convolutional front end loses its left context.
+   c. Encode a bounded sliding window (new chunk + N frames of left context)
+      and keep only the new chunk's embeddings: bounded cost and
+      approximately correct. This is the shape MiniCPM achieves via
+      ``cnn_redundancy_ms`` / ``prefix_extra_frames``, and it is the
+      recommended approach -- but the exact frame arithmetic (mel hop ->
+      conv stride -> pooling ratio -> embeddings per chunk) must be derived
+      from the checkpoint, not guessed.
+
+Reservation invariant
+---------------------
+``duplex_scheduler_token_budget`` in ``runtime.py`` reserves scheduler slots
+from ``Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN``. This module MUST
+produce exactly that many embeddings per chunk. If the counts disagree the
+model runner truncates or pads without raising, so the two calculations must
+be derived from the same constant and asserted against each other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from vllm_omni.experimental.fullduplex.qwen3omni.policy import Qwen3OmniDuplexPolicy
+
+
+@dataclass
+class Qwen3OmniStage0SessionState:
+    """Per-``(session_id, incarnation)`` worker state for the thinker."""
+
+    #: Raw float32 PCM not yet consumed into embeddings.
+    audio_buffer: Any = None
+    #: Count of chunks already turned into embeddings.
+    chunk_index: int = 0
+    #: Tail of the previous chunk retained as encoder left context (option
+    #: (c) above). Length is a function of the audio tower's receptive field.
+    left_context: Any = None
+    #: Memoized result keyed by (epoch, seq) so a scheduler retry of the same
+    #: append is idempotent -- mirrors minicpmo45/stage0.py:164-173.
+    prepared: dict[tuple[int, int], Any] = field(default_factory=dict)
+
+
+class Qwen3OmniStage0DuplexRuntime:
+    """Turns appended PCM into thinker input embeddings.
+
+    Constructed lazily off the live model instance, mirroring
+    ``minicpmo_4_5_omni.py:455-465``. There is no registry: the model class
+    imports and instantiates this itself on the first duplex append.
+    """
+
+    def __init__(self, stage_model: Any, *, model_path: str | None = None, device: str | None = None) -> None:
+        self._model = stage_model
+        self._model_path = model_path
+        self._device = device
+        self.sessions: dict[tuple[str, int], Qwen3OmniStage0SessionState] = {}
+
+    def session(self, session_id: str, incarnation: int) -> Qwen3OmniStage0SessionState:
+        key = (session_id, incarnation)
+        state = self.sessions.get(key)
+        if state is None:
+            state = Qwen3OmniStage0SessionState()
+            self.sessions[key] = state
+        return state
+
+    def drop_session(self, session_id: str, incarnation: int) -> None:
+        self.sessions.pop((session_id, incarnation), None)
+
+    def build_append_embeddings(
+        self,
+        *,
+        duplex: dict[str, Any],
+        token_offset: int,
+        prompt_len: int,
+    ) -> Any:
+        """Decode appended PCM and return thinker input embeddings.
+
+        Not implemented. See the module docstring for the two blockers.
+
+        A correct implementation must:
+
+        1. Decode ``duplex["payload"]`` (base64 ``pcm_f32le``) and append it
+           to ``state.audio_buffer``.
+        2. While a whole ``Qwen3OmniDuplexPolicy.CHUNK_SAMPLES`` unit is
+           available, encode ``left_context + chunk`` through the thinker's
+           audio tower and keep only the embeddings corresponding to
+           ``chunk`` -- discarding the left-context prefix outputs.
+        3. Retain a new ``left_context`` tail sized to the tower's receptive
+           field.
+        4. Assert the produced embedding count equals ``prompt_len`` (the
+           reserved slot count). A mismatch must raise here rather than be
+           silently absorbed downstream.
+        5. Return embeddings positioned at ``token_offset`` within the
+           request's prompt.
+
+        Deriving the frames-per-embedding ratio in step 2 from the
+        checkpoint's audio config -- not from
+        ``Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN``, which is currently
+        an unverified placeholder -- is the first thing to do.
+        """
+        raise NotImplementedError(
+            "Qwen3-Omni stage-0 duplex audio embedding is not implemented. "
+            "Two prerequisites are unmet: (1) the thinker stage sets "
+            "has_preprocess=False (qwen3_omni.py:107) and has no preprocess hook; "
+            "(2) Qwen3-Omni exposes no incremental audio encode equivalent to "
+            "MiniCPM's get_audio_embedding_streaming/audio_past_key_values. "
+            "See this module's docstring and "
+            "docs/design/qwen3_omni_duplex_assessment.md."
+        )
+
+    @staticmethod
+    def expected_embedding_count(num_samples: int, *, samples_per_token: int | None = None) -> int:
+        """Embeddings a chunk of ``num_samples`` must produce.
+
+        Must agree with ``runtime.duplex_scheduler_token_budget``.
+        """
+        per_token = samples_per_token or Qwen3OmniDuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
+        if per_token <= 0:
+            raise ValueError("samples_per_audio_token must be positive")
+        return max(1, -(-num_samples // per_token))

--- a/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
+++ b/vllm_omni/experimental/fullduplex/qwen3omni/stage0.py
@@ -167,6 +167,14 @@ class Qwen3OmniStage0DuplexRuntime:
             isinstance(payload, dict) and payload.get(Qwen3OmniDuplexPolicy.TURN_FINAL_KEY) is True
         )
 
+        # An append that reserved no `<|audio_pad|>` slots has no audio span to
+        # fill -- a text turn, or a commit whose buffer earlier appends already
+        # drained. Return before touching the audio buffer: leftover samples
+        # from an earlier partial turn would otherwise be encoded here and
+        # spliced over token ids that are already correct.
+        if _coerce_int(duplex.get("audio_tokens")) == 0:
+            return None
+
         state = self.session(session_id, incarnation)
 
         # Idempotent replay: the scheduler may re-present the same append.

--- a/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
@@ -23,6 +23,23 @@ QWEN3_OMNI_PIPELINE = PipelineConfig(
     model_type="qwen3_omni_moe",
     default_deploy_config_name="qwen3_omni_moe.yaml",
     model_arch="Qwen3OmniMoeForConditionalGeneration",
+    # Experimental full-duplex integration. Scope: client-signalled barge-in
+    # over a persistent session. Qwen3-Omni has no learned listen/speak
+    # control token, so there is no model-owned turn policy here (unlike
+    # MiniCPM-o 4.5).
+    #
+    # duplex_control_enabled stays False: the worker-side stage-0 audio
+    # embedding path is not implemented (see
+    # vllm_omni/experimental/fullduplex/qwen3omni/stage0.py), so arming the
+    # duplex endpoint would surface a NotImplementedError at the first
+    # append rather than a clean startup failure. The extension and adapter
+    # paths below are declared so the wiring is reviewable and testable, and
+    # so enabling the feature later is a one-line change.
+    duplex_runtime_extension=("vllm_omni.experimental.fullduplex.qwen3omni.runtime.Qwen3OmniDuplexRuntimeExtension"),
+    duplex_serving_adapter=(
+        "vllm_omni.experimental.fullduplex.qwen3omni.serving_adapter.Qwen3OmniServingRuntimeAdapter"
+    ),
+    duplex_control_enabled=False,
     endpoint_restrictions=(
         EndpointRestriction(
             OmniServingCapability.COMPLETIONS,

--- a/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
@@ -28,18 +28,14 @@ QWEN3_OMNI_PIPELINE = PipelineConfig(
     # control token, so there is no model-owned turn policy here (unlike
     # MiniCPM-o 4.5).
     #
-    # duplex_control_enabled stays False: the worker-side stage-0 audio
-    # embedding path is not implemented (see
-    # vllm_omni/experimental/fullduplex/qwen3omni/stage0.py), so arming the
-    # duplex endpoint would surface a NotImplementedError at the first
-    # append rather than a clean startup failure. The extension and adapter
-    # paths below are declared so the wiring is reviewable and testable, and
-    # so enabling the feature later is a one-line change.
+    # The duplex endpoint additionally requires the client to opt in per
+    # session via extra_body["qwen3_omni_native_duplex"], so enabling the
+    # control plane here does not change behaviour for ordinary requests.
     duplex_runtime_extension=("vllm_omni.experimental.fullduplex.qwen3omni.runtime.Qwen3OmniDuplexRuntimeExtension"),
     duplex_serving_adapter=(
         "vllm_omni.experimental.fullduplex.qwen3omni.serving_adapter.Qwen3OmniServingRuntimeAdapter"
     ),
-    duplex_control_enabled=False,
+    duplex_control_enabled=True,
     endpoint_restrictions=(
         EndpointRestriction(
             OmniServingCapability.COMPLETIONS,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -806,6 +806,16 @@ class Qwen3OmniMoeForConditionalGeneration(
             device=base_embeds.device,
             dtype=base_embeds.dtype,
         )
+        logger.info(
+            "[splice] span=%d audio_off=%s start=%d win=%s | pad_norm=%.4f audio_norm=%.4f "
+            "changed=%s ids[start]=%s dtype=%s/%s",
+            span, duplex.get("audio_offset"), start, tuple(window.shape),
+            float(base_embeds[start].norm()) if start < span else -1.0,
+            float(window[0].norm()),
+            not torch.equal(req_embeds, base_embeds),
+            int(input_ids[start]) if start < input_ids.numel() else -1,
+            base_embeds.dtype, window.dtype,
+        )
         return (
             input_ids,
             req_embeds,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -763,6 +763,10 @@ class Qwen3OmniMoeForConditionalGeneration(
             # come up empty and pad-fill over generated tokens.
             return input_ids, self._thinker_input_embeds(input_ids, input_embeds), {}
 
+        # Scaffolding positions (system block, turn openers, the assistant
+        # generation prompt) hold real token ids, so the ordinary embedding
+        # lookup is already correct for them. Only the `<|audio_pad|>` span
+        # needs replacing.
         base_embeds = self._thinker_input_embeds(input_ids, input_embeds)
         audio_embeds = self._duplex_stage0_runtime().build_append_embeddings(
             duplex=duplex,
@@ -774,16 +778,22 @@ class Qwen3OmniMoeForConditionalGeneration(
             return input_ids, base_embeds, {}
 
         offset = int(token_offset) if isinstance(token_offset, int) else 0
+        audio_start = int(duplex.get("audio_offset") or 0)
         span = base_embeds.shape[0]
-        window = audio_embeds[offset : offset + span].to(
-            device=base_embeds.device,
-            dtype=base_embeds.dtype,
-        )
-        if window.shape[0] == 0:
+
+        # Intersect the audio span with the slice of the prompt this call
+        # covers; the runner may split a prompt across several calls.
+        start = max(audio_start - offset, 0)
+        take_from = max(offset - audio_start, 0)
+        window = audio_embeds[take_from : take_from + max(span - start, 0)]
+        if start >= span or window.shape[0] == 0:
             return input_ids, base_embeds, {}
 
         req_embeds = base_embeds.clone()
-        req_embeds[: window.shape[0]] = window
+        req_embeds[start : start + window.shape[0]] = window.to(
+            device=base_embeds.device,
+            dtype=base_embeds.dtype,
+        )
         return (
             input_ids,
             req_embeds,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -158,6 +158,16 @@ class Qwen3OmniMoeForConditionalGeneration(
             # payload. Mirrors minicpmo_4_5_omni.py:140.
             self.has_preprocess = True
             self.set_custom_preprocess(self.thinker_duplex_preprocess)
+            # `talker_mtp` is an unconditional method on this class, so
+            # `GPUModelRunner._init_talker_mtp` would set has_talker_mtp=True
+            # even for the thinker. That was inert while the thinker had no
+            # preprocess hook, but the custom-preprocess path then requires
+            # every decode step to return `mtp_inputs`
+            # (gpu_model_runner.py:1787-1788) -- a talker-only contract the
+            # thinker cannot satisfy, producing KeyError: 'mtp_inputs'.
+            # Multi-token prediction belongs to the talker stage; shadow the
+            # method so this stage does not advertise it.
+            self.talker_mtp = None
             self.tts_tokens = torch.tensor(
                 [[self.config.tts_bos_token_id, self.config.tts_eos_token_id, self.config.tts_pad_token_id]],
                 device=self._module_device(self.thinker),

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -146,6 +146,18 @@ class Qwen3OmniMoeForConditionalGeneration(
             self.model = self.thinker
             self.talker = None
             self.code2wav = None
+            # Experimental full-duplex: audio appended mid-session cannot
+            # travel as multi_modal_data (the duplex submit path drops it, see
+            # experimental/fullduplex/qwen3omni/stage0.py), so the thinker
+            # needs a preprocess hook to turn appended PCM into embeddings.
+            # Safe for the normal path: the thinker is a multimodal stage, so
+            # the runner already routes it through inputs_embeds
+            # (gpu_model_runner.py:1569) rather than the token-id fast path;
+            # has_preprocess only adds the dispatch, and
+            # thinker_duplex_preprocess is a pass-through without a duplex
+            # payload. Mirrors minicpmo_4_5_omni.py:140.
+            self.has_preprocess = True
+            self.set_custom_preprocess(self.thinker_duplex_preprocess)
             self.tts_tokens = torch.tensor(
                 [[self.config.tts_bos_token_id, self.config.tts_eos_token_id, self.config.tts_pad_token_id]],
                 device=self._module_device(self.thinker),
@@ -685,6 +697,96 @@ class Qwen3OmniMoeForConditionalGeneration(
         Postprocess the talker hidden states.
         """
         return {"hidden_states": {"last": hidden_states[-1, :].detach()}}
+
+    # ==================== Experimental full-duplex (thinker) ====================
+
+    def _duplex_stage0_runtime(self):
+        """Lazily build the stage-0 duplex helper off this model instance.
+
+        No registry: the model owns its helper, mirroring
+        ``minicpmo_4_5_omni.py:455-465``.
+        """
+        helper = getattr(self, "_qwen3omni_duplex_stage0", None)
+        if helper is None:
+            from vllm_omni.experimental.fullduplex.qwen3omni.stage0 import (
+                Qwen3OmniStage0DuplexRuntime,
+            )
+
+            helper = Qwen3OmniStage0DuplexRuntime(
+                self,
+                model_path=getattr(getattr(self.vllm_config, "model_config", None), "model", None),
+                device=str(self._module_device(self.thinker)),
+            )
+            self._qwen3omni_duplex_stage0 = helper
+        return helper
+
+    def _thinker_input_embeds(self, input_ids: torch.Tensor, input_embeds: torch.Tensor | None) -> torch.Tensor:
+        if input_embeds is not None:
+            return input_embeds
+        return self.thinker.get_input_embeddings(input_ids)
+
+    def thinker_duplex_preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+        **info_dict: object,
+    ):
+        """Model-runner hook turning a duplex audio append into embeddings.
+
+        Pass-through unless this request carries a duplex data-plane payload,
+        so the ordinary Qwen3-Omni thinker path is unchanged.
+
+        The scheduler owns the request, block table, attention metadata, KV
+        and sampler; this only supplies the prompt embeddings for the
+        appended audio.
+        """
+        duplex = info_dict.get("duplex")
+        if not isinstance(duplex, dict) or duplex.get("data_plane") is not True:
+            return input_ids, self._thinker_input_embeds(input_ids, input_embeds), {}
+
+        prompt_len = info_dict.get("duplex_prompt_len")
+        token_offset = info_dict.get("duplex_token_offset", 0)
+        if isinstance(prompt_len, int) and isinstance(token_offset, int) and token_offset >= prompt_len:
+            # Decode step of the resumable duplex request: input_ids are the
+            # runner-sampled tokens, so the ordinary embedding lookup is
+            # correct. Slicing the prompt-only duplex embeddings here would
+            # come up empty and pad-fill over generated tokens.
+            return input_ids, self._thinker_input_embeds(input_ids, input_embeds), {}
+
+        base_embeds = self._thinker_input_embeds(input_ids, input_embeds)
+        audio_embeds = self._duplex_stage0_runtime().build_append_embeddings(
+            duplex=duplex,
+            token_offset=int(token_offset) if isinstance(token_offset, int) else 0,
+            prompt_len=int(prompt_len) if isinstance(prompt_len, int) else 0,
+        )
+        if audio_embeds is None:
+            # Append did not complete a whole chunk; nothing to splice.
+            return input_ids, base_embeds, {}
+
+        offset = int(token_offset) if isinstance(token_offset, int) else 0
+        span = base_embeds.shape[0]
+        window = audio_embeds[offset : offset + span].to(
+            device=base_embeds.device,
+            dtype=base_embeds.dtype,
+        )
+        if window.shape[0] == 0:
+            return input_ids, base_embeds, {}
+
+        req_embeds = base_embeds.clone()
+        req_embeds[: window.shape[0]] = window
+        return (
+            input_ids,
+            req_embeds,
+            {
+                "duplex": {
+                    "duplex_audio_embed_count": int(audio_embeds.shape[0]),
+                    "duplex_epoch": duplex.get("epoch"),
+                    "duplex_turn_id": duplex.get("turn_id"),
+                }
+            },
+        )
+
+    # ============================================================================
 
     def talker_preprocess(self, input_ids: torch.Tensor, input_embeds: torch.Tensor, **info_dict: dict):
         """

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -790,8 +790,31 @@ class Qwen3OmniMoeForConditionalGeneration(
             return input_ids, base_embeds, {}
 
         offset = int(token_offset) if isinstance(token_offset, int) else 0
-        audio_start = int(duplex.get("audio_offset") or 0)
         span = base_embeds.shape[0]
+
+        # `audio_offset` is relative to *this append's own* token span (it is
+        # `len(prefix)`; see `build_duplex_prompt_token_ids`), while
+        # `token_offset` is absolute within the session -- the runner sets it
+        # from `num_computed_tokens`. Convert before comparing them.
+        #
+        # On the session's first append the two frames coincide (`offset == 0`)
+        # and mixing them is harmless, which is why this only ever broke from
+        # the second turn on: `take_from` came out as the whole preceding
+        # conversation, the window sliced past the end of `audio_embeds`, and
+        # the empty-window guard below returned silently. The model then got a
+        # span of unfilled `<|audio_pad|>` placeholders and answered as though
+        # the user had said nothing -- generic replies, and eventually "it
+        # seems like you are sending a lot of empty messages".
+        #
+        # The append's absolute base is what the runner has already computed
+        # for the session minus this append, i.e. `prompt_len - append_len`.
+        # Verified against three consecutive turns: derived base 0/146/256
+        # against observed `token_offset` 0/146/256.
+        append_len = int(
+            duplex.get("append_token_count") or duplex.get("scheduler_token_budget") or (prompt_len or span)
+        )
+        append_base = max(int(prompt_len or 0) - append_len, 0)
+        audio_start = append_base + int(duplex.get("audio_offset") or 0)
 
         # Intersect the audio span with the slice of the prompt this call
         # covers; the runner may split a prompt across several calls.
@@ -799,6 +822,18 @@ class Qwen3OmniMoeForConditionalGeneration(
         take_from = max(offset - audio_start, 0)
         window = audio_embeds[take_from : take_from + max(span - start, 0)]
         if start >= span or window.shape[0] == 0:
+            # Reaching here means audio was produced for this append but none
+            # of it landed. The runner absorbs a reservation/embedding
+            # mismatch by leaving the placeholders in place rather than
+            # raising, so this is otherwise invisible -- the request succeeds
+            # and the model silently reads an empty user turn. Say so.
+            logger.warning(
+                "[qwen3omni-duplex] audio produced but not spliced: %d embeddings dropped for "
+                "req span=%d offset=%d prompt_len=%s append_len=%d audio_start=%d "
+                "(start=%d take_from=%d). The thinker will see unfilled <|audio_pad|> "
+                "placeholders and answer as if the turn were empty.",
+                audio_embeds.shape[0], span, offset, prompt_len, append_len, audio_start, start, take_from,
+            )
             return input_ids, base_embeds, {}
 
         req_embeds = base_embeds.clone()

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -751,6 +751,13 @@ class Qwen3OmniMoeForConditionalGeneration(
         appended audio.
         """
         duplex = info_dict.get("duplex")
+        logger.info(
+            "[qwen3omni-duplex] thinker preprocess: span=%s duplex=%s offset=%s prompt_len=%s",
+            tuple(input_ids.shape),
+            bool(isinstance(duplex, dict) and duplex.get("data_plane") is True),
+            info_dict.get("duplex_token_offset"),
+            info_dict.get("duplex_prompt_len"),
+        )
         if not isinstance(duplex, dict) or duplex.get("data_plane") is not True:
             return input_ids, self._thinker_input_embeds(input_ids, input_embeds), {}
 
@@ -772,6 +779,11 @@ class Qwen3OmniMoeForConditionalGeneration(
             duplex=duplex,
             token_offset=int(token_offset) if isinstance(token_offset, int) else 0,
             prompt_len=int(prompt_len) if isinstance(prompt_len, int) else 0,
+        )
+        logger.info(
+            "[qwen3omni-duplex] audio embeds=%s audio_offset=%s",
+            None if audio_embeds is None else tuple(audio_embeds.shape),
+            duplex.get("audio_offset"),
         )
         if audio_embeds is None:
             # Append did not complete a whole chunk; nothing to splice.


### PR DESCRIPTION
> **Draft, deliberately.** This is the whole working port in one branch so the
> approach can be reviewed and the seams agreed before it is carved up. It is
> **not** proposed for merge as-is — the decomposition plan is below and in
> `docs/design/qwen3_omni_duplex_pr_map.md`. Feedback on the seams is more
> useful to me right now than line-level review.

## Purpose

Brings Qwen3-Omni up on the experimental full-duplex framework added for
MiniCPM-o 4.5 (#3907) — the second native duplex model, and the first that is
not the one the framework was written against.

**Speech in → spoken answer out works end to end**, through
thinker → talker → code2wav over a persistent duplex WebSocket session, with
client-signalled barge-in.

Most of the value here may be the framework fixes rather than the adapter:
several defects are ones *any* second native duplex model would hit, and they
are already carved out (see "Relationship to other PRs").

## Test Plan

`examples/online_serving/qwen3_omni_duplex/` contains a browser demo and
`headless_client.py`, which replays the browser's exact wire protocol from a
sample clip — no microphone, no tunnel, and repeatable:

```bash
python examples/online_serving/qwen3_omni_duplex/headless_client.py --sessions 5 --turns 3
```

Exits non-zero unless every turn of every session produced audio.

Unit tests: `tests/core/sched/`, `tests/engine/`, `tests/e2e/features/fullduplex/`.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 8cb79308 (rebased onto current `main`)

## Test Result

On a freshly booted 3-stage duplex server:

| | result |
|---|---|
| consecutive sessions, all answering | 5 / 5 |
| turns producing audio (4 sessions × 3 turns) | 12 / 12 |

Content verified rather than just "audio came back" — two turns carrying
*different* audio, replies transcribed by a separate Qwen3-Omni:

| turn | audio in | reply |
|---|---|---|
| 1 | 他当时还跟线下其他的站姐吵 | 他当时还跟线下其他站姐一起吗？ |
| 2 | 吵架，然后打架进局子了 | 真的假的啊？打架还进去了？现在人怎么样了？ |

Turn 2's reply uses 打架 and 进去了, which occur only in turn 2's audio — i.e.
later turns are genuinely heard, not answered from context.

## What is in here

Written whole-first to find the hairy cases, then sliced. Every defect is its
own commit with its evidence and its ruled-out list in the message.

**Framework fixes** (no dependency on Qwen3-Omni; each is a bug the next duplex
model hits too)
- `DuplexFence` not JSON serializable in `runtime_control` — **merged as #5613**
- `num_waiting_for_streaming_input` leaks on abort and parks a stage forever — **carved out as #5662**
- abort raised inside the AR scheduler's dequeue kills the engine core
- downstream async-chunk stages not re-armed on later stage-0 submits

**Qwen3-Omni model code**
- thinker `preprocess` hook for duplex audio ingest
- do not advertise talker MTP on the thinker stage

**The adapter** — `vllm_omni/experimental/fullduplex/qwen3omni/`, ~1,900 lines:
policy + audio geometry, serving adapter + session state, runtime extension,
stage-0 audio ingest, data plane.

**Demo and docs** — browser demo, headless client, architecture primer, and the
decomposition map.

## Proposed decomposition

Framework fixes → model-code fixes → adapter → demo. Value front-loaded, risk
back-loaded; the first group is defensible without reference to this model.
Sub-seams for the adapter are listed in `docs/design/qwen3_omni_duplex_pr_map.md`,
along with the seams that turned out to matter and the fixes that were wrong.

Happy to reorder — that document is a proposal, not a decision.

## Relationship to other PRs

- #5613 — merged; the commit is in this branch's history.
- #5662 — the streaming-input counter fix, carved out and rebased clean.
- #5626 — duplex chat-fallback error reporting, independent.

Rebased onto current `main` (`8cb79308`) and re-verified after the rebase:
3/3 sessions x 2 turns produced audio, and the two-different-clips content
check reproduces (turn 2's reply still uses 打架 / 进去了). One commit was
dropped during the rebase -- the `runtime_control` JSON fix, which is already
in `main` as #5613.

## Known limitations

- **Transcripts are empty.** Direct response and stage advancement are mutually
  exclusive in the orchestrator, so stage-0 text can be surfaced *or* audio can
  flow, not both. Audio wins. Lifting this is a framework change I have not
  attempted.
- ~~No text input yet.~~ **Done.** Type a message and get a spoken reply, mixed
  freely with audio turns; cross-modal context works both ways. The recorded
  blocker ("needs a tokenizer where there isn't one") was wrong -- the serving
  layer already builds chat scaffolding with one.
- **Tool calling works.** Tools are declared as `extra_body.realtime_tools`,
  rendered with the checkpoint's own `# Tools` block, intercepted at stage 0
  and dispatched client-side; the answer comes back spoken. Finding it required
  three fixes, including a stranded-downstream-stage leak that wedges a stage
  for later sessions from the direct-response path -- the same failure as #5662
  reached a different way.
- **Audio is held until commit.** Qwen3-Omni has no learned listen/speak token,
  so an intermediate append asks it to continue a user turn with no
  `<|audio_end|>` and it produces garbage. Holding until commit gives it one
  well-formed turn, at the cost of time-to-first-token starting at release.
  This is a model property, not a framework limit.
- Experimental throughout; no CI coverage for the duplex path beyond the unit
  tests included here.


