### PR TITLE
[Model] Add SkyReels V3 R2V diffusion support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -37,6 +37,7 @@ th {
 | `Krea2Pipeline` | Krea 2 (Raw + Turbo) | `krea/Krea-2-Raw`, `krea/Krea-2-Turbo` | ✅︎ | | | |
 | `WanPipeline` | Wan2.1-T2V, Wan2.2-T2V, Wan2.2-TI2V | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, `Wan-AI/Wan2.1-T2V-14B-Diffusers`, `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanImageToVideoPipeline` | Wan2.2-I2V | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
+| `SkyReelsV3R2VPipeline` | SkyReels V3 R2V | `Skywork/SkyReels-V3-R2V-14B` | ✅︎ | | | |
 | `Cosmos3OmniDiffusersPipeline` | Cosmos3 T2I, T2V, I2V, V2V, T2V with sound, action policy | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22S2VPipeline` | Wan2.2-S2V | `Wan-AI/Wan2.2-S2V-14B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |

--- a/examples/offline_inference/image_to_video/README.md
+++ b/examples/offline_inference/image_to_video/README.md
@@ -1,7 +1,7 @@
 # Image-To-Video
 
 This shared example generates videos from images with VACE, Wan2.2, LTX-2,
-HunyuanVideo-1.5, Cosmos3, and other compatible pipelines.
+HunyuanVideo-1.5, Cosmos3, SkyReels V3 R2V, and other compatible pipelines.
 
 - `image_to_video.py`: command-line script for single video generation with advanced options.
 
@@ -25,6 +25,7 @@ This folder provides a unified CLI script for image-to-video generation using vL
 | ----- | ------------------ | -------------- | ------------- | -------- | ---------- |
 | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | 480 x 832 | 81 | 50 | 5.0 | Around 60 GiB BF16 for basic single-card usage |
 | `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | 480 x 832 | 81 | 50 | 4.0 | Around 20–25 GiB BF16, smallest I2V model |
+| `Skywork/SkyReels-V3-R2V-14B` | 544 x 960 | 105 | 50 | text 7.5 / image 5.0 | Large 14B video model; use multiple GPUs or offload if needed |
 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v` | 480 x 832 | 121 | 50 | 6.0 | Around 100 GiB at default settings; the example enables `--enable-cpu-offload` + VAE tiling/slicing to fit an 80 GiB card |
 | `Lightricks/LTX-2` | 512 x 768 | 121 | 40 | video 3.0 / audio 7.0 | Memory use depends on frame count and tensor parallelism |
 
@@ -175,6 +176,27 @@ python image_to_video.py \
   --output i2v_wan_ti2v.mp4
 ```
 
+### SkyReels V3 R2V
+
+SkyReels V3 R2V accepts one to four reference images. Use repeated
+`--reference-image` flags; `--image` is also accepted as a single reference.
+
+```bash
+python image_to_video.py \
+  --model Skywork/SkyReels-V3-R2V-14B \
+  --reference-image person_a.jpg \
+  --reference-image person_b.jpg \
+  --prompt "Two reference characters walk through a rainy neon street, cinematic motion" \
+  --height 544 \
+  --width 960 \
+  --num-frames 105 \
+  --guidance-scale 7.5 \
+  --extra-body '{"guidance_scale_img": 5.0}' \
+  --num-inference-steps 50 \
+  --fps 24 \
+  --output skyreels_r2v.mp4
+```
+
 ### HunyuanVideo-1.5 I2V (480p)
 
 ```bash
@@ -246,12 +268,12 @@ python image_to_video.py \
 Key arguments:
 
 - `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V, LTX-2,
-  Cosmos3, or VACE).
+  SkyReels V3 R2V, Cosmos3, or VACE).
 - `--image`: Path to the first-frame or source image.
 - `--last-image`: Optional last-frame condition for models such as VACE.
 - `--mask-image`: Optional inpainting mask. White pixels are regenerated and black pixels are preserved.
 - `--reference-image`: Optional reference image; repeat it to provide multiple references.
-- `--extra-body`: JSON object of model-specific generation params, filtered against the model's declared `extra_body_params` (see [`vllm_omni/model_extras`](../../../vllm_omni/model_extras)). Used by Cosmos3.
+- `--extra-body`: JSON object of model-specific generation params, filtered against the model's declared `extra_body_params` (see [`vllm_omni/model_extras`](../../../vllm_omni/model_extras)). Used by Cosmos3 and SkyReels V3 R2V image CFG.
 - `--prompt`: Text description of desired motion/animation.
 - `--height/--width`: Output resolution (auto-calculated from image if not set).
   Wan dimensions should be multiples of 16; LTX dimensions should be multiples

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -3,13 +3,14 @@
 
 """
 Image-to-Video generation example using Wan2.2 I2V/TI2V models, LTX2/LTX-2.3,
-HunyuanVideo-1.5, Cosmos3, or Wan2.1 VACE.
+HunyuanVideo-1.5, Cosmos3, SkyReels V3 R2V, or Wan2.1 VACE.
 
 Supports:
 - Wan2.2-I2V-A14B-Diffusers: MoE model with CLIP image encoder
 - Wan2.2-TI2V-5B-Diffusers: Unified T2V+I2V model (dense 5B)
 - LTX2 image-to-video pipeline
 - HunyuanVideo-1.5 I2V: SigLIP + VAE dual image conditioning
+- SkyReels V3 R2V: 1-4 reference images, text CFG + image CFG
 - Wan2.1 VACE: first/last-frame, inpainting, and reference conditioning
 
 Usage:
@@ -87,13 +88,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Generate a video from one or more images "
-            "(Wan2.2, LTX2/LTX-2.3, HunyuanVideo-1.5, Cosmos3, or Wan2.1 VACE)."
+            "(Wan2.2, LTX2/LTX-2.3, HunyuanVideo-1.5, Cosmos3, SkyReels V3 R2V, or Wan2.1 VACE)."
         )
     )
     parser.add_argument(
         "--model",
         default="Wan-AI/Wan2.2-I2V-A14B-Diffusers",
-        help="Diffusers I2V model ID or local path (Wan2.2, LTX2/LTX-2.3, HunyuanVideo-1.5, Cosmos3, or Wan2.1 VACE).",
+        help="Diffusers I2V model ID or local path (Wan2.2, LTX2/LTX-2.3, HunyuanVideo-1.5, Cosmos3, SkyReels V3 R2V, or Wan2.1 VACE).",
     )
     parser.add_argument(
         "--model-class-name",
@@ -335,6 +336,7 @@ def main():
     is_ltx2 = is_ltx2_distilled or is_ltx23 or "ltx2" in model_class_name_lower or "ltx-2" in model_name
     is_cosmos = "cosmos" in model_name or (model_class_name is not None and "cosmos" in model_class_name.lower())
     is_cosmos_edge = is_cosmos and ("edge" in model_name or "edge" in model_class_name_lower)
+    is_skyreels_r2v = "skyreels-v3-r2v" in model_name or model_class_name_lower == "skyreelsv3r2vpipeline"
 
     image = PIL.Image.open(args.image).convert("RGB") if args.image else None
     last_image = PIL.Image.open(args.last_image).convert("RGB") if args.last_image else None
@@ -390,6 +392,16 @@ def main():
             512 * 768,
             32,
         )
+    elif is_skyreels_r2v:
+        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
+            24,
+            7.5,
+            105,
+            50,
+            5.0,
+            544 * 960,
+            16,
+        )
     else:  # Wan2.2 / HunyuanVideo-1.5
         d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = 16, 5.0, 81, 50, 5.0, 480 * 832, 16
 
@@ -410,15 +422,19 @@ def main():
 
     media_inputs: dict[str, Any] = {}
     if image is not None:
-        media_inputs["image"] = image.resize((width, height), PIL.Image.Resampling.LANCZOS)
+        media_inputs["image"] = (
+            image if is_skyreels_r2v else image.resize((width, height), PIL.Image.Resampling.LANCZOS)
+        )
     if last_image is not None:
         media_inputs["last_image"] = last_image.resize((width, height), PIL.Image.Resampling.LANCZOS)
     if mask_image is not None:
         media_inputs["mask"] = mask_image.resize((width, height), PIL.Image.Resampling.NEAREST)
     if reference_images is not None:
-        media_inputs["reference_images"] = [
-            reference.resize((width, height), PIL.Image.Resampling.LANCZOS) for reference in reference_images
-        ]
+        media_inputs["reference_images"] = (
+            reference_images
+            if is_skyreels_r2v
+            else [reference.resize((width, height), PIL.Image.Resampling.LANCZOS) for reference in reference_images]
+        )
 
     # Configure cache based on backend type
     cache_config = None

--- a/tests/diffusion/models/skyreels_v3/test_skyreels_v3_r2v.py
+++ b/tests/diffusion/models/skyreels_v3/test_skyreels_v3_r2v.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from vllm_omni.config.config_factory import StageConfigFactory
+from vllm_omni.diffusion.data import OmniDiffusionConfig, resolve_model_class_name
+from vllm_omni.diffusion.io_support import get_dummy_run_num_frames
+from vllm_omni.diffusion.models.skyreels_v3.pipeline_skyreels_v3_r2v import (
+    SkyReelsV3R2VPipeline,
+    _resolve_guidance_scales,
+    get_skyreels_v3_r2v_pre_process_func,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.model_extras import build_image_to_video_prompt, get_extra_body_params
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _write_wan_like_model(tmp_path: Path, transformer_class_name: str) -> str:
+    model_dir = tmp_path / transformer_class_name
+    transformer_dir = model_dir / "transformer"
+    transformer_dir.mkdir(parents=True)
+    (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "WanPipeline"}), encoding="utf-8")
+    (transformer_dir / "config.json").write_text(json.dumps({"_class_name": transformer_class_name}), encoding="utf-8")
+    return str(model_dir)
+
+
+def _make_request(prompt, **sampling_kwargs) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompt=prompt,
+        sampling_params=OmniDiffusionSamplingParams(**sampling_kwargs),
+        request_id="skyreels-r2v-test",
+    )
+
+
+def test_skyreels_v3_r2v_model_resolution_overrides_wan_pipeline(tmp_path: Path):
+    model = _write_wan_like_model(tmp_path, "SkyReelsC1WanI2v3DModel")
+
+    assert resolve_model_class_name(model) == "SkyReelsV3R2VPipeline"
+
+    config = OmniDiffusionConfig(model=model)
+    config.enrich_config()
+    assert config.model_class_name == "SkyReelsV3R2VPipeline"
+    assert config.supports_multimodal_inputs
+    assert config.max_multimodal_image_inputs == 4
+
+
+def test_skyreels_v3_r2v_uses_default_diffusion_stage_config(tmp_path: Path):
+    model = _write_wan_like_model(tmp_path, "SkyReelsC1WanI2v3DModel")
+
+    StageConfigFactory.get_hf_config.cache_clear()
+    StageConfigFactory.try_infer_model_type.cache_clear()
+
+    assert StageConfigFactory.try_infer_model_type(model, trust_remote_code=False) == "skyreels_v3_r2v"
+    assert StageConfigFactory.get_pipeline_config(model, trust_remote_code=False) is None
+
+
+def test_skyreels_v3_r2v_declares_small_dummy_warmup():
+    assert get_dummy_run_num_frames("SkyReelsV3R2VPipeline", supports_audio_input=False) == 5
+    assert SkyReelsV3R2VPipeline.dummy_run_num_frames > 1
+
+
+def test_skyreels_v3_r2v_guidance_accepts_warmup_cfg_aliases():
+    request = _make_request(
+        {"prompt": "warmup", "multi_modal_data": {"image": Image.new("RGB", (8, 8))}},
+        guidance_scale=0.0,
+    )
+
+    text_scale, image_scale = _resolve_guidance_scales(
+        request.sampling_params,
+        {"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
+    )
+
+    assert text_scale == 1.0
+    assert image_scale == 1.0
+
+
+def test_non_r2v_wan_pipeline_is_not_routed_to_skyreels_r2v(tmp_path: Path):
+    model = _write_wan_like_model(tmp_path, "SkyReelsA2WanI2v3DModel")
+
+    assert resolve_model_class_name(model) == "WanPipeline"
+
+
+def test_skyreels_v3_r2v_preprocess_resizes_reference_alias():
+    image = Image.new("RGB", (320, 200), color=(10, 20, 30))
+    request = _make_request(
+        {"prompt": "animate the reference", "multi_modal_data": {"reference_images": image}},
+        extra_args={"resolution": "480P"},
+    )
+    preprocess = get_skyreels_v3_r2v_pre_process_func(OmniDiffusionConfig())
+
+    processed = preprocess(request)
+
+    assert processed.sampling_params.height is not None
+    assert processed.sampling_params.width is not None
+    assert processed.sampling_params.height % 16 == 0
+    assert processed.sampling_params.width % 16 == 0
+    processed_images = processed.prompt["multi_modal_data"]["image"]
+    assert len(processed_images) == 1
+    assert processed_images[0].size == (
+        processed.sampling_params.width,
+        processed.sampling_params.height,
+    )
+
+
+def test_skyreels_v3_r2v_preprocess_rejects_too_many_reference_images():
+    image = Image.new("RGB", (64, 64), color=(255, 255, 255))
+    request = _make_request(
+        {"prompt": "animate the reference", "multi_modal_data": {"image": [image] * 5}},
+    )
+    preprocess = get_skyreels_v3_r2v_pre_process_func(OmniDiffusionConfig())
+
+    with pytest.raises(ValueError, match="at most 4 reference images"):
+        preprocess(request)
+
+
+def test_skyreels_v3_r2v_image_to_video_prompt_builder_accepts_references():
+    images = [Image.new("RGB", (64, 64), color=(idx, idx, idx)) for idx in range(2)]
+
+    prompt = build_image_to_video_prompt(
+        "SkyReelsV3R2VPipeline",
+        "animate the references",
+        "",
+        {"reference_images": images},
+    )
+
+    assert prompt["multi_modal_data"]["reference_images"] is images
+    assert "guidance_scale_img" in get_extra_body_params("SkyReelsV3R2VPipeline")

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -36,6 +36,7 @@ EXCLUDED_MODELS = [
     "MiniMaxH3ModularPipeline",
     "StableAudioPipeline",
     "WanImageToVideoPipeline",
+    "SkyReelsV3R2VPipeline",
     "WanS2VPipeline",
     "WanT2VDMD2Pipeline",
     "WanI2VDMD2Pipeline",

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -30,7 +30,7 @@ from vllm_omni.config.stage_config import (
     merge_pipeline_deploy,
 )
 from vllm_omni.config.yaml_util import create_config
-from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
+from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero, _looks_like_skyreels_v3_r2v
 
 logger = init_logger(__name__)
 
@@ -136,6 +136,9 @@ class StageConfigFactory:
         Returns:
             model_type as a string; may be None on failure.
         """
+        if _looks_like_skyreels_v3_r2v(model):
+            return "skyreels_v3_r2v"
+
         model_type = cls._try_infer_model_type(
             model=model,
             trust_remote_code=trust_remote_code,

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -551,7 +551,13 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     # Diffusers models: read _class_name from the pipeline index.
     model_index = get_diffusion_model_index(model)
     if model_index is not None:
-        return model_index.get("_class_name")
+        class_name = model_index.get("_class_name")
+        if class_name == "WanPipeline":
+            from vllm_omni.diffusion.utils.hf_utils import _looks_like_skyreels_v3_r2v
+
+            if _looks_like_skyreels_v3_r2v(model):
+                return "SkyReelsV3R2VPipeline"
+        return class_name
     if diffusion_load_format == "diffusers":
         return "DiffusersAdapterPipeline"
 
@@ -1167,6 +1173,11 @@ class OmniDiffusionConfig:
             if config_dict is not None:
                 if self.model_class_name is None:
                     self.model_class_name = config_dict.get("_class_name", None)
+                    if self.model_class_name == "WanPipeline":
+                        from vllm_omni.diffusion.utils.hf_utils import _looks_like_skyreels_v3_r2v
+
+                        if _looks_like_skyreels_v3_r2v(self.model):
+                            self.model_class_name = "SkyReelsV3R2VPipeline"
                 self.update_multimodal_support()
 
                 # Skip transformer config loading for diffusers adapter

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -19,6 +19,8 @@ QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES = 4
 HUNYUAN_IMAGE3_MAX_INPUT_IMAGES = 3
 # Boogu-Image editing (TI2I) supports a single reference image for now.
 BOOGU_IMAGE_MAX_INPUT_IMAGES = 1
+# SkyReels V3 reference-to-video supports 1-4 reference images.
+SKYREELS_V3_R2V_MAX_INPUT_IMAGES = 4
 
 
 _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
@@ -54,6 +56,11 @@ _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
     ),
     "WanPipeline": DiffusionModelMetadata(attention_mask_free=True),
     "WanImageToVideoPipeline": DiffusionModelMetadata(attention_mask_free=True),
+    "SkyReelsV3R2VPipeline": DiffusionModelMetadata(
+        supports_multimodal_inputs=True,
+        max_multimodal_image_inputs=SKYREELS_V3_R2V_MAX_INPUT_IMAGES,
+        attention_mask_free=True,
+    ),
     "WanVACEPipeline": DiffusionModelMetadata(attention_mask_free=True),
     "WanS2VPipeline": DiffusionModelMetadata(attention_mask_free=True),
 }

--- a/vllm_omni/diffusion/models/skyreels_v3/__init__.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from .pipeline_skyreels_v3_r2v import (
+    SkyReelsV3R2VPipeline,
+    get_skyreels_v3_r2v_post_process_func,
+    get_skyreels_v3_r2v_pre_process_func,
+)
+
+__all__ = [
+    "SkyReelsV3R2VPipeline",
+    "get_skyreels_v3_r2v_post_process_func",
+    "get_skyreels_v3_r2v_pre_process_func",
+]

--- a/vllm_omni/diffusion/models/skyreels_v3/aspect_ratio.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/aspect_ratio.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolution buckets shared by the SkyReels-V3 pipelines.
+
+SkyReels-V3 was trained on a fixed set of ``(height, width)`` buckets per resolution tier
+instead of on free-form sizes, so an input image/video is mapped to the bucket whose aspect
+ratio is closest to its own. Reproducing the bucket table is required for output parity with
+the reference implementation.
+"""
+
+from __future__ import annotations
+
+ASPECT_RATIO_CONFIG: dict[str, dict[str, tuple[int, int]]] = {
+    "480P": {
+        "0.38": (392, 1046),
+        "0.43": (420, 980),
+        "0.48": (444, 925),
+        "0.50": (452, 904),
+        "0.53": (466, 880),
+        "0.54": (470, 870),
+        "0.56": (480, 854),
+        "0.62": (506, 810),
+        "0.67": (522, 784),
+        "0.75": (554, 738),
+        "1.00": (640, 640),
+        "1.33": (740, 555),
+        "1.50": (784, 522),
+        "1.78": (854, 480),
+        "1.89": (880, 466),
+        "2.00": (906, 454),
+        "2.08": (924, 444),
+    },
+    "540P": {
+        "0.34": (416, 1216),
+        "0.38": (464, 1216),
+        "0.40": (464, 1152),
+        "0.43": (496, 1152),
+        "0.48": (496, 1024),
+        "0.50": (512, 1024),
+        "0.53": (512, 960),
+        "0.57": (544, 960),
+        "0.60": (544, 912),
+        "0.63": (576, 912),
+        "0.67": (576, 864),
+        "0.72": (624, 864),
+        "0.75": (624, 832),
+        "0.79": (656, 832),
+        "0.84": (656, 784),
+        "0.92": (720, 784),
+        "1.00": (720, 720),
+        "1.09": (784, 720),
+        "1.26": (784, 624),
+        "1.33": (832, 624),
+        "1.40": (832, 592),
+        "1.49": (880, 592),
+        "1.62": (880, 544),
+        "1.78": (960, 544),
+        "1.88": (960, 512),
+        "2.00": (1024, 512),
+        "2.13": (1024, 480),
+    },
+    "720P": {
+        "0.38": (588, 1568),
+        "0.43": (628, 1466),
+        "0.48": (666, 1388),
+        "0.50": (678, 1356),
+        "0.53": (698, 1318),
+        "0.54": (706, 1306),
+        "0.56": (720, 1280),
+        "0.62": (758, 1212),
+        "0.67": (784, 1176),
+        "0.75": (832, 1110),
+        "1.00": (960, 960),
+        "1.33": (1108, 832),
+        "1.50": (1176, 784),
+        "1.78": (1280, 720),
+        "1.89": (1320, 698),
+        "2.00": (1358, 680),
+        "2.08": (1386, 666),
+    },
+}
+
+DEFAULT_SKYREELS_V3_RESOLUTION = "540P"
+
+# The VAE downsamples spatially by 8 and the transformer patchifies by 2, so both sides must
+# be a multiple of 16.
+SKYREELS_V3_SIZE_ALIGNMENT = 16
+
+
+def get_closest_aspect_ratio(height: float, width: float, ratios: dict[str, tuple[int, int]]) -> str:
+    """Return the bucket key of ``ratios`` whose aspect ratio is closest to ``height / width``."""
+    aspect_ratio = height / width
+    return min(ratios.keys(), key=lambda ratio: abs(float(ratio) - aspect_ratio))
+
+
+def resolve_bucket_size(height: float, width: float, resolution: str | None = None) -> tuple[int, int]:
+    """Map a source ``(height, width)`` onto the closest SkyReels-V3 training bucket.
+
+    The returned size is floored to :data:`SKYREELS_V3_SIZE_ALIGNMENT` because a few buckets
+    (e.g. ``(466, 880)``) are not themselves aligned.
+    """
+    resolution = (resolution or DEFAULT_SKYREELS_V3_RESOLUTION).upper()
+    if resolution not in ASPECT_RATIO_CONFIG:
+        raise ValueError(
+            f"Unsupported SkyReels-V3 resolution {resolution!r}, expected one of {sorted(ASPECT_RATIO_CONFIG)}."
+        )
+    ratios = ASPECT_RATIO_CONFIG[resolution]
+    bucket_height, bucket_width = ratios[get_closest_aspect_ratio(height, width, ratios)]
+    align = SKYREELS_V3_SIZE_ALIGNMENT
+    return bucket_height // align * align, bucket_width // align * align

--- a/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_r2v.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_r2v.py
@@ -1,0 +1,756 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Iterable
+from typing import Any, ClassVar, cast
+
+import PIL.Image
+import torch
+import torchvision.transforms.functional as TF
+from diffusers.utils.torch_utils import randn_tensor
+from PIL import ImageOps
+from torch import nn
+from transformers import AutoTokenizer, UMT5EncoderModel
+from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.sequence import IntermediateTensors
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import (
+    DistributedAutoencoderKLWan,
+)
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.pipeline_parallel import AsyncLatents, PipelineParallelMixin
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.forward_context import DenoiseProgressMixin
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.model_loader.hub_prefetch import (
+    from_pretrained_with_prefetch,
+    prefetch_subfolders,
+)
+from vllm_omni.diffusion.model_metadata import SKYREELS_V3_R2V_MAX_INPUT_IMAGES
+from vllm_omni.diffusion.models.interface import (
+    SupportImageInput,
+    SupportsComponentDiscovery,
+)
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
+from vllm_omni.diffusion.models.skyreels_v3.aspect_ratio import (
+    DEFAULT_SKYREELS_V3_RESOLUTION,
+    resolve_bucket_size,
+)
+from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
+    build_wan_scheduler,
+    create_transformer_from_config,
+    load_transformer_config,
+    resolve_wan_flow_shift,
+    resolve_wan_sample_solver,
+    retrieve_latents,
+)
+from vllm_omni.diffusion.postprocess import interpolate_video_tensor
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
+    DiffusionPipelineProfilerMixin,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.platforms import current_omni_platform
+
+logger = logging.getLogger(__name__)
+DEBUG_PERF = False
+
+# Keep this in sync with serving-facing admission metadata.
+MAX_SKYREELS_R2V_REF_IMAGES = SKYREELS_V3_R2V_MAX_INPUT_IMAGES
+DEFAULT_SKYREELS_R2V_HEIGHT = 544
+DEFAULT_SKYREELS_R2V_WIDTH = 960
+DEFAULT_SKYREELS_R2V_FRAMES = 105
+DEFAULT_SKYREELS_R2V_STEPS = 50
+DEFAULT_SKYREELS_R2V_GUIDANCE = 7.5
+DEFAULT_SKYREELS_R2V_IMAGE_GUIDANCE = 5.0
+
+
+def _load_image(image: str | PIL.Image.Image) -> PIL.Image.Image:
+    if isinstance(image, str):
+        return PIL.Image.open(image).convert("RGB")
+    if isinstance(image, PIL.Image.Image):
+        return image.convert("RGB")
+    raise TypeError(f"Unsupported image format {image.__class__}.")
+
+
+def _normalize_ref_images(raw_images: Any) -> list[PIL.Image.Image]:
+    if raw_images is None:
+        raise ValueError(
+            "SkyReels V3 R2V requires reference images. "
+            "Set `multi_modal_data` with key `image`, `ref_imgs`, or `reference_images`."
+        )
+    if isinstance(raw_images, (str, PIL.Image.Image)):
+        raw_images = [raw_images]
+    if not isinstance(raw_images, list):
+        raise TypeError(
+            "SkyReels V3 R2V reference images must be an image path, a PIL image, "
+            f"or a list of them, got {raw_images.__class__}."
+        )
+    if not raw_images:
+        raise ValueError("SkyReels V3 R2V requires at least one reference image.")
+    if len(raw_images) > MAX_SKYREELS_R2V_REF_IMAGES:
+        raise ValueError(
+            f"SkyReels V3 R2V supports at most {MAX_SKYREELS_R2V_REF_IMAGES} reference images, got {len(raw_images)}."
+        )
+    return [_load_image(image) for image in raw_images]
+
+
+def _infer_target_size(image: PIL.Image.Image, resolution: str | None = None) -> tuple[int, int]:
+    return resolve_bucket_size(image.height, image.width, resolution)
+
+
+def _resize_and_pad_ref_images(
+    ref_images: list[PIL.Image.Image],
+    *,
+    height: int,
+    width: int,
+) -> list[PIL.Image.Image]:
+    resized = []
+    target_ratio = width / height
+    for image in ref_images:
+        image = image.convert("RGB")
+        image_ratio = image.width / image.height
+        if image_ratio > target_ratio:
+            new_width = width
+            new_height = int(new_width / image_ratio)
+        else:
+            new_height = height
+            new_width = int(new_height * image_ratio)
+
+        image = image.resize((new_width, new_height), PIL.Image.Resampling.LANCZOS)
+        delta_w = width - image.size[0]
+        delta_h = height - image.size[1]
+        padding = (
+            delta_w // 2,
+            delta_h // 2,
+            delta_w - delta_w // 2,
+            delta_h - delta_h // 2,
+        )
+        resized.append(ImageOps.expand(image, padding, fill=(255, 255, 255)))
+    return resized
+
+
+def _resolve_guidance_scales(sampling_params: Any, extra_args: dict[str, Any]) -> tuple[float, float]:
+    text_scale = (
+        sampling_params.guidance_scale if sampling_params.guidance_scale_provided else DEFAULT_SKYREELS_R2V_GUIDANCE
+    )
+    if "cfg_text_scale" in extra_args:
+        text_scale = extra_args["cfg_text_scale"]
+
+    image_scale = extra_args.get(
+        "guidance_scale_img",
+        extra_args.get("cfg_img_scale", DEFAULT_SKYREELS_R2V_IMAGE_GUIDANCE),
+    )
+    return float(text_scale), float(image_scale)
+
+
+def get_skyreels_v3_r2v_post_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    from diffusers.video_processor import VideoProcessor
+
+    video_processor = VideoProcessor(vae_scale_factor=8)
+
+    def post_process_func(
+        video: torch.Tensor,
+        output_type: str = "np",
+        sampling_params=None,
+    ):
+        if output_type == "latent":
+            return video
+        video_metadata = {}
+        if sampling_params is not None and getattr(sampling_params, "enable_frame_interpolation", False):
+            video, multiplier = interpolate_video_tensor(
+                video,
+                exp=sampling_params.frame_interpolation_exp,
+                scale=sampling_params.frame_interpolation_scale,
+                model_path=sampling_params.frame_interpolation_model_path,
+            )
+            video_metadata["video_fps_multiplier"] = multiplier
+        return {
+            "payload": {"video": video_processor.postprocess_video(video, output_type=output_type)},
+            "metadata": {"video": video_metadata} if video_metadata else {},
+        }
+
+    return post_process_func
+
+
+def get_skyreels_v3_r2v_pre_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    def pre_process_func(request: OmniDiffusionRequest) -> OmniDiffusionRequest:
+        prompt = request.prompt
+        if isinstance(prompt, str):
+            prompt = OmniTextPrompt(prompt=prompt)
+        multi_modal_data = prompt.get("multi_modal_data") or {}
+        raw_images = (
+            multi_modal_data.get("image")
+            or multi_modal_data.get("ref_imgs")
+            or multi_modal_data.get("reference_images")
+        )
+        ref_images = _normalize_ref_images(raw_images)
+
+        extra_args = request.sampling_params.extra_args or {}
+        if request.sampling_params.height is None or request.sampling_params.width is None:
+            resolution = str(extra_args.get("resolution", DEFAULT_SKYREELS_V3_RESOLUTION))
+            height, width = _infer_target_size(ref_images[0], resolution)
+            if request.sampling_params.height is None:
+                request.sampling_params.height = height
+            if request.sampling_params.width is None:
+                request.sampling_params.width = width
+
+        height = cast(int, request.sampling_params.height)
+        width = cast(int, request.sampling_params.width)
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
+
+        prompt["multi_modal_data"] = dict(multi_modal_data)
+        prompt["multi_modal_data"]["image"] = _resize_and_pad_ref_images(ref_images, height=height, width=width)
+        request.prompt = prompt
+        return request
+
+    return pre_process_func
+
+
+class SkyReelsV3R2VPipeline(
+    nn.Module,
+    SupportImageInput,
+    PipelineParallelMixin,
+    CFGParallelMixin,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+    DenoiseProgressMixin,
+    SupportsComponentDiscovery,
+):
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+    dummy_run_num_frames: ClassVar[int] = 5
+
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.od_config = od_config
+        self.device = get_local_device()
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        component_subfolders = ["tokenizer", "text_encoder", "vae"]
+        prefetch_subfolders(model, component_subfolders, local_files_only=local_files_only)
+
+        self.tokenizer = from_pretrained_with_prefetch(
+            AutoTokenizer.from_pretrained,
+            model,
+            subfolder="tokenizer",
+            prefetch_list=component_subfolders,
+            local_files_only=local_files_only,
+        )
+        self.text_encoder = from_pretrained_with_prefetch(
+            UMT5EncoderModel.from_pretrained,
+            model,
+            subfolder="text_encoder",
+            prefetch_list=component_subfolders,
+            local_files_only=local_files_only,
+            torch_dtype=dtype,
+        ).to(self.device)
+        self.vae = from_pretrained_with_prefetch(
+            DistributedAutoencoderKLWan.from_pretrained,
+            model,
+            subfolder="vae",
+            prefetch_list=component_subfolders,
+            local_files_only=local_files_only,
+            torch_dtype=dtype,
+        ).to(self.device)
+
+        transformer_config = load_transformer_config(model, "transformer", local_files_only)
+        self.transformer = create_transformer_from_config(
+            transformer_config,
+            quant_config=od_config.quantization_config,
+        )
+
+        self._sample_solver = "unipc"
+        self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0
+        self.scheduler = build_wan_scheduler(self._sample_solver, self._flow_shift)
+
+        self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if hasattr(self.vae, "config") else 4
+        self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if hasattr(self.vae, "config") else 8
+
+        self._guidance_scale = None
+        self._guidance_scale_img = None
+        self._num_timesteps = None
+        self._current_timestep = None
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def guidance_scale_img(self):
+        return self._guidance_scale_img
+
+    @property
+    def do_classifier_free_guidance(self):
+        return (self._guidance_scale is not None and self._guidance_scale != 1.0) or (
+            self._guidance_scale_img is not None and self._guidance_scale_img != 1.0
+        )
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    def combine_multi_branch_cfg_noise(
+        self,
+        predictions: list[torch.Tensor | tuple[torch.Tensor, ...]],
+        true_cfg_scale: float | dict[str, Any],
+        cfg_normalize: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        if not isinstance(true_cfg_scale, dict) or true_cfg_scale.get("mode") != "skyreels_v3_r2v":
+            return super().combine_multi_branch_cfg_noise(predictions, true_cfg_scale, cfg_normalize)
+        if len(predictions) != 3:
+            raise ValueError(f"SkyReels V3 R2V CFG expects 3 branches, got {len(predictions)}.")
+        pred, pred_text_uncond, pred_text_image_uncond = predictions
+        if isinstance(pred, tuple) or isinstance(pred_text_uncond, tuple) or isinstance(pred_text_image_uncond, tuple):
+            raise ValueError("SkyReels V3 R2V CFG expects tensor predictions.")
+
+        text_scale = float(true_cfg_scale["guidance_scale"])
+        image_scale = float(true_cfg_scale["guidance_scale_img"])
+        combined = pred_text_image_uncond + image_scale * (pred_text_uncond - pred_text_image_uncond)
+        combined = combined + text_scale * (pred - pred_text_uncond)
+        if cfg_normalize:
+            combined = self.cfg_normalize_function(pred, combined)
+        return combined
+
+    def diffuse(
+        self,
+        latents: torch.Tensor,
+        condition: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        guidance_scale: float,
+        guidance_scale_img: float,
+        dtype: torch.dtype,
+        attention_kwargs: dict[str, Any] | None,
+    ) -> torch.Tensor | AsyncLatents:
+        if attention_kwargs is None:
+            attention_kwargs = {}
+        uncondition = torch.zeros_like(condition)
+        do_true_cfg = (guidance_scale != 1.0 or guidance_scale_img != 1.0) and negative_prompt_embeds is not None
+        with self.progress_bar(total=len(timesteps)) as pbar:
+            for step_idx, t in enumerate(timesteps):
+                self._current_timestep = t
+                self.record_denoise_step(step_idx, t)
+                timestep = t.expand(latents.shape[0])
+
+                positive_kwargs = {
+                    "hidden_states": torch.cat([latents, condition], dim=2).to(dtype),
+                    "timestep": timestep,
+                    "encoder_hidden_states": prompt_embeds,
+                    "attention_kwargs": attention_kwargs,
+                    "return_dict": False,
+                    "latent_num_frames": latents.shape[2],
+                }
+                if do_true_cfg:
+                    text_uncond_kwargs = {
+                        "hidden_states": torch.cat([latents, condition], dim=2).to(dtype),
+                        "timestep": timestep,
+                        "encoder_hidden_states": negative_prompt_embeds,
+                        "attention_kwargs": attention_kwargs,
+                        "return_dict": False,
+                        "latent_num_frames": latents.shape[2],
+                    }
+                    text_image_uncond_kwargs = {
+                        "hidden_states": torch.cat([latents, uncondition], dim=2).to(dtype),
+                        "timestep": timestep,
+                        "encoder_hidden_states": negative_prompt_embeds,
+                        "attention_kwargs": attention_kwargs,
+                        "return_dict": False,
+                        "latent_num_frames": latents.shape[2],
+                    }
+                    noise_pred = self.predict_noise_with_multi_branch_cfg(
+                        do_true_cfg=True,
+                        true_cfg_scale={
+                            "mode": "skyreels_v3_r2v",
+                            "guidance_scale": guidance_scale,
+                            "guidance_scale_img": guidance_scale_img,
+                        },
+                        branches_kwargs=[positive_kwargs, text_uncond_kwargs, text_image_uncond_kwargs],
+                        cfg_normalize=False,
+                    )
+                else:
+                    noise_pred = self.predict_noise(**positive_kwargs)
+
+                latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+                pbar.update()
+
+        return latents
+
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        prompt: str | None = None
+        negative_prompt: str | None = None
+        if len(req.prompts) > 1:
+            raise ValueError("SkyReels V3 R2V only supports a single prompt per request, not a batched request.")
+        if len(req.prompts) == 1:
+            first_prompt = req.prompts[0]
+            prompt = first_prompt if isinstance(first_prompt, str) else (first_prompt.get("prompt") or "")
+            negative_prompt = None if isinstance(first_prompt, str) else first_prompt.get("negative_prompt")
+
+        if not prompt:
+            raise ValueError("Prompt is required for SkyReels V3 R2V generation.")
+
+        multi_modal_data = req.prompts[0].get("multi_modal_data", {}) if not isinstance(req.prompts[0], str) else {}
+        raw_images = (
+            multi_modal_data.get("image")
+            or multi_modal_data.get("ref_imgs")
+            or multi_modal_data.get("reference_images")
+        )
+        ref_images = _normalize_ref_images(raw_images)
+
+        extra_args = req.sampling_params.extra_args or {}
+        height = req.sampling_params.height or DEFAULT_SKYREELS_R2V_HEIGHT
+        width = req.sampling_params.width or DEFAULT_SKYREELS_R2V_WIDTH
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
+        ref_images = _resize_and_pad_ref_images(ref_images, height=height, width=width)
+
+        num_frames = req.sampling_params.num_frames or DEFAULT_SKYREELS_R2V_FRAMES
+        if num_frames <= 1:
+            num_frames = DEFAULT_SKYREELS_R2V_FRAMES
+        num_steps = req.sampling_params.num_inference_steps or DEFAULT_SKYREELS_R2V_STEPS
+        output_type = req.sampling_params.output_type or "np"
+        max_sequence_length = req.sampling_params.max_sequence_length or 512
+        guidance_scale, guidance_scale_img = _resolve_guidance_scales(req.sampling_params, extra_args)
+        self._guidance_scale = guidance_scale
+        self._guidance_scale_img = guidance_scale_img
+
+        self.check_inputs(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            ref_images=ref_images,
+            height=height,
+            width=width,
+            guidance_scale=guidance_scale,
+            guidance_scale_img=guidance_scale_img,
+        )
+
+        device = self.device
+        dtype = self.transformer.dtype
+        generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        if DEBUG_PERF:
+            current_omni_platform.synchronize()
+            _t_pipeline_start = time.perf_counter()
+            _t_text_enc_start = _t_pipeline_start
+
+        prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            do_classifier_free_guidance=(guidance_scale != 1.0 or guidance_scale_img != 1.0),
+            num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
+            max_sequence_length=max_sequence_length,
+            device=device,
+            dtype=dtype,
+        )
+
+        if DEBUG_PERF:
+            current_omni_platform.synchronize()
+            _t_text_enc_ms = (time.perf_counter() - _t_text_enc_start) * 1000
+
+        sample_solver = resolve_wan_sample_solver(req, default=self._sample_solver)
+        flow_shift = resolve_wan_flow_shift(req, self.od_config)
+        if sample_solver != self._sample_solver or abs(flow_shift - self._flow_shift) > 1e-6:
+            self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
+            self._sample_solver = sample_solver
+            self._flow_shift = flow_shift
+
+        self.scheduler.set_timesteps(num_steps, device=device)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        if DEBUG_PERF:
+            _t_latent_prep_start = time.perf_counter()
+        latents, condition = self.prepare_latents(
+            ref_images=ref_images,
+            batch_size=prompt_embeds.shape[0],
+            num_channels_latents=self.transformer.config.out_channels,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+            latents=req.sampling_params.latents,
+        )
+        if DEBUG_PERF:
+            current_omni_platform.synchronize()
+            _t_latent_prep_ms = (time.perf_counter() - _t_latent_prep_start) * 1000
+
+        if DEBUG_PERF:
+            _t_denoise_start = time.perf_counter()
+        latents = self.diffuse(
+            latents=latents,
+            condition=condition,
+            timesteps=timesteps,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            guidance_scale=guidance_scale,
+            guidance_scale_img=guidance_scale_img,
+            dtype=dtype,
+            attention_kwargs=None,
+        )
+        if current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+        self._current_timestep = None
+
+        if DEBUG_PERF:
+            current_omni_platform.synchronize()
+            _t_denoise_ms = (time.perf_counter() - _t_denoise_start) * 1000
+
+        if DEBUG_PERF:
+            _t_decode_start = time.perf_counter()
+        if output_type == "latent":
+            output = latents
+        else:
+            latents = latents.to(self.vae.dtype)
+            latents_mean = (
+                torch.tensor(self.vae.config.latents_mean)
+                .view(1, self.vae.config.z_dim, 1, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+                latents.device, latents.dtype
+            )
+            latents = latents / latents_std + latents_mean
+            output = self.vae.decode(latents, return_dict=False)[0]
+
+        if DEBUG_PERF:
+            current_omni_platform.synchronize()
+            _t_decode_ms = (time.perf_counter() - _t_decode_start) * 1000
+            _t_pipeline_wall_ms = (time.perf_counter() - _t_pipeline_start) * 1000
+            _t_stages_sum = _t_text_enc_ms + _t_latent_prep_ms + _t_denoise_ms + _t_decode_ms
+            if _is_rank_zero():
+                logger.info(
+                    "SkyReels V3 R2V timing: TextEncoding=%.2f ms, LatentPreparation=%.2f ms, "
+                    "Denoising=%.2f ms (%d steps), Decoding=%.2f ms, StagesSum=%.2f ms, PipelineWall=%.2f ms",
+                    _t_text_enc_ms,
+                    _t_latent_prep_ms,
+                    _t_denoise_ms,
+                    len(timesteps),
+                    _t_decode_ms,
+                    _t_stages_sum,
+                    _t_pipeline_wall_ms,
+                )
+
+        return DiffusionOutput(
+            output=output,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def predict_noise(
+        self,
+        latent_num_frames: int | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor | IntermediateTensors:
+        result = self.transformer(**kwargs)
+        if isinstance(result, IntermediateTensors):
+            return result
+        noise_pred = result[0]
+        if latent_num_frames is not None:
+            noise_pred = noise_pred[:, :, :latent_num_frames, :, :]
+        return noise_pred
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        negative_prompt: str | list[str] | None = None,
+        do_classifier_free_guidance: bool = True,
+        num_videos_per_prompt: int = 1,
+        max_sequence_length: int = 512,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        device = device or self.device
+        dtype = dtype or self.text_encoder.dtype
+
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        prompt_clean = [self._prompt_clean(p) for p in prompt]
+        batch_size = len(prompt_clean)
+
+        text_inputs = self.tokenizer(
+            prompt_clean,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_attention_mask=True,
+            return_tensors="pt",
+        )
+        ids, mask = text_inputs.input_ids, text_inputs.attention_mask
+        seq_lens = mask.gt(0).sum(dim=1).long()
+
+        prompt_embeds = self.text_encoder(ids.to(device), mask.to(device)).last_hidden_state
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+        prompt_embeds = [u[:v] for u, v in zip(prompt_embeds, seq_lens)]
+        prompt_embeds = torch.stack(
+            [torch.cat([u, u.new_zeros(max_sequence_length - u.size(0), u.size(1))]) for u in prompt_embeds], dim=0
+        )
+
+        _, seq_len, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+
+        negative_prompt_embeds = None
+        if do_classifier_free_guidance:
+            negative_prompt = negative_prompt or ""
+            negative_prompt = batch_size * [negative_prompt] if isinstance(negative_prompt, str) else negative_prompt
+            neg_text_inputs = self.tokenizer(
+                [self._prompt_clean(p) for p in negative_prompt],
+                padding="max_length",
+                max_length=max_sequence_length,
+                truncation=True,
+                add_special_tokens=True,
+                return_attention_mask=True,
+                return_tensors="pt",
+            )
+            ids_neg, mask_neg = neg_text_inputs.input_ids, neg_text_inputs.attention_mask
+            seq_lens_neg = mask_neg.gt(0).sum(dim=1).long()
+            negative_prompt_embeds = self.text_encoder(ids_neg.to(device), mask_neg.to(device)).last_hidden_state
+            negative_prompt_embeds = negative_prompt_embeds.to(dtype=dtype, device=device)
+            negative_prompt_embeds = [u[:v] for u, v in zip(negative_prompt_embeds, seq_lens_neg)]
+            negative_prompt_embeds = torch.stack(
+                [
+                    torch.cat([u, u.new_zeros(max_sequence_length - u.size(0), u.size(1))])
+                    for u in negative_prompt_embeds
+                ],
+                dim=0,
+            )
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+
+        return prompt_embeds, negative_prompt_embeds
+
+    @staticmethod
+    def _prompt_clean(text: str) -> str:
+        return " ".join(text.strip().split())
+
+    def prepare_latents(
+        self,
+        ref_images: list[PIL.Image.Image],
+        batch_size: int,
+        num_channels_latents: int,
+        height: int,
+        width: int,
+        num_frames: int,
+        dtype: torch.dtype | None,
+        device: torch.device | None,
+        generator: torch.Generator | list[torch.Generator] | None,
+        latents: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
+        latent_height = height // self.vae_scale_factor_spatial
+        latent_width = width // self.vae_scale_factor_spatial
+        shape = (batch_size, num_channels_latents, num_latent_frames, latent_height, latent_width)
+
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(f"Received {len(generator)} generators but the effective batch size is {batch_size}.")
+        if latents is None:
+            latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        else:
+            latents = latents.to(device=device, dtype=dtype)
+
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latents.device, latents.dtype
+        )
+
+        ref_generator = generator[0] if isinstance(generator, list) else generator
+        ref_latents = []
+        for ref_image in ref_images:
+            ref_tensor = TF.to_tensor(ref_image).sub_(0.5).div_(0.5).to(device=device, dtype=self.vae.dtype)
+            ref_latent = self.vae.encode(ref_tensor.unsqueeze(1).unsqueeze(0))
+            ref_latent = retrieve_latents(ref_latent, generator=ref_generator)
+            ref_latent = (ref_latent - latents_mean) * latents_std
+            ref_latents.append(ref_latent.to(dtype=dtype))
+
+        while len(ref_latents) < MAX_SKYREELS_R2V_REF_IMAGES:
+            ref_latents.append(
+                torch.zeros(
+                    1,
+                    num_channels_latents,
+                    1,
+                    latent_height,
+                    latent_width,
+                    device=device,
+                    dtype=dtype,
+                )
+            )
+
+        condition = torch.cat(ref_latents, dim=2)
+        condition = condition.repeat(batch_size, 1, 1, 1, 1)
+        return latents, condition
+
+    def check_inputs(
+        self,
+        prompt,
+        negative_prompt,
+        ref_images,
+        height,
+        width,
+        guidance_scale,
+        guidance_scale_img,
+    ):
+        if not isinstance(prompt, str):
+            raise ValueError(f"`prompt` must be a string, got {type(prompt)}.")
+        if negative_prompt is not None and not isinstance(negative_prompt, str):
+            raise ValueError(f"`negative_prompt` must be a string, got {type(negative_prompt)}.")
+        if not ref_images:
+            raise ValueError("SkyReels V3 R2V requires at least one reference image.")
+        if len(ref_images) > MAX_SKYREELS_R2V_REF_IMAGES:
+            raise ValueError(
+                f"SkyReels V3 R2V supports at most {MAX_SKYREELS_R2V_REF_IMAGES} reference images, "
+                f"got {len(ref_images)}."
+            )
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
+        if guidance_scale < 0 or guidance_scale_img < 0:
+            raise ValueError("SkyReels V3 R2V guidance scales must be non-negative.")
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -106,6 +106,11 @@ _DIFFUSION_MODELS = {
         "pipeline_wan2_2_i2v",
         "Wan22I2VPipeline",
     ),
+    "SkyReelsV3R2VPipeline": (
+        "skyreels_v3",
+        "pipeline_skyreels_v3_r2v",
+        "SkyReelsV3R2VPipeline",
+    ),
     "WanS2VPipeline": (
         "wan2_2",
         "pipeline_wan2_2_s2v",
@@ -521,6 +526,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "SoulXSingerSVCPipeline": "get_soulxsinger_post_process_func",
     "AudioXPipeline": "get_audiox_post_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_post_process_func",
+    "SkyReelsV3R2VPipeline": "get_skyreels_v3_r2v_post_process_func",
     "WanS2VPipeline": "get_wan22_s2v_post_process_func",
     "WanT2VDMD2Pipeline": "get_wan22_post_process_func",
     "WanI2VDMD2Pipeline": "get_wan22_i2v_post_process_func",
@@ -579,6 +585,7 @@ _DIFFUSION_PRE_PROCESS_FUNCS = {
     "WanPipeline": "get_wan22_pre_process_func",
     "WanVACEPipeline": "get_wan22_vace_pre_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_pre_process_func",
+    "SkyReelsV3R2VPipeline": "get_skyreels_v3_r2v_pre_process_func",
     "WanS2VPipeline": "get_wan22_s2v_pre_process_func",
     "WanT2VDMD2Pipeline": "get_wan22_pre_process_func",
     "WanI2VDMD2Pipeline": "get_wan22_i2v_pre_process_func",

--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -71,6 +71,14 @@ def _looks_like_dreamzero(model_name: str) -> bool:
         return False
 
 
+def _looks_like_skyreels_v3_r2v(model_name: str) -> bool:
+    try:
+        tf_cfg = get_hf_file_to_dict("transformer/config.json", model_name) or {}
+        return tf_cfg.get("_class_name") == "SkyReelsC1WanI2v3DModel"
+    except Exception:
+        return False
+
+
 @lru_cache
 def is_diffusion_model(model_name: str) -> bool:
     """Check if a model is a diffusion model.

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -183,6 +183,36 @@ def default_image_to_video_prompt(
     return default_image_to_image_prompt(prompt, negative_prompt, media_inputs["image"])
 
 
+def skyreels_v3_r2v_image_to_video_prompt(
+    prompt: str,
+    negative_prompt: str | None,
+    media_inputs: Mapping[str, Any],
+    height: int | None = None,
+    width: int | None = None,
+    num_frames: int | None = None,
+) -> dict[str, Any]:
+    del height, width, num_frames
+    unsupported = set(media_inputs) - {"image", "reference_images"}
+    if unsupported:
+        raise ValueError(f"SkyReels V3 R2V does not support media inputs: {sorted(unsupported)}.")
+
+    reference_images = media_inputs.get("reference_images")
+    if reference_images is None and isinstance(media_inputs.get("image"), Image.Image):
+        reference_images = [media_inputs["image"]]
+    if not isinstance(reference_images, list) or not reference_images:
+        raise ValueError("SkyReels V3 R2V requires at least one --reference-image or --image input.")
+    if not all(isinstance(image, Image.Image) for image in reference_images):
+        raise ValueError("SkyReels V3 R2V reference images must be PIL images.")
+
+    result: dict[str, Any] = {
+        "prompt": prompt,
+        "multi_modal_data": {"reference_images": reference_images},
+    }
+    if negative_prompt is not None:
+        result["negative_prompt"] = negative_prompt
+    return result
+
+
 _EXTRA_SPECS: dict[str, dict[str, Any]] = {
     "AudioXPipeline": {
         "extra_body_params": AUDIOX_EXTRA_BODY_PARAMS,
@@ -238,6 +268,10 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
         "extra_body_params": VACE_EXTRA_BODY_PARAMS,
         "extra_output_params": VACE_EXTRA_OUTPUT_PARAMS,
         "image_to_video_prompt_builder": build_vace_image_to_video_prompt,
+    },
+    "SkyReelsV3R2VPipeline": {
+        "extra_body_params": frozenset({"guidance_scale_img", "resolution"}),
+        "image_to_video_prompt_builder": skyreels_v3_r2v_image_to_video_prompt,
     },
     "MammothModa2DiTPipeline": {
         "extra_body_params": MAMMOTHMODA2_PREVIEW_EXTRA_BODY_PARAMS,


### PR DESCRIPTION
## Purpose

Add native **SkyReels V3 Reference-to-Video (R2V)** diffusion support to vLLM-Omni.

Official GitHub: [SkyworkAI/SkyReels-V3](https://github.com/SkyworkAI/SkyReels-V3)  
Official R2V checkpoint: [Skywork/SkyReels-V3-R2V-14B](https://huggingface.co/Skywork/SkyReels-V3-R2V-14B)

This PR only covers the R2V pipeline. SkyReels V3 video extension and talking-avatar/A2V pipelines are different official tasks/checkpoints and are intentionally out of scope.

What is included:

- Register `SkyReelsV3R2VPipeline` and model detection for SkyReels V3 R2V checkpoints.
- Support text prompt + 1-4 reference images through the diffusion request path.
- Align R2V output sizing with the official SkyReels V3 training resolution buckets.
- Wire the image-to-video example/docs for SkyReels V3 R2V.
- Add focused unit coverage for request preprocessing, resolution bucket selection, registry/model detection, and diffusion model alignment.

## Visual Preview

Official README R2V prompt comparison. Left: official SkyReels V3 R2V. Right: vLLM-Omni R2V.

https://github.com/user-attachments/assets/5316780c-3745-425f-8b61-7dfd540b00f2

Additional vLLM-Omni R2V 2-GPU offline generation previews:

https://github.com/user-attachments/assets/dfa7818f-cfe9-4c71-b795-93a6efb61473

https://github.com/user-attachments/assets/6305d6a2-a026-4fc7-9bb7-b9b8ad48a7b2

https://github.com/user-attachments/assets/bcb93662-35e4-4ce5-8b5d-0fbb814fcabe

Preview artifacts are hosted as GitHub user attachments and are not committed to this PR.

## Test Plan

- Run unit tests for SkyReels V3 R2V preprocessing, resolution bucket selection, registry/model detection, and diffusion alignment.
- Run the official SkyReels V3 README R2V example from `SkyworkAI/SkyReels-V3@28c771e8456341be6a213e3d1133ed1fd19bf75d` with two public reference images, seed 42, 720p, 121 frames, and 8 denoising steps.
- Run the vLLM-Omni SkyReels V3 R2V path with the same public reference images, prompt, seed, resolution, frame count, fps, denoising steps, and `Skywork/SkyReels-V3-R2V-14B` weights.
- Run additional vLLM-Omni R2V 2-GPU offline generations with multi-reference and single-reference inputs.
- Run `/v1/videos` serving benchmark with custom single-reference R2V requests.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** a61c793e

## Test Result

- `pytest tests/diffusion/models/skyreels_v3/test_skyreels_v3_r2v.py tests/model_tests/diffusion/test_alignment.py -q`: 10 passed, 15 warnings.
- Official README R2V output: 1280x720, 24 fps, 121 frames, 5.041667 seconds.
- vLLM-Omni README-equivalent R2V output: 1280x720, 24 fps, 121 frames, 5.041667 seconds.
- Official-vs-vLLM-Omni R2V frame comparison: same output spec, not pixel-identical; mean MAE 12.5356/255, mean PSNR 20.37 dB across 121 frames.
- Additional 2-GPU offline R2V generations succeeded:
  - Two-reference README prompt: 960x544, 24 fps, 49 frames, 8 steps, 60.662 seconds.
  - Two-reference alternate prompt: 960x544, 24 fps, 49 frames, 8 steps, 60.502 seconds.
  - Single-reference prompt: 960x544, 24 fps, 49 frames, 8 steps, 60.308 seconds.
- Dedicated 2-GPU speed benchmark, three CUDA devices visible with two-device engine parallelism, one engine initialization + one warmup + three measured two-reference R2V runs:
  - Cold engine initialization: 127.648 seconds.
  - Warmup generation: 18.905 seconds with 49 frames and 2 denoising steps.
  - Measured generation latency: mean 60.470 seconds, median 60.377 seconds, min 60.298 seconds, max 60.736 seconds.
  - Per-step latency: mean 7.559 seconds/step across 8 denoising steps.
  - Generation throughput: mean 0.810 frames/second for 49-frame outputs.
  - GPU monitor: both active GPUs reached 100% utilization; peak memory was 35581 MiB and 35287 MiB.
- `/v1/videos` serving benchmark succeeded: 2/2 requests, 49 frames, 8 steps, max concurrency 1, mean latency 173.3043 seconds, p99 latency 174.2991 seconds, peak memory max 30960 MB.
