### PR TITLE
[Bugfix] Make diffusion output wait timeout configurable

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -61,6 +61,18 @@ uv pip install -e '.[fa4]'
 `ffmpeg` and `ffprobe` must be available on `PATH`. They are used for
 reference-video preparation and MP4 output.
 
+Long video requests have two relevant timeouts:
+
+- `VLLM_OMNI_VIDEO_SYNC_TIMEOUT` controls API-side video synchronization.
+- `VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT` controls the engine's wait for
+  background device-to-host transfer and shared-memory output packaging.
+
+The diffusion output timeout defaults to 30 seconds. When its dedicated
+variable is unset, it inherits `VLLM_OMNI_VIDEO_SYNC_TIMEOUT`; therefore the
+commands below set both waits to 1800 seconds. Set the dedicated variable when
+the background-output wait needs a different limit. Both values must be
+positive finite numbers.
+
 ## Start a server
 
 Pass the repository ID directly. The pipeline uses `FL2VA` for model discovery

--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import concurrent.futures
 import queue
 import threading
 from types import SimpleNamespace
@@ -45,6 +46,15 @@ def _make_engine() -> DiffusionEngine:
     return engine
 
 
+def test_async_output_timeout_defaults_to_30_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT", raising=False)
+    monkeypatch.delenv("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", raising=False)
+
+    assert diffusion_engine_module._get_async_output_timeout() == 30.0
+
+
 def test_async_output_timeout_uses_video_sync_timeout_as_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -72,6 +82,103 @@ def test_async_output_timeout_rejects_nonpositive_or_nonfinite_values(
 
     with pytest.raises(ValueError, match="positive finite"):
         diffusion_engine_module._get_async_output_timeout()
+
+
+@pytest.mark.asyncio
+async def test_step_streaming_uses_configured_async_output_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _make_engine()
+    engine._async_output_timeout = 45.5
+    engine.pre_process_func = None
+
+    async def check_background_loop() -> None:
+        return None
+
+    engine._check_and_start_background_loop = check_background_loop
+
+    pending = DiffusionOutput(async_output_id="output-1")
+    ready = DiffusionOutput(output="ready")
+    future: concurrent.futures.Future[DiffusionOutput] = concurrent.futures.Future()
+    future.set_result(ready)
+    waited_ids: list[str] = []
+
+    def wait_output_ready(output_id: str):
+        waited_ids.append(output_id)
+        return future
+
+    engine.executor = SimpleNamespace(wait_output_ready=wait_output_ready)
+
+    async def stream_response(_request):
+        yield pending
+
+    engine.async_add_req_and_stream_response = stream_response
+    engine.postprocess_output = lambda _request, output: [] if output is ready else None
+
+    observed_timeouts: list[float | None] = []
+    original_wait_for = asyncio.wait_for
+
+    async def capture_wait_for(awaitable, timeout):
+        observed_timeouts.append(timeout)
+        return await original_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(asyncio, "wait_for", capture_wait_for)
+
+    batches = [batch async for batch in engine.step_streaming(_make_request("async-timeout"))]
+
+    assert batches == [[]]
+    assert waited_ids == ["output-1"]
+    assert observed_timeouts == [45.5]
+
+
+def test_sync_output_wait_uses_configured_async_output_timeout() -> None:
+    engine = _make_engine()
+    engine._async_output_timeout = 72.0
+    pending = DiffusionOutput(async_output_id="output-2")
+    ready = DiffusionOutput(output="ready")
+
+    class FakeScheduler:
+        @staticmethod
+        def add_request(_request):
+            return "request-1"
+
+        @staticmethod
+        def schedule():
+            return SimpleNamespace(
+                is_empty=False,
+                scheduled_request_ids=["request-1"],
+            )
+
+        @staticmethod
+        def update_from_output(_sched_output, _runner_output):
+            return {"request-1"}
+
+    class FakeRunnerOutput:
+        @staticmethod
+        def get_request_output(_request_id):
+            return pending
+
+        def __len__(self):
+            return 1
+
+    class TimeoutRecordingFuture:
+        timeout = None
+
+        def result(self, *, timeout):
+            self.timeout = timeout
+            return ready
+
+    future = TimeoutRecordingFuture()
+    engine.scheduler = FakeScheduler()
+    engine.execute_fn = lambda _sched_output: FakeRunnerOutput()
+    engine._process_aborts_queue = lambda: None
+    engine._finalize_finished_request = lambda *_args, **_kwargs: pending
+    engine.executor = SimpleNamespace(wait_output_ready=lambda _output_id: future)
+
+    output = engine.add_req_and_wait_for_response(_make_request("sync-timeout"))
+
+    assert output is ready
+    assert future.timeout == 72.0
 
 
 def test_close_completes_pending_output_streams() -> None:

--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -45,6 +45,35 @@ def _make_engine() -> DiffusionEngine:
     return engine
 
 
+def test_async_output_timeout_uses_video_sync_timeout_as_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT", raising=False)
+    monkeypatch.setenv("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", "1800")
+
+    assert diffusion_engine_module._get_async_output_timeout() == 1800.0
+
+
+def test_async_output_timeout_prefers_specific_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", "1800")
+    monkeypatch.setenv("VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT", "45.5")
+
+    assert diffusion_engine_module._get_async_output_timeout() == 45.5
+
+
+@pytest.mark.parametrize("value", ["", "invalid", "0", "-1", "inf", "nan"])
+def test_async_output_timeout_rejects_nonpositive_or_nonfinite_values(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT", value)
+
+    with pytest.raises(ValueError, match="positive finite"):
+        diffusion_engine_module._get_async_output_timeout()
+
+
 def test_close_completes_pending_output_streams() -> None:
     engine = _make_engine()
     event_loop = asyncio.new_event_loop()

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -64,24 +64,19 @@ def _get_async_output_timeout() -> float:
         "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT",
         os.environ.get("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", "30"),
     )
+    error = (
+        "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT (or fallback "
+        "VLLM_OMNI_VIDEO_SYNC_TIMEOUT) must be a positive finite number, "
+        f"got {raw_timeout!r}."
+    )
     try:
         timeout = float(raw_timeout)
     except ValueError as exc:
-        raise ValueError(
-            "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT (or fallback "
-            "VLLM_OMNI_VIDEO_SYNC_TIMEOUT) must be a positive finite number, "
-            f"got {raw_timeout!r}."
-        ) from exc
+        raise ValueError(error) from exc
     if not math.isfinite(timeout) or timeout <= 0:
-        raise ValueError(
-            "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT (or fallback "
-            "VLLM_OMNI_VIDEO_SYNC_TIMEOUT) must be a positive finite number, "
-            f"got {raw_timeout!r}."
-        )
+        raise ValueError(error)
     return timeout
 
-
-_ASYNC_OUTPUT_TIMEOUT = _get_async_output_timeout()
 
 __all__ = [
     "DiffusionEngine",
@@ -210,6 +205,7 @@ class DiffusionEngine:
                 from the resolved execution mode.
         """
         self.od_config = od_config
+        self._async_output_timeout = _get_async_output_timeout()
 
         self._init_process_hooks(od_config)
         self.execution_mode = self._resolve_execution_mode(od_config)
@@ -349,7 +345,10 @@ class DiffusionEngine:
             # Async mode: wait for background D2H/SHM to complete.
             if output.async_output_id:
                 fut = self.executor.wait_output_ready(output.async_output_id)
-                output = await asyncio.wait_for(asyncio.wrap_future(fut), timeout=_ASYNC_OUTPUT_TIMEOUT)
+                output = await asyncio.wait_for(
+                    asyncio.wrap_future(fut),
+                    timeout=self._async_output_timeout,
+                )
             postprocess_start_time = time.perf_counter()
             formatted_outputs = self.postprocess_output(request, output)
             postprocess_time = time.perf_counter() - postprocess_start_time
@@ -816,7 +815,7 @@ class DiffusionEngine:
                     )
                     if output.async_output_id:
                         fut = self.executor.wait_output_ready(output.async_output_id)
-                        output = fut.result(timeout=_ASYNC_OUTPUT_TIMEOUT)
+                        output = fut.result(timeout=self._async_output_timeout)
                     return output
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import inspect
+import math
+import os
 import queue
 import threading
 import time
@@ -55,7 +57,31 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_ASYNC_OUTPUT_TIMEOUT = 30.0  # seconds
+
+def _get_async_output_timeout() -> float:
+    """Resolve the timeout for background D2H/shared-memory output transfer."""
+    raw_timeout = os.environ.get(
+        "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT",
+        os.environ.get("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", "30"),
+    )
+    try:
+        timeout = float(raw_timeout)
+    except ValueError as exc:
+        raise ValueError(
+            "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT (or fallback "
+            "VLLM_OMNI_VIDEO_SYNC_TIMEOUT) must be a positive finite number, "
+            f"got {raw_timeout!r}."
+        ) from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError(
+            "VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT (or fallback "
+            "VLLM_OMNI_VIDEO_SYNC_TIMEOUT) must be a positive finite number, "
+            f"got {raw_timeout!r}."
+        )
+    return timeout
+
+
+_ASYNC_OUTPUT_TIMEOUT = _get_async_output_timeout()
 
 __all__ = [
     "DiffusionEngine",


### PR DESCRIPTION
## Summary
- make the background diffusion D2H/shared-memory output wait configurable with `VLLM_OMNI_DIFFUSION_OUTPUT_TIMEOUT`
- fall back to the existing `VLLM_OMNI_VIDEO_SYNC_TIMEOUT` so long-video deployments need only one timeout unless they want separate control
- preserve the existing 30-second default and reject invalid, non-positive, or non-finite values at startup

The API-level video timeout currently does not cover the internal wait for an async output to finish D2H transfer and shared-memory packing. On a slower large-video path, model execution can finish successfully but the fixed 30-second internal wait cancels the result before the API receives it.

## Test plan
- [x] `18 passed` — `tests/diffusion/test_diffusion_engine_cleanup.py`
- [x] all pre-commit hooks pass for the changed files
- [x] tests cover dedicated override precedence, fallback to the video timeout, the unchanged default, and invalid timeout values
- [x] reproduced on a source-built ROCm environment with 209-frame 1344x768 MiniMax H3 output where model forward completed but output packing exceeded 30 seconds
- [x] patched path returned HTTP 200 for 209-frame 1344x768 and 2048x1088 video+audio outputs with `VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800/3600`

The default behavior is unchanged for deployments that do not set either environment variable. This is a platform-independent diffusion robustness fix.