### PR TITLE
[Frontend] Enforce upload size limit for video references (HTTP 413)

### DIFF
--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -9,6 +9,7 @@ import base64
 import io
 import json
 import os
+import tempfile
 import threading
 import time
 from contextlib import asynccontextmanager
@@ -1955,3 +1956,49 @@ def test_worker_fps_multiplier_is_applied_to_sync_encoding(test_client, mocker: 
     assert response.status_code == 200
     assert response.content == b"fps-multiplied"
     assert fps_values == [16]
+
+
+def test_video_upload_single_reference_rejected_when_too_large(test_client, monkeypatch):
+    """A single input_reference upload larger than the configured limit is
+    rejected with HTTP 413 before any decoding happens."""
+    monkeypatch.setattr(api_server, "VIDEO_MAX_UPLOAD_BYTES", 16)
+    oversized = b"x" * 1024
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={"prompt": "too big"},
+        files={"input_reference": ("ref.png", oversized, "image/png")},
+    )
+    assert response.status_code == 413
+    assert "VLLM_OMNI_VIDEO_MAX_UPLOAD_BYTES" in response.json()["detail"]
+
+
+def test_video_upload_multi_reference_rejected_when_too_large(test_client, monkeypatch):
+    """An input_references (multi-video) upload exceeding the limit is rejected
+    with HTTP 413 and leaves no persisted temp files behind."""
+    monkeypatch.setattr(api_server, "VIDEO_MAX_UPLOAD_BYTES", 16)
+    oversized = b"y" * 1024
+    tmp_before = set(Path(tempfile.gettempdir()).glob("vllm_omni_video_reference_*"))
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={"prompt": "too big"},
+        files={"input_references": ("ref.mp4", oversized, "video/mp4")},
+    )
+    assert response.status_code == 413
+    tmp_after = set(Path(tempfile.gettempdir()).glob("vllm_omni_video_reference_*"))
+    assert tmp_after == tmp_before, "oversized multi-upload must not leave temp files"
+
+
+def test_video_upload_within_limit_not_rejected_for_size(test_client, mocker: MockerFixture):
+    """An upload within the size limit is not rejected on size grounds; the
+    request proceeds past the 413 gate (size check must not affect valid uploads)."""
+    mocker.patch(
+        "vllm_omni.entrypoints.openai.serving_video._encode_video_bytes",
+        return_value=b"ok-mp4",
+    )
+    small_image = _make_test_image_bytes()
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={"prompt": "small ok"},
+        files={"input_reference": ("ref.png", small_image, "image/png")},
+    )
+    assert response.status_code != 413

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2954,6 +2954,39 @@ async def _run_video_generation_job(
 
 VIDEO_SYNC_TIMEOUT_S = float(os.environ.get("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", 600.0))
 
+# Maximum accepted size for a single uploaded reference (image/video) in bytes.
+# Enforced by streaming byte counting so an oversized upload is rejected without
+# first buffering the whole payload in memory or on disk. Configurable for
+# deployments that need to serve larger Ref2VA references or tighten the limit
+# on memory-constrained hosts.
+VIDEO_MAX_UPLOAD_BYTES = int(os.environ.get("VLLM_OMNI_VIDEO_MAX_UPLOAD_BYTES", 512 * 1024 * 1024))
+
+
+def _reject_oversized_upload(actual_bytes: int, *, filename: str | None = None) -> None:
+    """Raise HTTP 413 when an uploaded reference exceeds the configured limit."""
+    where = f" ({filename})" if filename else ""
+    raise HTTPException(
+        status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE.value,
+        detail=(
+            f"Uploaded reference{where} is {actual_bytes} bytes, exceeding the "
+            f"{VIDEO_MAX_UPLOAD_BYTES}-byte limit "
+            f"(set VLLM_OMNI_VIDEO_MAX_UPLOAD_BYTES to change it)."
+        ),
+    )
+
+
+async def _read_upload_capped(upload: UploadFile) -> bytes:
+    """Read an UploadFile fully into memory, rejecting it once the streamed
+    byte count exceeds ``VIDEO_MAX_UPLOAD_BYTES`` (HTTP 413)."""
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await upload.read(1024 * 1024):
+        total += len(chunk)
+        if total > VIDEO_MAX_UPLOAD_BYTES:
+            _reject_oversized_upload(total, filename=upload.filename)
+        chunks.append(chunk)
+    return b"".join(chunks)
+
 
 async def _persist_uploaded_video_references(uploads: list[UploadFile]) -> list[str]:
     paths: list[str] = []
@@ -2964,8 +2997,12 @@ async def _persist_uploaded_video_references(uploads: list[UploadFile]) -> list[
                 suffix = ".mp4"
             fd, path = tempfile.mkstemp(prefix="vllm_omni_video_reference_", suffix=suffix)
             paths.append(path)
+            written = 0
             with os.fdopen(fd, "wb") as output:
                 while chunk := await upload.read(1024 * 1024):
+                    written += len(chunk)
+                    if written > VIDEO_MAX_UPLOAD_BYTES:
+                        _reject_oversized_upload(written, filename=upload.filename)
                     output.write(chunk)
     except Exception:
         for path in paths:
@@ -3021,7 +3058,7 @@ async def _parse_video_form(
     Used by both ``POST /v1/videos`` (async) and ``POST /v1/videos/sync``.
     """
     input_references = input_references or []
-    input_reference_bytes = await input_reference.read() if input_reference is not None else None
+    input_reference_bytes = await _read_upload_capped(input_reference) if input_reference is not None else None
     parsed_image_reference = _parse_form_json(image_reference)
     parsed_video_reference = _parse_form_json(video_reference)
     parsed_audio_reference = _parse_form_json(audio_reference)


### PR DESCRIPTION
## Purpose

`/v1/videos` and `/v1/videos/sync` accept image/video reference uploads (e.g. MiniMax H3 FL2VA first-frame and Ref2VA references). Both upload paths in `_parse_video_form` currently read the payload with no size bound:

- single-file `input_reference` is read fully into memory (`await input_reference.read()`);
- multi-file `input_references` is streamed to a temp file but with no total-size cap.

An oversized (or malicious) upload can therefore buffer unbounded bytes in memory or on disk before any validation runs.

## Change

- Add `VLLM_OMNI_VIDEO_MAX_UPLOAD_BYTES` (default 512 MiB), following the existing `VLLM_OMNI_VIDEO_SYNC_TIMEOUT` env convention in the same module.
- Enforce it via **streaming byte counting** on both upload paths, returning **HTTP 413 (Request Entity Too Large)** as soon as the limit is exceeded — so an oversized payload is rejected without first being fully buffered.
- The multi-file path unlinks any partial temp files on rejection (existing cleanup path).
- The 413 `detail` reports the actual size, the limit, and the env var to tune it.

Default 512 MiB is chosen to comfortably cover Ref2VA multi-video references (official limit: ≤3 clips, ≤15s total) while bounding memory/disk. Reviewers: happy to adjust the default or move it into `server_settings` if preferred.

## Test Plan

- `test_video_upload_single_reference_rejected_when_too_large` — single upload over limit → 413.
- `test_video_upload_multi_reference_rejected_when_too_large` — multi upload over limit → 413, no temp files left behind.
- `test_video_upload_within_limit_not_rejected_for_size` — within-limit upload is not rejected on size grounds.

## Test Result

- `pytest tests/entrypoints/openai_api/test_video_server.py`: 74 passed.
- `ruff check`: passed.
