### PR TITLE
[Bugfix] Unify model settings and tiny model resolution for all model types

### DIFF
--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -56,6 +56,16 @@ from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
+_MODEL_TYPE_MARKERS = ("diffusion", "omni", "tts")
+
+
+def _has_model_type_marker(request) -> bool:
+    """Check whether the test node carries any known model-type marker."""
+    return any(
+        request.node.get_closest_marker(m) is not None
+        for m in _MODEL_TYPE_MARKERS
+    )
+
 
 def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     # Reset environment variable cache
@@ -3111,7 +3121,7 @@ def iter_omni_server(
         # be ideal to cleanup consistently everywhere.
         original_model = model_prefix + params.model
         model = original_model
-        if run_level == "core_model" and request.node.get_closest_marker("diffusion"):
+        if run_level == "core_model" and _has_model_type_marker(request):
             model = resolve_tiny_model_path(model)
         port = params.port
         stage_config_path = stage_config_path_for_run_level(params.stage_config_path, run_level)
@@ -3202,7 +3212,7 @@ def iter_omni_runner(
             extra_omni_kwargs = dict(extra) if extra is not None else {}
         stage_config_path = stage_config_path_for_run_level(stage_config_path, run_level)
         model = model_prefix + model
-        if run_level == "core_model" and request.node.get_closest_marker("diffusion"):
+        if run_level == "core_model" and _has_model_type_marker(request):
             model = resolve_tiny_model_path(model)
         with OmniRunner(model, seed=42, stage_configs_path=stage_config_path, **extra_omni_kwargs) as runner:
             print("OmniRunner started successfully")

--- a/tests/model_tests/conftest.py
+++ b/tests/model_tests/conftest.py
@@ -2,7 +2,7 @@ from shutil import rmtree
 
 import pytest
 
-from tests.model_tests.diffusion.model_settings import DIFFUSION_TEST_SETTINGS
+from tests.model_tests.diffusion.model_settings import MODEL_SETTINGS
 
 
 @pytest.fixture(scope="session")
@@ -22,10 +22,10 @@ def tiny_model_paths(request, run_level):
         if not hasattr(item, "callspec"):
             continue
         model_name = item.callspec.params.get("model_name")
-        if model_name is None or model_name not in DIFFUSION_TEST_SETTINGS:
+        if model_name is None or model_name not in MODEL_SETTINGS:
             continue
         if model_name not in model_paths:
-            settings = DIFFUSION_TEST_SETTINGS[model_name]
+            settings = MODEL_SETTINGS[model_name]
             if run_level == "core_model":
                 print(f"Calling tiny model builder for: {model_name}")
                 path = settings.builder()

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -52,3 +52,11 @@ DIFFUSION_TEST_SETTINGS = {
         ],
     ),
 }
+
+# Unified settings dict for all model types. Consumers that need to resolve
+# any model (not just diffusion) should use this instead of
+# DIFFUSION_TEST_SETTINGS.  test_alignment.py intentionally keeps using
+# DIFFUSION_TEST_SETTINGS because it validates diffusion registry alignment.
+MODEL_SETTINGS: dict[str, DiffusionModelTestOpts] = {
+    **DIFFUSION_TEST_SETTINGS,
+}

--- a/tests/model_tests/diffusion/utils.py
+++ b/tests/model_tests/diffusion/utils.py
@@ -4,7 +4,7 @@ Utilities for resolving real models to their tiny model equivalents.
 
 import logging
 
-from tests.model_tests.diffusion.model_settings import DIFFUSION_TEST_SETTINGS
+from tests.model_tests.diffusion.model_settings import MODEL_SETTINGS
 from vllm_omni.diffusion.data import resolve_model_class_name
 
 logger = logging.getLogger(__name__)
@@ -13,21 +13,24 @@ logger = logging.getLogger(__name__)
 def resolve_tiny_model_path(model: str) -> str:
     """Given a real model name/path, resolve it to a tiny model path.
 
-    Raises ValueError if the pipeline class cannot be determined (invalid
-    model). Returns the original model path if no tiny builder exists yet."""
+    Tries two strategies:
+      1. Resolve via diffusion pipeline class name (for diffusion models).
+      2. Match by HF model ID against MODEL_SETTINGS (for omni/tts models).
+
+    Returns the original model path if no tiny builder exists yet."""
+    # Strategy 1: diffusion pipeline class name
     pipeline_class = resolve_model_class_name(model)
-    if pipeline_class is None:
-        raise ValueError(
-            f"Cannot resolve pipeline class for model: {model}. The model path may be invalid or its config unreadable."
-        )
+    if pipeline_class is not None:
+        test_opts = MODEL_SETTINGS.get(pipeline_class)
+        if test_opts is not None:
+            return test_opts.builder()
 
-    test_opts = DIFFUSION_TEST_SETTINGS.get(pipeline_class)
-    if test_opts is None:
-        logger.warning(
-            "No tiny model builder for pipeline %s (model: %s). Using original model.",
-            pipeline_class,
-            model,
-        )
-        return model
+    # Strategy 2: match by HF model ID
+    for _name, opts in MODEL_SETTINGS.items():
+        if opts.model == model:
+            return opts.builder()
 
-    return test_opts.builder()
+    logger.warning(
+        "No tiny model builder for model: %s. Using original model.", model
+    )
+    return model


### PR DESCRIPTION
## Summary

Tiny model test framework was hardcoded to diffusion models in three places, blocking omni/TTS support. This PR adds a unified `MODEL_SETTINGS` dict, makes `resolve_tiny_model_path()` fall back to HF model ID matching, and broadens the runtime marker check to include `omni` and `tts`.

## Test plan

- [x] `pytest --collect-only -m diffusion tests/model_tests/` still collects 12 tests (Flux2Klein + LTX2)
- [x] `test_alignment.py` still uses `DIFFUSION_TEST_SETTINGS` directly
- [x] `resolve_tiny_model_path()` resolves omni models by HF model ID (no more `ValueError`)
- [x] Runtime fixtures substitute tiny models for `omni`/`tts` markers, not just `diffusion`
