### PR TITLE
[Perf][TTS] Single-flight reference-audio encoding for MOSS-TTS

### DIFF
--- a/tests/model_executor/models/moss_tts/test_reference_encoder_single_flight.py
+++ b/tests/model_executor/models/moss_tts/test_reference_encoder_single_flight.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Regression tests for single-flight reference-audio encoding in MOSS-TTS.
+
+Guards the duplicate-encode class from RFC #4676 ("Add single-flight for the
+same uncached reference audio so concurrent requests trigger only one real
+encoding job"). The speaker cache is written only *after* an encode finishes,
+so a burst of voice-clone requests arriving on one cold reference — the common
+shape: one speaker, many utterances — used to run N multi-second CPU codec
+passes before the first one populated the cache.
+
+The invariants under test are the ones that make single-flight safe to put in
+front of a shared cache: exactly one real encode per cold reference, distinct
+references never collapsed, failures never cached (the next request retries),
+one caller giving up never taking the others down, and every caller getting an
+independent tensor rather than a view of the cached one.
+
+CPU-only and weight-free: the MOSS processor and the audio resolver are both
+injected, so nothing here touches the codec, the talker, or torchaudio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
+
+
+torch = pytest.importorskip("torch")
+
+SR = 24000
+N_VQ = 4
+
+
+@pytest.fixture(autouse=True)
+def _clear_inflight():
+    """Keep the module-global in-flight table from leaking between tests."""
+    from vllm_omni.model_executor.models.moss_tts import reference_encoder
+
+    reference_encoder._INFLIGHT.clear()
+    yield
+    reference_encoder._INFLIGHT.clear()
+
+
+class _FakeProcessor:
+    """Counts real encodes and returns a code tensor derived from the waveform."""
+
+    def __init__(self):
+        self.calls = 0
+        self.fail_with: Exception | None = None
+
+    def encode_audios_from_wav(self, wavs, sampling_rate, n_vq):
+        self.calls += 1
+        if self.fail_with is not None:
+            raise self.fail_with
+        # First waveform sample doubles as a fingerprint, so a test can prove
+        # which reference a returned tensor actually came from.
+        marker = float(wavs[0].reshape(-1)[0])
+        return [torch.full((n_vq, 3), marker)]
+
+
+class _Gate:
+    """An async ``resolve_ref_audio`` the test can hold open and count."""
+
+    def __init__(self):
+        self.event = asyncio.Event()
+        self.calls = 0
+        self.fail_with: Exception | None = None
+        self.cache_key: str | None = None
+        self.waveform_marker: float | None = None
+
+    async def __call__(self, ref_str: str) -> tuple[list, int, str]:
+        self.calls += 1
+        await self.event.wait()
+        if self.fail_with is not None:
+            raise self.fail_with
+        # Encode the reference identity into the waveform itself unless a test
+        # deliberately models two locators for one resolved content snapshot.
+        marker = self.waveform_marker if self.waveform_marker is not None else float(len(ref_str))
+        return [marker] * 8, SR, self.cache_key or f"key:{ref_str}"
+
+
+def _make_cache():
+    from vllm_omni.utils.speaker_cache import SpeakerEmbeddingCache
+
+    return SpeakerEmbeddingCache()
+
+
+async def _encode(ref_str, *, processor, resolve, cache, voice_name=None):
+    from vllm_omni.model_executor.models.moss_tts.reference_encoder import encode_reference_codes
+
+    return await encode_reference_codes(
+        ref_str,
+        processor=processor,
+        resolve_ref_audio=resolve,
+        speaker_cache=cache,
+        variant="local",
+        n_vq=N_VQ,
+        sr_target=SR,
+        voice_name=voice_name,
+    )
+
+
+async def _let_callers_reach_the_join():
+    """Yield enough for every gathered caller to park on the shared task."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+async def test_concurrent_cold_requests_run_one_encode():
+    """Eight concurrent requests for one cold reference → one codec pass."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+
+    pending = asyncio.gather(*[_encode("ref-a", processor=processor, resolve=resolve, cache=cache) for _ in range(8)])
+    await _let_callers_reach_the_join()
+    resolve.event.set()
+    results = await pending
+
+    assert processor.calls == 1, "reference audio was encoded more than once"
+    # Main derives anonymous identity from the resolver result, so every
+    # caller resolves before joining the one encode keyed by that identity.
+    assert resolve.calls == 8
+    assert len(results) == 8
+    for codes in results:
+        assert torch.equal(codes, results[0])
+
+
+async def test_distinct_references_are_not_collapsed():
+    """Single-flight keys on the cache key, so two references stay independent."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+
+    pending = asyncio.gather(
+        _encode("ref-a", processor=processor, resolve=resolve, cache=cache),
+        _encode("ref-bb", processor=processor, resolve=resolve, cache=cache),
+    )
+    await _let_callers_reach_the_join()
+    resolve.event.set()
+    first, second = await pending
+
+    assert processor.calls == 2
+    # The fake encodes len(ref_str) into every element, proving each caller got
+    # codes built from its own reference rather than the other one's.
+    assert first.flatten()[0].item() == float(len("ref-a"))
+    assert second.flatten()[0].item() == float(len("ref-bb"))
+
+
+async def test_different_locators_with_same_resolver_key_are_collapsed():
+    """Anonymous single-flight identity comes from the resolver, not ref_str."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+    resolve.cache_key = "same-content-snapshot"
+    resolve.waveform_marker = 7.0
+
+    pending = asyncio.gather(
+        _encode("first-locator", processor=processor, resolve=resolve, cache=cache),
+        _encode("second-locator", processor=processor, resolve=resolve, cache=cache),
+    )
+    await _let_callers_reach_the_join()
+    resolve.event.set()
+    first, second = await pending
+
+    assert resolve.calls == 2
+    assert processor.calls == 1
+    assert torch.equal(first, second)
+
+
+async def test_warm_cache_skips_the_encode():
+    """Once stored, later requests hit the cache and never re-encode."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+    resolve.event.set()
+
+    first = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache)
+    second = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache)
+
+    assert processor.calls == 1
+    assert torch.equal(first, second)
+
+
+async def test_anonymous_resolver_key_change_reencodes():
+    """A changed content snapshot must not reuse the prior anonymous entry."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+    resolve.event.set()
+
+    resolve.cache_key = "snapshot-a"
+    resolve.waveform_marker = 1.0
+    first = await _encode("same-locator", processor=processor, resolve=resolve, cache=cache)
+    resolve.cache_key = "snapshot-b"
+    resolve.waveform_marker = 2.0
+    second = await _encode("same-locator", processor=processor, resolve=resolve, cache=cache)
+
+    assert processor.calls == 2
+    assert first.flatten()[0].item() == 1.0
+    assert second.flatten()[0].item() == 2.0
+
+
+async def test_named_warm_cache_skips_resolve():
+    """A named-voice hit keeps main's pre-resolve fast path."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+    resolve.event.set()
+
+    first = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice")
+    second = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice")
+
+    assert resolve.calls == 1
+    assert processor.calls == 1
+    assert torch.equal(first, second)
+
+
+async def test_failure_is_not_cached_and_next_request_retries():
+    """A failed encode propagates to every waiter and leaves no poisoned slot."""
+    from vllm_omni.model_executor.models.moss_tts import reference_encoder
+
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+    resolve.event.set()
+    processor.fail_with = RuntimeError("codec exploded")
+
+    pending = asyncio.gather(
+        *[_encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice") for _ in range(3)],
+        return_exceptions=True,
+    )
+    await _let_callers_reach_the_join()
+    results = await pending
+
+    assert all(isinstance(r, RuntimeError) for r in results), results
+    assert not reference_encoder._INFLIGHT, "failed encode left a poisoned in-flight entry"
+    assert processor.calls == 1
+
+    # The retry must run a fresh encode rather than inherit the failure.
+    processor.fail_with = None
+    codes = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice")
+    assert processor.calls == 2
+    assert codes.shape == (N_VQ, 3)
+
+
+async def test_cancelled_caller_does_not_abort_the_shared_encode():
+    """One client disconnecting must not fail the others sharing its encode."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+
+    quitter = asyncio.ensure_future(
+        _encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice")
+    )
+    stayer = asyncio.ensure_future(
+        _encode("ref-a", processor=processor, resolve=resolve, cache=cache, voice_name="alice")
+    )
+    await _let_callers_reach_the_join()
+
+    quitter.cancel()
+    resolve.event.set()
+    codes = await stayer
+
+    assert quitter.cancelled()
+    assert processor.calls == 1
+    assert codes.shape == (N_VQ, 3)
+
+
+async def test_every_caller_gets_an_independent_tensor():
+    """Callers must not share storage with each other or with the cache entry."""
+    processor, resolve, cache = _FakeProcessor(), _Gate(), _make_cache()
+
+    pending = asyncio.gather(*[_encode("ref-a", processor=processor, resolve=resolve, cache=cache) for _ in range(3)])
+    await _let_callers_reach_the_join()
+    resolve.event.set()
+    first, second, third = await pending
+
+    first.fill_(-1.0)
+    assert not torch.equal(first, second), "callers of one in-flight encode share storage"
+    assert torch.equal(second, third)
+
+    # The cache entry itself must survive a caller mutating its own copy.
+    fourth = await _encode("ref-a", processor=processor, resolve=resolve, cache=cache)
+    assert processor.calls == 1
+    assert torch.equal(fourth, second)

--- a/vllm_omni/model_executor/models/moss_tts/reference_encoder.py
+++ b/vllm_omni/model_executor/models/moss_tts/reference_encoder.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Reference-audio encoding + speaker cache for the MOSS-TTS-family talker.
 
 This lives in the model package (not the shared serving layer) so all
@@ -23,6 +26,15 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+# In-flight encodes, keyed by the same key the speaker cache uses so named
+# voices and anonymous content-hashed references collapse identically. The
+# cache is only written *after* an encode finishes, so without this table a
+# burst of requests sharing one cold reference (the common voice-clone shape:
+# one speaker, many utterances) each runs its own multi-second CPU codec pass.
+# Single event loop per API-server process, so plain dict access between two
+# awaits is atomic and needs no lock.
+_INFLIGHT: dict[tuple[str, str, int], asyncio.Task[torch.Tensor]] = {}
+
 
 def _encode_wav_sync(processor: Any, wav_list: list, sr: int, sr_target: int, n_vq: int) -> torch.Tensor:
     """Blocking resample + CPU codec encode (the expensive bit)."""
@@ -36,6 +48,84 @@ def _encode_wav_sync(processor: Any, wav_list: list, sr: int, sr_target: int, n_
     with torch.no_grad():
         codes_list = processor.encode_audios_from_wav([wav], sampling_rate=sr_target, n_vq=n_vq)
     return codes_list[0]
+
+
+async def _resolve_and_encode(
+    ref_str: str,
+    *,
+    processor: Any,
+    resolve_ref_audio: Callable[[str], Awaitable[tuple[list, int, str]]],
+    speaker_cache: Any,
+    cache_key: tuple[str, str, int],
+    speaker_name: str,
+    n_vq: int,
+    sr_target: int,
+) -> torch.Tensor:
+    """Resolve + encode one reference and publish it to the speaker cache.
+
+    Runs as the single-flight leader task. Returns the same CPU tensor that was
+    stored, so callers must clone before handing it downstream.
+    """
+    wav_list, sr, _ = await resolve_ref_audio(ref_str)
+    return await _encode_and_store(
+        processor=processor,
+        wav_list=wav_list,
+        sr=sr,
+        speaker_cache=speaker_cache,
+        cache_key=cache_key,
+        speaker_name=speaker_name,
+        n_vq=n_vq,
+        sr_target=sr_target,
+    )
+
+
+async def _encode_and_store(
+    *,
+    processor: Any,
+    wav_list: list,
+    sr: int,
+    speaker_cache: Any,
+    cache_key: tuple[str, str, int],
+    speaker_name: str,
+    n_vq: int,
+    sr_target: int,
+) -> torch.Tensor:
+    """Encode already-resolved audio and publish it to the speaker cache."""
+    codes = await asyncio.to_thread(_encode_wav_sync, processor, wav_list, sr, sr_target, n_vq)
+    codes = codes.detach().cpu()
+    speaker_cache.put(cache_key, {"codes": codes})
+    logger.debug("Speaker cache STORE for MOSS-TTS reference '%s'", speaker_name)
+    return codes
+
+
+def _retire_inflight(task: asyncio.Task[torch.Tensor], key: tuple[str, str, int]) -> None:
+    """Drop the finished task and retrieve any exception.
+
+    Removing the entry on failure means the next request retries rather than
+    inheriting a poisoned slot — failures are never cached. Reading the
+    exception here keeps asyncio quiet when every waiter was cancelled before
+    the leader failed.
+    """
+    if _INFLIGHT.get(key) is task:
+        _INFLIGHT.pop(key)
+    if not task.cancelled():
+        task.exception()
+
+
+def _join_or_start(
+    cache_key: tuple[str, str, int],
+    speaker_name: str,
+    encode_factory: Callable[[], Awaitable[torch.Tensor]],
+) -> asyncio.Task[torch.Tensor]:
+    """Return the current encode or create and register one without yielding."""
+    task = _INFLIGHT.get(cache_key)
+    if task is None:
+        task = asyncio.ensure_future(encode_factory())
+        _INFLIGHT[cache_key] = task
+        task.add_done_callback(lambda t, k=cache_key: _retire_inflight(t, k))
+    else:
+        logger.debug("Speaker cache JOIN in-flight encode for MOSS-TTS reference '%s'", speaker_name)
+    return task
 
 
 async def encode_reference_codes(
@@ -65,6 +155,11 @@ async def encode_reference_codes(
     avoiding the decode cost when the cache is warm.  For anonymous references
     the audio is resolved first so the cache key incorporates mtime/size from
     a single stat (no TOCTOU window).
+
+    Concurrent requests for the same *uncached* reference are single-flighted:
+    the first starts the encode, the rest join its task. The cache alone cannot
+    do this — it is written only after an encode completes, so a burst arriving
+    on a cold reference would otherwise run N duplicate codec passes.
 
     Args:
         ref_str: The raw reference audio (URL / path / data URL) as received.
@@ -99,8 +194,22 @@ async def encode_reference_codes(
         if cached is not None:
             logger.debug("Speaker cache HIT for MOSS-TTS reference '%s'", speaker_name)
             return cached["codes"].clone()
-        # Cache miss — resolve the audio for encoding.
-        wav_list, sr, _ = await resolve_ref_audio(ref_str)
+        # The final key is already known, so named requests single-flight the
+        # resolve and encode together.
+        task = _join_or_start(
+            cache_key,
+            speaker_name,
+            lambda: _resolve_and_encode(
+                ref_str,
+                processor=processor,
+                resolve_ref_audio=resolve_ref_audio,
+                speaker_cache=speaker_cache,
+                cache_key=cache_key,
+                speaker_name=speaker_name,
+                n_vq=n_vq,
+                sr_target=sr_target,
+            ),
+        )
     else:
         # ---- Anonymous branch: resolve first for content-addressed key ----
         # The resolve incorporates mtime/size from a single stat so the key
@@ -117,9 +226,26 @@ async def encode_reference_codes(
         if cached is not None:
             logger.debug("Speaker cache HIT for MOSS-TTS reference '%s'", speaker_name)
             return cached["codes"].clone()
+        # Anonymous requests must resolve before joining so the in-flight
+        # identity is the resolver-derived content key, not the raw locator.
+        task = _join_or_start(
+            cache_key,
+            speaker_name,
+            lambda: _encode_and_store(
+                processor=processor,
+                wav_list=wav_list,
+                sr=sr,
+                speaker_cache=speaker_cache,
+                cache_key=cache_key,
+                speaker_name=speaker_name,
+                n_vq=n_vq,
+                sr_target=sr_target,
+            ),
+        )
 
-    # ---- Cold miss: encode in a worker thread and store ----
-    codes = await asyncio.to_thread(_encode_wav_sync, processor, wav_list, sr, sr_target, n_vq)
-    speaker_cache.put(cache_key, {"codes": codes.detach().cpu()})
-    logger.debug("Speaker cache STORE for MOSS-TTS reference '%s'", speaker_name)
-    return codes
+    # ``shield`` so a caller that gives up (client disconnect) neither cancels
+    # the shared encode nor drags the other waiters down with it; the encode
+    # still finishes and warms the cache. Every caller gets its own clone for
+    # the same reason the cache-hit path clones: downstream may mutate.
+    codes = await asyncio.shield(task)
+    return codes.clone()


### PR DESCRIPTION
## Purpose

Part of #4676: add single-flight for identical uncached MOSS-TTS reference audio.

The speaker cache is populated only after encoding finishes. Concurrent requests that miss the same cold entry can therefore start duplicate CPU codec work before the first result is stored. This change makes eight concurrent requests sharing one resolved reference perform one codec encode instead of eight.

## What changed

In `reference_encoder.py`:

- Added an in-flight task table keyed by the same `(speaker, model variant/n_vq, created_at)` key as `SpeakerEmbeddingCache`.
- Preserved main's resolver-derived anonymous-reference identity. Anonymous requests resolve first, obtain the resolver's mtime/size content-snapshot key, and only then join or create the encode task for that final key. They intentionally still perform one resolve per request; only the expensive codec encode is collapsed.
- Kept the named-voice fast path: its stable voice/timestamp key is known before resolution, so a cold burst shares resolution and encoding, while a warm hit skips resolution.
- Used `asyncio.shield` so cancellation of one waiter does not cancel the shared work. Completion removes the in-flight entry; failures are not cached and a later request retries.
- Stored a detached CPU tensor and returned a clone to every caller so downstream mutation cannot affect the cache or another response.
- Kept the blocking codec call in `asyncio.to_thread`.

The lookup/create/register sequence contains no `await`; on the API server's single event loop, only one leader can be registered for a cache key.

## Test plan

Added nine CPU-only, weight-free tests in `tests/model_executor/models/moss_tts/test_reference_encoder_single_flight.py` covering:

1. Eight anonymous cold callers: one encode and eight resolver calls.
2. Different resolver keys remain independent.
3. Different locators with the same resolver key collapse.
4. Warm anonymous cache hits skip encoding.
5. A changed anonymous resolver key forces re-encoding.
6. A warm named cache hit skips resolution.
7. A shared encode failure is not cached and retry succeeds.
8. Cancelling one waiter does not cancel the shared named task.
9. Every caller receives independent tensor storage.

The file is marked `core_model`, `cpu`, and `tts`, and is collected by the existing ready/merge command:

```bash
pytest -sv tests/model_executor -m 'core_model and cpu'
```

No pipeline change is required.

## Test result

Validated at rebased head `58a92f655617e2f54f295694fec78bfc02c43208` on `upstream/main` `f7f48929db8dcd60c8ce538f4057bec5a789057c`:

- Focused import-light suite against the real production module: `9 passed` on Python 3.12.9 / Torch 2.3.1 and `9 passed` on Python 3.12.12 / Torch 2.7.0.
- File-scoped `pre-commit`: all applicable hooks passed, including Ruff, formatting, mypy, CI marks, SPDX, forbidden imports, and CUDA API checks.
- Regression proof against the exact base production implementation: the new concurrent-cold test observes eight codec calls and fails its `== 1` assertion; the rebased head passes with one codec call.

The local environments cannot boot the repository-wide pytest configuration because their installed vLLM/pyzmq stack is incompatible, so the focused local run used an import-light pytest harness. The normal marked suite is left to repository CI. No wall-clock hardware benchmark is claimed; the verified performance invariant is the codec-work count reduction from eight to one for the tested cold burst.
