### PR TITLE
[CI/Build][MiniCPM-o] Narrow nightly H100 function tests to MiniCPM-o 4.5

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -15,7 +15,7 @@ steps:
       - label: ":full_moon: Omni · Function Test with H100"
         timeout_in_minutes: 120
         commands:
-          - pytest -sv tests/e2e --run-level "full_model" -m "full_model and H100 and omni" --ignore=tests/e2e/accuracy --ignore=tests/e2e/online_serving/test_qwen3_omni_multi_replicas.py --ignore=tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
+          - pytest -sv tests/e2e/online_serving/test_minicpmo_4_5_expansion.py tests/e2e/online_serving/test_minicpmo_4_5.py tests/e2e/offline_inference/test_minicpmo_4_5.py --run-level "full_model" -m "full_model and H100 and omni"
         mirror_hardwares: h100_2
 
       - label: ":full_moon: Omni · MiniCPM-o 4.5 Duplex Test"


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

- Narrow the nightly Omni H100 function-test job on `minicpm-challenge` so it only runs MiniCPM-o 4.5 coverage, instead of the broad `tests/e2e` sweep with ignore filters.
- Explicitly target:
  - `tests/e2e/online_serving/test_minicpmo_4_5_expansion.py`
  - `tests/e2e/online_serving/test_minicpmo_4_5.py`
  - `tests/e2e/offline_inference/test_minicpmo_4_5.py`
- Keep markers/level unchanged: `-m "full_model and H100 and omni"` and `--run-level "full_model"`.
- Duplex MiniCPM-o coverage remains in the separate job `Omni · MiniCPM-o 4.5 Duplex Test`.

## Test Plan

**vLLM Version:** N/A (Buildkite YAML / test selection only)

**vLLM-Omni Commit:** `aec317d1`

- Dry-run collection for the updated command:

```bash
pytest -sv \
  tests/e2e/online_serving/test_minicpmo_4_5_expansion.py \
  tests/e2e/online_serving/test_minicpmo_4_5.py \
  tests/e2e/offline_inference/test_minicpmo_4_5.py \
  --run-level "full_model" -m "full_model and H100 and omni" --collect-only -q
```

- Rely on Buildkite nightly / label triggers for:
  - `Omni · Function Test with H100` (`h100_2`) on branch `minicpm-challenge`

## Test Result

- Pending Buildkite on `minicpm-challenge` for the updated MiniCPM-o 4.5 function-test job.
- No runtime product code changes in this PR (only `.buildkite/cuda/test-nightly.yml`).

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.