### PR TITLE
[Bugfix][Frontend] Preserve generated audio in ComfyUI video output

### DIFF
--- a/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/nodes.py
+++ b/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/nodes.py
@@ -163,6 +163,7 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
                 "height": ("INT", {"default": 480, "min": 1}),
                 "fps": ("INT", {"default": 16, "min": 1}),
                 "num_frames": ("INT", {"default": 41, "min": 1}),
+                "generate_sound": ("BOOLEAN", {"default": False}),
             },
             "optional": {
                 "frame": ("IMAGE",),
@@ -195,6 +196,7 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
         height: int,
         fps: int,
         num_frames: int,
+        generate_sound: bool,
         negative_prompt: str | None = None,
         frame: torch.Tensor | None = None,
         references: dict | None = None,
@@ -234,6 +236,7 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
             height=height,
             num_frames=num_frames,
             fps=fps,
+            generate_sound=generate_sound,
             negative_prompt=negative_prompt,
             sampling_params=sampling_params,
             lora=lora,

--- a/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/api_client.py
+++ b/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/api_client.py
@@ -265,6 +265,7 @@ class VLLMOmniClient:
         height: int,
         num_frames: int,
         fps: int,
+        generate_sound: bool = False,
         negative_prompt: str | None = None,
         frame: torch.Tensor | None = None,
         references: dict | None = None,
@@ -284,6 +285,10 @@ class VLLMOmniClient:
         form.add_field("height", str(height))
         form.add_field("num_frames", str(num_frames))
         form.add_field("fps", str(fps))
+        form.add_field(
+            "generate_sound",
+            "true" if generate_sound else "false",
+        )
         if negative_prompt:
             form.add_field("negative_prompt", negative_prompt)
         if sampling_params is not None:

--- a/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/format.py
+++ b/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/format.py
@@ -152,12 +152,29 @@ def bytes_to_video(video_bytes: bytes) -> VideoInput:
             if video_stream is None:
                 raise ValueError("No video stream found in decoded payload.")
 
+            audio_stream = container.streams.audio[-1] if len(container.streams.audio) else None
+
             frames = []
-            for frame in container.decode(video_stream):
-                if not isinstance(frame, VideoFrame):
-                    continue
-                image = frame.to_ndarray(format="rgb24")
-                frames.append(torch.from_numpy(image).float() / 255.0)
+            audio_frames = []
+            resampler = AudioResampler(format="fltp") if audio_stream is not None else None
+
+            streams = [video_stream]
+            if audio_stream is not None:
+                streams.append(audio_stream)
+
+            for frame in container.decode(*streams):
+                if isinstance(frame, VideoFrame):
+                    image = frame.to_ndarray(format="rgb24")
+                    frames.append(torch.from_numpy(image).float() / 255.0)
+
+                elif isinstance(frame, AudioFrame) and resampler is not None:
+                    resampled = resampler.resample(frame)
+                    if not isinstance(resampled, list):
+                        resampled = [resampled]
+
+                    for audio_frame in resampled:
+                        if audio_frame is not None:
+                            audio_frames.append(audio_frame.to_ndarray())
 
             if len(frames) == 0:
                 raise ValueError("No video frames found in decoded payload.")
@@ -166,27 +183,13 @@ def bytes_to_video(video_bytes: bytes) -> VideoInput:
             frame_rate = Fraction(video_stream.average_rate) if video_stream.average_rate else Fraction(1)
 
             audio: AudioInput | None = None
-            if len(container.streams.audio):
-                audio_stream = container.streams.audio[-1]
-                audio_frames = []
-                resampler = AudioResampler(format="fltp")
-                for frame in container.decode(audio_stream):
-                    if not isinstance(frame, AudioFrame):
-                        continue
-                    resampled = resampler.resample(frame)
-                    if not isinstance(resampled, list):
-                        resampled = [resampled]
-                    for audio_frame in resampled:
-                        if audio_frame is not None:
-                            audio_frames.append(audio_frame.to_ndarray())
-
-                if len(audio_frames) > 0:
-                    audio_data = np.concatenate(audio_frames, axis=1)
-                    sample_rate = int(audio_stream.sample_rate) if audio_stream.sample_rate else 1
-                    audio = {
-                        "waveform": torch.from_numpy(audio_data).unsqueeze(0),
-                        "sample_rate": sample_rate,
-                    }
+            if audio_stream is not None and len(audio_frames) > 0:
+                audio_data = np.concatenate(audio_frames, axis=1)
+                sample_rate = int(audio_stream.sample_rate) if audio_stream.sample_rate else 1
+                audio = {
+                    "waveform": torch.from_numpy(audio_data).unsqueeze(0),
+                    "sample_rate": sample_rate,
+                }
 
             components = Types.VideoComponents(
                 images=images,
@@ -194,6 +197,7 @@ def bytes_to_video(video_bytes: bytes) -> VideoInput:
                 audio=audio,
                 metadata=container.metadata if container.metadata else None,
             )
+
     except Exception as e:
         raise RuntimeError(f"Failed to decode video: {e}")
 


### PR DESCRIPTION
## Summary

Fix audio handling in the `ComfyUI-vLLM-Omni` video generation workflow.

This PR addresses two related issues:

1. Exposes the `/v1/videos` `generate_sound` option in the ComfyUI `Generate Video` node and forwards it to the vLLM-Omni API.
2. Fixes audio tracks being dropped when converting generated MP4 responses into ComfyUI `VIDEO` objects.

## Problem

Video models such as MiniMax-H3 can generate native audio together with video when `generate_sound=true`.

However, the current ComfyUI integration has two problems:

- `Generate Video` does not expose or forward the `generate_sound` request parameter.
- Even when the vLLM-Omni server returns an MP4 containing a valid audio stream, `bytes_to_video()` may drop the audio during decoding.

The second issue is caused by decoding the streams sequentially from the same PyAV container:

```python
container.decode(video_stream)
````

followed by:

```python
container.decode(audio_stream)
```

After the video stream has been fully decoded, the container has already been consumed to EOF, so the subsequent audio decode may return no frames.

As a result, the generated ComfyUI `VIDEO` object contains the video frames but has no audio.

## Changes

### Add `generate_sound` support

Add a `generate_sound` boolean option to the `Generate Video` node and forward it through `VLLMOmniClient.generate_video()` as a top-level multipart field for `/v1/videos`.

The default remains `false`, matching the API's existing behavior.

### Preserve audio during video decoding

Update `bytes_to_video()` to decode the selected video and audio streams together in a single pass:

```python
for frame in container.decode(*streams):
    ...
```

Video and audio frames are then handled according to their frame type.

This avoids consuming the container before the audio stream is decoded.

## Testing

Tested end-to-end with:

* MiniMax-H3 FL2VA
* vLLM-Omni video serving API
* ComfyUI-vLLM-Omni
* Python 3.12
* 2x NVIDIA H800 80GB

Verified the following cases:

* `generate_sound=true` produces a ComfyUI `VIDEO` object with working generated audio.
* The MP4 returned directly by the vLLM-Omni server contains both video and audio streams.
* Audio is preserved after conversion through `bytes_to_video()`.
* `generate_sound=false` continues to generate video without audio normally.
* Video-only responses continue to decode correctly.
* Ruff and the relevant pre-commit checks pass for the modified Python files.

## Scope

The decoding fix is not specific to MiniMax-H3. It should apply to any video generation backend that returns an MP4 containing both video and audio streams through the vLLM-Omni video API.
