### PR TITLE
[Bugfix][Core] Release downstream stages stranded by a duplex direct response

### DIFF
--- a/tests/engine/test_orchestrator_stage_input_bridge.py
+++ b/tests/engine/test_orchestrator_stage_input_bridge.py
@@ -344,3 +344,154 @@ async def test_streaming_segment_does_not_complete_final_output_stage() -> None:
     orchestrator._cleanup_request_ids.assert_not_awaited()
     routed = orchestrator.output_async_queue.get_nowait()
     assert routed.finished is False
+
+
+# --- direct responses must not strand prewarmed downstream stages -----------
+
+
+class FakeAbortablePool:
+    """Stage pool recording aborts, with a route binding like a live one."""
+
+    def __init__(self) -> None:
+        self.aborted: list[list[str]] = []
+        self.released: list[list[str]] = []
+
+    async def abort_requests(self, request_ids: list[str]) -> None:
+        self.aborted.append(list(request_ids))
+
+    def release_bindings(self, request_ids: list[str]) -> None:
+        self.released.append(list(request_ids))
+
+    def get_bound_replica_id(self, _request_id: str) -> int:
+        return 0
+
+
+def _direct_response_orchestrator(num_stages: int = 3):
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator.stage_pools = [FakeAbortablePool() for _ in range(num_stages)]
+    orchestrator.output_async_queue = AsyncMock()
+    return orchestrator
+
+
+def _decision(**metadata: Any):
+    from vllm_omni.experimental.fullduplex.engine.contracts import (
+        DuplexOutputAction,
+        DuplexOutputDecision,
+    )
+
+    return DuplexOutputDecision(
+        action=DuplexOutputAction.DIRECT_RESPONSE,
+        metadata={"duplex_direct_response": True, **metadata},
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_direct_response_releases_prewarmed_downstream_stages() -> None:
+    """The talker and code2wav were warmed for a reply that is not coming.
+
+    A direct response returns before ``_forward_to_next_stage``, so prewarmed
+    downstream stages sit waiting for chunks nobody will send. Left parked they
+    hold a slot and suppress ``EngineCore.has_work()``, and that stage stops
+    scheduling for every later request too.
+    """
+    orchestrator = _direct_response_orchestrator()
+
+    await orchestrator._emit_duplex_direct_output(
+        0,
+        "req-tool-call",
+        _request_output("req-tool-call"),
+        _decision(duplex_release_downstream=True),
+        None,
+        None,
+    )
+
+    assert orchestrator.stage_pools[1].aborted == [["req-tool-call"]]
+    assert orchestrator.stage_pools[2].aborted == [["req-tool-call"]]
+    assert orchestrator.stage_pools[1].released == [["req-tool-call"]]
+
+
+@pytest.mark.asyncio
+async def test_the_responding_stage_is_never_aborted() -> None:
+    """Only *downstream* stages are released.
+
+    Aborting the stage the response came from would kill the request that is
+    still serving the client.
+    """
+    orchestrator = _direct_response_orchestrator()
+
+    await orchestrator._emit_duplex_direct_output(
+        1,
+        "req-mid-pipeline",
+        _request_output("req-mid-pipeline"),
+        _decision(duplex_release_downstream=True),
+        None,
+        None,
+    )
+
+    assert orchestrator.stage_pools[0].aborted == []
+    assert orchestrator.stage_pools[1].aborted == []
+    assert orchestrator.stage_pools[2].aborted == [["req-mid-pipeline"]]
+
+
+@pytest.mark.asyncio
+async def test_a_non_terminal_direct_response_keeps_its_warm_stages() -> None:
+    """Opt-in, because parked is correct for some runtimes.
+
+    MiniCPM's ``listen`` decision reuses the same warm downstream stages when
+    the model later speaks, and prewarm only runs on the initial submit -- so
+    releasing them here would leave that later speak turn with no talker.
+    """
+    orchestrator = _direct_response_orchestrator()
+
+    await orchestrator._emit_duplex_direct_output(
+        0,
+        "req-listen",
+        _request_output("req-listen"),
+        _decision(duplex_native_decision="listen"),
+        None,
+        None,
+    )
+
+    assert all(pool.aborted == [] for pool in orchestrator.stage_pools)
+
+
+@pytest.mark.asyncio
+async def test_the_direct_response_still_reaches_the_client() -> None:
+    """Releasing downstream stages must not swallow the response itself."""
+    orchestrator = _direct_response_orchestrator()
+
+    await orchestrator._emit_duplex_direct_output(
+        0,
+        "req-tool-call",
+        _request_output("req-tool-call"),
+        _decision(duplex_release_downstream=True),
+        None,
+        None,
+    )
+
+    orchestrator.output_async_queue.put.assert_awaited_once()
+    message = orchestrator.output_async_queue.put.await_args.args[0]
+    assert message.request_id == "req-tool-call"
+    assert message.stage_id == 0
+    assert message.finished is True
+
+
+@pytest.mark.asyncio
+async def test_every_downstream_pool_is_walked() -> None:
+    """The release does not need to know the pipeline's final stage id.
+
+    It offers the abort to every downstream pool; ``StagePool.abort_requests``
+    already no-ops for a request it holds no route binding for.
+    """
+    orchestrator = _direct_response_orchestrator(num_stages=4)
+
+    await orchestrator._emit_duplex_direct_output(
+        0,
+        "req-deep-pipeline",
+        _request_output("req-deep-pipeline"),
+        _decision(duplex_release_downstream=True),
+        None,
+        None,
+    )
+
+    assert [bool(pool.aborted) for pool in orchestrator.stage_pools] == [False, True, True, True]

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import time as _time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -820,11 +820,12 @@ class Orchestrator:
                 )
             )
 
-    async def _abort_request_ids(self, request_ids: list[str]) -> None:
-        """Forward abort requests to all stage pools."""
+    async def _abort_request_ids(self, request_ids: list[str], *, stage_ids: Iterable[int] | None = None) -> None:
+        """Forward abort requests to stage pools, or to ``stage_ids`` only."""
         if not request_ids:
             return
-        for pool in self.stage_pools:
+        pools = self.stage_pools if stage_ids is None else [self.stage_pools[stage_id] for stage_id in stage_ids]
+        for pool in pools:
             await pool.abort_requests(request_ids)
             pool.release_bindings(request_ids)
 
@@ -1542,6 +1543,20 @@ class Orchestrator:
                 stage_submit_ts=submit_ts,
             )
         )
+
+        # A direct response returns without forwarding, leaving anything
+        # `_prewarm_async_chunk_stages` submitted downstream parked on chunks
+        # that will never arrive. Parked requests hold a slot and are subtracted
+        # by `get_num_unfinished_requests`, so `EngineCore.has_work()` reads
+        # false and that stage stops scheduling -- for every later request too.
+        #
+        # Opt-in: parked is correct when the direct response is *not* terminal.
+        # MiniCPM's `listen` decision reuses those warm stages when the model
+        # later speaks, and prewarm only runs on the initial submit.
+        if decision.metadata.get("duplex_release_downstream") is True:
+            # Pools this request never reached have no route binding, so
+            # aborting them is a no-op; no need to know the final stage id.
+            await self._abort_request_ids([req_id], stage_ids=range(stage_id + 1, len(self.stage_pools)))
 
     @staticmethod
     def _completion_multimodal_output(output: Any, completion: Any) -> dict[str, Any]:


### PR DESCRIPTION
## What broke

A duplex stage stops scheduling and never recovers. The server stays healthy
and keeps accepting requests; that stage simply never runs again, for the
current request or any later one. No error is logged.

`py-spy dump` on the stalled stage shows the engine parked in
`_process_input_queue`, which is only reachable when `has_work()` is false --
i.e. the engine believes it is idle while holding a queued request:

    Thread (idle): "MainThread"
        get (queue.py:171)
        _process_input_queue (vllm/v1/engine/core.py:1384)
        run_busy_loop (vllm/v1/engine/core.py:1362)

## Repro

Needs a duplex runtime whose `decide_output` returns a DIRECT_RESPONSE from a
non-final stage under `async_chunk: true` -- e.g. a runtime that intercepts a
tool call at stage 0 so it is not spoken. First such response strands the
prewarmed downstream stages; from then on that stage is dead.

The unit tests added here reproduce it without a GPU:

    pytest tests/engine/test_orchestrator_stage_input_bridge.py \
      -k "direct_response or downstream_pool or responding_stage"

Three of them fail on main and pass with this change.

## Root cause

`_emit_duplex_direct_output` emits the response and the caller `return`s
immediately, skipping `_forward_to_next_stage`. Anything
`_prewarm_async_chunk_stages` already submitted downstream is therefore left
waiting for chunks that will never be sent.

Those requests park as WAITING_FOR_STREAMING_REQ. Two consequences:

* they hold a stage slot for the lifetime of the process;
* `Scheduler.get_num_unfinished_requests` *subtracts* requests parked for
  streaming input, so with one parked request and one queued one it computes
  `(1 waiting - 1 parked) + 0 running == 0`. `EngineCore.has_work()` reads
  false and the engine blocks in `input_queue.get()` while holding live work.

Same failure mode as #5662 (a leaked `num_waiting_for_streaming_input`),
reached from the direct-response path rather than the abort path.

## Fix

Release the stranded downstream stages when the runtime marks the direct
response terminal, via `duplex_release_downstream` in the decision metadata.
`_abort_request_ids` already does abort + `release_bindings` per pool, so it
gains an optional `stage_ids` filter rather than growing a second loop; pools
the request never reached hold no route binding, so offering them the abort is
a no-op and the pipeline's final stage id is not needed.

Opt-in deliberately, and not a default: a parked downstream stage is *correct*
for a runtime whose direct response is not terminal. MiniCPM-o 4.5's `listen`
decision reuses those same warm stages when the model later speaks, and prewarm
only runs on the initial submit -- so releasing unconditionally would leave a
later speak turn with no talker. Existing runtimes are unaffected: nothing sets
the flag, and the tests pin that a non-terminal direct response keeps its warm
stages.

The next stage-0 submit re-prewarms, so the release costs only the warm slot.

## Test result

    tests/engine/test_orchestrator_stage_input_bridge.py    10 passed
    tests/engine tests/core/sched tests/e2e/features/fullduplex
      tests/entrypoints/test_async_omni_duplex.py           615 passed

The 12 remaining failures in that run are `huggingface_hub` downloads in a
sandbox with no network; they fail identically on unmodified main.

Also exercised live on a 3-stage Qwen3-Omni duplex pipeline (thinker -> talker
-> code2wav) with a runtime that intercepts tool calls: without this change the
stage wedged after the first tool call and 0/2 later audio sessions produced
output; with it, 2/2 sessions x 2 turns, and the speech accidentally generated
for the suppressed turn drops from 9.15 s to 0.00 s because aborting the
prewarmed talker also stops its in-flight audio.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 185e3d6d

## Note for reviewers

Nothing in this repository sets `duplex_release_downstream` yet -- the consumer
is a Qwen3-Omni duplex runtime that intercepts tool calls, in #5663. This is
carved out so the framework fix can land on its own merits: the bug is in the
orchestrator, it is reachable by any duplex runtime that returns a direct
response from a non-final stage, and it is the second way I have hit this same
`has_work()` starvation (the first was #5662).

Happy to make it unconditional instead if you would rather not add a metadata
flag -- but that needs `_prewarm_async_chunk_stages` to also run on
`submit_update`, or MiniCPM's `listen` path loses its warm talker. That felt
like a second, separable change rather than something to bundle here.
