### PR TITLE
[Bugfix] Drain async diffusion outputs before worker shutdown

### DIFF
--- a/tests/diffusion/test_async_output_worker.py
+++ b/tests/diffusion/test_async_output_worker.py
@@ -152,13 +152,14 @@ class TestAsyncOutputLoopLogic:
         """The real _async_output_loop packs via SHM with d2h_stream and
         enqueues an OUTPUT_READY message."""
         import threading
-        import time
 
         proc = _make_worker_proc(step_execution=False)
 
         mock_pack = mocker.patch(
             "vllm_omni.diffusion.worker.diffusion_worker.pack_diffusion_output_shm",
         )
+        packed = threading.Event()
+        mock_pack.side_effect = lambda *_args, **_kwargs: packed.set()
         # Mock torch to avoid device initialization
         mock_torch = mocker.MagicMock()
         mock_stream = mocker.MagicMock()
@@ -178,16 +179,98 @@ class TestAsyncOutputLoopLogic:
         t = threading.Thread(target=proc._async_output_loop, daemon=True)
         t.start()
 
-        # Give the loop time to process, then unblock and stop.
-        time.sleep(0.5)
-        proc._running = False
-        proc._async_output_queue.put((DiffusionOutput(), "sentinel", None))
-        t.join(timeout=2.0)
+        assert packed.wait(timeout=2.0)
+        proc._async_output_thread = t
+        proc._stop_async_output_thread()
 
         mock_pack.assert_called()
+        assert not t.is_alive()
+        assert proc._async_output_thread is None
+        assert proc._async_output_queue is None
         # Verify an OUTPUT_READY with the correct async_output_id was enqueued.
         output_ready_enqueued = any(
             c[0][0].kind == AsyncOutputKind.OUTPUT_READY and c[0][0].async_output_id == "abc123"
             for c in proc.result_mq.enqueue.call_args_list
         )
         assert output_ready_enqueued, "Expected OUTPUT_READY with async_output_id='abc123' in enqueue calls"
+
+    def test_stop_async_output_thread_drains_pending_outputs(self, mocker):
+        import threading
+
+        proc = _make_worker_proc(step_execution=False)
+        first_pack_started = threading.Event()
+        release_first_pack = threading.Event()
+        pack_count = 0
+
+        def blocking_pack(*_args, **_kwargs):
+            nonlocal pack_count
+            pack_count += 1
+            if pack_count == 1:
+                first_pack_started.set()
+                assert release_first_pack.wait(timeout=5.0)
+
+        mocker.patch(
+            "vllm_omni.diffusion.worker.diffusion_worker.pack_diffusion_output_shm",
+            side_effect=blocking_pack,
+        )
+        mock_torch = mocker.MagicMock()
+        mock_torch.Stream.return_value = mocker.MagicMock()
+        mock_torch.accelerator.current_accelerator.return_value.type = "cpu"
+        mock_torch.device.return_value = mocker.MagicMock()
+        mocker.patch(
+            "vllm_omni.diffusion.worker.diffusion_worker.torch",
+            mock_torch,
+        )
+
+        proc._async_output_queue.put((DiffusionOutput(output="first"), "first-id", None))
+        proc._async_output_queue.put((DiffusionOutput(output="second"), "second-id", None))
+        output_thread = threading.Thread(target=proc._async_output_loop, daemon=True)
+        proc._async_output_thread = output_thread
+        output_thread.start()
+        assert first_pack_started.wait(timeout=2.0)
+
+        stop_started = threading.Event()
+
+        def stop_output_thread():
+            stop_started.set()
+            proc._stop_async_output_thread()
+
+        stop_thread = threading.Thread(target=stop_output_thread)
+        stop_thread.start()
+        assert stop_started.wait(timeout=2.0)
+        assert stop_thread.is_alive()
+
+        release_first_pack.set()
+        stop_thread.join(timeout=2.0)
+
+        assert not stop_thread.is_alive()
+        assert not output_thread.is_alive()
+        assert pack_count == 2
+        ready_ids = {
+            call.args[0].async_output_id
+            for call in proc.result_mq.enqueue.call_args_list
+            if call.args[0].kind == AsyncOutputKind.OUTPUT_READY
+        }
+        assert ready_ids == {"first-id", "second-id"}
+
+    def test_stop_async_output_thread_is_noop_without_async_state(self):
+        proc = _make_worker_proc(step_execution=True)
+
+        assert proc._stop_async_output_thread()
+
+        assert proc._running is False
+        assert proc._async_output_thread is None
+        assert proc._async_output_queue is None
+
+    def test_stop_async_output_thread_timeout_is_bounded(self, mocker):
+        proc = _make_worker_proc(step_execution=False)
+        output_thread = mocker.MagicMock()
+        output_thread.is_alive.return_value = True
+        proc._async_output_thread = output_thread
+        mocker.patch.object(WorkerProc, "_ASYNC_OUTPUT_JOIN_TIMEOUT_S", 0.01)
+
+        assert not proc._stop_async_output_thread()
+
+        output_thread.join.assert_called_once_with(timeout=0.01)
+        assert proc._async_output_thread is output_thread
+        assert proc._async_output_queue.get_nowait() is WorkerProc._ASYNC_OUTPUT_STOP

--- a/tests/diffusion/test_multiproc_executor_shutdown.py
+++ b/tests/diffusion/test_multiproc_executor_shutdown.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for bounded diffusion worker process shutdown."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from vllm_omni.diffusion.executor.multiproc_executor import (
+    _WORKER_JOIN_TIMEOUT_S,
+    _WORKER_KILL_JOIN_TIMEOUT_S,
+    _ExecutorShutdownCleaner,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_shutdown_cleaner_kills_worker_stuck_after_terminate():
+    proc = MagicMock()
+    proc.name = "stuck-worker"
+    proc.is_alive.return_value = True
+    cleaner = _ExecutorShutdownCleaner(processes=[proc])
+
+    cleaner()
+
+    proc.terminate.assert_called_once_with()
+    proc.kill.assert_called_once_with()
+    assert proc.join.call_args_list == [
+        call(_WORKER_JOIN_TIMEOUT_S),
+        call(_WORKER_JOIN_TIMEOUT_S),
+        call(_WORKER_KILL_JOIN_TIMEOUT_S),
+    ]
+
+
+def test_shutdown_cleaner_leaves_gracefully_stopped_worker_alone():
+    proc = MagicMock()
+    proc.is_alive.side_effect = [True, False]
+    cleaner = _ExecutorShutdownCleaner(processes=[proc])
+
+    cleaner()
+
+    proc.join.assert_called_once_with(_WORKER_JOIN_TIMEOUT_S)
+    proc.terminate.assert_not_called()
+    proc.kill.assert_not_called()

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _DEQUEUE_TIMEOUT_S = 5.0
+_WORKER_JOIN_TIMEOUT_S = 5.0
+_WORKER_KILL_JOIN_TIMEOUT_S = 1.0
 
 
 @dataclass
@@ -55,11 +57,17 @@ class _ExecutorShutdownCleaner:
             for proc in self.processes:
                 if not proc.is_alive():
                     continue
-                proc.join(5)
-                if proc.is_alive():
-                    logger.warning("Terminating diffusion worker %s after timeout", proc.name)
-                    proc.terminate()
-                    proc.join(5)
+                proc.join(_WORKER_JOIN_TIMEOUT_S)
+                if not proc.is_alive():
+                    continue
+                logger.warning("Terminating diffusion worker %s after timeout", proc.name)
+                proc.terminate()
+                proc.join(_WORKER_JOIN_TIMEOUT_S)
+                if not proc.is_alive():
+                    continue
+                logger.error("Killing diffusion worker %s after termination timeout", proc.name)
+                proc.kill()
+                proc.join(_WORKER_KILL_JOIN_TIMEOUT_S)
 
 
 class MultiprocDiffusionExecutor(DiffusionExecutor):

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -789,6 +789,12 @@ class CustomPipelineWorkerExtension:
 class WorkerProc:
     """Wrapper that runs one Worker in a separate process."""
 
+    _ASYNC_OUTPUT_STOP = object()
+    # Keep this below the executor's graceful process join timeout so a stuck
+    # D2H operation takes the worker's force-exit path before the parent sends
+    # SIGTERM.
+    _ASYNC_OUTPUT_JOIN_TIMEOUT_S = 4.0
+
     def __init__(
         self,
         od_config: OmniDiffusionConfig,
@@ -895,35 +901,71 @@ class WorkerProc:
         """
         device = torch.device(torch.accelerator.current_accelerator().type, self.gpu_id)
         d2h_stream = torch.Stream(device=device)
-        while self._running:
-            output, async_output_id, gpu_event = self._async_output_queue.get()
-            try:
-                # Cross-stream ordering: wait for default stream to finish
-                # writing the output tensors before the side stream reads.
-                if gpu_event is not None:
-                    d2h_stream.wait_event(gpu_event)
-                pack_diffusion_output_shm(output, d2h_stream=d2h_stream)
-                d2h_stream.synchronize()
+        try:
+            while True:
+                item = self._async_output_queue.get()
+                if item is WorkerProc._ASYNC_OUTPUT_STOP:
+                    break
+                output, async_output_id, gpu_event = item
+                try:
+                    # Cross-stream ordering: wait for default stream to finish
+                    # writing the output tensors before the side stream reads.
+                    if gpu_event is not None:
+                        d2h_stream.wait_event(gpu_event)
+                    pack_diffusion_output_shm(output, d2h_stream=d2h_stream)
+                    d2h_stream.synchronize()
 
-                self.result_mq.enqueue(
-                    AsyncDiffusionOutput(
-                        kind=AsyncOutputKind.OUTPUT_READY,
-                        async_output_id=async_output_id,
-                        output=output,
+                    self.result_mq.enqueue(
+                        AsyncDiffusionOutput(
+                            kind=AsyncOutputKind.OUTPUT_READY,
+                            async_output_id=async_output_id,
+                            output=output,
+                        )
                     )
-                )
+                except Exception:
+                    logger.exception(
+                        "Async output packing failed for id '%s'; sending error",
+                        async_output_id,
+                    )
+                    self.result_mq.enqueue(
+                        AsyncDiffusionOutput(
+                            kind=AsyncOutputKind.OUTPUT_READY,
+                            async_output_id=async_output_id,
+                            error="Background D2H/SHM packing failed",
+                        )
+                    )
+        finally:
+            try:
+                d2h_stream.synchronize()
             except Exception:
-                logger.exception(
-                    "Async output packing failed for id '%s'; sending error",
-                    async_output_id,
-                )
-                self.result_mq.enqueue(
-                    AsyncDiffusionOutput(
-                        kind=AsyncOutputKind.OUTPUT_READY,
-                        async_output_id=async_output_id,
-                        error="Background D2H/SHM packing failed",
-                    )
-                )
+                logger.debug("Failed to synchronize async output stream during shutdown", exc_info=True)
+
+    def _stop_async_output_thread(self) -> bool:
+        """Drain queued output work within the shutdown deadline.
+
+        A thread blocked in a device runtime call cannot be cancelled safely.
+        Returning ``False`` tells the caller to skip device teardown and force
+        the worker process to exit instead.
+        """
+        self._running = False
+        output_queue = self._async_output_queue
+        output_thread = self._async_output_thread
+        if output_queue is None or output_thread is None:
+            return True
+
+        output_queue.put(WorkerProc._ASYNC_OUTPUT_STOP)
+        output_thread.join(timeout=WorkerProc._ASYNC_OUTPUT_JOIN_TIMEOUT_S)
+        if output_thread.is_alive():
+            logger.error(
+                "Async output thread did not stop within %.1f seconds; "
+                "skipping device teardown and forcing worker exit",
+                WorkerProc._ASYNC_OUTPUT_JOIN_TIMEOUT_S,
+            )
+            return False
+
+        self._async_output_thread = None
+        self._async_output_queue = None
+        return True
 
     def _gather_rpc_rank_statuses(self, status: dict[str, Any]) -> list[dict[str, Any]]:
         if not torch.distributed.is_initialized():
@@ -1195,6 +1237,11 @@ class WorkerProc:
             raise
         finally:
             if worker_proc is not None:
+                if not worker_proc._stop_async_output_thread():
+                    # The daemon thread may still own an active device stream.
+                    # Running Python or device-runtime destructors concurrently
+                    # with it is unsafe, so terminate this child immediately.
+                    os._exit(1)
                 try:
                     worker_proc.worker.shutdown()
                 except Exception as exc:


### PR DESCRIPTION
## Summary

Ensure the diffusion worker drains pending asynchronous output work and stops its background D2H thread before worker and device-context teardown.

## Problem

In request mode, the worker publishes `COMPUTE_DONE` after queueing an output. The background thread later waits for the device event, performs D2H and shared-memory packing, and publishes `OUTPUT_READY`.

The previous shutdown path set `_running` to false and immediately called `worker.shutdown()` and `context.term()`. A thread blocked in `Queue.get` was not awakened or joined. A thread processing one output could also exit before processing later queued outputs, leaving a published `COMPUTE_DONE` without its corresponding `OUTPUT_READY`.

## Changes

- Add an explicit stop sentinel to the asynchronous output queue.
- Place the sentinel after queued work so pending outputs are drained in FIFO order.
- Synchronize the D2H stream during thread teardown.
- Join the asynchronous output thread before worker and device-context cleanup.
- Clear the thread and queue references after shutdown.
- Preserve asynchronous packing error reporting.

## Regression coverage

`tests/diffusion/test_async_output_worker.py` covers:

- publishing `OUTPUT_READY` after background packing
- deterministic draining of two queued outputs while the first packing operation is blocked
- waiting for the background thread before shutdown returns
- shutdown when asynchronous state was not initialized

The pending-output test uses threading events rather than timing sleeps.

## Observed shutdown case

A single-card HunyuanImage3 request on Ascend 950PR completed and saved its image and latent trajectory. During close, the worker then exceeded the five-second process shutdown timeout and was force-terminated. The process subsequently aborted with `corrupted size vs. prev_size` and exit code 134.

The allocator abort can also be reproduced by importing `vllm_omni` and exiting without a diffusion request. This PR therefore addresses the concrete asynchronous-output teardown race and does not claim to fix every source of exit code 134.

Ruff checks, Ruff formatting, Python syntax compilation, and `git diff --check` pass for the changed files.