### PR TITLE
[Bugfix] Materialize safetensors before device copies

### DIFF
--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -48,7 +48,22 @@ Each entry under `stages:` accepts any `StageDeployConfig` field directly (no ne
 | `output_connectors` | dict \| null | optional | `null` | Keyed by `to_stage_<n>`; values are names registered under top-level `connectors:`. |
 | `input_connectors` | dict \| null | optional | `null` | Keyed by `from_stage_<n>`; values are names registered under top-level `connectors:`. |
 | `default_sampling_params` | dict \| null | optional | `null` | Baseline sampling params. Deep-merged with pipeline `sampling_constraints` (pipeline wins). |
+| `materialize_safetensors_weights` | bool | optional | `false` | Diffusion stages only. Materialize CPU safetensors into owned host memory before device copies. |
 | `engine_extras` | dict | optional | `{}` | Catch-all for keys not listed above; deep-merged across overlays. Also carries per-stage overrides of pipeline-wide settings (e.g. stage-specific `dtype`). |
+
+#### Materializing safetensors before device copies
+
+For diffusion stages, enable `materialize_safetensors_weights` when direct device copies from memory-mapped safetensors stall on the target accelerator:
+
+```yaml
+stages:
+  - stage_id: 1
+    materialize_safetensors_weights: true
+```
+
+The option defaults to `false`. When enabled, the diffusion loader clones each CPU tensor yielded by the safetensors iterator before passing it to the model weight loader. It has no effect on other checkpoint formats or tensors that are already on another device.
+
+Only the tensor currently being loaded is materialized. Peak additional host-memory usage is therefore approximately the size of the largest individual tensor in the checkpoint.
 
 ### Connector schema
 

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -904,6 +904,40 @@ def test_from_pipeline_config_normalizes_diffusion_config_aliases_from_engine_ar
     assert stage.diffusion_config.diffusion_attention_config.default.backend == "flash_attn"
 
 
+def test_stage_yaml_materialize_safetensors_weights_reaches_loader(tmp_path):
+    from vllm.config.load import LoadConfig
+
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+    from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+
+    deploy_path = tmp_path / "dreamzero_materialize_safetensors.yaml"
+    deploy_path.write_text(
+        "\n".join(
+            [
+                "pipeline: dreamzero",
+                "async_chunk: false",
+                "stages:",
+                "  - stage_id: 0",
+                "    materialize_safetensors_weights: true",
+            ]
+        )
+    )
+
+    stage = _from_pipeline_key(
+        "dreamzero",
+        deploy_config_path=str(deploy_path),
+    ).stage_by_id(0)
+    diffusion_kwargs = {
+        config_field.name: getattr(stage.diffusion_config, config_field.name)
+        for config_field in fields(stage.diffusion_config)
+    }
+    od_config = OmniDiffusionConfig.from_kwargs(**diffusion_kwargs)
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+
+    assert isinstance(stage, VllmOmniDiffusionStageConfig)
+    assert loader.od_config.materialize_safetensors_weights is True
+
+
 def test_diffusion_config_field_classification_covers_current_fields():
     classified_fields = (
         omni_config_module._DIFFUSION_SHARED_CONFIG_FIELDS

--- a/tests/diffusion/model_loader/test_diffusers_loader.py
+++ b/tests/diffusion/model_loader/test_diffusers_loader.py
@@ -15,13 +15,44 @@ from vllm.config.load import LoadConfig
 
 from vllm_omni.diffusion.config import get_current_diffusion_config, get_current_diffusion_config_or_none
 from vllm_omni.diffusion.data import OmniDiffusionConfig
-from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.model_loader.diffusers_loader import (
+    DiffusersPipelineLoader,
+    _materialize_safetensors_weights,
+)
 from vllm_omni.diffusion.models.helios import HeliosPipeline
 from vllm_omni.diffusion.registry import initialize_model
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 model_path = "hf-internal-testing/tiny-helios-modular-pipe"
+
+
+def test_materialize_safetensors_weights_clones_cpu_tensor():
+    tensor = torch.arange(4)
+
+    [(name, materialized)] = list(
+        _materialize_safetensors_weights(
+            [("weight", tensor)],
+            enabled=True,
+        )
+    )
+
+    assert name == "weight"
+    assert torch.equal(materialized, tensor)
+    assert materialized.data_ptr() != tensor.data_ptr()
+
+
+def test_materialize_safetensors_weights_is_disabled():
+    tensor = torch.arange(4)
+
+    [(_, unchanged)] = list(
+        _materialize_safetensors_weights(
+            [("weight", tensor)],
+            enabled=False,
+        )
+    )
+
+    assert unchanged is tensor
 
 
 @pytest.fixture(scope="module")

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -467,6 +467,7 @@ class _DiffusionConfigProjection:
     enable_prompt_embed_cache: bool = False
     prompt_embed_cache_size: int = Field(default=32, ge=1)
     diffusion_load_format: str = "default"
+    materialize_safetensors_weights: bool = False
     diffusers_load_kwargs: dict[str, Any] = field(default_factory=dict)
     diffusers_call_kwargs: dict[str, Any] = field(default_factory=dict)
     diffusers_pipeline_cls: Any = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -715,6 +715,7 @@ class OmniDiffusionConfig:
     # Parallel weight loading (for faster diffusion model startup)
     enable_multithread_weight_load: bool = True
     num_weight_load_threads: int = 4
+    materialize_safetensors_weights: bool = False
 
     # Enable sleep mode
     enable_sleep_mode: bool = False

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -74,6 +74,23 @@ def download_gguf(
 logger = init_logger(__name__)
 
 
+def _materialize_safetensors_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    enabled: bool,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Detach safetensors mmap storage before a platform device copy.
+
+    Some device runtimes can stall when copying directly from an mmap-backed
+    CPU tensor. This opt-in iterator keeps only one materialized tensor alive
+    at a time, so peak host memory grows by at most the current tensor size.
+    """
+    for name, tensor in weights:
+        if enabled and tensor.device.type == "cpu":
+            tensor = tensor.clone()
+        yield name, tensor
+
+
 def _natural_sort_key(filepath: str) -> list:
     """Natural sort key for filenames with numeric components, e.g.
     model-00001-of-00005.safetensors -> ['model-', 1, '-of-', 5, '.safetensors']."""
@@ -259,6 +276,11 @@ class DiffusersPipelineLoader:
                 hf_weights_files,
                 self.load_config.use_tqdm_on_load,
                 self.load_config.safetensors_load_strategy,
+            )
+        if use_safetensors:
+            weights_iterator = _materialize_safetensors_weights(
+                weights_iterator,
+                enabled=self.od_config.materialize_safetensors_weights,
             )
 
         if self.counter_before_loading_weights == 0.0:


### PR DESCRIPTION
## Summary

Add an optional stage-local weight-loading path that materializes memory-mapped safetensors on CPU before copying them to an accelerator device.

## Problem

Safetensors may expose CPU tensors backed directly by memory-mapped files. On some accelerator runtime and driver combinations, copying a large mmap-backed tensor directly to the device can stall during model loading. This was observed while loading quantized HunyuanImage3 weights on Ascend 950PR.

## Changes

Add `OmniDiffusionConfig.materialize_safetensors_weights`, which defaults to `false`. When enabled for a diffusion stage, its safetensors iterator clones each CPU tensor before passing it to the model weight loader.

```python
if enabled and tensor.device.type == "cpu":
    tensor = tensor.clone()
```

The option applies only to safetensors. Other checkpoint formats retain their current behavior.

## Usage

```yaml
stages:
  - stage_id: 0
    materialize_safetensors_weights: true
```

The setting is carried by each diffusion stage and does not introduce process-global environment state.

## Memory behavior

Only the current tensor is cloned. Additional peak host-memory usage is bounded by approximately the largest individual tensor being loaded.

## Validation

`tests/diffusion/model_loader/test_diffusers_loader.py` covers enabled and disabled iterator behavior, including storage independence for materialized CPU tensors.

Ruff checks, Ruff formatting, Python syntax compilation, and `git diff --check` pass for the changed files.