### PR TITLE
[Quant] Quark FP8/MXFP4 online quantization

### DIFF
--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -280,8 +280,8 @@ def parse_args() -> argparse.Namespace:
         "--quantization",
         type=str,
         default=None,
-        choices=["fp8", "mxfp8", "mxfp4", "mxfp4_dualscale", "int8"],
-        help="Quantization method for the transformer. mxfp8: W8A8 MXFP8 (NPU). mxfp4: W4A4 MXFP4 (NPU). mxfp4_dualscale: W4A4 MXFP4 dual-scale + BF16 fallback mixed (NPU). fp8: online FP8 (GPU).",
+        choices=["fp8", "mxfp8", "mxfp4", "mxfp4_dualscale", "quark_mxfp4", "int8"],
+        help="Quantization method for the transformer. mxfp8: W8A8 MXFP8 (NPU). mxfp4: W4A4 MXFP4 (NPU). mxfp4_dualscale: W4A4 MXFP4 dual-scale + BF16 fallback mixed (NPU). quark_mxfp4: W4A4 Quark MXFP4 online (ROCm gfx950; SCAFFOLD - Quark weight transform is a TODO). fp8: online FP8 (GPU).",
     )
 
     # Distributed and parallel execution

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -125,6 +125,13 @@ def _build_mxfp4_dualscale(**kw: Any) -> QuantizationConfig:
     return DiffusionMXFP4DualScaleMixedConfig(**kw)
 
 
+def _build_quark_mxfp4(**kw: Any) -> QuantizationConfig:
+    """Lazy import for W4A4 Quark MXFP4 online diffusion config (ROCm gfx950 only)."""
+    from .quark_mxfp4_config import DiffusionQuarkMXFP4Config
+
+    return DiffusionQuarkMXFP4Config(**kw)
+
+
 def _build_inc(**kw: Any) -> QuantizationConfig:
     """Lazy import for INC/AutoRound config with checkpoint kwarg normalization."""
     from .inc_config import OmniINCConfig
@@ -145,6 +152,7 @@ _OVERRIDES: dict[str, Callable[..., QuantizationConfig]] = {
     "mxfp8": _build_mxfp8,
     "mxfp4": _build_mxfp4,
     "mxfp4_dualscale": _build_mxfp4_dualscale,
+    "quark_mxfp4": _build_quark_mxfp4,
     "inc": _build_inc,
     "auto-round": _build_inc,
     "auto_round": _build_inc,

--- a/vllm_omni/quantization/quark_mxfp4_config.py
+++ b/vllm_omni/quantization/quark_mxfp4_config.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W4A4 Quark MXFP4 online quantization for diffusion transformers (ROCm gfx950).
+
+SCAFFOLD - the Quark weight/scale transform is not implemented yet (see the TODO
+in QuarkMxfp4OnlineLinearMethod.process_weights_after_loading). Everything else
+(config, platform dispatch, GEMM custom op, forward path) mirrors the working
+built-in ``mxfp4`` path in mxfp4_config.py.
+
+Why a separate method instead of reusing ``mxfp4``:
+  The built-in ROCmMxfp4OnlineLinearMethod uses AITER's NATIVE MX format
+  (aiter.get_hip_quant(per_1x32) + shuffle_weight(layout=(16,16)) + gemm_a4w4).
+  "Quark MXFP4" means matching QUARK's MXFP4 scale/packing layout produced by the
+  ``amd-quark`` package, which differs from AITER's native layout. This module
+  isolates that difference in one place.
+
+Online only: quantize a plain BF16 checkpoint to FP4 at load time (no calibration).
+Offline (pre-quantized Quark MXFP4 checkpoints) is intentionally out of scope here.
+
+Register via factory.register_quantization_override("quark_mxfp4", _build_quark_mxfp4)
+so this stays out-of-tree friendly (no edit to the _OVERRIDES literal required).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch.nn import Module
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
+from vllm.model_executor.model_loader.weight_utils import initialize_single_dummy_weight
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.model_executor.layers.quantization.fp8 import _copy_missing_attrs
+
+from vllm_omni.platforms import current_omni_platform
+from vllm_omni.quantization.mxfp8_config import (
+    MXFPLinearMethodBase,
+    _LazyWeightMixin,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.utils import WeightsMapper
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class DiffusionQuarkMXFP4Config(QuantizationConfig):
+    """W4A4 Quark MXFP4 online quantization config for diffusion transformers.
+
+    Online only (BF16 checkpoint -> FP4 at load). gfx950 (ROCm) only for now.
+    """
+
+    def __init__(self, ignored_layers: list[str] | None = None) -> None:
+        super().__init__()
+        # Online-only scaffold: no is_checkpoint_*_serialized flag yet.
+        self.ignored_layers = ignored_layers or []
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        # NOTE: "quark_mxfp4" is registered via register_quantization_override(),
+        # not present in vLLM's QuantizationMethods enum. Returned as a plain str.
+        return "quark_mxfp4"  # type: ignore[return-value]
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper") -> None:
+        if self.ignored_layers:
+            self.ignored_layers = hf_to_vllm_mapper.apply_list(self.ignored_layers)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "DiffusionQuarkMXFP4Config":
+        ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
+        if not ignored_layers:
+            ignored_layers = cls.get_from_keys_or(config, ["modules_to_not_convert"], None)
+        return cls(ignored_layers=ignored_layers)
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> QuantizeMethodBase | None:
+        if isinstance(layer, LinearBase):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedLinearMethod()
+            if current_omni_platform.is_rocm():
+                gcn_arch = torch.cuda.get_device_properties(
+                    torch.accelerator.current_device_index()
+                ).gcnArchName
+                if "gfx950" not in gcn_arch:
+                    raise NotImplementedError(
+                        f"Quark MXFP4 on ROCm requires gfx950 (MI355X). Detected: {gcn_arch}"
+                    )
+                return QuarkMxfp4OnlineLinearMethod(self)
+            raise NotImplementedError(
+                "DiffusionQuarkMXFP4Config (W4A4 Quark MXFP4) is currently only "
+                "supported on ROCm (AMD, gfx950)."
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# GEMM custom op
+# ---------------------------------------------------------------------------
+
+
+def _register_quark_mxfp4_op() -> None:
+    """Register vllm_omni::quark_mxfp4_gemm.
+
+    SCAFFOLD: currently delegates to the same AITER a4w4 GEMM as the native path.
+    If Quark's packed weight/scale layout is bit-compatible with AITER's
+    per_1x32 + bpreshuffle, this op can be dropped in favor of rocm_mxfp4_gemm.
+    If not, replace the body with Quark's kernel call.
+    """
+    import aiter
+
+    @torch.library.custom_op("vllm_omni::quark_mxfp4_gemm", mutates_args=())
+    def _quark_mxfp4_gemm(
+        a: torch.Tensor,
+        w_quant: torch.Tensor,
+        w_scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # TODO(quark): if Quark activation quant differs, replace this block.
+        quant_func = aiter.get_hip_quant(aiter.QuantType.per_1x32)
+        a_quant, a_scale = quant_func(a, shuffle=True)
+        return aiter.gemm_a4w4(
+            a_quant, w_quant, a_scale, w_scale, bpreshuffle=True, bias=bias
+        )
+
+    @_quark_mxfp4_gemm.register_fake
+    def _quark_mxfp4_gemm_fake(
+        a: torch.Tensor,
+        w_quant: torch.Tensor,
+        w_scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        M, _ = a.shape
+        N, _ = w_quant.shape
+        return torch.empty(M, N, dtype=a.dtype, device=a.device)
+
+
+# ---------------------------------------------------------------------------
+# ROCm Quark MXFP4 online linear method
+# ---------------------------------------------------------------------------
+
+
+class QuarkMxfp4OnlineLinearMethod(_LazyWeightMixin, MXFPLinearMethodBase):
+    """ROCm W4A4 Quark MXFP4 online linear method.
+
+    MRO: QuarkMxfp4OnlineLinearMethod -> _LazyWeightMixin -> MXFPLinearMethodBase
+      create_weights  : _LazyWeightMixin (meta device + patched loader)
+      process_weights : this class (meta -> materialize, then QUARK quant transform)
+      apply / ops     : MXFPLinearMethodBase (shared forward skeleton)
+    """
+
+    def __init__(self, quant_config: DiffusionQuarkMXFP4Config) -> None:
+        self.quant_config = quant_config
+        self.out_dtype = torch.get_default_dtype()
+        if not hasattr(torch.ops.vllm_omni, "quark_mxfp4_gemm"):
+            _register_quark_mxfp4_op()
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        # Materialise from meta device if needed (same pattern as the native online path).
+        if layer.weight is not None and layer.weight.device == torch.device("meta"):
+            weight = ModelWeightParameter(
+                data=torch.empty_like(layer.weight, device=layer._load_device),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=layer.weight.weight_loader,
+            )
+            _copy_missing_attrs(layer.weight, weight)
+            layer.register_parameter("weight", weight)
+            initialize_single_dummy_weight(layer.weight)
+
+        # -------------------------------------------------------------------
+        # TODO(quark): THE core work. Produce Quark's MXFP4 packed weight +
+        # scale from the BF16 layer.weight using the amd-quark package, e.g.:
+        #
+        #   from quark.torch.export.nn.modules... import <mxfp4 packer>
+        #   weight_quant, weight_scale = quark_mxfp4_quantize(layer.weight.data)
+        #
+        # Must match whatever layout quark_mxfp4_gemm() consumes. Until then,
+        # this scaffold falls back to AITER's native transform so the path is
+        # runnable end-to-end (i.e. identical numerics to --quantization mxfp4).
+        # -------------------------------------------------------------------
+        import aiter
+        from aiter.ops.shuffle import shuffle_weight
+
+        quant_func = aiter.get_hip_quant(aiter.QuantType.per_1x32)
+        weight_quant, weight_scale = quant_func(layer.weight.data, shuffle=True)
+        weight_shuffled = shuffle_weight(weight_quant, layout=(16, 16))
+
+        layer.register_buffer("weight_shuffle", weight_shuffled, persistent=True)
+        layer.register_buffer("weight_scale", weight_scale, persistent=True)
+
+        if hasattr(layer, "weight") and isinstance(layer.weight, torch.nn.Parameter):
+            delattr(layer, "weight")
+            layer.register_parameter("weight", None)
+
+        layer._already_called_process_weights_after_loading = True
+
+    def _quantize_activation(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # Activation quant happens inside the custom op (see quark_mxfp4_gemm).
+        return x, None
+
+    def _quant_matmul(
+        self,
+        x_q: torch.Tensor,
+        x_scale: torch.Tensor,
+        layer: torch.nn.Module,
+        bias: torch.Tensor | None,
+        ori_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        output = torch.ops.vllm_omni.quark_mxfp4_gemm(
+            x_q,
+            layer.weight_shuffle,
+            layer.weight_scale,
+            bias,
+        )
+        if output.dtype != ori_dtype:
+            output = output.to(ori_dtype)
+        return output


### PR DESCRIPTION
# [Quant] Online quantization for Wan2.2-T2V-A14B on ROCm gfx950 (FP8, MXFP4) + Quark MXFP4

## Summary

Benchmarked vLLM-Omni's online (load-time) quantization on Wan2.2-T2V-A14B, and scaffolded a Quark MXFP4 method. 

## Benchmark

- HW: AMD Instinct gfx950 (MI355-class), single GPU
- Model: Wan-AI/Wan2.2-T2V-A14B-Diffusers (MoE cascade: transformer + transformer_2)
- Config (identical all runs): 1280x720, 81 frames, 40 steps, guidance 4.0, seed 42, bf16
- Stack: vllm-omni d33c905d, vLLM 0.26.0+rocm723, torch 2.11 (HIP 7.2.5)

| Backend | Cmd | Infer time | Peak VRAM | s/step |
|---|---|---|---|---|
| BF16 (vllm-omni) | _(none)_ | 522.7 s | 87.3 GiB | 12.95 |
| FP8 online | `--quantization fp8` | 592.8 s | 62.2 GiB | 14.60 |
| **MXFP4 online** | `--quantization mxfp4` | **455.5 s** | **50.5 GiB** | **11.28** |
| BF16 (diffusers ref) | _(baseline)_ | 1088.7 s | 80.2 GiB | 27.22 |

vs BF16 (vllm-omni): **MXFP4 -13% time / -42% VRAM**; FP8 +13% time / -29% VRAM.

## Notes

- **MXFP4** uses dedicated aiter `f4gemm_*` FP4 kernels (gfx950) - fast even though the a4w4 blockscale table had no tuned entry for the Wan DiT shapes.
- **FP8** regressed on speed only because aiter's FP8 GEMM latency table has no entries for these shapes (untuned fallback). VRAM win is real. Tunable.

## Changes in this PR

- **New** `quark_mxfp4_config.py`: `DiffusionQuarkMXFP4Config` +  `QuarkMxfp4OnlineLinearMethod`, modeled on `ROCmMxfp4OnlineLinearMethod`.
- Register `quark_mxfp4` in the factory; add to `text_to_video` CLI choices.
- FP8 and native MXFP4 needed **no code** - already supported.

## Test plan

- [x] `--quantization fp8` end-to-end on gfx950 (exit 0)
- [x] `--quantization mxfp4` end-to-end on gfx950 (exit 0)
- [x] Scaffold compiles; `DiffusionQuarkMXFP4Config` imports + instantiates
- [ ] `--quantization quark_mxfp4` end-to-end (after Quark transform lands)
## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
