### PR TITLE
fix(minimax-h3): pass device_type to fork_rng so VAE condition encode works on NPU devices

### DIFF
--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -193,7 +193,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             self.to(torch.float32)
         devices = [parameter.device] if parameter.device.type != "cpu" else []
         try:
-            with torch.random.fork_rng(devices=devices):
+            with torch.random.fork_rng(devices=devices, device_type=parameter.device.type):
                 torch.default_generator.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
                 for device in devices:
                     with self.device_module.device(device):
@@ -237,7 +237,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             self.to(torch.float32)
         devices = [parameter.device] if parameter.device.type != "cpu" else []
         try:
-            with torch.random.fork_rng(devices=devices):
+            with torch.random.fork_rng(devices=devices, device_type=parameter.device.type):
                 torch.default_generator.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
                 for device in devices:
                     with self.device_module.device(device):


### PR DESCRIPTION
### Purpose

`MiniMaxH3VideoVAE.encode_image` / `encode_video` wrap the seeded VAE condition encode in
`torch.random.fork_rng(devices=devices)`, where `devices` is derived from the module's
parameter device. On non-CUDA platforms (e.g. Ascend NPU with `torch_npu`, where torch is a
`+cpu` build) this crashes any request with reference images/videos (fl2va, v2va):

```
File ".../models/minimax_h3/vae.py", line 196, in encode_image
    with torch.random.fork_rng(devices=devices):
File ".../torch/random.py", line 200, in fork_rng
    device_rng_states = [device_mod.get_rng_state(device) for device in devices]
File ".../torch/cuda/random.py", line 34, in get_rng_state
    _lazy_init()
File ".../torch/cuda/__init__.py", line 417, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

**Root cause.** `torch.random.fork_rng`'s `device_type` argument defaults to `"cuda"` and is
**not** inferred from the `devices` argument — torch uses it to pick the device module
(`getattr(torch, device_type)`), so the call unconditionally goes through `torch.cuda`
regardless of the actual devices passed in. On a torch build without CUDA this fails inside
CUDA lazy init.

**Fix.** Pass the parameter's actual device type through:

```python
torch.random.fork_rng(devices=devices, device_type=parameter.device.type)
```

- CUDA: `parameter.device.type == "cuda"` — behavior unchanged.
- NPU: `torch_npu` registers the `npu` device module via `torch._register_device_module`,
  so `getattr(torch, "npu")` resolves and RNG-state fork/restore works.
- CPU: `devices == []` already, so the fork is CPU-only either way.

### Test Plan

- NPU (Ascend, `torch 2.10.0+cpu` + `torch_npu`), vllm-omni serving MiniMax-H3:
  - `POST /v1/videos/sync` fl2va request with 2 reference images (2038-token prompt)
  - direct `torch.random.fork_rng(devices=[torch.device("npu", 0)], device_type="npu")` smoke test
- CUDA regression: `device_type` resolves to `"cuda"`, identical to the previous default.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 1c2a81f6 (main @ 2026-08-06) + this patch

### Test Result

Before: every fl2va / reference-conditioned request on NPU fails with
`AssertionError: Torch not compiled with CUDA enabled` (full server traceback above; request
returns HTTP 500).

After:

- `fork_rng(devices=[npu:0], device_type="npu")` round-trips RNG state on NPU without error;
  omitting `device_type` reproduces the original AssertionError (verified in the same container).
- fl2va request completes and returns video bytes (参考图条件编码、patchify、归一化路径不变,
  CUDA 数值契约不受影响)。
- `pre-commit run --files vllm_omni/diffusion/models/minimax_h3/vae.py` 全绿（ruff check /
  ruff format / typos 等）。

---

## 提交前 Checklist

- [x] 按模板要求跑一次 `precheck-pr` skill 自检
- [x] commit message 遵循仓库约定（参考 `feat(minimax-h3): ... (#5764)` 风格），只保留自己的 `Signed-off-by`


## 备注

- 该 bug 不影响 CUDA 用户，是纯 NPU/非 CUDA 平台的兼容性问题，预期上游 review 风险低。
- `fork_rng` 的 `device_type` 参数在 torch ≥ 2.3 均可用；vllm-omni 的 torch 版本下限
  已满足，无需额外版本判断。


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
