### PR TITLE
[Model][CosyVoice3] Add initial_codec_chunk_frames for async streaming

### DIFF
--- a/tests/model_executor/stage_input_processors/test_cosyvoice3_stage_input_processors.py
+++ b/tests/model_executor/stage_input_processors/test_cosyvoice3_stage_input_processors.py
@@ -28,26 +28,26 @@ def _source_output(request_id: str, prompt_ids: list[int], out_ids: list[int], m
 def _transfer_manager(
     *,
     chunk_frames: int = 2,
+    initial_chunk_frames: int = 0,
     pre_lookahead_frames: int = 0,
     stream_scale_factor: int = 1,
     max_chunk_frames: int | None = None,
 ):
     if max_chunk_frames is None:
         max_chunk_frames = chunk_frames
+    extra = {
+        "codec_chunk_frames": chunk_frames,
+        "codec_pre_lookahead_frames": pre_lookahead_frames,
+        "codec_max_chunk_frames": max_chunk_frames,
+        "codec_stream_scale_factor": stream_scale_factor,
+        "codec_vocab_size": 6561,
+    }
+    if initial_chunk_frames > 0:
+        extra["initial_codec_chunk_frames"] = initial_chunk_frames
     return SimpleNamespace(
         code_prompt_token_ids=defaultdict(list),
         request_payload={},
-        connector=SimpleNamespace(
-            config={
-                "extra": {
-                    "codec_chunk_frames": chunk_frames,
-                    "codec_pre_lookahead_frames": pre_lookahead_frames,
-                    "codec_max_chunk_frames": max_chunk_frames,
-                    "codec_stream_scale_factor": stream_scale_factor,
-                    "codec_vocab_size": 6561,
-                }
-            }
-        ),
+        connector=SimpleNamespace(config={"extra": extra}),
     )
 
 
@@ -294,6 +294,73 @@ def test_talker2code2wav_async_chunk_respects_prompt_token_pad_on_first_chunk():
     assert payload_ready is not None
     assert payload_ready.codes.audio.tolist() == [8, 9, 10, 11]
     assert payload_ready.meta.left_context_size == 0
+
+
+def test_talker2code2wav_async_chunk_uses_initial_codec_chunk_frames_for_first_emit():
+    transfer_manager = _transfer_manager(
+        chunk_frames=4,
+        initial_chunk_frames=1,
+        pre_lookahead_frames=0,
+    )
+    request = SimpleNamespace(
+        external_req_id="rid-ic",
+        output_token_ids=[1],
+        additional_information={},
+        is_finished=lambda: False,
+    )
+
+    payload_one = talker2code2wav_async_chunk(
+        transfer_manager=transfer_manager,
+        multimodal_output=None,
+        request=request,
+        is_finished=False,
+    )
+    request.output_token_ids = [1, 2, 3, 4, 5]
+    payload_second = talker2code2wav_async_chunk(
+        transfer_manager=transfer_manager,
+        multimodal_output=None,
+        request=request,
+        is_finished=False,
+    )
+    request.output_token_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    payload_third = talker2code2wav_async_chunk(
+        transfer_manager=transfer_manager,
+        multimodal_output=None,
+        request=request,
+        is_finished=False,
+    )
+
+    assert payload_one is not None
+    assert payload_one.codes.audio.tolist() == [1]
+    assert payload_one.meta.left_context_size == 0
+    assert payload_second is not None
+    assert payload_second.codes.audio.tolist() == [1, 2, 3, 4, 5]
+    assert payload_second.meta.left_context_size == 1
+    assert payload_third is not None
+    assert payload_third.codes.audio.tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert payload_third.meta.left_context_size == 5
+
+
+def test_talker2code2wav_async_chunk_honors_per_request_initial_codec_chunk_frames():
+    transfer_manager = _transfer_manager(chunk_frames=4, pre_lookahead_frames=0)
+    entry = SimpleNamespace(list_data=[2])
+    request = SimpleNamespace(
+        external_req_id="rid-ic-req",
+        output_token_ids=[1, 2, 3, 4],
+        additional_information=SimpleNamespace(entries={"initial_codec_chunk_frames": entry}),
+        is_finished=lambda: False,
+    )
+
+    payload = talker2code2wav_async_chunk(
+        transfer_manager=transfer_manager,
+        multimodal_output=None,
+        request=request,
+        is_finished=False,
+    )
+
+    assert payload is not None
+    assert payload.codes.audio.tolist() == [1, 2]
+    assert payload.meta.left_context_size == 0
 
 
 def test_talker2code2wav_async_chunk_emits_terminal_eof_without_duplicate_audio():

--- a/vllm_omni/deploy/cosyvoice3.yaml
+++ b/vllm_omni/deploy/cosyvoice3.yaml
@@ -33,6 +33,9 @@ connectors:
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
       codec_chunk_frames: 15
+      # Optional: emit a smaller first chunk so code2wav starts earlier (lower TTFA).
+      # Subsequent chunks use codec_chunk_frames. Same pattern as Qwen3-TTS deploy yaml.
+      initial_codec_chunk_frames: 5
       codec_left_context_frames: 25
       codec_vocab_size: 6561
 

--- a/vllm_omni/model_executor/stage_input_processors/cosyvoice3.py
+++ b/vllm_omni/model_executor/stage_input_processors/cosyvoice3.py
@@ -134,17 +134,45 @@ def talker2code2wav_async_chunk(
         raw_cfg = getattr(connector, "config", {}) or {}
         cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
         chunk_size = int(cfg.get("codec_chunk_frames", 25))
+        configured_initial_chunk_size = int(cfg.get("initial_codec_chunk_frames") or 0)
         code_vocab_size = int(cfg.get("codec_vocab_size", 6561))
         pre_lookahead_len = int(cfg.get("codec_pre_lookahead_frames", 3))
         max_chunk_size = int(cfg.get("codec_max_chunk_frames", 4 * chunk_size))
         stream_scale_factor = int(cfg.get("codec_stream_scale_factor", 2))
-        if chunk_size <= 0 or pre_lookahead_len < 0 or max_chunk_size <= 0 or stream_scale_factor <= 0:
+        if (
+            chunk_size <= 0
+            or configured_initial_chunk_size < 0
+            or pre_lookahead_len < 0
+            or max_chunk_size <= 0
+            or stream_scale_factor <= 0
+        ):
             raise ValueError(
                 f"Invalid codec chunk config: codec_chunk_frames={chunk_size}, "
+                f"initial_codec_chunk_frames={configured_initial_chunk_size}, "
                 f"codec_pre_lookahead_frames={pre_lookahead_len}, "
                 f"codec_max_chunk_frames={max_chunk_size}, "
                 f"codec_stream_scale_factor={stream_scale_factor}"
             )
+
+        initial_chunk_size = configured_initial_chunk_size
+        additional_information = getattr(request, "additional_information", None)
+        if (
+            additional_information is not None
+            and hasattr(additional_information, "entries")
+            and "initial_codec_chunk_frames" in additional_information.entries
+        ):
+            entry = additional_information.entries["initial_codec_chunk_frames"]
+            if entry.list_data is not None and len(entry.list_data) == 1:
+                initial_chunk_size = int(entry.list_data[0])
+
+        initial_token_hop_len = initial_chunk_size if initial_chunk_size > 0 else chunk_size
+        if initial_chunk_size > chunk_size:
+            logger.warning(
+                "initial_codec_chunk_frames=%d > codec_chunk_frames=%d, clamping to codec_chunk_frames.",
+                initial_chunk_size,
+                chunk_size,
+            )
+            initial_token_hop_len = chunk_size
 
         request_state = transfer_manager.request_payload.get(request_id)
         if not isinstance(request_state, dict) or "_cosyvoice3_async_state" not in request_state:
@@ -197,6 +225,7 @@ def talker2code2wav_async_chunk(
                     "emitted_chunks": 0,
                     "emitted_token_len": 0,
                     "token_hop_len": chunk_size,
+                    "initial_token_hop_len": initial_token_hop_len,
                     "prompt_token_pad": prompt_token_pad,
                     "pre_lookahead_len": pre_lookahead_len,
                     "token_max_hop_len": max(chunk_size, max_chunk_size),
@@ -255,10 +284,11 @@ def talker2code2wav_async_chunk(
 
         with nullcontext():
             token_hop_len = max(1, int(state.get("token_hop_len", chunk_size)))
+            first_token_hop_len = max(1, int(state.get("initial_token_hop_len", chunk_size)))
             prompt_token_pad = max(0, int(state.get("prompt_token_pad", 0)))
             pre_lookahead_len = max(0, int(state.get("pre_lookahead_len", pre_lookahead_len)))
             available = max(0, length - emitted_token_len)
-            this_token_hop_len = token_hop_len + prompt_token_pad if emitted_token_len == 0 else token_hop_len
+            this_token_hop_len = first_token_hop_len + prompt_token_pad if emitted_token_len == 0 else token_hop_len
             required = this_token_hop_len + pre_lookahead_len
 
             if not finished:


### PR DESCRIPTION
## Purpose

Add `initial_codec_chunk_frames` support to CosyVoice3 async streaming (connector yaml + per-request override, following the Qwen3-TTS pattern). The first emit uses a smaller hop; subsequent chunks use `codec_chunk_frames`. The deploy yaml example sets `initial_codec_chunk_frames: 5`.

## Test Plan

**vLLM Version:** N/A (stage input processor change only)

**vLLM-Omni Commit:** aad9565206cc587137c0997772918dbaad4e7a42

- [x] `pytest tests/model_executor/stage_input_processors/test_cosyvoice3_stage_input_processors.py` — 13 passed (test server)
- [x] `pre-commit run --files` for changed files (ruff-format fix applied)

## Test Result

```bash
pytest tests/model_executor/stage_input_processors/test_cosyvoice3_stage_input_processors.py
# 13 passed (test server, miniconda)
```