### PR TITLE
[Docs] Add MiniMax-H3 recipe for RTX PRO 5000

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
@@ -1,15 +1,16 @@
 # MiniMax-H3 on RTX PRO 5000 Blackwell GPUs
 
 This recipe runs MiniMax-H3 in BF16 on 72 GiB RTX PRO 5000 Blackwell GPUs. It
-contains only the recommended resident configurations: TP2 x Ulysses2 on four
-GPUs and TP4 x Ulysses2 on eight GPUs. CPU offload and distributed layerwise
-offload are not required.
+contains the validated two-GPU DLO configuration and the recommended resident
+configurations: TP1 x Ulysses2 with 20 resident layers on two GPUs, TP2 x
+Ulysses2 on four GPUs, and TP4 x Ulysses2 on eight GPUs. The four- and
+eight-GPU routes do not require offload.
 
 ## Capacity requirements
 
 | Resource | Requirement |
 | --- | ---: |
-| GPUs | 4 or 8 x RTX PRO 5000 Blackwell |
+| GPUs | 2, 4, or 8 x RTX PRO 5000 Blackwell |
 | GPU HBM | 72 GiB per GPU |
 | Checkpoint storage | 135 GiB per partition |
 | Available system RAM | 200 GiB minimum |
@@ -28,7 +29,8 @@ nvidia-smi topo -m
 nvidia-smi nvlink -s
 ```
 
-For four GPUs, select all cards from one NUMA node. On the validated host,
+For two GPUs, select the closest PCIe pair on one NUMA node. For four GPUs,
+select all cards from one NUMA node. On the validated host,
 physical GPUs `(0,1)` and `(2,3)` are the two `PXB` pairs on NUMA node 0. The
 order `CUDA_VISIBLE_DEVICES=0,2,1,3` maps the Ulysses groups to those local
 pairs. For eight GPUs, the validated order is `0,4,1,5,2,6,3,7`, with host
@@ -36,6 +38,42 @@ memory interleaved across NUMA nodes 0 and 1. Do not copy these IDs blindly:
 reproduce the same PCIe and NUMA relationships on the target host.
 
 ## Recommended serving configurations
+
+### Two GPUs
+
+Two 72 GiB cards require distributed layerwise offload. The validated route
+uses TP1 x Ulysses2, keeps 20 leading DiT layers resident, and streams
+rank-local weights without AllGather. Eager execution avoids regional-compile
+instability on this offload path.
+
+```bash
+export MODEL_ROOT=/path/to/MiniMax-H3
+export MODEL="${MODEL_ROOT}/FL2VA"
+export PORT=8091
+
+CUDA_VISIBLE_DEVICES=0,1 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800 \
+numactl --cpunodebind=0 --membind=0 \
+vllm serve "${MODEL}" \
+  --omni \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --trust-remote-code \
+  --num-gpus 2 \
+  --tensor-parallel-size 1 \
+  --usp 2 \
+  --ring 1 \
+  --text-encoder-tp-size 2 \
+  --vae-patch-parallel-size 2 \
+  --vae-parallel-mode tile \
+  --vae-use-tiling \
+  --diffusion-attention-backend CUDNN_ATTN \
+  --enable-distributed-layerwise-offload \
+  --dlo-no-use-allgather \
+  --dlo-resident-layers 20 \
+  --enforce-eager
+```
 
 ### Four GPUs
 
@@ -98,16 +136,17 @@ vllm serve "${MODEL}" \
   --diffusion-attention-backend CUDNN_ATTN
 ```
 
-Do not add `--enforce-eager` for the performance run. Warm the server once
-before measuring so regional compilation is outside the measured request.
+For the four- and eight-GPU resident routes, do not add `--enforce-eager`.
+Warm the server once before measuring so regional compilation is outside the
+measured request. The two-GPU DLO route intentionally remains eager.
 
 For Ref2VA, stop the FL2VA server and restart the same command with
 `MODEL="${MODEL_ROOT}/Ref2VA"`.
 
 ## Target-hardware validation
 
-Both configurations were exercised on a PCIe-only, dual-socket host with eight
-RTX PRO 5000 GPUs. The run used PyTorch 2.11.0+cu130, CUDA 13.0, driver
+All three configurations were exercised on a PCIe-only, dual-socket host with
+eight RTX PRO 5000 GPUs. The run used PyTorch 2.11.0+cu130, CUDA 13.0, driver
 580.95.05, 1344x768 output, 124 frames, and two warmups.
 
 The four-GPU route also received a five-step profiling validation for GPU
@@ -127,16 +166,18 @@ is `denoise / 49`.
 
 | GPUs | Workload | Parallelism | E2E (s) | Text encode (s) | Denoise (s) | VAE decode (s) | Per step (ms) | Peak memory (GiB) |
 | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2 | T2VA | TP1 x Ulysses2, DLO resident 20 | 515.57 | 1.19 | 504.69 | 8.79 | 10,300 | 36.38 |
+| 2 | FL2VA first-frame I2VA | TP1 x Ulysses2, DLO resident 20 | 553.45 | 1.27 | 541.90 | 8.76 | 11,059 | 36.38 |
 | 4 | T2VA | TP2 x Ulysses2 | 284.01 | 0.03 | 278.73 | 4.36 | 5,688 | 67.58 |
 | 4 | FL2VA first-frame I2VA | TP2 x Ulysses2 | 305.72 | 0.28 | 299.85 | 4.36 | 6,119 | 67.58 |
 | 8 | T2VA | TP4 x Ulysses2 | 163.20 | 0.04 | 159.40 | 2.58 | 3,253 | 45.83 |
 | 8 | FL2VA first-frame I2VA | TP4 x Ulysses2 | 171.62 | 0.27 | 167.25 | 2.57 | 3,413 | 45.83 |
 
 Peak memory is the maximum per-GPU value sampled externally with
-`nvidia-smi`. The four-GPU route leaves about 4.1 GiB below the reported
-73,415 MiB device capacity; the eight-GPU route leaves about 25.9 GiB.
-Re-measure memory for longer reference inputs, concurrency greater than one,
-or a different output shape.
+`nvidia-smi`. The two-GPU route leaves about 34.7 GiB below the reported
+73,415 MiB device capacity, the four-GPU route leaves about 4.1 GiB, and the
+eight-GPU route leaves about 25.9 GiB. Re-measure memory for longer reference
+inputs, concurrency greater than one, or a different output shape.
 
 ## T2VA request example
 

--- a/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
@@ -1,15 +1,15 @@
-# MiniMax-H3 on four RTX PRO 5000 Blackwell GPUs
+# MiniMax-H3 on RTX PRO 5000 Blackwell GPUs
 
-This recipe runs MiniMax-H3 in BF16 on four 72 GiB RTX PRO 5000
-Blackwell GPUs. It keeps the model resident, uses TP2 to shard the weights,
-Ulysses2 to shard the attention sequence, and tiled VAE decode across all four
-GPUs. CPU offload and distributed layerwise offload are not required.
+This recipe runs MiniMax-H3 in BF16 on 72 GiB RTX PRO 5000 Blackwell GPUs. It
+contains only the recommended resident configurations: TP2 x Ulysses2 on four
+GPUs and TP4 x Ulysses2 on eight GPUs. CPU offload and distributed layerwise
+offload are not required.
 
 ## Capacity requirements
 
 | Resource | Requirement |
 | --- | ---: |
-| GPUs | 4 x RTX PRO 5000 Blackwell |
+| GPUs | 4 or 8 x RTX PRO 5000 Blackwell |
 | GPU HBM | 72 GiB per GPU |
 | Checkpoint storage | 135 GiB per partition |
 | Available system RAM | 200 GiB minimum |
@@ -20,21 +20,24 @@ time on a host sized for the minimum system-memory requirement.
 
 ## PCIe topology and GPU order
 
-RTX PRO 5000 does not provide NVLink. Before starting the server, select four
-GPUs on the same NUMA node and identify the two closest PCIe pairs:
+RTX PRO 5000 does not provide NVLink. Before starting the server, identify the
+closest PCIe pairs and their NUMA affinity:
 
 ```bash
 nvidia-smi topo -m
 nvidia-smi nvlink -s
 ```
 
-On the validated host, physical GPUs `(0,1)` and `(2,3)` are the two `PXB`
-pairs on NUMA node 0. The order `CUDA_VISIBLE_DEVICES=0,2,1,3` maps the
-Ulysses groups to those local pairs. Do not copy these IDs blindly: reproduce
-the same relationship on the target host. For the second NUMA node of the
-validated host, the equivalent order is `4,6,5,7`.
+For four GPUs, select all cards from one NUMA node. On the validated host,
+physical GPUs `(0,1)` and `(2,3)` are the two `PXB` pairs on NUMA node 0. The
+order `CUDA_VISIBLE_DEVICES=0,2,1,3` maps the Ulysses groups to those local
+pairs. For eight GPUs, the validated order is `0,4,1,5,2,6,3,7`, with host
+memory interleaved across NUMA nodes 0 and 1. Do not copy these IDs blindly:
+reproduce the same PCIe and NUMA relationships on the target host.
 
-## Four-GPU serving configuration
+## Recommended serving configurations
+
+### Four GPUs
 
 The validated baseline uses TP2 x Ulysses2, text-encoder TP4, VAE patch
 parallelism 4, and explicit cuDNN BF16 attention. Selecting the backend
@@ -65,6 +68,36 @@ vllm serve "${MODEL}" \
   --diffusion-attention-backend CUDNN_ATTN
 ```
 
+### Eight GPUs
+
+The recommended eight-GPU route uses TP4 x Ulysses2, text-encoder TP8, VAE
+patch parallelism 8, and host-memory interleaving across both NUMA nodes.
+
+```bash
+export MODEL_ROOT=/path/to/MiniMax-H3
+export MODEL="${MODEL_ROOT}/FL2VA"
+export PORT=8091
+
+CUDA_VISIBLE_DEVICES=0,4,1,5,2,6,3,7 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800 \
+numactl --interleave=0,1 \
+vllm serve "${MODEL}" \
+  --omni \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --trust-remote-code \
+  --num-gpus 8 \
+  --tensor-parallel-size 4 \
+  --usp 2 \
+  --ring 1 \
+  --text-encoder-tp-size 8 \
+  --vae-patch-parallel-size 8 \
+  --vae-parallel-mode tile \
+  --vae-use-tiling \
+  --diffusion-attention-backend CUDNN_ATTN
+```
+
 Do not add `--enforce-eager` for the performance run. Warm the server once
 before measuring so regional compilation is outside the measured request.
 
@@ -73,9 +106,12 @@ For Ref2VA, stop the FL2VA server and restart the same command with
 
 ## Target-hardware validation
 
-The configuration was exercised on a PCIe-only, dual-socket host with four
-selected RTX PRO 5000 GPUs on one NUMA node. The run used PyTorch 2.11.0+cu130,
-CUDA 13.0, driver 580.95.05, 1344x768 output, 124 frames, and two warmups.
+Both configurations were exercised on a PCIe-only, dual-socket host with eight
+RTX PRO 5000 GPUs. The run used PyTorch 2.11.0+cu130, CUDA 13.0, driver
+580.95.05, 1344x768 output, 124 frames, and two warmups.
+
+The four-GPU route also received a five-step profiling validation for GPU
+balance:
 
 | Measurement | Result |
 | --- | ---: |
@@ -85,10 +121,22 @@ CUDA 13.0, driver 580.95.05, 1344x768 output, 124 frames, and two warmups.
 | T2VA maximum GPU kernel-time deviation | 0.56% |
 | First-frame FL2VA maximum GPU kernel-time deviation | 0.09% |
 
-The measured peak leaves about 4.1 GiB below the reported 73,415 MiB device
-capacity. Re-measure memory for longer reference inputs, concurrency greater
-than one, or a different output shape. The recorded run is a five-step
-profiling validation; it is not a production 50-step latency claim.
+The recommended routes produced the following 50-step results. MiniMax-H3
+requested 50 denoise steps and executed 49 denoise updates, so per-step latency
+is `denoise / 49`.
+
+| GPUs | Workload | Parallelism | E2E (s) | Text encode (s) | Denoise (s) | VAE decode (s) | Per step (ms) | Peak memory (GiB) |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4 | T2VA | TP2 x Ulysses2 | 284.01 | 0.03 | 278.73 | 4.36 | 5,688 | 67.58 |
+| 4 | FL2VA first-frame I2VA | TP2 x Ulysses2 | 305.72 | 0.28 | 299.85 | 4.36 | 6,119 | 67.58 |
+| 8 | T2VA | TP4 x Ulysses2 | 163.20 | 0.04 | 159.40 | 2.58 | 3,253 | 45.83 |
+| 8 | FL2VA first-frame I2VA | TP4 x Ulysses2 | 171.62 | 0.27 | 167.25 | 2.57 | 3,413 | 45.83 |
+
+Peak memory is the maximum per-GPU value sampled externally with
+`nvidia-smi`. The four-GPU route leaves about 4.1 GiB below the reported
+73,415 MiB device capacity; the eight-GPU route leaves about 25.9 GiB.
+Re-measure memory for longer reference inputs, concurrency greater than one,
+or a different output shape.
 
 ## T2VA request example
 

--- a/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md
@@ -1,0 +1,109 @@
+# MiniMax-H3 on four RTX PRO 5000 Blackwell GPUs
+
+This recipe runs MiniMax-H3 in BF16 on four 72 GiB RTX PRO 5000
+Blackwell GPUs. It keeps the model resident, uses TP2 to shard the weights,
+Ulysses2 to shard the attention sequence, and tiled VAE decode across all four
+GPUs. CPU offload and distributed layerwise offload are not required.
+
+## Capacity requirements
+
+| Resource | Requirement |
+| --- | ---: |
+| GPUs | 4 x RTX PRO 5000 Blackwell |
+| GPU HBM | 72 GiB per GPU |
+| Checkpoint storage | 135 GiB per partition |
+| Available system RAM | 200 GiB minimum |
+| Recommended system RAM | 384 GiB |
+
+`FL2VA` and `Ref2VA` are separate checkpoint partitions. Start one server at a
+time on a host sized for the minimum system-memory requirement.
+
+## PCIe topology and GPU order
+
+RTX PRO 5000 does not provide NVLink. Before starting the server, select four
+GPUs on the same NUMA node and identify the two closest PCIe pairs:
+
+```bash
+nvidia-smi topo -m
+nvidia-smi nvlink -s
+```
+
+On the validated host, physical GPUs `(0,1)` and `(2,3)` are the two `PXB`
+pairs on NUMA node 0. The order `CUDA_VISIBLE_DEVICES=0,2,1,3` maps the
+Ulysses groups to those local pairs. Do not copy these IDs blindly: reproduce
+the same relationship on the target host. For the second NUMA node of the
+validated host, the equivalent order is `4,6,5,7`.
+
+## Four-GPU serving configuration
+
+The validated baseline uses TP2 x Ulysses2, text-encoder TP4, VAE patch
+parallelism 4, and explicit cuDNN BF16 attention. Selecting the backend
+explicitly keeps the recipe independent of platform-default backend changes.
+
+```bash
+export MODEL_ROOT=/path/to/MiniMax-H3
+export MODEL="${MODEL_ROOT}/FL2VA"
+export PORT=8091
+
+CUDA_VISIBLE_DEVICES=0,2,1,3 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800 \
+numactl --cpunodebind=0 --membind=0 \
+vllm serve "${MODEL}" \
+  --omni \
+  --host 0.0.0.0 \
+  --port "${PORT}" \
+  --trust-remote-code \
+  --num-gpus 4 \
+  --tensor-parallel-size 2 \
+  --usp 2 \
+  --ring 1 \
+  --text-encoder-tp-size 4 \
+  --vae-patch-parallel-size 4 \
+  --vae-parallel-mode tile \
+  --vae-use-tiling \
+  --diffusion-attention-backend CUDNN_ATTN
+```
+
+Do not add `--enforce-eager` for the performance run. Warm the server once
+before measuring so regional compilation is outside the measured request.
+
+For Ref2VA, stop the FL2VA server and restart the same command with
+`MODEL="${MODEL_ROOT}/Ref2VA"`.
+
+## Target-hardware validation
+
+The configuration was exercised on a PCIe-only, dual-socket host with four
+selected RTX PRO 5000 GPUs on one NUMA node. The run used PyTorch 2.11.0+cu130,
+CUDA 13.0, driver 580.95.05, 1344x768 output, 124 frames, and two warmups.
+
+| Measurement | Result |
+| --- | ---: |
+| Maximum externally sampled peak | 69,219 MiB (67.60 GiB) per GPU |
+| T2VA worker-reported peak | 65,314 MiB |
+| First-frame FL2VA worker-reported peak | 66,780 MiB |
+| T2VA maximum GPU kernel-time deviation | 0.56% |
+| First-frame FL2VA maximum GPU kernel-time deviation | 0.09% |
+
+The measured peak leaves about 4.1 GiB below the reported 73,415 MiB device
+capacity. Re-measure memory for longer reference inputs, concurrency greater
+than one, or a different output shape. The recorded run is a five-step
+profiling validation; it is not a production 50-step latency claim.
+
+## T2VA request example
+
+```bash
+export API_URL="http://127.0.0.1:${PORT}/v1/videos/sync"
+
+curl -sS --max-time 1800 -X POST "${API_URL}" \
+  -F 'prompt=At night, three cats march into a bedroom playing tiny brass instruments, then abruptly file out, with synchronized room ambience.' \
+  -F 'width=1344' \
+  -F 'height=768' \
+  -F 'aspect_ratio=16:9' \
+  -F 'fps=24' \
+  -F 'num_inference_steps=50' \
+  -F 'flow_shift=12' \
+  -F 'seed=1101' \
+  -F 'extra_params={"task":"t2va","duration":5.0,"audio_flow_shift":3.0}' \
+  -o t2va.mp4
+```


### PR DESCRIPTION
## Summary

Add a target-hardware recipe for serving MiniMax-H3 on two, four, or eight
72 GiB RTX PRO 5000 Blackwell GPUs.

The recipe documents:

- a rank-local distributed layerwise-offload route for two GPUs;
- fully resident BF16 TP2 x Ulysses2 and TP4 x Ulysses2 routes for four and
  eight GPUs;
- topology-aware rank ordering for PCIe and dual-NUMA layouts;
- text-encoder tensor parallelism and tiled VAE patch parallelism;
- an explicit cuDNN attention baseline;
- measured latency, per-step denoise time, and peak GPU memory;
- a reproducible 1344x768 T2VA request.

## Target validation

The configurations were exercised on an eight-card, PCIe-only dual-NUMA host
using CUDA 13.0, driver 580.95.05, PyTorch 2.11.0+cu130, 1344x768 output, 124
frames, and two warmups for the four/eight-GPU resident matrix.

The validated two-GPU low-memory route is TP1 x Ulysses2 with rank-local DLO,
20 resident DiT layers, text-encoder TP2, tiled VAE patch parallelism, cuDNN
attention, and eager execution. It completed both FL2VA workloads:

- maximum externally sampled peak: 37,250 MiB (36.38 GiB) per GPU;
- T2VA: 515.57 s E2E, 504.69 s denoise, 10,299.7 ms/update;
- first-frame I2VA: 553.45 s E2E, 541.90 s denoise, 11,059.1 ms/update;
- both workloads produced valid 124-frame MP4 output with synchronized audio.

For the four/eight-GPU resident routes:

- maximum externally sampled peak: 69,219 MiB (67.60 GiB) per GPU;
- T2VA worker peak: 65,314 MiB;
- first-frame FL2VA worker peak: 66,780 MiB;
- maximum GPU kernel-time deviation: 0.56% for T2VA and 0.09% for FL2VA;
- both workloads produced valid 124-frame MP4 output with synchronized audio.

The target profile used the benchmark harness from #5852. The recipe itself
uses serving options available on `main` and does not depend on the
experimental SM120 kernel.

## 50-step benchmark matrix

All measurements use `CUDNN_ATTN`, 1344x768 output, 124 frames, and a 5-second
video. The two-GPU route uses rank-local DLO with 20 resident layers; the
four/eight-GPU routes are fully resident. A request for 50 denoise steps
executes 49 denoise updates, so the per-update column divides diffusion time
by 49. Peak memory is the maximum per-GPU value sampled externally by
`nvidia-smi`.

| GPUs | Workload | Parallelism | Placement | E2E (s) | Text encode (s) | Visual encode (s) | Denoise (s) | VAE decode (s) | Per update (ms) | Peak GiB/GPU | Result |
|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
| 2 | T2VA | TP1 x Ulysses2 | DLO, rank-local, resident 20 | **515.57** | 1.19 | n/a | **504.69** | 8.79 | **10,300** | 36.38 | Passed; validated low-memory route |
| 2 | first-frame I2VA | TP1 x Ulysses2 | DLO, rank-local, resident 20 | **553.45** | 1.27 | 0.03 | **541.90** | 8.76 | **11,059** | 36.38 | Passed; validated low-memory route |
| 4 | T2VA | TP2 x Ulysses2 | resident | **284.01** | 0.03 | n/a | **278.73** | 4.36 | **5,688** | 67.58 | Passed; performance winner; 4.1 GiB headroom |
| 4 | first-frame I2VA | TP2 x Ulysses2 | resident | **305.72** | 0.28 | 0.00 | **299.85** | 4.36 | **6,119** | 67.58 | Passed; performance winner; 4.1 GiB headroom |
| 4 | T2VA | TP4 x Ulysses1 | resident | 329.56 | 0.03 | n/a | 324.34 | 4.35 | 6,619 | 50.25 | Passed; safer-memory alternative |
| 4 | first-frame I2VA | TP4 x Ulysses1 | resident | 354.18 | 0.28 | 0.00 | 348.31 | 4.35 | 7,108 | 50.25 | Passed; safer-memory alternative |
| 8 | T2VA | TP2 x Ulysses4 | resident | **147.77** | 0.04 | n/a | **144.06** | 2.56 | **2,940** | 70.38 | Passed; performance winner; 1.3 GiB headroom |
| 8 | first-frame I2VA | TP2 x Ulysses4 | resident | **155.70** | 0.26 | 0.00 | **151.36** | 2.57 | **3,089** | 70.38 | Passed; performance winner; 1.3 GiB headroom |
| 8 | T2VA | TP4 x Ulysses2 | resident | 163.20 | 0.04 | n/a | 159.40 | 2.58 | 3,253 | 45.83 | Passed; production recommendation |
| 8 | first-frame I2VA | TP4 x Ulysses2 | resident | 171.62 | 0.27 | 0.00 | 167.25 | 2.57 | 3,413 | 45.83 | Passed; production recommendation |
| 8 | T2VA | TP8 x Ulysses1 | resident | 250.81 | 0.05 | n/a | 246.98 | 2.55 | 5,040 | 36.53 | Passed; lowest-memory candidate |
| 8 | first-frame I2VA | TP8 x Ulysses1 | resident | 266.65 | 0.26 | 0.00 | 262.34 | 2.55 | 5,354 | 36.53 | Passed; lowest-memory candidate |

The two-GPU recommendation is TP1 x Ulysses2 with rank-local DLO and 20
resident layers. The four-GPU performance recommendation is TP2 x Ulysses2.
On eight GPUs, TP2 x Ulysses4 is the latency winner, while TP4 x Ulysses2 is
the production recommendation because it retains substantially more memory
headroom. The spreadsheet-ready four/eight-GPU source rows are available in
the [measured matrix](https://github.com/lishunyang12/vllm-omni-rankings/blob/main/scripts/minimax_h3_rtx_pro_5000_matrix/measured_matrix_50step.csv).

## Test plan

- `pre-commit run --files recipes/MiniMaxAI/MiniMax-H3-RTX-PRO-5000.md`
- result: passed

The single/dual-GPU residency sweep is automated separately and evaluates
resident-layer candidates in ascending order, tests both two-GPU topologies
before one GPU, filters by memory headroom, and performs a final 50-step
confirmation of the selected route.
