### PR TITLE
[BugFix][Nightly CI] Opt in FA deterministic for Qwen-Image accuracy

### DIFF
--- a/tests/e2e/accuracy/test_qwen_image.py
+++ b/tests/e2e/accuracy/test_qwen_image.py
@@ -29,7 +29,7 @@ HEIGHT = 512
 NUM_INFERENCE_STEPS = 20
 TRUE_CFG_SCALE = 4.0
 SEED = 42
-SSIM_THRESHOLD = 0.94
+SSIM_THRESHOLD = 0.97
 PSNR_THRESHOLD = 30.0
 
 MODEL_2512_ID = "Qwen/Qwen-Image-2512"
@@ -69,7 +69,15 @@ def _local_files_only(model: str) -> bool:
 
 
 def _run_vllm_omni_qwen_image(*, model: str, output_path: Path) -> Image.Image:
-    server_args = ["--num-gpus", "1", "--stage-init-timeout", "300", "--init-timeout", "900"]
+    server_args = [
+        "--num-gpus",
+        "1",
+        "--stage-init-timeout",
+        "300",
+        "--init-timeout",
+        "900",
+        "--fa-deterministic",
+    ]
     with OmniServer(model, server_args, use_omni=True) as omni_server:
         response = requests.post(
             f"http://{omni_server.host}:{omni_server.port}/v1/images/generations",

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -394,6 +394,7 @@ class StageDeployConfig:
     # Diffusion execution, cache, and VAE behavior.
     diffusion_compile_granularity: str | None = None
     diffusion_compile_dynamic: bool | None = None
+    fa_deterministic: bool | None = None
     cache_backend: str | None = None
     cache_config: dict[str, Any] | None = None
     enable_cache_dit_summary: bool | None = None

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -15,6 +15,7 @@ from vllm_omni.diffusion.attention.backends.sdpa import _maybe_reshape_attn_mask
 from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
     piecewise_attn,
 )
+from vllm_omni.diffusion.config import get_current_diffusion_config_or_none
 
 logger = init_logger(__name__)
 
@@ -71,8 +72,19 @@ class FlashAttentionImpl(AttentionImpl):
         self.causal = causal
         self.softmax_scale = softmax_scale
         self.qkv_layout = qkv_layout
+        cfg = get_current_diffusion_config_or_none()
+        self.fa_deterministic = bool(getattr(cfg, "fa_deterministic", False)) if cfg is not None else False
         if backend_kwargs:
             logger.warning("FlashAttentionImpl ignoring backend_kwargs: %s", list(backend_kwargs.keys()))
+
+    def _warn_fa_deterministic_non_dense(self, path: str) -> None:
+        if not self.fa_deterministic:
+            return
+        logger.warning_once(
+            "fa_deterministic=True is ignored on the %s FlashAttention path; "
+            "only the dense flash_attn_func path passes deterministic=True.",
+            path,
+        )
 
     @staticmethod
     def _unwrap_flash_output(out: torch.Tensor | tuple[torch.Tensor, ...]) -> torch.Tensor:
@@ -250,6 +262,7 @@ class FlashAttentionImpl(AttentionImpl):
 
         # Try piecewise attention
         if full_attn_spans is not None:
+            self._warn_fa_deterministic_non_dense("piecewise")
             logger.debug("Using piecewise Flash Attention for mixed causal/full mask")
             if flash_attn_func is not None:
                 attn_func = partial(
@@ -280,6 +293,7 @@ class FlashAttentionImpl(AttentionImpl):
             if len(present_packed_keys) != len(packed_keys):
                 missing = sorted(set(packed_keys) - set(present_packed_keys))
                 raise ValueError(f"Incomplete packed FlashAttention metadata; missing {missing}")
+            self._warn_fa_deterministic_non_dense("packed-varlen")
             return self._forward_varlen_packed(
                 query,
                 key,
@@ -291,6 +305,7 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         if attention_mask is not None and torch.any(~attention_mask):
+            self._warn_fa_deterministic_non_dense("masked-varlen")
             return self._forward_varlen_masked(
                 query,
                 key,
@@ -299,15 +314,16 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         if flash_attn_func is not None:
-            out = flash_attn_func(
-                query,
-                key,
-                value,
-                causal=self.causal,
-                softmax_scale=self.softmax_scale,
-            )
+            fa_kwargs = {
+                "causal": self.causal,
+                "softmax_scale": self.softmax_scale,
+            }
+            if self.fa_deterministic:
+                fa_kwargs["deterministic"] = True
+            out = flash_attn_func(query, key, value, **fa_kwargs)
             return self._unwrap_flash_output(out)
 
+        self._warn_fa_deterministic_non_dense("dense-varlen-fallback")
         return self._forward_varlen_dense(
             query,
             key,

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -613,6 +613,9 @@ class OmniDiffusionConfig:
 
     # Attention
     diffusion_attention_config: "AttentionConfig" = field(default_factory=lambda: AttentionConfig())
+    # Opt-in FlashAttention deterministic kernel (slower). Default False keeps
+    # serving on the fast library path; enable via --fa-deterministic.
+    fa_deterministic: bool = False
 
     # Running mode
     # mode: ExecutionMode = ExecutionMode.INFERENCE

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -613,8 +613,6 @@ class OmniDiffusionConfig:
 
     # Attention
     diffusion_attention_config: "AttentionConfig" = field(default_factory=lambda: AttentionConfig())
-    # Opt-in FlashAttention deterministic kernel (slower). Default False keeps
-    # serving on the fast library path; enable via --fa-deterministic.
     fa_deterministic: bool = False
 
     # Running mode

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -188,7 +188,6 @@ class OmniEngineArgs(EngineArgs):
     omni: bool = False
     # Diffusion request-mode batch admission (forwarded to OmniDiffusionConfig).
     request_batch_max_wait_ms: float = 0.0
-    # Opt-in FlashAttention deterministic kernel for diffusion (CLI --fa-deterministic).
     fa_deterministic: bool = False
 
     @classmethod

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -188,6 +188,8 @@ class OmniEngineArgs(EngineArgs):
     omni: bool = False
     # Diffusion request-mode batch admission (forwarded to OmniDiffusionConfig).
     request_batch_max_wait_ms: float = 0.0
+    # Opt-in FlashAttention deterministic kernel for diffusion (CLI --fa-deterministic).
+    fa_deterministic: bool = False
 
     @classmethod
     def _add_omni_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1043,6 +1043,7 @@ class AsyncOmniEngine:
             "diffusion_compile_dynamic": (
                 True if kwargs.get("diffusion_compile_dynamic") is None else kwargs["diffusion_compile_dynamic"]
             ),
+            "fa_deterministic": bool(kwargs.get("fa_deterministic", False)),
             "boundary_ratio": kwargs.get("boundary_ratio", None),
             "flow_shift": kwargs.get("flow_shift", None),
             "diffusion_load_format": kwargs.get("diffusion_load_format", "default"),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -435,6 +435,17 @@ class OmniServeCommand(CLISubcommand):
             ),
         )
         omni_config_group.add_argument(
+            "--fa-deterministic",
+            dest="fa_deterministic",
+            action="store_true",
+            default=False,
+            help=(
+                "Request FlashAttention deterministic=True on the local FLASH_ATTN dense path. "
+                "Slower than the library default deterministic=False; intended for accuracy CI. "
+                "Serving default remains non-deterministic."
+            ),
+        )
+        omni_config_group.add_argument(
             "--diffusers-load-kwargs",
             dest="diffusers_load_kwargs",
             type=json.loads,


### PR DESCRIPTION
FlashAttention defaults to deterministic=False, which allows non-unique results under regional compile (Omni↔Omni bistable first-denoise outputs in #5734). Add OmniDiffusionConfig.fa_deterministic and CLI --fa-deterministic; honor the flag on the local FLASH_ATTN dense path. The Qwen-Image accuracy test enables the CLI via OmniServer and restores SSIM_THRESHOLD to 0.97; serving defaults stay unchanged.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Mitigates intermittent failures in the Qwen-Image accuracy test tracked by [#5734](https://github.com/vllm-project/vllm-omni/issues/5734).

Serving defaults are **unchanged**: regional `torch.compile` + platform-default local `FLASH_ATTN` still use FlashAttention’s library default `deterministic=False` (faster; does not guarantee unique/identical outputs across runs—`deterministic=True` is the slower tradeoff). This PR adds an **opt-in CLI** `--fa-deterministic` so accuracy CI can request `deterministic=True` on the dense local FA call (no env var).

Also restores `SSIM_THRESHOLD` from 0.94 → **0.97**, reversing the temporary workaround in [#4613](https://github.com/vllm-project/vllm-omni/pull/4613). That lower gate was needed because bistable runs could land on a low mode (~SSIM 0.958 on [#13108](https://buildkite.com/vllm/vllm-omni/builds/13108)); with CI pinning the stable FA mode, the original 0.97 gate is appropriate again.

## Investigation

Omni↔Omni divergence with identical inputs is **bistable** (two fixed modes). Pre-loop tensors stay bit-identical; first diverge at **`pos_noise_pred`** after the first denoise.

| Config | Stable? |
|--------|---------|
| `enforce_eager` + FA | Yes (≥15) |
| Regional compile + FA (in Inductor) | No — `pos_noise_pred` |
| Regional compile + `TORCH_SDPA` | Yes (≥15) |
| Regional compile + FA outside Inductor | Yes (≥15) |
| Regional compile + FA in Inductor + `deterministic=True` | Yes (≥15) |

Root cause: FA’s default nondeterministic dense kernel (`deterministic=False`). FA can stay in the compiled graph once `deterministic=True`.

Nightly [#13108](https://buildkite.com/vllm/vllm-omni/builds/13108) (same commit): fail SSIM **0.958** / PSNR **27.80**, manual retry SSIM **0.986** / PSNR **33.67** — classic bistable jump, not a hard regression. Omni↔Diffusers systematic bias on some boxes (~PSNR 28) is separate from this flake.

## Changes

1. `OmniDiffusionConfig.fa_deterministic` (default `False`) + CLI `--fa-deterministic`
2. Local `FLASH_ATTN` dense path passes `deterministic=True` when the flag is set (hub FA untouched)
3. `warning_once` if the flag is set but the call takes a non-dense (piecewise/varlen/masked) path
4. `test_qwen_image_matches_diffusers`: `OmniServer` `server_args` includes `--fa-deterministic`; restore `SSIM_THRESHOLD=0.97`

## Test Result

- [x] Config / dense FA path: default → omit `deterministic`; `fa_deterministic=True` → pass `deterministic=True`
- [x] `test_qwen_image_matches_diffusers` (`--run-level full_model`) on L20X with deterministic opt-in: SSIM **0.960** / PSNR **28.188** (L20X systematic Omni↔Diffusers bias; not the H100 bistable jump). H100 nightly is the real gate for PSNR≥30 and SSIM≥0.97.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)


## Supplement - Options considered

**A. Test-only `--enforce-eager` / `TORCH_SDPA`**  
Zero shared code, but CI leaves default FA+compile uncovered; eager misses Inductor×FA regressions; SDPA also mismatches Diffusers’ FA reference. Rejected.

**B. Qwen-only `@torch.compiler.disable` on joint attention**  
Keeps FA, no shared FA API change, CI≈new Qwen default—but changes Qwen serving compile semantics (product/perf). CI-only boundary rejected (greens a path users don’t run).

**C. Shared FA `deterministic` opt-in via CLI (this PR)**  
Keeps FA+compile in CI; serving default unchanged; no env var; matches the hunt that fixed bistability. Cost: CI ≠ stock serving bit-for-bit (`True` vs `False`); small shared FA / CLI surface.

**Why C:** we want CI on FA + regional compile, stop Omni↔Omni bistability, and not change serving defaults. A drops coverage; B changes Qwen production behavior; C is the smallest shared change that uses the proven knob and stays discoverable via `--help`.

Scope: CI runs FA + regional compile + `deterministic=True`—default architecture plus an accuracy-only kernel flag, not a claim that stock `deterministic=False` serving is bit-stable.
