### PR TITLE
[Model] MiniMax-H3 use direct embedding scatters

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_packing.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_packing.py
@@ -101,6 +101,62 @@ def test_ref2va_packing_tracks_video_and_audio_update_masks():
     assert packed["cu_seqlens"].tolist() == [0, 30, 64]
 
 
+def test_packed_modalities_partition_every_used_row():
+    from vllm_omni.diffusion.models.minimax_h3.packed_sequence import (
+        minimax_h3_packed_sequence,
+        minimax_h3_packed_sequence_ref2va_blocks,
+    )
+
+    common = dict(
+        text_len=4,
+        latent_t=2,
+        latent_h=4,
+        latent_w=6,
+        audio_t=3,
+    )
+    layouts = [
+        minimax_h3_packed_sequence(
+            **common,
+            include_keyframe_cond=False,
+        ),
+        minimax_h3_packed_sequence(
+            **common,
+            include_keyframe_cond=True,
+            keyframe_frame_indices=[0, -1],
+            frame_count=5,
+        ),
+        minimax_h3_packed_sequence_ref2va_blocks(
+            **common,
+            ref_blocks=[
+                {"kind": "image", "latent_h": 4, "latent_w": 4},
+                {"kind": "audio", "ref_audio_t": 2},
+                {
+                    "kind": "video_audio",
+                    "ref_audio_t": 2,
+                    "latent_t": 2,
+                    "latent_h": 4,
+                    "latent_w": 4,
+                },
+            ],
+        ),
+    ]
+
+    for packed in layouts:
+        positions = torch.cat(
+            [
+                packed["text_pos"],
+                packed["img_pos"],
+                packed["audio_pos"],
+            ]
+        )
+        used = int(packed["cu_seqlens"][1])
+        assert positions.numel() == used
+        torch.testing.assert_close(
+            positions.sort().values,
+            torch.arange(used),
+        )
+
+
 def test_condition_noise_is_seeded_and_keeps_clean_anchor_at_timestep_one():
     from vllm_omni.diffusion.models.minimax_h3.condition_noise import (
         minimax_h3_audio_cond_noise_aug_rows,

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -1067,9 +1067,11 @@ class MiniMaxH3DiTModel(nn.Module):
         )
 
         embeddings = torch.zeros((seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE)
-        embeddings.index_add_(0, text_pos, text_embed.to(_BF16_DTYPE)[: text_pos.shape[0]])
-        embeddings.index_add_(0, img_pos, video_embed.to(_BF16_DTYPE)[: img_pos.shape[0]])
-        embeddings.index_add_(0, audio_pos, audio_embed.to(_BF16_DTYPE)[: audio_pos.shape[0]])
+        # Every used packed row belongs to exactly one modality, so direct
+        # assignment avoids the atomic addition required by index_add_.
+        embeddings.index_copy_(0, text_pos, text_embed.to(_BF16_DTYPE)[: text_pos.shape[0]])
+        embeddings.index_copy_(0, img_pos, video_embed.to(_BF16_DTYPE)[: img_pos.shape[0]])
+        embeddings.index_copy_(0, audio_pos, audio_embed.to(_BF16_DTYPE)[: audio_pos.shape[0]])
 
         t_emb = self.time_embedder(unique_timesteps)
         return embeddings, t_emb


### PR DESCRIPTION
## Purpose

MiniMax-H3 assembles its packed multimodal embedding with three `index_add_` calls, one each for text, video, and audio. The packed-layout contract assigns every used row to exactly one modality, so these operations never perform a real reduction.

This change uses `index_copy_` for the three disjoint row sets. The regression test covers text-to-video, first/last-frame conditioning, and mixed image/audio/video reference layouts, verifying that text, image, and audio positions partition every used row exactly once.

Padding remains zero, packed row order is unchanged, and the resulting embedding tensor is bit-exact.

## Test plan

- verify modality positions are unique, disjoint, and exhaustive across supported layout families;
- retain current-main fused-RoPE coverage;
- run the complete MiniMax-H3 L1 CPU suite;
- run Ruff lint and formatting checks on all changed files.

**vLLM Version:** 0.26.0

**vLLM-Omni base:** `d219d93b`

## Test result

```text
80 passed, 1 skipped, 2 deselected, 15 warnings
Ruff 0.14.10 check: passed
Ruff 0.14.10 format: passed
```

## Isolated DGX Spark microbenchmark

For BF16 output `[6016, 5376]` with 5962 unique used rows:

| Packed assembly | Median | Range |
| --- | ---: | ---: |
| Three `index_add_` scatters | 1.1891 ms | 1.1858–1.2649 ms |
| Three `index_copy_` scatters | 0.8788 ms | 0.8776–0.9287 ms |

Outputs were bit-exact. Direct assignment was 1.353x faster in this isolated packed-assembly benchmark; no end-to-end generation claim is made.