### PR TITLE
[diffusion][perf] Fuse MiniMax H3 QK RMSNorm and 3D RoPE

### DIFF
--- a/benchmarks/diffusion/benchmark_minimax_h3_qk_norm_rope.py
+++ b/benchmarks/diffusion/benchmark_minimax_h3_qk_norm_rope.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Benchmark the MiniMax H3 Q/K RMSNorm + packed 3D RoPE fusion.
+
+Example:
+
+    CUDA_VISIBLE_DEVICES=0 python benchmarks/diffusion/benchmark_minimax_h3_qk_norm_rope.py
+
+The default shape is the TP=4 H3 5-second workload: 37,760 aligned tokens and
+14 local Q/K heads of width 128.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import torch
+import torch.nn.functional as F
+
+from vllm_omni.diffusion.models.minimax_h3.fused_qk_norm_rope import (
+    fused_qk_rmsnorm_rope,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=int, default=37_760)
+    parser.add_argument("--heads", type=int, default=14)
+    parser.add_argument("--kv-heads", type=int, default=14)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--dtype", choices=("bf16", "fp16", "fp32"), default="bf16")
+    return parser.parse_args()
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
+    }[name]
+
+
+def _eager(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_table: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q = F.rms_norm(q, (q.shape[-1],), q_weight, eps)
+    k = F.rms_norm(k, (k.shape[-1],), k_weight, eps)
+    half = rope_table.shape[-1] // 2
+    cos = rope_table[..., :half].to(q.dtype).unsqueeze(1)
+    sin = rope_table[..., half:].to(q.dtype).unsqueeze(1)
+
+    def _apply(x: torch.Tensor) -> torch.Tensor:
+        first = x[..., :half]
+        second = x[..., half : 2 * half]
+        return torch.cat(
+            (
+                first * cos - second * sin,
+                second * cos + first * sin,
+                x[..., 2 * half :],
+            ),
+            dim=-1,
+        )
+
+    return _apply(q), _apply(k)
+
+
+def _measure(fn, warmup: int, iters: int) -> list[float]:
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples = []
+    for _ in range(iters):
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+def main() -> None:
+    args = _parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA")
+    if args.head_dim != 128:
+        raise ValueError("MiniMax H3 fused QK/RoPE requires --head-dim 128")
+    device = torch.device("cuda")
+    dtype = _dtype(args.dtype)
+    eps = 1e-5
+    torch.manual_seed(17)
+    q = torch.randn(args.tokens, args.heads, args.head_dim, device=device, dtype=dtype)
+    k = torch.randn(args.tokens, args.kv_heads, args.head_dim, device=device, dtype=dtype)
+    q_weight = torch.randn(args.head_dim, device=device, dtype=dtype)
+    k_weight = torch.randn(args.head_dim, device=device, dtype=dtype)
+    raw_freqs = torch.randn(args.tokens, 48, device=device, dtype=torch.float32)
+    rope_table = torch.cat((torch.cos(raw_freqs), torch.sin(raw_freqs)), dim=-1).to(dtype)
+
+    def eager():
+        return _eager(q, k, q_weight, k_weight, rope_table, eps)
+
+    def fused():
+        return fused_qk_rmsnorm_rope(q, k, q_weight, k_weight, rope_table, eps)
+
+    eager_samples = _measure(eager, args.warmup, args.iters)
+    fused_samples = _measure(fused, args.warmup, args.iters)
+    ref_q, ref_k = eager()
+    out_q, out_k = fused()
+    torch.accelerator.synchronize()
+
+    def stats(samples: list[float]) -> dict[str, float]:
+        samples = sorted(samples)
+        return {
+            "median_ms": samples[len(samples) // 2],
+            "p90_ms": samples[int(len(samples) * 0.9)],
+            "mean_ms": sum(samples) / len(samples),
+        }
+
+    eager_stats = stats(eager_samples)
+    fused_stats = stats(fused_samples)
+    print(
+        json.dumps(
+            {
+                "device": torch.cuda.get_device_name(),
+                "tokens": args.tokens,
+                "heads": args.heads,
+                "kv_heads": args.kv_heads,
+                "head_dim": args.head_dim,
+                "dtype": args.dtype,
+                "eager": eager_stats,
+                "fused": fused_stats,
+                "speedup": eager_stats["median_ms"] / fused_stats["median_ms"],
+                "max_abs_q": (out_q.float() - ref_q.float()).abs().max().item(),
+                "max_abs_k": (out_k.float() - ref_k.float()).abs().max().item(),
+                "mean_abs_q": (out_q.float() - ref_q.float()).abs().mean().item(),
+                "mean_abs_k": (out_k.float() - ref_k.float()).abs().mean().item(),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_fused_kernel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_fused_kernel.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+from vllm.triton_utils import HAS_TRITON
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cuda, pytest.mark.diffusion]
+
+_DEVICE = torch.device("cuda")
+_HEAD_DIM = 128
+_ROTARY_DIM = 96
+_EPS = 1e-5
+
+
+def _reference(q, k, q_weight, k_weight, rope_table):
+    q = F.rms_norm(q, (_HEAD_DIM,), q_weight, _EPS)
+    k = F.rms_norm(k, (_HEAD_DIM,), k_weight, _EPS)
+    cos = rope_table[..., : _ROTARY_DIM // 2].to(q.dtype).unsqueeze(1)
+    sin = rope_table[..., _ROTARY_DIM // 2 :].to(q.dtype).unsqueeze(1)
+
+    def apply(x):
+        first = x[..., : _ROTARY_DIM // 2]
+        second = x[..., _ROTARY_DIM // 2 : _ROTARY_DIM]
+        rotated = torch.cat(
+            (
+                first * cos - second * sin,
+                second * cos + first * sin,
+                x[..., _ROTARY_DIM:],
+            ),
+            dim=-1,
+        )
+        return rotated
+
+    return apply(q), apply(k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton required")
+@pytest.mark.parametrize("seq_len", [1, 2, 7, 128, 257, 1024])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_minimax_h3_fused_qk_norm_rope_matches_reference(seq_len, dtype):
+    from vllm_omni.diffusion.models.minimax_h3.fused_qk_norm_rope import (
+        fused_qk_rmsnorm_rope,
+    )
+
+    torch.manual_seed(17)
+    q_heads = 14
+    k_heads = 14
+    qkv = torch.randn(
+        seq_len,
+        (q_heads + k_heads + k_heads) * _HEAD_DIM,
+        device=_DEVICE,
+        dtype=dtype,
+    )
+    q = qkv[:, : q_heads * _HEAD_DIM].view(seq_len, q_heads, _HEAD_DIM)
+    k_start = q_heads * _HEAD_DIM
+    k = qkv[:, k_start : k_start + k_heads * _HEAD_DIM].view(seq_len, k_heads, _HEAD_DIM)
+    q_weight = torch.randn(_HEAD_DIM, device=_DEVICE, dtype=dtype)
+    k_weight = torch.randn(_HEAD_DIM, device=_DEVICE, dtype=dtype)
+    raw_freqs = torch.randn(seq_len, _ROTARY_DIM, device=_DEVICE, dtype=torch.float32)
+    half = _ROTARY_DIM // 2
+    rope_table = torch.cat(
+        (torch.cos(raw_freqs[:, :half]), torch.sin(raw_freqs[:, :half])),
+        dim=-1,
+    ).to(dtype)
+
+    ref_q, ref_k = _reference(q, k, q_weight, k_weight, rope_table)
+    out_q, out_k = fused_qk_rmsnorm_rope(q, k, q_weight, k_weight, rope_table, _EPS)
+
+    if dtype == torch.bfloat16:
+        atol = rtol = 3e-2
+    else:
+        atol = rtol = 1e-5
+    torch.testing.assert_close(out_q, ref_q, atol=atol, rtol=rtol)
+    torch.testing.assert_close(out_k, ref_k, atol=atol, rtol=rtol)

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -61,6 +61,18 @@ def test_packed_attention_is_a_regional_compile_boundary():
     assert getattr(MiniMaxH3Attention._run_packed_attention, "_torchdynamo_disable", False)
 
 
+def test_rope_table_matches_repeated_frequency_layout():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        _build_rope_table,
+    )
+
+    torch.manual_seed(23)
+    half = torch.randn(7, 48)
+    freqs = torch.cat((half, half), dim=-1)
+    expected = torch.cat((torch.cos(half), torch.sin(half)), dim=-1).to(torch.bfloat16)
+    torch.testing.assert_close(_build_rope_table(freqs), expected)
+
+
 @pytest.mark.parametrize(
     ("tp_size", "message"),
     [

--- a/vllm_omni/diffusion/models/minimax_h3/fused_qk_norm_rope.py
+++ b/vllm_omni/diffusion/models/minimax_h3/fused_qk_norm_rope.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Fused MiniMax H3 Q/K RMSNorm and 3D RoPE.
+
+The H3 attention head is 128-wide and rotates the first 96 dimensions.  The
+frequency tensor contains two identical 48-wide halves, so the compiled
+request path stores only ``[cos(freqs[:48]), sin(freqs[:48])]``.
+"""
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_H3_HEAD_DIM = 128
+_H3_ROTARY_DIM = 96
+_H3_ROTARY_HALF_DIM = _H3_ROTARY_DIM // 2
+
+
+def _apply_rope_table(
+    x: torch.Tensor,
+    rope_table: torch.Tensor,
+) -> torch.Tensor:
+    """Reference H3 RoPE for a packed ``[cos, sin]`` table."""
+    half = _H3_ROTARY_HALF_DIM
+    cos = rope_table[..., :half].to(x.dtype).unsqueeze(1)
+    sin = rope_table[..., half:].to(x.dtype).unsqueeze(1)
+    x_rot = x[..., :_H3_ROTARY_DIM]
+    x_first, x_second = x_rot[..., :half], x_rot[..., half:]
+    rotated_first = (x_first * cos) - (x_second * sin)
+    rotated_second = (x_second * cos) + (x_first * sin)
+    return torch.cat((rotated_first, rotated_second, x[..., _H3_ROTARY_DIM:]), dim=-1)
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _h3_qk_norm_rope_kernel(
+        q_ptr,
+        k_ptr,
+        q_out_ptr,
+        k_out_ptr,
+        q_weight_ptr,
+        k_weight_ptr,
+        rope_table_ptr,
+        q_stride_t,
+        q_stride_h,
+        q_stride_d,
+        k_stride_t,
+        k_stride_h,
+        k_stride_d,
+        q_out_stride_t,
+        q_out_stride_h,
+        q_out_stride_d,
+        k_out_stride_t,
+        k_out_stride_h,
+        k_out_stride_d,
+        rope_stride_t,
+        num_q_heads: tl.constexpr,
+        head_dim: tl.constexpr,
+        rotary_dim: tl.constexpr,
+        eps: tl.constexpr,
+        input_dtype: tl.constexpr,
+        head_block: tl.constexpr,
+        rot_half_block: tl.constexpr,
+    ):
+        token = tl.program_id(0)
+        head = tl.program_id(1)
+        is_k = head >= num_q_heads
+        local_head = tl.where(is_k, head - num_q_heads, head)
+
+        if is_k:
+            in_base = k_ptr + token * k_stride_t + local_head * k_stride_h
+            out_base = k_out_ptr + token * k_out_stride_t + local_head * k_out_stride_h
+            weight_ptr = k_weight_ptr
+            in_stride_d = k_stride_d
+            out_stride_d = k_out_stride_d
+        else:
+            in_base = q_ptr + token * q_stride_t + local_head * q_stride_h
+            out_base = q_out_ptr + token * q_out_stride_t + local_head * q_out_stride_h
+            weight_ptr = q_weight_ptr
+            in_stride_d = q_stride_d
+            out_stride_d = q_out_stride_d
+
+        head_offsets = tl.arange(0, head_block)
+        head_mask = head_offsets < head_dim
+        x = tl.load(
+            in_base + head_offsets * in_stride_d,
+            mask=head_mask,
+            other=0.0,
+        ).to(tl.float32)
+        variance = tl.sum(x * x, axis=0) / head_dim
+        inv_rms = tl.rsqrt(variance + eps)
+
+        # Keep the non-rotary tail in the same output allocation. The cast
+        # before the store matches the eager RMSNorm BF16/FP16 boundary.
+        tail_mask = head_mask & (head_offsets >= rotary_dim)
+        tail_weight = tl.load(
+            weight_ptr + head_offsets,
+            mask=tail_mask,
+            other=0.0,
+        ).to(tl.float32)
+        tail = (x * inv_rms * tail_weight).to(input_dtype)
+        tl.store(out_base + head_offsets * out_stride_d, tail, mask=tail_mask)
+
+        # Triton does not provide a cheap slice of a register block.  Reload
+        # the rotated halves using the already computed inverse RMS.  This is
+        # the same tradeoff used by the existing vLLM fused QK/RoPE kernel.
+        rot_offsets = tl.arange(0, rot_half_block)
+        rot_mask = rot_offsets < (rotary_dim // 2)
+        first = tl.load(
+            in_base + rot_offsets * in_stride_d,
+            mask=rot_mask,
+            other=0.0,
+        ).to(tl.float32)
+        second = tl.load(
+            in_base + (rotary_dim // 2 + rot_offsets) * in_stride_d,
+            mask=rot_mask,
+            other=0.0,
+        ).to(tl.float32)
+        first_weight = tl.load(weight_ptr + rot_offsets, mask=rot_mask, other=0.0).to(tl.float32)
+        second_weight = tl.load(
+            weight_ptr + rotary_dim // 2 + rot_offsets,
+            mask=rot_mask,
+            other=0.0,
+        ).to(tl.float32)
+        first = (first * inv_rms * first_weight).to(input_dtype).to(tl.float32)
+        second = (second * inv_rms * second_weight).to(input_dtype).to(tl.float32)
+
+        table_base = rope_table_ptr + token * rope_stride_t
+        cos = tl.load(table_base + rot_offsets, mask=rot_mask, other=0.0).to(tl.float32)
+        sin = tl.load(
+            table_base + rotary_dim // 2 + rot_offsets,
+            mask=rot_mask,
+            other=0.0,
+        ).to(tl.float32)
+        rotated_first = first * cos - second * sin
+        rotated_second = second * cos + first * sin
+        tl.store(out_base + rot_offsets * out_stride_d, rotated_first, mask=rot_mask)
+        tl.store(
+            out_base + (rotary_dim // 2 + rot_offsets) * out_stride_d,
+            rotated_second,
+            mask=rot_mask,
+        )
+
+
+def _h3_qk_norm_rope_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_table: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not HAS_TRITON or not q.is_cuda:
+        q_norm = torch.nn.functional.rms_norm(q, (q.shape[-1],), q_weight, eps)
+        k_norm = torch.nn.functional.rms_norm(k, (k.shape[-1],), k_weight, eps)
+        return _apply_rope_table(q_norm, rope_table), _apply_rope_table(k_norm, rope_table)
+
+    if q.dtype == torch.bfloat16:
+        input_dtype = tl.bfloat16
+    elif q.dtype == torch.float16:
+        input_dtype = tl.float16
+    elif q.dtype == torch.float32:
+        input_dtype = tl.float32
+    else:
+        raise TypeError(f"MiniMax H3 fused QK/RoPE only supports floating inputs, got {q.dtype}")
+
+    q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    k_out = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+    if q.shape[0] == 0:
+        return q_out, k_out
+
+    head_block = triton.next_power_of_2(q.shape[-1])
+    rot_half_block = triton.next_power_of_2(_H3_ROTARY_HALF_DIM)
+    grid = (q.shape[0], q.shape[1] + k.shape[1])
+    _h3_qk_norm_rope_kernel[grid](
+        q,
+        k,
+        q_out,
+        k_out,
+        q_weight,
+        k_weight,
+        rope_table,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        q_out.stride(0),
+        q_out.stride(1),
+        q_out.stride(2),
+        k_out.stride(0),
+        k_out.stride(1),
+        k_out.stride(2),
+        rope_table.stride(0),
+        num_q_heads=q.shape[1],
+        head_dim=q.shape[2],
+        rotary_dim=_H3_ROTARY_DIM,
+        eps=eps,
+        input_dtype=input_dtype,
+        head_block=head_block,
+        rot_half_block=rot_half_block,
+        num_warps=2,
+        num_stages=2,
+    )
+    return q_out, k_out
+
+
+def _h3_qk_norm_rope_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_table: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del q_weight, k_weight, rope_table, eps
+    return torch.empty_like(q), torch.empty_like(k)
+
+
+direct_register_custom_op(
+    op_name="minimax_h3_qk_norm_rope",
+    op_func=_h3_qk_norm_rope_cuda,
+    fake_impl=_h3_qk_norm_rope_fake,
+    mutates_args=[],
+)
+
+
+def fused_qk_rmsnorm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_table: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply H3 Q/K RMSNorm followed by 3D RoPE in one custom op."""
+    if q.ndim != 3 or k.ndim != 3:
+        raise ValueError(f"q and k must be [T, heads, head_dim], got {q.shape} and {k.shape}")
+    if q.shape[0] != k.shape[0] or q.shape[2] != k.shape[2]:
+        raise ValueError(f"q and k shapes are incompatible: {q.shape} and {k.shape}")
+    if q.dtype != k.dtype:
+        raise ValueError(f"q and k must have the same dtype, got {q.dtype} and {k.dtype}")
+    if q.device != k.device:
+        raise ValueError(f"q and k must be on the same device, got {q.device} and {k.device}")
+    if q.shape[2] != _H3_HEAD_DIM:
+        raise ValueError(f"MiniMax H3 fused QK/RoPE expects head_dim=128, got {q.shape[2]}")
+    if q_weight.shape != (_H3_HEAD_DIM,) or k_weight.shape != (_H3_HEAD_DIM,):
+        raise ValueError(
+            "MiniMax H3 fused QK/RoPE expects one 128-element weight per norm, "
+            f"got {tuple(q_weight.shape)} and {tuple(k_weight.shape)}"
+        )
+    if q_weight.device != q.device or k_weight.device != q.device:
+        raise ValueError("MiniMax H3 fused QK/RoPE weights must be on the activation device")
+    if rope_table.device != q.device:
+        raise ValueError("MiniMax H3 fused QK/RoPE table must be on the activation device")
+    if rope_table.shape != (q.shape[0], _H3_ROTARY_DIM):
+        raise ValueError(
+            f"MiniMax H3 rope_table must be [T, 96] containing [cos(48), sin(48)], got {tuple(rope_table.shape)}"
+        )
+    if not rope_table.is_contiguous():
+        rope_table = rope_table.contiguous()
+    return torch.ops.vllm.minimax_h3_qk_norm_rope(q, k, q_weight, k_weight, rope_table, eps)
+
+
+__all__ = ["fused_qk_rmsnorm_rope"]

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -34,6 +34,8 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelOutput,
 )
 
+from .fused_qk_norm_rope import fused_qk_rmsnorm_rope
+
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (
         QuantizationConfig,
@@ -175,11 +177,6 @@ def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> nn.RMSN
     return nn.RMSNorm(size, eps=eps, dtype=dtype)
 
 
-def _rotate_half(x: torch.Tensor) -> torch.Tensor:
-    x1, x2 = torch.chunk(x, 2, dim=-1)
-    return torch.cat((-x2, x1), dim=-1)
-
-
 def _modulate_scale_shift(
     x: torch.Tensor,
     shift: torch.Tensor,
@@ -230,18 +227,10 @@ class MiniMaxH3Rope(nn.Module):
         return torch.cat((half, half), dim=-1)  # [S, 96]
 
 
-def _apply_rope(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-    """Rotate the first rot_dim head dims; pass the rest through.
-
-    x: [T, heads, head_dim]; freqs: [T, rot_dim]. In the unfused path, cos/sin
-    are cast to the activation dtype before the elementwise math.
-    """
-    rot_dim = freqs.shape[-1]
-    x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
-    cos = torch.cos(freqs).to(x.dtype).unsqueeze(1)  # [T, 1, rot_dim]
-    sin = torch.sin(freqs).to(x.dtype).unsqueeze(1)
-    x_rot = (x_rot * cos) + (_rotate_half(x_rot) * sin)
-    return torch.cat((x_rot, x_pass), dim=-1)
+def _build_rope_table(freqs: torch.Tensor) -> torch.Tensor:
+    """Materialize H3's packed ``[cos(freqs[:48]), sin(freqs[:48])]`` table."""
+    half = freqs.shape[-1] // 2
+    return torch.cat((torch.cos(freqs[..., :half]), torch.sin(freqs[..., :half])), dim=-1).to(_BF16_DTYPE)
 
 
 class MiniMaxH3TimeEmbedder(nn.Module):
@@ -422,7 +411,7 @@ class MiniMaxH3Attention(nn.Module):
         self,
         x: torch.Tensor,
         *,
-        rope_freqs: torch.Tensor | None,
+        rope_table: torch.Tensor | None,
         cu_seqlens: torch.Tensor,
         max_seqlen: int,
         sp_seq_lens: list[int] | None = None,
@@ -446,11 +435,18 @@ class MiniMaxH3Attention(nn.Module):
         q = q.view(total, self.num_heads, self.head_dim)
         k = k.view(total, self.num_kv_heads, self.head_dim)
         v = v.view(total, self.num_kv_heads, self.head_dim)
-        q = self.q_norm(q)
-        k = self.k_norm(k)
-        if rope_freqs is not None:
-            q = _apply_rope(q, rope_freqs)
-            k = _apply_rope(k, rope_freqs)
+        if rope_table is None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        else:
+            q, k = fused_qk_rmsnorm_rope(
+                q,
+                k,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                rope_table,
+                self.q_norm.eps,
+            )
 
         # The packed layout uses a second document for alignment padding.
         # Local/Ulysses backends unpad it, while Ring keeps aligned rows for
@@ -591,7 +587,7 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
     ) -> torch.Tensor:
         x = x + self.attn(
             self.norm1(x),
-            rope_freqs=None,
+            rope_table=None,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )
@@ -648,7 +644,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         *,
         t_emb: torch.Tensor,
         combined_indices: torch.Tensor,
-        rope_freqs: torch.Tensor,
+        rope_table: torch.Tensor,
         cu_seqlens: torch.Tensor,
         max_seqlen: int,
         sp_seq_lens: list[int] | None = None,
@@ -674,7 +670,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         h = _modulate_scale_shift(h, shift_msa, scale_msa, combined_indices, dtype=_BF16_DTYPE)
         h = self.attn(
             h,
-            rope_freqs=rope_freqs,
+            rope_table=rope_table,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
             sp_seq_lens=sp_seq_lens,
@@ -749,10 +745,10 @@ class MiniMaxH3SPPrepare(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        rope_freqs: torch.Tensor,
+        rope_table: torch.Tensor,
         combined_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        return hidden_states, rope_freqs, combined_indices
+        return hidden_states, rope_table, combined_indices
 
 
 class MiniMaxH3SPGather(nn.Module):
@@ -1037,8 +1033,8 @@ class MiniMaxH3DiTModel(nn.Module):
         if inverse_indices.shape[0] != seq_len:
             raise ValueError(f"inverse_indices must be [{seq_len}], got {list(inverse_indices.shape)}")
         device = x.device
-        # Compute RoPE frequencies over the full packed sequence.
-        rope_freqs = self.rope(img_position_ids).to(device)
+        # Compute the packed [cos, sin] RoPE table over the full sequence.
+        rope_table = _build_rope_table(self.rope(img_position_ids).to(device))
 
         decoder_input, t_emb = self._embed(
             x=x,
@@ -1059,7 +1055,7 @@ class MiniMaxH3DiTModel(nn.Module):
 
         hidden = decoder_input
         cu_seqlens = cu_seqlens.to(device)
-        block_rope = rope_freqs
+        block_rope = rope_table
         block_combined = combined_indices
 
         hidden, block_rope, block_combined = self.sp_prepare(
@@ -1072,7 +1068,7 @@ class MiniMaxH3DiTModel(nn.Module):
                 hidden,
                 t_emb=t_emb,
                 combined_indices=block_combined,
-                rope_freqs=block_rope,
+                rope_table=block_rope,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
             )


### PR DESCRIPTION
## What changed

- Add a Triton kernel that fuses MiniMax H3 per-head Q/K RMSNorm with packed 3D RoPE for the BF16 main DiT path.
- Materialize request-scoped `[cos, sin]` RoPE tables and keep the existing eager fallback for token-refiner/no-RoPE paths.
- Add CUDA correctness tests, a RoPE-layout contract test, dynamic `torch.compile` coverage, and a reproducible kernel benchmark.

## Why

The previous path performed Q/K RMSNorm and 3D RoPE as separate operations. MiniMax H3 uses a fixed head dimension of 128 and rotates 96 dimensions, making this layout suitable for a dedicated fusion that removes intermediate tensors and kernel launches across the main DiT blocks.

## Performance

Matched single-request latency comparison on 4x NVIDIA B300 SXM6 AC (SM 10.3), with torch 2.11.0+cu130 and CUDA 13.0. Both runs used TP4/Ulysses1/Ring1, text-encoder TP4, VAE tile4, CUDNN attention, regional compile, 5-second 1344x768 T2VA, and the same 50-step workload.

| Metric | Upstream | This PR | Change |
| --- | ---: | ---: | ---: |
| Steady diffuse | 58.047 s | 57.267 s | 1.34% faster |
| End-to-end wall time | 60.593 s | 59.844 s | 1.24% faster |
| Peak worker memory | 49,332 MB | 49,332 MB | unchanged |

Kernel-only benchmark at 37,760 tokens, 14 local Q/K heads, and head dimension 128: 1.8376 ms -> 0.5490 ms (3.35x faster), using `--warmup 5 --iters 50`.

## Correctness and validation

- `PYTHONPATH=/home/zjy/code/lsy/worktree/minimax-h3-pillar1 /home/zjy/code/lsy/tmp/minimax-h3-b300/.venv/bin/python -m pytest -q tests/diffusion/models/minimax_h3`: **40 passed, 1 skipped**.
- Targeted pre-commit hooks, Ruff, `compileall`, and `git diff --check` passed.
- `torch.compile(..., dynamic=True)` capture passed for 128-token and 64-token shapes.
- CUDA fused-kernel coverage includes BF16/FP32 and sequence lengths 1, 2, 7, 128, 257, and 1024.
- No algorithmic approximation is introduced. Because the fused path intentionally follows the eager BF16/FP16 boundaries and uses a different Triton reduction order, bitwise equality with eager is not promised; direct-kernel validation showed maximum absolute error 0.0625 and mean absolute error about 7e-4.

The local end-to-end summaries are saved in `tmp/minimax-h3-pillar1-baseline-e2e/summary.json` and `tmp/minimax-h3-pillar1-e2e/summary.json`. The standalone benchmark is `benchmarks/diffusion/benchmark_minimax_h3_qk_norm_rope.py`.
