### PR TITLE
[Frontend][Doc] Warn on misplaced Omni VAE config

### DIFF
--- a/docs/user_guide/diffusion/parallelism/vae_parallelism.md
+++ b/docs/user_guide/diffusion/parallelism/vae_parallelism.md
@@ -104,6 +104,15 @@ vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8091 \
     --vae-use-tiling
 ```
 
+!!! warning "Use the dedicated VAE CLI options"
+    `--additional-config` is forwarded to the platform plugin through
+    `VllmConfig.additional_config`; it is not merged into Omni's
+    `DiffusionParallelConfig`. Putting `vae_patch_parallel_size` or
+    `vae_parallel_mode` under `additional_config.parallel_config`, or putting
+    `vae_use_tiling` in `additional_config`, therefore does not configure the
+    VAE. Use `--vae-patch-parallel-size`, `--vae-parallel-mode`, and
+    `--vae-use-tiling` as shown above.
+
 ---
 
 ## Configuration Parameters

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -56,6 +56,61 @@ def test_serve_parser_accepts_four_way_cfg_parallelism() -> None:
     assert args.cfg_parallel_size == 4
 
 
+def test_validate_warns_for_omni_vae_fields_in_additional_config(mocker: MockerFixture) -> None:
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    command = OmniServeCommand()
+    command.subparser_init(subparsers)
+    args = parser.parse_args(
+        [
+            "serve",
+            "fake-model",
+            "--omni",
+            "--additional-config",
+            '{"vae_use_tiling":true,"parallel_config":'
+            '{"vae_patch_parallel_size":2,"vae_parallel_mode":"spatial_shard_height"}}',
+        ]
+    )
+    original_config = args.additional_config.copy()
+    warning = mocker.patch("vllm_omni.entrypoints.cli.serve.logger.warning")
+    mocker.patch("vllm_omni.diffusion.utils.hf_utils.is_diffusion_model", return_value=True)
+
+    command.validate(args)
+
+    warning.assert_called_once()
+    fmt, *fmt_args = warning.call_args.args
+    message = fmt % tuple(fmt_args)
+    assert "parallel_config.vae_patch_parallel_size" in message
+    assert "parallel_config.vae_parallel_mode" in message
+    assert "vae_use_tiling" in message
+    assert "--vae-patch-parallel-size" in message
+    assert "--vae-parallel-mode" in message
+    assert "--vae-use-tiling" in message
+    assert args.additional_config == original_config
+
+
+def test_validate_does_not_warn_for_platform_additional_config(mocker: MockerFixture) -> None:
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    command = OmniServeCommand()
+    command.subparser_init(subparsers)
+    args = parser.parse_args(
+        [
+            "serve",
+            "fake-model",
+            "--omni",
+            "--additional-config",
+            '{"torchair_graph_config":{"enabled":true}}',
+        ]
+    )
+    warning = mocker.patch("vllm_omni.entrypoints.cli.serve.logger.warning")
+    mocker.patch("vllm_omni.diffusion.utils.hf_utils.is_diffusion_model", return_value=True)
+
+    command.validate(args)
+
+    warning.assert_not_called()
+
+
 def _make_headless_args(**kwargs) -> TrackingNamespace:
     defaults = {
         "model": "fake-model",

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import signal
+from collections.abc import Mapping
 from types import FrameType
 
 import uvloop
@@ -41,6 +42,54 @@ Search by using: `--help=<ConfigGroup>` to explore options by section (e.g.,
 --help=OmniConfig)
   Use `--help=all` to show all available flags at once.
 """
+
+_OMNI_VAE_ADDITIONAL_CONFIG_PATHS: dict[tuple[str, ...], str] = {
+    ("vae_patch_parallel_size",): "--vae-patch-parallel-size",
+    ("vae_parallel_mode",): "--vae-parallel-mode",
+    ("vae_use_tiling",): "--vae-use-tiling",
+    ("parallel_config", "vae_patch_parallel_size"): "--vae-patch-parallel-size",
+    ("parallel_config", "vae_parallel_mode"): "--vae-parallel-mode",
+    ("parallel_config", "vae_use_tiling"): "--vae-use-tiling",
+}
+
+
+def _warn_on_misplaced_omni_vae_config(args: argparse.Namespace) -> None:
+    """Warn when platform config is mistaken for Omni VAE config.
+
+    ``--additional-config`` is forwarded unchanged to the platform plugin via
+    ``VllmConfig.additional_config``. It is not an overlay for Omni's
+    diffusion configuration, so VAE fields placed there would otherwise be
+    accepted by the parser but silently have no effect.
+    """
+    if not getattr(args, "omni", False):
+        return
+
+    additional_config = getattr(args, "additional_config", None)
+    if not isinstance(additional_config, Mapping):
+        return
+
+    misplaced: list[tuple[str, str]] = []
+    for path, flag in _OMNI_VAE_ADDITIONAL_CONFIG_PATHS.items():
+        value: object = additional_config
+        for key in path:
+            if not isinstance(value, Mapping) or key not in value:
+                break
+            value = value[key]
+        else:
+            misplaced.append((".".join(path), flag))
+
+    if not misplaced:
+        return
+
+    fields = ", ".join(path for path, _ in misplaced)
+    flags = ", ".join(dict.fromkeys(flag for _, flag in misplaced))
+    logger.warning(
+        "--additional-config is forwarded to the platform plugin and does not "
+        "configure Omni VAE options. These fields will not take effect here: "
+        "%s. Use the dedicated CLI flags instead: %s.",
+        fields,
+        flags,
+    )
 
 
 def _ensure_vllm_platform():
@@ -131,6 +180,8 @@ class OmniServeCommand(CLISubcommand):
         # vLLM equivalents on the command line would silently disagree with
         # those sources of truth, so reject them at parse time.
         if getattr(args, "omni", False):
+            _warn_on_misplaced_omni_vae_config(args)
+
             explicit_cli_keys: set[str] = getattr(args, "_cli_explicit_keys", set()) or set()
             prohibited_with_omni: dict[str, str] = {
                 "data_parallel_size": "--data-parallel-size",


### PR DESCRIPTION
## Purpose

Fixes #5639.

### What broke

`--additional-config` accepts JSON such as:

```bash
vllm serve MODEL --omni \
  --additional-config '{"vae_use_tiling":true,"parallel_config":{"vae_patch_parallel_size":8}}'
```

The command parses successfully, but those VAE values do not configure Omni's `DiffusionParallelConfig`. Operators receive no indication that VAE patch parallelism remains disabled.

### Root cause

`--additional-config` is intentionally forwarded unchanged to the platform plugin through `VllmConfig.additional_config`; it is not a generic overlay for Omni diffusion configuration. Treating it as another overlay would create ambiguous configuration precedence.

### Fix

- Warn when `--additional-config` contains known Omni VAE fields at the top level or under `parallel_config`.
- Point each misplaced field to the dedicated flags:
  - `--vae-patch-parallel-size`
  - `--vae-parallel-mode`
  - `--vae-use-tiling`
- Preserve `additional_config` unchanged for the platform plugin.
- Document this boundary in the VAE parallelism guide.
- Add real CLI-parser regression coverage for both misplaced VAE fields and valid platform configuration.

## Test Plan

**vLLM Version:** repository CI environment

**vLLM-Omni Commit:** `4b83848f187aeab44414293d0dfbb0dda5197aaf`

```bash
pytest -q tests/entrypoints/test_serve.py -m 'core_model and cpu'
uvx pre-commit run --files \
  vllm_omni/entrypoints/cli/serve.py \
  tests/entrypoints/test_serve.py \
  docs/user_guide/diffusion/parallelism/vae_parallelism.md
```

## Test Result

- Python 3.12 syntax compilation: passed.
- Ruff check and format check: passed.
- All changed-file pre-commit hooks: passed.
- Repository pytest suite: delegated to project CI because the local macOS environment does not provide vLLM runtime packages.
