### PR TITLE
ci(minimax-h3): add 2xH100 DLO function test to X2V nightly group

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -420,6 +420,15 @@ steps:
           - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_ltx2_expansion.py -m "full_model and cuda" --run-level "full_model"
         mirror_hardwares: h100_2
 
+      # H100 function coverage. MiniMax-H3 DLO is the first X2V model with an
+      # H100 function test (2x H100, DLO keeps the per-GPU peak far below the
+      # 80 GiB budget); add more H100-marked X2V cases here as validated.
+      - label: ":full_moon: Diffusion X2V(&A&T) · Function Test with H100"
+        timeout_in_minutes: 120
+        commands:
+          - pytest -sv tests/diffusion/models/minimax_h3/test_minimax_h3_dlo.py -m "full_model and diffusion and H100" --run-level "full_model"
+        mirror_hardwares: h100_2
+
       - label: ":full_moon: Diffusion X2V · Wan2.2 Accuracy Test"
         timeout_in_minutes: 180
         commands:

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_dlo.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_dlo.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""MiniMax-H3 distributed layerwise offload (DLO) function tests.
+
+The 2x H100 (80 GiB/GPU) case is a memory-first serving configuration
+validated on B300 hardware with DLO streaming the non-resident DiT blocks
+from pinned host memory. With TP2 + encoder TP2 + DLO (``dlo_resident_layers=8``,
+``--dlo-no-use-allgather``) and a 2-step smoke request, the per-GPU peak was
+~42 GiB, far below the 80 GiB H100 budget.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from huggingface_hub import snapshot_download
+
+from tests.helpers.mark import hardware_marks
+
+pytestmark = [pytest.mark.diffusion]
+
+MODEL_REPO_ID = "MiniMaxAI/MiniMax-H3"
+MODEL_REVISION = "main"
+MODEL_ENV_VAR = "VLLM_TEST_MINIMAX_H3_FL2VA_MODEL"
+
+
+def _fl2va_model_path() -> str:
+    configured = os.environ.get(MODEL_ENV_VAR)
+    if configured:
+        return configured
+    snapshot_root = snapshot_download(
+        repo_id=MODEL_REPO_ID,
+        revision=MODEL_REVISION,
+        allow_patterns=["FL2VA/**"],
+    )
+    return str(Path(snapshot_root) / "FL2VA")
+
+
+@pytest.mark.full_model
+@pytest.mark.parametrize(
+    "parallel_config",
+    [
+        pytest.param(
+            {
+                "tensor_parallel_size": 2,
+                "text_encoder_tp_size": 2,
+                "ulysses_degree": 1,
+                "ring_degree": 1,
+                "vae_patch_parallel_size": 1,
+            },
+            marks=hardware_marks(res={"cuda": "H100"}, num_cards=2),
+            id="dlo-2xH100",
+        ),
+    ],
+)
+def test_minimax_h3_t2va_dlo_2card_h100_smoke(parallel_config: dict):
+    """2-card DLO smoke: small steps, verifies DLO works on 2x H100."""
+    import torch
+
+    from vllm_omni.diffusion.data import DiffusionParallelConfig
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    if torch.accelerator.device_count() < 2:
+        pytest.skip("MiniMax H3 DLO smoke requires two GPUs")
+
+    engine = Omni(
+        model=_fl2va_model_path(),
+        parallel_config=DiffusionParallelConfig(**parallel_config),
+        trust_remote_code=True,
+        enable_distributed_layerwise_offload=True,
+        dlo_use_allgather=False,
+        dlo_resident_layers=8,
+        vae_parallel_mode="tile",
+        vae_use_tiling=True,
+        enforce_eager=True,
+        diffusion_attention_backend="CUDNN_ATTN",
+    )
+    try:
+        outputs = engine.generate(
+            "A quiet cinematic night scene with matching ambient sound.",
+            OmniDiffusionSamplingParams(
+                height=256,
+                width=448,
+                num_frames=29,
+                fps=24,
+                num_inference_steps=2,
+                seed=42,
+                output_type="np",
+                extra_args={
+                    "task": "t2va",
+                    "duration": 4.0,
+                    "aspect_ratio": "16:9",
+                    "flow_shift": 12.0,
+                    "audio_flow_shift": 3.0,
+                },
+            ),
+            use_tqdm=False,
+        )
+    finally:
+        engine.close()
+
+    assert len(outputs) == 1
+    frames = np.asarray(outputs[0].images[0])
+    assert frames.shape == (107, 256, 448, 3)
+    multimodal = outputs[0].multimodal_output
+    assert multimodal is not None
+    assert np.asarray(multimodal["audio"]).shape[1] == 2
+    assert multimodal["audio_sample_rate"] == 32000
+    assert multimodal["fps"] == 24


### PR DESCRIPTION
## Summary

Adds a MiniMax-H3 DLO (distributed layerwise offload) function test for **2x H100 (80 GiB/GPU)** and wires it into the Diffusion X2V(&A&T) nightly group as the first **X2V · Function Test with H100** entry point (`mirror_hardwares: h100_2`).

> Note: the initial revision targeted 4x L4, but the L4 CI machines do not have enough disk space for the MiniMax-H3 FL2VA checkpoint (~135 GiB per partition), so the test was moved to 2x H100.

## Changes

- `tests/diffusion/models/minimax_h3/test_minimax_h3_dlo.py`: new `full_model`/`diffusion`/`H100` (2-card) smoke test.
  - Small denoise steps (`num_inference_steps=2`) to keep CI fast while still verifying the DLO 2-card path end-to-end (joint T2VA output: 107-frame video + audio).
  - Config: `tensor_parallel_size=2`, `text_encoder_tp_size=2`, `vae_patch_parallel_size=1`, `enable_distributed_layerwise_offload`, `dlo_use_allgather=False`, `dlo_resident_layers=8`, tiled VAE, `CUDNN_ATTN`, `enforce_eager`.
  - Model resolution follows the existing MiniMax-H3 CI convention (`VLLM_TEST_MINIMAX_H3_FL2VA_MODEL` override, otherwise `snapshot_download(MiniMaxAI/MiniMax-H3, revision=main, allow_patterns=[FL2VA/**])`).
- `.buildkite/cuda/test-nightly.yml`: add `Diffusion X2V(&A&T) · Function Test with H100` step in the X2V group (`h100_2`), running the H100-marked X2V function test.

## Validation (verda_b300, 2 clean GPUs)

- DLO init: distributed layerwise offload enabled; encoder/VAE staged offload; worker GPU memory after model load ~1.4 GiB.
- Generation succeeded (2 steps, 256x448, 29 frames / duration 4.0s): output `(107, 256, 448, 3)` + audio (32 kHz).
- Per-GPU peak: **~42,142 MiB (~42 GiB) on each card — far below the 80 GiB H100 budget**.
- Verified via pytest (`1 passed`, ~2m38s).

## Notes

- `vae_patch_parallel_size=1` is required at small resolutions: MiniMax-H3 native VAE tile-parallel assigns `num_tiles / sp_size` tiles per rank, and at 256x448 the latent produces a single tile, so `vae_pp=2` leaves one rank empty (`Found empty tasks on sp rank N`). Transformer + text encoder use TP2; the VAE is tiled on the main rank.