### PR TITLE
[Misc] Replace use of deprecated pkg_resources with importlib.metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ def uninstall_onnxruntime() -> None:
     with ROCm-specific dependencies.
     """
     try:
-        import pkg_resources
+        from importlib.metadata import PackageNotFoundError, metadata
 
         try:
-            pkg_resources.get_distribution("onnxruntime")
+            metadata("onnxruntime")
             print("Found onnxruntime installed, uninstalling for ROCm compatibility...")
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "uninstall", "-y", "onnxruntime"],
@@ -34,7 +34,7 @@ def uninstall_onnxruntime() -> None:
                 stderr=subprocess.DEVNULL,
             )
             print("Successfully uninstalled onnxruntime")
-        except pkg_resources.DistributionNotFound:
+        except PackageNotFoundError:
             print("onnxruntime not installed, skipping uninstall")
     except Exception as e:
         print(f"Warning: Failed to uninstall onnxruntime: {e}")


### PR DESCRIPTION
## Purpose

To unblock setuptools 82.0.0+

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** a95da6c614a4f3d75228b19501a295d2ba53c026

```
python -c "import setup; setup.uninstall_onnxruntime()"
```

## Test Result

```
onnxruntime not installed, skipping uninstall
```