### PR TITLE
[Bugfix] Enable audio TTFP goodput SLOs

### DIFF
--- a/docs/cli/bench/serve.md
+++ b/docs/cli/bench/serve.md
@@ -55,6 +55,12 @@ You can use `vllm bench serve --omni --help=all` to get descriptions of all para
                     'Allowed metric names are "ttft", "tpot", "itl", "ttfc", "tpoc", "icl", '
                     '"tpop", "e2el", "audio_ttfp", "audio_rtf", "audio_duration". '
 
+- `--goodput`
+  Specify request-level service objectives as space-separated `KEY:VALUE` pairs, with values in milliseconds.
+  Supported metrics are `ttft`, `tpot`, `e2el`, and `audio_ttfp`. When multiple objectives are supplied, a
+  request contributes to goodput only when it satisfies every objective, for example
+  `--goodput ttft:500 audio_ttfp:1000`.
+
 - `--print-stage`
 Print per-stage benchmark metrics for --omni serving when stage metrics are returned by the server. Disabled by default.
 

--- a/tests/benchmarks/metrics/test_metrics.py
+++ b/tests/benchmarks/metrics/test_metrics.py
@@ -66,6 +66,63 @@ def _make_output(prompt_len: int, output_tokens: int = 10) -> MixRequestFuncOutp
     return output
 
 
+def test_audio_ttfp_goodput_and_combined_slos() -> None:
+    fast = _make_output(100)
+    fast.audio_ttfp = 0.2
+    slow_audio = _make_output(100)
+    slow_audio.audio_ttfp = 0.8
+
+    audio_metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=[fast, slow_audio],
+        dur_s=1.0,
+        tokenizer=None,
+        selected_percentiles=[99.0],
+        goodput_config_dict={"audio_ttfp": 500.0},
+        task_type=TaskType.GENERATION,
+        selected_percentile_metrics=[],
+        max_concurrency=None,
+        request_rate=float("inf"),
+        benchmark_duration=1.0,
+    )
+    assert audio_metrics.request_goodput == 1.0
+
+    slow_ttft = _make_output(100)
+    slow_ttft.audio_ttfp = 0.2
+    slow_ttft.ttft = 0.8
+    combined_metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=[fast, slow_ttft],
+        dur_s=1.0,
+        tokenizer=None,
+        selected_percentiles=[99.0],
+        goodput_config_dict={"ttft": 500.0, "audio_ttfp": 500.0},
+        task_type=TaskType.GENERATION,
+        selected_percentile_metrics=[],
+        max_concurrency=None,
+        request_rate=float("inf"),
+        benchmark_duration=1.0,
+    )
+    assert combined_metrics.request_goodput == 1.0
+
+
+def test_goodput_rejects_unsupported_direct_metric() -> None:
+    with pytest.raises(ValueError, match="Invalid metric name"):
+        calculate_metrics(
+            input_requests=[],
+            outputs=[],
+            dur_s=1.0,
+            tokenizer=None,
+            selected_percentiles=[99.0],
+            goodput_config_dict={"audio_ttft": 500.0},
+            task_type=TaskType.GENERATION,
+            selected_percentile_metrics=[],
+            max_concurrency=None,
+            request_rate=float("inf"),
+            benchmark_duration=1.0,
+        )
+
+
 # ============================================================================
 # total_input Tests
 # ============================================================================

--- a/tests/benchmarks/test_serve_cli.py
+++ b/tests/benchmarks/test_serve_cli.py
@@ -6,7 +6,9 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from vllm.benchmarks import serve as vllm_benchmark_serve
 
+import vllm_omni.benchmarks.patch.patch  # noqa: F401
 from vllm_omni.entrypoints.cli.benchmark.cli_args import (
     add_omni_args,
     extend_omni_choices,
@@ -87,6 +89,7 @@ def test_add_omni_args_preserves_implicit_defaults() -> None:
 def test_update_omni_help_updates_upstream_actions() -> None:
     parser = TrackingArgumentParser()
     parser.add_argument("--percentile-metrics", help="Upstream percentile help.")
+    parser.add_argument("--goodput", help="Upstream goodput help.")
     parser.add_argument("--random-mm-limit-mm-per-prompt", help="Upstream limit help.")
     parser.add_argument("--random-mm-bucket-config", help="Upstream bucket help.")
 
@@ -94,8 +97,25 @@ def test_update_omni_help_updates_upstream_actions() -> None:
 
     actions = {action.dest: action for action in parser._actions}
     assert all(metric in actions["percentile_metrics"].help for metric in ("ttfc", "tpop", "audio_rtf"))
+    assert "audio_ttfp" in actions["goodput"].help
     assert "probabilities are renormalized" in actions["random_mm_limit_mm_per_prompt"].help
     assert "Currently allows for 3 modalities" in actions["random_mm_bucket_config"].help
+
+
+def test_goodput_accepts_audio_ttfp_and_combines_slos() -> None:
+    args = argparse.Namespace(goodput=["ttft:500", "audio_ttfp:1000"])
+
+    assert vllm_benchmark_serve.check_goodput_args(args) == {
+        "ttft": 500.0,
+        "audio_ttfp": 1000.0,
+    }
+
+
+def test_goodput_rejects_unsupported_metric() -> None:
+    args = argparse.Namespace(goodput=["audio_ttft:500"])
+
+    with pytest.raises(ValueError, match="Invalid metric name"):
+        vllm_benchmark_serve.check_goodput_args(args)
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/benchmarks/metrics/metrics.py
+++ b/vllm_omni/benchmarks/metrics/metrics.py
@@ -13,6 +13,23 @@ from vllm_omni.metrics import definitions as defs
 _PERCENTILE_ROWS_TYPE = list[tuple[float, float]] | None
 _FLOAT_LIST_TYPE = list[float]
 _INT_LIST_TYPE = list[int]
+VALID_GOODPUT_METRICS = ("ttft", "tpot", "e2el", defs.AUDIO_TTFP)
+
+
+def validate_goodput_config(goodput_config_dict: dict[str, float]) -> None:
+    """Validate request-level goodput SLO names and values."""
+    for slo_name, slo_val in goodput_config_dict.items():
+        if slo_name not in VALID_GOODPUT_METRICS:
+            raise ValueError(
+                f"Invalid metric name found, {slo_name}: {slo_val}. "
+                "The service level objective name should be one of "
+                f"{list(VALID_GOODPUT_METRICS)}. "
+            )
+        if slo_val < 0:
+            raise ValueError(
+                f"Invalid value found, {slo_name}: {slo_val}. The service level objective value should be non-negative."
+            )
+
 
 _MULTIMODAL_BENCHMARK_FIELDS = [
     (defs.MEAN_AUDIO_TTFP_MS, float, field(default=0.0)),
@@ -712,6 +729,8 @@ def calculate_metrics(
     Returns:
         A tuple of the benchmark metrics and the actual output lengths.
     """
+    validate_goodput_config(goodput_config_dict)
+
     actual_output_lens: list[int] = []
     total_input = 0
     completed = 0
@@ -795,9 +814,9 @@ def calculate_metrics(
         if "ttft" in goodput_config_dict:
             valid_metrics.append(ttfts)
             slo_values.append(goodput_config_dict["ttft"] / MILLISECONDS_TO_SECONDS_CONVERSION)
-        if "audio_ttft" in goodput_config_dict:
+        if defs.AUDIO_TTFP in goodput_config_dict:
             valid_metrics.append(audio_ttfps)
-            slo_values.append(goodput_config_dict["audio_ttft"] / MILLISECONDS_TO_SECONDS_CONVERSION)
+            slo_values.append(goodput_config_dict[defs.AUDIO_TTFP] / MILLISECONDS_TO_SECONDS_CONVERSION)
         if "tpot" in goodput_config_dict:
             valid_metrics.append(all_tpots)
             slo_values.append(goodput_config_dict["tpot"] / MILLISECONDS_TO_SECONDS_CONVERSION)

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -1276,11 +1276,22 @@ from vllm.benchmarks.serve import TaskType, calculate_metrics_for_embeddings, ge
 from vllm_omni.benchmarks.metrics.metrics import (
     MultiModalsBenchmarkMetrics,
     calculate_metrics,
+    validate_goodput_config,
 )
 
 # ruff: noqa: E402
 
 benchmark_old = serve.benchmark
+
+
+def check_goodput_args(args):
+    """Parse goodput SLOs with vLLM-Omni request-level metrics."""
+    if not args.goodput:
+        return {}
+
+    goodput_config_dict = serve.parse_goodput(args.goodput)
+    validate_goodput_config(goodput_config_dict)
+    return goodput_config_dict
 
 
 def _merge_overrides(base: dict | None, overrides: dict | None) -> dict | None:
@@ -1711,3 +1722,4 @@ async def benchmark(
 
 
 serve.benchmark = benchmark
+serve.check_goodput_args = check_goodput_args

--- a/vllm_omni/entrypoints/cli/benchmark/cli_args.py
+++ b/vllm_omni/entrypoints/cli/benchmark/cli_args.py
@@ -219,6 +219,13 @@ def update_omni_help(parser: argparse.ArgumentParser) -> None:
                 'stream TPOP. "ttfc", "tpoc", and "icl" only affect internal stream stage metrics. '
                 'Audio metrics include "audio_ttfp", "audio_rtf", "audio_duration", and "audio_underrun".'
             )
+        if action.dest == "goodput":
+            action.help = (
+                'Specify service level objectives for goodput as "KEY:VALUE" pairs, where the key is a '
+                'request-level metric name and the value is in milliseconds. Multiple "KEY:VALUE" pairs '
+                "can be provided, separated by spaces, and a request must satisfy every SLO to count toward "
+                'goodput. Allowed metric names are "ttft", "tpot", "e2el", and "audio_ttfp".'
+            )
         if action.dest == "random_mm_limit_mm_per_prompt":
             action.help = (
                 "Per-modality hard caps for items attached per request, e.g. "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #5668.

`vllm bench serve --omni --goodput audio_ttfp:500` was unusable for two independent reasons:

1. vLLM-Omni reuses vLLM's `check_goodput_args()`, which only accepts `ttft`, `tpot`, and `e2el`, so the CLI rejected `audio_ttfp` before the benchmark started.
2. Omni's metric calculation checked the misspelled key `audio_ttft`, so a directly supplied `audio_ttfp` SLO was silently ignored.

This PR adds an Omni goodput validator that preserves the existing vLLM SLOs and accepts the canonical `audio_ttfp` metric. The same validator is used by direct metric calculation, so unsupported keys now fail clearly. It also applies the audio threshold using `defs.AUDIO_TTFP` and documents the new CLI option. Multiple SLOs keep the existing AND semantics: every configured threshold must pass for a request to contribute to goodput.

This completes the intent of #3799 for the current benchmark architecture by also covering the upstream-derived CLI validation path and direct-config validation.

cc @Gaohan123 @ZacheryAU @Ronnie-Rui

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 8e92d464

Reproduce the CLI validation path without launching a server:

```bash
PYTHONPATH=. python - <<'PY'
from argparse import Namespace

import vllm_omni.benchmarks.patch.patch  # noqa: F401
from vllm.benchmarks import serve

print(serve.check_goodput_args(Namespace(goodput=["audio_ttfp:500"])))
PY
```

On `main`, this raises `ValueError: Invalid metric name found, audio_ttfp: 500.0`. With this PR, it prints:

```text
{'audio_ttfp': 500.0}
```

Run the focused CLI and metric regression tests:

```bash
PYTHONPATH=. python -m pytest -q \
  tests/benchmarks/test_serve_cli.py \
  tests/benchmarks/metrics/test_metrics.py
```

The regression coverage verifies:

- CLI acceptance of `audio_ttfp` together with an existing `ttft` SLO;
- audio-only goodput calculation at a 500 ms threshold;
- AND semantics for combined `ttft` and `audio_ttfp` SLOs;
- explicit rejection of the unsupported `audio_ttft` spelling;
- `--goodput` help text includes `audio_ttfp`.

No GPU is required because the bug is in argument validation and deterministic metric aggregation.

## Test Result

```text
27 passed, 16 warnings in 13.43s
```

```text
pre-commit: all applicable hooks passed
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
