### PR TITLE
[Model] Optimize MiniCPM-o 4.5 initial codec chunk

### DIFF
--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
@@ -17,9 +17,12 @@ from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import (
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _manager():
+def _manager(*, initial_chunk_frames: int | None = None):
+    extra = {"codec_chunk_frames": 25, "codec_left_context_frames": 3}
+    if initial_chunk_frames is not None:
+        extra["initial_codec_chunk_frames"] = initial_chunk_frames
     return SimpleNamespace(
-        connector=SimpleNamespace(config={"extra": {"codec_chunk_frames": 25, "codec_left_context_frames": 3}}),
+        connector=SimpleNamespace(config={"extra": extra}),
         code_prompt_token_ids=defaultdict(list),
         request_payload={},
         put_req_chunk=defaultdict(int),
@@ -101,6 +104,46 @@ def test_steady_chunk_has_three_code_overlap_and_25_new_codes() -> None:
     assert steady is not None
     assert _codes(steady) == [22, 23, 24, *range(25, 50)]
     assert steady.meta.chunk_seq == 1
+
+
+def test_initial_chunk_then_steady_chunk() -> None:
+    manager = _manager(initial_chunk_frames=8)
+    request = _request("req")
+
+    assert tts2code2wav_async_chunk(manager, _delta(*range(7)), request, False) is None
+    first = tts2code2wav_async_chunk(manager, _delta(7), request, False)
+
+    assert first is not None
+    assert first.meta.codec_chunk_frames == 8
+    assert _codes(first) == [4218, 4218, 4218, *range(8)]
+
+    assert tts2code2wav_async_chunk(manager, _delta(*range(8, 32)), request, False) is None
+    steady = tts2code2wav_async_chunk(manager, _delta(32), request, False)
+
+    assert steady is not None
+    assert steady.meta.codec_chunk_frames == 25
+    assert _codes(steady) == [5, 6, 7, *range(8, 33)]
+
+
+def test_initial_chunk_resets_at_duplex_segment_boundary() -> None:
+    manager = _manager(initial_chunk_frames=8)
+    request = _request("req")
+
+    first = tts2code2wav_async_chunk(manager, _duplex_delta(*range(8)), request, False)
+    boundary = tts2code2wav_async_chunk(manager, _duplex_delta(), request, True)
+    next_segment = tts2code2wav_async_chunk(
+        manager,
+        _duplex_delta(*range(8, 16), turn_id=8),
+        request,
+        False,
+    )
+
+    assert first is not None
+    assert first.meta.codec_chunk_frames == 8
+    assert boundary is not None
+    assert boundary.meta.last_chunk is False
+    assert next_segment is not None
+    assert next_segment.meta.codec_chunk_frames == 8
 
 
 def test_exact_boundary_final_flushes_held_lookahead() -> None:

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -12,6 +12,7 @@ connectors:
       connector_get_sleep_s: 0.01
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
+      initial_codec_chunk_frames: 5
       codec_chunk_frames: 25
       codec_left_context_frames: 3
 

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -125,20 +125,23 @@ def _coerce_int(value):
         return None
 
 
-def _codec_config(transfer_manager: Any) -> tuple[int, int]:
+def _codec_config(transfer_manager: Any) -> tuple[int, int, int]:
     connector = getattr(transfer_manager, "connector", None)
     raw_config = getattr(connector, "config", {}) or {}
     config = raw_config.get("extra", raw_config) if isinstance(raw_config, dict) else {}
     config = config if isinstance(config, dict) else {}
     chunk_frames = int(config.get("codec_chunk_frames", 25))
+    initial_chunk_frames = int(config.get("initial_codec_chunk_frames") or 0)
     left_context_frames = int(config.get("codec_left_context_frames", 3))
-    if chunk_frames <= 0 or left_context_frames < 0:
+    if chunk_frames <= 0 or initial_chunk_frames < 0 or left_context_frames < 0:
         raise ValueError(
             "Invalid MiniCPM-o codec chunk config: "
             f"codec_chunk_frames={chunk_frames}, "
+            f"initial_codec_chunk_frames={initial_chunk_frames}, "
             f"codec_left_context_frames={left_context_frames}"
         )
-    return chunk_frames, left_context_frames
+    initial_chunk_frames = min(initial_chunk_frames or chunk_frames, chunk_frames)
+    return chunk_frames, initial_chunk_frames, left_context_frames
 
 
 def _codec_scalars(value: Any) -> list[int]:
@@ -269,6 +272,7 @@ def tts2code2wav_async_chunk(
             "pending": [],
             "pending_text_utf8": [],
             "segment_text_recorded": False,
+            "segment_chunks_emitted": 0,
             "left_context": [],
             "codec_end": 0,
         }
@@ -289,16 +293,17 @@ def tts2code2wav_async_chunk(
         state["segment_text_recorded"] = True
     request_finished = getattr(request, "is_finished", None)
     finished = bool(is_finished or (callable(request_finished) and request_finished()))
-    chunk_frames, left_context_frames = _codec_config(transfer_manager)
+    chunk_frames, initial_chunk_frames, left_context_frames = _codec_config(transfer_manager)
+    active_chunk_frames = initial_chunk_frames if state["segment_chunks_emitted"] == 0 else chunk_frames
     flush_pending = finished
     last_chunk = bool(flush_pending and (not native_duplex or turn_end))
-    if not flush_pending and len(pending) < chunk_frames:
+    if not flush_pending and len(pending) < active_chunk_frames:
         return None
 
     hold_short_unit = (
         native_duplex and flush_pending and not last_chunk and 0 < len(pending) < _MINICPMO45_MIN_STREAM_BODY_FRAMES
     )
-    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else chunk_frames)
+    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else active_chunk_frames)
     new_codes = pending[:new_token_count]
     del pending[:new_token_count]
     codec_start = int(state["codec_end"])
@@ -319,12 +324,16 @@ def tts2code2wav_async_chunk(
         context = []
         output_codes = []
     state["codec_end"] = codec_end
+    if new_token_count:
+        state["segment_chunks_emitted"] += 1
     code_flat_numel = len(output_codes)
     if native_duplex and code_flat_numel > 0:
         segment_text_utf8 = torch.tensor(pending_text_utf8, dtype=torch.uint8)
         pending_text_utf8.clear()
     if native_duplex and finished:
         state["segment_text_recorded"] = False
+        if not last_chunk:
+            state["segment_chunks_emitted"] = 0
     if flush_pending and not last_chunk and code_flat_numel == 0:
         # Keep the generic generation connector model-agnostic: a real token
         # makes this control-only TTS boundary schedulable, while the explicit
@@ -395,7 +404,7 @@ def tts2code2wav_full_payload(
     internal_id = getattr(request, "request_id", None)
     request_id = str(external_id if external_id is not None else internal_id)
     codes = _extract_codec_delta(pooling_output, request_id)
-    _, left_context_frames = _codec_config(transfer_manager)
+    _, _, left_context_frames = _codec_config(transfer_manager)
     context = [_MINICPMO45_SILENCE_CODE] * left_context_frames if codes else []
     output_codes = [*context, *codes]
 


### PR DESCRIPTION
## Purpose

Similar to Qwen3-omni, use a smaller codec chunk for the first audio payload while keeping the steady-state chunk size unchanged. 

## Implement and Test
I performed multiple paired experiments, fresh-service for 1)candidate frame-size and 2)their adjacent 25-frame baselines. Each arm contains 2 warmups and 32 measured Seed-TTS requests at C=1 as the bench.

| Initial frames | Mean TTFT, control → candidate (ms) | Mean audio TTFP, control → candidate (ms) | TTFP change | Mean RTF, control → candidate | RTF change | Mean E2E, control → candidate (ms) | Mean audio duration/request | Total audio/arm | Output tokens/arm | Success |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 5  | 326.71 → 324.65 | 1122.01 → 877.01 | **-21.84%** | 0.58067 → 0.58069 | +0.00% | 2483.55 → 2492.88 | 4.34375 s | 139.0 s | 481 | 64/64 |
| 8  | 319.99 → 320.70 | 1057.04 → 869.61 | **-17.73%** | 0.47955 → 0.47488 | -0.97% | 2036.71 → 2019.92 | 4.34375 s | 139.0 s | 481 | 64/64 |
| 12 | 320.75 → 322.51 | 1044.33 → 922.84 | **-11.63%** | 0.47126 → 0.48651 | +3.24% | 2000.29 → 2066.53 | 4.34375 s | 139.0 s | 481 | 64/64 |
| 16 | 305.26 → 317.91 | 1023.01 → 948.99 | **-7.24%** | 0.46791 → 0.47176 | +0.82% | 1980.13 → 2001.86 | 4.34375 s | 139.0 s | 481 | 64/64 |

The previous perf shaking is caused by CPU bound, which can be resolved after setting CPU_AFFINITY_CONF=1. 

@lishunyang12 @amy-why-3459 Now there is only 1 line changed for the default size from 12 to 5 (5 is the smallest frame size where the HiFT will keep 160ms PCM, making 4-frame output nothing)

## Future
Add this size to cuda graph batch size.