### PR TITLE
[Bugfix] Reset duplex segment watermark

### DIFF
--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -15,6 +15,7 @@ import pytest
 # isort: off
 import vllm_omni  # noqa: F401 - import for side effects (patch vLLM)
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
@@ -208,6 +209,78 @@ def test_running_decode_step_without_inter_stage_payload_does_not_raise() -> Non
 
     # Nothing to hand downstream: no payload, no segment boundary, not finished.
     sched.chunk_transfer_adapter.save_async.assert_not_called()
+
+
+def test_stale_async_frame_is_dropped_before_output_processing() -> None:
+    session = _make_request()
+    session.status = RequestStatus.RUNNING
+    session.num_in_flight_tokens = 2
+    session.num_computed_tokens = session.num_tokens + 1
+    session.num_output_placeholders = 1
+    session.async_tokens_to_discard = 1
+    session.sampling_params = SimpleNamespace(num_logprobs=1)
+    num_computed_tokens = session.num_computed_tokens
+    num_output_placeholders = session.num_output_placeholders
+
+    sched = MagicMock()
+    sched.requests = {session.request_id: session}
+    sched.perf_metrics = None
+    sched.structured_output_manager.should_advance.return_value = False
+    sched._update_request_with_output.side_effect = lambda request, token_ids: (
+        AsyncScheduler._update_request_with_output(sched, request, token_ids)
+    )
+    sched._process_kv_transfer_trigger.return_value = False
+    sched.chunk_transfer_adapter = MagicMock()
+    sched.running = [session]
+    sched.waiting_for_transfer_free = set()
+    sched.transfer_triggered_requests = set()
+    sched.active_kv_transfers = set()
+    sched.pending_stop_after_extraction = set()
+    sched.connector = None
+    sched.kv_cache_manager.take_events.return_value = None
+    sched.finished_req_ids_dict = {}
+    sched.make_stats.return_value = None
+
+    scheduler_output = MagicMock(spec=SchedulerOutput)
+    scheduler_output.num_scheduled_tokens = {session.request_id: 1}
+    scheduler_output.scheduled_spec_decode_tokens = {}
+    scheduler_output.num_invalid_spec_tokens = 0
+
+    model_runner_output = MagicMock(spec=ModelRunnerOutput)
+    model_runner_output.sampled_token_ids = [[42]]
+    model_runner_output.logprobs = None
+    model_runner_output.prompt_logprobs_dict = {}
+    model_runner_output.pooler_output = None
+    model_runner_output.multimodal_outputs = None
+    model_runner_output.inter_stage_outputs = [{"hidden": object()}]
+    model_runner_output.num_nans_in_logits = None
+    model_runner_output.kv_connector_output = None
+    model_runner_output.cudagraph_stats = None
+    model_runner_output.req_id_to_index = {session.request_id: 0}
+    model_runner_output.routed_experts = None
+
+    OmniARScheduler.update_from_output(sched, scheduler_output, model_runner_output)
+
+    assert session.async_tokens_to_discard == 0
+    assert session.status == RequestStatus.RUNNING
+    assert session.num_computed_tokens == num_computed_tokens
+    assert session.num_output_placeholders == num_output_placeholders
+    sched.chunk_transfer_adapter.save_async.assert_not_called()
+
+    session.sampling_params = SamplingParams(max_tokens=8)
+    next_payload = {"hidden": object()}
+    sched._update_request_with_output.side_effect = None
+    sched._update_request_with_output.return_value = ([43], False)
+    model_runner_output.sampled_token_ids = [[43]]
+    model_runner_output.inter_stage_outputs = [next_payload]
+
+    OmniARScheduler.update_from_output(sched, scheduler_output, model_runner_output)
+
+    sched.chunk_transfer_adapter.save_async.assert_called_once_with(
+        next_payload,
+        session,
+        False,
+    )
 
 
 def test_stage0_streaming_update_discards_outstanding_async_placeholder_token() -> None:

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -546,7 +546,7 @@ def test_personaplex_sender_cleanup_drops_delayed_frame_state(build_adapter):
     assert second.codes is None
 
 
-def test_save_async_skips_stale_resumable_chunk_until_dedup_is_reset(build_adapter):
+def test_save_async_skips_stale_resumable_chunk_within_segment(build_adapter):
     adapter, _ = build_adapter(stage_id=1)
     request = _req("req-stream", RequestStatus.WAITING, external_req_id="ext-stream")
     request.resumable = True
@@ -558,11 +558,37 @@ def test_save_async_skips_stale_resumable_chunk_until_dedup_is_reset(build_adapt
     assert len(adapter._pending_save_reqs) == 0
     assert adapter.requests_num_chunks_sent["ext-stream"] == 111
 
-    adapter.requests_num_chunks_sent.pop("ext-stream")
+
+def test_save_async_segment_boundary_resets_dedup_before_background_send(build_adapter):
+    adapter, connector = build_adapter(stage_id=1)
+    request = _req("req-stream", RequestStatus.WAITING, external_req_id="ext-stream")
+    request.resumable = True
+    adapter.requests_num_chunks_sent["ext-stream"] = 111
+    adapter.custom_process_next_stage_input_func = lambda **kwargs: OmniPayloadStruct()
+
+    request.num_computed_tokens = 0
+    adapter.save_async(multimodal_output=None, request=request, is_segment_finished=True)
+    request.num_computed_tokens = 3
     adapter.save_async(multimodal_output=None, request=request, is_segment_finished=False)
 
-    assert len(adapter._pending_save_reqs) == 1
-    assert adapter.requests_num_chunks_sent["ext-stream"] == 0
+    assert len(adapter._pending_save_reqs) == 2
+    boundary, next_segment = adapter._pending_save_reqs
+    assert boundary["is_segment_finished"] is True
+    assert next_segment["is_segment_finished"] is False
+    assert adapter.requests_num_chunks_sent["ext-stream"] == 3
+
+    # The queued boundary must not clear the new segment's watermark.
+    adapter._send_single_request(boundary)
+    assert adapter.requests_num_chunks_sent["ext-stream"] == 3
+    assert "ext-stream" not in adapter.ramp_chunk_count
+
+    adapter._send_single_request(next_segment)
+    assert adapter.requests_num_chunks_sent["ext-stream"] == 3
+    assert adapter.ramp_chunk_count["ext-stream"] == 1
+    assert [call.kwargs["put_key"] for call in connector.put.call_args_list] == [
+        "ext-stream_1_0",
+        "ext-stream_1_1",
+    ]
 
 
 def test_send_single_request_cleans_up_after_finished_payload(build_adapter, monkeypatch):

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -354,6 +354,11 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             req_index = model_runner_output.req_id_to_index[req_id]
             generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+
+            if generated_token_ids and getattr(request, "async_tokens_to_discard", 0) > 0:
+                self._update_request_with_output(request, generated_token_ids)
+                continue
+
             status_before_stop = request.status
             new_logprobs = None
             logprob_validation_failed = False

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -191,24 +191,31 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         confirmed_num_computed_tokens = self._confirmed_num_computed_tokens(request)
 
-        # If the request is preempted, skip the already saved chunks.
-        if confirmed_num_computed_tokens < self.requests_num_chunks_sent.get(request.external_req_id, 0):
+        external_req_id = request.external_req_id
+        previous_num_computed_tokens = self.requests_num_chunks_sent.get(external_req_id, 0)
+
+        # Segment boundaries may restart token accounting from zero.
+        if not is_segment_finished and confirmed_num_computed_tokens < previous_num_computed_tokens:
             logger.warning(
-                f"Enqueue save_async for request {request.external_req_id}, "
+                f"Skip stale save_async for request {external_req_id}, "
                 f"request.num_computed_tokens={request.num_computed_tokens}, "
                 f"request.num_output_placeholders={getattr(request, 'num_output_placeholders', 0)}, "
-                f"previous_chunks_sent={self.requests_num_chunks_sent.get(request.external_req_id, 0)}"
+                f"previous_chunks_sent={previous_num_computed_tokens}"
             )
             return
 
-        self.requests_num_chunks_sent[request.external_req_id] = confirmed_num_computed_tokens
         task = {
             "multimodal_output": multimodal_output,
             "request": request,
             "is_finished": is_finished,
             "is_segment_finished": is_segment_finished,
         }
-        self._pending_save_reqs.append(task)
+        if is_segment_finished:
+            self._pending_save_reqs.append(task)
+            self.requests_num_chunks_sent.pop(external_req_id, None)
+        else:
+            self.requests_num_chunks_sent[external_req_id] = confirmed_num_computed_tokens
+            self._pending_save_reqs.append(task)
         with self._save_cond:
             self._save_cond.notify()
 
@@ -425,7 +432,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         if is_segment_finished:
             self.code_prompt_token_ids.pop(external_req_id, None)
-            self.requests_num_chunks_sent.pop(external_req_id, None)
             self.ramp_chunk_count.pop(external_req_id, None)
             cached_ic = getattr(self, "_cached_ic", None)
             if cached_ic is not None:


### PR DESCRIPTION
## Purpose

Resumable duplex requests reuse the same external request ID across input segments. After a segment ends, token accounting restarts from zero while `requests_num_chunks_sent` still contains the previous segment's count. The adapter then treats the boundary and subsequent chunks as stale, which can stop audio forwarding in later turns.

## Root Cause

The dedup watermark was cleared by the background sender. A new segment could reach `save_async` before that sender processed the queued boundary.

## Fix

Reset the producer watermark when the segment boundary is queued. The send queue remains FIFO, so the boundary is still delivered before chunks from the next segment.

## Test Plan

```bash
pytest -q tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
```

The regression test queues a boundary and the next segment before the background sender runs, then checks that both chunks are sent in order.

**vLLM Version:** `0.1.dev18616+ge5588e49b`

**vLLM-Omni Commit:** `75b93e0c67586e64e455d820e9620777d293599d` (`minicpm-challenge`)

## Test Result

- Connector tests: `50 passed, 14 warnings`
- Ascend 910C, MiniCPM-o 4.5 BF16, three stages, `async_chunk=true`:

| | Before | After |
|---|---:|---:|
| Completed input segments | 3 / 6 | 6 / 6 |
| Stale watermark warnings | 18 | 0 |
| Completed audio responses | 2 | 4 |
| Result | timed out | passed |

The model selected listen mode for the other two segments in the passing run.
