### PR TITLE
[BugFix] Fix ZMQ bind failed issue when launch HunyuanImage3.0 AR+DiT

### DIFF
--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -2082,6 +2082,41 @@ class OmniConnectorModelRunnerMixin:
     # ------------------------------------------------------------------ #
 
     @staticmethod
+    def _maybe_update_extra_args(name: str, extra: dict):
+        from vllm_omni.distributed.omni_connectors.utils.config import TRANSFER_ENGINE_CONNECTOR_NAMES
+        from vllm_omni.distributed.omni_connectors.utils.kv_utils import (
+            KV_RANK_PORT_STRIDE,
+            KV_REPLICA_PORT_STRIDE,
+            get_omni_replica_id,
+        )
+        from vllm_omni.distributed.omni_connectors.utils.local_rank import get_connector_local_rank
+
+        if name in TRANSFER_ENGINE_CONNECTOR_NAMES:
+            role = extra.get("role", "")
+            if role == "sender":
+                base_port = int(extra.get("zmq_port", 50051))
+                from_stage = extra.get("stage_id", 0)
+                local_rank = get_connector_local_rank()
+                replica_id = get_omni_replica_id()
+                port = base_port + replica_id * KV_REPLICA_PORT_STRIDE + local_rank * KV_RANK_PORT_STRIDE + from_stage
+                extra["zmq_port"] = port
+                logger.info(
+                    "Stage connector %s (sender) zmq_port=%d (base=%d stage=%d rank=%d replica=%d)",
+                    name,
+                    port,
+                    base_port,
+                    from_stage,
+                    local_rank,
+                    replica_id,
+                )
+            elif role == "receiver":
+                extra.setdefault("sender_zmq_port", extra.get("zmq_port", 50051))
+            else:
+                raise ValueError(f"Invalid role:{role} from connector_config.")
+        else:
+            raise NotImplementedError(f"{name} engine connector not supported.")
+
+    @staticmethod
     def _create_connector(model_config: Any) -> OmniConnectorBase | None:
         """Create a connector from model_config, or None if unconfigured."""
         connector_config = getattr(model_config, "stage_connector_config", None)
@@ -2105,6 +2140,9 @@ class OmniConnectorModelRunnerMixin:
         elif not isinstance(extra, dict):
             raise RuntimeError(f"Invalid extra config for connector {name}: expected dict, got {type(extra).__name__}")
 
+        OmniConnectorModelRunnerMixin._maybe_update_extra_args(name, extra)
+
+        # TODO: refine connector_spec
         spec = ConnectorSpec(name=name, extra=extra)
         try:
             return OmniConnectorFactory.create_connector(spec)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Fix HunyuanImage3.0 AR + DiT KV Cache Transfer issue:
1. bind duplicate port issue:
When I launch HunyuanImage3.0 AR+DiT, the code report address already in use issue:
```bash
(Worker pid=551770) ERROR 08-03 17:09:12 [mooncake_transfer_engine_connector.py:1025] ZMQ bind failed on 51.62.5.21:50051: Address already in use (addr='tcp://51.62.5.21:50051') (errno=98)
(Worker_TP0 pid=551769) INFO 08-03 17:09:12 [gpu_model_runner.py:5307] Starting to load model /data/HunyuanImage-3.0-Instruct/...
(Worker pid=551770) ERROR 08-03 17:09:12 [factory.py:49] Failed to create connector MooncakeTransferEngineConnector: MooncakeTransferEngineConnector failed to bind ZMQ on 51.62.5.21:50051: Address already in use (addr='tcp://51.62.5.21:50051')
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] WorkerProc failed to start.
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] Traceback (most recent call last):
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py", line 1020, in _zmq_listener_loop
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     socket.bind(f"tcp://{self.host}:{self.zmq_port}")
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/usr/local/lib/python3.12/dist-packages/zmq/sugar/socket.py", line 320, in bind
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     super().bind(addr)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "zmq/backend/cython/_zmq.py", line 1009, in zmq.backend.cython._zmq.Socket.bind
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     _check_rc(rc)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     ^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "zmq/backend/cython/_zmq.py", line 190, in zmq.backend.cython._zmq._check_rc
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     raise ZMQError(errno)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     ^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] zmq.error.ZMQError: Address already in use (addr='tcp://51.62.5.21:50051')
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] The above exception was the direct cause of the following exception:
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] Traceback (most recent call last):
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/factory.py", line 45, in create_connector
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     connector = constructor(spec.extra)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]                 ^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/factory.py", line 114, in _create_mooncake_transfer_engine_connector
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     return MooncakeTransferEngineConnector(config)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py", line 185, in __init__
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self._init_listener(config)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py", line 243, in _init_listener
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     raise RuntimeError(
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] RuntimeError: MooncakeTransferEngineConnector failed to bind ZMQ on 51.62.5.21:50051: Address already in use (addr='tcp://51.62.5.21:50051')
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] During handling of the above exception, another exception occurred:
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] Traceback (most recent call last):
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/worker/omni_connector_model_runner_mixin.py", line 2110, in _create_connector
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     return OmniConnectorFactory.create_connector(spec)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/distributed/omni_connectors/factory.py", line 50, in create_connector
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     raise ValueError(f"Failed to create connector {spec.name}: {e}")
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] ValueError: Failed to create connector MooncakeTransferEngineConnector: MooncakeTransferEngineConnector failed to bind ZMQ on 51.62.5.21:50051: Address already in use (addr='tcp://51.62.5.21:50051')
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] The above exception was the direct cause of the following exception:
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] 
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] Traceback (most recent call last):
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 879, in worker_main
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     worker = WorkerProc(*args, **kwargs)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     return func(*args, **kwargs)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm/vllm/v1/executor/multiproc_executor.py", line 640, in __init__
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self.worker.init_device()
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm/vllm/v1/worker/worker_base.py", line 331, in init_device
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self.worker.init_device()  # type: ignore
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     return func(*args, **kwargs)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/worker/gpu_ar_worker.py", line 120, in init_device
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self.model_runner = GPUARModelRunner(self.vllm_config, self.device)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/worker/gpu_ar_model_runner.py", line 341, in __init__
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self.init_omni_connectors(
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/worker/omni_connector_model_runner_mixin.py", line 99, in init_omni_connectors
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     self._omni_connector: OmniConnectorBase | None = self._create_connector(model_config)
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]   File "/home/f00910569/Projects/vllm-omni/vllm_omni/worker/omni_connector_model_runner_mixin.py", line 2112, in _create_connector
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912]     raise RuntimeError(f"Failed to create connector {name}") from exc
(Worker pid=551770) ERROR 08-03 17:09:12 [multiproc_executor.py:912] RuntimeError: Failed to create connector MooncakeTransferEngineConnector
```

## Test Plan
Launch model with AR:TP4, DiT: TP2
Using following python code to imitate curl:
```python
def edit_image_stream():
    url_edit = "http://127.0.0.1:8080/v1/images/edits"
    form_data = {
        "prompt": "Please refer to the image, generate a image of that dog running on grass.",
        "bot_task": "think",
        "size": "auto",
        "n": "1",
        "seed": "1234",
    }

    image_path = "./corgi.jpg"

    with open(image_path, "rb") as f:
        files = {"image": ("corgi.jpg", f, "image/jpeg")}
        response_edit = requests.post(url_edit, data=form_data, files=files)

    response_edit.raise_for_status()

    res_data_edit = response_edit.json()

    cot_output_edit = res_data_edit.get("cot_output")
    if cot_output_edit is None and "data" in res_data_edit and len(res_data_edit["data"]) > 0:
        cot_output_edit = res_data_edit["data"][0].get("cot_output")

    print(f"=== Edits: Chain of Thought Output ===\n{cot_output_edit}\n")

    b64_image_edit = res_data_edit.get("b64_json")
    if not b64_image_edit and "data" in res_data_edit and len(res_data_edit["data"]) > 0:
        b64_image_edit = res_data_edit["data"][0].get("b64_json")

    if b64_image_edit:
        img_bytes = base64.b64decode(b64_image_edit)
        output_path = "edited_output.png"
        with open(output_path, "wb") as f:
            f.write(img_bytes)
        print(f"Edited image successfully saved to {output_path}")
    else:
        print("Error: 'b64_json' not found in edits response.")


if __name__ == "__main__":
    edit_image_stream()

```
The refer image used:
<img width="472" height="452" alt="D60D39A2-ABAD-422E-AF50-30302E4C3EC2" src="https://github.com/user-attachments/assets/450a29c8-c581-4a31-9f87-dc54d30604e7" />

**vLLM Version:**
vllm:main
**vLLM-Omni Commit:**
vllm:main
## Test Result

Output after this PR applied:
```bash
(APIServer pid=521997) INFO 08-03 16:58:26 [omni_base.py:190] [AsyncOmni] AsyncOmniEngine initialized in 328.08 seconds
(APIServer pid=521997) INFO 08-03 16:58:26 [omni_base.py:210] [AsyncOmni] Initialized with 2 stages for model /data/HunyuanImage-3.0-Instruct/
[...]
(APIServer pid=521997) INFO 08-03 16:58:28 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=521997) INFO 08-03 16:58:28 [api_server.py:538] Starting vLLM API server 0 on http://0.0.0.0:8080
(APIServer pid=521997) INFO 08-03 16:58:28 [launcher.py:37] Available routes are:
(APIServer pid=521997) INFO 08-03 16:58:28 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=521997) INFO 08-03 16:58:28 [launcher.py:46] Route: /docs, Methods: HEAD, GET
[...]
(APIServer pid=521997) INFO 08-03 16:58:28 [launcher.py:57] Route: /v1/duplex, Endpoint: duplex_websocket
(APIServer pid=521997) INFO:     Started server process [521997]
(APIServer pid=521997) INFO:     Waiting for application startup.
(APIServer pid=521997) INFO:     Application startup complete.
(APIServer pid=521997) WARNING 08-03 16:58:40 [input_processor.py:283] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
(APIServer pid=521997) INFO 08-03 16:58:40 [hunyuan_image3.py:947] Successfully processed 1 image(s). Final tensor shapes: {'vit_pixel_values': (1, 1024, 768), 'vit_pixel_attention_mask': (1, 1024), 'vit_spatial_shapes': (1, 2), 'vae_token_grid_hw': (1, 2), 'vae_pixel_size': (1,), 'base_size': (1,), 'ratio_index': (1,), 'vae_pixel_values': (3145728,)}
(Worker_TP0 pid=530422) WARNING 08-03 16:58:41 [jit_monitor.py:135] Triton kernel JIT compilation during inference: kernel_unified_attention. This causes a latency spike; consider extending warmup to cover this shape/config.
(Worker_TP0 pid=530422) (Worker_TP1 pid=530423) (Worker_TP3 pid=530425) (Worker_TP2 pid=530424) INFO 08-03 16:58:41 [prefix_cache.py:160] Omni prefix cache async-write copy stream initialized.
INFO 08-03 16:58:41 [prefix_cache.py:160] Omni prefix cache async-write copy stream initialized.
INFO 08-03 16:58:41 [prefix_cache.py:160] Omni prefix cache async-write copy stream initialized.
INFO 08-03 16:58:41 [prefix_cache.py:160] Omni prefix cache async-write copy stream initialized.
(Worker_TP0 pid=530422) WARNING 08-03 16:58:41 [jit_monitor.py:135] Triton kernel JIT compilation during inference: reduce_segments. This causes a latency spike; consider extending warmup to cover this shape/config.
(APIServer pid=521997) INFO 08-03 16:59:06 [hunyuan_image3.py:174] [ar2diffusion] Request 0: AR generated 405 tokens, text length=2046, cot_text length=2004, target size=1024x1024 (AR ratio_idx=16)
(APIServer pid=521997) INFO 08-03 16:59:06 [orchestrator.py:1814] [Orchestrator] ar2diffusion req=img_edit-9f56a93c5b96c65d-9c891f9c wall_time=0.696ms stage=0->1
(APIServer pid=521997) INFO 08-03 16:59:06 [stage_diffusion_client.py:340] [StageDiffusionClient] stage-1 [rep-0] add request: img_edit-9f56a93c5b96c65d-9c891f9c
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:300] Sender info updated (default): host='51.62.5.21', zmq_port=50151
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:300] Sender info updated (default): host='51.62.5.21', zmq_port=50167
INFO 08-03 16:59:06 [kv_transfer_manager.py:959] Sender info updated: host=51.62.5.21, base_port=50151, adjusted_port=50151 (local_rank=0)
INFO 08-03 16:59:06 [kv_transfer_manager.py:959] Sender info updated: host=51.62.5.21, base_port=50151, adjusted_port=50167 (local_rank=1)
INFO 08-03 16:59:06 [kv_transfer_manager.py:1425] Wait for KV cache for request img_edit-9f56a93c5b96c65d-9c891f9c from stage 0 to 1 via 2 key(s)...
INFO 08-03 16:59:06 [kv_transfer_manager.py:1425] Wait for KV cache for request img_edit-9f56a93c5b96c65d-9c891f9c from stage 0 to 1 via 2 key(s)...
(Worker_TP2 pid=530424) INFO 08-03 16:59:06 [kv_transfer_manager.py:1152] KV cache serialized for img_edit-9f56a93c5b96c65d-9c891f9c in 0.9 ms
(Worker_TP0 pid=530422) (Worker_TP1 pid=530423) (Worker_TP3 pid=530425) INFO 08-03 16:59:06 [kv_transfer_manager.py:1152] KV cache serialized for img_edit-9f56a93c5b96c65d-9c891f9c in 0.9 ms
INFO 08-03 16:59:06 [kv_transfer_manager.py:1152] KV cache serialized for img_edit-9f56a93c5b96c65d-9c891f9c in 1.0 ms
INFO 08-03 16:59:06 [kv_transfer_manager.py:1152] KV cache serialized for img_edit-9f56a93c5b96c65d-9c891f9c in 1.0 ms
(Worker_TP2 pid=530424) (Worker_TP3 pid=530425) INFO 08-03 16:59:06 [kv_transfer_manager.py:1166] KV transfer OK: img_edit-9f56a93c5b96c65d-9c891f9c, 222108725 bytes across 1 key(s), 0.009s, 23905.0 MB/s
INFO 08-03 16:59:06 [kv_transfer_manager.py:1166] KV transfer OK: img_edit-9f56a93c5b96c65d-9c891f9c, 222108725 bytes across 1 key(s), 0.009s, 24617.5 MB/s
(Worker_TP0 pid=530422) INFO 08-03 16:59:06 [kv_transfer_manager.py:1166] KV transfer OK: img_edit-9f56a93c5b96c65d-9c891f9c, 222108725 bytes across 1 key(s), 0.009s, 24128.1 MB/s
(Worker_TP1 pid=530423) INFO 08-03 16:59:06 [kv_transfer_manager.py:1166] KV transfer OK: img_edit-9f56a93c5b96c65d-9c891f9c, 222108725 bytes across 1 key(s), 0.009s, 23946.3 MB/s
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:834] [RDMA GET] img_edit-9f56a93c5b96c65d-9c891f9c_0_0_2_1@0_1: query=0.3ms, alloc=0.0ms, rdma=92.9ms, sync=0.0ms, total=93.2ms, 2271.9 MB/s (fast_path, zero-copy)
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:834] [RDMA GET] img_edit-9f56a93c5b96c65d-9c891f9c_0_0_0_0@0_1: query=0.3ms, alloc=0.0ms, rdma=93.2ms, sync=0.0ms, total=93.6ms, 2264.1 MB/s (fast_path, zero-copy)
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:834] [RDMA GET] img_edit-9f56a93c5b96c65d-9c891f9c_0_0_3_1@0_1: query=0.4ms, alloc=0.0ms, rdma=66.2ms, sync=0.0ms, total=66.7ms, 3177.7 MB/s (fast_path, zero-copy)
INFO 08-03 16:59:06 [mooncake_transfer_engine_connector.py:834] [RDMA GET] img_edit-9f56a93c5b96c65d-9c891f9c_0_0_1_0@0_1: query=0.4ms, alloc=0.0ms, rdma=90.8ms, sync=0.0ms, total=91.2ms, 2322.2 MB/s (fast_path, zero-copy)
INFO 08-03 16:59:08 [kv_transfer_manager.py:1524] Successfully received KV cache for img_edit-9f56a93c5b96c65d-9c891f9c, 444217450 bytes across 2 key(s), wait=0.197s, link=161.5ms
/home/f00910569/Projects/vllm/vllm/distributed/parallel_state.py:834: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /__w/pytorch/pytorch/torch/csrc/utils/tensor_new.cpp:1556.)
  object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
INFO 08-03 16:59:08 [kv_transfer_manager.py:1524] Successfully received KV cache for img_edit-9f56a93c5b96c65d-9c891f9c, 444217450 bytes across 2 key(s), wait=0.222s, link=186.5ms
INFO 08-03 16:59:08 [pipeline_hunyuan_image3.py:2315] HunyuanImage3.0 runs without classifier-free guidance when guidance_scale <= 1.0.
INFO 08-03 16:59:08 [pipeline_hunyuan_image3.py:2315] HunyuanImage3.0 runs without classifier-free guidance when guidance_scale <= 1.0.
INFO 08-03 16:59:08 [pipeline_hunyuan_image3.py:1855] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6778, 4, 128])
INFO 08-03 16:59:08 [pipeline_hunyuan_image3.py:1855] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6778, 4, 128])
INFO 08-03 16:59:08 [hunyuan_image3_transformer.py:2928] Handling AR KV reuse with positive_reuse_len=6774, negative_reuse_len=None
INFO 08-03 16:59:08 [hunyuan_image3_transformer.py:2928] Handling AR KV reuse with positive_reuse_len=6774, negative_reuse_len=None
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:23<00:00,  2.16it/s]
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] 
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] [Overall Summary]
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] +-----------------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | Field                       |      Value |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] +-----------------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_requests                |          1 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_wall_time_ms            | 52,991.131 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_total_tokens            |      6,779 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_avg_time_per_request_ms | 52,991.131 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_avg_tokens_per_s        |    127.927 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | input_preprocess_time_ms    |     82.231 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_stage_0_wall_time_ms    | 25,858.361 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] | e2e_stage_1_wall_time_ms    | 27,009.613 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:765] +-----------------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] 
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] [RequestE2EStats [request_id=img_edit-9f56a93c5b96c65d-9c891f9c]]
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] +------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] | Field            |      Value |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] +------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] | e2e_total_ms     | 52,868.955 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] | e2e_total_tokens |      6,779 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:791] +------------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:832] [OmniTiming] req=img_edit-9f56a93c5b96c65d-9c891f9c total=52.87s preprocess=0.08s engine=52.79s stages=[0:25.86s,1:27.01s] transfers=[0->1=0.00ms] ar2diffusion=0.70ms
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] 
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] [StageRequestStats [request_id=img_edit-9f56a93c5b96c65d-9c891f9c]]
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] +---------------------------------+----------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | Field                           |              0 |          1 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] +---------------------------------+----------------+------------+
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | batch_id                        |              1 |          1 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | batch_size                      |              1 |          1 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | denoise_step_latency_ms         |          0.000 |    540.185 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | image_pixels                    |              0 |  1,048,576 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | inter_output_latencies_ms       |                |            |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | num_tokens_in                   |          6,374 |          0 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | num_tokens_out                  |            405 |          0 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | output_unit_count               |            405 |          1 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | output_unit_type                |           text |      image |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | serving_time_to_first_output_ms |     25,978.629 | 52,990.287 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | stage_gen_time_ms               |     25,857.122 | 27,009.268 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | time_per_output_unit_ms         |          0.002 |      0.000 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | vllm_itl_ms                     |         60.586 |      0.000 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | vllm_itls_ms                    | 60.586 (n=404) |            |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | vllm_tpot_ms                    |         60.586 |      0.000 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] | vllm_ttft_ms                    |      1,514.479 |      0.000 |
(APIServer pid=521997) INFO 08-03 16:59:33 [stats.py:874] +---------------------------------+----------------+------------+
(APIServer pid=521997) INFO:     127.0.0.1:42700 - "POST /v1/images/edits HTTP/1.1" 200 OK
```

Output image:
<img width="559" height="562" alt="D223B8F7-DEB5-4329-987E-0E9EEB2B15DF" src="https://github.com/user-attachments/assets/c2fa0b0c-9af0-4869-af58-929f2151c60f" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
