### PR TITLE
[Model] Add SkyReels V3 V2V (single-shot video extension, 14B)

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -417,7 +417,7 @@ steps:
         timeout_in_minutes: 90
         commands:
           - pytest -s -v tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py -m "full_model and cuda" --run-level "full_model"
-          - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_ltx2_expansion.py -m "full_model and cuda" --run-level "full_model"
+          - pytest -s -v tests/e2e/online_serving/test_wan_2_1_vace_expansion.py tests/e2e/online_serving/test_ltx2_expansion.py tests/e2e/online_serving/test_skyreels_v3_v2v_expansion.py -m "full_model and cuda" --run-level "full_model"
         mirror_hardwares: h100_2
 
       - label: ":full_moon: Diffusion X2V · Wan2.2 Accuracy Test"
@@ -454,10 +454,13 @@ steps:
             EXIT1=$$?
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_cosmos3_vllm_omni.json
             EXIT2=$$?
+            pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_skyreels_v3_v2v_vllm_omni.json
+            EXIT3=$$?
             buildkite-agent artifact upload "tests/dfx/perf/results/diffusion_result_*.json"
             buildkite-agent artifact upload "tests/dfx/perf/results/logs/*.log"
             if [ $$EXIT1 -ne 0 ]; then exit $$EXIT1; fi
-            exit $$EXIT2
+            if [ $$EXIT2 -ne 0 ]; then exit $$EXIT2; fi
+            exit $$EXIT3
         mirror_hardwares: h100_2
 
   - group: ":card_index_dividers: Diffusion Test"

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -41,6 +41,7 @@ th {
 | `Wan22S2VPipeline` | Wan2.2-S2V | `Wan-AI/Wan2.2-S2V-14B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.2-VACE | `Pyros13/Wan2.2-VACE-Fun-A14B-Diffusers` | ✅︎ |   |   |   |
+| `SkyReelsV3V2VPipeline` | SkyReels V3 single-shot video extension | `Skywork/SkyReels-V3-Video-Extension` | ✅︎ | | | |
 | `LTX2Pipeline` | LTX-2 / LTX-2.3 one-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `LTX2DistilledPipeline` | LTX-2 distilled two-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled` | ✅︎ | ✅︎ | | |
 | `LingBotVideoPipeline` | LingBot-Video dense and MoE T2V | `robbyant/lingbot-video-dense-1.3b`, `robbyant/lingbot-video-moe-30b-a3b` | ✅︎ | | | |

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -106,6 +106,7 @@ def parse_args() -> argparse.Namespace:
         help="Optional deploy config YAML to use for pipeline-backed runs.",
     )
     parser.add_argument("--image", help="Path to the first-frame or source image.")
+    parser.add_argument("--video", help="Path to an input video for video-conditioned models (SkyReels V3 V2V).")
     parser.add_argument("--last-image", help="Path to a last-frame condition (used by models such as VACE).")
     parser.add_argument("--mask-image", help="Path to an inpainting mask (used by models such as VACE).")
     parser.add_argument(
@@ -335,6 +336,11 @@ def main():
     is_ltx2 = is_ltx2_distilled or is_ltx23 or "ltx2" in model_class_name_lower or "ltx-2" in model_name
     is_cosmos = "cosmos" in model_name or (model_class_name is not None and "cosmos" in model_class_name.lower())
     is_cosmos_edge = is_cosmos and ("edge" in model_name or "edge" in model_class_name_lower)
+    is_skyreels_v2v = (
+        "skyreels-v3-v2v" in model_name
+        or "skyreels-v3-video-extension" in model_name
+        or model_class_name_lower == "skyreelsv3v2vpipeline"
+    )
 
     image = PIL.Image.open(args.image).convert("RGB") if args.image else None
     last_image = PIL.Image.open(args.last_image).convert("RGB") if args.last_image else None
@@ -343,7 +349,7 @@ def main():
         [PIL.Image.open(path).convert("RGB") for path in args.reference_image] if args.reference_image else None
     )
     dimension_image = image or last_image or (reference_images[0] if reference_images else None)
-    if dimension_image is None:
+    if dimension_image is None and not is_skyreels_v2v:
         raise ValueError("Provide --image, --last-image, or at least one --reference-image.")
 
     # Per-model generation defaults, applied only when the matching flag is omitted.
@@ -403,12 +409,20 @@ def main():
     # Calculate dimensions if not provided (model-aware max area).
     height = args.height
     width = args.width
-    if height is None or width is None:
+    if is_skyreels_v2v:
+        # V2V's aspect_ratio bucket lookup happens inside the pipeline based on
+        # the input video's resolution.
+        pass
+    elif height is None or width is None:
         calc_height, calc_width = calculate_dimensions(dimension_image, max_area=d_max_area, mod_value=d_mod)
         height = height or calc_height
         width = width or calc_width
 
     media_inputs: dict[str, Any] = {}
+    if is_skyreels_v2v:
+        if args.video is None:
+            raise ValueError("SkyReels V3 V2V requires --video (path to the input video to extend).")
+        media_inputs["video"] = args.video
     if image is not None:
         media_inputs["image"] = image.resize((width, height), PIL.Image.Resampling.LANCZOS)
     if last_image is not None:

--- a/tests/dfx/perf/tests/test_skyreels_v3_v2v_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_skyreels_v3_v2v_vllm_omni.json
@@ -1,0 +1,105 @@
+[
+  {
+    "test_name": "test_skyreels_v3_v2v_single_device",
+    "mark": [
+      {
+        "hardware_marks": {
+          "res": {
+            "cuda": "H100"
+          },
+          "num_cards": 1
+        }
+      },
+      "full_model",
+      "diffusion"
+    ],
+    "description": "SkyReels V3 V2V single-shot extension baseline (720P bucket, 4 sampling steps, duration=5s, guidance=1 so CFG is off).",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Skywork/SkyReels-V3-V2V-14B",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "720p_duration5_steps4_g1",
+        "dataset": "random",
+        "task": "v2v",
+        "num-prompts": 3,
+        "max-concurrency": 1,
+        "num-input-videos": 1,
+        "seed": 42,
+        "random-request-config": [
+          {
+            "resolution": "720P",
+            "num_inference_steps": 4,
+            "duration": 5,
+            "fps": 24,
+            "guidance_scale": 1.0,
+            "weight": 1
+          }
+        ],
+        "baseline": {
+          "H100": {
+            "throughput_qps": 0.00115,
+            "latency_mean": 873.32,
+            "peak_memory_mb_mean": 77000.0
+          }
+        }
+      }
+    ]
+  },
+  {
+    "test_name": "test_skyreels_v3_v2v_cfg_g5_single_device",
+    "mark": [
+      {
+        "hardware_marks": {
+          "res": {
+            "cuda": "H100"
+          },
+          "num_cards": 1
+        }
+      },
+      "full_model",
+      "diffusion"
+    ],
+    "description": "SkyReels V3 V2V with guidance=5 on 1×H100 (three-branch CFG, ~2x the g=1 latency because pipeline currently runs cond+uncond sequentially without leveraging CFG-parallel — see BENCH_SUMMARY notes).",
+    "server_type": "vllm-omni",
+    "server_params": {
+      "model": "Skywork/SkyReels-V3-V2V-14B",
+      "serve_args": {
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "720p_duration5_steps4_g5",
+        "dataset": "random",
+        "task": "v2v",
+        "num-prompts": 2,
+        "max-concurrency": 1,
+        "num-input-videos": 1,
+        "seed": 42,
+        "enable-negative-prompt": true,
+        "random-request-config": [
+          {
+            "resolution": "720P",
+            "num_inference_steps": 4,
+            "duration": 5,
+            "fps": 24,
+            "guidance_scale": 5.0,
+            "weight": 1
+          }
+        ],
+        "baseline": {
+          "H100": {
+            "throughput_qps": 0.00059,
+            "latency_mean": 1696.47,
+            "peak_memory_mb_mean": 77000.0
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/diffusion/models/skyreels_v3/test_skyreels_v3_v2v.py
+++ b/tests/diffusion/models/skyreels_v3/test_skyreels_v3_v2v.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from vllm_omni.config.config_factory import StageConfigFactory
+from vllm_omni.diffusion.data import OmniDiffusionConfig, resolve_model_class_name
+from vllm_omni.diffusion.models.skyreels_v3.pipeline_skyreels_v3_v2v import (
+    DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES,
+    DEFAULT_SKYREELS_V3_V2V_DURATION,
+    DEFAULT_SKYREELS_V3_V2V_MAX_DURATION,
+    SkyReelsV3V2VPipeline,
+    get_skyreels_v3_v2v_pre_process_func,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.model_extras import get_extra_body_params
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _write_v2v_like_model(tmp_path: Path) -> str:
+    model_dir = tmp_path / "SkyReels-V3-V2V-14B"
+    (model_dir / "transformer").mkdir(parents=True)
+    (model_dir / "google" / "umt5-xxl").mkdir(parents=True)
+    (model_dir / "transformer" / "config.json").write_text(
+        json.dumps({"_class_name": "WanTransformer3DModel"}), encoding="utf-8"
+    )
+    for filename in ("Wan2.1_VAE.pth", "models_t5_umt5-xxl-enc-bf16.pth"):
+        (model_dir / filename).write_bytes(b"")
+    return str(model_dir)
+
+
+def _make_request(prompt, **sampling_kwargs) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompt=prompt,
+        sampling_params=OmniDiffusionSamplingParams(**sampling_kwargs),
+        request_id="skyreels-v2v-test",
+    )
+
+
+def _dummy_video(frames: int = 32, height: int = 720, width: int = 1280) -> np.ndarray:
+    return np.random.randint(0, 255, size=(frames, height, width, 3), dtype=np.uint8)
+
+
+def test_skyreels_v3_v2v_model_resolution_uses_v2v_pipeline(tmp_path: Path):
+    model = _write_v2v_like_model(tmp_path)
+
+    assert resolve_model_class_name(model) == "SkyReelsV3V2VPipeline"
+
+    config = OmniDiffusionConfig(model=model)
+    config.enrich_config()
+    assert config.model_class_name == "SkyReelsV3V2VPipeline"
+
+
+def test_skyreels_v3_v2v_uses_default_diffusion_stage_config(tmp_path: Path):
+    model = _write_v2v_like_model(tmp_path)
+
+    StageConfigFactory.get_hf_config.cache_clear()
+    StageConfigFactory.try_infer_model_type.cache_clear()
+
+    # V2V checkpoints have no root config.json, so HF-config inference returns
+    # None; the routing shortcut in entrypoints/utils.py maps them to the
+    # skyreels_v3_v2v type once resolve_model_config_path fires.
+    inferred = StageConfigFactory.try_infer_model_type(model, trust_remote_code=False)
+    assert inferred in (None, "skyreels_v3_v2v")
+    assert StageConfigFactory.get_pipeline_config(model, trust_remote_code=False) is None
+
+
+def test_skyreels_v3_v2v_declares_zero_dummy_frames():
+    assert SkyReelsV3V2VPipeline.dummy_run_num_frames == 0
+
+
+def test_skyreels_v3_v2v_preprocess_rejects_missing_video():
+    request = _make_request({"prompt": "extend"})
+    preprocess = get_skyreels_v3_v2v_pre_process_func(OmniDiffusionConfig())
+
+    with pytest.raises(ValueError, match="input video"):
+        preprocess(request)
+
+
+def test_skyreels_v3_v2v_preprocess_rejects_short_input():
+    frames = _dummy_video(frames=DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES - 1, height=64, width=64)
+    request = _make_request(
+        {"prompt": "extend", "multi_modal_data": {"video": frames}},
+        extra_args={"resolution": "480P"},
+    )
+    preprocess = get_skyreels_v3_v2v_pre_process_func(OmniDiffusionConfig())
+
+    with pytest.raises(ValueError, match="at least"):
+        preprocess(request)
+
+
+def test_skyreels_v3_v2v_preprocess_resizes_and_records_source_fps():
+    frames = _dummy_video(frames=DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES, height=1080, width=1920)
+    request = _make_request(
+        {"prompt": "extend", "multi_modal_data": {"video": frames}},
+        extra_args={"resolution": "720P", "duration": 5},
+    )
+    preprocess = get_skyreels_v3_v2v_pre_process_func(OmniDiffusionConfig())
+
+    processed = preprocess(request)
+
+    assert processed.sampling_params.height is not None
+    assert processed.sampling_params.width is not None
+    assert processed.sampling_params.height % 16 == 0
+    assert processed.sampling_params.width % 16 == 0
+    resized = processed.prompt["multi_modal_data"]["video"]
+    assert resized.shape[0] == DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES
+    assert resized.shape[1] == processed.sampling_params.height
+    assert resized.shape[2] == processed.sampling_params.width
+
+
+def test_skyreels_v3_v2v_extra_body_params_include_duration():
+    params = get_extra_body_params("SkyReelsV3V2VPipeline")
+    assert "duration" in params
+    assert "video_path" in params
+    assert "condition_frames" in params
+    assert DEFAULT_SKYREELS_V3_V2V_DURATION > 0

--- a/tests/e2e/online_serving/test_skyreels_v3_v2v_expansion.py
+++ b/tests/e2e/online_serving/test_skyreels_v3_v2v_expansion.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L4 expansion coverage for SkyReels V3 V2V (single-shot video extension)."""
+
+import pytest
+
+from tests.helpers.mark import hardware_marks
+from tests.helpers.media import generate_synthetic_video
+from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHandler
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
+
+MODEL = "Skywork/SkyReels-V3-V2V-14B"
+
+CUDA_SINGLE_CARD_MARKS = hardware_marks(res={"cuda": "H100"})
+
+
+def _get_v2v_feature_cases():
+    return [
+        pytest.param(
+            OmniServerParams(model=MODEL),
+            id="cuda_v2v_baseline",
+            marks=CUDA_SINGLE_CARD_MARKS,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "omni_server",
+    _get_v2v_feature_cases(),
+    indirect=True,
+)
+def test_skyreels_v3_v2v_features(
+    omni_server: OmniServer,
+    openai_client: OpenAIClientHandler,
+):
+    video_asset = generate_synthetic_video(num_frames=72, height=720, width=1280, fps=24)
+
+    form_data = {
+        "prompt": "A cinematic continuation of the scene.",
+        "num_inference_steps": 4,
+        "seed": 42,
+        "extra_params": '{"resolution": "720P", "duration": 3, "condition_frames": 25}',
+    }
+
+    request_config = {
+        "model": MODEL,
+        "form_data": form_data,
+        "video_reference": f"data:video/mp4;base64,{video_asset['base64']}",
+    }
+
+    openai_client.send_video_diffusion_request(request_config)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -541,12 +541,15 @@ def resolve_model_class_name(model: str | None, diffusion_load_format: str = "de
     """
     from vllm.transformers_utils.config import get_hf_file_to_dict
 
-    from vllm_omni.diffusion.utils.hf_utils import get_diffusion_model_index
+    from vllm_omni.diffusion.utils.hf_utils import get_diffusion_model_index, _looks_like_skyreels_v3_v2v
 
     if not model:
         return None
 
     is_lance_subfolder = os.path.basename(str(model).rstrip("/")) in {"Lance_3B", "Lance_3B_Video"}
+
+    if _looks_like_skyreels_v3_v2v(model):
+        return "SkyReelsV3V2VPipeline"
 
     # Diffusers models: read _class_name from the pipeline index.
     model_index = get_diffusion_model_index(model)
@@ -1152,11 +1155,18 @@ class OmniDiffusionConfig:
         """
         from vllm.transformers_utils.config import get_hf_file_to_dict
 
-        from vllm_omni.diffusion.utils.hf_utils import get_diffusion_model_index
+        from vllm_omni.diffusion.utils.hf_utils import get_diffusion_model_index, _looks_like_skyreels_v3_v2v
 
         # Default model_class_name for diffusers adapter
         if self.model_class_name is None and self.diffusion_load_format == "diffusers":
             self.model_class_name = "DiffusersAdapterPipeline"
+
+        if self.diffusion_load_format != "diffusers" and _looks_like_skyreels_v3_v2v(self.model):
+            self.model_class_name = "SkyReelsV3V2VPipeline"
+            tf_config_dict = get_hf_file_to_dict("transformer/config.json", self.model)
+            self.set_tf_model_config(TransformerConfig.from_dict(tf_config_dict or {}))
+            self.update_multimodal_support()
+            return
 
         try:
             config_dict = get_diffusion_model_index(

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -56,6 +56,10 @@ _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
     "WanImageToVideoPipeline": DiffusionModelMetadata(attention_mask_free=True),
     "WanVACEPipeline": DiffusionModelMetadata(attention_mask_free=True),
     "WanS2VPipeline": DiffusionModelMetadata(attention_mask_free=True),
+    "SkyReelsV3V2VPipeline": DiffusionModelMetadata(
+        supports_multimodal_inputs=True,
+        attention_mask_free=True,
+    ),
 }
 
 

--- a/vllm_omni/diffusion/models/skyreels_v3/__init__.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/__init__.py
@@ -1,0 +1,11 @@
+from .pipeline_skyreels_v3_v2v import (
+    SkyReelsV3V2VPipeline,
+    get_skyreels_v3_v2v_post_process_func,
+    get_skyreels_v3_v2v_pre_process_func,
+)
+
+__all__ = [
+    "SkyReelsV3V2VPipeline",
+    "get_skyreels_v3_v2v_post_process_func",
+    "get_skyreels_v3_v2v_pre_process_func",
+]

--- a/vllm_omni/diffusion/models/skyreels_v3/aspect_ratio.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/aspect_ratio.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolution buckets shared by the SkyReels-V3 pipelines.
+
+SkyReels-V3 was trained on a fixed set of ``(height, width)`` buckets per resolution tier
+instead of on free-form sizes, so an input image/video is mapped to the bucket whose aspect
+ratio is closest to its own. Reproducing the bucket table is required for output parity with
+the reference implementation.
+"""
+
+from __future__ import annotations
+
+ASPECT_RATIO_CONFIG: dict[str, dict[str, tuple[int, int]]] = {
+    "480P": {
+        "0.38": (392, 1046),
+        "0.43": (420, 980),
+        "0.48": (444, 925),
+        "0.50": (452, 904),
+        "0.53": (466, 880),
+        "0.54": (470, 870),
+        "0.56": (480, 854),
+        "0.62": (506, 810),
+        "0.67": (522, 784),
+        "0.75": (554, 738),
+        "1.00": (640, 640),
+        "1.33": (740, 555),
+        "1.50": (784, 522),
+        "1.78": (854, 480),
+        "1.89": (880, 466),
+        "2.00": (906, 454),
+        "2.08": (924, 444),
+    },
+    "540P": {
+        "0.34": (416, 1216),
+        "0.38": (464, 1216),
+        "0.40": (464, 1152),
+        "0.43": (496, 1152),
+        "0.48": (496, 1024),
+        "0.50": (512, 1024),
+        "0.53": (512, 960),
+        "0.57": (544, 960),
+        "0.60": (544, 912),
+        "0.63": (576, 912),
+        "0.67": (576, 864),
+        "0.72": (624, 864),
+        "0.75": (624, 832),
+        "0.79": (656, 832),
+        "0.84": (656, 784),
+        "0.92": (720, 784),
+        "1.00": (720, 720),
+        "1.09": (784, 720),
+        "1.26": (784, 624),
+        "1.33": (832, 624),
+        "1.40": (832, 592),
+        "1.49": (880, 592),
+        "1.62": (880, 544),
+        "1.78": (960, 544),
+        "1.88": (960, 512),
+        "2.00": (1024, 512),
+        "2.13": (1024, 480),
+    },
+    "720P": {
+        "0.38": (588, 1568),
+        "0.43": (628, 1466),
+        "0.48": (666, 1388),
+        "0.50": (678, 1356),
+        "0.53": (698, 1318),
+        "0.54": (706, 1306),
+        "0.56": (720, 1280),
+        "0.62": (758, 1212),
+        "0.67": (784, 1176),
+        "0.75": (832, 1110),
+        "1.00": (960, 960),
+        "1.33": (1108, 832),
+        "1.50": (1176, 784),
+        "1.78": (1280, 720),
+        "1.89": (1320, 698),
+        "2.00": (1358, 680),
+        "2.08": (1386, 666),
+    },
+}
+
+DEFAULT_SKYREELS_V3_RESOLUTION = "540P"
+
+# The VAE downsamples spatially by 8 and the transformer patchifies by 2, so both sides must
+# be a multiple of 16.
+SKYREELS_V3_SIZE_ALIGNMENT = 16
+
+
+def get_closest_aspect_ratio(height: float, width: float, ratios: dict[str, tuple[int, int]]) -> str:
+    """Return the bucket key of ``ratios`` whose aspect ratio is closest to ``height / width``."""
+    aspect_ratio = height / width
+    return min(ratios.keys(), key=lambda ratio: abs(float(ratio) - aspect_ratio))
+
+
+def resolve_bucket_size(height: float, width: float, resolution: str | None = None) -> tuple[int, int]:
+    """Map a source ``(height, width)`` onto the closest SkyReels-V3 training bucket.
+
+    The returned size is floored to :data:`SKYREELS_V3_SIZE_ALIGNMENT` because a few buckets
+    (e.g. ``(466, 880)``) are not themselves aligned.
+    """
+    resolution = (resolution or DEFAULT_SKYREELS_V3_RESOLUTION).upper()
+    if resolution not in ASPECT_RATIO_CONFIG:
+        raise ValueError(
+            f"Unsupported SkyReels-V3 resolution {resolution!r}, expected one of {sorted(ASPECT_RATIO_CONFIG)}."
+        )
+    ratios = ASPECT_RATIO_CONFIG[resolution]
+    bucket_height, bucket_width = ratios[get_closest_aspect_ratio(height, width, ratios)]
+    align = SKYREELS_V3_SIZE_ALIGNMENT
+    return bucket_height // align * align, bucket_width // align * align

--- a/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
@@ -55,6 +55,7 @@ DEFAULT_SKYREELS_V3_V2V_SHIFT = 8.0
 DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES = 25
 DEFAULT_SKYREELS_V3_V2V_LATENT_FRAMES_PER_SECOND = 6
 DEFAULT_SKYREELS_V3_V2V_MAX_DURATION = 30
+DEFAULT_SKYREELS_V3_V2V_RESOLUTION = "720P"
 
 
 def _resolve_v2v_model_path(model: str | None) -> str:
@@ -311,7 +312,7 @@ def get_skyreels_v3_v2v_pre_process_func(
             )
 
         if request.sampling_params.height is None or request.sampling_params.width is None:
-            resolution = str(extra_args.get("resolution", DEFAULT_SKYREELS_V3_RESOLUTION))
+            resolution = str(extra_args.get("resolution", DEFAULT_SKYREELS_V3_V2V_RESOLUTION))
             height, width = resolve_bucket_size(frames.shape[1], frames.shape[2], resolution)
             if request.sampling_params.height is None:
                 request.sampling_params.height = height
@@ -530,8 +531,10 @@ class SkyReelsV3V2VPipeline(
             if isinstance(stored_fps, (int, float)) and not isinstance(stored_fps, bool):
                 source_fps = float(stored_fps)
 
-        height = int(req.sampling_params.height or resolve_bucket_size(frames.shape[1], frames.shape[2])[0])
-        width = int(req.sampling_params.width or resolve_bucket_size(frames.shape[1], frames.shape[2])[1])
+        resolution = str(extra_args.get("resolution", DEFAULT_SKYREELS_V3_V2V_RESOLUTION))
+        bucket_height, bucket_width = resolve_bucket_size(frames.shape[1], frames.shape[2], resolution)
+        height = int(req.sampling_params.height or bucket_height)
+        width = int(req.sampling_params.width or bucket_width)
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
         if frames.shape[1] != height or frames.shape[2] != width:

--- a/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
@@ -423,10 +423,12 @@ class SkyReelsV3V2VPipeline(
         *,
         block_offload: bool = False,
     ) -> torch.Tensor:
+        transformer_dtype = self.transformer.patch_embedding.weight.dtype
+        transformer_device = self.transformer.patch_embedding.weight.device
         noise_pred = self.transformer(
-            latent_model_input,
-            t=timestep,
-            context=context,
+            latent_model_input.to(device=transformer_device, dtype=transformer_dtype),
+            t=timestep.to(device=transformer_device),
+            context=context.to(device=transformer_device, dtype=transformer_dtype),
             block_offload=block_offload,
         )
         if isinstance(noise_pred, tuple):
@@ -492,7 +494,7 @@ class SkyReelsV3V2VPipeline(
                         block_offload=block_offload,
                     )
 
-                noise_pred = noise_pred[:, -latents.shape[1] :]
+                noise_pred = noise_pred[:, -latents.shape[1] :].to(dtype=latents.dtype)
                 latents = self.scheduler.step(
                     noise_pred.unsqueeze(0),
                     timestep,

--- a/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/pipeline_skyreels_v3_v2v.py
@@ -1,0 +1,662 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import math
+import os
+from collections.abc import Iterable, Sequence
+from typing import Any, ClassVar
+
+import numpy as np
+import PIL.Image
+import torch
+import torch.nn.functional as F
+from diffusers.utils.torch_utils import randn_tensor
+from torch import nn
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.forward_context import DenoiseProgressMixin
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
+from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import (
+    FlowUniPCMultistepScheduler,
+)
+from vllm_omni.diffusion.models.skyreels_v3.aspect_ratio import (
+    DEFAULT_SKYREELS_V3_RESOLUTION,
+    resolve_bucket_size,
+)
+from vllm_omni.diffusion.models.skyreels_v3.v2v_t5 import T5EncoderModel
+from vllm_omni.diffusion.models.skyreels_v3.v2v_transformer import WanModel
+from vllm_omni.diffusion.models.skyreels_v3.v2v_vae import WanVAE
+from vllm_omni.diffusion.postprocess import interpolate_video_tensor
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
+    DiffusionPipelineProfilerMixin,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.platforms import current_omni_platform
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SKYREELS_V3_V2V_FPS = 24
+DEFAULT_SKYREELS_V3_V2V_DURATION = 5
+DEFAULT_SKYREELS_V3_V2V_STEPS = 8
+DEFAULT_SKYREELS_V3_V2V_GUIDANCE = 1.0
+DEFAULT_SKYREELS_V3_V2V_SHIFT = 8.0
+DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES = 25
+DEFAULT_SKYREELS_V3_V2V_LATENT_FRAMES_PER_SECOND = 6
+DEFAULT_SKYREELS_V3_V2V_MAX_DURATION = 30
+
+
+def _resolve_v2v_model_path(model: str | None) -> str:
+    if not model:
+        raise ValueError("SkyReels V3 V2V requires `od_config.model` to point to a model path or HF repo.")
+    if os.path.isdir(model):
+        return model
+    from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+
+    allow_patterns = [
+        "*.json",
+        "*.pth",
+        "transformer/**",
+        "google/**",
+    ]
+    return download_weights_from_hf_specific(model, None, allow_patterns)
+
+
+def _split_duration(duration: int, chunk_seconds: int = 5) -> list[int]:
+    if duration <= 0:
+        raise ValueError(f"SkyReels V3 V2V duration must be positive, got {duration}.")
+    chunks: list[int] = []
+    remaining = duration
+    while remaining >= chunk_seconds:
+        chunks.append(chunk_seconds)
+        remaining -= chunk_seconds
+    if remaining > 0:
+        chunks.append(remaining)
+    return chunks
+
+
+def _coerce_frames_to_uint8(frames: Any) -> tuple[np.ndarray, float | None]:
+    """Normalize a supported video input into ``uint8`` RGB frames ``[T, H, W, 3]``."""
+
+    if isinstance(frames, str):
+        return _load_video_from_path_or_url(frames)
+
+    if isinstance(frames, torch.Tensor):
+        tensor = frames.detach().cpu()
+        if tensor.ndim == 5:
+            if tensor.shape[0] != 1:
+                raise ValueError("SkyReels V3 V2V supports a single input video per request.")
+            tensor = tensor[0]
+        if tensor.ndim != 4:
+            raise ValueError(f"Unsupported video tensor shape {tuple(tensor.shape)}.")
+        if tensor.shape[-1] in (1, 3, 4):
+            pass
+        elif tensor.shape[0] in (1, 3, 4):
+            tensor = tensor.permute(1, 2, 3, 0)
+        else:
+            raise ValueError(f"Unsupported video tensor layout {tuple(tensor.shape)}.")
+        array = tensor.numpy()
+        return _normalize_frame_array(array), None
+
+    if isinstance(frames, np.ndarray):
+        return _normalize_frame_array(frames), None
+
+    if isinstance(frames, Sequence) and not isinstance(frames, (bytes, bytearray)):
+        if not frames:
+            raise ValueError("Input video contains no frames.")
+        frame_arrays = []
+        for frame in frames:
+            if isinstance(frame, PIL.Image.Image):
+                frame_arrays.append(np.asarray(frame.convert("RGB"), dtype=np.uint8))
+            elif isinstance(frame, torch.Tensor):
+                frame_tensor = frame.detach().cpu()
+                if frame_tensor.ndim == 3 and frame_tensor.shape[0] in (1, 3, 4):
+                    frame_tensor = frame_tensor.permute(1, 2, 0)
+                frame_arrays.append(_normalize_frame_array(frame_tensor.numpy())[0])
+            elif isinstance(frame, np.ndarray):
+                frame_arrays.append(_normalize_frame_array(frame)[0])
+            else:
+                raise TypeError(f"Unsupported video frame type {frame.__class__}.")
+        return np.stack(frame_arrays, axis=0), None
+
+    raise TypeError(
+        "SkyReels V3 V2V video input must be a path/URL, numpy array, torch tensor, "
+        f"or a sequence of frames, got {frames.__class__}."
+    )
+
+
+def _load_video_from_path_or_url(video: str) -> tuple[np.ndarray, float | None]:
+    try:
+        import av
+    except ImportError as exc:
+        raise ImportError("SkyReels V3 V2V requires PyAV (`av`) to load video paths or URLs.") from exc
+
+    source: str | io.BytesIO
+    if video.startswith("data:video"):
+        try:
+            _, payload = video.split(",", 1)
+            source = io.BytesIO(base64.b64decode(payload))
+        except ValueError as exc:
+            raise ValueError("Invalid data URL video input.") from exc
+    else:
+        source = video
+
+    with av.open(source) as container:
+        stream = container.streams.video[0]
+        fps = float(stream.average_rate) if stream.average_rate is not None else None
+        frames = [frame.to_ndarray(format="rgb24") for frame in container.decode(stream)]
+    if not frames:
+        raise ValueError("Input video contains no decodable frames.")
+    return np.stack(frames, axis=0), fps
+
+
+def _normalize_frame_array(array: np.ndarray) -> np.ndarray:
+    array = np.asarray(array)
+    if array.ndim == 3 and array.shape[-1] not in (1, 3, 4) and array.shape[0] in (1, 3, 4):
+        array = np.transpose(array, (1, 2, 0))
+    if array.ndim == 4 and array.shape[-1] not in (1, 3, 4) and array.shape[0] in (1, 3, 4):
+        array = np.transpose(array, (1, 2, 3, 0))
+    if array.ndim == 3:
+        array = array[None, ...]
+    if array.ndim != 4:
+        raise ValueError(f"Video frames must have shape [T,H,W,C], got {array.shape}.")
+    if array.shape[-1] == 4:
+        array = array[..., :3]
+    if array.shape[-1] == 1:
+        array = np.repeat(array, 3, axis=-1)
+    if array.shape[-1] != 3:
+        raise ValueError(f"Video frames must have 1, 3, or 4 channels, got shape {array.shape}.")
+
+    if array.dtype == np.uint8:
+        return np.ascontiguousarray(array)
+
+    array = array.astype(np.float32)
+    min_value = float(np.nanmin(array))
+    max_value = float(np.nanmax(array))
+    if min_value >= -1.0 and max_value <= 1.0:
+        if min_value < 0.0:
+            array = (array + 1.0) * 127.5
+        else:
+            array = array * 255.0
+    return np.ascontiguousarray(np.clip(array, 0, 255).round().astype(np.uint8))
+
+
+def _resize_video_uint8(frames: np.ndarray, *, height: int, width: int) -> np.ndarray:
+    tensor = torch.from_numpy(frames).permute(3, 0, 1, 2).unsqueeze(0).float()
+    tensor = F.interpolate(tensor, size=(tensor.shape[2], height, width))
+    return tensor.squeeze(0).permute(1, 2, 3, 0).clamp(0, 255).to(torch.uint8).cpu().numpy()
+
+
+def _video_uint8_to_vae_tensor(frames: np.ndarray, device: torch.device | str) -> torch.Tensor:
+    tensor = torch.from_numpy(frames).permute(3, 0, 1, 2).unsqueeze(0).float()
+    tensor = tensor / (255.0 / 2.0) - 1.0
+    return tensor.to(device)
+
+
+def _resolve_input_video(prompt: OmniTextPrompt, extra_args: dict[str, Any]) -> Any:
+    multi_modal_data = prompt.get("multi_modal_data") or {}
+    for source, key in (
+        (multi_modal_data, "video"),
+        (multi_modal_data, "input_video"),
+        (multi_modal_data, "cond_video"),
+        (extra_args, "video_path"),
+        (extra_args, "input_video"),
+    ):
+        if key in source and source[key] is not None:
+            return source[key]
+    else:
+        raise ValueError(
+            "SkyReels V3 V2V requires an input video. Use `multi_modal_data={'video': ...}` "
+            "or pass `video_path` in extra_args / extra_body."
+        )
+
+
+def _normalize_duration(req: DiffusionRequestBatch, extra_args: dict[str, Any], fps: float) -> tuple[int, int | None]:
+    requested_frames = req.sampling_params.num_frames
+    duration = extra_args.get("duration")
+    trim_frames: int | None = None
+    if duration is None and requested_frames is not None and requested_frames > 0:
+        duration = int(math.ceil(float(requested_frames) / max(float(fps), 1.0)))
+        trim_frames = int(requested_frames)
+    duration = int(duration or DEFAULT_SKYREELS_V3_V2V_DURATION)
+    if duration > DEFAULT_SKYREELS_V3_V2V_MAX_DURATION:
+        raise ValueError(
+            f"SkyReels V3 single-shot extension supports duration <= "
+            f"{DEFAULT_SKYREELS_V3_V2V_MAX_DURATION}s, got {duration}s."
+        )
+    return duration, trim_frames
+
+
+def get_skyreels_v3_v2v_post_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    del od_config
+
+    def post_process_func(
+        output: Any,
+        output_type: str = "np",
+        sampling_params=None,
+    ):
+        if sampling_params is not None and getattr(sampling_params, "output_type", None):
+            output_type = sampling_params.output_type
+        fps = DEFAULT_SKYREELS_V3_V2V_FPS
+        video = output
+        if isinstance(output, tuple) and len(output) == 2:
+            video, fps = output
+        if output_type == "latent":
+            return video
+
+        if isinstance(video, torch.Tensor):
+            if sampling_params is not None and getattr(sampling_params, "enable_frame_interpolation", False):
+                video, multiplier = interpolate_video_tensor(
+                    video,
+                    exp=sampling_params.frame_interpolation_exp,
+                    scale=sampling_params.frame_interpolation_scale,
+                    model_path=sampling_params.frame_interpolation_model_path,
+                )
+                fps = fps * multiplier
+            video = video.detach().cpu()
+            if video.ndim == 5:
+                video = video[0]
+            if video.ndim == 4 and video.shape[0] in (1, 3, 4):
+                video = video.permute(1, 2, 3, 0)
+            video = _normalize_frame_array(video.numpy())
+
+        if isinstance(video, np.ndarray):
+            video = _normalize_frame_array(video)
+            if output_type == "pil":
+                video = [PIL.Image.fromarray(frame) for frame in video]
+            elif output_type in {"pt", "tensor"}:
+                video = torch.from_numpy(video).permute(0, 3, 1, 2)
+
+        return {
+            "payload": {"video": video},
+            "metadata": {"video": {"fps": fps}},
+        }
+
+    return post_process_func
+
+
+def get_skyreels_v3_v2v_pre_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    del od_config
+
+    def pre_process_func(request: OmniDiffusionRequest) -> OmniDiffusionRequest:
+        prompt = request.prompt
+        if isinstance(prompt, str):
+            prompt = OmniTextPrompt(prompt=prompt)
+        extra_args = request.sampling_params.extra_args or {}
+        raw_video = _resolve_input_video(prompt, extra_args)
+        frames, source_fps = _coerce_frames_to_uint8(raw_video)
+        if frames.shape[0] < 1:
+            raise ValueError("SkyReels V3 V2V input video must contain at least one frame.")
+        condition_frames = int(extra_args.get("condition_frames", DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES))
+        if condition_frames <= 0:
+            raise ValueError(f"condition_frames must be positive, got {condition_frames}.")
+        if frames.shape[0] < condition_frames:
+            raise ValueError(
+                f"SkyReels V3 V2V requires at least {condition_frames} input frames, got {frames.shape[0]}."
+            )
+
+        if request.sampling_params.height is None or request.sampling_params.width is None:
+            resolution = str(extra_args.get("resolution", DEFAULT_SKYREELS_V3_RESOLUTION))
+            height, width = resolve_bucket_size(frames.shape[1], frames.shape[2], resolution)
+            if request.sampling_params.height is None:
+                request.sampling_params.height = height
+            if request.sampling_params.width is None:
+                request.sampling_params.width = width
+
+        height = int(request.sampling_params.height)
+        width = int(request.sampling_params.width)
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
+
+        prompt["multi_modal_data"] = dict(prompt.get("multi_modal_data") or {})
+        prompt["multi_modal_data"]["video"] = _resize_video_uint8(frames, height=height, width=width)
+        prompt.setdefault("additional_information", {})["source_video_fps"] = source_fps
+        request.prompt = prompt
+        return request
+
+    return pre_process_func
+
+
+class SkyReelsV3V2VPipeline(
+    nn.Module,
+    CFGParallelMixin,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+    DenoiseProgressMixin,
+    SupportsComponentDiscovery,
+):
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae.vae"]
+    # V2V warmup needs a real input video. Skip generic dummy warmup instead of
+    # manufacturing a tiny video that does not match extension constraints.
+    dummy_run_num_frames: ClassVar[int] = 0
+
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ):
+        del prefix
+        super().__init__()
+        self.od_config = od_config
+        self.device = get_local_device()
+        self.param_dtype = getattr(od_config, "dtype", torch.bfloat16)
+        self.model_path = _resolve_v2v_model_path(od_config.model)
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=self.model_path,
+                subfolder="transformer",
+                revision=od_config.revision,
+                prefix="transformer.",
+                fall_back_to_pt=False,
+            )
+        ]
+
+        self.text_encoder = T5EncoderModel(
+            checkpoint_path=os.path.join(self.model_path, "models_t5_umt5-xxl-enc-bf16.pth"),
+            tokenizer_path=os.path.join(self.model_path, "google", "umt5-xxl"),
+            shard_fn=None,
+        ).to(self.param_dtype)
+        self.vae = WanVAE(vae_pth=os.path.join(self.model_path, "Wan2.1_VAE.pth"))
+        self.transformer = WanModel.from_config(os.path.join(self.model_path, "transformer", "config.json")).to(
+            self.param_dtype
+        )
+
+        self.text_encoder.to(self.device)
+        self.vae.to(self.device)
+        self.scheduler = FlowUniPCMultistepScheduler()
+        self.vae_stride = (4, 8, 8)
+        self.patch_size = (1, 2, 2)
+        self.sp_size = 1
+
+        self._guidance_scale: float | None = None
+        self._num_timesteps: int | None = None
+        self._current_timestep: torch.Tensor | None = None
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def do_classifier_free_guidance(self):
+        return self._guidance_scale is not None and self._guidance_scale > 1.0
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    def to(self, *args: Any, **kwargs: Any):
+        super().to(*args, **kwargs)
+        if hasattr(self, "vae"):
+            self.vae.to(*args, **kwargs)
+        return self
+
+    def _predict_noise(
+        self,
+        latent_model_input: torch.Tensor,
+        timestep: torch.Tensor,
+        context: torch.Tensor,
+        *,
+        block_offload: bool = False,
+    ) -> torch.Tensor:
+        noise_pred = self.transformer(
+            latent_model_input,
+            t=timestep,
+            context=context,
+            block_offload=block_offload,
+        )
+        if isinstance(noise_pred, tuple):
+            noise_pred = noise_pred[0]
+        if not isinstance(noise_pred, torch.Tensor):
+            raise TypeError(f"SkyReels V3 V2V transformer returned {type(noise_pred)!r}, expected Tensor.")
+        return noise_pred[0]
+
+    def _diffuse_segment(
+        self,
+        *,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        condition_latents: torch.Tensor,
+        latent_num_frames: int,
+        height: int,
+        width: int,
+        num_inference_steps: int,
+        guidance_scale: float,
+        shift: float,
+        generator: torch.Generator | list[torch.Generator] | None,
+        block_offload: bool = False,
+    ) -> torch.Tensor:
+        target_shape = (
+            self.vae.vae.z_dim,
+            latent_num_frames,
+            height // self.vae_stride[1],
+            width // self.vae_stride[2],
+        )
+        latents = randn_tensor(target_shape, generator=generator, device=self.device, dtype=torch.float32)
+        self.scheduler.set_timesteps(num_inference_steps, device=self.device, shift=shift)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        with self.progress_bar(total=len(timesteps)) as pbar:
+            for step_idx, timestep in enumerate(timesteps):
+                self._current_timestep = timestep
+                self.record_denoise_step(step_idx, timestep)
+                latent_model_input = latents.unsqueeze(0)
+                latent_model_input = torch.cat([condition_latents, latent_model_input], dim=2)
+                model_timestep = timestep.view(1, 1).repeat(1, latent_model_input.shape[2])
+                model_timestep[:, : condition_latents.shape[2]] = 0
+
+                if guidance_scale > 1.0 and negative_prompt_embeds is not None:
+                    noise_pred_cond = self._predict_noise(
+                        latent_model_input,
+                        model_timestep,
+                        prompt_embeds,
+                        block_offload=block_offload,
+                    )
+                    noise_pred_uncond = self._predict_noise(
+                        latent_model_input,
+                        model_timestep,
+                        negative_prompt_embeds,
+                        block_offload=block_offload,
+                    )
+                    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_cond - noise_pred_uncond)
+                else:
+                    noise_pred = self._predict_noise(
+                        latent_model_input,
+                        model_timestep,
+                        prompt_embeds,
+                        block_offload=block_offload,
+                    )
+
+                noise_pred = noise_pred[:, -latents.shape[1] :]
+                latents = self.scheduler.step(
+                    noise_pred.unsqueeze(0),
+                    timestep,
+                    latents.unsqueeze(0),
+                    return_dict=False,
+                    generator=generator,
+                )[0].squeeze(0)
+                pbar.update()
+        return latents
+
+    @torch.no_grad()
+    def forward(self, req: DiffusionRequestBatch) -> DiffusionOutput:
+        if len(req.prompts) != 1:
+            raise ValueError("SkyReels V3 V2V only supports a single prompt per request.")
+        first_prompt = req.prompts[0]
+        if isinstance(first_prompt, str):
+            prompt = first_prompt
+            negative_prompt = ""
+            prompt_data = OmniTextPrompt(prompt=first_prompt)
+        else:
+            prompt = first_prompt.get("prompt") or ""
+            negative_prompt = first_prompt.get("negative_prompt") or ""
+            prompt_data = first_prompt
+        if not prompt:
+            raise ValueError("Prompt is required for SkyReels V3 V2V generation.")
+
+        extra_args = req.sampling_params.extra_args or {}
+        raw_video = _resolve_input_video(prompt_data, extra_args)
+        frames, source_fps = _coerce_frames_to_uint8(raw_video)
+        additional_info = prompt_data.get("additional_information") or {}
+        if source_fps is None and isinstance(additional_info, dict):
+            stored_fps = additional_info.get("source_video_fps")
+            if isinstance(stored_fps, (int, float)) and not isinstance(stored_fps, bool):
+                source_fps = float(stored_fps)
+
+        height = int(req.sampling_params.height or resolve_bucket_size(frames.shape[1], frames.shape[2])[0])
+        width = int(req.sampling_params.width or resolve_bucket_size(frames.shape[1], frames.shape[2])[1])
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` must be divisible by 16, got {height} and {width}.")
+        if frames.shape[1] != height or frames.shape[2] != width:
+            frames = _resize_video_uint8(frames, height=height, width=width)
+
+        fps = float(extra_args.get("fps") or source_fps or DEFAULT_SKYREELS_V3_V2V_FPS)
+        condition_frames = int(extra_args.get("condition_frames", DEFAULT_SKYREELS_V3_V2V_CONDITION_FRAMES))
+        if condition_frames <= 0:
+            raise ValueError(f"condition_frames must be positive, got {condition_frames}.")
+        if frames.shape[0] < condition_frames:
+            raise ValueError(
+                f"SkyReels V3 V2V requires at least {condition_frames} input frames, got {frames.shape[0]}."
+            )
+        prefix_np = frames[-condition_frames:]
+        if prefix_np.shape[0] < 1:
+            raise ValueError("SkyReels V3 V2V input video must contain at least one frame.")
+        prefix_video = _video_uint8_to_vae_tensor(prefix_np, self.device)
+
+        duration, trim_frames = _normalize_duration(req, extra_args, fps)
+        num_inference_steps = int(
+            extra_args.get(
+                "sampling_steps",
+                req.sampling_params.num_inference_steps or DEFAULT_SKYREELS_V3_V2V_STEPS,
+            )
+        )
+        guidance_scale = float(
+            extra_args.get(
+                "cfg_text_scale",
+                req.sampling_params.guidance_scale
+                if req.sampling_params.guidance_scale_provided
+                else DEFAULT_SKYREELS_V3_V2V_GUIDANCE,
+            )
+        )
+        shift = float(extra_args.get("shift", self.od_config.flow_shift or DEFAULT_SKYREELS_V3_V2V_SHIFT))
+        self._guidance_scale = guidance_scale
+
+        generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
+
+        if _is_rank_zero():
+            logger.debug(
+                "SkyReels V3 V2V request: size=%sx%s duration=%ss fps=%s condition_frames=%s steps=%s cfg=%s",
+                width,
+                height,
+                duration,
+                fps,
+                condition_frames,
+                num_inference_steps,
+                guidance_scale,
+            )
+
+        prompt_embeds = self.text_encoder.encode(prompt).to(device=self.device, dtype=self.param_dtype)
+        negative_prompt_embeds = None
+        if guidance_scale > 1.0:
+            negative_prompt_embeds = self.text_encoder.encode(negative_prompt).to(
+                device=self.device,
+                dtype=self.param_dtype,
+            )
+
+        output_segments: list[np.ndarray] = []
+        padding_frames = 0
+        block_offload = bool(extra_args.get("block_offload", False))
+        for gen_seconds in _split_duration(duration):
+            condition_latents = self.vae.encode(prefix_video).to(device=self.device, dtype=torch.float32)
+            latent_num_frames = DEFAULT_SKYREELS_V3_V2V_LATENT_FRAMES_PER_SECOND * gen_seconds
+            prefix_shape = condition_latents.shape[2]
+            rest_frames = (latent_num_frames + prefix_shape) % 8
+            if rest_frames > padding_frames:
+                padding_frames = padding_frames + (8 - rest_frames)
+                latent_num_frames = latent_num_frames - rest_frames + 8
+            else:
+                padding_frames = padding_frames - rest_frames
+                latent_num_frames = latent_num_frames - rest_frames
+            if latent_num_frames <= 0:
+                raise ValueError(
+                    "SkyReels V3 V2V resolved a non-positive latent frame count; "
+                    f"duration={duration}, condition_latents={prefix_shape}."
+                )
+
+            latents = self._diffuse_segment(
+                prompt_embeds=prompt_embeds,
+                negative_prompt_embeds=negative_prompt_embeds,
+                condition_latents=condition_latents,
+                latent_num_frames=latent_num_frames,
+                height=height,
+                width=width,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                shift=shift,
+                generator=generator,
+                block_offload=block_offload,
+            )
+            decoded = self.vae.decode(
+                torch.cat([condition_latents, latents.unsqueeze(0)], dim=2)
+            )
+            decoded = (decoded / 2 + 0.5).clamp(0, 1)
+            segment = (
+                (decoded[0].permute(1, 2, 3, 0) * 255)
+                .round()
+                .to(torch.uint8)
+                .cpu()
+                .numpy()
+            )
+            output_segments.append(segment[condition_frames:])
+            prefix_np = segment[-condition_frames:]
+            prefix_video = _video_uint8_to_vae_tensor(prefix_np, self.device)
+
+        self._current_timestep = None
+        output_video = (
+            np.concatenate(output_segments, axis=0)
+            if output_segments
+            else np.empty((0, height, width, 3), dtype=np.uint8)
+        )
+        if trim_frames is not None:
+            output_video = output_video[:trim_frames]
+        if bool(extra_args.get("include_input_video", False)):
+            output_video = np.concatenate([frames, output_video], axis=0)
+
+        if current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+
+        return DiffusionOutput(
+            output=(output_video, fps),
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_attention.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_attention.py
@@ -1,0 +1,188 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import torch
+
+try:
+    import flash_attn_interface
+
+    FLASH_ATTN_3_AVAILABLE = True
+except ModuleNotFoundError:
+    FLASH_ATTN_3_AVAILABLE = False
+
+try:
+    import flash_attn
+
+    FLASH_ATTN_2_AVAILABLE = True
+except ModuleNotFoundError:
+    FLASH_ATTN_2_AVAILABLE = False
+
+import warnings
+
+__all__ = [
+    "flash_attention",
+    "attention",
+]
+
+
+def flash_attention(
+    q,
+    k,
+    v,
+    q_lens=None,
+    k_lens=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    q_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    deterministic=False,
+    dtype=torch.bfloat16,
+    version=None,
+):
+    """
+    q:              [B, Lq, Nq, C1].
+    k:              [B, Lk, Nk, C1].
+    v:              [B, Lk, Nk, C2]. Nq must be divisible by Nk.
+    q_lens:         [B].
+    k_lens:         [B].
+    dropout_p:      float. Dropout probability.
+    softmax_scale:  float. The scaling of QK^T before applying softmax.
+    causal:         bool. Whether to apply causal attention mask.
+    window_size:    (left right). If not (-1, -1), apply sliding window local attention.
+    deterministic:  bool. If True, slightly slower and uses more memory.
+    dtype:          torch.dtype. Apply when dtype of q/k/v is not float16/bfloat16.
+    """
+    half_dtypes = (torch.float16, torch.bfloat16)
+    assert dtype in half_dtypes
+    assert q.device.type == "cuda" and q.size(-1) <= 256
+
+    # params
+    b, lq, lk, _ = q.size(0), q.size(1), k.size(1), q.dtype
+
+    def half(x):
+        return x if x.dtype in half_dtypes else x.to(dtype)
+
+    # preprocess query
+
+    q = half(q.flatten(0, 1))
+    q_lens = torch.tensor([lq] * b, dtype=torch.int32).to(
+        device=q.device, non_blocking=True
+    )
+
+    # preprocess key, value
+
+    k = half(k.flatten(0, 1))
+    v = half(v.flatten(0, 1))
+    k_lens = torch.tensor([lk] * b, dtype=torch.int32).to(
+        device=k.device, non_blocking=True
+    )
+
+    q = q.to(v.dtype)
+    k = k.to(v.dtype)
+
+    if q_scale is not None:
+        q = q * q_scale
+
+    if version is not None and version == 3 and not FLASH_ATTN_3_AVAILABLE:
+        warnings.warn(
+            "Flash attention 3 is not available, use flash attention 2 instead."
+        )
+
+    torch.cuda.nvtx.range_push(
+        f"{list(q.shape)}-{list(k.shape)}-{list(v.shape)}-{q.dtype}-{k.dtype}-{v.dtype}"
+    )
+    # apply attention
+    if (version is None or version == 3) and FLASH_ATTN_3_AVAILABLE:
+        # Note: dropout_p, window_size are not supported in FA3 now.
+        x = flash_attn_interface.flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=torch.cat([q_lens.new_zeros([1]), q_lens])
+            .cumsum(0, dtype=torch.int32)
+            .to(q.device, non_blocking=True),
+            cu_seqlens_k=torch.cat([k_lens.new_zeros([1]), k_lens])
+            .cumsum(0, dtype=torch.int32)
+            .to(q.device, non_blocking=True),
+            seqused_q=None,
+            seqused_k=None,
+            max_seqlen_q=lq,
+            max_seqlen_k=lk,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            deterministic=deterministic,
+        )[0].unflatten(0, (b, lq))
+    else:
+        assert FLASH_ATTN_2_AVAILABLE
+        x = flash_attn.flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=torch.cat([q_lens.new_zeros([1]), q_lens])
+            .cumsum(0, dtype=torch.int32)
+            .to(q.device, non_blocking=True),
+            cu_seqlens_k=torch.cat([k_lens.new_zeros([1]), k_lens])
+            .cumsum(0, dtype=torch.int32)
+            .to(q.device, non_blocking=True),
+            max_seqlen_q=lq,
+            max_seqlen_k=lk,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            deterministic=deterministic,
+        ).unflatten(0, (b, lq))
+    torch.cuda.nvtx.range_pop()
+
+    # output
+    return x
+
+
+def attention(
+    q,
+    k,
+    v,
+    q_lens=None,
+    k_lens=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    q_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    deterministic=False,
+    dtype=torch.bfloat16,
+    fa_version=None,
+):
+    if FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE:
+        return flash_attention(
+            q=q,
+            k=k,
+            v=v,
+            q_lens=q_lens,
+            k_lens=k_lens,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            q_scale=q_scale,
+            causal=causal,
+            window_size=window_size,
+            deterministic=deterministic,
+            dtype=dtype,
+            version=fa_version,
+        )
+    else:
+        if q_lens is not None or k_lens is not None:
+            warnings.warn(
+                "Padding mask is disabled when using scaled_dot_product_attention. "
+                "It can have a significant impact on performance."
+            )
+        attn_mask = None
+
+        q = q.transpose(1, 2).to(dtype)
+        k = k.transpose(1, 2).to(dtype)
+        v = v.transpose(1, 2).to(dtype)
+
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_mask, is_causal=causal, dropout_p=dropout_p
+        )
+
+        out = out.transpose(1, 2).contiguous()
+        return out

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_t5.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_t5.py
@@ -1,0 +1,558 @@
+# Modified from transformers.models.t5.modeling_t5
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import logging
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.models import ModelMixin
+
+from .v2v_tokenizers import HuggingfaceTokenizer
+
+__all__ = [
+    "T5Model",
+    "T5Encoder",
+    "T5Decoder",
+    "T5EncoderModel",
+]
+
+
+def fp16_clamp(x):
+    if x.dtype == torch.float16 and torch.isinf(x).any():
+        clamp = torch.finfo(x.dtype).max - 1000
+        x = torch.clamp(x, min=-clamp, max=clamp)
+    return x
+
+
+def init_weights(m):
+    if isinstance(m, T5LayerNorm):
+        nn.init.ones_(m.weight)
+    elif isinstance(m, T5Model):
+        nn.init.normal_(m.token_embedding.weight, std=1.0)
+    elif isinstance(m, T5FeedForward):
+        nn.init.normal_(m.gate[0].weight, std=m.dim**-0.5)
+        nn.init.normal_(m.fc1.weight, std=m.dim**-0.5)
+        nn.init.normal_(m.fc2.weight, std=m.dim_ffn**-0.5)
+    elif isinstance(m, T5Attention):
+        nn.init.normal_(m.q.weight, std=(m.dim * m.dim_attn) ** -0.5)
+        nn.init.normal_(m.k.weight, std=m.dim**-0.5)
+        nn.init.normal_(m.v.weight, std=m.dim**-0.5)
+        nn.init.normal_(m.o.weight, std=(m.num_heads * m.dim_attn) ** -0.5)
+    elif isinstance(m, T5RelativeEmbedding):
+        nn.init.normal_(
+            m.embedding.weight, std=(2 * m.num_buckets * m.num_heads) ** -0.5
+        )
+
+
+class GELU(nn.Module):
+    def forward(self, x):
+        return (
+            0.5
+            * x
+            * (
+                1.0
+                + torch.tanh(
+                    math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))
+                )
+            )
+        )
+
+
+class T5LayerNorm(nn.Module):
+    def __init__(self, dim, eps=1e-6):
+        super(T5LayerNorm, self).__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        x = x * torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + self.eps)
+        if self.weight.dtype in [torch.float16, torch.bfloat16]:
+            x = x.type_as(self.weight)
+        return self.weight * x
+
+
+class T5Attention(nn.Module):
+    def __init__(self, dim, dim_attn, num_heads, dropout=0.1):
+        assert dim_attn % num_heads == 0
+        super(T5Attention, self).__init__()
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.num_heads = num_heads
+        self.head_dim = dim_attn // num_heads
+
+        # layers
+        self.q = nn.Linear(dim, dim_attn, bias=False)
+        self.k = nn.Linear(dim, dim_attn, bias=False)
+        self.v = nn.Linear(dim, dim_attn, bias=False)
+        self.o = nn.Linear(dim_attn, dim, bias=False)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x, context=None, mask=None, pos_bias=None):
+        """
+        x:          [B, L1, C].
+        context:    [B, L2, C] or None.
+        mask:       [B, L2] or [B, L1, L2] or None.
+        """
+        # check inputs
+        context = x if context is None else context
+        b, n, c = x.size(0), self.num_heads, self.head_dim
+
+        # compute query, key, value
+        q = self.q(x).view(b, -1, n, c)
+        k = self.k(context).view(b, -1, n, c)
+        v = self.v(context).view(b, -1, n, c)
+
+        # attention bias
+        attn_bias = x.new_zeros(b, n, q.size(1), k.size(1))
+        if pos_bias is not None:
+            attn_bias += pos_bias
+        if mask is not None:
+            assert mask.ndim in [2, 3]
+            mask = mask.view(b, 1, 1, -1) if mask.ndim == 2 else mask.unsqueeze(1)
+            attn_bias.masked_fill_(mask == 0, torch.finfo(x.dtype).min)
+
+        # compute attention (T5 does not use scaling)
+        attn = torch.einsum("binc,bjnc->bnij", q, k) + attn_bias
+        attn = F.softmax(attn.float(), dim=-1).type_as(attn)
+        x = torch.einsum("bnij,bjnc->binc", attn, v)
+
+        # output
+        x = x.reshape(b, -1, n * c)
+        x = self.o(x)
+        x = self.dropout(x)
+        return x
+
+
+class T5FeedForward(nn.Module):
+    def __init__(self, dim, dim_ffn, dropout=0.1):
+        super(T5FeedForward, self).__init__()
+        self.dim = dim
+        self.dim_ffn = dim_ffn
+
+        # layers
+        self.gate = nn.Sequential(nn.Linear(dim, dim_ffn, bias=False), GELU())
+        self.fc1 = nn.Linear(dim, dim_ffn, bias=False)
+        self.fc2 = nn.Linear(dim_ffn, dim, bias=False)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        x = self.fc1(x) * self.gate(x)
+        x = self.dropout(x)
+        x = self.fc2(x)
+        x = self.dropout(x)
+        return x
+
+
+class T5SelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim,
+        dim_attn,
+        dim_ffn,
+        num_heads,
+        num_buckets,
+        shared_pos=True,
+        dropout=0.1,
+    ):
+        super(T5SelfAttention, self).__init__()
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.dim_ffn = dim_ffn
+        self.num_heads = num_heads
+        self.num_buckets = num_buckets
+        self.shared_pos = shared_pos
+
+        # layers
+        self.norm1 = T5LayerNorm(dim)
+        self.attn = T5Attention(dim, dim_attn, num_heads, dropout)
+        self.norm2 = T5LayerNorm(dim)
+        self.ffn = T5FeedForward(dim, dim_ffn, dropout)
+        self.pos_embedding = (
+            None
+            if shared_pos
+            else T5RelativeEmbedding(num_buckets, num_heads, bidirectional=True)
+        )
+
+    def forward(self, x, mask=None, pos_bias=None):
+        e = pos_bias if self.shared_pos else self.pos_embedding(x.size(1), x.size(1))
+        x = fp16_clamp(x + self.attn(self.norm1(x), mask=mask, pos_bias=e))
+        x = fp16_clamp(x + self.ffn(self.norm2(x)))
+        return x
+
+
+class T5CrossAttention(nn.Module):
+    def __init__(
+        self,
+        dim,
+        dim_attn,
+        dim_ffn,
+        num_heads,
+        num_buckets,
+        shared_pos=True,
+        dropout=0.1,
+    ):
+        super(T5CrossAttention, self).__init__()
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.dim_ffn = dim_ffn
+        self.num_heads = num_heads
+        self.num_buckets = num_buckets
+        self.shared_pos = shared_pos
+
+        # layers
+        self.norm1 = T5LayerNorm(dim)
+        self.self_attn = T5Attention(dim, dim_attn, num_heads, dropout)
+        self.norm2 = T5LayerNorm(dim)
+        self.cross_attn = T5Attention(dim, dim_attn, num_heads, dropout)
+        self.norm3 = T5LayerNorm(dim)
+        self.ffn = T5FeedForward(dim, dim_ffn, dropout)
+        self.pos_embedding = (
+            None
+            if shared_pos
+            else T5RelativeEmbedding(num_buckets, num_heads, bidirectional=False)
+        )
+
+    def forward(
+        self, x, mask=None, encoder_states=None, encoder_mask=None, pos_bias=None
+    ):
+        e = pos_bias if self.shared_pos else self.pos_embedding(x.size(1), x.size(1))
+        x = fp16_clamp(x + self.self_attn(self.norm1(x), mask=mask, pos_bias=e))
+        x = fp16_clamp(
+            x
+            + self.cross_attn(self.norm2(x), context=encoder_states, mask=encoder_mask)
+        )
+        x = fp16_clamp(x + self.ffn(self.norm3(x)))
+        return x
+
+
+class T5RelativeEmbedding(nn.Module):
+    def __init__(self, num_buckets, num_heads, bidirectional, max_dist=128):
+        super(T5RelativeEmbedding, self).__init__()
+        self.num_buckets = num_buckets
+        self.num_heads = num_heads
+        self.bidirectional = bidirectional
+        self.max_dist = max_dist
+
+        # layers
+        self.embedding = nn.Embedding(num_buckets, num_heads)
+
+    def forward(self, lq, lk):
+        device = self.embedding.weight.device
+        # rel_pos = torch.arange(lk).unsqueeze(0).to(device) - \
+        #     torch.arange(lq).unsqueeze(1).to(device)
+        rel_pos = torch.arange(lk, device=device).unsqueeze(0) - torch.arange(
+            lq, device=device
+        ).unsqueeze(1)
+        rel_pos = self._relative_position_bucket(rel_pos)
+        rel_pos_embeds = self.embedding(rel_pos)
+        rel_pos_embeds = rel_pos_embeds.permute(2, 0, 1).unsqueeze(0)  # [1, N, Lq, Lk]
+        return rel_pos_embeds.contiguous()
+
+    def _relative_position_bucket(self, rel_pos):
+        # preprocess
+        if self.bidirectional:
+            num_buckets = self.num_buckets // 2
+            rel_buckets = (rel_pos > 0).long() * num_buckets
+            rel_pos = torch.abs(rel_pos)
+        else:
+            num_buckets = self.num_buckets
+            rel_buckets = 0
+            rel_pos = -torch.min(rel_pos, torch.zeros_like(rel_pos))
+
+        # embeddings for small and large positions
+        max_exact = num_buckets // 2
+        rel_pos_large = (
+            max_exact
+            + (
+                torch.log(rel_pos.float() / max_exact)
+                / math.log(self.max_dist / max_exact)
+                * (num_buckets - max_exact)
+            ).long()
+        )
+        rel_pos_large = torch.min(
+            rel_pos_large, torch.full_like(rel_pos_large, num_buckets - 1)
+        )
+        rel_buckets += torch.where(rel_pos < max_exact, rel_pos, rel_pos_large)
+        return rel_buckets
+
+
+class T5Encoder(nn.Module):
+    def __init__(
+        self,
+        vocab,
+        dim,
+        dim_attn,
+        dim_ffn,
+        num_heads,
+        num_layers,
+        num_buckets,
+        shared_pos=True,
+        dropout=0.1,
+    ):
+        super(T5Encoder, self).__init__()
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.dim_ffn = dim_ffn
+        self.num_heads = num_heads
+        self.num_layers = num_layers
+        self.num_buckets = num_buckets
+        self.shared_pos = shared_pos
+
+        # layers
+        self.token_embedding = (
+            vocab if isinstance(vocab, nn.Embedding) else nn.Embedding(vocab, dim)
+        )
+        self.pos_embedding = (
+            T5RelativeEmbedding(num_buckets, num_heads, bidirectional=True)
+            if shared_pos
+            else None
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.blocks = nn.ModuleList(
+            [
+                T5SelfAttention(
+                    dim, dim_attn, dim_ffn, num_heads, num_buckets, shared_pos, dropout
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.norm = T5LayerNorm(dim)
+
+        # initialize weights
+        self.apply(init_weights)
+
+    def forward(self, ids, mask=None):
+        x = self.token_embedding(ids)
+        x = self.dropout(x)
+        e = self.pos_embedding(x.size(1), x.size(1)) if self.shared_pos else None
+        for block in self.blocks:
+            x = block(x, mask, pos_bias=e)
+        x = self.norm(x)
+        x = self.dropout(x)
+        return x
+
+
+class T5Decoder(nn.Module):
+    def __init__(
+        self,
+        vocab,
+        dim,
+        dim_attn,
+        dim_ffn,
+        num_heads,
+        num_layers,
+        num_buckets,
+        shared_pos=True,
+        dropout=0.1,
+    ):
+        super(T5Decoder, self).__init__()
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.dim_ffn = dim_ffn
+        self.num_heads = num_heads
+        self.num_layers = num_layers
+        self.num_buckets = num_buckets
+        self.shared_pos = shared_pos
+
+        # layers
+        self.token_embedding = (
+            vocab if isinstance(vocab, nn.Embedding) else nn.Embedding(vocab, dim)
+        )
+        self.pos_embedding = (
+            T5RelativeEmbedding(num_buckets, num_heads, bidirectional=False)
+            if shared_pos
+            else None
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.blocks = nn.ModuleList(
+            [
+                T5CrossAttention(
+                    dim, dim_attn, dim_ffn, num_heads, num_buckets, shared_pos, dropout
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.norm = T5LayerNorm(dim)
+
+        # initialize weights
+        self.apply(init_weights)
+
+    def forward(self, ids, mask=None, encoder_states=None, encoder_mask=None):
+        b, s = ids.size()
+
+        # causal mask
+        if mask is None:
+            mask = torch.tril(torch.ones(1, s, s).to(ids.device))
+        elif mask.ndim == 2:
+            mask = torch.tril(mask.unsqueeze(1).expand(-1, s, -1))
+
+        # layers
+        x = self.token_embedding(ids)
+        x = self.dropout(x)
+        e = self.pos_embedding(x.size(1), x.size(1)) if self.shared_pos else None
+        for block in self.blocks:
+            x = block(x, mask, encoder_states, encoder_mask, pos_bias=e)
+        x = self.norm(x)
+        x = self.dropout(x)
+        return x
+
+
+class T5Model(nn.Module):
+    def __init__(
+        self,
+        vocab_size,
+        dim,
+        dim_attn,
+        dim_ffn,
+        num_heads,
+        encoder_layers,
+        decoder_layers,
+        num_buckets,
+        shared_pos=True,
+        dropout=0.1,
+    ):
+        super(T5Model, self).__init__()
+        self.vocab_size = vocab_size
+        self.dim = dim
+        self.dim_attn = dim_attn
+        self.dim_ffn = dim_ffn
+        self.num_heads = num_heads
+        self.encoder_layers = encoder_layers
+        self.decoder_layers = decoder_layers
+        self.num_buckets = num_buckets
+
+        # layers
+        self.token_embedding = nn.Embedding(vocab_size, dim)
+        self.encoder = T5Encoder(
+            self.token_embedding,
+            dim,
+            dim_attn,
+            dim_ffn,
+            num_heads,
+            encoder_layers,
+            num_buckets,
+            shared_pos,
+            dropout,
+        )
+        self.decoder = T5Decoder(
+            self.token_embedding,
+            dim,
+            dim_attn,
+            dim_ffn,
+            num_heads,
+            decoder_layers,
+            num_buckets,
+            shared_pos,
+            dropout,
+        )
+        self.head = nn.Linear(dim, vocab_size, bias=False)
+
+        # initialize weights
+        self.apply(init_weights)
+
+    def forward(self, encoder_ids, encoder_mask, decoder_ids, decoder_mask):
+        x = self.encoder(encoder_ids, encoder_mask)
+        x = self.decoder(decoder_ids, decoder_mask, x, encoder_mask)
+        x = self.head(x)
+        return x
+
+
+def _t5(
+    name,
+    encoder_only=False,
+    decoder_only=False,
+    return_tokenizer=False,
+    tokenizer_kwargs={},
+    dtype=torch.float32,
+    device="cpu",
+    **kwargs,
+):
+    # sanity check
+    assert not (encoder_only and decoder_only)
+
+    # params
+    if encoder_only:
+        model_cls = T5Encoder
+        kwargs["vocab"] = kwargs.pop("vocab_size")
+        kwargs["num_layers"] = kwargs.pop("encoder_layers")
+        _ = kwargs.pop("decoder_layers")
+    elif decoder_only:
+        model_cls = T5Decoder
+        kwargs["vocab"] = kwargs.pop("vocab_size")
+        kwargs["num_layers"] = kwargs.pop("decoder_layers")
+        _ = kwargs.pop("encoder_layers")
+    else:
+        model_cls = T5Model
+
+    # init model
+    with torch.device(device):
+        model = model_cls(**kwargs)
+
+    # set device
+    model = model.to(dtype=dtype, device=device)
+
+    # init tokenizer
+    if return_tokenizer:
+        from .v2v_tokenizers import HuggingfaceTokenizer
+
+        tokenizer = HuggingfaceTokenizer(f"google/{name}", **tokenizer_kwargs)
+        return model, tokenizer
+    else:
+        return model
+
+
+def umt5_xxl(**kwargs):
+    cfg = dict(
+        vocab_size=256384,
+        dim=4096,
+        dim_attn=4096,
+        dim_ffn=10240,
+        num_heads=64,
+        encoder_layers=24,
+        decoder_layers=24,
+        num_buckets=32,
+        shared_pos=False,
+        dropout=0.1,
+    )
+    cfg.update(**kwargs)
+    return _t5("umt5-xxl", **cfg)
+
+
+class T5EncoderModel(ModelMixin):
+    def __init__(
+        self,
+        checkpoint_path=None,
+        tokenizer_path=None,
+        text_len=512,
+        shard_fn=None,
+    ):
+        self.text_len = text_len
+        self.checkpoint_path = checkpoint_path
+        self.tokenizer_path = tokenizer_path
+
+        super().__init__()
+        # init model
+        model = umt5_xxl(encoder_only=True, return_tokenizer=False)
+        logging.info(f"loading {checkpoint_path}")
+        model.load_state_dict(torch.load(checkpoint_path, map_location="cpu"))
+        self.model = model
+        if shard_fn is not None:
+            self.model = shard_fn(self.model, sync_module_states=False)
+        else:
+            self.model.eval().requires_grad_(False)
+        # init tokenizer
+        self.tokenizer = HuggingfaceTokenizer(
+            name=tokenizer_path, seq_len=text_len, clean="whitespace"
+        )
+
+    def encode(self, texts):
+        ids, mask = self.tokenizer(texts, return_mask=True, add_special_tokens=True)
+        ids = ids.to(self.device)
+        mask = mask.to(self.device)
+        # seq_lens = mask.gt(0).sum(dim=1).long()
+        context = self.model(ids, mask)
+        context = context * mask.to(context.device).unsqueeze(-1)
+
+        return context

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_tokenizers.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_tokenizers.py
@@ -1,0 +1,84 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import html
+import string
+
+import ftfy
+import regex as re
+from transformers import AutoTokenizer
+
+__all__ = ["HuggingfaceTokenizer"]
+
+
+def basic_clean(text):
+    text = ftfy.fix_text(text)
+    text = html.unescape(html.unescape(text))
+    return text.strip()
+
+
+def whitespace_clean(text):
+    text = re.sub(r"\s+", " ", text)
+    text = text.strip()
+    return text
+
+
+def canonicalize(text, keep_punctuation_exact_string=None):
+    text = text.replace("_", " ")
+    if keep_punctuation_exact_string:
+        text = keep_punctuation_exact_string.join(
+            part.translate(str.maketrans("", "", string.punctuation))
+            for part in text.split(keep_punctuation_exact_string)
+        )
+    else:
+        text = text.translate(str.maketrans("", "", string.punctuation))
+    text = text.lower()
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+class HuggingfaceTokenizer:
+    def __init__(self, name, seq_len=None, clean=None, **kwargs):
+        assert clean in (None, "whitespace", "lower", "canonicalize")
+        self.name = name
+        self.seq_len = seq_len
+        self.clean = clean
+
+        # init tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(name, **kwargs)
+        self.vocab_size = self.tokenizer.vocab_size
+
+    def __call__(self, sequence, **kwargs):
+        return_mask = kwargs.pop("return_mask", False)
+
+        # arguments
+        _kwargs = {"return_tensors": "pt"}
+        if self.seq_len is not None:
+            _kwargs.update(
+                {
+                    "padding": "max_length",
+                    "truncation": True,
+                    "max_length": self.seq_len,
+                }
+            )
+        _kwargs.update(**kwargs)
+
+        # tokenization
+        if isinstance(sequence, str):
+            sequence = [sequence]
+        if self.clean:
+            sequence = [self._clean(u) for u in sequence]
+        ids = self.tokenizer(sequence, **_kwargs)
+
+        # output
+        if return_mask:
+            return ids.input_ids, ids.attention_mask
+        else:
+            return ids.input_ids
+
+    def _clean(self, text):
+        if self.clean == "whitespace":
+            text = whitespace_clean(basic_clean(text))
+        elif self.clean == "lower":
+            text = whitespace_clean(basic_clean(text)).lower()
+        elif self.clean == "canonicalize":
+            text = canonicalize(basic_clean(text))
+        return text

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_transformer.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_transformer.py
@@ -161,9 +161,10 @@ def rope_apply(
 
 
 def fast_rms_norm(x, weight, eps):
+    input_dtype = x.dtype
     x = x.float()
     x = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
-    x = x.type_as(x) * weight
+    x = x.to(input_dtype) * weight
     return x
 
 
@@ -194,7 +195,19 @@ class WanLayerNorm(nn.LayerNorm):
         Args:
             x(Tensor): Shape [B, L, C]
         """
-        return super().forward(x)
+        weight = self.weight
+        bias = self.bias
+        if weight is not None and weight.dtype != x.dtype:
+            weight = weight.to(x.dtype)
+        if bias is not None and bias.dtype != x.dtype:
+            bias = bias.to(x.dtype)
+        return torch.nn.functional.layer_norm(
+            x,
+            self.normalized_shape,
+            weight,
+            bias,
+            self.eps,
+        )
 
 
 class WanSelfAttention(nn.Module):
@@ -280,6 +293,8 @@ class WanT2VCrossAttention(WanSelfAttention):
             context(Tensor): Shape [B, L2, C]
             context_lens(Tensor): Shape [B]
         """
+        x = x.to(self.q.weight.dtype)
+        context = context.to(self.k.weight.dtype)
         b, n, d = x.size(0), self.num_heads, self.head_dim
 
         # compute query, key, value
@@ -312,6 +327,8 @@ class WanI2VCrossAttention(WanSelfAttention):
             context(Tensor): Shape [B, L2, C]
             context_lens(Tensor): Shape [B]
         """
+        x = x.to(self.q.weight.dtype)
+        context = context.to(self.k.weight.dtype)
         context_img = context[:, :257]
         context = context[:, 257:]
         b, n, d = x.size(0), self.num_heads, self.head_dim
@@ -443,7 +460,7 @@ class WanAttentionBlock(nn.Module):
             y = self.ffn(
                 mul_add_add(
                     self.norm2(x).unflatten(1, (-1, expand_rate)), e[4], e[3]
-                ).flatten(1, 2)
+                ).flatten(1, 2).to(self.ffn[0].weight.dtype)
             )
             with amp.autocast("cuda", dtype=torch.float32):
                 x = mul_add(
@@ -487,7 +504,7 @@ class Head(nn.Module):
         x = self.head(
             mul_add_add(
                 self.norm(x).unflatten(1, (-1, expand_rate)), e[1], e[0]
-            ).flatten(1, 2)
+            ).flatten(1, 2).to(self.head.weight.dtype)
         )
 
         return x

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_transformer.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_transformer.py
@@ -1,0 +1,900 @@
+import math
+
+import torch
+import torch.amp as amp
+import torch.nn as nn
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.loaders import PeftAdapterMixin
+from diffusers.models.modeling_utils import ModelMixin
+
+from .v2v_attention import attention
+
+__all__ = ["WanModel"]
+
+
+def sinusoidal_embedding_1d(dim, position):
+    # preprocess
+    assert dim % 2 == 0
+    half = dim // 2
+    position = position.type(torch.float64)
+
+    # calculation
+    sinusoid = torch.outer(
+        position, torch.pow(10000, -torch.arange(half).to(position).div(half))
+    )
+    x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
+    return x
+
+
+@amp.autocast("cuda", enabled=False)
+def rope_params(max_seq_len, dim, theta=10000):
+    assert dim % 2 == 0
+    freqs = torch.outer(
+        torch.arange(max_seq_len),
+        1.0 / torch.pow(theta, torch.arange(0, dim, 2).to(torch.float32).div(dim)),
+    )
+    freqs = torch.polar(torch.ones_like(freqs), freqs)
+    return freqs
+
+
+@amp.autocast("cuda", enabled=False)
+def rope_apply(
+    x,
+    grid_sizes,
+    freqs,
+    context_window_size=0,
+    num_token_list=[],
+    num_frame_list=[],
+    grid_size_list=[],
+):
+    n, c = x.size(2), x.size(3) // 2
+    bs = x.size(0)
+
+    # split freqs
+    freqs = freqs.split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
+
+    # loop over samples
+    f, h, w = grid_sizes.tolist()
+
+    if context_window_size == 0 and len(num_frame_list) > 0:
+        seq_len = x.shape[1]
+        num_frame = f - sum(num_frame_list)
+
+        # precompute multipliers
+        x = torch.view_as_complex(x.to(torch.float32).reshape(bs, seq_len, n, -1, 2))
+
+        latent_seq_len = num_frame * h * w
+        freqs_i = torch.cat(
+            [
+                freqs[0][:num_frame]
+                .view(num_frame, 1, 1, -1)
+                .expand(num_frame, h, w, -1),
+                freqs[1][:h].view(1, h, 1, -1).expand(num_frame, h, w, -1),
+                freqs[2][:w].view(1, 1, w, -1).expand(num_frame, h, w, -1),
+            ],
+            dim=-1,
+        ).reshape(latent_seq_len, 1, -1)
+
+        freqs_context_list = []
+        for ii, num_frame in enumerate(num_frame_list):
+            if ii == 0:
+                start = 1024
+            else:
+                start = 1024 + sum(num_frame_list[:ii])
+
+            freqs_temp = torch.cat(
+                [
+                    freqs[0][start : start + num_frame]
+                    .view(num_frame, 1, 1, -1)
+                    .expand(num_frame, h, w, -1),
+                    freqs[1][:h].view(1, h, 1, -1).expand(num_frame, h, w, -1),
+                    freqs[2][:w].view(1, 1, w, -1).expand(num_frame, h, w, -1),
+                ],
+                dim=-1,
+            ).reshape(num_token_list[ii], 1, -1)
+            freqs_context_list.append(freqs_temp)
+        freqs_context = torch.cat(freqs_context_list, dim=0)
+        freqs_i = torch.cat([freqs_i, freqs_context], dim=0)
+        # apply rotary embedding
+        x = torch.view_as_real(x * freqs_i).flatten(3)
+    elif context_window_size != 0:
+        seq_len = x.shape[1]
+        # precompute multipliers
+        x = torch.view_as_complex(x.to(torch.float32).reshape(bs, seq_len, n, -1, 2))
+
+        num_latent_frame = f - sum(num_frame_list)
+        latent_seq_len = num_latent_frame * h * w
+
+        freqs_list = []
+        for i, num_frame in enumerate(num_frame_list):
+            if i == 0:
+                start = 0
+            else:
+                start = sum(num_frame_list[:i])
+
+            _, c_h, c_w = grid_size_list[i]
+            end = start + num_frame
+            freqs_tmp = torch.cat(
+                [
+                    freqs[0][start:end]
+                    .view(num_frame, 1, 1, -1)
+                    .expand(num_frame, c_h, c_w, -1),
+                    freqs[1][:c_h].view(1, c_h, 1, -1).expand(num_frame, c_h, c_w, -1),
+                    freqs[2][:c_w].view(1, 1, c_w, -1).expand(num_frame, c_h, c_w, -1),
+                ],
+                dim=-1,
+            ).reshape(num_frame * c_h * c_w, 1, -1)
+
+            freqs_list.append(freqs_tmp)
+
+        freqs_i = torch.cat(
+            [
+                freqs[0][sum(num_frame_list) : f]
+                .view(num_latent_frame, 1, 1, -1)
+                .expand(num_latent_frame, h, w, -1),
+                freqs[1][:h].view(1, h, 1, -1).expand(num_latent_frame, h, w, -1),
+                freqs[2][:w].view(1, 1, w, -1).expand(num_latent_frame, h, w, -1),
+            ],
+            dim=-1,
+        ).reshape(latent_seq_len, 1, -1)
+        freqs_list.append(freqs_i)
+
+        freqs_i = torch.cat(freqs_list, dim=0)
+
+        # apply rotary embedding
+        x = torch.view_as_real(x * freqs_i).flatten(3)
+    else:
+        # Standard rope apply (transformer_1)
+        seq_len = f * h * w
+        x = torch.view_as_complex(x.to(torch.float32).reshape(bs, seq_len, n, -1, 2))
+        freqs_i = torch.cat(
+            [
+                freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
+                freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
+                freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1),
+            ],
+            dim=-1,
+        ).reshape(seq_len, 1, -1)
+        x = torch.view_as_real(x * freqs_i).flatten(3)
+
+    return x
+
+
+def fast_rms_norm(x, weight, eps):
+    x = x.float()
+    x = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+    x = x.type_as(x) * weight
+    return x
+
+
+class WanRMSNorm(nn.Module):
+    def __init__(self, dim, eps=1e-5):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L, C]
+        """
+        return fast_rms_norm(x, self.weight, self.eps)
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + self.eps)
+
+
+class WanLayerNorm(nn.LayerNorm):
+    def __init__(self, dim, eps=1e-6, elementwise_affine=False):
+        super().__init__(dim, elementwise_affine=elementwise_affine, eps=eps)
+
+    def forward(self, x):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L, C]
+        """
+        return super().forward(x)
+
+
+class WanSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, window_size=(-1, -1), qk_norm=True, eps=1e-6):
+        assert dim % num_heads == 0
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.window_size = window_size
+        self.qk_norm = qk_norm
+        self.eps = eps
+
+        # layers
+        self.q = nn.Linear(dim, dim)
+        self.k = nn.Linear(dim, dim)
+        self.v = nn.Linear(dim, dim)
+        self.o = nn.Linear(dim, dim)
+        self.norm_q = WanRMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
+        self.norm_k = WanRMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
+
+    def forward(
+        self,
+        x,
+        grid_sizes,
+        freqs,
+        block_mask=None,
+        context_window_size=0,
+        num_token_list=[],
+        num_frame_list=[],
+        grid_size_list=[],
+    ):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L, num_heads, C / num_heads]
+            seq_lens(Tensor): Shape [B]
+            grid_sizes(Tensor): Shape [B, 3], the second dimension contains (F, H, W)
+            freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
+        """
+        b, s, n, d = *x.shape[:2], self.num_heads, self.head_dim
+
+        # query, key, value function
+        def qkv_fn(x):
+            q = self.norm_q(self.q(x)).view(b, s, n, d)
+            k = self.norm_k(self.k(x)).view(b, s, n, d)
+            v = self.v(x).view(b, s, n, d)
+            return q, k, v
+
+        x = x.to(self.q.weight.dtype)
+        q, k, v = qkv_fn(x)
+
+        q = rope_apply(
+            q,
+            grid_sizes,
+            freqs,
+            context_window_size,
+            num_token_list,
+            num_frame_list,
+            grid_size_list,
+        )
+        k = rope_apply(
+            k,
+            grid_sizes,
+            freqs,
+            context_window_size,
+            num_token_list,
+            num_frame_list,
+            grid_size_list,
+        )
+        x = attention(q=q, k=k, v=v, window_size=self.window_size)
+
+        # output
+        x = x.flatten(2)
+        x = self.o(x)
+        return x
+
+
+class WanT2VCrossAttention(WanSelfAttention):
+    def forward(self, x, context):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L1, C]
+            context(Tensor): Shape [B, L2, C]
+            context_lens(Tensor): Shape [B]
+        """
+        b, n, d = x.size(0), self.num_heads, self.head_dim
+
+        # compute query, key, value
+        q = self.norm_q(self.q(x)).view(b, -1, n, d)
+        k = self.norm_k(self.k(context)).view(b, -1, n, d)
+        v = self.v(context).view(b, -1, n, d)
+
+        # compute attention
+        x = attention(q, k, v)
+
+        # output
+        x = x.flatten(2)
+        x = self.o(x)
+        return x
+
+
+class WanI2VCrossAttention(WanSelfAttention):
+    def __init__(self, dim, num_heads, window_size=(-1, -1), qk_norm=True, eps=1e-6):
+        super().__init__(dim, num_heads, window_size, qk_norm, eps)
+
+        self.k_img = nn.Linear(dim, dim)
+        self.v_img = nn.Linear(dim, dim)
+        # self.alpha = nn.Parameter(torch.zeros((1, )))
+        self.norm_k_img = WanRMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
+
+    def forward(self, x, context):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L1, C]
+            context(Tensor): Shape [B, L2, C]
+            context_lens(Tensor): Shape [B]
+        """
+        context_img = context[:, :257]
+        context = context[:, 257:]
+        b, n, d = x.size(0), self.num_heads, self.head_dim
+
+        # compute query, key, value
+        q = self.norm_q(self.q(x)).view(b, -1, n, d)
+        k = self.norm_k(self.k(context)).view(b, -1, n, d)
+        v = self.v(context).view(b, -1, n, d)
+        k_img = self.norm_k_img(self.k_img(context_img)).view(b, -1, n, d)
+        v_img = self.v_img(context_img).view(b, -1, n, d)
+        img_x = attention(q, k_img, v_img)
+        # compute attention
+        x = attention(q, k, v)
+
+        # output
+        x = x.flatten(2)
+        img_x = img_x.flatten(2)
+        x = x + img_x
+        x = self.o(x)
+        return x
+
+
+WAN_CROSSATTENTION_CLASSES = {
+    "t2v_cross_attn": WanT2VCrossAttention,
+    "i2v_cross_attn": WanI2VCrossAttention,
+}
+
+
+def mul_add(x, y, z):
+    return x.float() + y.float() * z.float()
+
+
+def mul_add_add(x, y, z):
+    return x.float() * (1 + y) + z
+
+
+class WanAttentionBlock(nn.Module):
+    def __init__(
+        self,
+        cross_attn_type,
+        dim,
+        ffn_dim,
+        num_heads,
+        window_size=(-1, -1),
+        qk_norm=True,
+        cross_attn_norm=False,
+        eps=1e-6,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.ffn_dim = ffn_dim
+        self.num_heads = num_heads
+        self.window_size = window_size
+        self.qk_norm = qk_norm
+        self.cross_attn_norm = cross_attn_norm
+        self.eps = eps
+
+        # layers
+        self.norm1 = WanLayerNorm(dim, eps)
+        self.self_attn = WanSelfAttention(dim, num_heads, window_size, qk_norm, eps)
+        self.norm3 = (
+            WanLayerNorm(dim, eps, elementwise_affine=True)
+            if cross_attn_norm
+            else nn.Identity()
+        )
+        self.cross_attn = WAN_CROSSATTENTION_CLASSES[cross_attn_type](
+            dim, num_heads, (-1, -1), qk_norm, eps
+        )
+        self.norm2 = WanLayerNorm(dim, eps)
+        self.ffn = nn.Sequential(
+            nn.Linear(dim, ffn_dim),
+            nn.GELU(approximate="tanh"),
+            nn.Linear(ffn_dim, dim),
+        )
+
+        # modulation
+        self.modulation = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
+
+    def forward(
+        self,
+        x,
+        e,
+        grid_sizes,
+        freqs,
+        context,
+        block_mask=None,
+        context_window_size=0,
+        num_token_list=[],
+        num_frame_list=[],
+        grid_size_list=[],
+    ):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L, C]
+            e(Tensor): Shape [B, 6, C]
+            seq_lens(Tensor): Shape [B], length of each sequence in batch
+            grid_sizes(Tensor): Shape [B, 3], the second dimension contains (F, H, W)
+            freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
+        """
+        with amp.autocast("cuda", dtype=torch.float32):
+            e = (self.modulation.unsqueeze(2) + e.transpose(1, 2)).chunk(6, dim=1)
+            e = [e_i.transpose(1, 2) for e_i in e]  # [B, F, 1, C] * 6
+            expand_rate = x.shape[1] // e[0].shape[1]
+            assert x.shape[1] % e[0].shape[1] == 0
+
+        # self-attention
+        y = self.self_attn(
+            mul_add_add(
+                self.norm1(x).unflatten(1, (-1, expand_rate)), e[1], e[0]
+            ).flatten(1, 2),
+            grid_sizes,
+            freqs,
+            block_mask,
+            context_window_size,
+            num_token_list,
+            num_frame_list,
+            grid_size_list,
+        )
+        with amp.autocast("cuda", dtype=torch.float32):
+            x = mul_add(
+                x.unflatten(1, (-1, expand_rate)),
+                y.unflatten(1, (-1, expand_rate)),
+                e[2],
+            ).flatten(1, 2)
+
+        # cross-attention & ffn function
+        def cross_attn_ffn(x, context, e):
+            x = x + self.cross_attn(self.norm3(x), context)
+            y = self.ffn(
+                mul_add_add(
+                    self.norm2(x).unflatten(1, (-1, expand_rate)), e[4], e[3]
+                ).flatten(1, 2)
+            )
+            with amp.autocast("cuda", dtype=torch.float32):
+                x = mul_add(
+                    x.unflatten(1, (-1, expand_rate)),
+                    y.unflatten(1, (-1, expand_rate)),
+                    e[5],
+                ).flatten(1, 2)
+            return x
+
+        x = cross_attn_ffn(x, context, e)
+        return x.to(torch.bfloat16)
+
+
+class Head(nn.Module):
+    def __init__(self, dim, out_dim, patch_size, eps=1e-6):
+        super().__init__()
+        self.dim = dim
+        self.out_dim = out_dim
+        self.patch_size = patch_size
+        self.eps = eps
+
+        # layers
+        out_dim = math.prod(patch_size) * out_dim
+        self.norm = WanLayerNorm(dim, eps)
+        self.head = nn.Linear(dim, out_dim)
+
+        # modulation
+        self.modulation = nn.Parameter(torch.randn(1, 2, dim) / dim**0.5)
+
+    def forward(self, x, e):
+        r"""
+        Args:
+            x(Tensor): Shape [B, L1, C]
+            e(Tensor): Shape [B, C]
+        """
+        with amp.autocast("cuda", dtype=torch.float32):
+            e = (self.modulation.unsqueeze(2) + e.unsqueeze(1)).chunk(2, dim=1)
+            e = [e_i.transpose(1, 2) for e_i in e]  # [B, F, 1, C] * 2
+            expand_rate = x.shape[1] // e[0].shape[1]
+            assert x.shape[1] % e[0].shape[1] == 0
+        x = self.head(
+            mul_add_add(
+                self.norm(x).unflatten(1, (-1, expand_rate)), e[1], e[0]
+            ).flatten(1, 2)
+        )
+
+        return x
+
+
+class MLPProj(torch.nn.Module):
+    def __init__(self, in_dim, out_dim):
+        super().__init__()
+
+        self.proj = torch.nn.Sequential(
+            torch.nn.LayerNorm(in_dim),
+            torch.nn.Linear(in_dim, in_dim),
+            torch.nn.GELU(),
+            torch.nn.Linear(in_dim, out_dim),
+            torch.nn.LayerNorm(out_dim),
+        )
+
+    def forward(self, image_embeds):
+        clip_extra_context_tokens = self.proj(image_embeds)
+        return clip_extra_context_tokens
+
+
+class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
+    r"""
+    Wan diffusion backbone supporting both text-to-video and image-to-video.
+    """
+
+    ignore_for_config = [
+        "patch_size",
+        "cross_attn_norm",
+        "qk_norm",
+        "text_dim",
+        "window_size",
+    ]
+    _no_split_modules = ["WanAttentionBlock"]
+
+    _supports_gradient_checkpointing = True
+
+    @register_to_config
+    def __init__(
+        self,
+        model_type="t2v",
+        patch_size=(1, 2, 2),
+        text_len=512,
+        in_dim=16,
+        dim=2048,
+        ffn_dim=8192,
+        freq_dim=256,
+        text_dim=4096,
+        out_dim=16,
+        num_heads=16,
+        num_layers=32,
+        window_size=(-1, -1),
+        qk_norm=True,
+        cross_attn_norm=True,
+        eps=1e-6,
+    ):
+        r"""
+        Initialize the diffusion model backbone.
+
+        Args:
+            model_type (`str`, *optional*, defaults to 't2v'):
+                Model variant - 't2v' (text-to-video) or 'i2v' (image-to-video)
+            patch_size (`tuple`, *optional*, defaults to (1, 2, 2)):
+                3D patch dimensions for video embedding (t_patch, h_patch, w_patch)
+            text_len (`int`, *optional*, defaults to 512):
+                Fixed length for text embeddings
+            in_dim (`int`, *optional*, defaults to 16):
+                Input video channels (C_in)
+            dim (`int`, *optional*, defaults to 2048):
+                Hidden dimension of the transformer
+            ffn_dim (`int`, *optional*, defaults to 8192):
+                Intermediate dimension in feed-forward network
+            freq_dim (`int`, *optional*, defaults to 256):
+                Dimension for sinusoidal time embeddings
+            text_dim (`int`, *optional*, defaults to 4096):
+                Input dimension for text embeddings
+            out_dim (`int`, *optional*, defaults to 16):
+                Output video channels (C_out)
+            num_heads (`int`, *optional*, defaults to 16):
+                Number of attention heads
+            num_layers (`int`, *optional*, defaults to 32):
+                Number of transformer blocks
+            window_size (`tuple`, *optional*, defaults to (-1, -1)):
+                Window size for local attention (-1 indicates global attention)
+            qk_norm (`bool`, *optional*, defaults to True):
+                Enable query/key normalization
+            cross_attn_norm (`bool`, *optional*, defaults to False):
+                Enable cross-attention normalization
+            eps (`float`, *optional*, defaults to 1e-6):
+                Epsilon value for normalization layers
+        """
+
+        super().__init__()
+
+        assert model_type in ["t2v", "i2v"]
+        self.model_type = model_type
+
+        self.patch_size = patch_size
+        self.text_len = text_len
+        self.in_dim = in_dim
+        self.dim = dim
+        self.ffn_dim = ffn_dim
+        self.freq_dim = freq_dim
+        self.text_dim = text_dim
+        self.out_dim = out_dim
+        self.num_heads = num_heads
+        self.num_layers = num_layers
+        self.window_size = window_size
+        self.qk_norm = qk_norm
+        self.cross_attn_norm = cross_attn_norm
+        self.eps = eps
+        self.num_frame_per_block = 1
+        self.enable_teacache = False
+
+        # embeddings
+        self.patch_embedding = nn.Conv3d(
+            in_dim, dim, kernel_size=patch_size, stride=patch_size
+        )
+        self.text_embedding = nn.Sequential(
+            nn.Linear(text_dim, dim), nn.GELU(approximate="tanh"), nn.Linear(dim, dim)
+        )
+
+        self.time_embedding = nn.Sequential(
+            nn.Linear(freq_dim, dim), nn.SiLU(), nn.Linear(dim, dim)
+        )
+        self.time_projection = nn.Sequential(nn.SiLU(), nn.Linear(dim, dim * 6))
+
+        # blocks
+        cross_attn_type = "t2v_cross_attn" if model_type == "t2v" else "i2v_cross_attn"
+        self.blocks = nn.ModuleList(
+            [
+                WanAttentionBlock(
+                    cross_attn_type,
+                    dim,
+                    ffn_dim,
+                    num_heads,
+                    window_size,
+                    qk_norm,
+                    cross_attn_norm,
+                    eps,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        # head
+        self.head = Head(dim, out_dim, patch_size, eps)
+
+        # buffers (don't use register_buffer otherwise dtype will be changed in to())
+        assert (dim % num_heads) == 0 and (dim // num_heads) % 2 == 0
+        d = dim // num_heads
+        with torch.device("cpu"):
+            self.freqs = torch.cat(
+                [
+                    rope_params(2048, d - 4 * (d // 6)),
+                    rope_params(2048, 2 * (d // 6)),
+                    rope_params(2048, 2 * (d // 6)),
+                ],
+                dim=1,
+            )
+
+        if model_type == "i2v":
+            self.img_emb = MLPProj(1280, dim)
+
+        self.gradient_checkpointing = False
+
+        self.cpu_offloading = False
+
+        # initialize weights
+        self.init_weights()
+
+    def _set_gradient_checkpointing(self, module, value=False):
+        self.gradient_checkpointing = value
+
+    def zero_init_i2v_cross_attn(self):
+        print("zero init i2v cross attn")
+        for i in range(self.num_layers):
+            self.blocks[i].cross_attn.v_img.weight.data.zero_()
+            self.blocks[i].cross_attn.v_img.bias.data.zero_()
+
+    def forward(
+        self,
+        x,
+        t,
+        context,
+        clip_fea=None,
+        y=None,
+        block_mask=None,
+        context_window_size=0,
+        block_offload: bool = False,
+    ):
+        r"""
+        Forward pass through the diffusion model
+
+        Args:
+            x (Tensor or List[Tensor]):
+                Input video tensor [C_in, F, H, W] or list of tensors for context support.
+            t (Tensor):
+                Diffusion timesteps tensor of shape [B]
+            context (List[Tensor]):
+                List of text embeddings each with shape [L, C]
+            clip_fea (Tensor, *optional*):
+                CLIP image features for image-to-video mode
+            y (List[Tensor], *optional*):
+                Conditional video inputs for image-to-video mode, same shape as x
+            block_mask (Tensor, *optional*):
+                Attention block mask
+            context_window_size (int, *optional*):
+                Window size for context support
+
+        Returns:
+            Tensor:
+                Denoised video tensor with original input shapes [C_out, F, H / 8, W / 8]
+        """
+        if self.model_type == "i2v":
+            assert clip_fea is not None and y is not None
+
+        if block_offload:
+            self.patch_embedding.to("cuda")
+            self.text_embedding.to("cuda")
+            self.time_embedding.to("cuda")
+            self.time_projection.to("cuda")
+            if hasattr(self, "img_emb"):
+                self.img_emb.to("cuda")
+            self.freqs = self.freqs.to("cuda")
+
+            if isinstance(x, torch.Tensor):
+                x = x.to("cuda")
+            elif isinstance(x, list):
+                x = [item.to("cuda") for item in x]
+
+            t = t.to("cuda")
+            context = context.to("cuda")
+            if clip_fea is not None:
+                clip_fea = clip_fea.to("cuda")
+            if y is not None:
+                y = y.to("cuda")
+            if block_mask is not None:
+                block_mask = block_mask.to("cuda")
+
+        # params
+        device = self.patch_embedding.weight.device
+        if self.freqs.device != device:
+            self.freqs = self.freqs.to(device)
+
+        # Ensure freqs is always on the correct device if it wasn't moved in block_offload
+        if not block_offload and isinstance(x, torch.Tensor) and self.freqs.device != x.device:
+            self.freqs = self.freqs.to(x.device)
+        elif not block_offload and isinstance(x, list) and len(x) > 0 and self.freqs.device != x[0].device:
+            self.freqs = self.freqs.to(x[0].device)
+
+        if isinstance(x, torch.Tensor):
+            if y is not None:
+                if y.device != x.device:
+                    y = y.to(x.device)
+                x = torch.cat([x, y], dim=1)
+
+            # embeddings
+            x = self.patch_embedding(x)
+            grid_sizes = torch.tensor(x.shape[2:], dtype=torch.long)
+            x = x.flatten(2).transpose(1, 2)
+
+            grid_size_list = []
+            num_frame_list = []
+            num_token_list = []
+        else:
+            # list of tensors path (transformer_2)
+            x = [self.patch_embedding(item) for item in x]
+            grid_size_list = [
+                torch.tensor(item.shape[2:], dtype=torch.long) for item in x[1:]
+            ]
+            num_frame_list = [item.shape[2] for item in x[1:]]
+
+            grid_sizes = torch.tensor(x[0].shape[2:], dtype=torch.long)
+            grid_sizes[0] = grid_sizes[0] + sum(num_frame_list)
+
+            x = [item.flatten(2).transpose(1, 2) for item in x]
+            num_token_list = [item.shape[1] for item in x[1:]]
+
+            x = torch.cat(x, dim=1)
+
+        # time embeddings
+        with amp.autocast("cuda", dtype=torch.float32):
+            b, f = t.shape
+
+            e = self.time_embedding(
+                sinusoidal_embedding_1d(self.freq_dim, t.flatten()).to(
+                    self.patch_embedding.weight.dtype
+                )
+            )  # b, dim
+            e0 = self.time_projection(e).unflatten(1, (6, self.dim))  # b, 6, dim
+            e = e.view(b, f, -1)
+            e0 = e0.view(b, f, 6, self.dim)
+
+            assert e.dtype == torch.float32 and e0.dtype == torch.float32
+
+        # context
+        context = self.text_embedding(context)
+
+        if clip_fea is not None:
+            context_clip = self.img_emb(clip_fea)  # bs x 257 x dim
+            context = torch.concat([context_clip, context], dim=1)
+
+        if block_offload:
+            self.patch_embedding.to("cpu")
+            self.text_embedding.to("cpu")
+            self.time_embedding.to("cpu")
+            self.time_projection.to("cpu")
+            if hasattr(self, "img_emb"):
+                self.img_emb.to("cpu")
+            torch.cuda.empty_cache()
+
+        # arguments
+        kwargs = dict(
+            e=e0,
+            grid_sizes=grid_sizes,
+            freqs=self.freqs,
+            context=context,
+            grid_size_list=grid_size_list,
+            num_frame_list=num_frame_list,
+            num_token_list=num_token_list,
+            context_window_size=context_window_size,
+            block_mask=block_mask,
+        )
+
+        if block_offload:
+            for i, block in enumerate(self.blocks):
+                block.to("cuda")
+
+                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                    x = self._gradient_checkpointing_func(
+                        block,
+                        x,
+                        **kwargs,
+                    )
+                else:
+                    x = block(x, **kwargs)
+
+                block.to("cpu")
+                torch.cuda.empty_cache()
+        else:
+            for block in self.blocks:
+                x = block(x, **kwargs)
+
+        if block_offload:
+            self.head.to("cuda")
+
+        x = self.head(x, e)
+
+        if block_offload:
+            self.head.to("cpu")
+            torch.cuda.empty_cache()
+
+        if len(num_token_list) > 0:
+            num_context_token = sum(num_token_list)
+            x = x[:, :-num_context_token]
+            grid_sizes[0] = grid_sizes[0] - sum(num_frame_list)
+
+        # unpatchify
+        x = self.unpatchify(x, grid_sizes)
+        return x.float()
+
+    def unpatchify(self, x, grid_sizes):
+        r"""
+        Reconstruct video tensors from patch embeddings.
+
+        Args:
+            x (List[Tensor]):
+                List of patchified features, each with shape [L, C_out * prod(patch_size)]
+            grid_sizes (Tensor):
+                Original spatial-temporal grid dimensions before patching,
+                    shape [B, 3] (3 dimensions correspond to F_patches, H_patches, W_patches)
+
+        Returns:
+            List[Tensor]:
+                Reconstructed video tensors with shape [C_out, F, H / 8, W / 8]
+        """
+
+        c = self.out_dim
+        bs = x.shape[0]
+        x = x.view(bs, *grid_sizes, *self.patch_size, c)
+        x = torch.einsum("bfhwpqrc->bcfphqwr", x)
+        x = x.reshape(bs, c, *[i * j for i, j in zip(grid_sizes, self.patch_size)])
+
+        return x
+
+    def init_weights(self):
+        r"""
+        Initialize model parameters using Xavier initialization.
+        """
+
+        # basic init
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+        # init embeddings
+        nn.init.xavier_uniform_(self.patch_embedding.weight.flatten(1))
+        for m in self.text_embedding.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, std=0.02)
+        for m in self.time_embedding.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, std=0.02)
+
+        # init output layer
+        nn.init.zeros_(self.head.head.weight)

--- a/vllm_omni/diffusion/models/skyreels_v3/v2v_vae.py
+++ b/vllm_omni/diffusion/models/skyreels_v3/v2v_vae.py
@@ -1,0 +1,758 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+__all__ = [
+    "WanVAE",
+]
+
+CACHE_T = 2
+
+
+class CausalConv3d(nn.Conv3d):
+    """
+    Causal 3d convolusion.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._padding = (
+            self.padding[2],
+            self.padding[2],
+            self.padding[1],
+            self.padding[1],
+            2 * self.padding[0],
+            0,
+        )
+        self.padding = (0, 0, 0)
+
+    def forward(self, x, cache_x=None):
+        padding = list(self._padding)
+        if cache_x is not None and self._padding[4] > 0:
+            cache_x = cache_x.to(x.device)
+            x = torch.cat([cache_x, x], dim=2)
+            padding[4] -= cache_x.shape[2]
+        x = F.pad(x, padding)
+
+        return super().forward(x)
+
+
+class RMS_norm(nn.Module):
+    def __init__(self, dim, channel_first=True, images=True, bias=False):
+        super().__init__()
+        broadcastable_dims = (1, 1, 1) if not images else (1, 1)
+        shape = (dim, *broadcastable_dims) if channel_first else (dim,)
+
+        self.channel_first = channel_first
+        self.scale = dim**0.5
+        self.gamma = nn.Parameter(torch.ones(shape))
+        self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
+
+    def forward(self, x):
+        return (
+            F.normalize(x, dim=(1 if self.channel_first else -1))
+            * self.scale
+            * self.gamma
+            + self.bias
+        )
+
+
+class Upsample(nn.Upsample):
+    def forward(self, x):
+        """
+        Fix bfloat16 support for nearest neighbor interpolation.
+        """
+        return super().forward(x.float()).type_as(x)
+
+
+class Resample(nn.Module):
+    def __init__(self, dim, mode):
+        assert mode in (
+            "none",
+            "upsample2d",
+            "upsample3d",
+            "downsample2d",
+            "downsample3d",
+        )
+        super().__init__()
+        self.dim = dim
+        self.mode = mode
+
+        # layers
+        if mode == "upsample2d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"),
+                nn.Conv2d(dim, dim // 2, 3, padding=1),
+            )
+        elif mode == "upsample3d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"),
+                nn.Conv2d(dim, dim // 2, 3, padding=1),
+            )
+            self.time_conv = CausalConv3d(dim, dim * 2, (3, 1, 1), padding=(1, 0, 0))
+
+        elif mode == "downsample2d":
+            self.resample = nn.Sequential(
+                nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2))
+            )
+        elif mode == "downsample3d":
+            self.resample = nn.Sequential(
+                nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2))
+            )
+            self.time_conv = CausalConv3d(
+                dim, dim, (3, 1, 1), stride=(2, 1, 1), padding=(0, 0, 0)
+            )
+
+        else:
+            self.resample = nn.Identity()
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        b, c, t, h, w = x.size()
+        if self.mode == "upsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = "Rep"
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                    if (
+                        cache_x.shape[2] < 2
+                        and feat_cache[idx] is not None
+                        and feat_cache[idx] != "Rep"
+                    ):
+                        # cache last frame of last two chunk
+                        cache_x = torch.cat(
+                            [
+                                feat_cache[idx][:, :, -1, :, :]
+                                .unsqueeze(2)
+                                .to(cache_x.device),
+                                cache_x,
+                            ],
+                            dim=2,
+                        )
+                    if (
+                        cache_x.shape[2] < 2
+                        and feat_cache[idx] is not None
+                        and feat_cache[idx] == "Rep"
+                    ):
+                        cache_x = torch.cat(
+                            [torch.zeros_like(cache_x).to(cache_x.device), cache_x],
+                            dim=2,
+                        )
+                    if feat_cache[idx] == "Rep":
+                        x = self.time_conv(x)
+                    else:
+                        x = self.time_conv(x, feat_cache[idx])
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+
+                    x = x.reshape(b, 2, c, t, h, w)
+                    x = torch.stack((x[:, 0, :, :, :, :], x[:, 1, :, :, :, :]), 3)
+                    x = x.reshape(b, c, t * 2, h, w)
+        t = x.shape[2]
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.resample(x)
+        x = rearrange(x, "(b t) c h w -> b c t h w", t=t)
+
+        if self.mode == "downsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = x.clone()
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -1:, :, :].clone()
+                    # if cache_x.shape[2] < 2 and feat_cache[idx] is not None and feat_cache[idx]!='Rep':
+                    #     # cache last frame of last two chunk
+                    #     cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+
+                    x = self.time_conv(
+                        torch.cat([feat_cache[idx][:, :, -1:, :, :], x], 2)
+                    )
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+        return x
+
+    def init_weight(self, conv):
+        conv_weight = conv.weight
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        one_matrix = torch.eye(c1, c2)
+        init_matrix = one_matrix
+        nn.init.zeros_(conv_weight)
+        # conv_weight.data[:,:,-1,1,1] = init_matrix * 0.5
+        conv_weight.data[:, :, 1, 0, 0] = init_matrix  # * 0.5
+        conv.weight.data.copy_(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+    def init_weight2(self, conv):
+        conv_weight = conv.weight.data
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        init_matrix = torch.eye(c1 // 2, c2)
+        # init_matrix = repeat(init_matrix, 'o ... -> (o 2) ...').permute(1,0,2).contiguous().reshape(c1,c2)
+        conv_weight[: c1 // 2, :, -1, 0, 0] = init_matrix
+        conv_weight[c1 // 2 :, :, -1, 0, 0] = init_matrix
+        conv.weight.data.copy_(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout=0.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+
+        # layers
+        self.residual = nn.Sequential(
+            RMS_norm(in_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(in_dim, out_dim, 3, padding=1),
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            CausalConv3d(out_dim, out_dim, 3, padding=1),
+        )
+        self.shortcut = (
+            CausalConv3d(in_dim, out_dim, 1) if in_dim != out_dim else nn.Identity()
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        h = self.shortcut(x)
+        for layer in self.residual:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x + h
+
+
+class AttentionBlock(nn.Module):
+    """
+    Causal self-attention with a single head.
+    """
+
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+        # layers
+        self.norm = RMS_norm(dim)
+        self.to_qkv = nn.Conv2d(dim, dim * 3, 1)
+        self.proj = nn.Conv2d(dim, dim, 1)
+
+        # zero out the last layer params
+        nn.init.zeros_(self.proj.weight)
+
+    def forward(self, x):
+        identity = x
+        b, c, t, h, w = x.size()
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.norm(x)
+        # compute query, key, value
+        q, k, v = (
+            self.to_qkv(x)
+            .reshape(b * t, 1, c * 3, -1)
+            .permute(0, 1, 3, 2)
+            .contiguous()
+            .chunk(3, dim=-1)
+        )
+
+        # apply attention
+        x = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+        )
+        x = x.squeeze(1).permute(0, 2, 1).reshape(b * t, c, h, w)
+
+        # output
+        x = self.proj(x)
+        x = rearrange(x, "(b t) c h w-> b c t h w", t=t)
+        return x + identity
+
+
+class Encoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+
+        # dimensions
+        dims = [dim * u for u in [1] + dim_mult]
+        scale = 1.0
+
+        # init block
+        self.conv1 = CausalConv3d(3, dims[0], 3, padding=1)
+
+        # downsample blocks
+        downsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            # residual (+attention) blocks
+            for _ in range(num_res_blocks):
+                downsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+                if scale in attn_scales:
+                    downsamples.append(AttentionBlock(out_dim))
+                in_dim = out_dim
+
+            # downsample block
+            if i != len(dim_mult) - 1:
+                mode = "downsample3d" if temperal_downsample[i] else "downsample2d"
+                downsamples.append(Resample(out_dim, mode=mode))
+                scale /= 2.0
+        self.downsamples = nn.Sequential(*downsamples)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(out_dim, out_dim, dropout),
+            AttentionBlock(out_dim),
+            ResidualBlock(out_dim, out_dim, dropout),
+        )
+
+        # output blocks
+        self.head = nn.Sequential(
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(out_dim, z_dim, 3, padding=1),
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                # cache last frame of last two chunk
+                cache_x = torch.cat(
+                    [
+                        feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device),
+                        cache_x,
+                    ],
+                    dim=2,
+                )
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        # downsamples
+        for layer in self.downsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # middle
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x
+
+
+class Decoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_upsample=[False, True, True],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_upsample = temperal_upsample
+
+        # dimensions
+        dims = [dim * u for u in [dim_mult[-1]] + dim_mult[::-1]]
+        scale = 1.0 / 2 ** (len(dim_mult) - 2)
+
+        # init block
+        self.conv1 = CausalConv3d(z_dim, dims[0], 3, padding=1)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(dims[0], dims[0], dropout),
+            AttentionBlock(dims[0]),
+            ResidualBlock(dims[0], dims[0], dropout),
+        )
+
+        # upsample blocks
+        upsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            # residual (+attention) blocks
+            if i == 1 or i == 2 or i == 3:
+                in_dim = in_dim // 2
+            for _ in range(num_res_blocks + 1):
+                upsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+                if scale in attn_scales:
+                    upsamples.append(AttentionBlock(out_dim))
+                in_dim = out_dim
+
+            # upsample block
+            if i != len(dim_mult) - 1:
+                mode = "upsample3d" if temperal_upsample[i] else "upsample2d"
+                upsamples.append(Resample(out_dim, mode=mode))
+                scale *= 2.0
+        self.upsamples = nn.Sequential(*upsamples)
+
+        # output blocks
+        self.head = nn.Sequential(
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(out_dim, 3, 3, padding=1),
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        # conv1
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                # cache last frame of last two chunk
+                cache_x = torch.cat(
+                    [
+                        feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device),
+                        cache_x,
+                    ],
+                    dim=2,
+                )
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        # middle
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # upsamples
+        for layer in self.upsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x
+
+
+def count_conv3d(model):
+    count = 0
+    for m in model.modules():
+        if isinstance(m, CausalConv3d):
+            count += 1
+    return count
+
+
+class WanVAE_(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+        self.temperal_upsample = temperal_downsample[::-1]
+
+        # modules
+        self.encoder = Encoder3d(
+            dim,
+            z_dim * 2,
+            dim_mult,
+            num_res_blocks,
+            attn_scales,
+            self.temperal_downsample,
+            dropout,
+        )
+        self.conv1 = CausalConv3d(z_dim * 2, z_dim * 2, 1)
+        self.conv2 = CausalConv3d(z_dim, z_dim, 1)
+        self.decoder = Decoder3d(
+            dim,
+            z_dim,
+            dim_mult,
+            num_res_blocks,
+            attn_scales,
+            self.temperal_upsample,
+            dropout,
+        )
+
+    def forward(self, x):
+        mu, log_var = self.encode(x)
+        z = self.reparameterize(mu, log_var)
+        x_recon = self.decode(z)
+        return x_recon, mu, log_var
+
+    def encode(self, x, scale):
+        self.clear_cache()
+        # cache
+        t = x.shape[2]
+        iter_ = 1 + (t - 1) // 4
+        # 对encode输入的x，按时间拆分为1、4、4、4....
+        for i in range(iter_):
+            self._enc_conv_idx = [0]
+            if i == 0:
+                out = self.encoder(
+                    x[:, :, :1, :, :],
+                    feat_cache=self._enc_feat_map,
+                    feat_idx=self._enc_conv_idx,
+                )
+            else:
+                out_ = self.encoder(
+                    x[:, :, 1 + 4 * (i - 1) : 1 + 4 * i, :, :],
+                    feat_cache=self._enc_feat_map,
+                    feat_idx=self._enc_conv_idx,
+                )
+                out = torch.cat([out, out_], 2)
+        mu, log_var = self.conv1(out).chunk(2, dim=1)
+        if isinstance(scale[0], torch.Tensor):
+            mu = (mu - scale[0].view(1, self.z_dim, 1, 1, 1)) * scale[1].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        else:
+            mu = (mu - scale[0]) * scale[1]
+        self.clear_cache()
+        return mu
+
+    def decode(self, z, scale):
+        self.clear_cache()
+        # z: [b,c,t,h,w]
+        if isinstance(scale[0], torch.Tensor):
+            z = z / scale[1].view(1, self.z_dim, 1, 1, 1) + scale[0].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        else:
+            z = z / scale[1] + scale[0]
+        iter_ = z.shape[2]
+        x = self.conv2(z)
+        for i in range(iter_):
+            self._conv_idx = [0]
+            if i == 0:
+                out = self.decoder(
+                    x[:, :, i : i + 1, :, :],
+                    feat_cache=self._feat_map,
+                    feat_idx=self._conv_idx,
+                )
+            else:
+                out_ = self.decoder(
+                    x[:, :, i : i + 1, :, :],
+                    feat_cache=self._feat_map,
+                    feat_idx=self._conv_idx,
+                )
+                out = torch.cat([out, out_], 2)
+        self.clear_cache()
+        return out
+
+    def reparameterize(self, mu, log_var):
+        std = torch.exp(0.5 * log_var)
+        eps = torch.randn_like(std)
+        return eps * std + mu
+
+    def sample(self, imgs, deterministic=False):
+        mu, log_var = self.encode(imgs)
+        if deterministic:
+            return mu
+        std = torch.exp(0.5 * log_var.clamp(-30.0, 20.0))
+        return mu + std * torch.randn_like(std)
+
+    def clear_cache(self):
+        self._conv_num = count_conv3d(self.decoder)
+        self._conv_idx = [0]
+        self._feat_map = [None] * self._conv_num
+        # cache encode
+        self._enc_conv_num = count_conv3d(self.encoder)
+        self._enc_conv_idx = [0]
+        self._enc_feat_map = [None] * self._enc_conv_num
+
+
+def _video_vae(pretrained_path=None, z_dim=None, device="cpu", **kwargs):
+    """
+    Autoencoder3d adapted from Stable Diffusion 1.x, 2.x and XL.
+    """
+    # params
+    cfg = dict(
+        dim=96,
+        z_dim=z_dim,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[False, True, True],
+        dropout=0.0,
+    )
+    cfg.update(**kwargs)
+
+    # init model
+    with torch.device("meta"):
+        model = WanVAE_(**cfg)
+
+    # load checkpoint
+    logging.info(f"loading {pretrained_path}")
+    model.load_state_dict(torch.load(pretrained_path, map_location=device), assign=True)
+
+    return model
+
+
+class WanVAE:
+    def __init__(self, vae_pth="cache/vae_step_411000.pth", z_dim=16):
+        mean = [
+            -0.7571,
+            -0.7089,
+            -0.9113,
+            0.1075,
+            -0.1745,
+            0.9653,
+            -0.1517,
+            1.5508,
+            0.4134,
+            -0.0715,
+            0.5517,
+            -0.3632,
+            -0.1922,
+            -0.9497,
+            0.2503,
+            -0.2921,
+        ]
+        std = [
+            2.8184,
+            1.4541,
+            2.3275,
+            2.6558,
+            1.2196,
+            1.7708,
+            2.6052,
+            2.0743,
+            3.2687,
+            2.1526,
+            2.8652,
+            1.5579,
+            1.6382,
+            1.1253,
+            2.8251,
+            1.9160,
+        ]
+        self.vae_stride = (4, 8, 8)
+        self.mean = torch.tensor(mean)
+        self.std = torch.tensor(std)
+        self.scale = [self.mean, 1.0 / self.std]
+
+        # init model
+        self.vae = (
+            _video_vae(
+                pretrained_path=vae_pth,
+                z_dim=z_dim,
+            )
+            .eval()
+            .requires_grad_(False)
+        )
+
+    def encode(self, video):
+        """
+        videos: A list of videos each with shape [C, T, H, W].
+        """
+        return self.vae.encode(video, self.scale).float()
+
+    def to(self, *args, **kwargs):
+        self.mean = self.mean.to(*args, **kwargs)
+        self.std = self.std.to(*args, **kwargs)
+        self.scale = [self.mean, 1.0 / self.std]
+        self.vae = self.vae.to(*args, **kwargs)
+        return self
+
+    def decode(self, z):
+        return self.vae.decode(z, self.scale).float().clamp_(-1, 1)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -111,6 +111,11 @@ _DIFFUSION_MODELS = {
         "pipeline_wan2_2_s2v",
         "Wan22S2VPipeline",
     ),
+    "SkyReelsV3V2VPipeline": (
+        "skyreels_v3",
+        "pipeline_skyreels_v3_v2v",
+        "SkyReelsV3V2VPipeline",
+    ),
     "WanT2VDMD2Pipeline": (
         "wan2_2",
         "pipeline_wan2_2",
@@ -522,6 +527,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "AudioXPipeline": "get_audiox_post_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_post_process_func",
     "WanS2VPipeline": "get_wan22_s2v_post_process_func",
+    "SkyReelsV3V2VPipeline": "get_skyreels_v3_v2v_post_process_func",
     "WanT2VDMD2Pipeline": "get_wan22_post_process_func",
     "WanI2VDMD2Pipeline": "get_wan22_i2v_post_process_func",
     "LongCatImagePipeline": "get_longcat_image_post_process_func",
@@ -580,6 +586,7 @@ _DIFFUSION_PRE_PROCESS_FUNCS = {
     "WanVACEPipeline": "get_wan22_vace_pre_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_pre_process_func",
     "WanS2VPipeline": "get_wan22_s2v_pre_process_func",
+    "SkyReelsV3V2VPipeline": "get_skyreels_v3_v2v_pre_process_func",
     "WanT2VDMD2Pipeline": "get_wan22_pre_process_func",
     "WanI2VDMD2Pipeline": "get_wan22_i2v_pre_process_func",
     "OmniGen2Pipeline": "get_omnigen2_pre_process_func",

--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_file_to_dict
+from vllm.transformers_utils.repo_utils import file_exists
 
 logger = init_logger(__name__)
 
@@ -71,6 +72,36 @@ def _looks_like_dreamzero(model_name: str) -> bool:
         return False
 
 
+def _looks_like_skyreels_v3_v2v(model_name: str | None) -> bool:
+    """Best-effort detection for SkyReels-V3 video-extension checkpoints."""
+    if not model_name:
+        return False
+    normalized = str(model_name).lower().replace("_", "-")
+    if "skyreels-v3" in normalized and "video-extension" in normalized:
+        return True
+
+    required_files = (
+        "transformer/config.json",
+        "Wan2.1_VAE.pth",
+        "models_t5_umt5-xxl-enc-bf16.pth",
+    )
+    required_dirs = (
+        os.path.join("google", "umt5-xxl"),
+        "transformer",
+    )
+    if os.path.isdir(model_name):
+        return all(os.path.exists(os.path.join(model_name, path)) for path in required_files) and all(
+            os.path.isdir(os.path.join(model_name, path)) for path in required_dirs
+        )
+    if "skyreels" not in normalized:
+        return False
+
+    try:
+        return all(file_exists(model_name, path) for path in required_files)
+    except Exception:
+        return False
+
+
 @lru_cache
 def is_diffusion_model(model_name: str) -> bool:
     """Check if a model is a diffusion model.
@@ -97,6 +128,10 @@ def is_diffusion_model(model_name: str) -> bool:
             except Exception as e:
                 logger.debug("Failed to read local %s: %s", filename, e)
 
+    if _looks_like_skyreels_v3_v2v(model_name):
+        logger.debug("Detected SkyReels V3 V2V diffusion model")
+        return True
+
     # Strategy 2: Check using vllm's utility (works for both local and remote models)
     config_dict = get_diffusion_model_index(model_name)
     if config_dict is not None and config_dict.get("_class_name") and config_dict.get("_diffusers_version"):
@@ -118,4 +153,8 @@ def is_diffusion_model(model_name: str) -> bool:
         # Bagel and DreamZero are not diffusers pipelines (no model_index.json),
         # but are still diffusion-style models in vllm-omni. Detect them via
         # config.json.
-    return _looks_like_bagel(model_name) or _looks_like_dreamzero(model_name)
+    return (
+        _looks_like_bagel(model_name)
+        or _looks_like_dreamzero(model_name)
+        or _looks_like_skyreels_v3_v2v(model_name)
+    )

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -304,16 +304,18 @@ def resolve_model_config_path(model: str) -> str | None:
             except Exception as e:
                 raise ValueError(f"Failed to read config.json for model: {model}. Error: {e}") from e
         else:
-            # No config.json at repo root (e.g. GLM-TTS stores configs in
-            # subdirectories only).  Try matching against registered deploy
-            # YAML filenames before giving up.
-            model_type = _try_resolve_omni_model_type(model)
-            if model_type is None:
-                raise ValueError(
-                    f"Could not determine model_type for model: {model}. "
-                    "Model is not in standard transformers or Diffusers format. "
-                    f"Please ensure the model has proper configuration files with 'model_type' field"
-                )
+            from vllm_omni.diffusion.utils.hf_utils import _looks_like_skyreels_v3_v2v
+
+            if _looks_like_skyreels_v3_v2v(model):
+                model_type = "skyreels_v3_v2v"
+            else:
+                model_type = _try_resolve_omni_model_type(model)
+                if model_type is None:
+                    raise ValueError(
+                        f"Could not determine model_type for model: {model}. "
+                        "Model is not in standard transformers or Diffusers format. "
+                        f"Please ensure the model has proper configuration files with 'model_type' field"
+                    )
 
     default_config_path = current_omni_platform.get_default_stage_config_path()
     if model_type == "vla" and _looks_like_dreamzero(model):

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -187,6 +187,27 @@ def default_image_to_video_prompt(
     return default_image_to_image_prompt(prompt, negative_prompt, media_inputs["image"])
 
 
+def skyreels_v3_v2v_image_to_video_prompt(
+    prompt: str,
+    negative_prompt: str | None,
+    media_inputs: Mapping[str, Any],
+    height: int | None = None,
+    width: int | None = None,
+    num_frames: int | None = None,
+) -> dict[str, Any]:
+    del height, width, num_frames
+    unsupported = set(media_inputs) - {"video"}
+    if unsupported:
+        raise ValueError(f"SkyReels V3 V2V does not support media inputs: {sorted(unsupported)}.")
+    video = media_inputs.get("video")
+    if video is None:
+        raise ValueError("SkyReels V3 V2V requires --video (path to the input video to extend).")
+    result: dict[str, Any] = {"prompt": prompt, "multi_modal_data": {"video": video}}
+    if negative_prompt is not None:
+        result["negative_prompt"] = negative_prompt
+    return result
+
+
 _EXTRA_SPECS: dict[str, dict[str, Any]] = {
     "AudioXPipeline": {
         "extra_body_params": AUDIOX_EXTRA_BODY_PARAMS,
@@ -246,6 +267,7 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
     "SkyReelsV3V2VPipeline": {
         "extra_body_params": SKYREELS_V3_V2V_EXTRA_BODY_PARAMS,
         "extra_output_params": SKYREELS_V3_V2V_EXTRA_OUTPUT_PARAMS,
+        "image_to_video_prompt_builder": skyreels_v3_v2v_image_to_video_prompt,
     },
     "MammothModa2DiTPipeline": {
         "extra_body_params": MAMMOTHMODA2_PREVIEW_EXTRA_BODY_PARAMS,

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -68,6 +68,10 @@ from vllm_omni.model_extras.sensenova_u1 import (
     SENSENOVA_U1_EXTRA_BODY_PARAMS,
     SENSENOVA_U1_EXTRA_OUTPUT_PARAMS,
 )
+from vllm_omni.model_extras.skyreels_v3 import (
+    SKYREELS_V3_V2V_EXTRA_BODY_PARAMS,
+    SKYREELS_V3_V2V_EXTRA_OUTPUT_PARAMS,
+)
 from vllm_omni.model_extras.vace import (
     VACE_EXTRA_BODY_PARAMS,
     VACE_EXTRA_OUTPUT_PARAMS,
@@ -238,6 +242,10 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
         "extra_body_params": VACE_EXTRA_BODY_PARAMS,
         "extra_output_params": VACE_EXTRA_OUTPUT_PARAMS,
         "image_to_video_prompt_builder": build_vace_image_to_video_prompt,
+    },
+    "SkyReelsV3V2VPipeline": {
+        "extra_body_params": SKYREELS_V3_V2V_EXTRA_BODY_PARAMS,
+        "extra_output_params": SKYREELS_V3_V2V_EXTRA_OUTPUT_PARAMS,
     },
     "MammothModa2DiTPipeline": {
         "extra_body_params": MAMMOTHMODA2_PREVIEW_EXTRA_BODY_PARAMS,

--- a/vllm_omni/model_extras/skyreels_v3.py
+++ b/vllm_omni/model_extras/skyreels_v3.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+# SkyReels V3 V2V consumes video conditioning through extra_args because the
+# OpenAI diffusion chat path stores reference videos as `video_path` rather than
+# decoding them into `multi_modal_data`.
+SKYREELS_V3_V2V_EXTRA_BODY_PARAMS: frozenset[str] = frozenset(
+    {
+        "video_path",
+        "input_video",
+        "duration",
+        "fps",
+        "condition_frames",
+        "sampling_steps",
+        "cfg_text_scale",
+        "shift",
+        "block_offload",
+        "include_input_video",
+    }
+)
+
+SKYREELS_V3_V2V_EXTRA_OUTPUT_PARAMS: frozenset[str] = frozenset()


### PR DESCRIPTION
## Summary

Adds SkyReels V3 V2V (single-shot video extension, 14B) as a new diffusion pipeline. Same-seed apples-to-apples run vs the Skywork upstream `generate_video.py --task_type single_shot_extension` reference matches per-step kernel time byte-for-byte (207 s Skywork vs 209 s vllm-omni per denoise step at 1312×688 × 33 latent frames, guidance=1) and lands at PSNR mean 19.4 dB / SSIM 0.53 across 132 overlapping frames.

Companion PR to [#5888](https://github.com/vllm-project/vllm-omni/pull/5888) (A2V) and [#5856](https://github.com/vllm-project/vllm-omni/pull/5856) (R2V). Same three-branch layout that #5856 laid down for `SkyReelsV3R2VPipeline`.

## What's in this PR

**Model** — `SkyReelsV3V2VPipeline` under `vllm_omni/diffusion/models/skyreels_v3/` with V2V-specific transformer, T5 encoder, WanVAE decode path, and aspect-ratio bucket resolver. Registered in `vllm_omni/diffusion/registry.py` and exported from the package `__init__.py`.

**Entrypoint routing** — `entrypoints/utils.py::_try_resolve_omni_model_type` now short-circuits to `SkyReelsV3V2VPipeline` when a checkpoint dir matches the V2V shape (V2V-14B ships no root `config.json`/`model_index.json`, which previously raised `ValueError: Could not determine model_type for model...`).

**Prompt builder** — `model_extras/registry.py` registers `skyreels_v3_v2v_image_to_video_prompt` so a `--video` payload passes validation without requiring the usual `image` field.

**Example CLI** — `examples/offline_inference/image_to_video/image_to_video.py` gains a `--video` flag that routes into `multi_modal_data["video"]` and skips the `dimension_image` requirement (V2V picks output resolution from the input video via `resolve_bucket_size`).

**Tests + CI wiring** —

| Level | Path | Result |
|---|---|---|
| L1 CPU unit | `tests/diffusion/models/skyreels_v3/test_skyreels_v3_v2v.py` | 7 passed |
| L4 Function | `tests/e2e/online_serving/test_skyreels_v3_v2v_expansion.py` | 1 case (`cuda_v2v_baseline`), wired into `test-nightly.yml` X2V Other Function Test |
| L4 Perf | `tests/dfx/perf/tests/test_skyreels_v3_v2v_vllm_omni.json` | Baseline latency 873.32 s @ g=1, 1696.47 s @ g=5, peak ~77 GB, wired into X2V Perf Test |

## Speed and quality comparison

Same-seed 720P × 4-step × duration=5 s single-shot extension, seed=42, `flow_shift=8.0`.

| Pipeline | Init | Per-step | End-to-end | Notes |
|---|---:|---:|---:|---|
| Skywork upstream (`--offload`) | ~3 min | **207.32 s** | ~30 min | Encoders shuttled off GPU |
| **vllm-omni** | 216 s | **~209 s** | **873.32 s** (~14.5 min) | Encoders resident |

Per-step kernel path is byte-for-byte the same. End-to-end wall clock differs because Skywork uses `--offload`; vllm-omni V2V hits the same offload dtype bug as A2V's CLIP wrapper (see follow-ups below) so this run keeps encoders resident.

**Quality (132 overlapping frames, seed=42)** — PSNR mean 19.397 dB / median 17.264 dB / max 33.888 dB (frame 0, the shared input-video prefix). SSIM mean 0.530 / max 0.953 (frame 0). Beyond the shared prefix, PSNR ~17 / SSIM ~0.44 reflects two independent samplers taking different noise trajectories off the same integer seed — expected diffusion behavior, not a correctness gap.

Videos + per-frame metrics: [`NancyFyong/vllm-omni@skyreels-v3-v2v-assets:assets/skyreels-v3-v2v/`](https://github.com/NancyFyong/vllm-omni/tree/skyreels-v3-v2v-assets/assets/skyreels-v3-v2v).

## Known follow-ups (not in this PR)

- **CFG-parallel is a no-op for V2V** — `SkyReelsV3V2VPipeline.diffuse()` inherits `CFGParallelMixin` but bypasses `predict_noise_maybe_with_cfg(...)`, calling `_predict_noise` twice sequentially instead. Measured on 1×H20 vs 2×H20 at guidance=5, output is byte-identical and wall clock is unchanged (1696.47 s vs 1709.17 s). Fix mirrors the A2V pipeline's `diffuse()` pattern in #5888.
- **CPU offload dtype bug** — with `enable_cpu_offload=True`, VAE encode crashes on `F.conv3d` with `Input CPUBFloat16Type vs weight CUDABFloat16Type`. Same class of bug that A2V's `CLIPModel.visual` hits: a Python wrapper (`WanVAE.encode` → `WanVAE_.encode`) invokes a plain method that bypasses `nn.Module.__call__`, so the sequential-offload hook never fires and some intermediate cache tensor stays on CPU. Fix belongs in a shared refactor after A2V's #5888 lands.
- **Shot-switching** — checkpoint ships both `transformer/` and `shot_transformer/` weights; this PR only wires the single-shot path. Follow-up PR.
- **No Cache-DiT enabler** — no `CUSTOM_DIT_ENABLERS` entry for `SkyReelsV3V2VPipeline`.

## Test plan

- [x] `pytest -s -v tests/diffusion/models/skyreels_v3/test_skyreels_v3_v2v.py -m "core_model and diffusion and cpu"` — 7 passed
- [x] Collect `tests/e2e/online_serving/test_skyreels_v3_v2v_expansion.py` — 1 case
- [x] Same-seed apples-to-apples vs Skywork upstream — matched per-step kernel time
- [ ] L4 Function nightly on H100 (X2V group) — wired, will run on merge
- [ ] L4 Perf nightly on H100 — wired, will run on merge
- [ ] CFG-parallel fix — deferred follow-up PR
- [ ] CPU-offload dtype fix — deferred follow-up PR shared with A2V

---

*AI assistance used (Claude Code): guided the pipeline port, wrote the tests and CI wiring, produced the benchmark scripts and comparison metrics. Every commit line was reviewed by the author; the model was validated end-to-end on 1×H20 and matches Skywork's upstream output at kernel time.*
