### PR TITLE
[CI][Test] Add missing CI marks so Audex serving-guard tests are collected

### DIFF
--- a/tests/entrypoints/openai_api/test_audex_serving_guards.py
+++ b/tests/entrypoints/openai_api/test_audex_serving_guards.py
@@ -20,6 +20,10 @@ from vllm_omni.entrypoints.openai.serving_speech import (
     OmniOpenAIServingSpeech,
 )
 
+# Serving-layer only: the engine is stubbed, so these run on the CPU lane
+# alongside the other tests/entrypoints/openai_api suites.
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 
 def _serving(model_type: str = "audex") -> OmniOpenAIServingSpeech:
     serving = OmniOpenAIServingSpeech.__new__(OmniOpenAIServingSpeech)


### PR DESCRIPTION
## Problem

`tests/entrypoints/openai_api/test_audex_serving_guards.py` has carried **no `pytestmark`** since it landed with #4976. The Buildkite CPU lane selects `-m "core_model and cpu"` (`.buildkite/cuda/test-ready.yml`), so the whole file is deselected — its tests have never run in CI.

That file is the only coverage of the contract it was written to protect: a zero-codec-token (or phase-invalid TTA) request must fail the request rather than serialize as a successful empty WAV, for both the `audex` and `audex_tta` pipelines.

`tools/pre_commit/check_test_marks.py` exists to prevent exactly this and flags the file today:

```
$ python3 tools/pre_commit/check_test_marks.py tests/entrypoints/openai_api/test_audex_serving_guards.py
error: test files are missing pytest marks required for Buildkite CI collection.
  - tests/entrypoints/openai_api/test_audex_serving_guards.py [Level and Hardware]
```

The hook only runs on added/modified test files and was bypassed when the file was added, so nothing caught it afterwards.

## Fix

`pytestmark = [pytest.mark.core_model, pytest.mark.cpu]`, matching the sibling suites in `tests/entrypoints/openai_api/`. The tests stub the engine and need no GPU.

## Verification

On the same checkout, against the lane's own selector:

```
# before (upstream/main @ 67c54777b)
pytest -q tests/entrypoints/openai_api/test_audex_serving_guards.py -m "core_model and cpu"
no tests collected (49 deselected)

# after
49 passed
```

No test bodies changed — this only makes existing tests reachable.

## Related: there is a backlog

While verifying, I swept the tree with the same hook. **23 of 648 test files are unmarked** and therefore under-collected:

- 18 missing a hardware mark
- 4 missing both level and hardware
- 1 missing a level mark

This PR fixes one of them. The rest each need a judgement call about which lane they belong to (most are GPU/diffusion suites where enabling them may surface real failures), so they are not appropriate to bundle here. Happy to file a tracking issue with the full list if that is useful.