### PR TITLE
[Bugfix][Diffusion] Fix DLO AllGather size mismatch for models with h…

### DIFF
--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -504,6 +504,81 @@ class TestCrossGroupSharedBuffer:
         assert not sync_called[0], "Should skip sync-prefetch when slot_group matches (non-contaminated)"
 
 
+class TestAllGatherOutputSlicing:
+    """Regression test: with heterogeneous block sizes (e.g. MiniMax H3's
+    token_refiner with blocks of ~1231MB and ~239MB), the shared AllGather
+    output buffers are sized to the *largest* block across all groups.
+    prefetch_layer must slice the output buffer down to each block's actual
+    AllGather output size, otherwise output.numel() != dp_size * input.numel()
+    and all_gather_into_tensor raises during enable()'s first prefetch.
+    """
+
+    def test_prefetch_slices_shared_output_buffer_to_block_size(self, dist_group, patched_offload_runtime, monkeypatch):
+        dp_size = 2
+
+        # Heterogeneous block sizes: 8 vs 32 elements.
+        small_block = nn.Module()
+        small_block.weight = nn.Parameter(torch.arange(8, dtype=torch.float32))
+        large_block = nn.Module()
+        large_block.weight = nn.Parameter(torch.arange(100, 132, dtype=torch.float32))
+
+        def make_hook(next_block: nn.Module) -> DistributedLayerwiseOffloadHook:
+            hook = DistributedLayerwiseOffloadHook(
+                next_block=next_block,
+                device=torch.device("cpu"),
+                dp_group=dist.group.WORLD,  # non-None -> AllGather path (mocked below)
+                dp_size=dp_size,
+                rank=0,
+                pin_memory=False,
+            )
+            current_block = nn.Module()
+            current_block.weight = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+            hook.initialize_hook(current_block)
+            return hook
+
+        hook_small = make_hook(small_block)
+        hook_large = make_hook(large_block)
+        hooks = [hook_small, hook_large]
+
+        # Assign max-sized shared buffers exactly as backend.enable() does.
+        shared_buffers = DistributedLayerwiseOffloadBackend._allocate_shared_buffers(hooks)
+        shared_shard_buffers = DistributedLayerwiseOffloadBackend._allocate_shared_shard_buffers(hooks)
+        for hook in hooks:
+            hook.gpu_buffers = shared_buffers
+            hook.gpu_shard_buffers = shared_shard_buffers
+
+        # Shared output buffer must be sized to the largest block (32).
+        assert shared_buffers[0][torch.float32].numel() == 32
+
+        # Fake AllGather that enforces the real torch size contract and
+        # emulates reconstruction of the full block from all ranks' shards.
+        full_values = {
+            8: torch.arange(8, dtype=torch.float32),
+            32: torch.arange(100, 132, dtype=torch.float32),
+        }
+        ag_output_numels: list[int] = []
+
+        def fake_all_gather(output, input, group=None):
+            assert output.numel() == dp_size * input.numel(), (
+                f"AllGather contract violated: output.numel()={output.numel()} "
+                f"!= {dp_size} * input.numel()={input.numel()}"
+            )
+            ag_output_numels.append(output.numel())
+            output.copy_(full_values[output.numel()])
+
+        monkeypatch.setattr(dist, "all_gather_into_tensor", fake_all_gather)
+
+        # Small block: output must be sliced to dp_size * shard = 8, not 32.
+        hook_small.prefetch_layer(slot=0, non_blocking=False)
+        assert ag_output_numels[-1] == 8
+        assert torch.equal(small_block.weight, full_values[8])
+
+        # Large block: uses the full max-sized buffer.
+        hook_large.prefetch_layer(slot=1, non_blocking=False)
+        assert ag_output_numels[-1] == 32
+        assert torch.equal(large_block.weight, full_values[32])
+
+
 class TestOffloadPlan:
     """Test declarative OffloadPlan metadata."""
 

--- a/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
@@ -330,7 +330,15 @@ class DistributedLayerwiseOffloadHook(ModelHook):
             self.comm_stream.wait_stream(self.copy_stream)
             with current_omni_platform.stream(self.comm_stream):
                 for dtype, local_shard in gpu_shards.items():
-                    gw = gpu_weights[dtype]
+                    # Slice the shared (max-sized) output buffer down to this
+                    # block's actual AllGather output size.  The buffers are
+                    # sized to the *largest* block across all groups, so for
+                    # any smaller block the full buffer would violate the
+                    # all_gather_into_tensor contract
+                    # (output.numel() == world_size * input.numel()).
+                    # Repoint offsets are relative to the block's flattened
+                    # buffer, so a prefix slice is safe.
+                    gw = gpu_weights[dtype][: self._ag_output_sizes[dtype]]
                     torch.distributed.all_gather_into_tensor(
                         gw,
                         local_shard,


### PR DESCRIPTION
### Purpose

Distributed layerwise offload (DLO, `--enable-distributed-layerwise-offload` with AllGather)
crashes on models whose transformer blocks are **not all the same size** — e.g. MiniMax H3,
whose `token_refiner.blocks` contains 2 blocks of ~1231 MB and ~239 MB:

```
File ".../offloader/distributed_layerwise_backend.py", line 1349, in enable
    group[-1].prefetch_layer(slot=first_slot, non_blocking=False)
File ".../offloader/distributed_layerwise_backend.py", line 334, in prefetch_layer
    torch.distributed.all_gather_into_tensor(gw, local_shard, group=self.dp_group)
RuntimeError: output tensor size must be equal to world_size times input tensor size
```

**Root cause.** The 2 shared output buffers are sized to the **largest** block across all
groups (`_allocate_shared_buffers`), but `prefetch_layer` passed the **entire max-sized
buffer** as the AllGather output while the input is the **current** block's shard. For any
block smaller than the global max, `output.numel() != dp_size * input.numel()` and the
`all_gather_into_tensor` contract check fails — already during `enable()`'s first prefetch.
Models with uniform block sizes (Wan, Cosmos3, ...) never hit this because max == every
block's size.

Notably, each hook already precomputes its own correct AllGather output size in
`initialize_hook` (`self._ag_output_sizes[dtype] = shard_numel * dp_size`) — it was simply
never used. The H2D path slices the buffer (`gw[:cpu_shard.numel()]`), only the AllGather
path was missing the equivalent slice.

**Fix.** Slice the shared output buffer to the block's actual AllGather output size:

```python
gw = gpu_weights[dtype][: self._ag_output_sizes[dtype]]
```

The `_cached_repoint` offsets are relative to the block's flattened buffer, so the prefix
slice does not affect weight re-pointing.

### Reproduce (before this fix)

8x Ascend NPU, MiniMax H3 (FL2VA), USP=8 (SP group reused as the DLO shard group):

```bash
python examples/offline_inference/minimax_h3/end2end.py \
  --model /path/to/MiniMax-H3/FL2VA --task t2va \
  --usp 8 --enforce-eager \
  --height 768 --width 1344 --duration 8.7 --seed 1101 \
  --text-encoder-tp-size 8 \
  --vae-patch-parallel-size 8 --vae-parallel-mode tile --vae-use-tiling \
  --enable-distributed-layerwise-offload \
  --diffusion-attention-backend FLASH_ATTN --steps 50
```

All 8 worker ranks fail in `enable()` with the AllGather size-mismatch RuntimeError above.

### Test Plan

New regression test `TestAllGatherOutputSlicing` in
`tests/diffusion/offloader/test_distributed_layerwise_backend.py`:

- builds two hooks with heterogeneous block sizes (8 vs 32 elements, dp_size=2),
- assigns them max-sized shared buffers exactly as `backend.enable()` does,
- replaces `all_gather_into_tensor` with a fake that enforces the real torch size contract
  and emulates reconstruction,
- asserts the small block's prefetch slices the output to `dp_size * shard` (8, not 32),
  the large block still uses the full buffer, and the reconstructed weights land correctly.

```bash
pytest tests/diffusion/offloader/test_distributed_layerwise_backend.py::TestAllGatherOutputSlicing -v
# and the full existing suite to guard against regressions:
pytest tests/diffusion/offloader/test_distributed_layerwise_backend.py -v
```

### Test Result

- **vLLM Version:**0.26.0
- **vLLM-Omni Commit:** <填>
- `TestAllGatherOutputSlicing`：通过
- 既有 `test_distributed_layerwise_backend.py` 全量：通过
- MiniMax H3 复现命令修复后端到端：跑通

### Notes / Follow-ups

- MiniMax H3 does not support mmap weight loading, so DLO+AllGather falls back to the
  regular loader (`DLO+AllGather active but model does not support mmap ...`) — orthogonal
  to this fix.
- Without this fix, workarounds are `--enable-layerwise-offload` or
  `--enable-distributed-layerwise-offload --dlo-no-use-allgather` (both keep full weights
  per rank, i.e. Nx host memory).
