### PR TITLE
[Model] MiniMax-H3 precompute static conditioning

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -88,6 +88,148 @@ def test_h3_fused_rope_matches_reference_and_preserves_unrotated_dims():
     torch.testing.assert_close(actual[..., 96:], x[..., 96:], atol=0, rtol=0)
 
 
+def test_static_conditioning_matches_fallback_and_is_reused():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3DiTModel,
+    )
+
+    class Projection(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, values):
+            self.calls += 1
+            return values + 1, None
+
+    class Refiner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, values, *, cu_seqlens, max_seqlen):
+            self.calls += 1
+            assert cu_seqlens.tolist() == [0, 3, 3]
+            assert max_seqlen == 3
+            return values * 2
+
+    class Rope(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, position_ids):
+            self.calls += 1
+            return position_ids.to(torch.float32).unsqueeze(-1)
+
+    model = object.__new__(MiniMaxH3DiTModel)
+    nn.Module.__init__(model)
+    model.condition_proj = Projection()
+    model.token_refiner = Refiner()
+    model.rope = Rope()
+    device = torch.device("cpu")
+    prompt_embeds = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    img_position_ids = torch.arange(9).reshape(1, 3, 3)
+    refiner_cu = torch.tensor([0, 3, 3], dtype=torch.int32)
+    forward_hook_calls = 0
+
+    def count_forward_hook(*_args):
+        nonlocal forward_hook_calls
+        forward_hook_calls += 1
+
+    model.register_forward_pre_hook(count_forward_hook)
+
+    prepared = model.prepare_static_conditioning(
+        prompt_embeds=prompt_embeds,
+        img_position_ids=img_position_ids,
+        refiner_cu_seqlens=refiner_cu,
+        refiner_max_seqlen=3,
+    )
+    assert forward_hook_calls == 1
+    fallback = model._resolve_static_conditioning(
+        static_conditioning=None,
+        prompt_embeds=prompt_embeds,
+        img_position_ids=img_position_ids,
+        refiner_packed_seq_params={
+            "cu_seqlens_q": refiner_cu,
+            "max_seqlen_q": 3,
+        },
+        device=device,
+    )
+
+    torch.testing.assert_close(
+        prepared.refined_prompt_embeds,
+        fallback.refined_prompt_embeds,
+    )
+    torch.testing.assert_close(prepared.rope_freqs, fallback.rope_freqs)
+    assert model.condition_proj.calls == 2
+    assert model.token_refiner.calls == 2
+    assert model.rope.calls == 2
+
+    for _ in range(3):
+        resolved = model._resolve_static_conditioning(
+            static_conditioning=prepared,
+            prompt_embeds=None,
+            img_position_ids=None,
+            refiner_packed_seq_params=None,
+            device=device,
+        )
+        assert resolved is prepared
+
+    assert model.condition_proj.calls == 2
+    assert model.token_refiner.calls == 2
+    assert model.rope.calls == 2
+
+
+def test_denoise_branch_reuses_request_static_conditioning():
+    from vllm_omni.diffusion.models.minimax_h3.denoise_loop import (
+        MiniMaxH3DenoiseBranch,
+    )
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MINIMAX_H3_STATIC_CONDITIONING_KWARG,
+        MiniMaxH3StaticConditioning,
+    )
+    from vllm_omni.diffusion.models.minimax_h3.packed_sequence import (
+        minimax_h3_packed_sequence,
+    )
+
+    packed = minimax_h3_packed_sequence(
+        text_len=4,
+        latent_t=2,
+        latent_h=4,
+        latent_w=6,
+        audio_t=3,
+        include_keyframe_cond=False,
+    )
+    static_conditioning = MiniMaxH3StaticConditioning(
+        refined_prompt_embeds=torch.ones(4, 8),
+        rope_freqs=torch.ones(64, 3),
+    )
+    branch = MiniMaxH3DenoiseBranch(
+        packed=packed,
+        text_embeddings=torch.ones(4, 8),
+        token_tags=packed["token_tags"],
+        device=torch.device("cpu"),
+        static_conditioning=static_conditioning,
+    )
+
+    assert branch.static_kwargs[MINIMAX_H3_STATIC_CONDITIONING_KWARG] is static_conditioning
+    assert "prompt_embeds" not in branch.static_kwargs
+    assert "img_position_ids" not in branch.static_kwargs
+    assert "refiner_packed_seq_params" not in branch.static_kwargs
+
+    for _ in range(3):
+        kwargs = branch.forward_kwargs(
+            video_rows=torch.zeros(branch.img_pos.shape[0], 96),
+            audio_rows=torch.zeros(branch.audio_pos.shape[0], 32),
+            t_video=0.5,
+            t_audio=0.5,
+            imgvid_cond_timestep=0.999,
+            audio_ref_cond_timestep=1.0,
+        )
+        assert kwargs[MINIMAX_H3_STATIC_CONDITIONING_KWARG] is static_conditioning
+
+
 @pytest.mark.parametrize(
     ("tp_size", "message"),
     [

--- a/vllm_omni/diffusion/models/minimax_h3/denoise_loop.py
+++ b/vllm_omni/diffusion/models/minimax_h3/denoise_loop.py
@@ -17,6 +17,10 @@ import torch
 from vllm_omni.diffusion.attention.backends.abstract import VideoTokenLayout
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
 
+from .minimax_h3_transformer import (
+    MINIMAX_H3_STATIC_CONDITIONING_KWARG,
+    MiniMaxH3StaticConditioning,
+)
 from .scheduling_minimax_h3_euler_ancestral import (
     minimax_h3_euler_eta0_step,
     minimax_h3_rf_v_to_x0,
@@ -46,6 +50,7 @@ class MiniMaxH3DenoiseBranch:
         text_embeddings: torch.Tensor,
         token_tags: torch.Tensor,
         device: torch.device,
+        static_conditioning: MiniMaxH3StaticConditioning | None = None,
     ) -> None:
         seq_len = int(packed["seq_len"])
         self.seq_len = seq_len
@@ -72,11 +77,9 @@ class MiniMaxH3DenoiseBranch:
         self.audio_x_base = torch.zeros(1, seq_len, MINIMAX_H3_AUDIO_ROW_WIDTH, dtype=torch.float32, device=device)
         text_pos_dev = packed["text_pos"].view(-1).to(torch.long).to(device)
         self.static_kwargs: dict[str, Any] = {
-            "img_position_ids": packed["img_position_ids"][None].to(device),
             "update_mask": self.update_mask_dev,
             "token_tags": token_tags.view(-1).to(torch.long).to(device),
             "skip_mask_out_condition": False,
-            "prompt_embeds": text_embeddings.to(device),
             "img_pos_info": {"position_ids": self.img_pos_dev},
             "audio_pos_info": {"position_ids": self.audio_pos_dev},
             "text_pos_info": {"position_ids": text_pos_dev},
@@ -84,10 +87,6 @@ class MiniMaxH3DenoiseBranch:
             "packed_seq_params": {
                 "cu_seqlens_q": cu.to(device),
                 "max_seqlen_q": int(cu[1]),
-            },
-            "refiner_packed_seq_params": {
-                "cu_seqlens_q": torch.tensor([0, text_len, text_len], dtype=torch.int32, device=device),
-                "max_seqlen_q": text_len,
             },
         }
         # Where the video segment sits in the packed sequence. Resolved to plain
@@ -97,6 +96,24 @@ class MiniMaxH3DenoiseBranch:
             prefix_len=int(packed["video_row_start"]),
             latent_grid=(int(grid[0]), int(grid[1]), int(grid[2])),
         )
+        if static_conditioning is not None:
+            self.static_kwargs[MINIMAX_H3_STATIC_CONDITIONING_KWARG] = static_conditioning
+        else:
+            # Preserve the raw conditioning path for direct branch users.
+            self.static_kwargs.update(
+                {
+                    "img_position_ids": packed["img_position_ids"][None].to(device),
+                    "prompt_embeds": text_embeddings.to(device),
+                    "refiner_packed_seq_params": {
+                        "cu_seqlens_q": torch.tensor(
+                            [0, text_len, text_len],
+                            dtype=torch.int32,
+                            device=device,
+                        ),
+                        "max_seqlen_q": text_len,
+                    },
+                }
+            )
 
     def forward_kwargs(
         self,

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -106,6 +106,16 @@ MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
 # video/text/audio tokens (padding is clamped to 0 before the embedding
 # lookup and masked out afterwards).
 MINIMAX_H3_ADALN_MODALITY_NUM = 3
+MINIMAX_H3_STATIC_CONDITIONING_KWARG = "static_conditioning"
+_MINIMAX_H3_PREPARE_STATIC_CONDITIONING_KWARG = "prepare_static_conditioning"
+
+
+@dataclass(frozen=True)
+class MiniMaxH3StaticConditioning:
+    """Timestep-invariant conditioning prepared for one generation request."""
+
+    refined_prompt_embeds: torch.Tensor
+    rope_freqs: torch.Tensor
 
 
 def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
@@ -135,6 +145,8 @@ _FORWARD_SUPPORTED_KWARGS = frozenset(
         "packed_seq_params",
         "refiner_packed_seq_params",
         "video_token_layout",
+        MINIMAX_H3_STATIC_CONDITIONING_KWARG,
+        _MINIMAX_H3_PREPARE_STATIC_CONDITIONING_KWARG,
     }
 )
 
@@ -1032,18 +1044,117 @@ class MiniMaxH3DiTModel(nn.Module):
             raise ValueError(f"{key}.{field} is required")
         return value
 
+    def _refine_prompt_embeddings(
+        self,
+        *,
+        prompt_embeds: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        text_rows = prompt_embeds.to(device=device, dtype=_BF16_DTYPE)
+        text_embed, _ = self.condition_proj(text_rows)
+        return self.token_refiner(
+            text_embed,
+            cu_seqlens=refiner_cu_seqlens.to(device),
+            max_seqlen=refiner_max_seqlen,
+        )
+
+    def _prepare_static_conditioning(
+        self,
+        *,
+        prompt_embeds: torch.Tensor,
+        img_position_ids: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        device: torch.device,
+    ) -> MiniMaxH3StaticConditioning:
+        """Prepare prompt refinement and RoPE once for a denoise request."""
+        return MiniMaxH3StaticConditioning(
+            refined_prompt_embeds=self._refine_prompt_embeddings(
+                prompt_embeds=prompt_embeds,
+                refiner_cu_seqlens=refiner_cu_seqlens,
+                refiner_max_seqlen=refiner_max_seqlen,
+                device=device,
+            ),
+            rope_freqs=self.rope(img_position_ids.to(device)).to(device),
+        )
+
+    def prepare_static_conditioning(
+        self,
+        *,
+        prompt_embeds: torch.Tensor,
+        img_position_ids: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+    ) -> MiniMaxH3StaticConditioning:
+        """Prepare request conditioning through the model's forward hooks."""
+        result = self(
+            **{
+                _MINIMAX_H3_PREPARE_STATIC_CONDITIONING_KWARG: True,
+                "prompt_embeds": prompt_embeds,
+                "img_position_ids": img_position_ids,
+                "refiner_packed_seq_params": {
+                    "cu_seqlens_q": refiner_cu_seqlens,
+                    "max_seqlen_q": refiner_max_seqlen,
+                },
+            }
+        )
+        if not isinstance(result, MiniMaxH3StaticConditioning):
+            raise RuntimeError(f"unexpected static conditioning result: {type(result)!r}")
+        return result
+
+    def _resolve_static_conditioning(
+        self,
+        *,
+        static_conditioning: MiniMaxH3StaticConditioning | None,
+        prompt_embeds: torch.Tensor | None,
+        img_position_ids: torch.Tensor | None,
+        refiner_packed_seq_params: object | None,
+        device: torch.device,
+    ) -> MiniMaxH3StaticConditioning:
+        if static_conditioning is not None:
+            if not isinstance(static_conditioning, MiniMaxH3StaticConditioning):
+                raise TypeError(
+                    f"static_conditioning must be a MiniMaxH3StaticConditioning, got {type(static_conditioning)!r}"
+                )
+            return static_conditioning
+
+        if prompt_embeds is None or img_position_ids is None or refiner_packed_seq_params is None:
+            raise ValueError(
+                "MiniMaxH3DiTModel.forward requires static_conditioning or "
+                "prompt_embeds, img_position_ids, and refiner_packed_seq_params"
+            )
+        refiner_cu = self._psp_field(
+            refiner_packed_seq_params,
+            "refiner_packed_seq_params",
+            "cu_seqlens_q",
+        ).to(torch.int32)
+        refiner_max = int(
+            self._psp_field(
+                refiner_packed_seq_params,
+                "refiner_packed_seq_params",
+                "max_seqlen_q",
+            )
+        )
+        return self._prepare_static_conditioning(
+            prompt_embeds=prompt_embeds,
+            img_position_ids=img_position_ids,
+            refiner_cu_seqlens=refiner_cu,
+            refiner_max_seqlen=refiner_max,
+            device=device,
+        )
+
     def _embed(
         self,
         *,
         x: torch.Tensor,
         audio_x: torch.Tensor,
-        text_embeddings_selected: torch.Tensor,
+        refined_prompt_embeds: torch.Tensor,
         unique_timesteps: torch.Tensor,
         img_pos: torch.Tensor,
         audio_pos: torch.Tensor,
         text_pos: torch.Tensor,
-        refiner_cu_seqlens: torch.Tensor,
-        refiner_max_seqlen: int,
         seq_len: int,
         device: torch.device,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -1058,13 +1169,7 @@ class MiniMaxH3DiTModel(nn.Module):
         audio_rows = audio_x.view(-1, audio_x.shape[-1]).index_select(0, audio_pos).to(_FP32_DTYPE)
         audio_embed, _ = self.audio_patch_proj(audio_rows)
 
-        text_rows = text_embeddings_selected.to(device=device, dtype=_BF16_DTYPE)
-        text_embed, _ = self.condition_proj(text_rows)
-        text_embed = self.token_refiner(
-            text_embed,
-            cu_seqlens=refiner_cu_seqlens,
-            max_seqlen=refiner_max_seqlen,
-        )
+        text_embed = refined_prompt_embeds.to(device=device, dtype=_BF16_DTYPE)
 
         embeddings = torch.zeros((seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE)
         embeddings.index_add_(0, text_pos, text_embed.to(_BF16_DTYPE)[: text_pos.shape[0]])
@@ -1074,7 +1179,10 @@ class MiniMaxH3DiTModel(nn.Module):
         t_emb = self.time_embedder(unique_timesteps)
         return embeddings, t_emb
 
-    def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor] | MiniMaxH3StaticConditioning:
         """Packed inference forward.
 
         Keyword names follow the checkpoint's serving contract.
@@ -1091,16 +1199,26 @@ class MiniMaxH3DiTModel(nn.Module):
                 f"{sorted(_FORWARD_SUPPORTED_KWARGS)}"
             )
 
+        if kwargs.get(_MINIMAX_H3_PREPARE_STATIC_CONDITIONING_KWARG, False):
+            prompt_embeds = _required_kwarg(kwargs, "prompt_embeds")
+            return self._resolve_static_conditioning(
+                static_conditioning=None,
+                prompt_embeds=prompt_embeds,
+                img_position_ids=_required_kwarg(kwargs, "img_position_ids"),
+                refiner_packed_seq_params=_required_kwarg(
+                    kwargs,
+                    "refiner_packed_seq_params",
+                ),
+                device=prompt_embeds.device,
+            )
+
         x = _required_kwarg(kwargs, "x")
         audio_x = _required_kwarg(kwargs, "audio_x")
-        img_position_ids = _required_kwarg(kwargs, "img_position_ids")
         unique_timesteps = _required_kwarg(kwargs, "unique_timesteps")
         inverse_indices = _required_kwarg(kwargs, "inverse_indices").view(-1).to(torch.long)
         update_mask = _required_kwarg(kwargs, "update_mask")
         token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
         skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
-
-        text_selected = _required_kwarg(kwargs, "prompt_embeds")
 
         img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
         audio_pos = self._pos_ids(_required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info")
@@ -1116,9 +1234,6 @@ class MiniMaxH3DiTModel(nn.Module):
         psp = _required_kwarg(kwargs, "packed_seq_params")
         cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(torch.int32)
         max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
-        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
-        refiner_cu = self._psp_field(refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q").to(torch.int32)
-        refiner_max = int(self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q"))
         video_layout = kwargs.get("video_token_layout")
 
         if x.dim() != 3 or x.shape[0] != 1:
@@ -1129,19 +1244,23 @@ class MiniMaxH3DiTModel(nn.Module):
         if inverse_indices.shape[0] != seq_len:
             raise ValueError(f"inverse_indices must be [{seq_len}], got {list(inverse_indices.shape)}")
         device = x.device
-        # Compute RoPE frequencies over the full packed sequence.
-        rope_freqs = self.rope(img_position_ids).to(device)
+        static_conditioning = self._resolve_static_conditioning(
+            static_conditioning=kwargs.get(MINIMAX_H3_STATIC_CONDITIONING_KWARG),
+            prompt_embeds=kwargs.get("prompt_embeds"),
+            img_position_ids=kwargs.get("img_position_ids"),
+            refiner_packed_seq_params=kwargs.get("refiner_packed_seq_params"),
+            device=device,
+        )
+        rope_freqs = static_conditioning.rope_freqs
 
         decoder_input, t_emb = self._embed(
             x=x,
             audio_x=audio_x,
-            text_embeddings_selected=text_selected,
+            refined_prompt_embeds=static_conditioning.refined_prompt_embeds,
             unique_timesteps=unique_timesteps.view(-1).to(device),
             img_pos=img_pos.to(device),
             audio_pos=audio_pos.to(device),
             text_pos=text_pos.to(device),
-            refiner_cu_seqlens=refiner_cu.to(device),
-            refiner_max_seqlen=refiner_max,
             seq_len=seq_len,
             device=device,
         )
@@ -1201,6 +1320,8 @@ EntryClass = MiniMaxH3DiTModel
 __all__ = [
     "MINIMAX_H3_FP32_BUFFER_NAMES",
     "MINIMAX_H3_FP32_PARAM_NAMES",
+    "MINIMAX_H3_STATIC_CONDITIONING_KWARG",
     "MiniMaxH3DiTModel",
+    "MiniMaxH3StaticConditioning",
     "_reorder_grouped_qkv_to_qkv",
 ]

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -1300,11 +1300,23 @@ class MiniMaxH3Pipeline(
 
         tags = packed["token_tags"].clone()
         tags[packed["text_pos"]] = text_tags.cpu()
+        text_len = int(packed["text_pos"].view(-1).shape[0])
+        static_conditioning = self.transformer.prepare_static_conditioning(
+            prompt_embeds=text_embeddings.to(self.device),
+            img_position_ids=packed["img_position_ids"][None].to(self.device),
+            refiner_cu_seqlens=torch.tensor(
+                [0, text_len, text_len],
+                dtype=torch.int32,
+                device=self.device,
+            ),
+            refiner_max_seqlen=text_len,
+        )
         branch = MiniMaxH3DenoiseBranch(
             packed=packed,
             text_embeddings=text_embeddings,
             token_tags=tags,
             device=self.device,
+            static_conditioning=static_conditioning,
         )
 
         visual_anchor = visual_condition


### PR DESCRIPTION
## Purpose

MiniMax-H3's prompt projection, two-layer token refiner, and 3D RoPE inputs are invariant across a generation request, but `main` recomputes them inside every denoise forward.

This change prepares those tensors once after the packed layout is known and carries them through the denoise branch in a frozen, request-scoped `MiniMaxH3StaticConditioning` value. There is no model-global cache, so concurrent requests cannot share or overwrite conditioning state. The raw-input fallback remains available for direct transformer and denoise-branch callers.

Preparation calls the model through its normal forward path, preserving CPU-offload hooks. The implementation is rebased onto current `VideoTokenLayout` handling.

## Test plan

- verify prepared and fallback conditioning are numerically equivalent;
- verify model forward hooks run during preparation;
- verify repeated denoise forwards reuse request-scoped projection, refiner, and RoPE tensors;
- retain current-main video-layout and fused-RoPE coverage;
- run the complete MiniMax-H3 L1 CPU suite;
- run Ruff lint and formatting checks on all changed files.

**vLLM Version:** 0.26.0

**vLLM-Omni base:** `d219d93b`

## Test result

```text
81 passed, 1 skipped, 2 deselected, 15 warnings
Ruff 0.14.10 check: passed
Ruff 0.14.10 format: passed
```

For a 19-forward short schedule, prompt projection, token refinement, and RoPE generation each change from 19 calls to 1 (94.74% fewer). Tests enforce the call counts and numerical equivalence. No full-generation latency claim is made.