### PR TITLE
[Model] Optimize GLM-TTS WhisperVQ length transfers

### DIFF
--- a/tests/model_executor/models/common/test_whisper_vq.py
+++ b/tests/model_executor/models/common/test_whisper_vq.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
-
 import pytest
 import torch
+from transformers import WhisperConfig
 
 from vllm_omni.model_executor.models.common.whisper_vq import WhisperVQEncoder
 
@@ -14,7 +13,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
 def _make_encoder() -> WhisperVQEncoder:
     encoder = WhisperVQEncoder.__new__(WhisperVQEncoder)
     torch.nn.Module.__init__(encoder)
-    encoder.config = SimpleNamespace(pooling_kernel_size=2)
+    encoder.config = WhisperConfig(pooling_kernel_size=2)
     encoder.pooling_layer = torch.nn.MaxPool1d(kernel_size=2)
     encoder.codebook = torch.nn.Embedding(8, 2)
     encoder.embed_positions2 = None

--- a/tests/model_executor/models/common/test_whisper_vq.py
+++ b/tests/model_executor/models/common/test_whisper_vq.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.common.whisper_vq import WhisperVQEncoder
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
+
+
+def _make_encoder() -> WhisperVQEncoder:
+    encoder = WhisperVQEncoder.__new__(WhisperVQEncoder)
+    torch.nn.Module.__init__(encoder)
+    encoder.config = SimpleNamespace(pooling_kernel_size=2)
+    encoder.pooling_layer = torch.nn.MaxPool1d(kernel_size=2)
+    encoder.codebook = torch.nn.Embedding(8, 2)
+    encoder.embed_positions2 = None
+    return encoder
+
+
+def test_variable_length_helpers_batch_length_transfer(monkeypatch: pytest.MonkeyPatch):
+    encoder = _make_encoder()
+    hidden_states = torch.arange(30, dtype=torch.float32).reshape(3, 5, 2)
+    valid_mask = torch.tensor(
+        [
+            [True, True, True, True, True],
+            [True, True, True, False, False],
+            [False, False, False, False, False],
+        ]
+    )
+
+    def fail_item(*_args, **_kwargs):
+        raise AssertionError("per-sample Tensor.item() synchronizes the device")
+
+    monkeypatch.setattr(torch.Tensor, "item", fail_item)
+
+    pooled, pooled_mask = encoder._apply_pooling(hidden_states, valid_mask)
+    quantized, token_ids = encoder._apply_vq(hidden_states, valid_mask)
+
+    assert pooled.shape == (3, 3, 2)
+    assert pooled_mask.sum(dim=1).tolist() == [3, 2, 0]
+    assert token_ids is not None
+    assert token_ids.ne(-1).sum(dim=1).tolist() == [5, 3, 0]
+    assert torch.count_nonzero(quantized[2]) == 0

--- a/vllm_omni/model_executor/models/common/whisper_vq.py
+++ b/vllm_omni/model_executor/models/common/whisper_vq.py
@@ -248,8 +248,8 @@ class WhisperVQEncoder(WhisperEncoder):
         k = int(self.config.pooling_kernel_size)  # type: ignore[attr-defined]
         pooled_segments: list[Tensor] = []
         pooled_masks: list[Tensor] = []
-        for batch_idx in range(int(hidden_states.shape[0])):
-            length = int(valid_mask[batch_idx].sum().item())
+        valid_lengths = valid_mask.sum(dim=1).tolist()
+        for batch_idx, length in enumerate(valid_lengths):
             segment = hidden_states[batch_idx, :length]
             if segment.numel() == 0:
                 pooled = hidden_states.new_zeros((0, hidden_states.shape[-1]))
@@ -278,8 +278,8 @@ class WhisperVQEncoder(WhisperEncoder):
             dtype=torch.long,
             device=hidden_states.device,
         )
-        for batch_idx in range(int(hidden_states.shape[0])):
-            length = int(valid_mask[batch_idx].sum().item())
+        valid_lengths = valid_mask.sum(dim=1).tolist()
+        for batch_idx, length in enumerate(valid_lengths):
             if length <= 0:
                 continue
             segment = hidden_states[batch_idx : batch_idx + 1, :length]


### PR DESCRIPTION
## Purpose

### Problem

`WhisperVQEncoder._apply_pooling()` and `_apply_vq()` extracted each sample's valid length with `valid_mask[batch_idx].sum().item()` inside Python loops. On CUDA this performs one scalar device-to-host synchronization per sample in each helper, for up to `2 * batch_size` synchronizations across pooling and VQ.

### Root cause

The valid lengths are independent and already stored in one batched mask, but they were transferred from the device one scalar at a time.

### Solution

- Compute all valid lengths once per helper with `valid_mask.sum(dim=1).tolist()`.
- Keep the existing variable-length pooling and VQ behavior unchanged.
- Add a regression test that makes `Tensor.item()` fail and covers lengths `[5, 3, 0]`, including the empty-sequence path.

## Test Plan

```bash
python -B -m pytest -c /dev/null -p no:cacheprovider -q \
  tests/model_executor/models/common/test_whisper_vq.py \
  tests/model_executor/models/test_glm_tts_prompt_len.py \
  tests/model_executor/stage_input_processors/test_glm_tts_async_chunk.py

python -m py_compile \
  vllm_omni/model_executor/models/common/whisper_vq.py \
  tests/model_executor/models/common/test_whisper_vq.py

ruff check \
  vllm_omni/model_executor/models/common/whisper_vq.py \
  tests/model_executor/models/common/test_whisper_vq.py
ruff format --check \
  vllm_omni/model_executor/models/common/whisper_vq.py \
  tests/model_executor/models/common/test_whisper_vq.py
```

**vLLM Version:** `0.26.0`

**vLLM-Omni Commit:** base `67c54777bb22e9e7e08fdf7c47a64f06b566fc47`, PR head `4176be1378a95090656b81194127a794fa9926f7`

**Environment:** 1x NVIDIA A100 80GB PCIe, PyTorch 2.11.0, CUDA 13.1

## Test Result

### Correctness

- `24 passed, 25 warnings in 0.49s`
- Ruff check: passed
- Ruff format check: passed
- `py_compile`: passed
- The A100 helper benchmark runs the old and new implementations on identical tensors and uses `torch.testing.assert_close` for pooled outputs, masks, quantized outputs, and token IDs before timing.

### A100 length-extraction microbenchmark

Median of 200 measured iterations after 30 warmups; sequence length 1500.

| Batch | Before (us) | After (us) | Speedup | Before `item/scalar` | After `item/scalar` |
|---:|---:|---:|---:|---:|---:|
| 1 | 33.931 | 33.426 | 1.02x | 1 / 1 | 0 / 0 |
| 4 | 181.190 | 46.352 | 3.91x | 4 / 4 | 0 / 0 |
| 16 | 708.423 | 47.886 | 14.79x | 16 / 16 | 0 / 0 |
| 64 | 4377.985 | 85.324 | 51.31x | 64 / 64 | 0 / 0 |

### A100 full-helper microbenchmark

Median of 50 measured iterations after 10 warmups; sequence length 256, hidden size 64, codebook size 1024.

| Batch | Pooling before / after (us) | Pooling speedup | VQ before / after (us) | VQ speedup | Before / after `item+scalar` |
|---:|---:|---:|---:|---:|---:|
| 1 | 204.025 / 205.581 | 0.99x | 328.847 / 330.481 | 1.00x | 2 / 0 |
| 4 | 807.533 / 618.105 | 1.31x | 1375.530 / 1171.947 | 1.17x | 8 / 0 |
| 16 | 2910.985 / 1945.153 | 1.50x | 5144.954 / 4006.546 | 1.28x | 32 / 0 |

### Validation boundary

These are length-extraction and helper-level measurements, not full GLM-TTS end-to-end throughput or latency results. Peak VRAM was not separately measured because this change does not alter tensor shapes, model weights, or retained activations.
