### PR TITLE
[Bugfix][XPU][Tests] Add tests/e2e/accuracy/__init__.py to fix pytest…

### DIFF
--- a/tests/e2e/accuracy/__init__.py
+++ b/tests/e2e/accuracy/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end accuracy tests."""


### PR DESCRIPTION
## Summary
Fixes a pytest collection crash on the XPU CI caused by two test packages sharing the top-level name `minimax_h3`.

## Problem
`tests/e2e/accuracy/minimax_h3/` (added in #5709) and `tests/diffusion/models/minimax_h3/` both resolve to a top-level `minimax_h3` package under pytest's default `prepend` import mode, because `tests/e2e/accuracy/` has no `__init__.py`. When the XPU CI runs `pytest -m "... and xpu and B60"` over the whole `tests/` tree, both are imported in one session and collide:

This aborts collection (exit 2) even though the selected tests live elsewhere. Other platforms (CUDA/AMD/NPU) don't hit it because they scope pytest to specific paths/files and never collect both dirs together.

## Fix
Add `tests/e2e/accuracy/__init__.py` so the package resolves as `tests.e2e.accuracy.minimax_h3`, distinct from `tests/diffusion/models/minimax_h3`. Consistent with the existing layout (`tests/` and `tests/e2e/` already have `__init__.py`) and the repo's `from tests.e2e.accuracy...` import convention.

## Before
<img width="560" height="93" alt="Screenshot 2026-08-04 110153" src="https://github.com/user-attachments/assets/c90fce13-4c9f-409f-9892-0ade95e8c319" />


## After

<img width="636" height="36" alt="Screenshot 2026-08-04 110313" src="https://github.com/user-attachments/assets/3f355f88-d28c-439c-905f-eacddbbdab24" />

## Test
Full XPU CI (vLLM 0.26, Intel B60) passes: `core_model` 7 passed, `mxfp8_config` 24 passed, `advanced_model` 3 passed, `omni` 2 passed — 0 failures, 0 collection errors.