### PR TITLE
[BugFix][CI] Project fa_deterministic into OmniDiffusionConfig fields

### DIFF
--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -568,6 +568,7 @@ class _DiffusionConfigProjection:
     pin_cpu_memory: bool = True
     diffusion_compile_granularity: Literal["regional", "full"] = "regional"
     diffusion_compile_dynamic: bool = Field(default=True, strict=True)
+    fa_deterministic: bool = False
     vae_use_slicing: bool = False
     vae_use_tiling: bool = False
     mask_strategy_file_path: str | None = None


### PR DESCRIPTION

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Follow-up to [#5887](https://github.com/vllm-project/vllm-omni/pull/5887): that PR added `OmniDiffusionConfig.fa_deterministic` / CLI `--fa-deterministic`, but did not project the field onto `_DiffusionConfigProjection` in `vllm_omni/config/omni_config.py`. Ready/Merge CI then fails `test_diffusion_config_field_classification_covers_current_fields` with an **extra** field `fa_deterministic` ([#5893](https://github.com/vllm-project/vllm-omni/issues/5893)).

This PR adds `fa_deterministic: bool = False` to `_DiffusionConfigProjection` so it is classified with the other diffusion config fields. No serving-behavior change.

## Test Plan

- Run `tests/config/test_omni_config.py::test_diffusion_config_field_classification_covers_current_fields`

**vLLM Version:** `0.26.0`

**vLLM-Omni Commit:** `8d9272f41165f893d85fc8060d2e95970775c0d7`

## Test Result

- [x] `test_diffusion_config_field_classification_covers_current_fields` — passed

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
