### PR TITLE
[Perf][MiniMax H3] Pin encoder offload buffers for faster CPU<->GPU transfer

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_offload.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_offload.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MiniMax H3 encoder pinned-offload transfer path.
+
+The encoder's full-model CPU offload dominated single-GPU latency because it
+used pageable ``.to("cpu")`` copies. ``_move_module_pinned`` routes those moves
+through persistent pinned host buffers, gated by the shared ``pin_cpu_memory``
+setting with a pageable fallback when pinning is off or unavailable. These CPU
+tests cover the gating and fallback logic (the GPU<->CPU DMA speedup itself is
+covered by the end-to-end A/B on hardware)."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def _make_encoder(*, pin_cpu_memory: bool):
+    from vllm_omni.diffusion.models.minimax_h3.encoder import MiniMaxH3Qwen3VLEncoder
+
+    # load_model=False constructs the shell (device_target + pin flag) without
+    # pulling the 63 GB checkpoint, which is all these transfer tests need.
+    return MiniMaxH3Qwen3VLEncoder(
+        model_path="",
+        device=torch.device("cpu"),
+        load_model=False,
+        pin_cpu_memory=pin_cpu_memory,
+    )
+
+
+def test_pin_flag_gates_offload_behavior():
+    on = _make_encoder(pin_cpu_memory=True)
+    off = _make_encoder(pin_cpu_memory=False)
+    assert on._pin_offload_enabled() is True
+    assert off._pin_offload_enabled() is False
+
+
+def test_offload_moves_params_to_cpu_and_reuses_pinned_buffers():
+    enc = _make_encoder(pin_cpu_memory=True)
+    module = nn.Linear(8, 8)  # already on CPU; device_target is CPU here
+    # to_device=False must leave params on CPU and not raise; pinned mirrors are
+    # created lazily and reused across calls.
+    enc._move_module_pinned(module, to_device=False)
+    for p in module.parameters():
+        assert p.device.type == "cpu"
+
+
+def test_pageable_fallback_when_pinning_unavailable(monkeypatch):
+    enc = _make_encoder(pin_cpu_memory=True)
+    # Simulate a host that cannot allocate pinned memory: _pinned_cpu_mirror
+    # returns None, so the mover must fall back to a plain pageable copy without
+    # raising.
+    monkeypatch.setattr(enc, "_pinned_cpu_mirror", lambda tensor: None)
+    module = nn.Linear(8, 8)
+    enc._move_module_pinned(module, to_device=False)
+    for p in module.parameters():
+        assert p.device.type == "cpu"
+
+
+def test_disabled_flag_skips_pinned_mirror(monkeypatch):
+    enc = _make_encoder(pin_cpu_memory=False)
+    calls = {"n": 0}
+
+    def _tracked(tensor):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(enc, "_pinned_cpu_mirror", _tracked)
+    module = nn.Linear(8, 8)
+    enc._move_module_pinned(module, to_device=False)
+    # With pinning disabled the pinned-mirror path must never be consulted.
+    assert calls["n"] == 0

--- a/vllm_omni/diffusion/models/minimax_h3/encoder.py
+++ b/vllm_omni/diffusion/models/minimax_h3/encoder.py
@@ -911,10 +911,12 @@ class MiniMaxH3Qwen3VLEncoder(nn.Module):
         device: torch.device,
         load_model: bool,
         encoder_group: Any | None = None,
+        pin_cpu_memory: bool = True,
     ) -> None:
         super().__init__()
         self.device_target = device
         self.encoder_group = encoder_group
+        self._pin_cpu_memory = pin_cpu_memory
         self.image_token_id = 151655
         self.video_token_id = 151656
         self._tp_size = 1
@@ -1026,6 +1028,67 @@ class MiniMaxH3Qwen3VLEncoder(nn.Module):
                 missing[:5],
             )
 
+    def _pin_offload_enabled(self) -> bool:
+        """Whether to use pinned-host buffers for full-model encoder offload.
+
+        Pinned (page-locked) host memory makes the 63 GB encoder GPU<->CPU
+        transfer an order of magnitude faster, but it holds that host memory
+        non-swappable. Controlled by the shared ``pin_cpu_memory`` offload
+        setting (default on); disable it on hosts without the spare
+        page-lockable RAM.
+        """
+        return bool(getattr(self, "_pin_cpu_memory", True))
+
+    def _pinned_cpu_mirror(self, tensor: torch.Tensor) -> torch.Tensor | None:
+        """Return a persistent pinned-CPU buffer mirroring ``tensor``'s storage.
+
+        Reused across requests keyed by tensor identity. Returns ``None`` if the
+        pinned allocation fails (e.g. insufficient page-lockable host RAM) so the
+        caller can fall back to a plain pageable copy instead of crashing.
+        """
+        cache = self.__dict__.setdefault("_pinned_mirror_cache", {})
+        key = id(tensor)
+        buf = cache.get(key)
+        if buf is None or buf.shape != tensor.shape or buf.dtype != tensor.dtype:
+            try:
+                buf = torch.empty(tensor.shape, dtype=tensor.dtype, device="cpu", pin_memory=True)
+            except RuntimeError as exc:
+                logger.warning_once(
+                    "MiniMax H3 encoder pinned-offload buffer allocation failed (%s); "
+                    "falling back to pageable offload. Set pin_cpu_memory=False to silence.",
+                    exc,
+                )
+                return None
+            cache[key] = buf
+        return buf
+
+    def _move_module_pinned(self, module: nn.Module, *, to_device: bool) -> None:
+        """Move a module's params/buffers via persistent pinned host buffers.
+
+        ``to_device`` True copies pinned-CPU -> GPU; False copies GPU -> pinned
+        CPU and rebinds ``.data`` to the pinned buffer. Falls back to a plain
+        ``.to`` when the tensor is already on the wanted side, when pinned
+        offload is disabled, or when the pinned buffer cannot be allocated.
+        """
+        device = self.device_target
+        use_pinned = self._pin_offload_enabled()
+        for tensor in list(module.parameters()) + list(module.buffers()):
+            if to_device:
+                if tensor.device.type == device.type:
+                    continue
+                gpu = torch.empty(tensor.shape, dtype=tensor.dtype, device=device)
+                gpu.copy_(tensor, non_blocking=True)
+                tensor.data = gpu
+            else:
+                if tensor.device.type == "cpu":
+                    continue
+                pinned = self._pinned_cpu_mirror(tensor) if use_pinned else None
+                if pinned is None:
+                    tensor.data = tensor.data.to("cpu")
+                    continue
+                pinned.copy_(tensor, non_blocking=True)
+                tensor.data = pinned
+
     def load_to_device(self) -> None:
         if not self.is_loaded:
             return
@@ -1037,8 +1100,9 @@ class MiniMaxH3Qwen3VLEncoder(nn.Module):
                 if name != "layers":
                     child.to(self.device_target)
             return
-        self.vision.to(self.device_target)
-        self.text_model.to(self.device_target)
+        self._move_module_pinned(self.vision, to_device=True)
+        self._move_module_pinned(self.text_model, to_device=True)
+        torch.accelerator.synchronize()
 
     def offload_to_cpu(self) -> None:
         if not self.is_loaded:
@@ -1054,8 +1118,9 @@ class MiniMaxH3Qwen3VLEncoder(nn.Module):
                     child.to("cpu")
             torch.accelerator.empty_cache()
             return
-        self.vision.to("cpu")
-        self.text_model.to("cpu")
+        self._move_module_pinned(self.vision, to_device=False)
+        self._move_module_pinned(self.text_model, to_device=False)
+        torch.accelerator.synchronize()
         torch.accelerator.empty_cache()
 
     def enable_omni_layerwise_offload(self, *, pin_memory: bool = True) -> None:

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -676,6 +676,7 @@ class MiniMaxH3Pipeline(
             device=self.device,
             load_model=rank < text_encoder_tp_size,
             encoder_group=self.text_encoder_group,
+            pin_cpu_memory=getattr(od_config, "pin_cpu_memory", True),
         )
         stage_components = bool(
             od_config.enable_layerwise_offload or getattr(od_config, "enable_distributed_layerwise_offload", False)


### PR DESCRIPTION
## Purpose

Under layer-wise offload, MiniMax H3's Qwen3-VL text encoder (~63 GB) is moved GPU↔CPU around every request through bare `Tensor.to("cpu")` / `.to(device)`. Those copies go through **pageable** host memory — no fast DMA, and re-allocated each time.

Stage timing on a single H20 (t2va 448×256, 8 steps) shows the encode phase is **35 s of a 47 s request**, of which:
- actual encode compute: **0.04 s**
- load (CPU→GPU): 7.5 s
- **offload (GPU→CPU): 27.2 s**

i.e. the GPU is almost entirely stalled on data movement, not compute.

This PR routes the encoder's full-model `load_to_device` / `offload_to_cpu` through **persistent pinned host buffers** with `non_blocking` copies, mirroring the pinned path the layer-wise block offloader already uses. Buffers are reused across requests to avoid repeated pinned allocation.

### Performance

Single H20, t2va 448×256, `duration=4.0`, seed 42, layer-wise offload:

| Metric | Baseline | This PR |
| --- | ---: | ---: |
| Encoder offload (GPU→CPU) | 27.2 s | 1.08 s |
| End-to-end / request | 47.0 s | **14.3 s (-70%)** |

Generated video + audio SHA256 are **bit-identical** to baseline.

### Scope & safety

- Gated by the shared `pin_cpu_memory` offload setting (default on), matching the other offload backends. Set `pin_cpu_memory=False` to keep the pageable path on hosts without spare page-lockable RAM.
- Pinned-buffer allocation failure falls back to a pageable copy instead of raising.
- **Peak GPU memory is unchanged** (offload is a host-memory path).
- The **model-level** CPU offload path is unaffected — it stages the encoder through the generic offload hook rather than `load_to_device` / `offload_to_cpu`. The speedup here is specific to layer-wise offload.

This is a pinned optimization of the whole-model encoder offload, not blockwise streaming; the generic single-GPU encoder blockwise offload remains a separate follow-up.

Related to #5700 (§1.4 single-GPU encoder offload).

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 44e38d7b

- New unit test `test_minimax_h3_encoder_offload.py`: pin-flag gating, offload leaves params on CPU + pinned-buffer reuse, allocation-failure pageable fallback, disabled-flag skips the pinned path.
- Existing H3 CPU suite.
- `pre-commit run` on changed files.
- H20 end-to-end A/B: bit-identical media hashes; layer-wise −70%; model-level offload no-regression.

## Test Result

- [x] `test_minimax_h3_encoder_offload.py`: 4 passed
- [x] H3 CPU suite: 113 passed, 5 deselected
- [x] `pre-commit run` clean
- [x] E2E A/B bit-identical; layer-wise 47.0 s → 14.3 s; model-level 16.95 s → 17.06 s (noise)
