### PR TITLE
[Bugfix] Honor output_format in image file responses

### DIFF
--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1353,6 +1353,66 @@ def test_image_file_response_format_single(test_client):
     assert img.format == "PNG"
 
 
+@pytest.mark.parametrize(
+    "output_format,expected_media_type,expected_ext",
+    [
+        ("png", "image/png", ".png"),
+        ("jpeg", "image/jpeg", ".jpeg"),
+        ("jpg", "image/jpeg", ".jpg"),
+        ("webp", "image/webp", ".webp"),
+        ("JPEG", "image/jpeg", ".jpeg"),
+        (None, "image/png", ".png"),
+        ("bogus", "image/png", ".png"),
+    ],
+)
+def test_stream_response_single_honors_output_format(output_format, expected_media_type, expected_ext):
+    """Regression test for #5421: file responses must reflect output_format."""
+    from vllm_omni.entrypoints.openai.protocol.images import ImageData, ImageGenerationResponse
+
+    b64 = base64.b64encode(b"fake-image-bytes").decode()
+    response = ImageGenerationResponse(
+        created=0,
+        data=[ImageData(b64_json=b64)],
+        output_format=output_format,
+    ).stream_response()
+
+    assert response.media_type == expected_media_type
+    disposition = response.headers["content-disposition"]
+    assert disposition.endswith(f'{expected_ext}"')
+
+
+@pytest.mark.parametrize(
+    "output_format,expected_ext",
+    [("jpeg", ".jpeg"), ("webp", ".webp"), (None, ".png")],
+)
+def test_stream_response_zip_entries_honor_output_format(output_format, expected_ext):
+    from vllm_omni.entrypoints.openai.protocol.images import ImageData, ImageGenerationResponse
+
+    b64 = base64.b64encode(b"fake-image-bytes").decode()
+    response = ImageGenerationResponse(
+        created=0,
+        data=[ImageData(b64_json=b64), ImageData(b64_json=b64)],
+        output_format=output_format,
+    ).stream_response()
+
+    assert response.media_type == "application/zip"
+
+    import asyncio
+    import zipfile
+
+    async def _drain():
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+        return b"".join(chunks)
+
+    payload = asyncio.run(_drain())
+    with zipfile.ZipFile(io.BytesIO(payload), "r") as zf:
+        names = zf.namelist()
+        assert len(names) == 2
+        assert all(name.endswith(expected_ext) for name in names)
+
+
 def make_test_image_bytes(size=(64, 64)) -> bytes:
     img = Image.new(
         "RGB",

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -687,6 +687,11 @@ def test_multistage_images_async_omni_construction(async_omni_test_client):
     assert captured[1].num_inference_steps == 12
     assert captured[1].guidance_scale == 6.5
 
+    # The multi-stage response must propagate the requested size, matching the
+    # single-stage path (regression for size field being silently dropped).
+    payload = response.json()
+    assert payload["size"] == "128x256"
+
 
 def test_generate_images_async_omni_glm_image_sets_stage0_max_tokens():
     """GLM-Image multistage: stage-0 gets target_h/w from requested size.

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1358,7 +1358,7 @@ def test_image_file_response_format_single(test_client):
     [
         ("png", "image/png", ".png"),
         ("jpeg", "image/jpeg", ".jpeg"),
-        ("jpg", "image/jpeg", ".jpg"),
+        ("jpg", "image/jpeg", ".jpeg"),  # jpg normalized to jpeg
         ("webp", "image/webp", ".webp"),
         ("JPEG", "image/jpeg", ".jpeg"),
         (None, "image/png", ".png"),
@@ -1408,6 +1408,70 @@ def test_stream_response_zip_entries_honor_output_format(output_format, expected
 
     payload = asyncio.run(_drain())
     with zipfile.ZipFile(io.BytesIO(payload), "r") as zf:
+        names = zf.namelist()
+        assert len(names) == 2
+        assert all(name.endswith(expected_ext) for name in names)
+
+
+@pytest.mark.parametrize(
+    "output_format,expected_media_type,expected_ext",
+    [
+        ("png", "image/png", ".png"),
+        ("jpeg", "image/jpeg", ".jpeg"),
+        ("webp", "image/webp", ".webp"),
+    ],
+)
+def test_multistage_file_response_honors_output_format(
+    async_omni_test_client, output_format, expected_media_type, expected_ext
+):
+    """Regression for #5421: multi-stage (len(stage_configs) > 1) file responses
+    must honor output_format instead of always returning PNG."""
+    response = async_omni_test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": "a cat",
+            "n": 1,
+            "response_format": "file",
+            "output_format": output_format,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == expected_media_type
+    disposition = response.headers.get("content-disposition", "")
+    assert "attachment" in disposition
+    assert expected_ext in disposition
+
+    # Verify the bytes are actually encoded in the requested format.
+    img = Image.open(io.BytesIO(response.content))
+    assert img.format == expected_media_type.split("/")[1].upper()
+
+
+@pytest.mark.parametrize(
+    "output_format,expected_ext",
+    [("jpeg", ".jpeg"), ("webp", ".webp"), ("png", ".png")],
+)
+def test_multistage_file_response_zip_honors_output_format(
+    async_omni_test_client, output_format, expected_ext
+):
+    """Regression for #5421: multi-stage file responses with n>1 return a ZIP
+    whose entries are named with the requested output_format extension."""
+    response = async_omni_test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": "a cat",
+            "n": 2,
+            "response_format": "file",
+            "output_format": output_format,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+
+    import zipfile
+
+    with zipfile.ZipFile(io.BytesIO(response.content), "r") as zf:
         names = zf.namelist()
         assert len(names) == 2
         assert all(name.endswith(expected_ext) for name in names)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1831,9 +1831,27 @@ async def generate_images(
                     content=generation_result.model_dump(),
                 )
             flat_images, _, _, _ = generation_result
-            image_data = [ImageData(b64_json=encode_image_base64(img), revised_prompt=None) for img in flat_images]
 
-            return ImageGenerationResponse(created=int(time.time()), data=image_data)
+            # Determine output format (default to png) and encode with it,
+            # mirroring the single-stage path so output_format is honored.
+            output_format = _choose_output_format(request.output_format or "png", None)
+            image_data = [
+                ImageData(
+                    b64_json=encode_image_base64_with_compression(img, format=output_format),
+                    revised_prompt=None,
+                )
+                for img in flat_images
+            ]
+
+            response_kwargs = {
+                "created": int(time.time()),
+                "data": image_data,
+                "output_format": output_format,
+            }
+            response = ImageGenerationResponse(**response_kwargs)
+            if request.response_format != ResponseFormat.FILE:
+                return response
+            return response.stream_response()
 
         # Build params - pass through user values directly
         prompt: OmniTextPrompt = {"prompt": request.prompt, "modalities": ["image"]}
@@ -2628,9 +2646,12 @@ async def _load_input_images(
 
 
 def _choose_output_format(output_format: str | None, background: str | None) -> str:
-    # Normalize and choose extension
+    # Normalize and choose extension. Pillow only recognizes "jpeg" (not "jpg"),
+    # so normalize "jpg" -> "jpeg" before it reaches the encoder.
     fmt = (output_format or "").lower()
-    if fmt in {"jpg", "png", "webp", "jpeg"}:
+    if fmt == "jpg":
+        fmt = "jpeg"
+    if fmt in {"png", "webp", "jpeg"}:
         return fmt
     # If transparency requested, prefer png
     if (background or "auto").lower() == "transparent":

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1788,7 +1788,6 @@ async def generate_images(
                 "num_outputs_per_prompt": request.n,
             }
             if request.size is not None:
-                parse_size(request.size)
                 width, height = parse_size(request.size)
                 app_state_args = getattr(raw_request.app.state, "args", None)
                 _check_max_generated_image_size(app_state_args, width, height)
@@ -1843,11 +1842,15 @@ async def generate_images(
                 for img in flat_images
             ]
 
+            # Mirror the single-stage path: propagate size when requested.
+            # width/height were already parsed above when request.size is set.
             response_kwargs = {
                 "created": int(time.time()),
                 "data": image_data,
                 "output_format": output_format,
             }
+            if request.size:
+                response_kwargs["size"] = f"{width}x{height}"
             response = ImageGenerationResponse(**response_kwargs)
             if request.response_format != ResponseFormat.FILE:
                 return response

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -183,7 +183,7 @@ class ImageGenerationResponse(BaseModel):
 
     created: int = Field(..., description="Unix timestamp of when the generation completed")
     data: list[ImageData] = Field(..., description="Array of generated images")
-    output_format: str = Field(None, description="The output format of the image generation")
+    output_format: str | None = Field(default=None, description="The output format of the image generation")
     size: str = Field(None, description="The size of the image generated")
     cot_output: str | None = Field(
         None,
@@ -191,18 +191,27 @@ class ImageGenerationResponse(BaseModel):
         "Only present for image editing (IT2I) with CoT-enabled models.",
     )
 
+    def _file_extension_and_media_type(self) -> tuple[str, str]:
+        fmt = (self.output_format or "png").lower()
+        if fmt in ("jpg", "jpeg"):
+            return fmt, "image/jpeg"
+        if fmt == "webp":
+            return fmt, "image/webp"
+        return "png", "image/png"
+
     def stream_response(self) -> StreamingResponse:
         if not self.data or not self.data[0].b64_json:
             raise HTTPException(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
                 detail="No image data available for file response.",
             )
+        extension, media_type = self._file_extension_and_media_type()
         if len(self.data) == 1:
             image_bytes = base64.b64decode(self.data[0].b64_json)
-            filename = f"image_{uuid.uuid4().hex[:8]}.png"
+            filename = f"image_{uuid.uuid4().hex[:8]}.{extension}"
             return StreamingResponse(
                 io.BytesIO(image_bytes),
-                media_type="image/png",
+                media_type=media_type,
                 headers={
                     "Content-Disposition": f'attachment; filename="{filename}"',
                     "Content-Length": str(len(image_bytes)),
@@ -213,7 +222,7 @@ class ImageGenerationResponse(BaseModel):
             with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
                 for idx, item in enumerate(self.data):
                     if item.b64_json:
-                        zf.writestr(f"image_{idx}.png", base64.b64decode(item.b64_json))
+                        zf.writestr(f"image_{idx}.{extension}", base64.b64decode(item.b64_json))
             zip_bytes = zip_buffer.getvalue()
             filename = f"images_{uuid.uuid4().hex[:8]}.zip"
             return StreamingResponse(

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -184,7 +184,7 @@ class ImageGenerationResponse(BaseModel):
     created: int = Field(..., description="Unix timestamp of when the generation completed")
     data: list[ImageData] = Field(..., description="Array of generated images")
     output_format: str | None = Field(default=None, description="The output format of the image generation")
-    size: str = Field(None, description="The size of the image generated")
+    size: str | None = Field(default=None, description="The size of the image generated")
     cot_output: str | None = Field(
         None,
         description="Chain-of-thought text output from the AR stage. "

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -192,8 +192,11 @@ class ImageGenerationResponse(BaseModel):
     )
 
     def _file_extension_and_media_type(self) -> tuple[str, str]:
+        # Normalize "jpg" -> "jpeg" so the extension matches what Pillow produces.
         fmt = (self.output_format or "png").lower()
-        if fmt in ("jpg", "jpeg"):
+        if fmt == "jpg":
+            fmt = "jpeg"
+        if fmt == "jpeg":
             return fmt, "image/jpeg"
         if fmt == "webp":
             return fmt, "image/webp"


### PR DESCRIPTION
Fixes #5421.

This PR supersedes #5425 (closed due to force-push).

ImageGenerationResponse.stream_response() hardcoded PNG for response_format="file": the single-image branch always returned Content-Type: image/png with a .png filename, and the multi-image ZIP branch named every entry image_{idx}.png — even when the request asked for output_format="jpeg" or "webp".

Changes:
1. Derive file extension and MIME type from self.output_format (jpg/jpeg -> image/jpeg, webp -> image/webp), falling back to PNG
2. Fix output_format field annotation (str = Field(None) -> str | None = Field(default=None))
3. Fix size field annotation (str = Field(None) -> str | None = Field(default=None))
4. Honor output_format in multi-stage path (len(stage_configs) > 1)
5. Propagate size field in multi-stage path, matching single-stage behavior
6. Normalize jpg -> jpeg in _choose_output_format to avoid Pillow KeyError
7. Remove redundant parse_size() call in multi-stage path
8. Add endpoint-level regression tests for multi-stage path