### PR TITLE
[Bugfix] Fix MiniMax H3 reference video URL

### DIFF
--- a/tests/e2e/accuracy/minimax_h3/test_minimax_h3_t2va_similarity.py
+++ b/tests/e2e/accuracy/minimax_h3/test_minimax_h3_t2va_similarity.py
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.benchmark, pytest.mark.diffusion, pytest.mark.full_mod
 MODEL_REPO_ID = "MiniMaxAI/MiniMax-H3"
 MODEL_REVISION = "73372e6cf53e414edd3ab03e357717fb0602e758"
 MODEL_ENV_VAR = "VLLM_TEST_MINIMAX_H3_FL2VA_MODEL"
-REFERENCE_VIDEO_URL = f"https://huggingface.co/{MODEL_REPO_ID}/resolve/{MODEL_REVISION}/assets/t2va.mp4"
+REFERENCE_VIDEO_URL = f"https://huggingface.co/{MODEL_REPO_ID}/resolve/main/assets/t2va.mp4"
 
 # This is the official reproducible 768p T2VA prompt associated with
 # ``assets/t2va.mp4`` in the MiniMax H3 repository.


### PR DESCRIPTION
## Summary

- Fetch the MiniMax H3 T2VA reference video from the current `main` revision.
- Keep the model snapshot download pinned to `73372e6cf53e414edd3ab03e357717fb0602e758` for reproducible model loading.

## Root cause

The reference asset is unavailable at the pinned revision, so the nightly accuracy test receives a 404. The reference URL now uses Hugging Face's `resolve/main` download route.

## Validation

- `python -m py_compile tests/e2e/accuracy/minimax_h3/test_minimax_h3_t2va_similarity.py`
- `git diff --check`
- `pre-commit run --files tests/e2e/accuracy/minimax_h3/test_minimax_h3_t2va_similarity.py`
- `pytest --collect-only` was not runnable locally because `torch` is not installed.
- The H100 x4 accuracy test was not run locally.

Fixes #5736