### PR TITLE
[Bugfix][CI][MiniCPM-o] fix CI failure of text-audio output tests

### DIFF
--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -110,6 +110,13 @@ def test_text_to_audio_001(omni_server, openai_client) -> None:
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
         "key_words": {"audio": ["Beijing"]},
     }
 
@@ -175,6 +182,13 @@ def test_image_to_text_audio_001(omni_server, openai_client) -> None:
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
@@ -203,6 +217,13 @@ def test_video_to_text_audio_001(omni_server, openai_client) -> None:
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
@@ -236,6 +257,13 @@ def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())

--- a/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
@@ -127,6 +127,13 @@ def test_sequential_requests_independent(omni_server, openai_client) -> None:
             "model": omni_server.model,
             "messages": messages_1,
             "stream": True,
+            "modalities": ["text", "audio"],
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "use_tts_template": True,
+                    "enable_thinking": False,
+                }
+            },
         },
         request_num=1,
     )
@@ -137,6 +144,13 @@ def test_sequential_requests_independent(omni_server, openai_client) -> None:
             "model": omni_server.model,
             "messages": messages_2,
             "stream": True,
+            "modalities": ["text", "audio"],
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "use_tts_template": True,
+                    "enable_thinking": False,
+                }
+            },
             "key_words": {"text": ["Beijing"]},
         },
         request_num=1,
@@ -192,6 +206,13 @@ def test_chinese_text_to_audio(omni_server, openai_client) -> None:
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
         "key_words": {"text": ["北京"]},
     }
     openai_client.send_omni_request(request_config)


### PR DESCRIPTION
## Purpose
Add the patch from #5623 to tests with text-audio outputs in `tests/e2e/online_serving/test_minicpmo_4_5.py` and `tests/e2e/online_serving/test_minicpmo_4_5_expansion.py` to fix and avoid similar failures in minicpm-challenge branch

## Test Plan

**vLLM Version:** `0.25.0`

**vLLM-Omni Commit:** current commit based on 4ce5fcb16cbe0cef7def6d52a2e0a97d1a4dacde

Run:
```bash
pytest \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_text_to_audio_001 \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_audio_to_text_audio_001 \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_image_to_text_audio_001 \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_video_to_text_audio_001 \
  tests/e2e/online_serving/test_minicpmo_4_5.py::test_mix_to_text_audio_001 \
  tests/e2e/online_serving/test_minicpmo_4_5_expansion.py::test_sequential_requests_independent \
  tests/e2e/online_serving/test_minicpmo_4_5_expansion.py::test_text_to_audio_long_output_001 \
  tests/e2e/online_serving/test_minicpmo_4_5_expansion.py::test_chinese_text_to_audio \
  --run-level full_model \
  -m "(full_model or core_model) and H100 and omni" \
  -v
```

## Test Result

```
================================================ 11 passed, 15 warnings in 2076.96s (0:34:36) ================================================
```
