### PR TITLE
[NPU] Add configurable MoE communication method

### DIFF
--- a/docs/getting_started/installation/npu.md
+++ b/docs/getting_started/installation/npu.md
@@ -31,3 +31,43 @@ vLLM-Omni supports NPU through the vLLM Ascend Plugin (vllm-ascend). This is a c
 === "NPU from main"
 
     --8<-- "docs/getting_started/installation/npu/npu.inc.md:installation-main"
+
+## Configure MoE communication for diffusion stages
+
+Ascend NPU deployments can select the MoE communication method for each
+diffusion stage through `VllmConfig.additional_config`. Set
+`npu_moe_comm_method` in the stage configuration:
+
+```yaml
+stages:
+  - stage_id: 0
+    additional_config:
+      npu_moe_comm_method: ALLTOALL
+```
+
+The accepted values are case-insensitive:
+
+| Value | Requirement | Description |
+|-------|-------------|-------------|
+| `ALLGATHER` | None | Select the AllGather MoE communication method. |
+| `ALLTOALL` | Expert parallelism enabled with an effective EP world size greater than one | Select the AllToAll MoE communication method. |
+
+Enable expert parallelism and configure a multi-rank EP topology before using
+`ALLTOALL`. An incompatible `ALLTOALL` override fails during worker runtime
+preparation. See the [Expert Parallelism Guide](../../user_guide/diffusion/parallelism/expert_parallel.md)
+for EP configuration.
+
+For a single diffusion deployment, the same setting can be passed through the
+CLI:
+
+```bash
+vllm serve MODEL --omni \
+    --enable-expert-parallel \
+    --tensor-parallel-size 2 \
+    --additional-config '{"npu_moe_comm_method":"ALLTOALL"}'
+```
+
+When `npu_moe_comm_method` is omitted, vLLM-Omni keeps the automatic selection
+based on the Ascend device type and EP topology. The override is local to each
+diffusion stage, so stages with different parallel topologies can use different
+methods.

--- a/tests/platforms/npu/test_fused_moe_comm_selection.py
+++ b/tests/platforms/npu/test_fused_moe_comm_selection.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm_ascend")
+
+from vllm_ascend.ascend_forward_context import MoECommType
+
+from vllm_omni.platforms.npu.layers import fused_moe
+
+pytestmark = [pytest.mark.core_model, pytest.mark.npu]
+
+
+def _vllm_config(additional_config=None, *, enable_expert_parallel=True):
+    return SimpleNamespace(
+        additional_config=additional_config,
+        parallel_config=SimpleNamespace(enable_expert_parallel=enable_expert_parallel),
+    )
+
+
+def _set_ep_size(monkeypatch, ep_size):
+    monkeypatch.setattr(
+        fused_moe,
+        "get_ep_group",
+        lambda: SimpleNamespace(world_size=ep_size),
+    )
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("allgather", MoECommType.ALLGATHER),
+        ("ALLTOALL", MoECommType.ALLTOALL),
+    ],
+)
+def test_additional_config_override(monkeypatch, configured, expected):
+    _set_ep_size(monkeypatch, 2)
+
+    result = fused_moe._select_moe_comm_method(_vllm_config({"npu_moe_comm_method": configured}))
+
+    assert result is expected
+
+
+def test_invalid_override_fails_fast(monkeypatch):
+    _set_ep_size(monkeypatch, 2)
+
+    with pytest.raises(ValueError, match="Supported values"):
+        fused_moe._select_moe_comm_method(_vllm_config({"npu_moe_comm_method": "mc2"}))
+
+
+@pytest.mark.parametrize("configured", [False, 0, []])
+def test_falsey_non_string_override_fails_fast(monkeypatch, configured):
+    _set_ep_size(monkeypatch, 2)
+
+    with pytest.raises(TypeError, match="must be a string"):
+        fused_moe._select_moe_comm_method(_vllm_config({"npu_moe_comm_method": configured}))
+
+
+def test_empty_string_override_fails_fast(monkeypatch):
+    _set_ep_size(monkeypatch, 2)
+
+    with pytest.raises(ValueError, match="Supported values"):
+        fused_moe._select_moe_comm_method(_vllm_config({"npu_moe_comm_method": ""}))
+
+
+@pytest.mark.parametrize(
+    ("enable_expert_parallel", "ep_size"),
+    [(False, 1), (True, 1)],
+)
+def test_alltoall_override_requires_multi_rank_ep(
+    monkeypatch,
+    enable_expert_parallel,
+    ep_size,
+):
+    _set_ep_size(monkeypatch, ep_size)
+
+    with pytest.raises(ValueError, match="requires expert parallelism"):
+        fused_moe._select_moe_comm_method(
+            _vllm_config(
+                {"npu_moe_comm_method": "alltoall"},
+                enable_expert_parallel=enable_expert_parallel,
+            )
+        )

--- a/vllm_omni/platforms/npu/layers/fused_moe.py
+++ b/vllm_omni/platforms/npu/layers/fused_moe.py
@@ -47,8 +47,32 @@ def _init_mc2_group_for_diffusion(
 
 
 def _select_moe_comm_method(vllm_config: VllmConfig) -> MoECommType | None:
+    override = None
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if isinstance(additional_config, dict):
+        override = additional_config.get("npu_moe_comm_method")
+
+    enable_expert_parallel = vllm_config.parallel_config.enable_expert_parallel
+    ep_size = get_ep_group().world_size if enable_expert_parallel else 1
+
+    if override is not None:
+        if not isinstance(override, str):
+            raise TypeError(f"npu_moe_comm_method must be a string, got {type(override).__name__}")
+        normalized_override = override.strip().upper()
+        supported_overrides = {
+            "ALLGATHER": MoECommType.ALLGATHER,
+            "ALLTOALL": MoECommType.ALLTOALL,
+        }
+        if normalized_override not in supported_overrides:
+            supported = ", ".join(sorted(supported_overrides))
+            raise ValueError(f"Unsupported npu_moe_comm_method={override!r}. Supported values: {supported}")
+        moe_comm_type = supported_overrides[normalized_override]
+        if moe_comm_type is MoECommType.ALLTOALL and ep_size == 1:
+            raise ValueError("ALLTOALL requires expert parallelism with ep_size greater than 1")
+        return moe_comm_type
+
     soc_version = get_ascend_device_type()
-    if not vllm_config.parallel_config.enable_expert_parallel or get_ep_group().world_size == 1:
+    if ep_size == 1:
         moe_comm_type = MoECommType.ALLGATHER
     elif soc_version in {AscendDeviceType.A2}:
         moe_comm_type = MoECommType.ALLGATHER


### PR DESCRIPTION
## Summary

Add a stage-local configuration override for selecting the NPU MoE communication method used by diffusion models.

## Motivation

The optimal MoE communication method can vary with model topology, tensor parallel configuration, expert parallel configuration, and NPU platform. Automatic selection makes performance experiments difficult to reproduce and prevents a stage from selecting a known suitable method for its own topology.

## Changes

Read `npu_moe_comm_method` from each worker or stage's `VllmConfig.additional_config`.

Supported values:

```text
ALLGATHER
ALLTOALL
```

Values are case-insensitive. Invalid values and non-string values fail during runtime preparation with a clear error. Explicit `ALLTOALL` selection also fails early unless expert parallelism is enabled with an EP world size greater than one.

When the key is absent, the existing platform-based automatic selection remains unchanged.

## Usage

```python
additional_config = {
    "npu_moe_comm_method": "ALLTOALL",
}
```

For a diffusion stage YAML configuration:

```yaml
stages:
  - stage_id: 0
    additional_config:
      npu_moe_comm_method: ALLTOALL
```

Each stage carries its own value, allowing multi-stage deployments to select methods independently for different EP or TP topologies.

## Validation

The NPU regression test is located at:

```text
tests/platforms/npu/test_fused_moe_comm_selection.py
```

Coverage includes:

- ALLGATHER and ALLTOALL selection through `additional_config`
- invalid strings, empty strings, and falsey non-string values
- rejection of ALLTOALL when EP is disabled or the EP group has one rank
- NPU-only collection with `vllm_ascend` guarded by `pytest.importorskip`

Ruff checks, Ruff formatting, Python syntax compilation, and `git diff --check` pass for the changed files.