### PR TITLE
[Bugfix][Core] Sweep skipped_waiting for aborted requests in OmniARScheduler

### DIFF
--- a/tests/core/sched/test_omni_ar_scheduler_aborted_queue_sweep.py
+++ b/tests/core/sched/test_omni_ar_scheduler_aborted_queue_sweep.py
@@ -1,0 +1,115 @@
+"""Tests for ``OmniARScheduler._drop_aborted_queued_requests``.
+
+``schedule()`` sweeps ``FINISHED_ABORTED`` requests out of the queues before
+handing control to upstream, because upstream ``Scheduler.schedule()`` raises
+``RuntimeError: Invalid request status: FINISHED_ABORTED`` for any request it
+admits in a finished state -- which kills the stage's engine core, not just
+the request.
+
+Regression for the sweep missing ``skipped_waiting``, the third queue
+upstream admits from. An aborted duplex session parked there was re-selected
+by ``_select_waiting_queue_for_scheduling`` on a later tick and crashed the
+stage.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.request import RequestStatus
+
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_POLICIES = [
+    pytest.param(SchedulingPolicy.FCFS, id="fcfs"),
+    pytest.param(SchedulingPolicy.PRIORITY, id="priority"),
+]
+
+
+class _StubRequest:
+    """Minimal ``Request`` stub with the surface the sweep exercises.
+
+    Carries the ``(priority, arrival_time)`` ordering ``PriorityRequestQueue``
+    relies on so the same stub works under both scheduling policies.
+    """
+
+    def __init__(self, request_id: str, status: RequestStatus, arrival_time: float = 0.0) -> None:
+        self.request_id = request_id
+        self.status = status
+        self.priority = 0
+        self.arrival_time = arrival_time
+
+    def __lt__(self, other: _StubRequest) -> bool:
+        return (self.priority, self.arrival_time) < (other.priority, other.arrival_time)
+
+
+def _make_scheduler(policy: SchedulingPolicy, *, waiting=(), skipped_waiting=(), running=()):
+    """Bare scheduler with just the surface the sweep reads."""
+    scheduler = OmniARScheduler.__new__(OmniARScheduler)
+    scheduler.waiting = create_request_queue(policy)
+    for req in waiting:
+        scheduler.waiting.add_request(req)
+    scheduler.skipped_waiting = create_request_queue(policy)
+    for req in skipped_waiting:
+        scheduler.skipped_waiting.add_request(req)
+    scheduler.running = list(running)
+    return scheduler
+
+
+@pytest.mark.parametrize("policy", _POLICIES)
+def test_sweep_drops_aborted_request_from_skipped_waiting(policy: SchedulingPolicy) -> None:
+    """The sweep must cover ``skipped_waiting``.
+
+    Upstream ``schedule()`` admits from ``skipped_waiting`` as readily as from
+    ``waiting``, so an aborted request left there is re-selected and raises.
+    """
+    aborted = _StubRequest("req-aborted", RequestStatus.FINISHED_ABORTED)
+    scheduler = _make_scheduler(policy, skipped_waiting=[aborted])
+
+    scheduler._drop_aborted_queued_requests()
+
+    assert list(scheduler.skipped_waiting) == []
+
+
+@pytest.mark.parametrize("policy", _POLICIES)
+def test_sweep_drops_aborted_requests_from_waiting_and_running(policy: SchedulingPolicy) -> None:
+    """``waiting`` and ``running`` stay covered alongside the new queue."""
+    aborted_waiting = _StubRequest("req-waiting", RequestStatus.FINISHED_ABORTED)
+    aborted_running = _StubRequest("req-running", RequestStatus.FINISHED_ABORTED)
+    scheduler = _make_scheduler(
+        policy,
+        waiting=[aborted_waiting],
+        running=[aborted_running],
+    )
+
+    scheduler._drop_aborted_queued_requests()
+
+    assert list(scheduler.waiting) == []
+    assert scheduler.running == []
+
+
+@pytest.mark.parametrize("policy", _POLICIES)
+def test_sweep_leaves_live_requests_intact(policy: SchedulingPolicy) -> None:
+    """The sweep must not over-sweep.
+
+    A request parked in ``skipped_waiting`` on a blocked waiting status is one
+    upstream still intends to schedule; only the aborted entry may go.
+    """
+    blocked = _StubRequest("req-blocked", RequestStatus.WAITING_FOR_STREAMING_REQ, arrival_time=0.0)
+    aborted = _StubRequest("req-aborted", RequestStatus.FINISHED_ABORTED, arrival_time=1.0)
+    live_waiting = _StubRequest("req-live-waiting", RequestStatus.WAITING)
+    live_running = _StubRequest("req-live-running", RequestStatus.RUNNING)
+    scheduler = _make_scheduler(
+        policy,
+        waiting=[live_waiting],
+        skipped_waiting=[blocked, aborted],
+        running=[live_running],
+    )
+
+    scheduler._drop_aborted_queued_requests()
+
+    assert list(scheduler.skipped_waiting) == [blocked]
+    assert list(scheduler.waiting) == [live_waiting]
+    assert scheduler.running == [live_running]

--- a/tests/core/sched/test_omni_ar_scheduler_unified_decode_deferral.py
+++ b/tests/core/sched/test_omni_ar_scheduler_unified_decode_deferral.py
@@ -76,6 +76,9 @@ def _make_scheduler(
         else:
             hf_config.voxcpm2_runtime_config = runtime_config
     sched.vllm_config = SimpleNamespace(model_config=model_config)
+    # Upstream ``Scheduler.__init__`` always creates ``skipped_waiting``; the
+    # abort sweep at the top of ``schedule()`` reads it.
+    sched.skipped_waiting = _MockQueue()
     return sched
 
 

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -218,15 +218,32 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         if stop_after_transfer and req_id in self.requests_needing_kv_transfer:
             self.pending_stop_after_extraction.add(req_id)
 
+    def _drop_aborted_queued_requests(self) -> None:
+        """Drop ``FINISHED_ABORTED`` requests from every queue ``schedule()`` reads.
+
+        Upstream ``Scheduler.schedule()`` raises ``RuntimeError: Invalid
+        request status`` for any request it admits that is neither ``WAITING``
+        nor ``PREEMPTED``, and it admits from ``skipped_waiting`` as readily as
+        from ``waiting``: it loops while either queue is non-empty and
+        ``_select_waiting_queue_for_scheduling`` returns either one.
+
+        Omni can leave an aborted request in ``skipped_waiting`` because
+        ``OmniChunkTransferAdapter.finish_requests`` restores a stale
+        ``requests_origin_status`` of ``RUNNING`` onto a request parked there,
+        so upstream ``Scheduler.finish_requests`` takes its running-removal
+        branch and never touches the waiting queues. The next ``schedule()``
+        then re-selects the request and kills the stage's engine core.
+        """
+        for queue in (self.waiting, self.skipped_waiting):
+            aborted = [req for req in queue if req.status == RequestStatus.FINISHED_ABORTED]
+            if aborted:
+                # ``PriorityRequestQueue`` implements no ``remove``; both
+                # queue policies implement ``remove_requests``.
+                queue.remove_requests(aborted)
+        self.running[:] = [req for req in self.running if req.status != RequestStatus.FINISHED_ABORTED]
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        # Remove FINISHED_ABORTED requests before the upstream scheduler sees
-        # them. Upstream vllm raises RuntimeError on this status; omni allows
-        # async abort (e.g. client disconnect during TTS streaming) to leave
-        # requests in the waiting/running queues temporarily.
-        for queue in (self.waiting, self.running):
-            for req in list(queue):
-                if getattr(req, "status", None) == RequestStatus.FINISHED_ABORTED:
-                    queue.remove(req)
+        self._drop_aborted_queued_requests()
         self._process_pending_omni_inputs(model_mode="ar")
 
         original_waiting = None


### PR DESCRIPTION
## Purpose

`OmniARScheduler.schedule()` drops `FINISHED_ABORTED` requests before handing control to upstream, because upstream raises on that status instead of tolerating it. The sweep covered `waiting` and `running`. Upstream admits from **three** queues:

```python
# vllm/v1/core/sched/scheduler.py, Scheduler.schedule() — vLLM 0.26.0
669:  while (self.waiting or self.skipped_waiting) and token_budget > 0:
676:      request_queue = self._select_waiting_queue_for_scheduling()   # may return skipped_waiting
679:      request = request_queue.peek_request()
...
1011:     self.running.append(request)
1016:     if request.status == RequestStatus.WAITING:      ...
1018:     elif request.status == RequestStatus.PREEMPTED:  ...
1021:     else: raise RuntimeError(f"Invalid request status: {request.status}")
```

`skipped_waiting` is an admission source, not a holding area, and it persists across ticks (line 1057 merges each step's skipped set back into it). An aborted request parked there survives the sweep and raises on a later tick:

```
RuntimeError: Invalid request status: FINISHED_ABORTED
  vllm/v1/core/sched/scheduler.py in schedule
  vllm_omni/core/sched/omni_ar_scheduler.py in schedule
[Orchestrator] Orchestrator died unexpectedly. See logs above.
```

That kills the stage's engine core and takes the orchestrator with it — every in-flight session is lost. Observed under duplex load with 10 sessions closing together.

**The fix:** sweep `skipped_waiting` too.

### Why omni reaches this state and upstream does not

Upstream `finish_requests` does clean `skipped_waiting` — but only on its non-running branch:

```python
if request.status == RequestStatus.RUNNING:
    running_requests_to_remove.add(request)     # only self.running is filtered
else:
    waiting_requests_to_remove.append(request)  # waiting AND skipped_waiting
```

Omni can reach that branch with the wrong status. `OmniChunkTransferAdapter.finish_requests` runs first and restores `requests_origin_status[req_id]` onto `request.status`. That table is stamped `RUNNING` when a request is parked out of `self.running`, and `restore_queues` never clears it, so it goes stale across the admit transition — the same staleness already documented in `_realign_request_status_to_queues` (#3774).

If the request has since become `WAITING_FOR_STREAMING_REQ` (a duplex session awaiting its next input chunk) and been parked in `skipped_waiting`, the stale `RUNNING` sends `finish_requests` down the running branch, the waiting queues are never touched, and the request is stranded there with `FINISHED_ABORTED`. `_realign_request_status_to_queues` doesn't repair it either — it builds `waiting_ids` from `self.waiting` only. Stock vLLM never gets here because nothing rewrites `request.status` behind `finish_requests`.

Same shape as #5662 and #5672: omni keeps state alongside upstream's, and a path that updates one but not the other starves or crashes a stage.

### Also in this diff

Removal now goes through `RequestQueue.remove_requests()`. The old sweep called `queue.remove(req)`, which worked only because `FCFSRequestQueue` subclasses `deque` — `PriorityRequestQueue` has no `remove()`, so under `--scheduling-policy priority` the sweep raised `AttributeError` on the first abort. `remove_requests()` is implemented by both policies and is what upstream `finish_requests` and the rest of omni already use. Same statement as the primary fix, so it is fixed here rather than left as a landmine.

The sweep moves into `_drop_aborted_queued_requests()` so it is testable without a KV cache manager and a model config. Call-site behaviour is otherwise unchanged.

It stays on `OmniARScheduler` rather than moving to `OmniSchedulerMixin` alongside `_purge_finished_from_running`, because `OmniARScheduler.schedule()` is the only scheduler that sweeps today — hoisting it without a second caller would be an abstraction with one implementation, and giving `OmniGenerationScheduler` a caller is a behaviour change beyond this fix. Happy to move it if you'd rather it live with the shared lifecycle helpers from #5461.

### Out of scope

Each needs its own reproduction and PR:

- a retry loop around `super().schedule()` for the narrower race where a request is aborted *while* upstream is mid-`schedule()` (upstream appends to `self.running` before checking status, so no pre-sweep can prevent that one)
- teaching `_realign_request_status_to_queues` about `skipped_waiting`, which would fix the producer path rather than this symptom
- anything touching `active_stream_window` in shipped example configs

No functional overlap with #5662, which also adds to `schedule()` a few lines below this hunk.

## Test Plan

```bash
pytest -sv tests/core/sched/test_omni_ar_scheduler_aborted_queue_sweep.py -m "core_model and cpu"
pytest -q tests/core tests/engine tests/distributed tests/model_executor -m "core_model and cpu"
```

New tests, each parametrized over the FCFS and PRIORITY queue policies:

| Test | Pins |
|---|---|
| `..._drops_aborted_request_from_skipped_waiting` | the regression |
| `..._drops_aborted_requests_from_waiting_and_running` | the two queues already covered stay covered |
| `..._leaves_live_requests_intact` | no over-sweep: a live `WAITING_FOR_STREAMING_REQ` request in `skipped_waiting`, plus live `waiting` / `running` entries, survive |

`test_omni_ar_scheduler_unified_decode_deferral.py` needed `skipped_waiting` on its hand-built scheduler; the real `Scheduler.__init__` always creates it.

**vLLM Version:** 0.26.0 (torch 2.11.0+cu130, transformers 5.14.1)

**vLLM-Omni Commit:** 6fdc4ca62dc6080bc683552c6ec9e310e9c80867

## Test Result

New tests: **6 failed** with `upstream/main`'s version of `omni_ar_scheduler.py` in place, **6 passed** with the fix.

L1 (`core_model and cpu`) over `tests/core tests/engine tests/distributed tests/model_executor`, both sides on this rebase, same box and container:

```
6fdc4ca6 (base):  22 failed, 1627 passed, 8 skipped, 205 deselected in 270.88s
this branch:      22 failed, 1633 passed, 8 skipped, 205 deselected in 308.25s
```

Byte-identical failure sets — the 22 are pre-existing on the base commit in this environment (model-specific cosyvoice3 / step_audio2 / voxcpm2 tests plus one orchestrator test); none are in `tests/core` or `tests/distributed`. The 6 extra passes are the new tests.

For a quick look at the mechanism without running the suite, replaying the pre-fix sweep against the real `RequestQueue` types shows both defects directly (ad-hoc script, not checked in — the three tests above cover the same ground):

```
[fcfs]     after the sweep, skipped_waiting = [sess-aborted(FINISHED_ABORTED)]
[fcfs]     _select_waiting_queue_for_scheduling picked skipped_waiting, peek = sess-aborted(FINISHED_ABORTED)
[fcfs]     sweep of `waiting`: ok
[priority] after the sweep, skipped_waiting = [sess-aborted(FINISHED_ABORTED)]
[priority] _select_waiting_queue_for_scheduling picked skipped_waiting, peek = sess-aborted(FINISHED_ABORTED)
[priority] sweep of `waiting` raised AttributeError: 'PriorityRequestQueue' object has no attribute 'remove'
```

The aborted request survives the sweep and is the very request upstream picks next — one step from the `raise`.

### Not verified here

The original duplex crash reproduction bundled two other changes (a retry loop around `super().schedule()` and an `active_stream_window` config change), so its numbers don't isolate this one, and the live ramp has not been re-run with only this change. The mechanism and the queue-set gap are proven above; no end-to-end measurement is claimed.

Anyone reproducing live should know `active_stream_window: 1` **masks this crash** — it admits one stream at a time to the chunk-transfer adapter's active set, so aborts never overlap. Reproduce with `0`.
