### PR TITLE
[Doc] Document LingBot-Video's structured caption prompt format

### DIFF
--- a/recipes/Robbyant/LingBot-Video.md
+++ b/recipes/Robbyant/LingBot-Video.md
@@ -30,6 +30,42 @@ parallel, cache, quantized, or expert-kernel backends.
 - Related offline example: [`examples/offline_inference/text_to_video/text_to_video_lingbot.py`](../../examples/offline_inference/text_to_video/text_to_video_lingbot.py)
 - Related online video API docs: [`docs/serving/videos_api.md`](../../docs/serving/videos_api.md)
 
+## Prompt format
+
+LingBot-Video conditions its DiT on the structured caption used by its training
+data rather than on a free-form sentence. The upstream project keeps one caption
+per case in `assets/cases/t2v/<case>/prompt.json` and passes the `caption`
+sub-object to the pipeline as a compact JSON string:
+
+```python
+import json
+
+sample = json.loads(open("assets/cases/t2v/example_1/prompt.json").read())
+prompt = json.dumps(sample["caption"], ensure_ascii=False, separators=(",", ":"))
+```
+
+That caption object carries `comprehensive_description`
+(`scene_content_description` plus `camera_movement_description`), `camera_info`
+(`color`, `frame_size`, `shot_type_angle`, `lens_size`, `composition`,
+`lighting`, `lighting_type`), `world_knowledge`, and `prominent_elements`, where
+each element lists timestamped `actions`. Those timestamps describe the clip the
+caption was written for, so keep the request consistent with the sample's
+`duration`: `num_frames = duration * fps + 1`.
+
+`negative_prompt` follows the same convention. The pipeline default is itself a
+JSON string keyed by `universal_negative`, not prose, so pairing a free-form
+positive prompt with the default negative prompt asks classifier-free guidance
+to extrapolate between two different text distributions.
+
+The one-line prompts in the smoke commands below are deliberately trivial. At
+`192x320` / 9 frames / 2 steps the denoiser barely moves, so the caption format
+does not affect whether the run validates the plumbing. It does affect output
+quality once resolution, frame count, and step count approach the reference
+settings, on any vendor's hardware. Upstream issue
+<https://github.com/Robbyant/lingbot-video/issues/11> reports free-form prompts
+producing unusable video on NVIDIA GPUs. Start from an official caption whenever
+you evaluate quality rather than plumbing.
+
 ## Hardware Support
 
 This recipe documents the CUDA single-GPU dense and BF16 MoE checkpoint paths.
@@ -110,7 +146,8 @@ vllm serve robbyant/lingbot-video-moe-30b-a3b \
 
 These stage defaults match the LingBot reference pipeline. Request-level
 values continue to override them, so the smaller smoke request below remains
-unchanged.
+unchanged. Requests that do take these reference-scale defaults should also
+carry a structured caption, as described in [Prompt format](#prompt-format).
 
 When serving MoE, replace the request's `model` form value below with
 `robbyant/lingbot-video-moe-30b-a3b`.
@@ -150,13 +187,14 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o lingbot_t2v.mp4
 
 | Parameter | Suggested smoke value | Notes |
 |-----------|-----------------------|-------|
+| `prompt` | short sentence | A trivial sentence is enough for the smoke shape; quality runs need a structured caption, see [Prompt format](#prompt-format) |
 | `height` | `192` | Must be a multiple of 16 |
 | `width` | `320` | Must be a multiple of 16 |
 | `num_frames` | `9` | Must be `1` or `4n + 1`; this PR validates T2V with video outputs |
-| `num_inference_steps` | `2` | Use more steps for quality sweeps |
+| `num_inference_steps` | `2` | Use more steps for quality sweeps; those also need a structured caption, see [Prompt format](#prompt-format) |
 | `guidance_scale` | `3.0` | CFG is active when this is greater than `1.0` |
 | `flow_shift` | `3.0` | Scheduler flow-shift; aliases the pipeline's internal `shift` |
-| `negative_prompt` | model default | Optional text describing artifacts to avoid |
+| `negative_prompt` | model default | Structured JSON keyed by `universal_negative`; override it in that same shape, see [Prompt format](#prompt-format) |
 | `fps` | `24` | Output MP4 frame rate |
 
 ## Validation


### PR DESCRIPTION
## Purpose

The recipe documents the prompt as a free-form sentence, while its `vllm serve`
snippets already hand out reference-scale defaults (`num_frames: 81`,
`num_inference_steps: 40`) and the parameter table invites more steps for
quality sweeps. Following both yields a quality-scale request carrying a prompt
the DiT was never conditioned on: nothing errors, the video just comes back
washed out. The 2-step `192x320` smoke shape denoises too little to show it, so
the existing commands and e2e tests are unaffected and stay valid.

This PR adds a `## Prompt format` section for the caption contract used
upstream: the `caption` sub-object of `assets/cases/t2v/<case>/prompt.json`
serialized as compact JSON, plus `num_frames = duration * fps + 1`. It also
fixes the `negative_prompt` row, whose default is a JSON string keyed by
`universal_negative` rather than the prose the table implied; overriding it with
prose splits positive and negative conditioning across two text distributions
for CFG to extrapolate between.

Same failure mode on NVIDIA: Robbyant/lingbot-video#11.

Docs only, no code or test changes.

## Test Plan

One MI350X (gfx950), BF16, `robbyant/lingbot-video-moe-30b-a3b`, the recipe's
own offline command with only `--prompt` changed (seed 42, `guidance_scale` 3.0,
`negative_prompt` unset so the default JSON negative applies). Blankness is the
standard deviation of the decoded RGB frames.

## Test Result

| Prompt | Shape | Clip std | First frame | Last frame |
|--------|-------|----------|-------------|------------|
| Free-form sentence | `480x832`, 81 frames, 40 steps | `6.07` | `32.38` | `4.51` |
| Official caption JSON | `480x832`, 81 frames, 40 steps | `44.33` | `44.2` | `43.3` |
| Official caption JSON, native composition | `832x480`, 121 frames | `57.99` | `53.3` | `56.9` |

The free-form run starts plausible and decays to a flat image, which is exactly
what a two-step smoke run cannot surface. The last row is the reference
configuration end to end: 276 s, 77.51 GiB peak reserved.

Measured on ROCm only; the NVIDIA claim rests on the upstream issue above rather
than a run of my own. Related: #5035, #5830.


## Free-Form Sentence

https://github.com/user-attachments/assets/269c6693-203f-4bd7-87a0-75697d03a39f

## Official Caption 


https://github.com/user-attachments/assets/e5724b41-a615-4ab2-bb82-e400c8bd5ee5


