### PR TITLE
[diffusion][feature] Enable online FP8 for MiniMax-H3

### DIFF
--- a/benchmarks/diffusion/benchmark_minimax_h3_fp8.py
+++ b/benchmarks/diffusion/benchmark_minimax_h3_fp8.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reproduce the MiniMax-H3 BF16/FP8 latency and memory comparison.
+
+Example:
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3 \
+    python benchmarks/diffusion/benchmark_minimax_h3_fp8.py \
+        --model /path/to/MiniMax-H3/FL2VA \
+        --output-dir ./minimax-h3-fp8-benchmark
+
+The default workload matches the full benchmark reported in the MiniMax-H3
+online-FP8 pull request: T2VA, 1344x768, 5 seconds, 50 inference steps, and one
+warmup followed by one measured request. BF16 and FP8 run in separate child
+processes so CUDA and distributed state cannot leak between configurations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROMPT = (
+    "At night, three cats march into a bedroom playing tiny brass instruments, "
+    "then abruptly file out, with synchronized room ambience."
+)
+WORKER_MODE_ENV = "VLLM_OMNI_MINIMAX_H3_BENCH_MODE"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Local path to the MiniMax-H3 FL2VA partition.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("minimax-h3-fp8-benchmark"),
+        help="Directory for MP4 files and JSON summaries.",
+    )
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--duration-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--num-runs",
+        type=int,
+        default=2,
+        help="Requests per mode. Run 1 is warmup; run 2 is measured by default.",
+    )
+    return parser.parse_args()
+
+
+def _array_sha256(value: Any) -> str:
+    import numpy as np
+
+    array = np.ascontiguousarray(value)
+    return hashlib.sha256(array.tobytes()).hexdigest()
+
+
+def _peak_memory_mb(result: Any) -> float:
+    value = getattr(result, "peak_memory_mb", 0.0)
+    if not value:
+        inner = getattr(result, "request_output", None)
+        value = getattr(inner, "peak_memory_mb", 0.0)
+    return float(value or 0.0)
+
+
+def _validate_mp4(path: Path) -> dict[str, int]:
+    import av
+
+    with av.open(str(path)) as container:
+        decoded_video_frames = sum(1 for _ in container.decode(video=0))
+    with av.open(str(path)) as container:
+        decoded_audio_frames = sum(1 for _ in container.decode(audio=0))
+    if decoded_video_frames == 0 or decoded_audio_frames == 0:
+        raise RuntimeError(
+            f"Expected decodable video and audio in {path}, got "
+            f"video_frames={decoded_video_frames}, audio_frames={decoded_audio_frames}"
+        )
+    return {
+        "decoded_video_frames": decoded_video_frames,
+        "decoded_audio_frames": decoded_audio_frames,
+    }
+
+
+def _run_worker(args: argparse.Namespace, mode: str) -> None:
+    import numpy as np
+    import torch
+
+    from vllm_omni.diffusion.data import DiffusionParallelConfig
+    from vllm_omni.diffusion.utils.media_utils import mux_video_audio_bytes
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    visible_device_count = torch.accelerator.device_count()
+    if visible_device_count != 4:
+        raise RuntimeError(
+            "This benchmark requires exactly four visible GPUs; set CUDA_VISIBLE_DEVICES to four B300 devices."
+        )
+
+    mode_dir = args.output_dir / mode
+    mode_dir.mkdir(parents=True, exist_ok=True)
+    quantization = "fp8" if mode == "fp8" else None
+    hardware = []
+    for device_index in range(visible_device_count):
+        properties = torch.cuda.get_device_properties(device_index)
+        hardware.append(
+            {
+                "logical_index": device_index,
+                "name": properties.name,
+                "compute_capability": f"{properties.major}.{properties.minor}",
+                "total_memory_gib": properties.total_memory / 2**30,
+            }
+        )
+
+    engine = Omni(
+        model=args.model,
+        parallel_config=DiffusionParallelConfig(
+            tensor_parallel_size=4,
+            ulysses_degree=1,
+            ring_degree=1,
+            text_encoder_tp_size=4,
+            vae_patch_parallel_size=4,
+            vae_parallel_mode="tile",
+        ),
+        trust_remote_code=True,
+        enable_cpu_offload=False,
+        enforce_eager=False,
+        diffusion_attention_backend="CUDNN_ATTN",
+        enable_diffusion_pipeline_profiler=True,
+        quantization=quantization,
+    )
+
+    records: list[dict[str, Any]] = []
+    try:
+        for run_index in range(args.num_runs):
+            started = time.perf_counter()
+            outputs = engine.generate(
+                PROMPT,
+                OmniDiffusionSamplingParams(
+                    height=768,
+                    width=1344,
+                    fps=24,
+                    num_inference_steps=args.num_inference_steps,
+                    seed=1101,
+                    output_type="np",
+                    extra_args={
+                        "task": "t2va",
+                        "duration": args.duration_seconds,
+                        "flow_shift": 12.0,
+                        "audio_flow_shift": 3.0,
+                    },
+                ),
+                use_tqdm=False,
+            )
+            wall_time = time.perf_counter() - started
+            if len(outputs) != 1:
+                raise RuntimeError(f"Expected one output, found {len(outputs)}")
+
+            result = outputs[0]
+            frames = np.asarray(result.images[0])
+            multimodal = result.multimodal_output
+            if multimodal is None:
+                raise RuntimeError("MiniMax-H3 returned no audio metadata")
+            audio = np.asarray(multimodal["audio"])
+            fps = int(multimodal["fps"])
+            sample_rate = int(multimodal["audio_sample_rate"])
+            if frames.ndim != 4 or tuple(frames.shape[1:]) != (768, 1344, 3):
+                raise RuntimeError(f"Unexpected video shape: {frames.shape}")
+            if frames.dtype != np.uint8:
+                raise RuntimeError(f"Expected uint8 video frames, got {frames.dtype}")
+            if audio.ndim not in (2, 3) or 2 not in audio.shape:
+                raise RuntimeError(f"Unexpected audio shape: {audio.shape}")
+            if fps != 24 or sample_rate != 32000:
+                raise RuntimeError(f"Unexpected media rates: fps={fps}, audio_sample_rate={sample_rate}")
+
+            output_path = mode_dir / f"t2va_{mode}_run{run_index + 1}.mp4"
+            output_path.write_bytes(
+                mux_video_audio_bytes(
+                    frames,
+                    np.squeeze(audio).astype(np.float32),
+                    fps=fps,
+                    audio_sample_rate=sample_rate,
+                )
+            )
+            media_validation = _validate_mp4(output_path)
+            record = {
+                "run": run_index + 1,
+                "warmup": run_index == 0,
+                "wall_time_s": wall_time,
+                "stage_durations": dict(getattr(result, "stage_durations", {}) or {}),
+                "worker_peak_memory_mb": _peak_memory_mb(result),
+                "frames_shape": list(frames.shape),
+                "audio_shape": list(audio.shape),
+                "fps": fps,
+                "audio_sample_rate": sample_rate,
+                "frames_sha256": _array_sha256(frames),
+                "audio_sha256": _array_sha256(audio),
+                "mp4": str(output_path),
+                **media_validation,
+            }
+            records.append(record)
+            print("RUN_RESULT " + json.dumps(record, sort_keys=True), flush=True)
+    finally:
+        engine.close()
+
+    summary = {
+        "mode": mode,
+        "model": args.model,
+        "hardware": hardware,
+        "software": {
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+        },
+        "parallel_config": "tp4_ulysses1_ring1_text_encoder_tp4_vae_tile4",
+        "attention_backend": "CUDNN_ATTN",
+        "regional_compile": True,
+        "prompt": PROMPT,
+        "seed": 1101,
+        "height": 768,
+        "width": 1344,
+        "duration_seconds": args.duration_seconds,
+        "num_inference_steps": args.num_inference_steps,
+        "runs": records,
+    }
+    summary_path = mode_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print("FINAL_SUMMARY " + json.dumps(summary, sort_keys=True), flush=True)
+
+
+def _measured_run(summary: dict[str, Any]) -> dict[str, Any]:
+    runs = summary["runs"]
+    return runs[1] if len(runs) > 1 else runs[0]
+
+
+def _write_comparison(args: argparse.Namespace) -> None:
+    summaries = {}
+    for mode in ("bf16", "fp8"):
+        summary_path = args.output_dir / mode / "summary.json"
+        summaries[mode] = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    bf16 = _measured_run(summaries["bf16"])
+    fp8 = _measured_run(summaries["fp8"])
+    comparison = {
+        "measured_run": 2 if args.num_runs > 1 else 1,
+        "bf16": bf16,
+        "fp8": fp8,
+        "wall_time_speedup": bf16["wall_time_s"] / fp8["wall_time_s"],
+        "peak_memory_reduction_mb": (bf16["worker_peak_memory_mb"] - fp8["worker_peak_memory_mb"]),
+    }
+    (args.output_dir / "comparison.json").write_text(
+        json.dumps(comparison, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    print("\n| Mode | Wall time | Denoise | Decode | Peak/GPU |")
+    print("| --- | ---: | ---: | ---: | ---: |")
+    for mode, record in (("BF16/FP32", bf16), ("Online FP8", fp8)):
+        stages = record["stage_durations"]
+        print(
+            f"| {mode} | {record['wall_time_s']:.2f} s | "
+            f"{stages['MiniMaxH3Pipeline.diffuse']:.2f} s | "
+            f"{stages['MiniMaxH3Pipeline.decode']:.2f} s | "
+            f"{record['worker_peak_memory_mb']:.0f} MB |"
+        )
+    print(f"\nSpeedup: {comparison['wall_time_speedup']:.2f}x")
+    print(f"Peak memory reduction: {comparison['peak_memory_reduction_mb']:.0f} MB/GPU")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.num_runs < 1:
+        raise ValueError("--num-runs must be at least 1")
+    if args.num_inference_steps < 1:
+        raise ValueError("--num-inference-steps must be at least 1")
+    args.output_dir = args.output_dir.resolve()
+
+    worker_mode = os.environ.get(WORKER_MODE_ENV)
+    if worker_mode is not None:
+        if worker_mode not in {"bf16", "fp8"}:
+            raise ValueError(f"Unsupported {WORKER_MODE_ENV}={worker_mode!r}")
+        _run_worker(args, worker_mode)
+        return
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    script_path = Path(__file__).resolve()
+    child_args = [
+        sys.executable,
+        str(script_path),
+        "--model",
+        args.model,
+        "--output-dir",
+        str(args.output_dir),
+        "--num-inference-steps",
+        str(args.num_inference_steps),
+        "--duration-seconds",
+        str(args.duration_seconds),
+        "--num-runs",
+        str(args.num_runs),
+    ]
+    for mode in ("bf16", "fp8"):
+        environment = os.environ.copy()
+        environment[WORKER_MODE_ENV] = mode
+        environment["PYTHONUNBUFFERED"] = "1"
+        print(f"\nStarting {mode} benchmark...", flush=True)
+        subprocess.run(child_args, check=True, env=environment)
+    _write_comparison(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -93,6 +93,7 @@ warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 | HunyuanImage-3.0 | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | Yes | Yes | All layers; use the Hunyuan stage config for multi-stage runs | None | |
 | HunyuanVideo-1.5 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v`, `720p_t2v`, `480p_i2v` | Yes | Yes | All layers | None | |
 | Cosmos3 | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | Yes | Not validated | All layers | None | |
+| MiniMax-H3 | `MiniMaxAI/MiniMax-H3` (`FL2VA` / `Ref2VA`) | Yes | Not validated | Quantize the DiT; patch/time/final projections stay FP32 | Optional stable DiT prefixes such as `blocks.0.mlp` | No |
 
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 
@@ -132,6 +133,19 @@ omni_with_skips = Omni(
 outputs = omni.generate(
     "A cat sitting on a windowsill",
     OmniDiffusionSamplingParams(num_inference_steps=50),
+)
+```
+
+MiniMax-H3 keeps its released mixed-precision policy during online FP8:
+the video/audio patch projections, timestep MLP, and final video/audio heads
+remain FP32. The other DiT linear layers use online FP8, while the Qwen3-VL
+text encoder and both VAEs remain at checkpoint precision. Point `model` at
+one partition directory, for example `MiniMax-H3/FL2VA`:
+
+```python
+omni = Omni(
+    model="/path/to/MiniMax-H3/FL2VA",
+    quantization="fp8",
 )
 ```
 

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 import torch
 import torch.nn as nn
@@ -92,3 +96,121 @@ def test_tp_accepts_checkpoint_supported_sizes():
     arch = MiniMaxH3DiTArchConfig()
     for tp_size in (1, 2, 4, 7):
         model._validate_tp_config(arch=arch, tp_size=tp_size)
+
+
+@pytest.fixture
+def model_parallel():
+    from vllm.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29519")
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method="env://",
+        backend="gloo",
+    )
+    initialize_model_parallel()
+    yield
+    cleanup_dist_env_and_memory()
+
+
+def test_online_quantization_routes_supported_linears_and_preserves_fp32(model_parallel, monkeypatch):
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    import vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer as h3_transformer
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MINIMAX_H3_FP32_PARAM_NAMES,
+        MiniMaxH3DiTModel,
+    )
+
+    class FakeAttention(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            del kwargs
+
+    monkeypatch.setattr(h3_transformer, "Attention", FakeAttention)
+
+    arch = {
+        "num_layers": 1,
+        "token_refiner_num_layers": 1,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "attention_head_dim": 16,
+        "ffn_hidden_size": 128,
+        "latents_dim": 4,
+        "audio_latents_dim": 4,
+        "patch_size": [1, 2, 2],
+        "text_dim": 32,
+        "timestep_input_dim": 16,
+        "time_embed_hidden_size": 64,
+        "time_embed_dim": 32,
+        "adaln_out_features": 18 * 64,
+        "final_adaln_out_features": 2 * 64,
+        "rope_inv_freq_len": 4,
+    }
+    od_config = SimpleNamespace(
+        tf_model_config=arch,
+        parallel_config=SimpleNamespace(ulysses_degree=1),
+    )
+    quant_config = Mock()
+    quant_config.weight_block_size = None
+    quant_config.get_quant_method.return_value = UnquantizedLinearMethod()
+
+    model = MiniMaxH3DiTModel(od_config, quant_config=quant_config)
+
+    quantized_prefixes = [call.kwargs["prefix"] for call in quant_config.get_quant_method.call_args_list]
+    assert quantized_prefixes == [
+        "condition_proj",
+        "token_refiner.blocks.0.attn.qkv_proj",
+        "token_refiner.blocks.0.attn.out_proj",
+        "token_refiner.blocks.0.mlp.fc1",
+        "token_refiner.blocks.0.mlp.fc2",
+        "blocks.0.attn.qkv_proj",
+        "blocks.0.attn.out_proj",
+        "blocks.0.mlp.fc1",
+        "blocks.0.mlp.fc2",
+        "blocks.0.adaln_proj.linear",
+        "final_layer.adaln_proj.linear",
+    ]
+
+    params = dict(model.named_parameters())
+    assert MINIMAX_H3_FP32_PARAM_NAMES <= params.keys()
+    assert all(params[name].dtype == torch.float32 for name in MINIMAX_H3_FP32_PARAM_NAMES)
+
+
+def test_adaln_keeps_bf16_activations_with_fp8_weights():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3AdalnProj,
+    )
+
+    class CaptureLinear(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(
+                torch.empty(1, dtype=torch.float8_e4m3fn),
+                requires_grad=False,
+            )
+            self.input_dtype = None
+
+        def forward(self, x):
+            self.input_dtype = x.dtype
+            return torch.zeros((x.shape[0], 8), dtype=x.dtype), None
+
+    proj = object.__new__(MiniMaxH3AdalnProj)
+    nn.Module.__init__(proj)
+    proj.expand_ratio = 2
+    proj.modality_num = 1
+    proj.hidden_size = 4
+    proj.linear = CaptureLinear()
+
+    outputs = proj(torch.randn(1, 4, dtype=torch.float32))
+
+    assert proj.linear.input_dtype == torch.bfloat16
+    assert len(outputs) == 2
+    assert all(output.dtype == torch.bfloat16 for output in outputs)

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -106,6 +106,10 @@ MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
 MINIMAX_H3_ADALN_MODALITY_NUM = 3
 
 
+def _join_prefix(prefix: str, name: str) -> str:
+    return f"{prefix}.{name}" if prefix else name
+
+
 def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
     if key not in kwargs or kwargs[key] is None:
         raise ValueError(f"MiniMaxH3DiTModel.forward requires kwarg {key!r}")
@@ -249,8 +253,10 @@ class MiniMaxH3TimeEmbedder(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
+        del quant_config
         self.frequency_embedding_size = arch.timestep_input_dim
         self.proj_in = ColumnParallelLinear(
             arch.timestep_input_dim,
@@ -258,7 +264,8 @@ class MiniMaxH3TimeEmbedder(nn.Module):
             bias=True,
             gather_output=True,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "proj_in"),
         )
         self.proj_out = RowParallelLinear(
             arch.time_embed_hidden_size,
@@ -266,7 +273,8 @@ class MiniMaxH3TimeEmbedder(nn.Module):
             bias=True,
             input_is_parallel=False,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "proj_out"),
         )
 
     def forward(self, t: torch.Tensor) -> torch.Tensor:
@@ -324,6 +332,7 @@ class MiniMaxH3Attention(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         skip_sequence_parallel: bool = False,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.total_num_heads = arch.num_attention_heads
@@ -339,10 +348,10 @@ class MiniMaxH3Attention(nn.Module):
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
             return_bias=True,
+            prefix=_join_prefix(prefix, "qkv_proj"),
         )
         self.num_heads = self.qkv_proj.num_heads
         self.num_kv_heads = self.qkv_proj.num_kv_heads
-        self._install_qkv_weight_loader(arch)
         self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         self.out_proj = RowParallelLinear(
@@ -352,6 +361,7 @@ class MiniMaxH3Attention(nn.Module):
             input_is_parallel=True,
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
+            prefix=_join_prefix(prefix, "out_proj"),
         )
         self.attention = Attention(
             num_heads=self.num_heads,
@@ -361,24 +371,6 @@ class MiniMaxH3Attention(nn.Module):
             causal=False,
             skip_sequence_parallel=skip_sequence_parallel,
         )
-
-    def _install_qkv_weight_loader(self, arch: MiniMaxH3DiTArchConfig) -> None:
-        base_loader = self.qkv_proj.weight.weight_loader
-
-        def _weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
-            # The grouped checkpoint layout is
-            # [num_query_groups, q_per_group + k + v] before splitting.
-            # MiniMax H3 uses MHA, so checkpoint rows are per-head [q, k, v],
-            # while qkv_proj expects [q_all, k_all, v_all].
-            reordered = _reorder_grouped_qkv_to_qkv(
-                loaded_weight,
-                num_query_groups=arch.num_attention_heads,
-                heads_per_group=1,
-                head_dim=arch.attention_head_dim,
-            )
-            base_loader(param, reordered)
-
-        self.qkv_proj.weight.weight_loader = _weight_loader
 
     @torch.compiler.disable
     def _run_packed_attention(
@@ -472,6 +464,7 @@ class MiniMaxH3MLP(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.fc1 = MergedColumnParallelLinear(
@@ -481,8 +474,8 @@ class MiniMaxH3MLP(nn.Module):
             gather_output=False,
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
+            prefix=_join_prefix(prefix, "fc1"),
         )
-        self._install_fc1_weight_loader()
         # Chunk the fused fc1 output as [gate, up], then compute
         # silu(gate) * up.
         self.fc2 = RowParallelLinear(
@@ -492,22 +485,8 @@ class MiniMaxH3MLP(nn.Module):
             input_is_parallel=True,
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
+            prefix=_join_prefix(prefix, "fc2"),
         )
-
-    def _install_fc1_weight_loader(self) -> None:
-        base_loader = self.fc1.weight.weight_loader
-
-        def _weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
-            if loaded_weight.shape[0] % 2:
-                raise ValueError(
-                    "MiniMax H3 fc1 checkpoint rows must split evenly into "
-                    f"gate/up matrices, got {tuple(loaded_weight.shape)}"
-                )
-            gate, up = loaded_weight.chunk(2, dim=0)
-            base_loader(param, gate, 0)
-            base_loader(param, up, 1)
-
-        self.fc1.weight.weight_loader = _weight_loader
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden, _ = self.fc1(x)
@@ -534,6 +513,7 @@ class MiniMaxH3AdalnProj(nn.Module):
         *,
         expand_ratio: int,
         modality_num: int,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         if out_features != expand_ratio * arch.hidden_size * modality_num:
@@ -550,12 +530,13 @@ class MiniMaxH3AdalnProj(nn.Module):
             gather_output=True,
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
+            prefix=_join_prefix(prefix, "linear"),
         )
 
     def forward(self, t_emb: torch.Tensor) -> tuple[torch.Tensor, ...]:
         """t_emb: [M, t_dim] -> expand_ratio tensors of [M*modality_num, H]."""
         x = nn.functional.silu(t_emb)
-        x, _ = self.linear(x.to(self.linear.weight.dtype))
+        x, _ = self.linear(x.to(_BF16_DTYPE))
         m = x.shape[0]
         x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
         return tuple(x.chunk(self.expand_ratio, dim=-1))
@@ -568,6 +549,7 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
@@ -579,8 +561,9 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
             arch,
             quant_config,
             skip_sequence_parallel=True,
+            prefix=_join_prefix(prefix, "attn"),
         )
-        self.mlp = MiniMaxH3MLP(arch, quant_config)
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=_join_prefix(prefix, "mlp"))
 
     def forward(
         self,
@@ -604,10 +587,18 @@ class MiniMaxH3TokenRefiner(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.blocks = nn.ModuleList(
-            [MiniMaxH3TokenRefinerBlock(arch, quant_config) for _ in range(arch.token_refiner_num_layers)]
+            [
+                MiniMaxH3TokenRefinerBlock(
+                    arch,
+                    quant_config,
+                    prefix=_join_prefix(prefix, str(i)),
+                )
+                for i in range(arch.token_refiner_num_layers)
+            ]
         )
         self.final_norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
 
@@ -628,18 +619,20 @@ class MiniMaxH3DiTBlock(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
         self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
-        self.attn = MiniMaxH3Attention(arch, quant_config)
-        self.mlp = MiniMaxH3MLP(arch, quant_config)
+        self.attn = MiniMaxH3Attention(arch, quant_config, prefix=_join_prefix(prefix, "attn"))
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=_join_prefix(prefix, "mlp"))
         self.adaln_proj = MiniMaxH3AdalnProj(
             arch,
             arch.adaln_out_features,
             quant_config,
             expand_ratio=6,
             modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+            prefix=_join_prefix(prefix, "adaln_proj"),
         )
 
     def forward(
@@ -693,6 +686,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         quant_config: QuantizationConfig | None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         video_patch_dim = arch.latents_dim * arch.patch_size[0] * arch.patch_size[1] * arch.patch_size[2]
@@ -703,6 +697,7 @@ class MiniMaxH3FinalLayer(nn.Module):
             quant_config,
             expand_ratio=2,
             modality_num=1,
+            prefix=_join_prefix(prefix, "adaln_proj"),
         )
         self.video_out = ColumnParallelLinear(
             arch.hidden_size,
@@ -710,7 +705,8 @@ class MiniMaxH3FinalLayer(nn.Module):
             bias=True,
             gather_output=True,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "video_out"),
         )
         self.audio_out = ColumnParallelLinear(
             arch.hidden_size,
@@ -718,7 +714,8 @@ class MiniMaxH3FinalLayer(nn.Module):
             bias=True,
             gather_output=True,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "audio_out"),
         )
 
     def forward(
@@ -832,6 +829,7 @@ class MiniMaxH3DiTModel(nn.Module):
         self,
         od_config: OmniDiffusionConfig,
         quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         tf_config = od_config.tf_model_config
@@ -864,7 +862,8 @@ class MiniMaxH3DiTModel(nn.Module):
             bias=True,
             gather_output=True,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "video_patch_proj"),
         )
         self.audio_patch_proj = ColumnParallelLinear(
             arch.audio_latents_dim,
@@ -872,7 +871,8 @@ class MiniMaxH3DiTModel(nn.Module):
             bias=True,
             gather_output=True,
             params_dtype=_FP32_DTYPE,
-            quant_config=quant_config,
+            quant_config=None,
+            prefix=_join_prefix(prefix, "audio_patch_proj"),
         )
         self.condition_proj = ColumnParallelLinear(
             arch.text_dim,
@@ -881,14 +881,36 @@ class MiniMaxH3DiTModel(nn.Module):
             gather_output=True,
             params_dtype=_BF16_DTYPE,
             quant_config=quant_config,
+            prefix=_join_prefix(prefix, "condition_proj"),
         )
-        self.time_embedder = MiniMaxH3TimeEmbedder(arch, quant_config)
+        self.time_embedder = MiniMaxH3TimeEmbedder(
+            arch,
+            quant_config,
+            prefix=_join_prefix(prefix, "time_embedder"),
+        )
         self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
-        self.token_refiner = MiniMaxH3TokenRefiner(arch, quant_config)
-        self.blocks = nn.ModuleList([MiniMaxH3DiTBlock(arch, quant_config) for _ in range(arch.num_layers)])
+        self.token_refiner = MiniMaxH3TokenRefiner(
+            arch,
+            quant_config,
+            prefix=_join_prefix(prefix, "token_refiner.blocks"),
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3DiTBlock(
+                    arch,
+                    quant_config,
+                    prefix=_join_prefix(prefix, f"blocks.{i}"),
+                )
+                for i in range(arch.num_layers)
+            ]
+        )
         self.sp_prepare = MiniMaxH3SPPrepare()
         self.sp_gather = MiniMaxH3SPGather()
-        self.final_layer = MiniMaxH3FinalLayer(arch, quant_config)
+        self.final_layer = MiniMaxH3FinalLayer(
+            arch,
+            quant_config,
+            prefix=_join_prefix(prefix, "final_layer"),
+        )
         self._mark_missing_params_required()
 
     def _mark_missing_params_required(self) -> None:
@@ -917,7 +939,29 @@ class MiniMaxH3DiTModel(nn.Module):
                 logger.warning("Skipping MiniMax H3 weight not present in model: %s", name)
                 continue
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
+            if name.endswith(".attn.qkv_proj.weight"):
+                # The checkpoint stores each head as [q, k, v], while the
+                # fused vLLM QKV linear expects [q_all, k_all, v_all]. Do the
+                # architecture-specific reorder before entering vLLM's
+                # loader so online quantization can retain its wrapper.
+                loaded_weight = _reorder_grouped_qkv_to_qkv(
+                    loaded_weight,
+                    num_query_groups=self.arch.num_attention_heads,
+                    heads_per_group=1,
+                    head_dim=self.arch.attention_head_dim,
+                )
+                weight_loader(param, loaded_weight)
+            elif name.endswith(".mlp.fc1.weight"):
+                if loaded_weight.shape[0] % 2:
+                    raise ValueError(
+                        "MiniMax H3 fc1 checkpoint rows must split evenly into "
+                        f"gate/up matrices, got {tuple(loaded_weight.shape)}"
+                    )
+                gate, up = loaded_weight.chunk(2, dim=0)
+                weight_loader(param, gate, 0)
+                weight_loader(param, up, 1)
+            else:
+                weight_loader(param, loaded_weight)
             loaded.add(name)
         return loaded
 


### PR DESCRIPTION
## Purpose

Enable dynamic online FP8 quantization for the MiniMax-H3 DiT while preserving
the checkpoint's mixed BF16/FP32 precision policy.

This change:

- gives every quantizable DiT linear a stable full module prefix;
- keeps the video/audio patch projections, timestep MLP, and final video/audio
  heads in FP32;
- moves the H3-specific QKV reorder and fused gate/up split into
  `load_weights`, so vLLM's online-quantization weight-loader wrapper is not
  overwritten;
- keeps AdaLN activations in BF16 instead of casting them to the FP8 weight
  dtype; and
- documents the supported online FP8 scope and adds focused regression tests.

Online FP8 is approximate. The Qwen3-VL text encoder and both VAEs remain at
checkpoint precision.

## Test Plan

```bash
python -m pytest tests/diffusion/models/minimax_h3 -q \
  --ignore=tests/diffusion/models/minimax_h3/test_minimax_h3_e2e.py

pre-commit run --files \
  benchmarks/diffusion/benchmark_minimax_h3_fp8.py \
  docs/user_guide/quantization/fp8.md \
  tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py \
  vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
```

Reproduce the 4x B300 BF16/FP8 comparison (the defaults are T2VA, 1344x768,
124 frames at 24 FPS, 50 inference steps, 5 seconds, seed 1101, one warmup,
and one measured request):

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
python benchmarks/diffusion/benchmark_minimax_h3_fp8.py \
  --model /path/to/MiniMax-H3/FL2VA \
  --output-dir ./minimax-h3-fp8-benchmark
```

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 6e99997dd94985aecc68fc611c58ab043879a121

**Software:** PyTorch 2.11.0+cu130, CUDA 13.0, driver 610.43.02

## Test Result

- MiniMax-H3 CPU suite: `29 passed`
- Focused quantization/parallel tests after rebase: `8 passed`
- All selected pre-commit hooks passed.

| Mode | Steady wall time | Denoise | Decode | Peak/GPU |
| --- | ---: | ---: | ---: | ---: |
| BF16/FP32 | 79.08 s | 76.45 s | 1.61 s | 49,332 MB |
| Online FP8 | 58.42 s | 55.92 s | 1.28 s | 41,550 MB |

Online FP8 reduced steady latency by 26.1% (1.35x speedup) and sampled peak
memory by 7,782 MB/GPU (15.8%) for this workload.

### B300 text-encoder TP scaling

As a separate checkpoint-precision control, I profiled the Qwen3-VL encoder
with one B300 (`text_encoder_tp_size=1`) and four B300s
(`text_encoder_tp_size=4`). Both configurations were fully resident and used
the same T2VA input. Timings are CUDA-synchronized medians over five measured
requests after two warmups; each TP=4 sample uses the slowest rank as the
distributed wall time.

| Qwen presentation | Metric | 1x B300, TP=1 | 4x B300, TP=4 | TP=4 result |
| --- | --- | ---: | ---: | ---: |
| 25 tokens | Encoder (`encode_ids`) | 18.994 ms | 23.510 ms | 23.8% slower |
| 25 tokens | Full prompt-encode stage | 23.189 ms | 28.620 ms | 23.4% slower |
| 1,200 tokens | Encoder (`encode_ids`) | 65.494 ms | 43.400 ms | 1.51x faster |
| 1,200 tokens | Full prompt-encode stage | 71.267 ms | 49.719 ms | 1.43x faster |

For the normal short T2VA prompt, TP communication costs more than the
sharded encoder compute saves. At 1,200 tokens, TP=4 reduces encoder compute
latency by 33.7% and full prompt-encode latency by 30.2%. These are encoder TP
results, not FP8 gains; the encoder remains at checkpoint precision in the
BF16/FP8 comparison above.

Two FP8 requests completed. Each output decoded end-to-end as H.264 video plus
AAC stereo audio: 124 frames at 1344x768 and 24 FPS, with 32 kHz audio. Frame
sampling showed coherent motion without corrupt, black, or frozen output.
Because online FP8 changes the diffusion trajectory, same-seed BF16 and FP8
outputs are not expected to be pixel-identical.

https://github.com/user-attachments/assets/88e13614-efe4-4506-a8ad-f9a17f1a7d9d

https://github.com/user-attachments/assets/0b7c8f3c-c542-452a-871b-b0efd53dcea0
