### PR TITLE
[Model] Cosmos3: Reduce video output transfer overhead

### DIFF
--- a/tests/diffusion/models/cosmos3/test_cosmos3_guardrails.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_guardrails.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for the real Cosmos3 guardrail adapter.
+
+These live apart from ``test_cosmos3_pipeline.py`` because that module installs
+an autouse fixture replacing ``guardrails`` in ``sys.modules`` with a stub, so a
+test there can never reach the code below.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.cosmos3 import guardrails
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def test_check_video_safety_is_a_no_op_when_no_guardrail_is_loaded() -> None:
+    frames = torch.zeros(1, 2, 4, 4, 3, dtype=torch.uint8)
+
+    assert guardrails.check_video_safety(frames) is frames
+
+
+def test_check_video_safety_skips_conversions_for_display_frames(monkeypatch: pytest.MonkeyPatch) -> None:
+    """uint8 channel-last frames are already the guardrail's own format.
+
+    The float path has to denormalize, scale, round and permute on the way in and
+    undo all of it on the way out. Frames that arrive display-ready skip both.
+    """
+    seen: list[np.ndarray] = []
+
+    def _guardrail(frames: np.ndarray) -> np.ndarray:
+        seen.append(frames)
+        return frames
+
+    monkeypatch.setattr(guardrails, "_video_guardrail", _guardrail)
+    frames = torch.arange(2 * 4 * 4 * 3, dtype=torch.uint8).reshape(1, 2, 4, 4, 3)
+
+    checked = guardrails.check_video_safety(frames)
+
+    assert len(seen) == 1
+    assert seen[0].dtype == np.uint8
+    assert seen[0].shape == (2, 4, 4, 3)
+    assert checked.dtype == torch.uint8
+    assert torch.equal(checked, frames)
+
+
+def test_check_video_safety_accepts_unbatched_display_frames(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guardrails, "_video_guardrail", lambda frames: frames)
+    frames = torch.arange(2 * 4 * 4 * 3, dtype=torch.uint8).reshape(2, 4, 4, 3)
+
+    checked = guardrails.check_video_safety(frames)
+
+    assert checked.shape == frames.shape
+    assert torch.equal(checked, frames)
+
+
+@pytest.mark.parametrize(
+    ("frames", "message"),
+    [
+        (torch.zeros(1, 2, 4, 4, 4, dtype=torch.uint8), "display-frame guardrails expect"),
+        (torch.zeros(2, 2, 4, 4, 3, dtype=torch.uint8), "one video per request"),
+    ],
+)
+def test_check_video_safety_validates_display_frame_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    frames: torch.Tensor,
+    message: str,
+) -> None:
+    monkeypatch.setattr(guardrails, "_video_guardrail", lambda value: value)
+
+    with pytest.raises(ValueError, match=message):
+        guardrails.check_video_safety(frames)
+
+
+def test_check_video_safety_still_round_trips_the_vae_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callers that pass float [-1, 1] must get float [-1, 1] back."""
+    captured: list[np.ndarray] = []
+
+    def _guardrail(frames: np.ndarray) -> np.ndarray:
+        captured.append(frames)
+        return frames
+
+    monkeypatch.setattr(guardrails, "_video_guardrail", _guardrail)
+    video = torch.zeros(1, 3, 2, 4, 4)
+
+    checked = guardrails.check_video_safety(video)
+
+    # The guardrail sees uint8 channel-last either way; only the wrapping differs.
+    assert captured[0].dtype == np.uint8
+    assert captured[0].shape == (2, 4, 4, 3)
+    assert checked.shape == video.shape
+    assert checked.dtype == torch.float32
+    torch.testing.assert_close(checked, video, atol=1 / 127.5, rtol=0)

--- a/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
@@ -1164,6 +1164,144 @@ def test_postprocess_handles_image_video_audio_and_validation() -> None:
         func({"image": video, "video": video})
 
 
+def test_to_display_uint8_matches_the_float_path_it_replaces() -> None:
+    """The conversion moved to the GPU must not change a single pixel.
+
+    Callers used to get float32 in [0, 1] from ``postprocess_video`` and the
+    encoders scaled and rounded it themselves; doing both at once earlier has to
+    land on the same bytes.
+    """
+    from diffusers.video_processor import VideoProcessor
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    torch.manual_seed(0)
+    # Include out-of-range values: the old path clamped after the affine, not before.
+    video = torch.empty(1, 3, 5, 8, 6).uniform_(-1.4, 1.4)
+
+    reference = VideoProcessor(vae_scale_factor=16).postprocess_video(video, output_type="np")
+    expected = np.round(np.clip(reference, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+    assert np.array_equal(to_display_uint8(video).numpy(), expected)
+
+
+def test_to_display_uint8_matches_bfloat16_postprocess_bytes() -> None:
+    from diffusers.video_processor import VideoProcessor
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    torch.manual_seed(0)
+    video = torch.empty(1, 3, 5, 8, 6).uniform_(-1, 1).to(torch.bfloat16)
+    reference = VideoProcessor(vae_scale_factor=16).postprocess_video(video, output_type="np")
+    expected = np.round(np.clip(reference, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+    assert np.array_equal(to_display_uint8(video).numpy(), expected)
+
+
+def test_to_display_uint8_emits_channel_last_frames_at_half_the_width() -> None:
+    video = torch.zeros(1, 3, 5, 8, 6, dtype=torch.bfloat16)
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    frames = to_display_uint8(video)
+
+    assert frames.shape == (1, 5, 8, 6, 3)
+    assert frames.dtype == torch.uint8
+    assert frames.is_contiguous()
+    # Halving the payload is the whole point: this is what crosses every hop.
+    assert frames.numel() * frames.element_size() * 2 == video.numel() * video.element_size()
+
+
+def test_to_display_uint8_is_unchanged_by_how_many_slices_it_takes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slicing exists only to cap memory, so it must not touch the result.
+
+    Frames convert independently, so a one-frame-at-a-time pass and a
+    whole-tensor pass have to agree exactly.
+    """
+    from vllm_omni.diffusion.models.cosmos3 import pipeline_cosmos3
+
+    torch.manual_seed(0)
+    video = torch.empty(2, 3, 7, 8, 6).uniform_(-1.4, 1.4)
+
+    whole = pipeline_cosmos3.to_display_uint8(video)
+    monkeypatch.setattr(pipeline_cosmos3, "_DISPLAY_CHUNK_BYTES", 1)
+    sliced = pipeline_cosmos3.to_display_uint8(video)
+
+    assert torch.equal(whole, sliced)
+
+
+def test_display_chunk_frame_count_bounds_the_float32_intermediate() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _display_chunk_frame_count
+
+    # Two frames' worth of float32: 2 * 4 * 6 * 3 * 4 bytes.
+    video = torch.zeros(1, 3, 7, 4, 6)
+
+    assert _display_chunk_frame_count(video, chunk_bytes=2 * 4 * 6 * 3 * 4) == 2
+
+
+def test_display_chunk_frame_count_rejects_wrong_layout() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _display_chunk_frame_count
+
+    with pytest.raises(ValueError, match=r"shape \[B, C, T, H, W\]"):
+        _display_chunk_frame_count(torch.zeros(3, 4, 6))
+
+
+def test_to_display_uint8_does_not_mutate_a_float32_caller_tensor() -> None:
+    """A float32 input must not be aliased by the in-place conversion chain."""
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    video = torch.full((1, 3, 2, 4, 6), 0.5, dtype=torch.float32)
+    original = video.clone()
+
+    to_display_uint8(video)
+
+    assert torch.equal(video, original)
+
+
+def test_postprocess_passes_display_frames_through_without_widening() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
+
+    func = get_cosmos3_post_process_func(SimpleNamespace())
+    frames = torch.arange(1 * 5 * 8 * 6 * 3, dtype=torch.uint8).reshape(1, 5, 8, 6, 3)
+
+    processed = func({"video": frames})
+
+    assert isinstance(processed, np.ndarray)
+    assert processed.dtype == np.uint8
+    assert np.array_equal(processed, frames.numpy())
+    assert func({"video": frames}, output_type="pt") is frames
+    pil_frames = func({"video": frames}, output_type="pil")
+    assert isinstance(pil_frames, list)
+    assert isinstance(pil_frames[0][0], Image.Image)
+    with pytest.raises(ValueError, match="Unsupported Cosmos3 video output_type"):
+        func({"video": frames}, output_type="jpeg")
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_postprocess_moves_small_display_frames_to_cpu_for_numpy() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
+
+    func = get_cosmos3_post_process_func(SimpleNamespace())
+    frames = torch.arange(1 * 2 * 8 * 6 * 3, dtype=torch.uint8, device="cuda").reshape(1, 2, 8, 6, 3)
+
+    processed = func({"video": frames})
+
+    assert isinstance(processed, np.ndarray)
+    assert np.array_equal(processed, frames.cpu().numpy())
+
+
+def test_video_narrowing_preserves_cpu_offload_headroom() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _should_narrow_video_output
+
+    assert _should_narrow_video_output(is_output_rank=True, is_t2i=False, enable_cpu_offload=False)
+    assert not _should_narrow_video_output(is_output_rank=False, is_t2i=False, enable_cpu_offload=False)
+    assert not _should_narrow_video_output(is_output_rank=True, is_t2i=False, enable_cpu_offload=True)
+    assert not _should_narrow_video_output(is_output_rank=True, is_t2i=True, enable_cpu_offload=False)
+
+
 def test_action_postprocess_handles_robolab_policy_outputs() -> None:
     from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import (
         RoboLabPolicyInputs,

--- a/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
@@ -1439,21 +1439,39 @@ def test_to_display_uint8_does_not_mutate_a_float32_caller_tensor() -> None:
     assert torch.equal(video, original)
 
 
-def test_postprocess_passes_display_frames_through_without_widening() -> None:
+def test_postprocess_restores_np_and_pt_output_contracts() -> None:
     from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
 
     func = get_cosmos3_post_process_func(SimpleNamespace())
     frames = torch.arange(1 * 5 * 8 * 6 * 3, dtype=torch.uint8).reshape(1, 5, 8, 6, 3)
+    expected = frames.float() / 255.0
 
     processed = func({"video": frames})
 
     assert isinstance(processed, np.ndarray)
-    assert processed.dtype == np.uint8
-    assert np.array_equal(processed, frames.numpy())
-    assert func({"video": frames}, output_type="pt") is frames
+    assert processed.dtype == np.float32
+    assert processed.shape == (1, 5, 8, 6, 3)
+    np.testing.assert_array_equal(processed, expected.numpy())
+    processed_pt = func({"video": frames}, output_type="pt")
+    assert processed_pt.dtype == torch.float32
+    assert processed_pt.shape == (1, 5, 3, 8, 6)
+    torch.testing.assert_close(processed_pt, expected.permute(0, 1, 4, 2, 3))
+
+
+def test_postprocess_converts_display_frames_directly_to_pil() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
+
+    func = get_cosmos3_post_process_func(SimpleNamespace())
+    frames = torch.arange(1 * 2 * 8 * 6 * 3, dtype=torch.uint8).reshape(1, 2, 8, 6, 3)
+
     pil_frames = func({"video": frames}, output_type="pil")
+
     assert isinstance(pil_frames, list)
+    assert len(pil_frames) == 1
+    assert len(pil_frames[0]) == 2
     assert isinstance(pil_frames[0][0], Image.Image)
+    assert np.array_equal(np.asarray(pil_frames[0][0]), frames[0, 0].numpy())
+    assert np.array_equal(np.asarray(pil_frames[0][1]), frames[0, 1].numpy())
     with pytest.raises(ValueError, match="Unsupported Cosmos3 video output_type"):
         func({"video": frames}, output_type="jpeg")
 
@@ -1469,7 +1487,8 @@ def test_postprocess_moves_small_display_frames_to_cpu_for_numpy() -> None:
     processed = func({"video": frames})
 
     assert isinstance(processed, np.ndarray)
-    assert np.array_equal(processed, frames.cpu().numpy())
+    assert processed.dtype == np.float32
+    np.testing.assert_array_equal(processed, frames.cpu().float().numpy() / 255.0)
 
 
 def test_video_narrowing_preserves_cpu_offload_headroom() -> None:

--- a/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
@@ -1343,6 +1343,144 @@ def test_postprocess_handles_image_video_audio_and_validation() -> None:
         func({"image": video, "video": video})
 
 
+def test_to_display_uint8_matches_the_float_path_it_replaces() -> None:
+    """The conversion moved to the GPU must not change a single pixel.
+
+    Callers used to get float32 in [0, 1] from ``postprocess_video`` and the
+    encoders scaled and rounded it themselves; doing both at once earlier has to
+    land on the same bytes.
+    """
+    from diffusers.video_processor import VideoProcessor
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    torch.manual_seed(0)
+    # Include out-of-range values: the old path clamped after the affine, not before.
+    video = torch.empty(1, 3, 5, 8, 6).uniform_(-1.4, 1.4)
+
+    reference = VideoProcessor(vae_scale_factor=16).postprocess_video(video, output_type="np")
+    expected = np.round(np.clip(reference, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+    assert np.array_equal(to_display_uint8(video).numpy(), expected)
+
+
+def test_to_display_uint8_matches_bfloat16_postprocess_bytes() -> None:
+    from diffusers.video_processor import VideoProcessor
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    torch.manual_seed(0)
+    video = torch.empty(1, 3, 5, 8, 6).uniform_(-1, 1).to(torch.bfloat16)
+    reference = VideoProcessor(vae_scale_factor=16).postprocess_video(video, output_type="np")
+    expected = np.round(np.clip(reference, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+    assert np.array_equal(to_display_uint8(video).numpy(), expected)
+
+
+def test_to_display_uint8_emits_channel_last_frames_at_half_the_width() -> None:
+    video = torch.zeros(1, 3, 5, 8, 6, dtype=torch.bfloat16)
+
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    frames = to_display_uint8(video)
+
+    assert frames.shape == (1, 5, 8, 6, 3)
+    assert frames.dtype == torch.uint8
+    assert frames.is_contiguous()
+    # Halving the payload is the whole point: this is what crosses every hop.
+    assert frames.numel() * frames.element_size() * 2 == video.numel() * video.element_size()
+
+
+def test_to_display_uint8_is_unchanged_by_how_many_slices_it_takes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slicing exists only to cap memory, so it must not touch the result.
+
+    Frames convert independently, so a one-frame-at-a-time pass and a
+    whole-tensor pass have to agree exactly.
+    """
+    from vllm_omni.diffusion.models.cosmos3 import pipeline_cosmos3
+
+    torch.manual_seed(0)
+    video = torch.empty(2, 3, 7, 8, 6).uniform_(-1.4, 1.4)
+
+    whole = pipeline_cosmos3.to_display_uint8(video)
+    monkeypatch.setattr(pipeline_cosmos3, "_DISPLAY_CHUNK_BYTES", 1)
+    sliced = pipeline_cosmos3.to_display_uint8(video)
+
+    assert torch.equal(whole, sliced)
+
+
+def test_display_chunk_frame_count_bounds_the_float32_intermediate() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _display_chunk_frame_count
+
+    # Two frames' worth of float32: 2 * 4 * 6 * 3 * 4 bytes.
+    video = torch.zeros(1, 3, 7, 4, 6)
+
+    assert _display_chunk_frame_count(video, chunk_bytes=2 * 4 * 6 * 3 * 4) == 2
+
+
+def test_display_chunk_frame_count_rejects_wrong_layout() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _display_chunk_frame_count
+
+    with pytest.raises(ValueError, match=r"shape \[B, C, T, H, W\]"):
+        _display_chunk_frame_count(torch.zeros(3, 4, 6))
+
+
+def test_to_display_uint8_does_not_mutate_a_float32_caller_tensor() -> None:
+    """A float32 input must not be aliased by the in-place conversion chain."""
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import to_display_uint8
+
+    video = torch.full((1, 3, 2, 4, 6), 0.5, dtype=torch.float32)
+    original = video.clone()
+
+    to_display_uint8(video)
+
+    assert torch.equal(video, original)
+
+
+def test_postprocess_passes_display_frames_through_without_widening() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
+
+    func = get_cosmos3_post_process_func(SimpleNamespace())
+    frames = torch.arange(1 * 5 * 8 * 6 * 3, dtype=torch.uint8).reshape(1, 5, 8, 6, 3)
+
+    processed = func({"video": frames})
+
+    assert isinstance(processed, np.ndarray)
+    assert processed.dtype == np.uint8
+    assert np.array_equal(processed, frames.numpy())
+    assert func({"video": frames}, output_type="pt") is frames
+    pil_frames = func({"video": frames}, output_type="pil")
+    assert isinstance(pil_frames, list)
+    assert isinstance(pil_frames[0][0], Image.Image)
+    with pytest.raises(ValueError, match="Unsupported Cosmos3 video output_type"):
+        func({"video": frames}, output_type="jpeg")
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_postprocess_moves_small_display_frames_to_cpu_for_numpy() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import get_cosmos3_post_process_func
+
+    func = get_cosmos3_post_process_func(SimpleNamespace())
+    frames = torch.arange(1 * 2 * 8 * 6 * 3, dtype=torch.uint8, device="cuda").reshape(1, 2, 8, 6, 3)
+
+    processed = func({"video": frames})
+
+    assert isinstance(processed, np.ndarray)
+    assert np.array_equal(processed, frames.cpu().numpy())
+
+
+def test_video_narrowing_preserves_cpu_offload_headroom() -> None:
+    from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import _should_narrow_video_output
+
+    assert _should_narrow_video_output(is_output_rank=True, is_t2i=False, enable_cpu_offload=False)
+    assert not _should_narrow_video_output(is_output_rank=False, is_t2i=False, enable_cpu_offload=False)
+    assert not _should_narrow_video_output(is_output_rank=True, is_t2i=False, enable_cpu_offload=True)
+    assert not _should_narrow_video_output(is_output_rank=True, is_t2i=True, enable_cpu_offload=False)
+
+
 def test_action_postprocess_handles_robolab_policy_outputs() -> None:
     from vllm_omni.diffusion.models.cosmos3.pipeline_cosmos3 import (
         RoboLabPolicyInputs,

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -167,6 +167,26 @@ def check_video_safety(video_tensor: torch.Tensor) -> torch.Tensor:
     if _video_guardrail is None:
         return video_tensor
 
+    if video_tensor.dtype == torch.uint8:
+        if video_tensor.dim() not in (4, 5) or video_tensor.shape[-1] != 3:
+            raise ValueError(
+                "Cosmos3 display-frame guardrails expect [T, H, W, 3] or "
+                f"[1, T, H, W, 3] uint8 input, got {tuple(video_tensor.shape)}."
+            )
+        if video_tensor.dim() == 5 and video_tensor.shape[0] != 1:
+            raise ValueError(
+                "Cosmos3 video guardrails currently support one video per request, "
+                f"got batch size {video_tensor.shape[0]}."
+            )
+        # Already the guardrail's own channel-last format.
+        frames = video_tensor.detach().cpu()
+        batched = frames.dim() == 5
+        checked = _video_guardrail((frames[0] if batched else frames).numpy())
+        result = torch.from_numpy(checked.copy())
+        if batched:
+            result = result.unsqueeze(0)
+        return result.to(video_tensor.device)
+
     v = video_tensor.detach().cpu().float()
     if v.dim() == 5:
         v = v[0]

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -168,6 +168,26 @@ def check_video_safety(video_tensor: torch.Tensor) -> torch.Tensor:
     if _video_guardrail is None:
         return video_tensor
 
+    if video_tensor.dtype == torch.uint8:
+        if video_tensor.dim() not in (4, 5) or video_tensor.shape[-1] != 3:
+            raise ValueError(
+                "Cosmos3 display-frame guardrails expect [T, H, W, 3] or "
+                f"[1, T, H, W, 3] uint8 input, got {tuple(video_tensor.shape)}."
+            )
+        if video_tensor.dim() == 5 and video_tensor.shape[0] != 1:
+            raise ValueError(
+                "Cosmos3 video guardrails currently support one video per request, "
+                f"got batch size {video_tensor.shape[0]}."
+            )
+        # Already the guardrail's own channel-last format.
+        frames = video_tensor.detach().cpu()
+        batched = frames.dim() == 5
+        checked = _video_guardrail((frames[0] if batched else frames).numpy())
+        result = torch.from_numpy(checked.copy())
+        if batched:
+            result = result.unsqueeze(0)
+        return result.to(video_tensor.device)
+
     v = video_tensor.detach().cpu().float()
     if v.dim() == 5:
         v = v[0]

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -567,6 +567,68 @@ def get_cosmos3_pre_process_func(od_config: OmniDiffusionConfig):
     return pre_process_func
 
 
+# Bound the temporary float32 conversion immediately after VAE decode.
+_DISPLAY_CHUNK_BYTES = 64 << 20
+
+
+def _display_chunk_frame_count(video: torch.Tensor, chunk_bytes: int | None = None) -> int:
+    """Return the number of frames whose float32 form fits the budget."""
+    if video.ndim != 5:
+        raise ValueError(f"Expected decoded video with shape [B, C, T, H, W], got {tuple(video.shape)}.")
+    if chunk_bytes is None:
+        chunk_bytes = _DISPLAY_CHUNK_BYTES
+    batch, channels, _, height, width = video.shape
+    # Non-float32 inputs briefly coexist with their float32 form during the
+    # cast that precedes scaling to display bytes.
+    bytes_per_value = 4 if video.dtype == torch.float32 else video.element_size() + 4
+    intermediate_bytes_per_frame = batch * height * width * channels * bytes_per_value
+    return max(1, chunk_bytes // intermediate_bytes_per_frame)
+
+
+def to_display_uint8(video: torch.Tensor) -> torch.Tensor:
+    """Convert a decoded video from VAE range to display-ready uint8 frames.
+
+    The VAE emits ``[B, C, T, H, W]`` in ``[-1, 1]``; every consumer ultimately
+    wants ``[B, T, H, W, C]`` uint8 in ``[0, 255]``. Narrowing before IPC
+    reduces the device-to-host and shared-memory payload.
+
+    The arithmetic runs in float32 and matches the old two-step path exactly —
+    ``postprocess_video`` produced ``(x / 2 + 0.5).clamp(0, 1)`` and the encoders
+    then scaled and rounded — so output is bit-identical to what callers saw, and
+    slicing does not change that because frames convert independently.
+    """
+    video = video.detach()
+    batch, channels, frames, height, width = video.shape
+    out = torch.empty(
+        (batch, frames, height, width, channels),
+        dtype=torch.uint8,
+        device=video.device,
+    )
+
+    step = _display_chunk_frame_count(video)
+    for start in range(0, frames, step):
+        stop = min(start + step, frames)
+        # Preserve the input dtype for denormalization to match the historical
+        # VideoProcessor path, which performed this arithmetic before casting
+        # to float32 for NumPy.
+        chunk = video[:, :, start:stop].permute(0, 2, 3, 4, 1).to(video.dtype, copy=True)
+        chunk = chunk.mul_(0.5).add_(0.5).clamp_(0, 1)
+        if chunk.dtype != torch.float32:
+            chunk = chunk.float()
+        out[:, start:stop] = chunk.mul_(255).round_().to(torch.uint8)
+    return out
+
+
+def _should_narrow_video_output(
+    *,
+    is_output_rank: bool,
+    is_t2i: bool,
+    enable_cpu_offload: bool,
+) -> bool:
+    """Narrow only when GPU post-decode headroom is expected."""
+    return is_output_rank and not is_t2i and not enable_cpu_offload
+
+
 def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
     """Build the postprocessor for Cosmos3 image, video, and video+audio output.
 
@@ -688,7 +750,20 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
         guardrails_enabled = is_guardrails_enabled(od_config, sampling_params)
         if guardrails_enabled:
             video = check_video_safety(video)
-        processed_video = video_processor.postprocess_video(video, output_type=output_type)
+        if video.dtype == torch.uint8:
+            # Display-ready output intentionally remains uint8 for ``np`` and
+            # ``pt`` so serving does not widen it only to encode it as bytes.
+            if output_type == "pt":
+                processed_video = video
+            elif output_type == "np":
+                processed_video = video.detach().cpu().numpy()
+            elif output_type == "pil":
+                vae_video = video.detach().cpu().permute(0, 4, 1, 2, 3).float().div_(127.5).sub_(1.0)
+                processed_video = video_processor.postprocess_video(vae_video, output_type="pil")
+            else:
+                raise ValueError(f"Unsupported Cosmos3 video output_type: {output_type!r}.")
+        else:
+            processed_video = video_processor.postprocess_video(video, output_type=output_type)
         if audio is None:
             if pending_action is not None:
                 return {
@@ -3575,6 +3650,15 @@ class Cosmos3OmniDiffusersPipeline(
             logger.info("Decoding video...")
         decode_start = time.time()
         video = self._decode_latents(latents)
+        if _should_narrow_video_output(
+            is_output_rank=_is_rank_zero(),
+            is_t2i=is_t2i,
+            enable_cpu_offload=bool(getattr(self.od_config, "enable_cpu_offload", False)),
+        ):
+            # T2I keeps the VAE range because its postprocess hands back PIL
+            # images. CPU offload keeps conversion on the host to preserve the
+            # post-decode memory headroom it was enabled to provide.
+            video = to_display_uint8(video)
         if _is_rank_zero():
             logger.info("Video decoded in %.2fs", time.time() - decode_start)
             if not sound_enabled:

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -572,7 +572,7 @@ _DISPLAY_CHUNK_BYTES = 64 << 20
 
 
 def _display_chunk_frame_count(video: torch.Tensor, chunk_bytes: int | None = None) -> int:
-    """Return the number of frames whose float32 form fits the budget."""
+    """Return the max frames per slice that stay within the intermediate-byte budget (always >= 1)."""
     if video.ndim != 5:
         raise ValueError(f"Expected decoded video with shape [B, C, T, H, W], got {tuple(video.shape)}.")
     if chunk_bytes is None:

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -641,6 +641,68 @@ def get_cosmos3_pre_process_func(od_config: OmniDiffusionConfig):
     return pre_process_func
 
 
+# Bound the temporary float32 conversion immediately after VAE decode.
+_DISPLAY_CHUNK_BYTES = 64 << 20
+
+
+def _display_chunk_frame_count(video: torch.Tensor, chunk_bytes: int | None = None) -> int:
+    """Return the number of frames whose float32 form fits the budget."""
+    if video.ndim != 5:
+        raise ValueError(f"Expected decoded video with shape [B, C, T, H, W], got {tuple(video.shape)}.")
+    if chunk_bytes is None:
+        chunk_bytes = _DISPLAY_CHUNK_BYTES
+    batch, channels, _, height, width = video.shape
+    # Non-float32 inputs briefly coexist with their float32 form during the
+    # cast that precedes scaling to display bytes.
+    bytes_per_value = 4 if video.dtype == torch.float32 else video.element_size() + 4
+    intermediate_bytes_per_frame = batch * height * width * channels * bytes_per_value
+    return max(1, chunk_bytes // intermediate_bytes_per_frame)
+
+
+def to_display_uint8(video: torch.Tensor) -> torch.Tensor:
+    """Convert a decoded video from VAE range to display-ready uint8 frames.
+
+    The VAE emits ``[B, C, T, H, W]`` in ``[-1, 1]``; every consumer ultimately
+    wants ``[B, T, H, W, C]`` uint8 in ``[0, 255]``. Narrowing before IPC
+    reduces the device-to-host and shared-memory payload.
+
+    The arithmetic runs in float32 and matches the old two-step path exactly —
+    ``postprocess_video`` produced ``(x / 2 + 0.5).clamp(0, 1)`` and the encoders
+    then scaled and rounded — so output is bit-identical to what callers saw, and
+    slicing does not change that because frames convert independently.
+    """
+    video = video.detach()
+    batch, channels, frames, height, width = video.shape
+    out = torch.empty(
+        (batch, frames, height, width, channels),
+        dtype=torch.uint8,
+        device=video.device,
+    )
+
+    step = _display_chunk_frame_count(video)
+    for start in range(0, frames, step):
+        stop = min(start + step, frames)
+        # Preserve the input dtype for denormalization to match the historical
+        # VideoProcessor path, which performed this arithmetic before casting
+        # to float32 for NumPy.
+        chunk = video[:, :, start:stop].permute(0, 2, 3, 4, 1).to(video.dtype, copy=True)
+        chunk = chunk.mul_(0.5).add_(0.5).clamp_(0, 1)
+        if chunk.dtype != torch.float32:
+            chunk = chunk.float()
+        out[:, start:stop] = chunk.mul_(255).round_().to(torch.uint8)
+    return out
+
+
+def _should_narrow_video_output(
+    *,
+    is_output_rank: bool,
+    is_t2i: bool,
+    enable_cpu_offload: bool,
+) -> bool:
+    """Narrow only when GPU post-decode headroom is expected."""
+    return is_output_rank and not is_t2i and not enable_cpu_offload
+
+
 def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
     """Build the postprocessor for Cosmos3 image, video, and video+audio output.
 
@@ -762,7 +824,20 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
         guardrails_enabled = is_guardrails_enabled(od_config, sampling_params)
         if guardrails_enabled:
             video = check_video_safety(video)
-        processed_video = video_processor.postprocess_video(video, output_type=output_type)
+        if video.dtype == torch.uint8:
+            # Display-ready output intentionally remains uint8 for ``np`` and
+            # ``pt`` so serving does not widen it only to encode it as bytes.
+            if output_type == "pt":
+                processed_video = video
+            elif output_type == "np":
+                processed_video = video.detach().cpu().numpy()
+            elif output_type == "pil":
+                vae_video = video.detach().cpu().permute(0, 4, 1, 2, 3).float().div_(127.5).sub_(1.0)
+                processed_video = video_processor.postprocess_video(vae_video, output_type="pil")
+            else:
+                raise ValueError(f"Unsupported Cosmos3 video output_type: {output_type!r}.")
+        else:
+            processed_video = video_processor.postprocess_video(video, output_type=output_type)
         if audio is None:
             if pending_action is not None:
                 return {
@@ -3974,6 +4049,15 @@ class Cosmos3OmniDiffusersPipeline(
             logger.info("Decoding video...")
         decode_start = time.time()
         video = self._decode_latents(latents)
+        if _should_narrow_video_output(
+            is_output_rank=_is_rank_zero(),
+            is_t2i=is_t2i,
+            enable_cpu_offload=bool(getattr(self.od_config, "enable_cpu_offload", False)),
+        ):
+            # T2I keeps the VAE range because its postprocess hands back PIL
+            # images. CPU offload keeps conversion on the host to preserve the
+            # post-decode memory headroom it was enabled to provide.
+            video = to_display_uint8(video)
         if _is_rank_zero():
             logger.info("Video decoded in %.2fs", time.time() - decode_start)
             if not sound_enabled:

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -703,6 +703,15 @@ def _should_narrow_video_output(
     return is_output_rank and not is_t2i and not enable_cpu_offload
 
 
+def _display_uint8_to_pil(video: torch.Tensor) -> list[list[PIL.Image.Image]]:
+    """Convert ``[B, T, H, W, C]`` display bytes to PIL one frame at a time."""
+    if video.ndim != 5 or video.shape[-1] not in (1, 3, 4):
+        raise ValueError(
+            f"Expected display video with shape [B, T, H, W, C] and 1, 3, or 4 channels, got {tuple(video.shape)}."
+        )
+    return [[PIL.Image.fromarray(frame.detach().cpu().numpy()) for frame in sample] for sample in video]
+
+
 def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
     """Build the postprocessor for Cosmos3 image, video, and video+audio output.
 
@@ -825,15 +834,15 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
         if guardrails_enabled:
             video = check_video_safety(video)
         if video.dtype == torch.uint8:
-            # Display-ready output intentionally remains uint8 for ``np`` and
-            # ``pt`` so serving does not widen it only to encode it as bytes.
+            # The uint8 channel-last representation is an internal transport
+            # optimization. Restore the public VideoProcessor contracts here.
             if output_type == "pt":
-                processed_video = video
+                processed_video = video.permute(0, 1, 4, 2, 3).float().div_(255.0)
             elif output_type == "np":
-                processed_video = video.detach().cpu().numpy()
+                processed_video = video.detach().cpu().numpy().astype(np.float32)
+                processed_video /= 255.0
             elif output_type == "pil":
-                vae_video = video.detach().cpu().permute(0, 4, 1, 2, 3).float().div_(127.5).sub_(1.0)
-                processed_video = video_processor.postprocess_video(vae_video, output_type="pil")
+                processed_video = _display_uint8_to_pil(video)
             else:
                 raise ValueError(f"Unsupported Cosmos3 video output_type: {output_type!r}.")
         else:

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -646,7 +646,7 @@ _DISPLAY_CHUNK_BYTES = 64 << 20
 
 
 def _display_chunk_frame_count(video: torch.Tensor, chunk_bytes: int | None = None) -> int:
-    """Return the number of frames whose float32 form fits the budget."""
+    """Return the max frames per slice that stay within the intermediate-byte budget (always >= 1)."""
     if video.ndim != 5:
         raise ValueError(f"Expected decoded video with shape [B, C, T, H, W], got {tuple(video.shape)}.")
     if chunk_bytes is None:


### PR DESCRIPTION
## Purpose

Reduce Cosmos3 video response latency and peak GPU memory after VAE decode.

Previously, Cosmos3 returned decoded video as a bfloat16 tensor in
`[B, C, T, H, W]` layout. The diffusion IPC path then promoted bfloat16 to
float32 for NumPy/shared-memory compatibility, and postprocessing converted the
result to display range before the video encoder converted it again to uint8.
For a 1280x720, 189-frame video, this widened the shared-memory payload to about
2.09 GB even though the final encoder input is only about 0.52 GB of uint8
frames.

This change converts decoded video on the output rank directly to display-ready
uint8 `[B, T, H, W, C]` before IPC. The existing asynchronous pinned-memory D2H
path then transfers the narrower payload without an additional format
conversion.

Key details:

- A 64 MiB temporal chunk budget bounds conversion intermediates at the
  post-VAE memory peak.
- Historical bfloat16 arithmetic and final display bytes are preserved.
- Conversion runs only on the output rank and is skipped for T2I and CPU
  offload.
- Guardrails consume uint8 directly, avoiding a float round trip.
- `np`, `pt`, and `pil` output types remain supported.

## Test Plan

- CPU tests for output parity, chunking, rank/offload gates, output types, and
  guardrails.
- CUDA regression for sub-threshold device output reaching NumPy postprocess.
- Online-serving T2I/T2V/I2V/V2V smoke coverage.
- Same-node before/after serving benchmarks.

```bash
pytest -q \
  tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py \
  tests/diffusion/models/cosmos3/test_cosmos3_guardrails.py
```

**vLLM Version:** 0.25.0

**vLLM-Omni Baseline Commit:** `a4ea67a21b`

**vLLM-Omni Optimized Commit:** `d80fa73a8a`

## Test Result

### Unit and E2E correctness

- CPU: `89 passed, 1 skipped`; CUDA regression: `1 passed`; online smoke:
  `2 passed`; Ruff: all checks passed.
- Every baseline and optimized benchmark completed 5/5 measured requests.

### Single-GPU benchmark

NVIDIA GB300; T2V 1280x720, 189 frames, 35 steps; no VAE tiling;
concurrency 1; 1 warmup + 5 measured requests; CUDNN attention; guardrails off.

| revision | mean latency | median latency | throughput | peak GPU memory | mean stage generation |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 87.243 s | 87.295 s | 0.01146 req/s | 49.572 GB | 83.010 s |
| optimized | 84.131 s | 84.132 s | 0.01189 req/s | 47.560 GB | 82.144 s |
| change | **-3.112 s (-3.6%)** | **-3.163 s (-3.6%)** | **+0.00042 req/s (+3.7%)** | **-2.012 GB (-4.1%)** | **-0.865 s (-1.0%)** |

### Four-GPU benchmark

4x NVIDIA GB300; same workload; CFG parallel 2; Ulysses 2; VAE patch
parallel 4 with `spatial_shard_width`; concurrency 1; 1 warmup + 5 measured
requests; CUDNN attention; guardrails off.

| revision | mean latency | median latency | throughput | peak GPU memory | mean stage generation |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 28.846 s | 28.712 s | 0.03467 req/s | 41.240 GB | 24.622 s |
| optimized | 27.294 s | 27.285 s | 0.03664 req/s | 39.244 GB | 23.631 s |
| change | **-1.552 s (-5.4%)** | **-1.427 s (-5.0%)** | **+0.00197 req/s (+5.7%)** | **-1.996 GB (-4.8%)** | **-0.991 s (-4.0%)** |

### Notes

Pipeline `forward` and VAE decode times were unchanged, confirming that the gain
comes from output handling. MP4 encoding improved by 0.544 s (24.9%) on one GPU
and 0.547 s (25.1%) on four GPUs. The four-GPU stage-generation reduction
(0.991 s) plus encoding reduction accounts for nearly all of its 1.552 s E2E
improvement. Byte-parity tests confirm chunking does not alter display output.
