### PR TITLE
[Bugfix][CosyVoice3] Fix DiT streaming chunk attention mask

### DIFF
--- a/vllm_omni/diffusion/models/cosyvoice3_audio/cosyvoice3_dit.py
+++ b/vllm_omni/diffusion/models/cosyvoice3_audio/cosyvoice3_dit.py
@@ -15,8 +15,8 @@ from torch import nn
 from vllm.logger import init_logger
 from x_transformers.x_transformers import RotaryEmbedding, apply_rotary_pos_emb
 
-from vllm_omni.diffusion.attention.layer import Attention as DiffusionAttention
 from vllm_omni.model_executor.layers.timestep_embedding import DiTTimestepEmbedding
+from vllm_omni.model_executor.models.cosyvoice3.utils import add_optional_chunk_mask
 
 logger = init_logger(__name__)
 
@@ -69,10 +69,12 @@ class FeedForward(nn.Module):
 
 
 class DiTAttention(nn.Module):
-    """Attention module using diffusion infrastructure for optimized backends.
+    """DiT self-attention aligned with CosyVoice3_split ``AttnProcessor``.
 
-    This replaces the original Attention class to leverage FlashAttention,
-    SageAttention, or SDPA backends automatically.
+    Uses ``scaled_dot_product_attention`` with an explicit attention mask so
+    streaming chunk masks actually constrain who can attend to whom. The previous
+    DiffusionAttention path ignored the mask inside softmax and only zeroed
+    outputs afterward, which breaks CosyVoice3 streaming semantics.
     """
 
     def __init__(
@@ -83,6 +85,8 @@ class DiTAttention(nn.Module):
         dropout: float = 0.0,
     ):
         super().__init__()
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("DiTAttention requires PyTorch 2.0+ for SDPA.")
         self.dim = dim
         self.heads = heads
         self.dim_head = dim_head
@@ -90,21 +94,10 @@ class DiTAttention(nn.Module):
         self.dropout = dropout
         self.scale = 1.0 / math.sqrt(dim_head)
 
-        # Q/K/V projections
         self.to_q = nn.Linear(dim, self.inner_dim)
         self.to_k = nn.Linear(dim, self.inner_dim)
         self.to_v = nn.Linear(dim, self.inner_dim)
-
-        # Output projection
         self.to_out = nn.Sequential(nn.Linear(self.inner_dim, dim), nn.Dropout(dropout))
-
-        # Diffusion attention backend (Flash/Sage/SDPA)
-        self.attn = DiffusionAttention(
-            num_heads=heads,
-            head_size=dim_head,
-            softmax_scale=self.scale,
-            causal=False,
-        )
 
     def forward(
         self,
@@ -112,44 +105,44 @@ class DiTAttention(nn.Module):
         mask: torch.Tensor | None = None,
         rope=None,
     ) -> torch.Tensor:
-        batch_size, seq_len = x.shape[0], x.shape[1]
+        batch_size = x.shape[0]
 
-        # Project to Q, K, V
         query = self.to_q(x)
         key = self.to_k(x)
         value = self.to_v(x)
 
-        # Apply rotary position embedding
         if rope is not None:
             freqs, xpos_scale = rope
             q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
             query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
             key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
 
-        # Reshape for attention: (batch, seq, heads, head_dim)
-        query = query.view(batch_size, seq_len, self.heads, self.dim_head)
-        key = key.view(batch_size, seq_len, self.heads, self.dim_head)
-        value = value.view(batch_size, seq_len, self.heads, self.dim_head)
+        # (B, H, L, D) — same layout as CosyVoice3_split AttnProcessor
+        query = query.view(batch_size, -1, self.heads, self.dim_head).transpose(1, 2)
+        key = key.view(batch_size, -1, self.heads, self.dim_head).transpose(1, 2)
+        value = value.view(batch_size, -1, self.heads, self.dim_head).transpose(1, 2)
 
-        # Use diffusion attention backend
-        # The diffusion Attention layer expects (batch, seq, heads, head_dim)
-        out = self.attn(query, key, value, attn_metadata=None)
+        attn_mask = None
+        if mask is not None:
+            attn_mask = mask
+            if attn_mask.dim() == 2:
+                # (B, L) pad mask -> (B, H, L, L)
+                attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)
+                attn_mask = attn_mask.expand(batch_size, self.heads, query.shape[-2], key.shape[-2])
 
-        # Some attention backends return a non-contiguous layout.
-        out = out.reshape(batch_size, seq_len, self.inner_dim)
+        out = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        out = out.transpose(1, 2).reshape(batch_size, -1, self.inner_dim)
         out = out.to(query.dtype)
-
-        # Output projection
         out = self.to_out(out)
 
-        # Apply mask if provided
+        # Zero padded / invalid query rows (CosyVoice post-attention hygiene).
         if mask is not None:
             if mask.dim() == 2:
-                mask = mask.unsqueeze(-1)
-            elif mask.dim() == 4:
-                # (batch, heads, seq, seq) -> use last dim
-                mask = mask[:, 0, -1].unsqueeze(-1)
-            out = out.masked_fill(~mask.bool(), 0.0)
+                out_mask = mask.unsqueeze(-1)
+            else:
+                # (B, 1, L, L) or (B, H, L, L) -> validity of last query row keys
+                out_mask = mask[:, 0, -1].unsqueeze(-1)
+            out = out.masked_fill(~out_mask.bool(), 0.0)
 
         return out
 
@@ -384,7 +377,13 @@ class DiT(nn.Module):
         self.static_chunk_size = static_chunk_size
         self.num_decoding_left_chunks = num_decoding_left_chunks
 
-    def forward(self, x, mask, mu, t, spks=None, cond=None):
+    def forward(self, x, mask, mu, t, spks=None, cond=None, streaming: bool = False):
+        """Forward aligned with CosyVoice3_split ``flow/DiT/dit.py``.
+
+        When ``streaming=True``, attention uses a static chunk mask
+        (``static_chunk_size``) so each frame only attends within the allowed
+        causal chunk window — required for CosyVoice3 streaming flow matching.
+        """
         x = x.transpose(1, 2)
         mu = mu.transpose(1, 2)
         cond = cond.transpose(1, 2)
@@ -402,7 +401,15 @@ class DiT(nn.Module):
         if self.long_skip_connection is not None:
             residual = x
 
-        attn_mask = mask.bool().repeat(1, x.size(1), 1).unsqueeze(dim=1)
+        # Match CosyVoice3_split DiT.forward mask construction exactly.
+        if streaming is True:
+            attn_mask = add_optional_chunk_mask(x, mask.bool(), False, False, 0, self.static_chunk_size, -1).unsqueeze(
+                dim=1
+            )
+        else:
+            attn_mask = (
+                add_optional_chunk_mask(x, mask.bool(), False, False, 0, 0, -1).repeat(1, x.size(1), 1).unsqueeze(dim=1)
+            )
 
         for block in self.transformer_blocks:
             x = block(x, t, mask=attn_mask.bool(), rope=rope)

--- a/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/cfm.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/cfm.py
@@ -3,6 +3,7 @@
 # Adopted from https://github.com/FunAudioLLM/CosyVoice/tree/main/cosyvoice/flow
 """Conditional Flow Matching (CFM) classes for audio generation."""
 
+import inspect
 from abc import ABC
 
 import torch
@@ -89,7 +90,7 @@ class ConditionalCFM(BASECFM):
             t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
         return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), cache
 
-    def solve_euler(self, x, t_span, mu, mask, spks, cond):
+    def solve_euler(self, x, t_span, mu, mask, spks, cond, streaming: bool = False):
         """
         Fixed euler solver for ODEs.
         Args:
@@ -103,6 +104,7 @@ class ConditionalCFM(BASECFM):
             spks (torch.Tensor, optional): speaker ids. Defaults to None.
                 shape: (batch_size, spk_emb_dim)
             cond (Optional[Any], optional): Not used but kept for future purposes
+            streaming: forwarded to the PyTorch DiT estimator (chunk attention).
         """
         t, _, dt = t_span[0], t_span[-1], t_span[1] - t_span[0]
         t = t.unsqueeze(dim=0)
@@ -126,7 +128,7 @@ class ConditionalCFM(BASECFM):
             t_in[:] = t.unsqueeze(0)
             spks_in[0] = spks
             cond_in[0] = cond
-            dphi_dt = self.forward_estimator(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+            dphi_dt = self.forward_estimator(x_in, mask_in, mu_in, t_in, spks_in, cond_in, streaming=streaming)
             dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
             dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
             x = x + dt * dphi_dt
@@ -137,8 +139,17 @@ class ConditionalCFM(BASECFM):
 
         return sol[-1].float()
 
-    def forward_estimator(self, x, mask, mu, t, spks, cond):
+    def forward_estimator(self, x, mask, mu, t, spks, cond, streaming: bool = False):
         if isinstance(self.estimator, torch.nn.Module):
+            # CosyVoice3_split passes streaming into DiT; keep TRT path unchanged
+            # (chunk mask is baked into the ONNX/engine if present).
+            forward_fn = self.estimator.forward
+            try:
+                params = inspect.signature(forward_fn).parameters
+            except (TypeError, ValueError):
+                params = {}
+            if "streaming" in params:
+                return self.estimator(x, mask, mu, t, spks, cond, streaming=streaming)
             return self.estimator(x, mask, mu, t, spks, cond)
         else:
             # TensorRT estimator: bind raw device pointers. The flow runs in
@@ -200,6 +211,7 @@ class CausalConditionalCFM(ConditionalCFM):
             spks (torch.Tensor, optional): speaker ids. Defaults to None.
                 shape: (batch_size, spk_emb_dim)
             cond (Optional[Any], optional): Not used but kept for future purposes
+            streaming: forwarded to the DiT estimator for chunk attention.
 
         Returns:
             sample (torch.Tensor): generated mel-spectrogram
@@ -221,7 +233,7 @@ class CausalConditionalCFM(ConditionalCFM):
         if self.t_scheduler == "cosine":
             t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
 
-        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), None
+        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond, streaming=streaming), None
 
 
 class CausalMaskedDiffWithDiT(torch.nn.Module):

--- a/vllm_omni/model_executor/models/cosyvoice3/utils.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/utils.py
@@ -273,3 +273,77 @@ def make_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
     seq_length_expand = lengths.unsqueeze(-1)
     mask = seq_range_expand >= seq_length_expand
     return mask
+
+
+def subsequent_chunk_mask(
+    size: int,
+    chunk_size: int,
+    num_left_chunks: int = -1,
+    device: torch.device = torch.device("cpu"),
+) -> torch.Tensor:
+    """Create chunk-wise causal mask ``(size, size)`` for streaming DiT/encoder.
+
+    Aligned with CosyVoice3_split ``cosyvoice/utils/mask.py``.
+    ``True`` means the query position may attend to that key position.
+
+    Example (size=4, chunk_size=2)::
+
+        [[1, 1, 0, 0],
+         [1, 1, 0, 0],
+         [1, 1, 1, 1],
+         [1, 1, 1, 1]]
+    """
+    del num_left_chunks  # CosyVoice ONNX-friendly impl does not use left-chunk limit.
+    pos_idx = torch.arange(size, device=device)
+    block_value = (torch.div(pos_idx, chunk_size, rounding_mode="trunc") + 1) * chunk_size
+    return pos_idx.unsqueeze(0) < block_value.unsqueeze(1)
+
+
+def add_optional_chunk_mask(
+    xs: torch.Tensor,
+    masks: torch.Tensor,
+    use_dynamic_chunk: bool,
+    use_dynamic_left_chunk: bool,
+    decoding_chunk_size: int,
+    static_chunk_size: int,
+    num_decoding_left_chunks: int,
+    enable_full_context: bool = True,
+) -> torch.Tensor:
+    """Apply optional chunk / pad mask for CosyVoice DiT attention.
+
+    Aligned with CosyVoice3_split ``add_optional_chunk_mask``.
+    Inference path used by CosyVoice3 DiT:
+
+    - ``streaming=True`` → ``static_chunk_size > 0`` chunk mask
+    - ``streaming=False`` → ``static_chunk_size=0`` → pad mask only
+    """
+    del use_dynamic_left_chunk  # unused on CosyVoice3 DiT inference path
+    if use_dynamic_chunk:
+        max_len = xs.size(1)
+        if decoding_chunk_size < 0:
+            chunk_size = max_len
+            num_left_chunks = -1
+        elif decoding_chunk_size > 0:
+            chunk_size = decoding_chunk_size
+            num_left_chunks = num_decoding_left_chunks
+        else:
+            chunk_size = torch.randint(1, max_len, (1,)).item()
+            num_left_chunks = -1
+            if chunk_size > max_len // 2 and enable_full_context:
+                chunk_size = max_len
+            else:
+                chunk_size = chunk_size % 25 + 1
+        chunk_masks = subsequent_chunk_mask(xs.size(1), chunk_size, num_left_chunks, xs.device)
+        chunk_masks = chunk_masks.unsqueeze(0)
+        chunk_masks = masks & chunk_masks
+    elif static_chunk_size > 0:
+        chunk_masks = subsequent_chunk_mask(xs.size(1), static_chunk_size, num_decoding_left_chunks, xs.device)
+        chunk_masks = chunk_masks.unsqueeze(0)
+        chunk_masks = masks & chunk_masks
+    else:
+        chunk_masks = masks
+    assert chunk_masks.dtype == torch.bool
+    if (chunk_masks.sum(dim=-1) == 0).sum().item() != 0:
+        logger.warning("chunk_masks all-false at some timestep; forcing True so positions stay valid")
+        chunk_masks[chunk_masks.sum(dim=-1) == 0] = True
+    return chunk_masks


### PR DESCRIPTION
## Purpose

CosyVoice3 streaming code2wav requires chunk attention masks so each frame only attends within its allowed time window. The current `cosyvoice3_dit.py` uses `DiffusionAttention`, which does not pass the mask into softmax—it only zeroes outputs afterward via `masked_fill`. That breaks streaming semantics.

This PR:
- Switches `DiTAttention` to `F.scaled_dot_product_attention(..., attn_mask=...)` so masks take effect before softmax
- Adds `subsequent_chunk_mask` / `add_optional_chunk_mask` (aligned with CosyVoice3_split)
- Forwards `streaming` from CFM to the PyTorch DiT estimator (TRT path unchanged)

## Test Plan

- [x] Tests covering the three changed files: `DiTAttention`, `DiTBlock`, `DiT`, `subsequent_chunk_mask` / `add_optional_chunk_mask`, and CFM `streaming` passthrough
- [x] `pre-commit run --files` on the three changed files

**vLLM Version:** N/A (CosyVoice3 DiT mask fix only)

**vLLM-Omni Commit:** 67c54777 (base main)

## Test Result

**Environment:** NVIDIA GeForce RTX 4090, Python 3.12.13, torch 2.11.0+cu130, vllm 0.22.0, diffusers 0.38.0

**Tests for changed code:** 24 passed, 0 failed

Covers `test_cosyvoice3_components.py` (`TestDiTAttention`, `TestDiTBlock`, `TestDiT`) and `test_cosyvoice3_utils.py` (padding / chunk-mask helpers), with PR sources overlaid on the test runtime.

**pre-commit (Windows, 3 changed files):** Passed (ruff check/format, typos, whitespace)

<details>
<summary>Full-suite runs (failures are outside this PR's diff)</summary>

We also ran the broader CosyVoice3 suites on the same machine. This PR only touches `cosyvoice3_dit.py`, `utils.py` (chunk-mask helpers), and `cfm.py` (streaming flag passthrough). The failures below are in other modules and reproduce without these changes:

| Test | Failure | Why unrelated |
|------|---------|---------------|
| `test_forward_reuses_streaming_cache_state_between_chunks` | `AttributeError: CosyVoice3Model has no attribute '_stage1_chunk_counter'` | Bug/missing field in `cosyvoice3.py` talker→code2wav path; file not modified |
| `test_forward_clears_streaming_cache_on_terminal_chunk` | Same `_stage1_chunk_counter` error | Same as above |
| `test_sample_uses_ras_rejection_for_recent_repetition` | RAS sampler returned `[[1]]` instead of expected `[[2]]` | Talker RAS sampling logic; no sampler changes in this PR |
| `test_talker2code2wav_async_chunk_uses_initial_codec_chunk_frames_for_first_emit` | First async-chunk payload not `None` as test expects | Async-chunk framing in `stage_input_processors/cosyvoice3.py`; not modified (this PR only forwards `streaming` inside CFM→DiT) |

</details>
