### PR TITLE
[bugfix][CI][MiniCPM-o] fix CI failure of test_audio_to_text_audio_001 in Buildkit 13077

### DIFF
--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -140,6 +140,13 @@ def test_audio_to_text_audio_001(omni_server, openai_client) -> None:
         "messages": messages,
         "stream": True,
         "key_words": {"text": ["Beijing"]},
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())


### PR DESCRIPTION
## Purpose
Fix failure of `tests/e2e/online_serving/test_minicpmo_4_5.py::test_audio_to_text_audio_001[async_chunk]` in [Buildkit 13077](https://buildkite.com/vllm/vllm-omni/builds/13077/list?sid=019fc3db-cd0f-4a4d-8f75-e0b0a787ef05&tab=output)

Refer to #5623 

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** current commit

Run:
```
pytest tests/e2e/online_serving/test_minicpmo_4_5.py::test_audio_to_text_audio_001[async_chunk] --run-level "full_model" -m "full_model and H100 and omni" --ignore=tests/e2e/accuracy --ignore=tests/e2e/online_serving/test_qwen3_omni_multi_replicas.py --ignore=tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
```

## Test Result

```
=================================================== 1 passed, 15 warnings in 385.29s (0:06:25) ===================================================
```
