### PR TITLE
[Perf][CI] Use Whisper on GPU when memory permits

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -164,10 +164,11 @@ steps:
         commands:
           - pytest -s -v tests/e2e/offline_inference/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5.py -m 'advanced_model and cuda' --run-level 'advanced_model'
         # h100_2, not h100_1: advanced_model asserts transcribe every audio
-        # response with Whisper, and tests/helpers/media.py only uses an
-        # accelerator for Whisper when a spare GPU exists. On a single card it
-        # grades on CPU: ~8-10 min per clip vs ~30 s, which alone overruns the
-        # 50-minute job timeout (build 2956).
+        # response with Whisper, and tests/helpers/media.py requires at least
+        # 16 GiB free VRAM on a device to run Whisper on GPU. When the model
+        # server leaves insufficient memory, Whisper falls back to CPU:
+        # ~8-10 min per clip vs ~30 s, which overruns the 50-minute job timeout
+        # (build 2956). h100_2 guarantees a second GPU with ample free VRAM.
         mirror_hardwares: h100_2
 
       - label: "Omni · MiniCPM-o 4.5 Duplex Test"

--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -80,6 +80,7 @@ steps:
     steps:
       - label: "TTS · Qwen3-TTS CustomVoice Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_customvoice.py
           - tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
           - vllm_omni/model_executor/models/qwen3_tts/
@@ -102,6 +103,7 @@ steps:
 
       - label: "TTS · Qwen3-TTS Base Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_base.py
           - tests/e2e/offline_inference/test_qwen3_tts_base.py
           - vllm_omni/model_executor/models/qwen3_tts/

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -251,6 +251,7 @@ steps:
 
       - label: "TTS · Qwen3-TTS CustomVoice Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_customvoice.py
           - vllm_omni/model_executor/models/qwen3_tts/
           - vllm_omni/model_executor/models/common/qwen3_code_predictor.py

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -710,12 +710,14 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        # Single-GPU runners (e.g. the L4 nightly): the model server already
-        # occupies device 0, and a Whisper model resident there competes with
-        # it for VRAM and OOMs. Only borrow an accelerator when a spare device
-        # exists; otherwise validate on CPU.
-        if n > 1:
-            device_index = n - 1
+        if n > 0:
+            target = n - 1
+            # Load Whisper on GPU only when >=16 GiB free VRAM remains.
+            # Keeps 24 GiB L4 runners on CPU (avoiding OOMs) while
+            # picking up high-VRAM single-GPU (e.g. H100, MI325X) and multi-GPU hosts.
+            target_device = current_omni_platform.get_torch_device(target)
+            if current_omni_platform.get_free_memory(target_device) >= 16 * 1024**3:
+                device_index = target
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -31,6 +31,8 @@ from PIL import Image
 
 logger = logging.getLogger(__name__)
 
+_MIN_FREE_VRAM = 16 * 1024**3
+
 
 _synthetic_media_fallback_dir: Path | None = None
 
@@ -710,14 +712,15 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        if n > 0:
-            target = n - 1
-            # Load Whisper on GPU only when >=16 GiB free VRAM remains.
-            # Keeps 24 GiB L4 runners on CPU (avoiding OOMs) while
-            # picking up high-VRAM single-GPU (e.g. H100, MI325X) and multi-GPU hosts.
-            target_device = current_omni_platform.get_torch_device(target)
-            if current_omni_platform.get_free_memory(target_device) >= 16 * 1024**3:
-                device_index = target
+        # Check every visible device and use the one with the most free memory,
+        # but keep the CPU fallback when none has enough room for Whisper.
+        best_free_memory = _MIN_FREE_VRAM
+        for candidate_index in range(n):
+            candidate_device = current_omni_platform.get_torch_device(candidate_index)
+            free_memory = current_omni_platform.get_free_memory(candidate_device)
+            if free_memory >= best_free_memory:
+                device_index = candidate_index
+                best_free_memory = free_memory
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -712,15 +712,16 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        # Check every visible device and use the one with the most free memory,
-        # but keep the CPU fallback when none has enough room for Whisper.
-        best_free_memory = _MIN_FREE_VRAM
-        for candidate_index in range(n):
+        # Prefer the highest-index device with enough room for Whisper. The
+        # 16 GiB floor protects low-memory single-GPU runners such as the L4
+        # nightly, where the model server already occupies device 0, from the
+        # server-plus-Whisper OOM fixed in #3822. Keep the CPU fallback when no
+        # device has enough room.
+        for candidate_index in range(n - 1, -1, -1):
             candidate_device = current_omni_platform.get_torch_device(candidate_index)
-            free_memory = current_omni_platform.get_free_memory(candidate_device)
-            if free_memory >= best_free_memory:
+            if current_omni_platform.get_free_memory(candidate_device) >= _MIN_FREE_VRAM:
                 device_index = candidate_index
-                best_free_memory = free_memory
+                break
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import sys
 from concurrent.futures.process import BrokenProcessPool

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -105,6 +105,31 @@ def _reset_transcriber_singletons():
     media._WHISPER_MODELS.clear()
 
 
+@pytest.mark.parametrize(
+    ("device_count", "free_memory", "expected_device"),
+    [
+        (1, 16 * 1024**3, "cuda:0"),
+        (3, 16 * 1024**3, "cuda:2"),
+        (1, 16 * 1024**3 - 1, "cpu"),
+    ],
+)
+def test_select_whisper_device_by_available_memory(monkeypatch, device_count, free_memory, expected_device):
+    platform = SimpleNamespace(
+        is_available=lambda: True,
+        get_device_count=lambda: device_count,
+        get_torch_device=lambda index: f"cuda:{index}",
+        get_free_memory=lambda device: free_memory,
+        set_device=lambda device: None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_omni.platforms",
+        SimpleNamespace(current_omni_platform=platform),
+    )
+
+    assert media._select_whisper_device() == expected_device
+
+
 def test_bytes_entrypoint_forwards_language_to_subprocess(monkeypatch, tmp_path):
     """Cover the two hops the tests above skip: bytes -> file -> executor.submit.
 

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -4,6 +4,7 @@
 import sys
 from concurrent.futures.process import BrokenProcessPool
 from contextlib import nullcontext
+from multiprocessing.context import BaseContext
 from types import SimpleNamespace
 
 import numpy as np
@@ -61,6 +62,7 @@ class _FakeExecutor:
 
     def __init__(self, outcomes=()):
         self._outcomes = list(outcomes)
+        self.init_kwargs: dict[str, object] = {}
         self.submitted: list[tuple] = []
         self.shutdown_calls = 0
 
@@ -177,7 +179,9 @@ def test_parent_reuses_one_spawned_worker_across_calls(monkeypatch):
     assert len(created) == 1
     assert len(created[0].submitted) == 2
     assert created[0].init_kwargs["max_workers"] == 1
-    assert created[0].init_kwargs["mp_context"].get_start_method() == "spawn"
+    mp_context = created[0].init_kwargs["mp_context"]
+    assert isinstance(mp_context, BaseContext)
+    assert mp_context.get_start_method() == "spawn"
 
 
 def test_release_forces_a_new_process_pool(monkeypatch):

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -106,19 +106,22 @@ def _reset_transcriber_singletons():
 
 
 @pytest.mark.parametrize(
-    ("device_count", "free_memory", "expected_device"),
+    ("free_memory_by_device", "expected_device"),
     [
-        (1, 16 * 1024**3, "cuda:0"),
-        (3, 16 * 1024**3, "cuda:2"),
-        (1, 16 * 1024**3 - 1, "cpu"),
+        ([media._MIN_FREE_VRAM], "cuda:0"),
+        ([media._MIN_FREE_VRAM] * 3, "cuda:2"),
+        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2"),
+        ([media._MIN_FREE_VRAM - 1], "cpu"),
+        ([20 * 1024**3, 8 * 1024**3], "cuda:0"),
+        ([8 * 1024**3, 12 * 1024**3], "cpu"),
     ],
 )
-def test_select_whisper_device_by_available_memory(monkeypatch, device_count, free_memory, expected_device):
+def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_device, expected_device):
     platform = SimpleNamespace(
         is_available=lambda: True,
-        get_device_count=lambda: device_count,
+        get_device_count=lambda: len(free_memory_by_device),
         get_torch_device=lambda index: f"cuda:{index}",
-        get_free_memory=lambda device: free_memory,
+        get_free_memory=lambda device: free_memory_by_device[int(device.rsplit(":", 1)[1])],
         set_device=lambda device: None,
     )
     monkeypatch.setitem(

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -106,22 +106,31 @@ def _reset_transcriber_singletons():
 
 
 @pytest.mark.parametrize(
-    ("free_memory_by_device", "expected_device"),
+    ("free_memory_by_device", "expected_device", "expected_probe_order"),
     [
-        ([media._MIN_FREE_VRAM], "cuda:0"),
-        ([media._MIN_FREE_VRAM] * 3, "cuda:2"),
-        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2"),
-        ([media._MIN_FREE_VRAM - 1], "cpu"),
-        ([20 * 1024**3, 8 * 1024**3], "cuda:0"),
-        ([8 * 1024**3, 12 * 1024**3], "cpu"),
+        ([media._MIN_FREE_VRAM], "cuda:0", [0]),
+        ([media._MIN_FREE_VRAM] * 3, "cuda:2", [2]),
+        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2", [2]),
+        ([media._MIN_FREE_VRAM - 1], "cpu", [0]),
+        ([20 * 1024**3, 8 * 1024**3], "cuda:0", [1, 0]),
+        ([8 * 1024**3, 12 * 1024**3], "cpu", [1, 0]),
     ],
 )
-def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_device, expected_device):
+def test_select_whisper_device_by_available_memory(
+    monkeypatch, free_memory_by_device, expected_device, expected_probe_order
+):
+    probed_devices = []
+
+    def get_free_memory(device):
+        index = int(device.rsplit(":", 1)[1])
+        probed_devices.append(index)
+        return free_memory_by_device[index]
+
     platform = SimpleNamespace(
         is_available=lambda: True,
         get_device_count=lambda: len(free_memory_by_device),
         get_torch_device=lambda index: f"cuda:{index}",
-        get_free_memory=lambda device: free_memory_by_device[int(device.rsplit(":", 1)[1])],
+        get_free_memory=get_free_memory,
         set_device=lambda device: None,
     )
     monkeypatch.setitem(
@@ -131,6 +140,7 @@ def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_d
     )
 
     assert media._select_whisper_device() == expected_device
+    assert probed_devices == expected_probe_order
 
 
 def test_bytes_entrypoint_forwards_language_to_subprocess(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose
Previously, Whisper transcription used a GPU only when more than one GPU was available (`n > 1`). This meant that single-GPU runners, including , for example, H100 and MI300X machines, used the CPU even when the GPU had enough free memory.

The helper now checks GPUs from the highest index to the lowest. It uses the first GPU with at least 16 GiB of free VRAM. This keeps the existing preference for the last GPU and avoids checking devices that are not needed.

The 16 GiB threshold is only used to choose a device. It does not reserve memory. It leaves enough room for Whisper small and the large-v3 fallback.


## Test Plan
```bash
pytest -sv \
  'tests/e2e/online_serving/test_qwen3_tts_base_expansion.py::test_voice_clone_streaming_001[async_chunk]' \
  --run-level full_model
```
## ENV:
ROCM Version                 : 7.2.53211-c2d9476115
vLLM Version                 : 0.26.0
vLLM-Omni Version            : 0.1.dev2403+g67c54777b.rocm (git sha: 67c54777b, date: ocm)

GPU: MI300 x 1

## Test Result
On current main 67c54777 :
```bash
================= 1 passed, 15 warnings in 1942.26s (0:32:22) ==================
```

On this branch d9d96454:
```bash
================== 1 passed, 15 warnings in 254.84s (0:04:14) ==================

```

#### Logs:
- [qwen3_tts_test_pref.log](https://github.com/user-attachments/files/30621674/qwen3_tts_test_pref.log)
- [qwen3_tts_test_main.log](https://github.com/user-attachments/files/30621675/qwen3_tts_test_main.log)


cc: @linyueqian 
