### PR TITLE
[Model] MiniMax-H3 use fused SwiGLU activation

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -88,6 +88,27 @@ def test_h3_fused_rope_matches_reference_and_preserves_unrotated_dims():
     torch.testing.assert_close(actual[..., 96:], x[..., 96:], atol=0, rtol=0)
 
 
+def test_mlp_uses_fused_swiglu(init_fake_tp_group):
+    del init_fake_tp_group
+    from vllm.model_executor.layers.activation import SiluAndMul
+
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3DiTArchConfig,
+        MiniMaxH3MLP,
+    )
+
+    mlp = MiniMaxH3MLP(
+        MiniMaxH3DiTArchConfig(
+            hidden_size=4,
+            ffn_hidden_size=8,
+        ),
+        quant_config=None,
+        prefix="blocks.0.mlp",
+    )
+
+    assert isinstance(mlp.act_fn, SiluAndMul)
+
+
 @pytest.mark.parametrize(
     ("tp_size", "message"),
     [

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -18,6 +18,7 @@ import torch.nn as nn
 from cache_dit import ForwardPattern
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
+from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -499,8 +500,7 @@ class MiniMaxH3MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.fc1",
         )
-        # Chunk the fused fc1 output as [gate, up], then compute
-        # silu(gate) * up.
+        self.act_fn = SiluAndMul()
         self.fc2 = RowParallelLinear(
             arch.ffn_hidden_size,
             arch.hidden_size,
@@ -513,8 +513,7 @@ class MiniMaxH3MLP(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden, _ = self.fc1(x)
-        gate, up = hidden.chunk(2, dim=-1)
-        hidden = nn.functional.silu(gate) * up
+        hidden = self.act_fn(hidden)
         out, _ = self.fc2(hidden)
         return out
 


### PR DESCRIPTION
## Purpose

MiniMax-H3's MLP already produces a merged `[gate, up]` projection, but its forward path chunks that tensor and executes `silu(gate) * up` as separate eager operations. That materializes an additional full-size activation and adds avoidable memory traffic in every MLP layer.

This change uses vLLM's existing `SiluAndMul` operator. The checkpoint mapping and `[gate, up]` shard order are unchanged.

## Test plan

- verify the H3 MLP constructs vLLM's fused SwiGLU operator;
- retain current-main fused-RoPE coverage;
- run the complete MiniMax-H3 L1 CPU suite;
- run Ruff lint and formatting checks on all changed files.

**vLLM Version:** 0.26.0

**vLLM-Omni base:** `d219d93b`

## Test result

```text
80 passed, 1 skipped, 2 deselected, 15 warnings
Ruff 0.14.10 check: passed
Ruff 0.14.10 format: passed
```

## Isolated DGX Spark microbenchmark

BF16 production activation shape `[6016, 28672]`, 10 warmups, then 15 samples of 20 CUDA-event iterations:

| Activation | Median | Range |
| --- | ---: | ---: |
| Eager `silu(gate) * up` | 4.6124 ms | 3.7433–4.7752 ms |
| vLLM `SiluAndMul` | 2.4649 ms | 2.1885–2.5184 ms |

Outputs were bit-exact across BF16 values spanning `[-4, 4]`. The fused operator was 1.871x faster in this isolated kernel benchmark; no end-to-end generation claim is made.