### PR TITLE
[Bugfix][MiniCPM-o] Fix the audio_embeds input path

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_audio_embeds_input.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_audio_embeds_input.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for the MiniCPM-o 4.5 ``audio_embeds`` input path.
+
+Two defects made the OpenAI ``audio_embeds`` content part unusable with this model:
+
+1. ``MiniCPMOAudioEmbeddingItems`` registered itself under ``modality="image"``
+   (copy-pasted from ``MiniCPMVImageEmbeddingItems``), so every request failed with
+   ``Modality 'image' not found. Available modalities: {'audio'}``.
+2. ``_get_prompt_updates`` sized the placeholder from
+   ``sum(map(len, single_audio_embeds))``. ``MiniCPMOAudioEmbeddingInputs`` declares
+   ``TensorShape("bn", "s", "h")``, so one item is ``(s, h)`` and that expression
+   iterates rows and sums the hidden size -- ``s * h`` instead of ``s``. A one-second
+   slice of shape ``(10, 4096)`` asked for 40960 placeholder tokens instead of 10,
+   pushing every real request past ``max_model_len``.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.multimodal.parse import MultiModalDataItems
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
+    MiniCPMO45OmniLLMMultiModalProcessor,
+    MiniCPMO45OmniLLMProcessingInfo,
+    MiniCPMOAudioEmbeddingItems,
+    _minicpmo_field_config,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+POOL_STEP = 5
+HIDDEN_SIZE = 4096
+#: Audio embedding vectors produced per second: 100 mel -> 50 cnn -> (50-5)//5+1.
+EMBEDS_PER_SECOND = 10
+
+
+class _FakeProcessor:
+    """Minimal processor surface used by ``get_audio_placeholder``."""
+
+    def __init__(self) -> None:
+        self.pool_step = POOL_STEP
+        self.audio_processor = SimpleNamespace(hop_length=160)
+        self.image_processor = SimpleNamespace(mean=[0.0], std=[1.0])
+
+    def get_audio_placeholder(
+        self,
+        audio_lens: int,
+        chunk_input: bool = True,
+        chunk_length: int = 1,
+    ) -> str:
+        del chunk_input, chunk_length
+        feature_lens = math.ceil(audio_lens / self.audio_processor.hop_length)
+        cnn_feature_lens = (feature_lens - 1) // 2 + 1
+        output_lens = (cnn_feature_lens - self.pool_step) // self.pool_step + 1
+        return "<unk>" * output_lens
+
+
+class _IdentityTokenizer:
+    """``_get_prompt_updates`` round-trips the image/video patterns through the
+    tokenizer to detect encode/decode drift; an identity pair keeps that a no-op."""
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> str:
+        del add_special_tokens
+        return text
+
+    def decode(self, tokens: str) -> str:
+        return tokens
+
+
+def _processing_info() -> MiniCPMO45OmniLLMProcessingInfo:
+    processor = _FakeProcessor()
+    tokenizer = _IdentityTokenizer()
+    info = object.__new__(MiniCPMO45OmniLLMProcessingInfo)
+    info.ctx = SimpleNamespace(
+        tokenizer=tokenizer,
+        get_tokenizer=lambda: tokenizer,
+        get_hf_config=lambda: SimpleNamespace(audio_pool_step=POOL_STEP),
+        get_hf_processor=lambda **kwargs: processor,
+    )
+    return info
+
+
+def _audio_placeholder_for(single_audio_embeds: torch.Tensor) -> str:
+    """Run the real prompt-update path and return the audio placeholder text.
+
+    Goes through ``_get_prompt_updates`` rather than recomputing the length, so the
+    ``sum(map(len, ...))`` regression is actually exercised.
+    """
+    info = _processing_info()
+    proc = object.__new__(MiniCPMO45OmniLLMMultiModalProcessor)
+    proc.info = info
+
+    items = MiniCPMOAudioEmbeddingItems(
+        {"audio_embeds": single_audio_embeds.unsqueeze(0)},
+        fields_factory=_minicpmo_field_config,
+    )
+    mm_items = MultiModalDataItems({"audio": items})
+
+    updates = proc._get_prompt_updates(mm_items, {}, {})
+    audio_update = next(u for u in updates if u.modality == "audio")
+    return audio_update.content(0).full
+
+
+def test_audio_embedding_items_use_the_audio_modality() -> None:
+    """Registering under ``image`` makes every ``audio_embeds`` request fail."""
+    items = MiniCPMOAudioEmbeddingItems(
+        {"audio_embeds": torch.zeros(1, EMBEDS_PER_SECOND, HIDDEN_SIZE)},
+        fields_factory=_minicpmo_field_config,
+    )
+
+    assert items.modality == "audio"
+
+
+@pytest.mark.parametrize("num_seconds", [1, 3, 30])
+def test_placeholder_length_matches_embedding_count(num_seconds: int) -> None:
+    """An ``(s, h)`` item must yield exactly ``s`` placeholder tokens."""
+    num_embeds = num_seconds * EMBEDS_PER_SECOND
+
+    placeholder = _audio_placeholder_for(torch.zeros(num_embeds, HIDDEN_SIZE))
+
+    assert placeholder.count("<unk>") == num_embeds
+
+
+def test_placeholder_does_not_scale_with_hidden_size() -> None:
+    """The count must depend on ``s`` alone, never on ``h``.
+
+    ``sum(map(len, ...))`` returned ``s * h``, so the placeholder grew with the model's
+    hidden size. Two items with the same ``s`` but different ``h`` must agree.
+    """
+    narrow = _audio_placeholder_for(torch.zeros(EMBEDS_PER_SECOND, 8))
+    wide = _audio_placeholder_for(torch.zeros(EMBEDS_PER_SECOND, HIDDEN_SIZE))
+
+    assert narrow.count("<unk>") == wide.count("<unk>") == EMBEDS_PER_SECOND

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -3240,7 +3240,7 @@ class MiniCPMOAudioEmbeddingItems(DictEmbeddingItems):
     ) -> None:
         super().__init__(
             data,
-            modality="image",
+            modality="audio",
             required_fields={"audio_embeds"},
             fields_factory=fields_factory,
         )
@@ -3663,7 +3663,13 @@ class MiniCPMO45OmniLLMMultiModalProcessor(BaseMultiModalProcessor[MiniCPMO45Omn
 
             if isinstance(audios, MiniCPMOAudioEmbeddingItems):
                 single_audio_embeds = audios.get(item_idx)["audio_embeds"]
-                audio_len = self.info.get_audio_len_by_num_chunks(sum(map(len, single_audio_embeds)))
+                # ``MiniCPMOAudioEmbeddingInputs`` declares ``TensorShape("bn", "s", "h")``,
+                # so one item is ``(s, h)`` and ``s`` -- its leading dim -- is the number of
+                # audio embedding vectors. ``sum(map(len, ...))`` instead iterated the rows
+                # and summed the hidden size, yielding ``s * h``: a 1 s slice of shape
+                # ``(10, 4096)`` requested 40960 placeholder tokens instead of 10, so any
+                # real request exceeded ``max_model_len``.
+                audio_len = self.info.get_audio_len_by_num_chunks(len(single_audio_embeds))
             else:
                 audio_len = audios.get_audio_length(item_idx)
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -3663,12 +3663,7 @@ class MiniCPMO45OmniLLMMultiModalProcessor(BaseMultiModalProcessor[MiniCPMO45Omn
 
             if isinstance(audios, MiniCPMOAudioEmbeddingItems):
                 single_audio_embeds = audios.get(item_idx)["audio_embeds"]
-                # ``MiniCPMOAudioEmbeddingInputs`` declares ``TensorShape("bn", "s", "h")``,
-                # so one item is ``(s, h)`` and ``s`` -- its leading dim -- is the number of
-                # audio embedding vectors. ``sum(map(len, ...))`` instead iterated the rows
-                # and summed the hidden size, yielding ``s * h``: a 1 s slice of shape
-                # ``(10, 4096)`` requested 40960 placeholder tokens instead of 10, so any
-                # real request exceeded ``max_model_len``.
+                # One item is ``(s, h)``, so its leading dim is the audio embedding count.
                 audio_len = self.info.get_audio_len_by_num_chunks(len(single_audio_embeds))
             else:
                 audio_len = audios.get_audio_length(item_idx)


### PR DESCRIPTION
## Summary

Two defects made the OpenAI `audio_embeds` content part unusable with MiniCPM-o 4.5. Either one alone is fatal, so the path could never have worked end to end.

**1. Wrong modality.** `MiniCPMOAudioEmbeddingItems` registered itself under `modality="image"`, copy-pasted from `MiniCPMVImageEmbeddingItems` (the sibling video class already uses `"video"`). Every request failed with:

```
Modality 'image' not found. Available modalities: {'audio'}
```

**2. Placeholder sized by `s * h` instead of `s`.** `_get_prompt_updates` computed the length from `sum(map(len, single_audio_embeds))`. `MiniCPMOAudioEmbeddingInputs` declares `TensorShape("bn", "s", "h")`, so a single item is `(s, h)` and that expression iterates rows and sums the hidden size. A one-second slice of shape `(10, 4096)` requested **40960** placeholder tokens instead of 10, so any real request exceeded `max_model_len`:

```
The decoder prompt (length 123112) is longer than the maximum model length of 32768
```

## Verification

Reproduced and fixed against a live server. With both fixes, an interleaved `image_url` + `audio_embeds` request returns a coherent response that demonstrably attends to the audio content (it describes a background melody present only in the audio track), where before it could not be served at all.

## Tests

Adds `tests/model_executor/models/minicpmo_4_5/test_audio_embeds_input.py` — CPU-only, `core_model`, no GPU or checkpoint required. All five cases fail on the unfixed code and pass after.

The placeholder cases run through the real `_get_prompt_updates` path rather than recomputing the length independently, so they genuinely exercise the regression; one case asserts the count does not scale with hidden size, which is the precise failure mode of the old expression.

```
5 passed
```