### PR TITLE
[Perf] Bound memory during video frame conversion

### DIFF
--- a/tests/entrypoints/openai_api/test_video_api_utils.py
+++ b/tests/entrypoints/openai_api/test_video_api_utils.py
@@ -70,6 +70,30 @@ def test_float_frames_are_converted_without_stacking_full_video(monkeypatch):
     np.testing.assert_array_equal(frame, original)
 
 
+def test_two_dimensional_width_four_frames_are_not_treated_as_rgba():
+    frame = np.arange(8, dtype=np.float32).reshape(2, 4) / 8
+
+    frames = video_api_utils._coerce_video_to_uint8_frames([frame, frame])
+
+    expected = np.rint(frame * 255).astype(np.uint8)
+    assert frames.shape == (2, 2, 4)
+    np.testing.assert_array_equal(frames, np.stack([expected, expected]))
+
+
+def test_mixed_float_dtypes_preserve_stacked_rounding_semantics():
+    frames = [
+        np.full((1, 1, 3), 0.1, dtype=np.float16),
+        np.full((1, 1, 3), 0.2, dtype=np.float32),
+    ]
+    stacked = np.stack(frames)
+    expected = np.rint(np.clip(stacked, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+    actual = video_api_utils._coerce_video_to_uint8_frames(frames)
+
+    assert expected[0, 0, 0, 0] == 25
+    np.testing.assert_array_equal(actual, expected)
+
+
 @pytest.mark.parametrize("frame_count", [3, 4])
 def test_channel_last_video_tensor_preserves_channel_sized_frame_count(frame_count):
     video = torch.arange(frame_count * 2 * 5 * 3, dtype=torch.uint8).reshape(frame_count, 2, 5, 3)

--- a/tests/entrypoints/openai_api/test_video_api_utils.py
+++ b/tests/entrypoints/openai_api/test_video_api_utils.py
@@ -48,6 +48,28 @@ def test_encode_video_bytes_exports_frames_without_interpolation(monkeypatch):
     assert mux_calls[0]["audio"] is None
 
 
+def test_float_frames_are_converted_without_stacking_full_video(monkeypatch):
+    frame = np.array(
+        [
+            [[0.0, 0.5, 1.0, 0.2], [1.5, -0.5, 0.5, 0.8]],
+        ],
+        dtype=np.float32,
+    )
+    original = frame.copy()
+
+    def fail_stack(*args, **kwargs):
+        raise AssertionError("float video conversion must not stack all frames")
+
+    monkeypatch.setattr(video_api_utils.np, "stack", fail_stack)
+
+    frames = video_api_utils._coerce_video_to_uint8_frames([frame, frame])
+
+    expected = np.array([[[128, 191, 255], [255, 64, 191]]], dtype=np.uint8)
+    assert frames.flags.c_contiguous
+    np.testing.assert_array_equal(frames, np.array([expected, expected]))
+    np.testing.assert_array_equal(frame, original)
+
+
 @pytest.mark.parametrize("frame_count", [3, 4])
 def test_channel_last_video_tensor_preserves_channel_sized_frame_count(frame_count):
     video = torch.arange(frame_count * 2 * 5 * 3, dtype=torch.uint8).reshape(frame_count, 2, 5, 3)

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -429,8 +429,10 @@ def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
         raise ValueError("No frames found to encode.")
 
     frame_shape = frames[0].shape
-    output_shape = (*frame_shape[:-1], 3) if frame_shape[-1] == 4 else frame_shape
+    has_alpha = len(frame_shape) == 3 and frame_shape[-1] == 4
+    output_shape = (*frame_shape[:-1], 3) if has_alpha else frame_shape
     frames_u8 = np.empty((len(frames), *output_shape), dtype=np.uint8)
+    common_dtype = np.result_type(*(frame.dtype for frame in frames))
 
     # Convert one frame at a time instead of stacking the normalized float
     # payload first. Long videos can otherwise require another full-size
@@ -438,12 +440,15 @@ def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
     for index, frame in enumerate(frames):
         if frame.shape != frame_shape:
             raise ValueError("All video frames must have the same shape.")
-        frame = frame[..., :3] if frame.shape[-1] == 4 else frame
+        frame = frame[..., :3] if has_alpha else frame
         if frame.dtype == np.uint8:
             frames_u8[index] = frame
             continue
 
-        scaled = np.clip(frame, 0.0, 1.0)
+        # np.stack(), used by the previous implementation, promoted mixed
+        # frame dtypes before scaling. Preserve those rounding semantics
+        # without allocating a full-video float buffer.
+        scaled = np.clip(frame.astype(common_dtype, copy=False), 0.0, 1.0)
         scaled *= 255.0
         np.rint(scaled, out=scaled)
         frames_u8[index] = scaled

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -428,18 +428,27 @@ def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
     if not frames:
         raise ValueError("No frames found to encode.")
 
-    frames_np = np.stack(frames, axis=0)
-    if frames_np.ndim == 4 and frames_np.shape[-1] == 4:
-        frames_np = frames_np[..., :3]
+    frame_shape = frames[0].shape
+    output_shape = (*frame_shape[:-1], 3) if frame_shape[-1] == 4 else frame_shape
+    frames_u8 = np.empty((len(frames), *output_shape), dtype=np.uint8)
 
-    if frames_np.dtype == np.uint8:
-        frames_u8 = frames_np
-    else:
-        frames_np = np.clip(frames_np, 0.0, 1.0)
-        frames_np *= 255.0
-        frames_u8 = np.round(frames_np).astype(np.uint8)
+    # Convert one frame at a time instead of stacking the normalized float
+    # payload first. Long videos can otherwise require another full-size
+    # float array plus conversion temporaries before encoding.
+    for index, frame in enumerate(frames):
+        if frame.shape != frame_shape:
+            raise ValueError("All video frames must have the same shape.")
+        frame = frame[..., :3] if frame.shape[-1] == 4 else frame
+        if frame.dtype == np.uint8:
+            frames_u8[index] = frame
+            continue
 
-    return np.ascontiguousarray(frames_u8)
+        scaled = np.clip(frame, 0.0, 1.0)
+        scaled *= 255.0
+        np.rint(scaled, out=scaled)
+        frames_u8[index] = scaled
+
+    return frames_u8
 
 
 def _encode_video_bytes(


### PR DESCRIPTION
## Summary
- convert normalized video frames directly into the final contiguous uint8 buffer
- avoid stacking a full-size float video and allocating additional full-size conversion temporaries
- preserve RGB/RGBA normalization, rounding behavior, and input immutability

## Performance
Measured with a 362-frame 1344x768 MiniMax H3 float32 output:
- conversion latency: 79.17 s -> 0.97 s
- peak process RSS: 14.86 GiB -> 9.06 GiB
- output checksum: identical

On 4x MI300X with 209-frame H3 requests, mean client E2E improved from 83.23 s to 67.16 s and standard deviation dropped from 25.00 s to 0.36 s. MP4 stage median fell from 22.4 s to 8.4 s, while the observed maximum fell from 48.9 s to 8.8 s.

## Test plan
- [x] `pytest -q tests/entrypoints/openai_api/test_video_api_utils.py` (11 passed)
- [x] pre-commit on both changed files
- [x] full H3 API benchmark on 4x AMD Instinct MI300X
- [x] baseline and optimized conversion output checksums match