### PR TITLE
[CI/Build] Refresh Wan2.2 I2V baselines after guidance fix

### DIFF
--- a/tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
@@ -42,9 +42,9 @@
           }
         ],
         "baseline": {
-          "throughput_qps": 0.0434,
-          "latency_mean": 23.0654,
-          "peak_memory_mb_mean": 76360.0
+          "throughput_qps": 0.038,
+          "latency_mean": 26.3053,
+          "peak_memory_mb_mean": 76712.4
         }
       }
     ]
@@ -97,9 +97,9 @@
           }
         ],
         "baseline": {
-          "throughput_qps": 0.0606,
-          "latency_mean": 16.4928,
-          "peak_memory_mb_mean": 47164.8
+          "throughput_qps": 0.0554,
+          "latency_mean": 18.0395,
+          "peak_memory_mb_mean": 47670.2
         }
       },
       {
@@ -122,9 +122,9 @@
           }
         ],
         "baseline": {
-          "throughput_qps": 0.0124,
-          "latency_mean": 80.7784,
-          "peak_memory_mb_mean": 55374.3429
+          "throughput_qps": 0.0101,
+          "latency_mean": 99.1484,
+          "peak_memory_mb_mean": 56874.3
         }
       }
     ]


### PR DESCRIPTION
## Purpose

Refresh the Wan2.2 I2V nightly performance baselines after the guidance semantics correction in #5615.

Before #5615, an omitted `guidance_scale_2` was incorrectly treated as an explicit `1.0`, so the 4-step I2V benchmark executed six transformer forwards. The corrected `5.0 / 5.0` behavior executes eight forwards, which predicts a 33.3% denoising-cost increase. Public nightly artifacts show the increase is isolated to denoising and matches that call-count change.

This PR updates only the benchmark baselines. It does not revert the correctness fix or change runtime behavior.

Fixes #5694.

## Baseline Method

Use the plain average of every post-fix main nightly available through August 3, 2026:

| Build | Commit |
| --- | --- |
| #13064 | `67c54777` |
| #13076 | `67c54777` |
| #13090 | `24741961` |
| #13108 | `900a7f08` |

The values follow the existing four-decimal baseline convention used by #5231.

| Case | Metric | Old | New four-build average | Change |
| --- | --- | ---: | ---: | ---: |
| 1x H100, 832×480, 81 frames | throughput | 0.0434 qps | 0.0380 qps | -12.38% |
| | latency mean | 23.0654 s | 26.3053 s | +14.05% |
| | peak memory mean | 76360.0 MB | 76712.4 MB | +0.46% |
| USP2, 832×480, 81 frames | throughput | 0.0606 qps | 0.0554 qps | -8.53% |
| | latency mean | 16.4928 s | 18.0395 s | +9.38% |
| | peak memory mean | 47164.8 MB | 47670.2 MB | +1.07% |
| USP2, 1280×720, 121 frames | throughput | 0.0124 qps | 0.0101 qps | -18.66% |
| | latency mean | 80.7784 s | 99.1484 s | +22.74% |
| | peak memory mean | 55374.3429 MB | 56874.3 MB | +2.71% |

Across these four builds, latency coefficient of variation is 1.89%, 0.012%, and 0.28% for the three cases respectively. The single-device variation includes build #13090 rather than excluding the slower sample.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `113557a7f6c8639b7a894f370a4d3b43105587a3`

```bash
python3 -m json.tool \
  tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json

python -m pytest -q \
  tests/dfx/perf/tests/test_runner_metadata.py
```

A verification script also recomputed every baseline from builds #13064, #13076, #13090, and #13108 and asserted exact equality with the committed JSON values.

## Test Result

```text
baseline_mean_verification=PASS
13 passed, 18 warnings in 0.33s
```

Validation boundary: this PR uses the existing H100 nightly artifacts and changes only baseline metadata; it does not claim a performance improvement or repeat the 14B model runs locally.
