### PR TITLE
[Ascend][MiniCPM-o] Add competition baseline and public proxy benchmarks

### DIFF
--- a/.claude/skills/optimize-minicpmo-ascend/SKILL.md
+++ b/.claude/skills/optimize-minicpmo-ascend/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: optimize-minicpmo-ascend
+description: Optimize and validate MiniCPM-o 4.5 inference in vLLM-Omni for the OpenBMB Ascend high-performance inference competition. Use when adapting MiniCPM-o 4.5 to Ascend NPU, tuning TTFT or first-response latency, single-chunk or end-to-end latency, throughput, concurrent sessions, NPU utilization, memory, stability, accuracy, multimodal quality, benchmarking, profiling, or preparing a reproducible competition submission.
+---
+
+# Optimize MiniCPM-o 4.5 for the Ascend Competition
+
+Treat the competition as a gated multi-objective optimization problem:
+
+1. Pass effect, correctness, functional, and stability checks.
+2. Improve the official performance metrics without crossing those gates.
+3. Reproduce the result in the official Ascend environment from complete code,
+   configuration, benchmark scripts, and documentation.
+
+Do not optimize a private proxy at the expense of the official objective. Do
+not invent a composite score while the organizer has not published metric
+weights.
+
+## Required Context
+
+Read [references/competition-rules.md](references/competition-rules.md) before
+planning or evaluating an optimization. Read
+[references/repo-map.md](references/repo-map.md) before editing this repository.
+
+At the start of each competition task:
+
+1. Recheck the official competition page, toolkit page, announcements, and
+   latest starter kit.
+2. Record the rule and toolkit version or retrieval date used by the run.
+3. Let newer official material override this skill's dated rule snapshot.
+4. Resolve the official hardware, image, driver, CANN, PyTorch, torch-npu,
+   vLLM, vLLM-Ascend, model, benchmark, request schema, and pass thresholds.
+5. List every unresolved item. Never silently replace an unpublished rule with
+   a guess.
+
+## Optimization Objective
+
+Use this priority order until the official scoring formula says otherwise:
+
+1. **Eligibility gate:** model loads and serves the required text, image,
+   audio, and video workloads; outputs remain correct; multimodal and speech
+   quality remain acceptable; the service is stable.
+2. **Latency:** reduce TTFT or first response, first audio response when
+   applicable, single streaming chunk latency, and E2E latency.
+3. **Capacity:** increase throughput and stable concurrent sessions.
+4. **Efficiency:** improve NPU utilization and reduce HBM/host memory or
+   per-request resource cost when this helps official latency/capacity.
+5. **Engineering:** keep the solution explainable, portable to the official
+   environment, and reproducible from the submitted materials.
+
+Maintain a Pareto table rather than hiding tradeoffs in an unofficial scalar:
+
+| Config | Effect gate | TTFT p50/p95 | Chunk p50/p95 | E2E p50/p95 | Throughput | Stable sessions | NPU util | Peak HBM | Failures |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+
+Use the exact statistics emitted by the official benchmark once it is
+available. Until then, report both central tendency and tail behavior, and
+label every local metric as a proxy.
+
+## Workflow
+
+### 1. Freeze a Trustworthy Baseline
+
+Capture all of the following before changing code:
+
+- Git SHA and dirty-worktree diff.
+- NPU model/count/topology and CPU/RAM limits.
+- OS, container/image digest, driver, firmware, CANN, Python, PyTorch,
+  torch-npu, vLLM, vLLM-Ascend, and vLLM-Omni versions.
+- Model source, revision, checksum, dtype, quantization, and sampling settings.
+- Exact deploy config and stage placement.
+- Exact server, warmup, correctness, benchmark, profiling, and monitoring
+  commands.
+- Dataset/version, input modality and size distributions, output settings,
+  concurrency/request-rate policy, timeout, warmup count, repeat count, and
+  random seed.
+- TTFT, first audio response if present, chunk latency/jitter, E2E latency,
+  throughput, stable concurrent sessions, NPU utilization, peak HBM/host
+  memory, error rate, and effect/quality results.
+
+Separate text-only requests from text-plus-audio requests. Text-only isolates
+the Thinker path; audio output includes Talker, Code2Wav, connectors, and
+streaming behavior. Never compare those modes as if they were the same
+workload.
+
+Warm the service before measuring. Keep profiler runs separate from score
+runs because profiling overhead invalidates final performance numbers.
+
+### 2. Map Metrics to the Pipeline
+
+Use the three-stage MiniCPM-o 4.5 architecture to narrow hypotheses:
+
+- **Stage 0, Thinker:** multimodal preprocessing/encoding, prefill, text
+  decoding, and text TTFT.
+- **Stage 1, Talker:** codec-token generation, scheduling, batching, and delay
+  before audio work can begin.
+- **Stage 2, Code2Wav:** time to first audio packet, per-chunk compute,
+  chunk continuity, vocoder throughput, and audio completion time.
+- **Orchestrator/connectors/API:** queueing, inter-stage transfer, serialization,
+  request admission, end-to-end latency, concurrency, and cleanup stability.
+
+Measure per-stage queue, compute, transfer, and output time when possible. A
+global E2E regression can otherwise hide a faster kernel behind worse
+queueing or chunk scheduling.
+
+### 3. Search in Risk Order
+
+Test one hypothesis per comparison. Prefer this order:
+
+1. **Measurement and compatibility:** make the official workload run; remove
+   benchmark errors; verify NPU-specific paths and output contracts.
+2. **Configuration:** stage placement, memory budgets, `max_num_seqs`, batched
+   token limits, request admission, async chunk sizes/context, ACL graph or
+   compilation mode, dtype, and framework-supported parallelism.
+3. **Runtime:** reduce host-NPU synchronization, Python work in hot loops,
+   repeated allocation/copy/conversion, unnecessary serialization, connector
+   polling, and avoidable queueing.
+4. **Model hot paths:** optimize only operators proven hot on the official
+   shapes. Prefer supported Ascend/CANN kernels and platform-local patches.
+5. **Precision or algorithm changes:** quantization, approximation, cache
+   changes, or altered sampling only with a full effect and quality gate.
+
+Do not port CUDA assumptions mechanically to NPU. Confirm operator support,
+layout, dtype, graph behavior, dynamic-shape behavior, and synchronization on
+the actual Ascend stack.
+
+### 4. Run Controlled Experiments
+
+For each candidate:
+
+1. State the bottleneck evidence and expected metric impact.
+2. Change one primary variable.
+3. Keep environment, workload, sampling, seed, warmup, and repetition policy
+   fixed.
+4. Save raw benchmark JSON/logs, NPU monitoring, and output artifacts.
+5. Compare against same-session baseline variance.
+6. Run correctness/effect checks before accepting a performance result.
+7. Retest concurrency and long-running stability; request-local audio state can
+   fail only under load.
+8. Record wins, losses, confidence, and rollback condition.
+
+Never claim a win from a cold-start run, a profiler trace, a failed request,
+different output length, truncated generation, disabled modality, or a
+changed dataset.
+
+### 5. Profile Only After Baseline Evidence
+
+Use low-overhead service and NPU metrics first. When a bottleneck remains
+unclear, use the repository's NPU profiler and analyze traces offline.
+
+Inspect:
+
+- CPU/API time before NPU work begins.
+- Stage queue wait and inter-stage gaps.
+- NPU idle regions, synchronization, copies, layout conversions, and small
+  repeated operators.
+- Dynamic-shape recompilation or graph misses.
+- Rank/stage imbalance and HBM pressure.
+- Talker/Code2Wav chunk cadence, batching compatibility, and cache lifetime.
+
+Use traces to choose an experiment, not as the final benchmark result.
+
+### 6. Apply Acceptance Gates
+
+Accept an optimization only when all applicable gates pass:
+
+- Official or closest available effect/correctness check passes.
+- Required input and output modalities still work.
+- Text and audio content are not empty, truncated, duplicated, or reordered.
+- Streaming chunks are continuous enough for the official/user-facing target.
+- Concurrent requests do not share or leak request-local state.
+- The gain exceeds measurement noise on the target workload.
+- Peak memory, error rate, and long-run stability do not become disqualifying.
+- A clean environment can reproduce the commands and result.
+
+For quantization or altered precision, compare task accuracy plus reviewable
+text/audio/multimodal outputs. Treat an inconclusive quality check as a failed
+gate.
+
+## Implementation Rules
+
+- Preserve existing repository patterns and NPU platform guards.
+- Keep GPU behavior unchanged unless the task explicitly includes it.
+- Add focused tests for changed scheduling, request state, chunk boundaries,
+  cache lifetime, tensor shapes/dtypes, and output assembly.
+- Run CPU/unit tests first, then an Ascend smoke test, then the official or
+  closest benchmark and effect suite.
+- Keep benchmark-specific code out of model logic. Do not hardcode evaluation
+  samples, outputs, timings, or environment-specific shortcuts that violate
+  fair evaluation or general inference behavior.
+- Do not enable caches or alter request semantics unless the official rules
+  and benchmark permit them.
+- Keep submission artifacts below any official size/time limits published in
+  the latest starter kit.
+
+## Result Report
+
+Every optimization report must include:
+
+- Objective and official rule/toolkit version used.
+- Baseline and candidate SHAs/config IDs.
+- Exact commands and environment.
+- A baseline-versus-candidate metric table.
+- Effect/correctness and stability results.
+- NPU utilization and memory evidence.
+- Explanation of the mechanism, not only the measured number.
+- Known tradeoffs, unsupported workloads, and residual risk.
+- Reproduction steps and artifact paths.
+- Decision: keep, reject, or investigate further.
+
+## Submission Gate
+
+Before calling the work competition-ready, verify:
+
+- Reproducible source and configuration are complete.
+- Benchmark scripts use the official request schema and metric definitions.
+- Performance report includes raw and summarized results.
+- Deployment documentation lists all dependencies and commands.
+- Model/effect validation and multimodal output checks are included.
+- The package runs in the official unified Ascend environment.
+- No undeclared model replacement, hidden service, dataset leakage, or
+  machine-local dependency is required.
+- A second clean run reproduces the claimed result.

--- a/.claude/skills/optimize-minicpmo-ascend/agents/openai.yaml
+++ b/.claude/skills/optimize-minicpmo-ascend/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MiniCPM-o Ascend Competition Optimization"
+  short_description: "Optimize MiniCPM-o 4.5 for the Ascend competition."
+  default_prompt: "Use $optimize-minicpmo-ascend to optimize MiniCPM-o 4.5 on Ascend NPU against the current competition metrics and correctness gates."

--- a/.claude/skills/optimize-minicpmo-ascend/references/competition-rules.md
+++ b/.claude/skills/optimize-minicpmo-ascend/references/competition-rules.md
@@ -1,0 +1,124 @@
+# Competition Rules Snapshot
+
+Snapshot date: 2026-08-03 (China Standard Time)
+
+Primary source: https://ascend.openbmb.cn/competition
+
+This snapshot records the published rules used to prepare this baseline. The
+official site, organizer announcements, Feishu group, starter kit, and final
+evaluation document remain authoritative when they differ from this file.
+
+## Selected Track
+
+This repository targets Track 1, sub-track B: MiniCPM-o 4.5 inference with
+vLLM-Omni on Ascend.
+
+- Official evaluation hardware: one physical Ascend 910C card.
+- Official A3 image: `quay.io/ascend/vllm-omni:v0.25.0-a3`.
+- A2 reference image: `quay.io/ascend/vllm-omni:v0.25.0`.
+- Upstream contribution target: the vLLM-Omni `minicpm-challenge` branch.
+- Submissions close on 2026-08-17 (China Standard Time).
+- Each team may submit at most three times per day.
+
+The organizer evaluates the llama.cpp-omni and vLLM-Omni sub-tracks against
+their own official baselines. Results are not compared across frameworks.
+
+## Admission Gates
+
+A submission enters performance ranking only after both gates pass.
+
+### Accuracy and capability
+
+The optimized result may lose no more than 2 percentage points relative to the
+official vLLM-Omni baseline. The published benchmark families are:
+
+- Daily-Omni.
+- TTS-Seed.
+- Video-MME.
+
+The organizer still controls the exact dataset revisions, subsets, request
+format, evaluation scripts, and aggregation. A submission fails this gate if
+it cannot complete a benchmark, produces abnormal output, materially changes
+model behavior, or loses a core capability.
+
+### Demo usability
+
+The optimized service must connect to the designated vLLM-Omni Demo and run a
+stable end-to-end interaction. Validation covers service startup, Demo
+connection, audio/video/text input, complete output, continuous streamed
+speech, the full official interaction flow, and sustained stability. Passing
+benchmarks without a working Demo is insufficient.
+
+## Performance Metrics
+
+After admission, sub-track B is ranked using three lower-is-better metrics:
+
+- Per-chunk RTF: compute time for an audio chunk divided by that chunk's audio
+  duration.
+- TTFT: time from request receipt to the first valid output token.
+- TTFP: time from request receipt to the first usable audio packet/chunk.
+
+The official TTFT boundary, preprocessing treatment, valid-token definition,
+RTF aggregation, normalization, score formula, and metric weights are not yet
+published. Do not invent a composite score. Local first-text and first-audio
+timings are proxy evidence only until the official evaluator is available.
+
+## Required Submission Materials
+
+The published final deliverables are:
+
+1. Complete adaptation and optimization code and vLLM-Omni configuration.
+2. Service, benchmark, and Demo startup scripts plus dependency/environment
+   files.
+3. Complete Daily-Omni, TTS-Seed, and Video-MME results, including commands,
+   parameters, raw output, and summaries.
+4. A performance report containing RTF, TTFT, TTFP, environment, data, run
+   count, statistics, before/after comparison, resource usage, and anomalies.
+5. A runnable Demo, usage and access instructions, core interaction flow, and
+   a recorded demonstration video.
+6. Bottleneck analysis, optimization details, per-change performance effects,
+   capability retention, key technical notes, and complete reproduction steps.
+
+The organizer reproduces submissions in the unified environment. Missing
+files, unstable execution, or materially inconsistent reproduced results may
+invalidate a score.
+
+## Current Starter-Kit Status
+
+The competition frontend advertises:
+
+`https://oiac.openbmb.org/toolkit/oiac-toolkit-v1.0.tar.gz`
+
+On 2026-08-03 the hostname returned no DNS answer from the HiDevLab machine,
+so the artifact could not be downloaded or checksummed. The frontend also says
+that benchmark subsets, exact evaluation scripts, score weights, and final
+package format remain subject to the starter kit and final evaluation
+document. Keep those manifest fields unresolved until an authoritative
+artifact becomes accessible.
+
+## Rules That Remain Dynamic
+
+Recheck these items before every scored run or upload:
+
+- Starter-kit URL, version, checksum, and package schema.
+- Official model revision and model packaging rules.
+- Daily-Omni, TTS-Seed, and Video-MME revisions and subsets.
+- Request schema, concurrency, warmup, run count, timeouts, and statistics.
+- Exact RTF, TTFT, and TTFP definitions, normalization, weights, and score.
+- Demo document and endpoint.
+- Driver, firmware, CANN, Python, PyTorch, torch-npu, vLLM, and vLLM-Ascend
+  versions inside the official image.
+- Network, cache, quantization, runtime, and package-size restrictions.
+- Submission endpoint status and organizer announcements.
+
+## Refresh Checklist
+
+Before a formal run:
+
+1. Re-fetch the official competition page and announcements.
+2. Check the team Feishu group and submission guide.
+3. Download the current starter kit and record its SHA256.
+4. Resolve every required field in `environment_manifest.yaml`.
+5. Run all three official accuracy suites and the official Demo gate.
+6. Run the unprofiled official performance evaluator in a clean environment.
+7. Preserve raw output, logs, resource samples, exact commands, and Git SHA.

--- a/.claude/skills/optimize-minicpmo-ascend/references/repo-map.md
+++ b/.claude/skills/optimize-minicpmo-ascend/references/repo-map.md
@@ -1,0 +1,131 @@
+# vLLM-Omni MiniCPM-o 4.5 Optimization Map
+
+Use this map to locate the current implementation before proposing changes.
+Paths may move; use `rg --files` and `rg` to confirm them in the active branch.
+
+## Model and Deployment Baseline
+
+- `recipes/OpenBMB/MiniCPM-o-4_5.md`
+  - Known-good serving modes, architecture, performance examples, output
+    contracts, and operational notes.
+- `vllm_omni/deploy/minicpmo_4_5.yaml`
+  - Single-device three-stage layout and NPU platform overrides.
+- `vllm_omni/deploy/minicpmo_4_5_batching.yaml`
+  - Throughput-oriented split layout; use as a pattern, not as an official
+    Ascend competition topology.
+- Other `vllm_omni/deploy/minicpmo_4_5*.yaml` files
+  - Alternative stage placements and experimental duplex configuration.
+
+Do not assume GPU memory ratios or CUDA graph behavior transfer directly to
+the official Ascend environment.
+
+## Three-Stage Pipeline
+
+- `vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py`
+  - Pipeline registration and stage wiring.
+- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py`
+  - Thinker/Talker wrapper, multimodal preprocessing, stage behavior, and NPU
+    compatibility paths.
+- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py`
+  - Thinker-side LLM integration.
+- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py`
+  - Talker codec-token generation and request-local state.
+- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py`
+  - Code2Wav stage orchestration and streaming waveform output.
+- `vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py`
+  - Exact-shape-compatible Code2Wav batching and cache/state handling.
+- `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py`
+  - Token-to-wave adapter with device selection and NPU-aware behavior.
+- `vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py`
+  - Thinker-to-Talker and Talker-to-Code2Wav data flow, chunk metadata, and
+    terminal flush semantics.
+
+Metric ownership is approximate:
+
+| Surface | Primary competition impact |
+| --- | --- |
+| Thinker preprocessing/prefill/decode | TTFT, text E2E, text throughput, effect |
+| Talker generation/scheduling | first audio response, chunk readiness, concurrency |
+| Code2Wav/vocoder | audio first packet, chunk latency, continuity, audio E2E |
+| Connectors/orchestrator/API | queueing, transfer gaps, global E2E, stability |
+
+## Ascend Platform Layer
+
+- `vllm_omni/platforms/npu/platform.py`
+  - Platform registration and capability behavior.
+- `vllm_omni/platforms/npu/worker/`
+  - NPU model runners, generation runners, workers, and execution flow.
+- `vllm_omni/platforms/npu/models/`
+  - Model/operator-specific Ascend patches. Reuse established patterns for
+    dtype, layout, supported kernels, and compile fallbacks.
+- `vllm_omni/platforms/npu/quant/`
+  - NPU quantization integration currently present in the repository.
+- `vllm_omni/platforms/npu/profiler.py`
+  - `torch_npu.profiler` wrapper. Analyze output offline with
+    `torch_npu.profiler.profiler.analyse()`.
+- `.claude/skills/vllm-omni-npu-upgrade/`
+  - Existing workflow for keeping NPU runners aligned with vLLM-Ascend.
+
+When changing shared code, verify GPU behavior is preserved. Prefer an NPU
+platform patch when the behavior is Ascend-specific.
+
+## Serving and Benchmark Surfaces
+
+- `examples/online_serving/minicpmo/README.md`
+  - Current server and request examples, text/audio separation, Daily-Omni
+    notes, streaming, and duplex behavior.
+- `examples/online_serving/minicpmo/`
+  - Multimodal, streaming, concurrent, and realtime clients.
+- `vllm_omni/entrypoints/cli/benchmark/`
+  - `vllm bench serve --omni` integration and CLI arguments.
+- `vllm_omni/benchmarks/data_modules/daily_omni_dataset.py`
+  - Daily-Omni multimodal request construction.
+- `vllm_omni/benchmarks/data_modules/daily_omni_eval.py`
+  - Daily-Omni effect/accuracy calculation.
+- `benchmarks/tts/`
+  - TTS serving metrics such as TTFT, E2E, audio TTFP, audio RTF, throughput,
+    concurrency sweeps, and streaming underrun. These are useful local proxies
+    but are not automatically the official competition benchmark.
+- `tests/dfx/perf/scripts/run_benchmark.py`
+  - Existing performance sweep patterns and result comparison.
+
+Prefer the official competition benchmark as soon as it is published. Reuse
+repository tools for diagnosis and regression coverage, not to redefine the
+score.
+
+## Focused Validation
+
+- `tests/model_executor/models/minicpmo_4_5/`
+  - Pipeline, Talker, Code2Wav batching, audio processing, and model tests.
+- `tests/model_executor/stage_input_processors/test_minicpmo_4_5_*.py`
+  - Stage bridge, chunk, and metadata behavior.
+- `tests/examples/online_serving/test_minicpmo_streaming.py`
+  - Streaming client/output behavior.
+- `tests/e2e/online_serving/` MiniCPM-o scenarios
+  - Duplex, multi-session, and live serving coverage.
+- `tests/platforms/npu/`
+  - NPU-specific regression patterns.
+
+Match tests to the risk:
+
+- Config-only tuning: config validation plus Ascend smoke/performance run.
+- Scheduling/chunk changes: request-state, boundary, terminal flush, and
+  concurrent-request tests.
+- Kernel/dtype/layout changes: shape/dtype parity, effect output, and NPU trace.
+- Quantization: model load, task accuracy/effect, multimodal/audio quality,
+  memory, latency, and throughput.
+
+## Common Bottleneck Questions
+
+1. Is TTFT dominated by API/media preprocessing, Thinker prefill, graph
+   compilation, scheduling, or text decode?
+2. Does Talker emit the first codec chunk early enough, and does batching delay
+   it at higher concurrency?
+3. Is Code2Wav compute slower than real time, or are connector/queue gaps the
+   real cause of chunk delay?
+4. Are chunk shapes fragmenting batches or causing graph recompilation?
+5. Are host-device synchronizations, tensor conversions, copies, or temporary
+   allocations visible in the NPU trace?
+6. Does increased concurrency improve aggregate throughput while making TTFT,
+   chunk tails, or stability unacceptable?
+7. Does a precision change preserve official effect and multimodal capability?

--- a/.claude/skills/profile-minicpmo-ascend/SKILL.md
+++ b/.claude/skills/profile-minicpmo-ascend/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: profile-minicpmo-ascend
+description: Capture, analyze, compare, and interpret MiniCPM-o 4.5 online-serving profiles on Ascend NPU in vLLM-Omni. Use when locating Thinker, Talker, Code2Wav, connector, runtime API, kernel, synchronization, memory, batching, or first-chunk bottlenecks; establishing a profiler baseline; comparing a performance candidate; or producing evidence-backed MiniCPM Ascend optimization suggestions.
+---
+
+# Profile MiniCPM-o on Ascend
+
+Use profiling to choose one controlled experiment. Never use profiler timing as
+a score measurement.
+
+## Required Context
+
+Before profiling competition work, read:
+
+1. `../optimize-minicpmo-ascend/SKILL.md` for gates and measurement integrity.
+2. `../optimize-minicpmo-ascend/references/repo-map.md` for stage ownership.
+3. [references/analysis-guide.md](references/analysis-guide.md) before interpreting a trace.
+
+Read `../run-minicpmo-ascend-perf-cycle/SKILL.md` when the profile will lead to
+an implementation candidate, commit, or push.
+
+## Workflow
+
+### 1. Start from an Unprofiled Baseline
+
+- Confirm the functional/effect gate passes.
+- Record Git SHA, model revision, deploy config, workload, seed, warmups,
+  concurrency, environment, and unprofiled metrics.
+- Identify one symptom and the stage most likely to own it.
+
+Do not profile cold start, model loading, or graph compilation unless startup is
+the explicit target.
+
+### 2. Choose the Narrowest Capture
+
+- Stage 0: text TTFT, multimodal preprocessing, prefill, or decode.
+- Stage 1: codec generation, Talker scheduling, or first-codec delay.
+- Stage 2: first audio, chunk cadence, Flow/CFM/HiFT, or vocoder throughput.
+- All stages: only when queue ownership or inter-stage gaps are unclear.
+
+Keep the default capture to one request after two unprofiled warmups. Long or
+high-concurrency captures create excessive data and distort scheduling.
+
+### 3. Run the Repository Chain
+
+```bash
+MODEL=/path/to/MiniCPM-o-4_5 \
+PROFILE_ID=<candidate-id>-stage2 \
+PROFILE_STAGES=2 \
+bash benchmarks/competition/minicpmo_ascend/run_profile.sh
+```
+
+The runner generates a profiler-enabled deploy config, starts a clean server,
+warms outside the capture, calls `/start_profile`, runs the deterministic
+request, calls `/stop_profile`, shuts down, and writes raw traces plus
+`profile_analysis.json` and `profile_analysis.md`.
+
+Use `PROFILE_INPUT_MODALITY`, `PROFILE_OUTPUT_MODE`, `PROFILE_MEDIA`,
+`PROFILE_WARMUPS`, `PROFILE_REQUESTS`, `THINKER_MAX_TOKENS`, and
+`TALKER_MAX_TOKENS` only when the candidate record fixes the same values for
+baseline and candidate.
+
+### 4. Check Capture Integrity
+
+- Require successful warmups, request completion, non-empty output, and clean
+  profiler stop.
+- Confirm the selected stages produced exported CSV and a timeline.
+- Keep raw trace paths and the capture JSON with the candidate record.
+- Reject a capture that contains failures, different output length, changed
+  modalities, or unmatched profiler settings.
+
+### 5. Analyze Before Editing
+
+Use `profile_analysis.md` to rank device kernels, runtime APIs, Torch operators,
+and the <=50 us kernel fraction. Open `trace_view.json` in Perfetto or the CANN
+database in MindStudio when aggregate tables cannot distinguish compute from
+queue gaps.
+
+State:
+
+1. bottleneck evidence;
+2. stage and code path;
+3. one primary variable;
+4. expected unprofiled metric impact;
+5. correctness, memory, and stability guardrails;
+6. rollback condition.
+
+### 6. Compare Matching Captures
+
+After an unprofiled A/B/A benchmark, compare diagnostic traces only when the
+workload, stage selection, environment, and profiler configuration match:
+
+```bash
+.venv/bin/python -m benchmarks.competition.minicpmo_ascend.profile_analysis compare \
+  <baseline>/profile_analysis.json <candidate>/profile_analysis.json \
+  --output <comparison>/profile_comparison.json
+```
+
+Accept or reject the candidate from unprofiled benchmark and gate results. Use
+the profile comparison only to explain the mechanism.
+
+## Output Contract
+
+Report the unprofiled baseline, capture scope, top evidence, hypothesis,
+guardrails, artifact paths, and unresolved ambiguity. Label every profile
+number as diagnostic and every non-official workload as a local proxy.

--- a/.claude/skills/profile-minicpmo-ascend/agents/openai.yaml
+++ b/.claude/skills/profile-minicpmo-ascend/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Profile MiniCPM-o Ascend"
+  short_description: "Capture and analyze MiniCPM-o Ascend NPU profiles"
+  default_prompt: "Use $profile-minicpmo-ascend to capture and analyze one controlled MiniCPM-o Ascend profiling run."

--- a/.claude/skills/profile-minicpmo-ascend/references/analysis-guide.md
+++ b/.claude/skills/profile-minicpmo-ascend/references/analysis-guide.md
@@ -1,0 +1,35 @@
+# MiniCPM-o Ascend Profile Interpretation
+
+## Evidence to Hypothesis
+
+| Signal | Likely mechanism | First code surface | Candidate class |
+| --- | --- | --- | --- |
+| Long gap before Stage 0 kernels | media preprocessing, scheduling, or graph miss | Thinker wrapper and NPU runner | preprocessing/configuration |
+| Frequent synchronize APIs | host-device scalar reads, copies, or explicit waits | stage bridge and request loop | synchronization removal |
+| High <=50 us kernel ratio | fragmented shapes or repeated small operations | owning stage model path | fusion, caching, batching |
+| Stage 1 idle before Stage 2 | connector polling or codec chunk threshold | stage input processor and connector | queue/chunk scheduling |
+| Stage 2 compute exceeds audio duration | Flow/CFM/HiFT throughput | batched Token2Wav | dtype/operator/graph |
+| Stage 2 queue grows at concurrency | shape buckets or request-state fragmentation | Code2Wav batching | batch compatibility |
+| High HBM with low utilization | oversized caches/buffers or placement pressure | deploy config and stage state | capacity/memory tuning |
+| High Cube time/utilization | matrix compute bound | proven hot operator | supported kernel/precision |
+| High MTE or memory traffic | layout conversion, copies, or bandwidth bound | NPU patch/model adapter | layout/cache changes |
+
+## Interpretation Rules
+
+- Aggregated kernel/operator time can exceed request wall time when streams overlap.
+- Different profiler presets or stage selections are not timing-comparable.
+- A profiler trace is not a performance benchmark; profiling overhead changes latency and scheduling.
+- Operator names identify symptoms, not ownership. Confirm the stage and call path in the timeline.
+- A high call count is actionable only when its cumulative time, queue effect, or launch overhead is material.
+- Runtime API time may overlap device work. Inspect the timeline before adding API and kernel totals.
+- Memory growth across increasing concurrency may be legitimate shape/cache warmup. Confirm a fixed-shape stability window and post-shutdown release before calling it a leak.
+
+## First-Capture Order
+
+For audio latency under concurrency:
+
+1. Capture Stage 2 for one warmed text+audio request.
+2. Inspect top kernels, synchronization APIs, small-kernel ratio, and first audio timing.
+3. Capture Stage 1 only if Stage 2 begins late or lacks enough work.
+4. Capture all stages only if the connector/queue gap remains ambiguous.
+5. Choose one bounded candidate, then run unprofiled A/B/A before comparing traces.

--- a/.claude/skills/run-minicpmo-ascend-perf-cycle/SKILL.md
+++ b/.claude/skills/run-minicpmo-ascend-perf-cycle/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: run-minicpmo-ascend-perf-cycle
+description: Run the repeatable daily workflow for MiniCPM-o 4.5 Ascend performance candidates in this vLLM-Omni repository. Use when starting, implementing, measuring, accepting, rejecting, documenting, committing, or pushing one performance experiment; comparing a candidate with a baseline; preparing an atomic perf commit; or resuming the next item in the Ascend competition TODO.
+---
+
+# Run a MiniCPM-o Ascend Performance Cycle
+
+Move one optimization hypothesis from evidence to a reproducible decision and,
+only when accepted, an atomic performance commit. Keep correctness, experiment
+records, and Git history strong enough to compare or roll back every candidate.
+
+## Required Context
+
+For competition work, read the following before acting:
+
+1. `../optimize-minicpmo-ascend/SKILL.md` for optimization and acceptance rules.
+2. `../optimize-minicpmo-ascend/references/competition-rules.md` when official
+   rules, metrics, datasets, or submission requirements affect the experiment.
+3. `../optimize-minicpmo-ascend/references/repo-map.md` before changing an
+   unfamiliar pipeline stage.
+4. [references/candidate-record.md](references/candidate-record.md) before
+   recording, committing, or pushing a candidate.
+
+Prefer the repository tools in `benchmarks/competition/minicpmo_ascend/` for
+environment capture, smoke tests, benchmarks, resource collection, and gates.
+Treat `UNRESOLVED` official fields as blockers for formal claims, not as values
+to infer.
+
+## Daily Cycle
+
+### 1. Protect the Starting State
+
+- Inspect `git status`, current branch, HEAD, remotes, and recent commits.
+- Assume existing changes belong to the user. Never discard, overwrite, or
+  include unrelated paths in the candidate commit.
+- Verify that the target remote contains the current HEAD before building new
+  work on top of it.
+- Create a candidate ID in the form `YYYYMMDD-short-hypothesis`.
+- Record the baseline SHA, deploy config, model revision, and artifact root.
+- Recheck official material when the experiment depends on competition rules.
+
+If unrelated dirty changes overlap the candidate files, understand and work
+with them. Stop only when a safe, reviewable candidate cannot be isolated.
+
+### 2. Define the Candidate Before Editing
+
+Write down:
+
+- Evidence for the bottleneck.
+- One primary variable to change.
+- Target workload and metric expected to improve.
+- Correctness, effect, memory, latency, and stability guardrails.
+- Minimum gain needed to exceed baseline variance.
+- Rollback condition.
+
+Do not combine independent optimizations in one candidate. Compatibility fixes
+needed to make the benchmark valid belong in separate `fix` commits.
+
+### 3. Capture a Same-Session Baseline
+
+Use fixed model revision, sampling, seed, prompt/media, output limits, warmup,
+concurrency, and request count. Keep text-only and text-plus-audio separate.
+
+At minimum:
+
+1. Capture environment and exact commands.
+2. Run deterministic smoke and correctness gates.
+3. Run the target proxy or official benchmark after warmup.
+4. Save raw results, server logs, NPU samples, and output artifacts.
+5. Repeat enough to estimate run variance.
+
+Prefer an A/B/A comparison in one server session or equivalent clean restarts
+when configuration/model loading changes. Never use profiler timings as score
+timings.
+
+### 4. Implement One Primary Change
+
+- Follow existing repository and platform patterns.
+- Preserve GPU behavior unless the candidate explicitly targets it.
+- Keep benchmark-specific logic outside model code.
+- Add focused tests for changed state, shapes, dtypes, chunking, cleanup, or
+  scheduling behavior.
+- Avoid unrelated refactors and metadata churn.
+
+### 5. Validate in Increasing Cost Order
+
+Run the narrowest useful checks first:
+
+1. Focused unit tests for changed modules.
+2. Ruff/format, YAML or shell validation, and `git diff --check` as applicable.
+3. Ascend server startup and deterministic smoke requests.
+4. Machine-readable correctness/effect gate.
+5. Target benchmark with raw resource collection.
+6. Concurrency, cancellation, and stability checks when shared/request-local
+   state or memory lifetime changes.
+
+Stop performance evaluation when a correctness gate fails. Failed, truncated,
+timed-out, empty, or invalid-output requests count as failures and never as
+performance samples.
+
+### 6. Compare and Decide
+
+Compare baseline and candidate using the same workload and report central and
+tail statistics. Include TTFT/first text, first audio, chunk cadence, E2E,
+throughput, errors, NPU utilization, peak HBM, and host memory when applicable.
+
+Choose exactly one decision:
+
+- `keep`: gates pass and the gain exceeds noise without disqualifying tradeoffs.
+- `reject`: the candidate loses, fails a gate, or adds unjustified complexity.
+- `investigate`: evidence is inconclusive; do not claim or commit a performance
+  win.
+
+For `reject` or `investigate`, preserve the record when it prevents repeated
+work. Remove only edits made for that candidate; do not revert user changes.
+
+### 7. Commit an Accepted Candidate Atomically
+
+- Review the complete diff and staged diff.
+- Stage explicit candidate paths, never `git add -A` in a dirty worktree.
+- Keep tests and config needed by the candidate in the same commit.
+- Use `perf(minicpmo): <mechanism>` for a measured optimization.
+- Use a separate `fix`, `test`, `bench`, or `docs` commit for non-performance
+  prerequisites.
+- Put baseline/candidate identifiers, gate result, key metric delta, artifact
+  path, and rollback note in the commit body when useful.
+- Verify the resulting commit and clean/expected worktree before pushing.
+
+One accepted performance mechanism equals one performance commit. Do not amend
+or squash an already published candidate when doing so would erase comparison
+history.
+
+### 8. Push Without Weakening Safety
+
+- Push to the dedicated competition remote/branch configured for this project.
+- Never store a token in a remote URL, tracked file, shell script, log, or
+  artifact.
+- Never force-push unless the user explicitly authorizes rewriting that exact
+  remote branch.
+- Verify the remote commit SHA after pushing.
+- Report the commit URL, decision, validation, metrics, and remaining risk.
+
+External writes require user authorization. A prior instruction to maintain
+the dedicated competition repository authorizes normal non-force pushes for
+accepted candidates, but not repository deletion, visibility changes, branch
+protection changes, releases, or pull requests.
+
+## Completion Gate
+
+Finish a daily cycle only when all are true:
+
+- Candidate record identifies baseline, candidate, environment, workload, and
+  exact commands.
+- Correctness/effect and stability status are explicit.
+- Raw artifacts are traceable and formal/proxy metrics are labeled correctly.
+- Decision is one of `keep`, `reject`, or `investigate` with evidence.
+- An accepted change is isolated in one reviewable performance commit.
+- Remote state is verified when a push was requested or authorized.
+- The next highest-priority TODO or blocker is stated.

--- a/.claude/skills/run-minicpmo-ascend-perf-cycle/agents/openai.yaml
+++ b/.claude/skills/run-minicpmo-ascend-perf-cycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MiniCPM-o Ascend Performance Cycle"
+  short_description: "Run reproducible daily Ascend performance experiments."
+  default_prompt: "Use $run-minicpmo-ascend-perf-cycle to take one MiniCPM-o Ascend optimization hypothesis from baseline through validation, experiment recording, and an atomic commit."

--- a/.claude/skills/run-minicpmo-ascend-perf-cycle/references/candidate-record.md
+++ b/.claude/skills/run-minicpmo-ascend-perf-cycle/references/candidate-record.md
@@ -1,0 +1,93 @@
+# Candidate Record and Commit Policy
+
+Use this reference for every performance candidate. Keep raw logs and large
+audio/profiler artifacts outside Git unless the competition packaging rules
+require them. Commit a compact report or record whose artifact paths and
+checksums make the raw evidence traceable.
+
+## Candidate Record
+
+```markdown
+# <candidate-id>: <short title>
+
+- Decision: keep | reject | investigate
+- Baseline SHA/config:
+- Candidate SHA/diff:
+- Official rules/toolkit version or retrieval date:
+- Environment/NPU topology:
+- Model revision/dtype:
+- Hypothesis and mechanism:
+- Target metric/workload:
+- Guardrails and rollback condition:
+
+## Commands
+
+- Server:
+- Warmup:
+- Correctness/effect:
+- Benchmark:
+- Monitoring/profiling:
+
+## Results
+
+| Metric | Baseline | Candidate | Delta | Variance/confidence |
+| --- | ---: | ---: | ---: | ---: |
+| Gate pass | | | | |
+| TTFT/first text p50/p95 | | | | |
+| First audio p50/p95 | | | | |
+| Chunk latency p50/p95 | | | | |
+| E2E p50/p95 | | | | |
+| Throughput | | | | |
+| Stable sessions | | | | |
+| NPU utilization | | | | |
+| Peak HBM/host memory | | | | |
+| Errors/timeouts | | | | |
+
+## Evidence
+
+- Raw result paths/checksums:
+- Server log:
+- Output artifacts:
+- NPU samples/trace:
+- Correctness/effect report:
+
+## Decision Rationale
+
+Explain why the result exceeds noise, which tradeoffs remain, and what would
+cause rollback. Label local proxy metrics and unresolved official assumptions.
+```
+
+## Commit Boundaries
+
+Use these boundaries so history remains bisectable:
+
+- `perf(minicpmo)`: one accepted performance mechanism with its focused tests.
+- `fix(npu)` or `fix(scheduler)`: compatibility/correctness prerequisite.
+- `feat(bench)`: benchmark or observability capability, without model changes.
+- `test(minicpmo)`: test-only gate expansion.
+- `docs(minicpmo)`: records, reproduction notes, or rule snapshots.
+
+Do not mix benchmark fixes, unrelated cleanup, and a performance mechanism in
+one `perf` commit. If a candidate needs a prerequisite, land and validate the
+prerequisite first, then rerun the baseline before the performance candidate.
+
+## Pre-Commit Checklist
+
+- The staged diff contains only candidate-owned paths.
+- Focused tests pass.
+- Static checks for touched files pass.
+- Ascend smoke and applicable gates pass.
+- Baseline and candidate commands/workloads match.
+- The gain exceeds variance or the commit does not claim a performance win.
+- GPU and unsupported workloads are unchanged or explicitly documented.
+- Artifact paths contain no credentials, personal data, or machine secrets.
+
+## Pre-Push Checklist
+
+- Inspect `git status`, `git show --stat --oneline HEAD`, and the target remote.
+- Confirm the local commit is based on the intended remote branch.
+- Use a credential helper, `gh`, or an ephemeral environment token; keep the
+  remote URL credential-free.
+- Push normally without `--force`.
+- Read back the remote branch SHA and compare it with local `HEAD`.
+- Record the commit URL in the experiment report or handoff.

--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,8 @@ outputs/
 results/
 generated/
 output_*/
+/artifacts/minicpmo_ascend/
+/kernel_meta/
 
 # Configuration overrides
 configs/local.yaml

--- a/benchmarks/competition/__init__.py
+++ b/benchmarks/competition/__init__.py
@@ -1,0 +1,1 @@
+"""Competition-specific benchmark suites."""

--- a/benchmarks/competition/minicpmo_ascend/README.md
+++ b/benchmarks/competition/minicpmo_ascend/README.md
@@ -104,7 +104,47 @@ three effect checks below:
   benchmarks/competition/minicpmo_ascend/requirements-eval.txt
 ```
 
-## 4. Run the Daily-Omni proxy effect check
+## 4. Build and run the fixed public proxy benchmark
+
+Build the versioned four-workload sample set with seed 42. The default 400
+samples contain 100 Daily-Omni questions, 100 English Seed-TTS rows, 100
+Chinese Seed-TTS rows, and 100 Video-MME questions. Daily-Omni is balanced by
+video duration before category, Seed-TTS is balanced by target-text length
+quartile, and Video-MME is balanced by duration before domain. Media inputs are
+unique within each workload where the public data permits it.
+
+```bash
+/workspace/minicpmo-npu-venv/bin/python -m \
+  benchmarks.competition.minicpmo_ascend.build_public_benchmark \
+  --daily-qa /data/Daily-Omni/qa.json \
+  --daily-video-dir /data/Daily-Omni/Videos \
+  --seed-tts-root /data/seed-tts-eval \
+  --video-mme-metadata /data/Video-MME/videomme/test-00000-of-00001.parquet \
+  --video-mme-video-dir /data/Video-MME/extracted/data \
+  --output-dir /data/public-proxy-benchmark-v1 \
+  --seed 42
+```
+
+Start the server with local media access covering `/data` and MiniCPM
+interleaved AV strings enabled, then run all four workloads at concurrency 1:
+
+```bash
+SAMPLE_ROOT=/data/public-proxy-benchmark-v1 \
+DATA_ROOT=/data \
+MODEL=/path/to/MiniCPM-o-4_5 \
+BENCH_BIN=/path/to/vllm-omni \
+PYTHON=/path/to/python \
+SOURCE_REVISION=<tested-source-revision> \
+bash benchmarks/competition/minicpmo_ascend/run_public_proxy_benchmark.sh
+```
+
+This suite is a deterministic public-data proxy, not an official competition
+benchmark or score. Keep the generated `manifest.json`, `summary.json`, and
+`report.md` with every result set. The 100-row Seed-TTS passes measure
+generation success, streaming continuity, TTFP, E2E, RTF, and throughput; run
+the separate ASR evaluator when WER is required.
+
+## 5. Run the Daily-Omni proxy effect check
 
 ```bash
 DAILY_OMNI_QA_JSON=/data/Daily-Omni/qa.json \
@@ -119,7 +159,7 @@ stable. Start MiniCPM-o with `--interleave-mm-strings` when using the default
 `minicpm-interleave` pack mode. Replace this public benchmark with the exact
 competition subset and protocol when the organizer releases them.
 
-## 5. Run the public Seed-TTS effect check
+## 6. Run the public Seed-TTS effect check
 
 Use the standard `en/meta.lst` or `zh/meta.lst` split from the public
 `seed-tts-eval` release. Start the server with `ALLOWED_LOCAL_MEDIA_PATH`
@@ -139,7 +179,7 @@ Paraformer-zh. Keep WavLM SIM and UTMOS results labeled as proxies because
 their public checkpoints are not identical to the organizer's unreleased
 competition evaluator.
 
-## 6. Run the public Video-MME effect check
+## 7. Run the public Video-MME effect check
 
 Download and extract the public Video-MME release, then point the runner at
 the official parquet metadata and MP4 directory. Large local videos are sent
@@ -160,7 +200,7 @@ JSON structure documented by Video-MME. It evaluates the public,
 subtitles-free protocol; it is not a substitute for an unreleased competition
 subset or score.
 
-## 7. Capture an NPU profile
+## 8. Capture an NPU profile
 
 Keep profiling separate from score measurements. The profile runner generates
 a temporary deploy config, starts a clean server, warms it outside the capture

--- a/benchmarks/competition/minicpmo_ascend/README.md
+++ b/benchmarks/competition/minicpmo_ascend/README.md
@@ -1,0 +1,157 @@
+# MiniCPM-o 4.5 Ascend Competition Suite
+
+This directory provides the reproducible local proxy suite for Track 1,
+vLLM-Omni sub-track B. The organizer now publishes the single-card Ascend 910C
+target, the `v0.25.0-a3` image, the 2-percentage-point accuracy-loss gate, the
+Demo gate, and the RTF/TTFT/TTFP performance objectives. Exact evaluator
+statistics, score weights, benchmark subsets, and package schema still depend
+on the unavailable starter kit and final evaluation document.
+
+The local suite is a pre-submission gate, not an implementation of the
+official score. Its first-text and first-audio timings are explicitly proxy
+signals for TTFT and TTFP.
+
+## Official admission and submission gates
+
+Before uploading a package, all of the following must be present:
+
+- Daily-Omni, TTS-Seed, and Video-MME results against the official baseline,
+  with no more than 2 percentage points of accuracy loss.
+- A stable end-to-end run through the designated vLLM-Omni Demo, including
+  audio, video, text, and continuous streamed speech, plus a demonstration
+  recording.
+- RTF, TTFT, and TTFP results from the official evaluator, with raw output,
+  exact commands, environment, run count, statistics, before/after comparison,
+  resource use, and anomaly notes.
+- Complete code, deploy configuration, service/benchmark/Demo scripts,
+  dependencies, optimization analysis, and reproduction instructions.
+
+See `.claude/skills/optimize-minicpmo-ascend/references/competition-rules.md`
+and `environment_manifest.yaml` for the dated rule snapshot. Do not upload a
+proxy-only package as a formal scored submission.
+
+## 1. Resolve the environment
+
+Update `environment_manifest.yaml` from the newest official announcement.
+Every `UNRESOLVED` value must be resolved before a formal run. Capture the
+actual machine separately:
+
+```bash
+.venv/bin/python -m benchmarks.competition.minicpmo_ascend.collect_environment \
+  --output artifacts/minicpmo_ascend/environment.json \
+  --starter-kit /path/to/starter-kit.tar.gz \
+  --model-path /path/to/MiniCPM-o-4_5 \
+  --model-manifest /path/to/model-sha256.txt
+```
+
+The collector records the Git SHA and dirty diff, package versions, CANN
+version files, physical-card and logical-chip inventory from `npu-smi`, and
+checksums of supplied manifests/artifacts. It deliberately does not hash a
+multi-gigabyte model tree implicitly. When the model directory has no revision
+metadata, create a relative-path manifest explicitly:
+
+```bash
+cd /path/to/MiniCPM-o-4_5
+find . -type f -print0 | sort -z | xargs -0 sha256sum \
+  > /path/to/model-sha256.txt
+```
+
+## 2. Start the server
+
+```bash
+MODEL=/path/to/MiniCPM-o-4_5 \
+MODEL_REVISION=<fixed-revision> \
+bash benchmarks/competition/minicpmo_ascend/start_server.sh
+```
+
+The default deployment is
+`vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml`. It uses both logical
+chips exposed by one physical Ascend 910C card; device IDs `0` and `1` do not
+mean two cards. Override `DEPLOY_CONFIG` only with a checked-in candidate
+configuration.
+
+## 3. Run the gated proxy suite
+
+Provide a deterministic local video. Image and audio fixtures are generated
+offline by the suite.
+
+```bash
+VIDEO_INPUT=/path/to/official-or-local-fixture.mp4 \
+MODEL=/path/to/MiniCPM-o-4_5 \
+MODEL_PATH=/path/to/MiniCPM-o-4_5 \
+MODEL_MANIFEST=/path/to/model-sha256.txt \
+bash benchmarks/competition/minicpmo_ascend/run_suite.sh \
+  --concurrency 1 2 4 --num-requests 20 --warmups 2
+```
+
+The command runs multimodal smoke validation first, then separate text-only
+and text-plus-audio benchmarks, a text-plus-audio stability run, raw NPU/host
+resource collection, the machine-readable correctness gate, and a baseline
+report with an artifact checksum manifest. A failed, timed-out, truncated,
+empty, or invalid-audio request is excluded from metrics and makes the command
+fail.
+
+Raw per-request output includes first SSE event, first text, first audio,
+audio chunk arrival/inter-chunk times, E2E, finish reasons, error details, WAV
+format, chunk hashes, and reconstructed audio. Results are labeled
+`local_proxy`; no unofficial composite score is emitted.
+
+## 4. Run the Daily-Omni proxy effect check
+
+```bash
+DAILY_OMNI_QA_JSON=/data/Daily-Omni/qa.json \
+DAILY_OMNI_VIDEO_DIR=/data/Daily-Omni/videos \
+bash benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
+```
+
+This requests text only and disables thinking so A-D answer extraction is
+stable. Replace it with the official effect suite as soon as one is released.
+
+## 5. Capture an NPU profile
+
+Keep profiling separate from score measurements. The profile runner generates
+a temporary deploy config, starts a clean server, warms it outside the capture
+window, profiles a fixed request, stops the server, and emits a unified JSON
+and Markdown summary:
+
+```bash
+MODEL=/path/to/MiniCPM-o-4_5 \
+PROFILE_ID=stage2-baseline \
+PROFILE_STAGES=2 \
+bash benchmarks/competition/minicpmo_ascend/run_profile.sh
+```
+
+Use a unique `PROFILE_ID` for every capture; the runner refuses to mix a new
+capture into a non-empty artifact directory.
+
+Profile all stages only when stage ownership is unclear:
+
+```bash
+PROFILE_ID=all-stages-baseline PROFILE_STAGES=0,1,2 \
+bash benchmarks/competition/minicpmo_ascend/run_profile.sh
+```
+
+Artifacts are written under
+`artifacts/minicpmo_ascend/profiles/<profile-id>/`. Compare the same workload,
+stage selection, profiler configuration, and environment with:
+
+```bash
+.venv/bin/python -m benchmarks.competition.minicpmo_ascend.profile_analysis compare \
+  artifacts/minicpmo_ascend/profiles/baseline/profile_analysis.json \
+  artifacts/minicpmo_ascend/profiles/candidate/profile_analysis.json \
+  --output artifacts/minicpmo_ascend/profiles/comparison.json
+```
+
+Profiler timing is diagnostic evidence and must never replace the unprofiled
+baseline/candidate benchmark.
+
+## Formal-run rules
+
+- Use clean server restarts and record warmup separately from measurements.
+- Keep profiler runs separate from score runs.
+- Never compare text-only and text-plus-audio as the same workload.
+- Preserve raw JSON, server logs, resource samples, WAV artifacts, exact
+  commands, Git diff, model manifest, and starter-kit checksum.
+- Do not report a formal score until the starter kit and official evaluator
+  are available, all submission-critical `UNRESOLVED` manifest fields are
+  resolved, and the three official effect suites plus Demo gate pass.

--- a/benchmarks/competition/minicpmo_ascend/README.md
+++ b/benchmarks/competition/minicpmo_ascend/README.md
@@ -96,18 +96,71 @@ audio chunk arrival/inter-chunk times, E2E, finish reasons, error details, WAV
 format, chunk hashes, and reconstructed audio. Results are labeled
 `local_proxy`; no unofficial composite score is emitted.
 
+Install the optional public benchmark evaluator dependencies before running the
+three effect checks below:
+
+```bash
+.venv/bin/python -m pip install -r \
+  benchmarks/competition/minicpmo_ascend/requirements-eval.txt
+```
+
 ## 4. Run the Daily-Omni proxy effect check
 
 ```bash
 DAILY_OMNI_QA_JSON=/data/Daily-Omni/qa.json \
-DAILY_OMNI_VIDEO_DIR=/data/Daily-Omni/videos \
+DAILY_OMNI_VIDEO_DIR=/data/Daily-Omni/Videos \
+DAILY_OMNI_INPUT_MODE=all \
+DAILY_OMNI_PACK_MODE=minicpm-interleave \
 bash benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
 ```
 
 This requests text only and disables thinking so A-D answer extraction is
-stable. Replace it with the official effect suite as soon as one is released.
+stable. Start MiniCPM-o with `--interleave-mm-strings` when using the default
+`minicpm-interleave` pack mode. Replace this public benchmark with the exact
+competition subset and protocol when the organizer releases them.
 
-## 5. Capture an NPU profile
+## 5. Run the public Seed-TTS effect check
+
+Use the standard `en/meta.lst` or `zh/meta.lst` split from the public
+`seed-tts-eval` release. Start the server with `ALLOWED_LOCAL_MEDIA_PATH`
+covering the dataset root because reference WAV files are sent as `file://`
+URLs.
+
+```bash
+SEED_TTS_ROOT=/data/seed-tts-eval \
+SEED_TTS_LOCALE=en \
+MODEL=/path/to/MiniCPM-o-4_5 \
+bash benchmarks/competition/minicpmo_ascend/run_seed_tts.sh
+```
+
+Set `WER_EVAL=1` to run the public Seed-TTS ASR/WER evaluator. Its official
+English protocol loads Whisper-large-v3; the Chinese protocol loads
+Paraformer-zh. Keep WavLM SIM and UTMOS results labeled as proxies because
+their public checkpoints are not identical to the organizer's unreleased
+competition evaluator.
+
+## 6. Run the public Video-MME effect check
+
+Download and extract the public Video-MME release, then point the runner at
+the official parquet metadata and MP4 directory. Large local videos are sent
+as `file://` URLs, so start the server with `ALLOWED_LOCAL_MEDIA_PATH` covering
+the dataset root.
+
+```bash
+VIDEO_MME_METADATA=/data/Video-MME/videomme/test-00000-of-00001.parquet \
+VIDEO_MME_VIDEO_DIR=/data/Video-MME/videos \
+MODEL=/path/to/MiniCPM-o-4_5 \
+bash benchmarks/competition/minicpmo_ascend/run_video_mme.sh \
+  --durations short medium long --concurrency 1
+```
+
+Use `--max-videos 1` or `--num-questions 3` for a deterministic smoke run.
+The runner emits raw request records, an accuracy breakdown, and the grouped
+JSON structure documented by Video-MME. It evaluates the public,
+subtitles-free protocol; it is not a substitute for an unreleased competition
+subset or score.
+
+## 7. Capture an NPU profile
 
 Keep profiling separate from score measurements. The profile runner generates
 a temporary deploy config, starts a clean server, warms it outside the capture

--- a/benchmarks/competition/minicpmo_ascend/__init__.py
+++ b/benchmarks/competition/minicpmo_ascend/__init__.py
@@ -1,0 +1,1 @@
+"""MiniCPM-o 4.5 Ascend competition benchmark package."""

--- a/benchmarks/competition/minicpmo_ascend/baselines/20260726-ascend-910c-1card-local-proxy.md
+++ b/benchmarks/competition/minicpmo_ascend/baselines/20260726-ascend-910c-1card-local-proxy.md
@@ -1,0 +1,105 @@
+# 20260726 Ascend 910C Single-Card Local Proxy Baseline
+
+- Decision: keep as the pre-official local proxy baseline.
+- Benchmark Git SHA: `652bb664bcbccc316505f932146f6416df1d0173`.
+- Rules retrieval date: 2026-07-26.
+- Official dataset, starter kit, metric definitions, thresholds, and score: `UNRESOLVED`.
+- Hardware: one physical Ascend 910C card, NPU ID 0, two logical chips 0/1.
+- HBM: 64 GiB per logical chip, 128 GiB aggregate.
+- Deploy config: `vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml`.
+- Model: local `openbmb/MiniCPM-o-4_5` tree, bf16 model configuration.
+- Model manifest SHA256: `bb23a7b8b90f583de88a36661ed0648e7d291aa505e23958e019e8cd3e844226`.
+- Seed: 42; thinker max tokens: 256; talker max tokens: 256; warmups: 2.
+- Raw artifact root: `artifacts/minicpmo_ascend/baseline-910c-1card-20260726/`.
+- Artifact manifest SHA256: `f0ffcbb69b1b3baef96c9baa5d2571983dd8d9a0b0f03edc1e87c4503691e9c5`.
+- Generated report SHA256: `69280b62904564de773445a021d7c75d05b96fe8683b097164e681d39e3f5967`.
+
+## Gates
+
+The machine-readable gate passed with no failures. Text-only output contained
+no audio. Every audio response was non-empty 24 kHz PCM with ordered,
+non-duplicate adjacent chunks.
+
+| Request | Input | Output | Result | Audio chunks | PCM bytes |
+| --- | --- | --- | --- | ---: | ---: |
+| text_only | text | text | PASS | 0 | 0 |
+| text_audio | text | text + audio | PASS | 8 | 679680 |
+| image_audio | image | text + audio | PASS | 4 | 324480 |
+| audio_audio | audio | text + audio | PASS | 3 | 224640 |
+| video_audio | video | text + audio | PASS | 7 | 595200 |
+
+## Performance
+
+All latency values are seconds. Each configuration used 20 measured requests
+after two warmups. Failed requests are excluded from metrics and would fail the
+gate; this run had zero failures.
+
+| Mode | C | OK/Fail | First text p50/p95/p99 | First audio p50/p95/p99 | E2E p50/p95/p99 | Req/s | Audio s/s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| text | 1 | 20/0 | 0.060/0.062/0.064 | - | 0.862/0.875/0.876 | 1.159 | 0.000 |
+| text | 2 | 20/0 | 0.071/0.096/0.118 | - | 0.917/1.272/1.608 | 2.011 | 0.000 |
+| text | 4 | 20/0 | 0.082/0.120/0.120 | - | 0.934/0.988/0.989 | 4.231 | 0.000 |
+| text_audio | 1 | 20/0 | 0.448/0.459/0.462 | 1.164/1.207/1.219 | 3.461/3.596/3.601 | 0.287 | 3.493 |
+| text_audio | 2 | 20/0 | 0.474/0.495/0.504 | 1.724/1.851/1.860 | 4.355/4.517/4.523 | 0.457 | 6.026 |
+| text_audio | 4 | 20/0 | 0.525/0.535/0.538 | 2.029/2.133/2.133 | 5.440/5.712/5.715 | 0.730 | 9.414 |
+
+| Mode | C | Peak AI Core | Peak aggregate HBM MiB | HBM first/last delta MiB | Peak/first-last delta host GiB |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| text | 1 | 66% | 89501 | 0 | 84.624/+0.608 |
+| text | 2 | 66% | 89503 | 0 | 84.694/+0.054 |
+| text | 4 | 64% | 89503 | 0 | 85.317/+0.074 |
+| text_audio | 1 | 65% | 89504 | 0 | 85.436/+0.261 |
+| text_audio | 2 | 64% | 89963 | +461 | 86.232/+0.701 |
+| text_audio | 4 | 61% | 96833 | +4350 | 86.325/-0.007 |
+
+The positive HBM deltas while increasing concurrency are persistent runtime
+buffer/cache allocation. The stability run starts after those shapes have
+already been exercised.
+
+## Stability
+
+The stability run used text-plus-audio at concurrency 4 for 100 measured
+requests after two warmups.
+
+| OK/Fail | Wall time | First text p50/p95/p99 | First audio p50/p95/p99 | E2E p50/p95/p99 | Req/s | Audio s/s |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100/0 | 134.413 s | 0.518/0.530/0.535 | 2.012/2.049/2.058 | 5.319/5.553/5.563 | 0.744 | 9.600 |
+
+- Resource samples: 89.
+- Peak AI Core: 62%.
+- Peak aggregate HBM: 96836 MiB.
+- Aggregate HBM first/last delta: 0 MiB.
+- Peak host memory: 93.800 GiB.
+- Host memory first/last delta: +5.566 GiB.
+- Server errors, tracebacks, validation errors, or engine crashes: 0.
+- NPU processes after clean shutdown: 0; HBM returned to 3096/2883 MiB idle usage.
+
+The zero HBM delta proves no device-memory growth over this proxy stability
+window. The host-memory delta uses system-wide `MemTotal - MemAvailable` and
+includes page cache, so it is recorded as a follow-up signal rather than proof
+of a process leak or leak-free host state.
+
+## Reproduction
+
+```bash
+MODEL=/path/to/MiniCPM-o-4_5 \
+ARTIFACT_DIR=artifacts/minicpmo_ascend/baseline/server \
+bash benchmarks/competition/minicpmo_ascend/start_server.sh
+```
+
+```bash
+VIDEO_INPUT=/path/to/Skiing.mp4 \
+MODEL=/path/to/MiniCPM-o-4_5 \
+MODEL_PATH=/path/to/MiniCPM-o-4_5 \
+MODEL_MANIFEST=/path/to/model-sha256.txt \
+OUTPUT_DIR=artifacts/minicpmo_ascend/baseline \
+STABILITY_REQUESTS=100 \
+bash benchmarks/competition/minicpmo_ascend/run_suite.sh \
+  --concurrency 1 2 4 --num-requests 20 --warmups 2 \
+  --seed 42 --thinker-max-tokens 256 --talker-max-tokens 256
+```
+
+When official material is published, record its version and checksums, replace
+the proxy fixtures/requests with the official dataset and script, and rerun the
+same gated flow. Do not compare a future official score directly with this
+local proxy or infer unpublished weights from these measurements.

--- a/benchmarks/competition/minicpmo_ascend/baselines/20260803-ascend-910c-real-validation.md
+++ b/benchmarks/competition/minicpmo_ascend/baselines/20260803-ascend-910c-real-validation.md
@@ -1,0 +1,86 @@
+# 2026-08-03 Ascend 910C real-machine baseline validation
+
+This record captures the pre-submission validation of the competition baseline.
+The measurements below are local proxy results, not an official competition
+score.
+
+## Source and environment
+
+- Upstream base: `f05babab841e7374d0f4c98f5d289940f7118c49`
+  (`upstream/minicpm-challenge`, fetched 2026-08-03).
+- Official image reference: `quay.io/ascend/vllm-omni:v0.25.0-a3`.
+- Resolved arm64 image digest:
+  `sha256:6c22113f72a276bb4662d361680e14240189e8d01d31521cbef565f71dd0a078`.
+- The registry stopped allowing anonymous layer downloads during validation, so
+  the final run used an isolated environment reconstructed from the source
+  revisions embedded in the image rather than claiming an official-container
+  run.
+- vLLM source: `e5588e49bc2642670116664a7fc4096e27adb179`.
+- vLLM Ascend source: `8092d3f66599ce07cd0aca2bcc99d14b8a9192f8`.
+- Python 3.12.13, PyTorch 2.10.0, torch-npu 2.10.0,
+  triton-ascend 3.2.1, and stepaudio2-minicpmo 0.1.1.
+- Host CANN: 9.1.0-beta.3.
+- Hardware: one physical Ascend 910C card exposing logical devices 0 and 1,
+  each with 64 GiB HBM.
+- Model: complete MiniCPM-o-4_5 checkpoint downloaded through ModelScope;
+  checkpoint weight size reported by the loader was 17.46 GiB.
+
+Before server startup, tensor allocation and arithmetic passed independently
+on both logical NPU devices.
+
+## Service and multimodal validation
+
+The three-stage deployment in
+`vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml` initialized on the real
+device. Stage 0 loaded 16.8394 GiB of weights, stage 1 loaded 0.6422 GiB, and
+stage 2 loaded the Token2Wav stack. The API completed model warmup, returned
+HTTP 200 from `/health`, and served all five deterministic smoke cases:
+
+| Case | Input | Output | Result |
+| --- | --- | --- | --- |
+| `text_only` | text | text | PASS |
+| `text_audio` | text | text and audio | PASS |
+| `image_audio` | image | text and audio | PASS |
+| `audio_audio` | audio | text and audio | PASS |
+| `video_audio` | video | text and audio | PASS |
+
+All generated audio passed the suite's WAV structure, non-empty PCM, and
+stream-completion checks.
+
+## Reduced proxy benchmark
+
+The submission tooling was exercised with two measured requests per point and
+one warmup. These small samples verify the path and artifact schema; they are
+not statistically meaningful competition measurements.
+
+| Mode | Concurrency | OK/failed | First text p50 (s) | First audio p50 (s) | E2E p50 (s) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| text | 1 | 2/0 | 0.088 | - | 1.517 |
+| text | 2 | 2/0 | 7.468 | - | 10.571 |
+| text plus audio | 1 | 2/0 | 0.783 | 1.691 | 2.234 |
+| text plus audio | 2 | 2/0 | 0.817 | 2.500 | 3.450 |
+
+A separate text-plus-audio stability point at concurrency 1 passed 2/2
+requests with 0 failures. The machine-readable correctness gate passed with
+an empty failure list. Raw local artifacts were written to
+`artifacts/minicpmo_ascend/baseline-20260803-real/` and are intentionally not
+committed because they include generated media and machine-specific paths.
+
+## Regression validation
+
+- Competition and profile tools: 11 tests passed.
+- Scheduler, engine-output compatibility, Code2Wav batching, CosyVoice2 NPU,
+  StepAudio2 Token2Wav, and NPU worker compatibility: 65 tests passed.
+- Ruff checks passed for every changed Python file.
+- Python bytecode compilation, Bash syntax, YAML parsing, and
+  `git diff --cached --check` passed.
+
+## Formal submission blockers
+
+The organizer starter kit URL was unavailable from the development machine at
+validation time. Consequently, the official evaluator schema, exact benchmark
+subsets, and score weights remain unresolved. A formal submission still needs
+official Daily-Omni, TTS-Seed, and Video-MME effect results, the official
+RTF/TTFT/TTFP run, and the required stable Demo recording. This branch is a
+tested, reproducible baseline for those steps; it is not represented as a
+platform submission.

--- a/benchmarks/competition/minicpmo_ascend/baselines/20260803-ascend-910c-real-validation.md
+++ b/benchmarks/competition/minicpmo_ascend/baselines/20260803-ascend-910c-real-validation.md
@@ -47,24 +47,42 @@ HTTP 200 from `/health`, and served all five deterministic smoke cases:
 All generated audio passed the suite's WAV structure, non-empty PCM, and
 stream-completion checks.
 
-## Reduced proxy benchmark
+## Expanded proxy benchmark
 
-The submission tooling was exercised with two measured requests per point and
-one warmup. These small samples verify the path and artifact schema; they are
-not statistically meaningful competition measurements.
+The low-sample path check was superseded by an expanded run pinned to commit
+`69d29b78feeedd08ef3dd66986a05895ca7b0323`. Each primary configuration used
+three warmups followed by 30 measured requests. The matrix covered text and
+text-plus-audio output at concurrency 1, 2, and 4, for 180 measured requests.
 
-| Mode | Concurrency | OK/failed | First text p50 (s) | First audio p50 (s) | E2E p50 (s) |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| text | 1 | 2/0 | 0.088 | - | 1.517 |
-| text | 2 | 2/0 | 7.468 | - | 10.571 |
-| text plus audio | 1 | 2/0 | 0.783 | 1.691 | 2.234 |
-| text plus audio | 2 | 2/0 | 0.817 | 2.500 | 3.450 |
+| Mode | C | OK/failed | First text p50/p95 (s) | First audio p50/p95 (s) | E2E p50/p95 (s) | Req/s | Audio s/s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| text | 1 | 30/0 | 0.086/0.091 | -/- | 1.521/1.532 | 0.658 | - |
+| text | 2 | 30/0 | 0.104/0.113 | -/- | 1.564/1.878 | 1.209 | - |
+| text | 4 | 30/0 | 0.133/0.177 | -/- | 1.623/1.699 | 2.249 | - |
+| text plus audio | 1 | 30/0 | 0.772/0.778 | 1.702/1.714 | 3.834/3.924 | 0.257 | 1.914 |
+| text plus audio | 2 | 30/0 | 0.810/0.829 | 2.589/2.740 | 6.404/6.456 | 0.311 | 2.310 |
+| text plus audio | 4 | 30/0 | 0.824/0.875 | 2.774/3.320 | 8.287/9.684 | 0.468 | 3.410 |
 
-A separate text-plus-audio stability point at concurrency 1 passed 2/2
-requests with 0 failures. The machine-readable correctness gate passed with
-an empty failure list. Raw local artifacts were written to
-`artifacts/minicpmo_ascend/baseline-20260803-real/` and are intentionally not
-committed because they include generated media and machine-specific paths.
+A separate text-plus-audio concurrency-4 stability run used three warmups and
+200 measured requests. It completed 200/200 requests with no failures in
+471.806 seconds: first text p50/p95 was 0.788/1.176 seconds, first audio was
+2.962/3.712 seconds, E2E was 9.311/11.271 seconds, request throughput was 0.424
+requests/s, and generated-audio throughput was 3.113 audio seconds/s.
+
+Across the primary and stability runs, all 380 measured requests succeeded.
+All 290 measured audio responses were complete and non-empty, and no adjacent
+duplicate audio chunks were detected. The machine-readable correctness gate
+passed with an empty failure list. Peak aggregate HBM reported by the resource
+sampler was 108,899 MiB during stability.
+
+Raw local artifacts are under
+`artifacts/minicpmo_ascend/baseline-69d29b78-expanded/` and are intentionally
+ignored because they contain generated media and machine-specific paths. Key
+SHA-256 values:
+
+- Primary benchmark JSON: `ca45c3cc36a12146952a0891c90682c8a9e3852230695623361c0bee8b348997`
+- Stability benchmark JSON: `9277295da5a9b88ddf5935482aefa20a65e08ba993836c4b28aa23c45eca2e65`
+- Generated baseline report: `219f6aea4f5b0de57ba4f31da86a366dbd95443061dfb564e02a3ae45cbe27c3`
 
 ## Regression validation
 

--- a/benchmarks/competition/minicpmo_ascend/baselines/20260803-public-effect-validation.md
+++ b/benchmarks/competition/minicpmo_ascend/baselines/20260803-public-effect-validation.md
@@ -1,0 +1,106 @@
+# 2026-08-03 public effect validation
+
+This record captures public-data proxy checks for Daily-Omni, Seed-TTS, and
+Video-MME on the Ascend 910C development machine. These measurements are not
+official competition scores.
+
+## Starter Kit status
+
+The competition Toolkit page was checked again on 2026-08-03. Its two
+container addresses are explicitly described as placeholder examples, the old
+`oiac-toolkit-v1.0.tar.gz` host does not resolve, and both listed registries
+reject anonymous image access. The official Starter Kit, benchmark subsets,
+evaluator, and submission schema therefore remain unavailable. This run uses
+the upstream public benchmark releases and preserves that distinction.
+
+## Environment
+
+- Branch: `baseline/minicpmo-ascend-v0.25.0-20260803`.
+- Upstream integration: `63fdc8e7` from `upstream/minicpm-challenge`.
+- Hardware: one physical Ascend 910C card exposing logical devices 0 and 1.
+- Runtime: Python 3.12.13, PyTorch 2.10.0, torch-npu 2.10.0, CANN
+  9.1.0-beta.3.
+- Model: `/workspace/user_data/models/MiniCPM-o-4_5`.
+- Service: three-stage vLLM-Omni deployment, local OpenAI-compatible endpoint,
+  local media access enabled, MiniCPM interleaved AV strings enabled.
+
+## Daily-Omni
+
+The public `liarliar/Daily-Omni` release was downloaded at dataset revision
+`bf5a6ee4c829510b7a14869e3104efeafc330b07`. The local release contains 1,197
+questions and 684 videos. SHA-256 values:
+
+- `qa.json`: `3210a45d42424c7d57c1b40a0b9aa2708fc02fab2364bf01fd7d16e1242e146b`
+- `Videos.tar`: `5b42ca809bf1bfdc0894509755d5d5b2210994fa2e4c7149e3ce3db310db4afc`
+
+The deterministic first 100 questions were evaluated with all audio/video
+inputs, MiniCPM interleaving, temperature 0, output length 16, and concurrency
+2. All 100 requests completed and all answers parsed.
+
+| Metric | Result |
+| --- | ---: |
+| Accuracy | 71/100 (71.00%) |
+| 30-second videos | 39/51 (76.47%) |
+| 60-second videos | 32/49 (65.31%) |
+| Median E2E | 11.882 s |
+| P99 E2E | 17.251 s |
+| Run duration | 592.31 s |
+
+## Seed-TTS
+
+The public `zhaochenyang20/seed-tts-eval` reorganization was used with the
+standard prompt audio and metadata: 1,088 English rows, 2,020 Chinese rows,
+1,007 English prompt WAV files, and 1,010 Chinese prompt WAV files. All 2,017
+required prompt files were validated as real audio rather than Git LFS pointer
+files.
+
+An English five-item generation smoke test completed 5/5 requests and produced
+19.8 seconds of valid audio. Streaming continuity was 100%, audio underrun was
+zero, median audio TTFP was 1.480 seconds, median E2E was 2.249 seconds, and
+median audio RTF was 0.64. Whisper-large-v3 evaluated all five outputs under
+the public Seed-TTS English protocol; mean and median WER were both 0.0000,
+with no request, PCM capture, or ASR failures.
+
+A Chinese five-item generation smoke test also completed 5/5 requests and
+produced 21.88 seconds of valid audio. Streaming continuity was 100%, audio
+underrun was zero, median audio TTFP was 1.559 seconds, median E2E was 2.698
+seconds, and median audio RTF was 0.61.
+
+A subsequent five-item run using Paraformer-zh under the public Seed-TTS
+Chinese protocol evaluated all five outputs. Mean WER was 0.0091 and median WER
+was 0.0000, with no request, PCM capture, or ASR failures. WavLM similarity and
+UTMOS are intentionally not reported because their public checkpoints are not
+guaranteed to match the unreleased competition evaluator.
+
+## Video-MME
+
+The public `lmms-eval/Video-MME` metadata contains 2,700 questions. The full
+video payload is approximately 101 GB and split into 20 archives. At this
+validation point, 296 videos from completed public archives were available, so
+the deterministic first 100 resolvable questions were evaluated using the
+official subtitles-free multiple-choice prompt. This is a partial public-set
+check, not a full Video-MME score.
+
+All 100 requests completed and all answers parsed.
+
+| Metric | Result |
+| --- | ---: |
+| Accuracy | 79/100 (79.00%) |
+| Knowledge | 57/72 (79.17%) |
+| Film & TV | 22/28 (78.57%) |
+| Duration bucket | 100 short-video questions |
+
+## Reproduction and limitations
+
+Commands are documented in the parent README and saved with each ignored raw
+artifact under `artifacts/minicpmo_ascend/public-eval/`. Install public
+evaluator dependencies with:
+
+```bash
+.venv/bin/python -m pip install -r \
+  benchmarks/competition/minicpmo_ascend/requirements-eval.txt
+```
+
+Before a formal submission, replace every public subset and evaluator with the
+official Starter Kit versions, run the complete three-suite effect gate against
+the official baseline, and retain raw outputs and exact environment metadata.

--- a/benchmarks/competition/minicpmo_ascend/baselines/20260804-public-proxy-benchmark-v1.md
+++ b/benchmarks/competition/minicpmo_ascend/baselines/20260804-public-proxy-benchmark-v1.md
@@ -1,0 +1,69 @@
+# Public Proxy Benchmark v1 - 2026-08-04
+
+This report records a deterministic public-data proxy run. It is not an
+official competition benchmark or score. The official Starter Kit, evaluator
+subsets, score weights, and final package schema were not available for this
+run.
+
+## Run identity
+
+- Tested source revision: `69d29b78feeedd08ef3dd66986a05895ca7b0323`
+- Sample seed: `42`
+- Hardware: one physical Ascend 910C, logical devices 0 and 1
+- Concurrency: 1 for every workload
+- Requests: 400/400 completed, 0 failed
+- Raw artifacts: `artifacts/minicpmo_ascend/public-proxy-benchmark-v1-baseline-69d29b78`
+
+## Fixed sample protocol
+
+| Workload | Public source rows available | Selected | Stratification |
+| --- | ---: | ---: | --- |
+| Daily-Omni | 1,197 | 100 | 50 each for 30s/60s, then parent category; one question per video |
+| Seed-TTS English | 1,088 | 100 | 25 per target-text length quartile; unique prompt preferred |
+| Seed-TTS Chinese | 2,020 | 100 | 25 per target-text length quartile; unique prompt preferred |
+| Video-MME | 1,380 questions / 460 videos | 100 | 34 long, 33 medium, 33 short, then six domains; one question per video |
+
+## Results
+
+| Workload | Effect result | Throughput | P50 first response | P50 E2E | P99 E2E |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Daily-Omni | 73/100 (73.00%) | 0.1462 req/s | 5,557.30 ms | 5,623.38 ms | 9,545.29 ms |
+| Seed-TTS English | 100/100 generated | 1.6696 audio s/s | 1,489.78 ms TTFP | 2,611.86 ms | 3,457.90 ms |
+| Seed-TTS Chinese | 100/100 generated | 1.7262 audio s/s | 1,563.03 ms TTFP | 2,876.16 ms | 3,881.47 ms |
+| Video-MME | 65/100 (65.00%) | 0.1137 req/s | 5.71 s | 5.75 s | 27.54 s |
+
+Seed-TTS English generated 446.96 seconds of audio with median RTF 0.6040.
+Seed-TTS Chinese generated 501.08 seconds with median RTF 0.5844. Both runs
+had zero p99 audio underrun and a 100% streaming-continuity proxy rate.
+
+The separate five-sample public Whisper-large-v3 English check evaluated 5/5
+generated clips with mean WER 0.0000 and median WER 0.0000. The separate
+five-sample public Paraformer-zh Chinese check evaluated 5/5 clips with mean
+WER 0.0091 and median WER 0.0000. WER was not rerun for either 100-sample
+generation pass; those passes cover generation and performance rather than
+ASR quality.
+
+## Accuracy breakdown
+
+Daily-Omni:
+
+| Duration | Correct | Total | Accuracy |
+| --- | ---: | ---: | ---: |
+| 30s | 35 | 50 | 70.00% |
+| 60s | 38 | 50 | 76.00% |
+
+Video-MME:
+
+| Duration | Correct | Total | Accuracy |
+| --- | ---: | ---: | ---: |
+| Long | 16 | 34 | 47.06% |
+| Medium | 27 | 33 | 81.82% |
+| Short | 22 | 33 | 66.67% |
+
+## Interpretation
+
+The suite now covers the basic public data paths for all three organizer-named
+effect families: Daily-Omni, Seed-TTS in English and Chinese, and Video-MME.
+Seed-TTS is counted as two workloads because language-specific generation and
+ASR quality paths differ. These results remain proxy evidence until the
+organizer publishes the formal Starter Kit and exact evaluation protocol.

--- a/benchmarks/competition/minicpmo_ascend/benchmark.py
+++ b/benchmarks/competition/minicpmo_ascend/benchmark.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Run warmup and concurrent MiniCPM-o streaming proxy benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .client import build_payload, metric_summary, run_stream_request
+
+
+def _host_memory() -> dict[str, int]:
+    values = {}
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+            name, raw = line.split(":", 1)
+            values[name] = int(raw.strip().split()[0]) * 1024
+    except (OSError, ValueError, IndexError):
+        return {}
+    return values
+
+
+async def _npu_snapshot() -> dict[str, Any]:
+    if shutil.which("npu-smi") is None:
+        return {"error": "npu-smi not found"}
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "npu-smi",
+            "info",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+    except (OSError, asyncio.TimeoutError) as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+    return {
+        "returncode": process.returncode,
+        "stdout": stdout.decode(errors="replace"),
+        "stderr": stderr.decode(errors="replace"),
+    }
+
+
+async def _monitor_resources(stop: asyncio.Event, output: Path, interval: float) -> None:
+    samples = []
+    while True:
+        samples.append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "host_memory_bytes": _host_memory(),
+                "npu_smi": await _npu_snapshot(),
+            }
+        )
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval)
+            break
+        except asyncio.TimeoutError:
+            pass
+    output.write_text(json.dumps({"samples": samples}, indent=2) + "\n", encoding="utf-8")
+
+
+async def _run_configuration(
+    args: argparse.Namespace,
+    *,
+    mode: str,
+    concurrency: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    with_audio = mode == "text_audio"
+    payload = build_payload(
+        model=args.model,
+        prompt=args.prompt,
+        input_modality=args.input_modality,
+        media=args.media,
+        with_audio=with_audio,
+        seed=args.seed,
+        thinker_max_tokens=args.thinker_max_tokens,
+        talker_max_tokens=args.talker_max_tokens,
+    )
+    timeout = httpx.Timeout(args.timeout)
+    async with httpx.AsyncClient(timeout=timeout, headers={"Authorization": "Bearer EMPTY"}) as client:
+        warmups = []
+        for index in range(args.warmups):
+            warmups.append(
+                await run_stream_request(
+                    client,
+                    endpoint=f"{args.base_url.rstrip('/')}/chat/completions",
+                    payload=payload,
+                    request_name=f"warmup-{mode}-{index}",
+                    input_modality=args.input_modality,
+                    with_audio=with_audio,
+                )
+            )
+        if any(not record["success"] for record in warmups):
+            return {"mode": mode, "concurrency": concurrency, "warmups": warmups, "records": [], "aborted": True}
+
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def one(index: int) -> dict[str, Any]:
+            async with semaphore:
+                return await run_stream_request(
+                    client,
+                    endpoint=f"{args.base_url.rstrip('/')}/chat/completions",
+                    payload=payload,
+                    request_name=f"measure-{mode}-c{concurrency}-{index}",
+                    input_modality=args.input_modality,
+                    with_audio=with_audio,
+                    output_wav=output_dir / "audio" / f"request-{index:04d}.wav" if with_audio else None,
+                )
+
+        stop = asyncio.Event()
+        monitor = asyncio.create_task(_monitor_resources(stop, output_dir / "resources.json", args.resource_interval))
+        started = time.perf_counter()
+        try:
+            records = await asyncio.gather(*(one(index) for index in range(args.num_requests)))
+        finally:
+            duration = time.perf_counter() - started
+            stop.set()
+            await monitor
+
+    summary = metric_summary(records)
+    successful = [record for record in records if record["success"]]
+    summary["wall_time_s"] = duration
+    summary["request_throughput_per_s"] = len(successful) / duration if duration else None
+    audio_seconds = sum(
+        record["audio"]["pcm_bytes"]
+        / (record["audio"]["sample_rate_hz"] * record["audio"]["channels"] * record["audio"]["sample_width_bytes"])
+        for record in successful
+        if record["audio"]["pcm_bytes"] and record["audio"]["sample_rate_hz"]
+    )
+    summary["generated_audio_seconds"] = audio_seconds
+    summary["audio_seconds_throughput"] = audio_seconds / duration if duration else None
+    return {
+        "mode": mode,
+        "concurrency": concurrency,
+        "warmups": warmups,
+        "records": records,
+        "summary": summary,
+        "aborted": False,
+    }
+
+
+async def _main(args: argparse.Namespace) -> int:
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    configurations = []
+    for mode in args.modes:
+        for concurrency in args.concurrency:
+            current_dir = args.output_dir / f"{mode}_c{concurrency}"
+            current_dir.mkdir(parents=True, exist_ok=True)
+            result = await _run_configuration(
+                args,
+                mode=mode,
+                concurrency=concurrency,
+                output_dir=current_dir,
+            )
+            configurations.append(result)
+            (current_dir / "raw_results.json").write_text(
+                json.dumps(result, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            status = "ABORT" if result["aborted"] else ("PASS" if result["summary"]["failed_requests"] == 0 else "FAIL")
+            print(f"{mode} concurrency={concurrency}: {status}")
+
+    result = {
+        "schema_version": 1,
+        "metric_scope": "local_proxy",
+        "formal_score": None,
+        "official_metric_definitions": "UNRESOLVED",
+        "profiler_run": False,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "command": [sys.executable, *sys.argv],
+        "environment": {
+            "model_revision": os.environ.get("MINICPMO_MODEL_REVISION", "UNRESOLVED"),
+        },
+        "configurations": configurations,
+    }
+    result_path = args.output_dir / "benchmark_results.json"
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(result_path)
+    failed = any(
+        config["aborted"] or config.get("summary", {}).get("failed_requests", 1) > 0 for config in configurations
+    )
+    return 1 if failed else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8099/v1")
+    parser.add_argument("--model", default="openbmb/MiniCPM-o-4_5")
+    parser.add_argument("--input-modality", choices=["text", "image", "audio", "video"], default="text")
+    parser.add_argument("--media", help="Required for non-text input modalities")
+    parser.add_argument("--prompt", default="Introduce vLLM-Omni in one short sentence.")
+    parser.add_argument("--modes", nargs="+", choices=["text", "text_audio"], default=["text", "text_audio"])
+    parser.add_argument("--concurrency", nargs="+", type=int, default=[1, 2, 4])
+    parser.add_argument("--num-requests", type=int, default=8)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--resource-interval", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--thinker-max-tokens", type=int, default=256)
+    parser.add_argument("--talker-max-tokens", type=int, default=256)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    if any(value < 1 for value in args.concurrency):
+        parser.error("all concurrency values must be >= 1")
+    if args.num_requests < 1 or args.warmups < 0:
+        parser.error("num-requests must be >= 1 and warmups must be >= 0")
+    if args.input_modality != "text" and not args.media:
+        parser.error("--media is required for non-text input modalities")
+    raise SystemExit(asyncio.run(_main(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/build_public_benchmark.py
+++ b/benchmarks/competition/minicpmo_ascend/build_public_benchmark.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Build a deterministic four-workload public proxy benchmark sample set."""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import hashlib
+import json
+import random
+from collections import Counter, defaultdict
+from collections.abc import Callable, Hashable
+from pathlib import Path
+from typing import Any
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _distribution(rows: list[dict[str, Any]], key: Callable[[dict[str, Any]], Hashable]) -> dict[str, int]:
+    return dict(sorted(Counter(str(key(row)) for row in rows).items()))
+
+
+def select_stratified(
+    rows: list[dict[str, Any]],
+    *,
+    count: int,
+    seed: int,
+    stratum_key: Callable[[dict[str, Any]], Hashable],
+    unique_key: Callable[[dict[str, Any]], Hashable],
+) -> list[dict[str, Any]]:
+    """Round-robin over shuffled strata while preferring unique media inputs."""
+    if count < 1:
+        raise ValueError("sample count must be positive")
+    rng = random.Random(seed)
+    groups: dict[Hashable, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[stratum_key(row)].append(row)
+    group_keys = sorted(groups, key=str)
+    rng.shuffle(group_keys)
+    for values in groups.values():
+        rng.shuffle(values)
+
+    selected: list[dict[str, Any]] = []
+    seen: set[Hashable] = set()
+    while len(selected) < count:
+        progressed = False
+        for group_key in group_keys:
+            values = groups[group_key]
+            while values:
+                candidate = values.pop()
+                identity = unique_key(candidate)
+                if identity in seen:
+                    continue
+                selected.append(candidate)
+                seen.add(identity)
+                progressed = True
+                break
+            if len(selected) == count:
+                break
+        if not progressed:
+            break
+    if len(selected) != count:
+        raise ValueError(f"requested {count} unique samples, but only selected {len(selected)}")
+    return selected
+
+
+def select_hierarchical(
+    rows: list[dict[str, Any]],
+    *,
+    count: int,
+    seed: int,
+    primary_key: Callable[[dict[str, Any]], Hashable],
+    secondary_key: Callable[[dict[str, Any]], Hashable],
+    unique_key: Callable[[dict[str, Any]], Hashable],
+) -> list[dict[str, Any]]:
+    """Balance primary groups first, then round-robin secondary strata."""
+    primary_groups: dict[Hashable, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        primary_groups[primary_key(row)].append(row)
+    keys = sorted(primary_groups, key=str)
+    base, remainder = divmod(count, len(keys))
+    selected_groups: dict[Hashable, list[dict[str, Any]]] = {}
+    for index, key in enumerate(keys):
+        group_count = base + int(index < remainder)
+        selected_groups[key] = select_stratified(
+            primary_groups[key],
+            count=group_count,
+            seed=seed + index,
+            stratum_key=secondary_key,
+            unique_key=unique_key,
+        )
+
+    selected: list[dict[str, Any]] = []
+    while len(selected) < count:
+        for key in keys:
+            if selected_groups[key]:
+                selected.append(selected_groups[key].pop(0))
+    return selected
+
+
+def _load_seed_rows(root: Path, locale: str) -> list[dict[str, Any]]:
+    meta = root / locale / "meta.lst"
+    rows = []
+    for index, line in enumerate(meta.read_text(encoding="utf-8").splitlines()):
+        if not line.strip():
+            continue
+        parts = line.split("|", 3)
+        if len(parts) != 4:
+            raise ValueError(f"invalid Seed-TTS metadata at {meta}:{index + 1}")
+        utterance_id, prompt_text, prompt_wav, target_text = parts
+        prompt_path = root / locale / prompt_wav
+        if not prompt_path.is_file():
+            continue
+        rows.append(
+            {
+                "utterance_id": utterance_id,
+                "prompt_text": prompt_text,
+                "prompt_wav": prompt_wav,
+                "target_text": target_text,
+                "target_length": len(target_text),
+                "source_line": line,
+            }
+        )
+    return rows
+
+
+def _length_bins(rows: list[dict[str, Any]]) -> tuple[list[int], Callable[[dict[str, Any]], int]]:
+    lengths = sorted(int(row["target_length"]) for row in rows)
+    thresholds = [lengths[len(lengths) * numerator // 4] for numerator in (1, 2, 3)]
+
+    def bin_for(row: dict[str, Any]) -> int:
+        return bisect.bisect_right(thresholds, int(row["target_length"]))
+
+    return thresholds, bin_for
+
+
+def _ensure_prompt_link(output_root: Path, source_root: Path, locale: str) -> None:
+    locale_output = output_root / "seed_tts" / locale
+    locale_output.mkdir(parents=True, exist_ok=True)
+    link = locale_output / "prompt-wavs"
+    target = (source_root / locale / "prompt-wavs").resolve()
+    if link.is_symlink():
+        if link.resolve() != target:
+            raise ValueError(f"existing prompt link points elsewhere: {link}")
+        return
+    if link.exists():
+        raise ValueError(f"prompt link path already exists: {link}")
+    link.symlink_to(target, target_is_directory=True)
+
+
+def _daily_video_path(root: Path, video_id: str) -> Path | None:
+    candidates = [root / video_id / f"{video_id}_video.mp4", root / f"{video_id}.mp4"]
+    return next((path for path in candidates if path.is_file()), None)
+
+
+def build(args: argparse.Namespace) -> dict[str, Any]:
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    daily_rows = json.loads(args.daily_qa.read_text(encoding="utf-8"))
+    daily_available = [
+        row
+        for row in daily_rows
+        if _daily_video_path(args.daily_video_dir, str(row.get("video_id", ""))) is not None
+    ]
+    daily_selected = select_hierarchical(
+        daily_available,
+        count=args.daily_count,
+        seed=args.seed,
+        primary_key=lambda row: row.get("video_duration"),
+        secondary_key=lambda row: row.get("content_parent_category"),
+        unique_key=lambda row: str(row.get("video_id")),
+    )
+    daily_output = args.output_dir / "daily_omni" / "qa.json"
+    daily_output.parent.mkdir(parents=True, exist_ok=True)
+    daily_output.write_text(json.dumps(daily_selected, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    seed_manifest: dict[str, Any] = {}
+    for locale, count, offset in (
+        ("en", args.seed_en_count, 1000),
+        ("zh", args.seed_zh_count, 2000),
+    ):
+        rows = _load_seed_rows(args.seed_tts_root, locale)
+        thresholds, length_bin = _length_bins(rows)
+        selected = select_stratified(
+            rows,
+            count=count,
+            seed=args.seed + offset,
+            stratum_key=length_bin,
+            unique_key=lambda row: str(row["prompt_wav"]),
+        )
+        _ensure_prompt_link(args.output_dir, args.seed_tts_root, locale)
+        meta_output = args.output_dir / "seed_tts" / locale / "meta.lst"
+        meta_output.write_text("\n".join(str(row["source_line"]) for row in selected) + "\n", encoding="utf-8")
+        seed_manifest[locale] = {
+            "source_rows": len(rows),
+            "selected_rows": len(selected),
+            "selection": "target-text-length quartiles; unique reference prompt preferred",
+            "length_thresholds": thresholds,
+            "length_bin_distribution": _distribution(selected, length_bin),
+            "target_length_min": min(int(row["target_length"]) for row in selected),
+            "target_length_max": max(int(row["target_length"]) for row in selected),
+            "utterance_ids": [row["utterance_id"] for row in selected],
+            "metadata": str(meta_output),
+            "metadata_sha256": _sha256(meta_output),
+        }
+
+    import pyarrow.parquet as pq
+
+    video_rows = pq.read_table(args.video_mme_metadata).to_pylist()
+    video_files = {path.stem for path in args.video_mme_video_dir.glob("*.mp4")}
+    video_available = [
+        row
+        for row in video_rows
+        if str(row.get("videoID", "")) in video_files or str(row.get("video_id", "")) in video_files
+    ]
+    video_selected = select_hierarchical(
+        video_available,
+        count=args.video_mme_count,
+        seed=args.seed + 3000,
+        primary_key=lambda row: row.get("duration"),
+        secondary_key=lambda row: row.get("domain"),
+        unique_key=lambda row: str(row.get("videoID") or row.get("video_id")),
+    )
+    video_output = args.output_dir / "video_mme" / "metadata.json"
+    video_output.parent.mkdir(parents=True, exist_ok=True)
+    video_output.write_text(json.dumps(video_selected, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    manifest = {
+        "schema_version": 1,
+        "scope": "deterministic public-data proxy benchmark; not an official competition benchmark",
+        "formal_competition_score": None,
+        "seed": args.seed,
+        "total_selected_samples": len(daily_selected) + args.seed_en_count + args.seed_zh_count + len(video_selected),
+        "daily_omni": {
+            "source_rows": len(daily_rows),
+            "available_rows": len(daily_available),
+            "selected_rows": len(daily_selected),
+            "selection": "equal duration allocation, then parent-category strata; one question per video",
+            "duration_distribution": _distribution(daily_selected, lambda row: row.get("video_duration")),
+            "category_distribution": _distribution(daily_selected, lambda row: row.get("content_parent_category")),
+            "video_ids": [row["video_id"] for row in daily_selected],
+            "metadata": str(daily_output),
+            "metadata_sha256": _sha256(daily_output),
+        },
+        "seed_tts": seed_manifest,
+        "video_mme": {
+            "source_rows": len(video_rows),
+            "available_rows": len(video_available),
+            "available_videos": len(video_files),
+            "selected_rows": len(video_selected),
+            "selection": "equal duration allocation, then domain strata; one question per video",
+            "duration_distribution": _distribution(video_selected, lambda row: row.get("duration")),
+            "domain_distribution": _distribution(video_selected, lambda row: row.get("domain")),
+            "question_ids": [row["question_id"] for row in video_selected],
+            "metadata": str(video_output),
+            "metadata_sha256": _sha256(video_output),
+        },
+    }
+    manifest_output = args.output_dir / "manifest.json"
+    manifest_output.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(manifest_output)
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--daily-qa", type=Path, required=True)
+    parser.add_argument("--daily-video-dir", type=Path, required=True)
+    parser.add_argument("--seed-tts-root", type=Path, required=True)
+    parser.add_argument("--video-mme-metadata", type=Path, required=True)
+    parser.add_argument("--video-mme-video-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--daily-count", type=int, default=100)
+    parser.add_argument("--seed-en-count", type=int, default=100)
+    parser.add_argument("--seed-zh-count", type=int, default=100)
+    parser.add_argument("--video-mme-count", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=42)
+    build(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/client.py
+++ b/benchmarks/competition/minicpmo_ascend/client.py
@@ -24,7 +24,7 @@ SYSTEM_PROMPT = (
 
 def media_url(value: str | Path, modality: str) -> str:
     raw = str(value)
-    if raw.startswith(("http://", "https://", "data:")):
+    if raw.startswith(("http://", "https://", "file://", "data:")):
         return raw
     path = Path(raw).expanduser().resolve()
     if not path.is_file():

--- a/benchmarks/competition/minicpmo_ascend/client.py
+++ b/benchmarks/competition/minicpmo_ascend/client.py
@@ -1,0 +1,283 @@
+"""Streaming request helpers shared by the MiniCPM Ascend competition tools."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import mimetypes
+import time
+import wave
+from array import array
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+SYSTEM_PROMPT = (
+    "You are MiniCPM-o, a helpful multimodal assistant that can understand "
+    "images, audio and video, and respond in text and speech."
+)
+
+
+def media_url(value: str | Path, modality: str) -> str:
+    raw = str(value)
+    if raw.startswith(("http://", "https://", "data:")):
+        return raw
+    path = Path(raw).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    mime = (
+        mimetypes.guess_type(path.name)[0]
+        or {
+            "image": "image/png",
+            "audio": "audio/wav",
+            "video": "video/mp4",
+        }[modality]
+    )
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
+def build_payload(
+    *,
+    model: str,
+    prompt: str,
+    input_modality: str,
+    media: str | Path | None,
+    with_audio: bool,
+    seed: int,
+    thinker_max_tokens: int,
+    talker_max_tokens: int,
+) -> dict[str, Any]:
+    content: list[dict[str, Any]] = []
+    if input_modality != "text":
+        if media is None:
+            raise ValueError(f"{input_modality} input requires a media path or URL")
+        content.append(
+            {
+                "type": f"{input_modality}_url",
+                f"{input_modality}_url": {"url": media_url(media, input_modality)},
+            }
+        )
+    content.append({"type": "text", "text": prompt})
+    modalities = ["text", "audio"] if with_audio else ["text"]
+    return {
+        "model": model,
+        "stream": True,
+        "modalities": modalities,
+        "chat_template_kwargs": {"use_tts_template": with_audio},
+        "sampling_params_list": [
+            {
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "max_tokens": thinker_max_tokens,
+                "seed": seed,
+                "detokenize": True,
+                "repetition_penalty": 1.1,
+            },
+            {
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "max_tokens": talker_max_tokens,
+                "seed": seed,
+                "detokenize": False,
+            },
+        ],
+        "messages": [
+            {"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]},
+            {"role": "user", "content": content},
+        ],
+    }
+
+
+class WavAccumulator:
+    def __init__(self) -> None:
+        self.channels: int | None = None
+        self.sample_width: int | None = None
+        self.sample_rate: int | None = None
+        self.frames: list[bytes] = []
+        self.chunk_sha256: list[str] = []
+        self.boundary_jumps: list[int] = []
+        self._last_sample: int | None = None
+
+    def append(self, encoded: str) -> None:
+        raw = base64.b64decode(encoded, validate=True)
+        with wave.open(io.BytesIO(raw), "rb") as chunk:
+            current = (chunk.getnchannels(), chunk.getsampwidth(), chunk.getframerate())
+            expected = (self.channels, self.sample_width, self.sample_rate)
+            if self.channels is None:
+                self.channels, self.sample_width, self.sample_rate = current
+            elif current != expected:
+                raise ValueError(f"audio format changed from {expected} to {current}")
+            frames = chunk.readframes(chunk.getnframes())
+        if not frames:
+            raise ValueError("empty audio chunk")
+        if self.sample_width == 2:
+            samples = array("h")
+            samples.frombytes(frames)
+            if samples.itemsize != 2:
+                raise ValueError("host does not provide 16-bit signed samples")
+            if self._last_sample is not None:
+                self.boundary_jumps.append(abs(int(samples[0]) - self._last_sample))
+            self._last_sample = int(samples[-1])
+        self.frames.append(frames)
+        self.chunk_sha256.append(hashlib.sha256(frames).hexdigest())
+
+    def write(self, path: Path) -> None:
+        if not self.frames or self.channels is None or self.sample_width is None or self.sample_rate is None:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with wave.open(str(path), "wb") as output:
+            output.setnchannels(self.channels)
+            output.setsampwidth(self.sample_width)
+            output.setframerate(self.sample_rate)
+            output.writeframes(b"".join(self.frames))
+
+    def metadata(self) -> dict[str, Any]:
+        pcm = b"".join(self.frames)
+        return {
+            "chunk_count": len(self.frames),
+            "pcm_bytes": len(pcm),
+            "sample_rate_hz": self.sample_rate,
+            "channels": self.channels,
+            "sample_width_bytes": self.sample_width,
+            "pcm_sha256": hashlib.sha256(pcm).hexdigest() if pcm else None,
+            "chunk_sha256": self.chunk_sha256,
+            "adjacent_duplicate_chunks": sum(
+                left == right for left, right in zip(self.chunk_sha256, self.chunk_sha256[1:], strict=False)
+            ),
+            "boundary_jump_abs_pcm16": self.boundary_jumps,
+        }
+
+
+async def run_stream_request(
+    client: httpx.AsyncClient,
+    *,
+    endpoint: str,
+    payload: dict[str, Any],
+    request_name: str,
+    input_modality: str,
+    with_audio: bool,
+    output_wav: Path | None = None,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    record: dict[str, Any] = {
+        "request_name": request_name,
+        "input_modality": input_modality,
+        "output_mode": "text_audio" if with_audio else "text",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "success": False,
+        "complete": False,
+        "http_status": None,
+        "first_event_s": None,
+        "first_text_s": None,
+        "first_audio_s": None,
+        "audio_chunk_arrival_s": [],
+        "audio_chunk_intervals_s": [],
+        "e2e_s": None,
+        "text": "",
+        "finish_reasons": [],
+        "errors": [],
+    }
+    audio = WavAccumulator()
+    done = False
+    try:
+        async with client.stream("POST", endpoint, json=payload) as response:
+            record["http_status"] = response.status_code
+            if response.status_code != 200:
+                body = (await response.aread()).decode("utf-8", errors="replace")
+                raise RuntimeError(f"HTTP {response.status_code}: {body[:2000]}")
+            async for line in response.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                data = line.removeprefix("data:").strip()
+                if data == "[DONE]":
+                    done = True
+                    break
+                now = time.perf_counter() - started
+                if record["first_event_s"] is None:
+                    record["first_event_s"] = now
+                event = json.loads(data)
+                modality = event.get("modality", "text")
+                for choice in event.get("choices", []):
+                    finish_reason = choice.get("finish_reason")
+                    if finish_reason is not None:
+                        record["finish_reasons"].append(finish_reason)
+                    content = (choice.get("delta") or {}).get("content")
+                    if not content:
+                        continue
+                    if modality == "audio":
+                        if record["first_audio_s"] is None:
+                            record["first_audio_s"] = now
+                        record["audio_chunk_arrival_s"].append(now)
+                        audio.append(content)
+                    elif modality == "text":
+                        if record["first_text_s"] is None:
+                            record["first_text_s"] = now
+                        record["text"] += content
+    except Exception as exc:
+        record["errors"].append(f"{type(exc).__name__}: {exc}")
+
+    record["e2e_s"] = time.perf_counter() - started
+    arrivals = record["audio_chunk_arrival_s"]
+    record["audio_chunk_intervals_s"] = [right - left for left, right in zip(arrivals, arrivals[1:], strict=False)]
+    record["audio"] = audio.metadata()
+    record["complete"] = done
+    if not record["text"].strip():
+        record["errors"].append("empty text output")
+    if with_audio:
+        if not audio.frames:
+            record["errors"].append("empty audio output")
+        if audio.sample_rate != 24000:
+            record["errors"].append(f"unexpected audio sample rate: {audio.sample_rate}")
+        if audio.metadata()["adjacent_duplicate_chunks"]:
+            record["errors"].append("adjacent audio chunks are byte-identical")
+    if not done:
+        record["errors"].append("stream ended without [DONE]")
+    record["success"] = not record["errors"]
+    if output_wav is not None and audio.frames:
+        audio.write(output_wav)
+        record["audio_artifact"] = str(output_wav)
+    return record
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def metric_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    successful = [record for record in records if record.get("success")]
+    summary: dict[str, Any] = {
+        "requests": len(records),
+        "successful_requests": len(successful),
+        "failed_requests": len(records) - len(successful),
+    }
+    for metric in ("first_event_s", "first_text_s", "first_audio_s", "e2e_s"):
+        values = [float(record[metric]) for record in successful if record.get(metric) is not None]
+        summary[metric] = {
+            "count": len(values),
+            "mean": sum(values) / len(values) if values else None,
+            "p50": percentile(values, 0.50),
+            "p95": percentile(values, 0.95),
+            "p99": percentile(values, 0.99),
+        }
+    intervals = [float(value) for record in successful for value in record.get("audio_chunk_intervals_s", [])]
+    summary["audio_chunk_interval_s"] = {
+        "count": len(intervals),
+        "mean": sum(intervals) / len(intervals) if intervals else None,
+        "p50": percentile(intervals, 0.50),
+        "p95": percentile(intervals, 0.95),
+        "p99": percentile(intervals, 0.99),
+    }
+    return summary

--- a/benchmarks/competition/minicpmo_ascend/collect_environment.py
+++ b/benchmarks/competition/minicpmo_ascend/collect_environment.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Capture a reproducible local environment snapshot for competition runs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run(command: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"command": command, "error": f"{type(exc).__name__}: {exc}"}
+    return {
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _package_versions() -> dict[str, str]:
+    names = [
+        "vllm",
+        "vllm-omni",
+        "vllm-ascend",
+        "torch",
+        "torch-npu",
+        "transformers",
+        "stepaudio2-minicpmo",
+    ]
+    versions = {}
+    for name in names:
+        try:
+            versions[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            versions[name] = "NOT_INSTALLED"
+    return versions
+
+
+def _git_snapshot() -> dict[str, Any]:
+    head = _run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT)
+    status = _run(["git", "status", "--short"], cwd=REPO_ROOT)
+    diff = _run(["git", "diff", "--binary", "--no-ext-diff"], cwd=REPO_ROOT)
+    diff_text = diff.get("stdout", "")
+    return {
+        "head": head,
+        "status": status,
+        "diff_sha256": hashlib.sha256(diff_text.encode("utf-8")).hexdigest(),
+        "diff": diff,
+    }
+
+
+def _npu_inventory() -> dict[str, Any]:
+    npu_smi = shutil.which("npu-smi")
+    if npu_smi is None:
+        return {"npu_smi_path": None, "error": "npu-smi not found"}
+
+    commands = {
+        "info": [npu_smi, "info"],
+        "list": [npu_smi, "info", "-l"],
+        "mapping": [npu_smi, "info", "-m"],
+    }
+    raw = {name: _run(command) for name, command in commands.items()}
+    list_output = raw["list"].get("stdout", "")
+    mapping_output = raw["mapping"].get("stdout", "")
+    total_match = re.search(r"Total Count\s*:\s*(\d+)", list_output)
+    cards = []
+    current: dict[str, int] | None = None
+    for line in list_output.splitlines():
+        npu_match = re.search(r"NPU ID\s*:\s*(\d+)", line)
+        if npu_match:
+            current = {"npu_id": int(npu_match.group(1))}
+            cards.append(current)
+            continue
+        chip_match = re.search(r"Chip Count\s*:\s*(\d+)", line)
+        if chip_match and current is not None:
+            current["chip_count"] = int(chip_match.group(1))
+
+    chips = []
+    for line in mapping_output.splitlines():
+        fields = line.split()
+        if len(fields) < 5 or not fields[0].isdigit() or not fields[1].isdigit():
+            continue
+        if not fields[2].isdigit():
+            continue
+        chips.append(
+            {
+                "npu_id": int(fields[0]),
+                "chip_id": int(fields[1]),
+                "logical_id": int(fields[2]),
+                "physical_id": int(fields[3]) if fields[3].isdigit() else None,
+                "name": fields[4],
+            }
+        )
+    return {
+        "npu_smi_path": npu_smi,
+        "physical_card_count": int(total_match.group(1)) if total_match else None,
+        "cards": cards,
+        "logical_chips": chips,
+        "raw": raw,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, default=Path(__file__).with_name("environment_manifest.yaml"))
+    parser.add_argument("--starter-kit", type=Path)
+    parser.add_argument("--model-path", type=Path)
+    parser.add_argument(
+        "--model-manifest",
+        type=Path,
+        help="Optional precomputed SHA256 manifest. Model trees are not hashed implicitly.",
+    )
+    args = parser.parse_args()
+
+    artifacts = {}
+    for name, path in (
+        ("environment_manifest", args.manifest),
+        ("starter_kit", args.starter_kit),
+        ("model_manifest", args.model_manifest),
+    ):
+        if path is not None:
+            resolved = path.expanduser().resolve()
+            artifacts[name] = {
+                "path": str(resolved),
+                "exists": resolved.is_file(),
+                "sha256": _sha256(resolved) if resolved.is_file() else None,
+            }
+
+    snapshot = {
+        "schema_version": 1,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "argv": sys.argv,
+        "cwd": os.getcwd(),
+        "repo_root": str(REPO_ROOT),
+        "platform": {
+            "python": sys.version,
+            "executable": sys.executable,
+            "os": platform.platform(),
+            "machine": platform.machine(),
+            "cpu_count": os.cpu_count(),
+        },
+        "environment": {
+            "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH"),
+            "PYTHONPATH": os.environ.get("PYTHONPATH"),
+            "ASCEND_RT_VISIBLE_DEVICES": os.environ.get("ASCEND_RT_VISIBLE_DEVICES"),
+        },
+        "packages": _package_versions(),
+        "git": _git_snapshot(),
+        "npu": _npu_inventory(),
+        "cann": {
+            "ASCEND_HOME_PATH": os.environ.get("ASCEND_HOME_PATH"),
+            "ASCEND_TOOLKIT_HOME": os.environ.get("ASCEND_TOOLKIT_HOME"),
+            "version_files": {},
+        },
+        "model": {
+            "path": str(args.model_path.expanduser().resolve()) if args.model_path else None,
+            "revision": os.environ.get("MINICPMO_MODEL_REVISION", "UNRESOLVED"),
+        },
+        "artifacts": artifacts,
+    }
+    for path in (
+        Path("/usr/local/Ascend/ascend-toolkit/latest/version.cfg"),
+        Path("/usr/local/Ascend/driver/version.info"),
+    ):
+        if path.is_file():
+            snapshot["cann"]["version_files"][str(path)] = path.read_text(errors="replace").strip()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/correctness_gate.py
+++ b/benchmarks/competition/minicpmo_ascend/correctness_gate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Produce a machine-readable pass/fail gate from smoke and benchmark artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path, label: str, failures: list[str]) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(f"cannot load {label} results from {path}: {exc}")
+        return None
+
+
+def _check_benchmark(path: Path, label: str, failures: list[str]) -> None:
+    benchmark = _load(path, label, failures) or {}
+    configurations = benchmark.get("configurations", [])
+    if not configurations:
+        failures.append(f"{label}: contains no configurations")
+    for config in configurations:
+        config_label = f"{label} {config.get('mode')} c={config.get('concurrency')}"
+        if config.get("aborted"):
+            failures.append(f"{config_label}: aborted during warmup")
+            continue
+        summary = config.get("summary", {})
+        if summary.get("failed_requests", 1) != 0:
+            failures.append(f"{config_label}: contains failed requests")
+        if summary.get("successful_requests", 0) <= 0:
+            failures.append(f"{config_label}: contains no successful samples")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--smoke-results", type=Path, required=True)
+    parser.add_argument("--benchmark-results", type=Path)
+    parser.add_argument("--stability-results", type=Path)
+    parser.add_argument("--require-input-modalities", nargs="+", default=["text", "image", "audio", "video"])
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    failures = []
+    smoke = _load(args.smoke_results, "smoke", failures) or {}
+    records = smoke.get("records", [])
+    seen_modalities = {record.get("input_modality") for record in records}
+    missing = set(args.require_input_modalities) - seen_modalities
+    if missing:
+        failures.append(f"missing input modality smoke records: {sorted(missing)}")
+    for record in records:
+        name = record.get("request_name", "unknown")
+        if not record.get("success") or not record.get("complete"):
+            failures.append(f"{name}: incomplete or failed: {record.get('errors', [])}")
+        audio = record.get("audio", {})
+        if record.get("output_mode") == "text":
+            if audio.get("chunk_count", 0) != 0:
+                failures.append(f"{name}: text-only request unexpectedly produced audio")
+        else:
+            if audio.get("sample_rate_hz") != 24000 or audio.get("pcm_bytes", 0) <= 0:
+                failures.append(f"{name}: invalid 24 kHz audio output")
+            if audio.get("adjacent_duplicate_chunks", 0):
+                failures.append(f"{name}: adjacent duplicate audio chunks")
+
+    if args.benchmark_results:
+        _check_benchmark(args.benchmark_results, "benchmark", failures)
+    if args.stability_results:
+        _check_benchmark(args.stability_results, "stability", failures)
+
+    result = {
+        "schema_version": 1,
+        "passed": not failures,
+        "failures": failures,
+        "official_effect_gate": "UNRESOLVED",
+        "scope": "local functional, streaming, and stability proxy",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output)
+    raise SystemExit(0 if result["passed"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/environment_manifest.yaml
+++ b/benchmarks/competition/minicpmo_ascend/environment_manifest.yaml
@@ -1,0 +1,73 @@
+schema_version: 2
+snapshot_date: "2026-08-03"
+competition:
+  name: MiniCPM & Ascend Inference Optimization and Application Innovation Challenge
+  track: high-performance-inference
+  sub_track: vllm-omni
+  rules_url: https://ascend.openbmb.cn/competition
+  rules_retrieved_at: "2026-08-03T03:00:00Z"
+  submission_deadline_cst: "2026-08-17T12:00:00+08:00"
+  daily_submission_limit: 3
+  starter_kit:
+    url: https://oiac.openbmb.org/toolkit/oiac-toolkit-v1.0.tar.gz
+    version: v1.0-advertised-unavailable
+    sha256: UNRESOLVED
+    retrieval_status: dns-unresolved-on-2026-08-03
+  performance_metrics: [per_chunk_rtf, ttft, ttfp]
+  scoring_formula: UNRESOLVED_NORMALIZATION_AND_WEIGHTS
+  request_schema: UNRESOLVED
+  effect_benchmarks: [Daily-Omni, TTS-Seed, Video-MME]
+  effect_thresholds:
+    maximum_accuracy_drop_percentage_points: 2
+    comparison_baseline: official-vllm-omni-sub-track-baseline
+  demo_gate: official-vllm-omni-demo-required
+  concurrency_levels: UNRESOLVED
+  timeouts: UNRESOLVED
+  package_limits: UNRESOLVED
+
+official_environment:
+  npu_model: Ascend 910C
+  physical_card_count: 1
+  topology: one-physical-card-two-logical-chips
+  cpu_limit: UNRESOLVED
+  ram_limit: UNRESOLVED
+  network_policy: UNRESOLVED
+  image: quay.io/ascend/vllm-omni:v0.25.0-a3
+  driver: UNRESOLVED
+  firmware: UNRESOLVED
+  cann: UNRESOLVED
+  python: "3.12 (published vLLM-Omni NPU requirement; verify in image)"
+  pytorch: UNRESOLVED
+  torch_npu: UNRESOLVED
+  vllm: UNRESOLVED
+  vllm_ascend: UNRESOLVED
+  vllm_omni: "0.25.0 image release"
+
+model:
+  source: openbmb/MiniCPM-o-4_5
+  revision: UNRESOLVED
+  sha256_manifest: UNRESOLVED
+  packaging_rules: UNRESOLVED
+
+local_proxy:
+  hardware:
+    model: Ascend 910C
+    physical_card_count: 1
+    chips_per_card: 2
+    logical_device_ids: [0, 1]
+    hbm_per_chip_gib: 64
+    aggregate_hbm_gib: 128
+    evidence_command: npu-smi info -l
+  deploy_config: vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml
+  output_sample_rate_hz: 24000
+  seed: 42
+  thinker_max_tokens: 256
+  talker_max_tokens: 256
+  warmup_requests: 2
+  benchmark_concurrency: [1, 2, 4]
+  benchmark_requests_per_configuration: 20
+  stability_mode: text_audio
+  stability_concurrency: 4
+  stability_requests: 100
+  percentile_statistics: [p50, p95, p99]
+  note: Local proxy values are not official scoring definitions.

--- a/benchmarks/competition/minicpmo_ascend/generate_fixtures.py
+++ b/benchmarks/competition/minicpmo_ascend/generate_fixtures.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Generate deterministic offline image and audio smoke-test inputs."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import struct
+import wave
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    image_path = args.output_dir / "competition_smoke.png"
+    image = Image.new("RGB", (256, 256), "white")
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((32, 32, 224, 224), fill="navy")
+    draw.ellipse((80, 80, 176, 176), fill="yellow")
+    image.save(image_path, format="PNG")
+
+    audio_path = args.output_dir / "competition_smoke.wav"
+    sample_rate = 16000
+    frames = bytearray()
+    for index in range(sample_rate):
+        sample = int(0.2 * 32767 * math.sin(2 * math.pi * 440 * index / sample_rate))
+        frames.extend(struct.pack("<h", sample))
+    with wave.open(str(audio_path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(frames)
+
+    print(image_path)
+    print(audio_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/profile.py
+++ b/benchmarks/competition/minicpmo_ascend/profile.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Capture a controlled MiniCPM-o request with the online NPU profiler."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .client import build_payload, run_stream_request
+
+
+def service_root(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    return normalized[:-3] if normalized.endswith("/v1") else normalized
+
+
+def git_state(root: Path) -> dict[str, Any]:
+    def run(*args: str) -> str:
+        return subprocess.check_output(["git", *args], cwd=root, text=True, stderr=subprocess.DEVNULL).strip()
+
+    try:
+        return {
+            "sha": run("rev-parse", "HEAD"),
+            "branch": run("branch", "--show-current"),
+            "dirty": bool(run("status", "--short")),
+        }
+    except (OSError, subprocess.CalledProcessError):
+        return {"sha": None, "branch": None, "dirty": None}
+
+
+async def set_profile(
+    client: httpx.AsyncClient,
+    *,
+    root_url: str,
+    start: bool,
+    stages: list[int],
+) -> dict[str, Any]:
+    action = "start_profile" if start else "stop_profile"
+    response = await client.post(f"{root_url}/{action}", json={"stages": stages})
+    response.raise_for_status()
+    result = response.json()
+    if result.get("status") != "SUCCESS":
+        raise RuntimeError(f"{action} returned {result!r}")
+    return result
+
+
+async def run_one(
+    client: httpx.AsyncClient,
+    *,
+    endpoint: str,
+    payload: dict[str, Any],
+    name: str,
+    input_modality: str,
+    with_audio: bool,
+    output_wav: Path | None,
+) -> dict[str, Any]:
+    return await run_stream_request(
+        client,
+        endpoint=endpoint,
+        payload=payload,
+        request_name=name,
+        input_modality=input_modality,
+        with_audio=with_audio,
+        output_wav=output_wav,
+    )
+
+
+async def capture(args: argparse.Namespace) -> int:
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root_url = service_root(args.base_url)
+    endpoint = f"{root_url}/v1/chat/completions"
+    with_audio = args.output_mode == "text_audio"
+    payload = build_payload(
+        model=args.model,
+        prompt=args.prompt,
+        input_modality=args.input_modality,
+        media=args.media,
+        with_audio=with_audio,
+        seed=args.seed,
+        thinker_max_tokens=args.thinker_max_tokens,
+        talker_max_tokens=args.talker_max_tokens,
+    )
+    timeout = httpx.Timeout(args.timeout)
+    headers = {"Authorization": "Bearer EMPTY"}
+    warmups: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
+    profile_started = False
+    stop_result: dict[str, Any] | None = None
+    profile_error: str | None = None
+
+    async with httpx.AsyncClient(timeout=timeout, headers=headers) as client:
+        health = await client.get(f"{root_url}/health")
+        health.raise_for_status()
+        for index in range(args.warmups):
+            record = await run_one(
+                client,
+                endpoint=endpoint,
+                payload=payload,
+                name=f"warmup-{index + 1}",
+                input_modality=args.input_modality,
+                with_audio=with_audio,
+                output_wav=None,
+            )
+            warmups.append(record)
+            if not record["success"]:
+                profile_error = f"warmup {index + 1} failed"
+                break
+
+        if profile_error is None:
+            try:
+                await set_profile(client, root_url=root_url, start=True, stages=args.stages)
+                profile_started = True
+                for index in range(args.requests):
+                    record = await run_one(
+                        client,
+                        endpoint=endpoint,
+                        payload=payload,
+                        name=f"profile-{index + 1}",
+                        input_modality=args.input_modality,
+                        with_audio=with_audio,
+                        output_wav=(output_dir / f"profile-{index + 1}.wav") if with_audio else None,
+                    )
+                    records.append(record)
+                    if not record["success"]:
+                        profile_error = f"profile request {index + 1} failed"
+                        break
+            except Exception as exc:
+                profile_error = f"{type(exc).__name__}: {exc}"
+            finally:
+                if profile_started:
+                    try:
+                        stop_result = await set_profile(
+                            client,
+                            root_url=root_url,
+                            start=False,
+                            stages=args.stages,
+                        )
+                    except Exception as exc:
+                        stop_error = f"{type(exc).__name__}: {exc}"
+                        profile_error = f"{profile_error}; stop failed: {stop_error}" if profile_error else stop_error
+
+    root = Path(__file__).resolve().parents[3]
+    result = {
+        "schema_version": 1,
+        "metric_scope": "profiler_diagnostic_not_score",
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "git": git_state(root),
+        "command": shlex.join([sys.executable, *sys.argv]),
+        "base_url": args.base_url,
+        "profile_stages": args.stages,
+        "input_modality": args.input_modality,
+        "output_mode": args.output_mode,
+        "workload": {
+            "model": args.model,
+            "prompt": args.prompt,
+            "media": args.media,
+            "seed": args.seed,
+            "thinker_max_tokens": args.thinker_max_tokens,
+            "talker_max_tokens": args.talker_max_tokens,
+            "warmups": args.warmups,
+            "requests": args.requests,
+        },
+        "warmups": warmups,
+        "records": records,
+        "profile_stop": stop_result,
+        "error": profile_error,
+        "passed": profile_error is None and len(records) == args.requests,
+    }
+    path = output_dir / "profile_capture.json"
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(path)
+    return 0 if result["passed"] else 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8099/v1")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--stages", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--input-modality", choices=("text", "image", "audio", "video"), default="text")
+    parser.add_argument("--media")
+    parser.add_argument("--output-mode", choices=("text", "text_audio"), default="text_audio")
+    parser.add_argument("--prompt", default="Say one short sentence about efficient multimodal inference.")
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--requests", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--thinker-max-tokens", type=int, default=128)
+    parser.add_argument("--talker-max-tokens", type=int, default=128)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    args = parser.parse_args()
+    if args.input_modality != "text" and not args.media:
+        parser.error("--media is required for non-text input")
+    if args.warmups < 0 or args.requests < 1:
+        parser.error("--warmups must be >= 0 and --requests must be >= 1")
+    raise SystemExit(asyncio.run(capture(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/profile_analysis.py
+++ b/benchmarks/competition/minicpmo_ascend/profile_analysis.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Summarize and compare exported torch_npu/CANN profiler artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+
+def number(value: Any) -> float:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def rows(paths: Iterable[Path]) -> Iterable[dict[str, str]]:
+    for path in paths:
+        with path.open(newline="", encoding="utf-8-sig", errors="replace") as stream:
+            yield from csv.DictReader(stream)
+
+
+def _files(root: Path, *patterns: str) -> list[Path]:
+    result: set[Path] = set()
+    for pattern in patterns:
+        result.update(root.rglob(pattern))
+    return sorted(result)
+
+
+def _prefer_integrated(root: Path, exact_name: str, fallback_pattern: str) -> list[Path]:
+    integrated = _files(root, exact_name)
+    return integrated or _files(root, fallback_pattern)
+
+
+def _top(mapping: dict[str, dict[str, float]], limit: int = 30) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "count": int(values["count"]),
+            "total_us": round(values["total_us"], 3),
+            "avg_us": round(values["total_us"] / values["count"], 3) if values["count"] else 0.0,
+        }
+        for name, values in sorted(mapping.items(), key=lambda item: item[1]["total_us"], reverse=True)[:limit]
+    ]
+
+
+def _aggregate(
+    source_rows: Iterable[dict[str, str]],
+    *,
+    name_keys: tuple[str, ...],
+    duration_keys: tuple[str, ...],
+    count_key: str | None = None,
+) -> tuple[float, int, list[dict[str, Any]]]:
+    grouped: dict[str, dict[str, float]] = defaultdict(lambda: {"count": 0.0, "total_us": 0.0})
+    total_us = 0.0
+    total_count = 0
+    for row in source_rows:
+        name = next((row.get(key) for key in name_keys if row.get(key)), "unknown")
+        duration = next((number(row.get(key)) for key in duration_keys if row.get(key) not in (None, "")), 0.0)
+        count = int(number(row.get(count_key))) if count_key else 1
+        grouped[name]["count"] += count
+        grouped[name]["total_us"] += duration
+        total_us += duration
+        total_count += count
+    return round(total_us, 3), total_count, _top(grouped)
+
+
+def _capture_signature(capture: dict[str, Any] | None) -> dict[str, Any] | None:
+    if capture is None:
+        return None
+    return {
+        "profile_stages": capture.get("profile_stages"),
+        "input_modality": capture.get("input_modality"),
+        "output_mode": capture.get("output_mode"),
+        "workload": capture.get("workload"),
+    }
+
+
+def analyze_trace_root(trace_root: Path, capture: dict[str, Any] | None = None) -> dict[str, Any]:
+    trace_root = trace_root.resolve()
+    op_stat_files = _prefer_integrated(trace_root, "op_statistic.csv", "op_statistic*.csv")
+    api_stat_files = _prefer_integrated(trace_root, "api_statistic.csv", "api_statistic*.csv")
+    kernel_files = _files(trace_root, "kernel_details.csv") or _files(trace_root, "op_summary*.csv")
+    operator_files = _files(trace_root, "operator_details.csv")
+
+    op_time, op_calls, top_op_types = _aggregate(
+        rows(op_stat_files),
+        name_keys=("OP Type", "Type", "Name"),
+        duration_keys=("Total Time(us)", "Duration(us)"),
+        count_key="Count",
+    )
+    api_time, api_calls, top_apis = _aggregate(
+        rows(api_stat_files),
+        name_keys=("API Name", "Name"),
+        duration_keys=("Time(us)", "Total Time(us)", "Duration(us)"),
+        count_key="Count",
+    )
+    api_levels: dict[str, dict[str, float]] = defaultdict(lambda: {"count": 0.0, "total_us": 0.0})
+    for row in rows(api_stat_files):
+        level = row.get("Level") or "unknown"
+        api_levels[level]["count"] += int(number(row.get("Count")))
+        api_levels[level]["total_us"] += number(row.get("Time(us)"))
+    kernel_time, kernel_calls, top_kernels = _aggregate(
+        rows(kernel_files),
+        name_keys=("Name", "Op Name", "OP Type"),
+        duration_keys=("Duration(us)", "Task Duration(us)"),
+    )
+    host_time, operator_calls, top_host_ops = _aggregate(
+        rows(operator_files),
+        name_keys=("Name",),
+        duration_keys=("Host Self Duration(us)",),
+    )
+    device_time, _, top_device_ops = _aggregate(
+        rows(operator_files),
+        name_keys=("Name",),
+        duration_keys=("Device Self Duration(us)",),
+    )
+
+    small_kernel_count = 0
+    parsed_kernel_count = 0
+    for row in rows(kernel_files):
+        duration = number(row.get("Duration(us)") or row.get("Task Duration(us)"))
+        parsed_kernel_count += 1
+        small_kernel_count += duration <= 50.0
+
+    exported_dirs = sorted({str(path.parent) for path in (*op_stat_files, *kernel_files, *operator_files)})
+    traces = [str(path) for path in _files(trace_root, "trace_view.json", "msprof*.json")]
+    result = {
+        "schema_version": 1,
+        "metric_scope": "profiler_diagnostic_not_score",
+        "trace_root": str(trace_root),
+        "capture": _capture_signature(capture),
+        "exported_dirs": exported_dirs,
+        "source_files": {
+            "op_statistic": [str(path) for path in op_stat_files],
+            "api_statistic": [str(path) for path in api_stat_files],
+            "kernel_details": [str(path) for path in kernel_files],
+            "operator_details": [str(path) for path in operator_files],
+            "timelines": traces,
+        },
+        "operators": {"calls": op_calls, "total_us": op_time, "top": top_op_types},
+        "apis": {
+            "calls": api_calls,
+            "total_us": api_time,
+            "levels": {
+                level: {"calls": int(values["count"]), "total_us": round(values["total_us"], 3)}
+                for level, values in sorted(api_levels.items())
+            },
+            "top": top_apis,
+        },
+        "kernels": {
+            "calls": kernel_calls,
+            "total_us": kernel_time,
+            "small_le_50us_calls": small_kernel_count,
+            "small_le_50us_ratio": small_kernel_count / parsed_kernel_count if parsed_kernel_count else None,
+            "top": top_kernels,
+        },
+        "torch_operators": {
+            "calls": operator_calls,
+            "host_self_total_us": host_time,
+            "device_self_total_us": device_time,
+            "top_host_self": top_host_ops,
+            "top_device_self": top_device_ops,
+        },
+    }
+    if not any((op_stat_files, api_stat_files, kernel_files, operator_files)):
+        raise FileNotFoundError(f"no exported profiler CSV files under {trace_root}")
+    return result
+
+
+def write_analysis(result: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    lines = [
+        "# MiniCPM-o Ascend Profile Analysis",
+        "",
+        "- Scope: profiler diagnostic; never use profiler timing as a score result.",
+        f"- Trace root: `{result['trace_root']}`",
+        f"- Export directories: {len(result['exported_dirs'])}",
+        f"- Kernel calls: {result['kernels']['calls']}",
+        f"- Aggregated kernel time: {result['kernels']['total_us'] / 1000:.3f} ms",
+        f"- Aggregated API time across levels: {result['apis']['total_us'] / 1000:.3f} ms",
+        "",
+        "Aggregated device time may exceed wall time when streams overlap. "
+        "API levels may be nested and are not additive.",
+        "",
+        "## Top Kernels",
+        "",
+        "| Kernel | Calls | Total ms | Avg us |",
+        "|---|---:|---:|---:|",
+    ]
+    for item in result["kernels"]["top"][:20]:
+        lines.append(f"| {item['name']} | {item['count']} | {item['total_us'] / 1000:.3f} | {item['avg_us']:.3f} |")
+    lines += ["", "## Top Runtime APIs", "", "| API | Calls | Total ms | Avg us |", "|---|---:|---:|---:|"]
+    for item in result["apis"]["top"][:20]:
+        lines.append(f"| {item['name']} | {item['count']} | {item['total_us'] / 1000:.3f} | {item['avg_us']:.3f} |")
+    lines += [
+        "",
+        "## Top Torch Operators by Device Self Time",
+        "",
+        "| Operator | Calls | Total ms | Avg us |",
+        "|---|---:|---:|---:|",
+    ]
+    for item in result["torch_operators"]["top_device_self"][:20]:
+        lines.append(f"| {item['name']} | {item['count']} | {item['total_us'] / 1000:.3f} | {item['avg_us']:.3f} |")
+    lines += [
+        "",
+        "## Fragmentation Signal",
+        "",
+        f"- Kernels <= 50 us: {result['kernels']['small_le_50us_calls']} "
+        f"({(result['kernels']['small_le_50us_ratio'] or 0) * 100:.2f}%).",
+        "",
+    ]
+    output.with_suffix(".md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _metric_values(report: dict[str, Any]) -> dict[str, float]:
+    return {
+        "operator_time_us": report["operators"]["total_us"],
+        "operator_calls": report["operators"]["calls"],
+        "api_time_us": report["apis"]["total_us"],
+        "api_calls": report["apis"]["calls"],
+        "kernel_time_us": report["kernels"]["total_us"],
+        "kernel_calls": report["kernels"]["calls"],
+        "small_kernel_ratio": report["kernels"]["small_le_50us_ratio"] or 0.0,
+    }
+
+
+def compare_reports(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    before_values = _metric_values(before)
+    after_values = _metric_values(after)
+    metrics = {}
+    for key, left in before_values.items():
+        right = after_values[key]
+        metrics[key] = {
+            "before": left,
+            "after": right,
+            "delta": right - left,
+            "percent": ((right - left) * 100 / left) if left else None,
+        }
+    left_capture = before.get("capture") or {}
+    right_capture = after.get("capture") or {}
+    signature_keys = ("profile_stages", "input_modality", "output_mode", "workload")
+    mismatches = [
+        {"field": key, "before": left_capture.get(key), "after": right_capture.get(key)}
+        for key in signature_keys
+        if left_capture.get(key) != right_capture.get(key)
+    ]
+    return {
+        "schema_version": 1,
+        "metric_scope": "same-preset profiler diagnostic comparison",
+        "compatible": not mismatches,
+        "mismatches": mismatches,
+        "before": before.get("trace_root"),
+        "after": after.get("trace_root"),
+        "metrics": metrics,
+    }
+
+
+def write_comparison(result: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    lines = [
+        "# MiniCPM-o Ascend Profile Comparison",
+        "",
+        "Use this only when workload, stages, profiler configuration, and environment match.",
+        "",
+    ]
+    if not result["compatible"]:
+        lines += ["Warning: capture signatures differ; timing deltas are invalid.", ""]
+        for mismatch in result["mismatches"]:
+            lines.append(f"- `{mismatch['field']}`: `{mismatch['before']}` -> `{mismatch['after']}`")
+        lines.append("")
+    lines += ["| Metric | Before | After | Delta | Change |", "|---|---:|---:|---:|---:|"]
+    for name, item in result["metrics"].items():
+        change = "N/A" if item["percent"] is None else f"{item['percent']:+.2f}%"
+        lines.append(f"| {name} | {item['before']:.3f} | {item['after']:.3f} | {item['delta']:+.3f} | {change} |")
+    output.with_suffix(".md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_manifest(root: Path, output: Path) -> None:
+    root = root.resolve()
+    output = output.resolve()
+    entries = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file() and item.resolve() != output):
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        entries.append(f"{digest.hexdigest()}  {path.relative_to(root)}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    analyze_parser = subparsers.add_parser("analyze")
+    analyze_parser.add_argument("trace_root", type=Path)
+    analyze_parser.add_argument("--output", type=Path, required=True)
+    analyze_parser.add_argument("--capture", type=Path)
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("before", type=Path)
+    compare_parser.add_argument("after", type=Path)
+    compare_parser.add_argument("--output", type=Path, required=True)
+    manifest_parser = subparsers.add_parser("manifest")
+    manifest_parser.add_argument("root", type=Path)
+    manifest_parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.command == "analyze":
+        capture = json.loads(args.capture.read_text(encoding="utf-8")) if args.capture else None
+        result = analyze_trace_root(args.trace_root, capture=capture)
+        write_analysis(result, args.output)
+        print(args.output)
+        return
+    if args.command == "compare":
+        before = json.loads(args.before.read_text(encoding="utf-8"))
+        after = json.loads(args.after.read_text(encoding="utf-8"))
+        result = compare_reports(before, after)
+        write_comparison(result, args.output)
+        print(args.output)
+        if not result["compatible"]:
+            raise SystemExit("profile captures are not comparable; see mismatches in output")
+        return
+    write_manifest(args.root, args.output)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/profile_config.py
+++ b/benchmarks/competition/minicpmo_ascend/profile_config.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate a MiniCPM-o deployment config with NPU profiling enabled."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def build_profile_config(
+    config: dict[str, Any],
+    *,
+    trace_dir: Path,
+    stages: set[int],
+    with_stack: bool = False,
+    with_memory: bool = False,
+) -> dict[str, Any]:
+    stage_configs = config.get("stages")
+    if not isinstance(stage_configs, list):
+        raise ValueError("deployment config must contain a stages list")
+
+    available = {int(stage["stage_id"]) for stage in stage_configs}
+    missing = stages - available
+    if missing:
+        raise ValueError(f"profile stages are not in deployment config: {sorted(missing)}")
+
+    for stage in stage_configs:
+        stage_id = int(stage["stage_id"])
+        stage.pop("profiler_config", None)
+        if stage_id not in stages:
+            continue
+        stage["profiler_config"] = {
+            "profiler": "torch",
+            "torch_profiler_dir": str(trace_dir.resolve()),
+            "torch_profiler_use_gzip": False,
+            "torch_profiler_record_shapes": False,
+            "torch_profiler_with_stack": with_stack,
+            "torch_profiler_with_memory": with_memory,
+            "torch_profiler_with_flops": False,
+            "torch_profiler_dump_cuda_time_total": False,
+            "delay_iterations": 0,
+            "max_iterations": 0,
+            "wait_iterations": 0,
+            "warmup_iterations": 0,
+            "active_iterations": 1,
+        }
+    return config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-config", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--trace-dir", type=Path, required=True)
+    parser.add_argument("--stages", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--with-stack", action="store_true")
+    parser.add_argument("--with-memory", action="store_true")
+    args = parser.parse_args()
+
+    config = yaml.safe_load(args.base_config.read_text(encoding="utf-8"))
+    generated = build_profile_config(
+        config,
+        trace_dir=args.trace_dir,
+        stages=set(args.stages),
+        with_stack=args.with_stack,
+        with_memory=args.with_memory,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.trace_dir.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        yaml.safe_dump(generated, sort_keys=False, allow_unicode=False),
+        encoding="utf-8",
+    )
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/profiles/20260727-fused-gated-residual.md
+++ b/benchmarks/competition/minicpmo_ascend/profiles/20260727-fused-gated-residual.md
@@ -1,0 +1,71 @@
+# 20260727 Fused Gated Residual
+
+- Decision: keep.
+- Base Git SHA: `8dbb503e98119ea55d9cdfd5fcb1a817737d5fdd`.
+- Scope: local proxy, not an official score.
+- Hardware: one physical Ascend 910C card; Stage 2 uses logical chip 1.
+- Change: replace the three `x + gate * branch` pairs in each NPU CosyVoice2
+  DiT streaming block with `torch.addcmul`.
+- Rollback: set `VLLM_OMNI_MINICPMO_FUSED_GATED_RESIDUAL=off`.
+
+## Unprofiled A/B/A
+
+The fixed workload used text input, text+audio output, seed 42, 128
+Thinker/Talker tokens, two warmups, and 20 measured requests at C1 and C4. Each
+phase used a clean server restart; all 120 requests passed.
+
+| Concurrency | Metric | A1 | Candidate | A2 | Candidate vs A mean |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 1 | first audio p50 (s) | 1.1404 | 1.1417 | 1.1771 | +1.49% |
+| 1 | E2E p50 (s) | 2.2243 | 2.2371 | 2.3864 | +3.05% |
+| 1 | audio seconds/s | 4.5899 | 4.4917 | 4.2399 | +1.74% |
+| 4 | first audio p50 (s) | 2.0108 | 2.0175 | 2.0548 | +0.76% |
+| 4 | E2E p50 (s) | 4.0877 | 4.0388 | 4.0894 | +1.23% |
+| 4 | audio seconds/s | 9.8283 | 9.9297 | 9.8563 | +0.89% |
+
+C4 is the strongest attribution: baseline throughput differs by 0.28% and E2E
+p50 by 0.04%, while the candidate improves their mean by 0.89% and 1.23%.
+
+## Effect Proxy
+
+Every output remained valid non-empty 24 kHz PCM. At C4, candidate/baseline
+waveform correlation has median 1.0 and minimum 0.99999983, matching the two
+baseline runs; 15 of 20 files are byte-identical in both comparisons. The
+official effect threshold is still `UNRESOLVED`.
+
+## Profile Evidence
+
+Matching Stage-2-only captures used one request after two unprofiled warmups.
+The comparison signature passed.
+
+| Diagnostic | Baseline | Candidate | Delta |
+| --- | ---: | ---: | ---: |
+| Kernel/operator calls | 97,957 | 94,597 | -3,360 (-3.43%) |
+| Add calls | 11,968 | 8,608 | -3,360 |
+| Mul calls | 9,126 | 5,766 | -3,360 |
+| AxpyV2 calls | 0 | 3,360 | +3,360 |
+| Aggregate kernel time (ms) | 1,009.3 | 1,015.9 | +0.66% |
+
+The exact call-count change confirms the intended mechanism: each of the 1,120
+DiT block executions replaces three Mul+Add pairs with three fused operations.
+Profile time is diagnostic and not used as score evidence; the device-time
+increase reinforces that the unprofiled gain comes from lower launch/dispatch
+work rather than faster aggregate kernels.
+
+## Validation
+
+- Fresh-service smoke: text-only, text+audio, image+audio, audio+audio, and
+  video+audio all passed.
+- Correctness gate: passed with no failures.
+- Focused tests: 36 passed.
+- Ruff check/format and `git diff --check`: passed.
+- Service cleanup: no residual NPU process.
+
+Artifact SHA256 values:
+
+- Baseline profile analysis: `a4d7fc4fe3be430e667a34c4941dd54d1dcdf068e382fc3f279b4753ad766df0`
+- Candidate profile analysis: `ff6144ea4dd636c8d620bd5a40b539062439a37754963a3cdca04935c1537f83`
+- Profile comparison: `3abd205d2646e88afedb46468a1269b9d9e9c5c7850c377976c1919eeec36901`
+- Candidate benchmark: `fab1508ce33c19be564a5471ec714ba1d28773b87b8fb12966c8552d64c5564b`
+- Full smoke: `4078465d52db8ff86e3158531c20be89cef9caaa3ebc599c7433f4790f1478d9`
+- Correctness gate: `aacff4a0992bc7f57634477ca6d2ec7754bd78aafce3e6e6836165abe9f097cf`

--- a/benchmarks/competition/minicpmo_ascend/profiles/20260727-stage2-profile-v1.md
+++ b/benchmarks/competition/minicpmo_ascend/profiles/20260727-stage2-profile-v1.md
@@ -1,0 +1,110 @@
+# 20260727 Stage-2 Profile and First Optimization Suggestions
+
+- Decision: keep as the first validated profiling-chain record.
+- Base Git SHA: `ecf965fceb657f1449adc43609680191adb22298` plus the profiling-tool worktree diff.
+- Scope: local diagnostic profile, not a score run.
+- Hardware: one physical Ascend 910C card; Stage 2 uses logical chip 1.
+- Workload: text input, text+audio output, seed 42, 128 Thinker tokens, 128 Talker tokens.
+- Capture: two unprofiled warmups followed by one Stage-2-only profiled request.
+- Local artifact root: `artifacts/minicpmo_ascend/profiles/20260727-profile-v1-stage2/`.
+- Analysis SHA256: `363d96b21df5f0932e5cf1730e8a80b7e7e03580208ccdcbd7f19e067a104386`.
+- Capture SHA256: `bf4f7c5d05f69e0f8ae0771c9be98f410cef0da29ec771890656b8bc5b4ad94e`.
+- Artifact manifest SHA256: `16776147c213c434b8cf0c65c173490181b15425032243b7c2777f30eaea011d`.
+
+## Capture Gate
+
+- Request: PASS.
+- First text: 0.439 s.
+- First audio: 1.343 s.
+- E2E: 3.052 s.
+- Audio: six ordered, non-duplicate 24 kHz PCM chunks; 10.08 seconds reconstructed.
+- Profile export: PASS; CANN CSV, timeline, and database generated.
+- Shutdown: PASS; no NPU process remained and both logical chips returned to idle HBM.
+
+The profiled request is slower than the unprofiled warm request, as expected.
+Profiler timing must not be compared with the score baseline.
+
+## Stage-2 Evidence
+
+| Signal | Value | Interpretation |
+| --- | ---: | --- |
+| Kernel calls | 97,957 | Very fragmented eager execution |
+| Kernels <= 50 us | 95,418 (97.4%) | Launch/layout overhead is a first-order target |
+| Aggregated kernel time | 1,005.1 ms | Streams and nested work make this non-additive with E2E |
+| TransData | 222.2 ms / 8,313 calls | Largest operator family; layout conversion dominates |
+| Transpose | 145.7 ms / 9,860 calls | Repeated layout changes are material |
+| MatMulV2 | 108.8 ms / 8,714 calls | Main arithmetic family, but below layout total |
+| LayerNormV3 | 96.3 ms / 6,951 calls | High-frequency small normalization kernels |
+| ConcatD + Slice | 118.6 ms / 23,586 calls | Cache/chunk assembly is heavily fragmented |
+| `aclopCompileAndExecute` | 182.7 ms / 2,771 calls | Eager/dynamic operator dispatch is material |
+| `aclrtSynchronizeStream` | 17.5 ms / 94 calls | Explicit synchronization is not the primary Stage-2 cost |
+
+`TransData + Transpose` account for 367.9 ms, or 36.6% of aggregated Stage-2
+operator time. The trace matches code surfaces in `batched_token2wav.py` that
+repeatedly transpose/contiguous tensors and concatenate CFG inputs, request
+caches, attention caches, and mel/source/speech state.
+
+## Optimization Suggestions v1
+
+### 1. Reduce Layout Conversion in Batched Token2Wav
+
+Priority: P1, first candidate.
+
+- Keep Flow/CFM tensors in one Stage-2-native layout across `_encode_chunk`,
+  `_decode_cfm`, and HiFT instead of repeatedly converting BxTxC and BxCxT.
+- Audit the explicit `transpose(...).contiguous()` boundaries and the NPU HiFT
+  linear-downsample patch before changing kernels.
+- Cache or reuse shape-stable converted prompt features and windows.
+
+Expected effect: fewer `TransData`/`Transpose` calls, lower first-audio and
+chunk latency, and lower host launch work. Guardrails: byte-valid ordered audio,
+effect gate, numeric/audio review, GPU behavior unchanged, and no request-state
+sharing. Roll back if layout changes introduce copies elsewhere or fail NPU/GPU
+parity.
+
+### 2. Capture Exact Steady-State Stage-2 Shapes
+
+Priority: P1, after the layout candidate is measured.
+
+- Stage 2 currently runs eager while 2,771 `aclopCompileAndExecute` calls and a
+  97.4% small-kernel ratio appear in one request.
+- Evaluate ACL Graph capture only for proven exact-shape steady chunks; retain
+  eager fallback for prompt/first/terminal or unsupported dynamic shapes.
+- Bucket by the state-shape signature already used by Code2Wav batching.
+
+Expected effect: reduce dispatch/compile and launch overhead. Guardrails:
+warmup excluded, no graph reuse across incompatible request caches, terminal
+flush correctness, cancellation safety, and HBM headroom.
+
+### 3. Replace Repeated Cache Concatenation with Reusable Batch Buffers
+
+Priority: P1, separable from graph capture.
+
+- Profile evidence shows 7,041 ConcatD calls and 16,545 Slice calls.
+- Measure whether `_stack_flow_cache`, CFG duplication, attention trimming, and
+  HiFT cache assembly can use capacity-managed buffers or views.
+- Keep one primary change per candidate; do not combine this with layout and
+  graph experiments.
+
+Expected effect: reduce small-kernel launches, temporary allocation, and the
+concurrency-dependent HBM increase seen in the unprofiled baseline. Guardrails:
+request isolation, exact cache epochs, abort cleanup, and fixed-shape stability.
+
+## Deprioritized from This Capture
+
+- Explicit stream synchronization: only 17.5 ms aggregated in Stage 2.
+- Conv2DTranspose kernel tuning: six calls total 11.8 ms, too small for the
+  first optimization.
+- Quantization: higher risk and not justified before layout/dispatch work or
+  publication of the official effect threshold.
+
+## Next Experiment
+
+Run `20260727-stage2-layout-boundaries` as an A/B/A candidate:
+
+1. Add stage-local timing/counters around the explicit layout boundaries.
+2. Change one boundary or cache representation.
+3. Run focused CPU tests, Ascend smoke, correctness gate, and the unprofiled
+   C1/C2/C4 text+audio benchmark.
+4. Re-capture the identical Stage-2 profile only if the unprofiled candidate
+   passes and exceeds baseline variance.

--- a/benchmarks/competition/minicpmo_ascend/report.py
+++ b/benchmarks/competition/minicpmo_ascend/report.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Generate a compact baseline report and checksum index from raw artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _format(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _metric(summary: dict[str, Any], name: str, statistic: str) -> Any:
+    return summary.get(name, {}).get(statistic)
+
+
+def _percentile_pair(summary: dict[str, Any], name: str) -> str:
+    return f"{_format(_metric(summary, name, 'p50'))}/{_format(_metric(summary, name, 'p95'))}"
+
+
+def _resource_peaks(path: Path) -> dict[str, int | None]:
+    resources = _load(path)
+    peak_aicore = None
+    peak_hbm = None
+    peak_host = None
+    first_hbm = None
+    last_hbm = None
+    first_host = None
+    last_host = None
+    for sample in resources.get("samples", []):
+        memory = sample.get("host_memory_bytes", {})
+        total = memory.get("MemTotal")
+        available = memory.get("MemAvailable")
+        if total is not None and available is not None:
+            used = total - available
+            peak_host = used if peak_host is None else max(peak_host, used)
+            first_host = used if first_host is None else first_host
+            last_host = used
+
+        output = sample.get("npu_smi", {}).get("stdout", "")
+        sample_hbm = 0
+        saw_chip = False
+        for line in output.splitlines():
+            fields = line.split("|")
+            if len(fields) < 4 or not re.search(r"[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9]", fields[2]):
+                continue
+            values = [int(value) for value in re.findall(r"\d+", fields[3])]
+            if len(values) < 5:
+                continue
+            saw_chip = True
+            peak_aicore = values[0] if peak_aicore is None else max(peak_aicore, values[0])
+            sample_hbm += values[-2]
+        if saw_chip:
+            peak_hbm = sample_hbm if peak_hbm is None else max(peak_hbm, sample_hbm)
+            first_hbm = sample_hbm if first_hbm is None else first_hbm
+            last_hbm = sample_hbm
+    return {
+        "aicore_percent": peak_aicore,
+        "aggregate_hbm_mib": peak_hbm,
+        "host_memory_bytes": peak_host,
+        "aggregate_hbm_delta_mib": last_hbm - first_hbm if first_hbm is not None else None,
+        "host_memory_delta_bytes": last_host - first_host if first_host is not None else None,
+    }
+
+
+def _benchmark_table(result: dict[str, Any], root: Path) -> list[str]:
+    rows = [
+        "| Mode | C | OK/Fail | First text p50/p95 (s) | First audio p50/p95 (s) | "
+        "E2E p50/p95 (s) | Req/s | Audio s/s | Wall (s) | Peak AI Core | Peak HBM MiB | "
+        "HBM delta MiB | Peak/delta host GiB |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for config in result.get("configurations", []):
+        summary = config.get("summary", {})
+        mode = config.get("mode")
+        concurrency = config.get("concurrency")
+        resource_path = root / f"{mode}_c{concurrency}" / "resources.json"
+        peaks = _resource_peaks(resource_path)
+        host = peaks["host_memory_bytes"]
+        host_gib = host / (1024**3) if host is not None else None
+        host_delta = peaks["host_memory_delta_bytes"]
+        host_delta_gib = host_delta / (1024**3) if host_delta is not None else None
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    str(mode),
+                    str(concurrency),
+                    f"{summary.get('successful_requests', 0)}/{summary.get('failed_requests', 0)}",
+                    _percentile_pair(summary, "first_text_s"),
+                    _percentile_pair(summary, "first_audio_s"),
+                    _percentile_pair(summary, "e2e_s"),
+                    _format(summary.get("request_throughput_per_s")),
+                    _format(summary.get("audio_seconds_throughput")),
+                    _format(summary.get("wall_time_s")),
+                    _format(peaks["aicore_percent"], 0),
+                    _format(peaks["aggregate_hbm_mib"], 0),
+                    _format(peaks["aggregate_hbm_delta_mib"], 0),
+                    f"{_format(host_gib)}/{_format(host_delta_gib)}",
+                ]
+            )
+            + " |"
+        )
+    return rows
+
+
+def _command(result: dict[str, Any]) -> str:
+    return " ".join(shlex.quote(str(value)) for value in result.get("command", []))
+
+
+def _write_manifest(root: Path, output: Path) -> None:
+    entries = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path == output:
+            continue
+        entries.append(f"{_sha256(path)}  {path.relative_to(root)}")
+    output.write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--environment", type=Path, required=True)
+    parser.add_argument("--smoke-results", type=Path, required=True)
+    parser.add_argument("--benchmark-results", type=Path, required=True)
+    parser.add_argument("--stability-results", type=Path, required=True)
+    parser.add_argument("--gate", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--manifest-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    environment = _load(args.environment)
+    smoke = _load(args.smoke_results)
+    benchmark = _load(args.benchmark_results)
+    stability = _load(args.stability_results)
+    gate = _load(args.gate)
+    git = environment.get("git", {})
+    head = git.get("head", {}).get("stdout", "UNKNOWN")
+    status = git.get("status", {}).get("stdout", "")
+    npu = environment.get("npu", {})
+    cards = npu.get("cards", [])
+    logical_chips = npu.get("logical_chips", [])
+
+    lines = [
+        "# MiniCPM-o 4.5 Ascend 910C Single-Card Baseline",
+        "",
+        f"- Captured at: {environment.get('captured_at', 'UNKNOWN')}",
+        f"- Git SHA: `{head}`",
+        f"- Git worktree: {'clean' if not status else 'dirty'}",
+        "- Metric scope: local proxy; official dataset and scoring remain `UNRESOLVED`.",
+        f"- Gate: {'PASS' if gate.get('passed') else 'FAIL'}",
+        "",
+        "## Hardware",
+        "",
+        "- Target: one physical Ascend 910C card with two logical chips.",
+        f"- Detected physical cards: {npu.get('physical_card_count')}",
+        f"- Detected card inventory: `{json.dumps(cards, sort_keys=True)}`",
+        f"- Logical chips: `{json.dumps(logical_chips, sort_keys=True)}`",
+        "- Deployment uses logical devices `0` and `1` on the same card.",
+        "",
+        "## Smoke Gate",
+        "",
+        "| Request | Input | Output | Result | Text chars | Audio chunks | PCM bytes |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: |",
+    ]
+    for record in smoke.get("records", []):
+        audio = record.get("audio", {})
+        lines.append(
+            f"| {record.get('request_name')} | {record.get('input_modality')} | {record.get('output_mode')} | "
+            f"{'PASS' if record.get('success') else 'FAIL'} | {len(record.get('text', ''))} | "
+            f"{audio.get('chunk_count', 0)} | {audio.get('pcm_bytes', 0)} |"
+        )
+
+    lines.extend(["", "## Performance", "", *_benchmark_table(benchmark, args.benchmark_results.parent)])
+    lines.extend(["", "## Stability", "", *_benchmark_table(stability, args.stability_results.parent)])
+    lines.extend(
+        [
+            "",
+            "## Commands",
+            "",
+            f"- Benchmark: `{_command(benchmark)}`",
+            f"- Stability: `{_command(stability)}`",
+            "",
+            "## Gate Result",
+            "",
+            f"- Passed: `{gate.get('passed')}`",
+            f"- Failures: `{json.dumps(gate.get('failures', []))}`",
+            "- Formal score: not reported.",
+            "",
+            "Raw artifacts are indexed by `artifact_manifest.sha256`.",
+        ]
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _write_manifest(args.artifact_root, args.manifest_output)
+    print(args.output)
+    print(args.manifest_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/requirements-eval.txt
+++ b/benchmarks/competition/minicpmo_ascend/requirements-eval.txt
@@ -1,0 +1,8 @@
+# Public effect-evaluation dependencies. Keep these outside the serving env
+# unless the corresponding evaluator is needed. PyArrow 25 crashes while
+# reading Video-MME Parquet on the current aarch64 competition host.
+pyarrow==18.1.0
+jiwer==4.0.0
+zhon==2.1.1
+zhconv==1.4.3
+funasr==1.3.29

--- a/benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
+HOST="${HOST:-localhost}"
+PORT="${PORT:-8099}"
+NUM_PROMPTS="${NUM_PROMPTS:-100}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/daily_omni}"
+BENCH_BIN="${BENCH_BIN:-${ROOT_DIR}/.venv/bin/vllm-omni}"
+
+mkdir -p "${OUTPUT_DIR}"
+command=(
+    "${BENCH_BIN}" bench serve --omni
+    --backend openai-chat-omni
+    --endpoint /v1/chat/completions
+    --host "${HOST}"
+    --port "${PORT}"
+    --model "${MODEL}"
+    --dataset-name daily-omni
+    --num-prompts "${NUM_PROMPTS}"
+    --num-warmups 2
+    --max-concurrency 1
+    --request-rate inf
+    --percentile-metrics ttft,e2el
+    --extra-body '{"modalities":["text"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":false}}'
+    --save-result
+    --result-dir "${OUTPUT_DIR}"
+)
+if [[ -n "${DAILY_OMNI_QA_JSON:-}" ]]; then
+    command+=(--daily-omni-qa-json "${DAILY_OMNI_QA_JSON}")
+fi
+if [[ -n "${DAILY_OMNI_VIDEO_DIR:-}" ]]; then
+    command+=(--daily-omni-video-dir "${DAILY_OMNI_VIDEO_DIR}")
+fi
+
+printf '%q ' "${command[@]}" | tee "${OUTPUT_DIR}/command.txt"
+printf '\n' | tee -a "${OUTPUT_DIR}/command.txt"
+"${command[@]}" 2>&1 | tee "${OUTPUT_DIR}/run.log"

--- a/benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_daily_omni.sh
@@ -44,6 +44,7 @@ fi
 if [[ -n "${DAILY_OMNI_VIDEO_DIR:-}" ]]; then
     command+=(--daily-omni-video-dir "${DAILY_OMNI_VIDEO_DIR}")
 fi
+command+=("$@")
 
 printf '%q ' "${command[@]}" | tee "${OUTPUT_DIR}/command.txt"
 printf '\n' | tee -a "${OUTPUT_DIR}/command.txt"

--- a/benchmarks/competition/minicpmo_ascend/run_profile.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_profile.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-${ROOT_DIR}/.venv/bin/python}"
+MODEL="${MODEL:-/workspace/minicpmo-ascend/models/MiniCPM-o-4_5}"
+BASE_CONFIG="${BASE_CONFIG:-${ROOT_DIR}/vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml}"
+PROFILE_ID="${PROFILE_ID:-$(date -u +%Y%m%dT%H%M%SZ)-stage2-text-audio}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/profiles/${PROFILE_ID}}"
+TRACE_DIR="${TRACE_DIR:-${OUTPUT_DIR}/traces}"
+PROFILE_STAGES="${PROFILE_STAGES:-2}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8099}"
+BASE_URL="http://${HOST}:${PORT}/v1"
+SERVER_DIR="${OUTPUT_DIR}/server"
+WORKLOAD_DIR="${OUTPUT_DIR}/workload"
+PROFILE_CONFIG="${OUTPUT_DIR}/profile_deploy.yaml"
+
+IFS=',' read -r -a stage_args <<<"${PROFILE_STAGES}"
+config_args=()
+capture_stage_args=()
+for stage in "${stage_args[@]}"; do
+    config_args+=("${stage}")
+    capture_stage_args+=("${stage}")
+done
+
+if [[ -d "${OUTPUT_DIR}" ]] && [[ -n "$(find "${OUTPUT_DIR}" -mindepth 1 -print -quit)" ]]; then
+    echo "refusing to reuse non-empty profile output: ${OUTPUT_DIR}" >&2
+    exit 1
+fi
+mkdir -p "${OUTPUT_DIR}" "${SERVER_DIR}" "${WORKLOAD_DIR}" "${TRACE_DIR}"
+if curl --silent --show-error --fail "http://${HOST}:${PORT}/health" >/dev/null 2>&1; then
+    echo "refusing to start: a service is already healthy at http://${HOST}:${PORT}" >&2
+    exit 1
+fi
+"${PYTHON_BIN}" -m benchmarks.competition.minicpmo_ascend.profile_config \
+    --base-config "${BASE_CONFIG}" \
+    --output "${PROFILE_CONFIG}" \
+    --trace-dir "${TRACE_DIR}" \
+    --stages "${config_args[@]}"
+
+server_pid=""
+cleanup() {
+    if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+        kill -TERM -- "-${server_pid}" 2>/dev/null || kill -TERM "${server_pid}" 2>/dev/null || true
+        wait "${server_pid}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+if command -v setsid >/dev/null 2>&1; then
+    setsid env \
+        MODEL="${MODEL}" \
+        DEPLOY_CONFIG="${PROFILE_CONFIG}" \
+        HOST="${HOST}" \
+        PORT="${PORT}" \
+        ARTIFACT_DIR="${SERVER_DIR}" \
+        bash "${ROOT_DIR}/benchmarks/competition/minicpmo_ascend/start_server.sh" &
+else
+    env \
+        MODEL="${MODEL}" \
+        DEPLOY_CONFIG="${PROFILE_CONFIG}" \
+        HOST="${HOST}" \
+        PORT="${PORT}" \
+        ARTIFACT_DIR="${SERVER_DIR}" \
+        bash "${ROOT_DIR}/benchmarks/competition/minicpmo_ascend/start_server.sh" &
+fi
+server_pid=$!
+printf '%s\n' "${server_pid}" >"${SERVER_DIR}/server.pid"
+
+deadline=$((SECONDS + ${SERVER_START_TIMEOUT:-1200}))
+until curl --silent --show-error --fail "http://${HOST}:${PORT}/health" >/dev/null 2>&1; do
+    if ! kill -0 "${server_pid}" 2>/dev/null; then
+        echo "profile server exited before becoming healthy" >&2
+        exit 1
+    fi
+    if ((SECONDS >= deadline)); then
+        echo "profile server did not become healthy before timeout" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+capture_args=(
+    --base-url "${BASE_URL}"
+    --model "${MODEL}"
+    --output-dir "${WORKLOAD_DIR}"
+    --stages "${capture_stage_args[@]}"
+    --input-modality "${PROFILE_INPUT_MODALITY:-text}"
+    --output-mode "${PROFILE_OUTPUT_MODE:-text_audio}"
+    --warmups "${PROFILE_WARMUPS:-2}"
+    --requests "${PROFILE_REQUESTS:-1}"
+    --thinker-max-tokens "${THINKER_MAX_TOKENS:-128}"
+    --talker-max-tokens "${TALKER_MAX_TOKENS:-128}"
+    --timeout "${PROFILE_TIMEOUT:-900}"
+)
+if [[ -n "${PROFILE_MEDIA:-}" ]]; then
+    capture_args+=(--media "${PROFILE_MEDIA}")
+fi
+if [[ -n "${PROFILE_PROMPT:-}" ]]; then
+    capture_args+=(--prompt "${PROFILE_PROMPT}")
+fi
+
+"${PYTHON_BIN}" -m benchmarks.competition.minicpmo_ascend.profile "${capture_args[@]}"
+cleanup
+server_pid=""
+"${PYTHON_BIN}" -m benchmarks.competition.minicpmo_ascend.profile_analysis analyze \
+    "${TRACE_DIR}" \
+    --capture "${WORKLOAD_DIR}/profile_capture.json" \
+    --output "${OUTPUT_DIR}/profile_analysis.json"
+"${PYTHON_BIN}" -m benchmarks.competition.minicpmo_ascend.profile_analysis manifest \
+    "${OUTPUT_DIR}" \
+    --output "${OUTPUT_DIR}/artifact_manifest.sha256"
+
+echo "Profile artifacts: ${OUTPUT_DIR}"

--- a/benchmarks/competition/minicpmo_ascend/run_public_proxy_benchmark.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_public_proxy_benchmark.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
+BENCH_BIN="${BENCH_BIN:-${ROOT_DIR}/.venv/bin/vllm-omni}"
+PYTHON="${PYTHON:-${ROOT_DIR}/.venv/bin/python}"
+SAMPLE_ROOT="${SAMPLE_ROOT:?set SAMPLE_ROOT to the generated public benchmark sample directory}"
+DATA_ROOT="${DATA_ROOT:?set DATA_ROOT to the public evaluation data directory}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-${ROOT_DIR}/artifacts/minicpmo_ascend/public-proxy-benchmark-v1}"
+NUM_WARMUPS="${NUM_WARMUPS:-3}"
+SOURCE_REVISION="${SOURCE_REVISION:-$(git -C "${ROOT_DIR}" rev-parse HEAD)}"
+
+mkdir -p "${OUTPUT_ROOT}"
+
+DAILY_OMNI_QA_JSON="${SAMPLE_ROOT}/daily_omni/qa.json" \
+DAILY_OMNI_VIDEO_DIR="${DATA_ROOT}/Daily-Omni/Videos" \
+DAILY_OMNI_INPUT_MODE=all \
+DAILY_OMNI_PACK_MODE=minicpm-interleave \
+NUM_PROMPTS=100 \
+NUM_WARMUPS="${NUM_WARMUPS}" \
+MAX_CONCURRENCY=1 \
+MODEL="${MODEL}" \
+BENCH_BIN="${BENCH_BIN}" \
+OUTPUT_DIR="${OUTPUT_ROOT}/daily_omni" \
+bash "${ROOT_DIR}/benchmarks/competition/minicpmo_ascend/run_daily_omni.sh" --disable-shuffle
+
+for locale in en zh; do
+    SEED_TTS_ROOT="${SAMPLE_ROOT}/seed_tts" \
+    SEED_TTS_LOCALE="${locale}" \
+    NUM_PROMPTS=100 \
+    NUM_WARMUPS="${NUM_WARMUPS}" \
+    MAX_CONCURRENCY=1 \
+    OUTPUT_LEN=128 \
+    WER_EVAL=0 \
+    MODEL="${MODEL}" \
+    BENCH_BIN="${BENCH_BIN}" \
+    OUTPUT_DIR="${OUTPUT_ROOT}/seed_tts_${locale}" \
+    bash "${ROOT_DIR}/benchmarks/competition/minicpmo_ascend/run_seed_tts.sh" --disable-shuffle
+done
+
+PYTHON="${PYTHON}" \
+MODEL="${MODEL}" \
+VIDEO_MME_METADATA="${SAMPLE_ROOT}/video_mme/metadata.json" \
+VIDEO_MME_VIDEO_DIR="${DATA_ROOT}/Video-MME/extracted/data" \
+OUTPUT_DIR="${OUTPUT_ROOT}/video_mme" \
+bash "${ROOT_DIR}/benchmarks/competition/minicpmo_ascend/run_video_mme.sh" \
+    --num-questions 100 --concurrency 1
+
+cp "${SAMPLE_ROOT}/manifest.json" "${OUTPUT_ROOT}/sample_manifest.json"
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.summarize_public_benchmark \
+    --output-root "${OUTPUT_ROOT}" \
+    --source-revision "${SOURCE_REVISION}"
+echo "Public proxy benchmark completed: ${OUTPUT_ROOT}"

--- a/benchmarks/competition/minicpmo_ascend/run_seed_tts.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_seed_tts.sh
@@ -43,6 +43,7 @@ command=(
 if [[ "${WER_EVAL}" == "1" ]]; then
     command+=(--seed-tts-wer-eval --seed-tts-wer-save-items)
 fi
+command+=("$@")
 
 printf '%q ' "${command[@]}" | tee "${OUTPUT_DIR}/command.txt"
 printf '\n' | tee -a "${OUTPUT_DIR}/command.txt"

--- a/benchmarks/competition/minicpmo_ascend/run_seed_tts.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_seed_tts.sh
@@ -5,13 +5,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
 HOST="${HOST:-localhost}"
 PORT="${PORT:-8099}"
-NUM_PROMPTS="${NUM_PROMPTS:-100}"
+SEED_TTS_ROOT="${SEED_TTS_ROOT:?set SEED_TTS_ROOT to the public seed-tts-eval directory}"
+SEED_TTS_LOCALE="${SEED_TTS_LOCALE:-en}"
+NUM_PROMPTS="${NUM_PROMPTS:-20}"
 NUM_WARMUPS="${NUM_WARMUPS:-2}"
 MAX_CONCURRENCY="${MAX_CONCURRENCY:-1}"
-OUTPUT_LEN="${OUTPUT_LEN:-16}"
-DAILY_OMNI_INPUT_MODE="${DAILY_OMNI_INPUT_MODE:-all}"
-DAILY_OMNI_PACK_MODE="${DAILY_OMNI_PACK_MODE:-minicpm-interleave}"
-OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/daily_omni}"
+OUTPUT_LEN="${OUTPUT_LEN:-256}"
+WER_EVAL="${WER_EVAL:-0}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/seed_tts_${SEED_TTS_LOCALE}}"
 BENCH_BIN="${BENCH_BIN:-${ROOT_DIR}/.venv/bin/vllm-omni}"
 
 mkdir -p "${OUTPUT_DIR}"
@@ -23,26 +24,24 @@ command=(
     --port "${PORT}"
     --model "${MODEL}"
     --trust-remote-code
-    --dataset-name daily-omni
+    --dataset-name seed-tts
+    --dataset-path "${SEED_TTS_ROOT}"
+    --seed-tts-root "${SEED_TTS_ROOT}"
+    --seed-tts-locale "${SEED_TTS_LOCALE}"
+    --seed-tts-file-ref-audio
     --num-prompts "${NUM_PROMPTS}"
     --num-warmups "${NUM_WARMUPS}"
     --max-concurrency "${MAX_CONCURRENCY}"
     --output-len "${OUTPUT_LEN}"
-    --daily-omni-input-mode "${DAILY_OMNI_INPUT_MODE}"
-    --daily-omni-pack-mode "${DAILY_OMNI_PACK_MODE}"
-    --daily-omni-save-eval-items
     --request-rate inf
     --temperature 0
-    --percentile-metrics ttft,e2el
-    --extra-body '{"modalities":["text"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":false}}'
+    --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration,audio_underrun
+    --extra-body '{"modalities":["text","audio"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":true}}'
     --save-result
     --result-dir "${OUTPUT_DIR}"
 )
-if [[ -n "${DAILY_OMNI_QA_JSON:-}" ]]; then
-    command+=(--daily-omni-qa-json "${DAILY_OMNI_QA_JSON}")
-fi
-if [[ -n "${DAILY_OMNI_VIDEO_DIR:-}" ]]; then
-    command+=(--daily-omni-video-dir "${DAILY_OMNI_VIDEO_DIR}")
+if [[ "${WER_EVAL}" == "1" ]]; then
+    command+=(--seed-tts-wer-eval --seed-tts-wer-save-items)
 fi
 
 printf '%q ' "${command[@]}" | tee "${OUTPUT_DIR}/command.txt"

--- a/benchmarks/competition/minicpmo_ascend/run_suite.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_suite.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PYTHON="${PYTHON:-${ROOT_DIR}/.venv/bin/python}"
+BASE_URL="${BASE_URL:-http://localhost:8099/v1}"
+MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/${RUN_ID}}"
+VIDEO_INPUT="${VIDEO_INPUT:-}"
+STABILITY_CONCURRENCY="${STABILITY_CONCURRENCY:-4}"
+STABILITY_REQUESTS="${STABILITY_REQUESTS:-100}"
+STABILITY_WARMUPS="${STABILITY_WARMUPS:-2}"
+SEED="${SEED:-42}"
+THINKER_MAX_TOKENS="${THINKER_MAX_TOKENS:-256}"
+TALKER_MAX_TOKENS="${TALKER_MAX_TOKENS:-256}"
+
+if [[ -z "${VIDEO_INPUT}" ]]; then
+    echo "VIDEO_INPUT must point to a deterministic local video or official fixture." >&2
+    exit 2
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+collect_args=(--output "${OUTPUT_DIR}/environment.json")
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    collect_args+=(--model-path "${MODEL_PATH}")
+fi
+if [[ -n "${STARTER_KIT:-}" ]]; then
+    collect_args+=(--starter-kit "${STARTER_KIT}")
+fi
+if [[ -n "${MODEL_MANIFEST:-}" ]]; then
+    collect_args+=(--model-manifest "${MODEL_MANIFEST}")
+fi
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.generate_fixtures \
+    --output-dir "${OUTPUT_DIR}/fixtures"
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.collect_environment \
+    "${collect_args[@]}"
+set +e
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.smoke \
+    --base-url "${BASE_URL}" \
+    --model "${MODEL}" \
+    --image "${OUTPUT_DIR}/fixtures/competition_smoke.png" \
+    --audio "${OUTPUT_DIR}/fixtures/competition_smoke.wav" \
+    --video "${VIDEO_INPUT}" \
+    --require-all-modalities \
+    --output-dir "${OUTPUT_DIR}/smoke"
+smoke_status=$?
+
+benchmark_status=0
+if [[ ${smoke_status} -eq 0 ]]; then
+    "${PYTHON}" -m benchmarks.competition.minicpmo_ascend.benchmark \
+        --base-url "${BASE_URL}" \
+        --model "${MODEL}" \
+        --output-dir "${OUTPUT_DIR}/benchmark" \
+        "$@"
+    benchmark_status=$?
+fi
+
+stability_status=0
+if [[ ${smoke_status} -eq 0 && ${benchmark_status} -eq 0 ]]; then
+    "${PYTHON}" -m benchmarks.competition.minicpmo_ascend.benchmark \
+        --base-url "${BASE_URL}" \
+        --model "${MODEL}" \
+        --output-dir "${OUTPUT_DIR}/stability" \
+        --modes text_audio \
+        --concurrency "${STABILITY_CONCURRENCY}" \
+        --num-requests "${STABILITY_REQUESTS}" \
+        --warmups "${STABILITY_WARMUPS}" \
+        --seed "${SEED}" \
+        --thinker-max-tokens "${THINKER_MAX_TOKENS}" \
+        --talker-max-tokens "${TALKER_MAX_TOKENS}"
+    stability_status=$?
+fi
+
+gate_args=(
+    --smoke-results "${OUTPUT_DIR}/smoke/smoke_results.json"
+    --output "${OUTPUT_DIR}/gate.json"
+)
+if [[ -f "${OUTPUT_DIR}/benchmark/benchmark_results.json" ]]; then
+    gate_args+=(--benchmark-results "${OUTPUT_DIR}/benchmark/benchmark_results.json")
+fi
+if [[ -f "${OUTPUT_DIR}/stability/benchmark_results.json" ]]; then
+    gate_args+=(--stability-results "${OUTPUT_DIR}/stability/benchmark_results.json")
+fi
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.correctness_gate "${gate_args[@]}"
+gate_status=$?
+
+report_status=0
+"${PYTHON}" -m benchmarks.competition.minicpmo_ascend.report \
+    --artifact-root "${OUTPUT_DIR}" \
+    --environment "${OUTPUT_DIR}/environment.json" \
+    --smoke-results "${OUTPUT_DIR}/smoke/smoke_results.json" \
+    --benchmark-results "${OUTPUT_DIR}/benchmark/benchmark_results.json" \
+    --stability-results "${OUTPUT_DIR}/stability/benchmark_results.json" \
+    --gate "${OUTPUT_DIR}/gate.json" \
+    --output "${OUTPUT_DIR}/baseline_report.md" \
+    --manifest-output "${OUTPUT_DIR}/artifact_manifest.sha256"
+report_status=$?
+set -e
+
+if [[ ${smoke_status} -ne 0 || ${benchmark_status} -ne 0 || ${stability_status} -ne 0 || ${gate_status} -ne 0 || ${report_status} -ne 0 ]]; then
+    echo "Competition proxy suite failed: ${OUTPUT_DIR}" >&2
+    exit 1
+fi
+
+echo "Competition proxy suite passed: ${OUTPUT_DIR}"

--- a/benchmarks/competition/minicpmo_ascend/run_video_mme.sh
+++ b/benchmarks/competition/minicpmo_ascend/run_video_mme.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PYTHON="${PYTHON:-${ROOT_DIR}/.venv/bin/python}"
+MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
+VIDEO_MME_METADATA="${VIDEO_MME_METADATA:?set VIDEO_MME_METADATA to the official parquet or JSON file}"
+VIDEO_MME_VIDEO_DIR="${VIDEO_MME_VIDEO_DIR:?set VIDEO_MME_VIDEO_DIR to extracted MP4 files}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/video_mme}"
+
+exec "${PYTHON}" -m benchmarks.competition.minicpmo_ascend.video_mme \
+    --metadata "${VIDEO_MME_METADATA}" \
+    --video-dir "${VIDEO_MME_VIDEO_DIR}" \
+    --model "${MODEL}" \
+    --output-dir "${OUTPUT_DIR}" \
+    "$@"

--- a/benchmarks/competition/minicpmo_ascend/smoke.py
+++ b/benchmarks/competition/minicpmo_ascend/smoke.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Run deterministic text/image/audio/video input smoke requests."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+
+from .client import build_payload, run_stream_request
+
+
+async def _main(args: argparse.Namespace) -> int:
+    output = args.output_dir
+    output.mkdir(parents=True, exist_ok=True)
+    cases = [
+        ("text_only", "text", None, False, "Reply with one short sentence about vLLM-Omni."),
+        ("text_audio", "text", None, True, "Say hello and describe vLLM-Omni in one short sentence."),
+    ]
+    media_cases = [
+        ("image_audio", "image", args.image, "Name the two main shapes and their colors."),
+        ("audio_audio", "audio", args.audio, "Describe the sound briefly."),
+        ("video_audio", "video", args.video, "Describe the main action in this video briefly."),
+    ]
+    missing = [modality for _, modality, media, _ in media_cases if media is None]
+    if missing and args.require_all_modalities:
+        raise SystemExit(f"missing required media inputs: {', '.join(missing)}")
+    cases.extend((name, modality, media, True, prompt) for name, modality, media, prompt in media_cases if media)
+
+    timeout = httpx.Timeout(args.timeout)
+    records = []
+    async with httpx.AsyncClient(timeout=timeout, headers={"Authorization": "Bearer EMPTY"}) as client:
+        for name, modality, media, with_audio, prompt in cases:
+            payload = build_payload(
+                model=args.model,
+                prompt=prompt,
+                input_modality=modality,
+                media=media,
+                with_audio=with_audio,
+                seed=args.seed,
+                thinker_max_tokens=args.thinker_max_tokens,
+                talker_max_tokens=args.talker_max_tokens,
+            )
+            record = await run_stream_request(
+                client,
+                endpoint=f"{args.base_url.rstrip('/')}/chat/completions",
+                payload=payload,
+                request_name=name,
+                input_modality=modality,
+                with_audio=with_audio,
+                output_wav=output / f"{name}.wav" if with_audio else None,
+            )
+            records.append(record)
+            print(f"{name}: {'PASS' if record['success'] else 'FAIL'}")
+
+    result = {
+        "schema_version": 1,
+        "metric_scope": "local_proxy",
+        "official_schema_status": "UNRESOLVED",
+        "records": records,
+        "passed": all(record["success"] for record in records),
+    }
+    result_path = output / "smoke_results.json"
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(result_path)
+    return 0 if result["passed"] else 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8099/v1")
+    parser.add_argument("--model", default="openbmb/MiniCPM-o-4_5")
+    parser.add_argument("--image")
+    parser.add_argument("--audio")
+    parser.add_argument("--video")
+    parser.add_argument("--require-all-modalities", action="store_true")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--thinker-max-tokens", type=int, default=256)
+    parser.add_argument("--talker-max-tokens", type=int, default=256)
+    raise SystemExit(asyncio.run(_main(parser.parse_args())))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/start_server.sh
+++ b/benchmarks/competition/minicpmo_ascend/start_server.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODEL="${MODEL:-openbmb/MiniCPM-o-4_5}"
+DEPLOY_CONFIG="${DEPLOY_CONFIG:-${ROOT_DIR}/vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml}"
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8099}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/artifacts/minicpmo_ascend/server}"
+SERVER_BIN="${SERVER_BIN:-${ROOT_DIR}/.venv/bin/vllm-omni}"
+
+mkdir -p "${ARTIFACT_DIR}"
+if [[ ! -x "${SERVER_BIN}" ]]; then
+    SERVER_BIN="${SERVER_BIN_FALLBACK:-vllm-omni}"
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-${ROOT_DIR}/.venv/bin/python}"
+if [[ -x "${PYTHON_BIN}" ]]; then
+    VLLM_ASCEND_LIB_DIR="$("${PYTHON_BIN}" - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("vllm_ascend")
+if spec is not None and spec.origin is not None:
+    package_dir = Path(spec.origin).resolve().parent
+    for candidate in (package_dir / "lib", package_dir / "lib64", package_dir):
+        if (candidate / "libvllm_ascend_kernels.so").is_file():
+            print(candidate)
+            break
+PY
+)"
+    if [[ -n "${VLLM_ASCEND_LIB_DIR}" ]]; then
+        export LD_LIBRARY_PATH="${VLLM_ASCEND_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+    fi
+fi
+
+command=(
+    "${SERVER_BIN}" serve "${MODEL}"
+    --omni
+    --deploy-config "${DEPLOY_CONFIG}"
+    --trust-remote-code
+    --host "${HOST}"
+    --port "${PORT}"
+)
+if [[ -n "${MODEL_REVISION:-}" ]]; then
+    command+=(--revision "${MODEL_REVISION}")
+fi
+if [[ -n "${ALLOWED_LOCAL_MEDIA_PATH:-}" ]]; then
+    command+=(--allowed-local-media-path "${ALLOWED_LOCAL_MEDIA_PATH}")
+fi
+if [[ -n "${SERVER_EXTRA_ARGS:-}" ]]; then
+    # shellcheck disable=SC2206
+    extra_args=(${SERVER_EXTRA_ARGS})
+    command+=("${extra_args[@]}")
+fi
+
+printf '%q ' "${command[@]}" | tee "${ARTIFACT_DIR}/server_command.txt"
+printf '\n' | tee -a "${ARTIFACT_DIR}/server_command.txt"
+printf 'LD_LIBRARY_PATH=%q\n' "${LD_LIBRARY_PATH:-}" | tee "${ARTIFACT_DIR}/server_environment.txt"
+exec "${command[@]}" > >(tee "${ARTIFACT_DIR}/server.log") 2>&1

--- a/benchmarks/competition/minicpmo_ascend/summarize_public_benchmark.py
+++ b/benchmarks/competition/minicpmo_ascend/summarize_public_benchmark.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Summarize one deterministic public proxy benchmark run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .client import metric_summary
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return data
+
+
+def _newest_result(directory: Path, pattern: str) -> Path:
+    candidates = list(directory.glob(pattern))
+    if not candidates:
+        raise FileNotFoundError(f"no result matching {pattern!r} under {directory}")
+    return max(candidates, key=lambda path: path.stat().st_mtime_ns)
+
+
+def summarize_video_timing(items: list[dict[str, Any]]) -> dict[str, Any]:
+    metrics = metric_summary(items)
+    starts_and_ends = []
+    for item in items:
+        started_at = item.get("started_at")
+        e2e_s = item.get("e2e_s")
+        if started_at is None or e2e_s is None:
+            continue
+        start = datetime.fromisoformat(str(started_at))
+        starts_and_ends.append((start, start + timedelta(seconds=float(e2e_s))))
+    wall_s = None
+    if starts_and_ends:
+        wall_s = (max(end for _, end in starts_and_ends) - min(start for start, _ in starts_and_ends)).total_seconds()
+    successful = int(metrics["successful_requests"])
+    return {
+        **metrics,
+        "duration_s": wall_s,
+        "request_throughput": successful / wall_s if wall_s else None,
+    }
+
+
+def _timings_ms(data: dict[str, Any], first_key: str) -> dict[str, Any]:
+    return {
+        "first_response_p50": data.get(f"median_{first_key}_ms"),
+        "first_response_p99": data.get(f"p99_{first_key}_ms"),
+        "e2e_p50": data.get("median_e2el_ms"),
+        "e2e_p99": data.get("p99_e2el_ms"),
+    }
+
+
+def _seed_summary(data: dict[str, Any]) -> dict[str, Any]:
+    continuity = 100.0 if data.get("failed") == 0 and data.get("p99_audio_underrun_s") == 0 else None
+    return {
+        "samples": data.get("num_prompts"),
+        "completed": data.get("completed"),
+        "failed": data.get("failed"),
+        "duration_s": data.get("duration"),
+        "request_throughput": data.get("request_throughput"),
+        "generated_audio_s": data.get("total_audio_duration_s"),
+        "audio_throughput": data.get("audio_throughput"),
+        "timing_ms": _timings_ms(data, "audio_ttfp"),
+        "audio_rtf": {
+            "p50": data.get("median_audio_rtf"),
+            "p99": data.get("p99_audio_rtf"),
+        },
+        "p99_audio_underrun_s": data.get("p99_audio_underrun_s"),
+        "streaming_continuity_proxy_pct": continuity,
+        "wer": None,
+    }
+
+
+def build_summary(output_root: Path, source_revision: str) -> dict[str, Any]:
+    manifest_path = output_root / "sample_manifest.json"
+    daily_path = _newest_result(output_root / "daily_omni", "openai-chat-omni-*.json")
+    seed_en_path = _newest_result(output_root / "seed_tts_en", "openai-chat-omni-*.json")
+    seed_zh_path = _newest_result(output_root / "seed_tts_zh", "openai-chat-omni-*.json")
+    video_path = output_root / "video_mme" / "video_mme_results.json"
+
+    manifest = _load_json(manifest_path)
+    daily = _load_json(daily_path)
+    seed_en = _load_json(seed_en_path)
+    seed_zh = _load_json(seed_zh_path)
+    video = _load_json(video_path)
+    video_accuracy = video["summary"]
+    video_timing = summarize_video_timing(video["items"])
+
+    workloads = {
+        "daily_omni": {
+            "samples": daily.get("num_prompts"),
+            "completed": daily.get("completed"),
+            "failed": daily.get("failed"),
+            "correct": daily.get("daily_omni_correct"),
+            "evaluated": daily.get("daily_omni_evaluated"),
+            "accuracy": daily.get("daily_omni_accuracy"),
+            "duration_s": daily.get("duration"),
+            "request_throughput": daily.get("request_throughput"),
+            "timing_ms": _timings_ms(daily, "ttft"),
+            "by_duration": daily.get("daily_omni_per_duration"),
+            "by_task": daily.get("daily_omni_per_task"),
+        },
+        "seed_tts_en": _seed_summary(seed_en),
+        "seed_tts_zh": _seed_summary(seed_zh),
+        "video_mme": {
+            "samples": video_accuracy["total"],
+            "completed": video_timing["successful_requests"],
+            "failed": video_timing["failed_requests"],
+            "correct": video_accuracy["correct"],
+            "evaluated": video_accuracy["total"],
+            "accuracy": video_accuracy["accuracy"],
+            "duration_s": video_timing["duration_s"],
+            "request_throughput": video_timing["request_throughput"],
+            "timing_s": {
+                "first_text": video_timing["first_text_s"],
+                "e2e": video_timing["e2e_s"],
+            },
+            "unparsed_responses": video_accuracy["unparsed_responses"],
+            "by_duration": video_accuracy["by_duration"],
+            "by_domain": video_accuracy["by_domain"],
+        },
+    }
+    total_samples = sum(int(workload["samples"] or 0) for workload in workloads.values())
+    total_completed = sum(int(workload["completed"] or 0) for workload in workloads.values())
+    total_failed = sum(int(workload["failed"] or 0) for workload in workloads.values())
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "deterministic public-data proxy benchmark; not an official competition benchmark or score",
+        "formal_competition_score": None,
+        "source_revision": source_revision,
+        "sample_seed": manifest.get("seed"),
+        "totals": {
+            "samples": total_samples,
+            "completed": total_completed,
+            "failed": total_failed,
+        },
+        "sample_distribution": {
+            "daily_omni": {
+                "duration": manifest["daily_omni"]["duration_distribution"],
+                "category": manifest["daily_omni"]["category_distribution"],
+            },
+            "seed_tts_en": manifest["seed_tts"]["en"]["length_bin_distribution"],
+            "seed_tts_zh": manifest["seed_tts"]["zh"]["length_bin_distribution"],
+            "video_mme": {
+                "duration": manifest["video_mme"]["duration_distribution"],
+                "domain": manifest["video_mme"]["domain_distribution"],
+            },
+        },
+        "workloads": workloads,
+        "raw_results": {
+            "manifest": str(manifest_path.relative_to(output_root)),
+            "daily_omni": str(daily_path.relative_to(output_root)),
+            "seed_tts_en": str(seed_en_path.relative_to(output_root)),
+            "seed_tts_zh": str(seed_zh_path.relative_to(output_root)),
+            "video_mme": str(video_path.relative_to(output_root)),
+        },
+    }
+
+
+def _percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.2f}%"
+
+
+def _number(value: float | None, digits: int = 2) -> str:
+    return "n/a" if value is None else f"{value:.{digits}f}"
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    workloads = summary["workloads"]
+    daily = workloads["daily_omni"]
+    seed_en = workloads["seed_tts_en"]
+    seed_zh = workloads["seed_tts_zh"]
+    video = workloads["video_mme"]
+    lines = [
+        "# MiniCPM-o Ascend Public Proxy Benchmark v1",
+        "",
+        "> This is a deterministic public-data proxy benchmark, not an official competition benchmark or score.",
+        "",
+        f"- Source revision: `{summary['source_revision']}`",
+        f"- Sample seed: `{summary['sample_seed']}`",
+        f"- Requests: {summary['totals']['completed']}/{summary['totals']['samples']} completed, "
+        f"{summary['totals']['failed']} failed",
+        "- Concurrency: 1 for every workload",
+        "",
+        "## Results",
+        "",
+        "| Workload | Samples | Effect metric | Throughput | P50 first response | P50 E2E |",
+        "| --- | ---: | --- | ---: | ---: | ---: |",
+        f"| Daily-Omni | {daily['samples']} | {daily['correct']}/{daily['evaluated']} "
+        f"({_percent(daily['accuracy'])}) | {_number(daily['request_throughput'], 4)} req/s | "
+        f"{_number(daily['timing_ms']['first_response_p50'])} ms | "
+        f"{_number(daily['timing_ms']['e2e_p50'])} ms |",
+        f"| Seed-TTS English | {seed_en['samples']} | generation 100/100; WER not run in this 100-sample pass | "
+        f"{_number(seed_en['audio_throughput'], 4)} audio s/s | "
+        f"{_number(seed_en['timing_ms']['first_response_p50'])} ms | "
+        f"{_number(seed_en['timing_ms']['e2e_p50'])} ms |",
+        f"| Seed-TTS Chinese | {seed_zh['samples']} | generation 100/100; WER not run in this 100-sample pass | "
+        f"{_number(seed_zh['audio_throughput'], 4)} audio s/s | "
+        f"{_number(seed_zh['timing_ms']['first_response_p50'])} ms | "
+        f"{_number(seed_zh['timing_ms']['e2e_p50'])} ms |",
+        f"| Video-MME | {video['samples']} | {video['correct']}/{video['evaluated']} "
+        f"({_percent(video['accuracy'])}) | {_number(video['request_throughput'], 4)} req/s | "
+        f"{_number(video['timing_s']['first_text']['p50'])} s | {_number(video['timing_s']['e2e']['p50'])} s |",
+        "",
+        "Both Seed-TTS runs had zero p99 audio underrun and a 100% streaming-continuity proxy rate. "
+        f"English generated {_number(seed_en['generated_audio_s'])} seconds of audio; Chinese generated "
+        f"{_number(seed_zh['generated_audio_s'])} seconds.",
+        "",
+        "## Sampling",
+        "",
+        "- Daily-Omni: 100 unique videos, split equally between 30-second and 60-second groups, "
+        "then stratified by parent category.",
+        "- Seed-TTS English: 100 rows, 25 from each target-text length quartile, "
+        "with unique reference prompts preferred.",
+        "- Seed-TTS Chinese: 100 rows, 25 from each target-text length quartile, "
+        "with unique reference prompts preferred.",
+        "- Video-MME: 100 unique videos, 34 long, 33 medium, and 33 short, then stratified across six domains.",
+        "",
+        "## Accuracy Breakdown",
+        "",
+        "### Daily-Omni duration",
+        "",
+        "| Duration | Correct | Total | Accuracy |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for name, values in sorted(daily["by_duration"].items()):
+        accuracy = values["correct"] / values["total"]
+        lines.append(f"| {name} | {values['correct']} | {values['total']} | {_percent(accuracy)} |")
+    lines.extend(
+        [
+            "",
+            "### Video-MME duration",
+            "",
+            "| Duration | Correct | Total | Accuracy |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for name, values in sorted(video["by_duration"].items()):
+        lines.append(f"| {name} | {values['correct']} | {values['total']} | {_percent(values['accuracy'])} |")
+    lines.extend(
+        [
+            "",
+            "## Limitations",
+            "",
+            "- The official Starter Kit, evaluator subsets, score weights, and final package schema "
+            "were unavailable for this run.",
+            "- These public datasets are coverage proxies and cannot establish an official competition score.",
+            "- Seed-TTS quality evaluation is separate from this 100-sample generation/performance pass.",
+            "- Video-MME uses the available public, subtitles-free subset and is not a full Video-MME result.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    args = parser.parse_args()
+    summary = build_summary(args.output_root, args.source_revision)
+    summary_path = args.output_root / "summary.json"
+    report_path = args.output_root / "report.md"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report_path.write_text(render_report(summary), encoding="utf-8")
+    print(summary_path)
+    print(report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/competition/minicpmo_ascend/video_mme.py
+++ b/benchmarks/competition/minicpmo_ascend/video_mme.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Evaluate an OpenAI-compatible MiniCPM-o service on public Video-MME."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .client import build_payload, run_stream_request
+
+
+def extract_choice(text: str | None) -> str | None:
+    if not text:
+        return None
+    candidate = str(text).strip()
+    direct = re.match(r"(?i)^\s*(?:answer\s*[:：]?\s*)?\(?([A-D])\)?(?:[\s.\):：]|$)", candidate)
+    if direct:
+        return direct.group(1).upper()
+    fallback = re.search(r"(?i)(?:answer|option|choice)\s*(?:is|:)\s*\(?([A-D])\)?", candidate)
+    return fallback.group(1).upper() if fallback else None
+
+
+def _flatten_official_json(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for video in data:
+        for question in video.get("questions", []):
+            rows.append({**video, **question})
+    return rows
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    if path.suffix == ".parquet":
+        import pyarrow.parquet as pq
+
+        return pq.read_table(path).to_pylist()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Video-MME metadata must contain a JSON list")
+    if data and "questions" in data[0]:
+        return _flatten_official_json(data)
+    return data
+
+
+def index_videos(root: Path) -> dict[str, Path]:
+    videos: dict[str, Path] = {}
+    for path in sorted(root.rglob("*.mp4")):
+        videos.setdefault(path.stem, path.resolve())
+        videos.setdefault(path.name, path.resolve())
+    return videos
+
+
+def find_video(row: dict[str, Any], videos: dict[str, Path]) -> Path | None:
+    for key in ("video_id", "videoID", "videoId"):
+        value = str(row.get(key, "")).strip()
+        if value in videos:
+            return videos[value]
+        if f"{value}.mp4" in videos:
+            return videos[f"{value}.mp4"]
+    return None
+
+
+def build_prompt(row: dict[str, Any]) -> str:
+    options = row.get("options") or row.get("choice") or row.get("Choice") or []
+    if isinstance(options, str):
+        options = [part.strip() for part in options.splitlines() if part.strip()]
+    lines = [
+        "Select the best answer to the following multiple-choice question based on the video.",
+        "Respond with only the letter (A, B, C, or D) of the correct option.",
+        str(row.get("question") or row.get("Question") or "").strip(),
+        *(str(option).strip() for option in options),
+        "The best answer is:",
+    ]
+    return "\n".join(line for line in lines if line)
+
+
+def summarize(items: list[dict[str, Any]]) -> dict[str, Any]:
+    def bucket(field: str) -> dict[str, dict[str, Any]]:
+        groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for item in items:
+            groups[str(item.get(field) or "unknown")].append(item)
+        return {
+            key: {
+                "correct": sum(bool(item["correct"]) for item in values),
+                "total": len(values),
+                "accuracy": sum(bool(item["correct"]) for item in values) / len(values),
+            }
+            for key, values in sorted(groups.items())
+        }
+
+    total = len(items)
+    correct = sum(bool(item["correct"]) for item in items)
+    return {
+        "correct": correct,
+        "total": total,
+        "accuracy": correct / total if total else None,
+        "request_failures": sum(not item["success"] for item in items),
+        "unparsed_responses": sum(item["predicted"] is None for item in items),
+        "by_duration": bucket("duration"),
+        "by_domain": bucket("domain"),
+        "by_sub_category": bucket("sub_category"),
+        "by_task_type": bucket("task_type"),
+    }
+
+
+def build_official_results(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for item in items:
+        video_id = str(item["video_id"])
+        video = grouped.setdefault(
+            video_id,
+            {
+                "video_id": video_id,
+                "duration": item.get("duration"),
+                "domain": item.get("domain"),
+                "sub_category": item.get("sub_category"),
+                "questions": [],
+            },
+        )
+        video["questions"].append(
+            {
+                "question_id": item.get("question_id"),
+                "task_type": item.get("task_type"),
+                "question": item.get("question"),
+                "options": item.get("options"),
+                "answer": item.get("gold"),
+                "response": item.get("response", ""),
+            }
+        )
+    return list(grouped.values())
+
+
+async def _main(args: argparse.Namespace) -> int:
+    rows = load_rows(args.metadata)
+    if args.durations:
+        allowed = set(args.durations)
+        rows = [row for row in rows if row.get("duration") in allowed]
+    videos = index_videos(args.video_dir)
+    if not videos:
+        raise SystemExit(f"no MP4 files found under {args.video_dir}")
+    if args.skip_missing_videos:
+        rows = [row for row in rows if find_video(row, videos) is not None]
+    if args.max_videos is not None:
+        selected: set[str] = set()
+        kept = []
+        for row in rows:
+            video_id = str(row.get("video_id"))
+            if video_id not in selected and len(selected) >= args.max_videos:
+                continue
+            selected.add(video_id)
+            kept.append(row)
+        rows = kept
+    if args.num_questions is not None:
+        rows = rows[: args.num_questions]
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    semaphore = asyncio.Semaphore(args.concurrency)
+    timeout = httpx.Timeout(args.timeout)
+
+    async with httpx.AsyncClient(timeout=timeout, headers={"Authorization": "Bearer EMPTY"}) as client:
+
+        async def one(index: int, row: dict[str, Any]) -> dict[str, Any]:
+            video = find_video(row, videos)
+            base = {
+                "index": index,
+                "video_id": str(row.get("video_id", "")),
+                "question_id": row.get("question_id"),
+                "duration": row.get("duration"),
+                "domain": row.get("domain"),
+                "sub_category": row.get("sub_category"),
+                "task_type": row.get("task_type"),
+                "question": row.get("question"),
+                "options": row.get("options"),
+                "gold": str(row.get("answer", "")).strip().upper(),
+            }
+            if video is None:
+                return {
+                    **base,
+                    "success": False,
+                    "response": "",
+                    "predicted": None,
+                    "correct": False,
+                    "errors": ["video file not found"],
+                }
+            payload = build_payload(
+                model=args.model,
+                prompt=build_prompt(row),
+                input_modality="video",
+                media=video.as_uri(),
+                with_audio=False,
+                seed=args.seed,
+                thinker_max_tokens=args.max_tokens,
+                talker_max_tokens=args.max_tokens,
+            )
+            payload["chat_template_kwargs"]["enable_thinking"] = False
+            async with semaphore:
+                record = await run_stream_request(
+                    client,
+                    endpoint=f"{args.base_url.rstrip('/')}/chat/completions",
+                    payload=payload,
+                    request_name=str(row.get("question_id") or index),
+                    input_modality="video",
+                    with_audio=False,
+                )
+            response = record.get("text", "")
+            predicted = extract_choice(response)
+            item = {
+                **base,
+                **record,
+                "video_path": str(video),
+                "response": response,
+                "predicted": predicted,
+                "correct": predicted == base["gold"],
+            }
+            print(
+                f"[{index + 1}/{len(rows)}] {base['question_id']}: "
+                f"{'OK' if item['success'] else 'FAIL'} pred={predicted} gold={base['gold']}",
+                flush=True,
+            )
+            return item
+
+        items = await asyncio.gather(*(one(index, row) for index, row in enumerate(rows)))
+
+    result = {
+        "schema_version": 1,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "public Video-MME, subtitles-free",
+        "formal_competition_score": None,
+        "command": [sys.executable, *sys.argv],
+        "summary": summarize(items),
+        "items": items,
+    }
+    (args.output_dir / "video_mme_results.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (args.output_dir / "official_results.json").write_text(
+        json.dumps(build_official_results(items), indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(result["summary"], indent=2, sort_keys=True))
+    return 1 if result["summary"]["request_failures"] else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--video-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--base-url", default="http://localhost:8099/v1")
+    parser.add_argument("--model", default="openbmb/MiniCPM-o-4_5")
+    parser.add_argument("--durations", nargs="+", choices=["short", "medium", "long"])
+    parser.add_argument("--max-videos", type=int)
+    parser.add_argument("--num-questions", type=int)
+    parser.add_argument("--skip-missing-videos", action="store_true")
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--seed", type=int, default=42)
+    raise SystemExit(asyncio.run(_main(parser.parse_args())))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -103,6 +103,7 @@ nav:
   - Design Documents:
     - design/index.md
     - design/architecture_overview.md
+    - design/minicpmo_4_5_ascend_competition_todo.md
     - Feature Design:
       - design/feature/disaggregated_inference.md
       - design/feature/ray_based_execution.md

--- a/docs/design/minicpmo_4_5_ascend_competition_todo.md
+++ b/docs/design/minicpmo_4_5_ascend_competition_todo.md
@@ -1,0 +1,335 @@
+# MiniCPM-o 4.5 Ascend Competition TODO
+
+Status snapshot: 2026-07-25
+
+Competition: [MiniCPM & Ascend Inference Optimization and Application Innovation Challenge](https://ascend.openbmb.cn/competition)
+
+This document tracks the work required to use vLLM-Omni for the competition's
+high-performance inference track. New official rules, benchmark scripts, and
+starter kits override assumptions recorded here.
+
+## Competition Goal
+
+Treat the work as a gated multi-objective optimization:
+
+1. Pass model effect, correctness, functional, and stability validation.
+2. Reduce TTFT, single-chunk latency, and end-to-end latency.
+3. Increase throughput and stable concurrent sessions.
+4. Improve NPU utilization and memory efficiency.
+5. Reproduce the result in the official Ascend environment.
+
+Do not invent metric weights before the organizer publishes the formal scoring
+formula.
+
+## Current Pipeline
+
+```text
+OpenAI chat request: text / image / audio / video
+                         |
+                         v
+Stage 0: Thinker -> text + hidden states -> final text output
+                         |
+                         v
+                    llm2tts bridge
+                         |
+                         v
+Stage 1: Talker -> request-local autoregressive codec deltas
+                         |
+                         v
+        collect 25 new codec frames + 3 left-context frames
+                         |
+                         v
+Stage 2: Code2Wav -> Flow -> CFM -> HiFT -> 24 kHz audio chunks
+```
+
+Relevant implementation:
+
+- Pipeline topology: `vllm_omni/model_executor/models/minicpmo_4_5/pipeline.py`
+- Default deployment: `vllm_omni/deploy/minicpmo_4_5.yaml`
+- Thinker/Talker wrapper: `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py`
+- Talker: `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py`
+- Stage bridges: `vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py`
+- Code2Wav: `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py`
+- Batched vocoder: `vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py`
+- NPU-safe Token2Wav facade: `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py`
+
+## Current Readiness
+
+| Area | Status | Main gap |
+| --- | --- | --- |
+| Thinker on NPU | Partial | Generic NPU runner plus temporary input-shape workaround; no competition baseline |
+| Talker on NPU | Partial | Request-local batching exists; no real NPU concurrency/effect validation |
+| Code2Wav on NPU | Blocked | Production path still loads external `stepaudio2.Token2wav` with CUDA assumptions |
+| Correctness/effect | Partial | Generic Daily-Omni support exists; no MiniCPM competition gate |
+| Performance benchmark | Missing | No competition-specific TTFT/chunk/E2E/concurrency harness |
+| NPU observability | Partial | NPU profiler exists; no unified competition report collection |
+| Reproduction package | Missing | No official-environment deployment bundle and performance report |
+
+## P0: Competition Blockers
+
+### P0-1 Freeze Official Rules and Environment
+
+- [ ] Download the latest official starter kit and record its URL, date, version, and checksum.
+- [ ] Record the official NPU model, card count, topology, CPU/RAM limits, and network policy.
+- [ ] Record the official image, driver, firmware, CANN, Python, PyTorch, torch-npu, vLLM, vLLM-Ascend, and vLLM-Omni versions.
+- [ ] Record the required MiniCPM-o 4.5 model source, revision, checksum, and model packaging rules.
+- [ ] Record the official request schema, datasets, metric definitions, aggregation method, concurrency, timeouts, and effect thresholds.
+- [ ] Record package size, execution time, cache, quantization, dependency, and submission limits.
+- [ ] Update this document whenever official material changes.
+
+Acceptance:
+
+- [ ] A checked-in environment manifest contains every version and checksum needed for reproduction.
+- [ ] No benchmark or score calculation depends on an unpublished assumption.
+
+### P0-2 Make Code2Wav NPU-Native
+
+Current blockers:
+
+- `MiniCPMO45Code2Wav.load_weights()` imports the external
+  `stepaudio2.Token2wav` implementation.
+- The in-tree `MiniCPMO45Token2wav` facade documents that the external package
+  hard-codes `.cuda()`, but the production Code2Wav path does not use the
+  in-tree facade.
+- `BatchedToken2Wav` expects direct Flow/HiFT modules and cache attributes that
+  the current facade does not expose.
+- NPU-specific Step-Audio2/HiFT/DiT patches exist, but the MiniCPM production
+  path must be wired to the compatible in-tree core.
+
+TODO:
+
+- [ ] Decide the supported NPU backend contract for batched MiniCPM Code2Wav.
+- [ ] Replace the CUDA-only external loading path with an in-tree, device-aware backend.
+- [ ] Expose or adapt the Flow, HiFT, prompt feature, cache, dtype, and timestep interfaces needed by `BatchedToken2Wav`.
+- [ ] Ensure the Step-Audio2 NPU HiFT and DiT attention patches are applied on the actual MiniCPM path.
+- [ ] Remove hard-coded CUDA autocast usage from prompt extraction.
+- [ ] Add NPU-aware fp32/fp16/bf16 autocast and validate supported operator dtypes.
+- [ ] Verify model parameters, buffers, noise tensors, prompt features, and request caches are placed on the intended NPU.
+- [ ] Verify temporary reference-audio files and prompt feature caches are released after success, failure, abort, and timeout.
+- [ ] Preserve the existing GPU path and output contract.
+
+Acceptance:
+
+- [ ] Text-plus-audio serving starts without importing a CUDA-only runtime.
+- [ ] One text request produces valid text and non-empty 24 kHz audio on Ascend.
+- [ ] Image, audio, and video input requests produce valid text and audio outputs.
+- [ ] Multiple audio chunks are emitted in order and reconstruct one valid waveform.
+- [ ] Request-local Flow/HiFT state is isolated under concurrent requests.
+- [ ] No NPU memory leak remains after repeated request completion and cancellation.
+
+### P0-3 Establish an Ascend End-to-End Baseline
+
+- [ ] Add an official-environment server startup script.
+- [ ] Add deterministic text-only and text-plus-audio smoke requests.
+- [ ] Add image, audio, and video input smoke requests.
+- [ ] Fix model revision, sampling parameters, seed, output length, and modality settings.
+- [ ] Record warmup count and exclude initialization/graph compilation from formal measurements.
+- [ ] Save server logs, client results, audio artifacts, error counts, and NPU monitoring output.
+- [ ] Run at least one clean restart and reproduce the same functional result.
+
+Acceptance:
+
+- [ ] The full three-stage pipeline runs in the official or closest available Ascend environment.
+- [ ] Text-only requests skip Talker and Code2Wav as intended.
+- [ ] Text-plus-audio requests exercise all three stages.
+- [ ] Baseline commands are runnable without machine-local undocumented state.
+
+### P0-4 Implement the Competition Benchmark Harness
+
+The repository already provides Daily-Omni and generic TTS benchmark
+infrastructure, but MiniCPM-o 4.5 is not registered in the universal TTS model
+matrix and there is no competition-specific benchmark suite.
+
+- [ ] Implement the official request schema and benchmark invocation.
+- [ ] Measure TTFT or first response according to the official definition.
+- [ ] Measure first audio response if it is part of the official TTFT definition.
+- [ ] Measure single-chunk latency and chunk arrival jitter.
+- [ ] Measure E2E latency.
+- [ ] Measure request/token/audio throughput according to the official units.
+- [ ] Sweep the official concurrent-session configurations.
+- [ ] Track p50/p95/p99 or the exact official statistics.
+- [ ] Record NPU utilization, peak HBM, host memory, error rate, and timeout rate.
+- [ ] Keep profiler runs separate from formal score runs.
+- [ ] Save raw JSON results and emit a stable summary table.
+
+Acceptance:
+
+- [ ] One command runs warmup, benchmark, resource collection, and result export.
+- [ ] Failed or truncated requests cannot be counted as successful performance samples.
+- [ ] Text-only and text-plus-audio results are reported separately.
+- [ ] Every reported number is traceable to raw output and an exact command.
+
+### P0-5 Build the Effect and Correctness Gate
+
+- [ ] Integrate the official public effect dataset and evaluation script when released.
+- [ ] Add MiniCPM-o 4.5 Daily-Omni coverage as a local proxy until the official suite is available.
+- [ ] Fix chat template settings, output modalities, sampling, and answer extraction.
+- [ ] Validate text correctness for text, image, audio, and video inputs.
+- [ ] Validate speech is non-empty, finite, correctly sampled, and not truncated or duplicated.
+- [ ] Add streaming continuity and chunk-order checks.
+- [ ] Add concurrent-request state isolation checks.
+- [ ] Establish baseline self-run variance before evaluating precision changes.
+
+Acceptance:
+
+- [ ] A failing effect or stability check blocks performance acceptance.
+- [ ] The gate produces a machine-readable pass/fail result.
+- [ ] The same gate runs before and after every optimization candidate.
+
+## P1: Performance Work After P0 Passes
+
+### P1-1 Remove Talker-to-Code2Wav Host Synchronization
+
+The async bridge currently converts codec tensors to CPU Python scalars before
+forming each chunk. This can synchronize NPU execution on every codec delta.
+
+- [ ] Measure the synchronization cost in an NPU trace.
+- [ ] Keep codec accumulation in tensor/device-aware storage where possible.
+- [ ] Move to host only at the connector boundary if the connector requires it.
+- [ ] Avoid rebuilding Python lists and tensors for every generated codec token.
+- [ ] Preserve request routing, left context, terminal flush, abort, and epoch semantics.
+
+Acceptance:
+
+- [ ] Single-chunk latency and Talker-to-Code2Wav handoff time improve outside run variance.
+- [ ] Chunk contents and final audio remain equivalent to the baseline.
+
+### P1-2 Optimize Code2Wav Dtype and Operators
+
+- [ ] Establish fp32, fp16, and bf16 support per Code2Wav submodule on Ascend.
+- [ ] Keep fp32-only S3Tokenizer/HiFT operations in their required precision.
+- [ ] Measure Flow encoder, CFM estimator, and HiFT independently.
+- [ ] Verify the NPU-safe HiFT downsample and DiT attention paths on real hardware.
+- [ ] Remove avoidable layout conversions, copies, allocations, and synchronizations.
+- [ ] Cache static timelines, masks, windows, and other shape-stable tensors.
+
+Acceptance:
+
+- [ ] The selected dtype improves performance or memory without failing the effect gate.
+- [ ] No CPU fallback dominates the measured chunk path unless explicitly justified.
+
+### P1-3 Improve Stage-2 Batching and Graph Execution
+
+- [ ] Measure exact-shape bucket occupancy at each concurrency.
+- [ ] Quantify fragmentation from prompt identity, codec length, cache shape, terminal status, and epoch.
+- [ ] Test initial chunk size and steady-state chunk size separately.
+- [ ] Tune `codec_chunk_frames` and `codec_left_context_frames` against TTFT, chunk latency, E2E, and quality.
+- [ ] Evaluate static-buffer ACL Graph capture for supported exact shapes.
+- [ ] Keep an eager fallback for unsupported dynamic shapes.
+- [ ] Measure batching gains against queue delay and tail latency.
+
+Acceptance:
+
+- [ ] Throughput improves without unacceptable TTFT/chunk p95 regression.
+- [ ] All chunk boundaries, terminal flushes, and request caches remain correct.
+
+### P1-4 Remove the Thinker NPU Batch Workaround
+
+- [ ] Reproduce why the current NPU path squeezes batched inputs.
+- [ ] Align Thinker input shapes with the active vLLM-Ascend runner contract.
+- [ ] Validate multimodal positions, embeddings, and hidden-state shapes for batch size greater than one.
+- [ ] Add NPU-specific batch tests instead of retaining an undocumented shape conversion.
+
+Acceptance:
+
+- [ ] Batched Thinker requests run without the temporary workaround.
+- [ ] TTFT, correctness, and multimodal outputs remain stable at concurrency greater than one.
+
+### P1-5 Tune Deployment and Concurrency
+
+- [ ] Test official-card stage placement candidates.
+- [ ] Tune per-stage memory utilization and leave measured runtime headroom.
+- [ ] Tune `max_num_seqs`, `max_num_batched_tokens`, request admission, and timeouts.
+- [ ] Compare colocated and separated Thinker/Talker/Code2Wav layouts if multiple NPUs are allowed.
+- [ ] Measure inter-stage transport, queue wait, HCCL cost, and process contention.
+- [ ] Run a long-duration stability test at the target concurrent-session count.
+
+Acceptance:
+
+- [ ] The selected layout is Pareto-competitive for latency, throughput, memory, and stability.
+- [ ] No stage OOM, starvation, cache leak, or request timeout appears in the stability run.
+
+### P1-6 Add Competition Observability
+
+- [ ] Emit per-stage queue, compute, transfer, and output timing.
+- [ ] Emit per-request first-text, first-codec, first-audio, and completion timestamps.
+- [ ] Track chunk count, size, cadence, and underrun/jitter indicators.
+- [ ] Track actual execution batch size rather than request-scoped placeholders.
+- [ ] Collect NPU utilization, HBM, host memory, error count, and restart count.
+- [ ] Add a report generator for baseline-versus-candidate comparisons.
+
+Acceptance:
+
+- [ ] A global E2E regression can be attributed to a specific stage or queue.
+- [ ] Formal benchmark mode keeps observability overhead low and documented.
+
+## P2: High-Risk Optimizations
+
+Start these only after P0 and the relevant P1 measurement work is complete.
+
+### P2-1 Operator and Kernel Optimization
+
+- [ ] Rank NPU operators by total time and repeated launch count.
+- [ ] Optimize only operators proven hot for official shapes.
+- [ ] Prefer supported CANN/Ascend kernels and platform-local patches.
+- [ ] Add shape, dtype, numerical, effect, and performance validation for every custom kernel.
+
+### P2-2 Quantization and Precision Reduction
+
+- [ ] Confirm official rules and packaging requirements for quantized weights or runtime quantization.
+- [ ] Establish unquantized effect and performance baselines first.
+- [ ] Evaluate Thinker, Talker, and Code2Wav quantization independently.
+- [ ] Measure accuracy, multimodal behavior, speech quality, latency, throughput, and memory.
+- [ ] Reject any candidate that fails the official effect threshold or has inconclusive quality.
+
+### P2-3 Algorithmic Changes
+
+- [ ] Confirm whether altered sampling, speculative methods, approximation, or caching is permitted.
+- [ ] Keep benchmark-specific behavior out of model logic.
+- [ ] Document the mechanism and validate against hidden-distribution risk.
+
+## Submission Deliverables
+
+- [ ] Reproducible source code and configuration.
+- [ ] Environment manifest with versions and checksums.
+- [ ] Server startup, warmup, correctness, benchmark, profiling, and monitoring scripts.
+- [ ] Raw benchmark results and summarized performance report.
+- [ ] Effect/correctness report and reviewable output artifacts.
+- [ ] Deployment and reproduction instructions for the official Ascend environment.
+- [ ] Package-size and runtime-limit checks.
+- [ ] Clean-environment reproduction log.
+- [ ] Known limitations, tradeoffs, and rollback instructions.
+
+## Experiment Record Template
+
+Use one record per candidate:
+
+| Field | Value |
+| --- | --- |
+| Candidate ID | |
+| Git SHA / diff | |
+| Official rules/toolkit version | |
+| Environment and NPU topology | |
+| Model revision and dtype | |
+| Server command | |
+| Benchmark command | |
+| Workload and concurrency | |
+| Hypothesis | |
+| Baseline metrics | |
+| Candidate metrics | |
+| Effect/correctness result | |
+| NPU utilization / peak HBM | |
+| Stability result | |
+| Raw artifact paths | |
+| Decision: keep/reject/investigate | |
+
+## Recommended Execution Order
+
+1. P0-1 official rules and environment.
+2. P0-2 NPU-native Code2Wav.
+3. P0-3 end-to-end Ascend baseline.
+4. P0-4 benchmark harness and P0-5 effect gate.
+5. P1-1 host synchronization and P1-2 Code2Wav dtype/operator work.
+6. P1-3 batching/graph, P1-4 Thinker batch support, and P1-5 topology tuning.
+7. P1-6 observability and repeated baseline validation.
+8. P2 work only when profiling and competition rules justify it.

--- a/requirements/npu.txt
+++ b/requirements/npu.txt
@@ -1,3 +1,4 @@
 -r common.txt
 onnxruntime-cann>=1.23.2
 torchaudio==2.10.0
+stepaudio2-minicpmo==0.1.1

--- a/tests/benchmarks/test_minicpmo_ascend_competition.py
+++ b/tests/benchmarks/test_minicpmo_ascend_competition.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import io
+import json
+import subprocess
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+from benchmarks.competition.minicpmo_ascend.client import (
+    WavAccumulator,
+    build_payload,
+    metric_summary,
+    percentile,
+)
+from benchmarks.competition.minicpmo_ascend.report import _resource_peaks, _write_manifest
+
+
+def _wav_chunk(samples: list[int], sample_rate: int = 24000) -> str:
+    pcm = b"".join(sample.to_bytes(2, "little", signed=True) for sample in samples)
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(pcm)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def test_wav_accumulator_tracks_format_continuity_and_duplicates(tmp_path: Path) -> None:
+    audio = WavAccumulator()
+    audio.append(_wav_chunk([1, 2, 3]))
+    audio.append(_wav_chunk([1, 2, 3]))
+
+    metadata = audio.metadata()
+    assert metadata["chunk_count"] == 2
+    assert metadata["pcm_bytes"] == 12
+    assert metadata["sample_rate_hz"] == 24000
+    assert metadata["adjacent_duplicate_chunks"] == 1
+    assert metadata["boundary_jump_abs_pcm16"] == [2]
+
+    path = tmp_path / "joined.wav"
+    audio.write(path)
+    with wave.open(str(path), "rb") as joined:
+        assert joined.getnframes() == 6
+        assert joined.getframerate() == 24000
+
+
+def test_wav_accumulator_rejects_format_change() -> None:
+    audio = WavAccumulator()
+    audio.append(_wav_chunk([1, 2], sample_rate=24000))
+    with pytest.raises(ValueError, match="audio format changed"):
+        audio.append(_wav_chunk([3, 4], sample_rate=16000))
+
+
+def test_payload_and_metrics_keep_modes_and_failures_separate() -> None:
+    payload = build_payload(
+        model="model",
+        prompt="hello",
+        input_modality="text",
+        media=None,
+        with_audio=False,
+        seed=42,
+        thinker_max_tokens=8,
+        talker_max_tokens=16,
+    )
+    assert payload["modalities"] == ["text"]
+    assert payload["chat_template_kwargs"] == {"use_tts_template": False}
+    assert payload["sampling_params_list"][0]["max_tokens"] == 8
+    assert payload["sampling_params_list"][1]["max_tokens"] == 16
+
+    records = [
+        {"success": True, "first_text_s": 1.0, "e2e_s": 2.0},
+        {"success": True, "first_text_s": 3.0, "e2e_s": 4.0},
+        {"success": False, "first_text_s": 0.01, "e2e_s": 0.02},
+    ]
+    summary = metric_summary(records)
+    assert summary["successful_requests"] == 2
+    assert summary["failed_requests"] == 1
+    assert summary["first_text_s"]["p50"] == 2.0
+    assert summary["e2e_s"]["mean"] == 3.0
+    assert percentile([], 0.95) is None
+
+
+def test_correctness_gate_writes_failure_when_smoke_artifact_is_missing(tmp_path: Path) -> None:
+    output = tmp_path / "gate.json"
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.competition.minicpmo_ascend.correctness_gate",
+            "--smoke-results",
+            str(tmp_path / "missing.json"),
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert process.returncode == 1
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["passed"] is False
+    assert any("cannot load smoke results" in failure for failure in result["failures"])
+
+
+def test_resource_peaks_aggregate_single_card_chips(tmp_path: Path) -> None:
+    resources = {
+        "samples": [
+            {
+                "host_memory_bytes": {"MemTotal": 1000, "MemAvailable": 400},
+                "npu_smi": {
+                    "stdout": "\n".join(
+                        [
+                            "| 0 0 | 0000:9D:00.0 | 72 0 / 0 12000 / 65536 |",
+                            "| 0 1 | 0000:9F:00.0 | 81 0 / 0 13000 / 65536 |",
+                        ]
+                    )
+                },
+            }
+        ]
+    }
+    path = tmp_path / "resources.json"
+    path.write_text(json.dumps(resources), encoding="utf-8")
+
+    assert _resource_peaks(path) == {
+        "aicore_percent": 81,
+        "aggregate_hbm_mib": 25000,
+        "host_memory_bytes": 600,
+        "aggregate_hbm_delta_mib": 0,
+        "host_memory_delta_bytes": 0,
+    }
+
+
+def test_artifact_manifest_is_stable_and_excludes_itself(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a\n", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "b.txt").write_text("b\n", encoding="utf-8")
+    output = tmp_path / "artifact_manifest.sha256"
+
+    _write_manifest(tmp_path, output)
+    first = output.read_text(encoding="utf-8")
+    _write_manifest(tmp_path, output)
+
+    assert output.read_text(encoding="utf-8") == first
+    assert "artifact_manifest.sha256" not in first
+    assert "  a.txt" in first
+    assert "  nested/b.txt" in first

--- a/tests/benchmarks/test_minicpmo_ascend_competition.py
+++ b/tests/benchmarks/test_minicpmo_ascend_competition.py
@@ -13,10 +13,16 @@ import pytest
 from benchmarks.competition.minicpmo_ascend.client import (
     WavAccumulator,
     build_payload,
+    media_url,
     metric_summary,
     percentile,
 )
 from benchmarks.competition.minicpmo_ascend.report import _resource_peaks, _write_manifest
+from benchmarks.competition.minicpmo_ascend.video_mme import (
+    build_official_results,
+    extract_choice,
+    summarize,
+)
 
 
 def _wav_chunk(samples: list[int], sample_rate: int = 24000) -> str:
@@ -83,6 +89,55 @@ def test_payload_and_metrics_keep_modes_and_failures_separate() -> None:
     assert summary["first_text_s"]["p50"] == 2.0
     assert summary["e2e_s"]["mean"] == 3.0
     assert percentile([], 0.95) is None
+
+
+def test_media_url_preserves_explicit_file_uri(tmp_path: Path) -> None:
+    uri = (tmp_path / "large.mp4").as_uri()
+    assert media_url(uri, "video") == uri
+
+
+def test_video_mme_choice_and_summary_match_official_shape() -> None:
+    assert extract_choice("C") == "C"
+    assert extract_choice("Answer: D. Something") == "D"
+    assert extract_choice("I cannot tell") is None
+    items = [
+        {
+            "video_id": "001",
+            "question_id": "001-1",
+            "duration": "short",
+            "domain": "Knowledge",
+            "sub_category": "History",
+            "task_type": "Counting",
+            "question": "Q?",
+            "options": ["A. One", "B. Two", "C. Three", "D. Four"],
+            "gold": "C",
+            "response": "C",
+            "predicted": "C",
+            "correct": True,
+            "success": True,
+        },
+        {
+            "video_id": "001",
+            "question_id": "001-2",
+            "duration": "short",
+            "domain": "Knowledge",
+            "sub_category": "History",
+            "task_type": "Counting",
+            "question": "Q2?",
+            "options": ["A", "B", "C", "D"],
+            "gold": "A",
+            "response": "B",
+            "predicted": "B",
+            "correct": False,
+            "success": True,
+        },
+    ]
+    summary = summarize(items)
+    assert summary["accuracy"] == 0.5
+    assert summary["by_duration"]["short"] == {"correct": 1, "total": 2, "accuracy": 0.5}
+    official = build_official_results(items)
+    assert official[0]["video_id"] == "001"
+    assert [question["response"] for question in official[0]["questions"]] == ["C", "B"]
 
 
 def test_correctness_gate_writes_failure_when_smoke_artifact_is_missing(tmp_path: Path) -> None:

--- a/tests/benchmarks/test_minicpmo_ascend_profile.py
+++ b/tests/benchmarks/test_minicpmo_ascend_profile.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from benchmarks.competition.minicpmo_ascend.profile import service_root
+from benchmarks.competition.minicpmo_ascend.profile_analysis import (
+    analyze_trace_root,
+    compare_reports,
+)
+from benchmarks.competition.minicpmo_ascend.profile_config import build_profile_config
+
+pytestmark = [pytest.mark.core_model, pytest.mark.benchmark, pytest.mark.cpu]
+
+
+def _write_csv(path: Path, fieldnames: list[str], values: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(values)
+
+
+def test_profile_config_targets_only_selected_stages(tmp_path: Path) -> None:
+    config = {"pipeline": "minicpmo_4_5", "stages": [{"stage_id": 0}, {"stage_id": 1}, {"stage_id": 2}]}
+    result = build_profile_config(config, trace_dir=tmp_path / "traces", stages={1, 2})
+
+    assert "profiler_config" not in result["stages"][0]
+    assert result["stages"][1]["profiler_config"]["profiler"] == "torch"
+    assert result["stages"][2]["profiler_config"]["torch_profiler_dir"] == str((tmp_path / "traces").resolve())
+
+
+def test_profile_config_rejects_unknown_stage(tmp_path: Path) -> None:
+    config = {"stages": [{"stage_id": 0}]}
+    try:
+        build_profile_config(config, trace_dir=tmp_path, stages={2})
+    except ValueError as exc:
+        assert "not in deployment config" in str(exc)
+    else:
+        raise AssertionError("unknown profile stage was accepted")
+
+
+def test_service_root_normalizes_v1_suffix() -> None:
+    assert service_root("http://localhost:8099/v1/") == "http://localhost:8099"
+    assert service_root("http://localhost:8099") == "http://localhost:8099"
+
+
+def test_profile_analysis_aggregates_exported_csv(tmp_path: Path) -> None:
+    output = tmp_path / "stage2" / "mindstudio_profiler_output"
+    _write_csv(
+        output / "op_statistic.csv",
+        ["OP Type", "Count", "Total Time(us)"],
+        [
+            {"OP Type": "MatMul", "Count": 2, "Total Time(us)": 300},
+            {"OP Type": "Scatter", "Count": 1, "Total Time(us)": 200},
+        ],
+    )
+    _write_csv(
+        output / "api_statistic.csv",
+        ["API Name", "Count", "Time(us)"],
+        [{"API Name": "aclrtSynchronizeStream", "Count": 2, "Time(us)": 100}],
+    )
+    _write_csv(
+        output / "kernel_details.csv",
+        ["Name", "Duration(us)"],
+        [
+            {"Name": "matmul_kernel", "Duration(us)": 120},
+            {"Name": "tiny_kernel", "Duration(us)": 20},
+        ],
+    )
+    _write_csv(
+        output / "operator_details.csv",
+        ["Name", "Host Self Duration(us)", "Device Self Duration(us)"],
+        [{"Name": "aten::mm", "Host Self Duration(us)": 10, "Device Self Duration(us)": 120}],
+    )
+
+    result = analyze_trace_root(tmp_path)
+
+    assert result["operators"]["calls"] == 3
+    assert result["operators"]["total_us"] == 500
+    assert result["apis"]["top"][0]["name"] == "aclrtSynchronizeStream"
+    assert result["kernels"]["calls"] == 2
+    assert result["kernels"]["small_le_50us_ratio"] == 0.5
+    assert result["torch_operators"]["device_self_total_us"] == 120
+
+    comparison = compare_reports(result, {**result, "kernels": {**result["kernels"], "total_us": 100}})
+    assert comparison["compatible"] is True
+    assert comparison["metrics"]["kernel_time_us"]["delta"] == -40
+
+
+def test_profile_comparison_rejects_mismatched_stage_scope() -> None:
+    common = {
+        "trace_root": "/trace",
+        "operators": {"total_us": 1, "calls": 1},
+        "apis": {"total_us": 1, "calls": 1},
+        "kernels": {"total_us": 1, "calls": 1, "small_le_50us_ratio": 0.0},
+    }
+    result = compare_reports(
+        {**common, "capture": {"profile_stages": [1]}},
+        {**common, "capture": {"profile_stages": [2]}},
+    )
+
+    assert result["compatible"] is False
+    assert result["mismatches"][0]["field"] == "profile_stages"

--- a/tests/benchmarks/test_minicpmo_ascend_public_benchmark.py
+++ b/tests/benchmarks/test_minicpmo_ascend_public_benchmark.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+
+import pytest
+
+from benchmarks.competition.minicpmo_ascend.build_public_benchmark import (
+    _length_bins,
+    _load_seed_rows,
+    select_hierarchical,
+    select_stratified,
+)
+from benchmarks.competition.minicpmo_ascend.summarize_public_benchmark import (
+    render_report,
+    summarize_video_timing,
+)
+
+
+def test_select_stratified_is_deterministic_balanced_and_unique() -> None:
+    rows = [
+        {"id": f"{group}-{index}", "media": f"media-{index}", "group": group}
+        for group in ("a", "b", "c")
+        for index in range(8)
+    ]
+    first = select_stratified(
+        rows,
+        count=6,
+        seed=42,
+        stratum_key=lambda row: row["group"],
+        unique_key=lambda row: row["media"],
+    )
+    second = select_stratified(
+        rows,
+        count=6,
+        seed=42,
+        stratum_key=lambda row: row["group"],
+        unique_key=lambda row: row["media"],
+    )
+    assert [row["id"] for row in first] == [row["id"] for row in second]
+    assert len({row["media"] for row in first}) == 6
+    assert {row["group"] for row in first} == {"a", "b", "c"}
+
+
+def test_seed_rows_filter_missing_audio_and_support_length_bins(tmp_path: Path) -> None:
+    locale_root = tmp_path / "en"
+    prompt_root = locale_root / "prompt-wavs"
+    prompt_root.mkdir(parents=True)
+    (prompt_root / "present.wav").write_bytes(b"RIFF")
+    (locale_root / "meta.lst").write_text(
+        "one|prompt|prompt-wavs/present.wav|short\n"
+        "two|prompt|prompt-wavs/missing.wav|this row is unavailable\n"
+        "three|prompt|prompt-wavs/present.wav|a substantially longer target sentence\n",
+        encoding="utf-8",
+    )
+    rows = _load_seed_rows(tmp_path, "en")
+    thresholds, length_bin = _length_bins(rows)
+    assert [row["utterance_id"] for row in rows] == ["one", "three"]
+    assert len(thresholds) == 3
+    assert length_bin(rows[0]) < length_bin(rows[1])
+
+
+def test_select_hierarchical_balances_primary_groups_first() -> None:
+    rows = [
+        {"id": f"{duration}-{domain}-{index}", "duration": duration, "domain": domain}
+        for duration in ("short", "long")
+        for domain in ("knowledge", "sports", "film")
+        for index in range(4)
+    ]
+    selected = select_hierarchical(
+        rows,
+        count=10,
+        seed=42,
+        primary_key=lambda row: row["duration"],
+        secondary_key=lambda row: row["domain"],
+        unique_key=lambda row: row["id"],
+    )
+    assert sum(row["duration"] == "short" for row in selected) == 5
+    assert sum(row["duration"] == "long" for row in selected) == 5
+    assert {row["domain"] for row in selected} == {"knowledge", "sports", "film"}
+
+
+def test_summarize_video_timing_includes_percentiles_and_wall_throughput() -> None:
+    items = [
+        {
+            "success": True,
+            "started_at": "2026-08-04T00:00:00+00:00",
+            "first_event_s": 1.0,
+            "first_text_s": 1.5,
+            "first_audio_s": None,
+            "e2e_s": 2.0,
+            "audio_chunk_intervals_s": [],
+        },
+        {
+            "success": True,
+            "started_at": "2026-08-04T00:00:02+00:00",
+            "first_event_s": 2.0,
+            "first_text_s": 2.5,
+            "first_audio_s": None,
+            "e2e_s": 3.0,
+            "audio_chunk_intervals_s": [],
+        },
+    ]
+    summary = summarize_video_timing(items)
+    assert summary["duration_s"] == 5.0
+    assert summary["request_throughput"] == 0.4
+    assert summary["first_text_s"]["p50"] == 2.0
+    assert summary["e2e_s"]["p99"] == pytest.approx(2.99)
+
+
+def test_render_report_labels_proxy_scope() -> None:
+    summary = {
+        "source_revision": "abc123",
+        "sample_seed": 42,
+        "totals": {"samples": 4, "completed": 4, "failed": 0},
+        "workloads": {
+            "daily_omni": {
+                "samples": 1,
+                "correct": 1,
+                "evaluated": 1,
+                "accuracy": 1.0,
+                "request_throughput": 1.0,
+                "timing_ms": {"first_response_p50": 1.0, "e2e_p50": 2.0},
+                "by_duration": {"30s": {"correct": 1, "total": 1}},
+            },
+            "seed_tts_en": {
+                "samples": 1,
+                "audio_throughput": 1.0,
+                "generated_audio_s": 2.0,
+                "timing_ms": {"first_response_p50": 1.0, "e2e_p50": 2.0},
+            },
+            "seed_tts_zh": {
+                "samples": 1,
+                "audio_throughput": 1.0,
+                "generated_audio_s": 2.0,
+                "timing_ms": {"first_response_p50": 1.0, "e2e_p50": 2.0},
+            },
+            "video_mme": {
+                "samples": 1,
+                "correct": 1,
+                "evaluated": 1,
+                "accuracy": 1.0,
+                "request_throughput": 1.0,
+                "timing_s": {"first_text": {"p50": 1.0}, "e2e": {"p50": 2.0}},
+                "by_duration": {"short": {"correct": 1, "total": 1, "accuracy": 1.0}},
+            },
+        },
+    }
+    report = render_report(summary)
+    assert "not an official competition benchmark or score" in report
+    assert "WER not run in this 100-sample pass" in report

--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -61,6 +61,8 @@ def _run_resumable_segment_stop(
     session: Request,
     *,
     session_finished: bool = False,
+    stop_segment: bool = True,
+    chunk_transfer_adapter=None,
 ):
     sched = MagicMock()
     sched.requests = {session.request_id: session}
@@ -68,18 +70,20 @@ def _run_resumable_segment_stop(
     sched.structured_output_manager.should_advance.return_value = False
 
     def stop_request(request: Request, _token_ids: list[int]):
-        request.status = RequestStatus.FINISHED_STOPPED
-        return [42], True
+        if stop_segment:
+            request.status = RequestStatus.FINISHED_STOPPED
+        return [42], stop_segment
 
     sched._update_request_with_output.side_effect = stop_request
     sched._handle_stopped_request.return_value = session_finished
-    sched.chunk_transfer_adapter = None
+    sched.chunk_transfer_adapter = chunk_transfer_adapter
     sched.running = [session]
     sched.waiting_for_transfer_free = set()
     sched.transfer_triggered_requests = set()
     sched.active_kv_transfers = set()
     sched.pending_stop_after_extraction = set()
     sched.connector = None
+    sched._free_request.return_value = None
     sched.kv_cache_manager.take_events.return_value = None
     sched.finished_req_ids_dict = {}
     sched.make_stats.return_value = None

--- a/tests/core/sched/test_omni_scheduler_utils.py
+++ b/tests/core/sched/test_omni_scheduler_utils.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_omni.core.sched.utils import split_free_request_result
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_split_free_request_result_supports_old_and_new_vllm_contracts():
+    kv = {"kv": "ready"}
+    ec = {"ec": "ready"}
+
+    assert split_free_request_result(None) == (None, None)
+    assert split_free_request_result(kv) == (kv, None)
+    assert split_free_request_result((kv, ec)) == (kv, ec)
+
+
+@pytest.mark.parametrize("result", [([], None), (None, []), [None, None]])
+def test_split_free_request_result_rejects_non_mapping_wire_values(result):
+    with pytest.raises(TypeError):
+        split_free_request_result(result)

--- a/tests/engine/test_engine_core_output_compat.py
+++ b/tests/engine/test_engine_core_output_compat.py
@@ -1,0 +1,12 @@
+from vllm_omni.engine import OmniEngineCoreOutput
+
+
+def test_engine_core_output_accepts_ec_transfer_params() -> None:
+    transfer = {"connector": "test"}
+    output = OmniEngineCoreOutput(
+        request_id="request-0",
+        new_token_ids=[],
+        ec_transfer_params=transfer,
+    )
+
+    assert output.ec_transfer_params == transfer

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -5,6 +7,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from vllm_omni.model_executor.models.minicpmo_4_5 import minicpmo_4_5_code2wav
 from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
     BatchedToken2Wav,
 )
@@ -682,6 +685,79 @@ def test_cleanup_uses_generation_runner_internal_request_ids():
     model.on_requests_finished(["internal-a"])
 
     assert set(model._states) == {"internal-b"}
+
+
+def test_npu_load_weights_uses_in_tree_token2wav(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    token2wav_path = model_path / "assets" / "token2wav"
+    token2wav_path.mkdir(parents=True)
+    prompt_wav = model_path / "assets" / "HT_ref_audio.wav"
+    prompt_wav.touch()
+    constructed = {}
+
+    class _FakeNPUToken2Wav(_FakeToken2Wav):
+        def __init__(self, path, *, float16, n_timesteps, device, dtype):
+            super().__init__()
+            constructed.update(
+                path=path,
+                float16=float16,
+                n_timesteps=n_timesteps,
+                device=device,
+                dtype=dtype,
+            )
+
+    config = _config()
+    config.model_config.model = str(model_path)
+    config.model_config.stage_connector_config["extra"]["prompt_wav"] = str(prompt_wav)
+    monkeypatch.setattr(minicpmo_4_5_code2wav.current_omni_platform, "is_npu", lambda: True)
+    monkeypatch.setattr(minicpmo_4_5_code2wav.current_omni_platform, "get_torch_device", lambda: "npu:0")
+    module_name = "vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_token2wav"
+    fake_module = types.ModuleType(module_name)
+    fake_module.MiniCPMO45Token2wav = _FakeNPUToken2Wav
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    model = MiniCPMO45Code2Wav(vllm_config=config)
+    model.load_weights(iter(()))
+
+    assert constructed == {
+        "path": str(token2wav_path),
+        "float16": False,
+        "n_timesteps": 10,
+        "device": "npu:0",
+        "dtype": "float32",
+    }
+    assert isinstance(model.backend, BatchedToken2Wav)
+
+
+def test_npu_load_weights_accepts_bf16_autocast(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    (model_path / "assets" / "token2wav").mkdir(parents=True)
+    prompt_wav = model_path / "assets" / "HT_ref_audio.wav"
+    prompt_wav.touch()
+    constructed = {}
+
+    class _FakeNPUToken2Wav(_FakeToken2Wav):
+        def __init__(self, path, *, float16, n_timesteps, device, dtype):
+            super().__init__()
+            self.autocast_dtype = torch.bfloat16
+            constructed.update(float16=float16, dtype=dtype)
+
+    config = _config()
+    config.model_config.model = str(model_path)
+    extra = config.model_config.stage_connector_config["extra"]
+    extra.update(prompt_wav=str(prompt_wav), token2wav_dtype="bf16")
+    monkeypatch.setattr(minicpmo_4_5_code2wav.current_omni_platform, "is_npu", lambda: True)
+    monkeypatch.setattr(minicpmo_4_5_code2wav.current_omni_platform, "get_torch_device", lambda: "npu:0")
+    module_name = "vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_token2wav"
+    fake_module = types.ModuleType(module_name)
+    fake_module.MiniCPMO45Token2wav = _FakeNPUToken2Wav
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    model = MiniCPMO45Code2Wav(vllm_config=config)
+    model.load_weights(iter(()))
+
+    assert constructed == {"float16": False, "dtype": "bfloat16"}
+    assert model.backend.autocast_dtype is torch.bfloat16
 
 
 def test_reference_voice_and_duplex_metadata_follow_request_lifecycle():

--- a/tests/platforms/npu/test_cosyvoice2_dit_attn.py
+++ b/tests/platforms/npu/test_cosyvoice2_dit_attn.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU unit tests for CosyVoice2 DiT Ascend patches."""
+
+import pytest
+import torch
+
+from vllm_omni.platforms.npu.models import cosyvoice2_dit_attn
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_fused_residual_matches_unfused_formula() -> None:
+    x = torch.randn(2, 5, 8)
+    gate = torch.randn(2, 1, 8)
+    branch = torch.randn_like(x)
+
+    expected = x + gate * branch
+    actual = cosyvoice2_dit_attn._fused_residual(x, gate, branch)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("value", ["0", "false", "OFF", "no"])
+def test_fused_gated_residual_switch_disables_known_false_values(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("VLLM_OMNI_MINICPMO_FUSED_GATED_RESIDUAL", value)
+    assert not cosyvoice2_dit_attn._fused_gated_residual_enabled()

--- a/tests/platforms/npu/test_step_audio2_token2wav.py
+++ b/tests/platforms/npu/test_step_audio2_token2wav.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import types
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -194,3 +195,28 @@ def test_hift_patch_reports_incompatible_layout(monkeypatch: pytest.MonkeyPatch)
 
     with pytest.raises(TypeError, match=r"m_source\.l_sin_gen\._f02sine"):
         module.patch_step_audio2_hift_for_npu(SimpleNamespace())
+
+
+def test_sdpa_context_does_not_catch_inference_body_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_patch_module(monkeypatch)
+    events = []
+    fake_module = types.ModuleType("vllm_omni.platforms.npu.models.cosyvoice2_dit_attn")
+
+    @contextmanager
+    def fake_math_context():
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    fake_module.apply_cosyvoice2_dit_attn_npu_patch = lambda: events.append("patch")
+    fake_module.npu_math_sdpa_context = fake_math_context
+    monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
+
+    with pytest.raises(RuntimeError, match="inference failed"):
+        with module.npu_token2wav_sdpa_context():
+            events.append("body")
+            raise RuntimeError("inference failed")
+
+    assert events == ["patch", "enter", "body", "exit"]

--- a/tests/platforms/npu/test_worker_compat.py
+++ b/tests/platforms/npu/test_worker_compat.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.platforms.npu.worker.compat import async_exponential_enabled, profiling_chunk_enabled
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (SimpleNamespace(), False),
+        (SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=True)), True),
+        (
+            SimpleNamespace(
+                scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=True)),
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=False)),
+                profiling_chunk_config=SimpleNamespace(enabled=True),
+            ),
+            False,
+        ),
+    ],
+)
+def test_profiling_chunk_enabled_supports_old_and_new_layouts(config, expected):
+    assert profiling_chunk_enabled(config) is expected
+
+
+def test_async_exponential_defaults_off_but_preserves_legacy_flag():
+    assert async_exponential_enabled(SimpleNamespace()) is False
+    assert async_exponential_enabled(SimpleNamespace(enable_async_exponential=True)) is True

--- a/vllm_omni/benchmarks/data_modules/daily_omni_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/daily_omni_dataset.py
@@ -1029,27 +1029,58 @@ class DailyOmniDataset(BenchmarkDataset):
     ) -> tuple[list[Any], list[Any]]:
         """Port of MiniCPM ``get_video_frame_audio_segments`` (stack_frames=1, 1fps)."""
         import numpy as np
-        from decord import VideoReader, cpu
         from PIL import Image
         from vllm.multimodal.media.audio import load_audio
 
-        vr = VideoReader(str(video_path), ctx=cpu(0))
-        avg_fps = float(vr.get_avg_fps()) or 1.0
-        duration = len(vr) / avg_fps
+        try:
+            from decord import VideoReader, cpu
+
+            vr = VideoReader(str(video_path), ctx=cpu(0))
+            frame_count = len(vr)
+            avg_fps = float(vr.get_avg_fps()) or 1.0
+
+            def read_frames(indices: list[int]) -> Any:
+                return vr.get_batch(indices).asnumpy()
+
+        except ModuleNotFoundError:
+            import cv2
+
+            capture = cv2.VideoCapture(str(video_path))
+            if not capture.isOpened():
+                raise RuntimeError(f"OpenCV could not open Daily-Omni video: {video_path}")
+            frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+            avg_fps = float(capture.get(cv2.CAP_PROP_FPS)) or 1.0
+
+            def read_frames(indices: list[int]) -> Any:
+                decoded = []
+                try:
+                    for index in indices:
+                        capture.set(cv2.CAP_PROP_POS_FRAMES, index)
+                        ok, frame = capture.read()
+                        if not ok:
+                            raise RuntimeError(f"OpenCV failed to decode frame {index} from {video_path}")
+                        decoded.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+                finally:
+                    capture.release()
+                return np.stack(decoded)
+
+        if frame_count <= 0:
+            raise RuntimeError(f"Daily-Omni video contains no frames: {video_path}")
+        duration = frame_count / avg_fps
         num_seconds = max(1, int(math.ceil(duration)))
         second_timestamps = list(range(num_seconds))
 
         if duration > max_num_frames:
             timestamps = [round(i * 0.1, 1) for i in range(int(duration / 0.1))]
-            frame_idx = [min(int(ts * avg_fps), len(vr) - 1) for ts in timestamps]
+            frame_idx = [min(int(ts * avg_fps), frame_count - 1) for ts in timestamps]
             pick = _uniform_sample_indices(len(frame_idx), max_num_frames)
             frame_idx = [frame_idx[i] for i in pick]
             timestamps = [timestamps[i] for i in pick]
         else:
-            frame_idx = [min(int(i * avg_fps), len(vr) - 1) for i in range(num_seconds)]
+            frame_idx = [min(int(i * avg_fps), frame_count - 1) for i in range(num_seconds)]
             timestamps = second_timestamps
 
-        video = vr.get_batch(frame_idx).asnumpy()
+        video = read_frames(frame_idx)
         frames = [Image.fromarray(v.astype("uint8")).convert("RGB") for v in video]
 
         audio_segments: list[Any] = []
@@ -1093,7 +1124,7 @@ class DailyOmniDataset(BenchmarkDataset):
         """
         if choice is None:
             return ""
-        if isinstance(choice, (list, tuple)):
+        if isinstance(choice, list | tuple):
             lines = [str(x).strip() for x in choice if str(x).strip()]
             return "\n".join(lines)
         if isinstance(choice, dict):

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -24,7 +24,7 @@ from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
     uses_full_payload_input_coordinator,
 )
-from vllm_omni.core.sched.utils import omni_routed_experts_for_request
+from vllm_omni.core.sched.utils import omni_routed_experts_for_request, split_free_request_result
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
@@ -383,14 +383,15 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self._free_encoder_inputs(request)
 
             stopped = False
-            is_segment_finished = False
             finished = False
+            is_segment_finished = False
             new_logprobs = None
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             mm_output = mm_outputs[req_index] if mm_outputs else None
             inter_stage_output = inter_stage_outputs[req_index] if inter_stage_outputs else None
             kv_transfer_params = None
+            ec_transfer_params = None
             status_before_stop = request.status
             finish_reason = None
             routed_experts = None
@@ -451,7 +452,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     request.spec_token_ids = []
                     request._output_token_ids.clear()
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    kv_transfer_params, ec_transfer_params = split_free_request_result(self._free_request(request))
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
                 elif status_before_stop == RequestStatus.WAITING_FOR_CHUNK:
@@ -486,6 +487,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -29,7 +29,7 @@ from vllm_omni.core.sched.omni_scheduling_coordinator import (
     uses_full_payload_input_coordinator,
 )
 from vllm_omni.core.sched.output import OmniCachedRequestData, OmniNewRequestData
-from vllm_omni.core.sched.utils import omni_routed_experts_for_request
+from vllm_omni.core.sched.utils import omni_routed_experts_for_request, split_free_request_result
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
@@ -491,6 +491,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             new_logprobs = None
             new_token_ids = generated_token_ids
             kv_transfer_params = None
+            ec_transfer_params = None
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             mm_output = mm_outputs[req_index] if mm_outputs else None
             status_before_stop = request.status
@@ -525,7 +526,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     if self.chunk_transfer_adapter:
                         self.chunk_transfer_adapter.segment_finished_requests.discard(req_id)
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    kv_transfer_params, ec_transfer_params = split_free_request_result(self._free_request(request))
                     if self.chunk_transfer_adapter is not None:
                         self.chunk_transfer_adapter.cleanup(
                             request.request_id,
@@ -570,6 +571,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
@@ -590,8 +592,9 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             finished = self._handle_stopped_request(request)
             is_segment_finished = not finished
             kv_transfer_params = None
+            ec_transfer_params = None
             if finished:
-                kv_transfer_params = self._free_request(request)
+                kv_transfer_params, ec_transfer_params = split_free_request_result(self._free_request(request))
                 if self.chunk_transfer_adapter is not None:
                     self.chunk_transfer_adapter.cleanup(
                         request.request_id,
@@ -605,6 +608,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     stop_reason=request.stop_reason,
                     events=request.take_events(),
                     kv_transfer_params=kv_transfer_params,
+                    ec_transfer_params=ec_transfer_params,
                     trace_headers=request.trace_headers,
                     is_segment_finished=is_segment_finished,
                 )

--- a/vllm_omni/core/sched/utils.py
+++ b/vllm_omni/core/sched/utils.py
@@ -2,8 +2,26 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Shared utilities for omni schedulers."""
 
+from typing import Any
+
 import numpy as np
 from vllm.v1.outputs import RoutedExpertsLists
+
+
+def split_free_request_result(
+    result: Any,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Normalize old KV-only and new KV/EC scheduler cleanup results."""
+    if result is None or isinstance(result, dict):
+        return result, None
+    if isinstance(result, tuple) and len(result) == 2:
+        kv_transfer_params, ec_transfer_params = result
+        if kv_transfer_params is not None and not isinstance(kv_transfer_params, dict):
+            raise TypeError("_free_request KV transfer params must be a dict or None")
+        if ec_transfer_params is not None and not isinstance(ec_transfer_params, dict):
+            raise TypeError("_free_request EC transfer params must be a dict or None")
+        return kv_transfer_params, ec_transfer_params
+    raise TypeError(f"unsupported _free_request result: {type(result).__name__}")
 
 
 def omni_routed_experts_for_request(routed_experts: RoutedExpertsLists, request) -> np.ndarray | None:

--- a/vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_ascend_910c_1card.yaml
@@ -1,0 +1,78 @@
+# MiniCPM-o 4.5 deployment for one Ascend 910C card with two 64 GiB chips.
+# Device IDs 0 and 1 are logical chips on the same physical card (NPU ID 0).
+pipeline: minicpmo_4_5
+async_chunk: true
+
+trust_remote_code: true
+enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      codec_chunk_frames: 25
+      codec_left_context_frames: 3
+      code2wav_min_batch_size: 1
+      token2wav_dtype: float32
+      token2wav_n_timesteps: 10
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.90
+    enforce_eager: false
+    tensor_parallel_size: 1
+    max_num_batched_tokens: 8192
+    devices: "0"
+    limit_mm_per_prompt:
+      video: 1
+    compilation_config:
+      cudagraph_mode: PIECEWISE
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: true
+      repetition_penalty: 1.1
+
+  - stage_id: 1
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.55
+    enforce_eager: false
+    max_num_batched_tokens: 8192
+    devices: "1"
+    compilation_config:
+      cudagraph_mode: PIECEWISE
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      min_tokens: 50
+      max_tokens: 2048
+      stop_token_ids: [1]
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.35
+    enforce_eager: true
+    enable_chunked_prefill: false
+    max_num_batched_tokens: 65536
+    max_model_len: 65536
+    devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: true

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -124,15 +124,27 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         )
 
 
-class OmniEngineCoreOutput(EngineCoreOutput):
-    # Dedicated channel for multimodal outputs (image/audio/latent).
-    # pooling_output is inherited from EngineCoreOutput as torch.Tensor | None
-    # and retains its original vLLM semantics for pooling/embedding tasks.
-    multimodal_output: dict[str, torch.Tensor] | None = None
-    # Finished flag for streaming input segment
-    is_segment_finished: bool | None = False
-    # Streaming update prompt length
-    new_prompt_len_snapshot: int | None = None
+if "ec_transfer_params" in getattr(EngineCoreOutput, "__struct_fields__", ()):
+
+    class OmniEngineCoreOutput(EngineCoreOutput):
+        # Dedicated channel for multimodal outputs (image/audio/latent).
+        # pooling_output is inherited from EngineCoreOutput as torch.Tensor | None
+        # and retains its original vLLM semantics for pooling/embedding tasks.
+        multimodal_output: dict[str, torch.Tensor] | None = None
+        # Finished flag for streaming input segment
+        is_segment_finished: bool | None = False
+        # Streaming update prompt length
+        new_prompt_len_snapshot: int | None = None
+
+else:
+
+    class OmniEngineCoreOutput(EngineCoreOutput):
+        # vLLM added this transfer channel after the competition image's pinned
+        # revision. Keep the wire shape available on both sides of that change.
+        ec_transfer_params: dict[str, Any] | None = None
+        multimodal_output: dict[str, torch.Tensor] | None = None
+        is_segment_finished: bool | None = False
+        new_prompt_len_snapshot: int | None = None
 
 
 class OmniEngineCoreOutputs(EngineCoreOutputs):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -627,7 +627,7 @@ class Orchestrator:
                     self._shutdown_event.wait(),
                     timeout=self._duplex_reaper_interval_s,
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 plane = self.duplex_control_plane
                 if plane is not None:
                     try:
@@ -1528,7 +1528,7 @@ class Orchestrator:
                 value = value.detach().cpu().reshape(-1).tolist()
             except Exception:
                 return []
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, list | tuple):
             return []
         out: list[int] = []
         for item in value:

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -66,6 +66,16 @@ class BatchedToken2Wav(nn.Module):
         self.flow = token2wav.flow
         self.hift = token2wav.hift
         self.float16 = bool(token2wav.float16)
+        self.autocast_dtype = getattr(
+            token2wav,
+            "autocast_dtype",
+            torch.float16 if self.float16 else None,
+        )
+        if self.autocast_dtype not in (None, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "MiniCPM-o Token2Wav autocast_dtype must be float16, "
+                f"bfloat16, or None, got {self.autocast_dtype}"
+            )
         self.n_timesteps = int(token2wav.n_timesteps)
         self.mel_cache_len = int(token2wav.mel_cache_len)
         self.source_cache_len = int(token2wav.source_cache_len)
@@ -111,14 +121,25 @@ class BatchedToken2Wav(nn.Module):
         )
 
     def _autocast(self, device: torch.device):
-        if device.type != "cuda":
+        if self.autocast_dtype is None:
+            return _autocast_disabled(device)
+        try:
+            return torch.autocast(
+                device_type=device.type,
+                dtype=self.autocast_dtype,
+            )
+        except (RuntimeError, TypeError, ValueError):
             return nullcontext()
-        if not self.float16:
-            return torch.amp.autocast("cuda", enabled=False)
-        return torch.amp.autocast(
-            "cuda",
-            dtype=torch.float16,
+
+    @staticmethod
+    def _execution_context(device: torch.device):
+        if device.type != "npu":
+            return nullcontext()
+        from vllm_omni.platforms.npu.models.step_audio2_token2wav import (
+            npu_token2wav_sdpa_context,
         )
+
+        return npu_token2wav_sdpa_context()
 
     def _pre_lookahead_len(self) -> int | None:
         """Right-context width of the encoder's pre-lookahead convolution.
@@ -307,7 +328,7 @@ class BatchedToken2Wav(nn.Module):
             (batch_size, 3 if lookahead_width is None else lookahead_width),
             _SILENCE_TOKEN,
         )
-        with self._autocast(prompt_tokens.device):
+        with self._execution_context(prompt_tokens.device), self._autocast(prompt_tokens.device):
             hidden, conformer_cnn, conformer_att = self._encode_chunk(
                 torch.cat((prompt_tokens, lookahead), dim=1),
                 last_chunk=False,
@@ -387,7 +408,7 @@ class BatchedToken2Wav(nn.Module):
                 )
         flow_cache = self._stack_flow_cache(states)
         speakers = features.speaker_embedding.expand(batch_size, -1)
-        with self._autocast(tokens.device):
+        with self._execution_context(tokens.device), self._autocast(tokens.device):
             hidden, conformer_cnn, conformer_att = self._encode_chunk(
                 tokens,
                 last_chunk=last_chunk or flush_encoder,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -20,6 +20,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
 from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.platforms import current_omni_platform
 
 from .batched_token2wav import (
     BatchedToken2Wav,
@@ -30,6 +31,30 @@ from .batched_token2wav import (
 logger = init_logger(__name__)
 
 
+def _token2wav_dtype(extra: Mapping[str, Any]) -> str:
+    configured = extra.get("token2wav_dtype")
+    legacy_float16 = bool(extra.get("token2wav_float16", False))
+    if configured is None:
+        return "float16" if legacy_float16 else "float32"
+    aliases = {
+        "fp32": "float32",
+        "float32": "float32",
+        "fp16": "float16",
+        "float16": "float16",
+        "bf16": "bfloat16",
+        "bfloat16": "bfloat16",
+    }
+    normalized = aliases.get(str(configured).lower())
+    if normalized is None:
+        raise ValueError(
+            "MiniCPM-o Code2Wav token2wav_dtype must be fp32, fp16, or "
+            f"bf16, got {configured!r}"
+        )
+    if legacy_float16 and normalized != "float16":
+        raise ValueError("token2wav_float16=True conflicts with token2wav_dtype")
+    return normalized
+
+
 def _batch_error(reason: str, **details: Any) -> RuntimeError:
     payload = {"reason": reason, **details}
     return RuntimeError(f"MiniCPMO45Code2WavBatchError {json.dumps(payload, sort_keys=True)}")
@@ -38,7 +63,7 @@ def _batch_error(reason: str, **details: Any) -> RuntimeError:
 def _scalar(value: Any, default: Any = None) -> Any:
     if isinstance(value, torch.Tensor):
         return value.reshape(-1)[0].item() if value.numel() else default
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
         return _scalar(value[0], default) if value else default
     return default if value is None else value
 
@@ -46,7 +71,7 @@ def _scalar(value: Any, default: Any = None) -> Any:
 def _codec_tensor(value: Any, fallback: torch.Tensor) -> torch.Tensor:
     if isinstance(value, torch.Tensor):
         return value.reshape(-1).to(device=fallback.device, dtype=torch.long)
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
         return torch.as_tensor(value, device=fallback.device, dtype=torch.long).reshape(-1)
     return fallback.reshape(-1).to(dtype=torch.long)
 
@@ -305,7 +330,7 @@ class MiniCPMO45Code2Wav(nn.Module):
         flat = input_ids.reshape(-1)
         if counts is None:
             return [flat]
-        if not isinstance(counts, Sequence) or isinstance(counts, (str, bytes, bytearray)):
+        if not isinstance(counts, Sequence) or isinstance(counts, str | bytes | bytearray):
             raise _batch_error("invalid_seq_token_counts", value_type=type(counts).__name__)
         normalized = [int(value) for value in counts]
         if any(value < 0 for value in normalized):
@@ -740,8 +765,6 @@ class MiniCPMO45Code2Wav(nn.Module):
         if self.backend is not None:
             return
 
-        from vllm_omni.platforms import current_omni_platform
-
         if current_omni_platform.is_npu():
             # NPU/Ascend: the external `stepaudio2` package hard-codes `.cuda()`,
             # so use the in-tree NPU-aware adapter instead. It delegates to
@@ -761,18 +784,25 @@ class MiniCPMO45Code2Wav(nn.Module):
         token2wav_path = model_root / "assets" / "token2wav"
         if not token2wav_path.is_dir():
             raise FileNotFoundError(f"MiniCPM-o Code2Wav assets not found: {token2wav_path}")
-        use_float16 = bool(extra.get("token2wav_float16", False))
+        token2wav_dtype = _token2wav_dtype(extra)
+        use_float16 = token2wav_dtype == "float16"
+        is_npu = current_omni_platform.is_npu()
+        if token2wav_dtype == "bfloat16" and not is_npu:
+            raise ValueError("the external GPU Token2Wav backend does not support token2wav_dtype=bf16")
         previous_dtype = torch.get_default_dtype()
         try:
             # vLLM constructs bf16 models under a bf16 default-dtype context.
             # Token2wav contains fp32-only S3Tokenizer/HiFT modules, so build
             # its independent assets in their native precision.
             torch.set_default_dtype(torch.float32)
-            token2wav = Token2wav(
-                str(token2wav_path),
-                float16=use_float16,
-                n_timesteps=int(extra.get("token2wav_n_timesteps", 10)),
-            )
+            kwargs: dict[str, Any] = {
+                "float16": use_float16,
+                "n_timesteps": int(extra.get("token2wav_n_timesteps", 10)),
+            }
+            if is_npu:
+                kwargs["device"] = current_omni_platform.get_torch_device()
+                kwargs["dtype"] = token2wav_dtype
+            token2wav = Token2wav(str(token2wav_path), **kwargs)
         finally:
             torch.set_default_dtype(previous_dtype)
         self.backend = BatchedToken2Wav(token2wav)

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_token2wav.py
@@ -46,6 +46,41 @@ def _resolve_device(device: str | torch.device | None) -> str:
     return "cpu"
 
 
+def _resolve_autocast_dtype(
+    dtype: str | torch.dtype | None,
+    *,
+    float16: bool,
+) -> torch.dtype | None:
+    if dtype is None:
+        return torch.float16 if float16 else None
+    if isinstance(dtype, torch.dtype):
+        resolved = dtype
+    else:
+        aliases = {
+            "float32": None,
+            "fp32": None,
+            "float16": torch.float16,
+            "fp16": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "bf16": torch.bfloat16,
+        }
+        key = str(dtype).lower()
+        if key not in aliases:
+            raise ValueError(
+                "MiniCPM-o Token2Wav dtype must be one of "
+                f"fp32, fp16, or bf16, got {dtype!r}"
+            )
+        resolved = aliases[key]
+    if resolved not in (None, torch.float16, torch.bfloat16):
+        raise ValueError(
+            "MiniCPM-o Token2Wav dtype must resolve to float32, "
+            f"float16, or bfloat16, got {resolved}"
+        )
+    if float16 and resolved is not torch.float16:
+        raise ValueError("float16=True conflicts with a non-fp16 Token2Wav dtype")
+    return resolved
+
+
 class MiniCPMO45Token2wav:
     """Token2wav-compatible facade around ``StepAudio2Token2WavCore``.
 
@@ -64,8 +99,10 @@ class MiniCPMO45Token2wav:
         float16: bool = False,
         n_timesteps: int = 10,
         device: str | torch.device | None = None,
+        dtype: str | torch.dtype | None = None,
     ):
-        self.float16 = float16
+        self.autocast_dtype = _resolve_autocast_dtype(dtype, float16=float16)
+        self.float16 = self.autocast_dtype is torch.float16
         self.n_timesteps = n_timesteps
         self.device = _resolve_device(device)
         self._core = StepAudio2Token2WavCore(

--- a/vllm_omni/model_executor/models/step_audio2/step_audio2_token2wav.py
+++ b/vllm_omni/model_executor/models/step_audio2/step_audio2_token2wav.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
@@ -13,6 +14,21 @@ import torch
 import torch.nn as nn
 import torchaudio
 import torchaudio.compliance.kaldi as kaldi
+
+try:
+    import flashcosyvoice  # noqa: F401
+except ModuleNotFoundError:
+    from stepaudio2 import flashcosyvoice
+
+    sys.modules["flashcosyvoice"] = flashcosyvoice
+
+try:
+    import cosyvoice2  # noqa: F401
+except ModuleNotFoundError:
+    from stepaudio2 import cosyvoice2
+
+    sys.modules["cosyvoice2"] = cosyvoice2
+
 from flashcosyvoice.modules.hifigan import HiFTGenerator
 from flashcosyvoice.utils.audio import mel_spectrogram
 from hyperpyyaml import load_hyperpyyaml

--- a/vllm_omni/outputs/output_modality.py
+++ b/vllm_omni/outputs/output_modality.py
@@ -8,7 +8,14 @@ for type-safe multimodal output routing and tensor merging.
 from __future__ import annotations
 
 import re
-from enum import Enum, Flag, StrEnum, auto
+from enum import Enum, Flag, auto
+
+try:
+    from enum import StrEnum
+except ImportError:
+
+    class StrEnum(str, Enum):
+        """Python 3.10-compatible subset used by explicit string enums."""
 
 _MODALITY_ALIASES: dict[str, str] = {
     "speech": "audio",

--- a/vllm_omni/platforms/npu/models/cosyvoice2_dit_attn.py
+++ b/vllm_omni/platforms/npu/models/cosyvoice2_dit_attn.py
@@ -13,10 +13,12 @@ This module:
 1. Expands DiT attention masks to ``[B, 1, S, S]`` before SDPA.
 2. Provides a MATH-backend SDPA context so inference can avoid the fused FA
    kernel entirely when the platform still incorrectly routes SDPA.
+3. Fuses the three gated residual Mul+Add pairs in each streaming DiT block.
 """
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 
@@ -27,6 +29,65 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 _PATCHED = False
+_original_dit_block_forward_chunk = None
+_original_modulate = None
+
+
+def _fused_gated_residual_enabled() -> bool:
+    value = os.environ.get("VLLM_OMNI_MINICPMO_FUSED_GATED_RESIDUAL", "1")
+    return value.strip().lower() not in {"0", "false", "off", "no"}
+
+
+def _fused_residual(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    branch: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``x + gate * branch`` as one elementwise NPU operation."""
+    return torch.addcmul(x, gate, branch)
+
+
+def _patched_dit_block_forward_chunk(
+    self,
+    x: torch.Tensor,
+    c: torch.Tensor,
+    cnn_cache: torch.Tensor | None = None,
+    att_cache: torch.Tensor | None = None,
+    mask: torch.Tensor | None = None,
+):
+    assert _original_dit_block_forward_chunk is not None
+    assert _original_modulate is not None
+    if x.device.type != "npu":
+        return _original_dit_block_forward_chunk(self, x, c, cnn_cache, att_cache, mask)
+
+    (
+        shift_msa,
+        scale_msa,
+        gate_msa,
+        shift_mlp,
+        scale_mlp,
+        gate_mlp,
+        shift_conv,
+        scale_conv,
+        gate_conv,
+    ) = self.adaLN_modulation(c).chunk(9, dim=-1)
+    x_att, new_att_cache = self.attn.forward_chunk(
+        _original_modulate(self.norm1(x), shift_msa, scale_msa),
+        att_cache,
+        mask,
+    )
+    x = _fused_residual(x, gate_msa, x_att)
+    x_conv, new_cnn_cache = self.conv.forward_chunk(
+        _original_modulate(self.norm3(x), shift_conv, scale_conv),
+        cnn_cache,
+    )
+    x = _fused_residual(x, gate_conv, x_conv)
+    x = _fused_residual(
+        x,
+        gate_mlp,
+        self.mlp(_original_modulate(self.norm2(x), shift_mlp, scale_mlp)),
+    )
+    return x, new_cnn_cache, new_att_cache
 
 
 def _expand_attn_mask_for_npu(
@@ -147,8 +208,8 @@ def _disable_upsample_encoder_compile() -> None:
 
 
 def apply_cosyvoice2_dit_attn_npu_patch() -> None:
-    """Monkey-patch CosyVoice2 DiT Attention for Ascend FA mask constraints."""
-    global _PATCHED
+    """Apply CosyVoice2 DiT attention and residual patches for Ascend."""
+    global _PATCHED, _original_dit_block_forward_chunk, _original_modulate
     if _PATCHED:
         return
 
@@ -159,11 +220,21 @@ def apply_cosyvoice2_dit_attn_npu_patch() -> None:
         return
 
     attn_cls = getattr(decoder_dit, "Attention", None)
+    dit_block_cls = getattr(decoder_dit, "DiTBlock", None)
     if attn_cls is None:
         return
 
     attn_cls.forward = _patched_attention_forward  # type: ignore[method-assign]
     attn_cls.forward_chunk = _patched_attention_forward_chunk  # type: ignore[method-assign]
+    fused_residuals = dit_block_cls is not None and _fused_gated_residual_enabled()
+    if fused_residuals:
+        assert dit_block_cls is not None
+        _original_dit_block_forward_chunk = dit_block_cls.forward_chunk
+        _original_modulate = decoder_dit.modulate
+        dit_block_cls.forward_chunk = _patched_dit_block_forward_chunk  # type: ignore[method-assign]
     _disable_upsample_encoder_compile()
     _PATCHED = True
-    logger.info("Applied CosyVoice2 DiT Attention NPU patch (expand attn_mask to Bx1xSxS for aclnnFlashAttentionScore)")
+    logger.info(
+        "Applied CosyVoice2 DiT NPU patches (attention mask expand%s)",
+        " and fused gated residuals" if fused_residuals else "",
+    )

--- a/vllm_omni/platforms/npu/models/step_audio2_token2wav.py
+++ b/vllm_omni/platforms/npu/models/step_audio2_token2wav.py
@@ -122,11 +122,12 @@ def npu_token2wav_sdpa_context() -> Iterator[None]:
         )
 
         apply_cosyvoice2_dit_attn_npu_patch()
-        with npu_math_sdpa_context():
-            yield
     except Exception:
-        with nullcontext():
-            yield
+        context = nullcontext()
+    else:
+        context = npu_math_sdpa_context()
+    with context:
+        yield
 
 
 def _patched_ensure_models_loaded(self) -> None:

--- a/vllm_omni/platforms/npu/worker/compat.py
+++ b/vllm_omni/platforms/npu/worker/compat.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compatibility helpers for vLLM-Ascend configuration layout changes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def profiling_chunk_enabled(ascend_config: Any) -> bool:
+    """Return whether profiling chunks are enabled across old/new layouts."""
+    scheduler_config = getattr(ascend_config, "scheduler_config", None)
+    profiling_config = getattr(scheduler_config, "profiling_chunk_config", None)
+    if profiling_config is None:
+        profiling_config = getattr(ascend_config, "profiling_chunk_config", None)
+    return bool(getattr(profiling_config, "enabled", False))
+
+
+def async_exponential_enabled(ascend_config: Any) -> bool:
+    """Preserve the removed legacy sampler flag when an old release has it."""
+    return bool(getattr(ascend_config, "enable_async_exponential", False))

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -45,6 +45,7 @@ from vllm_omni.data_entry_keys import flatten_payload
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.distributed.omni_connectors.utils.config import stage_sends_async_output
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.platforms.npu.worker.compat import async_exponential_enabled, profiling_chunk_enabled
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
@@ -64,9 +65,9 @@ def _ensure_tensor_values(payload: dict[str, object]) -> dict[str, torch.Tensor]
     for key, val in payload.items():
         if isinstance(val, torch.Tensor):
             result[key] = val
-        elif isinstance(val, (int, float, bool)):
+        elif isinstance(val, int | float | bool):
             result[key] = torch.tensor(val)
-        elif isinstance(val, (list, tuple)):
+        elif isinstance(val, list | tuple):
             try:
                 result[key] = torch.tensor(val)
             except (ValueError, TypeError, RuntimeError):
@@ -358,7 +359,7 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin):
             capturer = self.routed_experts_capturer
             if capturer is not None and hasattr(capturer, "finalize_pending_copy"):
                 capturer.finalize_pending_copy()
-        if self.ascend_config.profiling_chunk_config.enabled:
+        if profiling_chunk_enabled(self.ascend_config):
             self._sync_device()
             self._execution_start_time = time.perf_counter()
         if self.execute_model_state is not None:
@@ -678,7 +679,7 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin):
                 self.debugger.start(model=self.model)
             else:
                 self.debugger.start()
-        if self.ascend_config.enable_async_exponential:
+        if async_exponential_enabled(self.ascend_config):
             self.sampler.do_async_exponential(
                 b_s=logits_indices.shape[0],
                 head_dim=self.model_config.get_vocab_size(),
@@ -1226,7 +1227,7 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin):
             model_runner_output.omni_connector_output = self.get_omni_connector_output()
         #  -------------------------------------- Omni-new -------------------------------------------------
 
-        if self.ascend_config.profiling_chunk_config.enabled and hasattr(self, "_execution_start_time"):
+        if profiling_chunk_enabled(self.ascend_config) and hasattr(self, "_execution_start_time"):
             self._sync_device()
             model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
 

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -33,6 +33,7 @@ from vllm_ascend.utils import enable_sp, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import SEQ_LEN_WITH_MAX_PA_WORKSPACE
 
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.platforms.npu.worker.compat import async_exponential_enabled, profiling_chunk_enabled
 from vllm_omni.platforms.npu.worker.npu_ar_model_runner import ExecuteModelState, _ensure_tensor_values
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import partition_payload_list
@@ -98,7 +99,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
             capturer = self.routed_experts_capturer
             if capturer is not None and hasattr(capturer, "finalize_pending_copy"):
                 capturer.finalize_pending_copy()
-        if self.ascend_config.profiling_chunk_config.enabled:
+        if profiling_chunk_enabled(self.ascend_config):
             self._sync_device()
             self._execution_start_time = time.perf_counter()
         if self.execute_model_state is not None:
@@ -355,7 +356,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
                 self.debugger.start(model=self.model)
             else:
                 self.debugger.start()
-        if self.ascend_config.enable_async_exponential:
+        if async_exponential_enabled(self.ascend_config):
             self.sampler.do_async_exponential(
                 b_s=logits_indices.shape[0],
                 head_dim=self.model_config.get_vocab_size(),
@@ -552,7 +553,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
         if self.speculative_config is not None:
             self.finalize_kv_connector()
 
-        if self.ascend_config.profiling_chunk_config.enabled and hasattr(self, "_execution_start_time"):
+        if profiling_chunk_enabled(self.ascend_config) and hasattr(self, "_execution_start_time"):
             self._sync_device()
             output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
 


### PR DESCRIPTION
## Summary

- add the single-card Ascend 910C MiniCPM-o 4.5 deployment baseline and competition workflow
- add reproducible correctness, performance, profiling, Daily-Omni, Seed-TTS, and Video-MME runners
- add a deterministic 400-sample public proxy benchmark with machine-readable summaries
- document measured Ascend baseline and public-data proxy results

## Public proxy validation

- 400/400 requests completed at concurrency 1
- Daily-Omni: 73/100 on the fixed public sample
- Seed-TTS English: 100/100 generated; median TTFP 1.490 s; median RTF 0.604
- Seed-TTS Chinese: 100/100 generated; median TTFP 1.563 s; median RTF 0.584
- Video-MME: 65/100 on the stratified available public subset

These values are public-data proxy evidence, not official competition scores. The official Starter Kit, evaluator subsets, score weights, and final package schema were unavailable for this validation.

## Tests

- 28 competition/profile/public-dataset tests passed
- 65 scheduler, Code2Wav, CosyVoice2, StepAudio2, and NPU worker tests passed
- 13 focused competition and public benchmark tests passed after the final benchmark tooling update
- changed-file Ruff, compileall, Bash syntax, diff whitespace, and credential scans passed