### PR TITLE
Add Quark offline mxfp4 quantization support

### DIFF
--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -10,15 +10,6 @@ loader (ROCmMxfp4OfflineLinearMethod, gfx950) reads it, packs to the AITER FP4
 layout at load, and runs the same gemm_a4w4 as the online path - only the weights
 are calibrated.
 
-Why "Route A" (float weights, not packed FP4 on disk): Quark's export_safetensors
-packing path is Transformers-only; for a bare DiT we keep the frozen bf16 weights
-(which already hold the calibrated FP4-rounded values) and let the loader pack at
-load. This delivers the calibration accuracy the uncalibrated online path cannot.
-
-Rotation (R1/R2) is intentionally OFF: Quark's RotationProcessor needs a decoder-
-shaped scaling dict that does not map cleanly onto Wan's DiT (follow-up). SmoothQuant
-uses the per-model scaling map in quark_mxfp4_scaling_maps.py.
-
 The A14B cascade has TWO transformers (transformer + transformer_2); both are
 quantized with the same config.
 

--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Quantize Wan2.2-T2V-A14B to a calibrated Quark MXFP4 checkpoint (offline, Route A).
+"""Quantize Wan2.2-T2V-A14B to a calibrated Quark MXFP4 checkpoint (offline).
 
 Produces a diffusers-style transformer directory whose weights are SmoothQuant-
 calibrated and MXFP4-rounded (bf16 tensors carrying FP4-grid values + a
@@ -13,11 +13,16 @@ are calibrated.
 The A14B cascade has TWO transformers (transformer + transformer_2); both are
 quantized with the same config.
 
+With --pack, weights are packed to the AITER FP4 layout (weight_shuffle +
+weight_scale, ~3.7x smaller on disk, no pack at load); vllm-omni's
+ROCmMxfp4PackedLinearMethod (gfx950) loads them directly. Without --pack, the export
+stays calibrated bf16 and is packed at load - portable across AITER versions.
+
 Example:
     python examples/quantization/quantize_wan2_2_quark_mxfp4.py \\
         --model /path/to/Wan2.2-T2V-A14B-Diffusers \\
         --output /path/to/wan2.2-t2v-a14b-quark-mxfp4 \\
-        --n-prompts 4 --n-steps 4
+        --n-prompts 4 --n-steps 4 [--pack]
 """
 
 from __future__ import annotations
@@ -108,6 +113,32 @@ def build_qconfig(model, alpha: float, smooth: bool, r1: bool, r2: bool):
     return QConfig(global_quant_config=global_cfg, algo_config=algo or None)
 
 
+def _pack_linear_weight(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack a calibrated bf16 weight (N, K) to the AITER FP4 layout.
+
+    Must match ROCmMxfp4LinearMethod.process_weights_after_loading (per_1x32 quant +
+    shuffle_weight(16, 16)) so the loader can consume the result as-is. Returns
+    weight_shuffle (float4_e2m1fn_x2, N, K/2) and weight_scale (float8_e8m0fnu, N, K/32),
+    both as uint8 (same bit width, lossless through safetensors).
+    """
+    import aiter
+    from aiter.ops.shuffle import shuffle_weight
+
+    quant_func = aiter.get_hip_quant(aiter.QuantType.per_1x32)
+    weight_quant, weight_scale = quant_func(w_bf16, shuffle=True)
+    weight_shuffle = shuffle_weight(weight_quant, layout=(16, 16))
+    return weight_shuffle.view(torch.uint8).contiguous(), weight_scale.view(torch.uint8).contiguous()
+
+
+def _quantized_linear_names(tq) -> set[str]:
+    """Names of frozen linears that Quark actually quantized (have a weight quantizer)."""
+    names = set()
+    for name, mod in tq.named_modules():
+        if hasattr(mod, "_weight_quantizer") and getattr(mod, "weight", None) is not None:
+            names.add(name)
+    return names
+
+
 def quantize_component(args, comp: str) -> dict:
     from diffusers import WanPipeline
     from quark.torch import ModelQuantizer
@@ -131,29 +162,68 @@ def quantize_component(args, comp: str) -> dict:
 
     out = os.path.join(args.output, comp)
     os.makedirs(out, exist_ok=True)
-    sd, dropped = {}, 0
-    for k, v in tq.state_dict().items():
-        if not isinstance(v, torch.Tensor):
-            continue
-        if any(m in k for m in _DROP_KEY_MARKERS):
-            dropped += 1
-            continue
-        sd[k] = v.to(torch.bfloat16).contiguous() if v.is_floating_point() else v.contiguous()
+
+    if args.pack:
+        export_format = "mxfp4_packed"
+        quantized = _quantized_linear_names(tq)
+        state = dict(tq.state_dict())
+        sd, packed, dropped = {}, 0, 0
+        for k, v in state.items():
+            if not isinstance(v, torch.Tensor):
+                continue
+            if any(m in k for m in _DROP_KEY_MARKERS):
+                dropped += 1
+                continue
+            mod_name = k.rsplit(".", 1)[0]
+            if k.endswith(".weight") and mod_name in quantized:
+                # Pack into weight_shuffle + weight_scale.
+                wsh, wsc = _pack_linear_weight(v.to(torch.bfloat16).cuda())
+                sd[f"{mod_name}.weight_shuffle"] = wsh.cpu()
+                sd[f"{mod_name}.weight_scale"] = wsc.cpu()
+                packed += 1
+            else:
+                sd[k] = v.to(torch.bfloat16).contiguous() if v.is_floating_point() else v.contiguous()
+        # Non-quantized linears load unquantized (bf16) at runtime.
+        all_linears = {n for n, m in tq.named_modules()
+                       if isinstance(m, torch.nn.Linear) or hasattr(m, "_weight_quantizer")}
+        ignored = sorted(all_linears - quantized)
+        note = f"packed {packed} linears"
+    else:
+        export_format = "mxfp4"
+        sd, dropped = {}, 0
+        for k, v in tq.state_dict().items():
+            if not isinstance(v, torch.Tensor):
+                continue
+            if any(m in k for m in _DROP_KEY_MARKERS):
+                dropped += 1
+                continue
+            sd[k] = v.to(torch.bfloat16).contiguous() if v.is_floating_point() else v.contiguous()
+        ignored = None
+        note = f"{len(sd)} tensors"
+
     save_file(sd, os.path.join(out, "diffusion_pytorch_model.safetensors"))
-    # config.json stanza so vllm-omni auto-selects the offline MXFP4 loader.
-    json.dump({"quantization_config": {
-        "quant_method": "quark", "quark_export_format": "mxfp4",
+    # config.json stanza so vllm-omni auto-selects the right offline MXFP4 loader.
+    qc = {
+        "quant_method": "quark", "quark_export_format": export_format,
         "is_checkpoint_mxfp4_serialized": True, "producer": "quark",
         "algo": {"smoothquant": not args.no_smooth, "alpha": args.alpha,
-                 "rotation_r1": args.r1, "rotation_r2": args.r2}}},
-        open(os.path.join(out, "quant_config.json"), "w"), indent=2)
-    print(f"[quark-mxfp4] {comp}: saved {len(sd)} tensors (dropped {dropped} quantizer keys) "
-          f"-> {out} in {dt:.0f}s")
+                 "rotation_r1": args.r1, "rotation_r2": args.r2},
+    }
+    if export_format == "mxfp4_packed":
+        # Loader must match this preshuffle layout.
+        qc["packing"] = "aiter_per_1x32_shuffle16x16"
+        if ignored:
+            qc["ignored_layers"] = ignored
+    json.dump({"quantization_config": qc},
+              open(os.path.join(out, "quant_config.json"), "w"), indent=2)
+    print(f"[quark-mxfp4] {comp}: saved {len(sd)} tensors ({note}, dropped {dropped} "
+          f"quantizer keys) format={export_format} -> {out} in {dt:.0f}s")
 
     del pipe, tf, tq
     gc.collect()
     torch.accelerator.empty_cache()
-    return {"saved": out, "tensors": len(sd), "dropped": dropped, "seconds": round(dt, 1)}
+    return {"saved": out, "tensors": len(sd), "dropped": dropped,
+            "format": export_format, "seconds": round(dt, 1)}
 
 
 def parse_args() -> argparse.Namespace:
@@ -169,6 +239,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--no-smooth", action="store_true", help="Disable SmoothQuant (plain MXFP4).")
     p.add_argument("--r1", action="store_true", help="Enable fused Hadamard R1 (experimental on DiT).")
     p.add_argument("--r2", action="store_true", help="Enable fused Hadamard R2 (experimental on DiT).")
+    p.add_argument("--pack", action="store_true",
+                   help="Pack weights offline to the AITER FP4 layout (weight_shuffle + "
+                        "weight_scale, ~3.7x smaller, no pack at load). ROCm gfx950 loader "
+                        "only. Omit for the portable calibrated-bf16 export.")
     return p.parse_args()
 
 

--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -34,7 +34,6 @@ import os
 import time
 
 import torch
-
 from quark_mxfp4_scaling_maps import (
     get_decoder_layers_attr,
     get_exclude_patterns,
@@ -88,15 +87,18 @@ class _SafeCalibLoader:
     def __iter__(self):
         for sample in self._dl:
             if isinstance(sample, dict):
-                yield {k: (v if isinstance(v, torch.Tensor) else _ToSafe(v))
-                       for k, v in sample.items()}
+                yield {k: (v if isinstance(v, torch.Tensor) else _ToSafe(v)) for k, v in sample.items()}
             else:
                 yield sample
 
 
 def build_qconfig(model, alpha: float, smooth: bool, r2: bool):
     from quark.torch.quantization.config.config import (
-        QConfig, QLayerConfig, OCP_MXFP4Spec, RotationConfig, SmoothQuantConfig,
+        OCP_MXFP4Spec,
+        QConfig,
+        QLayerConfig,
+        RotationConfig,
+        SmoothQuantConfig,
     )
 
     scaling_layers = get_scaling_map(model)
@@ -113,16 +115,28 @@ def build_qconfig(model, alpha: float, smooth: bool, r2: bool):
         # op the inference path does not have).
         rot = get_rotation_map(model)
         shim_rotation_config(model.config)
-        algo.append(RotationConfig(
-            scaling_layers=rot["scaling_layers"], model_decoder_layers=decoder_layers,
-            r1=False, r2=True, r3=False, r4=False,
-            v_proj=rot["v_proj"], o_proj=rot["o_proj"],
-            self_attn=rot["self_attn"], mlp=rot["mlp"],
-        ))
+        algo.append(
+            RotationConfig(
+                scaling_layers=rot["scaling_layers"],
+                model_decoder_layers=decoder_layers,
+                r1=False,
+                r2=True,
+                r3=False,
+                r4=False,
+                v_proj=rot["v_proj"],
+                o_proj=rot["o_proj"],
+                self_attn=rot["self_attn"],
+                mlp=rot["mlp"],
+            )
+        )
     if smooth:
-        algo.append(SmoothQuantConfig(
-            scaling_layers=scaling_layers, model_decoder_layers=decoder_layers, alpha=alpha,
-        ))
+        algo.append(
+            SmoothQuantConfig(
+                scaling_layers=scaling_layers,
+                model_decoder_layers=decoder_layers,
+                alpha=alpha,
+            )
+        )
     return QConfig(global_quant_config=global_cfg, algo_config=algo or None, exclude=exclude)
 
 
@@ -166,7 +180,7 @@ def quantize_component(args, comp: str) -> dict:
 
     qconfig = build_qconfig(tf, args.alpha, not args.no_smooth, args.r2)
     pipe.to(dev)
-    prompts = DEFAULT_CALIB_PROMPTS[:args.n_prompts]
+    prompts = DEFAULT_CALIB_PROMPTS[: args.n_prompts]
     dl = _SafeCalibLoader(get_calib_dataloader(pipe, tf, prompts, n_steps=args.n_steps, device=dev))
 
     quantizer = ModelQuantizer(qconfig)
@@ -197,8 +211,9 @@ def quantize_component(args, comp: str) -> dict:
             else:
                 sd[k] = v.to(torch.bfloat16).contiguous() if v.is_floating_point() else v.contiguous()
         # Non-quantized linears load unquantized (bf16) at runtime.
-        all_linears = {n for n, m in tq.named_modules()
-                       if isinstance(m, torch.nn.Linear) or hasattr(m, "_weight_quantizer")}
+        all_linears = {
+            n for n, m in tq.named_modules() if isinstance(m, torch.nn.Linear) or hasattr(m, "_weight_quantizer")
+        }
         ignored = sorted(all_linears - quantized)
         note = f"packed {packed} linears"
     else:
@@ -217,56 +232,75 @@ def quantize_component(args, comp: str) -> dict:
     save_file(sd, os.path.join(out, "diffusion_pytorch_model.safetensors"))
     # config.json stanza so vllm-omni auto-selects the right offline MXFP4 loader.
     qc = {
-        "quant_method": "quark", "quark_export_format": export_format,
-        "is_checkpoint_mxfp4_serialized": True, "producer": "quark",
-        "algo": {"smoothquant": not args.no_smooth, "alpha": args.alpha,
-                 "rotation_r2": args.r2},
+        "quant_method": "quark",
+        "quark_export_format": export_format,
+        "is_checkpoint_mxfp4_serialized": True,
+        "producer": "quark",
+        "algo": {"smoothquant": not args.no_smooth, "alpha": args.alpha, "rotation_r2": args.r2},
     }
     if export_format == "mxfp4_packed":
         # Loader must match this preshuffle layout.
         qc["packing"] = "aiter_per_1x32_shuffle16x16"
         if ignored:
             qc["ignored_layers"] = ignored
-    json.dump({"quantization_config": qc},
-              open(os.path.join(out, "quant_config.json"), "w"), indent=2)
-    print(f"[quark-mxfp4] {comp}: saved {len(sd)} tensors ({note}, dropped {dropped} "
-          f"quantizer keys) format={export_format} -> {out} in {dt:.0f}s")
+    json.dump({"quantization_config": qc}, open(os.path.join(out, "quant_config.json"), "w"), indent=2)
+    print(
+        f"[quark-mxfp4] {comp}: saved {len(sd)} tensors ({note}, dropped {dropped} "
+        f"quantizer keys) format={export_format} -> {out} in {dt:.0f}s"
+    )
 
     del pipe, tf, tq
     gc.collect()
     torch.accelerator.empty_cache()
-    return {"saved": out, "tensors": len(sd), "dropped": dropped,
-            "format": export_format, "seconds": round(dt, 1)}
+    return {"saved": out, "tensors": len(sd), "dropped": dropped, "format": export_format, "seconds": round(dt, 1)}
 
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Export a calibrated Quark MXFP4 Wan2.2 checkpoint.")
-    p.add_argument("--model", default="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-                   help="Source BF16 diffusers model path or id.")
+    p.add_argument(
+        "--model", default="Wan-AI/Wan2.2-T2V-A14B-Diffusers", help="Source BF16 diffusers model path or id."
+    )
     p.add_argument("--output", required=True, help="Export root directory.")
-    p.add_argument("--components", nargs="+", default=["transformer", "transformer_2"],
-                   help="Transformer components to quantize (A14B cascade = both).")
+    p.add_argument(
+        "--components",
+        nargs="+",
+        default=["transformer", "transformer_2"],
+        help="Transformer components to quantize (A14B cascade = both).",
+    )
     p.add_argument("--n-prompts", type=int, default=4, help="Calibration prompts.")
     p.add_argument("--n-steps", type=int, default=4, help="Denoise steps per calib prompt.")
     p.add_argument("--alpha", type=float, default=0.5, help="SmoothQuant alpha.")
     p.add_argument("--no-smooth", action="store_true", help="Disable SmoothQuant (plain MXFP4).")
-    p.add_argument("--r2", action="store_true",
-                   help="Enable R2 Hadamard rotation (folds into attn v/o proj offline; "
-                        "no runtime op). R1 is not supported on Wan (needs an online "
-                        "rotation op in the inference path).")
-    p.add_argument("--pack", action="store_true",
-                   help="Pack weights offline to the AITER FP4 layout (weight_shuffle + "
-                        "weight_scale, ~3.7x smaller, no pack at load). ROCm gfx950 loader "
-                        "only. Omit for the portable calibrated-bf16 export.")
+    p.add_argument(
+        "--r2",
+        action="store_true",
+        help="Enable R2 Hadamard rotation (folds into attn v/o proj offline; "
+        "no runtime op). R1 is not supported on Wan (needs an online "
+        "rotation op in the inference path).",
+    )
+    p.add_argument(
+        "--pack",
+        action="store_true",
+        help="Pack weights offline to the AITER FP4 layout (weight_shuffle + "
+        "weight_scale, ~3.7x smaller, no pack at load). ROCm gfx950 loader "
+        "only. Omit for the portable calibrated-bf16 export.",
+    )
     return p.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     os.makedirs(args.output, exist_ok=True)
-    summary = {"model": args.model, "output": args.output, "alpha": args.alpha,
-               "smoothquant": not args.no_smooth, "r2": args.r2,
-               "n_prompts": args.n_prompts, "n_steps": args.n_steps, "components": {}}
+    summary = {
+        "model": args.model,
+        "output": args.output,
+        "alpha": args.alpha,
+        "smoothquant": not args.no_smooth,
+        "r2": args.r2,
+        "n_prompts": args.n_prompts,
+        "n_steps": args.n_steps,
+        "components": {},
+    }
     for comp in args.components:
         print(f"\n{'=' * 60}\n[quark-mxfp4] component: {comp}\n{'=' * 60}")
         summary["components"][comp] = quantize_component(args, comp)

--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Quantize Wan2.2-T2V-A14B to a calibrated Quark MXFP4 checkpoint (offline, Route A).
+
+Produces a diffusers-style transformer directory whose weights are SmoothQuant-
+calibrated and MXFP4-rounded (bf16 tensors carrying FP4-grid values + a
+quantization config marking the checkpoint serialized). vllm-omni's ROCm offline
+loader (ROCmMxfp4OfflineLinearMethod, gfx950) reads it, packs to the AITER FP4
+layout at load, and runs the same gemm_a4w4 as the online path - only the weights
+are calibrated.
+
+Why "Route A" (float weights, not packed FP4 on disk): Quark's export_safetensors
+packing path is Transformers-only; for a bare DiT we keep the frozen bf16 weights
+(which already hold the calibrated FP4-rounded values) and let the loader pack at
+load. This delivers the calibration accuracy the uncalibrated online path cannot.
+
+Rotation (R1/R2) is intentionally OFF: Quark's RotationProcessor needs a decoder-
+shaped scaling dict that does not map cleanly onto Wan's DiT (follow-up). SmoothQuant
+uses the per-model scaling map in quark_mxfp4_scaling_maps.py.
+
+The A14B cascade has TWO transformers (transformer + transformer_2); both are
+quantized with the same config.
+
+Example:
+    python examples/quantization/quantize_wan2_2_quark_mxfp4.py \\
+        --model /path/to/Wan2.2-T2V-A14B-Diffusers \\
+        --output /path/to/wan2.2-t2v-a14b-quark-mxfp4 \\
+        --n-prompts 4 --n-steps 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import time
+
+import torch
+
+from quark_mxfp4_scaling_maps import get_decoder_layers_attr, get_scaling_map
+
+DEFAULT_CALIB_PROMPTS = [
+    "A serene lakeside sunrise with mist over the water.",
+    "A bustling city street at night with neon signs and rain.",
+    "A close-up of a hummingbird hovering over a red flower.",
+    "Aerial view of ocean waves crashing on a rocky coast.",
+    "A cat walking through tall grass in a sunny meadow.",
+    "Time-lapse of clouds moving over snowy mountain peaks.",
+]
+
+# Keys Quark adds that vllm-omni's WanTransformer3DModel does not expect. The offline
+# loader re-derives the per-32 scale from the calibrated weight via AITER, so these
+# are redundant and are stripped from the saved checkpoint.
+_DROP_KEY_MARKERS = ("_weight_quantizer", "_input_quantizer", "._amax")
+
+
+class _ToSafe:
+    """Make a non-tensor value survive Quark's cache_model_inps `.to(device)` call.
+
+    Quark's calib input-caching (built for LLMs whose block kwargs are all tensors)
+    calls .to(device) on EVERY value. Wan DiT blocks receive non-tensor kwargs
+    (bool/None/int); wrapping them so .to() returns the original primitive lets the
+    block forward receive the real value.
+    """
+
+    __slots__ = ("v",)
+
+    def __init__(self, v):
+        self.v = v
+
+    def to(self, *a, **k):
+        return self.v
+
+
+class _SafeCalibLoader:
+    """Re-iterable wrapper making non-tensor calib kwargs .to()-safe."""
+
+    def __init__(self, dl):
+        self._dl = dl
+
+    def __len__(self):
+        return len(self._dl)
+
+    def __iter__(self):
+        for sample in self._dl:
+            if isinstance(sample, dict):
+                yield {k: (v if isinstance(v, torch.Tensor) else _ToSafe(v))
+                       for k, v in sample.items()}
+            else:
+                yield sample
+
+
+def build_qconfig(model, alpha: float, smooth: bool, r1: bool, r2: bool):
+    from quark.torch.quantization.config.config import (
+        QConfig, QLayerConfig, OCP_MXFP4Spec, RotationConfig, SmoothQuantConfig,
+    )
+
+    scaling_layers = get_scaling_map(model)
+    decoder_layers = get_decoder_layers_attr(model)
+
+    w_spec = OCP_MXFP4Spec(ch_axis=-1, is_dynamic=False).to_quantization_spec()
+    global_cfg = QLayerConfig(weight=w_spec)
+
+    algo = []
+    if r1 or r2:
+        # Fused Hadamard (online_r1_rotation OFF -> folds into weights, no forward op).
+        algo.append(RotationConfig(
+            scaling_layers=scaling_layers, model_decoder_layers=decoder_layers,
+            r1=r1, r2=r2, r3=False, r4=False, online_r1_rotation=False,
+        ))
+    if smooth:
+        algo.append(SmoothQuantConfig(
+            scaling_layers=scaling_layers, model_decoder_layers=decoder_layers, alpha=alpha,
+        ))
+    return QConfig(global_quant_config=global_cfg, algo_config=algo or None)
+
+
+def quantize_component(args, comp: str) -> dict:
+    from diffusers import WanPipeline
+    from quark.torch import ModelQuantizer
+    from quark.torch.utils.diffusers.calibration import get_calib_dataloader
+    from safetensors.torch import save_file
+
+    dev = "cuda"
+    t0 = time.time()
+    pipe = WanPipeline.from_pretrained(args.model, torch_dtype=torch.bfloat16)
+    tf = getattr(pipe, comp)
+    print(f"[quark-mxfp4] {comp}: {type(tf).__name__} loaded in {time.time() - t0:.0f}s")
+
+    qconfig = build_qconfig(tf, args.alpha, not args.no_smooth, args.r1, args.r2)
+    pipe.to(dev)
+    prompts = DEFAULT_CALIB_PROMPTS[:args.n_prompts]
+    dl = _SafeCalibLoader(get_calib_dataloader(pipe, tf, prompts, n_steps=args.n_steps, device=dev))
+
+    quantizer = ModelQuantizer(qconfig)
+    tq = quantizer.freeze(quantizer.quantize_model(tf, dataloader=dl))
+    dt = time.time() - t0
+
+    out = os.path.join(args.output, comp)
+    os.makedirs(out, exist_ok=True)
+    sd, dropped = {}, 0
+    for k, v in tq.state_dict().items():
+        if not isinstance(v, torch.Tensor):
+            continue
+        if any(m in k for m in _DROP_KEY_MARKERS):
+            dropped += 1
+            continue
+        sd[k] = v.to(torch.bfloat16).contiguous() if v.is_floating_point() else v.contiguous()
+    save_file(sd, os.path.join(out, "diffusion_pytorch_model.safetensors"))
+    # config.json stanza so vllm-omni auto-selects the offline MXFP4 loader.
+    json.dump({"quantization_config": {
+        "quant_method": "quark", "quark_export_format": "mxfp4",
+        "is_checkpoint_mxfp4_serialized": True, "producer": "quark",
+        "algo": {"smoothquant": not args.no_smooth, "alpha": args.alpha,
+                 "rotation_r1": args.r1, "rotation_r2": args.r2}}},
+        open(os.path.join(out, "quant_config.json"), "w"), indent=2)
+    print(f"[quark-mxfp4] {comp}: saved {len(sd)} tensors (dropped {dropped} quantizer keys) "
+          f"-> {out} in {dt:.0f}s")
+
+    del pipe, tf, tq
+    gc.collect()
+    torch.cuda.empty_cache()
+    return {"saved": out, "tensors": len(sd), "dropped": dropped, "seconds": round(dt, 1)}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Export a calibrated Quark MXFP4 Wan2.2 checkpoint.")
+    p.add_argument("--model", default="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+                   help="Source BF16 diffusers model path or id.")
+    p.add_argument("--output", required=True, help="Export root directory.")
+    p.add_argument("--components", nargs="+", default=["transformer", "transformer_2"],
+                   help="Transformer components to quantize (A14B cascade = both).")
+    p.add_argument("--n-prompts", type=int, default=4, help="Calibration prompts.")
+    p.add_argument("--n-steps", type=int, default=4, help="Denoise steps per calib prompt.")
+    p.add_argument("--alpha", type=float, default=0.5, help="SmoothQuant alpha.")
+    p.add_argument("--no-smooth", action="store_true", help="Disable SmoothQuant (plain MXFP4).")
+    p.add_argument("--r1", action="store_true", help="Enable fused Hadamard R1 (experimental on DiT).")
+    p.add_argument("--r2", action="store_true", help="Enable fused Hadamard R2 (experimental on DiT).")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(args.output, exist_ok=True)
+    summary = {"model": args.model, "output": args.output, "alpha": args.alpha,
+               "smoothquant": not args.no_smooth, "r1": args.r1, "r2": args.r2,
+               "n_prompts": args.n_prompts, "n_steps": args.n_steps, "components": {}}
+    for comp in args.components:
+        print(f"\n{'=' * 60}\n[quark-mxfp4] component: {comp}\n{'=' * 60}")
+        summary["components"][comp] = quantize_component(args, comp)
+    json.dump(summary, open(os.path.join(args.output, "export_summary.json"), "w"), indent=2)
+    print(f"\n[quark-mxfp4] DONE\n{json.dumps(summary, indent=2)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -35,7 +35,13 @@ import time
 
 import torch
 
-from quark_mxfp4_scaling_maps import get_decoder_layers_attr, get_scaling_map
+from quark_mxfp4_scaling_maps import (
+    get_decoder_layers_attr,
+    get_exclude_patterns,
+    get_rotation_map,
+    get_scaling_map,
+    shim_rotation_config,
+)
 
 DEFAULT_CALIB_PROMPTS = [
     "A serene lakeside sunrise with mist over the water.",
@@ -88,7 +94,7 @@ class _SafeCalibLoader:
                 yield sample
 
 
-def build_qconfig(model, alpha: float, smooth: bool, r1: bool, r2: bool):
+def build_qconfig(model, alpha: float, smooth: bool, r2: bool):
     from quark.torch.quantization.config.config import (
         QConfig, QLayerConfig, OCP_MXFP4Spec, RotationConfig, SmoothQuantConfig,
     )
@@ -98,19 +104,26 @@ def build_qconfig(model, alpha: float, smooth: bool, r1: bool, r2: bool):
 
     w_spec = OCP_MXFP4Spec(ch_axis=-1, is_dynamic=False).to_quantization_spec()
     global_cfg = QLayerConfig(weight=w_spec)
+    exclude = get_exclude_patterns(model)
 
     algo = []
-    if r1 or r2:
-        # Fused Hadamard (online_r1_rotation OFF -> folds into weights, no forward op).
+    if r2:
+        # R2 folds into v_proj/o_proj weights offline (no runtime op). Uses the
+        # dict-form rotation map; R1 is excluded (Wan R1 requires an online rotation
+        # op the inference path does not have).
+        rot = get_rotation_map(model)
+        shim_rotation_config(model.config)
         algo.append(RotationConfig(
-            scaling_layers=scaling_layers, model_decoder_layers=decoder_layers,
-            r1=r1, r2=r2, r3=False, r4=False, online_r1_rotation=False,
+            scaling_layers=rot["scaling_layers"], model_decoder_layers=decoder_layers,
+            r1=False, r2=True, r3=False, r4=False,
+            v_proj=rot["v_proj"], o_proj=rot["o_proj"],
+            self_attn=rot["self_attn"], mlp=rot["mlp"],
         ))
     if smooth:
         algo.append(SmoothQuantConfig(
             scaling_layers=scaling_layers, model_decoder_layers=decoder_layers, alpha=alpha,
         ))
-    return QConfig(global_quant_config=global_cfg, algo_config=algo or None)
+    return QConfig(global_quant_config=global_cfg, algo_config=algo or None, exclude=exclude)
 
 
 def _pack_linear_weight(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -151,7 +164,7 @@ def quantize_component(args, comp: str) -> dict:
     tf = getattr(pipe, comp)
     print(f"[quark-mxfp4] {comp}: {type(tf).__name__} loaded in {time.time() - t0:.0f}s")
 
-    qconfig = build_qconfig(tf, args.alpha, not args.no_smooth, args.r1, args.r2)
+    qconfig = build_qconfig(tf, args.alpha, not args.no_smooth, args.r2)
     pipe.to(dev)
     prompts = DEFAULT_CALIB_PROMPTS[:args.n_prompts]
     dl = _SafeCalibLoader(get_calib_dataloader(pipe, tf, prompts, n_steps=args.n_steps, device=dev))
@@ -207,7 +220,7 @@ def quantize_component(args, comp: str) -> dict:
         "quant_method": "quark", "quark_export_format": export_format,
         "is_checkpoint_mxfp4_serialized": True, "producer": "quark",
         "algo": {"smoothquant": not args.no_smooth, "alpha": args.alpha,
-                 "rotation_r1": args.r1, "rotation_r2": args.r2},
+                 "rotation_r2": args.r2},
     }
     if export_format == "mxfp4_packed":
         # Loader must match this preshuffle layout.
@@ -237,8 +250,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--n-steps", type=int, default=4, help="Denoise steps per calib prompt.")
     p.add_argument("--alpha", type=float, default=0.5, help="SmoothQuant alpha.")
     p.add_argument("--no-smooth", action="store_true", help="Disable SmoothQuant (plain MXFP4).")
-    p.add_argument("--r1", action="store_true", help="Enable fused Hadamard R1 (experimental on DiT).")
-    p.add_argument("--r2", action="store_true", help="Enable fused Hadamard R2 (experimental on DiT).")
+    p.add_argument("--r2", action="store_true",
+                   help="Enable R2 Hadamard rotation (folds into attn v/o proj offline; "
+                        "no runtime op). R1 is not supported on Wan (needs an online "
+                        "rotation op in the inference path).")
     p.add_argument("--pack", action="store_true",
                    help="Pack weights offline to the AITER FP4 layout (weight_shuffle + "
                         "weight_scale, ~3.7x smaller, no pack at load). ROCm gfx950 loader "
@@ -250,7 +265,7 @@ def main() -> None:
     args = parse_args()
     os.makedirs(args.output, exist_ok=True)
     summary = {"model": args.model, "output": args.output, "alpha": args.alpha,
-               "smoothquant": not args.no_smooth, "r1": args.r1, "r2": args.r2,
+               "smoothquant": not args.no_smooth, "r2": args.r2,
                "n_prompts": args.n_prompts, "n_steps": args.n_steps, "components": {}}
     for comp in args.components:
         print(f"\n{'=' * 60}\n[quark-mxfp4] component: {comp}\n{'=' * 60}")

--- a/examples/quantization/quantize_wan2_2_quark_mxfp4.py
+++ b/examples/quantization/quantize_wan2_2_quark_mxfp4.py
@@ -161,7 +161,7 @@ def quantize_component(args, comp: str) -> dict:
 
     del pipe, tf, tq
     gc.collect()
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
     return {"saved": out, "tensors": len(sd), "dropped": dropped, "seconds": round(dt, 1)}
 
 

--- a/examples/quantization/quark_mxfp4_scaling_maps.py
+++ b/examples/quantization/quark_mxfp4_scaling_maps.py
@@ -44,14 +44,13 @@ WAN_MAP_I2V_EXTRA = [
 # first_layer/middle_layers/last_layer even for R2-only. With r1=False the entries
 # only need target_modules (the prev/norm/next requirements are R1-only). The actual
 # R2 fold uses the v_proj/o_proj fields below, rotating attention head_dim channels.
-_WAN_R2_TARGETS = [{"target_modules": ["blocks.layer_id.attn1.to_v",
-                                       "blocks.layer_id.attn1.to_out.0"]}]
+_WAN_R2_TARGETS = [{"target_modules": ["blocks.layer_id.attn1.to_v", "blocks.layer_id.attn1.to_out.0"]}]
 WAN_R2_ROTATION = {
-    "scaling_layers": {"first_layer": _WAN_R2_TARGETS,
-                       "middle_layers": _WAN_R2_TARGETS,
-                       "last_layer": _WAN_R2_TARGETS},
-    "v_proj": "attn1.to_v", "o_proj": "attn1.to_out.0",
-    "self_attn": "attn1", "mlp": "ffn",
+    "scaling_layers": {"first_layer": _WAN_R2_TARGETS, "middle_layers": _WAN_R2_TARGETS, "last_layer": _WAN_R2_TARGETS},
+    "v_proj": "attn1.to_v",
+    "o_proj": "attn1.to_out.0",
+    "self_attn": "attn1",
+    "mlp": "ffn",
 }
 
 # Flux - PLACEHOLDER, filled in during the Flux pass. Two block types (dual-stream
@@ -60,7 +59,7 @@ FLUX_MAP: list = []  # TODO(flux)
 
 SCALING_MAPS = {
     "WanTransformer3DModel": WAN_MAP,
-    "FluxTransformer2DModel": FLUX_MAP,   # placeholder
+    "FluxTransformer2DModel": FLUX_MAP,  # placeholder
 }
 
 # Structural linears that must stay bf16 (embedders / final projection). These are
@@ -69,8 +68,13 @@ SCALING_MAPS = {
 # checkpoint's ignored_layers.
 EXCLUDE_MAPS = {
     "WanTransformer3DModel": [
-        "*time_embedder*", "*time_proj*", "*text_embedder*",
-        "*condition_embedder*", "*patch_embedding*", "*norm_out*", "*proj_out*",
+        "*time_embedder*",
+        "*time_proj*",
+        "*text_embedder*",
+        "*condition_embedder*",
+        "*patch_embedding*",
+        "*norm_out*",
+        "*proj_out*",
     ],
 }
 
@@ -83,16 +87,14 @@ ROTATION_MAPS = {
 # this (model_decoder_layers); diffusers DiTs are not decoder-style (no model.layers).
 DECODER_LAYERS_ATTR = {
     "WanTransformer3DModel": "blocks",
-    "FluxTransformer2DModel": "transformer_blocks",   # placeholder (verify at Flux pass)
+    "FluxTransformer2DModel": "transformer_blocks",  # placeholder (verify at Flux pass)
 }
 
 
 def get_decoder_layers_attr(model) -> str:
     name = type(model).__name__
     if name not in DECODER_LAYERS_ATTR:
-        raise NotImplementedError(
-            f"No decoder-layers attr for {name!r}. Add it to DECODER_LAYERS_ATTR."
-        )
+        raise NotImplementedError(f"No decoder-layers attr for {name!r}. Add it to DECODER_LAYERS_ATTR.")
     return DECODER_LAYERS_ATTR[name]
 
 
@@ -106,8 +108,7 @@ def get_rotation_map(model) -> dict:
     name = type(model).__name__
     if name not in ROTATION_MAPS:
         raise NotImplementedError(
-            f"No Quark R2 rotation map for {name!r}. Add an entry to ROTATION_MAPS. "
-            f"Known: {list(ROTATION_MAPS)}"
+            f"No Quark R2 rotation map for {name!r}. Add an entry to ROTATION_MAPS. Known: {list(ROTATION_MAPS)}"
         )
     return ROTATION_MAPS[name]
 
@@ -119,8 +120,7 @@ def shim_rotation_config(cfg) -> None:
     for name, value in (
         ("head_dim", getattr(cfg, "attention_head_dim", None)),
         ("num_hidden_layers", getattr(cfg, "num_layers", None)),
-        ("hidden_size", (getattr(cfg, "num_attention_heads", 0) or 0)
-                        * (getattr(cfg, "attention_head_dim", 0) or 0)),
+        ("hidden_size", (getattr(cfg, "num_attention_heads", 0) or 0) * (getattr(cfg, "attention_head_dim", 0) or 0)),
     ):
         if getattr(cfg, name, None) is None and value:
             setattr(cfg, name, value)
@@ -137,14 +137,11 @@ def get_scaling_map(model, i2v: bool = False) -> list:
     name = type(model).__name__
     if name not in SCALING_MAPS:
         raise NotImplementedError(
-            f"No Quark scaling_layers map for {name!r}. Add an entry to SCALING_MAPS. "
-            f"Known: {list(SCALING_MAPS)}"
+            f"No Quark scaling_layers map for {name!r}. Add an entry to SCALING_MAPS. Known: {list(SCALING_MAPS)}"
         )
     m = list(SCALING_MAPS[name])
     if name == "WanTransformer3DModel" and i2v:
         m = m + WAN_MAP_I2V_EXTRA
     if not m:
-        raise NotImplementedError(
-            f"Scaling map for {name!r} is a placeholder (empty). Fill it before exporting."
-        )
+        raise NotImplementedError(f"Scaling map for {name!r} is a placeholder (empty). Fill it before exporting.")
     return m

--- a/examples/quantization/quark_mxfp4_scaling_maps.py
+++ b/examples/quantization/quark_mxfp4_scaling_maps.py
@@ -39,6 +39,21 @@ WAN_MAP_I2V_EXTRA = [
     {"prev_op": "norm2", "layers": ["attn2.add_k_proj", "attn2.add_v_proj"], "inp": "attn2.add_k_proj"},
 ]
 
+# R2 rotation (offline, folds into v_proj/o_proj within each block; no runtime op).
+# RotationProcessor.get_scaling_layers requires scaling_layers as a dict keyed
+# first_layer/middle_layers/last_layer even for R2-only. With r1=False the entries
+# only need target_modules (the prev/norm/next requirements are R1-only). The actual
+# R2 fold uses the v_proj/o_proj fields below, rotating attention head_dim channels.
+_WAN_R2_TARGETS = [{"target_modules": ["blocks.layer_id.attn1.to_v",
+                                       "blocks.layer_id.attn1.to_out.0"]}]
+WAN_R2_ROTATION = {
+    "scaling_layers": {"first_layer": _WAN_R2_TARGETS,
+                       "middle_layers": _WAN_R2_TARGETS,
+                       "last_layer": _WAN_R2_TARGETS},
+    "v_proj": "attn1.to_v", "o_proj": "attn1.to_out.0",
+    "self_attn": "attn1", "mlp": "ffn",
+}
+
 # Flux - PLACEHOLDER, filled in during the Flux pass. Two block types (dual-stream
 # + single-stream) plus a context branch (add_kv_proj / to_add_out) Wan lacks.
 FLUX_MAP: list = []  # TODO(flux)
@@ -46,6 +61,22 @@ FLUX_MAP: list = []  # TODO(flux)
 SCALING_MAPS = {
     "WanTransformer3DModel": WAN_MAP,
     "FluxTransformer2DModel": FLUX_MAP,   # placeholder
+}
+
+# Structural linears that must stay bf16 (embedders / final projection). These are
+# not wrapped as quantizable linears in the vllm-omni model, so quantizing them
+# produces packed keys the loader cannot place. Passed to QConfig.exclude and to the
+# checkpoint's ignored_layers.
+EXCLUDE_MAPS = {
+    "WanTransformer3DModel": [
+        "*time_embedder*", "*time_proj*", "*text_embedder*",
+        "*condition_embedder*", "*patch_embedding*", "*norm_out*", "*proj_out*",
+    ],
+}
+
+# R2 rotation configs (dict-form scaling_layers + v/o proj fields), per model.
+ROTATION_MAPS = {
+    "WanTransformer3DModel": WAN_R2_ROTATION,
 }
 
 # Attribute path to the ModuleList of transformer blocks. Quark's processors need
@@ -63,6 +94,38 @@ def get_decoder_layers_attr(model) -> str:
             f"No decoder-layers attr for {name!r}. Add it to DECODER_LAYERS_ATTR."
         )
     return DECODER_LAYERS_ATTR[name]
+
+
+def get_exclude_patterns(model) -> list:
+    """Structural linears (embedders/proj_out) that must stay bf16, or [] if none."""
+    return list(EXCLUDE_MAPS.get(type(model).__name__, []))
+
+
+def get_rotation_map(model) -> dict:
+    """Return the R2 rotation config for a diffusion transformer instance."""
+    name = type(model).__name__
+    if name not in ROTATION_MAPS:
+        raise NotImplementedError(
+            f"No Quark R2 rotation map for {name!r}. Add an entry to ROTATION_MAPS. "
+            f"Known: {list(ROTATION_MAPS)}"
+        )
+    return ROTATION_MAPS[name]
+
+
+def shim_rotation_config(cfg) -> None:
+    """Add the config attrs Quark's rotation processor reads (diffusers DiT configs
+    lack the HF-LLM names). R2 needs head_dim + num_hidden_layers; hidden_size is a
+    fallback for head_dim."""
+    for name, value in (
+        ("head_dim", getattr(cfg, "attention_head_dim", None)),
+        ("num_hidden_layers", getattr(cfg, "num_layers", None)),
+        ("hidden_size", (getattr(cfg, "num_attention_heads", 0) or 0)
+                        * (getattr(cfg, "attention_head_dim", 0) or 0)),
+    ):
+        if getattr(cfg, name, None) is None and value:
+            setattr(cfg, name, value)
+    if getattr(cfg, "intermediate_size", None) is None and getattr(cfg, "ffn_dim", None):
+        cfg.intermediate_size = cfg.ffn_dim
 
 
 def get_scaling_map(model, i2v: bool = False) -> list:

--- a/examples/quantization/quark_mxfp4_scaling_maps.py
+++ b/examples/quantization/quark_mxfp4_scaling_maps.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-model scaling_layers maps for Quark SmoothQuant (and, later, rotation).
+
+The ONLY per-model artifact needed to cover a new DiT with the offline Quark MXFP4
+flow. The export driver (quantize_wan2_2_quark_mxfp4.py) and the vllm-omni offline
+loader (ROCmMxfp4OfflineLinearMethod) are model-agnostic; adding a model = add one
+entry to SCALING_MAPS + DECODER_LAYERS_ATTR here.
+
+A scaling_layers entry (schema: quark/torch/algorithm/utils/prepare.py) needs:
+  prev_op        : module whose OUTPUT weight absorbs the (inverse) scale
+  layers         : the linear(s) whose INPUT is scaled (fused on input dim)
+  inp            : REQUIRED - the input-feature key (module name) whose captured
+                   activation feeds `layers`; usually the first entry of `layers`.
+  module2inspect : optional submodule run for the scale search (e.g. attn/ffn).
+
+Structure derived from vllm_omni/diffusion/models/*/*_transformer.py.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Wan2.2 (WanTransformer3DModel). The A14B cascade uses TWO of these
+# (transformer + transformer_2); the map applies to each identically.
+# WanTransformerBlock: norm1->attn1(self), norm2->attn2(cross), norm3->ffn.
+# ---------------------------------------------------------------------------
+WAN_MAP = [
+    {"prev_op": "norm1", "layers": ["attn1.to_qkv"], "inp": "attn1.to_qkv", "module2inspect": "attn1"},
+    {"prev_op": "attn1.to_qkv", "layers": ["attn1.to_out"], "inp": "attn1.to_out"},
+    {"prev_op": "norm2", "layers": ["attn2.to_q"], "inp": "attn2.to_q", "module2inspect": "attn2"},
+    {"prev_op": "attn2.to_v", "layers": ["attn2.to_out"], "inp": "attn2.to_out"},
+    {"prev_op": "norm3", "layers": ["ffn.net_0"], "inp": "ffn.net_0", "module2inspect": "ffn"},
+    {"prev_op": "ffn.net_0", "layers": ["ffn.net_2"], "inp": "ffn.net_2"},
+]
+
+# I2V variant adds encoder K/V projections; appended when i2v=True.
+WAN_MAP_I2V_EXTRA = [
+    {"prev_op": "norm2", "layers": ["attn2.add_k_proj", "attn2.add_v_proj"], "inp": "attn2.add_k_proj"},
+]
+
+# Flux - PLACEHOLDER, filled in during the Flux pass. Two block types (dual-stream
+# + single-stream) plus a context branch (add_kv_proj / to_add_out) Wan lacks.
+FLUX_MAP: list = []  # TODO(flux)
+
+SCALING_MAPS = {
+    "WanTransformer3DModel": WAN_MAP,
+    "FluxTransformer2DModel": FLUX_MAP,   # placeholder
+}
+
+# Attribute path to the ModuleList of transformer blocks. Quark's processors need
+# this (model_decoder_layers); diffusers DiTs are not decoder-style (no model.layers).
+DECODER_LAYERS_ATTR = {
+    "WanTransformer3DModel": "blocks",
+    "FluxTransformer2DModel": "transformer_blocks",   # placeholder (verify at Flux pass)
+}
+
+
+def get_decoder_layers_attr(model) -> str:
+    name = type(model).__name__
+    if name not in DECODER_LAYERS_ATTR:
+        raise NotImplementedError(
+            f"No decoder-layers attr for {name!r}. Add it to DECODER_LAYERS_ATTR."
+        )
+    return DECODER_LAYERS_ATTR[name]
+
+
+def get_scaling_map(model, i2v: bool = False) -> list:
+    """Return the scaling_layers map for a diffusion transformer instance.
+
+    Raises NotImplementedError (not KeyError) for unmapped/placeholder models so the
+    export script fails loudly with an actionable message.
+    """
+    name = type(model).__name__
+    if name not in SCALING_MAPS:
+        raise NotImplementedError(
+            f"No Quark scaling_layers map for {name!r}. Add an entry to SCALING_MAPS. "
+            f"Known: {list(SCALING_MAPS)}"
+        )
+    m = list(SCALING_MAPS[name])
+    if name == "WanTransformer3DModel" and i2v:
+        m = m + WAN_MAP_I2V_EXTRA
+    if not m:
+        raise NotImplementedError(
+            f"Scaling map for {name!r} is a placeholder (empty). Fill it before exporting."
+        )
+    return m

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -103,10 +103,15 @@ def _build_mxfp8(**kw: Any) -> QuantizationConfig:
 
 
 def _build_mxfp4(**kw: Any) -> QuantizationConfig:
-    """Lazy import for W4A4 MXFP4 diffusion config (NPU only)."""
+    """Lazy import for W4A4 MXFP4 diffusion config.
+
+    Route through from_config so a checkpoint's full quantization_config stanza
+    (with producer/algo/packing metadata) is tolerated rather than passed to
+    __init__ positionally.
+    """
     from .mxfp4_config import DiffusionMXFP4Config
 
-    return DiffusionMXFP4Config(**kw)
+    return DiffusionMXFP4Config.from_config(kw)
 
 
 def _build_mxfp4_dualscale(**kw: Any) -> QuantizationConfig:

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -538,9 +538,7 @@ class ROCmMxfp4OfflineLinearMethod(ROCmMxfp4LinearMethod):
         layer.register_parameter(
             "weight",
             ModelWeightParameter(
-                data=torch.empty(
-                    output_size_per_partition, input_size_per_partition, dtype=params_dtype
-                ),
+                data=torch.empty(output_size_per_partition, input_size_per_partition, dtype=params_dtype),
                 input_dim=1,
                 output_dim=0,
                 weight_loader=weight_loader,

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -105,10 +105,14 @@ class DiffusionMXFP4Config(QuantizationConfig):
         self,
         is_checkpoint_mxfp4_serialized: bool = False,
         ignored_layers: list[str] | None = None,
+        quark_export_format: str | None = None,
     ) -> None:
         super().__init__()
         self.is_checkpoint_mxfp4_serialized = is_checkpoint_mxfp4_serialized
         self.ignored_layers = ignored_layers or []
+        # "mxfp4": bf16 weights packed to FP4 at load. "mxfp4_packed": weights already
+        # packed on disk (weight_shuffle + weight_scale), loaded as-is.
+        self.quark_export_format = quark_export_format
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
@@ -136,9 +140,11 @@ class DiffusionMXFP4Config(QuantizationConfig):
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(config, ["modules_to_not_convert"], None)
+        export_format = cls.get_from_keys_or(config, ["quark_export_format"], None)
         return cls(
             is_checkpoint_mxfp4_serialized=is_serialized,
             ignored_layers=ignored_layers,
+            quark_export_format=export_format,
         )
 
     def get_quant_method(
@@ -162,8 +168,8 @@ class DiffusionMXFP4Config(QuantizationConfig):
                 if "gfx950" not in gcn_arch:
                     raise NotImplementedError(f"MXFP4 on ROCm requires gfx950 (MI355X). Detected: {gcn_arch}")
                 if self.is_checkpoint_mxfp4_serialized:
-                    # Route A: calibrated (Quark SmoothQuant+MXFP4) bf16 checkpoint;
-                    # packed to AITER FP4 at load. Same GEMM as online, calibrated weights.
+                    if self.quark_export_format == "mxfp4_packed":
+                        return ROCmMxfp4PackedLinearMethod(self)
                     return ROCmMxfp4OfflineLinearMethod(self)
                 return ROCmMxfp4OnlineLinearMethod(self)
             raise NotImplementedError(
@@ -491,17 +497,17 @@ class ROCmMxfp4OnlineLinearMethod(_LazyWeightMixin, ROCmMxfp4LinearMethod):
 
 
 # ---------------------------------------------------------------------------
-# ROCm MXFP4 offline method (pre-quantized/calibrated checkpoint, Route A)
+# ROCm MXFP4 offline method (pre-quantized/calibrated checkpoint)
 # ---------------------------------------------------------------------------
 
 
 class ROCmMxfp4OfflineLinearMethod(ROCmMxfp4LinearMethod):
     """ROCm W4A4 MXFP4 offline linear method for a Quark-calibrated checkpoint.
 
-    Route A: the checkpoint stores CALIBRATED float (bf16) weights that already hold
-    MXFP4-rounded values (produced offline by Quark: SmoothQuant + MXFP4). At load we
-    pack them to the AITER FP4 layout with the SAME transform the online path uses
-    (per_1x32 + shuffle) - identical GEMM, just calibrated weights.
+    The checkpoint stores calibrated bf16 weights that already hold MXFP4-rounded
+    values (produced offline by Quark: SmoothQuant + MXFP4). At load we pack them to
+    the AITER FP4 layout with the same transform the online path uses (per_1x32 +
+    shuffle) - identical GEMM, just calibrated weights.
 
     Difference from the online method: the weight arrives from a real serialized
     checkpoint (a normal loadable bf16 param), NOT from meta-device dummy init. So we
@@ -543,6 +549,86 @@ class ROCmMxfp4OfflineLinearMethod(ROCmMxfp4LinearMethod):
 
     # process_weights_after_loading inherited from ROCmMxfp4LinearMethod:
     # aiter per_1x32 quant + shuffle_weight(16,16) on the loaded calibrated weight.
+
+
+# ---------------------------------------------------------------------------
+# ROCm MXFP4 packed method (weights pre-packed to the AITER FP4 layout on disk)
+# ---------------------------------------------------------------------------
+
+
+class ROCmMxfp4PackedLinearMethod(ROCmMxfp4LinearMethod):
+    """ROCm W4A4 MXFP4 method for a checkpoint whose weights are already packed.
+
+    The checkpoint stores the AITER FP4 layout directly (as uint8):
+      weight_shuffle : float4_e2m1fn_x2 (N, K/2)   per_1x32 + shuffle_weight(16, 16)
+      weight_scale   : float8_e8m0fnu   (N, K/32)  per-group-of-32 scale
+    process_weights_after_loading only views the bytes back to their FP4/e8m0 dtypes;
+    no packing at load. apply/_quant_matmul are inherited.
+
+    TP=1 only: packing is per output row, so N-axis (output-dim) sharding and QKV/MLP
+    fusion are safe, but K-axis (input-dim) sharding of a packed weight is not.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        # Packed FP4 weight, 2 values per byte -> (N, K/2) uint8. output_dim=0 lets the
+        # fused/sharded loaders place row-slices; input_dim=None keeps the packed K axis
+        # unsharded.
+        layer.register_parameter(
+            "weight_shuffle",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, input_size_per_partition // 2, dtype=torch.uint8),
+                input_dim=None,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        # Per-group e8m0 scale: (N, K/32) uint8.
+        num_groups = (input_size_per_partition + 31) // 32
+        layer.register_parameter(
+            "weight_scale",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, num_groups, dtype=torch.uint8),
+                input_dim=None,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        # View the loaded uint8 bytes back to their real dtypes.
+        w = layer.weight_shuffle.data.view(torch.float4_e2m1fn_x2)
+        s = layer.weight_scale.data.view(torch.float8_e8m0fnu)
+
+        # Swap params for buffers so the inherited apply()/_quant_matmul reads
+        # weight_shuffle / weight_scale exactly as the pack-at-load path does.
+        if isinstance(layer.weight_shuffle, torch.nn.Parameter):
+            delattr(layer, "weight_shuffle")
+        if isinstance(layer.weight_scale, torch.nn.Parameter):
+            delattr(layer, "weight_scale")
+        layer.register_buffer("weight_shuffle", w, persistent=True)
+        layer.register_buffer("weight_scale", s, persistent=True)
+
+        layer._already_called_process_weights_after_loading = True
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -162,7 +162,9 @@ class DiffusionMXFP4Config(QuantizationConfig):
                 if "gfx950" not in gcn_arch:
                     raise NotImplementedError(f"MXFP4 on ROCm requires gfx950 (MI355X). Detected: {gcn_arch}")
                 if self.is_checkpoint_mxfp4_serialized:
-                    raise NotImplementedError("Pre-quantized MXFP4 checkpoints are not yet supported on ROCm.")
+                    # Route A: calibrated (Quark SmoothQuant+MXFP4) bf16 checkpoint;
+                    # packed to AITER FP4 at load. Same GEMM as online, calibrated weights.
+                    return ROCmMxfp4OfflineLinearMethod(self)
                 return ROCmMxfp4OnlineLinearMethod(self)
             raise NotImplementedError(
                 "DiffusionMXFP4Config (W4A4 MXFP4) is currently only supported "
@@ -486,6 +488,61 @@ class ROCmMxfp4OnlineLinearMethod(_LazyWeightMixin, ROCmMxfp4LinearMethod):
 
         # Delegate to the base class which does AITER quant + shuffle.
         ROCmMxfp4LinearMethod.process_weights_after_loading(self, layer)
+
+
+# ---------------------------------------------------------------------------
+# ROCm MXFP4 offline method (pre-quantized/calibrated checkpoint, Route A)
+# ---------------------------------------------------------------------------
+
+
+class ROCmMxfp4OfflineLinearMethod(ROCmMxfp4LinearMethod):
+    """ROCm W4A4 MXFP4 offline linear method for a Quark-calibrated checkpoint.
+
+    Route A: the checkpoint stores CALIBRATED float (bf16) weights that already hold
+    MXFP4-rounded values (produced offline by Quark: SmoothQuant + MXFP4). At load we
+    pack them to the AITER FP4 layout with the SAME transform the online path uses
+    (per_1x32 + shuffle) - identical GEMM, just calibrated weights.
+
+    Difference from the online method: the weight arrives from a real serialized
+    checkpoint (a normal loadable bf16 param), NOT from meta-device dummy init. So we
+    register a standard weight in create_weights and reuse the base pack in
+    process_weights_after_loading.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        # Calibrated bf16 weight (N, K) - a standard loadable param. The FP4 packing
+        # happens at process_weights_after_loading via the base AITER transform.
+        layer.register_parameter(
+            "weight",
+            ModelWeightParameter(
+                data=torch.empty(
+                    output_size_per_partition, input_size_per_partition, dtype=params_dtype
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    # process_weights_after_loading inherited from ROCmMxfp4LinearMethod:
+    # aiter per_1x32 quant + shuffle_weight(16,16) on the loaded calibrated weight.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an **offline MXFP4** path for diffusion transformers on ROCm/gfx950: load a pre-quantized, **SmoothQuant-calibrated** Quark MXFP4 checkpoint instead of quantizing a raw BF16 model at load. Previously ROCm MXFP4 was online-only and **uncalibrated** (`raise NotImplementedError` for serialized checkpoints); this enables the calibrated
weights the online path structurally cannot produce, at the same speed/VRAM.

- **Loader:** `ROCmMxfp4OfflineLinearMethod` - loads calibrated bf16 weights and packs   them to the AITER FP4 layout at load (same `gemm_a4w4` as online; only the weights   differ). Dispatched on `is_checkpoint_mxfp4_serialized` + gfx950.
- **Export example:** `quantize_wan2_2_quark_mxfp4.py` (+ per-model scaling registry)  produces the checkpoint via Quark SmoothQuant + MXFP4, handling the A14B cascade.

## Changes

| File | +/- | What |
|------|-----|------|
| `vllm_omni/quantization/mxfp4_config.py` | +59/-1 | `ROCmMxfp4OfflineLinearMethod`; dispatch serialized+gfx950 (removes NotImplementedError) |
| `examples/quantization/quantize_wan2_2_quark_mxfp4.py` | +198 | SmoothQuant-calibrated MXFP4 export (Route A) |
| `examples/quantization/quark_mxfp4_scaling_maps.py` | +87 | per-model scaling_layers registry (Wan mapped; Flux placeholder) |

Offline matches online speed/VRAM (same GEMM); the value is **calibration accuracy**,
not throughput. Model load 25.7 GiB (FP4-packed at load), identical to online.
## Test Plan
- [x] Export: Wan2.2-T2V-A14B -> Quark MXFP4 + SmoothQuant, both transformer +
      transformer_2 (29 GB each, bf16).
- [x] Serve end-to-end on gfx950: offline loader dispatches, diffusers->vllm-omni key
      remap OK, packs at load, generates a valid 720p/81f video (exit 0).
- [x] Perf parity with online MXFP4 (452.0 s / 48.6 GiB).

**vLLM Version:**
  - vLLM: 0.26.0+rocm723 (from wheels.vllm.ai/rocm/0.26.0/rocm723)
  - vllm-omni: 0.26.0rc2.dev58+gd33c905d8.rocm (git d33c905d)
  - torch: 2.11.0+gitd0c8b1f, HIP 7.2.5 (ROCm 7.2.x)

**vLLM-Omni Commit:**

## Test Result
## End-to-end benchmark (Wan2.2-T2V-A14B)

HW: AMD gfx950 (MI355-class), single GPU. Config: 1280x720, 81 frames, 40 steps,
guidance 4.0, seed 42, bf16. Stack: vLLM 0.26.0+rocm723, torch 2.11 (HIP 7.2.5).

| Backend | Infer | Peak VRAM | Notes |
|---|---|---|---|
| BF16 (vllm-omni) | 522.7 s | 87.3 GiB | baseline |
| MXFP4 online (uncalibrated) | 455.5 s | 50.5 GiB | existing built-in |
| **MXFP4 offline (Quark + SmoothQuant)** | **452.0 s** | **48.6 GiB** | **this PR - calibrated** |

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
