### PR TITLE
[Diffusion] Enable independent requests for rank-local DLO DP

### DIFF
--- a/docs/design/feature/distributed_layerwise_offload.md
+++ b/docs/design/feature/distributed_layerwise_offload.md
@@ -88,6 +88,36 @@ This path is intentionally not implemented by reusing the AllGather mmap
 loader. It relies on the standard loader so model-specific TP/HSDP transforms
 remain intact.
 
+### Replica-local dispatch and collectives
+
+When DP is greater than one, both DLO modes expose up to `dp_size` scheduler
+slots, but they apply different admission rules. AllGather mode retains the
+normal sampling-parameter compatibility key so a collective wave follows one
+execution schedule. Rank-local mode bypasses that compatibility gate and may
+admit requests with different shapes, denoising steps, guidance, output counts,
+LoRA settings, and model-specific `extra_args`.
+
+The executor broadcasts one assignment vector with one entry per DP replica.
+For a partial rank-local wave, unused entries are `None`; that replica returns
+an empty tagged response without entering model execution. Active workers select
+the assignment at their DP rank, execute it independently, and tag the result
+with that rank so the executor can restore scheduler order. This prevents a
+single request from being duplicated merely to fill a DP wave.
+
+Request-local model collectives must also exclude other DP replicas. The DiT
+group therefore contains the TP/SP/PP/CFG ranks inside one DP replica, and KV
+transfer consensus uses that replica-local group (or its narrower TP group).
+The DLO weight-sharding group is orthogonal: only AllGather mode uses the DP
+group to reconstruct layer weights.
+
+These rules establish three invariants:
+
+1. ordinary batching and AllGather DLO keep compatible-wave admission;
+2. rank-local DLO permits heterogeneous admission only when DP is greater than
+   one; and
+3. idle replicas skip the complete request path but still return a response so
+   RPC collection and teardown remain deterministic.
+
 ## Parallelism compatibility
 
 | Parallelism | DLO + AllGather | DLO without AllGather |
@@ -115,12 +145,16 @@ remain intact.
 
 AllGather DP multi-concurrency requires:
 
-- explicit `num_inference_steps`;
-- the same `num_inference_steps` for all requests in a wave; and
-- identical request arguments that affect the collective execution path.
+- the same explicit `num_inference_steps` for all requests, or the default
+  (`None`) for every request in the wave;
+- identical shape, CFG, output-count, LoRA, and model-specific arguments that
+  affect the collective execution path; and
+- a non-empty prompt for every participating request.
 
 The no-AllGather path does not impose these DLO-specific synchronized-wave
-requirements.
+requirements. Up to `dp_size` heterogeneous requests may run independently;
+partial waves leave unmatched replicas idle. Model-parallel constraints within
+each replica still apply.
 
 The mmap loader is used only by the supported DLO+AllGather path when the
 model has a compatible checkpoint layout. Online quantization is incompatible
@@ -136,7 +170,9 @@ Current source-level validation includes:
 - HSDP + DLO without AllGather acceptance at configuration level;
 - TP rejection in the DLO+AllGather mmap path;
 - resident-layer requests requiring no-AllGather;
-- DP request-wave validation for denoising-step compatibility;
+- compatible-wave admission for AllGather DLO and heterogeneous admission for
+  rank-local DLO;
+- partial-wave idle-rank dispatch and DP-rank result routing;
 - sharding, double-buffer, AllGather-size, and heterogeneous-block regression
   tests.
 
@@ -150,7 +186,9 @@ on the target CUDA/NCCL or CANN/HCCL hardware.
   scaling path.
 - Use **SP + DLO AllGather** for long-sequence workloads when DP concurrency is
   not the goal.
-- Use **no-AllGather** to bring up TP or workstation PCIe configurations, with
-  the expectation of higher host-memory use and lower validation confidence.
+- Use **DP + no-AllGather** for mixed request shapes or asynchronous arrivals
+  that benefit from independent replicas, accepting a full host-side model per
+  DP rank.
+- Also use **no-AllGather** to bring up TP or workstation PCIe configurations.
 - Prefer **HSDP alone** for production HSDP deployments until the combined
   HSDP + DLO no-AllGather path has broader end-to-end coverage.

--- a/docs/design/module/diffusion/continuous_batching.md
+++ b/docs/design/module/diffusion/continuous_batching.md
@@ -31,6 +31,10 @@ requests up to DP capacity because each replica executes one independently
 routed request. This exception MUST NOT relax batching for ordinary request
 batches or AllGather-backed DLO.
 
+Independent rank-local routing currently applies only to request-batch execution.
+Step execution, including `streaming_output=True`, is limited to one running
+request until step dispatch and result routing become DP-aware.
+
 ## Candidate invariants
 
 ### BATCH-INV-001: Compatibility is explicit

--- a/docs/design/module/diffusion/continuous_batching.md
+++ b/docs/design/module/diffusion/continuous_batching.md
@@ -14,13 +14,22 @@ depends_on:
 validation_paths:
   - tests/diffusion/batching/**
 upstream_refs: []
-last_reviewed: 2026-07-16
+last_reviewed: 2026-08-09
 ---
 
 # Diffusion continuous batching
 
 Continuous batching defines when diffusion requests are compatible, how they
 share an execution step, and how each request advances independently.
+
+## DLO admission contract
+
+Request compatibility depends on the DLO execution mode. AllGather-backed DLO
+retains the normal sampling-parameter compatibility gate so each collective wave
+is homogeneous. Rank-local DLO with DP greater than one may admit heterogeneous
+requests up to DP capacity because each replica executes one independently
+routed request. This exception MUST NOT relax batching for ordinary request
+batches or AllGather-backed DLO.
 
 ## Candidate invariants
 

--- a/docs/design/module/diffusion/offloader.md
+++ b/docs/design/module/diffusion/offloader.md
@@ -35,8 +35,8 @@ Distributed layerwise offload has two scheduling contracts:
   weight collective in the same order.
 - **Rank-local mode** streams the tensors produced by the standard loader on
   each rank. DP replicas may execute heterogeneous requests independently, idle
-  replicas skip model execution, and request-scoped process groups keep runtime
-  collectives local to the assigned replica.
+  replicas skip model execution, and replica-local DiT groups keep runtime
+  collectives inside the assigned replica.
 
 These modes trade host-memory efficiency for scheduling independence. Changing
 the mode MUST update admission, dispatch, result routing, abort handling, and

--- a/docs/design/module/diffusion/offloader.md
+++ b/docs/design/module/diffusion/offloader.md
@@ -18,13 +18,29 @@ validation_paths:
   - tests/diffusion/offloader/**
 upstream_refs:
   - torch.nn.Module.to
-last_reviewed: 2026-07-16
+last_reviewed: 2026-08-09
 ---
 
 # Diffusion offloader
 
 The offloader owns component residency, transfer scheduling, memory accounting,
 prefetch, and teardown for diffusion execution.
+
+## Distributed layerwise execution modes
+
+Distributed layerwise offload has two scheduling contracts:
+
+- **AllGather mode** shards each layer across the participating ranks. Requests
+  execute in compatible collective waves because every rank must enter the same
+  weight collective in the same order.
+- **Rank-local mode** streams the tensors produced by the standard loader on
+  each rank. DP replicas may execute heterogeneous requests independently, idle
+  replicas skip model execution, and request-scoped process groups keep runtime
+  collectives local to the assigned replica.
+
+These modes trade host-memory efficiency for scheduling independence. Changing
+the mode MUST update admission, dispatch, result routing, abort handling, and
+teardown as one contract.
 
 ## Candidate invariants
 

--- a/docs/user_guide/diffusion/cpu_offload.md
+++ b/docs/user_guide/diffusion/cpu_offload.md
@@ -199,8 +199,9 @@ For the implementation design and compatibility matrix, see
   reconstructed per-layer via `all_gather_into_tensor`
 - **Fixed double-buffer**: exactly 2 transformer blocks on each device at any
   time, regardless of model size
-- **DP multi-concurrency**: N concurrent requests processed in parallel
-  (AllGather only gathers weight shards, which are request-independent)
+- **DP replica concurrency**: up to N requests execute across N DP replicas;
+  AllGather mode uses compatible waves, while no-AllGather mode permits
+  heterogeneous independent requests and idle replicas in partial waves
 - **mmap weight loading**: weights loaded as mmap views pointing to shared OS
   page cache, eliminating O(dp_size × model_size) RSS during model creation
 - **Platform-agnostic**: works on NVIDIA GPU (CUDA/NCCL) and Ascend NPU
@@ -224,7 +225,7 @@ vllm serve /path/to/model --omni \
   --enable-distributed-layerwise-offload \
   --data-parallel-size 4
 
-# Without DLO AllGather (each rank streams standard-loader rank-local weights)
+# Without DLO AllGather (independent replicas; heterogeneous requests allowed)
 vllm serve /path/to/model --omni \
   --enable-distributed-layerwise-offload \
   --data-parallel-size 4 \
@@ -294,17 +295,27 @@ When not declared, the offloader falls back to `_layerwise_offload_blocks_attrs`
 and heuristic attribute search.  This is backward-compatible — existing models
 work without any changes.
 
-### DP Multi-concurrency
+### DP request concurrency
 
-When `--data-parallel-size > 1` and AllGather is enabled, the scheduler batches
-up to `dp_size` requests per denoise step.  Each DP rank processes a different
-request while AllGather synchronizes only weight shards (request-independent).
+With `--data-parallel-size N`, both DLO modes admit up to N requests and assign
+at most one request to each DP replica. Submit requests normally; the scheduler
+forms replica waves automatically.
 
-**Requirements for concurrent requests:**
-- `num_inference_steps` must be specified explicitly (None is not allowed)
-- All concurrent requests must have the same `num_inference_steps` value
-- These constraints exist because AllGather is a collective that requires
-  every rank to participate at each denoise step
+| Mode | Requests admitted together | Partial wave behavior |
+|------|----------------------------|-----------------------|
+| DLO + AllGather | Requests must share shape, CFG, denoising schedule, output count, LoRA settings, and `extra_args`. Prompts must be non-empty. | Assignments may repeat so every rank enters the same weight collectives. |
+| DLO without AllGather | Requests may use different shapes, steps, guidance, output counts, LoRAs, and `extra_args`. | Unassigned replicas are idle and skip model execution. |
+
+For AllGather, all requests may either use the same explicit
+`num_inference_steps` or all use the model's default (`None`); mixing the two is
+incompatible. These constraints keep every rank on the same collective path.
+
+Rank-local DLO has no DLO weight collective, so heterogeneous requests can
+progress independently. The standard loader still defines each rank's tensor
+layout, and TP/SP/PP/CFG collectives remain active inside each DP replica. Pure
+DP also keeps a full host-side model copy per rank. This makes no-AllGather a
+good fit for mixed workloads and asynchronous arrivals, while AllGather is the
+host-memory-efficient choice for homogeneous waves.
 
 ### Limitations
 - Online quantization (FP8) is incompatible with mmap loading — falls back to
@@ -317,7 +328,7 @@ request while AllGather synchronizes only weight shards (request-independent).
 - HSDP + AllGather is rejected because it would double-shard parameters. HSDP
   with no-AllGather is accepted at configuration level, but has limited
   end-to-end validation.
-- `num_inference_steps=None` is not allowed in DP multi-concurrency mode
+- AllGather DP waves cannot mix incompatible sampling parameters or `extra_args`
 
 **Module Discovery**
 

--- a/examples/offline_inference/minimax_h3/dlo_dp2_lifecycle.py
+++ b/examples/offline_inference/minimax_h3/dlo_dp2_lifecycle.py
@@ -45,9 +45,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True, help="Path to MiniMax-H3/FL2VA")
     parser.add_argument(
         "--mode",
-        choices=("dlo-dp2", "request"),
+        choices=("dlo-dp2", "dlo-dp2-rank-local", "request"),
         required=True,
-        help="DLO AllGather DP2 or ordinary non-DLO TP2 request mode",
+        help="DLO DP2 (AllGather or rank-local) or ordinary non-DLO TP2 request mode",
     )
     parser.add_argument("--steps", type=int, default=2)
     parser.add_argument("--duration", type=float, default=5.0)
@@ -74,14 +74,14 @@ def engine_kwargs(args: argparse.Namespace) -> dict[str, Any]:
         "stage_init_timeout": args.init_timeout,
         "init_timeout": args.init_timeout,
     }
-    if args.mode == "dlo-dp2":
+    if args.mode in ("dlo-dp2", "dlo-dp2-rank-local"):
         common.update(
             tensor_parallel_size=1,
             data_parallel_size=2,
             text_encoder_tp_size=1,
             vae_patch_parallel_size=1,
             enable_distributed_layerwise_offload=True,
-            dlo_use_allgather=True,
+            dlo_use_allgather=args.mode == "dlo-dp2",
             dlo_resident_layers=0,
         )
     else:
@@ -99,13 +99,14 @@ def sampling_params(
     engine: AsyncOmni,
     args: argparse.Namespace,
     seed: int,
+    steps: int | None = None,
 ) -> list[Any]:
     params = copy.deepcopy(engine.default_sampling_params_list)
     diffusion = params[0]
     diffusion.width = args.width
     diffusion.height = args.height
     diffusion.fps = 24
-    diffusion.num_inference_steps = args.steps
+    diffusion.num_inference_steps = args.steps if steps is None else steps
     diffusion.seed = seed
     diffusion.extra_args = {
         "task": "t2va",
@@ -124,12 +125,13 @@ async def generate_one(
     request_id: str,
     prompt: str,
     seed: int,
+    steps: int | None = None,
 ) -> Any:
     final_output = None
     async for output in engine.generate(
         prompt=prompt,
         request_id=request_id,
-        sampling_params_list=sampling_params(engine, args, seed),
+        sampling_params_list=sampling_params(engine, args, seed, steps),
     ):
         if output.finished:
             final_output = output
@@ -198,22 +200,64 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
             if len(summary["asymmetric_errors"]) != 2:
                 raise RuntimeError("Both requests in the asymmetric DP wave must fail before dispatch")
 
-        started = time.perf_counter()
-        request_count = 2 if args.mode == "dlo-dp2" else 1
-        outputs = await asyncio.gather(
-            *(
-                generate_one(
+        is_rank_local = args.mode == "dlo-dp2-rank-local"
+        request_count = 2 if args.mode in ("dlo-dp2", "dlo-dp2-rank-local") else 1
+        request_steps = [args.steps + index if is_rank_local else args.steps for index in range(request_count)]
+
+        if is_rank_local:
+            started = time.perf_counter()
+            partial_output = await generate_one(
+                engine,
+                args,
+                request_id="partial-wave",
+                prompt=DEFAULT_PROMPTS[0],
+                seed=1500,
+                steps=args.steps,
+            )
+            summary["partial_wave_s"] = time.perf_counter() - started
+            summary["partial_output"] = output_summary(partial_output, args)
+            del partial_output
+
+        async def run_pair(prefix: str, seed_base: int) -> list[Any]:
+            return await asyncio.gather(
+                *(
+                    generate_one(
+                        engine,
+                        args,
+                        request_id=f"{prefix}-{index}",
+                        prompt=DEFAULT_PROMPTS[index],
+                        seed=seed_base + index,
+                        steps=request_steps[index],
+                    )
+                    for index in range(request_count)
+                )
+            )
+
+        if is_rank_local:
+            warmup_outputs = await run_pair("warmup", 1800)
+            del warmup_outputs
+
+            started = time.perf_counter()
+            serial_summaries = []
+            for index in range(request_count):
+                output = await generate_one(
                     engine,
                     args,
-                    request_id=f"recovery-{index}",
+                    request_id=f"serial-{index}",
                     prompt=DEFAULT_PROMPTS[index],
-                    seed=2000 + index,
+                    seed=1900 + index,
+                    steps=request_steps[index],
                 )
-                for index in range(request_count)
-            )
-        )
+                serial_summaries.append(output_summary(output, args))
+            summary["serial_pair_s"] = time.perf_counter() - started
+            summary["serial_outputs"] = serial_summaries
+
+        started = time.perf_counter()
+        outputs = await run_pair("recovery", 2000)
         summary["valid_wave_s"] = time.perf_counter() - started
         summary["outputs"] = [output_summary(output, args) for output in outputs]
+        if is_rank_local:
+            summary["concurrent_speedup"] = summary["serial_pair_s"] / summary["valid_wave_s"]
     finally:
         started = time.perf_counter()
         engine.close()

--- a/tests/diffusion/distributed/test_parallel_state_sp_groups.py
+++ b/tests/diffusion/distributed/test_parallel_state_sp_groups.py
@@ -9,7 +9,8 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm_omni.diffusion.distributed.parallel_state import RankGenerator, set_seq_parallel_pg
+import vllm_omni.diffusion.distributed.parallel_state as parallel_state
+from vllm_omni.diffusion.distributed.parallel_state import RankGenerator, init_dit_group, set_seq_parallel_pg
 
 pytestmark = [pytest.mark.diffusion, pytest.mark.parallel, pytest.mark.core_model, pytest.mark.cpu]
 
@@ -103,3 +104,39 @@ def test_set_seq_parallel_pg_validates_sp_group_ranks(monkeypatch):
             world_size=4,
             sp_group_ranks=[[0, 2]],
         )
+
+
+@pytest.mark.parametrize(
+    "rank, expected_group",
+    [
+        (0, [0, 1, 2, 3]),
+        (3, [0, 1, 2, 3]),
+        (4, [4, 5, 6, 7]),
+        (7, [4, 5, 6, 7]),
+    ],
+)
+def test_init_dit_group_is_local_to_each_dp_replica(rank, expected_group, monkeypatch):
+    created_coordinators: list[SimpleNamespace] = []
+
+    def fake_group_coordinator(group_ranks, local_rank, torch_distributed_backend):
+        local_group = next(group for group in group_ranks if rank in group)
+        coordinator = SimpleNamespace(
+            all_group_ranks=group_ranks,
+            ranks=local_group,
+            local_rank=local_rank,
+            backend=torch_distributed_backend,
+            device_group=SimpleNamespace(ranks=local_group),
+        )
+        created_coordinators.append(coordinator)
+        return coordinator
+
+    monkeypatch.setattr(parallel_state, "GroupCoordinator", fake_group_coordinator)
+    monkeypatch.setattr(parallel_state, "_DIT", None)
+
+    rank_generator = RankGenerator(1, 4, 1, 1, 2, "tp-sp-pp-cfg-dp")
+    group_ranks = rank_generator.get_ranks("tp-sp-pp-cfg")
+    init_dit_group(group_ranks, rank, "gloo")
+
+    assert created_coordinators[0].all_group_ranks == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert parallel_state.get_dit_group_coordinator().ranks == expected_group
+    assert parallel_state.get_dit_group().ranks == expected_group

--- a/tests/diffusion/test_diffusion_engine.py
+++ b/tests/diffusion/test_diffusion_engine.py
@@ -436,6 +436,21 @@ class TestRequestBatchCapability:
         assert scheduled.num_waiting_reqs == int(dlo_use_allgather)
         fake_executor_cls.assert_called_once_with(od_config)
 
+    def test_dlo_dp_step_execution_remains_serial(self) -> None:
+        engine = object.__new__(DiffusionEngine)
+        engine.od_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(data_parallel_size=2),
+            enable_distributed_layerwise_offload=True,
+            request_batch_max_wait_ms=0,
+        )
+        engine.step_execution = True
+        engine.scheduler = SimpleNamespace(max_num_running_reqs=2)
+
+        engine._init_runtime_state()
+
+        assert engine.dp_concurrent is False
+        assert engine.scheduler.max_num_running_reqs == 1
+
     @pytest.mark.parametrize("request_ids", [("req-a",), ("req-a", "req-b")])
     def test_engine_enables_batch_dispatch_for_request_batch_pipeline(
         self,

--- a/tests/diffusion/test_diffusion_engine.py
+++ b/tests/diffusion/test_diffusion_engine.py
@@ -371,8 +371,10 @@ class TestRequestBatchCapability:
             DiffusionEngine(od_config)
         fake_executor_cls.assert_not_called()
 
+    @pytest.mark.parametrize("dlo_use_allgather", [True, False])
     def test_engine_allows_independent_dlo_dp_requests_for_single_request_pipeline(
         self,
+        dlo_use_allgather: bool,
         monkeypatch: pytest.MonkeyPatch,
         mocker: MockerFixture,
     ) -> None:
@@ -384,7 +386,7 @@ class TestRequestBatchCapability:
             request_batch_max_wait_ms=0,
             parallel_config=SimpleNamespace(data_parallel_size=2),
             enable_distributed_layerwise_offload=True,
-            dlo_use_allgather=True,
+            dlo_use_allgather=dlo_use_allgather,
         )
         fake_executor = SimpleNamespace(
             execute_request=mocker.Mock(return_value="per-request"),

--- a/tests/diffusion/test_diffusion_engine.py
+++ b/tests/diffusion/test_diffusion_engine.py
@@ -372,7 +372,7 @@ class TestRequestBatchCapability:
         fake_executor_cls.assert_not_called()
 
     @pytest.mark.parametrize("dlo_use_allgather", [True, False])
-    def test_engine_allows_independent_dlo_dp_requests_for_single_request_pipeline(
+    def test_engine_configures_dlo_dp_request_admission(
         self,
         dlo_use_allgather: bool,
         monkeypatch: pytest.MonkeyPatch,
@@ -420,6 +420,20 @@ class TestRequestBatchCapability:
         assert engine.dp_concurrent is True
         assert engine.scheduler.max_num_running_reqs == 2
         assert od_config.request_batch_max_wait_ms == 0
+
+        for request_id, num_steps in (("req-a", 2), ("req-b", 3)):
+            engine.scheduler.add_request(
+                OmniDiffusionRequest(
+                    prompt=f"prompt_{request_id}",
+                    sampling_params=OmniDiffusionSamplingParams(num_inference_steps=num_steps),
+                    request_id=request_id,
+                )
+            )
+        scheduled = engine.scheduler.schedule()
+
+        expected_ids = ["req-a"] if dlo_use_allgather else ["req-a", "req-b"]
+        assert [request.request_id for request in scheduled.scheduled_new_reqs] == expected_ids
+        assert scheduled.num_waiting_reqs == int(dlo_use_allgather)
         fake_executor_cls.assert_called_once_with(od_config)
 
     @pytest.mark.parametrize("request_ids", [("req-a",), ("req-a", "req-b")])

--- a/tests/diffusion/test_multiproc_engine_concurrency.py
+++ b/tests/diffusion/test_multiproc_engine_concurrency.py
@@ -26,7 +26,7 @@ from vllm_omni.diffusion.sched.interface import (
     NewRequestData,
 )
 from vllm_omni.diffusion.stage_diffusion_proc import StageDiffusionProc
-from vllm_omni.diffusion.worker.diffusion_worker import WorkerProc
+from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker, WorkerProc
 from vllm_omni.diffusion.worker.utils import BatchRunnerOutput, RunnerOutput
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
@@ -265,6 +265,82 @@ class TestRequestModeDispatch:
         assert result == "dlo-dp"
         executor.execute_request.assert_called_once_with(scheduler_output)
         executor.collective_rpc.assert_not_called()
+
+    def test_rank_local_dlo_dp_routes_multiple_requests_without_pipeline_batching(self):
+        executor, _, _ = _make_executor(num_gpus=2)
+        executor.od_config = SimpleNamespace(
+            step_execution=False,
+            parallel_config=SimpleNamespace(data_parallel_size=2),
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+        )
+        executor.execute_request = Mock(return_value="rank-local-dlo-dp")
+        executor.collective_rpc = Mock()
+        scheduler_output = _make_sched_output("A", "B")
+
+        result = executor.execute_batch(scheduler_output)
+
+        assert result == "rank-local-dlo-dp"
+        executor.execute_request.assert_called_once_with(scheduler_output)
+        executor.collective_rpc.assert_not_called()
+
+    def test_rank_local_dlo_dp_allows_heterogeneous_requests(self):
+        executor, _, _ = _make_executor(num_gpus=2)
+        executor.od_config = SimpleNamespace(
+            step_execution=False,
+            parallel_config=SimpleNamespace(data_parallel_size=2),
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+        )
+        executor.collective_rpc = Mock(return_value=[_tagged_output("A"), _tagged_output("B")])
+        scheduler_output = _make_sched_output("A", "B")
+        scheduler_output.scheduled_new_reqs[1].req.sampling_params.num_inference_steps = 2
+        scheduler_output.scheduled_new_reqs[1].req.sampling_params.guidance_scale = 7.5
+        scheduler_output.scheduled_new_reqs[1].req.sampling_params.width = 1024
+        scheduler_output.scheduled_new_reqs[1].req.sampling_params.extra_args = {"task": "image-to-video"}
+
+        result = executor.execute_request(scheduler_output)
+
+        assert [output.result.error for output in result.runner_outputs] == ["A", "B"]
+        assignments = executor.collective_rpc.call_args.kwargs["args"][0]
+        assert [request.request_id for request in assignments] == ["A", "B"]
+        assert executor.collective_rpc.call_args.kwargs["unique_reply_rank"] is None
+
+    def test_rank_local_dlo_dp_partial_wave_pads_idle_replica(self):
+        executor, _, _ = _make_executor(num_gpus=2)
+        executor.od_config = SimpleNamespace(
+            step_execution=False,
+            parallel_config=SimpleNamespace(data_parallel_size=2),
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+        )
+        executor.collective_rpc = Mock(return_value=[_tagged_output("A"), None])
+
+        result = executor.execute_request(_make_sched_output("A"))
+
+        assert [output.result.error for output in result.runner_outputs] == ["A"]
+        assignments = executor.collective_rpc.call_args.kwargs["args"][0]
+        assert assignments[0].request_id == "A"
+        assert assignments[1] is None
+        assert executor.collective_rpc.call_args.kwargs["unique_reply_rank"] is None
+
+    def test_rank_local_dlo_worker_skips_idle_replica(self, monkeypatch):
+        worker = object.__new__(DiffusionWorker)
+        worker.model_runner = Mock()
+        worker.lora_manager = None
+        worker._get_profiler = Mock(return_value=None)
+        monkeypatch.setattr(
+            "vllm_omni.diffusion.distributed.parallel_state.get_data_parallel_rank",
+            lambda: 1,
+        )
+
+        result = worker.execute_model(
+            [_mock_request("A"), None],
+            SimpleNamespace(dlo_use_allgather=False),
+        )
+
+        assert result == {"dp_rank": 1, "output": None}
+        worker.model_runner.execute_model.assert_not_called()
 
     def test_dlo_dp_multi_rank_reply_uses_synchronous_rpc_collection(self):
         executor, req_q, res_q = _make_executor(num_gpus=2)

--- a/tests/distributed/omni_connectors/test_kv_async_prefetch.py
+++ b/tests/distributed/omni_connectors/test_kv_async_prefetch.py
@@ -242,7 +242,9 @@ import vllm_omni.diffusion.distributed.parallel_state as ps  # noqa: E402
 
 
 def _patch_topo(monkeypatch, *, world_size, world_rank=0, cfg_size=1, cfg_rank=0, sp_size=1, sp_rank=0):
-    monkeypatch.setattr(ps, "get_world_group", lambda: SimpleNamespace(world_size=world_size, rank_in_group=world_rank))
+    monkeypatch.setattr(
+        ps, "get_dit_group_coordinator", lambda: SimpleNamespace(world_size=world_size, rank_in_group=world_rank)
+    )
     monkeypatch.setattr(ps, "get_classifier_free_guidance_world_size", lambda: cfg_size)
     monkeypatch.setattr(ps, "get_classifier_free_guidance_rank", lambda: cfg_rank)
     monkeypatch.setattr(ps, "get_cfg_group", lambda: None)
@@ -319,7 +321,7 @@ def test_recv_role_uninitialized_defaults_local(monkeypatch):
     def _boom():
         raise AssertionError("world group is not initialized")
 
-    monkeypatch.setattr(ps, "get_world_group", _boom)
+    monkeypatch.setattr(ps, "get_dit_group_coordinator", _boom)
     assert _role(mgr) is ReceiveRole.LOCAL
 
 

--- a/tests/distributed/omni_connectors/test_kv_recv_tp_consensus.py
+++ b/tests/distributed/omni_connectors/test_kv_recv_tp_consensus.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import vllm_omni.diffusion.distributed.parallel_state as parallel_state
 from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
     OmniKVCacheConfig,
@@ -134,6 +135,20 @@ def test_world_group_is_never_used_for_the_exchange():
     assert mgr._tp_local_receive_consensus(req, True) is True
     assert tp_group.touched
     assert not world.touched
+
+
+def test_transfer_topology_uses_replica_local_dit_group(monkeypatch):
+    replica = SimpleNamespace(world_size=1, rank_in_group=0)
+    monkeypatch.setattr(parallel_state, "get_dit_group_coordinator", lambda: replica)
+    monkeypatch.setattr(
+        parallel_state,
+        "get_world_group",
+        lambda: pytest.fail("global world must not be used for request-local KV transfer"),
+    )
+
+    manager = OmniKVTransferManager(OmniKVCacheConfig())
+    assert manager.topo_config.is_local
+    assert manager.topo_config.world is replica
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/distributed/omni_connectors/test_tp_rank_aware.py
+++ b/tests/distributed/omni_connectors/test_tp_rank_aware.py
@@ -576,7 +576,7 @@ class TestDistributedReceive:
 
         mgr.receive_multi_kv_cache = MagicMock(side_effect=_receive)
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=3,
@@ -641,7 +641,7 @@ class TestDistributedReceive:
 
         mgr.receive_multi_kv_cache = MagicMock(return_value=True)
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=2,
@@ -689,7 +689,7 @@ class TestDistributedReceive:
         mgr.receive_multi_kv_cache = MagicMock(return_value=True)
 
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=1,
@@ -753,7 +753,7 @@ class TestDistributedReceive:
 
         mgr.receive_multi_kv_cache = MagicMock(side_effect=_receive)
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=1,
@@ -848,7 +848,7 @@ class TestDistributedReceive:
             mgr.receive_multi_kv_cache = MagicMock(return_value=True)
 
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=2,
@@ -913,7 +913,7 @@ class TestDistributedReceive:
 
         mgr.receive_multi_kv_cache = MagicMock(return_value=False)
         with (
-            patch("vllm_omni.diffusion.distributed.parallel_state.get_world_group", return_value=world_group),
+            patch("vllm_omni.diffusion.distributed.parallel_state.get_dit_group_coordinator", return_value=world_group),
             patch(
                 "vllm_omni.diffusion.distributed.parallel_state.get_classifier_free_guidance_world_size",
                 return_value=cfg_size,

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -254,7 +254,12 @@ class DiffusionEngine:
         # dispatch heterogeneous requests independently. Ordinary DP with a
         # non-batch pipeline still does not schedule multiple requests.
         dp_size = getattr(getattr(self.od_config, "parallel_config", None), "data_parallel_size", 1)
-        if _uses_dlo_dp_concurrency(self.od_config):
+        uses_dlo_dp_concurrency = _uses_dlo_dp_concurrency(self.od_config)
+        if uses_dlo_dp_concurrency and self.step_execution:
+            self.scheduler.max_num_running_reqs = 1
+            self.dp_concurrent = False
+            logger.info("DLO DP concurrency is disabled for step execution until step dispatch is DP-aware.")
+        elif uses_dlo_dp_concurrency:
             self.scheduler.max_num_running_reqs = dp_size
             self.dp_concurrent = True
             logger.info(

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -119,11 +119,7 @@ def _max_num_seqs(od_config: OmniDiffusionConfig) -> int:
 def _uses_dlo_dp_concurrency(od_config: OmniDiffusionConfig) -> bool:
     parallel_config = getattr(od_config, "parallel_config", None)
     dp_size = getattr(parallel_config, "data_parallel_size", 1)
-    return (
-        dp_size > 1
-        and getattr(od_config, "enable_distributed_layerwise_offload", False)
-        and getattr(od_config, "dlo_use_allgather", True)
-    )
+    return dp_size > 1 and getattr(od_config, "enable_distributed_layerwise_offload", False)
 
 
 def _move_tensor_tree_to_cpu(value: object) -> object:
@@ -253,10 +249,10 @@ class DiffusionEngine:
 
     def _init_runtime_state(self) -> None:
         # DP multi-concurrency: allow batching dp_size requests so each
-        # worker processes a different request in parallel.  Only enabled
-        # for distributed layerwise offload (which shards weights and
-        # needs all ranks active simultaneously).  Ordinary DP with a
-        # non-batch pipeline should not schedule multiple requests.
+        # DP replica processes one request in parallel. AllGather-backed DLO
+        # keeps replicas in a compatible collective wave; rank-local DLO can
+        # dispatch heterogeneous requests independently. Ordinary DP with a
+        # non-batch pipeline still does not schedule multiple requests.
         dp_size = getattr(getattr(self.od_config, "parallel_config", None), "data_parallel_size", 1)
         if _uses_dlo_dp_concurrency(self.od_config):
             self.scheduler.max_num_running_reqs = dp_size

--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -547,14 +547,24 @@ def init_vllm_model_parallel_group(
 
 
 def init_dit_group(
-    dit_parallel_size: int,
+    group_ranks: list[list[int]],
+    local_rank: int,
     backend: str,
 ):
     global _DIT
-    _DIT = torch.distributed.new_group(ranks=list(range(dit_parallel_size)), backend=backend)
+    assert _DIT is None, "DIT group is already initialized"
+    _DIT = GroupCoordinator(
+        group_ranks=group_ranks,
+        local_rank=local_rank,
+        torch_distributed_backend=backend,
+    )
 
 
 def get_dit_group():
+    return get_dit_group_coordinator().device_group
+
+
+def get_dit_group_coordinator() -> GroupCoordinator:
     assert _DIT is not None, "DIT group is not initialized"
     return _DIT
 
@@ -969,12 +979,20 @@ def initialize_model_parallel(
             use_all2all=True,
         )
 
-    init_dit_group(dit_parallel_size, backend)
+    # A DiT group contains the model-parallel ranks for one DP replica. DP
+    # replicas must not share request-local collectives (for example condition
+    # broadcasts or VAE patch parallelism), because they may execute different
+    # requests. DLO weight sharing uses the orthogonal DP groups above.
+    init_dit_group(
+        rank_generator.get_ranks("tp-sp-pp-cfg"),
+        get_world_group().local_rank,
+        backend,
+    )
 
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
-    global _DP, _CFG, _SP, _PP, _FS, _EXPERT_PARALLEL_GROUP_RANKS
+    global _DP, _CFG, _SP, _PP, _FS, _DIT, _EXPERT_PARALLEL_GROUP_RANKS
 
     if vllm_parallel_state._DP and vllm_parallel_state._DP is not _DP:
         vllm_parallel_state._DP.destroy()
@@ -1012,6 +1030,10 @@ def destroy_model_parallel():
     if _FS:
         _FS.destroy()
     _FS = None
+
+    if _DIT:
+        _DIT.destroy()
+    _DIT = None
 
 
 def destroy_distributed_environment():

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -461,24 +461,30 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
         has_diffusion_kv_metadata = any(new_req.diffusion_kv_metadata is not None for new_req in new_reqs)
 
-        # DP multi-concurrency: when DLO+AllGather is active and multiple
-        # requests are scheduled, send ALL requests in one broadcast RPC.
-        # Each rank picks req[rank % len(reqs)] and computes independently.
-        # All ranks reply (unique_reply_rank=None) so we collect dp_size
-        # responses and match by dp_rank.
-        if (
-            len(new_reqs) > 1
+        parallel_config = getattr(self.od_config, "parallel_config", None)
+        dp_size = getattr(parallel_config, "data_parallel_size", 1)
+        dlo_enabled = getattr(self.od_config, "enable_distributed_layerwise_offload", False)
+        dlo_use_allgather = getattr(self.od_config, "dlo_use_allgather", True)
+        use_dp_replica_dispatch = (
+            bool(new_reqs)
             and not has_diffusion_kv_metadata
-            and getattr(self.od_config, "enable_distributed_layerwise_offload", False)
-            and getattr(self.od_config, "dlo_use_allgather", True)
-        ):
+            and dp_size > 1
+            and dlo_enabled
+            and (not dlo_use_allgather or len(new_reqs) > 1)
+        )
+
+        # DLO DP dispatches one request assignment per replica. AllGather
+        # waves keep their compatibility constraints and may repeat partial
+        # waves so every rank enters the collectives. Rank-local DLO pads
+        # unused replicas with None so a partial wave never duplicates work.
+        if use_dp_replica_dispatch:
             # Reuse the request scheduler's complete compatibility key. DLO
             # AllGather requires every DP rank to execute the same collective
             # schedule, including shape, CFG, denoise steps, output count,
             # and LoRA settings. Two default (None) step counts are valid and
             # resolve identically inside the same pipeline.
             compatibility_keys = [build_request_batch_sampling_params_key(nr.req) for nr in new_reqs]
-            if any(key != compatibility_keys[0] for key in compatibility_keys[1:]):
+            if dlo_use_allgather and any(key != compatibility_keys[0] for key in compatibility_keys[1:]):
                 raise ValueError(
                     "DLO DP multi-concurrency requires compatible shape, CFG, "
                     "denoise schedule, output count, and LoRA settings for all "
@@ -488,20 +494,24 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             for nr in new_reqs:
                 ea = getattr(nr.req.sampling_params, "extra_args", None)
                 extra_args_signatures.add(json.dumps(ea, sort_keys=True, default=repr) if ea is not None else None)
-            if len(extra_args_signatures) > 1:
+            if dlo_use_allgather and len(extra_args_signatures) > 1:
                 raise ValueError(
                     "DP multi-concurrency requires all concurrent requests to "
                     "share identical extra_args. Different extra_args can change "
                     "the forward schedule and cause AllGather deadlock."
                 )
             empty_prompt_ids = [nr.request_id for nr in new_reqs if _is_empty_dp_prompt(nr.req.prompt)]
-            if empty_prompt_ids:
+            if dlo_use_allgather and empty_prompt_ids:
                 raise ValueError(
                     "DP multi-concurrency requires a non-empty prompt for every request; "
                     f"empty prompt request IDs: {empty_prompt_ids}."
                 )
 
             reqs_list = [nr.req for nr in new_reqs]
+            if not dlo_use_allgather:
+                if len(reqs_list) > dp_size:
+                    raise RuntimeError(f"Scheduled {len(reqs_list)} requests for {dp_size} DP replicas.")
+                reqs_list.extend([None] * (dp_size - len(reqs_list)))
             try:
                 results = self.collective_rpc(
                     "execute_model",
@@ -602,11 +612,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
         parallel_config = getattr(self.od_config, "parallel_config", None)
         dp_size = getattr(parallel_config, "data_parallel_size", 1)
-        if (
-            dp_size > 1
-            and getattr(self.od_config, "enable_distributed_layerwise_offload", False)
-            and getattr(self.od_config, "dlo_use_allgather", True)
-        ):
+        if dp_size > 1 and getattr(self.od_config, "enable_distributed_layerwise_offload", False):
             # DLO DP uses one independent request per DP replica.  It is not a
             # fused pipeline request batch, so models such as MiniMax-H3 do not
             # need to advertise supports_request_batch=True.

--- a/vllm_omni/diffusion/sched/request_scheduler.py
+++ b/vllm_omni/diffusion/sched/request_scheduler.py
@@ -12,6 +12,7 @@ from vllm_omni.diffusion.sched.interface import (
     DiffusionRequestStatus,
     DiffusionSchedulerOutput,
     RequestBatchSamplingParamsKey,
+    SchedulerRequestState,
     _AdmissionWaitDecision,
 )
 
@@ -33,6 +34,16 @@ def build_request_batch_sampling_params_key(request: OmniDiffusionRequest) -> Re
     key_kwargs = {name: getattr(sampling, name) for name in _REQUEST_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES}
     key_kwargs["lora_int_id"] = lora_request.lora_int_id if lora_request is not None else None
     return RequestBatchSamplingParamsKey(**key_kwargs)
+
+
+def _uses_rank_local_dlo_dp(od_config: object) -> bool:
+    parallel_config = getattr(od_config, "parallel_config", None)
+    dp_size = getattr(parallel_config, "data_parallel_size", 1)
+    return (
+        dp_size > 1
+        and getattr(od_config, "enable_distributed_layerwise_offload", False)
+        and not getattr(od_config, "dlo_use_allgather", True)
+    )
 
 
 class RequestScheduler(BaseScheduler):
@@ -73,6 +84,11 @@ class RequestScheduler(BaseScheduler):
             or (waiting > 0 and now - stable_since >= decision.stable_window_s)
             or (decision.deadline is not None and now >= decision.deadline)
         )
+
+    def _can_schedule_waiting(self, state: SchedulerRequestState) -> bool:
+        if self.od_config is not None and _uses_rank_local_dlo_dp(self.od_config):
+            return True
+        return super()._can_schedule_waiting(state)
 
     def _build_sampling_params_key(self, request: OmniDiffusionRequest) -> RequestBatchSamplingParamsKey:
         return build_request_batch_sampling_params_key(request)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -437,18 +437,18 @@ class DiffusionWorker:
 
     def execute_model(
         self,
-        req: OmniDiffusionRequest | list[OmniDiffusionRequest],
+        req: OmniDiffusionRequest | list[OmniDiffusionRequest | None],
         od_config: OmniDiffusionConfig,
         kv_prefetch_job: KVPrefetchJob | None = None,
         diffusion_kv_metadata: DiffusionKVMetadata | None = None,
-    ) -> DiffusionOutput:
+    ) -> DiffusionOutput | dict[str, object]:
         """Execute a forward pass by delegating to the model runner.
 
-        If *req* is a list (DP multi-concurrency), each rank picks one
-        request based on its distributed rank.  AllGather in the layerwise
-        offload only gathers weight shards (request-independent), so all
-        ranks stay synchronised at each AllGather call while computing
-        different activations.
+        If *req* is a list (DP multi-concurrency), each replica picks the
+        assignment at its DP rank. AllGather waves repeat partial assignments
+        to keep every replica in the collective schedule. Rank-local DLO uses
+        explicit None entries so idle replicas do not duplicate another
+        request.
 
         Each rank returns its OWN DiffusionOutput (no gather). The executor
         collects N responses via the per-worker result queues.
@@ -463,8 +463,17 @@ class DiffusionWorker:
             from vllm_omni.diffusion.distributed.parallel_state import get_data_parallel_rank
 
             dp_rank = get_data_parallel_rank()
-            idx = dp_rank % len(req)
+            if not req:
+                raise ValueError("DP request assignments must not be empty.")
+            if getattr(od_config, "dlo_use_allgather", True):
+                idx = dp_rank % len(req)
+            else:
+                if dp_rank >= len(req):
+                    raise RuntimeError(f"Missing request assignment for DP rank {dp_rank}; got {len(req)} assignments.")
+                idx = dp_rank
             req = req[idx]
+            if req is None:
+                return {"dp_rank": dp_rank, "output": None}
 
         if self.lora_manager is not None:
             try:

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -68,11 +68,13 @@ class _TransferTopoConfig:
     sp_size: int
     sp_rank: int
     sp_group: Any
+    # Model-parallel ranks within one DP replica. Request-local KV payloads
+    # must never be broadcast across replicas that may execute other requests.
     world: Any
     # The stage's tensor-model-parallel group (vLLM parallel state). Only the
-    # ranks in this group execute the same request in lockstep — DP replicas
-    # and PP stages in ``world`` do not — so per-request consensus exchanges
-    # must use this group, never ``world``.
+    # ranks in this group execute the same TP kernel sequence in lockstep, so
+    # per-request receive consensus must use this narrower group rather than
+    # all model-parallel ranks in ``world``.
     tp_group: Any = None
     tp_size: int = 1
 
@@ -584,18 +586,18 @@ class OmniKVTransferManager:
             get_cfg_group,
             get_classifier_free_guidance_rank,
             get_classifier_free_guidance_world_size,
+            get_dit_group_coordinator,
             get_sequence_parallel_rank,
             get_sequence_parallel_world_size,
             get_sp_group,
-            get_world_group,
         )
 
         try:
-            world = get_world_group()
+            world = get_dit_group_coordinator()
             world_size = world.world_size
             world_rank = world.rank_in_group
         except Exception:
-            logger.exception("World group unavailable; defaulting to LOCAL")
+            logger.exception("DiT replica group unavailable; defaulting to LOCAL")
             return _TransferTopoConfig(
                 role=ReceiveRole.LOCAL,
                 tp_active=False,


### PR DESCRIPTION
## Summary

Follow-up to #5864. This PR enables independent request dispatch when distributed layerwise offload runs with `data_parallel_size > 1` and `dlo_use_allgather=False`.

- dispatch one request assignment per DP replica
- pad partial waves with an explicit idle assignment instead of duplicating work
- allow heterogeneous prompts, shapes, CFG values, denoise steps, and `extra_args` in rank-local mode
- keep the existing compatibility checks for DLO AllGather waves
- scope request-local DiT and KV-transfer collectives to one DP replica

This PR does **not** claim the existing DLO GPU-memory reduction as a new benefit. mmap sharing, SP-local weight AllGather, and component-selective offload remain separate follow-ups.

## Problem

The scheduler previously enabled DP request concurrency only for DLO AllGather. Simply enabling it for rank-local DLO was not enough: request-local collectives still used a process group containing every DP rank.

For a partial DP wave, rank 0 executed request A while rank 1 was idle. Rank 0 then blocked in:

```text
_prepare_request_for_forward
  -> receive_multi_kv_cache_distributed
  -> _broadcast_kv_payload(world)
```

because `world` still included the idle DP rank.

## Topology

```mermaid
flowchart LR
    A[request A] --> R0[DP replica 0]
    B[request B or idle] --> R1[DP replica 1]

    subgraph Request-local groups
      R0 --> D0[DiT / KV group 0]
      R1 --> D1[DiT / KV group 1]
    end

    subgraph DLO weight topology
      W0[DP rank 0 weight shard] <-->|AllGather mode only| W1[DP rank 1 weight shard]
    end

    D0 -. no request payload collective .- D1
```

For `DP=2, SP=4`, request-local groups are `[0,1,2,3]` and `[4,5,6,7]`. Orthogonal DP peer groups remain `[0,4]`, `[1,5]`, `[2,6]`, and `[3,7]` for DLO weight AllGather.

## Behavior

- `dlo_use_allgather=True`: every DP rank remains in a compatible collective wave; existing shape/CFG/step/`extra_args` checks stay enabled.
- `dlo_use_allgather=False`: each DP replica owns complete rank-local CPU weights and may execute a different request. Missing assignments are `None`, so an idle replica returns without running the model.
- `get_dit_group()` still exposes the underlying device `ProcessGroup` for existing VAE and model consumers; KV transfer uses the new coordinator to access the replica-local CPU/device groups.

## Tests

CPU regression suite:

```text
172 passed
ruff check: passed
ruff format --check: 11 files already formatted
```

2x B300 MiniMax-H3 FL2VA rank-local DLO E2E (`DP=2`, `TP=1`, `dlo_use_allgather=False`, 768x1344, 124 frames):

| Case | Before | After |
| --- | --- | --- |
| Partial wave (one request, one idle replica) | hangs in global KV broadcast | completes in 15.399s |
| Heterogeneous pair (2 vs 3 denoise steps, different prompts) | unsupported | both outputs complete in 25.853s |
| Output validation | N/A | video `[124,768,1344,3]`, audio `[1,2,165600]` for all 7 requests |
| Shutdown | N/A | `active_children=[]` |

Serial heterogeneous pair: 26.272s. Concurrent heterogeneous pair: 25.853s (`1.016x` on this host). The primary benefit here is correctness and independent scheduling; rank-local DLO streams contend for host-to-device bandwidth, so this test does not claim linear throughput scaling.

2x B300 DLO AllGather regression (`dlo_use_allgather=True`):

- incompatible asymmetric wave rejected for both requests in 6.3ms
- compatible pair completed in 31.808s
- both video/audio outputs validated
- clean shutdown with no active child processes
