### PR TITLE
[Tests] Report coverage from subprocesses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,16 @@ filterwarnings = [
     "ignore:.*does not have '__bases__' attribute.*:UserWarning",
 ]
 
+[tool.coverage.run]
+core = "sysmon"
+source = ["vllm_omni"]
+patch = ["subprocess"]
+concurrency = ["multiprocessing", "thread"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
 [tool.typos.default]
 extend-ignore-identifiers-re = [
     ".*_thw",


### PR DESCRIPTION
## Purpose

To improve the accuracy of coverage reporting. Also switching to the sysmon coverage backend for a huge performance improvement during coverage testing.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 36c304d6400943d3b1fff67212a7ece0147120c5

```
pytest -s -v tests/model_tests/diffusion/ --cov --cov-report=term
```

## Test Result

Overall coverage before: 7%, after 12%.