### PR TITLE
[CI/Build][MiniCPM-o] Fix NPU accuracy job timeout and silent Daily-O…

### DIFF
--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -1,3 +1,9 @@
+env:
+  VLLM_WORKER_MULTIPROC_METHOD: spawn
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  HF_HUB_DOWNLOAD_TIMEOUT: 300
+  HF_HUB_ETAG_TIMEOUT: 60
+
 steps:
   # - group: ":card_index_dividers: Diffusion X2V Model Test"
   #   key: nightly-diffusion-x2v-group
@@ -41,13 +47,14 @@ steps:
     if: build.env("NIGHTLY") == "1" || build.pull_request.labels includes "nightly-test" || build.pull_request.labels includes "omni-test"
     steps:
       - label: ":full_moon: Omni · MiniCPM-o 4.5 Test"
+        timeout_in_minutes: 180
         mirror_hardwares: a3_npu_2
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
           HF_TOKEN: "${HF_TOKEN}"
         commands:
-          - pytest -s -v tests/e2e/offline_inference/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5_expansion.py -m 'full_model' --run-level 'full_model'
+          - pytest -s -v tests/e2e/offline_inference/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5.py tests/e2e/online_serving/test_minicpmo_4_5_expansion.py -m 'full_model and npu and A3 and omni' --run-level 'full_model'
       - label: ":full_moon: Omni · MiniCPM-o 4.5 · Duplex Test"
         timeout_in_minutes: 180
         mirror_hardwares: a3_npu_2
@@ -76,6 +83,8 @@ steps:
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
           HF_TOKEN: "${HF_TOKEN}"
         commands:
+          - export SEED_TTS_WER_EVAL=1
+          - export SEED_TTS_EVAL_DEVICE=npu:1
           - |
             set +e
             pytest -s -v tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py -m "full_model and npu and A3" --run-level full_model

--- a/docker/Dockerfile.npu.ci
+++ b/docker/Dockerfile.npu.ci
@@ -44,6 +44,7 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "jiwer>=4.0.0" \
       "zhon>=2.1.1" \
       "zhconv>=1.4.3" \
+      "datasets>=3.0.0" \
       --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
       --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
       --default-timeout=60 && \

--- a/docker/Dockerfile.npu.ci.a3
+++ b/docker/Dockerfile.npu.ci.a3
@@ -44,6 +44,7 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
       "jiwer>=4.0.0" \
       "zhon>=2.1.1" \
       "zhconv>=1.4.3" \
+      "datasets>=3.0.0" \
       --index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple \
       --trusted-host cache-service.nginx-pypi-cache.svc.cluster.local \
       --default-timeout=60 && \

--- a/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
@@ -29,7 +29,7 @@
         "backend": "openai-realtime-tts",
         "endpoint": "/v1/realtime",
         "num_prompts": [
-          1
+          32
         ],
         "max_concurrency": [
           1

--- a/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
+++ b/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
@@ -9,6 +9,7 @@ text modalities with ``use_tts_template``, and server ``--interleave-mm-strings`
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -64,6 +65,15 @@ _SEED_TTS_SERVER_ARGS = [
 
 pytestmark = [pytest.mark.full_model, pytest.mark.omni]
 
+# Evaluated at setup time, before the ``omni_server`` fixture boots a server. An
+# ``importorskip`` inside the test body would skip only after paying several minutes
+# of startup, and the resulting skip is easy to miss in a nightly log.
+_missing_daily_omni_deps = [name for name in ("datasets", "huggingface_hub") if importlib.util.find_spec(name) is None]
+requires_daily_omni_deps = pytest.mark.skipif(
+    bool(_missing_daily_omni_deps),
+    reason=f"Daily-Omni accuracy bench needs {', '.join(_missing_daily_omni_deps)}",
+)
+
 daily_test_params = [
     OmniServerParams(
         model=_MODEL,
@@ -103,12 +113,11 @@ def _inline_daily_omni_media(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
 
+@requires_daily_omni_deps
 @hardware_test(res={"cuda": "H100", "npu": "A3"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", daily_test_params, indirect=True)
 def test_minicpmo_4_5_daily_omni_accuracy_bench(omni_server) -> None:
     _require_vllm_cli()
-    pytest.importorskip("datasets")
-    pytest.importorskip("huggingface_hub")
 
     argv = build_acc_benchmark_cli_argv(
         omni_server,

--- a/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
@@ -125,10 +125,24 @@ def _get_eval_device() -> str:
         return explicit
     try:
         import torch
-
-        return "cuda:0" if torch.cuda.is_available() else "cpu"
     except ImportError:
         return "cpu"
+
+    if torch.cuda.is_available():
+        return "cuda:0"
+
+    # Ascend: ``torch.npu`` only exists once ``torch_npu`` has been imported, which does
+    # not necessarily happen in the benchmark client process. Without this branch the
+    # eval silently lands on CPU, where Whisper-large-v3 needs hours for a full Seed-TTS
+    # run and the CI job is killed by its timeout instead of reporting a WER.
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        pass
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return "npu:0"
+
+    return "cpu"
 
 
 def _punctuation_all() -> str:


### PR DESCRIPTION
The NPU nightly MiniCPM-o 4.5 · Accuracy Test job was killed at its 180-minute timeout without ever reporting a WER, and its Daily-Omni half never ran at all.

1. Seed-TTS eval fell back to CPU on Ascend
_get_eval_device() only checked torch.cuda.is_available(), so on A3 the Seed-TTS scorer loaded openai/whisper-large-v3 on CPU. Transcribing 1088 clips ran 2 h 20 m without finishing and the job was killed. Added an Ascend branch (CUDA → NPU → CPU); SEED_TTS_EVAL_DEVICE still overrides. _load_wavlm resolves through the same helper and benefits too.

2. Daily-Omni bench silently skipped, after paying full server startup
The NPU CI image lacks datasets, so test_minicpmo_4_5_daily_omni_accuracy_bench hit pytest.importorskip("datasets") — but only after the omni_server fixture had spent 264 s booting a three-stage server, and the resulting SKIP is easy to miss in a nightly log. Added datasets to both NPU CI images and moved the dependency check to a collection-time skipif so it costs nothing and is visible.

3. NPU nightly job config (second commit)
The Accuracy step now exports `SEED_TTS_WER_EVAL=1` and `SEED_TTS_EVAL_DEVICE=npu:1`: the new
Ascend branch would auto-pick `npu:0`, which the omni server already occupies, so the scorer is
pinned to the second card. Also hoisted `VLLM_WORKER_MULTIPROC_METHOD`,
`VLLM_ALLOW_LONG_MAX_MODEL_LEN` and the HF_HUB download/etag timeouts to a pipeline-level `env`
block, gave `MiniCPM-o 4.5 Test` the 180-minute timeout its sibling steps already carry, and
narrowed its marker filter to `full_model and npu and A3 and omni` to match the other MiniCPM-o
NPU steps. Unrelated but bundled at reviewer request: duplex Seed-TTS perf config
`num_prompts` 1 → 32.

---

## Verification on A3 (Ascend NPU)

Run on an A3 box with the same setup as the nightly `Omni · MiniCPM-o 4.5 · Accuracy Test` job.

### Test 1 — device selection + HF Whisper forward on NPU

Standalone check (no omni server) that `_get_eval_device()` now resolves to NPU and that
`openai/whisper-large-v3` actually runs there, rather than trading the CPU timeout for an
OOM or an unsupported-op failure:

```python
import numpy as np
from vllm_omni.benchmarks.data_modules import seed_tts_eval as ev
wav = (0.1 * np.random.randn(16000 * 5)).astype(np.float32)   # 5 s @ 16 kHz
ev._transcribe_en_f32_16k(wav)
```

| Item | Result |
| --- | --- |
| Chosen eval device (no override set) | `npu:0` |
| Whisper forward on NPU | OK — no OOM, no unsupported op |
| First call (weight load + infer) | 13.2 s |
| Warm transcription | 0.17 s/clip |

```
WARNING 08-07 02:46:04 [seed_tts_eval.py:420] Loading Seed-TTS eval Whisper HF model
  'openai/whisper-large-v3' on npu:0 (one-time, seed-tts-eval protocol)...
Loading weights: 100%|██████████| 1259/1259 [00:00<00:00, 2281.20it/s]
first(load+infer) 13.2s
warm 0.17s/clip
```

Only benign warnings surfaced from torch_npu — one `Cannot create tensor with internal format
while allow_internel_format=False` notice from `SuppressTokensLogitsProcessor`, plus the usual
transformers deprecation notices. No functional failure.

### Test 2 — `test_minicpmo_4_5_seed_tts_wer_bench` (full Seed-TTS WER path)

```bash
export SEED_TTS_WER_EVAL=1
export SEED_TTS_EVAL_DEVICE=npu:1   # keep the scorer off the card the omni server occupies
pytest -s -v tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py \
  -k seed_tts_wer -m "full_model and npu and A3" --run-level full_model
```

Both exports are now part of the nightly Accuracy step, so CI runs the same configuration
this was verified under.

| Item | Result |
| --- | --- |
| Chosen eval device | `npu:1` — the `SEED_TTS_EVAL_DEVICE` override is still honoured |
| Outcome | **1 passed**, 2 deselected |
| Wall clock | **43 m 04 s** (2584.51 s) vs. the job's 180-minute timeout |
| Serving benchmark duration | 1504.36 s, 1088 successful requests, 0 failed |
| Clips evaluated for WER | 1088 |
| **Mean WER** | **0.0348** (gate: `_MAX_SEED_TTS_MEAN_WER = 0.05`) |
| Median WER | 0.0000 |
| No PCM captured / ASR-WER failures | 0 / 0 |
| SIM / UTMOS | not enabled in this run |
| Whisper transcription pass | ≈ 3 min, extrapolated from 0.17 s/clip × 1088 (not separately timed) |

```
================== Audio Result ==================
Total audio duration generated(s):       4941.84
Streaming continuity OK rate:            100.00%
Mean AUDIO_TTFP (ms):                    2351.44
Mean AUDIO_RTF:                          1.26
==================================================
WARNING 08-07 03:20:58 [seed_tts_eval.py:420] Loading Seed-TTS eval Whisper HF model
  'openai/whisper-large-v3' on npu:1 (one-time, seed-tts-eval protocol)...
===== Seed-TTS eval (seed-tts-eval protocol) =====
Evaluated (WER, lower is better):        1088
Mean WER:                                0.0348
Median WER:                              0.0000
Request failed:                          0
No PCM captured:                         0
ASR / WER failed:                        0
==================================================
========== 1 passed, 2 deselected, 15 warnings in 2584.51s (0:43:04) ===========

real    43m25.934s
```

This is the behaviour the fix targets: the job now reports a WER and finishes in 43 minutes
instead of being killed at 180 without a number.

### Daily-Omni path

Agreed with the reviewer that the Daily-Omni half does not need a separate run here. The change
on that side is a collection-time `skipif` replacing an in-body `importorskip` plus the `datasets`
dependency added to both NPU CI images — the skip becomes visible at collection and costs no
server startup once the images are rebuilt.
