### PR TITLE
[Attention] Add SM120 CuTe DSL prims path to TRTLLM backend

### DIFF
--- a/examples/offline_inference/minimax_h3/benchmark_sm120_bf16_attention.py
+++ b/examples/offline_inference/minimax_h3/benchmark_sm120_bf16_attention.py
@@ -41,7 +41,13 @@ non_diegetic_music: Cinematic space-opera orchestral score, slow tempo, featurin
 DIFFUSE_KEY = "MiniMaxH3Pipeline.diffuse"
 MODE_CONFIGS = {
     "cudnn_bf16": {"default": {"backend": "CUDNN_ATTN"}},
-    "fa4_bf16": {"default": {"backend": "FLASH_ATTN"}},
+    # FA4 SM120 currently fails on MiniMax-H3's packed/ragged token refiner.
+    # Keep that small dense component on cuDNN and benchmark FA4 where it
+    # matters: the main DiT self-attention path.
+    "fa4_main_dit_bf16": {
+        "default": {"backend": "FLASH_ATTN"},
+        "per_role": {"minimax_h3.token_refiner": {"backend": "CUDNN_ATTN"}},
+    },
 }
 TELEMETRY_FIELDS = (
     "timestamp,index,temperature.gpu,utilization.gpu,clocks.sm,power.draw,"
@@ -67,6 +73,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--text-encoder-tp-size", type=int, default=4)
     parser.add_argument("--video-run", type=int, default=2, help="Request number saved as MP4")
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        choices=tuple(MODE_CONFIGS),
+        default=list(MODE_CONFIGS),
+        help="Run a subset while debugging; the default runs the matched cuDNN and FA4-main-DiT pair.",
+    )
     args = parser.parse_args()
     if args.num_runs < 6:
         parser.error("--num-runs must be at least 6 (one warmup plus five measured requests)")
@@ -310,14 +323,21 @@ def main() -> None:
     diffusion_engine._ASYNC_OUTPUT_TIMEOUT = 1800
     telemetry = Telemetry(args.output_dir, physical_gpus)
     try:
-        results = [run_mode(args, mode) for mode in MODE_CONFIGS]
+        results = []
+        for mode in args.modes:
+            result = run_mode(args, mode)
+            (args.output_dir / mode / "summary.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+            results.append(result)
     finally:
         telemetry.close()
 
     thermal = telemetry.audit()
-    cudnn = next(result for result in results if result["mode"] == "cudnn_bf16")
-    fa4_result = next(result for result in results if result["mode"] == "fa4_bf16")
-    speedup = float(cudnn["timing"]["median_s"]) / float(fa4_result["timing"]["median_s"])
+    by_mode = {result["mode"]: result for result in results}
+    speedup = None
+    if set(MODE_CONFIGS).issubset(by_mode):
+        speedup = float(by_mode["cudnn_bf16"]["timing"]["median_s"]) / float(
+            by_mode["fa4_main_dit_bf16"]["timing"]["median_s"]
+        )
     passed = (
         all(result["passed_timing_gate"] and result["steady_output_deterministic"] for result in results)
         and thermal["accepted"]

--- a/examples/offline_inference/minimax_h3/benchmark_sm120_bf16_attention.py
+++ b/examples/offline_inference/minimax_h3/benchmark_sm120_bf16_attention.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Matched RTX PRO 5000 (SM120) BF16 cuDNN vs FA4 benchmark for MiniMax-H3.
+
+Run with exactly four visible SM120 GPUs. The first request for each backend is
+regional-compile warmup; the following five requests are the reported samples.
+MP4 encoding is deliberately deferred until after each backend's timed requests.
+
+Example:
+  CUDA_VISIBLE_DEVICES=4,6,5,7 numactl --cpunodebind=1 --membind=1 \
+    python examples/offline_inference/minimax_h3/benchmark_sm120_bf16_attention.py \
+      --model /path/to/MiniMax-H3/FL2VA --output-dir /path/to/results
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+import time
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+import vllm_omni.diffusion.diffusion_engine as diffusion_engine
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.entrypoints.openai.video_api_utils import _encode_video_bytes
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+PROMPT = """integrated_multimodal_description: [Shot 1] Cinematic, medium wide shot, pushing in slowly. In the cavernous, dimly lit bridge of a starship, sleek metallic consoles with glowing amber displays flank a massive, curved observation window. A female captain, in her late 40s with an athletic build and short silver-streaked black hair, stands in the center midground. She wears a structured, high-collared dark navy military tunic with silver chest insignias. Her back is to the camera, silhouetted against the cool, ambient starlight pouring through the thick glass. She stands perfectly still with her hands clasped tightly behind her back. Outside the window, a massive armada of jagged, dark grey dreadnoughts hovers in tight formation against a deep purple space nebula. The fleet's massive rear thrusters begin to glow with an intense, escalating bright blue light. [Shot 2] At 00:04.500, the camera cuts to a close-up of the captain's face and shakes strongly. The brilliant blue-white light from the fleet's gathering energy reflects vividly in her dark eyes. Suddenly, a blinding white flash floods through the window, completely washing out the background as the fleet jumps to hyperspace. The sheer spatial force violently jolts the bridge, causing the captain from Shot 1 to stagger slightly forward, her shoulders tensing as she visibly braces herself against the physical tremors. As the intense white light fades abruptly, leaving only the dim, empty expanse of the purple nebula reflected on her starkly lit skin, her jaw clenches, and she slowly closes her eyes in the newly emptied space.
+overall_soundscape: A low, resonant hum of the ship's ambient life support systems serves as the baseline, soon drowned out by an audible, escalating, high-pitched electronic whine as the fleet outside charges its hyperdrives. A massive, deafening, bass-heavy boom and sharp crackle erupts during the blinding flash, accompanied by the loud metallic creaking, rattling, and deep thuds of the bridge's bulkheads vibrating under immense physical stress. The intense roaring impact then cuts abruptly back to a hollow, echoing room tone, leaving only the faint, steady hum of the isolated bridge.
+non_diegetic_music: Cinematic space-opera orchestral score, slow tempo, featuring a solitary, mournful French horn melody over deep, sustained string dissonances that build rapidly in volume and intensity, swelling to a massive orchestral peak before snapping immediately into silence right after the jump."""
+
+DIFFUSE_KEY = "MiniMaxH3Pipeline.diffuse"
+MODE_CONFIGS = {
+    "cudnn_bf16": {"default": {"backend": "CUDNN_ATTN"}},
+    "fa4_bf16": {"default": {"backend": "FLASH_ATTN"}},
+}
+TELEMETRY_FIELDS = (
+    "timestamp,index,temperature.gpu,utilization.gpu,clocks.sm,power.draw,"
+    "clocks_event_reasons.sw_thermal_slowdown,"
+    "clocks_event_reasons_counters.sw_thermal_slowdown"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True, help="MiniMax-H3 FL2VA directory")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--num-runs", type=int, default=6, help="One warmup plus measured requests")
+    parser.add_argument("--height", type=int, default=768)
+    parser.add_argument("--width", type=int, default=1344)
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=5.0,
+        help="Use 5s by default: the 10s/243-frame B300 input exceeds the validated 5K memory envelope.",
+    )
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--text-encoder-tp-size", type=int, default=4)
+    parser.add_argument("--video-run", type=int, default=2, help="Request number saved as MP4")
+    args = parser.parse_args()
+    if args.num_runs < 6:
+        parser.error("--num-runs must be at least 6 (one warmup plus five measured requests)")
+    if not args.model.is_dir():
+        parser.error(f"--model is not a directory: {args.model}")
+    return args
+
+
+def visible_physical_gpus() -> list[int]:
+    value = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not value:
+        raise RuntimeError("Set CUDA_VISIBLE_DEVICES to exactly four physical SM120 GPU indices.")
+    try:
+        devices = [int(item) for item in value.split(",")]
+    except ValueError as exc:
+        raise RuntimeError("CUDA_VISIBLE_DEVICES must contain numeric physical GPU indices.") from exc
+    if len(devices) != 4 or len(set(devices)) != 4:
+        raise RuntimeError(f"Expected four distinct visible GPUs, got {value!r}")
+    return devices
+
+
+def hardware() -> list[dict[str, Any]]:
+    device_count = torch.accelerator.device_count()
+    if device_count != 4:
+        raise RuntimeError(f"Expected four visible GPUs, found {device_count}")
+    result = []
+    for index in range(device_count):
+        props = torch.cuda.get_device_properties(index)
+        capability = (props.major, props.minor)
+        if capability != (12, 0):
+            raise RuntimeError(f"Logical GPU {index} must be SM120, got {capability[0]}.{capability[1]}")
+        result.append(
+            {
+                "logical_index": index,
+                "name": props.name,
+                "compute_capability": f"{props.major}.{props.minor}",
+                "total_memory_gib": round(props.total_memory / 2**30, 3),
+            }
+        )
+    return result
+
+
+def require_fa4() -> dict[str, str]:
+    try:
+        from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+    except Exception as exc:
+        raise RuntimeError(
+            "FA4 is required. Install with: python -m pip install 'flash-attn-4[cu13]==4.0.0b18'"
+        ) from exc
+    return {
+        "flash_attn_4": metadata.version("flash-attn-4"),
+        "dense_module": flash_attn_func.__module__,
+        "varlen_module": flash_attn_varlen_func.__module__,
+    }
+
+
+class Telemetry:
+    def __init__(self, output_dir: Path, physical_gpus: list[int]) -> None:
+        self.path = output_dir / "gpu_telemetry.csv"
+        self.physical_gpus = physical_gpus
+        self._stream = self.path.open("w", encoding="utf-8")
+        self._process = subprocess.Popen(
+            [
+                "nvidia-smi",
+                f"--query-gpu={TELEMETRY_FIELDS}",
+                "--format=csv,noheader,nounits",
+                "--loop-ms=5000",
+            ],
+            stdout=self._stream,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def close(self) -> None:
+        if self._process.poll() is None:
+            self._process.terminate()
+            self._process.wait(timeout=10)
+        self._stream.close()
+
+    def audit(self) -> dict[str, Any]:
+        samples: dict[int, list[dict[str, Any]]] = {index: [] for index in self.physical_gpus}
+        with self.path.open(encoding="utf-8") as stream:
+            for row in csv.reader(stream):
+                if len(row) != 8:
+                    continue
+                index = int(row[1])
+                if index not in samples:
+                    continue
+                samples[index].append(
+                    {
+                        "temperature_c": int(row[2]),
+                        "utilization_percent": int(row[3]),
+                        "sm_clock_mhz": int(row[4]),
+                        "thermal_active": row[6].strip() == "Active",
+                        "thermal_counter_us": int(row[7]),
+                    }
+                )
+
+        per_gpu: dict[str, dict[str, Any]] = {}
+        accepted = True
+        for index, values in samples.items():
+            if not values:
+                per_gpu[str(index)] = {"accepted": False, "reason": "no telemetry samples"}
+                accepted = False
+                continue
+            loaded = [sample for sample in values if sample["utilization_percent"] >= 90]
+            counters = [sample["thermal_counter_us"] for sample in values]
+            active = sum(sample["thermal_active"] for sample in values)
+            gpu_accepted = bool(loaded) and active == 0 and max(counters) == min(counters)
+            per_gpu[str(index)] = {
+                "sample_count": len(values),
+                "loaded_sample_count": len(loaded),
+                "maximum_temperature_c": max(sample["temperature_c"] for sample in values),
+                "minimum_loaded_sm_clock_mhz": min((sample["sm_clock_mhz"] for sample in loaded), default=None),
+                "thermal_slowdown_active_samples": active,
+                "thermal_slowdown_counter_delta_us": max(counters) - min(counters),
+                "accepted": gpu_accepted,
+            }
+            accepted &= gpu_accepted
+        return {"accepted": accepted, "gpus": per_gpu}
+
+
+def sha256(value: np.ndarray) -> str:
+    return hashlib.sha256(np.ascontiguousarray(value).tobytes()).hexdigest()
+
+
+def sampling_params(args: argparse.Namespace) -> OmniDiffusionSamplingParams:
+    return OmniDiffusionSamplingParams(
+        height=args.height,
+        width=args.width,
+        fps=24,
+        num_inference_steps=args.num_inference_steps,
+        seed=args.seed,
+        output_type="np",
+        extra_args={
+            "task": "t2va",
+            "aspect_ratio": "16:9",
+            "duration": args.duration_seconds,
+            "flow_shift": 12.0,
+            "audio_flow_shift": 3.0,
+        },
+    )
+
+
+def run_mode(args: argparse.Namespace, mode: str) -> dict[str, Any]:
+    mode_dir = args.output_dir / mode
+    mode_dir.mkdir(parents=True, exist_ok=True)
+    engine = Omni(
+        model=str(args.model),
+        parallel_config=DiffusionParallelConfig(
+            tensor_parallel_size=2,
+            ulysses_degree=2,
+            ring_degree=1,
+            text_encoder_tp_size=args.text_encoder_tp_size,
+            vae_patch_parallel_size=4,
+            vae_parallel_mode="tile",
+        ),
+        trust_remote_code=True,
+        enforce_eager=False,
+        diffusion_attention_config=MODE_CONFIGS[mode],
+        enable_diffusion_pipeline_profiler=True,
+    )
+    records: list[dict[str, Any]] = []
+    video: tuple[Path, np.ndarray, int, np.ndarray, int] | None = None
+    try:
+        for run_index in range(args.num_runs):
+            torch.accelerator.synchronize()
+            started = time.perf_counter()
+            outputs = engine.generate(PROMPT, sampling_params(args), use_tqdm=False)
+            torch.accelerator.synchronize()
+            wall_time = time.perf_counter() - started
+            if len(outputs) != 1:
+                raise RuntimeError(f"Expected one output, got {len(outputs)}")
+
+            result = outputs[0]
+            frames = np.asarray(result.images[0])
+            multimodal = result.multimodal_output
+            if multimodal is None:
+                raise RuntimeError("MiniMax-H3 returned no audio metadata")
+            audio = np.asarray(multimodal["audio"])
+            fps = int(multimodal["fps"])
+            sample_rate = int(multimodal["audio_sample_rate"])
+            if frames.ndim != 4 or tuple(frames.shape[1:]) != (args.height, args.width, 3):
+                raise RuntimeError(f"Unexpected video shape: {frames.shape}")
+            if fps != 24 or sample_rate != 32000:
+                raise RuntimeError(f"Unexpected media rates: fps={fps}, sample_rate={sample_rate}")
+
+            run_number = run_index + 1
+            if run_number == args.video_run:
+                video = (mode_dir / f"{mode}_run{run_number}.mp4", frames.copy(), fps, audio.copy(), sample_rate)
+            record = {
+                "run": run_number,
+                "warmup": run_index == 0,
+                "wall_time_s": wall_time,
+                "stage_durations": dict(getattr(result, "stage_durations", {}) or {}),
+                "worker_peak_memory_mb": float(getattr(result, "peak_memory_mb", 0.0) or 0.0),
+                "frames_shape": list(frames.shape),
+                "audio_shape": list(audio.shape),
+                "frames_sha256": sha256(frames),
+                "audio_sha256": sha256(audio),
+            }
+            records.append(record)
+            print("RUN_RESULT " + json.dumps({"mode": mode, **record}, sort_keys=True), flush=True)
+    finally:
+        engine.close()
+
+    if video is not None:
+        output_path, frames, fps, audio, sample_rate = video
+        output_path.write_bytes(_encode_video_bytes(frames, fps=fps, audio=audio, audio_sample_rate=sample_rate))
+
+    measured = [record for record in records if not record["warmup"]]
+    diffuse = [float(record["stage_durations"][DIFFUSE_KEY]) for record in measured]
+    median = statistics.median(diffuse)
+    mean = statistics.fmean(diffuse)
+    stdev = statistics.stdev(diffuse)
+    output_hashes = {(record["frames_sha256"], record["audio_sha256"]) for record in measured}
+    timing = {
+        "values_s": diffuse,
+        "median_s": median,
+        "mean_s": mean,
+        "cv": stdev / mean,
+        "span_over_median": (max(diffuse) - min(diffuse)) / median,
+    }
+    return {
+        "mode": mode,
+        "attention_config": MODE_CONFIGS[mode],
+        "parallel_config": "tp2_ulysses2_ring1_text_encoder_tp4_vae_tile4",
+        "runs": records,
+        "timing": timing,
+        "steady_output_deterministic": len(output_hashes) == 1,
+        "video": str(video[0]) if video is not None else None,
+        "passed_timing_gate": timing["cv"] <= 0.02 and timing["span_over_median"] <= 0.05,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    physical_gpus = visible_physical_gpus()
+    fa4 = require_fa4()
+    diffusion_engine._ASYNC_OUTPUT_TIMEOUT = 1800
+    telemetry = Telemetry(args.output_dir, physical_gpus)
+    try:
+        results = [run_mode(args, mode) for mode in MODE_CONFIGS]
+    finally:
+        telemetry.close()
+
+    thermal = telemetry.audit()
+    cudnn = next(result for result in results if result["mode"] == "cudnn_bf16")
+    fa4_result = next(result for result in results if result["mode"] == "fa4_bf16")
+    speedup = float(cudnn["timing"]["median_s"]) / float(fa4_result["timing"]["median_s"])
+    passed = (
+        all(result["passed_timing_gate"] and result["steady_output_deterministic"] for result in results)
+        and thermal["accepted"]
+    )
+    summary = {
+        "protocol": "one warmup plus five measured requests per serial mode; deferred MP4 encoding",
+        "model": str(args.model),
+        "physical_gpus": physical_gpus,
+        "hardware": hardware(),
+        "fa4": fa4,
+        "height": args.height,
+        "width": args.width,
+        "duration_seconds": args.duration_seconds,
+        "num_inference_steps": args.num_inference_steps,
+        "seed": args.seed,
+        "modes": results,
+        "fa4_speedup_vs_cudnn": speedup,
+        "thermal_audit": thermal,
+        "passed": passed,
+    }
+    summary_path = args.output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print("FINAL_SUMMARY " + json.dumps(summary, sort_keys=True), flush=True)
+    if not passed:
+        raise SystemExit(f"Benchmark gate failed; inspect {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -271,6 +271,46 @@ FA4 remains available by explicitly selecting the `FLASH_ATTN` backend:
 On Blackwell, `FLASH_ATTN` selects FA4. Confirm the server log contains
 `Using CuTe FlashAttention-4 on Blackwell` before recording FA4 measurements.
 
+#### Experimental SM120 FP8 CuTe DSL prims
+
+RTX PRO 5000/6000 Blackwell (SM120) can opt into the experimental FlashInfer
+CuTe DSL kernel through `TRTLLM_ATTN`. Build the exact tested FlashInfer fork
+and revision first:
+
+```bash
+git clone --recursive https://github.com/Tom-Zheng/flashinfer.git
+cd flashinfer
+git checkout 4a2345906256da0849d7e1e4681db514ab9b800e
+python -m pip install -v '.[cu13]'
+python -m pytest -q tests/attention/test_sm120_prims_prefill_backend.py
+```
+
+Then select the kernel explicitly. Q/K/V are quantized to FP8 E4M3 and the
+kernel returns BF16/FP16. The short token-refiner attention remains dense:
+
+```bash
+--diffusion-attention-config '{
+  "default": {
+    "backend": "TRTLLM_ATTN",
+    "quant": {
+      "dtype_qk": "fp8_e4m3",
+      "dtype_vo": "fp8_e4m3",
+      "flashinfer_backend": "cute-dsl-prims"
+    }
+  },
+  "per_role": {
+    "minimax_h3.token_refiner": {"backend": "TRTLLM_ATTN"}
+  }
+}'
+```
+
+If `q_scale`, `k_scale`, and `v_scale` are omitted, each layer calibrates a
+scale once on its first call with 2x FP8 headroom. Warm up the same engine
+before measuring. For reproducible production measurements, copy validated
+per-model scales into the three optional quant fields. This path requires
+compute capability 12.0 and fails explicitly on B300/SM103; use dense
+`TRTLLM_ATTN` or `CUDNN_ATTN` for the B300 baseline.
+
 `TRTLLM_ATTN` additionally supports two **lossy** optimizations for the long main
 DiT attention sequence: SAGE attention quantization and Skip-Softmax Sparse
 Attention. SAGE quantizes Q/K to the configured dtype and V to FP8. This example uses

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -278,11 +278,13 @@ CuTe DSL kernel through `TRTLLM_ATTN`. Build the exact tested FlashInfer fork
 and revision first:
 
 ```bash
-git clone --recursive https://github.com/Tom-Zheng/flashinfer.git
+git clone --recursive https://github.com/lishunyang12/flashinfer.git
 cd flashinfer
-git checkout 4a2345906256da0849d7e1e4681db514ab9b800e
+git checkout f764a6c868543fcf581da43b4ecef4de9b5aaa6a
 python -m pip install -v '.[cu13]'
-python -m pytest -q tests/attention/test_sm120_prims_prefill_backend.py
+python -m pytest -q tests/attention/test_sm120_fmha_api.py
+python -m pytest -q tests/attention/test_sm120_fmha.py \
+  -k 'sm120_ragged_skip_softmax_omits_negligible_tiles'
 ```
 
 Then select the kernel explicitly. Q/K/V are quantized to FP8 E4M3 and the
@@ -296,6 +298,10 @@ kernel returns BF16/FP16. The short token-refiner attention remains dense:
       "dtype_qk": "fp8_e4m3",
       "dtype_vo": "fp8_e4m3",
       "flashinfer_backend": "cute-dsl-prims"
+    },
+    "skip_softmax": {
+      "threshold": 0.05,
+      "disabled_until_timestep": 0.97
     }
   },
   "per_role": {
@@ -310,6 +316,11 @@ before measuring. For reproducible production measurements, copy validated
 per-model scales into the three optional quant fields. This path requires
 compute capability 12.0 and fails explicitly on B300/SM103; use dense
 `TRTLLM_ATTN` or `CUDNN_ATTN` for the B300 baseline.
+
+The optional `skip_softmax` block uses the same threshold and timestep-gating
+semantics as dense `TRTLLM_ATTN`. It requires the FlashInfer revision above;
+an older `cute-dsl-prims` wrapper fails explicitly instead of silently running
+dense attention.
 
 `TRTLLM_ATTN` additionally supports two **lossy** optimizations for the long main
 DiT attention sequence: SAGE attention quantization and Skip-Softmax Sparse

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -72,6 +72,23 @@ class TestAttentionSpec:
         assert bk["dtype_vo"] == "fp8_e4m3"
         assert bk["flashinfer_backend"] == "trtllm-gen"
 
+    def test_trtllm_sm120_prims_fields_passed_through(self):
+        bk = AttentionSpec(
+            backend="TRTLLM_ATTN",
+            quant={
+                "dtype_qk": "fp8_e4m3",
+                "dtype_vo": "fp8_e4m3",
+                "flashinfer_backend": "cute-dsl-prims",
+                "q_scale": 0.5,
+                "k_scale": 0.25,
+                "v_scale": 0.125,
+            },
+        ).backend_kwargs()["quant"]
+        assert bk["dtype_qk"] == "fp8_e4m3"
+        assert bk["dtype_vo"] == "fp8_e4m3"
+        assert bk["flashinfer_backend"] == "cute-dsl-prims"
+        assert (bk["q_scale"], bk["k_scale"], bk["v_scale"]) == (0.5, 0.25, 0.125)
+
     def test_quant_and_skip_softmax_coexist(self):
         bk = AttentionSpec(
             backend="TRTLLM_ATTN", quant={"dtype_qk": "int8"}, skip_softmax={"target_sparsity": 0.5}
@@ -84,6 +101,8 @@ class TestAttentionSpec:
             ({"backend": "TORCH_SDPA", "quant": {"dtype_qk": "int8"}}, "only supported by the TRTLLM_ATTN"),
             ({"backend": "TRTLLM_ATTN", "quant": {"dtype_qk": "int4"}}, "quant.dtype_qk"),
             ({"backend": "TRTLLM_ATTN", "quant": {"dtype_qk": "int8", "k_block_size": 8}}, "quant.k_block_size"),
+            ({"backend": "TRTLLM_ATTN", "quant": {"dtype_qk": "fp8_e4m3", "q_scale": 0}}, "quant.q_scale"),
+            ({"backend": "TRTLLM_ATTN", "quant": {"dtype_qk": "fp8_e4m3", "v_scale": float("nan")}}, "quant.v_scale"),
         ],
     )
     def test_quant_validation_rejects(self, spec, match):

--- a/tests/diffusion/attention/test_kernels_hub.py
+++ b/tests/diffusion/attention/test_kernels_hub.py
@@ -54,6 +54,26 @@ def test_kernels_hub_platform_fallback(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.core_model
+@pytest.mark.cpu
+def test_explicit_trtllm_backend_accepts_sm120(monkeypatch: pytest.MonkeyPatch):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
+    monkeypatch.setitem(sys.modules, "flashinfer", types.ModuleType("flashinfer"))
+    monkeypatch.setattr(
+        CudaOmniPlatform,
+        "get_device_capability",
+        classmethod(lambda cls, device_id=0: DeviceCapability(12, 0)),
+    )
+    monkeypatch.setattr(PACKAGES_CHECKER, "get_packages_info", lambda: {"has_flash_attn": False})
+
+    backend_path = CudaOmniPlatform.get_diffusion_attn_backend_cls("TRTLLM_ATTN", head_size=128)
+    assert backend_path == DiffusionAttentionBackendEnum.TRTLLM_ATTN.get_path()
+
+
+@pytest.mark.core_model
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 def test_kernels_hub_execution():
     """Verify basic forward of flash_attn_hub and flash_attn_3_hub, comparing with SDPA reference."""

--- a/tests/diffusion/attention/test_trtllm_attn.py
+++ b/tests/diffusion/attention/test_trtllm_attn.py
@@ -56,6 +56,119 @@ def test_quant_config_from_backend_kwargs():
     assert QuantConfig.from_backend_kwargs({"quant": {"dtype_qk": "fp8_e4m3"}}) == QuantConfig("fp8_e4m3", 1, 16)
     qc = QuantConfig.from_backend_kwargs({"quant": {"dtype_qk": "int8", "q_block_size": 4, "k_block_size": 16}})
     assert qc.enabled and (qc.dtype_qk, qc.q_block_size, qc.k_block_size) == ("int8", 4, 16)
+    prims = QuantConfig.from_backend_kwargs(
+        {
+            "quant": {
+                "dtype_qk": "fp8_e4m3",
+                "dtype_vo": "fp8_e4m3",
+                "flashinfer_backend": "cute-dsl-prims",
+                "q_scale": 0.5,
+                "k_scale": 0.25,
+                "v_scale": 0.125,
+            }
+        }
+    )
+    assert prims.use_sm120_prims
+    assert prims.configured_scales == (0.5, 0.25, 0.125)
+
+
+def test_sm120_prims_requires_explicit_fp8_qk_and_vo():
+    with pytest.raises(RuntimeError, match="dtype_qk and quant.dtype_vo"):
+        _impl(quant={"dtype_qk": "fp8_e4m3", "flashinfer_backend": "cute-dsl-prims"})
+    with pytest.raises(RuntimeError, match="does not support skip_softmax"):
+        _impl(
+            quant={
+                "dtype_qk": "fp8_e4m3",
+                "dtype_vo": "fp8_e4m3",
+                "flashinfer_backend": "cute-dsl-prims",
+            },
+            skip_softmax_threshold=0.1,
+        )
+
+
+def test_sm120_prims_scale_validation_and_calibration():
+    with pytest.raises(ValueError, match="q_scale"):
+        _impl(
+            quant={
+                "dtype_qk": "fp8_e4m3",
+                "dtype_vo": "fp8_e4m3",
+                "flashinfer_backend": "cute-dsl-prims",
+                "q_scale": 0,
+            }
+        )
+    impl = _impl(
+        quant={
+            "dtype_qk": "fp8_e4m3",
+            "dtype_vo": "fp8_e4m3",
+            "flashinfer_backend": "cute-dsl-prims",
+        }
+    )
+    first = impl._resolve_sm120_scales(
+        torch.tensor([1.0, -2.0]),
+        torch.tensor([3.0, -1.0]),
+        torch.tensor([4.0, -2.0]),
+    )
+    assert first == pytest.approx((2.0 / 224.0, 3.0 / 224.0, 4.0 / 224.0))
+    assert impl._resolve_sm120_scales(torch.tensor([100.0]), torch.tensor([100.0]), torch.tensor([100.0])) == first
+
+
+def test_sm120_prims_wrapper_is_planned_once_and_receives_scales(monkeypatch):
+    observed = {"plans": 0, "runs": 0}
+
+    class FakeWrapper:
+        def __init__(self, workspace, layout, backend):
+            observed.update(workspace=workspace, layout=layout, backend=backend)
+
+        def plan(self, qo, kv, hq, hkv, dim, **kwargs):
+            observed["plans"] += 1
+            observed.update(qo=qo.clone(), kv=kv.clone(), hq=hq, hkv=hkv, dim=dim, plan_kwargs=kwargs)
+
+        def run(self, q, k, v, *, out, q_scale, k_scale, v_scale):
+            observed["runs"] += 1
+            observed.update(dtypes=(q.dtype, k.dtype, v.dtype), scales=(q_scale, k_scale, v_scale))
+            out.zero_()
+            return out
+
+    monkeypatch.setattr(tg, "HAS_FLASHINFER", True)
+    monkeypatch.setattr(tg, "_sm120_prims_wrapper_cls", lambda: FakeWrapper)
+    monkeypatch.setattr(TrtllmAttentionImpl, "_get_sm120_workspace", classmethod(lambda cls, device: torch.empty(1)))
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    impl = _impl(
+        quant={
+            "dtype_qk": "fp8_e4m3",
+            "dtype_vo": "fp8_e4m3",
+            "flashinfer_backend": "cute-dsl-prims",
+            "q_scale": 0.5,
+            "k_scale": 0.25,
+            "v_scale": 0.125,
+        }
+    )
+    q = torch.randn(1, 4, 8, 128, dtype=torch.bfloat16)
+    first = impl.forward_cuda(q, q, q)
+    second = impl.forward_cuda(q, q, q)
+
+    assert first.shape == q.shape and second.shape == q.shape
+    assert observed["layout"] == "NHD" and observed["backend"] == "cute-dsl-prims"
+    assert observed["plans"] == 1 and observed["runs"] == 2
+    assert observed["dtypes"] == (torch.float8_e4m3fn,) * 3
+    assert observed["scales"] == (0.5, 0.25, 0.125)
+    assert observed["qo"].tolist() == [0, 4]
+
+
+def test_sm120_prims_fails_fast_on_b300(monkeypatch):
+    monkeypatch.setattr(tg, "HAS_FLASHINFER", True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 3))
+    impl = _impl(
+        quant={
+            "dtype_qk": "fp8_e4m3",
+            "dtype_vo": "fp8_e4m3",
+            "flashinfer_backend": "cute-dsl-prims",
+        }
+    )
+    q = torch.zeros(1, 4, 8, 128, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="B300/SM103"):
+        impl.forward_cuda(q, q, q)
 
 
 def test_quant_rejects_non_sage_dtype():

--- a/tests/diffusion/attention/test_trtllm_attn.py
+++ b/tests/diffusion/attention/test_trtllm_attn.py
@@ -75,15 +75,15 @@ def test_quant_config_from_backend_kwargs():
 def test_sm120_prims_requires_explicit_fp8_qk_and_vo():
     with pytest.raises(RuntimeError, match="dtype_qk and quant.dtype_vo"):
         _impl(quant={"dtype_qk": "fp8_e4m3", "flashinfer_backend": "cute-dsl-prims"})
-    with pytest.raises(RuntimeError, match="does not support skip_softmax"):
-        _impl(
-            quant={
-                "dtype_qk": "fp8_e4m3",
-                "dtype_vo": "fp8_e4m3",
-                "flashinfer_backend": "cute-dsl-prims",
-            },
-            skip_softmax_threshold=0.1,
-        )
+    impl = _impl(
+        quant={
+            "dtype_qk": "fp8_e4m3",
+            "dtype_vo": "fp8_e4m3",
+            "flashinfer_backend": "cute-dsl-prims",
+        },
+        skip_softmax_threshold=0.1,
+    )
+    assert impl.skip.enabled
 
 
 def test_sm120_prims_scale_validation_and_calibration():
@@ -123,9 +123,24 @@ def test_sm120_prims_wrapper_is_planned_once_and_receives_scales(monkeypatch):
             observed["plans"] += 1
             observed.update(qo=qo.clone(), kv=kv.clone(), hq=hq, hkv=hkv, dim=dim, plan_kwargs=kwargs)
 
-        def run(self, q, k, v, *, out, q_scale, k_scale, v_scale):
+        def run(
+            self,
+            q,
+            k,
+            v,
+            *,
+            out,
+            q_scale,
+            k_scale,
+            v_scale,
+            skip_softmax_threshold_scale_factor,
+        ):
             observed["runs"] += 1
-            observed.update(dtypes=(q.dtype, k.dtype, v.dtype), scales=(q_scale, k_scale, v_scale))
+            observed.update(
+                dtypes=(q.dtype, k.dtype, v.dtype),
+                scales=(q_scale, k_scale, v_scale),
+                skip_factor=skip_softmax_threshold_scale_factor,
+            )
             out.zero_()
             return out
 
@@ -142,7 +157,8 @@ def test_sm120_prims_wrapper_is_planned_once_and_receives_scales(monkeypatch):
             "q_scale": 0.5,
             "k_scale": 0.25,
             "v_scale": 0.125,
-        }
+        },
+        skip_softmax_threshold=0.25,
     )
     q = torch.randn(1, 4, 8, 128, dtype=torch.bfloat16)
     first = impl.forward_cuda(q, q, q)
@@ -153,7 +169,44 @@ def test_sm120_prims_wrapper_is_planned_once_and_receives_scales(monkeypatch):
     assert observed["plans"] == 1 and observed["runs"] == 2
     assert observed["dtypes"] == (torch.float8_e4m3fn,) * 3
     assert observed["scales"] == (0.5, 0.25, 0.125)
+    assert observed["skip_factor"] == pytest.approx(1.0)
     assert observed["qo"].tolist() == [0, 4]
+
+
+def test_sm120_prims_skip_requires_updated_flashinfer_wrapper(monkeypatch):
+    class LegacyWrapper:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def plan(self, *args, **kwargs):
+            pass
+
+        def run(self, q, k, v, *, out, q_scale, k_scale, v_scale):
+            return out
+
+    monkeypatch.setattr(tg, "HAS_FLASHINFER", True)
+    monkeypatch.setattr(tg, "_sm120_prims_wrapper_cls", lambda: LegacyWrapper)
+    monkeypatch.setattr(
+        TrtllmAttentionImpl,
+        "_get_sm120_workspace",
+        classmethod(lambda cls, device: torch.empty(1)),
+    )
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    impl = _impl(
+        quant={
+            "dtype_qk": "fp8_e4m3",
+            "dtype_vo": "fp8_e4m3",
+            "flashinfer_backend": "cute-dsl-prims",
+            "q_scale": 0.5,
+            "k_scale": 0.25,
+            "v_scale": 0.125,
+        },
+        skip_softmax_threshold=0.25,
+    )
+    q = torch.zeros(1, 4, 8, 128, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="ragged prefill wrapper exposes"):
+        impl.forward_cuda(q, q, q)
 
 
 def test_sm120_prims_fails_fast_on_b300(monkeypatch):

--- a/tests/diffusion/attention/test_trtllm_attn.py
+++ b/tests/diffusion/attention/test_trtllm_attn.py
@@ -324,9 +324,10 @@ def test_masked_layer_raises():
 
 def test_packed_metadata_trims_padding_mask(monkeypatch):
     b, s, h, d = 1, 8, 8, 128
-    q, k, v = (torch.zeros(b, s, h, d) for _ in range(3))
-    mask = torch.tensor([[True, True, True, True, True, True, False, False]])
-    cu_seqlens = torch.tensor([0, 6, 8], dtype=torch.int32)
+    with torch.inference_mode():
+        q, k, v = (torch.zeros(b, s, h, d) for _ in range(3))
+        mask = torch.tensor([[True, True, True, True, True, True, False, False]])
+        cu_seqlens = torch.tensor([0, 6, 8], dtype=torch.int32)
     metadata = AttentionMetadata(
         attn_mask=mask,
         extra={

--- a/vllm_omni/diffusion/attention/backends/trtllm_attn.py
+++ b/vllm_omni/diffusion/attention/backends/trtllm_attn.py
@@ -367,7 +367,7 @@ class TrtllmAttentionImpl(AttentionImpl):
         v: torch.Tensor,
         cu_seq_lens_q: torch.Tensor,
         cu_seq_lens_kv: torch.Tensor,
-        plan_key: tuple,
+        plan_key: tuple | None,
     ) -> torch.Tensor:
         capability = torch.cuda.get_device_capability(q.device)
         if capability != (12, 0):
@@ -389,7 +389,7 @@ class TrtllmAttentionImpl(AttentionImpl):
                 "NHD",
                 backend=_SM120_PRIMS_BACKEND,
             )
-        if plan_key != self._sm120_plan_key:
+        if plan_key is None or plan_key != self._sm120_plan_key:
             self._sm120_wrapper.plan(
                 cu_seq_lens_q,
                 cu_seq_lens_kv,
@@ -507,16 +507,8 @@ class TrtllmAttentionImpl(AttentionImpl):
             seq_lens = (cu_seq_lens_kv[1:] - cu_seq_lens_kv[:-1]).to(dtype=torch.int32).contiguous()
             max_q_len = int(extra["max_seqlen_q"])
             max_kv_len = int(extra["max_seqlen_k"])
-            sm120_plan_key = (
-                cu_seq_lens_q.data_ptr(),
-                getattr(cu_seq_lens_q, "_version", 0),
-                cu_seq_lens_kv.data_ptr(),
-                getattr(cu_seq_lens_kv, "_version", 0),
-                tuple(q.shape),
-                tuple(k.shape),
-                q.dtype,
-                self.causal,
-            )
+            # Packed inference tensors have no version counter; re-plan dynamic indptrs.
+            sm120_plan_key = None
         else:
             batch = physical_batch
             seq_lens = torch.full((batch,), kv_len, dtype=torch.int32, device=device)

--- a/vllm_omni/diffusion/attention/backends/trtllm_attn.py
+++ b/vllm_omni/diffusion/attention/backends/trtllm_attn.py
@@ -255,8 +255,6 @@ class TrtllmAttentionImpl(AttentionImpl):
                 raise RuntimeError(
                     "TRTLLM_ATTN cute-dsl-prims requires quant.dtype_qk and quant.dtype_vo to both be 'fp8_e4m3'."
                 )
-            if self.skip.configured:
-                raise RuntimeError("TRTLLM_ATTN cute-dsl-prims does not support skip_softmax.")
         elif self.quant.enabled:
             if self.quant.dtype_vo is not None:
                 raise RuntimeError(
@@ -368,6 +366,7 @@ class TrtllmAttentionImpl(AttentionImpl):
         cu_seq_lens_q: torch.Tensor,
         cu_seq_lens_kv: torch.Tensor,
         plan_key: tuple | None,
+        skip_softmax_threshold_scale_factor: float | None,
     ) -> torch.Tensor:
         capability = torch.cuda.get_device_capability(q.device)
         if capability != (12, 0):
@@ -388,6 +387,14 @@ class TrtllmAttentionImpl(AttentionImpl):
                 self._get_sm120_workspace(q.device),
                 "NHD",
                 backend=_SM120_PRIMS_BACKEND,
+            )
+        if (
+            skip_softmax_threshold_scale_factor is not None
+            and "skip_softmax_threshold_scale_factor" not in inspect.signature(self._sm120_wrapper.run).parameters
+        ):
+            raise RuntimeError(
+                "TRTLLM_ATTN cute-dsl-prims skip_softmax requires a FlashInfer build "
+                "whose ragged prefill wrapper exposes skip_softmax_threshold_scale_factor."
             )
         if plan_key is None or plan_key != self._sm120_plan_key:
             self._sm120_wrapper.plan(
@@ -413,6 +420,7 @@ class TrtllmAttentionImpl(AttentionImpl):
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
         )
         return output
 
@@ -450,6 +458,15 @@ class TrtllmAttentionImpl(AttentionImpl):
         kv_len, num_kv_heads = key.shape[1], key.shape[2]
 
         device = query.device
+        if (
+            device.type == "cuda"
+            and torch.cuda.get_device_capability(device) == (12, 0)
+            and not self.quant.use_sm120_prims
+        ):
+            raise RuntimeError(
+                "TRTLLM_ATTN on SM120 requires quant.dtype_qk='fp8_e4m3', "
+                "quant.dtype_vo='fp8_e4m3', and quant.flashinfer_backend='cute-dsl-prims'."
+            )
 
         q = query.reshape(physical_batch * q_len, num_q_heads, head_dim).contiguous()
         k = key.reshape(physical_batch * kv_len, num_kv_heads, head_dim).contiguous()
@@ -523,7 +540,15 @@ class TrtllmAttentionImpl(AttentionImpl):
             sm120_plan_key = ("uniform", batch, q_len, kv_len, tuple(q.shape), tuple(k.shape), q.dtype, self.causal)
 
         if self.quant.use_sm120_prims:
-            out = self._run_sm120_prims(q, k, v, cu_seq_lens_q, cu_seq_lens_kv, sm120_plan_key)
+            out = self._run_sm120_prims(
+                q,
+                k,
+                v,
+                cu_seq_lens_q,
+                cu_seq_lens_kv,
+                sm120_plan_key,
+                self._resolve_skip_factor(max_kv_len),
+            )
             if out.shape[0] != output_tokens:
                 padded_out = torch.zeros((output_tokens, num_q_heads, head_dim), dtype=out.dtype, device=out.device)
                 padded_out[: out.shape[0]] = out

--- a/vllm_omni/diffusion/attention/backends/trtllm_attn.py
+++ b/vllm_omni/diffusion/attention/backends/trtllm_attn.py
@@ -105,6 +105,36 @@ def _sage_quantize_fn():
         return None
 
 
+_SM120_PRIMS_BACKEND = "cute-dsl-prims"
+_SM120_PRIMS_DTYPE = "fp8_e4m3"
+_SM120_FP8_DTYPE = torch.float8_e4m3fn
+_SM120_FP8_MAX_WITH_HEADROOM = torch.finfo(_SM120_FP8_DTYPE).max / 2.0
+_SM120_WORKSPACE_BYTES = 16 << 20
+
+
+def _positive_optional_scale(value: float | None, name: str) -> float | None:
+    if value is None:
+        return None
+    scale = float(value)
+    if not math.isfinite(scale) or scale <= 0:
+        raise ValueError(f"{name} must be finite and > 0, got {value!r}")
+    return scale
+
+
+def _sm120_prims_wrapper_cls():
+    try:
+        from flashinfer import BatchPrefillWithRaggedKVCacheWrapper
+        from flashinfer.attention.cute_dsl.sm120_fmha import (  # noqa: F401
+            SM120PrimsBatchPrefillBackend,
+        )
+    except Exception as exc:
+        raise ImportError(
+            "TRTLLM_ATTN cute-dsl-prims requires the FlashInfer SM120 CuTe DSL "
+            "implementation from commit 4a2345906256 and its cutlass.experimental dependency"
+        ) from exc
+    return BatchPrefillWithRaggedKVCacheWrapper
+
+
 _QK_QUANT_DTYPES = {
     "int8": torch.int8,
     "fp8_e4m3": torch.float8_e4m3fn,
@@ -116,6 +146,11 @@ class QuantConfig:
     dtype_qk: str | None = None
     q_block_size: int = 1
     k_block_size: int = 16
+    dtype_vo: str | None = None
+    flashinfer_backend: str | None = None
+    q_scale: float | None = None
+    k_scale: float | None = None
+    v_scale: float | None = None
 
     @classmethod
     def from_backend_kwargs(cls, backend_kwargs: dict | None) -> "QuantConfig":
@@ -124,11 +159,24 @@ class QuantConfig:
             dtype_qk=q.get("dtype_qk"),
             q_block_size=int(q.get("q_block_size", 1) or 1),
             k_block_size=int(q.get("k_block_size", 16) or 16),
+            dtype_vo=q.get("dtype_vo"),
+            flashinfer_backend=q.get("flashinfer_backend"),
+            q_scale=_positive_optional_scale(q.get("q_scale"), "quant.q_scale"),
+            k_scale=_positive_optional_scale(q.get("k_scale"), "quant.k_scale"),
+            v_scale=_positive_optional_scale(q.get("v_scale"), "quant.v_scale"),
         )
 
     @property
     def enabled(self) -> bool:
-        return self.dtype_qk is not None
+        return self.dtype_qk is not None or self.dtype_vo is not None
+
+    @property
+    def use_sm120_prims(self) -> bool:
+        return self.flashinfer_backend == _SM120_PRIMS_BACKEND
+
+    @property
+    def configured_scales(self) -> tuple[float | None, float | None, float | None]:
+        return self.q_scale, self.k_scale, self.v_scale
 
     def quantize(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, quantize_fn):
         qk_quant_dtype = _QK_QUANT_DTYPES[self.dtype_qk]
@@ -169,6 +217,7 @@ class TrtllmAttentionBackend(AttentionBackend):
 
 class TrtllmAttentionImpl(AttentionImpl):
     _workspace: torch.Tensor | None = None
+    _sm120_workspaces: dict[tuple[str, int | None], torch.Tensor] = {}
 
     def __init__(
         self,
@@ -196,8 +245,23 @@ class TrtllmAttentionImpl(AttentionImpl):
         self.quant = QuantConfig.from_backend_kwargs(backend_kwargs)
         # Resolve the SAGE quantize fn once at init so the compiled forward path never calls the
         # lru_cache-wrapped getter (which triggers a Dynamo graph break every step).
+        self._sm120_wrapper = None
+        self._sm120_plan_key: tuple | None = None
+        self._sm120_resolved_scales: tuple[float, float, float] | None = None
+        self._sm120_uniform_indptr_cache: dict[tuple, torch.Tensor] = {}
         self._sage_quantize_fn = None
-        if self.quant.enabled:
+        if self.quant.use_sm120_prims:
+            if self.quant.dtype_qk != _SM120_PRIMS_DTYPE or self.quant.dtype_vo != _SM120_PRIMS_DTYPE:
+                raise RuntimeError(
+                    "TRTLLM_ATTN cute-dsl-prims requires quant.dtype_qk and quant.dtype_vo to both be 'fp8_e4m3'."
+                )
+            if self.skip.configured:
+                raise RuntimeError("TRTLLM_ATTN cute-dsl-prims does not support skip_softmax.")
+        elif self.quant.enabled:
+            if self.quant.dtype_vo is not None:
+                raise RuntimeError(
+                    "TRTLLM_ATTN quant.dtype_vo is only supported with quant.flashinfer_backend='cute-dsl-prims'."
+                )
             if self.quant.dtype_qk not in _QK_QUANT_DTYPES:
                 raise RuntimeError(
                     f"TRTLLM_ATTN quant (SAGE) supports dtype_qk in {sorted(_QK_QUANT_DTYPES)}, got "
@@ -249,6 +313,108 @@ class TrtllmAttentionImpl(AttentionImpl):
             ws = torch.zeros(nbytes, dtype=torch.uint8, device=device)
             cls._workspace = ws
         return ws
+
+    @classmethod
+    def _get_sm120_workspace(cls, device: torch.device) -> torch.Tensor:
+        key = (device.type, device.index)
+        workspace = cls._sm120_workspaces.get(key)
+        if workspace is None:
+            workspace = torch.empty(_SM120_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+            cls._sm120_workspaces[key] = workspace
+        return workspace
+
+    def _get_sm120_uniform_indptr(self, batch: int, length: int, device: torch.device) -> torch.Tensor:
+        key = (device.type, device.index, batch, length)
+        indptr = self._sm120_uniform_indptr_cache.get(key)
+        if indptr is None:
+            indptr = torch.arange(batch + 1, dtype=torch.int32, device=device).mul_(length)
+            self._sm120_uniform_indptr_cache[key] = indptr
+        return indptr
+
+    def _resolve_sm120_scales(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> tuple[float, float, float]:
+        if self._sm120_resolved_scales is not None:
+            return self._sm120_resolved_scales
+
+        configured = self.quant.configured_scales
+        if all(scale is not None for scale in configured):
+            self._sm120_resolved_scales = configured  # type: ignore[assignment]
+            return self._sm120_resolved_scales
+
+        maxima = torch.stack(tuple(t.detach().abs().amax().float() for t in (q, k, v))).cpu()
+        calibrated = tuple(
+            max(float(value) / _SM120_FP8_MAX_WITH_HEADROOM, torch.finfo(torch.float32).tiny)
+            for value in maxima.tolist()
+        )
+        self._sm120_resolved_scales = tuple(
+            static if static is not None else dynamic for static, dynamic in zip(configured, calibrated, strict=True)
+        )
+        logger.info(
+            "Calibrated TRTLLM_ATTN cute-dsl-prims scales for role %s: q=%g k=%g v=%g",
+            self.role,
+            *self._sm120_resolved_scales,
+        )
+        return self._sm120_resolved_scales
+
+    @staticmethod
+    def _quantize_sm120(value: torch.Tensor, scale: float) -> torch.Tensor:
+        scaled = value if scale == 1.0 else value / scale
+        return scaled.to(_SM120_FP8_DTYPE).contiguous()
+
+    def _run_sm120_prims(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seq_lens_q: torch.Tensor,
+        cu_seq_lens_kv: torch.Tensor,
+        plan_key: tuple,
+    ) -> torch.Tensor:
+        capability = torch.cuda.get_device_capability(q.device)
+        if capability != (12, 0):
+            raise RuntimeError(
+                "TRTLLM_ATTN cute-dsl-prims requires an SM120 GPU (compute capability 12.0); "
+                f"got {capability[0]}.{capability[1]}. B300/SM103 must use dense TRTLLM_ATTN or CUDNN_ATTN."
+            )
+        if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+            raise TypeError("TRTLLM_ATTN cute-dsl-prims expects matching FP16/BF16 Q/K/V activations.")
+        if q.shape[2] not in (32, 64, 128, 256) or k.shape[2] != q.shape[2] or v.shape != k.shape:
+            raise ValueError("TRTLLM_ATTN cute-dsl-prims requires matching Q/K/V head sizes in {32,64,128,256}.")
+        if q.shape[1] % k.shape[1]:
+            raise ValueError("TRTLLM_ATTN cute-dsl-prims requires num_q_heads divisible by num_kv_heads.")
+
+        if self._sm120_wrapper is None:
+            wrapper_cls = _sm120_prims_wrapper_cls()
+            self._sm120_wrapper = wrapper_cls(
+                self._get_sm120_workspace(q.device),
+                "NHD",
+                backend=_SM120_PRIMS_BACKEND,
+            )
+        if plan_key != self._sm120_plan_key:
+            self._sm120_wrapper.plan(
+                cu_seq_lens_q,
+                cu_seq_lens_kv,
+                q.shape[1],
+                k.shape[1],
+                q.shape[2],
+                causal=self.causal,
+                q_data_type=_SM120_FP8_DTYPE,
+                kv_data_type=_SM120_FP8_DTYPE,
+                o_data_type=q.dtype,
+            )
+            self._sm120_plan_key = plan_key
+
+        q_scale, k_scale, v_scale = self._resolve_sm120_scales(q, k, v)
+        output = torch.empty_like(q)
+        self._sm120_wrapper.run(
+            self._quantize_sm120(q, q_scale),
+            self._quantize_sm120(k, k_scale),
+            self._quantize_sm120(v, v_scale),
+            out=output,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        return output
 
     def forward_cuda(
         self,
@@ -341,13 +507,37 @@ class TrtllmAttentionImpl(AttentionImpl):
             seq_lens = (cu_seq_lens_kv[1:] - cu_seq_lens_kv[:-1]).to(dtype=torch.int32).contiguous()
             max_q_len = int(extra["max_seqlen_q"])
             max_kv_len = int(extra["max_seqlen_k"])
+            sm120_plan_key = (
+                cu_seq_lens_q.data_ptr(),
+                getattr(cu_seq_lens_q, "_version", 0),
+                cu_seq_lens_kv.data_ptr(),
+                getattr(cu_seq_lens_kv, "_version", 0),
+                tuple(q.shape),
+                tuple(k.shape),
+                q.dtype,
+                self.causal,
+            )
         else:
             batch = physical_batch
             seq_lens = torch.full((batch,), kv_len, dtype=torch.int32, device=device)
-            cu_seq_lens_q = torch.arange(0, (batch + 1) * q_len, step=q_len, dtype=torch.int32, device=device)
-            cu_seq_lens_kv = torch.arange(0, (batch + 1) * kv_len, step=kv_len, dtype=torch.int32, device=device)
+            if self.quant.use_sm120_prims:
+                cu_seq_lens_q = self._get_sm120_uniform_indptr(batch, q_len, device)
+                cu_seq_lens_kv = self._get_sm120_uniform_indptr(batch, kv_len, device)
+            else:
+                cu_seq_lens_q = torch.arange(0, (batch + 1) * q_len, step=q_len, dtype=torch.int32, device=device)
+                cu_seq_lens_kv = torch.arange(0, (batch + 1) * kv_len, step=kv_len, dtype=torch.int32, device=device)
             max_q_len = q_len
             max_kv_len = kv_len
+            sm120_plan_key = ("uniform", batch, q_len, kv_len, tuple(q.shape), tuple(k.shape), q.dtype, self.causal)
+
+        if self.quant.use_sm120_prims:
+            out = self._run_sm120_prims(q, k, v, cu_seq_lens_q, cu_seq_lens_kv, sm120_plan_key)
+            if out.shape[0] != output_tokens:
+                padded_out = torch.zeros((output_tokens, num_q_heads, head_dim), dtype=out.dtype, device=out.device)
+                padded_out[: out.shape[0]] = out
+                out = padded_out
+            return out.reshape(physical_batch, q_len, num_q_heads, head_dim)
+
         workspace = self._get_workspace(device)
 
         bmm1_scale = self.softmax_scale

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1454,6 +1454,9 @@ class AttnQuantSpec:
     q_block_size: int = 1
     k_block_size: int = 16
     flashinfer_backend: str | None = None
+    q_scale: float | None = None
+    k_scale: float | None = None
+    v_scale: float | None = None
 
     _VALID_DTYPES = frozenset({"float16", "bfloat16", "int8", "fp8_e4m3"})
     _VALID_BLOCK_SIZES = frozenset({1, 4, 16})
@@ -1467,6 +1470,9 @@ class AttnQuantSpec:
                 raise ValueError(
                     f"quant.{name}={v!r} unsupported; kernels exist only for {sorted(self._VALID_BLOCK_SIZES)}."
                 )
+        for name, v in (("q_scale", self.q_scale), ("k_scale", self.k_scale), ("v_scale", self.v_scale)):
+            if v is not None and (not math.isfinite(float(v)) or float(v) <= 0):
+                raise ValueError(f"quant.{name} must be finite and > 0; got {v!r}.")
 
     @property
     def enabled(self) -> bool:
@@ -1566,6 +1572,10 @@ class AttentionSpec:
                 quant_kw["dtype_vo"] = q.dtype_vo
             if q.flashinfer_backend is not None:
                 quant_kw["flashinfer_backend"] = q.flashinfer_backend
+            for name in ("q_scale", "k_scale", "v_scale"):
+                value = getattr(q, name)
+                if value is not None:
+                    quant_kw[name] = value
             kw["quant"] = quant_kw
         if self.block_sparse is not None:
             bs = self.block_sparse

--- a/vllm_omni/platforms/cuda/platform.py
+++ b/vllm_omni/platforms/cuda/platform.py
@@ -187,12 +187,15 @@ class CudaOmniPlatform(OmniPlatform, CudaPlatformBase):
                     )
                     return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
             if backend_upper == "TRTLLM_ATTN":
-                trtllm_attn_supported = compute_capability is not None and compute_capability.major == 10
+                trtllm_attn_supported = compute_capability is not None and (
+                    compute_capability.major == 10 or tuple(compute_capability) == (12, 0)
+                )
                 if not trtllm_attn_supported:
                     raise ValueError(
-                        "TRTLLM_ATTN diffusion attention backend requires a datacenter "
-                        "Blackwell GPU (SM100 / SM103, compute capability 10.x). Select a "
-                        "different --diffusion-attention-backend."
+                        "TRTLLM_ATTN diffusion attention backend requires SM100/SM103 "
+                        "(compute capability 10.x), or SM120 with "
+                        "quant.flashinfer_backend='cute-dsl-prims'. Select a different "
+                        "--diffusion-attention-backend."
                     )
                 if not flashinfer_available:
                     raise ValueError(


### PR DESCRIPTION
## Summary

- add an explicit `cute-dsl-prims` sub-backend under `TRTLLM_ATTN` for dense SM120 DiT attention
- route FP8 E4M3 Q/K/V through FlashInfer `BatchPrefillWithRaggedKVCacheWrapper`, with BF16/FP16 output
- support explicit scalar Q/K/V scales or one-time calibrated scales with FP8 headroom
- retain the existing dense TRT-LLM and SAGE paths unchanged
- fail fast outside SM120; B300/SM103 should use dense `TRTLLM_ATTN` or `CUDNN_ATTN`
- document the exact FlashInfer dependency and MiniMax-H3 configuration

## Base and dependency

- rebased onto `main` at `48298030`, which includes MiniMax-H3 modular pipeline PR #5720
- requires FlashInfer built from Tom-Zheng/flashinfer commit `4a2345906256da0849d7e1e4681db514ab9b800e`
- the experimental backend is opt-in and is never selected automatically

## Validation

- `ruff check`: passed
- changed-file pre-commit hooks: passed before rebase
- attention/config unit tests after rebase: 93 passed, 1 skipped
- real B300/SM103 capability guard: passed; the SM120-only path fails fast with an actionable error
- packed inference-mode metadata regression: fixed and covered
- real RTX PRO 5000 SM120 end-to-end validation: pending

The existing complete B300 Starship matrix remains the comparison baseline: https://github.com/bobboli/vllm-omni-rankings/blob/minimax-h3-trtllm-b300-matrix/scripts/minimax_h3_trtllm_e2e/README.md#b300-official-starship-prompt

## Notes

This remains a Draft while the RTX PRO 5000 kernel benchmark and accuracy comparison are collected.