### PR TITLE
[NPU] Add offline MXFP8 support for routed experts

### DIFF
--- a/.buildkite/npu/test-npu-ready.yml
+++ b/.buildkite/npu/test-npu-ready.yml
@@ -20,6 +20,11 @@ steps:
         commands:
           - pytest -s -v tests/e2e/offline_inference/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5.py -m 'core_model' --run-level 'core_model'
 
+      - label: ":test_tube: NPU · MXFP8 Routed Experts Test"
+        mirror_hardwares: a3_npu_2
+        commands:
+          - pytest -s -v tests/platforms/npu/test_mxfp8_routed_experts.py -m 'core_model and npu' --run-level 'core_model'
+
   - group: ":card_index_dividers: TTS Model Test"
     key: ready-tts-group
     depends_on: upload-ready-pipeline

--- a/tests/diffusion/quantization/test_mxfp8_config.py
+++ b/tests/diffusion/quantization/test_mxfp8_config.py
@@ -127,6 +127,82 @@ def test_get_quant_method_offline_npu(mocker: MockerFixture):
     assert type(method).__name__ == "NPUMxfp8LinearMethod"
 
 
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="Native MXFP8 offline only supported on NPU")
+def test_get_quant_method_offline_npu_wraps_moe_scheme(mocker: MockerFixture):
+    """The Ascend MoE scheme must be adapted to vLLM's FusedMoEMethodBase API."""
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    layer = object.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = mocker.sentinel.moe_config
+    scheme = mocker.sentinel.scheme
+    adapter = mocker.sentinel.adapter
+    scheme_cls = mocker.patch(
+        "vllm_ascend.quantization.methods.w8a8_mxfp8.AscendW8A8MXFP8DynamicFusedMoEMethod",
+        return_value=scheme,
+    )
+    adapter_cls = mocker.patch(
+        "vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod",
+        return_value=adapter,
+    )
+    config = DiffusionMXFP8Config(is_checkpoint_mxfp8_serialized=True)
+    method = config.get_quant_method(
+        layer,
+        "layers.0.mlp.experts.routed_experts",
+    )
+
+    assert method is adapter
+    scheme_cls.assert_called_once_with()
+    adapter_cls.assert_called_once_with(scheme, layer.moe_config)
+
+
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="Native MXFP8 offline only supported on NPU")
+def test_get_quant_method_offline_npu_skips_ignored_moe(mocker: MockerFixture):
+    """Ignored routed experts must use vLLM's unquantized MoE fallback."""
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    layer = object.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    config = DiffusionMXFP8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        ignored_layers=["layers.0"],
+    )
+    scheme_cls = mocker.patch(
+        "vllm_ascend.quantization.methods.w8a8_mxfp8.AscendW8A8MXFP8DynamicFusedMoEMethod",
+    )
+
+    method = config.get_quant_method(
+        layer,
+        "layers.0.mlp.experts.routed_experts",
+    )
+
+    assert method is None
+    scheme_cls.assert_not_called()
+
+
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="Native MXFP8 offline only supported on NPU")
+def test_get_quant_method_offline_npu_skips_child_linear(mocker: MockerFixture):
+    """A block prefix must skip every linear module inside that block."""
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    config = DiffusionMXFP8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        ignored_layers=["model.layers.7"],
+    )
+    layer = mocker.Mock(spec=LinearBase)
+
+    method = config.get_quant_method(
+        layer,
+        "layers.7.self_attn.qkv_proj",
+    )
+
+    assert type(method).__name__ == "UnquantizedLinearMethod"
+
+
 @pytest.mark.skipif(not current_omni_platform.is_xpu(), reason="XPU platform not available")
 def test_get_quant_method_offline_xpu_raises(mocker: MockerFixture):
     """XPU offline mode must raise NotImplementedError (use AutoRound MXFP8 instead)."""

--- a/tests/platforms/npu/test_mxfp8_routed_experts.py
+++ b/tests/platforms/npu/test_mxfp8_routed_experts.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.diffusion,
+    pytest.mark.skipif(
+        not current_omni_platform.is_npu(),
+        reason="MXFP8 routed experts require an NPU",
+    ),
+]
+
+
+@hardware_test(res={"npu": "A3"}, num_cards=1)
+def test_load_serialized_mxfp8_routed_experts(monkeypatch: pytest.MonkeyPatch):
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        RoutingMethodType,
+    )
+    from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+        ExpertMapManager,
+    )
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+    from vllm_ascend.quantization.method_adapters import AscendFusedMoEMethod
+    from vllm_ascend.quantization.methods import w8a8_mxfp8
+    from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+        AscendW8A8MXFP8DynamicFusedMoEMethod,
+    )
+
+    from vllm_omni.quantization.mxfp8_config import DiffusionMXFP8Config
+
+    quant_config = DiffusionMXFP8Config(is_checkpoint_mxfp8_serialized=True)
+    vllm_config = SimpleNamespace(
+        quant_config=quant_config,
+        compilation_config=SimpleNamespace(mode=None),
+        model_config=SimpleNamespace(enforce_eager=True),
+    )
+    ascend_config = SimpleNamespace(eplb_config=SimpleNamespace(dynamic_eplb=False))
+    monkeypatch.setattr(w8a8_mxfp8, "get_current_vllm_config", lambda: vllm_config)
+    monkeypatch.setattr(w8a8_mxfp8, "get_ascend_config", lambda: ascend_config)
+
+    parallel_config = FusedMoEParallelConfig.make_no_parallel()
+    moe_config = FusedMoEConfig(
+        num_experts=2,
+        experts_per_token=1,
+        hidden_dim=64,
+        intermediate_size=64,
+        num_local_experts=2,
+        num_logical_experts=2,
+        activation=MoEActivation.SILU,
+        device="npu:0",
+        routing_method=RoutingMethodType.Default,
+        moe_parallel_config=parallel_config,
+        in_dtype=torch.bfloat16,
+    )
+    expert_map_manager = ExpertMapManager(
+        max_num_batched_tokens=8,
+        top_k=1,
+        global_num_experts=2,
+        num_redundant_experts=0,
+        num_expert_group=None,
+        moe_parallel_config=parallel_config,
+        placement_strategy="linear",
+        enable_eplb=False,
+    )
+
+    torch.npu.set_device(0)
+    with torch.device("npu:0"):
+        layer = RoutedExperts(
+            layer_name="layers.0.mlp.experts.routed_experts",
+            params_dtype=torch.bfloat16,
+            moe_config=moe_config,
+            quant_config=quant_config,
+            expert_map_manager=expert_map_manager,
+        )
+
+    assert isinstance(layer.quant_method, AscendFusedMoEMethod)
+    assert isinstance(
+        layer.quant_method.quant_method,
+        AscendW8A8MXFP8DynamicFusedMoEMethod,
+    )
+    assert layer.w13_weight.device.type == "npu"
+
+    def fp8_weight(value: float) -> torch.Tensor:
+        return torch.full((64, 64), value).to(torch.float8_e4m3fn)
+
+    checkpoint = {
+        "gate_proj.weight": fp8_weight(1.0),
+        "up_proj.weight": fp8_weight(2.0),
+        "down_proj.weight": fp8_weight(3.0),
+        "gate_proj.weight_scale": torch.full((64, 2), 4, dtype=torch.uint8),
+        "up_proj.weight_scale": torch.full((64, 2), 5, dtype=torch.uint8),
+        "down_proj.weight_scale": torch.full((64, 2), 6, dtype=torch.uint8),
+    }
+    mapping = {
+        "gate_proj.weight": (layer.w13_weight, "w1"),
+        "up_proj.weight": (layer.w13_weight, "w3"),
+        "down_proj.weight": (layer.w2_weight, "w2"),
+        "gate_proj.weight_scale": (layer.w13_weight_scale, "w1"),
+        "up_proj.weight_scale": (layer.w13_weight_scale, "w3"),
+        "down_proj.weight_scale": (layer.w2_weight_scale, "w2"),
+    }
+    for expert_id in range(2):
+        for weight_name, loaded_weight in checkpoint.items():
+            param, shard_id = mapping[weight_name]
+            param.weight_loader(
+                param=param,
+                loaded_weight=loaded_weight,
+                weight_name=f"experts.{expert_id}.{weight_name}",
+                shard_id=shard_id,
+                expert_id=expert_id,
+            )
+
+    torch.npu.synchronize()
+    assert torch.all(layer.w13_weight[:, :64].float().cpu() == 1)
+    assert torch.all(layer.w13_weight[:, 64:].float().cpu() == 2)
+    assert torch.all(layer.w2_weight.float().cpu() == 3)
+    assert torch.all(layer.w13_weight_scale[:, :64].cpu() == 4)
+    assert torch.all(layer.w13_weight_scale[:, 64:].cpu() == 5)
+    assert torch.all(layer.w2_weight_scale.cpu() == 6)
+
+    layer.quant_method.process_weights_after_loading(layer)
+    assert layer.w13_weight.shape == (2, 64, 128)
+    assert layer.w2_weight.shape == (2, 64, 64)
+    assert layer.w13_weight_scale.shape == (2, 1, 128, 2)
+    assert layer.w2_weight_scale.shape == (2, 1, 64, 2)

--- a/vllm_omni/quantization/mxfp8_config.py
+++ b/vllm_omni/quantization/mxfp8_config.py
@@ -34,6 +34,7 @@ Extending to a new MX precision with a different calling convention (e.g. dual-s
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -62,6 +63,24 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _is_layer_or_child_skipped(
+    prefix: str,
+    ignored_layers: list[str],
+    fused_mapping: Mapping[str, list[str]],
+) -> bool:
+    if is_layer_skipped(
+        prefix=prefix,
+        ignored_layers=ignored_layers,
+        fused_mapping=fused_mapping,
+    ):
+        return True
+    prefix_without_model = prefix.removeprefix("model.")
+    return any(
+        prefix_without_model.startswith(f"{ignored_layer.removeprefix('model.')}.") for ignored_layer in ignored_layers
+    )
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -85,6 +104,7 @@ class DiffusionMXFP8Config(QuantizationConfig):
         super().__init__()
         self.is_checkpoint_mxfp8_serialized = is_checkpoint_mxfp8_serialized
         self.ignored_layers = ignored_layers or []
+        self.quant_description = {"group_size": 32}
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
@@ -122,11 +142,33 @@ class DiffusionMXFP8Config(QuantizationConfig):
         layer: torch.nn.Module,
         prefix: str,
     ) -> QuantizeMethodBase | None:
+        if current_omni_platform.is_npu() and self.is_checkpoint_mxfp8_serialized:
+            from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+
+            if isinstance(layer, RoutedExperts):
+                if _is_layer_or_child_skipped(
+                    prefix,
+                    self.ignored_layers,
+                    self.packed_modules_mapping,
+                ):
+                    return None
+                from vllm_ascend.quantization.method_adapters import (
+                    AscendFusedMoEMethod,
+                )
+                from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+                    AscendW8A8MXFP8DynamicFusedMoEMethod,
+                )
+
+                scheme = AscendW8A8MXFP8DynamicFusedMoEMethod()
+                return AscendFusedMoEMethod(
+                    scheme,
+                    layer.moe_config,
+                )
         if isinstance(layer, LinearBase):
-            if is_layer_skipped(
-                prefix=prefix,
-                ignored_layers=self.ignored_layers,
-                fused_mapping=self.packed_modules_mapping,
+            if _is_layer_or_child_skipped(
+                prefix,
+                self.ignored_layers,
+                self.packed_modules_mapping,
             ):
                 return UnquantizedLinearMethod()
             if current_omni_platform.is_npu():


### PR DESCRIPTION
## Summary

Add offline MXFP8 checkpoint support for NPU `RoutedExperts` layers.

This connects vLLM Omni diffusion MoE layers to the existing vLLM Ascend MXFP8 fused MoE implementation while preserving the standard vLLM quantization method interface.

## Motivation

The diffusion MXFP8 configuration supports NPU linear layers but previously returned no quantization method for `RoutedExperts`. Offline MXFP8 MoE checkpoints therefore could not select the Ascend MXFP8 fused expert implementation through the standard quantization path.

## Changes

- Detect `RoutedExperts` for serialized MXFP8 checkpoints on NPU.
- Create `AscendW8A8MXFP8DynamicFusedMoEMethod` for expert execution.
- Adapt the scheme with `AscendFusedMoEMethod`.
- Keep `get_quant_method` aligned with the two-argument vLLM `QuantizationConfig` interface.
- Provide the MXFP8 group size through `quant_description`.
- Preserve the unquantized fallback for ignored routed-expert layers.
- Extend ignored-layer matching so a parent block prefix excludes its child modules.

## Behavior

```text
RoutedExperts
  -> AscendW8A8MXFP8DynamicFusedMoEMethod
  -> AscendFusedMoEMethod
```

When the layer or a parent prefix appears in `ignored_layers`, routed experts retain the existing unquantized fallback. Child linear layers under the same prefix use `UnquantizedLinearMethod`.

Existing linear-layer and non-NPU behavior remains unchanged.

## Validation

`tests/diffusion/quantization/test_mxfp8_config.py` covers:

- existing offline NPU MXFP8 linear selection
- Ascend fused MoE method creation
- ignored routed-expert fallback
- child linear exclusion through a parent prefix

Ruff checks, Ruff formatting, Python syntax compilation, and `git diff --check` pass for the changed files.