### PR TITLE
 [Hardware][Ascend] MiniMax H3: route packed-sequence attention through npu_fused_infer_attention_score varlen 

### DIFF
--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from functools import partial
 
 import torch
@@ -17,6 +18,12 @@ from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
 )
 
 logger = init_logger(__name__)
+
+# When enabled, NPU attention uses npu_fused_infer_attention_score (FIA) in
+# TND varlen mode instead of fused_attn_score + full-QK-mask, avoiding the
+# O(S^2) mask/workspace for long packed sequences. Off by default: it changes
+# the attention operator and may shift numerics at ~1e-3.
+ENABLE_NPU_FIA_VARLEN = os.getenv("VLLM_OMNI_NPU_FIA_VARLEN", "0") == "1"
 
 
 class FlashAttentionBackend(AttentionBackend):
@@ -390,6 +397,16 @@ class FlashAttentionImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata = None,
     ) -> torch.Tensor:
+        # Optional varlen fast path (VLLM_OMNI_NPU_FIA_VARLEN=1); falls back
+        # to fused_attn_score when metadata or the varlen contract is absent.
+        if ENABLE_NPU_FIA_VARLEN and attn_metadata is not None and attn_metadata.extra:
+            cu_q = attn_metadata.extra.get("cu_seqlens_q")
+            cu_k = attn_metadata.extra.get("cu_seqlens_k")
+            if cu_q is not None and cu_k is not None:
+                v3_out = self._forward_fa_varlen_npu(query, key, value, cu_q, cu_k)
+                if v3_out is not None:
+                    return v3_out
+
         try:
             from mindiesd import attention_forward
         except ImportError:
@@ -417,3 +434,38 @@ class FlashAttentionImpl(AttentionImpl):
             op_type="fused_attn_score",
             layout=layout,
         )
+
+    def _forward_fa_varlen_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """FIA TND varlen path, mirroring CUDA ``_forward_varlen_packed``.
+
+        vLLM cu_seqlens (prefix-accumulated, leading 0) map directly onto the
+        op's ``actual_seq_lengths``; torch_npu accepts device int32 tensors
+        there. Returns None to fall back on contract mismatch.
+        """
+        if query.dim() != 4 or len(cu_seqlens_q) < 2 or len(cu_seqlens_kv) < 2:
+            return None
+        B, S, N, D = query.shape
+
+        q = query.reshape(-1, N, D)
+        k = key.reshape(key.shape[0] * key.shape[1], N, D)
+        v = value.reshape(value.shape[0] * value.shape[1], N, D)
+        out = torch.ops.npu.npu_fused_infer_attention_score(
+            q,
+            k,
+            v,
+            num_heads=N,
+            num_key_value_heads=N,
+            scale=self.softmax_scale,
+            input_layout="TND",
+            actual_seq_lengths=cu_seqlens_q,
+            actual_seq_lengths_kv=cu_seqlens_kv,
+            sparse_mode=0,
+        )[0]
+        return out.reshape(B, S, N, D)

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -397,15 +397,25 @@ class FlashAttentionImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata = None,
     ) -> torch.Tensor:
-        # Optional varlen fast path (VLLM_OMNI_NPU_FIA_VARLEN=1); falls back
-        # to fused_attn_score when metadata or the varlen contract is absent.
-        if ENABLE_NPU_FIA_VARLEN and attn_metadata is not None and attn_metadata.extra:
+        # Optional varlen fast path (VLLM_OMNI_NPU_FIA_VARLEN=1). Only for
+        # non-causal attention with a trivial/absent mask: a 2D row-level mask
+        # (e.g. H3's alignment-padding prefix) is redundant with cu_seqlens and
+        # safe to drop, but a causal or 3D/4D-masked NPU model must not
+        # silently lose its mask. Falls back to fused_attn_score otherwise.
+        attention_mask = attn_metadata.attn_mask if attn_metadata else None
+        if (
+            ENABLE_NPU_FIA_VARLEN
+            and not self.causal
+            and (attention_mask is None or attention_mask.dim() == 2)
+            and attn_metadata is not None
+            and attn_metadata.extra
+        ):
             cu_q = attn_metadata.extra.get("cu_seqlens_q")
             cu_k = attn_metadata.extra.get("cu_seqlens_k")
             if cu_q is not None and cu_k is not None:
-                v3_out = self._forward_fa_varlen_npu(query, key, value, cu_q, cu_k)
-                if v3_out is not None:
-                    return v3_out
+                out = self._forward_fa_varlen_npu(query, key, value, cu_q, cu_k)
+                if out is not None:
+                    return out
 
         try:
             from mindiesd import attention_forward
@@ -416,7 +426,6 @@ class FlashAttentionImpl(AttentionImpl):
                 "For installation details, see https://gitcode.com/Ascend/MindIE-SD"
                 "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
             )
-        attention_mask = attn_metadata.attn_mask if attn_metadata else None
 
         # NPU aclnnFlashAttentionScore requires mask shape to be one of:
         # [B, N, Sq, Skv], [B, 1, Sq, Skv], [1, 1, Sq, Skv], or [Sq, Skv]
@@ -449,19 +458,20 @@ class FlashAttentionImpl(AttentionImpl):
         op's ``actual_seq_lengths``; torch_npu accepts device int32 tensors
         there. Returns None to fall back on contract mismatch.
         """
-        if query.dim() != 4 or len(cu_seqlens_q) < 2 or len(cu_seqlens_kv) < 2:
+        if query.dim() != 4 or key.dim() != 4 or len(cu_seqlens_q) < 2 or len(cu_seqlens_kv) < 2:
             return None
         B, S, N, D = query.shape
+        kv_heads = key.shape[2]
 
         q = query.reshape(-1, N, D)
-        k = key.reshape(key.shape[0] * key.shape[1], N, D)
-        v = value.reshape(value.shape[0] * value.shape[1], N, D)
+        k = key.reshape(key.shape[0] * key.shape[1], kv_heads, D)
+        v = value.reshape(value.shape[0] * value.shape[1], kv_heads, D)
         out = torch.ops.npu.npu_fused_infer_attention_score(
             q,
             k,
             v,
             num_heads=N,
-            num_key_value_heads=N,
+            num_key_value_heads=kv_heads,
             scale=self.softmax_scale,
             input_layout="TND",
             actual_seq_lengths=cu_seqlens_q,


### PR DESCRIPTION
## Purpose

Route NPU attention through `torch.ops.npu.npu_fused_infer_attention_score` (FIA)
in TND varlen mode when `VLLM_OMNI_NPU_FIA_VARLEN=1`, as an opt-in alternative
to the default `fused_attn_score` + full-QK-mask path in
`FlashAttentionImpl.forward_fa_npu`.

The default path materializes a `[B,1,Sq,Skv]` attention mask and operator
workspace that is O(S^2) in HBM and dominates peak memory for long packed
sequences. **MiniMax H3** packs text/audio/video latents into one sequence (S can
exceed 100k rows); 15 s 1344x768 requests failed with an NPU OOM at a 45 GiB
attention allocation before the first denoise step.

The FIA varlen path mirrors the CUDA `flash_attn_varlen_func` contract used by
`_forward_varlen_packed`: packed (T, N, D) rows with vLLM cu_seqlens document
boundaries mapped directly onto the op's `actual_seq_lengths` (prefix-accumulated
with leading 0, segment length = adjacent difference). torch_npu accepts device
int32 tensors there, so no host-side copy or sync is introduced per call. It
covers any batch size / document count and falls back to the default path on
contract mismatch (input rank / missing boundaries).

Off by default: it changes the attention operator and may shift numerics at
~1e-3.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** b55ab5f7 (branch `feat/npu-fia-varlen-attention`)

Environment: 8 x 910B3 (CANN 9.0.1, torch_npu 2.10.0.post4),
MiniMax-H3 FL2VA partition.

- Single-op correctness vs PyTorch SDPA (bf16): two-segment, three-segment,
  single-segment, and multi-batch cross-batch cu_seqlens scenarios, plus
  56-head no-pad (token_refiner) — all max_err < 5e-3.
- Peak-memory scaling at H3 shape (N=7, D=128): S=109,912 attention peak
  increment ~2.9 GiB vs 45 GiB (S^2 x 4B) on the default path.
- End-to-end: T2VA 15 s 1344x768 (previously OOM at first denoise step) now
  completes; output verified 1344x768@24fps / 362 frames / 32 kHz stereo.

## Test Result

- Single-op script: `scripts/test_fia_sem.py`, `scripts/test_fia_generic.py`
  (all PASS)
- E2E: `videos/t2va_15s_768p_fia.mp4` generated without OOM; 