### PR TITLE
[Bugfix] npu omni runner alignment

### DIFF
--- a/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
@@ -45,19 +45,19 @@
         "percentile-metrics": "ttft,e2el,audio_ttfp,audio_rtf,audio_duration",
         "baseline": {
           "request_throughput": [
-            0.2415
+            0.1594
           ],
           "mean_ttft_ms": [
-            122.6731
+            274.164
           ],
           "mean_e2el_ms": [
-            4073.804
+            6250.7696
           ],
           "mean_audio_ttfp_ms": [
-            523.4768
+            994.422
           ],
           "mean_audio_rtf": [
-            0.28295
+            0.46163
           ]
         }
       }

--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -19,7 +19,7 @@ _MODEL = "openbmb/MiniCPM-o-4_5"
 _CI_DEPLOY = modify_stage_config(
     get_deploy_config_path("minicpmo_4_5.yaml"),
     updates={
-        "stages": {0: {"default_sampling_params.max_tokens": 128}, 1: {"default_sampling_params.max_tokens": 1024}}
+        "stages": {0: {"default_sampling_params.max_tokens": 64}, 1: {"default_sampling_params.max_tokens": 1024}}
     },
 )
 

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -43,7 +43,7 @@ from vllm_ascend.worker.model_runner_v1 import graph_capture
 
 from vllm_omni.data_entry_keys import flatten_payload
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
-from vllm_omni.distributed.omni_connectors.utils.config import stage_sends_async_output
+from vllm_omni.distributed.omni_connectors.utils.config import get_stage_connector_role, stage_sends_async_output
 from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
@@ -125,7 +125,16 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin):
             "DyninOmniForConditionalGeneration",
             "IndexTTS2TalkerForConditionalGeneration",
         }
-        if getattr(self.model_config, "model_arch", None) in _OMNI_CONNECTOR_INIT_ARCHS:
+        # Mirrors gpu_ar_model_runner: an arch missing from the hardcoded allowlist
+        # still needs connectors when the deploy config hands the stage a
+        # sender/receiver role (e.g. MiniCPM-o 4.5, whose archs are not listed but
+        # whose YAML wires stage 1 -> stage 2). Without the role check the
+        # full-payload (``--no-async-chunk``) handoff never initializes: nothing
+        # accumulates, nothing flushes, and the downstream stage starves silently.
+        if (
+            getattr(self.model_config, "model_arch", None) in _OMNI_CONNECTOR_INIT_ARCHS
+            or get_stage_connector_role(self.model_config) is not None
+        ):
             self.init_omni_connectors(
                 model_config=self.model_config,
                 kv_transfer_manager=self.kv_transfer_manager,

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -32,6 +32,7 @@ from vllm_ascend.ops.rotary_embedding import update_cos_sin
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import SEQ_LEN_WITH_MAX_PA_WORKSPACE
 
+from vllm_omni.distributed.omni_connectors.utils.config import get_stage_connector_role
 from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.platforms.npu.worker.npu_ar_model_runner import ExecuteModelState, _ensure_tensor_values
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
@@ -56,7 +57,13 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
             "DyninOmniForConditionalGeneration",
             "IndexTTS2S2MelDecoder",
         }
-        if getattr(self.model_config, "model_arch", None) in _OMNI_CONNECTOR_INIT_ARCHS:
+        # See npu_ar_model_runner: the role check keeps connector-configured stages
+        # whose arch is not in the allowlist (e.g. MiniCPMO45Code2Wav) from silently
+        # skipping connector init and starving on the full-payload receive path.
+        if (
+            getattr(self.model_config, "model_arch", None) in _OMNI_CONNECTOR_INIT_ARCHS
+            or get_stage_connector_role(self.model_config) is not None
+        ):
             self.init_omni_connectors(
                 model_config=self.model_config,
             )
@@ -332,6 +339,14 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
 
             # [Omni] Pass token counts per request for code2wav output slicing
             model_kwargs["seq_token_counts"] = tokens
+            # [Omni] Mirrors gpu_generation_model_runner: models that declare
+            # ``requires_request_ids`` (e.g. MiniCPMO45Code2Wav) key their per-request
+            # streaming state on this. Without it they fall back to scraping ids out of
+            # ``runtime_additional_information``, which yields the literal string "None"
+            # when the producer payload carries no id -- every concurrent request then
+            # collapses onto the same state key and the stage aborts the batch.
+            if getattr(self.model, "requires_request_ids", False):
+                model_kwargs["request_ids"] = list(req_ids)
 
             # update global cos, sin
             update_cos_sin(positions)


### PR DESCRIPTION
Two NPU model-runner divergences from their GPU counterparts break MiniCPM-o 4.5 on the --no-async-chunk (full-payload) path. Both are omissions from the original port; the GPU runners have had the missing logic all along.

1. Connector init gated only on a hardcoded arch allowlist
npu_ar_model_runner.py / npu_generation_model_runner.py decide whether to call init_omni_connectors() purely from _OMNI_CONNECTOR_INIT_ARCHS. The GPU runners additionally accept any stage the deploy config has given a sender/receiver role:


if (model_arch in _OMNI_CONNECTOR_INIT_ARCHS
        or get_stage_connector_role(self.model_config) is not None):
MiniCPMO45OmniForConditionalGeneration and MiniCPMO45Code2Wav are not in the allowlist but are wired stage 1 → stage 2 in minicpmo_4_5.yaml. On NPU init_omni_connectors therefore never ran: _omni_connector was absent, the hasattr guard in execute_model skipped the whole recv/flush block, _should_accumulate_full_payload_output() returned False, and stage 2 starved forever. Streaming audio requests hung until the client timed out, with no server-side error.

2. requires_request_ids not forwarded
MiniCPMO45Code2Wav sets requires_request_ids = True. gpu_generation_model_runner honours it; the NPU runner never sets model_kwargs["request_ids"]. Code2Wav then falls back to scraping ids out of runtime_additional_information, where tts2code2wav_full_payload writes the literal string "None" when the producer request carries no id. Every concurrent request collapses onto the same state key:


RuntimeError: MiniCPMO45Code2WavBatchError
  {"reason": "duplicate_request_in_forward", "request_ids": ["None", "None"]}
→ EngineDeadError → API server dies
Single-request runs pass only because ["None"] has no duplicate and "None" is a non-empty string — the per-request streaming state was already keyed on garbage.

Verified on A3 NPU, tests/e2e/online_serving/test_minicpmo_4_5_expansion.py, both [default] (--no-async-chunk) and [async_chunk] groups green. Previously 3 of the [default] cases hung for the full 600 s client timeout.

Follow-up (not in this PR): tts2code2wav_full_payload should fall back to req_id the way the mixin's _resolve_external_req_id does, instead of emitting str(None).

3. Update baseline metrics for test_minicpmo_4_5_duplex_seed_tts