### PR TITLE
[Bugfix] Fix MooncakeConnector PD parameter validation

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -45,6 +45,50 @@ def test_orchestrator_startup_timeout_warns_how_to_raise_limits(monkeypatch):
     assert "--stage-init-timeout" in message
 
 
+@pytest.mark.parametrize(
+    ("connector_name", "expected_bootstrap_addr"),
+    [
+        ("MooncakeConnector", "http://10.0.0.8:25301"),
+        ("NixlConnector", "http://10.0.0.8:25301"),
+    ],
+)
+def test_detect_pd_config_returns_connector_metadata(monkeypatch, connector_name, expected_bootstrap_addr):
+    monkeypatch.setattr(async_omni_engine_module.vllm_envs, "VLLM_MOONCAKE_BOOTSTRAP_PORT", 25301)
+    engine = object.__new__(AsyncOmniEngine)
+    kv_cfg = types.SimpleNamespace(
+        kv_connector=connector_name,
+        kv_ip="10.0.0.8",
+    )
+    engine.stage_configs = [
+        types.SimpleNamespace(
+            stage_id=0,
+            is_prefill_only=True,
+            engine_input_source=[],
+            engine_args=types.SimpleNamespace(kv_transfer_config=kv_cfg),
+        ),
+        types.SimpleNamespace(
+            stage_id=1,
+            is_decode_only=True,
+            engine_input_source=[0],
+            engine_args=types.SimpleNamespace(),
+        ),
+    ]
+    engine.stage_clients = [
+        types.SimpleNamespace(
+            vllm_config=types.SimpleNamespace(
+                kv_transfer_config=types.SimpleNamespace(engine_id="prefill-engine"),
+            )
+        )
+    ]
+
+    assert engine._detect_pd_config() == {
+        "pd_pair": (0, 1),
+        "connector_name": connector_name,
+        "bootstrap_addr": expected_bootstrap_addr,
+        "prefill_engine_id": "prefill-engine",
+    }
+
+
 def _make_llm_metadata(
     stage_id: int,
     *,

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -286,6 +286,83 @@ def _sampling_params(max_tokens: int = 4) -> SamplingParams:
     return SamplingParams(max_tokens=max_tokens)
 
 
+def _pd_orchestrator(
+    connector_name: str,
+    *,
+    kv_prefill_params: dict[str, Any] | None = None,
+    bootstrap_addr: str | None = None,
+    prefill_engine_id: str | None = None,
+) -> Orchestrator:
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator._pd_connector_name = connector_name
+    orchestrator._pd_bootstrap_addr = bootstrap_addr
+    orchestrator._pd_prefill_engine_id = prefill_engine_id
+    orchestrator._pd_kv_params = {}
+    if kv_prefill_params is not None:
+        orchestrator._pd_kv_params["req-1"] = kv_prefill_params
+    return orchestrator
+
+
+@pytest.mark.parametrize(
+    ("orchestrator", "expected_key", "expected_value"),
+    [
+        (
+            _pd_orchestrator(
+                "MooncakeConnector",
+                bootstrap_addr="http://127.0.0.1:25201",
+                prefill_engine_id="prefill-engine",
+            ),
+            "remote_bootstrap_addr",
+            "http://127.0.0.1:25201",
+        ),
+        (
+            _pd_orchestrator(
+                "NixlConnector",
+                kv_prefill_params={
+                    "remote_request_id": "prefill-request",
+                },
+            ),
+            "remote_request_id",
+            "prefill-request",
+        ),
+        (
+            _pd_orchestrator(
+                "CustomConnector",
+                kv_prefill_params={"remote_request_id": "prefill-request"},
+            ),
+            "remote_request_id",
+            "prefill-request",
+        ),
+    ],
+)
+def test_build_pd_decode_params_uses_connector_contract(orchestrator, expected_key, expected_value):
+    result = orchestrator._build_pd_decode_params("req-1", _sampling_params())
+    kv_params = result.extra_args["kv_transfer_params"]
+
+    assert kv_params[expected_key] == expected_value
+    assert kv_params["do_remote_prefill"] is True
+    assert kv_params["do_remote_decode"] is False
+
+
+@pytest.mark.parametrize(
+    ("orchestrator", "missing_key"),
+    [
+        (
+            _pd_orchestrator(
+                "MooncakeConnector",
+                bootstrap_addr="http://127.0.0.1:25201",
+            ),
+            "remote_engine_id",
+        ),
+        (_pd_orchestrator("NixlConnector"), "remote_request_id"),
+        (_pd_orchestrator("CustomConnector"), "remote_request_id"),
+    ],
+)
+def test_build_pd_decode_params_reports_missing_connector_metadata(orchestrator, missing_key):
+    with pytest.raises(RuntimeError, match=missing_key):
+        orchestrator._build_pd_decode_params("req-1", _sampling_params())
+
+
 def _engine_core_outputs(tag: str, timestamp: float) -> SimpleNamespace:
     return SimpleNamespace(outputs=[tag], timestamp=timestamp, scheduler_stats=None, finished_requests=None)
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -884,25 +884,29 @@ class AsyncOmniEngine:
 
     def _detect_pd_config(self) -> dict[str, Any] | None:
         """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
-        Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.
+        Returns connector-specific routing metadata, or None.
         """
         pd_pair = PDDisaggregationMixin.detect_pd_separation_from_stage_configs(self.stage_configs)
         if pd_pair is None:
             return None
         prefill_idx, decode_idx = pd_pair
 
-        # Extract bootstrap address from prefill stage engine_args
+        # Extract connector routing metadata from prefill stage engine_args.
+        connector_name: str | None = None
         bootstrap_addr: str | None = None
         try:
             prefill_cfg = self.stage_configs[prefill_idx]
             ea = getattr(prefill_cfg, "engine_args", None)
             kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
             if kv_cfg is not None:
+                raw_connector_name = getattr(kv_cfg, "kv_connector", None)
+                if raw_connector_name:
+                    connector_name = str(raw_connector_name)
                 port = vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT
                 kv_ip = getattr(kv_cfg, "kv_ip", None) or "127.0.0.1"
                 bootstrap_addr = f"http://{kv_ip}:{port}"
         except Exception as exc:
-            logger.warning("[AsyncOmniEngine] Could not extract PD bootstrap address: %s", exc)
+            logger.warning("[AsyncOmniEngine] Could not extract PD connector metadata: %s", exc)
 
         logger.info(
             "[AsyncOmniEngine] PD disaggregation detected: prefill=stage-%d, decode=stage-%d, bootstrap=%s",
@@ -920,6 +924,7 @@ class AsyncOmniEngine:
 
         return {
             "pd_pair": (prefill_idx, decode_idx),
+            "connector_name": connector_name,
             "bootstrap_addr": bootstrap_addr,
             "prefill_engine_id": prefill_engine_id,
         }

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -336,6 +336,7 @@ class Orchestrator:
     _transfer_emitter: Any = None
     _stat_logger: OmniPrometheusStatLogger | None = None
     duplex_control_plane: DuplexControlPlanePort | None = None
+    _pd_connector_name: str | None = None
 
     def __init__(
         self,
@@ -373,11 +374,13 @@ class Orchestrator:
 
         # PD disaggregation state
         self._pd_pair: tuple[int, int] | None = None
+        self._pd_connector_name = None
         self._pd_bootstrap_addr: str | None = None
         self._pd_prefill_engine_id: str | None = None
         self._pd_kv_params: dict[str, Any] = {}
         if pd_config is not None:
             self._pd_pair = pd_config.get("pd_pair")
+            self._pd_connector_name = pd_config.get("connector_name")
             self._pd_bootstrap_addr = pd_config.get("bootstrap_addr")
             self._pd_prefill_engine_id = pd_config.get("prefill_engine_id")
         self.request_states: dict[str, OrchestratorRequestState] = {}
@@ -1655,12 +1658,10 @@ class Orchestrator:
         if sp.extra_args is None:
             sp.extra_args = {}
 
-        # Get KV params captured from the prefill output (must include remote_request_id).
+        # NIXL returns request-scoped routing metadata when prefill finishes.
+        # Mooncake returns None and instead uses the static engine/bootstrap
+        # information discovered during engine initialization.
         kv_prefill_params = self._pd_kv_params.pop(req_id, None)
-        if not kv_prefill_params or "remote_request_id" not in kv_prefill_params:
-            raise RuntimeError(
-                f"[Orchestrator][PD] Missing prefill kv_transfer_params.remote_request_id for req={req_id}"
-            )
 
         decode_kv_params: dict[str, Any] = {
             "transfer_id": f"xfer-{req_id}",
@@ -1672,14 +1673,38 @@ class Orchestrator:
         if self._pd_prefill_engine_id:
             decode_kv_params["remote_engine_id"] = self._pd_prefill_engine_id
 
-        # Overlay params from prefill side (includes remote_request_id set by monkey patch).
-        decode_kv_params.update(kv_prefill_params)
+        # Overlay any request-scoped params returned by the prefill connector.
+        if kv_prefill_params:
+            decode_kv_params.update(kv_prefill_params)
 
         # Ensure these flags are set correctly after any overlay.
         decode_kv_params["do_remote_prefill"] = True
         decode_kv_params["do_remote_decode"] = False
         if not decode_kv_params.get("transfer_id"):
             decode_kv_params["transfer_id"] = f"xfer-{req_id}"
+
+        connector_name = (self._pd_connector_name or "").casefold()
+        if "mooncake" in connector_name:
+            # Mooncake request_finished() returns no request-scoped routing
+            # metadata. The decode side instead uses transfer_id to match the
+            # producer request, remote_bootstrap_addr to discover producer
+            # workers, and remote_engine_id to select the producer engine
+            # registered with that bootstrap server.
+            required_keys = (
+                "transfer_id",
+                "remote_engine_id",
+                "remote_bootstrap_addr",
+            )
+        else:
+            # Preserve the existing NIXL/third-party connector contract.
+            required_keys = ("remote_request_id",)
+
+        missing_keys = [key for key in required_keys if key not in decode_kv_params or decode_kv_params[key] is None]
+        if missing_keys:
+            connector_label = self._pd_connector_name or "KV connector"
+            raise RuntimeError(
+                f"[Orchestrator][PD] Missing {connector_label} decode KV parameters for req={req_id}: {missing_keys}"
+            )
 
         sp.extra_args["kv_transfer_params"] = decode_kv_params
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR fixes connector-specific KV transfer parameter validation in the Prefill-Decode Orchestrator.

The issue was discovered while working on Qwen2.5-Omni 1P1D support. Full Qwen2.5-Omni 1P1D support is still under development and is intentionally outside the scope of this PR.

When a Prefill request finishes, vLLM invokes the KV connector's `request_finished()` method and propagates its second return value as the output `kv_transfer_params`.

`MooncakeConnector.request_finished()` returns:

```python
(delay_free_blocks, None)
```

However, `Orchestrator._build_pd_decode_params()` previously required the Prefill output to contain non-empty kv_transfer_params with remote_request_id. As a result, Mooncake routing failed before the Decode request could be submitted:

```
[Orchestrator][PD] Missing prefill kv_transfer_params.remote_request_id
```

The remote_request_id requirement matches the NIXL connector contract.
NIXL returns request-scoped routing metadata from the Prefill request, and its consumer uses remote_request_id to identify the remote request.

Mooncake uses a different contract. Its Decode request relies on:
- transfer_id to correlate the Prefill and Decode sides of the transfer;
- remote_bootstrap_addr to discover the Prefill workers;
- remote_engine_id to select the Prefill engine registered with the bootstrap server.

This change:
- propagates the configured connector name to the Orchestrator;
- validates Mooncake Decode parameters using transfer_id, remote_engine_id, and remote_bootstrap_addr;
- preserves the existing remote_request_id requirement for NIXL and other connectors;
- keeps the existing bootstrap_addr construction behavior unchanged.

This PR does not add or claim complete Qwen2.5-Omni 1P1D support. The complete deployment configuration and end-to-end coverage will be submitted separately.

## Test Plan

run the newly-added tests:

```bash
pytest -q tests/engine/test_orchestrator.py \
  -k build_pd_decode_params

pytest -q tests/engine/test_async_omni_engine_stage_init.py \
  -k detect_pd_config
```

**vLLM Version:** v0.26.0

**vLLM-Omni Commit:** e9d4a501a7f82f67ef304d9b020458b02844c1a1

## Test Result

All tests passed.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
