### PR TITLE
[Model] [Ascend] Add soundfile fallback for MiniMax H3 audio loading for NPU support

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3-NPU.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-NPU.md
@@ -20,7 +20,7 @@ environments. Differences from the GPU path:
 - Audio loading does **not** require TorchCodec (whose aarch64 wheels are
   built against CUDA torch and fail to load on CPU-only builds). vLLM-Omni
   automatically falls back to soundfile / ffmpeg for wav/mp3/m4a/mp4 audio
-  inputs. 
+  inputs.
 
 ## Prerequisites
 
@@ -40,8 +40,8 @@ hf download MiniMaxAI/MiniMax-H3 --local-dir "${MODEL_ROOT}"
 - CANN toolkit: 9.0.1
 - Python: 3.12
 - PyTorch: 2.10.0+cpu
-- TorchNpu: 2.10.0.post2
-- vLLM-Omni 安装：
+- torch_npu: 2.10.0.post2
+- Install vLLM-Omni from a checkout with MiniMax H3 support:
 
 ```bash
 uv venv
@@ -49,10 +49,12 @@ source .venv/bin/activate
 uv pip install -e .
 ```
 
-- `ffmpeg` / `ffprobe` 必须在 `PATH` 上（参考视频准备与 MP4 输出使用）。
-- `decord` 
-- 音频输入无需 TorchCodec：wav/mp3/m4a/mp4 均通过 soundfile / ffmpeg
-  fallback 以原生采样率加载。
+- `ffmpeg` and `ffprobe` must be available on `PATH`. They are used for
+  reference-video preparation and MP4 output.
+- Reference-video decoding uses `decord` when available and falls back to
+  PyAV otherwise.
+- Audio inputs do not require TorchCodec: wav/mp3/m4a/mp4 files are loaded
+  at native sample rate through the soundfile / ffmpeg fallback.
 
 ## Start a server
 
@@ -61,8 +63,12 @@ and FL2VA requests, or to `Ref2VA` for Ref2VA requests.
 
 ### Multi-NPU: 768P validated configuration
 
+Validated on eight NPUs of an Atlas 800I A3 server with Ulysses sequence
+parallelism degree 8, text-encoder tensor parallelism degree 8, native tiled
+VAE patch parallelism degree 8, and layerwise offload:
+
 ```bash
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PORT=9098
 export MODEL="${MODEL_ROOT}/FL2VA"
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -87,6 +93,10 @@ vllm serve "${MODEL}" \
   --diffusion-attention-backend FLASH_ATTN
 ```
 
+Do not add `--enforce-eager`. The first request includes regional
+compilation; warm the server once before measuring steady-state latency.
+H3 is CFG-distilled, so `--cfg-parallel-size` must remain 1.
+
 To serve Ref2VA, stop the FL2VA server and restart with:
 
 ```bash
@@ -95,43 +105,44 @@ export MODEL="${MODEL_ROOT}/Ref2VA"
 
 ## HTTP API examples
 
-请求方式与 GPU 版完全一致，见
-[MiniMax-H3.md § HTTP API examples](MiniMax-H3.md#http-api-examples)。
-注意在 NPU 环境下使用 **768P 规格**（如 `width=1344 height=768`）。
+The request format is identical to the GPU recipe; see
+[MiniMax-H3.md § HTTP API examples](MiniMax-H3.md#http-api-examples).
+Use the validated 768P shapes (e.g. `width=1344 height=768`) on NPU.
 
 ## Key parameters
 
-与 GPU 版一致，见 [MiniMax-H3.md § Key parameters](MiniMax-H3.md#key-parameters)。
-NPU 环境额外约束：
-
-| Parameter | Recommended value | Notes |
-|-----------|-------------------|-------|
-| `width`, `height` | 短边 ≤ 768（如 1344x768） | 2K 分辨率当前会 OOM |
+Same as the GPU recipe; see
+[MiniMax-H3.md § Key parameters](MiniMax-H3.md#key-parameters).
+The validated resolution on NPU is 768P (e.g. 1344x768).
 
 ## Validated NPU evidence
 
+Measured on an Atlas 800I A3 server (8x NPU) with CANN 9.0.1,
+PyTorch 2.10.0+cpu, and torch_npu 2.10.0.post2, using the multi-NPU
+configuration above:
+
 | Workload | Configuration | Observed result |
 |----------|---------------|-----------------|
-| T2VA, 209, 1344x768 | Text Encoder TP8, Dit offload + U8, VPP8 tile, regional compile | 480s |
-| Ref2VA（prompt+video）, 124, 1344x768 | Text Encoder TP8, Dit offload + U8, VPP8 tile, regional compile | 980s |
+| T2VA, 209 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile | 480 s end-to-end request latency |
+| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile | 980 s end-to-end request latency |
 
-- 验证环境：800I A3 x 8，CANN 9.0.1 /torch 2.10.0+cpu /torch_npu 2.10.0.post2
+These measurements describe the validated shapes rather than a general
+throughput guarantee.
 
 ## Known limitations
 
 - Each server process loads only one checkpoint partition.
 - H3 currently executes one generation request per diffusion batch.
-- The first regional-compile request is a warmup and should not be included in
-  steady-state performance measurements.
+- The first regional-compile request is a warmup and should not be included
+  in steady-state performance measurements.
 - Image+audio Ref2VA accepts exactly one image and one audio reference.
-- Video Ref2VA accepts one or more video files, but not an additional standalone
-  audio reference.
-- VAE patch parallelism requires size 1 or the full DiT group size and supports
-  the H3 native `tile` mode only.
-
+- Video Ref2VA accepts one or more video files, but not an additional
+  standalone audio reference.
+- VAE patch parallelism requires size 1 or the full DiT group size and
+  supports the H3 native `tile` mode only.
 
 ## Additional resources
 
-- [MiniMax-H3.md](MiniMax-H3.md)（GPU 版完整指南）
+- [MiniMax-H3.md](MiniMax-H3.md) — full GPU guide
 - [Supported models](../../docs/models/supported_models.md)
 - [Video API](../../docs/serving/videos_api.md)

--- a/recipes/MiniMaxAI/MiniMax-H3-NPU.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-NPU.md
@@ -49,6 +49,20 @@ source .venv/bin/activate
 uv pip install -e .
 ```
 
+Install the **mindie-sd** operator library to enable Ascend-optimized fused
+operators (`adalayernorm`, etc.):
+
+```bash
+git clone https://gitcode.com/Ascend/MindIE-SD.git && cd MindIE-SD
+
+# Comment out the tik_ops build step (not needed for this use case)
+sed -i 's|^\(\s*\)source ${current_script_dir}/build_tik_ops.sh|\1# source ${current_script_dir}/build_tik_ops.sh|' build/build_ops.sh
+
+python setup.py bdist_wheel
+cd dist
+pip install mindiesd-*.whl
+```
+
 - `ffmpeg` and `ffprobe` must be available on `PATH`. They are used for
   reference-video preparation and MP4 output.
 - Reference-video decoding uses `decord` when available and falls back to
@@ -121,10 +135,10 @@ Measured on an Atlas 800I A3 server (8x NPU) with CANN 9.0.1,
 PyTorch 2.10.0+cpu, and torch_npu 2.10.0.post2, using the multi-NPU
 configuration above:
 
-| Workload | Configuration | Observed result |
-|----------|---------------|-----------------|
-| T2VA, 209 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile | 480 s end-to-end request latency |
-| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile | 980 s end-to-end request latency |
+| Workload | Configuration |
+|----------|---------------|
+| T2VA, 209 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile |
+| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile |
 
 These measurements describe the validated shapes rather than a general
 throughput guarantee.

--- a/recipes/MiniMaxAI/MiniMax-H3-NPU.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-NPU.md
@@ -1,0 +1,137 @@
+# MiniMax H3 on Ascend NPU
+
+> Joint video and audio generation with text, first-frame, image/audio, or
+> multi-video conditions — Ascend NPU deployment guide
+
+## Summary
+
+- Vendor: MiniMaxAI
+- Model: [`MiniMaxAI/MiniMax-H3`](https://huggingface.co/MiniMaxAI/MiniMax-H3)
+- Tasks: T2VA, FL2VA, and Ref2VA
+- Mode: OpenAI-compatible `/v1/videos` HTTP serving
+- Hardware: Atlas 800I A3
+- Maintainer: Community
+
+This recipe adapts [MiniMax-H3.md](MiniMax-H3.md) for Ascend NPU
+environments. Differences from the GPU path:
+
+- Runs on a CPU-only (aarch64) PyTorch build with `torch_npu`; no CUDA
+  runtime is present.
+- Audio loading does **not** require TorchCodec (whose aarch64 wheels are
+  built against CUDA torch and fail to load on CPU-only builds). vLLM-Omni
+  automatically falls back to soundfile / ffmpeg for wav/mp3/m4a/mp4 audio
+  inputs. 
+
+## Prerequisites
+
+### Checkpoint
+
+Same as the GPU recipe — Hugging Face access approval is required:
+
+```bash
+hf auth login
+export MODEL_ROOT=/path/to/MiniMax-H3
+hf download MiniMaxAI/MiniMax-H3 --local-dir "${MODEL_ROOT}"
+```
+
+### Environment
+
+- Ascend driver & firmware: 25.5.1
+- CANN toolkit: 9.0.1
+- Python: 3.12
+- PyTorch: 2.10.0+cpu
+- TorchNpu: 2.10.0.post2
+- vLLM-Omni 安装：
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+```
+
+- `ffmpeg` / `ffprobe` 必须在 `PATH` 上（参考视频准备与 MP4 输出使用）。
+- `decord` 
+- 音频输入无需 TorchCodec：wav/mp3/m4a/mp4 均通过 soundfile / ffmpeg
+  fallback 以原生采样率加载。
+
+## Start a server
+
+One server loads one checkpoint partition. Set `MODEL` to `FL2VA` for T2VA
+and FL2VA requests, or to `Ref2VA` for Ref2VA requests.
+
+### Multi-NPU: 768P validated configuration
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+export PORT=9098
+export MODEL="${MODEL_ROOT}/FL2VA"
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800
+export PYTHONDONTWRITEBYTECODE=1
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+vllm serve "${MODEL}" \
+  --omni \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --trust-remote-code \
+  --num-gpus 8 \
+  --usp 8 \
+  --ring 1 \
+  --text-encoder-tp-size 8 \
+  --enable-layerwise-offload \
+  --vae-parallel-mode tile \
+  --vae-use-tiling \
+  --vae-patch-parallel-size 8 \
+  --diffusion-attention-backend FLASH_ATTN
+```
+
+To serve Ref2VA, stop the FL2VA server and restart with:
+
+```bash
+export MODEL="${MODEL_ROOT}/Ref2VA"
+```
+
+## HTTP API examples
+
+请求方式与 GPU 版完全一致，见
+[MiniMax-H3.md § HTTP API examples](MiniMax-H3.md#http-api-examples)。
+注意在 NPU 环境下使用 **768P 规格**（如 `width=1344 height=768`）。
+
+## Key parameters
+
+与 GPU 版一致，见 [MiniMax-H3.md § Key parameters](MiniMax-H3.md#key-parameters)。
+NPU 环境额外约束：
+
+| Parameter | Recommended value | Notes |
+|-----------|-------------------|-------|
+| `width`, `height` | 短边 ≤ 768（如 1344x768） | 2K 分辨率当前会 OOM |
+
+## Validated NPU evidence
+
+| Workload | Configuration | Observed result |
+|----------|---------------|-----------------|
+| T2VA, 209, 1344x768 | Text Encoder TP8, Dit offload + U8, VPP8 tile, regional compile | 480s |
+| Ref2VA（prompt+video）, 124, 1344x768 | Text Encoder TP8, Dit offload + U8, VPP8 tile, regional compile | 980s |
+
+- 验证环境：800I A3 x 8，CANN 9.0.1 /torch 2.10.0+cpu /torch_npu 2.10.0.post2
+
+## Known limitations
+
+- Each server process loads only one checkpoint partition.
+- H3 currently executes one generation request per diffusion batch.
+- The first regional-compile request is a warmup and should not be included in
+  steady-state performance measurements.
+- Image+audio Ref2VA accepts exactly one image and one audio reference.
+- Video Ref2VA accepts one or more video files, but not an additional standalone
+  audio reference.
+- VAE patch parallelism requires size 1 or the full DiT group size and supports
+  the H3 native `tile` mode only.
+
+
+## Additional resources
+
+- [MiniMax-H3.md](MiniMax-H3.md)（GPU 版完整指南）
+- [Supported models](../../docs/models/supported_models.md)
+- [Video API](../../docs/serving/videos_api.md)

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -65,6 +65,7 @@ from .presentation import (
     minimax_h3_text_only_ids,
 )
 from .reference_video import (
+    load_audio_file,
     load_video_audio,
     load_video_frames,
     prepare_reference_videos,
@@ -146,14 +147,12 @@ def _load_image(value: Any) -> Image.Image:
 
 
 def _load_audio(value: Any) -> tuple[torch.Tensor, int]:
-    import torchaudio
-
     if isinstance(value, list):
         if len(value) != 1:
             raise ValueError("MiniMax H3 currently supports exactly one audio")
         value = value[0]
     if isinstance(value, (str, os.PathLike)):
-        return torchaudio.load(str(value))
+        return load_audio_file(str(value))
     if isinstance(value, tuple) and len(value) == 2:
         waveform, sample_rate = value
         waveform = torch.as_tensor(waveform).float()

--- a/vllm_omni/diffusion/models/minimax_h3/reference_video.py
+++ b/vllm_omni/diffusion/models/minimax_h3/reference_video.py
@@ -260,10 +260,57 @@ def sample_reference_video_frames(
     }
 
 
+def _soundfile_to_waveform(path: str) -> tuple[torch.Tensor, int]:
+    import soundfile as sf
+
+    data, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    # soundfile is (samples, channels); torchaudio.load is (channels, samples).
+    waveform = torch.from_numpy(data).t().contiguous()
+    return waveform, int(sample_rate)
+
+
+def load_audio_file(path: str) -> tuple[torch.Tensor, int]:
+    """Load an audio file as ``(waveform[C, T] float32, sample_rate)``.
+
+    torchaudio 2.6+ routes ``load`` through TorchCodec, whose wheels do not load
+    on aarch64 with a CPU-only torch (they link CUDA libraries that are absent).
+    Fall back to soundfile; if the container is not libsndfile-readable (e.g.
+    mp3/m4a/mp4), demux to wav with ffmpeg first so any ffmpeg-supported input
+    works at its native sample rate.
+    """
+    try:
+        import torchaudio
+
+        return torchaudio.load(path)
+    except (ImportError, RuntimeError, OSError):
+        pass
+    try:
+        return _soundfile_to_waveform(path)
+    except Exception:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="minimax_h3_audio_") as tmpdir:
+            wav = str(Path(tmpdir) / "audio.wav")
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-i",
+                    path,
+                    "-vn",
+                    "-f",
+                    "wav",
+                    wav,
+                ],
+                check=True,
+            )
+            return _soundfile_to_waveform(wav)
+
+
 def load_video_audio(path: str) -> tuple[torch.Tensor, int]:
     import tempfile
-
-    import torchaudio
 
     with tempfile.TemporaryDirectory(prefix="minimax_h3_video_audio_") as tmpdir:
         output = str(Path(tmpdir) / "audio.wav")
@@ -286,10 +333,11 @@ def load_video_audio(path: str) -> tuple[torch.Tensor, int]:
             ],
             check=True,
         )
-        return torchaudio.load(output)
+        return load_audio_file(output)
 
 
 __all__ = [
+    "load_audio_file",
     "load_video_audio",
     "load_video_frames",
     "prepare_reference_videos",


### PR DESCRIPTION
## Purpose

### 1. Soundfile fallback for MiniMax H3 audio loading

torchaudio 2.6+ routes `load()` through TorchCodec, whose aarch64 wheels are
built against a CUDA torch and fail to load (`libnvrtc.so.13` missing) under a
CPU-only torch (e.g. Ascend/NPU environments). This breaks MiniMax H3 ref2va
video+audio input with:

    RuntimeError: TorchCodec is required for load_with_torchcodec

This PR routes both audio load sites (`reference_video.load_video_audio` and
pipeline `_load_audio`) through a new `load_audio_file()` helper that tries
torchaudio first, then falls back to soundfile, then to an ffmpeg-demux
fallback — so wav/mp3/m4a/mp4 inputs all work at native sample rate without
requiring TorchCodec.

Behavior is unchanged on platforms where torchaudio/TorchCodec works; the
fallback chain only activates when the primary path raises.

### 2. Ascend NPU recipe for MiniMax H3

Adds `recipes/MiniMaxAI/MiniMax-H3-NPU.md`, an Ascend NPU deployment guide
adapted from the GPU recipe (`recipes/MiniMaxAI/MiniMax-H3.md`):

- Environment: Atlas 800I A3, aarch64 CPU-only PyTorch 2.10.0 + torch_npu
  2.10.0.post2, CANN 9.0.1; no CUDA runtime required
- Validated multi-NPU configuration: 8x NPU with Ulysses 8, text-encoder
  TP 8, native tiled VAE patch parallelism 8, and layerwise offload
- Documents that audio inputs work without TorchCodec via the fallback
  introduced in this PR
- Reuses the GPU recipe's HTTP API examples and parameter tables by
  reference to avoid duplicated content

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** &lt;推送后的最新 commit sha&gt;

1. On an Atlas 800I A3 (8x NPU) with CPU-only torch (no TorchCodec), follow
   the new NPU recipe to serve the `FL2VA` and `Ref2VA` partitions and run
   T2VA and Ref2VA (prompt + video) requests at 1344x768.
2. Exercise the audio fallback chain with wav / mp3 / m4a inputs and with a
   reference video carrying an embedded audio track (mp4).
3. Regression: on a CUDA torch environment where TorchCodec loads normally,
   confirm the primary torchaudio path is used and outputs are identical.

## Test Result

Validated on an Atlas 800I A3 server (8x NPU), CANN 9.0.1,
PyTorch 2.10.0+cpu, torch_npu 2.10.0.post2:

| Workload | Configuration | 
|----------|---------------|-
| T2VA, 209 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile | 
| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile |

Audio fallback verified on the same NPU environment: wav/mp3/m4a/mp4
reference inputs load at native sample rate without TorchCodec.

1. t2va
输入prompt: In a snowy blue-purple forest, Ori carefully walks past a sleeping giant; footsteps crunch in the snow while the creature breathes and softly snorts.
生成视频：

https://github.com/user-attachments/assets/d79eda49-5b18-445a-a19f-198796b3f73d

2. fl2va
输入prompt: A little girl grows up.
输入首帧参考图像：
<img width="1280" height="720" alt="first_frame" src="https://github.com/user-attachments/assets/0581dbb2-0e6a-432f-b141-10328cd1d533" />
生成视频：

https://github.com/user-attachments/assets/b790b88b-0155-4c59-8ec7-e046f9024094

3. refva
输入prompt: 参考 Video 1 的希区柯克镜头运动，人物沿古老石板小巷行走，背景纵深产生标志性的推拉变形；沿用 Video 1 音轨中的人声节奏与环境氛围，自然采光，电影感色调。
输入参考视频：

https://github.com/user-attachments/assets/082c985c-448b-4806-9627-ee0b7764a7bb

生成视频：

https://github.com/user-attachments/assets/2f9436a7-f607-4c8c-adb7-0c6a4d527a8d

