### PR TITLE
[Refactor] Introduce StorageBackend abstraction for artifact storage

### DIFF
--- a/vllm_omni/entrypoints/openai/storage/__init__.py
+++ b/vllm_omni/entrypoints/openai/storage/__init__.py
@@ -1,0 +1,38 @@
+"""Pluggable storage backend for generated artifacts (e.g. video files).
+
+Public surface: the ``StorageBackend`` contract, local filesystem
+implementations, and the shared ``STORAGE_MANAGER`` instance.
+"""
+
+# Re-exported for ``vllm_omni.entrypoints.openai.storage`` callers that
+# patch ``storage_module.time.time`` in tests.
+import time  # noqa: F401
+
+from vllm_omni.entrypoints.openai.storage.base import (
+    BaseStorageHandle,
+    FileStorageHandle,
+    SaveContext,
+    StorageBackend,
+)
+from vllm_omni.entrypoints.openai.storage.factory import STORAGE_MANAGER, get_storage_manager
+from vllm_omni.entrypoints.openai.storage.local import (
+    LocalStorageManager,
+    LocalStorageTTLManager,
+)
+
+__all__ = [
+    # base
+    "BaseStorageHandle",
+    "FileStorageHandle",
+    "SaveContext",
+    "StorageBackend",
+    # local implementations
+    "LocalStorageManager",
+    "LocalStorageTTLManager",
+    # factory / instance
+    "get_storage_manager",
+    "STORAGE_MANAGER",
+]
+
+# ``time`` stays out of ``__all__``: it is exported for the test patch
+# mentioned above, not part of the public API.

--- a/vllm_omni/entrypoints/openai/storage/base.py
+++ b/vllm_omni/entrypoints/openai/storage/base.py
@@ -1,0 +1,53 @@
+"""Base abstractions for the storage backend layer."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Literal
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class SaveContext:
+    key: str
+    created_at: int
+    expires_at: int | None = None
+
+
+@dataclass(frozen=True)
+class BaseStorageHandle:
+    kind: str
+
+
+@dataclass(frozen=True)
+class FileStorageHandle(BaseStorageHandle):
+    path: str
+    kind: Literal["path"] = field(default="path", init=False)
+
+
+class StorageBackend(ABC):
+    """Common contract for storing generated artifacts (e.g. video files).
+
+    Concrete backends may expose extra convenience helpers beyond the
+    contract (e.g. ``LocalStorageManager.exists``).
+    """
+
+    @abstractmethod
+    async def save(self, data: bytes, file_name: str) -> SaveContext:
+        """Persist ``data`` under ``file_name`` (relative to the backend root)."""
+
+    @abstractmethod
+    async def delete(self, file_name: str) -> bool:
+        """Remove the object stored under ``file_name``. Returns True if removed."""
+
+    @abstractmethod
+    async def open(self, storage_key: str) -> BaseStorageHandle | None:
+        """Return a handle usable to read back the object, or None if missing."""
+
+    async def start(self) -> None:
+        """Optional resource startup (e.g. background TTL sweeper tasks)."""
+
+    async def stop(self) -> None:
+        """Optional resource shutdown."""

--- a/vllm_omni/entrypoints/openai/storage/factory.py
+++ b/vllm_omni/entrypoints/openai/storage/factory.py
@@ -1,0 +1,32 @@
+"""Storage backend factory and the application-wide instance."""
+
+from vllm_omni.config.server_settings import SERVER_SETTINGS_CONFIG, FileBackend
+from vllm_omni.entrypoints.openai.storage.base import StorageBackend
+from vllm_omni.entrypoints.openai.storage.local import (
+    LocalStorageManager,
+    LocalStorageTTLManager,
+)
+
+
+def get_storage_manager(storage_config: FileBackend) -> StorageBackend:
+    if isinstance(storage_config, FileBackend):
+        if storage_config.file_ttl is not None and storage_config.ttl_sweep_interval is not None:
+            manager: StorageBackend = LocalStorageTTLManager(
+                storage_path=storage_config.path,
+                max_concurrency=storage_config.file_concurrency,
+                ttl_seconds=storage_config.file_ttl,
+                sweep_interval_seconds=storage_config.ttl_sweep_interval,
+            )
+        else:
+            manager = LocalStorageManager(
+                storage_path=storage_config.path, max_concurrency=storage_config.file_concurrency
+            )
+    else:
+        raise ValueError("No supported storage managers")
+
+    return manager
+
+
+STORAGE_MANAGER = get_storage_manager(SERVER_SETTINGS_CONFIG.storage)
+
+__all__ = ["get_storage_manager", "STORAGE_MANAGER"]

--- a/vllm_omni/entrypoints/openai/storage/local.py
+++ b/vllm_omni/entrypoints/openai/storage/local.py
@@ -1,62 +1,24 @@
+"""Local filesystem storage backend."""
+
 import asyncio
 import contextlib
 import os
 import stat
 import time
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from tempfile import NamedTemporaryFile
-from typing import Generic, Literal, TypeVar
 
 from vllm.logger import init_logger
 
-from vllm_omni.config.server_settings import SERVER_SETTINGS_CONFIG, FileBackend
+from vllm_omni.entrypoints.openai.storage.base import (
+    FileStorageHandle,
+    SaveContext,
+    StorageBackend,
+)
 
 logger = init_logger(__name__)
 
 
-@dataclass
-class SaveContext:
-    key: str
-    created_at: int
-    expires_at: int | None = None
-
-
-@dataclass(frozen=True)
-class BaseStorageHandle:
-    kind: str
-
-
-@dataclass(frozen=True)
-class FileStorageHandle(BaseStorageHandle):
-    path: str
-    kind: Literal["path"] = field(default="path", init=False)
-
-
-K = TypeVar("K", bound=BaseStorageHandle, covariant=True)
-
-
-class StorageBaseManager(Generic[K], ABC):
-    @abstractmethod
-    async def save(self, *args, **kwargs) -> SaveContext:
-        pass
-
-    @abstractmethod
-    async def delete(self, *args, **kwargs) -> bool:
-        pass
-
-    async def start(self, *args, **kwargs) -> None:
-        pass
-
-    async def stop(self, *args, **kwargs) -> None:
-        pass
-
-    @abstractmethod
-    async def open(self, storage_key: str) -> K | None:
-        pass
-
-
-class LocalStorageManager(StorageBaseManager[FileStorageHandle]):
+class LocalStorageManager(StorageBackend):
     def __init__(self, storage_path: str, max_concurrency: int = 4):
         self.storage_path = os.path.realpath(storage_path)
         os.makedirs(self.storage_path, exist_ok=True)
@@ -118,7 +80,13 @@ class LocalStorageManager(StorageBaseManager[FileStorageHandle]):
 
 
 class LocalStorageTTLManager(LocalStorageManager):
-    def __init__(self, ttl_seconds: int, sweep_interval_seconds: int, *args, **kwargs):
+    def __init__(
+        self,
+        ttl_seconds: int,
+        sweep_interval_seconds: int,
+        storage_path: str,
+        max_concurrency: int = 4,
+    ):
         if ttl_seconds <= 0:
             raise ValueError("`ttl_seconds` must be greater than or equal to 1.")
         if sweep_interval_seconds <= 0:
@@ -128,7 +96,7 @@ class LocalStorageTTLManager(LocalStorageManager):
         self._sweep_interval_seconds = sweep_interval_seconds
         self._sweeper_task: asyncio.Task[None] | None = None
 
-        super().__init__(*args, **kwargs)
+        super().__init__(storage_path=storage_path, max_concurrency=max_concurrency)
 
     async def save(self, data: bytes, file_name: str) -> SaveContext:
         result = await super().save(data, file_name)
@@ -186,25 +154,3 @@ class LocalStorageTTLManager(LocalStorageManager):
         with contextlib.suppress(asyncio.CancelledError):
             await self._sweeper_task
         self._sweeper_task = None
-
-
-def get_storage_manager(storage_config: FileBackend) -> StorageBaseManager[FileStorageHandle]:
-    if isinstance(storage_config, FileBackend):
-        if storage_config.file_ttl is not None and storage_config.ttl_sweep_interval is not None:
-            manager = LocalStorageTTLManager(
-                storage_path=storage_config.path,
-                max_concurrency=storage_config.file_concurrency,
-                ttl_seconds=storage_config.file_ttl,
-                sweep_interval_seconds=storage_config.ttl_sweep_interval,
-            )
-        else:
-            manager = LocalStorageManager(
-                storage_path=storage_config.path, max_concurrency=storage_config.file_concurrency
-            )
-    else:
-        raise ValueError("No supported storage managers")
-
-    return manager
-
-
-STORAGE_MANAGER = get_storage_manager(SERVER_SETTINGS_CONFIG.storage)


### PR DESCRIPTION
## Purpose

Introduce a `StorageBackend` abstraction for artifact storage, the first step of the unified storage design in RFC #5809.

Split `storage.py` into a package (base/local/factory/__init__.py), replacing the generic `StorageBaseManager` with a concrete ABC. The next step implements the abstraction on OpenDAL, which provides S3 and other storage schemes. Zero behavior change: local manager logic kept verbatim, public API (STORAGE_MANAGER, handles, managers, get_storage_manager) unchanged.

## Test Plan

- ruff check / format on the new package
- mypy (strict) on the package files
- pytest tests/entrypoints/openai_api/test_storage_manager.py -> 5 passed

## Test Result

Existing storage tests pass; no behavior change.

Related: #5809, #2227, #2361
