### PR TITLE
[Bugfix] Fix SenseNova-U1 head dtype config compatibility

### DIFF
--- a/tests/diffusion/test_diffusion_vllm_model_config.py
+++ b/tests/diffusion/test_diffusion_vllm_model_config.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+from vllm_omni.diffusion.worker.diffusion_worker import _DiffusionVllmModelConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_diffusion_model_config_provides_head_dtype_to_logits_processor():
+    vllm_config = VllmConfig(device_config=DeviceConfig(device="cpu"))
+    vllm_config.model_config = _DiffusionVllmModelConfig(
+        model="test-model",
+        dtype=torch.bfloat16,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        logits_processor = LogitsProcessor(vocab_size=16)
+
+    assert logits_processor.head_dtype is torch.bfloat16

--- a/tests/diffusion/test_diffusion_vllm_model_config.py
+++ b/tests/diffusion/test_diffusion_vllm_model_config.py
@@ -1,14 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 
-from vllm_omni.diffusion.worker.diffusion_worker import _DiffusionVllmModelConfig
+from vllm_omni.diffusion.worker.diffusion_worker import (
+    _DiffusionVllmModelConfig,
+    _make_diffusion_vllm_model_config,
+)
+from vllm_omni.quantization import build_quant_config
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_diffusion_vllm_model_config_supplies_dtype_for_quant_methods():
+    od_config = SimpleNamespace(
+        model="dummy",
+        dtype=torch.bfloat16,
+        quantization_config=build_quant_config(
+            {
+                "quant_method": "modelopt",
+                "quant_algo": "FP8",
+                "ignore": [],
+            }
+        ),
+        tf_model_config=SimpleNamespace(),
+        enforce_eager=True,
+        is_moe=False,
+    )
+
+    model_config = _make_diffusion_vllm_model_config(od_config)
+
+    assert model_config.dtype is torch.bfloat16
+    assert model_config.quantization == "modelopt"
+    assert model_config.quantization_config is od_config.quantization_config
+    assert model_config.is_quantized()
 
 
 def test_diffusion_model_config_provides_head_dtype_to_logits_processor():

--- a/tests/diffusion/test_diffusion_worker.py
+++ b/tests/diffusion/test_diffusion_worker.py
@@ -16,7 +16,6 @@ from pytest_mock import MockerFixture
 from vllm_omni.diffusion.worker.diffusion_worker import (
     DiffusionWorker,
     _create_diffusion_worker_vllm_config,
-    _make_diffusion_vllm_model_config,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.gpu]
@@ -56,34 +55,6 @@ def mock_gpu_worker(mocker: MockerFixture, mock_od_config):
     worker.device = torch.device("cuda", 0)
     worker._sleep_saved_buffers = {}
     return worker
-
-
-def test_diffusion_vllm_model_config_supplies_dtype_for_quant_methods():
-    from types import SimpleNamespace
-
-    from vllm_omni.quantization import build_quant_config
-
-    od_config = SimpleNamespace(
-        model="dummy",
-        dtype=torch.bfloat16,
-        quantization_config=build_quant_config(
-            {
-                "quant_method": "modelopt",
-                "quant_algo": "FP8",
-                "ignore": [],
-            }
-        ),
-        tf_model_config=SimpleNamespace(),
-        enforce_eager=True,
-        is_moe=False,
-    )
-
-    model_config = _make_diffusion_vllm_model_config(od_config)
-
-    assert model_config.dtype is torch.bfloat16
-    assert model_config.quantization == "modelopt"
-    assert model_config.quantization_config is od_config.quantization_config
-    assert model_config.is_quantized()
 
 
 class TestDiffusionWorkerSleep:

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -91,6 +91,10 @@ class _DiffusionVllmModelConfig:
     def is_diffusion(self) -> bool:
         return False
 
+    @property
+    def head_dtype(self) -> torch.dtype:
+        return self.dtype
+
 
 def _make_diffusion_vllm_model_config(od_config: OmniDiffusionConfig) -> _DiffusionVllmModelConfig:
     quant_config = getattr(od_config, "quantization_config", None)


### PR DESCRIPTION
## Purpose

### What broke

The SenseNova-U1 weekly LoRA test fails during model initialization on vLLM 0.26 with:

```text
AttributeError: '_DiffusionVllmModelConfig' object has no attribute 'head_dtype'
```

### Reproduction

```bash
python -m pytest -q \
  tests/e2e/offline_inference/test_sensenova_u1_expansion.py::test_sensenova_u1_lora_scale_and_deactivation
```

The focused regression can be run with:

```bash
python -m pytest -q tests/diffusion/test_diffusion_vllm_model_config.py
```

### Root cause

Diffusion workers install `_DiffusionVllmModelConfig` as `VllmConfig.model_config`. vLLM 0.26's `LogitsProcessor` now reads `model_config.head_dtype` during initialization, but the diffusion compatibility config did not expose that part of the `ModelConfig` contract.

### Fix

Expose `head_dtype` from `_DiffusionVllmModelConfig`, returning the model dtype. This matches vLLM's default behavior for generation models and preserves the existing logits precision. Add a CPU regression test that installs the diffusion config in `VllmConfig` and constructs the real vLLM `LogitsProcessor`.

Fixes #5748.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `bc1b8bb70b37ee48b2214716455e231cb4022ded`

```bash
uvx --offline ruff check \
  vllm_omni/diffusion/worker/diffusion_worker.py \
  tests/diffusion/test_diffusion_vllm_model_config.py

uvx --offline ruff format --check \
  vllm_omni/diffusion/worker/diffusion_worker.py \
  tests/diffusion/test_diffusion_vllm_model_config.py

python -m pytest -q \
  tests/diffusion/test_diffusion_vllm_model_config.py \
  tests/diffusion/test_diffusion_worker_cuda_profiler.py
```

## Test Result

```text
5 passed, 18 warnings in 0.91s
```

The focused CPU test reproduces the exact `LogitsProcessor` initialization failure on the pre-fix code and passes with this change. The full 8B H100 LoRA generation test was not rerun locally because the SenseNova-U1 checkpoint was not cached; the existing weekly E2E remains the end-to-end validation boundary.
