### PR TITLE
[Bugfix] Support bfloat16 tensor serialization in data_entry_keys

### DIFF
--- a/tests/test_data_entry_keys.py
+++ b/tests/test_data_entry_keys.py
@@ -372,8 +372,9 @@ class TestSerializeDeserializePayload:
         assert torch.equal(restored["hidden_states"]["layers"][24], torch.tensor([3.0]))
 
     def test_tensor_dtype_preserved(self):
-        # bfloat16 excluded: numpy() doesn't support it; callers must cast before serializing.
-        for dtype in [torch.float16, torch.float32, torch.int64, torch.int32, torch.bool]:
+        # bfloat16 is stored as float32 bytes and rebound to bfloat16 on
+        # decode (numpy has no native bfloat16, see _serialize_tensor).
+        for dtype in [torch.float16, torch.bfloat16, torch.float32, torch.int64, torch.int32, torch.bool]:
             original: OmniPayload = {"codes": {"audio": torch.tensor([1], dtype=dtype)}}
             wire = serialize_payload(original)
             restored = deserialize_payload(wire)
@@ -386,6 +387,18 @@ class TestSerializeDeserializePayload:
         restored = deserialize_payload(wire)
         assert restored["hidden_states"]["output"].shape == (3, 4, 5)
         assert torch.allclose(restored["hidden_states"]["output"], t)
+
+    def test_bfloat16_round_trip_preserves_values(self):
+        # Regression for #5739: numpy() would raise "Got unsupported ScalarType
+        # BFloat16"; bfloat16 tensors are now stored as float32 bytes and
+        # rebound to bfloat16 with the same values on decode.
+        t = torch.tensor([[1.5, 2.5, 100.0, 0.125]], dtype=torch.bfloat16)
+        original: OmniPayload = {"codes": {"audio": t}}
+        wire = serialize_payload(original)
+        restored = deserialize_payload(wire)
+        assert restored["codes"]["audio"].dtype == torch.bfloat16
+        assert restored["codes"]["audio"].shape == t.shape
+        assert torch.equal(restored["codes"]["audio"], t)
 
     def test_empty_payload_returns_none(self):
         assert serialize_payload({}) is None

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -352,18 +352,34 @@ def _serialize_tensor(t: torch.Tensor) -> AdditionalInformationEntry:
     from vllm_omni.engine import AdditionalInformationEntry
 
     t_cpu = t.detach().to("cpu").contiguous()
+    # ``numpy`` does not support ``torch.bfloat16`` (``.numpy()`` would raise
+    # ``TypeError: Got unsupported ScalarType BFloat16``). Store the raw bytes
+    # as ``float32`` but keep the real dtype name in ``tensor_dtype``, and let
+    # :func:`_deserialize_tensor` restore the ``bfloat16`` dtype on decode.
+    dtype_name = _dtype_to_name(t_cpu.dtype)
+    if t_cpu.dtype == torch.bfloat16:
+        t_cpu = t_cpu.to(dtype=torch.float32)
+        np_dtype = np.dtype("float32")
+    else:
+        np_dtype = np.dtype(dtype_name)
     return AdditionalInformationEntry(
-        tensor_data=t_cpu.numpy().tobytes(),
+        tensor_data=t_cpu.numpy().astype(np_dtype).tobytes(),
         tensor_shape=list(t_cpu.shape),
-        tensor_dtype=_dtype_to_name(t_cpu.dtype),
+        tensor_dtype=dtype_name,
     )
 
 
 def _deserialize_tensor(entry: AdditionalInformationEntry) -> torch.Tensor:
-    dt = np.dtype(entry.tensor_dtype or "float32")
+    # ``bfloat16`` tensor bytes are stored as ``float32`` (see
+    # :func:`_serialize_tensor`); decode as float32 and cast back.
+    if entry.tensor_dtype == "bfloat16":
+        dt = np.dtype("float32")
+    else:
+        dt = np.dtype(entry.tensor_dtype or "float32")
     arr = np.frombuffer(entry.tensor_data, dtype=dt)  # type: ignore[arg-type]
     arr = arr.reshape(entry.tensor_shape)
-    return torch.from_numpy(arr.copy())
+    tensor = torch.from_numpy(arr.copy())
+    return tensor.to(dtype=torch.bfloat16) if entry.tensor_dtype == "bfloat16" else tensor
 
 
 def serialize_payload(


### PR DESCRIPTION
The `_serialize_tensor` path called `t_cpu.numpy().tobytes()` which raises `TypeError: Got unsupported ScalarType BFloat16` for bfloat16 tensors. This crashed CosyVoice3 inter-stage communication where hidden states flow as bfloat16 (see #5739).

Store bfloat16 tensor bytes as float32 but keep the real dtype name in `tensor_dtype`, and have `_deserialize_tensor` decode them as float32 and cast back to bfloat16. Other dtypes are unchanged.

Add a regression test that round-trips a bfloat16 tensor and asserts the dtype, shape and values are preserved. Fixes #5739.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
