### PR TITLE
[Perf][MUSA] Restore MiniMax-H3 dynamic RoPE fusion

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -69,6 +69,7 @@ def test_h3_fused_rope_matches_reference_and_preserves_unrotated_dims():
 
     attention = object.__new__(MiniMaxH3Attention)
     nn.Module.__init__(attention)
+    attention.rot_dim = 96
     attention.rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
     attention.rope._forward_method = attention.rope.forward_native
 

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -68,6 +68,7 @@ class RMSNorm(CustomOp):
     def __init__(self, hidden_size: int, eps: float = 1e-6, dtype: torch.dtype = torch.float32) -> None:
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.hidden_size = hidden_size
         self.variance_epsilon = eps
 
     def _forward_fused(self, x: torch.Tensor) -> torch.Tensor:
@@ -106,6 +107,19 @@ class RMSNorm(CustomOp):
             return self._forward_fused(x)
         except Exception:
             return self.forward_native(x)
+
+    def forward_musa(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        # Preserve the aten::rms_norm graph so dynamic Inductor can fuse the
+        # H3 Q/K norm with its inline RoPE path on MUSA.
+        return F.rms_norm(
+            x,
+            (self.hidden_size,),
+            self.weight,
+            self.variance_epsilon,
+        )
 
     def forward_npu(
         self,

--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -190,7 +190,16 @@ class RotaryEmbedding(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        return self.forward_native(x, cos, sin)
+        # Keep the full-dimension NeoX form inline for MUSA compilation.
+        # Other layouts use the shared native implementation.
+        if self.half_head_dim or self.interleaved:
+            return self.forward_native(x, cos, sin)
+        if cos.dim() == 3:
+            cos, sin = cos[0], sin[0]
+        cos = cos.unsqueeze(-2)
+        sin = sin.unsqueeze(-2)
+        x1, x2 = x.chunk(2, dim=-1)
+        return x * cos + torch.cat((-x2, x1), dim=-1) * sin
 
     def forward_native(
         self,

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -333,6 +333,7 @@ class MiniMaxH3Attention(nn.Module):
         )
         self.num_heads = self.qkv_proj.num_heads
         self.num_kv_heads = self.qkv_proj.num_kv_heads
+        self.rot_dim = 6 * arch.rope_inv_freq_len
         self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         self.rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
@@ -365,7 +366,7 @@ class MiniMaxH3Attention(nn.Module):
         x: [T, heads, head_dim]; freqs: [T, rot_dim]. In the unfused path, cos/sin
         are cast to the activation dtype before the elementwise math.
         """
-        rot_dim = freqs.shape[-1]
+        rot_dim = self.rot_dim
         x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
         cos = torch.cos(freqs).to(x.dtype)  # [T, rot_dim]
         sin = torch.sin(freqs).to(x.dtype)


### PR DESCRIPTION
## Summary

- add a MUSA `RMSNorm.forward_musa` path that preserves `aten::rms_norm` for dynamic Inductor fusion;
- implement full-dimension NeoX RoPE in the shared `RotaryEmbedding.forward_musa` backend while retaining `forward_native` for other MUSA layouts;
- keep the MiniMax-H3 caller platform-agnostic and derive its static rotary width from the model config.

## Motivation

This is a MUSA follow-up to #5801. After #5801, MiniMax-H3 routes Q/K normalization and RoPE through the shared RMSNorm/RotaryEmbedding implementation. On MUSA with the production regional compile mode (`torch.compile(fullgraph=True, dynamic=True)`), the actual H3 `_apply_rope` path no longer forms the previous fused schedule.

`RotaryEmbedding.forward_native` is functionally correct, but its generic frequency normalization and expansion do not preserve the fast H3 schedule on MUSA. This PR keeps the model caller on the shared custom-op interface and puts the verified full-dimension NeoX implementation in `RotaryEmbedding.forward_musa`. Half-dimension and interleaved MUSA layouts continue to use `forward_native`; non-MUSA backends are unchanged.

## Performance

Measured from `main` at `a874b8e09bb5251bb16e3de8bc22edf3880eec09`, which contains #5801 merge commit `f2e3d2e25bebc0c7110ccb945d7dcf4be81bf6db`.

Environment and shape:

- 1x MTT S5000, MUSA driver `3.3.5-server`;
- image `registry.mthreads.com/mcconline/inference/vllm-omni@sha256:bdf15f76a86a736cb64bea41a46eeb05be4382f9efe5a520034e7b2f07ce04a5`;
- BF16 packed QKV, sequence length 96,000, 7 local heads, head dimension 128, rotary dimension 96;
- `torch.compile(fullgraph=True, dynamic=True)`;
- 5 warmups, 2 discarded pilot cycles, 20 interleaved cold-cache samples with a 512 MiB cache flush;
- MUSA event timing cross-checked with synchronized wall time.

| exact H3 Q/K norm + RoPE path | MUSA event median | synchronized wall median |
| --- | ---: | ---: |
| current main | 30.0062 ms | 30.0695 ms |
| this PR through `RotaryEmbedding.forward_musa` | 1.6323 ms | 1.6893 ms |
| change | **-94.56% (18.38x)** | **-94.38% (17.80x)** |

In the final interface A/B, the platform-dispatched path was within noise of the direct inline reference (`1.6323` vs `1.6316` ms by MUSA events). A forced shared-native control measured `3.3009` ms, confirming that calling `forward_native` directly does not retain the MUSA fast path. Output is finite, shape-identical, and passes the BF16 correctness gate.

These numbers cover the exact Q/K RMSNorm + H3 RoPE compiled region; they are not presented as TP8 end-to-end request latency.

## Tests

```text
ruff check vllm_omni/diffusion/layers/norm.py \
  vllm_omni/diffusion/layers/rope.py \
  vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py \
  tests/diffusion/layers/test_norm.py \
  tests/diffusion/layers/test_rope_broadcast.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
# All checks passed

pytest -q -p no:cacheprovider \
  tests/diffusion/layers/test_norm.py \
  tests/diffusion/layers/test_rope_broadcast.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
# The 64 remaining cases were all included in the passing 69-case superset run.
```
