### PR TITLE
[Perf][DreamZero] Build the RoPE freqs table once per forward, and rotate in real float32 arithmetic

### DIFF
--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -70,6 +70,12 @@ def sinusoidal_embedding_1d(dim: int, position: torch.Tensor) -> torch.Tensor:
 
 def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
     """Precompute complex-valued RoPE frequencies (polar form).
+
+    The angles are accumulated in float64 -- at the far end of the table they
+    reach 1e4 radians, where float32 would resolve them to only ~1e-3 -- and the
+    table is handed out as complex64, since cos and sin land in [-1, 1] and the
+    rotation they feed ends in bfloat16.
+
     Returns: complex tensor [max_seq_len, dim // 2]
     """
     if dim % 2 != 0:
@@ -79,7 +85,7 @@ def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
         1.0 / torch.pow(10000, torch.arange(0, dim, 2).to(torch.float64).div(dim)),
     )
     freqs = torch.polar(torch.ones_like(freqs), freqs)
-    return freqs
+    return freqs.to(torch.complex64)
 
 
 def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
@@ -94,14 +100,19 @@ def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
     gfx950 as three kernels collapsing to one.
 
     Eager: the real form is the slower one by about 4x, because each of its
-    multiply-adds becomes its own pass over a float64 temporary while the complex
+    multiply-adds becomes its own pass over a temporary while the complex
     multiply is a single elementwise kernel.
 
     Both branches evaluate the same products in the same order and agree bitwise
     once the caller casts back to bfloat16.
+
+    The rotation runs in float32. Only the angles need anything wider, and they
+    are already spent by the time ``rope_params`` hands over cos and sin: those
+    live in [-1, 1], where float32 carries four more decimal digits than the
+    bfloat16 this result is cast back to.
     """
     B, seq_len, n, _ = x.shape
-    pairs = x.to(torch.float64).reshape(B, seq_len, n, -1, 2)
+    pairs = x.to(torch.float32).reshape(B, seq_len, n, -1, 2)
     if not torch.compiler.is_compiling():
         rotated = torch.view_as_complex(pairs) * torch.view_as_complex(freqs).unsqueeze(0)
         return torch.view_as_real(rotated).flatten(3)
@@ -121,7 +132,7 @@ def rope_action_apply(
 ) -> torch.Tensor:
     """RoPE with action/state frequency tables for multi-step sequences."""
     B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
+    x = torch.view_as_complex(x.to(torch.float32).reshape(B, seq_len, n, -1, 2))
     if action_register_length is not None:
         if num_action_per_block is None:
             raise ValueError("num_action_per_block is required when action_register_length is set.")

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -119,8 +119,7 @@ def rope_action_apply(
     return x
 
 
-def causal_rope_action_apply(
-    x: torch.Tensor,
+def causal_rope_action_freqs(
     freqs: torch.Tensor,
     freqs_action: torch.Tensor,
     freqs_state: torch.Tensor,
@@ -129,27 +128,26 @@ def causal_rope_action_apply(
     num_state_per_block: int,
     action_state_index: int,
 ) -> torch.Tensor:
-    """RoPE for single inference step (causal / KV-cache mode)."""
-    B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
-    if action_register_length is not None:
-        expected_length = num_action_per_block + num_state_per_block
-        if action_register_length != expected_length:
-            raise ValueError(
-                f"action_register_length must equal num_action_per_block + num_state_per_block "
-                f"({expected_length}), got {action_register_length}."
-            )
-        freqs_action = freqs_action[
-            action_state_index * num_action_per_block : (action_state_index + 1) * num_action_per_block
-        ]
-        freqs_state = freqs_state[
-            action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block
-        ]
-        freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
-        freqs = torch.cat([freqs, freqs_1d], dim=0)
-    freqs = freqs.unsqueeze(0)
-    x = torch.view_as_real(x * freqs).flatten(3)
-    return x
+    """Video RoPE table with the current step's action/state rows appended.
+
+    Single inference step (causal / KV-cache mode). A function of the step index
+    only, so all layers and both q and k share one build -- see ``_forward_blocks``,
+    which calls this once per forward and passes the result down.
+    """
+    if action_register_length is None:
+        return freqs
+    expected_length = num_action_per_block + num_state_per_block
+    if action_register_length != expected_length:
+        raise ValueError(
+            f"action_register_length must equal num_action_per_block + num_state_per_block "
+            f"({expected_length}), got {action_register_length}."
+        )
+    freqs_action = freqs_action[
+        action_state_index * num_action_per_block : (action_state_index + 1) * num_action_per_block
+    ]
+    freqs_state = freqs_state[action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block]
+    freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
+    return torch.cat([freqs, freqs_1d], dim=0)
 
 
 # ── Normalization ───────────────────────────────────────────────────
@@ -521,14 +519,15 @@ class CausalWanSelfAttention(nn.Module):
         self,
         x: torch.Tensor,
         freqs: torch.Tensor,
-        freqs_action: torch.Tensor,
-        freqs_state: torch.Tensor,
         action_register_length: int | None,
         kv_cache: torch.Tensor | Any | None = None,
-        current_start_frame: int = 0,
         is_tf: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Inference-only forward (KV cache path)."""
+        """Inference-only forward (KV cache path).
+
+        ``freqs`` already carries this step's action/state rows (built once per
+        forward by ``causal_rope_action_freqs``).
+        """
         n, d = self.tp_num_heads, self.head_dim
 
         # Single fused QKV GEMM, then split into the per-rank q/k/v shards.
@@ -546,28 +545,8 @@ class CausalWanSelfAttention(nn.Module):
         if kv_cache is None:
             raise RuntimeError("Inference only: kv_cache is required.")
 
-        action_state_index = max(0, (current_start_frame - 1) // self.num_frame_per_block)
-
-        roped_query = causal_rope_action_apply(
-            q,
-            freqs,
-            freqs_action,
-            freqs_state,
-            action_register_length,
-            self.num_action_per_block,
-            self.num_state_per_block,
-            action_state_index,
-        ).type_as(v)
-        roped_key = causal_rope_action_apply(
-            k,
-            freqs,
-            freqs_action,
-            freqs_state,
-            action_register_length,
-            self.num_action_per_block,
-            self.num_state_per_block,
-            action_state_index,
-        ).type_as(v)
+        roped_query = rope_apply(q, freqs).type_as(v)
+        roped_key = rope_apply(k, freqs).type_as(v)
 
         roped_action_query = None
         roped_action_key = None
@@ -676,13 +655,10 @@ class CausalWanAttentionBlock(nn.Module):
         x: torch.Tensor,
         e: torch.Tensor,
         freqs: torch.Tensor,
-        freqs_action: torch.Tensor,
-        freqs_state: torch.Tensor,
         context: torch.Tensor,
         action_register_length: int | None = None,
         kv_cache: torch.Tensor | Any | None = None,
         crossattn_cache: dict | None = None,
-        current_start_frame: int = 0,
         is_tf: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         e = (self.modulation.unsqueeze(1) + e).chunk(6, dim=2)
@@ -690,12 +666,9 @@ class CausalWanAttentionBlock(nn.Module):
         y, updated_kv_cache = self.self_attn(
             x=(self.norm1(x) * (1 + e[1].squeeze(2)) + e[0].squeeze(2)),
             freqs=freqs,
-            freqs_action=freqs_action,
-            freqs_state=freqs_state,
             action_register_length=action_register_length,
             kv_cache=kv_cache,
             is_tf=is_tf,
-            current_start_frame=current_start_frame,
         )
         x = x + (y * e[2].squeeze(2))
 
@@ -1021,19 +994,28 @@ class CausalWanModel(nn.Module):
             )
             kv_cache = [c.to_layer_inputs() for c in kv_cache]
 
+        # Append this step's action/state RoPE rows once, outside the compiled blocks:
+        # the table is the same for all 40 layers and for both q and k.
+        freqs = causal_rope_action_freqs(
+            freqs,
+            self.freqs_action,
+            self.freqs_state,
+            action_register_length,
+            self.num_action_per_block,
+            self.num_state_per_block,
+            max(0, (current_start_frame - 1) // self.num_frame_per_block),
+        )
+
         updated_kv_caches: list[torch.Tensor | None] = []
         for block_index, block in enumerate(self.blocks):
             x, updated_kv_cache = block(
                 x=x,
                 e=e0,
                 freqs=freqs,
-                freqs_action=self.freqs_action,
-                freqs_state=self.freqs_state,
                 context=context,
                 action_register_length=action_register_length,
                 kv_cache=kv_cache[block_index] if kv_cache else None,
                 crossattn_cache=crossattn_cache[block_index] if crossattn_cache else None,
-                current_start_frame=current_start_frame,
             )
             updated_kv_caches.append(updated_kv_cache)
 

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -83,12 +83,31 @@ def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
 
 
 def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-    """Apply RoPE to x using precomputed complex freqs."""
+    """Apply RoPE to x, with ``freqs`` as a real ``(..., 2)`` cos/sin table.
+
+    Two forms of the same rotation, picked by whether inductor is generating code.
+
+    Compiled: inductor cannot generate code for complex operators, so a complex
+    multiply here falls back to eager, and being opaque to the scheduler it also
+    splits the surrounding qk-norm and layout work into separate fusion groups.
+    Written out in real arithmetic the whole segment fuses instead, measured on
+    gfx950 as three kernels collapsing to one.
+
+    Eager: the real form is the slower one by about 4x, because each of its
+    multiply-adds becomes its own pass over a float64 temporary while the complex
+    multiply is a single elementwise kernel.
+
+    Both branches evaluate the same products in the same order and agree bitwise
+    once the caller casts back to bfloat16.
+    """
     B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
-    freqs = freqs.unsqueeze(0)
-    x = torch.view_as_real(x * freqs).flatten(3)
-    return x
+    pairs = x.to(torch.float64).reshape(B, seq_len, n, -1, 2)
+    if not torch.compiler.is_compiling():
+        rotated = torch.view_as_complex(pairs) * torch.view_as_complex(freqs).unsqueeze(0)
+        return torch.view_as_real(rotated).flatten(3)
+    x_re, x_im = pairs[..., 0], pairs[..., 1]
+    cos, sin = freqs[..., 0].unsqueeze(0), freqs[..., 1].unsqueeze(0)
+    return torch.stack((x_re * cos - x_im * sin, x_re * sin + x_im * cos), dim=-1).flatten(3)
 
 
 def rope_action_apply(
@@ -133,9 +152,14 @@ def causal_rope_action_freqs(
     Single inference step (causal / KV-cache mode). A function of the step index
     only, so all layers and both q and k share one build -- see ``_forward_blocks``,
     which calls this once per forward and passes the result down.
+
+    Returned as a real ``(..., 2)`` cos/sin table: the complex form is only used
+    to build it, so no complex tensor reaches the compiled blocks, where inductor
+    would fall back to eager. Converting here costs one view of a table that is
+    four orders of magnitude smaller than the tensors it rotates.
     """
     if action_register_length is None:
-        return freqs
+        return torch.view_as_real(freqs)
     expected_length = num_action_per_block + num_state_per_block
     if action_register_length != expected_length:
         raise ValueError(
@@ -147,7 +171,7 @@ def causal_rope_action_freqs(
     ]
     freqs_state = freqs_state[action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block]
     freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
-    return torch.cat([freqs, freqs_1d], dim=0)
+    return torch.view_as_real(torch.cat([freqs, freqs_1d], dim=0))
 
 
 # ── Normalization ───────────────────────────────────────────────────
@@ -525,8 +549,8 @@ class CausalWanSelfAttention(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Inference-only forward (KV cache path).
 
-        ``freqs`` already carries this step's action/state rows (built once per
-        forward by ``causal_rope_action_freqs``).
+        ``freqs`` is the real cos/sin table already carrying this step's
+        action/state rows (built once per forward by ``causal_rope_action_freqs``).
         """
         n, d = self.tp_num_heads, self.head_dim
 


### PR DESCRIPTION
## Purpose

Three inefficiencies on the same RoPE path in `causal_wan_model.py`, one commit each, separable.

**The table was rebuilt per call.** `causal_rope_action_apply()` appended the step's action/state rows to
the video table inside itself, so its two `torch.cat` ran 40 layers × q and k = 80 times per forward for a
table that depends only on the step index. It is now split out as `causal_rope_action_freqs()` and called
once in `_forward_blocks`; `freqs_action`, `freqs_state` and `current_start_frame` retire from two
module-internal signatures.

**The rotation broke inductor's fusion.** Inductor cannot generate code for complex operators, so the
complex multiply falls back to eager and, being opaque to the scheduler, also splits the surrounding
qk-norm and layout work into separate fusion groups — three kernels where one would do. Written out in real
arithmetic the whole segment fuses. Eager keeps the complex form, selected by
`torch.compiler.is_compiling()`: unfused, the real form is about 4x slower.

**The rotation ran in float64 to produce a bfloat16 result.** Only the angles need the width — the table
reaches 1e4 radians, where float32 would resolve about 1e-3 per radian — and they are spent once
`torch.polar` has run. So `rope_params()` still accumulates in float64 and hands the table over as
complex64, and the rotation runs in float32. Dropping only one of the two would not help: a complex128
table promotes a complex64 activation straight back.

## Numerical behaviour

**The first two commits are bitwise identical on the bf16 output; the third moves it by up to one bfloat16
ulp.**

The hoist is a seam split — the build moves out verbatim and the rotation that followed it is already
`rope_apply()` line for line — and the `cat` feeds no reduction, so the packed table does not depend on how
many times it is evaluated. The real form evaluates the same products as the complex multiply; their
intermediates can differ by under 1 ulp where a complex multiply contracts into an FMA, but that does not
survive the cast back to bfloat16: `torch.equal` holds over 1.83e8 elements.

Float32 rotation moves 4595 of those 1.83e8 elements (2.5e-5), by at most 1.562e-2 = 2⁻⁶, one bfloat16 ulp
for values in [4, 8). Measured over 20 seeds at the rollout's shapes, after the `.type_as(v)` that feeds
attention.

This also matches what the rest of the repo does. `x.to(torch.float64)` appears in two places — this file
and `diffusion/layers/rope.py`, both carried over from the Wan2.1 reference — while `qwen_image`,
`omnigen2`, `boogu_image`, `lingbot_video` and `z_image` build the table in float64 and rotate in float32.
Three transformers already gate on `current_omni_platform.supports_float64()`, so this also lets DreamZero
run where float64 is unavailable.

## Performance

**DreamZero-DROID rollout on MI350X (gfx950), TP=1 + CFG-parallel=2, 15 chunks / 16 steps**, mean over the
steady-state steps. Each commit is measured against the tree carrying the ones before it, comparing per
step position so the 4-step window-refresh cycle cancels:

| commit | before | after | paired per-step diff |
|---|---|---|---|
| rotate in real arithmetic | 502.8 ms | **497.2 ms** | **−5.6 ms, 30/30 positions faster** |
| rotate in float32 | 499.8 ms | **492.2 ms** | **−7.6 ms, sd 1.3, 15/15 positions faster** |

The two rows are separate sessions; the absolute numbers are not additive.

The compiled segment (qk-norm + RoPE + layout) at q of `[1, 1785, 40, 128]` goes **96.4 → 78.2 → 65.7 µs**
across the second and third commits. The hoist takes the table build from 1333 µs per forward to 22 µs,
worth 469–556 µs (1.08–1.10x) over all 80 projections.

Both mechanisms are TorchInductor and bandwidth properties rather than ROCm ones, so they should carry to
NVIDIA; the magnitude has not been measured there.

## Test Plan

```bash
pytest -sv tests/diffusion/models/dreamzero/
```

MI350X (gfx950), ROCm 7.2.3, torch 2.11.0+gitd0c8b1f, image
`vllm/vllm-openai-rocm:nightly-49f31d7cee425a6d38f8c5bc76877986daf832ed` plus this repo's runtime deps.

**vLLM Version:** 0.23.1rc1.dev1533+g49f31d7ce.rocm723

**vLLM-Omni Commit:** 2eada79b99ae64acd835e5ca3794eb6ff60f4424

## Test Result

```
49 passed in 1.13s
```

Same 49 on the base with the change reverted.