### PR TITLE
[CI/Build] Add g2pM/g2p-en to dev extras for SoulX SVS weekly CI (#5745)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ dev = [
     "zhconv==1.4.3",
     "scipy==1.18.0",
     "funasr==1.3.29",
-    "g2pM>=0.1.2.5", # SoulX-Singer SVS (also in soulx-svs extra); needed by weekly CI
-    "g2p-en>=2.1.0", # SoulX-Singer SVS English G2P (also in soulx-svs extra)
+    "g2pM==0.1.2.5", # SoulX-Singer SVS (also in soulx-svs extra); needed by weekly CI
+    "g2p-en==2.1.0", # SoulX-Singer SVS English G2P (also in soulx-svs extra)
     "lpips==0.1.4", # for quantization fp8
     "orjson==3.11.9", # to make v1/embeddings API fast
     "voxcpm==2.0.3", # for VoxCPM2 path-locating in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ dev = [
     "zhconv==1.4.3",
     "scipy==1.18.0",
     "funasr==1.3.29",
+    "g2pM>=0.1.2.5", # SoulX-Singer SVS (also in soulx-svs extra); needed by weekly CI
+    "g2p-en>=2.1.0", # SoulX-Singer SVS English G2P (also in soulx-svs extra)
     "lpips==0.1.4", # for quantization fp8
     "orjson==3.11.9", # to make v1/embeddings API fast
     "voxcpm==2.0.3", # for VoxCPM2 path-locating in tests


### PR DESCRIPTION
## Purpose

Fix weekly CI failure for SoulX-Singer SVS ([#5745](https://github.com/vllm-project/vllm-omni/issues/5745)):

`tests/e2e/offline_inference/test_soulxsinger_expansion.py::test_soulxsinger_multistage_from_audio[svs]` fails with `ModuleNotFoundError: No module named 'g2pM'` because CI installs the `dev` extra, while `g2pM` / `g2p-en` previously lived only under the optional `soulx-svs` extra.

Add pinned `g2pM==0.1.2.5` and `g2p-en==2.1.0` to `[project.optional-dependencies].dev` so weekly CI has the SVS G2P deps available.


## Test Plan

**vLLM Version:** 0.26.0 (aligned with current main CI)

**vLLM-Omni Commit:** this PR head

- [ ] Confirm `pyproject.toml` `dev` extras include `g2pM==0.1.2.5` and `g2p-en==2.1.0`
- [ ] Weekly CI: `test_soulxsinger_multistage_from_audio[svs]` no longer fails on missing `g2pM`

## Test Result

Local: dependency pins added to `dev` only; no production/runtime code change.
