### PR TITLE
[Bugfix][XPU] Fix diffusion output corruption from async D2H copy

### DIFF
--- a/vllm_omni/diffusion/ipc.py
+++ b/vllm_omni/diffusion/ipc.py
@@ -16,6 +16,7 @@ from typing import Any
 import torch
 
 from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.platforms import current_omni_platform
 
 _SHM_TENSOR_THRESHOLD = 1_000_000  # 1 MB
 DIFFUSION_RPC_RESULT_ENVELOPE = "diffusion_rpc_result"
@@ -40,6 +41,10 @@ def _tensor_to_shm(
     import numpy as np
 
     original_dtype = tensor.dtype
+    # XPU's stream synchronization is unreliable (see sequential_backend.py:79-82).
+    # Force the blocking .cpu().contiguous() path to avoid corrupted D2H transfers.
+    if d2h_stream is not None and current_omni_platform.is_xpu():
+        d2h_stream = None
     if d2h_stream is not None:
         # Non-blocking D2H: copy on side stream to pinned CPU memory.
         old_stream = torch.accelerator.current_stream()


### PR DESCRIPTION
## Summary
Diffusion output on XPU shows a band of corrupted pixels along the bottom
edge of generated images. This forces the blocking D2H copy on XPU to fix it.

## Root cause
The async output path (#4981) records a GPU event and copies the result
device→host on a side stream gated by that event. On XPU this cross-stream
ordering is unreliable, so the copy can start before the compute stream
finishes writing the last rows, reading stale memory.

## Fix
Disable the async D2H path on XPU in `_tensor_to_shm`  the single choke
point every large diffusion output passes through, so it falls back to the
existing synchronous `.cpu()` copy. On XPU the async overlap saves nothing
(millisecond copy vs seconds of compute).

## Scope
Applies to all diffusion modalities (image, video, audio) since they share
the `_tensor_to_shm` path. Verified on images only; the corruption has not
been observed on video or audio, so no before/after is included for those.

## Before / After bottom strips
<img width="814" height="380" alt="Screenshot 2026-08-04 141740" src="https://github.com/user-attachments/assets/50f182ab-ccf7-4b1c-bf31-a790e490822f" />

<img width="835" height="385" alt="Screenshot 2026-08-04 141814" src="https://github.com/user-attachments/assets/6520e5b9-9815-48fa-8c9b-a18cb3e0955d" />

<img width="858" height="389" alt="Screenshot 2026-08-04 141828" src="https://github.com/user-attachments/assets/9c756c0c-454d-4ea6-955f-fb8836a75bac" />

## Test
Built from upstream `main` + this change and ran each model's standard CLI on
Intel XPU. The bottom-edge band is eliminated (last-row pixel discontinuity
drops to the image median): Z-Image-Turbo 23.5→2.3, ERNIE-Image 25–29→4,
FLUX.1-dev 14–33→0.3.
