### PR TITLE
[Perf][MiniMax H3] Skip redundant per-step token-refiner recompute

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_token_refiner_cache.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_token_refiner_cache.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The token-refiner output is request-static, so the denoise loop avoids
+recomputing it every step. How it does so depends on the offload mode:
+
+* layerwise / no offload -- the refiner weights are resident on GPU for the
+  whole request, so the loop precomputes the refined text once above the step
+  loop and every ``forward`` receives it via ``refined_text_embed``.
+* model (cpu) offload -- the model-level hook only onloads the transformer
+  inside ``forward``; hoisting the refiner above the loop would run it while its
+  weights are still on CPU, forcing an extra CPU<->GPU round-trip that a
+  two-layer refiner can't pay back. So the loop does *not* hoist: it passes the
+  raw text inputs and ``forward`` refines internally every step (weights already
+  onloaded, no extra transfer), exactly matching the pre-optimization path and
+  guaranteeing parity rather than a regression.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+class _RefinerCountingModel:
+    """Minimal stand-in for MiniMaxH3DiTModel used by the denoise loop.
+
+    ``compute_refined_text`` is the sole wrapper around ``condition_proj`` +
+    ``token_refiner``; counting its calls counts the refiner runs. ``forward``
+    mirrors the real contract: it uses the cached ``refined_text_embed`` when
+    present, otherwise refines from the raw ``prompt_embeds`` inputs — exactly
+    what the model does under model cpu offload.
+    """
+
+    def __init__(self, *, img_rows: int, audio_rows: int, hidden: int, enable_cpu_offload: bool) -> None:
+        self.refine_calls = 0
+        self.forward_calls = 0
+        self._img_rows = img_rows
+        self._audio_rows = audio_rows
+        self._hidden = hidden
+        self.od_config = SimpleNamespace(enable_cpu_offload=enable_cpu_offload)
+
+    def compute_refined_text(self, *, prompt_embeds, refiner_packed_seq_params):
+        self.refine_calls += 1
+        text_len = int(prompt_embeds.shape[0])
+        return torch.zeros(text_len, self._hidden, dtype=torch.bfloat16)
+
+    def __call__(self, **kwargs):
+        self.forward_calls += 1
+        # Raw inputs are always present so either path works.
+        assert "prompt_embeds" in kwargs
+        assert "refiner_packed_seq_params" in kwargs
+        if kwargs.get("refined_text_embed") is None:
+            # Model cpu offload path: forward refines internally each step.
+            self.compute_refined_text(
+                prompt_embeds=kwargs["prompt_embeds"],
+                refiner_packed_seq_params=kwargs["refiner_packed_seq_params"],
+            )
+        video_logits = torch.zeros(self._img_rows, 96, dtype=torch.float32)
+        audio_logits = torch.zeros(self._audio_rows, 32, dtype=torch.float32)
+        return video_logits, audio_logits
+
+
+def _build_branch():
+    from vllm_omni.diffusion.models.minimax_h3.denoise_loop import (
+        MiniMaxH3DenoiseBranch,
+    )
+    from vllm_omni.diffusion.models.minimax_h3.packed_sequence import (
+        minimax_h3_packed_sequence,
+    )
+
+    packed = minimax_h3_packed_sequence(
+        text_len=4,
+        latent_t=2,
+        latent_h=4,
+        latent_w=6,
+        audio_t=3,
+        include_keyframe_cond=False,
+    )
+    text_len = int(packed["text_pos"].view(-1).shape[0])
+    branch = MiniMaxH3DenoiseBranch(
+        packed=packed,
+        text_embeddings=torch.zeros(text_len, 5120, dtype=torch.float32),
+        token_tags=packed["token_tags"].clone(),
+        device=torch.device("cpu"),
+    )
+    return branch
+
+
+def _run_loop(branch, model, num_steps):
+    from vllm_omni.diffusion.models.minimax_h3.denoise_loop import (
+        minimax_h3_denoise_loop,
+    )
+
+    img_rows = int(branch.img_pos.shape[0])
+    audio_rows = int(branch.audio_pos.shape[0])
+    sigmas = torch.linspace(1.0, 0.0, num_steps + 1).tolist()
+    minimax_h3_denoise_loop(
+        model=model,
+        positive=branch,
+        initial_video_rows=torch.zeros(img_rows, 96, dtype=torch.float32),
+        initial_audio_rows=torch.zeros(audio_rows, 32, dtype=torch.float32),
+        keyframe_cond_rows=None,
+        sigmas_video=sigmas,
+        sigmas_audio=sigmas,
+        device=torch.device("cpu"),
+    )
+
+
+def _model_for(branch, *, enable_cpu_offload):
+    return _RefinerCountingModel(
+        img_rows=int(branch.img_pos.shape[0]),
+        audio_rows=int(branch.audio_pos.shape[0]),
+        hidden=5120,
+        enable_cpu_offload=enable_cpu_offload,
+    )
+
+
+def test_refiner_hoisted_once_without_model_offload():
+    """layerwise / no offload: refiner runs once, forward gets the cached value."""
+    num_steps = 5
+    branch = _build_branch()
+    model = _model_for(branch, enable_cpu_offload=False)
+
+    _run_loop(branch, model, num_steps)
+
+    assert model.forward_calls == num_steps
+    assert model.refine_calls == 1
+    # The cached embedding is what every forward consumed.
+    assert branch.static_kwargs.get("refined_text_embed") is not None
+
+
+def test_refiner_refined_per_step_under_model_offload():
+    """model cpu offload: no hoist. ``forward`` refines internally every step
+    (matching the pre-optimization path), so there is no cached
+    ``refined_text_embed`` and no extra CPU<->GPU transfer to regress on."""
+    num_steps = 5
+    branch = _build_branch()
+    model = _model_for(branch, enable_cpu_offload=True)
+
+    _run_loop(branch, model, num_steps)
+
+    assert model.forward_calls == num_steps
+    # The loop never hoists under model offload, so every forward refines
+    # internally: one refine per step, and nothing cached on the branch.
+    assert model.refine_calls == num_steps
+    assert branch.static_kwargs.get("refined_text_embed") is None

--- a/vllm_omni/diffusion/models/minimax_h3/denoise_loop.py
+++ b/vllm_omni/diffusion/models/minimax_h3/denoise_loop.py
@@ -71,12 +71,24 @@ class MiniMaxH3DenoiseBranch:
         self.x_base = torch.zeros(1, seq_len, MINIMAX_H3_VIDEO_ROW_WIDTH, dtype=torch.float32, device=device)
         self.audio_x_base = torch.zeros(1, seq_len, MINIMAX_H3_AUDIO_ROW_WIDTH, dtype=torch.float32, device=device)
         text_pos_dev = packed["text_pos"].view(-1).to(torch.long).to(device)
+        # Request-static text hidden states + refiner layout. The refined text
+        # embedding is timestep-independent, so it is computed once and reused
+        # across steps. Depending on offload mode it is either precomputed by
+        # ``prepare_refined_text`` (stored under ``refined_text_embed``) or
+        # refined inside ``forward`` from these raw inputs (model cpu offload);
+        # both are always available so either path works.
+        self._prompt_embeds = text_embeddings.to(device)
+        self._refiner_packed_seq_params = {
+            "cu_seqlens_q": torch.tensor([0, text_len, text_len], dtype=torch.int32, device=device),
+            "max_seqlen_q": text_len,
+        }
         self.static_kwargs: dict[str, Any] = {
             "img_position_ids": packed["img_position_ids"][None].to(device),
             "update_mask": self.update_mask_dev,
             "token_tags": token_tags.view(-1).to(torch.long).to(device),
             "skip_mask_out_condition": False,
-            "prompt_embeds": text_embeddings.to(device),
+            "prompt_embeds": self._prompt_embeds,
+            "refiner_packed_seq_params": self._refiner_packed_seq_params,
             "img_pos_info": {"position_ids": self.img_pos_dev},
             "audio_pos_info": {"position_ids": self.audio_pos_dev},
             "text_pos_info": {"position_ids": text_pos_dev},
@@ -84,10 +96,6 @@ class MiniMaxH3DenoiseBranch:
             "packed_seq_params": {
                 "cu_seqlens_q": cu.to(device),
                 "max_seqlen_q": int(cu[1]),
-            },
-            "refiner_packed_seq_params": {
-                "cu_seqlens_q": torch.tensor([0, text_len, text_len], dtype=torch.int32, device=device),
-                "max_seqlen_q": text_len,
             },
         }
         # Where the video segment sits in the packed sequence. Resolved to plain
@@ -97,6 +105,22 @@ class MiniMaxH3DenoiseBranch:
             prefix_len=int(packed["video_row_start"]),
             latent_grid=(int(grid[0]), int(grid[1]), int(grid[2])),
         )
+
+    def prepare_refined_text(self, model: Any) -> None:
+        """Precompute this branch's request-static refined text embedding.
+
+        Called once by the denoise loop for the layerwise / no-offload path so
+        the token-refiner runs once per request instead of once per step. Under
+        model cpu offload the loop skips this and lets ``forward`` refine from
+        the raw text inputs instead (see the loop for why); in that case
+        ``refined_text_embed`` is simply absent from ``static_kwargs`` and the
+        raw ``prompt_embeds`` / ``refiner_packed_seq_params`` carry the work.
+        """
+        refined = model.compute_refined_text(
+            prompt_embeds=self._prompt_embeds,
+            refiner_packed_seq_params=self._refiner_packed_seq_params,
+        )
+        self.static_kwargs["refined_text_embed"] = refined
 
     def forward_kwargs(
         self,
@@ -199,6 +223,27 @@ def minimax_h3_denoise_loop(
         audio_rows[~audio_update] = audio_anchor
 
     num_steps = len(sigmas_video) - 1
+    # Token-refiner output is request-static (no timestep dependency), so where
+    # possible we compute it once and reuse it across steps instead of once per
+    # forward. Whether that hoist is a win depends on where the refiner weights
+    # live during the loop:
+    #   * layerwise / no offload: refiner weights are resident on GPU for the
+    #     whole request, so hoisting the compute above the loop is a clean win --
+    #     the refiner runs once and ``compute_refined_text``'s onload guard is a
+    #     no-op. Every ``forward`` then consumes the cached ``refined_text_embed``.
+    #   * model (cpu) offload: the model-level hook onloads the transformer only
+    #     *inside* ``forward``. Hoisting here would run the refiner while its
+    #     weights are still on CPU, forcing an extra CPU->GPU->CPU round-trip --
+    #     a net regression for a refiner too small to pay it back. So we simply
+    #     don't hoist: ``forward`` refines internally each step from the raw text
+    #     inputs (weights already onloaded, no extra transfer), exactly matching
+    #     the pre-optimization path. This is deliberately a no-op branch, not an
+    #     oversight -- see PR discussion / tests for the measured parity.
+    is_model_offload = bool(getattr(getattr(model, "od_config", None), "enable_cpu_offload", False))
+    if not is_model_offload:
+        # Kept under inference_mode to match the per-step forward's context.
+        with torch.inference_mode():
+            positive.prepare_refined_text(model)
     for step in range(num_steps):
         step_cm = step_profiler(step) if step_profiler is not None else nullcontext()
         with step_cm:

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -127,13 +128,14 @@ _FORWARD_SUPPORTED_KWARGS = frozenset(
         "update_audio_mask",
         "token_tags",
         "skip_mask_out_condition",
+        "refined_text_embed",
         "prompt_embeds",
+        "refiner_packed_seq_params",
         "img_pos_info",
         "audio_pos_info",
         "text_pos_info",
         "img_pos_for_infer_output_info",
         "packed_seq_params",
-        "refiner_packed_seq_params",
         "video_token_layout",
     }
 )
@@ -1032,24 +1034,83 @@ class MiniMaxH3DiTModel(nn.Module):
             raise ValueError(f"{key}.{field} is required")
         return value
 
+    def compute_refined_text(
+        self,
+        *,
+        prompt_embeds: torch.Tensor,
+        refiner_packed_seq_params: Any,
+    ) -> torch.Tensor:
+        """Project and refine text hidden states into [text_len, H] bf16.
+
+        This output depends only on the request's text embeddings and refiner
+        packed-sequence layout; it carries no timestep dependency, so the
+        denoise loop computes it once and reuses it across every step. It lives
+        outside the regionally compiled DiT blocks, so caching it does not cross
+        a torch.compile / cudagraph capture boundary.
+
+        Because this runs outside :meth:`forward`, the model-level CPU-offload
+        hook (which onloads the DiT only around ``forward``) does not stage the
+        projection/refiner weights. They are onloaded here just for this call and
+        restored to their original devices afterward, so the offload residency
+        contract and peak-memory footprint are unchanged. When the weights are
+        already resident (layer-wise or no offload) the moves are no-ops.
+        """
+        device = prompt_embeds.device
+        refiner_cu = self._psp_field(refiner_packed_seq_params, "refiner_packed_seq_params", "cu_seqlens_q").to(
+            device=device, dtype=torch.int32
+        )
+        refiner_max = int(self._psp_field(refiner_packed_seq_params, "refiner_packed_seq_params", "max_seqlen_q"))
+        with self._modules_onloaded(self.condition_proj, self.token_refiner, device=device):
+            text_rows = prompt_embeds.to(device=device, dtype=_BF16_DTYPE)
+            text_embed, _ = self.condition_proj(text_rows)
+            return self.token_refiner(
+                text_embed,
+                cu_seqlens=refiner_cu,
+                max_seqlen=refiner_max,
+            )
+
+    @staticmethod
+    @contextmanager
+    def _modules_onloaded(*modules: nn.Module, device: torch.device):
+        """Temporarily move ``modules`` to ``device``, restoring origin devices.
+
+        Each module's parameters/buffers are moved to ``device`` on entry and
+        moved back to whatever device they started on upon exit. A module whose
+        weights already live on ``device`` is left untouched (no redundant copy).
+        """
+        original: list[tuple[nn.Module, torch.device]] = []
+        for module in modules:
+            src = next((p.device for p in module.parameters()), None)
+            if src is None or src == device:
+                continue
+            original.append((module, src))
+            module.to(device)
+        try:
+            yield
+        finally:
+            for module, src in original:
+                module.to(src)
+
     def _embed(
         self,
         *,
         x: torch.Tensor,
         audio_x: torch.Tensor,
-        text_embeddings_selected: torch.Tensor,
+        refined_text_embed: torch.Tensor,
         unique_timesteps: torch.Tensor,
         img_pos: torch.Tensor,
         audio_pos: torch.Tensor,
         text_pos: torch.Tensor,
-        refiner_cu_seqlens: torch.Tensor,
-        refiner_max_seqlen: int,
         seq_len: int,
         device: torch.device,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Build packed multimodal embeddings for the TP=1/SP=1 inference path.
 
         Returns (decoder_input [S, H] bf16, t_emb [M, t_dim] fp32).
+
+        ``refined_text_embed`` is the request-static token-refiner output built
+        once by :meth:`compute_refined_text`; the latent embedders below are the
+        only per-step work here.
         """
         # Latent embedders stay fp32 in and out; their outputs are cast to the
         # bf16 sequence dtype only during indexed scattering.
@@ -1058,16 +1119,10 @@ class MiniMaxH3DiTModel(nn.Module):
         audio_rows = audio_x.view(-1, audio_x.shape[-1]).index_select(0, audio_pos).to(_FP32_DTYPE)
         audio_embed, _ = self.audio_patch_proj(audio_rows)
 
-        text_rows = text_embeddings_selected.to(device=device, dtype=_BF16_DTYPE)
-        text_embed, _ = self.condition_proj(text_rows)
-        text_embed = self.token_refiner(
-            text_embed,
-            cu_seqlens=refiner_cu_seqlens,
-            max_seqlen=refiner_max_seqlen,
-        )
+        text_embed = refined_text_embed.to(device=device, dtype=_BF16_DTYPE)
 
         embeddings = torch.zeros((seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE)
-        embeddings.index_add_(0, text_pos, text_embed.to(_BF16_DTYPE)[: text_pos.shape[0]])
+        embeddings.index_add_(0, text_pos, text_embed[: text_pos.shape[0]])
         embeddings.index_add_(0, img_pos, video_embed.to(_BF16_DTYPE)[: img_pos.shape[0]])
         embeddings.index_add_(0, audio_pos, audio_embed.to(_BF16_DTYPE)[: audio_pos.shape[0]])
 
@@ -1100,7 +1155,19 @@ class MiniMaxH3DiTModel(nn.Module):
         token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
         skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
 
-        text_selected = _required_kwarg(kwargs, "prompt_embeds")
+        # Refined text is request-static. The denoise loop precomputes it once
+        # and passes it in via ``refined_text_embed`` (layerwise / no-offload,
+        # where the refiner weights are resident for the whole request). Under
+        # model (cpu) offload there is no loop-level point where the weights are
+        # resident, so the loop passes the raw text inputs instead and we refine
+        # here — inside forward, where the model-level hook has already onloaded
+        # the transformer, so ``compute_refined_text``'s guard is a no-op.
+        refined_text_embed = kwargs.get("refined_text_embed")
+        if refined_text_embed is None:
+            refined_text_embed = self.compute_refined_text(
+                prompt_embeds=_required_kwarg(kwargs, "prompt_embeds"),
+                refiner_packed_seq_params=_required_kwarg(kwargs, "refiner_packed_seq_params"),
+            )
 
         img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
         audio_pos = self._pos_ids(_required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info")
@@ -1116,9 +1183,6 @@ class MiniMaxH3DiTModel(nn.Module):
         psp = _required_kwarg(kwargs, "packed_seq_params")
         cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(torch.int32)
         max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
-        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
-        refiner_cu = self._psp_field(refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q").to(torch.int32)
-        refiner_max = int(self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q"))
         video_layout = kwargs.get("video_token_layout")
 
         if x.dim() != 3 or x.shape[0] != 1:
@@ -1135,13 +1199,11 @@ class MiniMaxH3DiTModel(nn.Module):
         decoder_input, t_emb = self._embed(
             x=x,
             audio_x=audio_x,
-            text_embeddings_selected=text_selected,
+            refined_text_embed=refined_text_embed,
             unique_timesteps=unique_timesteps.view(-1).to(device),
             img_pos=img_pos.to(device),
             audio_pos=audio_pos.to(device),
             text_pos=text_pos.to(device),
-            refiner_cu_seqlens=refiner_cu.to(device),
-            refiner_max_seqlen=refiner_max,
             seq_len=seq_len,
             device=device,
         )


### PR DESCRIPTION
## Purpose

MiniMax H3's token-refiner output (`condition_proj` → `token_refiner`) depends only on the request's text embeddings and refiner packed-sequence layout — it has **no timestep dependency** — yet it is recomputed inside every denoise forward. A 50-step request runs the projection + two refiner blocks 50 times when once is enough.

This PR removes that redundancy in an **offload-mode-aware** way:

- extract `MiniMaxH3DiTModel.compute_refined_text(...)`, a request-static helper outside the regionally compiled DiT blocks (no torch.compile / cudagraph capture boundary crossed);
- **layer-wise / no offload** (refiner weights resident for the whole request): `MiniMaxH3DenoiseBranch.prepare_refined_text(model)` runs it **once** before the loop; every `forward` consumes the cached `refined_text_embed`;
- **model (CPU) offload**: the model-level hook only onloads the transformer *inside* `forward`. Hoisting would run the refiner while its weights are still on CPU, forcing an extra CPU↔GPU round-trip a two-block refiner can't pay back — so the loop does **not** hoist; `forward` refines internally each step, exactly matching the pre-optimization path.

For valid inputs this does not change the denoise algorithm or outputs.

### Correctness

Generated video + audio SHA256 match baseline **bit-for-bit**, verified on **two independent H20 machines** with separately downloaded weights, in **both** offload modes:
- video `9d76478d…`, audio `a7f6bb80…` — identical across both machines and both versions.

### Performance

Single H20, t2va 448×256, `duration=4.0`, seed 42, layer-wise offload. The token-refiner is a 2-block, text-only module (well under 1% of a forward), so the saving is at the level of run-to-run timing noise. Wall-clock jitter is one-directional, so the **minimum over repeated runs** best reflects true compute time; across 15 interleaved runs each:

| Mode | metric | Baseline | This PR | Δ |
| --- | --- | ---: | ---: | ---: |
| layer-wise | min of 15 runs | 46.517 s | 46.418 s | **-0.21% (faster)** |
| model (CPU) offload | — | (byte-identical fallback: same code path) | | 0 |

This is a redundancy-removal / clarity cleanup with a **no-regression** contract: the change does strictly less work in the layer-wise path and takes the unchanged code path under model offload. It is not a meaningful speedup on its own.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 44e38d7b (rebased)

- New unit test `test_minimax_h3_token_refiner_cache.py`: drives the real denoise loop with a call-counting model; asserts the refiner runs **once** under layer-wise/no-offload (cached embed consumed) and **once per step** under model offload (no hoist, nothing cached).
- Existing H3 CPU suite.
- `pre-commit run` (ruff check / ruff format / typos / pytestmark checks).
- H20 end-to-end A/B: bit-identical media hashes in both offload modes, cross-verified on two machines.

## Test Result

- [x] `test_minimax_h3_token_refiner_cache.py`: 2 passed
- [x] H3 CPU suite: 111 passed, 5 deselected
- [x] `pre-commit run` clean on changed files
- [x] E2E A/B bit-identical (layer-wise + model offload), two-machine cross-verified
