### PR TITLE
[Model] Optimize MIMO Audio tokenizer length grouping

### DIFF
--- a/tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py
+++ b/tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.mimo_audio.mimo_audio_code2wav import MiMoAudioTokenizerWorker
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_group_by_length_batches_length_transfer(monkeypatch: pytest.MonkeyPatch):
+    worker = MiMoAudioTokenizerWorker.__new__(MiMoAudioTokenizerWorker)
+    features = torch.arange(30, dtype=torch.float32).reshape(15, 2)
+    lengths = torch.tensor([4, 3, 6, 2])
+
+    def fail_item(*_args, **_kwargs):
+        raise AssertionError("per-length Tensor.item() synchronizes the device")
+
+    monkeypatch.setattr(torch.Tensor, "item", fail_item)
+
+    feature_groups, length_groups = worker.group_by_length(features, lengths, max_length=7)
+
+    assert [group.shape[0] for group in feature_groups] == [7, 6, 2]
+    assert [group.tolist() for group in length_groups] == [[4, 3], [6], [2]]

--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
@@ -180,18 +180,20 @@ class MiMoAudioTokenizerWorker:
         return torch.log(torch.clip(spec, min=1e-7)).squeeze()
 
     def group_by_length(self, features: torch.Tensor, lengths: torch.Tensor, max_length: int):
-        if features.size(0) != lengths.sum().item():
-            raise ValueError(f"Feature size mismatch: {features.size(0)} vs {lengths.sum().item()}")
+        length_values = lengths.tolist()
+        total_length = sum(length_values)
+        if features.size(0) != total_length:
+            raise ValueError(f"Feature size mismatch: {features.size(0)} vs {total_length}")
 
         split_points = []
         current_sum = 0
 
-        for i, seq_len in enumerate(lengths):
+        for i, seq_len in enumerate(length_values):
             if current_sum + seq_len > max_length and current_sum > 0:
                 split_points.append(i)
-                current_sum = seq_len.item()
+                current_sum = seq_len
             else:
-                current_sum += seq_len.item()
+                current_sum += seq_len
 
         # Convert split points to group sizes
         group_sizes = []
@@ -203,7 +205,11 @@ class MiMoAudioTokenizerWorker:
             group_sizes.append(len(lengths) - prev)
 
         len_groups = torch.split(lengths, group_sizes)
-        feature_sizes = [group.sum().item() for group in len_groups]
+        feature_sizes = []
+        offset = 0
+        for group_size in group_sizes:
+            feature_sizes.append(sum(length_values[offset : offset + group_size]))
+            offset += group_size
         feature_groups = torch.split(features, feature_sizes)
 
         return feature_groups, len_groups


### PR DESCRIPTION
## Purpose

### Problem

`MiMoAudioTokenizerWorker.group_by_length()` keeps `lengths` on the tokenizer device, but repeatedly converts CUDA scalars to Python values while grouping long audio segments:

- `lengths.sum().item()` for validation, evaluated again in the error message;
- a tensor comparison plus `seq_len.item()` for each segment;
- `group.sum().item()` for every output group.

These operations introduce multiple scalar device-to-host synchronizations before tokenizer encoding. The profiler observed 4 synchronizations for one segment and 601 for a 256-segment input.

### Root cause

The complete length vector is needed on the host because the grouping algorithm uses Python control flow and passes Python split sizes to `torch.split()`. Transferring each scalar separately adds synchronization overhead without preserving any useful device-side work.

### Solution

- Transfer all segment lengths once with `lengths.tolist()`.
- Reuse that list for total-length validation, group-boundary calculation, and feature split sizes.
- Keep the original device tensor for `len_groups`, so tokenizer encoder inputs retain their existing dtype and device.
- Add a regression test that rejects `Tensor.item()` calls and verifies the original variable-length grouping result.

## Test Plan

```bash
python -B -m pytest -q \
  tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py \
  tests/model_executor/models/mimo_audio/test_mimo_audio_code2wav_batch_decode.py

python -m py_compile \
  vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py \
  tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py

ruff check \
  vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py \
  tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py
ruff format --check \
  vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py \
  tests/model_executor/models/mimo_audio/test_mimo_audio_group_by_length.py
```

**vLLM Version:** `0.26.0`

**vLLM-Omni Commit:** base `67c54777bb22e9e7e08fdf7c47a64f06b566fc47`, PR head `8beefec4fd4c6bb41014f6b89774e2c4743006bb`

**Environment:** 1x NVIDIA A100 80GB PCIe, PyTorch 2.11.0, CUDA 13.1

## Test Result

### Correctness

- Focused and adjacent tests: `9 passed, 22 warnings in 0.23s`.
- The new test monkeypatches `torch.Tensor.item` to fail while checking feature group sizes `[7, 6, 2]` and length groups `[[4, 3], [6], [2]]`.
- A separate randomized parity harness compared the old and new implementations for 500 CPU and 500 CUDA cases, covering empty length vectors, zero-length segments, segments larger than `max_length`, multiple groups, and mismatch errors.
- Python compile, Ruff check, Ruff format, and `git diff --check` passed.

### A100 full-helper microbenchmark

Each case uses segment lengths sampled from `[1000, 6000]`, `max_length=12000`, 20 warmups, and 100 measured calls. Feature allocation is outside the timed region. Values are median wall time for the complete grouping helper.

| Segments | Output groups | Before (us) | After (us) | Speedup | Before `item/scalar` | After `item/scalar` |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 112.964 | 28.729 | 3.93x | 4 / 4 | 0 / 0 |
| 4 | 2 | 356.356 | 34.177 | 10.43x | 11 / 11 | 0 / 0 |
| 16 | 5 | 1099.740 | 42.672 | 25.77x | 38 / 38 | 0 / 0 |
| 64 | 24 | 4269.831 | 79.308 | 53.84x | 153 / 153 | 0 / 0 |
| 256 | 88 | 25763.019 | 206.853 | 124.55x | 601 / 601 | 0 / 0 |

### Validation boundary

This benchmark isolates MIMO Audio tokenizer length grouping before encoder execution. It is not a complete tokenizer encode, speech-to-speech latency, RTF, TTFA, or throughput measurement. Peak VRAM was not separately measured because the change does not alter model tensors or retained activations; it replaces repeated scalar reads with one host list transfer.
