### PR TITLE
[Frontend] Loosen Validation for TTS Models with No Uploaded Speakers

### DIFF
--- a/tests/e2e/online_serving/test_omnivoice_expansion.py
+++ b/tests/e2e/online_serving/test_omnivoice_expansion.py
@@ -17,6 +17,7 @@ from tests.helpers.mark import hardware_test
 from tests.helpers.media import get_asset_path, load_test_audio_data_url
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
+from vllm_omni.entrypoints.openai.serving_speech import _DEFAULT_VOICE_NAME
 
 try:
     from transformers import HiggsAudioV2TokenizerModel  # noqa: F401
@@ -144,13 +145,10 @@ class TestOmniVoiceVoiceCloning:
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
-@pytest.mark.parametrize("voice", ["default", {"id": "default"}])
+@pytest.mark.parametrize("voice", [_DEFAULT_VOICE_NAME, {"id": _DEFAULT_VOICE_NAME}])
 def test_speech_with_voice_param_accepted(omni_server, openai_client, voice) -> None:
-    """Ensure that we can pass a voice string to OmniVoice without exploding;
-    this is because the OpenAI spec technically has this param as a required
-    string, so for models that don't have any uploaded speakers, passing a
-    voice doesn't do anything, and we log a warning instead of throwing.
-    """
+    """The default voice should be accepted as both a plain string and a
+    VoiceID dict, even when the model has no uploaded speakers."""
     request_config = {
         "model": omni_server.model,
         "input": get_prompt("text"),
@@ -164,18 +162,37 @@ def test_speech_with_voice_param_accepted(omni_server, openai_client, voice) -> 
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
+def test_unknown_voice_rejected(omni_server, openai_client) -> None:
+    """An unrecognized voice name should be rejected with a 400."""
+    request_config = {
+        "model": omni_server.model,
+        "input": get_prompt("text"),
+        "voice": "nonexistent_voice",
+        "status_code": 400,
+        "err_message": "Invalid voice",
+    }
+    openai_client.send_audio_speech_request(request_config)
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
 def test_voice_request_before_and_after_clone_registration(omni_server, openai_client) -> None:
-    # FIXME - this is bad behavior and needs to be consistent.
+    """The default voice should always be listed and usable, even after
+    a different cloned voice is registered."""
     speech_config = {
         "model": omni_server.model,
         "input": get_prompt("text"),
-        "voice": "foo",
+        "voice": _DEFAULT_VOICE_NAME,
     }
 
-    # 1) Request with an unregistered voice name — should succeed (warning only)
+    # 1) "default" should appear in the voices list before any uploads
+    voices = openai_client.send_audio_voices_list_http_request()[0]
+    assert _DEFAULT_VOICE_NAME in voices.json_body["voices"]
+
+    # 2) Speech with the default voice should succeed
     openai_client.send_audio_speech_request(speech_config)
 
-    # 2) Register a different cloned voice via POST /v1/audio/voices
+    # 3) Register a cloned voice under a different name
     register_config = {
         "data": {"name": "bar", "consent": "test-consent"},
         "files": {
@@ -188,5 +205,57 @@ def test_voice_request_before_and_after_clone_registration(omni_server, openai_c
     }
     openai_client.send_audio_voices_create_http_request(register_config)
 
-    # 3) Same request again — voice is now registered, should still succeed
+    # 4) "default" should still be listed alongside the new voice
+    voices = openai_client.send_audio_voices_list_http_request()[0]
+    assert _DEFAULT_VOICE_NAME in voices.json_body["voices"]
+    assert "bar" in voices.json_body["voices"]
+
+    # 5) Speech with the default voice should still succeed
+    openai_client.send_audio_speech_request(speech_config)
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
+def test_registered_default_voice_overrides_placeholder(omni_server, openai_client) -> None:
+    """When a real voice is uploaded under the default name, it should be
+    used as a cloned voice; after deletion, the placeholder behavior resumes."""
+    speech_config = {
+        "model": omni_server.model,
+        "input": get_prompt("text"),
+        "voice": _DEFAULT_VOICE_NAME,
+    }
+
+    # 1) Placeholder default works before any registration
+    openai_client.send_audio_speech_request(speech_config)
+
+    # 2) Register a real voice under the default name
+    register_config = {
+        "data": {"name": _DEFAULT_VOICE_NAME, "consent": "test-consent"},
+        "files": {
+            "audio_sample": (
+                "clone_2.wav",
+                get_asset_path("qwen3_tts/clone_2.wav").read_bytes(),
+                "audio/wav",
+            ),
+        },
+    }
+    openai_client.send_audio_voices_create_http_request(register_config)
+
+    # 3) After creating the voice with the default name, it's visible as an uploaded_voice
+    voices = openai_client.send_audio_voices_list_http_request()[0]
+    assert _DEFAULT_VOICE_NAME in voices.json_body["voices"]
+    uploaded_names = [v["name"] for v in voices.json_body["uploaded_voices"]]
+    assert _DEFAULT_VOICE_NAME in uploaded_names
+    openai_client.send_audio_speech_request(speech_config)
+
+    # 4) Delete the uploaded default voice
+    openai_client.send_audio_voices_delete_http_request(
+        {"name": _DEFAULT_VOICE_NAME},
+    )
+
+    # 5) Ensure the placeholder behavior is consistent, but it's not an uploaded voice now
+    voices = openai_client.send_audio_voices_list_http_request()[0]
+    assert _DEFAULT_VOICE_NAME in voices.json_body["voices"]
+    uploaded_names = [v["name"] for v in voices.json_body["uploaded_voices"]]
+    assert _DEFAULT_VOICE_NAME not in uploaded_names
     openai_client.send_audio_speech_request(speech_config)

--- a/tests/e2e/online_serving/test_omnivoice_expansion.py
+++ b/tests/e2e/online_serving/test_omnivoice_expansion.py
@@ -144,7 +144,8 @@ class TestOmniVoiceVoiceCloning:
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
-def test_speech_with_voice_param_accepted(omni_server, openai_client) -> None:
+@pytest.mark.parametrize("voice", ["default", {"id": "default"}])
+def test_speech_with_voice_param_accepted(omni_server, openai_client, voice) -> None:
     """Ensure that we can pass a voice string to OmniVoice without exploding;
     this is because the OpenAI spec technically has this param as a required
     string, so for models that don't have any uploaded speakers, passing a
@@ -153,7 +154,7 @@ def test_speech_with_voice_param_accepted(omni_server, openai_client) -> None:
     request_config = {
         "model": omni_server.model,
         "input": get_prompt("text"),
-        "voice": "default",
+        "voice": voice,
         "response_format": "wav",
         "timeout": 180.0,
         "min_audio_bytes": _DEFAULT_MIN_AUDIO_BYTES,

--- a/tests/e2e/online_serving/test_omnivoice_expansion.py
+++ b/tests/e2e/online_serving/test_omnivoice_expansion.py
@@ -14,7 +14,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 import pytest
 
 from tests.helpers.mark import hardware_test
-from tests.helpers.media import load_test_audio_data_url
+from tests.helpers.media import get_asset_path, load_test_audio_data_url
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
 
@@ -160,3 +160,33 @@ def test_speech_with_voice_param_accepted(omni_server, openai_client, voice) -> 
         "min_audio_bytes": _DEFAULT_MIN_AUDIO_BYTES,
     }
     openai_client.send_audio_speech_request(request_config)
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
+def test_voice_request_before_and_after_clone_registration(omni_server, openai_client) -> None:
+    # FIXME - this is bad behavior and needs to be consistent.
+    speech_config = {
+        "model": omni_server.model,
+        "input": get_prompt("text"),
+        "voice": "foo",
+    }
+
+    # 1) Request with an unregistered voice name — should succeed (warning only)
+    openai_client.send_audio_speech_request(speech_config)
+
+    # 2) Register a different cloned voice via POST /v1/audio/voices
+    register_config = {
+        "data": {"name": "bar", "consent": "test-consent"},
+        "files": {
+            "audio_sample": (
+                "clone_2.wav",
+                get_asset_path("qwen3_tts/clone_2.wav").read_bytes(),
+                "audio/wav",
+            ),
+        },
+    }
+    openai_client.send_audio_voices_create_http_request(register_config)
+
+    # 3) Same request again — voice is now registered, should still succeed
+    openai_client.send_audio_speech_request(speech_config)

--- a/tests/e2e/online_serving/test_omnivoice_expansion.py
+++ b/tests/e2e/online_serving/test_omnivoice_expansion.py
@@ -140,3 +140,22 @@ class TestOmniVoiceVoiceCloning:
             "min_audio_bytes": _DEFAULT_MIN_AUDIO_BYTES,
         }
         openai_client.send_audio_speech_request(request_config)
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
+def test_speech_with_voice_param_accepted(omni_server, openai_client) -> None:
+    """Ensure that we can pass a voice string to OmniVoice without exploding;
+    this is because the OpenAI spec technically has this param as a required
+    string, so for models that don't have any uploaded speakers, passing a
+    voice doesn't do anything, and we log a warning instead of throwing.
+    """
+    request_config = {
+        "model": omni_server.model,
+        "input": get_prompt("text"),
+        "voice": "default",
+        "response_format": "wav",
+        "timeout": 180.0,
+        "min_audio_bytes": _DEFAULT_MIN_AUDIO_BYTES,
+    }
+    openai_client.send_audio_speech_request(request_config)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1481,8 +1481,7 @@ async def list_voices(raw_request: Request):
             status_code=HTTPStatus.NOT_FOUND,
         )
 
-    # Get all speakers (both model built-in and uploaded)
-    speakers = sorted(handler.supported_speakers) if handler.supported_speakers else []
+    speakers = sorted(handler._get_available_voices())
 
     # Get uploaded speakers details
     uploaded_speakers = []

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -2,7 +2,6 @@ import math
 from typing import Any, Literal
 
 import numpy as np
-from openai.types.audio.speech_create_params import Voice
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 _MAX_EMBEDDING_DIM = 8192
@@ -55,11 +54,21 @@ class OpenAICreateSpeechRequest(BaseModel):
     # Accept both "voice" (OpenAI convention) and "speaker" (model/internal
     # convention) as input keys.  Intentionally global — all TTS backends
     # (Qwen3-TTS, Voxtral, Fish Speech) use this field for the speaker name.
-    voice: Voice | None = Field(
+    voice: str | None = Field(
         default=None,
         validation_alias=AliasChoices("voice", "speaker"),
         description="Speaker/voice to use. For Qwen3-TTS: vivian, ryan, aiden, etc.",
     )
+
+    @field_validator("voice", mode="before")
+    @classmethod
+    def _normalize_voice(cls, voice: str | dict[str, str]) -> str:
+        if isinstance(voice, dict):
+            if "id" not in voice:
+                raise ValueError("voice dict must contain 'id'")
+            return voice["id"]
+        return voice
+
     instructions: str | None = Field(
         default=None,
         description="Instructions for voice style/emotion (maps to 'instruct' for Qwen3-TTS)",

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -2,6 +2,7 @@ import math
 from typing import Any, Literal
 
 import numpy as np
+from openai.types.audio.speech_create_params import Voice
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 _MAX_EMBEDDING_DIM = 8192
@@ -54,7 +55,7 @@ class OpenAICreateSpeechRequest(BaseModel):
     # Accept both "voice" (OpenAI convention) and "speaker" (model/internal
     # convention) as input keys.  Intentionally global — all TTS backends
     # (Qwen3-TTS, Voxtral, Fish Speech) use this field for the speaker name.
-    voice: str | None = Field(
+    voice: Voice | None = Field(
         default=None,
         validation_alias=AliasChoices("voice", "speaker"),
         description="Speaker/voice to use. For Qwen3-TTS: vivian, ryan, aiden, etc.",

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -135,6 +135,12 @@ _QWEN3_TTS_REF_AUDIO_CACHE_KEY = "_qwen3_tts_ref_audio_cache_key"
 _TTS_MAX_INSTRUCTIONS_LENGTH = 500
 _TTS_MAX_NEW_TOKENS_MAX = 4096
 _MING_DEFAULT_PROMPT = MING_DEFAULT_PROMPT
+_DEFAULT_VOICE_NAME = "default"
+
+def _is_default_voice(voice, supported_speakers):
+    """Check if a lowercased voice name is the placeholder default and not
+    an actual registered/built-in speaker."""
+    return voice == _DEFAULT_VOICE_NAME and voice not in supported_speakers
 
 
 def _create_wav_header(sample_rate: int, num_channels: int = 1, bits_per_sample: int = 16) -> bytes:
@@ -471,7 +477,14 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         self._audex_tta_rvq = None
         self._voxcpm2_split_map: dict[int, list[int]] = {}
 
-        logger.info("Loaded %d supported speakers: %s", len(self.supported_speakers), sorted(self.supported_speakers))
+        if self.supported_speakers:
+            logger.info(
+                "Loaded %d supported speakers: %s", len(self.supported_speakers), sorted(self.supported_speakers)
+            )
+        else:
+            logger.info(
+                "No built-in speakers configured; only '%s' and uploaded voices are available", _DEFAULT_VOICE_NAME
+            )
 
         # Batch configuration
         self._batch_max_items: int = getattr(self.engine_client, "tts_batch_max_items", 32)
@@ -759,6 +772,10 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
 
         # 3. Default fallback
         return _TTS_MAX_INSTRUCTIONS_LENGTH
+
+    def _get_available_voices(self) -> set[str]:
+        """Get all voice names accepted by the API, including the placeholder default."""
+        return self.supported_speakers | self.uploaded_speakers.keys() | {_DEFAULT_VOICE_NAME}
 
     def _load_supported_speakers(self) -> set[str]:
         """Load supported speakers (case-insensitive) from the model configuration."""
@@ -3561,26 +3578,17 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
     def _get_normalized_voice(self, voice: Voice | None) -> str | None:
         """Get the normalized voice to be used; currently this means that
         the voice is a:
-            - lowercase str if it's a valid supported speaker
-            - None if the the model doesn't have any uploaded speakers
-
-        If a voice is passed and we do have uploaded speakers, but it's still
-        not supported, we raise an error.
+            - lowercase str if it's a valid supported/uploaded speaker
+            - None if the voice is the placeholder default or not provided
         """
         if voice is not None:
-            # It's a VoiceID typed dict
             if not isinstance(voice, str):
                 voice = voice["id"]
             voice = voice.lower()
-            if self.uploaded_speakers:
-                if voice not in self.uploaded_speakers and voice not in self.supported_speakers:
-                    all_voices = sorted(self.uploaded_speakers.keys() | self.supported_speakers)
-                    raise ValueError(f"Invalid normalized voice '{voice}'. Supported: {', '.join(all_voices)}")
-            else:
-                logger.warning(
-                    "This model does not have any uploaded speakers, but one was provided; its value will be ignored."
+            if voice not in self.uploaded_speakers and voice not in self.supported_speakers:
+                raise ValueError(
+                    f"Invalid voice '{voice}'. Supported: {', '.join(sorted(self._get_available_voices()))}"
                 )
-                return None
         return voice
 
     async def _create_diffusion_speech(
@@ -3755,6 +3763,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         Raw audio streaming yields each Code2Wav chunk as raw bytes as soon as it is
         decoded. Raw WAV streaming emits a header with placeholder size values first.
         """
+        if request.voice is not None:
+            voice = request.voice if isinstance(request.voice, str) else request.voice["id"]
+            if _is_default_voice(voice.lower(), self.supported_speakers):
+                request.voice = None
+
         if self._diffusion_mode:
             return await self._create_diffusion_speech(request)
 

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -3557,6 +3557,28 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if not artifact_ready:
                 self._discard_ref_audio_artifact_warmup(request_id)
 
+    def _get_normalized_voice(self, voice: str | None) -> str | None:
+        """Get the normalized voice to be used; currently this means that
+        the voice is:
+            - lowercased if it's a valid supported speaker
+            - None if the the model doesn't have any uploaded speakers
+
+        If a voice is passed and we do have uploaded speakers, but it's still
+        not supported, we raise an error.
+        """
+        if voice:
+            voice = voice.lower()
+            if self.uploaded_speakers:
+                if voice not in self.uploaded_speakers and voice not in self.supported_speakers:
+                    all_voices = sorted(self.uploaded_speakers.keys() | self.supported_speakers)
+                    raise ValueError(f"Invalid normalized voice '{voice}'. Supported: {', '.join(all_voices)}")
+            else:
+                logger.warning(
+                    "This model does not have any uploaded speakers, but one was provided; its value will be ignored."
+                )
+                return None
+        return voice
+
     async def _create_diffusion_speech(
         self,
         request: OpenAICreateSpeechRequest,
@@ -3573,11 +3595,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 if fmt_err:
                     return self._diffusion_error_response(fmt_err, status_code=400)
 
-            if request.voice:
-                voice_lower = request.voice.lower()
-                if voice_lower not in self.uploaded_speakers and voice_lower not in self.supported_speakers:
-                    all_voices = sorted(self.uploaded_speakers.keys() | self.supported_speakers)
-                    raise ValueError(f"Invalid voice '{request.voice}'. Supported: {', '.join(all_voices) or 'none'}")
+            request.voice = self._get_normalized_voice(request.voice)
 
             has_inline_ref_audio = request.ref_audio is not None
             err = self._apply_uploaded_speaker(request)
@@ -3592,10 +3610,9 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if request.ref_text:
                 prompt["ref_text"] = request.ref_text
             if request.voice:
-                voice_lower = request.voice.lower()
-                if voice_lower in self.uploaded_speakers and not has_inline_ref_audio:
-                    prompt["voice_name"] = voice_lower
-                    prompt["voice_created_at"] = self._voice_created_at(voice_lower)
+                if request.voice in self.uploaded_speakers and not has_inline_ref_audio:
+                    prompt["voice_name"] = request.voice
+                    prompt["voice_created_at"] = self._voice_created_at(request.voice)
             if request.language:
                 prompt["lang"] = request.language
             if request.instructions:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -20,6 +20,7 @@ import soundfile as sf
 import torch
 from fastapi import HTTPException, Request, UploadFile
 from fastapi.responses import Response, StreamingResponse
+from openai.types.audio.speech_create_params import Voice
 from transformers.utils.hub import cached_file
 from vllm.entrypoints.generate.base.serving import GenerateBaseServing as OpenAIServing
 from vllm.entrypoints.launcher import terminate_if_errored
@@ -3557,16 +3558,19 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if not artifact_ready:
                 self._discard_ref_audio_artifact_warmup(request_id)
 
-    def _get_normalized_voice(self, voice: str | None) -> str | None:
+    def _get_normalized_voice(self, voice: Voice | None) -> str | None:
         """Get the normalized voice to be used; currently this means that
-        the voice is:
-            - lowercased if it's a valid supported speaker
+        the voice is a:
+            - lowercase str if it's a valid supported speaker
             - None if the the model doesn't have any uploaded speakers
 
         If a voice is passed and we do have uploaded speakers, but it's still
         not supported, we raise an error.
         """
-        if voice:
+        if voice is not None:
+            # It's a VoiceID typed dict
+            if not isinstance(voice, str):
+                voice = voice["id"]
             voice = voice.lower()
             if self.uploaded_speakers:
                 if voice not in self.uploaded_speakers and voice not in self.supported_speakers:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -20,7 +20,6 @@ import soundfile as sf
 import torch
 from fastapi import HTTPException, Request, UploadFile
 from fastapi.responses import Response, StreamingResponse
-from openai.types.audio.speech_create_params import Voice
 from transformers.utils.hub import cached_file
 from vllm.entrypoints.generate.base.serving import GenerateBaseServing as OpenAIServing
 from vllm.entrypoints.launcher import terminate_if_errored
@@ -136,6 +135,7 @@ _TTS_MAX_INSTRUCTIONS_LENGTH = 500
 _TTS_MAX_NEW_TOKENS_MAX = 4096
 _MING_DEFAULT_PROMPT = MING_DEFAULT_PROMPT
 _DEFAULT_VOICE_NAME = "default"
+
 
 def _is_default_voice(voice, supported_speakers):
     """Check if a lowercased voice name is the placeholder default and not
@@ -3575,15 +3575,13 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if not artifact_ready:
                 self._discard_ref_audio_artifact_warmup(request_id)
 
-    def _get_normalized_voice(self, voice: Voice | None) -> str | None:
+    def _get_normalized_voice(self, voice: str | None) -> str | None:
         """Get the normalized voice to be used; currently this means that
         the voice is a:
             - lowercase str if it's a valid supported/uploaded speaker
             - None if the voice is the placeholder default or not provided
         """
         if voice is not None:
-            if not isinstance(voice, str):
-                voice = voice["id"]
             voice = voice.lower()
             if voice not in self.uploaded_speakers and voice not in self.supported_speakers:
                 raise ValueError(
@@ -3764,8 +3762,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         decoded. Raw WAV streaming emits a header with placeholder size values first.
         """
         if request.voice is not None:
-            voice = request.voice if isinstance(request.voice, str) else request.voice["id"]
-            if _is_default_voice(voice.lower(), self.supported_speakers):
+            if _is_default_voice(request.voice.lower(), self.supported_speakers):
                 request.voice = None
 
         if self._diffusion_mode:


### PR DESCRIPTION
## Purpose
The OpenAI spec has `voice` as a required string parameter that should not be optional (i.e., see [here](https://github.com/openai/openai-python/blob/main/src/openai/resources/audio/speech.py#L55); voice is not optional, and the `Voice` type alias does not include None type.

```python
Voice: TypeAlias = Union[
    str, Literal["alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse", "marin", "cedar"], VoiceID
]
```

This means that if you start a model that doesn't have any uploaded speakers, e.g., `OmniVoice`, you end up with the following point of awkwardness:
```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:9999/v1", api_key="unused")
response = client.audio.speech.create(
    model="k2-fsa/OmniVoice",
    input="Hello, world.",
)
```

raises on the client side:
```
TypeError: Speech.create() missing 1 required keyword-only argument: 'voice'
```

while passing any string for voice:
```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:9999/v1", api_key="unused")
response = client.audio.speech.create(
    model="k2-fsa/OmniVoice",
    input="Hello, world.",
    voice="vivian",
)
```

gives a 400 on the omni side
```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid voice 'vivian'. Supported: none", 'type': 'BadRequestError', 'param': None, 'code': 400}}
```
including if you pass `voice="none"`, which is how most users probably interpret this. I.e., in that case you'll get this very confusing response:
```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid voice 'none'. Supported: none", 'type':'BadRequestError', 'param': None, 'code': 400}}
```

It is worth noting that you technically _can_ pass `voice=None` currently, and it will pass it and succeed, but this is awkward, and we should not rely on it since `None` is not a valid type for that kwarg.

This PR cleans up voice validation a bit and allows `voice` to be passed as a string for models that do not have any uploaded speakers, so that the request will still work, but they'll just get a warning that voice has no effect. So we only raise if the model actually has supported speakers, and the one that was passed is wrong.

## Test Plan
Add a unit test to omni voice expansion tests to ensure we can succeed when a voice is passed.

## Test Result
unit test passes, and
```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:9999/v1", api_key="unused")
response = client.audio.speech.create(
    model="k2-fsa/OmniVoice",
    input="Hello, world.",
    voice="vivian",
)
```

runs without issues, with the server side log
```
(APIServer pid=1256471) WARNING 08-06 23:58:21 [serving_speech.py:3627] This model does not have any uploaded speakers, but one was provided; its value will be ignored.
```

CC @NickCao @clodaghwalsh17